### PR TITLE
libs/libc/time/lib_gmtimer.c:  Fix compile problem from PR317

### DIFF
--- a/libs/libc/time/lib_gmtimer.c
+++ b/libs/libc/time/lib_gmtimer.c
@@ -46,6 +46,7 @@
 #include <debug.h>
 
 #include <nuttx/time.h>
+#include <nuttx/clock.h>
 
 /****************************************************************************
  * Private Function Prototypes


### PR DESCRIPTION
PR317 removed definitions for SEC_PER_MIN, SEC_PER_HOUR, and SEC_PER_DAY because these were duplicates of definitions in include/nuttx/clock.h.  However, the PR did not include nuttx/clock.h so the removal of these definitions resulted in compilation failures.

Noted by Ouss4