### PR TITLE
arch: armv7-a: Fix heap corruption in SMP mode

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpuhead.S
+++ b/arch/arm/src/armv7-a/arm_cpuhead.S
@@ -494,5 +494,14 @@ g_cpu3_idlestack:
 #endif /* CONFIG_SMP_NCPUS > 3 */
 #endif /* CONFIG_SMP_NCPUS > 2 */
 #endif /* CONFIG_SMP_NCPUS > 1 */
-#endif
+
+	.align	8
+	.globl	g_idle_topstack
+	.type	g_idle_topstack, object
+
+g_idle_topstack:
+	.long	_enoinit
+	.size	g_idle_topstack, .-g_idle_topstack
+
+#endif /* CONFIG_SMP */
 	.end

--- a/arch/arm/src/armv7-a/arm_head.S
+++ b/arch/arm/src/armv7-a/arm_head.S
@@ -784,6 +784,7 @@ arm_data_initialize:
  * Data section variables
  ***************************************************************************/
 
+#ifndef CONFIG_SMP
 	/* This global variable is unsigned long g_idle_topstack and is
 	 * exported from here only because of its coupling to .Linitparms
 	 * above.
@@ -804,3 +805,4 @@ g_idle_topstack:
 	.size	g_idle_topstack, .-g_idle_topstack
 #endif
 	.end
+#endif


### PR DESCRIPTION
### Summary

- Currently up_allocate_heap() assumes that g_idle_topstack points top of the heap memory. However, g_idle_topstack pointed incorrect address in SMP mode which resulted in heap corruption. This PR moves g_idle_topstack at the end of .noinit to avoid this issue.

### Impact

- This PR affects Cortex-A architectures.

### Testing

- I tested sabre-6quad:smp and sabre-6quad:nsh with QEMU.
