### PR TITLE
arch/arm/src/stm32l4/stm32l4_flash.c: Fix flash_erase(page) when page…

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_flash.c
+++ b/arch/arm/src/stm32l4/stm32l4_flash.c
@@ -176,7 +176,20 @@ static inline void flash_erase(size_t page)
   finfo("erase page %u\n", page);
 
   modifyreg32(STM32L4_FLASH_CR, 0, FLASH_CR_PAGE_ERASE);
-  modifyreg32(STM32L4_FLASH_CR, FLASH_CR_PNB_MASK, FLASH_CR_PNB(page));
+  modifyreg32(STM32L4_FLASH_CR, FLASH_CR_PNB_MASK, FLASH_CR_PNB(page & 0xFF));
+
+#if defined(CONFIG_STM32L4_STM32L4X5) || defined(CONFIG_STM32L4_STM32L4X6) || \
+    defined(CONFIG_STM32L4_STM32L4XR)
+  if (page <= 0xFF)
+    {
+      modifyreg32(STM32L4_FLASH_CR, FLASH_CR_BKER, 0);
+    }
+  else
+    {
+      modifyreg32(STM32L4_FLASH_CR, 0, FLASH_CR_BKER);
+    }
+#endif
+
   modifyreg32(STM32L4_FLASH_CR, 0, FLASH_CR_START);
 
   while (getreg32(STM32L4_FLASH_SR) & FLASH_SR_BSY)


### PR DESCRIPTION
… >= 256

All STM32L4 MPUs have FLASH_CR_PNB bits (8 bits), and some MPUs have FLASH_CR_BKER bit for change bank if page >= 256. But present code not set and clear FLASH_CR_BKER correctly.

Note: I tried to change macro FLASH_CR_PNB(n) in arch/arm/src/stm32l4/hardware/stm32l4_flash.h, but this file is not according to coding standard (long line), so I gave up to format this... I want to change to:
 #define FLASH_CR_PNB(n)             ((n & 0xFF)  << FLASH_CR_PNB_SHIFT)