### PR TITLE
net/igmp/igmp.h: include <nuttx/semaphore.h> to fix build break

### DIFF
--- a/net/igmp/igmp.h
+++ b/net/igmp/igmp.h
@@ -77,6 +77,7 @@
 
 #include <sys/types.h>
 
+#include <nuttx/semaphore.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/net/ip.h>
 


### PR DESCRIPTION
Build nucleo-144/f767-netnsh fail with below error:
In file included from igmp/igmp_initialize.c:54:
./igmp/igmp.h:130:3: error: unknown type name 'sem_t'
  130 |   sem_t                sem;     /* Used to wait for message transmission */
      |   ^~~~~
make[1]: *** [igmp_initialize.o] Error 1

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>