### PR TITLE
z20x:  Timer/Spi Fixes

### DIFF
--- a/arch/z80/src/ez80/ez80_timerisr.c
+++ b/arch/z80/src/ez80/ez80_timerisr.c
@@ -176,7 +176,7 @@ void up_timer_initialize(void)
    * EZ80_TMRCTL_EN:      Bit 6: Enable timer interrupt requests
    */
 
-  outp(EZ80_TMR0_CTL, (EZ80_TMRCTL_TIMEN | : |
+  outp(EZ80_TMR0_CTL, (EZ80_TMRCTL_TIMEN | EZ80_TMRCTL_RSTEN |
                        EZ80_TMRCLKDIV_4 | EZ80_TMRCTL_TIMCONT |
                        EZ80_TMRCTL_EN));
 

--- a/boards/z80/ez80/z20x/src/ez80_spi.c
+++ b/boards/z80/ez80/z20x/src/ez80_spi.c
@@ -55,7 +55,7 @@
 
 void ez80_spidev_initialize(void)
 {
-#if defined(HAVE_MMCSD) || defined(HAVE_XPT2046)
+#if defined(HAVE_SPIFLASH) || defined(HAVE_MMCSD) || defined(HAVE_XPT2046)
   uint8_t regval;
   uint8_t pins;
 


### PR DESCRIPTION
arch/z80/src/ez80/ez80_timerisr.c:  Fix an error that looks the file got damaged by a bad keystroke in the editor while a string was highlighted.
boards/z80/ez80/z20x/src/ez80_spi.c:  Fix some bad conditional compilationi. Prevented W25 chip select from being initialized.