### PR TITLE
ez80f92:  Interrupt improvements.

### DIFF
--- a/arch/z80/include/ez80/irq.h
+++ b/arch/z80/include/ez80/irq.h
@@ -112,50 +112,51 @@
 #  define NR_IRQS            (46)
 #elif defined(CONFIG_ARCH_CHIP_EZ80F92) || defined(CONFIG_ARCH_CHIP_EZ80F93)
 
-#                                 /* Vectors 0x40-0x4c unused */
-#  define EZ80_FLASH_IRQ      (0) /* Vector 0x50 */
+#                                 /* Vectors 0x00-0x06 unused */
+#  define EZ80_FLASH_IRQ      (0) /* Vector 0x08 */
 
-#  define EZ80_TIMER0_IRQ     (1) /* Vector 0x54 */
-#  define EZ80_TIMER1_IRQ     (2) /* Vector 0x58 */
-#  define EZ80_TIMER2_IRQ     (3) /* Vector 0x5c */
-#  define EZ80_TIMER3_IRQ     (4) /* Vector 0x60 */
-#  define EZ80_TIMER4_IRQ     (5) /* Vector 0x64 */
-#  define EZ80_TIMER5_IRQ     (6) /* Vector 0x68 */
+#  define EZ80_TIMER0_IRQ     (1) /* Vector 0x0a */
+#  define EZ80_TIMER1_IRQ     (2) /* Vector 0x0c */
+#  define EZ80_TIMER2_IRQ     (3) /* Vector 0x0e */
+#  define EZ80_TIMER3_IRQ     (4) /* Vector 0x10 */
+#  define EZ80_TIMER4_IRQ     (5) /* Vector 0x12 */
+#  define EZ80_TIMER5_IRQ     (6) /* Vector 0x14 */
 
-#  define EZ80_RTC_IRQ        (7) /* Vector 0x6C */
-#  define EZ80_UART0_IRQ      (8) /* Vector 0x70 */
-#  define EZ80_UART1_IRQ      (9) /* Vector 0x74 */
+#  define EZ80_RTC_IRQ        (7) /* Vector 0x16 */
+#  define EZ80_UART0_IRQ      (8) /* Vector 0x18 */
+#  define EZ80_UART1_IRQ      (9) /* Vector 0x1a */
 
-#  define EZ80_I2C_IRQ       (10) /* Vector 0x78 */
-#  define EZ80_SPI_IRQ       (11) /* Vector 0x7c */
-#                                 /* Vectors 0x80-0x9c unused */
+#  define EZ80_I2C_IRQ       (10) /* Vector 0x1c */
+#  define EZ80_SPI_IRQ       (11) /* Vector 0x1e */
+#                                 /* Vectors 0x20-0x2e unused */
 
-#  define EZ80_PORTB0_IRQ    (12) /* Vector 0xa0 */
-#  define EZ80_PORTB1_IRQ    (13) /* Vector 0xa4 */
-#  define EZ80_PORTB2_IRQ    (14) /* Vector 0xa8 */
-#  define EZ80_PORTB3_IRQ    (15) /* Vector 0xac */
-#  define EZ80_PORTB4_IRQ    (16) /* Vector 0xb0 */
-#  define EZ80_PORTB5_IRQ    (17) /* Vector 0xb4 */
-#  define EZ80_PORTB6_IRQ    (18) /* Vector 0xb8 */
-#  define EZ80_PORTB7_IRQ    (19) /* Vector 0xbc */
+#  define EZ80_PORTB0_IRQ    (12) /* Vector 0x30 */
+#  define EZ80_PORTB1_IRQ    (13) /* Vector 0x32 */
+#  define EZ80_PORTB2_IRQ    (14) /* Vector 0x34 */
+#  define EZ80_PORTB3_IRQ    (15) /* Vector 0x36 */
+#  define EZ80_PORTB4_IRQ    (16) /* Vector 0x38 */
+#  define EZ80_PORTB5_IRQ    (17) /* Vector 0x3a */
+#  define EZ80_PORTB6_IRQ    (18) /* Vector 0x3c */
+#  define EZ80_PORTB7_IRQ    (19) /* Vector 0x3e */
 
-#  define EZ80_PORTC0_IRQ    (20) /* Vector 0xc0 */
-#  define EZ80_PORTC1_IRQ    (21) /* Vector 0xc4 */
-#  define EZ80_PORTC2_IRQ    (22) /* Vector 0xc8 */
-#  define EZ80_PORTC3_IRQ    (23) /* Vector 0xcc */
-#  define EZ80_PORTC4_IRQ    (24) /* Vector 0xd0 */
-#  define EZ80_PORTC5_IRQ    (25) /* Vector 0xd4 */
-#  define EZ80_PORTC6_IRQ    (26) /* Vector 0xd8 */
-#  define EZ80_PORTC7_IRQ    (27) /* Vector 0xdc */
+#  define EZ80_PORTC0_IRQ    (20) /* Vector 0x40 */
+#  define EZ80_PORTC1_IRQ    (21) /* Vector 0x42 */
+#  define EZ80_PORTC2_IRQ    (22) /* Vector 0x44 */
+#  define EZ80_PORTC3_IRQ    (23) /* Vector 0x46 */
+#  define EZ80_PORTC4_IRQ    (24) /* Vector 0x48 */
+#  define EZ80_PORTC5_IRQ    (25) /* Vector 0x4a */
+#  define EZ80_PORTC6_IRQ    (26) /* Vector 0x4c */
+#  define EZ80_PORTC7_IRQ    (27) /* Vector 0x4e */
 
