### PR TITLE
CXD56: move isx012 driver to board specific drivers

### DIFF
--- a/boards/arm/cxd56xx/drivers/Kconfig
+++ b/boards/arm/cxd56xx/drivers/Kconfig
@@ -3,6 +3,14 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+config SPECIFIC_DRIVERS
+       bool "Board specific drivers"
+       default n
+       ---help---
+               Board specific drivers located in each board/driver folder.
+
+if SPECIFIC_DRIVERS
 source "drivers/platform/audio/Kconfig"
 source "drivers/platform/sensors/Kconfig"
 source "drivers/platform/camera/Kconfig"
+endif

--- a/boards/arm/cxd56xx/drivers/Make.defs
+++ b/boards/arm/cxd56xx/drivers/Make.defs
@@ -35,3 +35,4 @@
 
 include platform$(DELIM)audio$(DELIM)Make.defs
 include platform$(DELIM)sensors$(DELIM)Make.defs
+include platform$(DELIM)camera$(DELIM)Make.defs

--- a/boards/arm/cxd56xx/drivers/camera/Kconfig
+++ b/boards/arm/cxd56xx/drivers/camera/Kconfig
@@ -3,6 +3,7 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-source "drivers/platform/audio/Kconfig"
-source "drivers/platform/sensors/Kconfig"
-source "drivers/platform/camera/Kconfig"
+config VIDEO_ISX012
+	bool "ISX012 Image sensor"
+	default n
+	select I2C

--- a/boards/arm/cxd56xx/drivers/camera/Make.defs
+++ b/boards/arm/cxd56xx/drivers/camera/Make.defs
@@ -1,0 +1,27 @@
+/****************************************************************************
+ * boards/arm/cxd56xx/drivers/video/Make.defs
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+ifeq ($(VIDEO_ISX012),y)
+  CSRCS += isx012.c
+endif
+
+DEPPATH += --dep-path platform$(DELIM)camera
+VPATH += :platform$(DELIM)camera
+CFLAGS += $(shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)platform$(DELIM)camera)

--- a/boards/arm/cxd56xx/drivers/camera/isx012.c
+++ b/boards/arm/cxd56xx/drivers/camera/isx012.c
@@ -1,35 +1,20 @@
 /****************************************************************************
- * drivers/video/isx012.c
+ * boards/arm/cxd56xx/drivers/video/isx012.c
  *
- *   Copyright 2018 Sony Semiconductor Solutions Corporation
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name of Sony Semiconductor Solutions Corporation nor
- *    the names of its contributors may be used to endorse or promote
- *    products derived from this software without specific prior written
- *    permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/boards/arm/cxd56xx/drivers/sensors/Kconfig
+++ b/boards/arm/cxd56xx/drivers/sensors/Kconfig
@@ -174,5 +174,4 @@ config RPR0521RS_PROXIMITY_INTERRUPT
 		In this case, SCU sequencer is not used.
 
 endif # SENSORS_RPR0521RS_SCU
-
 endif # SCU_SENSORS

--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -60,11 +60,6 @@ config VIDEO_MAX7456
 		Support for the Maxim 7456 monochrome on-screen display
 		multiplexer.
 
-config VIDEO_ISX012
-	bool "ISX012 Image sensor"
-	default n
-	select I2C
-
 config VIDEO_OV2640
 	bool "OV2640 camera chip"
 	default n

--- a/drivers/video/Make.defs
+++ b/drivers/video/Make.defs
@@ -49,10 +49,6 @@ endif
 
 ifeq ($(CONFIG_I2C),y)
 
-ifeq ($(CONFIG_VIDEO_ISX012),y)
-CSRCS += isx012.c
-endif
-
 ifeq ($(CONFIG_VIDEO_OV2640),y)
   CSRCS += ov2640.c
 endif


### PR DESCRIPTION
workaround for issue 438
https://github.com/apache/incubator-nuttx/issues/438