### PR TITLE
net/tcp/tcp_getsockopt.c:  Fix compilation failure found in build testing

### DIFF
--- a/net/tcp/tcp_getsockopt.c
+++ b/net/tcp/tcp_getsockopt.c
@@ -39,6 +39,7 @@
 
 #include <nuttx/config.h>
 
+#include <sys/time.h>
 #include <stdint.h>
 #include <errno.h>
 #include <assert.h>


### PR DESCRIPTION
Error:  invalid application of 'sizeof' to incomplete type 'struct timeval'.  Fixed by including sys/time.h.  Same problem and same fix as for setsockopt earlier."