### PR TITLE
stm32h7: support SDRAM via FMC peripherial

### DIFF
--- a/arch/arm/src/common/up_arch.h
+++ b/arch/arm/src/common/up_arch.h
@@ -58,6 +58,12 @@
 # define getreg32(a)          (*(volatile uint32_t *)(a))
 # define putreg32(v,a)        (*(volatile uint32_t *)(a) = (v))
 
+/* Non-atomic, but more effective modification of registers */
+
+# define modreg8(v,m,a)       putreg8((getreg8(a) & ~(m)) | ((v) & (m)), a)
+# define modreg16(v,m,a)      putreg16((getreg16(a) & ~(m)) | ((v) & (m)), a)
+# define modreg32(v,m,a)      putreg32((getreg32(a) & ~(m)) | ((v) & (m)), a)
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -281,9 +281,13 @@ config STM32H7_ETHMAC
 	select ARCH_HAVE_PHY
 
 config STM32H7_FMC
-    bool "FMC"
-    default n
-    depends on STM32H7_HAVE_FMC
+        bool "FMC"
+        default n
+        depends on STM32H7_HAVE_FMC
+        ---help---
+                Enable Flexible Memory Controller.
+                To correctly configure FMC for your hardware, you will have to define
+                a number of macros in your board.h file. See stm32_fmc.c for directions.
 
 config STM32H7_OTGFS
 	bool "OTG FS"

--- a/arch/arm/src/stm32h7/hardware/stm32_fmc.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_fmc.h
@@ -68,39 +68,25 @@
 #define STM32_FMC_BWTR3_OFFSET   0x0114 /* SRAM/NOR-Flash write timing registers 3 */
 #define STM32_FMC_BWTR4_OFFSET   0x011c /* SRAM/NOR-Flash write timing registers 4 */
 
-#define STM32_FMC_PCR_OFFSET(n)  (0x0020*((n)-1)+0x0040)
-#define STM32_FMC_PCR2_OFFSET    0x0060 /* NAND Flash/PC Card controller register 2 */
-#define STM32_FMC_PCR3_OFFSET    0x0080 /* NAND Flash/PC Card controller register 3 */
-#define STM32_FMC_PCR4_OFFSET    0x00a0 /* NAND Flash/PC Card controller register 4 */
+#define STM32_FMC_PCR_OFFSET     0x0080 /* NAND Flash control register */
 
-#define STM32_FMC_SR_OFFSET(n)   (0x0020*((n)-1)+0x0044)
-#define STM32_FMC_SR2_OFFSET     0x0064 /* NAND Flash/PC Card controller register 2 */
-#define STM32_FMC_SR3_OFFSET     0x0084 /* NAND Flash/PC Card controller register 3 */
-#define STM32_FMC_SR4_OFFSET     0x00a4 /* NAND Flash/PC Card controller register 4 */
+#define STM32_FMC_SR_OFFSET      0x0084 /* FIFO status and interrupt register */
 
-#define STM32_FMC_PMEM_OFFSET(n) (0x0020*((n)-1)+0x0048)
-#define STM32_FMC_PMEM2_OFFSET   0x0068 /* Common memory space timing register 2 */
-#define STM32_FMC_PMEM3_OFFSET   0x0088 /* Common memory space timing register 3 */
-#define STM32_FMC_PMEM4_OFFSET   0x00a8 /* Common memory space timing register 4 */
+#define STM32_FMC_PMEM_OFFSET    0x0088 /* Common memory space timing register */
 
-#define STM32_FMC_PATT_OFFSET(n) (0x0020*((n)-1)+0x004c)
-#define STM32_FMC_PATT2_OFFSET   0x006c /* Attribute memory space timing register 2 */
-#define STM32_FMC_PATT3_OFFSET   0x008c /* Attribute memory space timing register 3 */
-#define STM32_FMC_PATT4_OFFSET   0x00ac /* Attribute memory space timing register 4 */
+#define STM32_FMC_PATT_OFFSET    0x008c /* Attribute memory space timing register */
 
-#define STM32_PIO4_OFFSET        0x00b0  /* I/O space timing register 4 */
+#define STM32_FMC_ECCR_OFFSET    0x0094 /* ECC result register */
 
-#define STM32_FMC_ECCR_OFFSET(n) (0x0020*((n)-1)+0x003c)
-#define STM32_FMC_ECCR2_OFFSET   0x0054 /* ECC result register 2 */
-#define STM32_FMC_ECCR3_OFFSET   0x0074 /* ECC result register 3 */
-
-#define STM32_FMC_SDCR1_OFFSET   0x0140 /* SDRAM Control Register, Bank 0 */
+#define STM32_FMC_SDCR_OFFSET(n) (4*((n)-1)+0x0140)
+#define STM32_FMC_SDCR1_OFFSET   0x0140 /* SDRAM Control Register, Bank 1 */
 #define STM32_FMC_SDCR2_OFFSET   0x0144 /* SDRAM Control Register, Bank 1 */
 
+#define STM32_FMC_SDTR_OFFSET(n) (4*((n)-1)+0x0148)
 #define STM32_FMC_SDTR1_OFFSET   0x0148 /* SDRAM Timing Register, Bank 0 */
 #define STM32_FMC_SDTR2_OFFSET   0x014c /* SDRAM Timing Register, Bank 1 */
 
-#define STM32_FMC_SDCMR_OFFSET   0x0150 /* SDRAM Config Memory register */
+#define STM32_FMC_SDCMR_OFFSET   0x0150 /* SDRAM Command mode register */
 #define STM32_FMC_SDRTR_OFFSET   0x0154 /* SDRAM Refresh Timing Register maybe */
 #define STM32_FMC_SDSR_OFFSET    0x0158 /* SDRAM Status Register */
 
@@ -124,31 +110,15 @@
 #define STM32_FMC_BWTR3          (STM32_FMC_BASE+STM32_FMC_BWTR3_OFFSET )
 #define STM32_FMC_BWTR4          (STM32_FMC_BASE+STM32_FMC_BWTR4_OFFSET )
 
-#define STM32_FMC_PCR(n)         (STM32_FMC_BASE+STM32_FMC_PCR_OFFSET(n))
-#define STM32_FMC_PCR2           (STM32_FMC_BASE+STM32_FMC_PCR2_OFFSET )
-#define STM32_FMC_PCR3           (STM32_FMC_BASE+STM32_FMC_PCR3_OFFSET )
-#define STM32_FMC_PCR4           (STM32_FMC_BASE+STM32_FMC_PCR4_OFFSET )
+#define STM32_FMC_PCR            (STM32_FMC_BASE+STM32_FMC_PCR_OFFSET)
 
-#define STM32_FMC_SR(n)          (STM32_FMC_BASE+STM32_FMC_SR_OFFSET(n))
-#define STM32_FMC_SR2            (STM32_FMC_BASE+STM32_FMC_SR2_OFFSET )
-#define STM32_FMC_SR3            (STM32_FMC_BASE+STM32_FMC_SR3_OFFSET )
-#define STM32_FMC_SR4            (STM32_FMC_BASE+STM32_FMC_SR4_OFFSET )
+#define STM32_FMC_SR             (STM32_FMC_BASE+STM32_FMC_SR_OFFSET)
 
-#define STM32_FMC_PMEM(n)        (STM32_FMC_BASE+STM32_FMC_PMEM_OFFSET(n))
-#define STM32_FMC_PMEM2          (STM32_FMC_BASE+STM32_FMC_PMEM2_OFFSET )
-#define STM32_FMC_PMEM3          (STM32_FMC_BASE+STM32_FMC_PMEM3_OFFSET )
-#define STM32_FMC_PMEM4          (STM32_FMC_BASE+STM32_FMC_PMEM4_OFFSET )
+#define STM32_FMC_PMEM           (STM32_FMC_BASE+STM32_FMC_PMEM_OFFSET)
 
-#define STM32_FMC_PATT(n)        (STM32_FMC_BASE+STM32_FMC_PATT_OFFSET(n))
-#define STM32_FMC_PATT2          (STM32_FMC_BASE+STM32_FMC_PATT2_OFFSET )
-#define STM32_FMC_PATT3          (STM32_FMC_BASE+STM32_FMC_PATT3_OFFSET )
-#define STM32_FMC_PATT4          (STM32_FMC_BASE+STM32_FMC_PATT4_OFFSET )
+#define STM32_FMC_PATT           (STM32_FMC_BASE+STM32_FMC_PATT_OFFSET)
 
-#define STM32_PIO4               (STM32_FMC_BASE+STM32_FMC_PIO4_OFFSET )
-
-#define STM32_FMC_ECCR(n)        (STM32_FMC_BASE+STM32_FMC_ECCR_OFFSET(n))
-#define STM32_FMC_ECCR2          (STM32_FMC_BASE+STM32_FMC_ECCR2_OFFSET )
-#define STM32_FMC_ECCR3          (STM32_FMC_BASE+STM32_FMC_ECCR3_OFFSET )
+#define STM32_FMC_ECCR           (STM32_FMC_BASE+STM32_FMC_ECCR_OFFSET)
 
 #define STM32_FMC_SDCR1          (STM32_FMC_BASE+STM32_FMC_SDCR1_OFFSET)
 #define STM32_FMC_SDCR2          (STM32_FMC_BASE+STM32_FMC_SDCR2_OFFSET)
@@ -175,24 +145,32 @@
 #define FMC_BCR_MWID_MASK        (3 <<  FMC_BCR_MWID_SHIFT)
 #  define FMC_BCR_MWID8          (0 << FMC_BCR_MWID_SHIFT)
 #  define FMC_BCR_MWID16         (1 << FMC_BCR_MWID_SHIFT)
+#  define FMC_BCR_MWID32         (2 << FMC_BCR_MWID_SHIFT)
 #define FMC_BCR_FACCEN           (1 << 6)   /* Flash access enable */
 #define FMC_BCR_BURSTEN          (1 << 8)   /* Burst enable bit */
 #define FMC_BCR_WAITPOL          (1 << 9)   /* Wait signal polarity bit */
-#define FMC_BCR_WRAPMOD          (1 << 10)  /* Wrapped burst mode support */
 #define FMC_BCR_WAITCFG          (1 << 11)  /* Wait timing configuration */
 #define FMC_BCR_WREN             (1 << 12)  /* Write enable bit */
 #define FMC_BCR_WAITEN           (1 << 13)  /* Wait enable bit */
 #define FMC_BCR_EXTMOD           (1 << 14)  /* Extended mode enable */
 #define FMC_BCR_ASYNCWAIT        (1 << 15)  /* Wait signal during asynchronous transfers */
+#define FMC_BCR_CPSIZE_SHIFT     (16)
+#define FMC_BCR_CPSIZE_MASK      (7 << FMC_BCR_CPSIZE_SHIFT)
+#  define FMC_BCR_CPSIZE0        (0 << FMC_BCR_CPSIZE_SHIFT)
+#  define FMC_BCR_CPSIZE128      (1 << FMC_BCR_CPSIZE_SHIFT)
+#  define FMC_BCR_CPSIZE256      (2 << FMC_BCR_CPSIZE_SHIFT)
+#  define FMC_BCR_CPSIZE1024     (3 << FMC_BCR_CPSIZE_SHIFT)
 #define FMC_BCR_CBURSTRW         (1 << 19)  /* Write burst enable */
