### PR TITLE
drivers: serial: Fix a wrong variable in serial.c in SMP mode.

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -210,7 +210,7 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
   int ret;
 
 #ifdef CONFIG_SMP
-  flags = enter_critical_section();
+  irqstate_t flags2 = enter_critical_section();
 #endif
 
   /* Increment to see what the next head pointer will be.  We need to use the "next"
@@ -347,7 +347,7 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
 err_out:
 
 #ifdef CONFIG_SMP
-  leave_critical_section(flags);
+  leave_critical_section(flags2);
 #endif
 
   return ret;


### PR DESCRIPTION
### Summary

- During testing K210 (RV64GC) in SMP mode, I found a bug in drivers/serial/serial.c which I added code to avoid data corruption in the following commit. 

  commit dacd041a94b4150a90b401ef2098ae0015c7fa97
  Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>
  Date:   Wed Oct 16 13:09:03 2019 +0000

  Actually the variable 'flags' was override (i.e. destroyed) in uart_putxmitchar() and thus interrupt would be disabled. In this PR, I Introduced a new variable flags2 to avoid this bug.

### Impact

- SMP systems which write to serial driver will be affected.

### Limitations / TODO

-  No limitations

### Testing

- I tested this PR with K210 and Spresense in SMP mode and finally smp app and ostest ostest app passed on both platforms!

