### PR TITLE
net: move the _SF*/_SS* definitions to net.h

### DIFF
--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -109,6 +109,32 @@
 #define SOCKCAP_NONBLOCKING (1 << 0)  /* Bit 0: Socket supports non-blocking
                                        *        operation. */
 
+/* Definitions of 8-bit socket flags */
+
+#define _SF_CLOEXEC         0x04  /* Bit 2: Close on execute */
+#define _SF_NONBLOCK        0x08  /* Bit 3: Don't block if no data (TCP/READ only) */
+#define _SF_LISTENING       0x10  /* Bit 4: SOCK_STREAM is listening */
+#define _SF_BOUND           0x20  /* Bit 5: SOCK_STREAM is bound to an address */
+                                  /* Bits 6-7: Connection state */
+#define _SF_CONNECTED       0x40  /* Bit 6: SOCK_STREAM/SOCK_DGRAM is connected */
+#define _SF_CLOSED          0x80  /* Bit 7: SOCK_STREAM was gracefully disconnected */
+
+/* Connection state encoding:
+ *
+ *  _SF_CONNECTED==1 && _SF_CLOSED==0 - the socket is connected
+ *  _SF_CONNECTED==0 && _SF_CLOSED==1 - the socket was gracefully disconnected
+ *  _SF_CONNECTED==0 && _SF_CLOSED==0 - the socket was rudely disconnected
+ */
+
+/* Macro to manage the socket state and flags */
+
+#define _SS_ISCLOEXEC(s)    (((s) & _SF_CLOEXEC)   != 0)
+#define _SS_ISNONBLOCK(s)   (((s) & _SF_NONBLOCK)  != 0)
+#define _SS_ISLISTENING(s)  (((s) & _SF_LISTENING) != 0)
+#define _SS_ISBOUND(s)      (((s) & _SF_BOUND)     != 0)
+#define _SS_ISCONNECTED(s)  (((s) & _SF_CONNECTED) != 0)
+#define _SS_ISCLOSED(s)     (((s) & _SF_CLOSED)    != 0)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/net/socket/socket.h
+++ b/net/socket/socket.h
@@ -55,32 +55,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Definitions of 8-bit socket flags */
-
-#define _SF_CLOEXEC         0x04  /* Bit 2: Close on execute */
-#define _SF_NONBLOCK        0x08  /* Bit 3: Don't block if no data (TCP/READ only) */
-#define _SF_LISTENING       0x10  /* Bit 4: SOCK_STREAM is listening */
-#define _SF_BOUND           0x20  /* Bit 5: SOCK_STREAM is bound to an address */
-                                  /* Bits 6-7: Connection state */
-#define _SF_CONNECTED       0x40  /* Bit 6: SOCK_STREAM/SOCK_DGRAM is connected */
-#define _SF_CLOSED          0x80  /* Bit 7: SOCK_STREAM was gracefully disconnected */
-
-/* Connection state encoding:
- *
- *  _SF_CONNECTED==1 && _SF_CLOSED==0 - the socket is connected
- *  _SF_CONNECTED==0 && _SF_CLOSED==1 - the socket was gracefully disconnected
- *  _SF_CONNECTED==0 && _SF_CLOSED==0 - the socket was rudely disconnected
- */
-
-/* Macro to manage the socket state and flags */
-
-#define _SS_ISCLOEXEC(s)    (((s) & _SF_CLOEXEC)   != 0)
-#define _SS_ISNONBLOCK(s)   (((s) & _SF_NONBLOCK)  != 0)
-#define _SS_ISLISTENING(s)  (((s) & _SF_LISTENING) != 0)
-#define _SS_ISBOUND(s)      (((s) & _SF_BOUND)     != 0)
-#define _SS_ISCONNECTED(s)  (((s) & _SF_CONNECTED) != 0)
-#define _SS_ISCLOSED(s)     (((s) & _SF_CLOSED)    != 0)
-
 /* This macro converts a socket option value into a bit setting */
 
 #define _SO_BIT(o)       (1 << (o))


### PR DESCRIPTION
Build break caused by 23b8b397999136c61b3c834956ad1da55fb0e072

Change-Id: I4a63ede90fbe3385423a9d88ae811cd596491fec
Signed-off-by: chao.an <anchao@xiaomi.com>