### PR TITLE
arch: k210: Applied changes doned for fe310 recently.

### DIFF
--- a/arch/risc-v/include/k210/irq.h
+++ b/arch/risc-v/include/k210/irq.h
@@ -45,7 +45,9 @@
 
 /* Machine Interrupt Enable bit in mstatus register */
 
-#define MSTATUS_MIE  (0x1 << 3)
+#define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
+#define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
+#define MSTATUS_MPPM  (0x3 << 11) /* Machine Previous Privilege (m-mode) */
 
 /* In mie (machine interrupt enable) register */
 

--- a/arch/risc-v/src/k210/k210_clockconfig.c
+++ b/arch/risc-v/src/k210/k210_clockconfig.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/k210/k210_clockconfig.c
+ * arch/risc-v/src/k210/k210_clockconfig.c
  *
  *   Copyright (C) 2019 Masayuki Ishikawa. All rights reserved.
  *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>

--- a/arch/risc-v/src/k210/k210_clockconfig.h
+++ b/arch/risc-v/src/k210/k210_clockconfig.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/k210/k210_clockconfig.h
+ * arch/risc-v/src/k210/k210_clockconfig.h
  *
  *   Copyright (C) 2019 Masayuki Ishikawa. All rights reserved.
  *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -103,7 +103,6 @@ void up_irqinitialize(void)
   /* Attach the ecall interrupt handler */
 
   irq_attach(K210_IRQ_ECALLM, up_swint, NULL);
-  up_enable_irq(K210_IRQ_ECALLM);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 
@@ -191,13 +190,17 @@ void up_enable_irq(int irq)
  * Name: up_get_newintctx
  *
  * Description:
- *   Return a value for EPIC. But K210 doesn't use EPIC for event control.
+ *   Return initial mstatus when a task is created.
  *
  ****************************************************************************/
 
 uint32_t up_get_newintctx(void)
 {
-  return 0;
+  /* Set machine previous privilege mode to machine mode.
+   * Also set machine previous interrupt enable
+   */
+
+  return (MSTATUS_MPPM | MSTATUS_MPIE);
 }
 
 /****************************************************************************
@@ -240,7 +243,7 @@ irqstate_t up_irq_save(void)
 
 void up_irq_restore(irqstate_t flags)
 {
-  /* Machine mode - mstatus */
+  /* Write flags to mstatus */
 
   asm volatile("csrw mstatus, %0" : /* no output */ : "r" (flags));
 }

--- a/arch/risc-v/src/k210/k210_start.c
+++ b/arch/risc-v/src/k210/k210_start.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/k210/k210_init.c
+ * arch/risc-v/src/k210/k210_start.c
  *
  *   Copyright (C) 2019 Masayuki Ishikawa. All rights reserved.
  *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>


### PR DESCRIPTION
### Summary

- Applied changes such as comments and initial int status which were done for fe310 so far.
https://github.com/apache/incubator-nuttx/pull/55

### Impact

- This PR only affects K210 and initial interrupt status when creating a task is set correctly.

### Testing

- I only tested this PR with available commands (i.e. ps/free/hello/getprime)

