### PR TITLE
tools: Add workaround not to build in parallel for ELF in testbuild.sh

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -190,7 +190,16 @@ function configure {
 function build {
   echo "  Building NuttX..."
   echo "------------------------------------------------------------------------------------"
-  makefunc ${JOPTION} ${MAKE_FLAGS} 1>/dev/null
+
+  elf=`grep CONFIG_ELF=y $nuttx/.config || true`
+
+  # NOTE: workaround to avoid errors in parallel build
+
+  if [ ! -z "${elf}" ]; then
+      makefunc ${MAKE_FLAGS} 1>/dev/null
+  else
+      makefunc ${JOPTION} ${MAKE_FLAGS} 1>/dev/null
+  fi
 }
 
 # Coordinate the steps for the next build test


### PR DESCRIPTION
### Summary

- As long as I checked nightly build results, build errors sometimes happen if a target has CONFIG_ELF=y. I think there still have a root cause in parallel build but I'd like to propose this PR to avoid such a parallel build error.

### Impact

- This PR affects testbuild (e.g. build time will be longer) if a target configuration has CONFIG_ELF=y
- However, as long as I checked all configurations, only 4% defconfigs have CONFIG_ELF=y.

### Limitations / TODO

- It seems that kostest sometimes causes build errors but I'm not sure why this happens.

### Testing

- I tested this PR for RISC-V targets.
