### PR TITLE
tools/nxstyle.c:  Correct false alarm detection

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -844,15 +844,24 @@ int main(int argc, char **argv, char **envp)
                      {
                        if (g_section != PRE_PROCESSOR_DEFINITIONS)
                          {
-                           /* Only a warning because there is some usage of
-                            * define outside the Pre-processor Definitions
-                            * section which is justifiable.  Should be
-                            * manually checked.
+                           /* A complication is the header files always have
+                            * the idempotence guard definitions before the
+                            * "Pre-processor Definitions section".
                             */
 
-                           WARN("#define outside of 'Pre-processor "
-                                "Definitions' section",
-                                lineno, ii);
+                           if (g_section == NO_SECTION &&
+                               g_file_type != C_HEADER)
+                             {
+                               /* Only a warning because there is some usage
+                                * of define outside the Pre-processor
+                                * Definitions section which is justifiable.
+                                * Should be manually checked.
+                                */
+
+                               WARN("#define outside of 'Pre-processor "
+                                    "Definitions' section",
+                                    lineno, ii);
+                             }
                          }
                      }
 


### PR DESCRIPTION
Commit cf5d17f7959a593b87b7d624a8ac63f241f8cd85 added logic to detect #define pre-processor definitions outside of the "Pre-processor Definitions" file section.  That commit was verified against numerous .c source files.  But not against any .h header files.

When run against a header file, that change causes a false alarm warning like:

  file:line:pos: warning: #define outside of 'Pre-processor Definitions' section

That is caused the idempotence, guard definition that must appear in the header file BEFORE the first file section.

This commit adds logic to nxstyle to ignore pre-processor definitions in header files that occur before the first file section is encountered.