### PR TITLE
Example of use of tools/Jenkinsfile

### DIFF
--- a/tools/Jenkinsfile
+++ b/tools/Jenkinsfile
@@ -1,0 +1,26 @@
+#!/usr/bin/env groovy
+
+/****************************************************************************
+ * tools/Jenkinsfile
+ * Marker file to link to the Continuous Integration pipeline
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+@Library('incubator-nuttx-testing') _
+
+runContinuousIntegrationPipeline() // see https://github.com/apache/incubator-nuttx-testing/blob/master/vars/runContinuousIntegrationPipeline.groovy


### PR DESCRIPTION
Companion pull request for the one at [this pull request](https://github.com/apache/incubator-nuttx-testing/pull/2) to illustrate relation of the two repositories. See description there.

Not intended to be merged right now.