### PR TITLE
Small I2C fixups

### DIFF
--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -253,7 +253,7 @@ static int ee24xx_waitwritecomplete(FAR struct ee24xx_dev_s *eedev,
 {
   struct i2c_msg_s msgs[1];
   int ret;
-  int retries = 100;
+  int retries = 500;
   uint8_t adr;
   uint32_t addr_hi = (memaddr >> (eedev->addrlen << 3));
 

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -3,10 +3,6 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config ARCH_HAVE_I2CRESET
-	bool
-	default n
-
 if I2C
 
 config I2C_SLAVE
@@ -54,3 +50,7 @@ config I2CMULTIPLEXER_PCA9540BDP
 endmenu # I2C Multiplexer Support
 
 endif
+
+config ARCH_HAVE_I2CRESET
+	bool
+	default n


### PR DESCRIPTION
Commit a44fb6e simply switches the place of a symbol so I2C options are nested under "I2C Driver Support" properly.

Commit 0ec84b8 is for an issue I was seeing with my IMXRT platform where it seemed to poll the AT24 so fast that it burned through the 100 retries before the AT24 was ready to accept commands. 500 retries is the absolute max that you should need as 500 NACK'd transaction at 1MHz takes the same time as the AT24's max write time.