### PR TITLE
tools/nxstyle.c: Add -r option to check specified range lines

### DIFF
--- a/tools/README.txt
+++ b/tools/README.txt
@@ -316,7 +316,7 @@ nxstyle.c
   Prints formatted messages that are classified as info, warn, error, 
   fatal. In a parsable format that can be used by editors and IDEs.
 
-  Usage: nxstyle [-m <maxline>] [-v <level>] <filename>
+  Usage: nxstyle [-m <maxline>] [-v <level>] [-r <start,count>] <filename>
         nxstyle -h this help
         nxstyle -v <level> where level is
                    0 - no output


### PR DESCRIPTION
Usage: ./nxstyle -r start,count filename

nxstyle with -r option used to parse the range lines rather than the whole file.

Change-Id: I58ec56511fde14d6ec914400a7849e69960a3711
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>