### PR TITLE
make/distclean: unlink the dir after subdir clean

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -406,13 +406,6 @@ clean_context:
 	$(call DELFILE, include/math.h)
 	$(call DELFILE, include/stdarg.h)
 	$(call DELFILE, include/setjmp.h)
-	$(Q) $(DIRUNLINK) include/arch/board
-	$(Q) $(DIRUNLINK) include/arch/chip
-	$(Q) $(DIRUNLINK) include/arch
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board/board
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/chip
-	$(Q) $(DIRUNLINK) $(TOPDIR)/drivers/platform
 
 # check_context
 #
@@ -668,6 +661,13 @@ endif
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
 	$(call DELFILE, .gdbinit)
+	$(Q) $(DIRUNLINK) include/arch/board
+	$(Q) $(DIRUNLINK) include/arch/chip
+	$(Q) $(DIRUNLINK) include/arch
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board/board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/chip
+	$(Q) $(DIRUNLINK) $(TOPDIR)/drivers/platform
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps/ directory is included with NuttX,

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -424,13 +424,6 @@ clean_context:
 	$(call DELFILE, include\math.h)
 	$(call DELFILE, include\stdarg.h)
 	$(call DELFILE, include\setjmp.h)
-	$(call DELDIR, include\arch\board)
-	$(call DELDIR, include\arch\chip)
-	$(call DELDIR, include\arch)
-	$(call DELDIR, $(ARCH_SRC)\board\board)
-	$(call DELDIR, $(ARCH_SRC)\board)
-	$(call DELDIR, $(ARCH_SRC)\chip)
-	$(call DELDIR, $(TOPDIR)\drivers\platform)
 
 # check_context
 #
@@ -645,6 +638,13 @@ endif
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
+	$(call DELDIR, include\arch\board)
+	$(call DELDIR, include\arch\chip)
+	$(call DELDIR, include\arch)
+	$(call DELDIR, $(ARCH_SRC)\board\board)
+	$(call DELDIR, $(ARCH_SRC)\board)
+	$(call DELDIR, $(ARCH_SRC)\chip)
+	$(call DELDIR, $(TOPDIR)\drivers\platform)
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps\ directory is included with NuttX,


### PR DESCRIPTION
Ensure the linked dir can be clean complete in multi-job case

Change-Id: Ie8c0b29ece1f727fd93f2e640c3f1cc7876a358b
Signed-off-by: chao.an <anchao@xiaomi.com>