### PR TITLE
Add .asf.yaml to enable GitHub features for issues and projects

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,22 @@
+github:
+  description: "Apache NuttX is a mature, real-time embedded operating system (RTOS)"
+  homepage: https://nuttx.apache.org/
+  features:
+    # Enable issues managment
+    issues: true
+    # Enable project for project managment boards
+    projects: true
+  labels:
+    - nuttx
+    - rtos
+    - embedded
+    - real-time
+    - mcu
+    - microcontroller
+  enabled_merge_buttons:
+    # enable squash button:
+    squash:  true
+    # enable merge button:
+    merge:   true
+    # enable rebase button:
+    rebase:  true


### PR DESCRIPTION
Add the Apache .asf.yaml file to control GitHub features.
* Enable issue tracking
* Enable project board
* Add some labels
* Control merge options (same as default for now)

Signed-off-by: Brennan Ashton <bashton@brennanashton.com>