### PR TITLE
include/sys/un.h:  Remove an incorrect comment and fix some types.

### DIFF
--- a/include/sys/un.h
+++ b/include/sys/un.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/sys/un.h
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2015, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,10 +40,6 @@
  * Included Files
  ****************************************************************************/
 
-/* The sys/un.> header defines the type sa_family_t as described in
- * sys/socket.h.
- */
-
 #include <sys/socket.h>
 
 /****************************************************************************
@@ -80,7 +76,7 @@ struct sockaddr_un
  *    size may be variable:  sizeof(sa_family_t) + strlen(pathname) + 1
  * 2. unnamed:  A unix socket that is not bound to any name.  This case
  *    there is no path.  The allocated size may be sizeof(sa_family_t)
- * 3. abstract. The abstract path is destinguished because the pathname
+ * 3. abstract. The abstract path is distinguished because the pathname
  *    consists of only the NUL terminator.  The allocated size is then
  *    sizeof(s_family_t) + 1.
  */


### PR DESCRIPTION
Remove an incorrect comment and fix some types.  Bad comment reported by Junmin Kim <trimind0210@gmail.com> via the NuttX Google group.