### PR TITLE
include/netinet/arp.h:  Previous network changes broke the build test

### DIFF
--- a/include/netinet/arp.h
+++ b/include/netinet/arp.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/netinet/arp.h
  *
- *   Copyright (C) 2009, 2012 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2009, 2012, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,8 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <net/if.h>
+
 #include <nuttx/fs/ioctl.h>
 
 /****************************************************************************

--- a/include/netinet/arp.h
+++ b/include/netinet/arp.h
@@ -43,7 +43,7 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
-#include <net/if.h>
+#include <netinet/if.h>
 
 #include <nuttx/fs/ioctl.h>
 
@@ -83,7 +83,7 @@ struct arpreq
   struct sockaddr arp_ha;          /* Hardware address */
   struct sockaddr arp_netmask;     /* Netmask of protocol address */
   uint8_t         arp_flags;       /* Flags */
-  uint8_t         arp_dev[IFNAMSIZ+1]; /* Device name (zero terminated)*/
+  uint8_t         arp_dev[IFNAMSIZ + 1]; /* Device name (zero terminated) */
 };
 
 /****************************************************************************

--- a/include/netinet/arp.h
+++ b/include/netinet/arp.h
@@ -43,7 +43,7 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
-#include <netinet/if.h>
+#include <net/if.h>
 
 #include <nuttx/fs/ioctl.h>
 


### PR DESCRIPTION
Previous PR broke the build.  Compilation fails with:

    include/netinet/arp.h:84:27:  error: `IFNAMSIZ` undeclared here (not in a function)