### PR TITLE
z20x:  Fix some SPI/W25/Timer issues.

### DIFF
--- a/arch/z80/src/ez80/ez80_spi.c
+++ b/arch/z80/src/ez80/ez80_spi.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * arch/z80/src/ez80/ez80_spi.c
  *
- *   Copyright (C) 2009-2010, 2016-2017, 2019 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -64,13 +48,18 @@
  ****************************************************************************/
 
 #if defined(CONFIG_ARCH_CHIP_EZ80F91) || defined(CONFIG_ARCH_CHIP_EZ80F92)
+
+/* PB2/#SS is controlled by board specific logic and is not used by this
+ * driver.  This permits supporting multiple, different devices with
+ * different chip selects on the bus.
+ */
+
 #  define GPIOB_SPI_SS      (1 << 2)  /* PB2: /SS (not used by driver) */
 #  define GPIOB_SPI_SCK     (1 << 3)  /* PB3: SCK */
 #  define GPIOB_SPI_MISO    (1 << 6)  /* PB6: MISO */
 #  define GPIOB_SPI_MOSI    (1 << 7)  /* PB7: MOSI */
 
-#  define GPIOB_SPI_PINSET  (GPIOB_SPI_SS | GPIOB_SPI_SCK | GPIOB_SPI_MISO | \
-                             GPIOB_SPI_MOSI)
+#  define GPIOB_SPI_PINSET  (GPIOB_SPI_SCK | GPIOB_SPI_MISO | GPIOB_SPI_MOSI)
 #else
 #  error "Check GPIO initialization for this chip"
 #endif
@@ -206,6 +195,7 @@ static int spi_lock(FAR struct spi_dev_s *dev, bool lock)
 static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
                                  uint32_t frequency)
 {
+  uint32_t actual;
   uint32_t brg;
 
   spiinfo("frequency: %lu\n", (unsigned long)frequency);
@@ -239,7 +229,10 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
   outp(EZ80_SPI_BRG_L, brg & 0xff);
   outp(EZ80_SPI_BRG_H, (brg >> 8) & 0xff);
 
-  return ((EZ80_SYS_CLK_FREQ + 1) / 2 + brg - 1) / brg;
+  actual = ((EZ80_SYS_CLK_FREQ + 1) / 2 + brg - 1) / brg;
+
+  finfo("BRG=%lu Actual=%lu\n", (unsigned long)brg, (unsigned long)actual);
+  return actual;
 }
 
 /****************************************************************************
@@ -334,6 +327,7 @@ static int spi_waitspif(void)
         }
     }
 
+  spierr("ERROR: SPI timed out\n");
   return -ETIMEDOUT;
 }
 
@@ -405,7 +399,7 @@ static uint16_t spi_send(FAR struct spi_dev_s *dev, uint16_t wd)
   ret = spi_transfer((uint8_t)wd, &response);
   if (ret < 0)
     {
-      spierr("ERROR: spi_waitspif returned %d\n", ret);
+      spierr("ERROR: spi_transfer returned %d\n", ret);
       return (uint16_t)0xff;
     }
 
@@ -460,7 +454,7 @@ static void spi_exchange(FAR struct spi_dev_s *dev,
       ret = spi_transfer(outword, outptr);
       if (ret < 0)
         {
-          spierr("ERROR: spi_waitspif returned %d\n", ret);
+          spierr("ERROR: spi_transfer returned %d\n", ret);
           break;
         }
 
@@ -510,7 +504,7 @@ static void spi_sndblock(FAR struct spi_dev_s *dev, FAR const void *buffer,
       ret = spi_transfer(*ptr++, NULL);
       if (ret < 0)
         {
-          spierr("ERROR: spi_waitspif returned %d\n", ret);
+          spierr("ERROR: spi_transfer returned %d\n", ret);
           break;
         }
     }
@@ -552,7 +546,7 @@ static void spi_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
       ret = spi_transfer(0xff, ptr++);
       if (ret < 0)
         {
-          spierr("ERROR: spi_waitspif returned %d\n", ret);
+          spierr("ERROR: spi_transfer returned %d\n", ret);
           break;
         }
     }

--- a/arch/z80/src/ez80/ez80_timerisr.c
+++ b/arch/z80/src/ez80/ez80_timerisr.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/z80/src/ez80/ez80_timerisr.c
  *
- *   Copyright (C) 2008-2009, 2017, 2020 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -69,7 +54,11 @@ static int ez80_timerisr(int irq, chipreg_t *regs, void *arg)
 #ifdef CONFIGS_ARCH_CHIP_EZ80F91
   inp(EZ80_TMR0_IIR);
 #else
-  /* _EZ80190, _EZ80L92, _EZ80F92, _EZ80F93 */
+  /* _EZ80190, _EZ80L92, _EZ80F92, _EZ80F93:  PRT_IRQ, is set to 1 when the
+   * timer reloads the start value in CONTINUOUS mode.  The PRT_IRQ is
+   * cleared to 0 and the interrupt service request signal is inactivated
+   * when the CPU reads from the timer control register, TMRx_CTL.
+   */
 
   inp(EZ80_TMR0_CTL);
 #endif