+#define FMC_BCR_CCLKEN           (1 << 20)  /* Continuous Clock Enable */
+#define FMC_BCR_WFDIS            (1 << 21)  /* Write FIFO Disable */
 #define FMC_BCR_BMAP_SHIFT       (24)
-#  define FMC_BCR_BMAP_0         (0 << FMC_BCR_BMAP_SHIFT)
-#  define FMC_BCR_BMAP_1         (1 << FMC_BCR_BMAP_SHIFT)
-#  define FMC_BCR_BMAP_2         (2 << FMC_BCR_BMAP_SHIFT)
+#define FMC_BCR_BMAP_MASK        (3 << FMC_BCR_BMAP_SHIFT)
+#  define FMC_BCR_BMAP0          (0 << FMC_BCR_BMAP_SHIFT) /* Default mapping */
+#  define FMC_BCR_BMAP1          (1 << FMC_BCR_BMAP_SHIFT) /* NOR/PSRAM bank and SDRAM bank 1/bank2 are swapped */
+#  define FMC_BCR_BMAP2          (2 << FMC_BCR_BMAP_SHIFT) /* SDRAM Bank2 remapped on FMC bank2 and still accessible at default mapping */
+#define FMC_BCR_FMCEN            (1 << 31)  /* FMC controller Enable */
 
-#define FMC_BCR_FMCEN            (1 << 31)  /* Write burst enable */
-
-#define FMC_BCR_RSTVALUE         0x000003d2
+#define FMC_BCR_RSTVALUE(n)      ((n == 0) ? 0x000030db : 0x000030d2) /* Reset value for BCR */
 
 #define FMC_BTR_ADDSET_SHIFT     (0)        /* Address setup phase duration */
 #define FMC_BTR_ADDSET_MASK      (15 << FMC_BTR_ADDSET_SHIFT)
@@ -241,11 +219,12 @@
 #  define FMC_BWTR_ACCMODA       (0 << FMC_BWTR_ACCMOD_SHIFT)
 #  define FMC_BWTR_ACCMODB       (1 << FMC_BWTR_ACCMOD_SHIFT)
 #  define FMC_BWTR_ACCMODC       (2 << FMC_BWTR_ACCMOD_SHIFT)
-#  define FMC_BWTR_ACCMODD       (3 << FMC_BTR_ACCMOD_SHIFT)
+#  define FMC_BWTR_ACCMODD       (3 << FMC_BWTR_ACCMOD_SHIFT)
+
+#define FMC_PCR_RSTVALUE         (0x00000018)
 
 #define FMC_PCR_PWAITEN          (1 << 1)  /* Wait feature enable bit */
 #define FMC_PCR_PBKEN            (1 << 2)  /* PC Card/NAND Flash memory bank enable bit */
-#define FMC_PCR_PTYP             (1 << 3)  /* Memory type */
 #define FMC_PCR_PWID_SHIFT       (4)       /* NAND Flash databus width */
 #define FMC_PCR_PWID_MASK        (3 <<  FMC_PCR_PWID_SHIFT)
 #  define FMC_PCR_PWID8          (0 <<  FMC_PCR_PWID_SHIFT)
@@ -274,6 +253,8 @@
 #define FMC_SR_IFEN              (1 << 5)  /* Interrupt Falling Edge detection Enable bit */
 #define FMC_SR_FEMPT             (1 << 6)  /* FIFO empty */
 
+#define FMC_PMEM_RSTVALUE        (0xfcfcfcfc)
+
 #define FMC_PMEM_MEMSET_SHIFT    (0)       /* Common memory setup time */
 #define FMC_PMEM_MEMSET_MASK     (255 << FMC_PMEM_MEMSET_SHIFT)
 #  define FMC_PMEM_MEMSET(n)     ((n-1) << FMC_PMEM_MEMSET_SHIFT) /* (n)xHCLK n=1..256 */
@@ -300,91 +281,129 @@
 #define FMC_PATT_ATTHIZ_MASK     (255 << FMC_PATT_ATTHIZ_SHIFT)
 #  define FMC_PATT_ATTHIZ(n)     ((n) << FMC_PATT_ATTHIZ_SHIFT) /* (n)xHCLK n=0..255 */
 
-#define FMC_PIO4_IOSET_SHIFT     (0)       /* IOribute memory setup time */
-#define FMC_PIO4_IOSET_MASK      (255 << FMC_PIO4_IOSET_SHIFT)
-#  define FMC_PIO4_IOSET(n)      ((n-1) << FMC_PIO4_IOSET_SHIFT) /* (n)xHCLK n=1..256 */
-#define FMC_PIO4_IOWAIT_SHIFT    (8)       /* IOribute memory wait time */
-#define FMC_PIO4_IOWAIT_MASK     (255 << FMC_PIO4_IOWAIT_SHIFT)
-#  define FMC_PIO4_IOWAIT(n)     ((n-1) << FMC_PIO4_IOWAIT_SHIFT) /* (n)xHCLK n=2..256 */
-#define FMC_PIO4_IOHOLD_SHIFT    (16)      /* IOribute memory hold time */
-#define FMC_PIO4_IOHOLD_MASK     (255 << FMC_PIO4_IOHOLD_SHIFT)
-#  define FMC_PIO4_IOHOLD(n)     ((n) <<  FMC_PIO4_IOHOLD_SHIFT) /* (n)xHCLK n=1..255 */
-#define FMC_PIO4_IOHIZ_SHIFT     (24)       /* IOribute memory databus HiZ time */
-#define FMC_PIO4_IOHIZ_MASK      (255 << FMC_PIO4_IOHIZ_SHIFT)
-#  define FMC_PIO4_IOHIZ(n)      ((n) << FMC_PIO4_IOHIZ_SHIFT) /* (n)xHCLK n=0..255 */
+#  define FMC_SDCR_COLBITS_SHIFT        (0)
+#  define FMC_SDCR_COLBITS_MASK         (3 << FMC_SDCR_COLBITS_SHIFT)
+#  define FMC_SDCR_COLBITS_8            0x00000000
+#  define FMC_SDCR_COLBITS_9            0x00000001
+#  define FMC_SDCR_COLBITS_10           0x00000002
+#  define FMC_SDCR_COLBITS_11           0x00000003
 
-#define FMC_SDCMR_RESERVED                        (0x3ff << 22)  /* reserved bits */
-#define FMC_SDCMR_CMD_LOAD_MODE                   (4 << 0)
+#  define FMC_SDCR_ROWBITS_SHIFT        (2)
+#  define FMC_SDCR_ROWBITS_MASK         (3 << FMC_SDCR_ROWBITS_SHIFT)
+#  define FMC_SDCR_ROWBITS_11           0x00000000
+#  define FMC_SDCR_ROWBITS_12           0x00000004
+#  define FMC_SDCR_ROWBITS_13           0x00000008
 
-#  define FMC_SDRAM_CR_COLBITS_8                       0x00000000
-#  define FMC_SDRAM_CR_COLBITS_9                       0x00000001
-#  define FMC_SDRAM_CR_COLBITS_10                      0x00000002
-#  define FMC_SDRAM_CR_COLBITS_11                      0x00000003
+#  define FMC_SDCR_WIDTH_SHIFT          (4)
+#  define FMC_SDCR_WIDTH_MASK           (3 << FMC_SDCR_WIDTH_SHIFT)
+#  define FMC_SDCR_WIDTH_8              0x00000000
+#  define FMC_SDCR_WIDTH_16             0x00000010
+#  define FMC_SDCR_WIDTH_32             0x00000020
 
-#  define FMC_SDRAM_CR_ROWBITS_11                      0x00000000
-#  define FMC_SDRAM_CR_ROWBITS_12                      0x00000004
-#  define FMC_SDRAM_CR_ROWBITS_13                      0x00000008
+#  define FMC_SDCR_BANKS_SHIFT          (6)
+#  define FMC_SDCR_BANKS_MASK           (1 << FMC_SDCR_BANKS_SHIFT)
+#  define FMC_SDCR_BANKS_2              0x00000000
+#  define FMC_SDCR_BANKS_4              0x00000040
 
-#  define FMC_SDRAM_CR_WIDTH_8                         0x00000000
-#  define FMC_SDRAM_CR_WIDTH_16                        0x00000010
-#  define FMC_SDRAM_CR_WIDTH_32                        0x00000020
+#  define FMC_SDCR_CASLAT_SHIFT         (7)
+#  define FMC_SDCR_CASLAT_MASK          (3 << FMC_SDCR_CASLAT_SHIFT)
+#  define FMC_SDCR_CASLAT_1             0x00000080
+#  define FMC_SDCR_CASLAT_2             0x00000100
+#  define FMC_SDCR_CASLAT_3             0x00000180
 
-#  define FMC_SDRAM_CR_BANKS_2                         0x00000000
-#  define FMC_SDRAM_CR_BANKS_4                         0x00000040
+#  define FMC_SDCR_WP                   0x00000200
 
-#  define FMC_SDRAM_CR_CASLAT_1                        0x00000080
-#  define FMC_SDRAM_CR_CASLAT_2                        0x00000100
-#  define FMC_SDRAM_CR_CASLAT_3                        0x00000180
+#  define FMC_SDCR_SDCLK_SHIFT          (10)
+#  define FMC_SDCR_SDCLK_MASK           (3 << FMC_SDCR_SDCLK_SHIFT)
+#  define FMC_SDCR_SDCLK_DISABLE        0x00000000
+#  define FMC_SDCR_SDCLK_2X             0x00000800
+#  define FMC_SDCR_SDCLK_3X             0x00000C00
 
-#  define FMC_SDRAM_CR_WRITE_PROTECT                   0x00000200
+#  define FMC_SDCR_BURST_READ           0x00001000
 
-#  define FMC_SDRAM_CR_SDCLK_DISABLE                   0x00000000
-#  define FMC_SDRAM_CR_SDCLK_2X                        0x00000800
-#  define FMC_SDRAM_CR_SDCLK_3X                        0x00000C00
+#  define FMC_SDCR_RPIPE_SHIFT          (13)
+#  define FMC_SDCR_RPIPE_MASK           (3 << FMC_SDCR_RPIPE_SHIFT)
+#  define FMC_SDCR_RPIPE_0              0x00000000
+#  define FMC_SDCR_RPIPE_1              0x00002000
+#  define FMC_SDCR_RPIPE_2              0x00004000
 
-#  define FMC_SDRAM_CR_BURST_READ                      0x00001000
+#define FMC_SDCR_RESERVED               (0x1FFFF << 15) /* reserved bits */
 
