### PR TITLE
cxd56xx: correct comment format in Make.defs to fix build break

### DIFF
--- a/boards/arm/cxd56xx/drivers/camera/Make.defs
+++ b/boards/arm/cxd56xx/drivers/camera/Make.defs
@@ -1,22 +1,22 @@
-/****************************************************************************
- * boards/arm/cxd56xx/drivers/video/Make.defs
- *
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- ****************************************************************************/
+############################################################################
+# boards/arm/cxd56xx/drivers/video/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
 
 ifeq ($(VIDEO_ISX012),y)
   CSRCS += isx012.c


### PR DESCRIPTION
Error log as below:
platform/camera/Make.defs:1: *** missing separator.  Stop.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>