### PR TITLE
support FIONBIO/MSG_DONTWAIT

### DIFF
--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -43,6 +43,7 @@
 #include <sys/ioctl.h>
 #include <sched.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <assert.h>
 
 #include <net/if.h>
@@ -136,7 +137,6 @@ int fs_ioctl(int fd, int req, unsigned long arg)
 int ioctl(int fd, int req, unsigned long arg)
 #endif
 {
-  int errcode;
   FAR struct file *filep;
   int ret;
 
@@ -147,50 +147,65 @@ int ioctl(int fd, int req, unsigned long arg)
       /* Perform the socket ioctl */
 
 #ifdef CONFIG_NET
-      if ((unsigned int)fd < (CONFIG_NFILE_DESCRIPTORS + CONFIG_NSOCKET_DESCRIPTORS))
+      if ((unsigned int)fd <
+          (CONFIG_NFILE_DESCRIPTORS + CONFIG_NSOCKET_DESCRIPTORS))
         {
           ret = netdev_ioctl(fd, req, arg);
-          if (ret < 0)
-            {
-              errcode = -ret;
-              goto errout;
-            }
-
-          return ret;
         }
       else
 #endif
         {
-          errcode = EBADF;
+          ret = -EBADF;
           goto errout;
         }
     }
-
-  /* Get the file structure corresponding to the file descriptor. */
-
-  ret = fs_getfilep(fd, &filep);
-  if (ret < 0)
+  else
     {
-      errcode = -ret;
-      goto errout;
+      /* Get the file structure corresponding to the file descriptor. */
+
+      ret = fs_getfilep(fd, &filep);
+      if (ret < 0)
+        {
+          goto errout;
+        }
+
+      DEBUGASSERT(filep != NULL);
+
+      /* Perform the file ioctl. */
+
+      ret = file_ioctl(filep, req, arg);
     }
 
-  DEBUGASSERT(filep != NULL);
+  /* Check for File system IOCTL commands */
 
-  /* Perform the file ioctl.  If file_ioctl() fails, it will set the errno
-   * value appropriately.
-   */
+  if (ret == -ENOTTY)
+    {
+      switch (req)
+        {
+          case FIONBIO:
+            {
+              if (*(FAR int *)((uintptr_t)arg))
+                {
+                  return fcntl(fd, F_SETFL,
+                               fcntl(fd, F_GETFL) | O_NONBLOCK);
+                }
+              else
+                {
+                  return fcntl(fd, F_SETFL,
+                               fcntl(fd, F_GETFL) & ~O_NONBLOCK);
+                }
+            }
+            break;
+        }
+    }
 
-  ret = file_ioctl(filep, req, arg);
+errout:
+
   if (ret < 0)
     {
-      errcode = -ret;
-      goto errout;
+      set_errno(-ret);
+      ret = ERROR;
     }
 
   return ret;
-
-errout:
-  set_errno(errcode);
-  return ERROR;
 }

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -66,6 +66,7 @@
 #define O_DSYNC     O_SYNC          /* Equivalent to OSYNC in NuttX */
 #define O_BINARY    (1 << 8)        /* Open the file in binary (untranslated) mode. */
 #define O_DIRECT    (1 << 9)        /* Avoid caching, write directly to hardware */
+#define O_CLOEXEC   (1 << 10)       /* Close on execute */
 
 /* Unsupported, but required open flags */
 

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -172,6 +172,10 @@
                                            * OUT: Instance number is returned on
                                            *      success.
                                            */
+#define FIONBIO         _FIOC(0x000b)     /* IN:  Boolean option takes an
+                                           *      int value.
+                                           * OUT: Origin option.
+                                           */
 
 /* NuttX file system ioctl definitions **************************************/
 

--- a/include/sys/file.h
+++ b/include/sys/file.h
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * include/sys/file.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ********************************************************************************/
+
+#ifndef __INCLUDE_SYS_FILE_H
+#define __INCLUDE_SYS_FILE_H
+
+#include <unistd.h>
+#include <fcntl.h>
+
+#endif /* __INCLUDE_SYS_FILE_H */

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -301,6 +301,9 @@ typedef CODE int (*main_t)(int argc, FAR char *argv[]);
 
 #endif /* __ASSEMBLY__ */
 
+/* Defines `fd_set' and the FD_* macros for `select'. */
+#include <sys/select.h>
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/include/time.h
+++ b/include/time.h
@@ -240,6 +240,8 @@ int nanosleep(FAR const struct timespec *rqtp, FAR struct timespec *rmtp);
 void tzset(void);
 #endif
 
+#include <sys/time.h>
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/libs/libc/stdio/lib_getdelim.c
+++ b/libs/libc/stdio/lib_getdelim.c
@@ -53,7 +53,7 @@
  */
 
 #undef HAVE_GETLINE
