### PR TITLE
include/nuttx/cache.h:  Fix errors in previous commit

### DIFF
--- a/include/nuttx/cache.h
+++ b/include/nuttx/cache.h
@@ -124,7 +124,7 @@ void up_disable_icache(void);
 #ifdef CONFIG_ARCH_ICACHE
 void up_invalidate_icache(uintptr_t start, uintptr_t end);
 #else
-#  define up_invalidate_icache()
+#  define up_invalidate_icache(start, end)
 #endif
 
 /****************************************************************************
@@ -187,9 +187,7 @@ void up_enable_dcache(void);
 #ifdef CONFIG_ARCH_DCACHE
 void up_disable_dcache(void);
 #else
-static inline void up_disable_dcache(void)
-{
-}
+#  define up_disable_dcache()
 #endif
 
 /****************************************************************************
@@ -212,9 +210,7 @@ static inline void up_disable_dcache(void)
 #ifdef CONFIG_ARCH_DCACHE
 void up_invalidate_dcache(uintptr_t start, uintptr_t end);
 #else
-static inline void up_invalidate_dcache(uintptr_t start, uintptr_t end)
-{
-}
+#  define up_disable_dcache(start, end)
 #endif
 
 /****************************************************************************
@@ -234,9 +230,7 @@ static inline void up_invalidate_dcache(uintptr_t start, uintptr_t end)
 #ifdef CONFIG_ARCH_DCACHE
 void up_invalidate_dcache_all(void);
 #else
-static inline void up_invalidate_dcache_all(void)
-{
-}
+#  define up_invalidate_dcache_all()
 #endif
 
 /****************************************************************************
@@ -258,9 +252,7 @@ static inline void up_invalidate_dcache_all(void)
 #ifdef CONFIG_ARCH_DCACHE
 void up_clean_dcache(uintptr_t start, uintptr_t end);
 #else
-static inline void up_clean_dcache(uintptr_t start, uintptr_t end)
-{
-}
+#  define up_clean_dcache(start, end)
 #endif
 
 /****************************************************************************
@@ -281,9 +273,7 @@ static inline void up_clean_dcache(uintptr_t start, uintptr_t end)
 #ifdef CONFIG_ARCH_DCACHE
 void up_clean_dcache_all(void);
 #else
-static inline void up_clean_dcache_all(void)
-{
-}
+#  define up_clean_dcache_all()
 #endif
 
 /****************************************************************************
@@ -305,9 +295,7 @@ static inline void up_clean_dcache_all(void)
 #ifdef CONFIG_ARCH_DCACHE
 void up_flush_dcache(uintptr_t start, uintptr_t end);
 #else
-static inline void up_flush_dcache(uintptr_t start, uintptr_t end)
-{
-}
+#  define up_flush_dcache(start, end)
 #endif
 
 /****************************************************************************
@@ -327,9 +315,7 @@ static inline void up_flush_dcache(uintptr_t start, uintptr_t end)
 #ifdef CONFIG_ARCH_DCACHE
 void up_flush_dcache_all(void);
 #else
-static inline void up_flush_dcache_all(void)
-{
-}
+#  define up_flush_dcache_all()
 #endif
 
 /****************************************************************************
@@ -353,9 +339,7 @@ static inline void up_flush_dcache_all(void)
 #ifdef CONFIG_ARCH_ICACHE
 void up_coherent_dcache(uintptr_t addr, size_t len);
 #else
-static inline void up_coherent_dcache(uintptr_t addr, size_t len)
-{
-}
+#  define up_coherent_dcache(addr, len)
 #endif
 
 #undef EXTERN


### PR DESCRIPTION
Commit 3b53cd1e578de1e6bddfae605452a77323e5a70b, "Fix improper use of inline" missed conversion of several inline functions.  Also, some functions that require arguments were not handled correctly,

This was noted because there were still hundreds of implementations of the cache stubs in the ez80 build.  This commit adds the missing conversions and fixes the bad function arguments.