-#  define FMC_SDRAM_CR_RPIPE_0                         0x00000000
-#  define FMC_SDRAM_CR_RPIPE_1                         0x00002000
-#  define FMC_SDRAM_CR_RPIPE_2                         0x00004000
+#define FMC_SDTR_TMRD_SHIFT             (0)
+#define FMC_SDTR_TMRD_MASK              FMC_SDTR_TMRD(16)
+#define FMC_SDTR_TMRD(n)                (((n) - 1) << FMC_SDTR_TMRD_SHIFT) /* 1 to 16 cycles */
+#define FMC_SDTR_TXSR_SHIFT             (4)
+#define FMC_SDTR_TXSR_MASK              FMC_SDTR_TXSR(16)
+#define FMC_SDTR_TXSR(n)                (((n) - 1) << FMC_SDTR_TXSR_SHIFT) /* 1 to 16 cycles */
+#define FMC_SDTR_TRAS_SHIFT             (8)
+#define FMC_SDTR_TRAS_MASK              FMC_SDTR_TRAS(16)
+#define FMC_SDTR_TRAS(n)                (((n) - 1) << FMC_SDTR_TRAS_SHIFT) /* 1 to 16 cycles */
+#define FMC_SDTR_TRC_SHIFT              (12)
+#define FMC_SDTR_TRC_MASK               FMC_SDTR_TRC(16)
+#define FMC_SDTR_TRC(n)                 (((n) - 1) << FMC_SDTR_TRC_SHIFT) /* 1 to 16 cycles */
+#define FMC_SDTR_TWR_SHIFT              (16)
+#define FMC_SDTR_TWR_MASK               FMC_SDTR_TWR(16)
+#define FMC_SDTR_TWR(n)                 (((n) - 1) << FMC_SDTR_TWR_SHIFT) /* 1 to 16 cycles */
+#define FMC_SDTR_TRP_SHIFT              (20)
+#define FMC_SDTR_TRP_MASK               FMC_SDTR_TRP(16)
+#define FMC_SDTR_TRP(n)                 (((n) - 1) << FMC_SDTR_TRP_SHIFT) /* 1 to 16 cycles */
+#define FMC_SDTR_TRCD_SHIFT             (24)
+#define FMC_SDTR_TRCD_MASK              FMC_SDTR_TRCD(16)
+#define FMC_SDTR_TRCD(n)                (((n) - 1) << FMC_SDTR_TRCD_SHIFT) /* 1 to 16 cycles */
 
-#  define FMC_SDRAM_CR_RESERVED                        (0x1FFFF << 15)  /* reserved bits */
+#define FMC_SDTR_RESERVED               (0xF << 28)  /* reserved bits */
 
-#  define FMC_SDRAM_TR_TMRD_SHIFT                      0
-#  define FMC_SDRAM_TR_TXSR_SHIFT                      4
-#  define FMC_SDRAM_TR_TRAS_SHIFT                      8
-#  define FMC_SDRAM_TR_TRC_SHIFT                       12
-#  define FMC_SDRAM_TR_TWR_SHIFT                       16
-#  define FMC_SDRAM_TR_TRP_SHIFT                       20
-#  define FMC_SDRAM_TR_TRCD_SHIFT                      24
+#define FMC_SDCMR_MODE_SHIFT            (0)
+#define FMC_SDCMR_MODE_MASK             (7 << FMC_SDCMR_MODE_SHIFT)
+#  define FMC_SDCMR_MODE_NORMAL         (0 << FMC_SDCMR_MODE_SHIFT)
+#  define FMC_SDCMR_MODE_CLK_ENABLE     (1 << FMC_SDCMR_MODE_SHIFT)
+#  define FMC_SDCMR_MODE_PALL           (2 << FMC_SDCMR_MODE_SHIFT)
+#  define FMC_SDCMR_MODE_AUTO_REFRESH   (3 << FMC_SDCMR_MODE_SHIFT)
+#  define FMC_SDCMR_MODE_LOAD_MODE      (4 << FMC_SDCMR_MODE_SHIFT)
+#  define FMC_SDCMR_MODE_SELF_REFRESH   (5 << FMC_SDCMR_MODE_SHIFT)
+#  define FMC_SDCMR_MODE_POWER_DOWN     (6 << FMC_SDCMR_MODE_SHIFT)
+#define FMC_SDCMR_CTB2                  (1 << 3)
+#define FMC_SDCMR_CTB1                  (1 << 4)
+#define FMC_SDCMR_NRFS_SHIFT            (5)
+#define FMC_SDCMR_NRFS(n)               (((n) - 1) << FMC_SDCMR_NRFS_SHIFT) /* 1 to 16 cycles */
+#define FMC_SDCMR_MRD_SHIFT             (9)
+#define FMC_SDCMR_MRD_MASK              FMC_SDCMR_MRD(16383)
+#define FMC_SDCMR_MRD(n)                ((n) << FMC_SDCMR_MRD_SHIFT) /* SDRAM Mode Register */
+#  define FMC_SDCMR_MRD_BURST_LENGTH_1             FMC_SDCMR_MRD(0x0000)
+#  define FMC_SDCMR_MRD_BURST_LENGTH_2             FMC_SDCMR_MRD(0x0001)
+#  define FMC_SDCMR_MRD_BURST_LENGTH_4             FMC_SDCMR_MRD(0x0002)
+#  define FMC_SDCMR_MRD_BURST_LENGTH_8             FMC_SDCMR_MRD(0x0004)
+#  define FMC_SDCMR_MRD_BURST_TYPE_SEQUENTIAL      FMC_SDCMR_MRD(0x0000)
+#  define FMC_SDCMR_MRD_BURST_TYPE_INTERLEAVED     FMC_SDCMR_MRD(0x0008)
+#  define FMC_SDCMR_MRD_CAS_LATENCY_2              FMC_SDCMR_MRD(0x0020)
+#  define FMC_SDCMR_MRD_CAS_LATENCY_3              FMC_SDCMR_MRD(0x0030)
+#  define FMC_SDCMR_MRD_OPERATING_MODE_STANDARD    FMC_SDCMR_MRD(0x0000)
+#  define FMC_SDCMR_MRD_WRITEBURST_MODE_PROGRAMMED FMC_SDCMR_MRD(0x0000)
+#  define FMC_SDCMR_MRD_WRITEBURST_MODE_SINGLE     FMC_SDCMR_MRD(0x0200)
 
-#  define FMC_SDRAM_TR_RESERVED                        (0xF << 28)  /* reserved bits */
+#define FMC_SDCMR_RESERVED              (0x1ff << 23) /* reserved bits */
 
-#  define FMC_SDRAM_MODE_CMD_NORMAL                    0
-#  define FMC_SDRAM_MODE_CMD_CLK_ENABLE                1
-#  define FMC_SDRAM_MODE_CMD_PALL                      2
-#  define FMC_SDRAM_MODE_CMD_AUTO_REFRESH              3
-#  define FMC_SDRAM_MODE_CMD_LOAD_MODE                 4
-#  define FMC_SDRAM_MODE_CMD_SELF_REFRESH              5
-#  define FMC_SDRAM_MODE_CMD_POWER_DOWN                6
+#define FMC_SDRTR_CRE                   (1 << 0)
+#define FMC_SDRTR_COUNT_SHIFT           (1)
+#define FMC_SDRTR_COUNT_MASK            FMC_SDRTR_COUNT(0x1fff)
+#define FMC_SDRTR_COUNT(val)            ((val) << FMC_SDRTR_COUNT_SHIFT)
+#define FMC_SDRTR_REIE                  (14 << 0)
 
-#  define FMC_SDRAM_CMD_BANK_1                         0x00000010
-#  define FMC_SDRAM_CMD_BANK_2                         0x00000008
-#  define FMC_SDRAM_CMD_RESERVED                       (0x200 << 23)  /* reserved bits */
-
-#  define FMC_SDRAM_AUTO_REFRESH_SHIFT                 5
-#  define FMC_SDRAM_MODEREG_SHIFT                      9
-
-#  define FMC_SDRAM_MODEREG_BURST_LENGTH_1             (0x0000 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_BURST_LENGTH_2             (0x0001 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_BURST_LENGTH_4             (0x0002 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_BURST_LENGTH_8             (0x0004 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_BURST_TYPE_SEQUENTIAL      (0x0000 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_BURST_TYPE_INTERLEAVED     (0x0008 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_CAS_LATENCY_2              (0x0020 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_CAS_LATENCY_3              (0x0030 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_OPERATING_MODE_STANDARD    (0x0000 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_WRITEBURST_MODE_PROGRAMMED (0x0000 << FMC_SDRAM_MODEREG_SHIFT)
-#  define FMC_SDRAM_MODEREG_WRITEBURST_MODE_SINGLE     (0x0200 << FMC_SDRAM_MODEREG_SHIFT)
+#define FMC_SDSR_RE                     (1 << 0)
+#define FMC_SDSR_MODES1_SHIFT           (1)
+#define FMC_SDSR_MODES1_MASK            FMC_SDSR_MODES1(3)
+#define FMC_SDSR_MODES1(n)              ((n) << FMC_SDSR_MODES1_SHIFT)
+#  define FMC_SDSR_MODES1_NORMAL        FMC_SDSR_MODES1(FMC_SDSR_MODES_NORMAL)
+#  define FMC_SDSR_MODES1_SELF_REFRESH  FMC_SDSR_MODES1(FMC_SDSR_MODES_SELF_REFRESH)
+#  define FMC_SDSR_MODES1_POWER_DOWN    FMC_SDSR_MODES1(FMC_SDSR_MODES_POWER_DOWN)
+#define FMC_SDSR_MODES2_SHIFT           (3)
+#define FMC_SDSR_MODES2_MASK            FMC_SDSR_MODES2(3)
+#define FMC_SDSR_MODES2(n)              ((n) << FMC_SDSR_MODES2_SHIFT)
+#  define FMC_SDSR_MODES2_NORMAL        FMC_SDSR_MODES2(FMC_SDSR_MODES_NORMAL)
+#  define FMC_SDSR_MODES2_SELF_REFRESH  FMC_SDSR_MODES2(FMC_SDSR_MODES_SELF_REFRESH)
+#  define FMC_SDSR_MODES2_POWER_DOWN    FMC_SDSR_MODES2(FMC_SDSR_MODES_POWER_DOWN)
+#define FMC_SDSR_MODES_NORMAL           (0)
+#define FMC_SDSR_MODES_SELF_REFRESH     (1)
+#define FMC_SDSR_MODES_POWER_DOWN       (2)
 
 #endif /* __ARCH_ARM_SRC_STM32H7_HARDWARE_STM32_FMC_H */

--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_rcc.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_rcc.h
@@ -382,15 +382,15 @@
 #define RCC_PLLCFGR_PLL1RGE_4_8_MHZ     (0x2ul << RCC_PLLCFGR_PLL1RGE_SHIFT) /* The PLL input clock range frequency is between 4 and 8 MHz */
 #define RCC_PLLCFGR_PLL1RGE_8_16_MHZ    (0x3ul << RCC_PLLCFGR_PLL1RGE_SHIFT) /* The PLL input clock range frequency is between 8 and 16 MHz */
 