-#if defined(CONFIG_EOL_IS_CR)
+#if defined(CONFIG_EOL_IS_CR) || defined(CONFIG_EOL_IS_EITHER_CRLF)
 #  define HAVE_GETLINE 1
 #  define EOLCH        '/r'
 #elif defined(CONFIG_EOL_IS_LF)

--- a/libs/libc/stdio/lib_getdelim.c
+++ b/libs/libc/stdio/lib_getdelim.c
@@ -55,10 +55,10 @@
 #undef HAVE_GETLINE
 #if defined(CONFIG_EOL_IS_CR) || defined(CONFIG_EOL_IS_EITHER_CRLF)
 #  define HAVE_GETLINE 1
-#  define EOLCH        '/r'
+#  define EOLCH        '\r'
 #elif defined(CONFIG_EOL_IS_LF)
 #  define HAVE_GETLINE 1
-#  define EOLCH        '/n'
+#  define EOLCH        '\n'
 #endif
 
 #define BUFSIZE_INIT   64

--- a/libs/libc/time/lib_gmtimer.c
+++ b/libs/libc/time/lib_gmtimer.c
@@ -51,10 +51,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define SEC_PER_MIN  ((time_t)60)
-#define SEC_PER_HOUR ((time_t)60 * SEC_PER_MIN)
-#define SEC_PER_DAY  ((time_t)24 * SEC_PER_HOUR)
-
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -1076,11 +1076,11 @@ static ssize_t inet_send(FAR struct socket *psock, FAR const void *buf,
             {
               /* TCP/IP packet send */
 
-              ret = psock_tcp_send(psock, buf, len);
+              ret = psock_tcp_send(psock, buf, len, flags);
             }
 #endif /* NET_TCP_HAVE_STACK */
 #elif defined(NET_TCP_HAVE_STACK)
-          ret = psock_tcp_send(psock, buf, len);
+          ret = psock_tcp_send(psock, buf, len, flags);
 #else
           ret = -ENOSYS;
 #endif /* CONFIG_NET_6LOWPAN */
@@ -1348,7 +1348,7 @@ static ssize_t inet_recvfrom(FAR struct socket *psock, FAR void *buf,
     case SOCK_STREAM:
       {
 #ifdef NET_TCP_HAVE_STACK
-        ret = psock_tcp_recvfrom(psock, buf, len, from, fromlen);
+        ret = psock_tcp_recvfrom(psock, buf, len, flags, from, fromlen);
 #else
         ret = -ENOSYS;
 #endif
@@ -1360,7 +1360,7 @@ static ssize_t inet_recvfrom(FAR struct socket *psock, FAR void *buf,
     case SOCK_DGRAM:
       {
 #ifdef NET_UDP_HAVE_STACK
-        ret = psock_udp_recvfrom(psock, buf, len, from, fromlen);
+        ret = psock_udp_recvfrom(psock, buf, len, flags, from, fromlen);
 #else
         ret = -ENOSYS;
 #endif

--- a/net/local/local_recvfrom.c
+++ b/net/local/local_recvfrom.c
@@ -279,7 +279,8 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
   /* Open the receiving side of the transfer */
 
-  ret = local_open_receiver(conn, _SS_ISNONBLOCK(psock->s_flags));
+  ret = local_open_receiver(conn, _SS_ISNONBLOCK(psock->s_flags) ||
+                            (flags & MSG_DONTWAIT) != 0);
   if (ret < 0)
     {
       nerr("ERROR: Failed to open FIFO for %s: %d\n",

--- a/net/local/local_sendto.c
+++ b/net/local/local_sendto.c
@@ -138,7 +138,8 @@ ssize_t psock_local_sendto(FAR struct socket *psock, FAR const void *buf,
   /* Open the sending side of the transfer */
 
   ret = local_open_sender(conn, unaddr->sun_path,
-                          _SS_ISNONBLOCK(psock->s_flags));
+                          _SS_ISNONBLOCK(psock->s_flags) ||
+                          (flags & MSG_DONTWAIT) != 0);
   if (ret < 0)
     {
       nerr("ERROR: Failed to open FIFO for %s: %d\n",

--- a/net/netlink/netlink_route.c
+++ b/net/netlink/netlink_route.c
@@ -1058,7 +1058,7 @@ ssize_t netlink_route_recvfrom(FAR struct socket *psock,
        * select Netlink non-blocking sockets.
        */
 
-      if (_SS_ISNONBLOCK(psock->s_flags))
+      if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
         {
           return -EAGAIN;
         }

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1274,10 +1274,12 @@ int psock_tcp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
  *   Perform the recvfrom operation for a TCP/IP SOCK_STREAM
  *
  * Input Parameters:
- *   psock  Pointer to the socket structure for the SOCK_DRAM socket
- *   buf    Buffer to receive data
- *   len    Length of buffer
- *   from   INET address of source (may be NULL)
+ *   psock    Pointer to the socket structure for the SOCK_DRAM socket
+ *   buf      Buffer to receive data
+ *   len      Length of buffer
+ *   flags    Receive flags
+ *   from     INET address of source (may be NULL)
+ *   fromlen  The length of the address structure
  *
  * Returned Value:
  *   On success, returns the number of characters received.  On  error,
@@ -1288,7 +1290,7 @@ int psock_tcp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
  ****************************************************************************/
 
 ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
-                           size_t len, FAR struct sockaddr *from,
+                           size_t len, int flags, FAR struct sockaddr *from,
                            FAR socklen_t *fromlen);
 
 /****************************************************************************
@@ -1302,6 +1304,7 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
  *   psock    An instance of the internal socket structure.
  *   buf      Data to send
  *   len      Length of data to send
+ *   flags    Send flags
  *
  * Returned Value:
  *   On success, returns the number of characters sent.  On  error,
@@ -1350,7 +1353,7 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
 
 struct socket;
 ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
-                       size_t len);
+                       size_t len, int flags);
 
 /****************************************************************************
  * Name: tcp_setsockopt

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -628,10 +628,12 @@ static ssize_t tcp_recvfrom_result(int result, struct tcp_recvfrom_s *pstate)
  *   Perform the recvfrom operation for a TCP/IP SOCK_STREAM
  *
  * Input Parameters:
- *   psock  Pointer to the socket structure for the SOCK_DRAM socket
- *   buf    Buffer to receive data
- *   len    Length of buffer
- *   from   INET address of source (may be NULL)
+ *   psock    Pointer to the socket structure for the SOCK_DRAM socket
+ *   buf      Buffer to receive data
+ *   len      Length of buffer
+ *   flags    Receive flags
+ *   from     INET address of source (may be NULL)
+ *   fromlen  The length of the address structure
  *
  * Returned Value:
  *   On success, returns the number of characters received.  On  error,
@@ -642,7 +644,7 @@ static ssize_t tcp_recvfrom_result(int result, struct tcp_recvfrom_s *pstate)
  ****************************************************************************/
 
 ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
-                           size_t len, FAR struct sockaddr *from,
+                           size_t len, int flags, FAR struct sockaddr *from,
                            FAR socklen_t *fromlen)
 {
   struct tcp_recvfrom_s state;
@@ -702,7 +704,7 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
    * if no data was obtained from the read-ahead buffers.
    */
 
-  else if (_SS_ISNONBLOCK(psock->s_flags))
+  else if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
     {
       /* Return the number of bytes read from the read-ahead buffer if
        * something was received (already in 'ret'); EAGAIN if not.

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -886,6 +886,7 @@ static inline void send_txnotify(FAR struct socket *psock,
  *   psock    An instance of the internal socket structure.
  *   buf      Data to send
  *   len      Length of data to send
+ *   flags    Send flags
  *
  * Returned Value:
  *   On success, returns the number of characters sent.  On  error,
@@ -931,11 +932,12 @@ static inline void send_txnotify(FAR struct socket *psock,
  ****************************************************************************/
 
 ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
-                       size_t len)
+                       size_t len, int flags)
 {
   FAR struct tcp_conn_s *conn;
   FAR struct tcp_wrbuffer_s *wrb;
   ssize_t    result = 0;
+  bool       nonblock;
   int        ret = OK;
 
   if (psock == NULL || psock->s_crefs <= 0)
@@ -990,6 +992,8 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
     }
 #endif /* CONFIG_NET_ARP_SEND || CONFIG_NET_ICMPv6_NEIGHBOR */
 
+  nonblock = _SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0;
+
   /* Dump the incoming buffer */
 
   BUF_DUMP("psock_tcp_send", buf, len);
@@ -1001,7 +1005,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
        */
 
       net_lock();
-      if (_SS_ISNONBLOCK(psock->s_flags))
+      if (nonblock)
         {
           wrb = tcp_wrbuffer_tryalloc();
         }
@@ -1015,7 +1019,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
           /* A buffer allocation error occurred */
 
           nerr("ERROR: Failed to allocate write buffer\n");
-          ret = _SS_ISNONBLOCK(psock->s_flags) ? -EAGAIN : -ENOMEM;
+          ret = nonblock ? -EAGAIN : -ENOMEM;
           goto errout_with_lock;
         }
 
@@ -1033,7 +1037,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
           /* A buffer allocation error occurred */
 
           nerr("ERROR: Failed to allocate callback\n");
-          ret = _SS_ISNONBLOCK(psock->s_flags) ? -EAGAIN : -ENOMEM;
+          ret = nonblock ? -EAGAIN : -ENOMEM;
           goto errout_with_wrb;
         }
 
@@ -1053,7 +1057,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
        * buffer space if the socket was opened non-blocking.
        */
 
-      if (_SS_ISNONBLOCK(psock->s_flags))
+      if (nonblock)
         {
           /* The return value from TCP_WBTRYCOPYIN is either OK or
            * -ENOMEM if less than the entire data chunk could be allocated.

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -537,6 +537,7 @@ static inline void send_txnotify(FAR struct socket *psock,
  *   psock    An instance of the internal socket structure.
  *   buf      Data to send
  *   len      Length of data to send
+ *   flags    Send flags
  *
  * Returned Value:
  *   On success, returns the number of characters sent.  On  error,
@@ -582,7 +583,7 @@ static inline void send_txnotify(FAR struct socket *psock,
  ****************************************************************************/
 
 ssize_t psock_tcp_send(FAR struct socket *psock,
-                       FAR const void *buf, size_t len)
+                       FAR const void *buf, size_t len, int flags)
 {
   FAR struct tcp_conn_s *conn;
   struct send_s state;

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -644,10 +644,12 @@ uint16_t udp_callback(FAR struct net_driver_s *dev,
  *   Perform the recvfrom operation for a UDP SOCK_DGRAM
  *
  * Input Parameters:
- *   psock  Pointer to the socket structure for the SOCK_DRAM socket
- *   buf    Buffer to receive data
- *   len    Length of buffer
- *   from   INET address of source (may be NULL)
+ *   psock    Pointer to the socket structure for the SOCK_DRAM socket
+ *   buf      Buffer to receive data
+ *   len      Length of buffer
+ *   flags    Receive flags
+ *   from     INET address of source (may be NULL)
+ *   fromlen  The length of the address structure
  *
  * Returned Value:
  *   On success, returns the number of characters received.  On  error,
@@ -658,7 +660,7 @@ uint16_t udp_callback(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR void *buf,
-                           size_t len, FAR struct sockaddr *from,
+                           size_t len, int flags, FAR struct sockaddr *from,
                            FAR socklen_t *fromlen);
 
 /****************************************************************************

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -606,7 +606,7 @@ static ssize_t udp_recvfrom_result(int result, struct udp_recvfrom_s *pstate)
  ****************************************************************************/
 
 ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR void *buf,
-                           size_t len, FAR struct sockaddr *from,
+                           size_t len, int flags, FAR struct sockaddr *from,
                            FAR socklen_t *fromlen)
 {
   FAR struct udp_conn_s *conn = (FAR struct udp_conn_s *)psock->s_conn;
@@ -637,7 +637,7 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR void *buf,
 
   /* Handle non-blocking UDP sockets */
 
-  if (_SS_ISNONBLOCK(psock->s_flags))
+  if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
     {
       /* Return the number of bytes read from the read-ahead buffer if
        * something was received (already in 'ret'); EAGAIN if not.

--- a/net/usrsock/usrsock_recvfrom.c
+++ b/net/usrsock/usrsock_recvfrom.c
@@ -308,7 +308,7 @@ ssize_t usrsock_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
       if (!(conn->flags & USRSOCK_EVENT_RECVFROM_AVAIL))
         {
-          if (_SS_ISNONBLOCK(psock->s_flags))
+          if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
             {
               /* Nothing to receive from daemon side. */
 

--- a/net/usrsock/usrsock_sendto.c
+++ b/net/usrsock/usrsock_sendto.c
@@ -294,7 +294,7 @@ ssize_t usrsock_sendto(FAR struct socket *psock, FAR const void *buf,
 
       if (!(conn->flags & USRSOCK_EVENT_SENDTO_READY))
         {
-          if (_SS_ISNONBLOCK(psock->s_flags))
+          if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
             {
               /* Send busy at daemon side. */
 

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1116,6 +1116,12 @@ config NAME_MAX
 	---help---
 	The maximum size of a file name.
 
+config PATH_MAX
+	int "Maximum size of path name"
+	default 256
+	---help---
+	The maximum size of path name.
+
 endmenu # Files and I/O
 
 menuconfig PRIORITY_INHERITANCE


### PR DESCRIPTION
time/gmtimer: remove unnecessary definition
stdio/getline: correct the character slash
stdio/getline: enable getline in either CRLF
Kconfig: add PATH_MAX config
time: nest sys/time.h to avoid undefined types
type/select: add select fd_set to types include
net/socket: add MSG_DONTWAIT support
net/ioctl: add FIONBIO support
sys/file: dummy header for POSIX compliance
fcntl: add O_CLOEXEC flag