### PR TITLE
drivers/net/tun.c:  Eliminate unused function.

### DIFF
--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -1042,28 +1042,6 @@ static int tun_rmmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
 #endif
 
 /****************************************************************************
- * Name: tun_ipv6multicast
- *
- * Description:
- *   Configure the IPv6 multicast MAC address.
- *
- * Input Parameters:
- *   priv - A reference to the private driver state structure
- *
- * Returned Value:
- *   OK on success; Negated errno on failure.
- *
- * Assumptions:
- *
- ****************************************************************************/
-
-#ifdef CONFIG_NET_ICMPv6
-static void tun_ipv6multicast(FAR struct tun_device_s *priv)
-{
-}
-#endif /* CONFIG_NET_ICMPv6 */
-
-/****************************************************************************
  * Name: tun_dev_init
  *
  * Description:


### PR DESCRIPTION
Eliminated unused function tun_ipv6multicast().  This eliminates a warning from the build test:

net/tun.c:1061:13: warning: 'tun_ipv6multicast' defined but not used [-Wunused-function]
 static void tun_ipv6multicast(FAR struct tun_device_s *priv)
             ^~~~~~~~~~~~~~~~~