### PR TITLE
drivers/Kconfig: move if/endif to subfolder Kconfig

### DIFF
--- a/drivers/1wire/Kconfig
+++ b/drivers/1wire/Kconfig
@@ -3,9 +3,13 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if 1WIRE
+
 config 1WIRE_DS28E17
 	bool "DS28E17 1-wire to I2C converter"
 	default n
 	depends on I2C
 	---help---
 		Enable support for the Maxim DS28E17 1-wire to I2C converter
+
+endif # 1WIRE

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -84,9 +84,7 @@ menuconfig CAN
 		This selection enables building of the "upper-half" CAN driver.
 		See include/nuttx/can/can.h for further CAN driver information.
 
-if CAN
 source drivers/can/Kconfig
-endif
 
 menuconfig I2C
 	bool "I2C Driver Support"
@@ -95,10 +93,7 @@ menuconfig I2C
 		This selection enables building of the "upper-half" I2C driver.
 		See include/nuttx/i2c/i2c_master.h for further I2C driver information.
 
-if I2C
 source drivers/i2c/Kconfig
-endif
-
 source drivers/spi/Kconfig
 
 menuconfig I2S
@@ -109,10 +104,7 @@ menuconfig I2S
 		should be enabled by all platforms that support I2S interfaces.
 		See include/nuttx/audio/i2s.h for further I2S driver information.
 
-if I2S
 source drivers/i2s/Kconfig
-endif # I2S
-
 source drivers/timers/Kconfig
 
 menuconfig ANALOG
