### PR TITLE
tools/nxstyle.c:  Correct indexing error noted by Xaio Xaing in commit comments

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -245,7 +245,7 @@ static int block_comment_width(char *line)
    */
 
   if (strncmp(&line[b], "***", 3) == 0 &&
-      strncmp(&line[e - 4], "***/", 4) == 0)
+      strncmp(&line[e - 3], "***/", 4) == 0)
     {
       /* Return the the length of the line up to the final '*' */
 
@@ -257,7 +257,7 @@ static int block_comment_width(char *line)
    */
 
   if (strncmp(&line[b], "/*", 2) == 0 &&
-      strncmp(&line[e - 4], "***/", 4) == 0)
+      strncmp(&line[e - 3], "***/", 4) == 0)
     {
       /* Return the the length of the line up to the final '*' */
 


### PR DESCRIPTION
Difference in index from the last byte of a 4-character string to the beginning of the string is -3, not -4.