### PR TITLE
tools/configure.c: Add missing k210 support.

### DIFF
--- a/tools/configure.c
+++ b/tools/configure.c
@@ -221,6 +221,7 @@ static const char *g_chipnames[] =
   "sh7032",
   "fe310",
   "gap8",
+  "k210",
   "nr5m100",
   "sim",
   "qemu",


### PR DESCRIPTION
Fix a minor but necessary addition to configure.c for the K210 port that was missed in commit e33fc3dc895dacf55a0020852a8f3e303c1f52ca