### PR TITLE
Timer improvement

### DIFF
--- a/arch/arm/src/a1x/a1x_timerisr.c
+++ b/arch/arm/src/a1x/a1x_timerisr.c
@@ -103,7 +103,7 @@ static int a1x_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -111,7 +111,7 @@ static int a1x_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/am335x/am335x_i2c.c
+++ b/arch/arm/src/am335x/am335x_i2c.c
@@ -544,7 +544,7 @@ static inline int am335x_i2c_sem_waitdone(FAR struct am335x_i2c_priv_s *priv)
     {
       /* Get the current time */
 
-      (void)clock_gettime(CLOCK_REALTIME, &abstime);
+      clock_gettime(CLOCK_REALTIME, &abstime);
 
       /* Calculate a time in the future */
 
@@ -1294,8 +1294,8 @@ static int am335x_i2c_init(FAR struct am335x_i2c_priv_s *priv)
 
   /* Configure pins */
 
-  (void)am335x_gpio_config(priv->config->scl_pin);
-  (void)am335x_gpio_config(priv->config->sda_pin);
+  am335x_gpio_config(priv->config->scl_pin);
+  am335x_gpio_config(priv->config->sda_pin);
 
   /* Disable I2C module */
 

--- a/arch/arm/src/am335x/am335x_timerisr.c
+++ b/arch/arm/src/am335x/am335x_timerisr.c
@@ -117,7 +117,7 @@ static int am335x_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -125,7 +125,7 @@ static int am335x_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/c5471/c5471_timerisr.c
+++ b/arch/arm/src/c5471/c5471_timerisr.c
@@ -95,7 +95,7 @@ static int c5471_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -103,7 +103,7 @@ static int c5471_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t val;
 

--- a/arch/arm/src/common/up_initialize.c
+++ b/arch/arm/src/common/up_initialize.c
@@ -127,13 +127,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the system timer interrupt */
-
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS) && \
-    !defined(CONFIG_SYSTEMTICK_EXTCLK)
-  arm_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/arm/src/common/up_initialize.c
+++ b/arch/arm/src/common/up_initialize.c
@@ -127,10 +127,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
   /* Initialize the system timer interrupt */
 
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS) && \

--- a/arch/arm/src/common/up_internal.h
+++ b/arch/arm/src/common/up_internal.h
@@ -337,8 +337,6 @@ void up_pminitialize(void);
 
 /* Interrupt handling *******************************************************/
 
-void up_irqinitialize(void);
-
 /* Exception handling logic unique to the Cortex-M family */
 
 #if defined(CONFIG_ARCH_CORTEXM0) || defined(CONFIG_ARCH_ARMV7M)

--- a/arch/arm/src/common/up_internal.h
+++ b/arch/arm/src/common/up_internal.h
@@ -429,10 +429,6 @@ void up_restorefpu(const uint32_t *regs);
 #  define up_restorefpu(regs)
 #endif
 
-/* System timer *************************************************************/
-
-void arm_timer_initialize(void);
-
 /* Low level serial output **************************************************/
 
 void up_lowputc(char ch);

--- a/arch/arm/src/cxd56xx/cxd56_timerisr.c
+++ b/arch/arm/src/cxd56xx/cxd56_timerisr.c
@@ -160,7 +160,7 @@ static int cxd56_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/dm320/dm320_timerisr.c
+++ b/arch/arm/src/dm320/dm320_timerisr.c
@@ -122,7 +122,7 @@ static int dm320_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -130,7 +130,7 @@ static int dm320_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   up_disable_irq(DM320_IRQ_SYSTIMER);
 

--- a/arch/arm/src/efm32/efm32_timerisr.c
+++ b/arch/arm/src/efm32/efm32_timerisr.c
@@ -99,7 +99,7 @@ static int efm32_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -107,7 +107,7 @@ static int efm32_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/imx1/imx_timerisr.c
+++ b/arch/arm/src/imx1/imx_timerisr.c
@@ -92,7 +92,7 @@ static int imx_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -100,7 +100,7 @@ static int imx_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t tctl;
 

--- a/arch/arm/src/imx6/imx_timerisr.c
+++ b/arch/arm/src/imx6/imx_timerisr.c
@@ -153,7 +153,7 @@ static int imx_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -161,7 +161,7 @@ static int imx_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
   uint32_t cr;

--- a/arch/arm/src/imxrt/imxrt_timerisr.c
+++ b/arch/arm/src/imxrt/imxrt_timerisr.c
@@ -198,7 +198,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -206,7 +206,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 #ifdef CONFIG_PM

--- a/arch/arm/src/kinetis/kinetis_timerisr.c
+++ b/arch/arm/src/kinetis/kinetis_timerisr.c
@@ -103,7 +103,7 @@ static int kinetis_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -111,7 +111,7 @@ static int kinetis_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/kl/kl_timerisr.c
+++ b/arch/arm/src/kl/kl_timerisr.c
@@ -118,7 +118,7 @@ static int kl_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -126,7 +126,7 @@ static int kl_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/lc823450/lc823450_timer.c
+++ b/arch/arm/src/lc823450/lc823450_timer.c
@@ -470,10 +470,10 @@ static uint64_t up_get_timer_fraction(void)
 }
 
 /****************************************************************************
- * Name: arm_timer_initialize
+ * Name: up_timer_initialize
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
 #ifdef CHECK_INTERVAL
   lc823450_gpio_config(TIMER_PIN |

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_timerisr.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_timerisr.c
@@ -104,7 +104,7 @@ static int lpc17_40_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -112,7 +112,7 @@ static int lpc17_40_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/lpc214x/lpc214x_timerisr.c
+++ b/arch/arm/src/lpc214x/lpc214x_timerisr.c
@@ -111,7 +111,7 @@ static int lpc214x_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -119,7 +119,7 @@ static int lpc214x_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint16_t mcr;
 

--- a/arch/arm/src/lpc2378/lpc23xx_timerisr.c
+++ b/arch/arm/src/lpc2378/lpc23xx_timerisr.c
@@ -134,7 +134,7 @@ static int lpc23xx_timerisr(int irq, uint32_t * regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -142,7 +142,7 @@ static int lpc23xx_timerisr(int irq, uint32_t * regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint16_t mcr;
 

--- a/arch/arm/src/lpc31xx/lpc31_timerisr.c
+++ b/arch/arm/src/lpc31xx/lpc31_timerisr.c
@@ -85,7 +85,7 @@ static int lpc31_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -93,7 +93,7 @@ static int lpc31_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
   uint64_t load;

--- a/arch/arm/src/lpc43xx/lpc43_rit.c
+++ b/arch/arm/src/lpc43xx/lpc43_rit.c
@@ -154,7 +154,7 @@ static inline void lpc43_RIT_timer_stop(void)
  * Public Functions
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t ticks_per_int;
   uint32_t mask_bits = 0;

--- a/arch/arm/src/lpc43xx/lpc43_tickless_rit.c
+++ b/arch/arm/src/lpc43xx/lpc43_tickless_rit.c
@@ -595,7 +595,7 @@ static int lpc43_tl_isr(int irq, FAR void *context, FAR void *arg)
  * Public Functions
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   irqstate_t flags;
   flags = enter_critical_section();

--- a/arch/arm/src/lpc43xx/lpc43_timerisr.c
+++ b/arch/arm/src/lpc43xx/lpc43_timerisr.c
@@ -103,7 +103,7 @@ static int lpc43_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -111,7 +111,7 @@ static int lpc43_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/lpc54xx/lpc54_tickless.c
+++ b/arch/arm/src/lpc54xx/lpc54_tickless.c
@@ -625,7 +625,7 @@ static int lpc54_tl_isr(int irq, FAR void *context, FAR void *arg)
  * Public Functions
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   irqstate_t flags;
   flags = enter_critical_section();

--- a/arch/arm/src/lpc54xx/lpc54_timerisr.c
+++ b/arch/arm/src/lpc54xx/lpc54_timerisr.c
@@ -115,7 +115,7 @@ static int lpc54_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -123,7 +123,7 @@ static int lpc54_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/max326xx/common/max326_timerisr.c
+++ b/arch/arm/src/max326xx/common/max326_timerisr.c
@@ -102,7 +102,7 @@ static int max326_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -110,7 +110,7 @@ static int max326_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/moxart/moxart_timer.c
+++ b/arch/arm/src/moxart/moxart_timer.c
@@ -121,7 +121,7 @@ static int moxart_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   Setup MoxaRT timer 0 to cause system ticks.
@@ -131,7 +131,7 @@ static int moxart_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t tmp;
 

--- a/arch/arm/src/nrf52/nrf52_timerisr.c
+++ b/arch/arm/src/nrf52/nrf52_timerisr.c
@@ -113,7 +113,7 @@ static int nrf52_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -121,7 +121,7 @@ static int nrf52_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/nuc1xx/nuc_timerisr.c
+++ b/arch/arm/src/nuc1xx/nuc_timerisr.c
@@ -169,7 +169,7 @@ static int nuc_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -177,7 +177,7 @@ static int nuc_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/s32k1xx/s32k11x/s32k11x_timerisr.c
+++ b/arch/arm/src/s32k1xx/s32k11x/s32k11x_timerisr.c
@@ -105,7 +105,7 @@ static int s32k11x_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -113,7 +113,7 @@ static int s32k11x_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t coreclk;
   uint32_t reload;

--- a/arch/arm/src/s32k1xx/s32k14x/s32k14x_timerisr.c
+++ b/arch/arm/src/s32k1xx/s32k14x/s32k14x_timerisr.c
@@ -99,7 +99,7 @@ static int s32k14x_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -107,7 +107,7 @@ static int s32k14x_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t coreclk;
   uint32_t reload;

--- a/arch/arm/src/sam34/sam4cm_tickless.c
+++ b/arch/arm/src/sam34/sam4cm_tickless.c
@@ -39,7 +39,7 @@
  * is suppressed and the platform specific code is expected to provide the
  * following custom functions.
  *
- *   void arm_timer_initialize(void): Initializes the timer facilities.  Called
+ *   void up_timer_initialize(void): Initializes the timer facilities.  Called
  *     early in the initialization sequence (by up_initialize()).
  *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
@@ -206,7 +206,7 @@ static void sam_oneshot_handler(void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arm_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   Initializes all platform-specific timer facilities.  This function is
@@ -230,7 +230,7 @@ static void sam_oneshot_handler(void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
 #ifdef CONFIG_SCHED_TICKLESS_LIMIT_MAX_SLEEP
   uint64_t max_delay;
@@ -292,7 +292,7 @@ void arm_timer_initialize(void)
  *
  * Description:
  *   Return the elapsed time since power-up (or, more correctly, since
- *   arm_timer_initialize() was called).  This function is functionally
+ *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
  *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);

--- a/arch/arm/src/sam34/sam_timerisr.c
+++ b/arch/arm/src/sam34/sam_timerisr.c
@@ -125,7 +125,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -133,7 +133,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/sama5/sam_tickless.c
+++ b/arch/arm/src/sama5/sam_tickless.c
@@ -39,7 +39,7 @@
  * is suppressed and the platform specific code is expected to provide the
  * following custom functions.
  *
- *   void arm_timer_initialize(void): Initializes the timer facilities.  Called
+ *   void up_timer_initialize(void): Initializes the timer facilities.  Called
  *     early in the initialization sequence (by up_initialize()).
  *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
@@ -218,7 +218,7 @@ static void sam_oneshot_handler(void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arm_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   Initializes all platform-specific timer facilities.  This function is
@@ -242,7 +242,7 @@ static void sam_oneshot_handler(void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
 #ifdef CONFIG_SCHED_TICKLESS_LIMIT_MAX_SLEEP
   uint64_t max_delay;
@@ -304,7 +304,7 @@ void arm_timer_initialize(void)
  *
  * Description:
  *   Return the elapsed time since power-up (or, more correctly, since
- *   arm_timer_initialize() was called).  This function is functionally
+ *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
  *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);

--- a/arch/arm/src/sama5/sam_timerisr.c
+++ b/arch/arm/src/sama5/sam_timerisr.c
@@ -114,7 +114,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -122,7 +122,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/samd2l2/sam_timerisr.c
+++ b/arch/arm/src/samd2l2/sam_timerisr.c
@@ -108,7 +108,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -116,7 +116,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -752,8 +752,8 @@ static int sam_transmit(struct sam_gmac_s *priv)
 
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
-  (void)wd_start(priv->txtimeout, SAM_TXTIMEOUT, sam_txtimeout_expiry, 1,
-                 (uint32_t)priv);
+  wd_start(priv->txtimeout, SAM_TXTIMEOUT, sam_txtimeout_expiry, 1,
+          (uint32_t)priv);
 
   /* Set d_len to zero meaning that the d_buf[] packet buffer is again
    * available.
@@ -895,7 +895,7 @@ static void sam_dopoll(struct sam_gmac_s *priv)
     {
       /* If we have the descriptor, then poll the network for new XMIT data. */
 
