### PR TITLE
drivers/telnet: Stop the loop if SIGSTP char is match

### DIFF
--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -308,6 +308,7 @@ static void telnet_check_ctrlchar(FAR struct telnet_dev_s *priv,
         }
       else
 #endif
+
 #ifdef CONFIG_TTY_SIGSTP
       /* Is this the special character that will generate the SIGSTP signal? */
 
@@ -318,6 +319,9 @@ static void telnet_check_ctrlchar(FAR struct telnet_dev_s *priv,
            */
 
           signo = SIGSTP;
+#ifndef CONFIG_TTY_SIGINT
+          break;
+#endif
         }
 #endif
     }


### PR DESCRIPTION
drivers/telnet: Stop the loop if SIGSTP char is match and SIGINT not enabled