-#  define EZ80_PORTD0_IRQ    (28) /* Vector 0xe0 */
-#  define EZ80_PORTD1_IRQ    (29) /* Vector 0xe4 */
-#  define EZ80_PORTD2_IRQ    (30) /* Vector 0xe8 */
-#  define EZ80_PORTD3_IRQ    (31) /* Vector 0xec */
-#  define EZ80_PORTD4_IRQ    (32) /* Vector 0xf0 */
-#  define EZ80_PORTD5_IRQ    (33) /* Vector 0xf4 */
-#  define EZ80_PORTD6_IRQ    (34) /* Vector 0xf8 */
-#  define EZ80_PORTD7_IRQ    (35) /* Vector 0xfc */
+#  define EZ80_PORTD0_IRQ    (28) /* Vector 0x50 */
+#  define EZ80_PORTD1_IRQ    (29) /* Vector 0x52 */
+#  define EZ80_PORTD2_IRQ    (30) /* Vector 0x54 */
+#  define EZ80_PORTD3_IRQ    (31) /* Vector 0x56 */
+#  define EZ80_PORTD4_IRQ    (32) /* Vector 0x58 */
+#  define EZ80_PORTD5_IRQ    (33) /* Vector 0x5a */
+#  define EZ80_PORTD6_IRQ    (34) /* Vector 0x5c */
+#  define EZ80_PORTD7_IRQ    (35) /* Vector 0x5e */
+#                                 /* Vectors 0x60-0x66 unused */
 
 #  define NR_IRQS            (36)
 #endif

--- a/arch/z80/src/ez80/ez80f92_handlers.asm
+++ b/arch/z80/src/ez80/ez80f92_handlers.asm
@@ -151,71 +151,71 @@ _ez80_vectable:
 						; Symbol           Val VecNo Addr
 						;----------------- --- ----- -----
 _ez80_handlers:
