### PR TITLE
Fixed STM32L4_NUSART for STM32L433XX.

### DIFF
--- a/arch/arm/include/stm32l4/chip.h
+++ b/arch/arm/include/stm32l4/chip.h
@@ -285,7 +285,7 @@
 #  define STM32L4_NLPTIM                   2   /* Two low-power timers, LPTIM1-2 */
 #  define STM32L4_NRNG                     1   /* Random number generator (RNG) */
 #  define STM32L4_NUART                    0   /* No UART */
-#  define STM32L4_NUSART                   4   /* USART 1-4 */
+#  define STM32L4_NUSART                   3   /* USART 1-3 */
 #  define STM32L4_NLPUART                  1   /* LPUART 1 */
 #  define STM32L4_QSPI                     1   /* QuadSPI1 */
 #  define STM32L4_NSPI                     3   /* SPI1-SPI3 */


### PR DESCRIPTION
STM32L4_NUSART was set to 4. The spec at
https://www.st.com/resource/en/datasheet/stm32l433cc.pdf states the
following on page 1:

   - 4x USARTs (ISO 7816, LIN, IrDA, modem)
   - 1x LPUART (Stop 2 wake-up)

However it on page 49, it states:

   The STM32L433xx devices have three embedded universal synchronous
   receiver transmitters (USART1, USART2 and USART3).

The latter is correct.

This patch sets STM32L4_NUSART to 3.