### PR TITLE
Fix SAMA5D* warnings

### DIFF
--- a/arch/arm/src/sama5/sam_irq.c
+++ b/arch/arm/src/sama5/sam_irq.c
@@ -841,6 +841,8 @@ int up_prioritize_irq(int irq, int priority)
     {
       sam_prioritize_irq(SAM_AIC_VBASE, irq, priority);
     }
+
+  return OK;
 }
 #endif
 

--- a/arch/arm/src/sama5/sam_udphs.c
+++ b/arch/arm/src/sama5/sam_udphs.c
@@ -3392,7 +3392,7 @@ static int sam_ep_configure(struct usbdev_ep_s *ep,
 
   /* Verify parameters.  Endpoint 0 is not available at this interface */
 
-#if defined(CONFIG_DEBUG_FEATURES) || defined(CONFIG_USBDEV_TRACE)
+#if defined(CONFIG_DEBUG_ASSERTIONS) || defined(CONFIG_USBDEV_TRACE)
   uint8_t epno = USB_EPNO(desc->addr);
   usbtrace(TRACE_EPCONFIGURE, (uint16_t)epno);
 

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_usb.c
@@ -108,7 +108,7 @@ static xcpt_t g_ochandler;
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 #ifdef CONFIG_DEBUG_USB
 static int usbhost_waiter(struct usbhost_connection_s *dev,
                           const char *hcistr)
@@ -298,7 +298,7 @@ void weak_function sam_usbinitialize(void)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 int sam_usbhost_initialize(void)
 {
   pid_t pid;
@@ -416,7 +416,7 @@ int sam_usbhost_initialize(void)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 void sam_usbhost_vbusdrive(int rhport, bool enable)
 {
   pio_pinset_t pinset = 0;
@@ -500,7 +500,7 @@ void sam_usbhost_vbusdrive(int rhport, bool enable)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 xcpt_t sam_setup_overcurrent(xcpt_t handler)
 {
 #if defined(CONFIG_SAMA5_PIOD_IRQ) && (defined(CONFIG_SAMA5_UHPHS_RHPORT2) || \

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_usb.c
@@ -108,7 +108,7 @@ static xcpt_t g_ochandler;
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 #ifdef CONFIG_DEBUG_USB
 static int usbhost_waiter(struct usbhost_connection_s *dev,
                           const char *hcistr)
@@ -296,7 +296,7 @@ void weak_function sam_usbinitialize(void)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 int sam_usbhost_initialize(void)
 {
   pid_t pid;
@@ -415,7 +415,7 @@ int sam_usbhost_initialize(void)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 void sam_usbhost_vbusdrive(int rhport, bool enable)
 {
   pio_pinset_t pinset = 0;
@@ -493,7 +493,7 @@ void sam_usbhost_vbusdrive(int rhport, bool enable)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 xcpt_t sam_setup_overcurrent(xcpt_t handler)
 {
 #if defined(CONFIG_SAMA5_PIOD_IRQ) && (defined(CONFIG_SAMA5_UHPHS_RHPORT2) || \

--- a/boards/arm/sama5/sama5d4-ek/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d4-ek/src/sam_usb.c
@@ -108,7 +108,7 @@ static xcpt_t g_ochandler;
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 #ifdef CONFIG_DEBUG_USB
 static int usbhost_waiter(struct usbhost_connection_s *dev,
                           const char *hcistr)
@@ -296,7 +296,7 @@ void weak_function sam_usbinitialize(void)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 int sam_usbhost_initialize(void)
 {
   pid_t pid;
@@ -414,7 +414,7 @@ int sam_usbhost_initialize(void)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 void sam_usbhost_vbusdrive(int rhport, bool enable)
 {
   pio_pinset_t pinset = 0;
@@ -493,7 +493,7 @@ void sam_usbhost_vbusdrive(int rhport, bool enable)
  *
  ****************************************************************************/
 
-#if HAVE_USBHOST
+#ifdef HAVE_USBHOST
 xcpt_t sam_setup_overcurrent(xcpt_t handler)
 {
 #if defined(CONFIG_SAMA5_PIOD_IRQ) && (defined(CONFIG_SAMA5_UHPHS_RHPORT2) || \


### PR DESCRIPTION
sama5d3-xplained:ethernet-over-phy configuration found in build testing:

  arch/arm/src/sama5/sam_irq.c:  Fix "Control reaches end of non-void function " warning
  arch/arm/src/sama5/sam_udphs.c:  Fix "unused variable 'epno'" warning
  boards/arm/sama5/sama5d*-*/src/sam_usb.c:  Fix "warning 'HAVE_USBHOST' not defined" warnings