### PR TITLE
arch: xtensa: Call the waiti instruction in up_idle()

### DIFF
--- a/arch/xtensa/src/common/xtensa_idle.c
+++ b/arch/xtensa/src/common/xtensa_idle.c
@@ -92,4 +92,11 @@ void up_idle(void)
   leave_critical_section(flags);
 #endif
 #endif
+
+  /* This would be an appropriate place to put some MCU-specific logic to
+   * sleep in a reduced power mode until an interrupt occurs to save power
+   */
+
+  asm("waiti 0");
+
 }


### PR DESCRIPTION
### Summary

- This PR calls the waiti (wait for interrupt) instruction in up_idle() to reduce power consumption.

### Impact

- This PR affects xtensa architecture (e.g. esp32)

### Testing

- I tested this PR with both ESP32-DevKitC and QEMU for ESP32.
