### PR TITLE
drivers/*/Kconfig:  Consolidate driver Kconfig Files.

### DIFF
--- a/drivers/1wire/Kconfig
+++ b/drivers/1wire/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig 1WIRE
+	bool "1wire Device Support"
+	default n
+	---help---
+		Drivers for various 1wire devices.
+
 if 1WIRE
 
 config 1WIRE_DS28E17

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -76,264 +76,36 @@ endmenu # Buffering
 
 source drivers/crypto/Kconfig
 source drivers/loop/Kconfig
-
-menuconfig CAN
-	bool "CAN Driver Support"
-	default n
-	---help---
-		This selection enables building of the "upper-half" CAN driver.
-		See include/nuttx/can/can.h for further CAN driver information.
-
 source drivers/can/Kconfig
-
-menuconfig I2C
-	bool "I2C Driver Support"
-	default n
-	---help---
-		This selection enables building of the "upper-half" I2C driver.
-		See include/nuttx/i2c/i2c_master.h for further I2C driver information.
-
 source drivers/i2c/Kconfig
 source drivers/spi/Kconfig
-
-menuconfig I2S
-	bool "I2S Driver Support"
-	default n
-	---help---
-		This selection enables selection of common I2S options.  This option
-		should be enabled by all platforms that support I2S interfaces.
-		See include/nuttx/audio/i2s.h for further I2S driver information.
-
 source drivers/i2s/Kconfig
 source drivers/timers/Kconfig
-
-menuconfig ANALOG
-	bool "Analog Device(ADC/DAC) Support"
-	default n
-	---help---
-		This directory holds implementations of analog device drivers.
-		This includes drivers for Analog to Digital Conversion (ADC) as
-		well as drivers for Digital to Analog Conversion (DAC).
-		See include/nuttx/analog/*.h for registration information.
-
 source drivers/analog/Kconfig
-
-menuconfig DRIVERS_AUDIO
-	bool "Audio Device Support"
-	default n
-	---help---
-		Enable support for audio device drivers.  This includes drivers for
-		MP3, WMA and Ogg Vorbis encoding, decoding, as well as drivers for
-		interfacing with external DSP chips to perform custom audio functions.
-
-		NOTE: All of these drivers depend on support from the audio subsystem
-		enabled with the AUDIO selection.
-
 source drivers/audio/Kconfig
-
-menuconfig DRIVERS_VIDEO
-	bool "Video Device Support"
-	default n
-	---help---
-		Enable support for video device drivers.
-
 source drivers/video/Kconfig
-
-menuconfig BCH
-	bool "Block-to-Character (BCH) Support"
-	default n
-	---help---
-		Contains logic that may be used to convert a block driver into
-		a character driver.  This is the complementary conversion as that
-		performed by loop.c.  See include/nuttx/drivers/drivers.h for
-		registration information.
-
 source drivers/bch/Kconfig
-
-menuconfig INPUT
-	bool "Input Device Support"
-	default n
-	---help---
-		This directory holds implementations of input device drivers.
-		This includes such things as touchscreen and keypad drivers.
-		See include/nuttx/input/*.h for registration information.
-
 source drivers/input/Kconfig
 source drivers/ioexpander/Kconfig
 source drivers/lcd/Kconfig
 source drivers/leds/Kconfig
-
-# MMC/SD-related platform capabilities
-
-menuconfig MMCSD
-	bool "MMC/SD Driver Support"
-	default n
-	---help---
-		Support for MMC/SD block drivers.  MMC/SD block drivers based on
-		SPI and SDIO/MCI interfaces are supported.  See include/nuttx/mmcsd.h
-		and include/nuttx/sdio.h for further information.
-
 source drivers/mmcsd/Kconfig
-
-menuconfig MODEM
-	bool "Modem Support"
-	default n
-	---help---
-		Enable modem support.
-
 source drivers/modem/Kconfig
-
-menuconfig MTD
-	bool "Memory Technology Device (MTD) Support"
-	default n
-	---help---
-		Memory Technology Device (MTD) drivers.  Some simple drivers for
-		memory technologies like FLASH, EEPROM, NVRAM, etc.  See
-		include/nuttx/mtd/mtd.h
-
-		(Note: This is a simple memory interface and should not be
-		confused with the "real" MTD developed at infradead.org.  This
-		logic is unrelated; I just used the name MTD because I am not
-		aware of any other common way to refer to this class of devices).
-
 source drivers/mtd/Kconfig
-
-menuconfig EEPROM
-	bool "EEPROM support"
-	default n
-	---help---
-		This directory holds implementations of EEPROM drivers.
-
 source drivers/eeprom/Kconfig
-
-menuconfig NETDEVICES
-	bool "Network Device/PHY Support"
-	default n if !ARCH_HAVE_PHY
-	default y if ARCH_HAVE_PHY
-	depends on NET
-	---help---
-		Network interface driver and PHY selections.  This options enables
-		selection of drivers for external Ethernet MAC chips.  The majority
-		of MCUs, however, have built-in, internal Ethernet MAC peripherals
-		and that Ethernet support is selected in the MCU-specific
-		configuration menus.
-
-		Most Ethernet MAC drivers, whether internal or external, will
-		require configuration of an external PHY device.  That external PHY
-		device is also selected via this menu.
-
 source drivers/net/Kconfig
-
-menuconfig PIPES
-	bool "FIFO and named pipe drivers"
-	default n
-	---help---
-		FIFO and named pipe drivers.  Standard interfaces are declared
-		in include/unistd.h
-
 source drivers/pipes/Kconfig
 source drivers/power/Kconfig
-
-menuconfig RPTUN
-	bool "Remote Proc Tunnel Driver Support"
-	default n
-	depends on OPENAMP
-	---help---
-		RPTUN driver is used for multi-cores' communication.
-
 source drivers/rptun/Kconfig
-
-menuconfig SENSORS
-	bool "Sensor Device Support"
-	default n
-	---help---
-		Drivers for various sensors
-
 source drivers/sensors/Kconfig
-
-menuconfig SERIAL
-	bool "Serial Driver Support"
-	default y
-	---help---
-		Front-end character drivers for chip-specific UARTs.  This provide
-		some TTY-like functionality and are commonly used (but not required
-		for) the NuttX system console.  See also include/nuttx/serial/serial.h
-
 source drivers/serial/Kconfig
-
-menuconfig USBDEV
-	bool "USB Device Driver Support"
-	default n
-	---help---
-		USB device drivers.  See also include/nuttx/usb/usbdev.h
-
 source drivers/usbdev/Kconfig
-
-menuconfig USBHOST
-	bool "USB Host Driver Support"
-	default n
-	---help---
-		USB host drivers.  See also include/nuttx/usb/usbhost.h
-
 source drivers/usbhost/Kconfig
-
-menuconfig USBMISC
-	bool "USB Miscellaneous drivers"
-	default n
-	---help---
-		USB Miscellaneous drivers.
-
 source drivers/usbmisc/Kconfig
-
-menuconfig USBMONITOR
-	bool "USB Monitor"
-	default n
-	depends on HAVE_USBTRACE
-	---help---
-		If USB device tracing (USBDEV_TRACE) AND/OR USB host tracing
-		(USBHOST_TRACE) are enabled then this option will select the USB
-		monitor.  The USB monitor is a daemon that will periodically collect
-		the buffered USB trace data and dump it to the SYSLOG device.
-
 source drivers/usbmonitor/Kconfig
-
-menuconfig DRIVERS_WIRELESS
-	bool "Wireless Device Support"
-	default n
-	---help---
-		Drivers for various wireless devices.
-
 source drivers/wireless/Kconfig
-
-menuconfig DRIVERS_CONTACTLESS
-	bool "Contactless Device Support"
-	default n
-	---help---
-		Drivers for various contactless devices.
-
 source drivers/contactless/Kconfig
-
-menuconfig 1WIRE
-	bool "1wire Device Support"
-	default n
-	---help---
-		Drivers for various 1wire devices.
-
 source drivers/1wire/Kconfig
 source drivers/syslog/Kconfig
-
-menuconfig SPECIFIC_DRIVERS
-	bool "Board specific drivers"
-	default n
-	---help---
-		Board specific drivers located in each board/driver folder.
-
 source drivers/platform/Kconfig
-
-menuconfig DRIVERS_RF
-	bool "RF Device Support"
-	default n
-	---help---
-		Drivers for various RF devices
-
 source drivers/rf/Kconfig

--- a/drivers/analog/Kconfig
+++ b/drivers/analog/Kconfig
@@ -3,6 +3,15 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig ANALOG
+	bool "Analog Device(ADC/DAC) Support"
+	default n
+	---help---
+		This directory holds implementations of analog device drivers.
+		This includes drivers for Analog to Digital Conversion (ADC) as
+		well as drivers for Digital to Analog Conversion (DAC).
+		See include/nuttx/analog/*.h for registration information.
+
 if ANALOG
 
 config ADC

--- a/drivers/audio/Kconfig
+++ b/drivers/audio/Kconfig
@@ -3,6 +3,17 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig DRIVERS_AUDIO
+	bool "Audio Device Support"
+	default n
+	---help---
+		Enable support for audio device drivers.  This includes drivers for
+		MP3, WMA and Ogg Vorbis encoding, decoding, as well as drivers for
+		interfacing with external DSP chips to perform custom audio functions.
+
+		NOTE: All of these drivers depend on support from the audio subsystem
+		enabled with the AUDIO selection.
+
 if DRIVERS_AUDIO
 
 config AUDIO_TONE

--- a/drivers/bch/Kconfig
+++ b/drivers/bch/Kconfig
@@ -3,6 +3,15 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig BCH
+	bool "Block-to-Character (BCH) Support"
+	default n
+	---help---
+		Contains logic that may be used to convert a block driver into
+		a character driver.  This is the complementary conversion as that
+		performed by loop.c.  See include/nuttx/drivers/drivers.h for
+		registration information.
+
 if BCH
 
 config BCH_ENCRYPTION

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -7,6 +7,13 @@ config ARCH_HAVE_CAN_ERRORS
 	bool
 	default n
 
+menuconfig CAN
+	bool "CAN Driver Support"
+	default n
+	---help---
+		This selection enables building of the "upper-half" CAN driver.
+		See include/nuttx/can/can.h for further CAN driver information.
+
 if CAN
 
 config CAN_EXTID

--- a/drivers/contactless/Kconfig
+++ b/drivers/contactless/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig DRIVERS_CONTACTLESS
+	bool "Contactless Device Support"
+	default n
+	---help---
+		Drivers for various contactless devices.
+
 if DRIVERS_CONTACTLESS
 
 config CL_MFRC522

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig EEPROM
+	bool "EEPROM support"
+	default n
+	---help---
+		This directory holds implementations of EEPROM drivers.
+
 if EEPROM
 
 config SPI_EE_25XX

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -7,6 +7,13 @@ config ARCH_HAVE_I2CRESET
 	bool
 	default n
 
+menuconfig I2C
+	bool "I2C Driver Support"
+	default n
+	---help---
+		This selection enables building of the "upper-half" I2C driver.
+		See include/nuttx/i2c/i2c_master.h for further I2C driver information.
+
 if I2C
 
 config I2C_SLAVE

--- a/drivers/i2s/Kconfig
+++ b/drivers/i2s/Kconfig
@@ -3,6 +3,14 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig I2S
+	bool "I2S Driver Support"
+	default n
+	---help---
+		This selection enables selection of common I2S options.  This option
+		should be enabled by all platforms that support I2S interfaces.
+		See include/nuttx/audio/i2s.h for further I2S driver information.
+
 if I2S
 
 config AUDIO_I2SCHAR

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -3,6 +3,14 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig INPUT
+	bool "Input Device Support"
+	default n
+	---help---
+		This directory holds implementations of input device drivers.
+		This includes such things as touchscreen and keypad drivers.
+		See include/nuttx/input/*.h for registration information.
+
 if INPUT
 
 config MOUSE

--- a/drivers/mmcsd/Kconfig
+++ b/drivers/mmcsd/Kconfig
@@ -3,6 +3,8 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+# MMC/SD-related platform capabilities
+
 config ARCH_HAVE_SDIO
 	bool
 	default n
@@ -18,6 +20,14 @@ config ARCH_HAVE_SDIO_PREFLIGHT
 config ARCH_HAVE_SDIO_DELAYED_INVLDT
 	bool
 	default n
+
+menuconfig MMCSD
+	bool "MMC/SD Driver Support"
+	default n
+	---help---
+		Support for MMC/SD block drivers.  MMC/SD block drivers based on
+		SPI and SDIO/MCI interfaces are supported.  See include/nuttx/mmcsd.h
+		and include/nuttx/sdio.h for further information.
 
 if MMCSD
 

--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig MODEM
+	bool "Modem Support"
+	default n
+	---help---
+		Enable modem support.
+
 if MODEM
 
 config MODEM_U_BLOX

--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -3,9 +3,20 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-if MTD
+menuconfig MTD
+	bool "Memory Technology Device (MTD) Support"
+	default n
+	---help---
+		Memory Technology Device (MTD) drivers.  Some simple drivers for
+		memory technologies like FLASH, EEPROM, NVRAM, etc.  See
+		include/nuttx/mtd/mtd.h
 
-comment "MTD Configuration"
+		(Note: This is a simple memory interface and should not be
+		confused with the "real" MTD developed at infradead.org.  This
+		logic is unrelated; I just used the name MTD because I am not
+		aware of any other common way to refer to this class of devices).
+
+if MTD
 
 config MTD_PARTITION
 	bool "Support MTD partitions"

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -3,6 +3,22 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig NETDEVICES
+	bool "Network Device/PHY Support"
+	default n if !ARCH_HAVE_PHY
+	default y if ARCH_HAVE_PHY
+	depends on NET
+	---help---
+		Network interface driver and PHY selections.  This options enables
+		selection of drivers for external Ethernet MAC chips.  The majority
+		of MCUs, however, have built-in, internal Ethernet MAC peripherals
+		and that Ethernet support is selected in the MCU-specific
+		configuration menus.
+
+		Most Ethernet MAC drivers, whether internal or external, will
+		require configuration of an external PHY device.  That external PHY
+		device is also selected via this menu.
+
 if NETDEVICES
 
 comment "General Ethernet MAC Driver Options"

--- a/drivers/pipes/Kconfig
+++ b/drivers/pipes/Kconfig
@@ -3,6 +3,13 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig PIPES
+	bool "FIFO and named pipe drivers"
+	default n
+	---help---
+		FIFO and named pipe drivers.  Standard interfaces are declared
+		in include/unistd.h
+
 if PIPES
 
 config DEV_PIPE_MAXSIZE

--- a/drivers/rf/Kconfig
+++ b/drivers/rf/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig DRIVERS_RF
+	bool "RF Device Support"
+	default n
+	---help---
+		Drivers for various RF devices
+
 if DRIVERS_RF
 
 config RF_DAT31R5SP

--- a/drivers/rptun/Kconfig
+++ b/drivers/rptun/Kconfig
@@ -3,6 +3,13 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig RPTUN
+	bool "Remote Proc Tunnel Driver Support"
+	default n
+	depends on OPENAMP
+	---help---
+		RPTUN driver is used for multi-cores' communication.
+
 if RPTUN
 
 config RPTUN_PRIORITY

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig SENSORS
+	bool "Sensor Device Support"
+	default n
+	---help---
+		Drivers for various sensors
+
 if SENSORS
 
 config SENSORS_APDS9960

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -7,6 +7,14 @@ config ARCH_HAVE_SERIAL_TERMIOS
 	bool
 	default n
 
+menuconfig SERIAL
+	bool "Serial Driver Support"
+	default y
+	---help---
+		Front-end character drivers for chip-specific UARTs.  This provide
+		some TTY-like functionality and are commonly used (but not required
+		for) the NuttX system console.  See also include/nuttx/serial/serial.h
+
 if SERIAL
 
 config DEV_LOWCONSOLE

--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig USBDEV
+	bool "USB Device Driver Support"
+	default n
+	---help---
+		USB device drivers.  See also include/nuttx/usb/usbdev.h
+
 if USBDEV
 
 comment "USB Device Controller Driver Options"

--- a/drivers/usbhost/Kconfig
+++ b/drivers/usbhost/Kconfig
@@ -7,6 +7,12 @@ config USBHOST_HAVE_ASYNCH
 	bool
 	default n
 
+menuconfig USBHOST
+	bool "USB Host Driver Support"
+	default n
+	---help---
+		USB host drivers.  See also include/nuttx/usb/usbhost.h
+
 if USBHOST
 
 config USBHOST_NPREALLOC

--- a/drivers/usbmisc/Kconfig
+++ b/drivers/usbmisc/Kconfig
@@ -3,9 +3,13 @@
 # see misc/tools/kconfig-language.txt.
 #
 
-if USBMISC
+menuconfig USBMISC
+	bool "USB Miscellaneous drivers"
+	default n
+	---help---
+		USB Miscellaneous drivers.
 
-comment "USB Miscellaneous drivers"
+if USBMISC
 
 config FUSB301
 	bool "On Semiconductor FUSB301 USB Type-C controller support"

--- a/drivers/usbmonitor/Kconfig
+++ b/drivers/usbmonitor/Kconfig
@@ -7,6 +7,16 @@ config HAVE_USBTRACE
 	bool
 	default n
 
+menuconfig USBMONITOR
+	bool "USB Monitor"
+	default n
+	depends on HAVE_USBTRACE
+	---help---
+		If USB device tracing (USBDEV_TRACE) AND/OR USB host tracing
+		(USBHOST_TRACE) are enabled then this option will select the USB
+		monitor.  The USB monitor is a daemon that will periodically collect
+		the buffered USB trace data and dump it to the SYSLOG device.
+
 if USBMONITOR
 
 config USBMONITOR_STACKSIZE

--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig DRIVERS_VIDEO
+	bool "Video Device Support"
+	default n
+	---help---
+		Enable support for video device drivers.
+
 if DRIVERS_VIDEO
 
 config VIDEO_FB

--- a/drivers/wireless/Kconfig
+++ b/drivers/wireless/Kconfig
@@ -3,6 +3,12 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+menuconfig DRIVERS_WIRELESS
+	bool "Wireless Device Support"
+	default n
+	---help---
+		Drivers for various wireless devices.
+
 if DRIVERS_WIRELESS
 
 config WL_CC1101


### PR DESCRIPTION
This commit does two things:

1. First, it reorganizes the driver Kconfig files so that each is self contained.  Before, a part of the driver configuration was in drivers/Kconfig and the rest was in in drivers/xyz/Konfig.  Now, all of the driver configuration is consolitated in the latter.

2. Second, this commit correct numerous serious errors introduced in a previous reorganization of the driver Kconfig files.  This was first noted by Nicholas Chin in PR270 for the case of the drivers/i2c/Kconfig but some examination indicates that the error was introduced into several other Kconfig files as well.

The nature of the introduced error was basically this:

- Nothing must intervene between the menuconfig selection and the following conditional configuration otpions.
- A previous PR erroneously introduced unconditional options between the menuconfig and the following confditional logic, thus corrupting the driver menus.

This error was easy to make because the driver Kconfig files were not well modularized.  Making them fully self-contained should eliminate this kind of error in the future.