### PR TITLE
Revert "tools/nxstyle:  Back out part of last commit.  Logic to avoid…

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -700,7 +700,7 @@ int main(int argc, char **argv, char **envp)
                * preceding line has no comment.
                */
 
-              if (line[n] != '}' /* && line[n] != '#' */ && !prevbrhcmt)
+              if (line[n] != '}' && line[n] != '#' && !prevbrhcmt)
                 {
                    ERROR("Missing blank line after comment", comment_lineno,
                          1);


### PR DESCRIPTION
… some false alarms was causing real style problems from being reported."

If we are going to use this tool for things like
git pre-commit hook or CI workflow, it's critical to
avoid false alarms.

This reverts commit de764af9aa5364d2dc02e09e377cbab230302d74.