### PR TITLE
net: socket: Enable parameter check (addr and addrlen) in getsockname.c

### DIFF
--- a/net/socket/getsockname.c
+++ b/net/socket/getsockname.c
@@ -101,16 +101,12 @@ int psock_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
       return -EBADF;
     }
 
-  /* Some sanity checking... Shouldn't need this on a buckled up embedded
-   * system (?)
-   */
+  /* Some sanity checking... */
 
-#ifdef CONFIG_DEBUG_FEATURES
-  if (addr == NULL || *addrlen <= 0)
+  if (addr == NULL || addrlen == NULL)
     {
       return -EINVAL;
     }
-#endif
 
   /* Let the address family's send() method handle the operation */
 


### PR DESCRIPTION
### Summary

- This PR reinforces parameter check in getsockname()
- With this fix, an error in BasicGetSockName test in usrsocktest will be fixed.

### Impact

- This PR affects network programs which use getsockname()
- However, this is a minor error case, so existing application should work.

### Limitations / TODO

- There still remain errors in usrsocktest and need more investigation.

### Testing

- I tested this PR with spresense:wifi which I added usrsocktest application.
