### PR TITLE
fix gran_alloc() miss allocation in mm_granalloc.c.

### DIFF
--- a/mm/mm_gran/mm_granalloc.c
+++ b/mm/mm_gran/mm_granalloc.c
@@ -105,8 +105,6 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
 
       /* Now search the granule allocation table for that number of contiguous */
 
-      alloc = priv->heapstart;
-
       for (granidx = 0; granidx < priv->ngranules; granidx += 32)
         {
           /* Get the GAT index associated with the granule table entry */
@@ -118,7 +116,6 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
 
           if (curr == 0xffffffff)
             {
-              alloc += (32 << priv->log2gran);
               continue;
             }
 
@@ -146,6 +143,8 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
            * examined (bitidx >= 32), or until there are insufficient
            * granules left to satisfy the allocation.
            */
+
+          alloc = priv->heapstart + (granidx << priv->log2gran);
 
           for (bitidx = 0;
                bitidx < 32 && (granidx + bitidx + ngranules) <= priv->ngranules;


### PR DESCRIPTION
fix gran_alloc() miss allocation in mm_granalloc.c.

problem sequence:
 1. ptr0 = gran_alloc(handle, 8 << MM_PGSHIFT);
 2. ptr1 = gran_alloc(handle, 32 << MM_PGSHIFT);
 3. gran_free(handle, ptr0, 8 << MM_PGSHIFT);
 4. ptr2 = gran_alloc(handle, 10 << MM_PGSHIFT);
      => ptr2 value is incorrect address.

In the gran_alloc()'s bitidx for loop,
if "if (curr == 0xffffffff)" condition is true,
"alloc" value become incorrect.