### PR TITLE
net/tcp/tcp_send_unbuffered.c:  Correct a bad error number introduced in recent PR.

### DIFF
--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -704,7 +704,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
 
               ret = net_timedwait(&state.snd_sem,
                                   _SO_TIMEOUT(psock->s_sndtimeo));
-              if (ret != -ETIMEDOUT || acked == state.snd_acked)
+              if (ret == -ETIMEDOUT && acked == state.snd_acked)
                 {
                   break; /* Timeout without any progress */
                 }

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -704,7 +704,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
 
               ret = net_timedwait(&state.snd_sem,
                                   _SO_TIMEOUT(psock->s_sndtimeo));
-              if (ret != -ETIMEOUT || acked == state.snd_acked)
+              if (ret != -ETIMEDOUT || acked == state.snd_acked)
                 {
                   break; /* Timeout without any progress */
                 }

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -704,7 +704,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
 
               ret = net_timedwait(&state.snd_sem,
                                   _SO_TIMEOUT(psock->s_sndtimeo));
-              if (ret == -ETIMEDOUT && acked == state.snd_acked)
+              if (ret != -ETIMEDOUT || acked == state.snd_acked)
                 {
                   break; /* Timeout without any progress */
                 }


### PR DESCRIPTION
There is no errno ETIMEOUT.  Probably should be ETIMEDOUT.