### PR TITLE
net/pkt:  Fix inconsistent use of FAR

### DIFF
--- a/net/pkt/pkt.h
+++ b/net/pkt/pkt.h
@@ -289,8 +289,8 @@ void pkt_poll(FAR struct net_driver_s *dev, FAR struct pkt_conn_s *conn);
  * Name: psock_pkt_send
  *
  * Description:
- *   The psock_pkt_send() call may be used only when the packet socket is in a
- *   connected state (so that the intended recipient is known).
+ *   The psock_pkt_send() call may be used only when the packet socket is in
+ *   a connected state (so that the intended recipient is known).
  *
  * Input Parameters:
  *   psock    An instance of the internal socket structure.

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -96,7 +96,7 @@ static dq_queue_t g_active_pkt_connections;
  *
  ****************************************************************************/
 
-static inline void _pkt_semtake(sem_t *sem)
+static inline void _pkt_semtake(FAR sem_t *sem)
 {
   net_lockedwait_uninterruptible(sem);
 }

--- a/net/pkt/pkt_input.c
+++ b/net/pkt/pkt_input.c
@@ -2,7 +2,7 @@
  * net/pkt/pkt_input.c
  * Handling incoming packet input
  *
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2014, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Adapted for NuttX from logic in uIP which also has a BSD-like license:
@@ -58,7 +58,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define PKTBUF ((struct eth_hdr_s *)&dev->d_buf)
+#define PKTBUF ((FAR struct eth_hdr_s *)&dev->d_buf)
 
 /****************************************************************************
  * Public Functions
@@ -87,7 +87,7 @@
 int pkt_input(struct net_driver_s *dev)
 {
   FAR struct pkt_conn_s *conn;
-  FAR struct eth_hdr_s  *pbuf = (struct eth_hdr_s *)dev->d_buf;
+  FAR struct eth_hdr_s  *pbuf = (FAR struct eth_hdr_s *)dev->d_buf;
   int ret = OK;
 
   conn = pkt_active(pbuf);

--- a/net/pkt/pkt_recvfrom.c
+++ b/net/pkt/pkt_recvfrom.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * net/pkt/pkt_recvfrom.c
  *
- *   Copyright (C) 2007-2009, 2011-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2011-2017, 2020 Gregory Nutt. All rights
+ *     reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,11 +69,11 @@
 struct pkt_recvfrom_s
 {
   FAR struct devif_callback_s *pr_cb;  /* Reference to callback instance */
-  sem_t    pr_sem;                     /* Semaphore signals recv completion */
-  size_t   pr_buflen;                  /* Length of receive buffer */
-  uint8_t *pr_buffer;                  /* Pointer to receive buffer */
-  ssize_t  pr_recvlen;                 /* The received length */
-  int      pr_result;                  /* Success:OK, failure:negated errno */
+  sem_t        pr_sem;                 /* Semaphore signals recv completion */
+  size_t       pr_buflen;              /* Length of receive buffer */
+  FAR uint8_t *pr_buffer;              /* Pointer to receive buffer */
+  ssize_t      pr_recvlen;             /* The received length */
+  int          pr_result;              /* Success:OK, failure:negated errno */
 };
 
 /****************************************************************************
@@ -293,7 +294,8 @@ static void pkt_recvfrom_initialize(FAR struct socket *psock, FAR void *buf,
  *
  ****************************************************************************/
 
-static ssize_t pkt_recvfrom_result(int result, struct pkt_recvfrom_s *pstate)
+static ssize_t pkt_recvfrom_result(int result,
+                                   FAR struct pkt_recvfrom_s *pstate)
 {
   /* Check for a error/timeout detected by the event handler.  Errors are
    * signaled by negative errno values for the rcv length
@@ -308,8 +310,9 @@ static ssize_t pkt_recvfrom_result(int result, struct pkt_recvfrom_s *pstate)
       return pstate->pr_result;
     }
 
-  /* If net_lockedwait failed, then we were probably reawakened by a signal. In
-   * this case, net_lockedwait will have returned negated errno appropriately.
+  /* If net_lockedwait failed, then we were probably reawakened by a signal.
+   * In this case, net_lockedwait will have returned negated errno
+   * appropriately.
    */
 
   if (result < 0)
@@ -356,8 +359,8 @@ static ssize_t pkt_recvfrom_result(int result, struct pkt_recvfrom_s *pstate)
  ****************************************************************************/
 
 ssize_t pkt_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
-                      int flags, FAR struct sockaddr *from,
-                      FAR socklen_t *fromlen)
+                     int flags, FAR struct sockaddr *from,
+                     FAR socklen_t *fromlen)
 {
   FAR struct pkt_conn_s *conn = (FAR struct pkt_conn_s *)psock->s_conn;
   FAR struct net_driver_s *dev;
@@ -397,8 +400,8 @@ ssize_t pkt_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
       goto errout_with_state;
     }
 