-      (void)devif_poll(dev, sam_txpoll);
+      devif_poll(dev, sam_txpoll);
     }
 }
 
@@ -1764,12 +1764,12 @@ static void sam_poll_work(FAR void *arg)
     {
       /* Update TCP timing states and poll the network for new XMIT data. */
 
-      (void)devif_timer(dev, sam_txpoll);
+      devif_timer(dev, sam_txpoll);
     }
 
   /* Setup the watchdog poll timer again */
 
-  (void)wd_start(priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, priv);
+  wd_start(priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, priv);
   net_unlock();
 }
 
@@ -1871,7 +1871,7 @@ static int sam_ifup(struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  (void)wd_start(priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (uint32_t)priv);
+  wd_start(priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (uint32_t)priv);
 
   /* Enable the GMAC interrupt */
 
@@ -3576,7 +3576,7 @@ static void sam_ipv6multicast(struct sam_gmac_s *priv)
   ninfo("IPv6 Multicast: %02x:%02x:%02x:%02x:%02x:%02x\n",
         mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
-  (void)sam_addmac(dev, mac);
+  sam_addmac(dev, mac);
 
 #ifdef CONFIG_NET_ICMPv6_AUTOCONF
   /* Add the IPv6 all link-local nodes Ethernet address.  This is the
@@ -3584,7 +3584,7 @@ static void sam_ipv6multicast(struct sam_gmac_s *priv)
    * packets.
    */
 
-  (void)sam_addmac(dev, g_ipv6_ethallnodes.ether_addr_octet);
+  sam_addmac(dev, g_ipv6_ethallnodes.ether_addr_octet);
 
 #endif /* CONFIG_NET_ICMPv6_AUTOCONF */
 #ifdef CONFIG_NET_ICMPv6_ROUTER
@@ -3593,7 +3593,7 @@ static void sam_ipv6multicast(struct sam_gmac_s *priv)
    * packets.
    */
 
-  (void)sam_addmac(dev, g_ipv6_ethallrouters.ether_addr_octet);
+  sam_addmac(dev, g_ipv6_ethallrouters.ether_addr_octet);
 
 #endif /* CONFIG_NET_ICMPv6_ROUTER */
 }
@@ -3645,7 +3645,7 @@ static int sam_gmac_configure(struct sam_gmac_s *priv)
 
   /* Clear any pending interrupts */
 
-  (void)sam_getreg(priv, SAM_GMAC_ISR);
+  sam_getreg(priv, SAM_GMAC_ISR);
 
   /* Initial configuration:
    *

--- a/arch/arm/src/samd5e5/sam_timerisr.c
+++ b/arch/arm/src/samd5e5/sam_timerisr.c
@@ -103,7 +103,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -111,7 +111,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/samv7/sam_tickless.c
+++ b/arch/arm/src/samv7/sam_tickless.c
@@ -39,7 +39,7 @@
  * is suppressed and the platform specific code is expected to provide the
  * following custom functions.
  *
- *   void arm_timer_initialize(void): Initializes the timer facilities.  Called
+ *   void up_timer_initialize(void): Initializes the timer facilities.  Called
  *     early in the initialization sequence (by up_initialize()).
  *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
@@ -230,7 +230,7 @@ static void sam_oneshot_handler(void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arm_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   Initializes all platform-specific timer facilities.  This function is
@@ -254,7 +254,7 @@ static void sam_oneshot_handler(void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   int ret;
 
@@ -290,7 +290,7 @@ void arm_timer_initialize(void)
  *
  * Description:
  *   Return the elapsed time since power-up (or, more correctly, since
- *   arm_timer_initialize() was called).  This function is functionally
+ *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
  *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);

--- a/arch/arm/src/samv7/sam_timerisr.c
+++ b/arch/arm/src/samv7/sam_timerisr.c
@@ -111,7 +111,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -119,7 +119,7 @@ static int sam_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/stm32/stm32_tickless.c
+++ b/arch/arm/src/stm32/stm32_tickless.c
@@ -41,7 +41,7 @@
  * is suppressed and the platform specific code is expected to provide the
  * following custom functions.
  *
- *   void arm_timer_initialize(void): Initializes the timer facilities.
+ *   void up_timer_initialize(void): Initializes the timer facilities.
  *     Called early in the initialization sequence (by up_initialize()).
  *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
@@ -385,7 +385,7 @@ static int stm32_tickless_handler(int irq, void *context, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arm_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   Initializes all platform-specific timer facilities.  This function is
@@ -409,7 +409,7 @@ static int stm32_tickless_handler(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   switch (CONFIG_STM32_TICKLESS_TIMER)
     {
@@ -590,7 +590,7 @@ void arm_timer_initialize(void)
  *
  * Description:
  *   Return the elapsed time since power-up (or, more correctly, since
- *   arm_timer_initialize() was called).  This function is functionally
+ *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
  *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);

--- a/arch/arm/src/stm32/stm32_timerisr.c
+++ b/arch/arm/src/stm32/stm32_timerisr.c
@@ -111,7 +111,7 @@ static int stm32_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -119,7 +119,7 @@ static int stm32_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/stm32f0l0g0/stm32_timerisr.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_timerisr.c
@@ -120,7 +120,7 @@ static int stm32_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -128,7 +128,7 @@ static int stm32_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/stm32f7/stm32_sai.c
+++ b/arch/arm/src/stm32f7/stm32_sai.c
@@ -1041,7 +1041,7 @@ static void sai_worker(void *arg)
 
       flags = enter_critical_section();
 #ifdef CONFIG_STM32F7_SAI_DMA
-      (void)sai_dma_setup(priv);
+      sai_dma_setup(priv);
 #endif
       leave_critical_section(flags);
     }
@@ -1160,7 +1160,7 @@ static void sai_dma_callback(DMA_HANDLE handle, uint8_t isr, void *arg)
 
   /* Cancel the watchdog timeout */
 
-  (void)wd_cancel(priv->dog);
+  wd_cancel(priv->dog);
 
   /* Then schedule completion of the transfer to occur on the worker thread */
 

--- a/arch/arm/src/stm32f7/stm32_tickless.c
+++ b/arch/arm/src/stm32f7/stm32_tickless.c
@@ -41,7 +41,7 @@
  * is suppressed and the platform specific code is expected to provide the
  * following custom functions.
  *
- *   void arm_timer_initialize(void): Initializes the timer facilities.
+ *   void up_timer_initialize(void): Initializes the timer facilities.
  *     Called early in the initialization sequence (by up_initialize()).
  *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
@@ -398,7 +398,7 @@ static int stm32_tickless_handler(int irq, void *context, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arm_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   Initializes all platform-specific timer facilities.  This function is
@@ -422,7 +422,7 @@ static int stm32_tickless_handler(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   switch (CONFIG_STM32F7_TICKLESS_TIMER)
     {
@@ -604,7 +604,7 @@ void arm_timer_initialize(void)
  *
  * Description:
  *   Return the elapsed time since power-up (or, more correctly, since
- *   arm_timer_initialize() was called).  This function is functionally
+ *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
  *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);

--- a/arch/arm/src/stm32f7/stm32_timerisr.c
+++ b/arch/arm/src/stm32f7/stm32_timerisr.c
@@ -117,7 +117,7 @@ static int stm32_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -125,7 +125,7 @@ static int stm32_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/stm32h7/stm32_qspi.c
+++ b/arch/arm/src/stm32h7/stm32_qspi.c
@@ -1380,7 +1380,7 @@ static void qspi_dma_callback(DMA_HANDLE handle, uint8_t isr, void *arg)
 
   /* Cancel the watchdog timeout */
 
-  (void)wd_cancel(priv->dmadog);
+  wd_cancel(priv->dmadog);
 
   /* Sample DMA registers at the time of the callback */
 
@@ -1529,7 +1529,7 @@ static int qspi_memory_dma(struct stm32h7_qspidev_s *priv,
 
       /* Cancel the watchdog timeout */
 
-      (void)wd_cancel(priv->dmadog);
+      wd_cancel(priv->dmadog);
 
       /* Check if we were awakened by an error of some kind */
 
@@ -1774,8 +1774,7 @@ static int qspi_lock(struct qspi_dev_s *dev, bool lock)
     }
   else
     {
-      (void)nxsem_post(&priv->exclsem);
-      ret = OK;
+      ret = nxsem_post(&priv->exclsem);
     }
 
   return ret;
@@ -2107,7 +2106,7 @@ static int qspi_command(struct qspi_dev_s *dev,
 
   /* Wait for the interrupt routine to finish it's magic */
 
-  (void)nxsem_wait(&priv->op_sem);
+  nxsem_wait(&priv->op_sem);
   MEMORY_SYNC();
 
   /* Convey the result */
@@ -2265,7 +2264,7 @@ static int qspi_memory(struct qspi_dev_s *dev,
 
   /* Wait for the interrupt routine to finish it's magic */
 
-  (void)nxsem_wait(&priv->op_sem);
+  nxsem_wait(&priv->op_sem);
   MEMORY_SYNC();
 
   /* convey the result */

--- a/arch/arm/src/stm32h7/stm32_timerisr.c
+++ b/arch/arm/src/stm32h7/stm32_timerisr.c
@@ -140,7 +140,7 @@ static int stm32_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -148,7 +148,7 @@ static int stm32_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/stm32l4/stm32l4_tickless.c
+++ b/arch/arm/src/stm32l4/stm32l4_tickless.c
@@ -40,7 +40,7 @@
  * is suppressed and the platform specific code is expected to provide the
  * following custom functions.
  *
- *   void arm_timer_initialize(void): Initializes the timer facilities.
+ *   void up_timer_initialize(void): Initializes the timer facilities.
  *     Called early in the initialization sequence (by up_initialize()).
  *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
@@ -163,7 +163,7 @@ static void stm32l4_oneshot_handler(FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arm_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   Initializes all platform-specific timer facilities.  This function is
@@ -187,7 +187,7 @@ static void stm32l4_oneshot_handler(FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
 #ifdef CONFIG_SCHED_TICKLESS_LIMIT_MAX_SLEEP
   uint64_t max_delay;
@@ -245,7 +245,7 @@ void arm_timer_initialize(void)
  *
  * Description:
  *   Return the elapsed time since power-up (or, more correctly, since
- *   arm_timer_initialize() was called).  This function is functionally
+ *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
  *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);

--- a/arch/arm/src/stm32l4/stm32l4_timerisr.c
+++ b/arch/arm/src/stm32l4/stm32l4_timerisr.c
@@ -111,7 +111,7 @@ static int stm32l4_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -119,7 +119,7 @@ static int stm32l4_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/str71x/str71x_timerisr.c
+++ b/arch/arm/src/str71x/str71x_timerisr.c
@@ -146,7 +146,7 @@ static int str71x_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -154,7 +154,7 @@ static int str71x_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   irqstate_t flags;
 

--- a/arch/arm/src/tiva/common/tiva_timerisr.c
+++ b/arch/arm/src/tiva/common/tiva_timerisr.c
@@ -101,7 +101,7 @@ static int tiva_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -109,7 +109,7 @@ static int tiva_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/arm/src/tms570/tms570_timerisr.c
+++ b/arch/arm/src/tms570/tms570_timerisr.c
@@ -147,7 +147,7 @@ static int tms570_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name:  arm_timer_initialize
+ * Name:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -155,7 +155,7 @@ static int tms570_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Disable all RTI interrupts */
 

--- a/arch/arm/src/xmc4/xmc4_timerisr.c
+++ b/arch/arm/src/xmc4/xmc4_timerisr.c
@@ -120,7 +120,7 @@ static int xmc4_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  arm_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -128,7 +128,7 @@ static int xmc4_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void arm_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/avr/src/at32uc3/at32uc3_timerisr.c
+++ b/arch/avr/src/at32uc3/at32uc3_timerisr.c
@@ -174,7 +174,7 @@ static int at32uc3_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  avr_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -183,7 +183,7 @@ static int at32uc3_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void avr_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t regval;
 

--- a/arch/avr/src/at90usb/at90usb_timerisr.c
+++ b/arch/avr/src/at90usb/at90usb_timerisr.c
@@ -127,7 +127,7 @@ static int at90usb_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  avr_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -136,7 +136,7 @@ static int at90usb_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void avr_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Setup timer 1 compare match A to generate a tick interrupt.
    *

--- a/arch/avr/src/atmega/atmega_timerisr.c
+++ b/arch/avr/src/atmega/atmega_timerisr.c
@@ -127,7 +127,7 @@ static int atmega_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  avr_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -136,7 +136,7 @@ static int atmega_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void avr_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Setup timer 1 compare match A to generate a tick interrupt.
    *

--- a/arch/avr/src/common/up_initialize.c
+++ b/arch/avr/src/common/up_initialize.c
@@ -168,12 +168,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the system timer interrupt */
-
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
-  avr_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/avr/src/common/up_initialize.c
+++ b/arch/avr/src/common/up_initialize.c
@@ -168,10 +168,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
   /* Initialize the system timer interrupt */
 
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)

--- a/arch/avr/src/common/up_internal.h
+++ b/arch/avr/src/common/up_internal.h
@@ -167,10 +167,6 @@ void lowconsole_init(void);
 # define lowconsole_init()
 #endif
 
-/* Defined in chip/xxx_timerisr.c */
-
-void avr_timer_initialize(void);
-
 /* Defined in chip/xxx_ethernet.c */
 
 #if defined(CONFIG_NET) && !defined(CONFIG_NETDEV_LATEINIT)

--- a/arch/avr/src/common/up_internal.h
+++ b/arch/avr/src/common/up_internal.h
@@ -123,7 +123,6 @@ extern uint32_t _ebss;            /* End+1 of .bss */
 
 /* Defined in files with the same name as the function */
 
-void up_irqinitialize(void);
 #ifdef CONFIG_ARCH_DMA
 void weak_function up_dma_initialize(void);
 #endif

--- a/arch/hc/src/common/up_initialize.c
+++ b/arch/hc/src/common/up_initialize.c
@@ -90,12 +90,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the system timer interrupt */
-
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
-  hc_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/hc/src/common/up_initialize.c
+++ b/arch/hc/src/common/up_initialize.c
@@ -90,10 +90,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
   /* Initialize the system timer interrupt */
 
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)

--- a/arch/hc/src/common/up_internal.h
+++ b/arch/hc/src/common/up_internal.h
@@ -144,7 +144,6 @@ extern uint32_t g_intstackbase;
 
 void up_copystate(uint8_t *dest, uint8_t *src);
 void up_decodeirq(uint8_t *regs);
-void up_irqinitialize(void);
 int  up_saveusercontext(uint8_t *saveregs);
 void up_fullcontextrestore(uint8_t *restoreregs) noreturn_function;
 void up_switchcontext(uint8_t *saveregs, uint8_t *restoreregs);

--- a/arch/hc/src/common/up_internal.h
+++ b/arch/hc/src/common/up_internal.h
@@ -156,10 +156,6 @@ uint8_t *up_doirq(int irq, uint8_t *regs);
 
 void up_sigdeliver(void);
 
-/* System timer initialization */
-
-void hc_timer_initialize(void);
-
 /* Debug output */
 
 void up_earlyserialinit(void);

--- a/arch/hc/src/m9s12/m9s12_timerisr.c
+++ b/arch/hc/src/m9s12/m9s12_timerisr.c
@@ -148,7 +148,7 @@ static int m9s12_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  hc_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the system timer
@@ -156,7 +156,7 @@ static int m9s12_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void hc_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t tmp;
   uint8_t  regval;

--- a/arch/mips/src/common/up_initialize.c
+++ b/arch/mips/src/common/up_initialize.c
@@ -92,10 +92,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
   /* Initialize the system timer interrupt */
 
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)

--- a/arch/mips/src/common/up_initialize.c
+++ b/arch/mips/src/common/up_initialize.c
@@ -92,12 +92,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the system timer interrupt */
-
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
-  mips_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/mips/src/common/up_internal.h
+++ b/arch/mips/src/common/up_internal.h
@@ -260,10 +260,6 @@ void up_serialinit(void);
 
 void rpmsg_serialinit(void);
 
-/* System timer */
-
-void mips_timer_initialize(void);
-
 /* Network */
 
 #if defined(CONFIG_NET) && !defined(CONFIG_NETDEV_LATEINIT)

--- a/arch/mips/src/common/up_internal.h
+++ b/arch/mips/src/common/up_internal.h
@@ -235,7 +235,6 @@ void up_sigdeliver(void);
 
 /* IRQs */
 
-void up_irqinitialize(void);
 bool up_pending_irq(int irq);
 void up_clrpend_irq(int irq);
 

--- a/arch/mips/src/pic32mx/pic32mx-timerisr.c
+++ b/arch/mips/src/pic32mx/pic32mx-timerisr.c
@@ -154,7 +154,7 @@ static int pc32mx_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  mips_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -162,7 +162,7 @@ static int pc32mx_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void mips_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Configure and enable TIMER1.  Used the computed TCKPS divider and timer
    * match value.  The source will be either the internal PBCLOCK (TCS=0) or

--- a/arch/mips/src/pic32mz/pic32mz-spi.c
+++ b/arch/mips/src/pic32mz/pic32mz-spi.c
@@ -753,7 +753,7 @@ static inline void spi_flush(FAR struct pic32mz_dev_s *priv)
 
   while ((spi_getreg(priv, PIC32MZ_SPI_STAT_OFFSET) & SPI_STAT_SPIRBF) != 0)
     {
-      (void)spi_getreg(priv, PIC32MZ_SPI_BUF_OFFSET);
+      spi_getreg(priv, PIC32MZ_SPI_BUF_OFFSET);
     }
 }
 
@@ -889,7 +889,7 @@ static void spi_dmarxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
 
   /* Cancel the watchdog timeout */
 
-  (void)wd_cancel(priv->dmadog);
+  wd_cancel(priv->dmadog);
 
   /* Sample DMA registers at the time of the callback */
 
@@ -944,7 +944,7 @@ static void spi_dmatxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
 
   /* Cancel the watchdog timeout */
 
-  (void)wd_cancel(priv->dmadog);
+  wd_cancel(priv->dmadog);
 
   /* Sample DMA registers at the time of the callback */
 
@@ -1785,7 +1785,7 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
 
       /* Cancel the watchdog timeout */
 
-      (void)wd_cancel(priv->dmadog);
+      wd_cancel(priv->dmadog);
 
       /* Check if we were awakened by an error of some kind. EINTR is not a
        * failure. It simply means that the wait was awakened by a signal.

--- a/arch/mips/src/pic32mz/pic32mz-timerisr.c
+++ b/arch/mips/src/pic32mz/pic32mz-timerisr.c
@@ -153,7 +153,7 @@ static int pc32mz_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  mips_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -161,7 +161,7 @@ static int pc32mz_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void mips_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Configure and enable TIMER1.  Used the computed TCKPS divider and timer
    * match value.  The source will be either the internal PBCLOCK (TCS=0) or

--- a/arch/misoc/src/common/misoc.h
+++ b/arch/misoc/src/common/misoc.h
@@ -64,16 +64,6 @@
 #ifndef __ASSEMBLY__
 
 /****************************************************************************
- * Name: misoc_timer_initialize
- *
- * Description:
- *   Initialize and start the system timer.
- *
- ****************************************************************************/
-
-void misoc_timer_initialize(void);
-
-/****************************************************************************
  * Name: flush_cpu_dcache
  *
  * Description:

--- a/arch/misoc/src/common/misoc_timerisr.c
+++ b/arch/misoc/src/common/misoc_timerisr.c
@@ -108,7 +108,7 @@ int misoc_timer_isr(int irq, void *context, void *arg)
 }
 
 /****************************************************************************
- * Function:  misoc_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -116,7 +116,7 @@ int misoc_timer_isr(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-void misoc_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Clear event pending */
 

--- a/arch/misoc/src/lm32/lm32.h
+++ b/arch/misoc/src/lm32/lm32.h
@@ -128,10 +128,6 @@ void lm32_add_region(void);
 
 void lm32_copystate(uint32_t *dest, uint32_t *src);
 
-/* IRQ initialization *******************************************************/
-
-void lm32_irq_initialize(void);
-
 /* Interrupt decode *********************************************************/
 
 uint32_t *lm32_decodeirq(uint32_t intstat, uint32_t *regs);

--- a/arch/misoc/src/lm32/lm32_initialize.c
+++ b/arch/misoc/src/lm32/lm32_initialize.c
@@ -75,10 +75,6 @@ void up_initialize(void)
   rpmsg_serialinit();
 #endif
 
-  /* Initialize the system timer */
-
-  misoc_timer_initialize();
-
 #ifdef CONFIG_MM_IOB
   /* Initialize IO buffering */
 

--- a/arch/misoc/src/lm32/lm32_initialize.c
+++ b/arch/misoc/src/lm32/lm32_initialize.c
@@ -67,10 +67,6 @@
 
 void up_initialize(void)
 {
-  /* Initialize the System Timer */
-
-  lm32_irq_initialize();
-
   /* Initialize the serial driver */
 
   misoc_serial_initialize();

--- a/arch/misoc/src/lm32/lm32_irq.c
+++ b/arch/misoc/src/lm32/lm32_irq.c
@@ -60,10 +60,10 @@ volatile uint32_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lm32_irq_initialize
+ * Name: up_irqinitialize
  ****************************************************************************/
 
-void lm32_irq_initialize(void)
+void up_irqinitialize(void)
 {
   /* currents_regs is non-NULL only while processing an interrupt */
 

--- a/arch/misoc/src/minerva/minerva.h
+++ b/arch/misoc/src/minerva/minerva.h
@@ -128,10 +128,6 @@ void minerva_add_region(void);
 
 void minerva_copystate(uint32_t * dest, uint32_t * src);
 
-/* IRQ initialization *******************************************************/
-
-void minerva_irq_initialize(void);
-
 /* Interrupt decode *********************************************************/
 
 uint32_t *minerva_decodeirq(uint32_t intstat, uint32_t * regs);

--- a/arch/misoc/src/minerva/minerva_initialize.c
+++ b/arch/misoc/src/minerva/minerva_initialize.c
@@ -75,10 +75,6 @@ void up_initialize(void)
   rpmsg_serialinit();
 #endif
 
-  /* Initialize the system timer */
-
-  misoc_timer_initialize();
-
 #ifdef CONFIG_MM_IOB
   /* Initialize IO buffering */
 

--- a/arch/misoc/src/minerva/minerva_initialize.c
+++ b/arch/misoc/src/minerva/minerva_initialize.c
@@ -67,10 +67,6 @@
 
 void up_initialize(void)
 {
-  /* Initialize the System Timer */
-
-  minerva_irq_initialize();
-
   /* Initialize the serial driver */
 
   misoc_serial_initialize();

--- a/arch/misoc/src/minerva/minerva_irq.c
+++ b/arch/misoc/src/minerva/minerva_irq.c
@@ -60,10 +60,10 @@ volatile uint32_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: minerva_irq_initialize
+ * Name: up_irqinitialize
  ****************************************************************************/
 
-void minerva_irq_initialize(void)
+void up_irqinitialize(void)
 {
   /* currents_regs is non-NULL only while processing an interrupt */
 

--- a/arch/or1k/src/common/up_initialize.c
+++ b/arch/or1k/src/common/up_initialize.c
@@ -185,10 +185,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
   /* Initialize the system timer interrupt */
 
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS) && \

--- a/arch/or1k/src/common/up_initialize.c
+++ b/arch/or1k/src/common/up_initialize.c
@@ -185,13 +185,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the system timer interrupt */
-
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS) && \
-    !defined(CONFIG_SYSTEMTICK_EXTCLK)
-  or1k_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/or1k/src/common/up_internal.h
+++ b/arch/or1k/src/common/up_internal.h
@@ -263,8 +263,6 @@ void up_pminitialize(void);
 
 /* Interrupt handling *******************************************************/
 
-void up_irqinitialize(void);
-
 /* Exception handling logic unique to the Cortex-M family */
 
 /* Interrupt acknowledge and dispatch */

--- a/arch/or1k/src/common/up_internal.h
+++ b/arch/or1k/src/common/up_internal.h
@@ -283,10 +283,6 @@ uint32_t *or1k_doirq(int irq, uint32_t *regs);
 
 uint32_t *or1k_syscall(uint32_t *regs);
 
-/* System timer *************************************************************/
-
-void or1k_timer_initialize(void);
-
 /* Low level serial output **************************************************/
 
 void up_lowputc(char ch);

--- a/arch/or1k/src/common/up_timer.c
+++ b/arch/or1k/src/common/up_timer.c
@@ -86,14 +86,14 @@ static int or1k_timer_isr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: or1k_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   Initialize the OpenRISC Tick Timer unit
  *
  ****************************************************************************/
 
-void or1k_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t ttmr = TTMR_LOAD;
 

--- a/arch/renesas/src/common/up_initialize.c
+++ b/arch/renesas/src/common/up_initialize.c
@@ -86,10 +86,6 @@ void up_initialize(void)
 
   g_current_regs = NULL;
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
   /* Initialize the system timer interrupt */
 

--- a/arch/renesas/src/common/up_initialize.c
+++ b/arch/renesas/src/common/up_initialize.c
@@ -86,12 +86,6 @@ void up_initialize(void)
 
   g_current_regs = NULL;
 
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
-  /* Initialize the system timer interrupt */
-
-  renesas_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/renesas/src/common/up_internal.h
+++ b/arch/renesas/src/common/up_internal.h
@@ -185,10 +185,6 @@ void lowconsole_init(void);
 
 void up_wdtinit(void);
 
-/* Defined in xyz_timerisr.c */
-
-void renesas_timer_initialize(void);
-
 /* Defined in board/xyz_lcd.c */
 
 #ifdef CONFIG_SLCD_CONSOLE

--- a/arch/renesas/src/common/up_internal.h
+++ b/arch/renesas/src/common/up_internal.h
@@ -143,7 +143,6 @@ void up_dataabort(uint32_t *regs);
 void up_decodeirq(uint32_t *regs);
 uint32_t *up_doirq(int irq, uint32_t *regs);
 void up_fullcontextrestore(uint32_t *regs) noreturn_function;
-void up_irqinitialize(void);
 void up_prefetchabort(uint32_t *regs);
 int  up_saveusercontext(uint32_t *regs);
 void up_sigdeliver(void);

--- a/arch/renesas/src/m16c/m16c_timerisr.c
+++ b/arch/renesas/src/m16c/m16c_timerisr.c
@@ -132,7 +132,7 @@ static int m16c_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  renesas_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -140,7 +140,7 @@ static int m16c_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void renesas_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Make sure that no timers are running and that all timer interrupts are
    * disabled.

--- a/arch/renesas/src/rx65n/rx65n_timerisr.c
+++ b/arch/renesas/src/rx65n/rx65n_timerisr.c
@@ -111,7 +111,7 @@ static int rx65n_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  renesas_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -119,7 +119,7 @@ static int rx65n_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void renesas_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint16_t reg16;
   uint32_t reg32;

--- a/arch/renesas/src/sh1/sh1_timerisr.c
+++ b/arch/renesas/src/sh1/sh1_timerisr.c
@@ -147,7 +147,7 @@ static int sh1_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  renesas_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -155,7 +155,7 @@ static int sh1_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void renesas_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint8_t reg8;
 

--- a/arch/risc-v/include/rv64gc/syscall.h
+++ b/arch/risc-v/include/rv64gc/syscall.h
@@ -87,7 +87,7 @@
 
 #define SYS_restore_context (1)
 #define up_fullcontextrestore(restoreregs) \
-  (void)sys_call1(SYS_restore_context, (uintptr_t)restoreregs)
+  sys_call1(SYS_restore_context, (uintptr_t)restoreregs)
 
 /* SYS call 2:
  *
@@ -96,7 +96,7 @@
 
 #define SYS_switch_context (2)
 #define up_switchcontext(saveregs, restoreregs) \
-  (void)sys_call2(SYS_switch_context, (uintptr_t)saveregs, (uintptr_t)restoreregs)
+  sys_call2(SYS_switch_context, (uintptr_t)saveregs, (uintptr_t)restoreregs)
 
 #ifdef CONFIG_BUILD_KERNEL
 /* SYS call 3:
@@ -105,7 +105,7 @@
  */
 
 #define SYS_syscall_return (3)
-#define up_syscall_return() (void)sys_call0(SYS_syscall_return)
+#define up_syscall_return() sys_call0(SYS_syscall_return)
 
 #endif
 #endif /* __ASSEMBLY__ */

--- a/arch/risc-v/src/common/up_initialize.c
+++ b/arch/risc-v/src/common/up_initialize.c
@@ -114,13 +114,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the system timer interrupt */
-
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS) && \
-    !defined(CONFIG_SYSTEMTICK_EXTCLK)
-  riscv_timer_initialize();
-#endif
-
 #ifdef CONFIG_MM_IOB
   /* Initialize IO buffering */
 

--- a/arch/risc-v/src/common/up_initialize.c
+++ b/arch/risc-v/src/common/up_initialize.c
@@ -114,10 +114,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
   /* Initialize the system timer interrupt */
 
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS) && \

--- a/arch/risc-v/src/common/up_internal.h
+++ b/arch/risc-v/src/common/up_internal.h
@@ -176,7 +176,6 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size);
 
 /* IRQ initialization *******************************************************/
 
-void up_irqinitialize(void);
 void up_ack_irq(int irq);
 
 #ifdef CONFIG_ARCH_RV64GC

--- a/arch/risc-v/src/common/up_internal.h
+++ b/arch/risc-v/src/common/up_internal.h
@@ -188,10 +188,6 @@ void up_sigdeliver(void);
 int up_swint(int irq, FAR void *context, FAR void *arg);
 uint32_t up_get_newintctx(void);
 
-/* System timer *************************************************************/
-
-void riscv_timer_initialize(void);
-
 /* Low level serial output **************************************************/
 
 void up_lowputc(char ch);

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -65,7 +65,7 @@ void up_irqinitialize(void)
 {
   /* Disable Machine interrupts */
 
-  (void)up_irq_save();
+ up_irq_save();
 
   /* Disable all global interrupts */
 
@@ -105,7 +105,7 @@ void up_irqinitialize(void)
 
   /* And finally, enable interrupts */
 
-  (void)up_irq_enable();
+  up_irq_enable();
 #endif
 }
 

--- a/arch/risc-v/src/fe310/fe310_serial.c
+++ b/arch/risc-v/src/fe310/fe310_serial.c
@@ -646,14 +646,14 @@ void up_serialinit(void)
   /* Register the console */
 
 #ifdef HAVE_SERIAL_CONSOLE
-  (void)uart_register("/dev/console", &CONSOLE_DEV);
+  uart_register("/dev/console", &CONSOLE_DEV);
 #endif
 
   /* Register all UARTs */
 
-  (void)uart_register("/dev/ttyS0", &TTYS0_DEV);
+  uart_register("/dev/ttyS0", &TTYS0_DEV);
 #ifdef TTYS1_DEV
-  (void)uart_register("/dev/ttyS1", &TTYS1_DEV);
+  uart_register("/dev/ttyS1", &TTYS1_DEV);
 #endif
 }
 

