### PR TITLE
devif_poll_tcp_timer shouldn't be skipped in the multiple card case

### DIFF
--- a/arch/arm/src/c5471/c5471_ethernet.c
+++ b/arch/arm/src/c5471/c5471_ethernet.c
@@ -1778,7 +1778,7 @@ static void c5471_poll_work(FAR void *arg)
     {
       /* If so, update TCP timing states and poll the network for new XMIT data */
 
-      (void)devif_timer(&priv->c_dev, c5471_txpoll);
+      (void)devif_timer(&priv->c_dev, C5471_WDDELAY, c5471_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -1231,7 +1231,7 @@ static void imxrt_poll_work(FAR void *arg)
        * transmit in progress, we will missing TCP time state updates?
        */
 
-      (void)devif_timer(&priv->dev, imxrt_txpoll);
+      (void)devif_timer(&priv->dev, IMXRT_WDDELAY, imxrt_txpoll);
     }
 
   /* Setup the watchdog poll timer again in any case */

--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -1083,7 +1083,7 @@ static void kinetis_poll_work(FAR void *arg)
        * in progress, we will missing TCP time state updates?
        */
 
-      (void)devif_timer(&priv->dev, kinetis_txpoll);
+      (void)devif_timer(&priv->dev, KINETIS_WDDELAY, kinetis_txpoll);
     }
 
   /* Setup the watchdog poll timer again in any case */

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -1480,7 +1480,7 @@ static void lpc17_40_poll_work(FAR void *arg)
        * transmit in progress, we will missing TCP time state updates?
        */
 
-      (void)devif_timer(&priv->lp_dev, lpc17_40_txpoll);
+      (void)devif_timer(&priv->lp_dev, LPC17_40_WDDELAY, lpc17_40_txpoll);
     }
 
   /* Simulate a fake receive to relaunch the data exchanges when a receive

--- a/arch/arm/src/lpc43xx/lpc43_ethernet.c
+++ b/arch/arm/src/lpc43xx/lpc43_ethernet.c
@@ -2169,7 +2169,7 @@ static void lpc43_poll_work(FAR void *arg)
           /* Update TCP timing states and poll for new XMIT data.
            */
 