-	irqhandler	EZ80_UNUSED		;                0   0x040
-	_handlersize equ $-_ez80_handlers
-	irqhandler	EZ80_UNUSED+1	;                1   0x044
-	irqhandler	EZ80_UNUSED+2	;                2   0x045
-	irqhandler	EZ80_UNUSED+3	;                3   0x04c
-	irqhandler	 0		; EZ80_FLASH_IRQ    0    4   0x050
-	irqhandler	 1		; EZ80_TIMER0_IRQ   1    5   0x054
-	irqhandler	 2		; EZ80_TIMER1_IRQ   2    6   0x058
-	irqhandler	 3		; EZ80_TIMER2_IRQ   3    7   0x05c
-	irqhandler	 4		; EZ80_TIMER3_IRQ   4    8   0x060
-	irqhandler	 5		; EZ80_TIMER4_IRQ   5    9   0x064
-	irqhandler	 6		; EZ80_TIMER5_IRQ   6   10   0x068
-	irqhandler	 7		; EZ80_RTC_IRQ      7   11   0x06C
-	irqhandler	 8		; EZ80_UART0_IRQ    8   12   0x070
-	irqhandler	 9		; EZ80_UART1_IRQ    9   13   0x074
-	irqhandler	10		; EZ80_I2C_IRQ     10   14   0x078
-	irqhandler	11		; EZ80_SPI_IRQ     11   15   0x07c
-	irqhandler	EZ80_UNUSED+4	;               16   0x080
-	irqhandler	EZ80_UNUSED+5	;               17   0x084
-	irqhandler	EZ80_UNUSED+6	;               18   0x088
-	irqhandler	EZ80_UNUSED+7	;               19   0x08c
-	irqhandler	EZ80_UNUSED+8	;               16   0x080
-	irqhandler	EZ80_UNUSED+9	;               17   0x094
-	irqhandler	EZ80_UNUSED+10	;               18   0x098
-	irqhandler	EZ80_UNUSED+11	;               19   0x09c
-	irqhandler	12		; EZ80_PORTB0_IRQ  12   24   0x0a0
-	irqhandler	13		; EZ80_PORTB1_IRQ  13   25   0x0a4
-	irqhandler	14		; EZ80_PORTB2_IRQ  14   26   0x0a8
-	irqhandler	15		; EZ80_PORTB3_IRQ  15   27   0x0ac
-	irqhandler	16		; EZ80_PORTB4_IRQ  16   28   0x0b0
-	irqhandler	17		; EZ80_PORTB5_IRQ  17   29   0x0b4
-	irqhandler	18		; EZ80_PORTB6_IRQ  18   20   0x0b8
-	irqhandler	19		; EZ80_PORTB7_IRQ  19   21   0x0bc
-	irqhandler	20		; EZ80_PORTC0_IRQ  20   22   0x0c0
-	irqhandler	21		; EZ80_PORTC1_IRQ  21   23   0x0c4
-	irqhandler	22		; EZ80_PORTC2_IRQ  22   24   0x0c8
-	irqhandler	23		; EZ80_PORTC3_IRQ  23   25   0x0cc
-	irqhandler	24		; EZ80_PORTC4_IRQ  24   26   0x0d0
-	irqhandler	25		; EZ80_PORTC5_IRQ  25   27   0x0d4
-	irqhandler	26		; EZ80_PORTC6_IRQ  26   28   0x0d8
-	irqhandler	27		; EZ80_PORTC7_IRQ  27   29   0x0dc
-	irqhandler	28		; EZ80_PORTD0_IRQ  28   40   0x0e0
-	irqhandler	29		; EZ80_PORTD1_IRQ  29   41   0x0e4
-	irqhandler	30		; EZ80_PORTD2_IRQ  30   42   0x0e8
-	irqhandler	31		; EZ80_PORTD3_IRQ  31   43   0x0ec
-	irqhandler	32		; EZ80_PORTD4_IRQ  32   44   0x0f0
-	irqhandler	33		; EZ80_PORTD5_IRQ  33   45   0x0f4
-	irqhandler	34		; EZ80_PORTD6_IRQ  34   46   0x0f8
-	irqhandler	35		; EZ80_PORTD7_IRQ  35   47   0x0fc
-	irqhandler	EZ80_UNUSED+12	;               48   0x100
-	irqhandler	EZ80_UNUSED+13	;               49   0x104
-	irqhandler	EZ80_UNUSED+14	;               50   0x108
-	irqhandler	EZ80_UNUSED+15	;               51   0x10c
-	irqhandler	EZ80_UNUSED+16	;               52   0x110
-	irqhandler	EZ80_UNUSED+17	;               53   0x114
-	irqhandler	EZ80_UNUSED+18	;               54   0x118
-	irqhandler	EZ80_UNUSED+19	;               55   0x11c
-	irqhandler	EZ80_UNUSED+20	;               56   0x120
-	irqhandler	EZ80_UNUSED+21	;               57   0x124
-	irqhandler	EZ80_UNUSED+22	;               58   0x128
-	irqhandler	EZ80_UNUSED+23	;               59   0x12c
-	irqhandler	EZ80_UNUSED+24	;               60   0x130
-	irqhandler	EZ80_UNUSED+25	;               61   0x134
-	irqhandler	EZ80_UNUSED+26	;               62   0x138
-	irqhandler	EZ80_UNUSED+27	;               63   0x13c
+	irqhandler	EZ80_UNUSED		;                0   0x000
+	_handlersize EQU $-_ez80_handlers
+	irqhandler	EZ80_UNUSED+1	;                1   0x002
+	irqhandler	EZ80_UNUSED+2	;                2   0x004
+	irqhandler	EZ80_UNUSED+3	;                3   0x006
+	irqhandler	 0		; EZ80_FLASH_IRQ    0    4   0x008
+	irqhandler	 1		; EZ80_TIMER0_IRQ   1    5   0x00a
+	irqhandler	 2		; EZ80_TIMER1_IRQ   2    6   0x00c
+	irqhandler	 3		; EZ80_TIMER2_IRQ   3    7   0x00e
+	irqhandler	 4		; EZ80_TIMER3_IRQ   4    8   0x010
+	irqhandler	 5		; EZ80_TIMER4_IRQ   5    9   0x012
+	irqhandler	 6		; EZ80_TIMER5_IRQ   6   10   0x014
+	irqhandler	 7		; EZ80_RTC_IRQ      7   11   0x016
+	irqhandler	 8		; EZ80_UART0_IRQ    8   12   0x018
+	irqhandler	 9		; EZ80_UART1_IRQ    9   13   0x01a
+	irqhandler	10		; EZ80_I2C_IRQ     10   14   0x01c
+	irqhandler	11		; EZ80_SPI_IRQ     11   15   0x01e
+	irqhandler	EZ80_UNUSED+4	;               16   0x020
+	irqhandler	EZ80_UNUSED+5	;               17   0x022
+	irqhandler	EZ80_UNUSED+6	;               18   0x024
+	irqhandler	EZ80_UNUSED+7	;               19   0x026
+	irqhandler	EZ80_UNUSED+8	;               16   0x028
+	irqhandler	EZ80_UNUSED+9	;               17   0x02a
+	irqhandler	EZ80_UNUSED+10	;               18   0x02c
+	irqhandler	EZ80_UNUSED+11	;               19   0x02e
+	irqhandler	12		; EZ80_PORTB0_IRQ  12   24   0x030
+	irqhandler	13		; EZ80_PORTB1_IRQ  13   25   0x032
+	irqhandler	14		; EZ80_PORTB2_IRQ  14   26   0x034
+	irqhandler	15		; EZ80_PORTB3_IRQ  15   27   0x036
+	irqhandler	16		; EZ80_PORTB4_IRQ  16   28   0x038
+	irqhandler	17		; EZ80_PORTB5_IRQ  17   29   0x03a
+	irqhandler	18		; EZ80_PORTB6_IRQ  18   20   0x03c
+	irqhandler	19		; EZ80_PORTB7_IRQ  19   21   0x03e
+	irqhandler	20		; EZ80_PORTC0_IRQ  20   22   0x040
+	irqhandler	21		; EZ80_PORTC1_IRQ  21   23   0x042
+	irqhandler	22		; EZ80_PORTC2_IRQ  22   24   0x044
+	irqhandler	23		; EZ80_PORTC3_IRQ  23   25   0x046
+	irqhandler	24		; EZ80_PORTC4_IRQ  24   26   0x048
+	irqhandler	25		; EZ80_PORTC5_IRQ  25   27   0x04a
+	irqhandler	26		; EZ80_PORTC6_IRQ  26   28   0x04c
+	irqhandler	27		; EZ80_PORTC7_IRQ  27   29   0x04e
+	irqhandler	28		; EZ80_PORTD0_IRQ  28   40   0x050
+	irqhandler	29		; EZ80_PORTD1_IRQ  29   41   0x052
+	irqhandler	30		; EZ80_PORTD2_IRQ  30   42   0x054
+	irqhandler	31		; EZ80_PORTD3_IRQ  31   43   0x056
+	irqhandler	32		; EZ80_PORTD4_IRQ  32   44   0x058
+	irqhandler	33		; EZ80_PORTD5_IRQ  33   45   0x05a
+	irqhandler	34		; EZ80_PORTD6_IRQ  34   46   0x05c
+	irqhandler	35		; EZ80_PORTD7_IRQ  35   47   0x05e
+	irqhandler	EZ80_UNUSED+12	;               48   0x060
+	irqhandler	EZ80_UNUSED+13	;               49   0x062
+	irqhandler	EZ80_UNUSED+14	;               50   0x064
+	irqhandler	EZ80_UNUSED+15	;               51   0x066
+	irqhandler	EZ80_UNUSED+16	;               52   0x068
+	irqhandler	EZ80_UNUSED+17	;               53   0x06a
+	irqhandler	EZ80_UNUSED+18	;               54   0x06c
+	irqhandler	EZ80_UNUSED+19	;               55   0x06e
+	irqhandler	EZ80_UNUSED+20	;               56   0x070
+	irqhandler	EZ80_UNUSED+21	;               57   0x072
+	irqhandler	EZ80_UNUSED+22	;               58   0x074
+	irqhandler	EZ80_UNUSED+23	;               59   0x076
+	irqhandler	EZ80_UNUSED+24	;               60   0x078
+	irqhandler	EZ80_UNUSED+25	;               61   0x07a
+	irqhandler	EZ80_UNUSED+26	;               62   0x07c
+	irqhandler	EZ80_UNUSED+27	;               63   0x07e
 
 ;**************************************************************************
 ; Vector Setup Logic

