### PR TITLE
libs/libc/stdio:  Names of files do not match content

### DIFF
--- a/libs/libc/stdio/lib_rawinstream.c
+++ b/libs/libc/stdio/lib_rawinstream.c
@@ -1,35 +1,20 @@
 /****************************************************************************
- * libs/libc/stdio/lib_rawsistream.c
+ * libs/libc/stdio/lib_rawinstream.c
  *
- *   Copyright (C) 2014, 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -52,12 +37,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: rawsistream_getc
+ * Name: rawinstream_getc
  ****************************************************************************/
 
-static int rawsistream_getc(FAR struct lib_sistream_s *this)
+static int rawinstream_getc(FAR struct lib_instream_s *this)
 {
-  FAR struct lib_rawsistream_s *rthis = (FAR struct lib_rawsistream_s *)this;
+  FAR struct lib_rawinstream_s *rthis = (FAR struct lib_rawinstream_s *)this;
   int nwritten;
   char ch;
 
@@ -82,31 +67,18 @@ static int rawsistream_getc(FAR struct lib_sistream_s *this)
 }
 
 /****************************************************************************
- * Name: rawsistream_seek
- ****************************************************************************/
-
-static off_t rawsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
-                              int whence)
-{
-  FAR struct lib_rawsistream_s *mthis = (FAR struct lib_rawsistream_s *)this;
-
-  DEBUGASSERT(this);
-  return lseek(mthis->fd, offset, whence);
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lib_rawsistream
+ * Name: lib_rawinstream
  *
  * Description:
  *   Initializes a stream for use with a file descriptor.
  *
  * Input Parameters:
  *   instream - User allocated, uninitialized instance of struct
- *              lib_rawsistream_s to be initialized.
+ *              lib_rawinstream_s to be initialized.
  *   fd       - User provided file/socket descriptor (must have been opened
  *              for the correct access).
  *
@@ -115,10 +87,9 @@ static off_t rawsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
  *
  ****************************************************************************/
 
-void lib_rawsistream(FAR struct lib_rawsistream_s *instream, int fd)
+void lib_rawinstream(FAR struct lib_rawinstream_s *instream, int fd)
 {
-  instream->public.get  = rawsistream_getc;
-  instream->public.seek = rawsistream_seek;
+  instream->public.get  = rawinstream_getc;
   instream->public.nget = 0;
   instream->fd          = fd;
 }

--- a/libs/libc/stdio/lib_rawsistream.c
+++ b/libs/libc/stdio/lib_rawsistream.c
@@ -1,35 +1,20 @@
 /****************************************************************************
- * libs/libc/stdio/lib_rawinstream.c
+ * libs/libc/stdio/lib_rawsistream.c
  *
- *   Copyright (C) 2007-2009, 2011-2012, 2014 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -52,12 +37,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: rawinstream_getc
+ * Name: rawsistream_getc
  ****************************************************************************/
 
-static int rawinstream_getc(FAR struct lib_instream_s *this)
+static int rawsistream_getc(FAR struct lib_sistream_s *this)
 {
-  FAR struct lib_rawinstream_s *rthis = (FAR struct lib_rawinstream_s *)this;
+  FAR struct lib_rawsistream_s *rthis = (FAR struct lib_rawsistream_s *)this;
   int nwritten;
   char ch;
 
@@ -82,18 +67,31 @@ static int rawinstream_getc(FAR struct lib_instream_s *this)
 }
 
 /****************************************************************************
+ * Name: rawsistream_seek
+ ****************************************************************************/
+
+static off_t rawsistream_seek(FAR struct lib_sistream_s *this, off_t offset,
+                              int whence)
+{
+  FAR struct lib_rawsistream_s *mthis = (FAR struct lib_rawsistream_s *)this;
+
+  DEBUGASSERT(this);
+  return lseek(mthis->fd, offset, whence);
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lib_rawinstream
+ * Name: lib_rawsistream
  *
  * Description:
  *   Initializes a stream for use with a file descriptor.
  *
  * Input Parameters:
  *   instream - User allocated, uninitialized instance of struct
- *              lib_rawinstream_s to be initialized.
+ *              lib_rawsistream_s to be initialized.
  *   fd       - User provided file/socket descriptor (must have been opened
  *              for the correct access).
  *
@@ -102,9 +100,10 @@ static int rawinstream_getc(FAR struct lib_instream_s *this)
  *
  ****************************************************************************/
 
-void lib_rawinstream(FAR struct lib_rawinstream_s *instream, int fd)
+void lib_rawsistream(FAR struct lib_rawsistream_s *instream, int fd)
 {
-  instream->public.get  = rawinstream_getc;
+  instream->public.get  = rawsistream_getc;
+  instream->public.seek = rawsistream_seek;
   instream->public.nget = 0;
   instream->fd          = fd;
 }


### PR DESCRIPTION
Rename lib_rawinstream.c to lib_rawsistream.c and lib_rawsistream.c to lib_rawinstream.c so that the content of the files match the name of the files.  While we are at it, update the file license to Apache 2.0