### PR TITLE
fix sim:bluetooth compiler error

### DIFF
--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -79,7 +79,7 @@ int sim_bringup(void)
 #ifdef CONFIG_RAMMTD
   FAR uint8_t *ramstart;
 #endif
-  int ret;
+  int ret = OK;
 
 #ifdef CONFIG_FS_BINFS
   /* Mount the binfs file system */
@@ -300,7 +300,6 @@ int sim_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_WIRELESS_BLUETOOTH
 #ifdef CONFIG_BLUETOOTH_NULL
   /* Register the NULL Bluetooth network device */
 
@@ -311,18 +310,5 @@ int sim_bringup(void)
     }
 #endif
 
-  /* Initialize the Bluetooth stack (This will fail if no device has been
-   * registered).
-   */
-
-  ret = bt_netdev_register();
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: bt_netdev_register() failed: %d\n", ret);
-    }
-
-#endif
-
-  UNUSED(ret);
-  return OK;
+  return ret;
 }

--- a/drivers/wireless/bluetooth/bt_null.c
+++ b/drivers/wireless/bluetooth/bt_null.c
@@ -271,5 +271,5 @@ int btnull_register(void)
 {
   /* Register the driver with the Bluetooth stack */
 
-  return bt_driver_register(&g_bt_null);
+  return bt_netdev_register(&g_bt_null);
 }

--- a/drivers/wireless/bluetooth/bt_uart_bcm4343x.c
+++ b/drivers/wireless/bluetooth/bt_uart_bcm4343x.c
@@ -471,7 +471,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   ret = bt_netdev_register(&upper->dev);
   if (ret < 0)
     {
-      wlerr("ERROR: bt_driver_register failed: %d\n", ret);
+      wlerr("ERROR: bt_netdev_register failed: %d\n", ret);
       kmm_free(upper);
     }
 

--- a/drivers/wireless/bluetooth/bt_uart_cc2564.c
+++ b/drivers/wireless/bluetooth/bt_uart_cc2564.c
@@ -216,7 +216,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   ret = bt_netdev_register(&upper->dev);
   if (ret < 0)
     {
-      wlerr("ERROR: bt_driver_register failed: %d\n", ret);
+      wlerr("ERROR: bt_netdev_register failed: %d\n", ret);
       kmm_free(upper);
     }
 

--- a/drivers/wireless/bluetooth/bt_uart_generic.c
+++ b/drivers/wireless/bluetooth/bt_uart_generic.c
@@ -110,7 +110,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   ret = bt_netdev_register(&upper->dev);
   if (ret < 0)
     {
-      wlerr("ERROR: bt_driver_register failed: %d\n", ret);
+      wlerr("ERROR: bt_netdev_registe failed: %d\n", ret);
       kmm_free(upper);
     }
 


### PR DESCRIPTION
wireless/bluetooth/bt_null.c:274:10: warning: implicit declaration of function 'bt_driver_register'; did you mean 'bt_netdev_register'? [-Wimplicit-function-declaration]
   return bt_driver_register(&g_bt_null);

sim_bringup.c:324:9: error: too few arguments to function 'bt_netdev_register'
   ret = bt_netdev_register();

Change-Id: I61bab23e6b1d6aa70e6c2da03f345f8d0701d862
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>