### PR TITLE
tools/nxstyle:  Allow mixed case system calls.

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1272,9 +1272,12 @@ int main(int argc, char **argv, char **envp)
                    * considered false alarms.
                    */
 
-                  /* Ignore inttype.h strings beginning with PRIx */
+                  /* Ignore inttype.h strings beginning with PRIx and
+                   * system calls beginning with SYS_
+                   */
 
-                  if ((strncmp(&line[ident_index], "PRIx", 4) == 0))
+                  if ((strncmp(&line[ident_index], "PRIx", 4) == 0) ||
+                      (strncmp(&line[ident_index], "SYS_", 4) == 0))
                     {
                       /* No error */
                     }


### PR DESCRIPTION
System calls have mixed case.  They begin with SYS_ but then are followed by the system function name in lower case.