### PR TITLE
syslog/file: Remove syslog_dev_uninitialize in syslog_file_channel

### DIFF
--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -119,7 +119,7 @@ int syslog_dev_initialize(FAR const char *devpath, int oflags, int mode);
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_FILE
-int syslog_dev_uninitialize(void);
+void syslog_dev_uninitialize(void);
 #endif /* CONFIG_SYSLOG_FILE */
 
 /****************************************************************************

--- a/drivers/syslog/syslog_device.c
+++ b/drivers/syslog/syslog_device.c
@@ -413,8 +413,15 @@ int syslog_dev_initialize(FAR const char *devpath, int oflags, int mode)
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_FILE /* Currently only used in this configuration */
-int syslog_dev_uninitialize(void)
+void syslog_dev_uninitialize(void)
 {
+  /* Check if the system is ready */
+
+  if (syslog_dev_outputready() < 0)
+    {
+      return;
+    }
+
   /* Attempt to flush any buffered data */
 
   sched_lock();
@@ -422,6 +429,7 @@ int syslog_dev_uninitialize(void)
 
   /* Close the detached file instance */
 
+  g_syslog_dev.sl_state = SYSLOG_UNINITIALIZED;
   file_close(&g_syslog_dev.sl_file);
 
   /* Free the device path */
@@ -439,7 +447,6 @@ int syslog_dev_uninitialize(void)
 
   memset(&g_syslog_dev, 0, sizeof(struct syslog_dev_s));
   sched_unlock();
-  return OK;
 }
 #endif /* CONFIG_SYSLOG_FILE */
 

--- a/drivers/syslog/syslog_filechannel.c
+++ b/drivers/syslog/syslog_filechannel.c
@@ -139,7 +139,6 @@ static int syslog_file_force(int ch)
 
 int syslog_file_channel(FAR const char *devpath)
 {
-  FAR const struct syslog_channel_s *saved_channel;
   int ret;
 
   /* Reset the default SYSLOG channel so that we can safely modify the
@@ -151,34 +150,16 @@ int syslog_file_channel(FAR const char *devpath)
    */
 
   sched_lock();
-  saved_channel = g_syslog_channel;
-  ret = syslog_channel(&g_default_channel);
-  if (ret < 0)
-    {
-      goto errout_with_lock;
-    }
 
   /* Uninitialize any driver interface that may have been in place */
 
-  ret = syslog_dev_uninitialize();
-  if (ret < 0)
-    {
-      /* Nothing fatal has happened yet, we can restore the last channel
-       * since it was not uninitialized (was it?)
-       */
-
-      syslog_channel(saved_channel);
-      goto errout_with_lock;
-    }
+  syslog_dev_uninitialize();
 
   /* Then initialize the file interface */
 
   ret = syslog_dev_initialize(devpath, OPEN_FLAGS, OPEN_MODE);
   if (ret < 0)
     {
-      /* We should still be able to back-up and re-initialized everything */
-
-      syslog_channel(saved_channel);
       goto errout_with_lock;
     }
 


### PR DESCRIPTION
it is impossible that syslog device get initialized before
since board_app_initialize call syslog_file_channel only once

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: Ia72c931f5e19f771e1864f63ede8565624c8c6b4