### PR TITLE
boards: Remove unnecessary section descriptions from linker scripts of RISC-V boards

### DIFF
--- a/boards/risc-v/fe310/hifive1-revb/scripts/ld-qemu.script
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/ld-qemu.script
@@ -67,16 +67,6 @@ SECTIONS
         _einit = ABSOLUTE(.);
     } > flash
 
-    .ARM.extab : ALIGN(4) {
-        *(.ARM.extab*)
-    } > flash
-
-    .ARM.exidx : ALIGN(4) {
-        __exidx_start = ABSOLUTE(.);
-        *(.ARM.exidx*)
-        __exidx_end = ABSOLUTE(.);
-    } > flash
-
     _eronly = ABSOLUTE(.);
 
     .data : ALIGN(4) {

--- a/boards/risc-v/fe310/hifive1-revb/scripts/ld.script
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/ld.script
@@ -67,16 +67,6 @@ SECTIONS
         _einit = ABSOLUTE(.);
     } > flash
 
-    .ARM.extab : ALIGN(4) {
-        *(.ARM.extab*)
-    } > flash
-
-    .ARM.exidx : ALIGN(4) {
-        __exidx_start = ABSOLUTE(.);
-        *(.ARM.exidx*)
-        __exidx_end = ABSOLUTE(.);
-    } > flash
-
     _eronly = ABSOLUTE(.);
 
     .data : ALIGN(4) {

--- a/boards/risc-v/k210/maix-bit/scripts/ld.script
+++ b/boards/risc-v/k210/maix-bit/scripts/ld.script
@@ -74,16 +74,6 @@ SECTIONS
         _einit = ABSOLUTE(.);
     } > progmem
 
-    .ARM.extab : ALIGN(4) {
-        *(.ARM.extab*)
-    } > progmem
-
-    .ARM.exidx : ALIGN(4) {
-        __exidx_start = ABSOLUTE(.);
-        *(.ARM.exidx*)
-        __exidx_end = ABSOLUTE(.);
-    } > progmem
-
     _eronly = ABSOLUTE(.);
 
     .data : ALIGN(4) {


### PR DESCRIPTION
# Summary
* This PR removes unnecessary section descriptions from linker scripts of RISC-V boards.

# Impact
* This PR only affects hifive-revb and maix-bit.

# Testing
* I checked booting on QEMU.
* I checked that .ARM.extab and .ARM.exidx did not exist in ELFs of hifive-revb and maix-bit before modification.