### PR TITLE
arch: esp32: Fix compile error with xtensa-esp32-elf-gcc 8.2.0

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpuidlestack.c
+++ b/arch/xtensa/src/esp32/esp32_cpuidlestack.c
@@ -43,8 +43,7 @@
 /* Address of the CPU0 IDLE thread */
 
 uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS]
-  __attribute__((aligned(16) section(".noinit")));
-
+  __attribute__((aligned(16), section(".noinit")));
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
### Summary

- Multiple attributes must be separated by commas.
- This PR fixes compile error with xtensa-esp32-elf-gcc 8.2.0

### Impact

- This PR affects ESP32 for SMP configuration.

### Testing

- Tested with both xtensa-esp32-elf-gcc 5.2.0 and 8.2.0