-  /* TODO pkt_recvfrom_initialize() expects from to be of type sockaddr_in, but
-   * in our case is sockaddr_ll
+  /* TODO pkt_recvfrom_initialize() expects from to be of type sockaddr_in,
+   * but in our case is sockaddr_ll
    */
 
 #if 0

--- a/net/pkt/pkt_send.c
+++ b/net/pkt/pkt_send.c
@@ -153,8 +153,8 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
  * Name: psock_pkt_send
  *
  * Description:
- *   The psock_pkt_send() call may be used only when the packet socket is in a
- *   connected state (so that the intended recipient is known).
+ *   The psock_pkt_send() call may be used only when the packet socket is in
+ *   a connected state (so that the intended recipient is known).
  *
  * Input Parameters:
  *   psock    An instance of the internal socket structure.
@@ -253,8 +253,9 @@ ssize_t psock_pkt_send(FAR struct socket *psock, FAR const void *buf,
       return state.snd_sent;
     }
 
-  /* If net_lockedwait failed, then we were probably reawakened by a signal. In
-   * this case, net_lockedwait will have returned negated errno appropriately.
+  /* If net_lockedwait failed, then we were probably reawakened by a signal.
+   * In this case, net_lockedwait will have returned negated errno
+   * appropriately.
    */
 
   if (ret < 0)

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -74,8 +74,9 @@ static int        pkt_getpeername(FAR struct socket *psock,
 static int        pkt_listen(FAR struct socket *psock, int backlog);
 static int        pkt_connect(FAR struct socket *psock,
                     FAR const struct sockaddr *addr, socklen_t addrlen);
-static int        pkt_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
-                   FAR socklen_t *addrlen, FAR struct socket *newsock);
+static int        pkt_accept(FAR struct socket *psock,
+                   FAR struct sockaddr *addr, FAR socklen_t *addrlen,
+                   FAR struct socket *newsock);
 static int        pkt_poll_local(FAR struct socket *psock,
                     FAR struct pollfd *fds, bool setup);
 static ssize_t    pkt_send(FAR struct socket *psock, FAR const void *buf,
@@ -303,7 +304,8 @@ static int pkt_connect(FAR struct socket *psock,
  * Input Parameters:
  *   psock    Reference to the listening socket structure
  *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr', Return: returned size of 'addr'
+ *   addrlen  Input: allocated size of 'addr', Return: returned size of
+ *            'addr'
  *   newsock  Location to return the accepted socket information.
  *
  * Returned Value:
@@ -341,8 +343,8 @@ static int pkt_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
  *
  ****************************************************************************/
 
-static int pkt_bind(FAR struct socket *psock, FAR const struct sockaddr *addr,
-                    socklen_t addrlen)
+static int pkt_bind(FAR struct socket *psock,
+                    FAR const struct sockaddr *addr, socklen_t addrlen)
 {
   int ifindex;
 
@@ -433,10 +435,10 @@ static int pkt_getsockname(FAR struct socket *psock,
  * Name: pkt_getpeername
  *
  * Description:
- *   The pkt_getpeername() function retrieves the remote-connected name of the
- *   specified packet socket, stores this address in the sockaddr structure
- *   pointed to by the 'addr' argument, and stores the length of this
- *   address in the object pointed to by the 'addrlen' argument.
+ *   The pkt_getpeername() function retrieves the remote-connected name of
+ *   the specified packet socket, stores this address in the sockaddr
+ *   structure pointed to by the 'addr' argument, and stores the length of
+ *   this address in the object pointed to by the 'addrlen' argument.
  *
  *   If the actual length of the address is greater than the length of the
  *   supplied sockaddr structure, the stored address will be truncated.
@@ -551,8 +553,8 @@ static ssize_t pkt_send(FAR struct socket *psock, FAR const void *buf,
     }
   else
     {
-      /* EDESTADDRREQ.  Signifies that the socket is not connection-mode and no peer
-       * address is set.
+      /* EDESTADDRREQ.  Signifies that the socket is not connection-mode and
+       * no peer address is set.
        */
 
       ret = -EDESTADDRREQ;
@@ -583,8 +585,8 @@ static ssize_t pkt_send(FAR struct socket *psock, FAR const void *buf,
  ****************************************************************************/
 
 static ssize_t pkt_sendto(FAR struct socket *psock, FAR const void *buf,
-                          size_t len, int flags, FAR const struct sockaddr *to,
-                          socklen_t tolen)
+                          size_t len, int flags,
+                          FAR const struct sockaddr *to, socklen_t tolen)
 {
   nerr("ERROR: sendto() not supported for raw packet sockets\n");
   return -EAFNOSUPPORT;


### PR DESCRIPTION
Also run all .c and .h files through nxstyle (with -m 0)