-#define RCC_PLLCFGR_PLL2FRACEN_SHIFT    (0ul)
+#define RCC_PLLCFGR_PLL2FRACEN_SHIFT    (4ul)
 #define RCC_PLLCFGR_PLL2FRACEN_MASK     (0x1ul << RCC_PLLCFGR_PLL2FRACEN_SHIFT)
 #define RCC_PLLCFGR_PLL2FRACEN          RCC_PLLCFGR_PLL2FRACEN_MASK       /* Fractional latch enable */
-#define RCC_PLLCFGR_PLL2VCOSEL_SHIFT    (1ul)
+#define RCC_PLLCFGR_PLL2VCOSEL_SHIFT    (5ul)
 #define RCC_PLLCFGR_PLL2VCOSEL_MASK     (0x1ul << RCC_PLLCFGR_PLL2VCOSEL_SHIFT)
 #define RCC_PLLCFGR_PLL2VCOSEL          RCC_PLLCFGR_PLL2VCOSEL_MASK       /* VCO frequency range: 1 = Medium VCO range: 150 to 420 MHz, 0 = Wide VCO range: 192 to 836 MHz */
 #define RCC_PLLCFGR_PLL2VCOSEL_WIDE     (0ul)                             /* VCO frequency range: Wide VCO range: 192 to 836 MHz, input clock >= 2 MHz */
 #define RCC_PLLCFGR_PLL2VCOSEL_MEDIUM   RCC_PLLCFGR_PLL3VCOSEL            /* VCO frequency range: Medium VCO range: 150 to 420 MHz, input clock <= 2 MHz */
-#define RCC_PLLCFGR_PLL2RGE_SHIFT       (2ul)
+#define RCC_PLLCFGR_PLL2RGE_SHIFT       (6ul)
 #define RCC_PLLCFGR_PLL2RGE_MASK        (0x3ul << RCC_PLLCFGR_PLL2RGE_SHIFT)
 #define RCC_PLLCFGR_PLL2RGE             RCC_PLLCFGR_PLL2RGE_MASK
 #define RCC_PLLCFGR_PLL2RGE_1_2_MHZ     (0x0ul << RCC_PLLCFGR_PLL2RGE_SHIFT) /* The PLL input clock range frequency is between 1 and 2 MHz */
@@ -398,15 +398,15 @@
 #define RCC_PLLCFGR_PLL2RGE_4_8_MHZ     (0x2ul << RCC_PLLCFGR_PLL2RGE_SHIFT) /* The PLL input clock range frequency is between 4 and 8 MHz */
 #define RCC_PLLCFGR_PLL2RGE_8_16_MHZ    (0x3ul << RCC_PLLCFGR_PLL2RGE_SHIFT) /* The PLL input clock range frequency is between 8 and 16 MHz */
 
-#define RCC_PLLCFGR_PLL3FRACEN_SHIFT    (0ul)
+#define RCC_PLLCFGR_PLL3FRACEN_SHIFT    (8ul)
 #define RCC_PLLCFGR_PLL3FRACEN_MASK     (0x1ul << RCC_PLLCFGR_PLL3FRACEN_SHIFT)
 #define RCC_PLLCFGR_PLL3FRACEN          RCC_PLLCFGR_PLL3FRACEN_MASK       /* Fractional latch enable */
-#define RCC_PLLCFGR_PLL3VCOSEL_SHIFT    (1ul)
+#define RCC_PLLCFGR_PLL3VCOSEL_SHIFT    (9ul)
 #define RCC_PLLCFGR_PLL3VCOSEL_MASK     (0x1ul << RCC_PLLCFGR_PLL3VCOSEL_SHIFT)
 #define RCC_PLLCFGR_PLL3VCOSEL          RCC_PLLCFGR_PLL3VCOSEL_MASK       /* VCO frequency range: 1 = Medium VCO range: 150 to 420 MHz, 0 = Wide VCO range: 192 to 836 MHz */
 #define RCC_PLLCFGR_PLL3VCOSEL_WIDE     (0ul)                             /* VCO frequency range: Wide VCO range: 192 to 836 MHz, input clock >= 2 MHz */
 #define RCC_PLLCFGR_PLL3VCOSEL_MEDIUM   RCC_PLLCFGR_PLL3VCOSEL            /* VCO frequency range: Medium VCO range: 150 to 420 MHz, input clock <= 2 MHz */
-#define RCC_PLLCFGR_PLL3RGE_SHIFT       (2ul)
+#define RCC_PLLCFGR_PLL3RGE_SHIFT       (10ul)
 #define RCC_PLLCFGR_PLL3RGE_MASK        (0x3ul << RCC_PLLCFGR_PLL3RGE_SHIFT)
 #define RCC_PLLCFGR_PLL3RGE             RCC_PLLCFGR_PLL3RGE_MASK
 #define RCC_PLLCFGR_PLL3RGE_1_2_MHZ     (0x0ul << RCC_PLLCFGR_PLL3RGE_SHIFT) /* The PLL input clock range frequency is between 1 and 2 MHz */

--- a/arch/arm/src/stm32h7/stm32_allocateheap.c
+++ b/arch/arm/src/stm32h7/stm32_allocateheap.c
@@ -60,33 +60,56 @@
 #include "hardware/stm32_memorymap.h"
 #include "stm32_mpuinit.h"
 #include "stm32_dtcm.h"
+#include "stm32_fmc.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Internal SRAM is available in all members of the STM32 family. The
- * following definitions must be provided to specify the size and
- * location of internal(system) SRAM:
+/* At startup the kernel will invoke up_addregion() so that platform code
+ * may register available memories for use as part of system heap.
+ * The global configuration option CONFIG_MM_REGIONS defines the maximal
+ * number of non-contiguous memory ranges that may be registered with the
+ * system heap. You must make sure it is large enough to hold all memory
+ * regions you intend to use.
  *
- * In addition to internal SRAM, external RAM may also be available through
- * the FMC.  In order to use FMC RAM, the following additional things need
- * to be present in the NuttX configuration file:
+ * The following memory types can be used for system heap on STM32H7 platform:
  *
- * CONFIG_STM32H7_FMC=y         : Enables the FMC
- * CONFIG_STM32H7_FMC_S[D]RAM=y : SRAM and/or SDRAM is available via the FMC.
- *                                Either of these autoselects
- *                                CONFIG_ARCH_HAVE_HEAP2 which is what we
- *                                are interested in here.
- * CONFIG_HEAP2_BASE            : The base address of the external RAM in
- *                                the FMC address space
- * CONFIG_HEAP2_SIZE            : The size of the external RAM in the FMC
- *                                address space
- * CONFIG_MM_REGIONS            : Must be set to a large enough value to
- *                                include the FMC external RAM (as determined
- *                                by the rules provided below)
+ * - AXI SRAM is a 512kb memory area. This will be automatically registered
+ *      with the system heap in up_allocate_heap, all the other memory
+ *      regions will be registered in up_addregion().
+ *      So, CONFIG_MM_REGIONS must be at least 1 to use AXI SRAM.
  *
- *  CONFIG_STM32H7_DTCMEXCLUDE  : Set to exclude the DTCM from heap
+ * - Internal SRAM is available in all members of the STM32 family.
+ *      This is always registered with system heap.
+ *      There are two contiguous regions of internal SRAM:
+ *      SRAM1+SRAM2+SRAM3 and SRAM4 at a separate address.
+ *      So, add 2 more to CONFIG_MM_REGIONS.
+ *
+ * - Tightly Coupled Memory (TCM RAM), we can use Data TCM (DTCM) for system
+ *      heap. Note that DTCM has a number of limitations, for example DMA
+ *      transfers to/from DTCM are impossible.
+ *      Define CONFIG_STM32H7_DTCMEXCLUDE to exclude the DTCM from heap.
+ *      +1 to CONFIG_MM_REGIONS if you want to use DTCM.
+ *
+ * - External SDRAM can be connected to the FMC peripherial. Initialization
+ *      of FMC is done as up_addregion() will invoke stm32_fmc_init().
+ *      Please read the comment in stm32_fmc.c how to initialize FMC correctly.
+ *
+ *      Then, up to two regions of SDRAM may be registered with the system heap:
+ *
+ *      - BOARD_SDRAM1_SIZE, if defined, declares the size of SDRAM
+ *              at address STM32_FMC_BANK5. +1 to CONFIG_MM_REGIONS.
+ *      - BOARD_SDRAM2_SIZE, if defined, declares the size of SDRAM
+ *              at address STM32_FMC_BANK6. +1 to CONFIG_MM_REGIONS.
+ *
+ * - Additionaly, you may use the following options to add one more region
+ *      of memory to system heap:
+ *
+ *      - CONFIG_ARCH_HAVE_HEAP2=y
+ *      - CONFIG_HEAP2_BASE=base address of memory area.
+ *      - CONFIG_HEAP2_SIZE=size of memory area.
+ *      - +1 to CONFIG_MM_REGIONS
  */
 
 /* Set the start and end of the SRAMs */
@@ -113,28 +136,6 @@
 #ifdef CONFIG_STM32H7_DTCMEXCLUDE
 #  undef HAVE_DTCM
 #endif
-
-/* There are <x> possible heap configurations:
- *
- * Configuration 1. System SRAM (only)
- *                  CONFIG_MM_REGIONS == 1
- * Configuration 2. System SRAM and SRAM123
- *                  CONFIG_MM_REGIONS == 2
- * Configuration 3. System SRAM and SRAM123 and DTCM
- *                  CONFIG_MM_REGIONS == 3
- *                  HAVE_DTCM defined
- * Configuration 4. System SRAM and SRAM123 and DTCM and SRAM4
- *                  CONFIG_MM_REGIONS == 4
- *                  HAVE_DTCM defined
- * Configuration 5. System SRAM and SRAM123 and DTCM and SRAM4 and FMC RAM
- *                  CONFIG_MM_REGIONS == 5
- *                  HAVE_DTCM defined
- *
- * TODO ....
- *
- * Let's make sure that all definitions are consistent before doing
- * anything else
- */
 
 /****************************************************************************
  * Private Functions
@@ -246,6 +247,14 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 
   up_heap_color(*heap_start, *heap_size);
 #endif
+
+#if defined(CONFIG_DEBUG_FEATURES)
+
+  /* Display memory ranges to help debugging */
+
+  _info("%uKb of SRAM at %p\n", *heap_size / 1024, *heap_start);
+
+#endif
 }
 
 /****************************************************************************
@@ -293,6 +302,42 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
 #endif
 
 /****************************************************************************
+ * Name: addregion
+ *
+ * Description:
+ *   Make a range of memory available for allocation from system heap.
+ *   If debug is disabled, compiler should optimize out the "desc" strings.
+ *
+ ****************************************************************************/
+
+static void addregion (uintptr_t start, uint32_t size, const char *desc)
+{
+#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
+
+  /* Allow user-mode access to the SRAM123 heap */
+
+  stm32_mpu_uheap(start, size);
+
+#endif
+
+  /* Colorize the heap for debug */
+
+  up_heap_color((FAR void *)start, size);
+
+  /* Add the SRAM123 user heap region. */
+
+  kumm_addregion((FAR void *)start, size);
+
+#if defined(CONFIG_DEBUG_FEATURES)
+
+  /* Display memory ranges to help debugging */
+
+  _info("%uKb of %s at %p\n", size / 1024, desc, (FAR void *)start);
+
+#endif
+}
+
+/****************************************************************************
  * Name: up_addregion
  *
  * Description:
@@ -301,81 +346,51 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
  *
  ****************************************************************************/
 
