### PR TITLE
nfs: fix warning: 'byteswritten' may be used uninitialized

### DIFF
--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -939,7 +939,7 @@ static ssize_t nfs_write(FAR struct file *filep, FAR const char *buffer,
   FAR struct nfsnode    *np;
   ssize_t                writesize;
   ssize_t                bufsize;
-  ssize_t                byteswritten;
+  ssize_t                byteswritten = 0;
   size_t                 reqlen;
   FAR uint32_t          *ptr;
   uint32_t               tmp;


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: Iff329c90d2ab10d0094a34fd8680923c89d338b1