### PR TITLE
Fix fe310

### DIFF
--- a/arch/risc-v/include/fe310/irq.h
+++ b/arch/risc-v/include/fe310/irq.h
@@ -46,6 +46,7 @@
 /* In mstatus register */
 
 #define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
+#define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
 
 /* In mie (machine interrupt enable) register */
 

--- a/arch/risc-v/src/fe310/fe310_clockconfig.c
+++ b/arch/risc-v/src/fe310/fe310_clockconfig.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/fe310/fe310_clockconfig.c
+ * arch/risc-v/src/fe310/fe310_clockconfig.c
  *
  *   Copyright (C) 2019 Masayuki Ishikawa. All rights reserved.
  *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>

--- a/arch/risc-v/src/fe310/fe310_clockconfig.h
+++ b/arch/risc-v/src/fe310/fe310_clockconfig.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/fe310/fe310_clockconfig.h
+ * arch/risc-v/src/fe310/fe310_clockconfig.h
  *
  *   Copyright (C) 2019 Masayuki Ishikawa. All rights reserved.
  *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>

--- a/arch/risc-v/src/fe310/fe310_gpio.c
+++ b/arch/risc-v/src/fe310/fe310_gpio.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/fe310/fe310_gpio.c
+ * arch/risc-v/src/fe310/fe310_gpio.c
  *
  *   Copyright (C) 2019 Masayuki Ishikawa. All rights reserved.
  *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -100,7 +100,6 @@ void up_irqinitialize(void)
   /* Attach the ecall interrupt handler */
 
   irq_attach(FE310_IRQ_ECALLM, up_swint, NULL);
-  up_enable_irq(FE310_IRQ_ECALLM);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 
@@ -188,13 +187,13 @@ void up_enable_irq(int irq)
  * Name: up_get_newintctx
  *
  * Description:
- *   Return a value for EPIC. But FE310 doesn't use EPIC for event control.
+ *   Return initial mstatus when a task is created.
  *
  ****************************************************************************/
 
 uint32_t up_get_newintctx(void)
 {
-  return 0;
+  return (MSTATUS_MPIE | MSTATUS_MIE);
 }
 
 /****************************************************************************
@@ -238,7 +237,7 @@ irqstate_t up_irq_save(void)
 
 void up_irq_restore(irqstate_t flags)
 {
-  /* Machine mode - mstatus */
+  /* Write flags to mstatus */
 
   asm volatile("csrw mstatus, %0" : /* no output */ : "r" (flags));
 }

--- a/arch/risc-v/src/fe310/fe310_serial.c
+++ b/arch/risc-v/src/fe310/fe310_serial.c
@@ -398,6 +398,11 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
 
       status = up_serialin(priv, UART_IP_OFFSET);
 
+      if (status == 0)
+        {
+          break;
+        }
+
       if (status & UART_IP_RXWM)
         {
           /* Process incoming bytes */
@@ -405,9 +410,12 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
           uart_recvchars(dev);
         }
 
-      /* Process outgoing bytes */
+      if (status & UART_IP_TXWM)
+        {
+          /* Process outgoing bytes */
 
-      uart_xmitchars(dev);
+          uart_xmitchars(dev);
+        }
     }
 
   return OK;


### PR DESCRIPTION
### Summary

- Fixed SiFive FE310 related code (comments, improve serial irq handling, initial int status)

### Impact

- This PR only affects FE310 and initial interrupt status when creating a task is now enabled.

### Testing

- I only tested this PR with available commands (i.e. ps/free/hello/getprime/buttons)