### PR TITLE
tools/testbuild.sh: prevent grep from exiting in case of nomatch

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -131,8 +131,8 @@ fi
 
 export APPSDIR
 
-testlist=`grep -v "^-" $testfile`
-blacklist=`grep "^-" $testfile`
+testlist=`grep -v "^-" $testfile || true`
+blacklist=`grep "^-" $testfile || true`
 
 cd $nuttx || { echo "ERROR: failed to CD to $nuttx"; exit 1; }
 


### PR DESCRIPTION
Prevent grep from exiting in case of nomatch for blacklist when testbuild.sh called
with -x option which set -e in bash.

Change-Id: Ibf9a47de342cfe111303ea9bcd47c2c1db3149e9
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>