### PR TITLE
Makefile: Remove @echo from ARCHIVE

### DIFF
--- a/boards/z16/z16f/z16f2800100zcog/scripts/Make.defs
+++ b/boards/z16/z16f/z16f2800100zcog/scripts/Make.defs
@@ -194,8 +194,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	@echo AR: $2
-	$(Q) for %%G in ($(2)) do ( "$(AR)" $(ARFLAGS) $1=-+%%G )
+	for %%G in ($(2)) do ( "$(AR)" $(ARFLAGS) $1=-+%%G )
 endef
 
 define CLEAN
@@ -228,8 +227,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	$(Q) for __obj in $(2) ; do \
-		echo "AR: $$__obj"; \
+	for __obj in $(2) ; do \
 		"$(AR)" $(ARFLAGS) $1=-+$$__obj || { echo "$(AR) $1=-+$$__obj FAILED!" ; exit 1 ; } \
 	done
 endef

--- a/boards/z80/ez80/ez80f910200kitg/scripts/Make.defs
+++ b/boards/z80/ez80/ez80f910200kitg/scripts/Make.defs
@@ -205,8 +205,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	@echo AR: $2
-	$(Q) for %%G in ($(2)) do ( $(AR) $(ARFLAGS) $1=-+%%G )
+	for %%G in ($(2)) do ( $(AR) $(ARFLAGS) $1=-+%%G )
 endef
 
 define CLEAN
@@ -240,8 +239,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	$(Q) for __obj in $(2) ; do \
-		echo "AR: $$__obj"; \
+	for __obj in $(2) ; do \
 		$(AR) $(ARFLAGS) $1=-+$$__obj || { echo "$(AR) $1=-+$$__obj FAILED!" ; exit 1 ; } \
 	done
 endef

--- a/boards/z80/ez80/ez80f910200zco/scripts/Make.defs
+++ b/boards/z80/ez80/ez80f910200zco/scripts/Make.defs
@@ -205,8 +205,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	@echo AR: $2
-	$(Q) for %%G in ($(2)) do ( $(AR) $(ARFLAGS) $1=-+%%G )
+	for %%G in ($(2)) do ( $(AR) $(ARFLAGS) $1=-+%%G )
 endef
 
 define CLEAN
@@ -240,8 +239,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	$(Q) for __obj in $(2) ; do \
-		echo "AR: $$__obj"; \
+	for __obj in $(2) ; do \
 		$(AR) $(ARFLAGS) $1=-+$$__obj || { echo "$(AR) $1=-+$$__obj FAILED!" ; exit 1 ; } \
 	done
 endef

--- a/boards/z80/ez80/makerlisp/scripts/Make.defs
+++ b/boards/z80/ez80/makerlisp/scripts/Make.defs
@@ -213,8 +213,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	@echo AR: $2
-	$(Q) for %%G in ($(2)) do ( $(AR) $(ARFLAGS) $1=-+%%G )
+	for %%G in ($(2)) do ( $(AR) $(ARFLAGS) $1=-+%%G )
 endef
 
 define CLEAN
@@ -248,8 +247,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	$(Q) for __obj in $(2) ; do \
-		echo "AR: $$__obj"; \
+	for __obj in $(2) ; do \
 		$(AR) $(ARFLAGS) $1=-+$$__obj || { echo "$(AR) $1=-+$$__obj FAILED!" ; exit 1 ; } \
 	done
 endef

--- a/boards/z80/z8/z8encore000zco/configs/ostest/Make.defs
+++ b/boards/z80/z8/z8encore000zco/configs/ostest/Make.defs
@@ -223,8 +223,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	@echo AR: $2
-	$(Q) for %%G in ($(2)) do ( "$(AR)" $(ARFLAGS) $1=-+%%G )
+	for %%G in ($(2)) do ( "$(AR)" $(ARFLAGS) $1=-+%%G )
 endef
 
 define CLEAN
@@ -258,8 +257,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	$(Q) for __obj in $(2) ; do \
-		echo "AR: $$__obj"; \
+	for __obj in $(2) ; do \
 		"$(AR)" $(ARFLAGS) $1=-+$$__obj || { echo "$(AR) $1=-+$$__obj FAILED!" ; exit 1 ; } \
 	done
 endef

--- a/boards/z80/z8/z8f64200100kit/configs/ostest/Make.defs
+++ b/boards/z80/z8/z8f64200100kit/configs/ostest/Make.defs
@@ -229,8 +229,7 @@ define MOVEOBJ
 endef
 
 define ARCHIVE
-	@echo AR: $2
-	$(Q) for %%G in ($(2)) do ( "$(AR)" $(ARFLAGS) $1=-+%%G )
+	for %%G in ($(2)) do ( "$(AR)" $(ARFLAGS) $1=-+%%G )
 endef
 
 define CLEAN
@@ -258,8 +257,7 @@ define ASSEMBLE
 endef
 
 define ARCHIVE
-	$(Q) for __obj in $(2) ; do \
-		echo "AR: $$__obj"; \
+	for __obj in $(2) ; do \
 		"$(AR)" $(ARFLAGS) $1=-+$$__obj || { echo "$(AR) $1=-+$$__obj FAILED!" ; exit 1 ; } \
 	done
 endef

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -215,13 +215,11 @@ endef
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 define ARCHIVE
-	@echo AR: $2
-	$(Q) $(AR) $1 $(2)
+	$(AR) $1 $(2)
 endef
 else
 define ARCHIVE
-	@echo "AR: $2"
-	$(Q) $(AR) $1 $(2) || { echo "$(AR) $1 FAILED!" ; exit 1 ; }
+	$(AR) $1 $(2) || { echo "$(AR) $1 FAILED!" ; exit 1 ; }
 endef
 endif
 


### PR DESCRIPTION
to avoid shell complain that @echo can't find if the variable expand in the compound
command(e.g. ARLOCK) and remove $(Q) before $AR so the result is almost same as before.

Change-Id: Ie9c218172ada50902352e4cd67a4d96bbef71099
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>