### PR TITLE
sched: timer: Fix inappropriate cast in timer_settime()

### DIFF
--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -372,7 +372,7 @@ int timer_settime(timer_t timerid, int flags,
 
       timer->pt_last = delay;
       ret = wd_start(timer->pt_wdog, delay, (wdentry_t)timer_timeout,
-                     1, (uint32_t)((wdparm_t)timer));
+                     1, (wdparm_t)timer);
       if (ret < 0)
         {
           set_errno(-ret);


### PR DESCRIPTION
### Summary

- This PR fixes inappropriate cast in timer_settime() 
- Actually I found this bug when running ostest (POSIX timer test) on RV64GC (RISC-V 64bit).

### Impact

-  This PR affects POSIX timer

### Testing

- I tested this PR with ostest (POSIX timer test) on both RV64GC (64bit) and Cortex-M4 (32bit)

