### PR TITLE
arch/xtensa/src/esp32/esp32_cpustart.c: nxstyle fixes

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -88,6 +88,7 @@ static inline void xtensa_registerdump(FAR struct tcb_s *tcb)
   _info("CPU%d:\n", up_cpu_index());
 
   /* Dump the startup registers */
+
   /* To be provided */
 }
 #else
@@ -149,12 +150,12 @@ void xtensa_appcpu_start(void)
   register uint32_t sp;
 
 #ifdef CONFIG_STACK_COLORATION
-  {
-    register uint32_t *ptr;
-    register int i;
+    {
+      register uint32_t *ptr;
+      register int i;
 
-      /* If stack debug is enabled, then fill the stack with a recognizable value
-       * that we can use later to test for high water marks.
+      /* If stack debug is enabled, then fill the stack with a recognizable
+       * value that we can use later to test for high water marks.
        */
 
       for (i = 0, ptr = (uint32_t *)tcb->stack_alloc_ptr;
@@ -163,7 +164,7 @@ void xtensa_appcpu_start(void)
         {
           *ptr++ = STACK_COLOR;
         }
-  }
+    }
 #endif
 
   /* Move to the stack assigned to us by up_smp_start immediately.  Although


### PR DESCRIPTION
The remaining errors:

    Mixed case identifier found

I didn't fix them because they were on ROM symbols,
which are not supposed to obey NuttX's coding style.