### PR TITLE
arch/arm/include/stm32f010g0/chip.h: correct wrong #if defined to fix…

### DIFF
--- a/arch/arm/include/stm32f0l0g0/chip.h
+++ b/arch/arm/include/stm32f0l0g0/chip.h
@@ -50,7 +50,7 @@
 
 /* Get customizations for each supported chip */
 
-#if defined(CONFIG_ARCH_CHIP_STM32F030RC || CONFIG_ARCH_CHIP_STM32F030CC)
+#if defined(CONFIG_ARCH_CHIP_STM32F030RC) || defined(CONFIG_ARCH_CHIP_STM32F030CC)
 
 #  define STM32_FLASH_SIZE      (256*1024) /* 256Kb */
 #  define STM32_SRAM_SIZE       (32*1024)  /*  32Kb */


### PR DESCRIPTION
… build break

/home/jenkins/jenkins-slave/workspace/NuttX-Nightly-Build/nuttx/include/arch/stm32f0l0g0/chip.h:53:42: error: missing ')' after "defined"
   53 | #if defined(CONFIG_ARCH_CHIP_STM32F030RC || CONFIG_ARCH_CHIP_STM32F030CC)
      |                                          ^~
/home/jenkins/jenkins-slave/workspace/NuttX-Nightly-Build/nuttx/include/arch/stm32f0l0g0/chip.h:53:45: error: missing binary operator before token "CONFIG_ARCH_CHIP_STM32F030CC"
   53 | #if defined(CONFIG_ARCH_CHIP_STM32F030RC || CONFIG_ARCH_CHIP_STM32F030CC)

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>