### PR TITLE
kwork/notifier: initialize the work handler

### DIFF
--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -257,6 +257,10 @@ int work_notifier_setup(FAR struct work_notifier_s *info)
     }
   else
     {
+      /* Initialize the work structure */
+
+      memset(&notifier->work, 0, sizeof(notifier->work));
+
       /* Duplicate the notification info */
 
       memcpy(&notifier->info, info, sizeof(struct work_notifier_s));


### PR DESCRIPTION
kworker dqueue corruption if the garbage in work->worker handler

Change-Id: Ice5e66e8ed080a7539d5fe02f946a66794cbda7d
Signed-off-by: chao.an <anchao@xiaomi.com>