### PR TITLE
Build System:  Resolve CPU-specific logic in common build files

### DIFF
--- a/boards/arm/cxd56xx/scripts/Config.mk
+++ b/boards/arm/cxd56xx/scripts/Config.mk
@@ -1,0 +1,41 @@
+############################################################################
+# board/arm/cxd56xx/script/Config.mk
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# These are the macros that will be used in the NuttX make system to compile
+# and assembly source files and to insert the resulting object files into an
+# archive.  These replace the default definitions at tools/Config.mk
+
+# POSTBUILD -- Perform post build operations
+
+ifeq ($(CONFIG_CXD56_BINARY),y)
+define POSTBUILD
+	$(Q) if [ ! -f "tools/cxd56/mkspk" ] ; then \
+		echo ""; \
+		echo "Please run the following command to build the needed tool"; \
+		echo ""; \
+		echo "cd tools/cxd56 && make && cd ../.."; \
+		echo ""; \
+		echo "run make again to create the nuttx.spk image."; \
+	else \
+		echo "Generating: $(NUTTXNAME).spk"; \
+		tools/cxd56/mkspk -c2 nuttx nuttx nuttx.spk; \
+	fi
+endef
+endif

--- a/boards/arm/cxd56xx/spresense/scripts/Make.defs
+++ b/boards/arm/cxd56xx/spresense/scripts/Make.defs
@@ -35,6 +35,7 @@
 
 include ${TOPDIR}/.config
 include ${TOPDIR}/tools/Config.mk
+include ${TOPDIR}/boards/arm/cxd56xx/scripts/Config.mk
 include ${TOPDIR}/arch/arm/src/armv7-m/Toolchain.defs
 
 # Setup for the kind of memory that we are executing from

--- a/boards/z16/z16f/z16f2800100zcog/scripts/Make.defs
+++ b/boards/z16/z16f/z16f2800100zcog/scripts/Make.defs
@@ -36,7 +36,7 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include ${TOPDIR}/arch/z16/src/z16f/Toolchain.defs
-include $(TOPDIR)/tools/zds/zds_Config.mk
+include $(TOPDIR)/tools/zds/Config.mk
 
 # CFLAGS
 

--- a/boards/z80/ez80/ez80f910200kitg/scripts/Make.defs
+++ b/boards/z80/ez80/ez80f910200kitg/scripts/Make.defs
@@ -36,7 +36,7 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include ${TOPDIR}/arch/z80/src/ez80/Toolchain.defs
-include $(TOPDIR)/tools/zds/zds_Config.mk
+include $(TOPDIR)/tools/zds/Config.mk
 
 # CFLAGS
 

--- a/boards/z80/ez80/ez80f910200zco/scripts/Make.defs
+++ b/boards/z80/ez80/ez80f910200zco/scripts/Make.defs
@@ -36,7 +36,7 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include ${TOPDIR}/arch/z80/src/ez80/Toolchain.defs
-include $(TOPDIR)/tools/zds/zds_Config.mk
+include $(TOPDIR)/tools/zds/Config.mk
 
 # CFLAGS
 

--- a/boards/z80/ez80/makerlisp/scripts/Make.defs
+++ b/boards/z80/ez80/makerlisp/scripts/Make.defs
@@ -36,7 +36,7 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include ${TOPDIR}/arch/z80/src/ez80/Toolchain.defs
-include $(TOPDIR)/tools/zds/zds_Config.mk
+include $(TOPDIR)/tools/zds/Config.mk
 
 # CFLAGS
 

--- a/boards/z80/ez80/z20x/scripts/Make.defs
+++ b/boards/z80/ez80/z20x/scripts/Make.defs
@@ -21,7 +21,7 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include ${TOPDIR}/arch/z80/src/ez80/Toolchain.defs
-include $(TOPDIR)/tools/zds/zds_Config.mk
+include $(TOPDIR)/tools/zds/Config.mk
 
 # CFLAGS
 

--- a/boards/z80/z8/z8encore000zco/scripts/Make.defs
+++ b/boards/z80/z8/z8encore000zco/scripts/Make.defs
@@ -36,7 +36,7 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include ${TOPDIR}/arch/z80/src/z8/Toolchain.defs
-include $(TOPDIR)/tools/zds/zds_Config.mk
+include $(TOPDIR)/tools/zds/Config.mk
 
 # CFLAGS
 

--- a/boards/z80/z8/z8f64200100kit/scripts/Make.defs
+++ b/boards/z80/z8/z8f64200100kit/scripts/Make.defs
@@ -36,7 +36,7 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include ${TOPDIR}/arch/z80/src/z8/Toolchain.defs
-include $(TOPDIR)/tools/zds/zds_Config.mk
+include $(TOPDIR)/tools/zds/Config.mk
 
 # CFLAGS
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -2,7 +2,7 @@
 # tools/Config.mk
 # Global build rules and macros.
 #
