### PR TITLE
restore lines from bad nxstyle fixes

### DIFF
--- a/arch/arm/src/sama5/hardware/_sama5d3x_memorymap.h
+++ b/arch/arm/src/sama5/hardware/_sama5d3x_memorymap.h
@@ -103,6 +103,8 @@
 #  define SAM_ISI_OFFSET         0x00034000 /* 0x00034000-0x00037fff: ISI */
 #  define SAM_SFR_OFFSET         0x00038000 /* 0x00038000-0x0003bfff: SFR */
                                             /* 0x0003c000-0x07ffffff: Reserved */
+
+#define SAM_PERIPHB_PSECTION     0xf8000000 /* 0xf8000000-0xffffbfff: Internal Peripherals B */
 #  define SAM_HSMCI1_OFFSET      0x00000000 /* 0x00000000-0x00000fff: HSMCI1 */
 #  define SAM_HSMCI2_OFFSET      0x00004000 /* 0x00004000-0x00007fff: HSMCI2 */
 #  define SAM_SPI1_OFFSET        0x00008000 /* 0x00008000-0x0000bfff: SPI1 */
@@ -121,6 +123,7 @@
 #  define SAM_TDES_OFFSET        0x0003c000 /* 0x0003c000-0x0003ffff: TDES */
 #  define SAM_TRNG_OFFSET        0x00040000 /* 0x00040000-0x00043fff: TRNG */
                                             /* 0x00044000-0x00ffbfff: Reserved */
+#define SAM_SYSC_PSECTION        0xfff00000 /* 0xfff00000-0xffffffff: System Controller */
 #  define SAM_SYSC_PADDR         0xffffc000 /* 0xffffc000-0xffffffff: System Controller */
 #  define SAM_SYSC_OFFSET        0x00000000 /* 0x0fffc000-0x0fffffff: System Controller */
 
@@ -130,6 +133,7 @@
 
 #define SAM_HSMC_OFFSET          0x00000000 /* 0x00000000-0x00000fff: HSMC */
                                             /* 0x00001000-0x000023ff: Reserved */
+#define SAM_FUSE_OFFSET          0x00002400 /* 0x00002400-0x000025ff: FUSE */
 #define SAM_DMAC0_OFFSET         0x00002600 /* 0x00002600-0x000027ff: DMAC0 */
 #define SAM_DMAC1_OFFSET         0x00002800 /* 0x00002800-0x000029ff: DMAC1 */
 #define SAM_MPDDRC_OFFSET        0x00002a00 /* 0x00002a00-0x00002bff: MPDDRC */
@@ -146,11 +150,13 @@
 #define SAM_RSTC_OFFSET          0x00003e00 /* 0x00003e00-0x00003e0f: RSTC */
 #define SAM_SHDC_OFFSET          0x00003e10 /* 0x00003e10-0x00003e1f: SHDC */
                                             /* 0x00003e20-0x00003e2f: Reserved */
+#define SAM_PITC_OFFSET          0x00003e30 /* 0x00003e30-0x00003e3f: PITC */
 #define SAM_WDT_OFFSET           0x00003e40 /* 0x00003e40-0x00003e4f: WDT */
 #define SAM_SCKCR_OFFSET         0x00003e50 /* 0x00003e50-0x00003e53: SCKCR */
 #define SAM_BSC_OFFSET           0x00003e54 /* 0x00003e54-0x00003e5f: BSC */
 #define SAM_GPBR_OFFSET          0x00003e60 /* 0x00003e60-0x00003e6f: GPBR */
                                             /* 0x00003e70-0x00003eaf: Reserved */
+#define SAM_RTCC_OFFSET          0x00003eb0 /* 0x00003eb0-0x00003edf: RTCC */
                                             /* 0x00003ee0-0x00003fff: Reserved */
 
 /* Sizes of memory regions in bytes.
@@ -161,6 +167,7 @@
  */
 
                                                  /* 0x00000000-0x0fffffff: Internal Memories */
