### PR TITLE
esp32-core: Fix BOARD_CLOCK_FREQUENCY

### DIFF
--- a/boards/xtensa/esp32/esp32-core/include/board.h
+++ b/boards/xtensa/esp32/esp32-core/include/board.h
@@ -63,10 +63,20 @@
  * Don't ask me for an explanation.
  */
 
+/* Note: The bootloader (esp-idf bootloader.bin) configures:
+ *
+ * - CPU frequency to 80MHz
+ * - The XTAL frequency according to the SDK config CONFIG_ESP32_XTAL_FREQ,
+ *   which is 40MHz by default.
+ *
+ * Reference:
+ *     https://github.com/espressif/esp-idf/blob/6fd855ab8d00d23bad4660216bc2122c2285d5be/components/bootloader_support/src/bootloader_clock.c#L38-L62
+ */
+
 #ifdef CONFIG_ESP32CORE_RUN_IRAM
 #  define BOARD_CLOCK_FREQUENCY (2 * BOARD_XTAL_FREQUENCY)
 #else
-#  define BOARD_CLOCK_FREQUENCY BOARD_XTAL_FREQUENCY
+#  define BOARD_CLOCK_FREQUENCY 80000000
 #endif
 
 #endif /* __BOARDS_XTENSA_ESP32_ESP32_CORE_INCLUDE_BOARD_H */


### PR DESCRIPTION
Tested on qemu.

I left CONFIG_ESP32CORE_RUN_IRAM case and the "Don't ask me" comment
as it is because I don't understand it or can test it.