### PR TITLE
xtensa: Use ar and nm from the toolchain

### DIFF
--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -48,6 +48,7 @@
 #
 
 CROSSDEV = xtensa-esp32-elf-
+ARCROSSDEV = xtensa-esp32-elf-
 
 ARCHCPUFLAGS =
 


### PR DESCRIPTION
This fixes build on macOS, where native ar is incompatible.