### PR TITLE
include/nuttx/net/igmp.h: fix build break by previous network changes

### DIFF
--- a/include/nuttx/net/igmp.h
+++ b/include/nuttx/net/igmp.h
@@ -52,6 +52,7 @@
 #include <stdbool.h>
 
 #include <nuttx/net/netconfig.h>
+#include <nuttx/net/netdev.h>
 #include <nuttx/net/ip.h>
 
 #ifdef CONFIG_NET_IGMP


### PR DESCRIPTION
Build nucleo-144:f767-netnsh config with following error:
igmp/igmp_group.c: In function 'igmp_grpalloc':
igmp/igmp_group.c:145:27: error: dereferencing pointer to incomplete type 'struct net_driver_s'
  145 |       group->ifindex = dev->d_ifindex;
      |                           ^~
make[1]: *** [igmp_group.o] Error 1

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>