### PR TITLE
sched/group/group_setuptaskfiles.c:  Fix bad file inclusion.

### DIFF
--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -76,5 +76,3 @@ endif
 
 DEPPATH += --dep-path group
 VPATH += :group
-
-CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)net}

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -47,7 +47,6 @@
 #include <nuttx/net/net.h>
 
 #include "sched/sched.h"
-#include "socket/socket.h"
 #include "group/group.h"
 
 /****************************************************************************


### PR DESCRIPTION
commit d07afc934e272cbbd63e355d9e12db333b2e2978, "fcntl: add O_CLOEXEC/FD_CLOEXEC support" introduce a compilation error .. a bad file inclusion.  That commit added an unnecessary inclusion of "socket/socket.h" which is NOT available in the sched sub-directory. It is only available under the net/ sub-directory.

There is no include path for such and inclusion and there must NEVER be such a include path.  Module design forbids including header files between diffent "silos" in the design.  Nothing under net/ can ever be available to logic under sched/.