@@ -113,6 +102,7 @@ void up_timer_initialize(void)
   irq_attach(EZ80_IRQ_SYSTIMER, (xcpt_t)ez80_timerisr, NULL);
 
   /* Set up the timer reload value */
+
   /* Write to the timer reload register to set the reload value.
    *
    * In continuous mode:
@@ -121,12 +111,21 @@ void up_timer_initialize(void)
    * or
    *   reload_value = (timer_period * system_clock_frequency) / clock_divider
    *
-   * For timer_period=10mS, and clock_divider=16, that would yield:
+   * eZ80F91:
+   *   For timer_period=10mS, and clock_divider=16, that would yield:
    *
-   *   reload_value = system_clock_frequency / 1600
+   *     reload_value = system_clock_frequency / 1600
    *
-   * For a system timer of 50,000,000 that would result in a reload value of
-   * 31,250
+   *   For a system timer of 50,000,000, that would result in a reload value
+   *   of 31,250.
+   *
+   * eZ80F92:
+   *   For timer_period=10mS, and clock_divider=4, that would yield:
+   *
+   *     reload_value = system_clock_frequency / 400
+   *
+   *   For a system timer of 20,000,000, * divider of 4, that would result
+   *   in a reload value of 50,000.
    *
    * NOTE: The system clock frequency value is defined in the board.h file
    */
@@ -135,12 +134,14 @@ void up_timer_initialize(void)
   outp(EZ80_TMR0_RRH, (uint8_t)(reload >> 8));
   outp(EZ80_TMR0_RRL, (uint8_t)(reload));
 
-  /* Clear any pending timer interrupts */
-
 #if defined(CONFIGS_ARCH_CHIP_EZ80F91)
+  /* Clear any pending timer interrupts by reading the IIR register */
+
   inp(EZ80_TMR0_IIR);
 #elif defined(CONFIGS_ARCH_CHIP_EZ80L92) || defined(CONFIGS_ARCH_CHIP_EZ80F92) || \
       defined(CONFIGS_ARCH_CHIP_EZ80F93)
+  /* Clear any pending timer interrupts by reading the CTL register */
+
   inp(EZ80_TMR0_CTL);
 #endif
 
@@ -149,15 +150,30 @@ void up_timer_initialize(void)
 #if defined(_EZ80190)
   outp(EZ80_TMR0_CTL, 0x5f);
 #elif defined(CONFIGS_ARCH_CHIP_EZ80F91)
