### PR TITLE
arch: risc-v: Fix a warning in common/up_exit.c

### DIFF
--- a/arch/risc-v/src/common/up_exit.c
+++ b/arch/risc-v/src/common/up_exit.c
@@ -194,5 +194,5 @@ void _exit(int status)
    * interrupts are disabled.
    */
 
-  DEBUGPANIC();
+  PANIC();
 }


### PR DESCRIPTION
common/up_exit.c:198:1: warning: 'noreturn' function does return
