### PR TITLE
Fix non C89 noncompliant code that causes ZDS-II compile failures

### DIFF
--- a/libs/libc/unistd/lib_alarm.c
+++ b/libs/libc/unistd/lib_alarm.c
@@ -70,10 +70,12 @@ unsigned int alarm(unsigned int seconds)
 {
   struct itimerval value =
   {
+    0, 0
   };
 
   struct itimerval ovalue =
   {
+    0, 0
   };
 
   value.it_value.tv_sec = seconds;

--- a/mm/mm_heap/mm_addfreechunk.c
+++ b/mm/mm_heap/mm_addfreechunk.c
@@ -60,13 +60,14 @@ void mm_addfreechunk(FAR struct mm_heap_s *heap, FAR struct mm_freenode_s *node)
 {
   FAR struct mm_freenode_s *next;
   FAR struct mm_freenode_s *prev;
+  int ndx;
 
   DEBUGASSERT(node->size >= SIZEOF_MM_FREENODE);
   DEBUGASSERT((node->preceding & MM_ALLOC_BIT) == 0);
 
   /* Convert the size to a nodelist index */
 
-  int ndx = mm_size2ndx(node->size);
+  ndx = mm_size2ndx(node->size);
 
   /* Now put the new node into the next */
 

--- a/sched/timer/timer_getitimer.c
+++ b/sched/timer/timer_getitimer.c
@@ -86,6 +86,7 @@ int getitimer(int which, FAR struct itimerval *value)
   FAR struct tcb_s *rtcb = this_task();
   struct itimerspec spec =
   {
+    0, 0
   };
 
   int ret = OK;


### PR DESCRIPTION
Breaks several architectures that do not use GCC