+#define SAM_BOOTMEM_SIZE         (1*1024*1024)   /* 0x00000000-0x000fffff: Boot memory */
 #define SAM_ROM_SIZE             (1*1024*1024)   /* 0x00100000-0x001fffff: ROM */
 #define SAM_NFCSRAM_SIZE         (1*1024*1024)   /* 0x00200000-0x002fffff: NFC SRAM */
                                                  /* 0x00300000-0x003fffff: SRAM0 and SRAM1 */
@@ -174,6 +181,7 @@
 #define SAM_DAP_SIZE             (1*1024*1024)   /* 0x00900000-0x009fffff: DAP */
 #define SAM_NFCCR_SIZE           (256*1024*1024) /* 0x70000000-0x7fffffff: NFC Command Registers */
                                                  /* 0xf0000000-0xffffffff: Internal Peripherals */
+#define SAM_PERIPHA_SIZE         (240*1024)      /* 0xf0000000-0xf003bfff: Internal Peripherals */
 #define SAM_PERIPHB_SIZE         (272*1024)      /* 0xf8000000-0xf8043fff: Internal Peripherals */
 #define SAM_SYSC_SIZE            (1*1024*1024)   /* 0xfff00000-0x0ffffedf: Internal Peripherals */
 
@@ -355,8 +363,8 @@
 #define SAM_PERIPH_VSECTION      0xf0000000 /* 0xf0000000-0xffffffff: Internal Peripherals */
 #  define SAM_PERIPHA_VSECTION   0xf0000000 /* 0xf0000000-0xf7ffffff: Internal Peripherals A */
 #  define SAM_PERIPHB_VSECTION   0xf8000000 /* 0xf8000000-0xffefffff: Internal Peripherals B */
-#  define SAM_SYSC_VSECTION      0xf8048000 /* 0xf8048000-0xf8048fff: System Controller */
-#  define SAM_SYSC_VADDR         0xf80fc000 /* 0xf8048000-0xf8048fff: System Controller */
+#  define SAM_SYSC_VSECTION      0xfff00000 /* 0xfff00000-0xffffbfff: System Controller */
+#  define SAM_SYSC_VADDR         0xffffc000 /* 0xffffc000-0xffffffff: System Controller */
 #else
 #define SAM_PERIPH_VSECTION      0xf0000000 /* 0xf0000000-0xffffffff: Internal Peripherals */
 #  define SAM_PERIPHA_VSECTION   0xf0000000 /* 0xf0000000-0xf00fffff: Internal Peripherals A */

--- a/arch/arm/src/sama5/hardware/_sama5d3x_memorymap.h
+++ b/arch/arm/src/sama5/hardware/_sama5d3x_memorymap.h
@@ -103,7 +103,6 @@
 #  define SAM_ISI_OFFSET         0x00034000 /* 0x00034000-0x00037fff: ISI */
 #  define SAM_SFR_OFFSET         0x00038000 /* 0x00038000-0x0003bfff: SFR */
                                             /* 0x0003c000-0x07ffffff: Reserved */
-
 #define SAM_PERIPHB_PSECTION     0xf8000000 /* 0xf8000000-0xffffbfff: Internal Peripherals B */
 #  define SAM_HSMCI1_OFFSET      0x00000000 /* 0x00000000-0x00000fff: HSMCI1 */
 #  define SAM_HSMCI2_OFFSET      0x00004000 /* 0x00004000-0x00007fff: HSMCI2 */


### PR DESCRIPTION
### Summary

* Fix for SAMA5D3 build break introduced in #444 
* Lines were mistakenly deleted during nxstyle fixes or a bad merge

### Impact

* SAMA5D3 build is unbroken

### Detail

* arch/arm/src/sama5/hardware/_sama5d3x_memorymap.h file is restored to its previous state 

### Testing

* Compiled and ran the build on a SAMA5D3-Xplained board
