### PR TITLE
Remove the additional apps checkout step for PR check job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,13 +27,6 @@ jobs:
         path: nuttx
         fetch-depth: 0
 
-    - name: Checkout apps repo
-      uses: actions/checkout@v2
-      with:
-        repository: apache/incubator-nuttx-apps
-        path: apps
-        fetch-depth: 0
-
     - name: Check Pull Request
       run: |
         cd nuttx


### PR DESCRIPTION
Remove the apps checkout step to save check job time.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>