### PR TITLE
Prevents NuttX crashing if MM_REGIONS is too small.

### DIFF
--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -75,6 +75,13 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   uintptr_t heapend;
 #if CONFIG_MM_REGIONS > 1
   int IDX = heap->mm_nregions;
+
+  /* Writing past CONFIG_MM_REGIONS would have catastrophic consequences */
+  DEBUGASSERT(IDX < CONFIG_MM_REGIONS);
+  if (IDX >= CONFIG_MM_REGIONS)
+    {
+      return;
+    }
 #else
 # define IDX 0
 #endif


### PR DESCRIPTION
Added a DEBUGASSERT and a runtime check so that mm_region will not
overwrite critical heap data if user incorrectly defines MM_REGIONS.