### PR TITLE
boards: stm32f4discovery: Modify a default path to a romfs image

### DIFF
--- a/boards/arm/stm32/stm32f4discovery/Kconfig
+++ b/boards/arm/stm32/stm32f4discovery/Kconfig
@@ -32,7 +32,7 @@ config STM32_ROMFS_MOUNTPOINT
 config STM32_ROMFS_IMAGEFILE
 	string "ROMFS image file to include into build"
 	depends on STM32_ROMFS
-	default "../../../rom.img"
+	default "../../../../../rom.img"
 
 config STM32F4DISCO_USBHOST_STACKSIZE
 	int "USB host waiter stack size"


### PR DESCRIPTION
Modify a default path to a romfs image because the stm32f4discovery directory has been moved from configs/ to boards/arm/stm32/.