### PR TITLE
drivers: wireless: Return OK with 0 bytes in gs2200m_send_bulk()

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -972,9 +972,9 @@ retry:
   if (WR_RESP_NOK == res[1])
     {
       wlwarn("*** warning: WR_RESP_NOK received.. retrying. (n=%d) \n", n);
-      nxsig_usleep(100 * 1000);
+      nxsig_usleep(10 * 1000);
 
-      if (100 < n)
+      if (9 < n)
         {
           return SPI_TIMEOUT;
         }
@@ -1862,6 +1862,15 @@ static enum pkt_type_e gs2200m_send_bulk(FAR struct gs2200m_dev_s *dev,
   /* Send the bulk data */
 
   s = gs2200m_hal_write(dev, (char *)dev->tx_buff, msg->len + bulk_hdr_size);
+
+  if (s == SPI_TIMEOUT)
+    {
+      /* In case of SPI_TIMEOUT, return OK with 0 bytes sent */
+
+      s = SPI_OK;
+      msg->len = 0;
+    }
+
   r = _spi_err_to_pkt_type(s);
 
   return r;


### PR DESCRIPTION
### Summary

- When GS2200M device returned WR_RESP_NOK in gs2200m_send_bulk(), a receiver side might not be ready to receive a new packet (i.e. TCP window size is zero). In previous implementation, the driver retried to send the packet in driver and give up to send when it reached a max retry count (e.g. 100).  In this implementation. I changed the max retry cont to 10 and it returns OK with 0 bytes sent when it reached to the max retry count to let an application retry to send. Also, gs2200m daemon need to be fixed which I'll send another PR later.

### Impact

- This PR only affects the gs2200m driver and typically for congested network or receiver window size is zero cases. 

### Testing

- To test this PR, I had to use another patch which was applied to gs2200m daemon. Test was mainly done by sending MP3 audio files from webserver on Spresense as well as telnet. And at a receiver side, I used Firefox on macOS. 