-#   Copyright (C) 2011, 2013-2014, 2018-2019 Gregory Nutt. All rights
+#   Copyright (C) 2011, 2013-2014, 2018-2019, 2020 Gregory Nutt. All rights
 #     reserved.
 #   Author: Richard Cochran
 #           Gregory Nutt <gnutt@nuttx.org>
@@ -238,6 +238,15 @@ define PRELINK
 	$(Q) $(LD) -Ur -o $1 $2 && $(OBJCOPY) --localize-hidden $1
 endef
 endif
+
+# POSTBUILD -- Perform post build operations
+# Some architectures require the use of special tools and special handling
+# AFTER building the NuttX binary.  Make.defs files for thos architectures
+# should override the following define with the correct operations for
+# that platform
+
+define POSTBUILD
+endef
 
 # DELFILE - Delete one file
 

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -480,19 +480,6 @@ ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: $(NUTTXNAME).bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
 endif
-ifeq ($(CONFIG_CXD56_BINARY),y)
-	$(Q) if [ ! -f "tools/cxd56/mkspk" ] ; then \
-		echo ""; \
-		echo "Please run the following command to build the needed tool"; \
-		echo ""; \
-		echo "cd tools/cxd56 && make && cd ../.."; \
-		echo ""; \
-		echo "run make again to create the nuttx.spk image."; \
-	else \
-		echo "Generating: $(NUTTXNAME).spk"; \
-		tools/cxd56/mkspk -c2 nuttx nuttx nuttx.spk; \
-	fi
-endif
 ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	@echo "MKIMAGE: uImage"
 	$(Q) mkimage -A $(CONFIG_ARCH) -O linux -C none -T kernel -a $(CONFIG_UIMAGE_LOAD_ADDRESS) \
@@ -501,6 +488,7 @@ ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 		cp -f uImage /tftpboot/uImage; \
 	fi
 endif
+	$(call POSTBUILD)
 
 # $(BIN)
 #

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -490,19 +490,7 @@ ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: $(NUTTXNAME).bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
 endif
-ifeq ($(CONFIG_CXD56_BINARY),y)
-	$(Q) if [ ! -f "tools/cxd56/mkspk.exe" ] ; then \
-		echo ""; \
-		echo "Please run the following command to build the needed tool"; \
-		echo ""; \
-		echo "cd tools/cxd56 && make && cd ../.."; \
-		echo ""; \
-		echo "run make again to create the nuttx.spk image."; \
-	else \
-		echo "Generating: $(NUTTXNAME).spk"; \
-		tools\cxd56\mkspk.exe -c2 nuttx nuttx nuttx.spk; \
-	fi
-endif
+	$(call POSTBUILD)
 
 # $(BIN)
 #

--- a/tools/zds/Config.mk
+++ b/tools/zds/Config.mk
@@ -1,5 +1,5 @@
 ############################################################################
-# tools/zds/zds_Config.defs
+# tools/zds/Config.mk
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/tools/zds/README.txt
+++ b/tools/zds/README.txt
@@ -7,10 +7,10 @@ tools/zds/zdsar.c:  This is a wrapper around the ZDS_II librarian.  It
   the build files but it also improves performance and, more importantly,i
   provides a common solution for the Windows native build case.
 
-tools/zds/zds_Config.mk:  This makefile fragment is include by ZDS-II
-  Make.defs files after including tools/Config.mk.  The definitions in this
-  file override some of the the definitions in tools/Config.mk to customize
-  the build for use with the ZDS-II tools.
+tools/zds/Config.mk:  This makefile fragment is include by ZDS-II Make.defs
+  files after including tools/Config.mk.  The definitions in this file
+  override some of the the definitions in tools/Config.mk to customize the
+  build for use with the ZDS-II tools.
 
 These tools should work with all ZDS-II based platforms including z8, zNeo,
 and ez80.


### PR DESCRIPTION
* tools/Config.mk - Add empty definition POSTBUILD
* tools/Makefile.unix/win - Replace CXD56xx specific logic with $(call POSTBUILD)
* boards/arm/cxd56xx/scripts/cxd56xx_Config.mk - Add POSTBUILD definitions with logic removed from Makefile.unix/win
* boards/arm/cxd56xx/spresense/scripts/Make.defs - Include cxd56xx_Config.mk immediately after tools/Config.mk so that the empty POSTBUILD definition will be replaced with the correct one

NOTE: There is a precedent for this approach.  This is the way that other architecture-specific build options are implemented.  See, for example, tools/zds/zds_Config.mk