### PR TITLE
boards/z80/ez80:  Update compiler support

### DIFF
--- a/arch/z80/src/ez80/Kconfig
+++ b/arch/z80/src/ez80/Kconfig
@@ -73,7 +73,7 @@ config EZ80_TOOLCHAIN_ZDSII
 
 choice
 	prompt "ZDS-II Toolchain version"
-	default EZ80_ZDSII_V530
+	default EZ80_ZDSII_V533
 
 config EZ80_ZDSII_V511
 	bool "ZDS-II 5.1.1"
@@ -83,6 +83,9 @@ config EZ80_ZDSII_V521
 
 config EZ80_ZDSII_V530
 	bool "ZDS-II 5.3.0"
+
+config EZ80_ZDSII_V533
+	bool "ZDS-II 5.3.3"
 
 endchoice # ZDS-II Toolchain version
 

--- a/arch/z80/src/ez80/ez80_vectors.asm
+++ b/arch/z80/src/ez80/ez80_vectors.asm
@@ -53,6 +53,7 @@ EZ80_S_FLAG	EQU	80h		; Bit 7: Sign flag
 ;**************************************************************************
 
 	xref	_ez80_handlers
+	xref	_handlersize
 	xref	_ez80_startup
 	xref	_z80_doirq
 
@@ -212,7 +213,7 @@ _ez80_initvectors:
 	ld		bc, 4
 	ld		b, NVECTORS
 	xor		a, a				; Clear carry
-	ld		de, handlersize		; Length of one irq handler in de
+	ld		de, _handlersize	; Length of one irq handler in de
 	ld		hl, _ez80_handlers 	; Start of handlers in hl
 
 	ld		a, 0

--- a/arch/z80/src/ez80/ez80f91_handlers.asm
+++ b/arch/z80/src/ez80/ez80f91_handlers.asm
@@ -37,6 +37,7 @@ EZ80_UNUSED		EQU	40h
 ;**************************************************************************
 
 	xdef	_ez80_handlers
+	xdef	_handlersize
 
 ;**************************************************************************
 ; Macros
@@ -65,7 +66,7 @@ irqhandler: macro vectno
 						;----------------- --- ----- -----
 _ez80_handlers:
 	irqhandler	 0		; EZ80_EMACRX_IRQ   0    0   0x040
-	handlersize equ $-_ez80_handlers
+	_handlersize equ $-_ez80_handlers
 	irqhandler	 1		; EZ80_EMACTX_IRQ   1    1   0x044
 	irqhandler	 2		; EZ80_EMACSYS_IRQ  2    2   0x048
 	irqhandler	 3		; EZ80_PLL_IRQ      3    3   0x04c

--- a/arch/z80/src/ez80/ez80f92_handlers.asm
+++ b/arch/z80/src/ez80/ez80f92_handlers.asm
@@ -37,6 +37,7 @@ EZ80_UNUSED		EQU	40h
 ;**************************************************************************
 
 	xdef	_ez80_handlers
+	xdef	_handlersize
 
 ;**************************************************************************
 ; Macros
@@ -65,7 +66,7 @@ irqhandler: macro vectno
 						;----------------- --- ----- -----
 _ez80_handlers:
 	irqhandler	EZ80_UNUSED		;                0   0x040
-	handlersize equ $-_ez80_handlers
+	_handlersize equ $-_ez80_handlers
 	irqhandler	EZ80_UNUSED+1	;                1   0x044
 	irqhandler	EZ80_UNUSED+2	;                2   0x045
 	irqhandler	EZ80_UNUSED+3	;                3   0x04c

--- a/boards/z80/ez80/ez80f910200kitg/README.txt
+++ b/boards/z80/ez80/ez80f910200kitg/README.txt
@@ -12,9 +12,13 @@ ZDSVERSION (if present) and ZDSINSTALLDIR.
 NOTE:  Different versions of the ZDS-II compiler may also require
 different versions of .linkcmd and .zdsproj files as well.
 
+Version 5.3.3
+
+  As of this writing, this is the latest version available.
+
 Version 4.11.0
 
-  The 5.1.1 version of the ZDS-II tools are currently configured for
+  The 5.3.3 version of the ZDS-II tools is the default configured for
   all ez80 boards.  However, it is the older version 4.11.0 that this code
   has been verified against.
 

--- a/boards/z80/ez80/ez80f910200kitg/scripts/Make.defs
+++ b/boards/z80/ez80/ez80f910200kitg/scripts/Make.defs
@@ -46,7 +46,7 @@ include $(TOPDIR)/tools/Config.mk
 #
 # Your PC may be configured differently.
 #
-# Version 5.3.0, the default install location is C:\ZiLOG
+# Version 5.3.0 and 5.3.3, the default install location is C:\ZiLOG
 
 ifeq ($(CONFIG_EZ80_ZDSII_V511),y)
 INSTALLROOT = C:/PROGRA~2/ZiLOG
@@ -57,6 +57,9 @@ ZDSVERSION := 5.2.1
 else ifeq ($(CONFIG_EZ80_ZDSII_V530),y)
 INSTALLROOT = C:/ZiLOG
 ZDSVERSION := 5.3.0
+else ifeq ($(CONFIG_EZ80_ZDSII_V533),y)
+INSTALLROOT = C:/ZiLOG
+ZDSVERSION := 5.3.3
 endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
