### PR TITLE
tools/nxstyle: clean up the no and unknown file extension info

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -598,7 +598,6 @@ int main(int argc, char **argv, char **envp)
 
   if (ext == 0)
     {
-      INFOFL("No file extension", g_file_name);
     }
   else if (strcmp(ext, ".h") == 0)
     {
@@ -611,7 +610,6 @@ int main(int argc, char **argv, char **envp)
 
   if (g_file_type == UNKNOWN)
     {
-      INFOFL("Unknown file extension", g_file_name);
       return 0;
     }
 


### PR DESCRIPTION
Clean up the no and unknown file extension info since only .h and .c
files supported. Just ignore them quietly.