### PR TITLE
nxglib: Remove warning "Assuming 24-bit color is not packed"

### DIFF
--- a/graphics/nxglib/nxglib_fillrun.h
+++ b/graphics/nxglib/nxglib_fillrun.h
@@ -164,7 +164,6 @@ static inline void nxgl_fillrun_24bpp(FAR uint32_t *run, nxgl_mxpixel_t color, s
 {
   /* Fill the run with the color (it is okay to run a fractional byte overy the end */
 
-#warning "Assuming 24-bit color is not packed"
   while (npixels-- > 0)
     {
       *run++ = (uint32_t)color;


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>