### PR TITLE
tools/nxstyle.c:  Detect blank line before opening left brace

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -2269,12 +2269,22 @@ int main(int argc, char **argv, char **envp)
             }
           else if (line[indent] == '{')
             {
+              /* Check for left brace in first column, but preceded by a
+               * blank line.  Should never happen (but could happen with
+               * internal compound statements).
+               */
+
+              if (indent == 0 && lineno == blank_lineno + 1)
+                {
+                  ERROR("Blank line before opening left brace", lineno, indent);
+                }
+
               /* REVISIT:  Possible false alarms in compound statements
                * without a preceding conditional.  That usage often violates
                * the coding standard.
                */
 
-              if (!bfunctions && (indent & 1) != 0)
+              else if (!bfunctions && (indent & 1) != 0)
                 {
                   ERROR("Bad left brace alignment", lineno, indent);
                 }


### PR DESCRIPTION
Add logic to detect check for left brace in first column, but preceded by a blank line.  That should never happen for the outermost opening branch (but could happen with internal compound statements).

Consider junk.c for example:

    /****************************************************************************
     * xx
     ****************************************************************************/

    /****************************************************************************
     * Private Types
     ****************************************************************************/

    struct foo_s

    {
      int bar;
    };

    /****************************************************************************
     * Public Functions
     ****************************************************************************/

    int dofoo(int barin)

    {
      barout = barin;
      return barout;
    }

nxstyle not detects these problems:

    $ tools/nxstyle.exe junk.c
    junk.c:11:0: error: Blank line before opening left brace
    junk.c:21:0: error: Blank line before opening left brace