### PR TITLE
arch: armv7-a: Fix stack pointer alignment at startup

### DIFF
--- a/arch/arm/src/armv7-a/arm_head.S
+++ b/arch/arm/src/armv7-a/arm_head.S
@@ -631,6 +631,7 @@ __start:
 	/* Set up the stack pointer and clear the frame pointer */
 
 	ldr		sp, .Lstackpointer
+	bic		sp, sp, #7	/* Get the stack pointer with 8-byte alignment */
 	mov		fp, #0
 
 #ifndef CONFIG_BOOT_SDRAM_DATA

--- a/arch/arm/src/armv7-a/arm_pghead.S
+++ b/arch/arm/src/armv7-a/arm_pghead.S
@@ -662,7 +662,8 @@ __start:
 	/* Set up the stack pointer and clear the frame pointer */
 
 	ldr		sp, .Lstackpointer
-	mov     fp, #0
+	bic		sp, sp, #7	/* Get the stack pointer with 8-byte alignment */
+	mov		fp, #0
 
 #ifndef CONFIG_BOOT_SDRAM_DATA
 	/* Initialize .bss and .data ONLY if .bss and .data lie in SRAM that is


### PR DESCRIPTION
### Summary

- Fix stack pointer alignment for the idle task (armv7-a, non-SMP)
- For armv7-a architecture, stack pointer needs 8-byte alignment.
- Also, fix indentation in arm_pghead.S
- This PR fixes a Data abort issue on Beagle Bone Black reported by Merlin Hansen

### Impact

- This PR affects Cortex-A architectures.

### Testing

- I tested this PR with both beaglebone-black:nsh and sabre-6quad:nsh (QEMU)
- NOTE:  I did not test arm_pghead.S but should work.
