### PR TITLE
sched/group/group_setuptaskfiles.c

### DIFF
--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -172,8 +172,7 @@ static inline void sched_dupsockets(FAR struct task_tcb_s *tcb)
        * reference count.
        */
 
-      if (parent[i].s_crefs > 0 &&
-          !_SS_ISCLOEXEC(parent[i].s_flags))
+      if (parent[i].s_crefs > 0)
         {
           /* Yes... duplicate it for the child */
 


### PR DESCRIPTION
Parts of commit d07afc934e272cbbd63e355d9e12db333b2e2978 were previously reverted by it did a forbidden inclusion of a private net/ header file in sched/ code.  That is not permissible.  That is is gross violation of the modular architecture. You may not include header files from net/ under ANY circumstance. Never!!!!!!!!!!!!!!!!!!!

This PR is optional, it should fix some code breakage resulting from removing the FORBIDDEN header file inclusions.  The logic will need to be redesigned. _SS_ISCLOEXEC is defined in network code, but IT IS NOT PERMISSIBLE to include net/ header files header. That will not be tolerated UNDER ANY CIRCUMSTANCE.

A proper designed might be to move sched_dupsockets() into net/sockets. That would be a clean partititioning of functionality. I would prefer the the code to broken then to accept this violation of the modular design.