-  outp(EZ80_TMR0_CTL, (EZ80_TMRCLKDIV_16|EZ80_TMRCTL_TIMCONT|EZ80_TMRCTL_RLD|EZ80_TMRCTL_TIMEN));
+  /* EZ80_TMRCTL_TIMEN:   Bit 0: The programmable reload timer is enabled
+   * EZ80_TMRCTL_RLD:     Bit 1: Force reload
+   * EZ80_TMRCTL_TIMCONT: Bit 2: The timer operates in CONTINUOUS mode.
+   * EZ80_TMRCLKDIV_16:   Bits 3-4: System clock divider = 16
+   */
+
+  outp(EZ80_TMR0_CTL, (EZ80_TMRCLKDIV_16 | EZ80_TMRCTL_TIMCONT |
+                       EZ80_TMRCTL_RLD | EZ80_TMRCTL_TIMEN));
+
+  /* Enable timer end-of-count interrupts */
+
+  outp(EZ80_TMR0_IER, EZ80_TMRIER_EOCEN);
+
 #elif defined(CONFIGS_ARCH_CHIP_EZ80L92) || defined(CONFIGS_ARCH_CHIP_EZ80F92) || \
       defined(CONFIGS_ARCH_CHIP_EZ80F93)
-  outp(EZ80_TMR0_CTL, 0x57);
-#endif
+  /* EZ80_TMRCTL_TIMEN:   Bit 0: Programmable reload timer enabled.
+   * EZ80_TMRCTL_RSTEN:   Bit 1: Reload and start function enabled.
+   * EZ80_TMRCLKDIV_4:    Bits 2-3: Timer input clock divided by 4 (5Mhz)
+   * EZ80_TMRCTL_TIMCONT: Bit 4: Continuous mode
+   * EZ80_TMRCTL_EN:      Bit 6: Enable timer interrupt requests
+   */
 
-/* Enable timer end-of-count interrupts */
-
-#if defined(CONFIGS_ARCH_CHIP_EZ80F91)
-  outp(EZ80_TMR0_IER, EZ80_TMRIER_EOCEN);
+  outp(EZ80_TMR0_CTL, (EZ80_TMRCTL_TIMEN | EZ80_TMRCTL_RSTEN |
+                       EZ80_TMRCLKDIV_4 | EZ80_TMRCTL_TIMCONT |
+                       EZ80_TMRCTL_EN);
 #endif
 }

--- a/boards/z80/ez80/z20x/src/ez80_w25.c
+++ b/boards/z80/ez80/z20x/src/ez80_w25.c
@@ -58,7 +58,7 @@ int ez80_w25_initialize(int minor)
 
   /* Get the SPI port */
 
-  spi = ez80_spibus_initialize(0);
+  spi = ez80_spibus_initialize(1);
   if (!spi)
     {
       ferr("ERROR: Failed to initialize SPI port %d\n", 0);

--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -2,35 +2,20 @@
  * drivers/mtd/w25.c
  * Driver for SPI-based W25x16, x32, and x64 and W25q16, q32, q64, and q128 FLASH
  *
- *   Copyright (C) 2012-2013, 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ************************************************************************************/
 
@@ -434,6 +419,7 @@ static inline int w25_readid(struct w25_dev_s *priv)
         {
           /* Nope.. we don't understand this capacity. */
 
+          ferr("ERROR: Unsupported capacity: %02x\n", capacity);
           return -ENODEV;
         }
 
@@ -442,6 +428,8 @@ static inline int w25_readid(struct w25_dev_s *priv)
 
   /* We don't understand the manufacturer or the memory type */
 
+  ferr("ERROR: Unrecognized manufacturer/memory type: %02x/%02x\n",
+       manufacturer, memory);
   return -ENODEV;
 }
 


### PR DESCRIPTION
arch/z80/src/ez80/ez80_spi.c:  Do not configure SPI chip select pin.  It is not used by the driver and configuring it just clobbers other usage of that pin.  Add some additional debug outputs; correct some exiting debug outputs.

drivers/mtd/w25.c:  Add some debug output.

boards/z80/ez80/z20x/src/ez80_w25.c:  Correct SPI bus number used in initialization.  Only SPI1 is supported.

arch/z80/src/ez80/ez80_timerisr.c:  Some initial timer configuration fixes.