### PR TITLE
Documentation: change README.txt link to github and add link to NuttX Companion

### DIFF
--- a/Documentation/NuttXGettingStarted.html
+++ b/Documentation/NuttXGettingStarted.html
@@ -15,11 +15,11 @@
 </table>
 <hr><hr>
 <p><b>Getting Started</b>.
-  There is no &quot;Getting Started&quot; Guide for NuttX yet.
-  However, most everything that you need to get started with NuttX can be found in the <code>README.txt</code> file located in the top-level NuttX directory.
-  That <code>README.txt</code> can also be read online in the NuttX GIT repository
-  <a href="https://bitbucket.org/nuttx/nuttx/src/master/README.txt" target="_blank">here</a>.
-  Just click on &quot;Links to HEAD: (view)&quot; on that page.
+  There is no official &quot;Getting Started&quot; Guide for NuttX yet.
+  However, most everything that you need to get started with NuttX can be found in the
+  <a href="https://github.com/apache/incubator-nuttx/blob/master/README.txt" target="_blank">NuttX README.txt</a>.
 </p>
+<p>There is an unofficial introductory guide to NuttX available called the
+  <a href="https://nuttx-companion.readthedocs.io/">NuttX Companion</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
### Summary

* Documentation only
* In `NuttXGettingStarted.html`:
  * change README.txt link to Apache Github incubator-nuttx (was linked to old Bitbucket NuttX repository)
  * add link to NuttX Companion

### Impact

* Changes Getting Started documentation page README.txt link so it will stay updated 
* Adds link to external introductory documentation project