-#if CONFIG_MM_REGIONS > 1
 void up_addregion(void)
 {
-#  if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
+  addregion (SRAM123_START, SRAM123_END - SRAM123_START, "SRAM1,2,3");
 
-  /* Allow user-mode access to the SRAM123 heap */
+  unsigned mm_regions = 1;
 
-  stm32_mpu_uheap((uintptr_t)SRAM123_START, SRAM123_END - SRAM123_START);
+  if (mm_regions < CONFIG_MM_REGIONS)
+    {
+      addregion (SRAM4_START, SRAM4_END - SRAM4_START, "SRAM4");
+      mm_regions++;
+    }
 
-#  endif
-
-  /* Colorize the heap for debug */
-
-  up_heap_color((FAR void *)SRAM123_START, SRAM123_END - SRAM123_START);
-
-  /* Add the SRAM123 user heap region. */
-
-  kumm_addregion((FAR void *)SRAM123_START, SRAM123_END - SRAM123_START);
-
-#  if CONFIG_MM_REGIONS > 2
-#    if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
-
-  /* Allow user-mode access to the SRAM4 user heap memory */
-
-  stm32_mpu_uheap((uintptr_t)SRAM4_START, SRAM4_END - SRAM4_START);
-
-#    endif
-
-  /* Colorize the heap for debug */
-
-  up_heap_color((FAR void *)SRAM4_START, SRAM4_END - SRAM4_START);
-
-  /* Add the external SRAM4 user heap region. */
-
-  kumm_addregion((FAR void *)SRAM4_START, SRAM4_END - SRAM4_START);
-#  endif
-
-#  if CONFIG_MM_REGIONS > 3
-#    ifdef HAVE_DTCM
-#      if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
-
-  /* Allow user-mode access to the DTCM heap */
-
-  stm32_mpu_uheap((uintptr_t)DTCM_START, DTCM_END - DTCM_START);
-
-#      endif
-
-  /* Colorize the heap for debug */
-
-  up_heap_color((FAR void *)DTCM_START, DTCM_END - DTCM_START);
-
-  /* Add the DTCM user heap region. */
-
-  kumm_addregion((FAR void *)DTCM_START, DTCM_END - DTCM_START);
-#    endif
-#  endif
-
-#  if CONFIG_MM_REGIONS > 4
-#    ifdef CONFIG_ARCH_HAVE_HEAP2
-#      if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
-
-  /* Allow user-mode access to the FMC RAM user heap memory */
-
-  stm32_mpu_uheap((uintptr_t)CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE);
-
-#      endif
-
-  /* Colorize the heap for debug */
-
-  up_heap_color((FAR void *)CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE);
-
-  /* Add the external FMC RAM user heap region. */
-
-  kumm_addregion((FAR void *)CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE);
-#    endif
-#  endif
-}
+#ifdef HAVE_DTCM
+  if (mm_regions < CONFIG_MM_REGIONS)
+    {
+      addregion (DTCM_START, DTCM_END - DTCM_START, "DTCM");
+      mm_regions++;
+    }
 #endif
+
+#ifdef CONFIG_STM32H7_FMC
+  stm32_fmc_init();
+#endif
+
+#ifdef BOARD_SDRAM1_SIZE
+  if (mm_regions < CONFIG_MM_REGIONS)
+    {
+      addregion (STM32_FMC_BANK5, BOARD_SDRAM1_SIZE, "SDRAM1");
+      mm_regions++;
+    }
+#endif
+
+#ifdef BOARD_SDRAM2_SIZE
+  if (mm_regions < CONFIG_MM_REGIONS)
+    {
+      addregion (STM32_FMC_BANK6, BOARD_SDRAM2_SIZE, "SDRAM2");
+      mm_regions++;
+    }
+#endif
+
+#ifdef CONFIG_ARCH_HAVE_HEAP2
+  if (mm_regions < CONFIG_MM_REGIONS)
+    {
+      addregion (CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE, "HEAP2");
+      mm_regions++;
+    }
+#endif
+}

--- a/arch/arm/src/stm32h7/stm32_fmc.c
+++ b/arch/arm/src/stm32h7/stm32_fmc.c
@@ -39,39 +39,386 @@
 
 #include <nuttx/config.h>
 
+#if defined(CONFIG_STM32H7_FMC)
+
 #include "stm32.h"
 
