### PR TITLE
arch/arm/include/cxd56xx/audio.h: Fix minor typos

### DIFF
--- a/arch/arm/include/cxd56xx/audio.h
+++ b/arch/arm/include/cxd56xx/audio.h
@@ -38,7 +38,7 @@
 #ifndef __ARCH_ARM_INCLUDE_CXD56XX_AUDIO_H
 #define __ARCH_ARM_INCLUDE_CXD56XX_AUDIO_H
 
-/* API Documents creater with Doxgen */
+/* API Documents created with Doxygen */
 
 /* cxd56_audio_api Audio Driver API
  *


### PR DESCRIPTION
Just fixing minor typos in comments:
- creater -> created
- Doxgen -> Doxygen

No functional changes.