### PR TITLE
tools/Makefile.host:  Fix several errors for native build

### DIFF
--- a/tools/Makefile.host
+++ b/tools/Makefile.host
@@ -43,18 +43,18 @@ include ${TOPDIR}/tools/Config.mk
 # Define HOSTCC on the make command line if it differs from these defaults
 # Define HOSTCFLAGS with -g on the make command line to build debug versions
 
-HOSTOS = ${shell uname -o 2>/dev/null || echo "Other"}
+HOSTOS = ${shell uname -o || echo "Other"}
 
-ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+ifeq ($(HOSTOS),MinGW)
 
-# In the Windows native environment, the MinGW GCC compiler is assumed
+# In the Windows native environment, the MinGW GCC compiler is used
 
-HOSTCC ?= mingw-gcc.exe
+HOSTCC ?= mingw32-gcc.exe
 HOSTCFLAGS ?= -O2 -Wall -Wstrict-prototypes -Wshadow -I. -DCONFIG_WINDOWS_NATIVE=y
 
 else
 
-# GCC is assumed in the POSIX environment (Linux or Cygwin).
+# GCC is assumed in all other POSIX environments (Linux, Cygwin, MSYS2).
 # strtok_r is used in some tools, but does not seem to be available in
 # the MinGW environment.
 


### PR DESCRIPTION
1. Can't pipe uname stderr output to /dev/null.  /dev/null does not exist in the Windows native enviornment.
2. Don't test if CONFIG_WINDOWS_NATIVE is defined.  That leads to a "chicken'n'egg" problem:  We need to build configure.c in order to configure the system, but we can't get the CONFIG_WINDOWS_NATIVE setting until after the system is configured.  Instead, check if the output of 'uname -o' is MinGW.
3. The default name of the MinGW GCC compiler is now mingw32-gcc.exe, not mingw-gcc.exe