### PR TITLE
net/recv: correct the return value

### DIFF
--- a/net/inet/inet_recvfrom.c
+++ b/net/inet/inet_recvfrom.c
@@ -1086,6 +1086,10 @@ static ssize_t inet_udp_recvfrom(FAR struct socket *psock, FAR void *buf, size_t
            */
 
           ret = net_timedwait(&state. ir_sem, _SO_TIMEOUT(psock->s_rcvtimeo));
+          if (ret == -ETIMEDOUT)
+            {
+              ret = -EAGAIN;
+            }
 
           /* Make sure that no further events are processed */
 
@@ -1236,6 +1240,10 @@ static ssize_t inet_tcp_recvfrom(FAR struct socket *psock, FAR void *buf, size_t
            */
 
           ret = net_timedwait(&state.ir_sem, _SO_TIMEOUT(psock->s_rcvtimeo));
+          if (ret == -ETIMEDOUT)
+            {
+              ret = -EAGAIN;
+            }
 
           /* Make sure that no further events are processed */
 


### PR DESCRIPTION
Linux Programmer's Manual:

RECV(2)

NAME
       recv, recvfrom, recvmsg - receive a message from a socket

...
ERRORS

...
EAGAIN or EWOULDBLOCK
       The socket is marked nonblocking and the receive operation
       would block, or a receive timeout had been set and the timeout
       expired before data was received. POSIX.1 allows either error
       to be returned for this case, and does not require these constants
       to have the same value, so a portable application should check
       for both possibilities.

Change-Id: I1b917d819dcc396689c81bd63ac0faa21706db78
Signed-off-by: chao.an <anchao@xiaomi.com>