### PR TITLE
include/nuttx:  Fix improper use of inline

### DIFF
--- a/include/nuttx/cache.h
+++ b/include/nuttx/cache.h
@@ -83,9 +83,7 @@ extern "C"
 #ifdef CONFIG_ARCH_ICACHE
 void up_enable_icache(void);
 #else
-static inline void up_enable_icache(void)
-{
-}
+#  define up_enable_icache()
 #endif
 
 /****************************************************************************
@@ -105,9 +103,7 @@ static inline void up_enable_icache(void)
 #ifdef CONFIG_ARCH_ICACHE
 void up_disable_icache(void);
 #else
-static inline void up_disable_icache(void)
-{
-}
+#  define up_disable_icache()
 #endif
 
 /****************************************************************************
@@ -128,9 +124,7 @@ static inline void up_disable_icache(void)
 #ifdef CONFIG_ARCH_ICACHE
 void up_invalidate_icache(uintptr_t start, uintptr_t end);
 #else
-static inline void up_invalidate_icache(uintptr_t start, uintptr_t end)
-{
-}
+#  define up_invalidate_icache()
 #endif
 
 /****************************************************************************
@@ -150,9 +144,7 @@ static inline void up_invalidate_icache(uintptr_t start, uintptr_t end)
 #ifdef CONFIG_ARCH_ICACHE
 void up_invalidate_icache_all(void);
 #else
-static inline void up_invalidate_icache_all(void)
-{
-}
+#  define up_invalidate_icache_all()
 #endif
 
  /****************************************************************************
@@ -175,9 +167,7 @@ static inline void up_invalidate_icache_all(void)
 #ifdef CONFIG_ARCH_DCACHE
 void up_enable_dcache(void);
 #else
-static inline void up_enable_dcache(void)
-{
-}
+#  define up_enable_dcache()
 #endif
 
 /****************************************************************************

--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  * include/nuttx/semaphore.h
  *
- *   Copyright (C) 2014-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2014-2017, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <errno.h>
 #include <semaphore.h>
@@ -539,6 +540,7 @@ int sem_setprotocol(FAR sem_t *sem, int protocol);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_HAVE_INLINE
 static inline int nxsem_wait_uninterruptible(FAR sem_t *sem)
 {
   int ret;
@@ -553,6 +555,9 @@ static inline int nxsem_wait_uninterruptible(FAR sem_t *sem)
 
   return ret;
 }
+#else
+int nxsem_wait_uninterruptible(FAR sem_t *sem);
+#endif
 
 /****************************************************************************
  * Name: nxsem_timedwait_uninterruptible
@@ -576,9 +581,10 @@ static inline int nxsem_wait_uninterruptible(FAR sem_t *sem)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_HAVE_INLINE
 static inline int
-nxsem_timedwait_uninterruptible(FAR sem_t *sem,
-                                FAR const struct timespec *abstime)
+  nxsem_timedwait_uninterruptible(FAR sem_t *sem,
+                                  FAR const struct timespec *abstime)
 {
   int ret;
 
@@ -592,6 +598,10 @@ nxsem_timedwait_uninterruptible(FAR sem_t *sem,
 
   return ret;
 }
+#else
+int nxsem_timedwait_uninterruptible(FAR sem_t *sem,
+                                    FAR const struct timespec *abstime);
+#endif
 
 /****************************************************************************
  * Name: nxsem_tickwait_uninterruptible
@@ -616,8 +626,9 @@ nxsem_timedwait_uninterruptible(FAR sem_t *sem,
  *
  ****************************************************************************/
 
+#ifdef CONFIG_HAVE_INLINE
 static inline int
-nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start, uint32_t delay)
+  nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start, uint32_t delay)
 {
   int ret;
 
@@ -631,6 +642,10 @@ nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start, uint32_t delay)
 
   return ret;
 }
+#else
+int nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start,
+                                   uint32_t delay);
+#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * sched/semaphore/sem_tickwait.c
  *
- *   Copyright (C) 2015-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2015-2017, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -176,3 +176,44 @@ errout_with_irqdisabled:
   rtcb->waitdog = NULL;
   return ret;
 }