-#if defined(CONFIG_STM32H7_FMC)
+#include <debug.h>
+
+//#include "stm32_fmc.h"
+//#include "hardware/stm32_pinmap.h"
+//#include "stm32_gpio.h"
+//#include "stm32_rcc.h"
+
+#include <nuttx/arch.h>
+#include <arch/board/board.h>
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+/****************************************************************************
+ * To use FMC, you must first enable it in configuration:
+ *
+ * CONFIG_STM32H7_FMC=y
+ *
+ * FMC is statically configured at startup. Its configuration is adjusted
+ * using BOARD_XXX macros described below, which should be declared
+ * in your board.h file.
+ *
+ * The BOARD_FMC_CLK macro can be defined to select the clock source for FMC.
+ * This can be one of RCC_D1CCIPR_FMCSEL_xxx macros, and defaults to
+ * RCC_D1CCIPR_FMCSEL_PLL2 (which means PLL2R).
+ *
+ *
+ * To correctly initialize GPIO pins the macro BOARD_FMC_GPIO_CONFIGS should
+ * define a list of 32-bit GPIO configuration bitmasks. Example:
+ *
+ * #define BOARD_FMC_GPIO_CONFIGS       GPIO_FMC_A0,GPIO_FMC_A1,\
+ *         GPIO_FMC_A2,...,GPIO_FMC_D0,...,GPIO_FMC_NBL0,...
+ *
+ *
+ * For SRAM/NOR-Flash memories FMC defines 4 x 64Mb sub-banks at addresses
+ * 0x60000000, 0x64000000, 0x68000000, 0x6C000000. The following macros
+ * can be defined in board.h to initialize FMC for use with SRAM/NOR-Flash:
+ *
+ * *** CURRENTLY SRAM/NOR-FLASH SUPPORT IS NOT IMPLEMENTED ***
+ *
+ * BOARD_FMC_BCR[1..4] - Initial value for control registers
+ *      for subbanks 1-4.
+ * BOARD_FMC_BTR[1..4] - Initial value for SRAM/NOR-Flash timing registers
+ *      for subbanks 1-4.
+ * BOARD_FMC_BWTR[1..4] - Initial value for SRAM/NOR-Flash write timing registers
+ *      for subbanks 1-4.
+ *
+ *
+ * For NAND flash memories FMC reserves 64Mb at 0x80000000. Define the following
+ * macros in your board.h file to initialize FMC for this type of memory:
+ *
+ * *** CURRENTLY NAND FLASH SUPPORT IS NOT IMPLEMENTED ***
+ *
+ * BOARD_FMC_PCR - Initial value for NAND flash control register.
+ * BOARD_FMC_PMEM - Initial value for NAND flash common memory space timing register.
+ * BOARD_FMC_PATT - Initial value for NAND flash attribute memory space timing register.
+ *
+ *
+ * For SDRAM memory FMC reserves 2 x 256Mb address ranges at 0xC0000000 and 0xD0000000.
+ * Define the following macros to initialize FMC to work with SDRAM:
+ *
+ * BOARD_FMC_SDCR[1..2] - Initial value for SDRAM control registers for SDRAM bank 1-2.
+ *      Note that some bits in SDCR1 influence both SDRAM banks and are unused in SDCR2!
+ * BOARD_FMC_SDTR[1..2] - Initial value for SDRAM timing registeres for SDRAM bank 1-2.
+ *      Note that some bits in SDTR1 influence both SDRAM banks and are unused in SDTR2!
+ * BOARD_FMC_SDRAM_REFR_PERIOD - The SDRAM refresh rate period in FMC clocks, OR
+ * BOARD_FMC_SDRAM_REFR_CYCLES and BOARD_FMC_SDRAM_REFR_PERIOD can be used to automatically
+ *      compute refresh counter using data from SDRAM datasheet (cycles usually is 4096, 8192
+ *      and such, and typical period is 64 (ms)) and knowing FMC clock frequency.
+ * BOARD_FMC_SDRAM_AUTOREFRESH may be defined to a number between 1 and 16 to issue
+ *      given number of SDRAM auto-refresh cycles before using it. This defaults to 3.
+ *
+ *
+ * Special notes:
+ *      - FMC bank remapping (FMC_BCR_BMAP*) is not currently supported.
+ *
+ *
+ * Here's a working example of a configured IS42S16320D SDRAM on a particular board:
+ *
+ *#define BOARD_SDRAM1_SIZE               (64*1024*1024)
+ *
+ *#define BOARD_FMC_SDCR1                 (FMC_SDCR_COLBITS_10 | FMC_SDCR_ROWBITS_13 | FMC_SDCR_WIDTH_16 | FMC_SDCR_BANKS_4 | FMC_SDCR_CASLAT_2 | FMC_SDCR_SDCLK_2X | FMC_SDCR_BURST_READ | FMC_SDCR_RPIPE_1)
+ *#define BOARD_FMC_SDTR1                 (FMC_SDTR_TMRD(2) | FMC_SDTR_TXSR(7) | FMC_SDTR_TRAS(4) | FMC_SDTR_TRC(7) | FMC_SDTR_TWR(4) | FMC_SDTR_TRP(2) | FMC_SDTR_TRCD(2))
+ *#define BOARD_FMC_SDRAM_REFR_CYCLES     8192
+ *#define BOARD_FMC_SDRAM_REFR_PERIOD     64
+ *#define BOARD_FMC_SDRAM_MODE            FMC_SDCMR_MRD_BURST_LENGTH_8 | \
+ *                                        FMC_SDCMR_MRD_BURST_TYPE_SEQUENTIAL | \
+ *                                        FMC_SDCMR_MRD_CAS_LATENCY_2
+ *
+ *#define BOARD_FMC_GPIO_CONFIGS \
+ *    GPIO_FMC_A0,GPIO_FMC_A1,GPIO_FMC_A2,GPIO_FMC_A3,GPIO_FMC_A4,GPIO_FMC_A5,GPIO_FMC_A6,GPIO_FMC_A7,\
+ *    GPIO_FMC_A8,GPIO_FMC_A9,GPIO_FMC_A10,GPIO_FMC_A11,GPIO_FMC_A12,\
+ *    GPIO_FMC_D0,GPIO_FMC_D1,GPIO_FMC_D2,GPIO_FMC_D3,GPIO_FMC_D4,GPIO_FMC_D5,GPIO_FMC_D6,GPIO_FMC_D7,\
+ *    GPIO_FMC_D8,GPIO_FMC_D9,GPIO_FMC_D10,GPIO_FMC_D11,GPIO_FMC_D12,GPIO_FMC_D13,GPIO_FMC_D14,GPIO_FMC_D15,\
+ *    GPIO_FMC_NBL0,GPIO_FMC_NBL1,GPIO_FMC_BA0,GPIO_FMC_BA1,\
+ *    GPIO_FMC_SDNWE_2,GPIO_FMC_SDNCAS,GPIO_FMC_SDNRAS,GPIO_FMC_SDNE0_1,GPIO_FMC_SDCKE0_1,GPIO_FMC_SDCLK
+ *
+ ****************************************************************************/
+
+#ifndef BOARD_FMC_CLK
+/* Clock FMC from PLL2R by default */
+#  define BOARD_FMC_CLK         RCC_D1CCIPR_FMCSEL_PLL2
+#endif
+
+/* A couple of macros to know if user uses SDRAM1 and/or SDRAM2 */
+
+#if defined BOARD_FMC_SDCR1 && ((BOARD_FMC_SDCR1 & FMC_SDCR_CASLAT_MASK) != 0)
+#  define HAVE_FMC_SDRAM1        1
+#endif
+#if defined BOARD_FMC_SDCR2 && ((BOARD_FMC_SDCR2 & FMC_SDCR_CASLAT_MASK) != 0)
+#  define HAVE_FMC_SDRAM2        1
+#endif
+
+#if defined HAVE_FMC_SDRAM1 || defined HAVE_FMC_SDRAM2
+#  define HAVE_FMC_SDRAM         1
+#endif
+
+/* Number of auto-refresh cycles to issue at SDRAM initialization */
+
+#ifndef BOARD_FMC_SDRAM_AUTOREFRESH
+#  define BOARD_FMC_SDRAM_AUTOREFRESH   3
+#endif
+
+/* Find out the clock frequency for FMC */
+
+#if BOARD_FMC_CLK == RCC_D1CCIPR_FMCSEL_HCLK
+#  define FMC_CLK_FREQUENCY     STM32_HCLK_FREQUENCY
+#elif BOARD_FMC_CLK == RCC_D1CCIPR_FMCSEL_PLL1
+#  define FMC_CLK_FREQUENCY     STM32_PLL1Q_FREQUENCY
+#elif BOARD_FMC_CLK == RCC_D1CCIPR_FMCSEL_PLL2
+#  define FMC_CLK_FREQUENCY     STM32_PLL2R_FREQUENCY
+#elif BOARD_FMC_CLK == RCC_D1CCIPR_FMCSEL_PER
+#  define FMC_CLK_FREQUENCY     STM32_PER_FREQUENCY
+#else
+#  error "BOARD_FMC_CLK has unknown value!"
+#endif
+
+/* Compute the refresh rate in clocks */
+
+#ifndef BOARD_FMC_SDRAM_REFR_PERIOD
+
+#  if !defined(BOARD_FMC_SDRAM_REFR_CYCLES) || !defined(BOARD_FMC_SDRAM_REFR_PERIOD)
+#    error "Both BOARD_FMC_SDRAM_REFR_CYCLES and BOARD_FMC_SDRAM_REFR_PERIOD have to be defined to compute BOARD_FMC_SDRAM_REFR_PERIOD!"
+#  else
+     /* Take care not to overflow on 32-bit arithmetic */
+#    define BOARD_FMC_SDRAM_REFR_PERIOD        ((uint32_t)((uint64_t)BOARD_FMC_SDRAM_REFR_PERIOD * FMC_CLK_FREQUENCY / BOARD_FMC_SDRAM_REFR_CYCLES - 20))
+#  endif
+
+#endif /* BOARD_FMC_SDRAM_REFR_PERIOD */
+
+/* The bits in FMC_SDCR we will alter at initialization */
+#define FMC_SDCR_MASK           (FMC_SDCR_COLBITS_MASK | FMC_SDCR_ROWBITS_MASK | \
+    FMC_SDCR_WIDTH_MASK | FMC_SDCR_BANKS_MASK | FMC_SDCR_CASLAT_MASK | FMC_SDCR_WP | \
+    FMC_SDCR_SDCLK_MASK | FMC_SDCR_BURST_READ | FMC_SDCR_RPIPE_MASK)
+
+/* The bits in FMC_SDTR we will alter at initialization */
+#define FMC_SDTR_MASK           (FMC_SDTR_TMRD_MASK | FMC_SDTR_TXSR_MASK | \
+    FMC_SDTR_TRAS_MASK | FMC_SDTR_TRC_MASK | FMC_SDTR_TWR_MASK | FMC_SDTR_TRP_MASK | \
+    FMC_SDTR_TRCD_MASK)
+
+/* The timeout while waiting for SDRAM controller to initialize, in us */
+#define SDRAM_INIT_TIMEOUT      (1000)
+
+
+/****************************************************************************
+ * Private data
+ ****************************************************************************/
+
+static uint32_t fmc_gpios[] =
+{
+    BOARD_FMC_GPIO_CONFIGS
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void stm32_fmc_sdram_init(void);
+static int stm32_fmc_sdram_wait(unsigned timeout);
+
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: stm32_fmc_enable
+ * Name: stm32_fmc_init
  *
  * Description:
- *   Enable clocking to the FMC.
+ *   Initialize the FMC peripherial. Because FMC initialization is highly
+ *   dependent on the used parts, definition of the initial values for FMC
+ *   registers is mostly left to board designer.
+ *
+ *   Typically called from up_addregion().
  *
  ****************************************************************************/
 
-void stm32_fmc_enable_clk(void)
+void stm32_fmc_init(void)
 {
-  modifyreg32(STM32_RCC_AHB3ENR, 0, RCC_AHB3ENR_FMCEN);
+  uint32_t regval;
+
+  /* Reset the FMC on the AHB3 bus */
+
+  regval  = getreg32(STM32_RCC_AHB3RSTR);
+  regval |= RCC_AHB3RSTR_FMCRST;
+  putreg32(regval, STM32_RCC_AHB3RSTR);
+
+  /* Leave reset state */
+
+  regval &= ~RCC_AHB3RSTR_FMCRST;
+  putreg32(regval, STM32_RCC_AHB3RSTR);
+
+  /* Set FMC clocking */
+
+  modreg32 (BOARD_FMC_CLK, RCC_D1CCIPR_FMCSEL_MASK, STM32_RCC_D1CCIPR);
+
+  /* Set up FMC GPIOs */
+
+  for (regval = 0; regval < ARRAY_SIZE(fmc_gpios); regval++)
+    stm32_configgpio(fmc_gpios[regval]);
+
+  /* Set up FMC registers */
+
+#ifdef BOARD_FMC_SDCR1
+  modreg32(BOARD_FMC_SDCR1, FMC_SDCR_MASK, STM32_FMC_SDCR1);
+#endif
+#ifdef BOARD_FMC_SDCR2
+  modreg32(BOARD_FMC_SDCR2, FMC_SDCR_MASK, STM32_FMC_SDCR2);
+#endif
+
+#ifdef BOARD_FMC_SDTR1
+  modreg32(BOARD_FMC_SDTR1, FMC_SDTR_MASK, STM32_FMC_SDTR1);
+#endif
+#ifdef BOARD_FMC_SDTR2
+  modreg32(BOARD_FMC_SDTR2, FMC_SDTR_MASK, STM32_FMC_SDTR2);
+#endif
+
+  /* Enable the FMC peripherial */
+
+  modreg32(FMC_BCR_FMCEN, FMC_BCR_FMCEN, STM32_FMC_BCR1);
+
+  /* Initialize the SDRAM chips themselves */
+
+#ifdef HAVE_FMC_SDRAM
+  stm32_fmc_sdram_init();
+#endif
+
+  /* Set up SDRAM refresh timings */
+
+#ifdef BOARD_FMC_SDRAM_REFR_PERIOD
+  /* ... The programmed COUNT value must not be equal to the sum of the following timings:
+     TWR+TRP+TRC+TRCD+4 memory clock cycles */
+#ifdef BOARD_FMC_SDTR1
+  DEBUGASSERT (BOARD_FMC_SDRAM_REFR_PERIOD !=
+    (4 +
+     (1 + ((BOARD_FMC_SDTR1 & FMC_SDTR_TWR_MASK) >> FMC_SDTR_TWR_SHIFT)) +
+     (1 + ((BOARD_FMC_SDTR1 & FMC_SDTR_TRP_MASK) >> FMC_SDTR_TRP_SHIFT)) +
+     (1 + ((BOARD_FMC_SDTR1 & FMC_SDTR_TRC_MASK) >> FMC_SDTR_TRC_SHIFT)) +
+     (1 + ((BOARD_FMC_SDTR1 & FMC_SDTR_TRCD_MASK) >> FMC_SDTR_TRCD_SHIFT))));
+#endif
+#ifdef BOARD_FMC_SDTR2
+  DEBUGASSERT (BOARD_FMC_SDRAM_REFR_PERIOD !=
+    (4 +
+     (1 + ((BOARD_FMC_SDTR2 & FMC_SDTR_TWR_MASK) >> FMC_SDTR_TWR_SHIFT)) +
+     (1 + ((BOARD_FMC_SDTR2 & FMC_SDTR_TRP_MASK) >> FMC_SDTR_TRP_SHIFT)) +
+     (1 + ((BOARD_FMC_SDTR2 & FMC_SDTR_TRC_MASK) >> FMC_SDTR_TRC_SHIFT)) +
+     (1 + ((BOARD_FMC_SDTR2 & FMC_SDTR_TRCD_MASK) >> FMC_SDTR_TRCD_SHIFT))));
+#endif
+
+  stm32_fmc_sdram_set_refresh_rate(BOARD_FMC_SDRAM_REFR_PERIOD);
+#endif /* BOARD_FMC_SDRTR */
+}
+
+#ifdef HAVE_FMC_SDRAM
+
+/****************************************************************************
+ * Name: stm32_fmc_sdram_init
+ *
+ * Description:
+ *   Initialize the SDRAM chips.
+ *
+ ****************************************************************************/
+
+#if defined HAVE_FMC_SDRAM1 && defined HAVE_FMC_SDRAM2
+#  define FMC_SDCMR_CTB                 FMC_SDCMR_CTB1 | FMC_SDCMR_CTB2
+#elif defined HAVE_FMC_SDRAM1
+#  define FMC_SDCMR_CTB                 FMC_SDCMR_CTB1
+#else
+#  define FMC_SDCMR_CTB                 FMC_SDCMR_CTB2
+#endif
+
+void stm32_fmc_sdram_init(void)
+{
+  /* What is happening here:
+   * ... A 100μs delay is required prior to issuing any command [...]
+   * a PRECHARGE command should be applied once the 100μs delay has been satisfied.
+   *
+   * All banks must be precharged.  This will leave all banks in an idle state after
+   * which at least two AUTO REFRESH cycles must be performed. After the AUTO REFRESH
+   * cycles are complete, the SDRAM is then ready for mode register programming.
+   *
+   * The mode register should be loaded prior to applying any operational command
+   * because it will power up in an unknown state.
+   */
+
+  up_udelay(100);
+
+  /* Clock Configuration Enable */
+
+  stm32_fmc_sdram_command(FMC_SDCMR_CTB | FMC_SDCMR_MODE_CLK_ENABLE);
+
+  /* Wait for clock to stabilize */
+
+  up_mdelay(1);
+
+  /* Precharge all banks */
+
+  stm32_fmc_sdram_wait(SDRAM_INIT_TIMEOUT);
+  stm32_fmc_sdram_command(FMC_SDCMR_CTB | FMC_SDCMR_MODE_PALL);
+
+  /* Auto refresh */
+
+  stm32_fmc_sdram_wait(SDRAM_INIT_TIMEOUT);
+  stm32_fmc_sdram_command(FMC_SDCMR_CTB | FMC_SDCMR_MODE_AUTO_REFRESH |
+                          FMC_SDCMR_NRFS(BOARD_FMC_SDRAM_AUTOREFRESH));
+
+  /* Program the SDRAM mode register */
+
+  /* If using two SDRAM chips, this will write same mode for both.
+   * If different mode is required for every chip (why?), it would be
+   * needed to split code into two separate LOAD_MODE commands,
+   * one for every SDRAM chip.
+   */
+
+  stm32_fmc_sdram_wait(SDRAM_INIT_TIMEOUT);
+  stm32_fmc_sdram_command(FMC_SDCMR_CTB | FMC_SDCMR_MODE_LOAD_MODE |
+                          BOARD_FMC_SDRAM_MODE);
 }
 
 /****************************************************************************
- * Name: stm32_fmc_disable
+ * Name: stm32_fmc_sdram_wait
  *
  * Description:
- *   Disable clocking to the FMC.
+ *   Wait until SDRAM controller is ready for all configured SDRAM banks.
+ *
+ * Parameters:
+ *   timeout - number of microseconds before giving up waiting.
+ *
+ * Returns:
+ *   0 if all configured SDRAM banks are ready, -1 on timeout
  *
  ****************************************************************************/
 
-void stm32_fmc_disable(void)
+int stm32_fmc_sdram_wait(unsigned timeout)
 {
-  modifyreg32(STM32_RCC_AHB3ENR, RCC_AHB3ENR_FMCEN, 0);
+  /* Wait until the SDRAM controller is ready */
+
+  for (; timeout; timeout--)
+    {
+      uint32_t sdsr = getreg32(STM32_FMC_SDSR);
+      if (1
+#if defined HAVE_FMC_SDRAM1
+          && ((sdsr & FMC_SDSR_MODES1_MASK) == FMC_SDSR_MODES1_NORMAL)
+#endif
+#if defined HAVE_FMC_SDRAM2
+          && ((sdsr & FMC_SDSR_MODES2_MASK) == FMC_SDSR_MODES2_NORMAL)
+#endif
+         )
+        return 0;
+
+      up_udelay(1);
+    }
+
+  return -1;
 }
+
+#endif
 
 /****************************************************************************
  * Name: stm32_fmc_sdram_write_protect
@@ -92,11 +439,11 @@ void stm32_fmc_sdram_write_protect(int bank, bool state)
   val = getreg32(sdcr);
   if (state)
     {
-      val |= FMC_SDRAM_CR_WRITE_PROTECT;       /* wp == 1 */
+      val |= FMC_SDCR_WP;       /* wp == 1 */
     }
   else
     {
-      val &= ~FMC_SDRAM_CR_WRITE_PROTECT;      /* wp == 0 */
+      val &= ~FMC_SDCR_WP;      /* wp == 0 */
     }
 
   putreg32(val, sdcr);
