### PR TITLE
arch/x86_64: fix two typo errors to pass build

### DIFF
--- a/arch/x86_64/src/intel64/up_map_region.c
+++ b/arch/x86_64/src/intel64/up_map_region.c
@@ -57,7 +57,7 @@ int up_map_region(void *base, int size, int flags)
   /* Increase size if the base address is rounded off */
 
   size += (uint64_t)base - bb;
-  uint64_t num_of_pages = (size + PAGE_SIZE - 1) / PAGE_SIZE;
+  num_of_pages = (size + PAGE_SIZE - 1) / PAGE_SIZE;
 
   if (bb > 0xffffffff)
     {

--- a/arch/x86_64/src/intel64/up_regdump.c
+++ b/arch/x86_64/src/intel64/up_regdump.c
@@ -37,7 +37,7 @@
  * Name: up_registerdump
  ****************************************************************************/
 
-void print_mem(void *sp, size_t size
+void print_mem(void *sp, size_t size)
 {
   char buf[9];
   int i;


### PR DESCRIPTION
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>