### PR TITLE
sama5/serial: correct usage of USE_SERIALDRIVER and USE_EARLYSERIALINIT

### DIFF
--- a/arch/arm/src/sama5/sam_flexcom_serial.c
+++ b/arch/arm/src/sama5/sam_flexcom_serial.c
@@ -1124,6 +1124,8 @@ static bool flexus_txempty(struct uart_dev_s *dev)
  * Public Functions
  ****************************************************************************/
 
+#ifdef USE_EARLYSERIALINIT
+
 /****************************************************************************
  * Name: flexus_earlyserialinit
  *
@@ -1195,6 +1197,7 @@ void flexus_earlyserialinit(void)
   flexus_setup(&CONSOLE_DEV);
 #endif
 }
+#endif
 
 /****************************************************************************
  * Name: flexus_serialinit

--- a/arch/arm/src/sama5/sam_serial.c
+++ b/arch/arm/src/sama5/sam_serial.c
@@ -1576,6 +1576,8 @@ static bool up_txempty(struct uart_dev_s *dev)
  * Public Functions
  ****************************************************************************/
 
+#ifdef USE_EARLYSERIALINIT
+
 /****************************************************************************
  * Name: uart_earlyserialinit
  *
@@ -1632,6 +1634,7 @@ void uart_earlyserialinit(void)
   up_setup(&CONSOLE_DEV);
 #endif
 }
+#endif
 
 /****************************************************************************
  * Name: uart_serialinit

--- a/arch/arm/src/sama5/sam_serial.h
+++ b/arch/arm/src/sama5/sam_serial.h
@@ -127,7 +127,7 @@ void flexus_earlyserialinit(void);
  *
  ****************************************************************************/
 
-#if defined(SAMA5_HAVE_UART) || defined(SAMA5_HAVE_USART)
+#if defined(USE_SERIALDRIVER) && (defined(SAMA5_HAVE_UART) || defined(SAMA5_HAVE_USART))
 void uart_serialinit(void);
 #endif
 
@@ -140,7 +140,7 @@ void uart_serialinit(void);
  *
  ****************************************************************************/
 
-#if defined(USE_EARLYSERIALINIT) && defined(SAMA5_HAVE_FLEXCOM_USART)
+#if defined(USE_SERIALDRIVER) && defined(SAMA5_HAVE_FLEXCOM_USART)
 void flexus_serialinit(void);
 #endif
 

--- a/arch/arm/src/sama5/sam_serialinit.c
+++ b/arch/arm/src/sama5/sam_serialinit.c
@@ -49,6 +49,8 @@
  * Public Functions
  ****************************************************************************/
 
+#ifdef USE_EARLYSERIALINIT
+
 /****************************************************************************
  * Name: sam_earlyserialinit
  *
@@ -77,6 +79,7 @@ void sam_earlyserialinit(void)
   flexus_earlyserialinit();
 #endif
 }
+#endif
 
 /****************************************************************************
  * Name: up_serialinit


### PR DESCRIPTION
Also fix the following build warning:
chip/sam_serialinit.c: In function 'sam_earlyserialinit':
chip/sam_serialinit.c:71:4: warning: implicit declaration of function 'uart_earlyserialinit'; did you mean 'sam_earlyserialinit'? [-Wimplicit-function-declaration]
   71 |    uart_earlyserialinit();
      |    ^~~~~~~~~~~~~~~~~~~~
      |    sam_earlyserialinit

Change-Id: I93adc5be739c222482b552b6e143e44c8c047794
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>