@@ -112,10 +459,8 @@ void stm32_fmc_sdram_write_protect(int bank, bool state)
 
 void stm32_fmc_sdram_set_refresh_rate(int count)
 {
-  uint32_t val;
-
   DEBUGASSERT(count <= 0x1fff && count >= 0x29);
-  putreg32(count << 1, STM32_FMC_SDRTR);
+  putreg32(FMC_SDRTR_COUNT(count), STM32_FMC_SDRTR);
 }
 
 /****************************************************************************
@@ -132,11 +477,11 @@ void stm32_fmc_sdram_set_timing(int bank, uint32_t timing)
   uint32_t sdtr;
 
   DEBUGASSERT((bank == 1) || (bank == 2));
-  DEBUGASSERT((timing & FMC_SDRAM_TR_RESERVED) == 0);
+  DEBUGASSERT((timing & FMC_SDTR_RESERVED) == 0);
 
   sdtr = (bank == 1) ? STM32_FMC_SDTR1 : STM32_FMC_SDTR2;
   val  = getreg32(sdtr);
-  val &= FMC_SDRAM_TR_RESERVED;     /* preserve reserved bits */
+  val &= FMC_SDTR_RESERVED;             /* preserve reserved bits */
   val |= timing;
   putreg32(val, sdtr);
 }
@@ -170,11 +515,11 @@ void stm32_fmc_sdram_set_control(int bank, uint32_t ctrl)
   uint32_t sdcr;
 
   DEBUGASSERT((bank == 1) || (bank == 2));
-  DEBUGASSERT((ctrl & FMC_SDRAM_CR_RESERVED) == 0);
+  DEBUGASSERT((ctrl & FMC_SDCR_RESERVED) == 0);
 
   sdcr = (bank == 1) ? STM32_FMC_SDCR1 : STM32_FMC_SDCR2;
   val  = getreg32(sdcr);
-  val &= FMC_SDRAM_CR_RESERVED;     /* preserve reserved bits */
+  val &= FMC_SDCR_RESERVED;             /* preserve reserved bits */
   val |= ctrl;
   putreg32(val, sdcr);
 }
@@ -189,7 +534,7 @@ void stm32_fmc_sdram_set_control(int bank, uint32_t ctrl)
 
 void stm32_fmc_sdram_command(uint32_t cmd)
 {
-  DEBUGASSERT((cmd & FMC_SDRAM_CMD_RESERVED) == 0);
+  DEBUGASSERT((cmd & FMC_SDCMR_RESERVED) == 0);
   putreg32(cmd, STM32_FMC_SDCMR);
 }
 

--- a/arch/arm/src/stm32h7/stm32_fmc.h
+++ b/arch/arm/src/stm32h7/stm32_fmc.h
@@ -61,14 +61,18 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: stm32_fmc_sdram_wait
+ * Name: stm32_fmc_init
  *
  * Description:
- *   Wait for the SDRAM controller to be ready.
+ *   Initialize the FMC peripherial. Because FMC initialization is highly
+ *   dependent on the used parts, definition of the initial values for FMC
+ *   registers is mostly left to board designer.
+ *
+ *   Typically called from up_addregion().
  *
  ****************************************************************************/
 
-void stm32_fmc_sdram_wait(void);
+void stm32_fmc_init(void);
 
 /****************************************************************************
  * Name: stm32_fmc_enable

--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -298,6 +298,12 @@ static inline void rcc_enableahb3(void)
   regval |= RCC_AHB3ENR_SDMMC1EN;
 #endif
 
+#ifdef CONFIG_STM32H7_FMC
+  /* Flexible static memory controller module clock enable */
+
+  regval |= RCC_AHB3ENR_FMCEN;
+#endif
+
   /* TODO: ... */
 
   putreg32(regval, STM32_RCC_AHB3ENR);   /* Enable peripherals */

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -75,6 +75,13 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   uintptr_t heapend;
 #if CONFIG_MM_REGIONS > 1
   int IDX = heap->mm_nregions;
+
+  /* Writing past CONFIG_MM_REGIONS would have catastrophic consequences */
+  DEBUGASSERT(IDX < CONFIG_MM_REGIONS);
+  if (IDX >= CONFIG_MM_REGIONS)
+    {
+      return;
+    }
 #else
 # define IDX 0
 #endif

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -350,3 +350,44 @@ define TESTANDREPLACEFILE
 	fi
 endef
 endif
+
+# BOARD_DIR - Directory where board-specific files are located.
+# This can be either boards/<arch>/<chip>/<board> or
+# $(CONFIG_ARCH_BOARD_CUSTOM_DIR) if using an out-of-tree board directory.
+ifeq ($(CONFIG_ARCH_BOARD_CUSTOM),y)
+ifeq ($(CONFIG_ARCH_BOARD_CUSTOM_DIR_RELPATH),y)
+BOARD_DIR = $(TOPDIR)/$(CONFIG_ARCH_BOARD_CUSTOM_DIR)
+else
+BOARD_DIR = $(CONFIG_ARCH_BOARD_CUSTOM_DIR)
+endif
+else
+BOARD_DIR = $(TOPDIR)/boards/$(CONFIG_ARCH)/$(CONFIG_ARCH_CHIP)/$(CONFIG_ARCH_BOARD)
+endif
+
+# CHIP_DIR - Chip-specific directory tree.
+# These are always located in kernel tree, even when using
+# out-of-tree board directory.
+CHIP_DIR = $(TOPDIR)/boards/$(CONFIG_ARCH)/$(CONFIG_ARCH_CHIP)
+
+# Detect default values for tools
+ifeq ($(WINTOOL),y)
+  # Windows-native toolchains
+  DIRLINK = $(TOPDIR)/tools/copydir.sh
+  DIRUNLINK = $(TOPDIR)/tools/unlink.sh
+  MKDEP = $(TOPDIR)/tools/mkwindeps.sh
+else
+  # Linux/Cygwin-native toolchain
+  MKDEP = $(TOPDIR)/tools/mkdeps$(HOSTEXEEXT)
+  # DIRLINK and DIRUNLINK, if not set, will be set to default values in Makefile.unix
+endif
+
+# Arch-dependent include flags; board Make.defs may override these to its taste
+ifeq ($(WINTOOL),y)
+  ARCHINCLUDES = -I. -isystem "${shell cygpath -w $(TOPDIR)/include}"
+  ARCHXXINCLUDES = -I. -isystem "${shell cygpath -w $(TOPDIR)/include}" -isystem "${shell cygpath -w $(TOPDIR)/include/cxx}"
+  ARCHSCRIPT = -T "${shell cygpath -w $(BOARD_DIR)/scripts/$(LDSCRIPT)}"
+else
+  ARCHINCLUDES = -I. -isystem $(TOPDIR)/include
+  ARCHXXINCLUDES = -I. -isystem $(TOPDIR)/include -isystem $(TOPDIR)/include/cxx
+  ARCHSCRIPT = -T$(BOARD_DIR)/scripts/$(LDSCRIPT)
+endif

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -89,17 +89,7 @@ ARCH_DIR = arch/$(CONFIG_ARCH)
 ARCH_SRC = $(ARCH_DIR)/src
 ARCH_INC = $(ARCH_DIR)/include
 