@@ -68,7 +71,7 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   ZDSSTDLIBDIR := $(INSTALLDIR)\lib\std
   ZDSZILOGLIBDIR := $(INSTALLDIR)\lib\zilog
 
-  # CFLAGs
+  # CFLAGS
 
   ARCHASMINCLUDES = -include:$(TOPDIR)\include;$(ZDSSTDINCDIR);$(ZDSZILOGINCDIR)
   EARCHASMINCLUDES = -include:$(TOPDIR)\include;$(ZDSSTDINCDIR);$(ZDSZILOGINCDIR)

--- a/boards/z80/ez80/ez80f910200zco/README.txt
+++ b/boards/z80/ez80/ez80f910200zco/README.txt
@@ -12,9 +12,13 @@ ZDSVERSION (if present) and ZDSINSTALLDIR.
 NOTE:  Different versions of the ZDS-II compiler may also require
 different versions of .linkcmd and .zdsproj files as well.
 
+Version 5.3.3
+
+  As of this writing, this is the latest version available.
+
 Version 4.11.0
 
-  The 5.1.1 version of the ZDS-II tools are currently configured for
+  The 5.3.3 version of the ZDS-II tools is the default configured for
   all ez80 boards.  However, it is the older version 4.11.0 that this code
   has been verified against.
 

--- a/boards/z80/ez80/ez80f910200zco/scripts/Make.defs
+++ b/boards/z80/ez80/ez80f910200zco/scripts/Make.defs
@@ -46,7 +46,7 @@ include $(TOPDIR)/tools/Config.mk
 #
 # Your PC may be configured differently.
 #
-# Version 5.3.0, the default install location is C:\ZiLOG
+# Version 5.3.0 and 5.3.3, the default install location is C:\ZiLOG
 
 ifeq ($(CONFIG_EZ80_ZDSII_V511),y)
 INSTALLROOT = C:/PROGRA~2/ZiLOG
@@ -57,6 +57,9 @@ ZDSVERSION := 5.2.1
 else ifeq ($(CONFIG_EZ80_ZDSII_V530),y)
 INSTALLROOT = C:/ZiLOG
 ZDSVERSION := 5.3.0
+else ifeq ($(CONFIG_EZ80_ZDSII_V533),y)
+INSTALLROOT = C:/ZiLOG
+ZDSVERSION := 5.3.3
 endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
@@ -68,7 +71,7 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   ZDSSTDLIBDIR := $(INSTALLDIR)\lib\std
   ZDSZILOGLIBDIR := $(INSTALLDIR)\lib\zilog
 
-  # CFLAGs
+  # CFLAGS
 
   ARCHASMINCLUDES = -include:$(TOPDIR)\include;$(ZDSSTDINCDIR);$(ZDSZILOGINCDIR)
   EARCHASMINCLUDES = -include:$(TOPDIR)\include;$(ZDSSTDINCDIR);$(ZDSZILOGINCDIR)

--- a/boards/z80/ez80/makerlisp/README.txt
+++ b/boards/z80/ez80/makerlisp/README.txt
@@ -35,6 +35,11 @@ Contents
 ZDS-II Compiler Versions
 ========================
 
+Version 5.3.3
+
+  As of this writing, this is the latest version available.  This is the
+  default configured for all ez80 boards.
+
 Version 5.3.0
 
   I verified compilation using 5.30 on June 2, 2019.  To use this version,

--- a/boards/z80/ez80/makerlisp/scripts/Make.defs
+++ b/boards/z80/ez80/makerlisp/scripts/Make.defs
@@ -46,7 +46,7 @@ include $(TOPDIR)/tools/Config.mk
 #
 # Your PC may be configured differently.
 #
-# Version 5.3.0, the default install location is C:\ZiLOG
+# Version 5.3.0 and 5.3.3, the default install location is C:\ZiLOG
 
 ifeq ($(CONFIG_EZ80_ZDSII_V511),y)
 INSTALLROOT = C:/PROGRA~2/ZiLOG
@@ -57,6 +57,9 @@ ZDSVERSION := 5.2.1
 else ifeq ($(CONFIG_EZ80_ZDSII_V530),y)
 INSTALLROOT = C:/ZiLOG
 ZDSVERSION := 5.3.0
+else ifeq ($(CONFIG_EZ80_ZDSII_V533),y)
+INSTALLROOT = C:/ZiLOG
+ZDSVERSION := 5.3.3
 endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
@@ -68,7 +71,7 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   ZDSSTDLIBDIR := $(INSTALLDIR)\lib\std
   ZDSZILOGLIBDIR := $(INSTALLDIR)\lib\zilog
 
-  # CFLAGs
+  # CFLAGS
 
   ARCHASMINCLUDES = -include:$(TOPDIR)\include;$(ZDSSTDINCDIR);$(ZDSZILOGINCDIR)
   EARCHASMINCLUDES = -include:$(TOPDIR)\include;$(ZDSSTDINCDIR);$(ZDSZILOGINCDIR)


### PR DESCRIPTION
boards/z80/ez80:  Update to latest ZDS-II verstion 5.3.3 compiler
arch/z80/src/ez80:  Fix some regressions on ez80f91 build due to ez80f92
changes.