### PR TITLE
Fix implicit definition warnings due to missing inclusion of nuttx/time.h

### DIFF
--- a/arch/arm/src/stm32/stm32_rtcc.c
+++ b/arch/arm/src/stm32/stm32_rtcc.c
@@ -46,6 +46,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/time.h>
 
 #include <arch/board/board.h>
 

--- a/arch/arm/src/stm32/stm32f40xxx_rtcc.c
+++ b/arch/arm/src/stm32/stm32f40xxx_rtcc.c
@@ -48,6 +48,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/time.h>
 
 #include "up_arch.h"
 


### PR DESCRIPTION
Recent changes removed CONFI_TIME_ENHANCED and umasked some warning.  These warnings were because nuttx/time.h was not being included by files that now referenced clock_daysbeforemonth() and clock_isleapyear() in all configurations.

This commit adds those missing inclusions and eliminates the warnings.