### PR TITLE
Fix assertion occurrence in rwb_invalidate_writebuffer()

### DIFF
--- a/drivers/rwbuffer.c
+++ b/drivers/rwbuffer.c
@@ -428,7 +428,7 @@ int rwb_invalidate_writebuffer(FAR struct rwbuffer_s *rwb,
       wrbend = rwb->wrblockstart + rwb->wrnblocks;
       invend = startblock + blockcount;
 
-      if (rwb->wrblockstart > invend || wrbend < startblock)
+      if (wrbend <= startblock || rwb->wrblockstart >= invend)
         {
           ret = OK;
         }
@@ -1130,4 +1130,3 @@ int rwb_flush(FAR struct rwbuffer_s *rwb)
 #endif
 
 #endif /* CONFIG_DRVR_WRITEBUFFER || CONFIG_DRVR_READAHEAD */
-


### PR DESCRIPTION
When calling rwb_invalidate_writebuffer(), assertion occured in some case.

Assertion not occured:
startblock = 0, blockcount = 1, rwb->wrblockstart = 0, rwb->wrnblocks = 1
(So , invend = 1, wrbend = 1)

Assertion occured:
(It is "We invalidate nothing" condition since buffer and invalidated block not overlap)
startblock = 1, blockcount = 1, rwb->wrblockstart = 0, rwb->wrnblocks = 1
(So  invend = 2, wrbend = 1)

And rwb_invalidate_readahead() seems to be able to handle this condition correctly.
So I took from it.