@@ -124,9 +116,7 @@ menuconfig ANALOG
 		well as drivers for Digital to Analog Conversion (DAC).
 		See include/nuttx/analog/*.h for registration information.
 
-if ANALOG
 source drivers/analog/Kconfig
-endif # ANALOG
 
 menuconfig DRIVERS_AUDIO
 	bool "Audio Device Support"
@@ -139,9 +129,7 @@ menuconfig DRIVERS_AUDIO
 		NOTE: All of these drivers depend on support from the audio subsystem
 		enabled with the AUDIO selection.
 
-if DRIVERS_AUDIO
 source drivers/audio/Kconfig
-endif # DRIVERS_AUDIO
 
 menuconfig DRIVERS_VIDEO
 	bool "Video Device Support"
@@ -149,9 +137,7 @@ menuconfig DRIVERS_VIDEO
 	---help---
 		Enable support for video device drivers.
 
-if DRIVERS_VIDEO
 source drivers/video/Kconfig
-endif # DRIVERS_VIDEO
 
 menuconfig BCH
 	bool "Block-to-Character (BCH) Support"
@@ -162,9 +148,7 @@ menuconfig BCH
 		performed by loop.c.  See include/nuttx/drivers/drivers.h for
 		registration information.
 
-if BCH
 source drivers/bch/Kconfig
-endif # BCH
 
 menuconfig INPUT
 	bool "Input Device Support"
@@ -174,10 +158,7 @@ menuconfig INPUT
 		This includes such things as touchscreen and keypad drivers.
 		See include/nuttx/input/*.h for registration information.
 
-if INPUT
 source drivers/input/Kconfig
-endif # INPUT
-
 source drivers/ioexpander/Kconfig
 source drivers/lcd/Kconfig
 source drivers/leds/Kconfig
@@ -192,9 +173,7 @@ menuconfig MMCSD
 		SPI and SDIO/MCI interfaces are supported.  See include/nuttx/mmcsd.h
 		and include/nuttx/sdio.h for further information.
 
-if MMCSD
 source drivers/mmcsd/Kconfig
-endif # MMCSD
 
 menuconfig MODEM
 	bool "Modem Support"
@@ -202,9 +181,7 @@ menuconfig MODEM
 	---help---
 		Enable modem support.
 
-if MODEM
 source drivers/modem/Kconfig
-endif # MODEM
 
 menuconfig MTD
 	bool "Memory Technology Device (MTD) Support"
@@ -219,9 +196,7 @@ menuconfig MTD
 		logic is unrelated; I just used the name MTD because I am not
 		aware of any other common way to refer to this class of devices).
 
-if MTD
 source drivers/mtd/Kconfig
-endif # MTD
 
 menuconfig EEPROM
 	bool "EEPROM support"
@@ -229,9 +204,7 @@ menuconfig EEPROM
 	---help---
 		This directory holds implementations of EEPROM drivers.
 
-if EEPROM
 source drivers/eeprom/Kconfig
-endif
 
 menuconfig NETDEVICES
 	bool "Network Device/PHY Support"
@@ -249,9 +222,7 @@ menuconfig NETDEVICES
 		require configuration of an external PHY device.  That external PHY
 		device is also selected via this menu.
 
-if NETDEVICES
 source drivers/net/Kconfig
-endif # NETDEVICES
 
 menuconfig PIPES
 	bool "FIFO and named pipe drivers"
@@ -260,10 +231,7 @@ menuconfig PIPES
 		FIFO and named pipe drivers.  Standard interfaces are declared
 		in include/unistd.h
 
-if PIPES
 source drivers/pipes/Kconfig
-endif # PIPES
-
 source drivers/power/Kconfig
 
 menuconfig RPTUN
@@ -273,9 +241,7 @@ menuconfig RPTUN
 	---help---
 		RPTUN driver is used for multi-cores' communication.
 
-if RPTUN
 source drivers/rptun/Kconfig
-endif # RPTUN
 
 menuconfig SENSORS
 	bool "Sensor Device Support"
@@ -283,9 +249,7 @@ menuconfig SENSORS
 	---help---
 		Drivers for various sensors
 
-if SENSORS
 source drivers/sensors/Kconfig
-endif # SENSORS
 
 menuconfig SERIAL
 	bool "Serial Driver Support"
@@ -295,9 +259,7 @@ menuconfig SERIAL
 		some TTY-like functionality and are commonly used (but not required
 		for) the NuttX system console.  See also include/nuttx/serial/serial.h
 
-if SERIAL
 source drivers/serial/Kconfig
-endif # SERIAL
 
 menuconfig USBDEV
 	bool "USB Device Driver Support"
@@ -305,9 +267,7 @@ menuconfig USBDEV
 	---help---
 		USB device drivers.  See also include/nuttx/usb/usbdev.h
 
-if USBDEV
 source drivers/usbdev/Kconfig
-endif # USBDEV
 
 menuconfig USBHOST
 	bool "USB Host Driver Support"
@@ -315,9 +275,7 @@ menuconfig USBHOST
 	---help---
 		USB host drivers.  See also include/nuttx/usb/usbhost.h
 
-if USBHOST
 source drivers/usbhost/Kconfig
-endif # USBHOST
 
 menuconfig USBMISC
 	bool "USB Miscellaneous drivers"
@@ -325,13 +283,7 @@ menuconfig USBMISC
 	---help---
 		USB Miscellaneous drivers.
 
-if USBMISC
 source drivers/usbmisc/Kconfig
-endif # USBMISC
-
-config HAVE_USBTRACE
-	bool
-	default n
 
 menuconfig USBMONITOR
 	bool "USB Monitor"
@@ -343,9 +295,7 @@ menuconfig USBMONITOR
 		monitor.  The USB monitor is a daemon that will periodically collect
 		the buffered USB trace data and dump it to the SYSLOG device.
 
-if USBMONITOR
 source drivers/usbmonitor/Kconfig
-endif # USBMONITOR
 
 menuconfig DRIVERS_WIRELESS
 	bool "Wireless Device Support"
@@ -353,9 +303,7 @@ menuconfig DRIVERS_WIRELESS
 	---help---
 		Drivers for various wireless devices.
 
-if DRIVERS_WIRELESS
 source drivers/wireless/Kconfig
-endif # DRIVERS_WIRELESS
 
 menuconfig DRIVERS_CONTACTLESS
 	bool "Contactless Device Support"
@@ -363,9 +311,7 @@ menuconfig DRIVERS_CONTACTLESS
 	---help---
 		Drivers for various contactless devices.
 
-if DRIVERS_CONTACTLESS
 source drivers/contactless/Kconfig
-endif # DRIVERS_CONTACTLESS
 
 menuconfig 1WIRE
 	bool "1wire Device Support"
@@ -373,10 +319,7 @@ menuconfig 1WIRE
 	---help---
 		Drivers for various 1wire devices.
 
-if 1WIRE
 source drivers/1wire/Kconfig
-endif # 1WIRE
-
 source drivers/syslog/Kconfig
 
 menuconfig SPECIFIC_DRIVERS
@@ -385,9 +328,7 @@ menuconfig SPECIFIC_DRIVERS
 	---help---
 		Board specific drivers located in each board/driver folder.
 
-if SPECIFIC_DRIVERS
 source drivers/platform/Kconfig
-endif # SPECIFIC_DRIVERS
 
 menuconfig DRIVERS_RF
 	bool "RF Device Support"
@@ -395,6 +336,4 @@ menuconfig DRIVERS_RF
 	---help---
 		Drivers for various RF devices
 
-if DRIVERS_RF
 source drivers/rf/Kconfig
-endif # DRIVERS_RF

--- a/drivers/analog/Kconfig
+++ b/drivers/analog/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if ANALOG
+
 config ADC
 	bool "Analog-to-Digital Conversion"
 	default n
@@ -185,3 +187,5 @@ config LMP92001_I2C_FREQUENCY
 	int "LMP92001 I2C frequency"
 	default 400000
 	depends on LMP92001
+
+endif # ANALOG

--- a/drivers/audio/Kconfig
+++ b/drivers/audio/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if DRIVERS_AUDIO
+
 config AUDIO_TONE
 	bool "Audio Tone Generator using PWM"
 	default n
@@ -244,3 +246,5 @@ config AUDIO_I2S
 	bool "Audio I2S"
 	depends on AUDIO
 	depends on I2S
+
+endif # DRIVERS_AUDIO

--- a/drivers/bch/Kconfig
+++ b/drivers/bch/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if BCH
+
 config BCH_ENCRYPTION
 	bool "Enable BCH encryption"
 	default n
@@ -12,3 +14,5 @@ config BCH_ENCRYPTION_KEY_SIZE
 	int "AES key size"
 	default 16
 	depends on BCH_ENCRYPTION
+
+endif # BCH

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -3,16 +3,18 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+config ARCH_HAVE_CAN_ERRORS
+	bool
+	default n
+
+if CAN
+
 config CAN_EXTID
 	bool "CAN extended IDs"
 	default n
 	---help---
 		Enables support for the 29-bit extended ID.  Default Standard 11-bit
 		IDs.
-
-config ARCH_HAVE_CAN_ERRORS
-	bool
-	default n
 
 config CAN_ERRORS
 	bool "CAN error reporting"
@@ -177,3 +179,5 @@ config MCP2515_SPI_SCK_FREQUENCY
 	range 100000 10000000
 
 endif # CAN_MCP2515
+
+endif

--- a/drivers/contactless/Kconfig
+++ b/drivers/contactless/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if DRIVERS_CONTACTLESS
+
 config CL_MFRC522
 	bool "NXP MFRC522 ISO14443/Mifare Transceiver"
 	default n
@@ -54,3 +56,5 @@ config CL_PN532_DEBUG_RX
 	depends on DEBUG_CONTACTLESS
 
 endif # CL_PN532
+
+endif # DRIVERS_CONTACTLESS

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if EEPROM
+
 config SPI_EE_25XX
 	bool "Microchip 25xxNNN / Atmel AT25NNN / ST M95NNN SPI EEPROM devices"
 	default n
@@ -50,3 +52,5 @@ config AT24CS_UUID
 		This option registers a char device driver with the ".uuid" suffix.
 
 endif # I2C_EE_24XX
+
+endif

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -7,6 +7,8 @@ config ARCH_HAVE_I2CRESET
 	bool
 	default n
 
+if I2C
+
 config I2C_SLAVE
 	bool "I2C Slave"
 	default n
@@ -50,3 +52,5 @@ config I2CMULTIPLEXER_PCA9540BDP
 # put more i2c mux devices here
 
 endmenu # I2C Multiplexer Support
+
+endif

--- a/drivers/i2s/Kconfig
+++ b/drivers/i2s/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if I2S
+
 config AUDIO_I2SCHAR
 	bool "I2S character driver (for testing only)"
 	default n
@@ -33,3 +35,5 @@ config AUDIO_I2SCHAR_TXTIMEOUT
 		The special value of zero disables RX timeouts.  Default: 0
 
 endif # AUDIO_I2SCHAR
+
+endif # I2S

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if INPUT
+
 config MOUSE
 	bool "Enable mouse support"
 	default n
@@ -510,3 +512,5 @@ config NUNCHUCK_NPOLLWAITERS
 	default 2
 
 endif # INPUT_NUNCHUCK
+
+endif # INPUT

--- a/drivers/mmcsd/Kconfig
+++ b/drivers/mmcsd/Kconfig
@@ -19,6 +19,8 @@ config ARCH_HAVE_SDIO_DELAYED_INVLDT
 	bool
 	default n
 
+if MMCSD
+
 config MMCSD_NSLOTS
 	int "Number of MMC/SD slots"
 	default 1
@@ -134,3 +136,5 @@ config SDIO_BLOCKSETUP
 		enables the block setup method in the SDIO vtable.
 
 endif
+
+endif # MMCSD

--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if MODEM
+
 config MODEM_U_BLOX
 	bool "Enable u-blox modem driver"
 	default n
@@ -20,3 +22,5 @@ config MODEM_U_BLOX_DEBUG
 
 
 source "drivers/modem/altair/Kconfig"
+
+endif # MODEM

--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if MTD
+
 comment "MTD Configuration"
 
 config MTD_PARTITION
@@ -1087,3 +1089,5 @@ config GD5F_SPIFREQUENCY
 	default 20000000
 
 endif # MTD_GD5F
+
+endif # MTD

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if NETDEVICES
+
 comment "General Ethernet MAC Driver Options"
 
 config NET_RPMSG_DRV
@@ -483,3 +485,5 @@ config NETDEV_PHY_DEBUG
 		the NSH network initialization logic.
 
 endif # ARCH_HAVE_PHY
+
+endif # NETDEVICES

--- a/drivers/pipes/Kconfig
+++ b/drivers/pipes/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if PIPES
+
 config DEV_PIPE_MAXSIZE
 	int "Maximum pipe/FIFO size"
 	default 1024 if !DEFAULT_SMALL
@@ -25,3 +27,5 @@ config DEV_FIFO_SIZE
 	---help---
 		Sets the default size of the FIFO ringbuffer in bytes.  A value of
 		zero disables FIFO support.
+
+endif # PIPES

--- a/drivers/rf/Kconfig
+++ b/drivers/rf/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if DRIVERS_RF
+
 config RF_DAT31R5SP
 	bool "Mini-Circuits DAT-31R5-SP digital attenuator support"
 	default n
@@ -10,3 +12,5 @@ config RF_DAT31R5SP
 	---help---
 		Enable driver support for the Mini-Circuits DAT-31R5-SP digital
 		attenuator.
+
+endif # DRIVERS_RF

--- a/drivers/rptun/Kconfig
+++ b/drivers/rptun/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if RPTUN
+
 config RPTUN_PRIORITY
 	int "rpturn thread priority"
 	default 224
@@ -10,3 +12,5 @@ config RPTUN_PRIORITY
 config RPTUN_STACKSIZE
 	int "rptun stack size"
 	default 2048
+
+endif # RPTUN

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if SENSORS
+
 config SENSORS_APDS9960
 	bool "Avago APDS-9960 Gesture Sensor support"
 	default n
@@ -843,3 +845,5 @@ config SENSORS_ADT7320
 	select SPI
 	---help---
 		Enables support for the ADT7320 Driver
+
+endif # SENSORS

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+config ARCH_HAVE_SERIAL_TERMIOS
+	bool
+	default n
+
+if SERIAL
+
 config DEV_LOWCONSOLE
 	bool "Low-level console support"
 	default n
@@ -158,10 +164,6 @@ config SERIAL_TIOCSERGSTRUCT
 		IOCTL is not supported in order to reduce footprint.  But if (1) the driver
 		supports the TIOCSERGSTRUCT ioctl, and (2) this option is selected, then
 		support for the TIOCSERGSTRUCT will be enabled.
-
-config ARCH_HAVE_SERIAL_TERMIOS
-	bool
-	default n
 
 config SERIAL_TERMIOS
 	bool "Serial TERMIOS support"
@@ -617,3 +619,5 @@ config PSEUDOTERM_TXBUFSIZE
 		Slave-to-master pipe buffer size.  Default: 256
 
 endif # PSEUDOTERM
+
+endif # SERIAL

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -3,6 +3,18 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+config ARCH_HAVE_SPI_CRCGENERATION
+	bool
+	default n
+
+config ARCH_HAVE_SPI_CS_CONTROL
+	bool
+	default n
+
+config ARCH_HAVE_SPI_BITORDER
+	bool
+	default n
+
 menuconfig SPI
 	bool "SPI Driver Support"
 	default n
@@ -12,18 +24,6 @@ menuconfig SPI
 		See include/nuttx/spi/spi.h for further SPI driver information.
 
 if SPI
-
-config ARCH_HAVE_SPI_CRCGENERATION
-bool
-default n
-
-config ARCH_HAVE_SPI_CS_CONTROL
-bool
-default n
-
-config ARCH_HAVE_SPI_BITORDER
-bool
-default n
 
 config SPI_SLAVE
 	bool "SPI slave"

--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -5,6 +5,14 @@
 
 menu "Timer Driver Support"
 
+config ARCH_HAVE_PWM_PULSECOUNT
+	bool
+	default n
+
+config ARCH_HAVE_PWM_MULTICHAN
+	bool
+	default n
+
 config PWM
 	bool "PWM Driver Support"
 	default n
@@ -13,14 +21,6 @@ config PWM
 		See include/nuttx/timers/pwm.h for further PWM driver information.
 
 if PWM
-
-config ARCH_HAVE_PWM_PULSECOUNT
-	bool
-	default n
-
-config ARCH_HAVE_PWM_MULTICHAN
-	bool
-	default n
 
 config PWM_PULSECOUNT
 	bool "PWM Pulse Count Support"

--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if USBDEV
+
 comment "USB Device Controller Driver Options"
 
 config USBDEV_ISOCHRONOUS
@@ -995,3 +997,5 @@ config CDCECM_PRODUCTSTR
 
 endif # !CDCECM_COMPOSITE
 endif # CDCECM
+
+endif # USBDEV

--- a/drivers/usbhost/Kconfig
+++ b/drivers/usbhost/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+config USBHOST_HAVE_ASYNCH
+	bool
+	default n
+
+if USBHOST
+
 config USBHOST_NPREALLOC
 	int "Number of pre-allocated class instances"
 	default 4
@@ -29,10 +35,6 @@ config USBHOST_ISOC_DISABLE
 	---help---
 		On some architectures, selecting this setting will reduce driver size
 		by disabling isochronous endpoint support
-
-config USBHOST_HAVE_ASYNCH
-	bool
-	default n
 
 config USBHOST_ASYNCH
 	bool "Asynchronous transfer support"
@@ -591,3 +593,5 @@ config USBHOST_TRACE_VERBOSE
 		information would also be included.
 
 endif
+
+endif # USBHOST

--- a/drivers/usbmisc/Kconfig
+++ b/drivers/usbmisc/Kconfig
@@ -3,6 +3,8 @@
 # see misc/tools/kconfig-language.txt.
 #
 
+if USBMISC
+
 comment "USB Miscellaneous drivers"
 
 config FUSB301
@@ -60,3 +62,5 @@ config FUSB303_NPOLLWAITERS
 		Maximum number of threads that can be waiting on poll()
 
 endif
+
+endif # USBMISC

--- a/drivers/usbmonitor/Kconfig
+++ b/drivers/usbmonitor/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+config HAVE_USBTRACE
+	bool
+	default n
+
+if USBMONITOR
+
 config USBMONITOR_STACKSIZE
 	int "USB Monitor daemon stack size"
 	default 2048
@@ -55,3 +61,5 @@ config USBMONITOR_TRACEINTERRUPTS
 		Show interrupt-related events
 
 endif # USBDEV && USBDEV_TRACE
+
+endif # USBMONITOR

--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if DRIVERS_VIDEO
+
 config VIDEO_FB
 	bool "Framebuffer character driver"
 	default n
@@ -163,3 +165,5 @@ config OV2640_REGDEBUG
 		Enable details, register level debug output.
 
 endif
+
+endif # DRIVERS_VIDEO

--- a/drivers/wireless/Kconfig
+++ b/drivers/wireless/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+if DRIVERS_WIRELESS
+
 config WL_CC1101
 	bool "CC1101 RF transceiver support"
 	default n
@@ -132,3 +134,5 @@ config WL_NRF24L01_RXFIFO_LEN
 
 endif # WL_NRF24L01_RXSUPPORT
 endif # WL_NRF24L01
+
+endif # DRIVERS_WIRELESS


### PR DESCRIPTION
and make ARCH_HAVE_XXX option always selectable by moving out of if/endif

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>