### PR TITLE
Fix an inverted logic in the following commit.

### DIFF
--- a/arch/sim/src/sim/up_setjmp32.S
+++ b/arch/sim/src/sim/up_setjmp32.S
@@ -47,9 +47,9 @@
 # define SYMBOL(s) _##s
 #else
 #ifdef __ELF__
-# define SYMBOL(s) _##s
-#else
 # define SYMBOL(s) s
+#else
+# define SYMBOL(s) _##s
 #endif
 #endif
 


### PR DESCRIPTION
	commit 39bd9ff670e552f33fc11e7513b63b86a75ee542
	Author: YAMAMOTO Takashi <yamamoto@midokura.com>
	Date:   Wed Jan 29 00:17:05 2020 +0900

		sim: Prefix symbols with _ for non-ELF

		Namely for Mach-O.  Leave __CYGWIN__ case as it is.