### PR TITLE
tools/testbuild.sh: kconfig-tweak disable CONFIG_TOOLCHAIN_WINDOWS un…

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -173,6 +173,8 @@ function configure {
     kconfig-tweak --file $nuttx/.config --enable CONFIG_HOST_LINUX
     kconfig-tweak --file $nuttx/.config --disable CONFIG_HOST_WINDOWS
 
+    kconfig-tweak --file $nuttx/.config --disable CONFIG_TOOLCHAIN_WINDOWS
+
     kconfig-tweak --file $nuttx/.config --disable CONFIG_WINDOWS_NATIVE
     kconfig-tweak --file $nuttx/.config --disable CONFIG_WINDOWS_CYGWIN
     kconfig-tweak --file $nuttx/.config --disable CONFIG_WINDOWS_MSYS


### PR DESCRIPTION
…der linux host

Make sure kconfig-tweak disable CONFIG_TOOLCHAIN_WINDOWS under linux host, or it would build break
in using testbuild.sh for some configs.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>