--- a/arch/z80/src/ez80/ez80f92_loader.asm
+++ b/arch/z80/src/ez80/ez80f92_loader.asm
@@ -250,74 +250,74 @@ _ez80_redirect:
 ; address given by VECSTART by _ez80_initvectors.  FLASH based interrupt
 ; handling will vector here to support interrupts in the RAM-based program.
 
-						; Symbol           Val VecNo Addr
-						;----------------- --- ----- -----
+						; Symbol           Val VecNo VecOffset
+						;----------------- --- ----- ---------
 _ez80_handlers:
-	irqhandler	EZ80_UNUSED		;                0   0x040
+	irqhandler	EZ80_UNUSED		;                0   0x000
 	_handlersize EQU $-_ez80_handlers
-	irqhandler	EZ80_UNUSED+1	;                1   0x044
-	irqhandler	EZ80_UNUSED+2	;                2   0x045
-	irqhandler	EZ80_UNUSED+3	;                3   0x04c
-	irqhandler	 0		; EZ80_FLASH_IRQ    0    4   0x050
-	irqhandler	 1		; EZ80_TIMER0_IRQ   1    5   0x054
-	irqhandler	 2		; EZ80_TIMER1_IRQ   2    6   0x058
-	irqhandler	 3		; EZ80_TIMER2_IRQ   3    7   0x05c
-	irqhandler	 4		; EZ80_TIMER3_IRQ   4    8   0x060
-	irqhandler	 5		; EZ80_TIMER4_IRQ   5    9   0x064
-	irqhandler	 6		; EZ80_TIMER5_IRQ   6   10   0x068
-	irqhandler	 7		; EZ80_RTC_IRQ      7   11   0x06C
-	irqhandler	 8		; EZ80_UART0_IRQ    8   12   0x070
-	irqhandler	 9		; EZ80_UART1_IRQ    9   13   0x074
-	irqhandler	10		; EZ80_I2C_IRQ     10   14   0x078
-	irqhandler	11		; EZ80_SPI_IRQ     11   15   0x07c
-	irqhandler	EZ80_UNUSED+4	;               16   0x080
-	irqhandler	EZ80_UNUSED+5	;               17   0x084
-	irqhandler	EZ80_UNUSED+6	;               18   0x088
-	irqhandler	EZ80_UNUSED+7	;               19   0x08c
-	irqhandler	EZ80_UNUSED+8	;               16   0x080
-	irqhandler	EZ80_UNUSED+9	;               17   0x094
-	irqhandler	EZ80_UNUSED+10	;               18   0x098
-	irqhandler	EZ80_UNUSED+11	;               19   0x09c
-	irqhandler	12		; EZ80_PORTB0_IRQ  12   24   0x0a0
-	irqhandler	13		; EZ80_PORTB1_IRQ  13   25   0x0a4
-	irqhandler	14		; EZ80_PORTB2_IRQ  14   26   0x0a8
-	irqhandler	15		; EZ80_PORTB3_IRQ  15   27   0x0ac
-	irqhandler	16		; EZ80_PORTB4_IRQ  16   28   0x0b0
-	irqhandler	17		; EZ80_PORTB5_IRQ  17   29   0x0b4
-	irqhandler	18		; EZ80_PORTB6_IRQ  18   20   0x0b8
-	irqhandler	19		; EZ80_PORTB7_IRQ  19   21   0x0bc
-	irqhandler	20		; EZ80_PORTC0_IRQ  20   22   0x0c0
-	irqhandler	21		; EZ80_PORTC1_IRQ  21   23   0x0c4
-	irqhandler	22		; EZ80_PORTC2_IRQ  22   24   0x0c8
-	irqhandler	23		; EZ80_PORTC3_IRQ  23   25   0x0cc
-	irqhandler	24		; EZ80_PORTC4_IRQ  24   26   0x0d0
-	irqhandler	25		; EZ80_PORTC5_IRQ  25   27   0x0d4
-	irqhandler	26		; EZ80_PORTC6_IRQ  26   28   0x0d8
-	irqhandler	27		; EZ80_PORTC7_IRQ  27   29   0x0dc
-	irqhandler	28		; EZ80_PORTD0_IRQ  28   40   0x0e0
-	irqhandler	29		; EZ80_PORTD1_IRQ  29   41   0x0e4
-	irqhandler	30		; EZ80_PORTD2_IRQ  30   42   0x0e8
-	irqhandler	31		; EZ80_PORTD3_IRQ  31   43   0x0ec
-	irqhandler	32		; EZ80_PORTD4_IRQ  32   44   0x0f0
-	irqhandler	33		; EZ80_PORTD5_IRQ  33   45   0x0f4
-	irqhandler	34		; EZ80_PORTD6_IRQ  34   46   0x0f8
-	irqhandler	35		; EZ80_PORTD7_IRQ  35   47   0x0fc
-	irqhandler	EZ80_UNUSED+12	;               48   0x100
-	irqhandler	EZ80_UNUSED+13	;               49   0x104
-	irqhandler	EZ80_UNUSED+14	;               50   0x108
-	irqhandler	EZ80_UNUSED+15	;               51   0x10c
-	irqhandler	EZ80_UNUSED+16	;               52   0x110
-	irqhandler	EZ80_UNUSED+17	;               53   0x114
-	irqhandler	EZ80_UNUSED+18	;               54   0x118
-	irqhandler	EZ80_UNUSED+19	;               55   0x11c
-	irqhandler	EZ80_UNUSED+20	;               56   0x120
-	irqhandler	EZ80_UNUSED+21	;               57   0x124
-	irqhandler	EZ80_UNUSED+22	;               58   0x128
-	irqhandler	EZ80_UNUSED+23	;               59   0x12c
-	irqhandler	EZ80_UNUSED+24	;               60   0x130
-	irqhandler	EZ80_UNUSED+25	;               61   0x134
-	irqhandler	EZ80_UNUSED+26	;               62   0x138
-	irqhandler	EZ80_UNUSED+27	;               63   0x13c
+	irqhandler	EZ80_UNUSED+1	;                1   0x002
+	irqhandler	EZ80_UNUSED+2	;                2   0x004
+	irqhandler	EZ80_UNUSED+3	;                3   0x006
+	irqhandler	 0		; EZ80_FLASH_IRQ    0    4   0x008
+	irqhandler	 1		; EZ80_TIMER0_IRQ   1    5   0x00a
+	irqhandler	 2		; EZ80_TIMER1_IRQ   2    6   0x00c
+	irqhandler	 3		; EZ80_TIMER2_IRQ   3    7   0x00e
+	irqhandler	 4		; EZ80_TIMER3_IRQ   4    8   0x010
+	irqhandler	 5		; EZ80_TIMER4_IRQ   5    9   0x012
+	irqhandler	 6		; EZ80_TIMER5_IRQ   6   10   0x014
+	irqhandler	 7		; EZ80_RTC_IRQ      7   11   0x016
+	irqhandler	 8		; EZ80_UART0_IRQ    8   12   0x018
+	irqhandler	 9		; EZ80_UART1_IRQ    9   13   0x01a
+	irqhandler	10		; EZ80_I2C_IRQ     10   14   0x01c
+	irqhandler	11		; EZ80_SPI_IRQ     11   15   0x01e
+	irqhandler	EZ80_UNUSED+4	;               16   0x020
+	irqhandler	EZ80_UNUSED+5	;               17   0x022
+	irqhandler	EZ80_UNUSED+6	;               18   0x024
+	irqhandler	EZ80_UNUSED+7	;               19   0x026
+	irqhandler	EZ80_UNUSED+8	;               16   0x028
+	irqhandler	EZ80_UNUSED+9	;               17   0x02a
+	irqhandler	EZ80_UNUSED+10	;               18   0x02c
+	irqhandler	EZ80_UNUSED+11	;               19   0x02e
+	irqhandler	12		; EZ80_PORTB0_IRQ  12   24   0x030
+	irqhandler	13		; EZ80_PORTB1_IRQ  13   25   0x032
+	irqhandler	14		; EZ80_PORTB2_IRQ  14   26   0x034
+	irqhandler	15		; EZ80_PORTB3_IRQ  15   27   0x036
+	irqhandler	16		; EZ80_PORTB4_IRQ  16   28   0x038
+	irqhandler	17		; EZ80_PORTB5_IRQ  17   29   0x03a
+	irqhandler	18		; EZ80_PORTB6_IRQ  18   20   0x03c
+	irqhandler	19		; EZ80_PORTB7_IRQ  19   21   0x03e
+	irqhandler	20		; EZ80_PORTC0_IRQ  20   22   0x040
+	irqhandler	21		; EZ80_PORTC1_IRQ  21   23   0x042
+	irqhandler	22		; EZ80_PORTC2_IRQ  22   24   0x044
+	irqhandler	23		; EZ80_PORTC3_IRQ  23   25   0x046
+	irqhandler	24		; EZ80_PORTC4_IRQ  24   26   0x048
+	irqhandler	25		; EZ80_PORTC5_IRQ  25   27   0x04a
+	irqhandler	26		; EZ80_PORTC6_IRQ  26   28   0x04c
+	irqhandler	27		; EZ80_PORTC7_IRQ  27   29   0x04e
+	irqhandler	28		; EZ80_PORTD0_IRQ  28   40   0x050
+	irqhandler	29		; EZ80_PORTD1_IRQ  29   41   0x052
+	irqhandler	30		; EZ80_PORTD2_IRQ  30   42   0x054
+	irqhandler	31		; EZ80_PORTD3_IRQ  31   43   0x056
+	irqhandler	32		; EZ80_PORTD4_IRQ  32   44   0x058
+	irqhandler	33		; EZ80_PORTD5_IRQ  33   45   0x05a
+	irqhandler	34		; EZ80_PORTD6_IRQ  34   46   0x05c
+	irqhandler	35		; EZ80_PORTD7_IRQ  35   47   0x05e
+	irqhandler	EZ80_UNUSED+12	;               48   0x060
+	irqhandler	EZ80_UNUSED+13	;               49   0x062
+	irqhandler	EZ80_UNUSED+14	;               50   0x064
+	irqhandler	EZ80_UNUSED+15	;               51   0x066
+	irqhandler	EZ80_UNUSED+16	;               52   0x068
+	irqhandler	EZ80_UNUSED+17	;               53   0x06a
+	irqhandler	EZ80_UNUSED+18	;               54   0x06c
+	irqhandler	EZ80_UNUSED+19	;               55   0x06e
+	irqhandler	EZ80_UNUSED+20	;               56   0x070
+	irqhandler	EZ80_UNUSED+21	;               57   0x072
+	irqhandler	EZ80_UNUSED+22	;               58   0x074
+	irqhandler	EZ80_UNUSED+23	;               59   0x076
+	irqhandler	EZ80_UNUSED+24	;               60   0x078
+	irqhandler	EZ80_UNUSED+25	;               61   0x07a
+	irqhandler	EZ80_UNUSED+26	;               62   0x07c
+	irqhandler	EZ80_UNUSED+27	;               63   0x07e
 	_copysize EQU $-_ez80_handlers
 
 ;**************************************************************************

