### PR TITLE
Fixed a compilation error, with irq debugging for stm32f7 and stm32h7 archs.

### DIFF
--- a/arch/arm/include/stm32f7/stm32f76xx77xx_irq.h
+++ b/arch/arm/include/stm32f7/stm32f76xx77xx_irq.h
@@ -179,7 +179,6 @@
 #define STM32_IRQ_MDIOS       (STM32_IRQ_FIRST + 109) /* 109: MDIO slave global interrupt */
 
 #define STM32_IRQ_NEXTINTS    110
-#define STM32_IRQ_NIRQS       (STM32_IRQ_FIRST + 110)
 
 /* EXTI interrupts (Do not use IRQ numbers) */
 

--- a/arch/arm/src/stm32f7/stm32_irq.c
+++ b/arch/arm/src/stm32f7/stm32_irq.c
@@ -494,7 +494,7 @@ void up_irqinitialize(void)
   irq_attach(STM32_IRQ_RESERVED, stm32_reserved, NULL);
 #endif
 
-  stm32_dumpnvic("initial", STM32_IRQ_NIRQS);
+  stm32_dumpnvic("initial", NR_IRQS);
 
   /* If a debugger is connected, try to prevent it from catching hardfaults.
    * If CONFIG_ARMV7M_USEBASEPRI, no hardfaults are expected in normal

--- a/arch/arm/src/stm32h7/stm32_irq.c
+++ b/arch/arm/src/stm32h7/stm32_irq.c
@@ -519,7 +519,7 @@ void up_irqinitialize(void)
   irq_attach(STM32_IRQ_RESERVED, stm32_reserved, NULL);
 #endif
 
-  stm32_dumpnvic("initial", STM32_IRQ_NIRQS);
+  stm32_dumpnvic("initial", NR_IRQS);
 
   /* If a debugger is connected, try to prevent it from catching hardfaults.
    * If CONFIG_ARMV7M_USEBASEPRI, no hardfaults are expected in normal


### PR DESCRIPTION
This commit fixes a compilation error that occurs when enabling the
following configuration items for stm32f7 and stm32h7 architectures:
```
   CONFIG_DEBUG_FEATURES=y
   CONFIG_DEBUG_ERROR=y
   CONFIG_DEBUG_WARN=y
   CONFIG_DEBUG_INFO=y
   CONFIG_DEBUG_IRQ=y
   CONFIG_DEBUG_IRQ_ERROR=y
   CONFIG_DEBUG_IRQ_WARN=y
   CONFIG_DEBUG_IRQ_INFO=y
```
The compiler error for stm32f7:
```
make[1]: Entering directory '/home/pdupreez/dev/wingunder/nuttx/arch/arm/src'
CC:  chip/stm32_irq.c
chip/stm32_irq.c: In function 'up_irqinitialize':
chip/stm32_irq.c:497:29: error: 'STM32_IRQ_NIRQS' undeclared (first use in this function); did you mean 'STM32_IRQ_FIRST'?
   stm32_dumpnvic("initial", STM32_IRQ_NIRQS);
                                ^~~~~~~~~~~~~~~
                             STM32_IRQ_FIRST
chip/stm32_irq.c:497:29: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [Makefile:172: stm32_irq.o] Error 1
make[1]: Leaving directory '/home/pdupreez/dev/wingunder/nuttx/arch/arm/src'
```
And the compiler error for stm32h7:
```
make[1]: Entering directory '/home/pdupreez/dev/wingunder/nuttx/arch/arm/src'
CC:  chip/stm32_irq.c
chip/stm32_irq.c: In function 'stm32_dumpnvic':
chip/stm32_irq.c:164:4: warning: #warning Missing logic [-Wcpp]
 #  warning Missing logic
     ^~~~~~~
     chip/stm32_irq.c: In function 'up_irqinitialize':
     chip/stm32_irq.c:522:29: error: 'STM32_IRQ_NIRQS' undeclared (first use in this function); did you mean 'STM32_IRQ_CRS'?
        stm32_dumpnvic("initial", STM32_IRQ_NIRQS);
                                     ^~~~~~~~~~~~~~~
                                  STM32_IRQ_CRS
chip/stm32_irq.c:522:29: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [Makefile:172: stm32_irq.o] Error 1
make[1]: Leaving directory '/home/pdupreez/dev/wingunder/nuttx/arch/arm/src'
```
This commit replaces all STM32_IRQ_NIRQS defines with the NR_IRQS
define, which seems to be consistent with the rest of the code in
Nuttx.