### PR TITLE
Fix LMS36965 memory card detection

### DIFF
--- a/boards/arm/tiva/lm3s6965-ek/src/lm_appinit.c
+++ b/boards/arm/tiva/lm3s6965-ek/src/lm_appinit.c
@@ -64,11 +64,7 @@
 
 /* Can't support MMC/SD features if mountpoints or MMC/SPI are disabled */
 
-#if defined(CONFIG_DISABLE_MOUNTPOINT)
-#  undef NSH_HAVEMMCSD
-#endif
-
-#ifndef CONFIG_CONFIG_MMCSD_SPI
+#if defined(CONFIG_DISABLE_MOUNTPOINT) || !defined(CONFIG_MMCSD_SPI)
 #  undef NSH_HAVEMMCSD
 #endif
 

--- a/boards/arm/tiva/lm3s6965-ek/src/lm_appinit.c
+++ b/boards/arm/tiva/lm3s6965-ek/src/lm_appinit.c
@@ -39,6 +39,7 @@
 
 #include <nuttx/config.h>
 
+#include <debug.h>
 #include <stdio.h>
 #include <syslog.h>
 #include <errno.h>
@@ -128,36 +129,33 @@ int board_app_initialize(uintptr_t arg)
 
   /* Get the SPI port */
 
-  syslog(LOG_INFO, "Initializing SPI port %d\n",
-         CONFIG_NSH_MMCSDSPIPORTNO);
+  mcinfo("Initializing SPI port %d\n", CONFIG_NSH_MMCSDSPIPORTNO);
 
   spi = tiva_ssibus_initialize(CONFIG_NSH_MMCSDSPIPORTNO);
   if (!spi)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize SPI port %d\n",
+      mcerr("ERROR: Failed to initialize SPI port %d\n",
              CONFIG_NSH_MMCSDSPIPORTNO);
       return -ENODEV;
     }
 
-  syslog(LOG_INFO, "Successfully initialized SPI port %d\n",
-         CONFIG_NSH_MMCSDSPIPORTNO);
+  mcinfo("Successfully initialized SPI port %d\n", CONFIG_NSH_MMCSDSPIPORTNO);
 
   /* Bind the SPI port to the slot */
 
-  syslog(LOG_INFO, "Binding SPI port %d to MMC/SD slot %d\n",
+  mcinfo("Binding SPI port %d to MMC/SD slot %d\n",
          CONFIG_NSH_MMCSDSPIPORTNO, CONFIG_NSH_MMCSDSLOTNO);
 
   ret = mmcsd_spislotinitialize(CONFIG_NSH_MMCSDMINOR,
                                 CONFIG_NSH_MMCSDSLOTNO, spi);
   if (ret < 0)
     {
-      syslog(LOG_ERR,
-             "ERROR: Failed to bind SPI port %d to MMC/SD slot %d: %d\n",
+      mcerr("ERROR: Failed to bind SPI port %d to MMC/SD slot %d: %d\n",
              CONFIG_NSH_MMCSDSPIPORTNO, CONFIG_NSH_MMCSDSLOTNO, ret);
       return ret;
     }
 
-  syslog(LOG_INFO, "Successfully bound SPI port %d to MMC/SD slot %d\n",
+  mcinfo("Successfully bound SPI port %d to MMC/SD slot %d\n",
          CONFIG_NSH_MMCSDSPIPORTNO, CONFIG_NSH_MMCSDSLOTNO);
 #endif
   return OK;

--- a/boards/arm/tiva/lm3s6965-ek/src/lm_appinit.c
+++ b/boards/arm/tiva/lm3s6965-ek/src/lm_appinit.c
@@ -54,14 +54,7 @@
 
 /* Configuration ************************************************************/
 
-#undef NSH_HAVEUSBDEV
 #define NSH_HAVEMMCSD  1
-
-/* Can't support USB features if USB is not enabled */
-
-#ifndef CONFIG_USBDEV
-#  undef NSH_HAVEUSBDEV
-#endif
 
 /* Can't support MMC/SD features if mountpoints or MMC/SPI are disabled */
 


### PR DESCRIPTION
Some code changes to allow Stellaris LMS36965 Evaluation Kit board initialization code to run, so the MMC/SD card can be setup.