--- a/arch/z80/src/ez80/ez80f92_program.asm
+++ b/arch/z80/src/ez80/ez80f92_program.asm
@@ -87,71 +87,71 @@ irqhandler: macro vectno
 						; Symbol           Val VecNo Addr
 						;----------------- --- ----- -----
 _ez80_handlers:
-	irqhandler	EZ80_UNUSED		;                0   0x040
+	irqhandler	EZ80_UNUSED		;                0   0x000
 	_handlersize EQU $-_ez80_handlers
-	irqhandler	EZ80_UNUSED+1	;                1   0x044
-	irqhandler	EZ80_UNUSED+2	;                2   0x045
-	irqhandler	EZ80_UNUSED+3	;                3   0x04c
-	irqhandler	 0		; EZ80_FLASH_IRQ    0    4   0x050
-	irqhandler	 1		; EZ80_TIMER0_IRQ   1    5   0x054
-	irqhandler	 2		; EZ80_TIMER1_IRQ   2    6   0x058
-	irqhandler	 3		; EZ80_TIMER2_IRQ   3    7   0x05c
-	irqhandler	 4		; EZ80_TIMER3_IRQ   4    8   0x060
-	irqhandler	 5		; EZ80_TIMER4_IRQ   5    9   0x064
-	irqhandler	 6		; EZ80_TIMER5_IRQ   6   10   0x068
-	irqhandler	 7		; EZ80_RTC_IRQ      7   11   0x06C
-	irqhandler	 8		; EZ80_UART0_IRQ    8   12   0x070
-	irqhandler	 9		; EZ80_UART1_IRQ    9   13   0x074
-	irqhandler	10		; EZ80_I2C_IRQ     10   14   0x078
-	irqhandler	11		; EZ80_SPI_IRQ     11   15   0x07c
-	irqhandler	EZ80_UNUSED+4	;               16   0x080
-	irqhandler	EZ80_UNUSED+5	;               17   0x084
-	irqhandler	EZ80_UNUSED+6	;               18   0x088
-	irqhandler	EZ80_UNUSED+7	;               19   0x08c
-	irqhandler	EZ80_UNUSED+8	;               16   0x080
-	irqhandler	EZ80_UNUSED+9	;               17   0x094
-	irqhandler	EZ80_UNUSED+10	;               18   0x098
-	irqhandler	EZ80_UNUSED+11	;               19   0x09c
-	irqhandler	12		; EZ80_PORTB0_IRQ  12   24   0x0a0
-	irqhandler	13		; EZ80_PORTB1_IRQ  13   25   0x0a4
-	irqhandler	14		; EZ80_PORTB2_IRQ  14   26   0x0a8
-	irqhandler	15		; EZ80_PORTB3_IRQ  15   27   0x0ac
-	irqhandler	16		; EZ80_PORTB4_IRQ  16   28   0x0b0
-	irqhandler	17		; EZ80_PORTB5_IRQ  17   29   0x0b4
-	irqhandler	18		; EZ80_PORTB6_IRQ  18   20   0x0b8
-	irqhandler	19		; EZ80_PORTB7_IRQ  19   21   0x0bc
-	irqhandler	20		; EZ80_PORTC0_IRQ  20   22   0x0c0
-	irqhandler	21		; EZ80_PORTC1_IRQ  21   23   0x0c4
-	irqhandler	22		; EZ80_PORTC2_IRQ  22   24   0x0c8
-	irqhandler	23		; EZ80_PORTC3_IRQ  23   25   0x0cc
-	irqhandler	24		; EZ80_PORTC4_IRQ  24   26   0x0d0
-	irqhandler	25		; EZ80_PORTC5_IRQ  25   27   0x0d4
-	irqhandler	26		; EZ80_PORTC6_IRQ  26   28   0x0d8
-	irqhandler	27		; EZ80_PORTC7_IRQ  27   29   0x0dc
-	irqhandler	28		; EZ80_PORTD0_IRQ  28   40   0x0e0
-	irqhandler	29		; EZ80_PORTD1_IRQ  29   41   0x0e4
-	irqhandler	30		; EZ80_PORTD2_IRQ  30   42   0x0e8
-	irqhandler	31		; EZ80_PORTD3_IRQ  31   43   0x0ec
-	irqhandler	32		; EZ80_PORTD4_IRQ  32   44   0x0f0
-	irqhandler	33		; EZ80_PORTD5_IRQ  33   45   0x0f4
-	irqhandler	34		; EZ80_PORTD6_IRQ  34   46   0x0f8
-	irqhandler	35		; EZ80_PORTD7_IRQ  35   47   0x0fc
-	irqhandler	EZ80_UNUSED+12	;               48   0x100
-	irqhandler	EZ80_UNUSED+13	;               49   0x104
-	irqhandler	EZ80_UNUSED+14	;               50   0x108
-	irqhandler	EZ80_UNUSED+15	;               51   0x10c
-	irqhandler	EZ80_UNUSED+16	;               52   0x110
-	irqhandler	EZ80_UNUSED+17	;               53   0x114
-	irqhandler	EZ80_UNUSED+18	;               54   0x118
-	irqhandler	EZ80_UNUSED+19	;               55   0x11c
-	irqhandler	EZ80_UNUSED+20	;               56   0x120
-	irqhandler	EZ80_UNUSED+21	;               57   0x124
-	irqhandler	EZ80_UNUSED+22	;               58   0x128
-	irqhandler	EZ80_UNUSED+23	;               59   0x12c
-	irqhandler	EZ80_UNUSED+24	;               60   0x130
-	irqhandler	EZ80_UNUSED+25	;               61   0x134
-	irqhandler	EZ80_UNUSED+26	;               62   0x138
-	irqhandler	EZ80_UNUSED+27	;               63   0x13c
+	irqhandler	EZ80_UNUSED+1	;                1   0x002
+	irqhandler	EZ80_UNUSED+2	;                2   0x004
+	irqhandler	EZ80_UNUSED+3	;                3   0x006
+	irqhandler	 0		; EZ80_FLASH_IRQ    0    4   0x008
+	irqhandler	 1		; EZ80_TIMER0_IRQ   1    5   0x00a
+	irqhandler	 2		; EZ80_TIMER1_IRQ   2    6   0x00c
+	irqhandler	 3		; EZ80_TIMER2_IRQ   3    7   0x00e
+	irqhandler	 4		; EZ80_TIMER3_IRQ   4    8   0x010
+	irqhandler	 5		; EZ80_TIMER4_IRQ   5    9   0x012
+	irqhandler	 6		; EZ80_TIMER5_IRQ   6   10   0x014
+	irqhandler	 7		; EZ80_RTC_IRQ      7   11   0x016
+	irqhandler	 8		; EZ80_UART0_IRQ    8   12   0x018
+	irqhandler	 9		; EZ80_UART1_IRQ    9   13   0x01a
+	irqhandler	10		; EZ80_I2C_IRQ     10   14   0x01c
+	irqhandler	11		; EZ80_SPI_IRQ     11   15   0x01e
+	irqhandler	EZ80_UNUSED+4	;               16   0x020
+	irqhandler	EZ80_UNUSED+5	;               17   0x022
+	irqhandler	EZ80_UNUSED+6	;               18   0x024
+	irqhandler	EZ80_UNUSED+7	;               19   0x026
+	irqhandler	EZ80_UNUSED+8	;               16   0x028
+	irqhandler	EZ80_UNUSED+9	;               17   0x02a
+	irqhandler	EZ80_UNUSED+10	;               18   0x02c
+	irqhandler	EZ80_UNUSED+11	;               19   0x02e
+	irqhandler	12		; EZ80_PORTB0_IRQ  12   24   0x030
+	irqhandler	13		; EZ80_PORTB1_IRQ  13   25   0x032
+	irqhandler	14		; EZ80_PORTB2_IRQ  14   26   0x034
+	irqhandler	15		; EZ80_PORTB3_IRQ  15   27   0x036
+	irqhandler	16		; EZ80_PORTB4_IRQ  16   28   0x038
+	irqhandler	17		; EZ80_PORTB5_IRQ  17   29   0x03a
+	irqhandler	18		; EZ80_PORTB6_IRQ  18   20   0x03c
+	irqhandler	19		; EZ80_PORTB7_IRQ  19   21   0x03e
+	irqhandler	20		; EZ80_PORTC0_IRQ  20   22   0x040
+	irqhandler	21		; EZ80_PORTC1_IRQ  21   23   0x042
+	irqhandler	22		; EZ80_PORTC2_IRQ  22   24   0x044
+	irqhandler	23		; EZ80_PORTC3_IRQ  23   25   0x046
+	irqhandler	24		; EZ80_PORTC4_IRQ  24   26   0x048
+	irqhandler	25		; EZ80_PORTC5_IRQ  25   27   0x04a
+	irqhandler	26		; EZ80_PORTC6_IRQ  26   28   0x04c
+	irqhandler	27		; EZ80_PORTC7_IRQ  27   29   0x04e
+	irqhandler	28		; EZ80_PORTD0_IRQ  28   40   0x050
+	irqhandler	29		; EZ80_PORTD1_IRQ  29   41   0x052
+	irqhandler	30		; EZ80_PORTD2_IRQ  30   42   0x054
+	irqhandler	31		; EZ80_PORTD3_IRQ  31   43   0x056
+	irqhandler	32		; EZ80_PORTD4_IRQ  32   44   0x058
+	irqhandler	33		; EZ80_PORTD5_IRQ  33   45   0x05a
+	irqhandler	34		; EZ80_PORTD6_IRQ  34   46   0x05c
+	irqhandler	35		; EZ80_PORTD7_IRQ  35   47   0x05e
+	irqhandler	EZ80_UNUSED+12	;               48   0x060
+	irqhandler	EZ80_UNUSED+13	;               49   0x062
+	irqhandler	EZ80_UNUSED+14	;               50   0x064
+	irqhandler	EZ80_UNUSED+15	;               51   0x066
+	irqhandler	EZ80_UNUSED+16	;               52   0x068
+	irqhandler	EZ80_UNUSED+17	;               53   0x06a
+	irqhandler	EZ80_UNUSED+18	;               54   0x06c
+	irqhandler	EZ80_UNUSED+19	;               55   0x06e
+	irqhandler	EZ80_UNUSED+20	;               56   0x070
+	irqhandler	EZ80_UNUSED+21	;               57   0x072
+	irqhandler	EZ80_UNUSED+22	;               58   0x074
+	irqhandler	EZ80_UNUSED+23	;               59   0x076
+	irqhandler	EZ80_UNUSED+24	;               60   0x078
+	irqhandler	EZ80_UNUSED+25	;               61   0x07a
+	irqhandler	EZ80_UNUSED+26	;               62   0x07c
+	irqhandler	EZ80_UNUSED+27	;               63   0x07e
 	_copysize EQU $-_ez80_handlers
 
 ;**************************************************************************

