### PR TITLE
net/devif/devif_poll.c:  Correct a new warning found in build testing

### DIFF
--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -765,7 +765,9 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 int devif_timer(FAR struct net_driver_s *dev, int delay,
                 devif_poll_callback_t callback)
 {
+#if defined(CONFIG_NET_IPv4_REASSEMBLY) || defined(NET_TCP_HAVE_STACK)
   int hsec = TICK2HSEC(delay);
+#endif
   int bstop = false;
 
 #ifdef CONFIG_NET_IPv4_REASSEMBLY


### PR DESCRIPTION
devif/devif_poll.c:768:7: warning: unused variable 'hsec' [-Wunused-variable]