+/****************************************************************************
+ * Name: nxsem_tickwait_uninterruptible
+ *
+ * Description:
+ *   This function is wrapped version of nxsem_tickwait(), which is
+ *   uninterruptible and convenient for use.
+ *
+ * Input Parameters:
+ *   sem     - Semaphore object
+ *   start   - The system time that the delay is relative to.  If the
+ *             current time is not the same as the start time, then the
+ *             delay will be adjust so that the end time will be the same
+ *             in any event.
+ *   delay   - Ticks to wait from the start time until the semaphore is
+ *             posted.  If ticks is zero, then this function is equivalent
+ *             to sem_trywait().
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  A negated errno value is returned
+ *   on failure. -ETIMEDOUT is returned on the timeout condition.
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_HAVE_INLINE
+int nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start,
+                                   uint32_t delay)
+{
+  int ret;
+
+  do
+    {
+      /* Take the semaphore (perhaps waiting) */
+
+      ret = nxsem_tickwait(sem, start, delay);
+    }
+  while (ret == -EINTR || ret == -ECANCELED);
+
+  return ret;
+}
+#endif
+

--- a/sched/semaphore/sem_timedwait.c
+++ b/sched/semaphore/sem_timedwait.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * sched/semaphore/sem_timedwait.c
  *
- *   Copyright (C) 2011, 2013-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2011, 2013-201, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -212,6 +212,46 @@ errout_with_irqdisabled:
   rtcb->waitdog = NULL;
   return ret;
 }
+
+/****************************************************************************
+ * Name: nxsem_timedwait_uninterruptible
+ *
+ * Description:
+ *   This function is wrapped version of nxsem_timedwait(), which is
+ *   uninterruptible and convenient for use.
+ *
+ * Input Parameters:
+ *   sem     - Semaphore object
+ *   abstime - The absolute time to wait until a timeout is declared.
+ *
+ * Returned Value:
+ *   EINVAL    The sem argument does not refer to a valid semaphore.  Or the
+ *             thread would have blocked, and the abstime parameter specified
+ *             a nanoseconds field value less than zero or greater than or
+ *             equal to 1000 million.
+ *   ETIMEDOUT The semaphore could not be locked before the specified timeout
+ *             expired.
+ *   EDEADLK   A deadlock condition was detected.
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_HAVE_INLINE
+int nxsem_timedwait_uninterruptible(FAR sem_t *sem,
+                                    FAR const struct timespec *abstime)
+{
+  int ret;
+
+  do
+    {
+      /* Take the semaphore (perhaps waiting) */
+
+      ret = nxsem_timedwait(sem, abstime);
+    }
+  while (ret == -EINTR || ret == -ECANCELED);
+
+  return ret;
+}
+#endif
 
 /****************************************************************************
  * Name: sem_timedwait

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -1,7 +1,7 @@
 /****************************************************************************
  * sched/semaphore/sem_wait.c
  *
- *   Copyright (C) 2007-2013, 2016 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2013, 2016, 2020 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -212,6 +212,39 @@ int nxsem_wait(FAR sem_t *sem)
   leave_critical_section(flags);
   return ret;
 }
+
+/****************************************************************************
+ * Name: nxsem_wait_uninterruptible
+ *
+ * Description:
+ *   This function is wrapped version of nxsem_wait(), which is uninterruptible
+ *   and convenient for use.
+ *
+ * Parameters:
+ *   sem - Semaphore descriptor.
+ *
+ * Return Value:
+ *   Zero(OK) - On success
+ *   EINVAL - Invalid attempt to get the semaphore
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_HAVE_INLINE
+int nxsem_wait_uninterruptible(FAR sem_t *sem)
+{
+  int ret;
+
+  do
+    {
+      /* Take the semaphore (perhaps waiting) */
+
+      ret = nxsem_wait(sem);
+    }
+  while (ret == -EINTR || ret == -ECANCELED);
+
+  return ret;
+}
+#endif
 
 /****************************************************************************
  * Name: sem_wait


### PR DESCRIPTION
I finally figured out why the ez80 code has gotten so big.  It is because people have been put putting big inline functions in header files.  That is a violation of the coding standard, since only c89 compatibility is required in all common code. But we have been tolerating inline function it because include/nuttx/compiler.h defines 'inline' to be nothing for C89 compilers.

As a result, static inline functions declared within a C file not so bad; the inline qualifier is ignored, if not supported, but otherwise all is well.

But it is catastrophic in header files.  Those static inline functions are included as static functions and implemented in EVERY file that includes those header files, even if the functions are never called.  That makes the code base huge!So there is another PR coming to fix some of the worst offenders.

This commit fixes two of the worst offenders I have encountered so far:  include/nuttx/sempahore.h and cache.h.  But there may be a few other changes needed.  Under include/nuttx there are still inline functions thread.h, inclue/nuttx/list.h, mutex.h, tree.h, and include/nuttx/crypto/blake2s.h with no protection for compilers that do not handler the inline qualifier.  Otherwise we are clean.

With the changes to these two header files, the size of the z20x build is reduced by about 40%.  And incredible size savings.