--- a/boards/z80/ez80/z20x/scripts/z20x_loader.linkcmd
+++ b/boards/z80/ez80/z20x/scripts/z20x_loader.linkcmd
@@ -24,7 +24,7 @@
 -sort NAME=ascending -warn -debug -NOigcase
 
 RANGE ROM $000000 : $01ffff
-RANGE RAM $040000 : $04ffff
+RANGE RAM $040200 : $04ffff
 RANGE EXTIO $000000 : $00ffff
 RANGE INTIO $000000 : $0000ff
 

--- a/boards/z80/ez80/z20x/scripts/z20x_program.linkcmd
+++ b/boards/z80/ez80/z20x/scripts/z20x_program.linkcmd
@@ -23,10 +23,10 @@
 -map -maxhexlen=64 -quiet -warnoverlap -xref -unresolved=fatal
 -sort NAME=ascending -warn -debug -NOigcase
 
-RANGE ROM $000000 : $01FFFF
-RANGE RAM $050000 : $0BFFFF
-RANGE EXTIO $000000 : $00FFFF
-RANGE INTIO $000000 : $0000FF
+RANGE ROM $000000 : $01ffff
+RANGE RAM $050000 : $0bffff
+RANGE EXTIO $000000 : $00ffff
+RANGE INTIO $000000 : $0000ff
 
 CHANGE .RESET is RAM
 CHANGE .STARTUP is RAM


### PR DESCRIPTION
arch/z80/: include/ez80/irq.h, src/ez80/ez80f92_*.asm:  Correct some comments related to vector address offsets.
boards/z80/ez80/z20x/scripts/z20x_loader.linkcmd:  Fix RAM offset in linker script