### PR TITLE
Fix size zero malloc()/realloc() freeze in the kernel build mode.

### DIFF
--- a/mm/umm_heap/umm_malloc.c
+++ b/mm/umm_heap/umm_malloc.c
@@ -70,6 +70,11 @@ FAR void *malloc(size_t size)
   FAR void *brkaddr;
   FAR void *mem;
 
+  if (size < 1)
+    {
+      return NULL;
+    }
+
   /* Loop until we successfully allocate the memory or until an error
    * occurs. If we fail to allocate memory on the first pass, then call
    * sbrk to extend the heap by one page.  This may require several

--- a/mm/umm_heap/umm_realloc.c
+++ b/mm/umm_heap/umm_realloc.c
@@ -71,6 +71,12 @@ FAR void *realloc(FAR void *oldmem, size_t size)
   FAR void *brkaddr;
   FAR void *mem;
 
+  if (size < 1)
+    {
+      mm_free(USR_HEAP, oldmem);
+      return NULL;
+    }
+
   /* Loop until we successfully allocate the memory or until an error
    * occurs. If we fail to allocate memory on the first pass, then call
    * sbrk to extend the heap by one page.  This may require several


### PR DESCRIPTION
Fix size zero malloc() and realloc() freeze problem.
This problem is only for kernel build mode.