### PR TITLE
AT24 EEPROM Increase Polling Retries

### DIFF
--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -240,11 +240,6 @@ static const struct file_operations at24cs_uuid_fops =
  *
  * Use ACK polling to detect the completion of the write operation.
  * Returns TRUE if write is complete (device replies to ACK).
- * Note: The device always replies an ACK for the control byte, the polling
- * shall be done using the ACK for the memory address byte. Read or write does
- * not matter.
- * Note: We should sleep a bit between retries, the write time is around 5 ms,
- * but the bus is slow, so, a few retries at most will happen.
  *
  ****************************************************************************/
 
@@ -253,7 +248,7 @@ static int ee24xx_waitwritecomplete(FAR struct ee24xx_dev_s *eedev,
 {
   struct i2c_msg_s msgs[1];
   int ret;
-  int retries = 100;
+  int retries = 500;
   uint8_t adr;
   uint32_t addr_hi = (memaddr >> (eedev->addrlen << 3));
 


### PR DESCRIPTION
I was seeing an issue with my IMXRT platform that uses an AT24 EEPROM. Driver currently polls the AT24 after a write, and knows the write is completely when the AT24 ACKS the transfer. Right now the IMXRT seems to poll the AT24 so fast that it burns through the 100 retries before the AT24 is ready to accept commands.

500 retries is the absolute max that you should need as 500 NACK'd transaction at 1MHz takes the same time as the AT24's max write time.