### PR TITLE
tools/Makefile.win and link.bat:  Fix for 'make menuconfig'

### DIFF
--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -335,7 +335,7 @@ ifeq ($(CONFIG_WINDOWS_MKLINK),y)
 	$(Q) /user:administrator mklink /d $(TOPDIR)\drivers\platform $(BOARD_DIR)\drivers
 else
 	$(Q) xcopy $(BOARD_DIR)\drivers $(TOPDIR)\drivers\platform /c /q /s /e /y /i
-	$(Q) echo FAKELNK > $(TOPDIR)\drivers\platform .fakelnk
+	$(Q) echo FAKELNK > $(TOPDIR)\drivers\platform\.fakelnk
 endif
 
 ifeq ($(COMMON_DIR),y)

--- a/tools/link.bat
+++ b/tools/link.bat
@@ -88,7 +88,9 @@ if "%usemklink%"=="y" (
 goto :End
 )
 
-xcopy %src% %link% /c /q /s /e /y /i
+rem %src% may include forward slashes.  That upsets xcopy, but not GNUWin32 cp
+rem xcopy %src% %link% /c /q /s /e /y /i
+cp -dR %src% %link%
 echo FAKELNK > %link%\.fakelnk
 goto :End
 


### PR DESCRIPTION
With these changes I can successfully do 'make menuconfig' and 'make olddefconfig' with the Native Windows build.