### PR TITLE
net/:  Initialize sin_zero

### DIFF
--- a/net/inet/ipv4_getpeername.c
+++ b/net/inet/ipv4_getpeername.c
@@ -141,6 +141,7 @@ int ipv4_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   outaddr->sin_family      = psock->s_domain;
   outaddr->sin_addr.s_addr = ripaddr;
+  memset(outaddr->sin_zero, 0, sizeof(outaddr->sin_zero));
   *addrlen = sizeof(struct sockaddr_in);
 
   /* Return success */

--- a/net/inet/ipv4_getsockname.c
+++ b/net/inet/ipv4_getsockname.c
@@ -137,6 +137,7 @@ int ipv4_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
     {
        outaddr->sin_family      = psock->s_domain;
        outaddr->sin_addr.s_addr = 0;
+       memset(outaddr->sin_zero, 0, sizeof(outaddr->sin_zero));
        *addrlen = sizeof(struct sockaddr_in);
 
        return OK;
@@ -166,6 +167,8 @@ int ipv4_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   outaddr->sin_family      = psock->s_domain;
   outaddr->sin_addr.s_addr = dev->d_ipaddr;
+  memset(outaddr->sin_zero, 0, sizeof(outaddr->sin_zero));
+
   *addrlen = sizeof(struct sockaddr_in);
 
   net_unlock();

--- a/net/netdev/netdev_ifconf.c
+++ b/net/netdev/netdev_ifconf.c
@@ -142,6 +142,7 @@ static int ifconf_ipv4_callback(FAR struct net_driver_s *dev, FAR void *arg)
           inaddr->sin_family = AF_INET;
           inaddr->sin_port   = 0;
           net_ipv4addr_copy(inaddr->sin_addr.s_addr, dev->d_ipaddr);
+          memset(inaddr->sin_zero, 0, sizeof(inaddr->sin_zero));
         }
 
       /* Increment the size of the buffer in any event */

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -286,6 +286,7 @@ static void ioctl_get_ipv4addr(FAR struct sockaddr *outaddr,
   dest->sin_family              = AF_INET;
   dest->sin_port                = 0;
   dest->sin_addr.s_addr         = inaddr;
+  memset(dest->sin_zero, 0, sizeof(dest->sin_zero));
 }
 #endif
 
@@ -310,6 +311,7 @@ static void inline ioctl_get_ipv4broadcast(FAR struct sockaddr *outaddr,
   dest->sin_family              = AF_INET;
   dest->sin_port                = 0;
   dest->sin_addr.s_addr         = net_ipv4addr_broadcast(inaddr, netmask);
+  memset(dest->sin_zero, 0, sizeof(dest->sin_zero));
 }
 #endif
 

--- a/net/tcp/tcp_accept.c
+++ b/net/tcp/tcp_accept.c
@@ -117,6 +117,7 @@ static inline void accept_tcpsender(FAR struct socket *psock,
           inaddr->sin_family = AF_INET;
           inaddr->sin_port   = conn->rport;
           net_ipv4addr_copy(inaddr->sin_addr.s_addr, conn->u.ipv4.raddr);
+          memset(inaddr->sin_zero, 0, sizeof(inaddr->sin_zero));
 
           *addrlen = sizeof(struct sockaddr_in);
         }

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -372,6 +372,7 @@ static inline void tcp_sender(FAR struct net_driver_s *dev,
 
           net_ipv4addr_copy(infrom->sin_addr.s_addr,
                             net_ip4addr_conv32(ipv4->srcipaddr));
+          memset(infrom->sin_zero, 0, sizeof(infrom->sin_zero));
         }
     }
 #endif /* CONFIG_NET_IPv4 */

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -165,6 +165,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
 
           net_ipv4addr_copy(src_addr4.sin_addr.s_addr,
                             net_ip4addr_conv32(ipv4->srcipaddr));
+          memset(src_addr4.sin_zero, 0, sizeof(src_addr4.sin_zero));
 
           src_addr_size = sizeof(src_addr4);
           src_addr = &src_addr4;

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -375,6 +375,7 @@ static inline void udp_sender(FAR struct net_driver_s *dev,
 
               net_ipv4addr_copy(infrom->sin_addr.s_addr,
                                 net_ip4addr_conv32(ipv4->srcipaddr));
+              memset(infrom->sin_zero, 0, sizeof(infrom->sin_zero));
             }
         }
     }

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -681,6 +681,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
               addr4->sin_family = AF_INET;
               addr4->sin_port   = conn->rport;
               net_ipv4addr_copy(addr4->sin_addr.s_addr, conn->u.ipv4.raddr);
+              memset(addr4->sin_zero, 0, sizeof(addr4->sin_zero));
             }
 #endif /* CONFIG_NET_IPv4 */
 


### PR DESCRIPTION
Whenever the network intialized an IPv4 address, it must clear sin_zero.