### PR TITLE
arch: fe310: Fix mstatus handlings

### DIFF
--- a/arch/risc-v/include/fe310/irq.h
+++ b/arch/risc-v/include/fe310/irq.h
@@ -47,6 +47,7 @@
 
 #define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
 #define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
+#define MSTATUS_MPPM  (0x3 << 11) /* Machine Previous Privilege (m-mode) */
 
 /* In mie (machine interrupt enable) register */
 

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -193,7 +193,11 @@ void up_enable_irq(int irq)
 
 uint32_t up_get_newintctx(void)
 {
-  return (MSTATUS_MPIE | MSTATUS_MIE);
+  /* Set machine previous privilege mode to machine mode.
+   * Also set machine previous interrupt enable
+   */
+
+  return (MSTATUS_MPPM | MSTATUS_MPIE);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/fe310/fe310_irq_dispatch.c
+++ b/arch/risc-v/src/fe310/fe310_irq_dispatch.c
@@ -131,10 +131,6 @@ void *fe310_dispatch_irq(uint32_t vector, uint32_t *regs)
   regs = (uint32_t *)g_current_regs;
   g_current_regs = NULL;
 
-  /* Set machine previous privilege mode to machine mode */
-
-  *(regs + REG_INT_CTX_NDX) |= 0x3 << 11;
-
   return regs;
 }
 


### PR DESCRIPTION
### Summary

- This PR fixes incorrect mstatus.mie initial setting introduced in previous commit.
- Also, refactor mstatus.mpp settings.

### Impact

- This PR only affects interrupt handlings on FE310

### Testing

- I only tested this PR with nsh commands on qemu and also checked with gdb.
