### PR TITLE
bcm43xxx: correct typo error to fix build break in photon board

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -623,7 +623,7 @@ static void bcmf_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(priv->bc_txpoll, BCMF_WDDELAY, bcmf_poll_expiry, 1,
-  ,        (wdparm_t)priv);
+           (wdparm_t)priv);
 exit_unlock:
   net_unlock();
 }


### PR DESCRIPTION
Change-Id: I340b8d6d939b5049d25789d04c4a334bc97b1067
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>