-ifeq ($(CONFIG_ARCH_BOARD_CUSTOM),y)
-ifeq ($(CONFIG_ARCH_BOARD_CUSTOM_DIR_RELPATH),y)
-BOARD_DIR = $(TOPDIR)$(DELIM)$(CONFIG_ARCH_BOARD_CUSTOM_DIR)
-else
-BOARD_DIR = $(CONFIG_ARCH_BOARD_CUSTOM_DIR)
-endif
-else
-BOARD_DIR = $(TOPDIR)$(DELIM)boards$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)
-endif
-
-COMMON_DIR = $(if $(wildcard $(BOARD_DIR)/common/Makefile),y,)
+COMMON_DIR = $(if $(wildcard $(CHIP_DIR)/common/Makefile),y,)
 
 # CONFIG_APPS_DIR can be over-ridden from the command line or in the .config file.
 # The default value of CONFIG_APPS_DIR is ../apps.  Ultimately, the application
@@ -335,31 +325,31 @@ include/arch: .config
 # Link the boards/<arch>/<chip>/<board>/include directory to include/arch/board
 
 include/arch/board: include/arch
-	@echo "LN: include/arch/board to $(BOARD_DIR)/$(CONFIG_ARCH_BOARD)/include"
-	$(Q) $(DIRLINK) $(BOARD_DIR)/$(CONFIG_ARCH_BOARD)/include include/arch/board
+	@echo "LN: include/arch/board to $(BOARD_DIR)/include"
+	$(Q) $(DIRLINK) $(BOARD_DIR)/include include/arch/board
 
 ifeq ($(COMMON_DIR),y)
 # Link the boards/<arch>/<chip>/common dir to arch/<arch-name>/src/board
 # Link the boards/<arch>/<chip>/<board>/src dir to arch/<arch-name>/src/board/board
 
 $(ARCH_SRC)/board: .config
-	@echo "LN: $(ARCH_SRC)/board to $(BOARD_DIR)/common"
-	$(Q) $(DIRLINK) $(BOARD_DIR)/common $(ARCH_SRC)/board
-	@echo "LN: $(ARCH_SRC)/board/board to $(BOARD_DIR)/$(CONFIG_ARCH_BOARD)/src"
-	$(Q) $(DIRLINK) $(BOARD_DIR)/$(CONFIG_ARCH_BOARD)/src $(ARCH_SRC)/board/board
+	@echo "LN: $(ARCH_SRC)/board to $(CHIP_DIR)/common"
+	$(Q) $(DIRLINK) $(CHIP_DIR)/common $(ARCH_SRC)/board
+	@echo "LN: $(ARCH_SRC)/board/board to $(BOARD_DIR)/src"
+	$(Q) $(DIRLINK) $(BOARD_DIR)/src $(ARCH_SRC)/board/board
 else
 # Link the boards/<arch>/<chip>/<board>/src dir to arch/<arch-name>/src/board
 
 $(ARCH_SRC)/board: .config
-	@echo "LN: $(ARCH_SRC)/board to $(BOARD_DIR)/$(CONFIG_ARCH_BOARD)/src"
-	$(Q) $(DIRLINK) $(BOARD_DIR)/$(CONFIG_ARCH_BOARD)/src $(ARCH_SRC)/board
+	@echo "LN: $(ARCH_SRC)/board to $(BOARD_DIR)/src"
+	$(Q) $(DIRLINK) $(BOARD_DIR)/src $(ARCH_SRC)/board
 endif
 
 # Link the boards/<arch>/<chip>/drivers dir to drivers/platform
 
 $(ARCH_SRC)/drivers: .config
-	@echo "LN: $(TOPDIR)/drivers/platform to $(BOARD_DIR)/drivers"
-	$(Q) $(DIRLINK) $(BOARD_DIR)/drivers $(TOPDIR)/drivers/platform
+	@echo "LN: $(TOPDIR)/drivers/platform to $(CHIP_DIR)/drivers"
+	$(Q) $(DIRLINK) $(CHIP_DIR)/drivers $(TOPDIR)/drivers/platform
 
 # Link arch/<arch-name>/src/<chip-name> to arch/<arch-name>/src/chip
 

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -74,17 +74,7 @@ ARCH_DIR = arch\$(CONFIG_ARCH)
 ARCH_SRC = $(ARCH_DIR)\src
 ARCH_INC = $(ARCH_DIR)\include
 
-ifeq ($(CONFIG_ARCH_BOARD_CUSTOM),y)
-ifeq ($(CONFIG_ARCH_BOARD_CUSTOM_DIR_RELPATH),y)
-BOARD_DIR = $(TOPDIR)$(DELIM)$(CONFIG_ARCH_BOARD_CUSTOM_DIR)
-else
-BOARD_DIR = $(CONFIG_ARCH_BOARD_CUSTOM_DIR)
-endif
-else
-BOARD_DIR = $(TOPDIR)$(DELIM)boards$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)
-endif
-
-COMMON_DIR = $(if $(wildcard $(BOARD_DIR)$(DELIM)common$(DELIM)Makefile),y,)
+COMMON_DIR = $(if $(wildcard $(CHIP_DIR)$(DELIM)common$(DELIM)Makefile),y,)
 
 # CONFIG_APPS_DIR can be over-ridden from the command line or in the .config file.
 # The default value of CONFIG_APPS_DIR is ..\apps.  Ultimately, the application
@@ -321,22 +311,22 @@ endif
 # Link the boards\<arch>\<chip>\<board>\include directory to include\arch\board
 
 include\arch\board: include\arch
-	@echo LN: include\arch\board to $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\include
+	@echo LN: include\arch\board to $(BOARD_DIR)\include
 ifeq ($(CONFIG_WINDOWS_MKLINK),y)
-	$(Q) /user:administrator mklink /d include\arch\board $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\include
+	$(Q) /user:administrator mklink /d include\arch\board $(BOARD_DIR)\include
 else
-	$(Q) xcopy $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\include include\arch\board /c /q /s /e /y /i
+	$(Q) xcopy $(BOARD_DIR)\include include\arch\board /c /q /s /e /y /i
 	$(Q) echo FAKELNK > include\arch\board\.fakelnk
 endif
 
 # Link the boards\<arch>\<chip>\drivers dir to drivers\platform
 
 $(ARCH_SRC)\drivers: .config
-	@echo LN: $(TOPDIR)\drivers\platform to $(BOARD_DIR)\drivers
+	@echo LN: $(TOPDIR)\drivers\platform to $(CHIP_DIR)\drivers
 ifeq ($(CONFIG_WINDOWS_MKLINK),y)
-	$(Q) /user:administrator mklink /d $(TOPDIR)\drivers\platform $(BOARD_DIR)\drivers
+	$(Q) /user:administrator mklink /d $(TOPDIR)\drivers\platform $(CHIP_DIR)\drivers
 else
-	$(Q) xcopy $(BOARD_DIR)\drivers $(TOPDIR)\drivers\platform /c /q /s /e /y /i
+	$(Q) xcopy $(CHIP_DIR)\drivers $(TOPDIR)\drivers\platform /c /q /s /e /y /i
 	$(Q) echo FAKELNK > $(TOPDIR)\drivers\platform\.fakelnk
 endif
 
@@ -345,30 +335,30 @@ ifeq ($(COMMON_DIR),y)
 # Link the boards\<arch>\<chip>\<board>\src dir to arch\<arch-name>\src\board\board
 
 $(ARCH_SRC)\board: .config
-	@echo "LN: $(ARCH_SRC)\board to $(BOARD_DIR)\common"
+	@echo "LN: $(ARCH_SRC)\board to $(CHIP_DIR)\common"
 ifeq ($(CONFIG_WINDOWS_MKLINK),y)
-	$(Q) /user:administrator mklink /d $(ARCH_SRC)\board $(BOARD_DIR)\common
+	$(Q) /user:administrator mklink /d $(ARCH_SRC)\board $(CHIP_DIR)\common
 else
-	$(Q) xcopy $(BOARD_DIR)\common $(ARCH_SRC)\board /c /q /s /e /y /i
+	$(Q) xcopy $(CHIP_DIR)\common $(ARCH_SRC)\board /c /q /s /e /y /i
 	$(Q) echo FAKELNK > $(ARCH_SRC)\board\.fakelnk
 endif
-	@echo "LN: $(ARCH_SRC)\board\board to $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\src"
-	$(Q) $(DIRLINK) $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\src $(ARCH_SRC)\board\board
+	@echo "LN: $(ARCH_SRC)\board\board to $(BOARD_DIR)\src"
+	$(Q) $(DIRLINK) $(BOARD_DIR)\src $(ARCH_SRC)\board\board
 ifeq ($(CONFIG_WINDOWS_MKLINK),y)
-	$(Q) /user:administrator mklink /d $(ARCH_SRC)\board\board $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\src
+	$(Q) /user:administrator mklink /d $(ARCH_SRC)\board\board $(BOARD_DIR)\src
 else
-	$(Q) xcopy $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\src $(ARCH_SRC)\board\board /c /q /s /e /y /i
+	$(Q) xcopy $(BOARD_DIR)\src $(ARCH_SRC)\board\board /c /q /s /e /y /i
 	$(Q) echo FAKELNK > $(ARCH_SRC)\board\board\.fakelnk
 endif
 else
 # Link the boards\<arch>\<chip>\<board>\src dir to arch\<arch-name>\src\board
 
 $(ARCH_SRC)\board: .config
-	@echo LN: $(ARCH_SRC)\board to $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\src
+	@echo LN: $(ARCH_SRC)\board to $(BOARD_DIR)\src
 ifeq ($(CONFIG_WINDOWS_MKLINK),y)
-	$(Q) /user:administrator mklink /d $(ARCH_SRC)\board $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\src
+	$(Q) /user:administrator mklink /d $(ARCH_SRC)\board $(BOARD_DIR)\src
 else
-	$(Q) xcopy $(BOARD_DIR)\$(CONFIG_ARCH_BOARD)\src $(ARCH_SRC)\board /c /q /s /e /y /i
+	$(Q) xcopy $(BOARD_DIR)\src $(ARCH_SRC)\board /c /q /s /e /y /i
 	$(Q) echo FAKELNK > $(ARCH_SRC)\board\.fakelnk
 endif
 endif


### PR DESCRIPTION
This patchset contains three commits:

- f047619 fixes out-of-tree board directory support, making it work like it was intended (according to docs). I couldn’t test my later patches without this one, as I use a non-standard board for development.
- d6213fe is a small patch that prevents NuttX from crashing if developer sets MM_REGIONS too low.
- 051e74e contains mostly changes to stm32h7/stm32_fmc.{c,h} and stm32_allocateheap.c. Also it fixes a serious typo in stm32h7x3xx_rcc.h which caused PLL2 and PLL3 not to work at all on stm32h7.