--- a/arch/risc-v/src/fe310/fe310_timerisr.c
+++ b/arch/risc-v/src/fe310/fe310_timerisr.c
@@ -120,7 +120,7 @@ static int fe310_timerisr(int irq, void *context, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: riscv_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -128,7 +128,7 @@ static int fe310_timerisr(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-void riscv_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Attach timer interrupt handler */
 

--- a/arch/risc-v/src/fe310/fe310_timerisr.c
+++ b/arch/risc-v/src/fe310/fe310_timerisr.c
@@ -132,7 +132,7 @@ void riscv_timer_initialize(void)
 {
   /* Attach timer interrupt handler */
 
-  (void)irq_attach(FE310_IRQ_MTIMER, fe310_timerisr, NULL);
+  irq_attach(FE310_IRQ_MTIMER, fe310_timerisr, NULL);
 
   /* Reload CLINT mtimecmp */
 

--- a/arch/risc-v/src/gap8/gap8_tim.c
+++ b/arch/risc-v/src/gap8/gap8_tim.c
@@ -93,7 +93,7 @@ static int gap8_timisr(int irq, void *context, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: riscv_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   Initialize the timer based on the frequency of source clock and ticks
@@ -101,7 +101,7 @@ static int gap8_timisr(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-void riscv_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Set input clock to 1MHz. FC won't exceed 250MHz */
 

--- a/arch/risc-v/src/k210/k210_cpuidlestack.c
+++ b/arch/risc-v/src/k210/k210_cpuidlestack.c
@@ -98,7 +98,7 @@
 int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
 {
 #if CONFIG_SMP_NCPUS > 1
-  (void)up_create_stack(tcb, stack_size, TCB_FLAG_TTYPE_KERNEL);
+  up_create_stack(tcb, stack_size, TCB_FLAG_TTYPE_KERNEL);
 #endif
   return OK;
 }

--- a/arch/risc-v/src/k210/k210_cpustart.c
+++ b/arch/risc-v/src/k210/k210_cpustart.c
@@ -139,11 +139,11 @@ void k210_cpu_boot(int cpu)
   sched_note_cpu_started(this_task());
 #endif
 
-  (void)up_irq_enable();
+  up_irq_enable();
 
   /* Then transfer control to the IDLE task */
 
-  (void)nx_idle_task(0, NULL);
+  nx_idle_task(0, NULL);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -81,7 +81,7 @@ void up_irqinitialize(void)
 {
   /* Disable Machine interrupts */
 
-  (void)up_irq_save();
+  up_irq_save();
 
   /* Disable all global interrupts */
 
@@ -137,7 +137,7 @@ void up_irqinitialize(void)
 
   /* And finally, enable interrupts */
 
-  (void)up_irq_enable();
+  up_irq_enable();
 #endif
 }
 

--- a/arch/risc-v/src/k210/k210_serial.c
+++ b/arch/risc-v/src/k210/k210_serial.c
@@ -646,14 +646,14 @@ void up_serialinit(void)
   /* Register the console */
 
 #ifdef HAVE_SERIAL_CONSOLE
-  (void)uart_register("/dev/console", &CONSOLE_DEV);
+  uart_register("/dev/console", &CONSOLE_DEV);
 #endif
 
   /* Register all UARTs */
 
-  (void)uart_register("/dev/ttyS0", &TTYS0_DEV);
+  uart_register("/dev/ttyS0", &TTYS0_DEV);
 #ifdef TTYS1_DEV
-  (void)uart_register("/dev/ttyS1", &TTYS1_DEV);
+  uart_register("/dev/ttyS1", &TTYS1_DEV);
 #endif
 }
 

--- a/arch/risc-v/src/k210/k210_timerisr.c
+++ b/arch/risc-v/src/k210/k210_timerisr.c
@@ -135,7 +135,7 @@ void riscv_timer_initialize(void)
 #if 1
   /* Attach timer interrupt handler */
 
-  (void)irq_attach(K210_IRQ_MTIMER, k210_timerisr, NULL);
+  irq_attach(K210_IRQ_MTIMER, k210_timerisr, NULL);
 
   /* Reload CLINT mtimecmp */
 

--- a/arch/risc-v/src/k210/k210_timerisr.c
+++ b/arch/risc-v/src/k210/k210_timerisr.c
@@ -122,7 +122,7 @@ static int k210_timerisr(int irq, void *context, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: riscv_timer_initialize
+ * Name: up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -130,7 +130,7 @@ static int k210_timerisr(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-void riscv_timer_initialize(void)
+void up_timer_initialize(void)
 {
 #if 1
   /* Attach timer interrupt handler */

--- a/arch/risc-v/src/nr5m100/nr5_timerisr.c
+++ b/arch/risc-v/src/nr5m100/nr5_timerisr.c
@@ -129,7 +129,7 @@ uint64_t up_get_systick(void)
 }
 
 /****************************************************************************
- * Function:  riscv_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -137,7 +137,7 @@ uint64_t up_get_systick(void)
  *
  ****************************************************************************/
 
-void riscv_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* Set the SysTick interrupt to the default priority */
 

--- a/arch/risc-v/src/rv64gc/up_assert.c
+++ b/arch/risc-v/src/rv64gc/up_assert.c
@@ -307,19 +307,19 @@ static void _up_assert(int errorcode)
 {
   /* Flush any buffered SYSLOG data */
 
-  (void)syslog_flush();
+  syslog_flush();
 
   /* Are we in an interrupt handler or the idle task? */
 
   if (CURRENT_REGS || running_task()->flink == NULL)
     {
-      (void)up_irq_save();
+      up_irq_save();
       for (; ; )
         {
 #ifdef CONFIG_SMP
           /* Try (again) to stop activity on other CPUs */
 
-          (void)spin_trylock(&g_cpu_irqlock);
+          spin_trylock(&g_cpu_irqlock);
 #endif
 
 #if CONFIG_BOARD_RESET_ON_ASSERT >= 1
@@ -385,7 +385,7 @@ void up_assert(const uint8_t *filename, int lineno)
 
   /* Flush any buffered SYSLOG data (from prior to the assertion) */
 
-  (void)syslog_flush();
+  syslog_flush();
 
 #ifdef CONFIG_SMP
 #if CONFIG_TASK_NAME_SIZE > 0
@@ -420,12 +420,12 @@ void up_assert(const uint8_t *filename, int lineno)
 #ifdef CONFIG_ARCH_USBDUMP
   /* Dump USB trace data */
 
-  (void)usbtrace_enumerate(assert_tracecallback, NULL);
+  usbtrace_enumerate(assert_tracecallback, NULL);
 #endif
 
   /* Flush any buffered SYSLOG data (from the above) */
 
-  (void)syslog_flush();
+  syslog_flush();
 
 #ifdef CONFIG_BOARD_CRASHDUMP
   board_crashdump(up_getsp(), running_task(), filename, lineno);

--- a/arch/risc-v/src/rv64gc/up_fault.c
+++ b/arch/risc-v/src/rv64gc/up_fault.c
@@ -119,5 +119,5 @@ void up_fault(int irq, uint64_t *regs)
          CURRENT_REGS[REG_TP], CURRENT_REGS[REG_RA]);
 #endif
 
-  (void)up_irq_save();
+  up_irq_save();
 }

--- a/arch/risc-v/src/rv64gc/up_sigdeliver.c
+++ b/arch/risc-v/src/rv64gc/up_sigdeliver.c
@@ -155,9 +155,9 @@ void up_sigdeliver(void)
    */
 
 #ifdef CONFIG_SMP
-  (void)enter_critical_section();
+  enter_critical_section();
 #else
-  (void)up_irq_save();
+  up_irq_save();
 #endif
 
   /* Restore the saved errno value */

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -62,7 +62,7 @@
 
 #  define XCPTCONTEXT_REGS    6
 #elif defined(CONFIG_HOST_ARM)
-#  define XCPTCONTEXT_REGS 16
+#  define XCPTCONTEXT_REGS    16
 #endif
 
 /****************************************************************************
@@ -70,7 +70,6 @@
  ****************************************************************************/
 
 #ifndef __ASSEMBLY__
-/* Number of registers saved in context switch */
 
 #if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
 typedef unsigned long xcpt_reg_t;
@@ -93,6 +92,14 @@ struct xcptcontext
  ****************************************************************************/
 
 #ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Name: up_irqinitialize
+ ****************************************************************************/
+
+static inline void up_irqinitialize(void)
+{
+}
 
 /* Name: up_irq_save, up_irq_restore, and friends.
  *

--- a/arch/sim/src/sim/up_initialize.c
+++ b/arch/sim/src/sim/up_initialize.c
@@ -296,3 +296,16 @@ void up_initialize(void)
   up_init_smartfs();
 #endif
 }
+
+/****************************************************************************
+ * Function:  up_timer_initialize
+ *
+ * Description:
+ *   This function is called during start-up to initialize
+ *   the timer hardware.
+ *
+ ****************************************************************************/
+
+void up_timer_initialize(void)
+{
+}

--- a/arch/x86/src/common/up_initialize.c
+++ b/arch/x86/src/common/up_initialize.c
@@ -92,12 +92,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the system timer interrupt */
-
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
-  x86_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/x86/src/common/up_initialize.c
+++ b/arch/x86/src/common/up_initialize.c
@@ -92,10 +92,6 @@ void up_initialize(void)
 
   up_addregion();
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
   /* Initialize the system timer interrupt */
 
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)

--- a/arch/x86/src/common/up_internal.h
+++ b/arch/x86/src/common/up_internal.h
@@ -177,7 +177,6 @@ void x86_boardinitialize(void);
 void up_copystate(uint32_t *dest, uint32_t *src);
 void up_savestate(uint32_t *regs);
 void up_decodeirq(uint32_t *regs);
-void up_irqinitialize(void);
 #ifdef CONFIG_ARCH_DMA
 void weak_function up_dma_initialize(void);
 #endif

--- a/arch/x86/src/common/up_internal.h
+++ b/arch/x86/src/common/up_internal.h
@@ -222,10 +222,6 @@ void lowconsole_init(void);
 
 void up_wdtinit(void);
 
-/* Defined in xyz_timerisr.c */
-
-void x86_timer_initialize(void);
-
 /* Defined in board/up_network.c */
 
 #if defined(CONFIG_NET) && !defined(CONFIG_NETDEV_LATEINIT)

--- a/arch/x86/src/qemu/qemu_timerisr.c
+++ b/arch/x86/src/qemu/qemu_timerisr.c
@@ -106,7 +106,7 @@ static int qemu_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  x86_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -114,7 +114,7 @@ static int qemu_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void x86_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* uint32_t to avoid compile time overflow errors */
 

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -308,7 +308,6 @@ void xtensa_sig_deliver(void);
 /* Chip specific functions defined in arch/xtensa/src/<chip> */
 /* IRQs */
 
-void xtensa_irq_initialize(void);
 bool xtensa_pending_irq(int irq);
 void xtensa_clrpend_irq(int irq);
 

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -333,10 +333,6 @@ void xtensa_serial_initialize(void);
 
 void rpmsg_serialinit(void);
 
-/* System timer */
-
-void xtensa_timer_initialize(void);
-
 /* Network */
 
 #if defined(CONFIG_NET) && !defined(CONFIG_NETDEV_LATEINIT)

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -100,12 +100,6 @@ void up_initialize(void)
 
   xtensa_add_region();
 
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
-  /* Initialize the system timer interrupt */
-
-  xtensa_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -100,10 +100,6 @@ void up_initialize(void)
 
   xtensa_add_region();
 
-  /* Initialize the interrupt subsystem */
-
-  xtensa_irq_initialize();
-
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
   /* Initialize the system timer interrupt */
 

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -132,10 +132,10 @@ static inline void xtensa_attach_fromcpu1_interrupt(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: xtensa_irq_initialize
+ * Name: up_irqinitialize
  ****************************************************************************/
 
-void xtensa_irq_initialize(void)
+void up_irqinitialize(void)
 {
   /* Initialize CPU interrupts */
 

--- a/arch/xtensa/src/esp32/esp32_timerisr.c
+++ b/arch/xtensa/src/esp32/esp32_timerisr.c
@@ -160,7 +160,7 @@ static int esp32_timerisr(int irq, uint32_t *regs, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  xtensa_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -168,7 +168,7 @@ static int esp32_timerisr(int irq, uint32_t *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-void xtensa_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t divisor;
   uint32_t count;

--- a/arch/z16/src/common/up_initialize.c
+++ b/arch/z16/src/common/up_initialize.c
@@ -105,10 +105,6 @@ void up_initialize(void)
   up_addregion();
 #endif
 
-  /* Initialize the interrupt subsystem */
-
-  up_irqinitialize();
-
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
   /* Initialize the system timer interrupt */
 

--- a/arch/z16/src/common/up_initialize.c
+++ b/arch/z16/src/common/up_initialize.c
@@ -105,12 +105,6 @@ void up_initialize(void)
   up_addregion();
 #endif
 
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
-  /* Initialize the system timer interrupt */
-
-  z16_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/z16/src/common/up_internal.h
+++ b/arch/z16/src/common/up_internal.h
@@ -167,10 +167,6 @@ void rpmsg_serialinit(void);
 void lowconsole_init(void);
 #endif
 
-/* Defined in xyz_timerisr.c */
-
-void z16_timer_initialize(void);
-
 /* Defined in xyz_irq.c */
 
 void up_ack_irq(int irq);

--- a/arch/z16/src/common/up_internal.h
+++ b/arch/z16/src/common/up_internal.h
@@ -135,7 +135,6 @@ extern volatile FAR chipreg_t *g_current_regs;
 void up_copystate(FAR chipreg_t *dest, FAR chipreg_t *src);
 FAR chipreg_t *up_doirq(int irq, FAR chipreg_t *regs);
 void up_restoreusercontext(FAR chipreg_t *regs);
-void up_irqinitialize(void);
 int  up_saveusercontext(FAR chipreg_t *regs);
 void up_sigdeliver(void);
 

--- a/arch/z16/src/z16f/z16f_timerisr.c
+++ b/arch/z16/src/z16f/z16f_timerisr.c
@@ -95,7 +95,7 @@ static int z16f_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  z16_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize
@@ -103,7 +103,7 @@ static int z16f_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void z16_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t reload;
   uint32_t scaledfreq;

--- a/arch/z80/src/common/up_initialize.c
+++ b/arch/z80/src/common/up_initialize.c
@@ -96,16 +96,6 @@ void up_initialize(void)
   up_addregion();
 #endif
 
-  /* Initialize the interrupt subsystem */
-
-  z80_irq_initialize();
-
-#ifdef CONFIG_RTC_ALARM
-  /* Enable RTC alarm interrupts */
-
-  z80_rtc_irqinitialize();
-#endif
-
 #if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
   /* Initialize the system timer interrupt */
 

--- a/arch/z80/src/common/up_initialize.c
+++ b/arch/z80/src/common/up_initialize.c
@@ -96,12 +96,6 @@ void up_initialize(void)
   up_addregion();
 #endif
 
-#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && !defined(CONFIG_SUPPRESS_TIMER_INTS)
-  /* Initialize the system timer interrupt */
-
-  z80_timer_initialize();
-#endif
-
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function
    * must be called *very* early in the initialization sequence *before* any

--- a/arch/z80/src/common/z80_internal.h
+++ b/arch/z80/src/common/z80_internal.h
@@ -104,14 +104,6 @@ extern "C"
 {
 #endif
 
-/* Supplied by chip- or board-specific logic */
-
-void z80_irq_initialize(void);
-
-#ifdef CONFIG_RTC_ALARM
-void z80_rtc_irqinitialize(void);
-#endif
-
 #ifdef USE_LOWSERIALINIT
 void z80_lowserial_initialize(void);
 #endif

--- a/arch/z80/src/common/z80_internal.h
+++ b/arch/z80/src/common/z80_internal.h
@@ -164,10 +164,6 @@ void ramlog_consoleinit(void);
 
 void up_puts(const char *str);
 
-/* Defined in xyz_timerisr.c */
-
-void z80_timer_initialize(void);
-
 /* Architecture specific hook into the timer interrupt handler */
 
 #ifdef CONFIG_ARCH_TIMERHOOK

--- a/arch/z80/src/ez80/ez80_irq.c
+++ b/arch/z80/src/ez80/ez80_irq.c
@@ -60,10 +60,10 @@ volatile chipreg_t *g_current_regs;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: z80_irq_initialize
+ * Name: up_irqinitialize
  ****************************************************************************/
 
-void z80_irq_initialize(void)
+void up_irqinitialize(void)
 {
   g_current_regs = NULL;
 

--- a/arch/z80/src/ez80/ez80_rtc.c
+++ b/arch/z80/src/ez80/ez80_rtc.c
@@ -446,32 +446,14 @@ int up_rtc_initialize(void)
 
   outp(EZ80_RTC_CTRL, regval);
 
+#ifdef CONFIG_RTC_ALARM
+  irq_attach(EZ80_RTC_IRQ, ez80_alarm_interrupt, NULL);
+#endif
+
   rtc_dumpregs("After Initialization");
   g_rtc_enabled = true;
   return OK;
 }
-
-/****************************************************************************
- * Name: z80_rtc_irqinitialize
- *
- * Description:
- *   Initialize IRQs for RTC, not possible during up_rtc_initialize because
- *   z80_irq_initialize is called later.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno on failure
- *
- ****************************************************************************/
-
-#ifdef CONFIG_RTC_ALARM
-int z80_rtc_irqinitialize(void)
-{
-  return irq_attach(EZ80_RTC_IRQ, ez80_alarm_interrupt, NULL);
-}
-#endif
 
 /****************************************************************************
  * Name: up_rtc_getdatetime

--- a/arch/z80/src/ez80/ez80_timerisr.c
+++ b/arch/z80/src/ez80/ez80_timerisr.c
@@ -92,7 +92,7 @@ static int ez80_timerisr(int irq, chipreg_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  z80_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -100,7 +100,7 @@ static int ez80_timerisr(int irq, chipreg_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void z80_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint16_t reload;
 

--- a/arch/z80/src/z180/z180_irq.c
+++ b/arch/z80/src/z180/z180_irq.c
@@ -160,14 +160,14 @@ irqstate_t up_irq_enable(void) __naked
 }
 
 /****************************************************************************
- * Name: z80_irq_initialize
+ * Name: up_irqinitialize
  *
  * Description:
  *   Initialize and enable interrupts
  *
  ****************************************************************************/
 
-void z80_irq_initialize(void)
+void up_irqinitialize(void)
 {
   uint16_t vectaddr = (uint16_t)up_vectors;
   uint8_t regval;

--- a/arch/z80/src/z180/z180_timerisr.c
+++ b/arch/z80/src/z180/z180_timerisr.c
@@ -106,7 +106,7 @@ static int z180_timerisr(int irq, chipreg_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function: z80_timer_initialize
+ * Function: up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -114,7 +114,7 @@ static int z180_timerisr(int irq, chipreg_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void z80_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint8_t regval;
 

--- a/arch/z80/src/z8/z8_irq.c
+++ b/arch/z80/src/z8/z8_irq.c
@@ -60,10 +60,10 @@ struct z8_irqstate_s g_z8irqstate;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: z80_irq_initialize
+ * Name: up_irqinitialize
  ****************************************************************************/
 
-void z80_irq_initialize(void)
+void up_irqinitialize(void)
 {
   /* Clear and disable all interrupts.  Set all to priority 0. */
 

--- a/arch/z80/src/z8/z8_timerisr.c
+++ b/arch/z80/src/z8/z8_timerisr.c
@@ -83,7 +83,7 @@ static int z8_timerisr(int irq, uint32_t *regs, void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Function:  z80_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -91,7 +91,7 @@ static int z8_timerisr(int irq, uint32_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void z80_timer_initialize(void)
+void up_timer_initialize(void)
 {
   uint32_t reload;
 

--- a/boards/arm/lpc31xx/ea3131/locked/mklocked.sh
+++ b/boards/arm/lpc31xx/ea3131/locked/mklocked.sh
@@ -115,7 +115,7 @@ echo "EXTERN(up_vectoraddrexcptn)" >>ld-locked.inc
 #
 # Of course, this list must be extended as interrupt handlers are added.
 
-echo "EXTERN(arm_timer_initialize)" >>ld-locked.inc
+echo "EXTERN(up_timer_initialize)" >>ld-locked.inc
 
 answer=$(checkconfig CONFIG_LPC31_UART)
 if [ "$answer" = y ]; then

--- a/boards/xtensa/esp32/esp32-core/README.txt
+++ b/boards/xtensa/esp32/esp32-core/README.txt
@@ -566,7 +566,7 @@ OpenOCD for the ESP32
 
   Single stepping works fine for me as do breakpoints:
 
-    Breakpoint 1, xtensa_timer_initialize () at chip/esp32_timerisr.c:172
+    Breakpoint 1, up_timer_initialize () at chip/esp32_timerisr.c:172
     72 {
     (gdb) n
     esp32.cpu0: Target halted, pc=0x400835BF

--- a/boards/z80/z80/z80sim/src/z80_irq.c
+++ b/boards/z80/z80/z80sim/src/z80_irq.c
@@ -55,10 +55,10 @@ int z80sim_timerisr(int irq, FAR chipreg_t *regs);
  ****************************************************************************/
 
 /****************************************************************************
- * Name: z80_irq_initialize
+ * Name: up_irqinitialize
  ****************************************************************************/
 
-void z80_irq_initialize(void)
+void up_irqinitialize(void)
 {
   /* Attach the timer interrupt -- There is not special timer interrupt
    * enable in the simulation so it must be enabled here before interrupts

--- a/boards/z80/z80/z80sim/src/z80_irq.c
+++ b/boards/z80/z80/z80sim/src/z80_irq.c
@@ -67,7 +67,7 @@ void up_irqinitialize(void)
    * NOTE:  Normally, there are separate enables for "global" interrupts
    * and specific device interrupts.  In such a "normal" case, the timer
    * interrupt should be attached and enabled in the function
-   * z80_timer_initialize()
+   * up_timer_initialize()
    */
 
   irq_attach(Z80_IRQ_SYSTIMER, (xcpt_t)z80sim_timerisr, NULL);

--- a/boards/z80/z80/z80sim/src/z80_timerisr.c
+++ b/boards/z80/z80/z80sim/src/z80_timerisr.c
@@ -78,7 +78,7 @@ int z80sim_timerisr(int irq, FAR chipreg_t *regs, void *arg)
 
 void z80_timer_initialize(void)
 {
-  /* The timer interrupt was attached in z80_irq_initialize -- see comments
+  /* The timer interrupt was attached in up_irqinitialize -- see comments
    * there.
    */
 }

--- a/boards/z80/z80/z80sim/src/z80_timerisr.c
+++ b/boards/z80/z80/z80sim/src/z80_timerisr.c
@@ -68,7 +68,7 @@ int z80sim_timerisr(int irq, FAR chipreg_t *regs, void *arg)
 }
 
 /****************************************************************************
- * Function:  z80_timer_initialize
+ * Function:  up_timer_initialize
  *
  * Description:
  *   This function is called during start-up to initialize the timer
@@ -76,7 +76,7 @@ int z80sim_timerisr(int irq, FAR chipreg_t *regs, void *arg)
  *
  ****************************************************************************/
 
-void z80_timer_initialize(void)
+void up_timer_initialize(void)
 {
   /* The timer interrupt was attached in up_irqinitialize -- see comments
    * there.

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1332,6 +1332,12 @@ int up_shmdt(uintptr_t vaddr, unsigned int npages);
 /* See prototype in include/nuttx/elf.h */
 
 /****************************************************************************
+ * Name: up_irqinitialize
+ ****************************************************************************/
+
+void up_irqinitialize(void);
+
+/****************************************************************************
  * Name: up_interrupt_context
  *
  * Description:

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1417,6 +1417,17 @@ int up_prioritize_irq(int irq, int priority);
 #endif
 
 /****************************************************************************
+ * Function:  up_timer_initialize
+ *
+ * Description:
+ *   This function is called during start-up to initialize
+ *   the timer hardware.
+ *
+ ****************************************************************************/
+
+void up_timer_initialize(void);
+
+/****************************************************************************
  * Tickless OS Support.
  *
  * When CONFIG_SCHED_TICKLESS is enabled, all support for timer interrupts

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -65,9 +65,9 @@
 
 #ifndef CONFIG_SCHED_TICKLESS
 #ifdef CONFIG_SYSTEM_TIME64
-volatile uint64_t g_system_timer;
+volatile uint64_t g_system_timer = INITIAL_SYSTEM_TIMER_TICKS;
 #else
-volatile uint32_t g_system_timer;
+volatile uint32_t g_system_timer = INITIAL_SYSTEM_TIMER_TICKS;
 #endif
 #endif
 
@@ -170,37 +170,31 @@ int clock_basetime(FAR struct timespec *tp)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_RTC
 static void clock_inittime(void)
 {
   /* (Re-)initialize the time value to match the RTC */
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
+  struct timespec ts;
+
   clock_basetime(&g_basetime);
+  clock_systimespec(&ts);
 
-#ifndef CONFIG_SCHED_TICKLESS
-  g_system_timer = INITIAL_SYSTEM_TIMER_TICKS;
-  if (g_system_timer > 0)
+  /* Adjust base time to hide initial timer ticks. */
+
+  g_basetime.tv_sec  -= ts.tv_sec;
+  g_basetime.tv_nsec -= ts.tv_nsec;
+  while (g_basetime.tv_nsec < 0)
     {
-      struct timespec ts;
-
-      clock_ticks2time((sclock_t)g_system_timer, &ts);
-
-      /* Adjust base time to hide initial timer ticks. */
-
-      g_basetime.tv_sec  -= ts.tv_sec;
-      g_basetime.tv_nsec -= ts.tv_nsec;
-      while (g_basetime.tv_nsec < 0)
-        {
-          g_basetime.tv_nsec += NSEC_PER_SEC;
-          g_basetime.tv_sec--;
-        }
+      g_basetime.tv_nsec += NSEC_PER_SEC;
+      g_basetime.tv_sec--;
     }
-#endif /* !CONFIG_SCHED_TICKLESS */
-
 #else
   clock_inittimekeeping();
 #endif
 }
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -216,17 +210,25 @@ static void clock_inittime(void)
 
 void clock_initialize(void)
 {
+#if !defined(CONFIG_SUPPRESS_INTERRUPTS) && \
+    !defined(CONFIG_SUPPRESS_TIMER_INTS) && \
+    !defined(CONFIG_SYSTEMTICK_EXTCLK)
+  /* Initialize the system timer interrupt */
+
+  up_timer_initialize();
+#endif
+
 #if defined(CONFIG_RTC) && !defined(CONFIG_RTC_EXTERNAL)
   /* Initialize the internal RTC hardware.  Initialization of external RTC
    * must be deferred until the system has booted.
    */
 
   up_rtc_initialize();
-#endif
 
   /* Initialize the time value to match the RTC */
 
   clock_inittime();
+#endif
 }
 
 /****************************************************************************

--- a/sched/irq/irq_initialize.c
+++ b/sched/irq/irq_initialize.c
@@ -106,4 +106,6 @@ void irq_initialize(void)
 
   irqchain_initialize();
 #endif
+
+  up_irqinitialize();
 }


### PR DESCRIPTION
Reorder the irq and timer initializition as commit 0863e771a99553e suggestion:
Since the tickless mode timer is very special, one solution might be to

1. Rename xxx_timer_initialize to up_timer_initialize
2  Move up_timer_initialize to include/nuttx/arch.h
3.  Call it from clock subsystem instead up_initialize

Basically, this change make timer initialization almost same as rtc initialization(up_rtc_initialize).
