### PR TITLE
arch: Move iob_initialize into nx_start just after heap initialization

### DIFF
--- a/arch/arm/src/common/up_initialize.c
+++ b/arch/arm/src/common/up_initialize.c
@@ -44,7 +44,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -148,12 +147,6 @@ void up_initialize(void)
     {
       up_dma_initialize();
     }
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/avr/src/common/up_initialize.c
+++ b/arch/avr/src/common/up_initialize.c
@@ -43,7 +43,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -189,12 +188,6 @@ void up_initialize(void)
     {
       up_dma_initialize();
     }
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/hc/src/common/up_initialize.c
+++ b/arch/hc/src/common/up_initialize.c
@@ -44,7 +44,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -111,12 +110,6 @@ void up_initialize(void)
     {
       up_dma_initialize();
     }
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/mips/src/common/up_initialize.c
+++ b/arch/mips/src/common/up_initialize.c
@@ -44,7 +44,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -113,12 +112,6 @@ void up_initialize(void)
     {
       up_dma_initialize();
     }
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/misoc/src/lm32/lm32_initialize.c
+++ b/arch/misoc/src/lm32/lm32_initialize.c
@@ -44,7 +44,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -73,12 +72,6 @@ void up_initialize(void)
 
 #ifdef CONFIG_RPMSG_UART
   rpmsg_serialinit();
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
 #if 0 /* REVISIT */

--- a/arch/misoc/src/minerva/minerva_initialize.c
+++ b/arch/misoc/src/minerva/minerva_initialize.c
@@ -44,7 +44,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -73,12 +72,6 @@ void up_initialize(void)
 
 #ifdef CONFIG_RPMSG_UART
   rpmsg_serialinit();
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Initialize the network cores */

--- a/arch/or1k/src/common/up_initialize.c
+++ b/arch/or1k/src/common/up_initialize.c
@@ -44,7 +44,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -206,12 +205,6 @@ void up_initialize(void)
     {
       up_dma_initialize();
     }
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/renesas/src/common/up_initialize.c
+++ b/arch/renesas/src/common/up_initialize.c
@@ -44,7 +44,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -94,12 +93,6 @@ void up_initialize(void)
    */
 
   up_pminitialize();
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/risc-v/src/common/up_initialize.c
+++ b/arch/risc-v/src/common/up_initialize.c
@@ -43,7 +43,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/syslog/syslog.h>
 #include <nuttx/drivers/drivers.h>
@@ -113,12 +112,6 @@ void up_initialize(void)
   /* Add any extra memory fragments to the memory manager */
 
   up_addregion();
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
-#endif
 
   /* Register devices */
 

--- a/arch/sim/src/sim/up_initialize.c
+++ b/arch/sim/src/sim/up_initialize.c
@@ -43,7 +43,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/fs/ioctl.h>
@@ -190,12 +189,6 @@ void up_initialize(void)
    */
 
   pm_initialize();
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/x86/src/common/up_initialize.c
+++ b/arch/x86/src/common/up_initialize.c
@@ -44,7 +44,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -113,12 +112,6 @@ void up_initialize(void)
     {
       up_dma_initialize();
     }
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -44,7 +44,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -121,12 +120,6 @@ void up_initialize(void)
     {
       xtensa_dma_initialize();
     }
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/z16/src/common/up_initialize.c
+++ b/arch/z16/src/common/up_initialize.c
@@ -44,7 +44,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -113,12 +112,6 @@ void up_initialize(void)
    */
 
   up_pminitialize();
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/arch/z80/src/common/up_initialize.c
+++ b/arch/z80/src/common/up_initialize.c
@@ -45,7 +45,6 @@
 #include <nuttx/board.h>
 #include <nuttx/sched_note.h>
 #include <nuttx/mm/mm.h>
-#include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
@@ -112,12 +111,6 @@ void up_initialize(void)
 
 #ifdef CONFIG_ARCH_ADDRENV
   z80_mmu_initialize();
-#endif
-
-#ifdef CONFIG_MM_IOB
-  /* Initialize IO buffering */
-
-  iob_initialize();
 #endif
 
   /* Register devices */

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -51,6 +51,7 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
 #include <nuttx/lib/lib.h>
+#include <nuttx/mm/iob.h>
 #include <nuttx/mm/mm.h>
 #include <nuttx/mm/shm.h>
 #include <nuttx/kmalloc.h>
@@ -608,6 +609,12 @@ void nx_start(void)
     mm_pginitialize(heap_start, heap_size);
 #endif
   }
+#endif
+
+#ifdef CONFIG_MM_IOB
+  /* Initialize IO buffering */
+
+  iob_initialize();
 #endif
 
   /* The memory manager is available */


### PR DESCRIPTION
it doesn't make sense that iob initialization is in up_initialize
but other memory components initialization is called in nx_start

Change-Id: Id43aeaa995f340c5943f59a0067a483ff3ac34a2
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>