### PR TITLE
Add Imxrt usdhc insert or remove detection

### DIFF
--- a/arch/arm/src/imxrt/imxrt_usdhc.c
+++ b/arch/arm/src/imxrt/imxrt_usdhc.c
@@ -3019,6 +3019,12 @@ void imxrt_usdhc_set_sdio_card_isr(FAR struct sdio_dev_s *dev,
       priv->cintints = 0;
     }
 
+#if defined(CONFIG_MMCSD_HAVE_CARDDETECT)
+  if (priv->sw_cd_gpio == 0)
+    {
+      priv->cintints |= USDHC_INT_CINS | USDHC_INT_CRM;
+	}
+#endif
   flags = enter_critical_section();
   regval = getreg32(priv->addr + IMXRT_USDHC_IRQSIGEN_OFFSET);
   regval = (regval & ~USDHC_INT_CINT) | priv->cintints;

--- a/arch/arm/src/imxrt/imxrt_usdhc.c
+++ b/arch/arm/src/imxrt/imxrt_usdhc.c
@@ -1232,9 +1232,28 @@ static int imxrt_interrupt(int irq, void *context, FAR void *arg)
 
       /* We don't want any more ints now, so switch it off */
 
-      priv->cintints  = 0;
       regval         &= ~USDHC_INT_CINT;
+      priv->cintints  = regval;
       putreg32(regval, priv->addr + IMXRT_USDHC_IRQSIGEN_OFFSET);
+    }
+
+  if ((pending & USDHC_INT_CINS) != 0 || (pending & USDHC_INT_CRM) != 0)
+    {
+      if (up_interrupt_context())
+        {
+          /* Yes.. queue it */
+
+          mcinfo("Queuing callback to %p(%p)\n", priv->callback, priv->cbarg);
+          (void)work_queue(HPWORK, &priv->cbwork, (worker_t)priv->callback,
+                          priv->cbarg, 0);
+        }
+      else
+        {
+          /* No.. then just call the callback here */
+
+          mcinfo("Callback to %p(%p)\n", priv->callback, priv->cbarg);
+          priv->callback(priv->cbarg);
+        }
     }
 
   /* Handle wait events *****************************************************/

--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_bringup.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_bringup.c
@@ -121,6 +121,7 @@ static int nsh_sdmmc_initialize(void)
                  "ERROR: Failed to bind SDIO to the MMC/SD driver: %d\n",
                  ret);
         }
+      imxrt_usdhc_set_sdio_card_isr(sdmmc, NULL, NULL);
     }
   return OK;
 }


### PR DESCRIPTION
1. Enable USDHC_INT_CINS & USDHC_INT_CRM bit in function  imxrt_usdhc_set_sdio_card_isr.
2. When card insert or remove interrupt arrived, call the callback function.
3. After usdhc init, call imxrt_usdhc_set_sdio_card_isr.