### PR TITLE
z20x: Fixes related to W25 boot configurations.

### DIFF
--- a/arch/z80/src/ez80/ez80f92.h
+++ b/arch/z80/src/ez80/ez80f92.h
@@ -101,9 +101,9 @@
 #define EZ80_TMRCTL_TIMCONT    0x10        /* Bit 4: Continuous mode */
 #define EZ80_TMRCTL_CLKDIV     0x18        /* Bits 2-3: Timer input clock divider */
 #  define EZ80_TMRCLKDIV_4     0x00        /*   00:   4 */
-#  define EZ80_TMRCLKDIV_16    0x08        /*   01:  16 */
-#  define EZ80_TMRCLKDIV_64    0x10        /*   10:  64 */
-#  define EZ80_TMRCLKDIV_256   0x18        /*   11: 256 */
+#  define EZ80_TMRCLKDIV_16    0x04        /*   01:  16 */
+#  define EZ80_TMRCLKDIV_64    0x08        /*   10:  64 */
+#  define EZ80_TMRCLKDIV_256   0x0c        /*   11: 256 */
 #define EZ80_TMRCTL_RSTEN      0x02        /* Bit 1: Reload and start function enabled */
 #define EZ80_TMRCTL_TIMEN      0x01        /* Bit 0: Programmable reload timer enabled */
 

--- a/boards/z80/ez80/z20x/README.txt
+++ b/boards/z80/ez80/z20x/README.txt
@@ -317,6 +317,31 @@ Configuration Subdirectories
 
     The boot loader source is located at boards/z20x/src/w25_main.c.
 
+    When starting, you may see one of two things, depending upon whether or
+    not there is a valid, bootable image in the W25 FLASH partition:
+
+    1. If there is a bootable image in FLASH, you should see something like:
+
+        Verifying 203125 bytes in the W25 Serial FLASH
+        Successfully verified 203125 bytes in the W25 Serial FLASH
+        [L]oad [B]oot
+        .........
+
+       The program will wait up to 5 seconds for you to provide a response:
+       B to load the program program from the W25 and start it, or L to
+       download a new program from serial and write it to FLASH.
+
+       If nothing is pressed in within the 5 second delay, the program will
+       continue to boot the program just as though B were pressed.
+
+       If L is pressed, then you should see the same dialog as for the case
+       where there is no valid binary image in FLASH.
+
+    2. If there is no valid program in FLASH (or if L is pressed), you will
+       be asked to :
+
+         Send HEX file now.
+
     NOTES:
 
     1. A large UART1 Rx buffer (4Kb), a slow UART1 BAUD (2400), and a very
@@ -346,3 +371,8 @@ Configuration Subdirectories
 
        Things worth trying:  4800 BAUD, smaller Rx buffer, large Rx FIFO
        trigger level.
+
+    2. Booting large programs from the serial FLASH is unbearably slow;
+       you will think that the system is simply not booting at all.  There
+       is probably some bug contributing to this probably (maybe the timer
+       interrupt rate?)

--- a/boards/z80/ez80/z20x/src/w25_main.c
+++ b/boards/z80/ez80/z20x/src/w25_main.c
@@ -287,6 +287,7 @@ static int w25_read_binary(FAR struct prog_header_s *hdr)
   fd = open(W25_CHARDEV, O_RDONLY);
   if (fd < 0)
     {
+      ret = -get_errno();
       return ret;
     }
 
@@ -342,17 +343,21 @@ errout:
  *
  ****************************************************************************/
 
-uint24_t w25_crc24(uint32_t len)
+static uint24_t w25_crc24(uint32_t len)
 {
   FAR const uint8_t *src = (FAR const uint8_t *)PROGSTART;
   uint32_t crc = 0;
   int i;
   int j;
 
+  /* Loop for each byte in the binary image */
+
   for (i = 0; i < len; i++)
     {
       uint8_t val = *src++;
       crc ^= (uint32_t)val << 16;
+
+      /* Loop for each bit in each byte */
 
       for (j = 0; j < 8; j++)
         {
@@ -548,7 +553,7 @@ static int w25_wait_keypress(FAR char *keyset, int nseconds)
         {
           char tmpch;
 
-          /* Read handling retries.  We get out of this loop if a key is press*/
+          /* Read handling retries.  We get out of this loop if a key is press. */
 
           for (; ; )
             {


### PR DESCRIPTION
arch/z80/src/ez80/ez80_timerisr.c:  Correct a mismatch between the programmed reload value and the timer input clock frequency.

arch/z80/src/ez80/ez80f92.h:  Correct error in timer input clock divider:  Bits 2-3, not bits 3-4.

boards/z80/ez80/z20x/src/w25_main.c:  Correct an uninitialized return value; private function was not declared static.