### PR TITLE
Fixed RTC periodic callback issue

### DIFF
--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -234,10 +234,6 @@ static void rtc_periodic_callback(FAR void *priv, int alarmid)
       nxsig_notification(alarminfo->pid, &alarminfo->event,
                          SI_QUEUE, &alarminfo->work);
     }
-
-  /* The alarm is no longer active */
-
-  alarminfo->active = false;
 }
 #endif
 


### PR DESCRIPTION
alarminfo->active = false will kill the signal which will disable the interrupt.
In effect, periodic interrupt will behave like alarm interrupt.

So, removed alarminfo->active = false from rtc_periodic_callback() function