### PR TITLE
net: socket: Introduce net_clear_sinzero()

### DIFF
--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -479,6 +479,26 @@ FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid);
 int net_checksd(int fd, int oflags);
 
 /****************************************************************************
+ * Name: net_clear_sinzero()
+ *
+ * Description:
+ *   In IPv4, sin_zero field exists in sockaddr_in for padding and should
+ *   be set to zero.
+ *
+ * Input Parameters:
+ *   from    - Address of source (may be NULL)
+ *   fromlen - The length of the address structure
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_IPv4
+void net_clear_sinzero(FAR struct sockaddr *from, socklen_t len);
+#endif
+
+/****************************************************************************
  * Name: net_initlist
  *
  * Description:

--- a/net/socket/Make.defs
+++ b/net/socket/Make.defs
@@ -64,6 +64,12 @@ ifneq ($(CONFIG_NFILE_STREAMS),0)
 SOCK_CSRCS += net_checksd.c
 endif
 
+# Support for clearing sin_zero field
+
+ifeq ($(CONFIG_NET_IPv4),y)
+SOCK_CSRCS += net_clear_sinzero.c
+endif
+
 # Support for sendfile()
 
 ifeq ($(CONFIG_NET_SENDFILE),y)

--- a/net/socket/accept.c
+++ b/net/socket/accept.c
@@ -147,6 +147,12 @@ int psock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   DEBUGASSERT(psock->s_sockif != NULL && psock->s_sockif->si_accept != NULL);
 
+  /* Save *addrlen before calling si_accept() */
+
+#ifdef CONFIG_NET_IPv4
+  socklen_t reqlen = *addrlen;
+#endif
+
   net_lock();
   ret = psock->s_sockif->si_accept(psock, addr, addrlen, newsock);
   if (ret < 0)
@@ -154,6 +160,10 @@ int psock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
       nerr("ERROR: si_accept failed: %d\n", ret);
       goto errout_with_lock;
     }
+
+#ifdef CONFIG_NET_IPv4
+  net_clear_sinzero(addr, reqlen);
+#endif
 
   /* Mark the new socket as connected. */
 

--- a/net/socket/net_clear_sinzero.c
+++ b/net/socket/net_clear_sinzero.c
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * net/socket/net_clear_sinzero.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include <errno.h>
+#include <debug.h>
+#include <string.h>
+
+#include "socket/socket.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: net_clear_sinzero()
+ *
+ * Description:
+ *   In IPv4, sin_zero field exists in sockaddr_in for padding and should
+ *   be set to zero.
+ *
+ * Input Parameters:
+ *   from    - Address of source (may be NULL)
+ *   fromlen - The length of the address structure
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void net_clear_sinzero(FAR struct sockaddr *from, socklen_t len)
+{
+  struct sockaddr_in *sin;
+
+  /* Check if from->sa_family is AF_INET(IPv4) and len is enough */
+
+  if (from && from->sa_family == AF_INET &&
+      sizeof(struct sockaddr_in) <= len)
+    {
+      /* Clear the sin_zero field */
+
+      sin = (struct sockaddr_in *)from;
+      memset(sin->sin_zero, 0, sizeof(sin->sin_zero));
+    }
+}


### PR DESCRIPTION
### Summary

- In https://github.com/apache/incubator-nuttx-apps/pull/85, we finally found that sin_zero field in sockaddr_in should be set to zero in the kernel space. This PR introduces net_clear_sinzero() for it.

### Impact

-  Some socket APIs such as accept(), getpeername(), getsockname() and recvfrom() are affected, if they are used with IPv4 address.

### Testing

- I tested this PR with spresense:wifi with usrsocktest application which I modified to check all address field. Also, I confirmed spresense:rndis which does not use usrsock also works.
