### PR TITLE
toos/testbuild.sh: Remove the below warnning in nightly build

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -160,7 +160,7 @@ function configure {
   ./tools/configure.sh ${HOPTION} $config
 
   if [ "X$toolchain" != "X" ]; then
-    setting=`grep _TOOLCHAIN_ $nuttx/.config | grep -v CONFIG_ARCH_TOOLCHAIN_*=y | grep =y`
+    setting=`grep _TOOLCHAIN_ $nuttx/.config | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y`
     varname=`echo $setting | cut -d'=' -f1`
     if [ ! -z "$varname" ]; then
       echo "  Disabling $varname"
@@ -168,6 +168,7 @@ function configure {
     fi
 
     echo "  Enabling $toolchain"
+    sed -i -e "/$toolchain/d" $nuttx/.config
     echo "$toolchain=y" >> $nuttx/.config
 
     if [ "X$sizet" == "Xuint" ]; then


### PR DESCRIPTION
====================================================================================
Configuration/Tool: lm3s6432-s2e/nsh,CONFIG_ARMV7M_TOOLCHAIN_GNU_EABIL

Change-Id: I95cd6f0c00f68c68f9175574d44e75e24c41bc12
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
  Disabling CONFIG_ARMV7M_TOOLCHAIN_CODESOURCERYL
  Enabling CONFIG_ARMV7M_TOOLCHAIN_GNU_EABIL
  Refreshing...
.config:1542:warning: override: reassigning to symbol ARMV7M_TOOLCHAIN_GNU_EABIL
  Building NuttX...
------------------------------------------------------------------------------------

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>