-          (void)devif_timer(dev, lpc43_txpoll);
+          (void)devif_timer(dev, LPC43_WDDELAY, lpc43_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -1731,7 +1731,7 @@ static void lpc54_eth_dotimer(struct lpc54_ethdriver_s *priv)
       priv->eth_dev.d_buf = (uint8_t *)lpc54_pktbuf_alloc(priv);
       if (priv->eth_dev.d_buf != NULL)
         {
-          (void)devif_timer(&priv->eth_dev, lpc54_eth_txpoll);
+          (void)devif_timer(&priv->eth_dev, LPC54_WDDELAY, lpc54_eth_txpoll);
 
           /* Make sure that the Tx buffer remaining after the poll is
            * freed.

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -1230,7 +1230,7 @@ static void s32k1xx_poll_work(FAR void *arg)
        * transmit in progress, we will missing TCP time state updates?
        */
 
-      (void)devif_timer(&priv->dev, s32k1xx_txpoll);
+      (void)devif_timer(&priv->dev, S32K1XX_WDDELAY, s32k1xx_txpoll);
     }
 
   /* Setup the watchdog poll timer again in any case */

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -1773,7 +1773,7 @@ static void sam_poll_work(FAR void *arg)
     {
       /* Update TCP timing states and poll the network for new XMIT data. */
 
-      (void)devif_timer(dev, sam_txpoll);
+      (void)devif_timer(dev, SAM_WDDELAY, sam_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -1808,7 +1808,7 @@ static void sam_poll_work(FAR void *arg)
     {
       /* Update TCP timing states and poll the network for new XMIT data. */
 
-      (void)devif_timer(dev, sam_txpoll);
+      (void)devif_timer(dev, SAM_WDDELAY, sam_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -2169,7 +2169,7 @@ static void sam_poll_work(FAR void *arg)
     {
       /* Update TCP timing states and poll the network for new XMIT data. */
 
-      (void)devif_timer(dev, sam_txpoll);
+      (void)devif_timer(dev, SAM_WDDELAY, sam_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -1760,7 +1760,7 @@ static void sam_poll_work(FAR void *arg)
     {
       /* Update TCP timing states and poll the network for new XMIT data. */
 
-      (void)devif_timer(dev, sam_txpoll);
+      (void)devif_timer(dev, SAM_WDDELAY, sam_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -2636,7 +2636,7 @@ static void sam_poll_work(FAR void *arg)
     {
       /* Update TCP timing states and poll the network for new XMIT data. */
 
-      (void)devif_timer(dev, sam_txpoll);
+      (void)devif_timer(dev, SAM_WDDELAY, sam_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -2275,7 +2275,7 @@ static void stm32_poll_work(FAR void *arg)
           /* Update TCP timing states and poll the network for new XMIT data.
            */
 
-          (void)devif_timer(dev, stm32_txpoll);
+          (void)devif_timer(dev, STM32_WDDELAY, stm32_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -2380,7 +2380,7 @@ static void stm32_poll_work(void *arg)
           /* Update TCP timing states and poll the network for new XMIT data.
            */
 
-          (void)devif_timer(dev, stm32_txpoll);
+          (void)devif_timer(dev, STM32_WDDELAY, stm32_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -2469,7 +2469,7 @@ static void stm32_poll_work(void *arg)
            * data.
            */
 
-          (void)devif_timer(dev, stm32_txpoll);
+          (void)devif_timer(dev, STM32_WDDELAY, stm32_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -1218,7 +1218,7 @@ static void tiva_poll_work(void *arg)
        * data.
        */
 
-      (void)devif_timer(&priv->ld_dev, tiva_txpoll);
+      (void)devif_timer(&priv->ld_dev, TIVA_WDDELAY, tiva_txpoll);
 
       /* Setup the watchdog poll timer again */
 

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -2283,7 +2283,7 @@ static void tiva_poll_work(FAR void *arg)
           /* Update TCP timing states and poll the network for new XMIT data.
            */
 
-          (void)devif_timer(dev, tiva_txpoll);
+          (void)devif_timer(dev, TIVA_WDDELAY, tiva_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -530,7 +530,7 @@ static void emac_polltimer(int argc, uint32_t arg, ...)
    * we will missing TCP time state updates?
    */
 
-  (void)devif_timer(&priv->d_dev, emac_txpoll);
+  (void)devif_timer(&priv->d_dev, HCS12_WDDELAY, emac_txpoll);
 
   /* Setup the watchdog poll timer again */
 

--- a/arch/mips/src/pic32mx/pic32mx-ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx-ethernet.c
@@ -1278,7 +1278,7 @@ static void pic32mx_timerpoll(struct pic32mx_driver_s *priv)
           /* And perform the poll */
 
           priv->pd_polling = true;
-          (void)devif_timer(&priv->pd_dev, pic32mx_txpoll);
+          (void)devif_timer(&priv->pd_dev, PIC32MX_WDDELAY, pic32mx_txpoll);
 
           /* Free any buffer left attached after the poll */
 

--- a/arch/mips/src/pic32mz/pic32mz-ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz-ethernet.c
@@ -1396,7 +1396,7 @@ static void pic32mz_timerpoll(struct pic32mz_driver_s *priv)
           /* And perform the poll */
 
           priv->pd_polling = true;
-          (void)devif_timer(&priv->pd_dev, pic32mz_txpoll);
+          (void)devif_timer(&priv->pd_dev, PIC32MZ_WDDELAY, pic32mz_txpoll);
 
           /* Free any buffer left attached after the poll */
 

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -770,7 +770,7 @@ static void misoc_net_poll_work(FAR void *arg)
    * progress, we will missing TCP time state updates?
    */
 
-  (void)devif_timer(&priv->misoc_net_dev, misoc_net_txpoll);
+  (void)devif_timer(&priv->misoc_net_dev, MISOC_NET_WDDELAY, misoc_net_txpoll);
 
   /* Setup the watchdog poll timer again */
 

--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -2176,7 +2176,7 @@ static void rx65n_poll_work(FAR void *arg)
           /* Update TCP timing states and poll the network for new XMIT data.
            */
 
-          (void)devif_timer(dev, rx65n_txpoll);
+          (void)devif_timer(dev, CLK_TCK, rx65n_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -322,7 +322,7 @@ void netdriver_loop(void)
   else if (timer_expired(&g_periodic_timer))
     {
       timer_reset(&g_periodic_timer);
-      devif_timer(&g_sim_dev, sim_txpoll);
+      devif_timer(&g_sim_dev, MSEC2TICK(g_periodic_timer.interval), sim_txpoll);
     }
 
   sched_unlock();

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -1928,7 +1928,7 @@ static void ez80emac_poll_work(FAR void *arg)
   /* Poll the network for new XMIT data */
 
   net_lock();
-  (void)devif_timer(&priv->dev, ez80emac_txpoll);
+  (void)devif_timer(&priv->dev, EMAC_WDDELAY, ez80emac_txpoll);
 
   /* Setup the watchdog poll timer again */
 

--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -1416,7 +1416,7 @@ static void dm9x_poll_work(FAR void *arg)
     {
       /* If so, update TCP timing states and poll the network for new XMIT data */
 
-      (void)devif_timer(&priv->dm_dev, dm9x_txpoll);
+      (void)devif_timer(&priv->dm_dev, DM9X_WDDELAY, dm9x_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -2005,7 +2005,7 @@ static void enc_pollworker(FAR void *arg)
        * is a transmit in progress, we will missing TCP time state updates?
        */
 
-      (void)devif_timer(&priv->dev, enc_txpoll);
+      (void)devif_timer(&priv->dev, ENC_WDDELAY, enc_txpoll);
     }
 
   /* Release lock on the SPI bus and the network */

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -2157,7 +2157,7 @@ static void enc_pollworker(FAR void *arg)
        * is a transmit in progress, we will missing TCP time state updates?
        */
 
-      (void)devif_timer(&priv->dev, enc_txpoll);
+      (void)devif_timer(&priv->dev, ENC_WDDELAY, enc_txpoll);
     }
 
   /* Release lock on the SPI bus and the network */

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -1130,7 +1130,7 @@ static void ftmac100_poll_work(FAR void *arg)
    * progress, we will missing TCP time state updates?
    */
 
-  (void)devif_timer(&priv->ft_dev, ftmac100_txpoll);
+  (void)devif_timer(&priv->ft_dev, FTMAC100_WDDELAY, ftmac100_txpoll);
 
   /* Setup the watchdog poll timer again */
 

--- a/drivers/net/lan91c111.c
+++ b/drivers/net/lan91c111.c
@@ -1027,7 +1027,7 @@ static void lan91c111_poll_work(FAR void *arg)
        * transmit in progress, we will missing TCP time state updates?
        */
 
-      devif_timer(dev, lan91c111_txpoll);
+      devif_timer(dev, LAN91C111_WDDELAY, lan91c111_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -234,7 +234,7 @@ static void lo_poll_work(FAR void *arg)
 
   net_lock();
   priv->lo_txdone = false;
-  (void)devif_timer(&priv->lo_dev, lo_txpoll);
+  (void)devif_timer(&priv->lo_dev, LO_WDDELAY, lo_txpoll);
 
   /* Was something received and looped back? */
 

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -847,7 +847,7 @@ static void net_rpmsg_drv_poll_work(FAR void *arg)
        * progress, we will missing TCP time state updates?
        */
 
-      devif_timer(dev, net_rpmsg_drv_txpoll);
+      devif_timer(dev, NET_RPMSG_DRV_WDDELAY, net_rpmsg_drv_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -740,7 +740,7 @@ static void skel_poll_work(FAR void *arg)
    * progress, we will missing TCP time state updates?
    */
 
-  (void)devif_timer(&priv->sk_dev, skel_txpoll);
+  (void)devif_timer(&priv->sk_dev, skeleton_WDDELAY, skel_txpoll);
 
   /* Setup the watchdog poll timer again */
 

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -494,7 +494,7 @@ static void slip_txtask(int argc, FAR char *argv[])
             {
               /* Yes, perform the timer poll */
 
-              (void)devif_timer(&priv->dev, slip_txpoll);
+              (void)devif_timer(&priv->dev, hsec * TICK_PER_HSEC, slip_txpoll);
               start_ticks += hsec * TICK_PER_HSEC;
             }
           else

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -846,7 +846,7 @@ static void tun_poll_work(FAR void *arg)
       /* If so, poll the network for new XMIT data. */
 
       priv->dev.d_buf = priv->read_buf;
-      (void)devif_timer(&priv->dev, tun_txpoll);
+      (void)devif_timer(&priv->dev, TUN_WDDELAY, tun_txpoll);
     }
 
   /* Setup the watchdog poll timer again */

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -699,7 +699,7 @@ static void cdcecm_poll_work(FAR void *arg)
    * become available.
    */
 
-  (void)devif_timer(&self->dev, cdcecm_txpoll);
+  (void)devif_timer(&self->dev, CDCECM_WDDELAY, cdcecm_txpoll);
 
   /* Setup the watchdog poll timer again */
 

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -1064,7 +1064,7 @@ static void rndis_pollworker(FAR void *arg)
 
   if (rndis_allocnetreq(priv))
     {
-      devif_timer(&priv->netdev, rndis_txpoll);
+      devif_timer(&priv->netdev, RNDIS_WDDELAY, rndis_txpoll);
 
       if (priv->net_req != NULL)
         {

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -618,7 +618,7 @@ static void bcmf_poll_work(FAR void *arg)
 
   priv->bc_dev.d_buf = priv->cur_tx_frame->data;
   priv->bc_dev.d_len = 0;
-  (void)devif_timer(&priv->bc_dev, bcmf_txpoll);
+  (void)devif_timer(&priv->bc_dev, BCMF_WDDELAY, bcmf_txpoll);
 
   /* Setup the watchdog poll timer again */
 

--- a/drivers/wireless/ieee802154/xbee/xbee_netdev.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_netdev.c
@@ -611,7 +611,7 @@ static void xbeenet_txpoll_work(FAR void *arg)
 
   /* Then perform the poll */
 
-  (void)devif_timer(&priv->xd_dev.r_dev, xbeenet_txpoll_callback);
+  (void)devif_timer(&priv->xd_dev.r_dev, TXPOLL_WDDELAY, xbeenet_txpoll_callback);
 
   /* Setup the watchdog poll timer again */
 

--- a/drivers/wireless/spirit/drivers/spirit_netdev.c
+++ b/drivers/wireless/spirit/drivers/spirit_netdev.c
@@ -1812,7 +1812,7 @@ static void spirit_txpoll_work(FAR void *arg)
       /* Perform the periodic poll */
 
       priv->needpoll = false;
-      (void)devif_timer(&priv->radio.r_dev, spirit_txpoll_callback);
+      (void)devif_timer(&priv->radio.r_dev, SPIRIT_WDDELAY, spirit_txpoll_callback);
 
       /* Setup the watchdog poll timer again */
 

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -544,7 +544,7 @@ int sixlowpan_input(FAR struct radio_driver_s *ieee,
  ****************************************************************************/
 
 int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback);
-int devif_timer(FAR struct net_driver_s *dev, devif_poll_callback_t callback);
+int devif_timer(FAR struct net_driver_s *dev, int delay, devif_poll_callback_t callback);
 
 /****************************************************************************
  * Name: neighbor_out

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -281,10 +281,6 @@ extern "C"
 EXTERN uint8_t g_reassembly_timer;
 #endif
 
-/* Time of last poll */
-
-EXTERN clock_t g_polltime;
-
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/net/devif/devif_initialize.c
+++ b/net/devif/devif_initialize.c
@@ -44,9 +44,6 @@
 #include <nuttx/config.h>
 #ifdef CONFIG_NET
 
-#include <stdint.h>
-
-#include <nuttx/clock.h>
 #include <nuttx/net/netstats.h>
 
 #include "devif/devif.h"
@@ -95,10 +92,6 @@ uint8_t g_reassembly_timer;
 
 void devif_initialize(void)
 {
-  /* Initialize the time of the last timer poll */
-
-  g_polltime = clock_systimer();
-
   /* Initialize callback support */
 
   devif_callback_init();

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -542,7 +542,7 @@ static void btnet_txpoll_work(FAR void *arg)
 
   /* Then perform the poll */
 
-  (void)devif_timer(&priv->bd_dev.r_dev, btnet_txpoll_callback);
+  (void)devif_timer(&priv->bd_dev.r_dev, TXPOLL_WDDELAY, btnet_txpoll_callback);
 
   /* Setup the watchdog poll timer again */
 

--- a/wireless/ieee802154/mac802154_loopback.c
+++ b/wireless/ieee802154/mac802154_loopback.c
@@ -476,7 +476,7 @@ static void lo_poll_work(FAR void *arg)
 
   /* Then perform the poll */
 
-  (void)devif_timer(&priv->lo_radio.r_dev, lo_loopback);
+  (void)devif_timer(&priv->lo_radio.r_dev, LO_WDDELAY, lo_loopback);
 
   /* Setup the watchdog poll timer again */
 

--- a/wireless/ieee802154/mac802154_netdev.c
+++ b/wireless/ieee802154/mac802154_netdev.c
@@ -579,7 +579,7 @@ static void macnet_txpoll_work(FAR void *arg)
 
   /* Then perform the poll */
 
-  (void)devif_timer(&priv->md_dev.r_dev, macnet_txpoll_callback);
+  (void)devif_timer(&priv->md_dev.r_dev, TXPOLL_WDDELAY, macnet_txpoll_callback);
 
   /* Setup the watchdog poll timer again */
 

--- a/wireless/pktradio/pktradio_loopback.c
+++ b/wireless/pktradio/pktradio_loopback.c
@@ -434,7 +434,7 @@ static void lo_poll_work(FAR void *arg)
 
   /* And perform the poll */
 
-  (void)devif_timer(&priv->lo_radio.r_dev, lo_loopback);
+  (void)devif_timer(&priv->lo_radio.r_dev, LO_WDDELAY, lo_loopback);
 
   /* Setup the watchdog poll timer again */
 


### PR DESCRIPTION
devif_timer will be called multiple time in one period if the multiple card exist,
the elapsed time calculated for the first callback is right, but the flowing callback
in the same period is wrong(very short) because the global variable g_polltimer is
used in the calculation.

so let's pass the delay time to devif_timer and remove g_polltimer.

Change-Id: I6ac3d1135e08cc0f34c51916fa713bd6e6892d04
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>