### PR TITLE
include: audio: Remove packed_struct from struct ap_buffer_s

### DIFF
--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -403,7 +403,7 @@ struct ap_buffer_info_s
 
 /* This structure describes an Audio Pipeline Buffer */
 
-begin_packed_struct struct ap_buffer_s
+struct ap_buffer_s
 {
   struct dq_entry_s     dq_entry;   /* Double linked queue entry */
   struct audio_info_s   i;          /* The info for samples in this buffer */
@@ -417,7 +417,7 @@ begin_packed_struct struct ap_buffer_s
   uint16_t              flags;      /* Buffer flags */
   uint16_t              crefs;      /* Number of reference counts */
   FAR uint8_t           *samp;      /* Offset of the first sample */
-} end_packed_struct;
+};
 
 /* Structure defining the messages passed to a listening audio thread
  * for dequeuing buffers and other operations.  Also used to allocate


### PR DESCRIPTION
### Summary

- Remove  begin_packed_struct and end_packed_struct from struct_ap_buffer_s.
- This change suppresses unaligned access warnings with arm gcc9.
- I believe no hardware assumes that 'struct ap_buffer_s' is packed.

### Impact

- Audio drivers and framework which use struct ap_buffer_s

### Testing

- I tested this PR with lc823450-xgevk:audio (both playback and capture)
