### PR TITLE
NXP S32K1XX EVB boards - clock config cleanup

### DIFF
--- a/boards/arm/s32k1xx/s32k118evb/src/s32k118evb.h
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k118evb.h
@@ -82,7 +82,7 @@
 
 /* Count of peripheral clock user configurations */
 
-#define NUM_OF_PERIPHERAL_CLOCKS_0 10
+#define NUM_OF_PERIPHERAL_CLOCKS_0 11
 
 /****************************************************************************
  * Public Types

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
@@ -79,117 +79,117 @@ const struct clock_configuration_s g_initial_clkconfig =
   {
     .sirc          =
     {
-      .range       = SCG_SIRC_RANGE_HIGH,      /* RANGE - High range (8 MHz) */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .stopmode    = false, /* SIRCSTEN */
-      .lowpower    = true,  /* SIRCLPEN */
-      .locked      = false, /* LK */
+      .range       = SCG_SIRC_RANGE_HIGH,              /* RANGE - High range (8 MHz) */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .stopmode    = false,                            /* SIRCSTEN */
+      .lowpower    = true,                             /* SIRCLPEN */
+      .locked      = false,                            /* LK */
     },
     .firc          =
     {
-      .range       = SCG_FIRC_RANGE_48M,       /* RANGE */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .regulator   = true,  /* FIRCREGOFF */
-      .locked      = false, /* LK */
+      .range       = SCG_FIRC_RANGE_48M,               /* RANGE */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .regulator   = true,                             /* FIRCREGOFF */
+      .locked      = false,                            /* LK */
     },
     .sosc          =
     {
-      .mode        = SCG_SOSC_MONITOR_DISABLE, /* SOSCCM */
-      .gain        = SCG_SOSC_GAIN_LOW,        /* HGO */
-      .range       = SCG_SOSC_RANGE_HIGH,      /* RANGE */
-      .extref      = SCG_SOSC_REF_OSC,         /* EREFS */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .locked      = false, /* LK */
+      .mode        = SCG_SOSC_MONITOR_DISABLE,         /* SOSCCM */
+      .gain        = SCG_SOSC_GAIN_LOW,                /* HGO */
+      .range       = SCG_SOSC_RANGE_HIGH,              /* RANGE */
+      .extref      = SCG_SOSC_REF_OSC,                 /* EREFS */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SOSCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SOSCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .locked      = false,                            /* LK */
     },
     .rtc           =
     {
-      .initialize  = true, /* Initialize */
-      .clkin       = 0,    /* RTC_CLKIN */
+      .initialize  = true,                             /* Initialize */
+      .clkin       = 0,                                /* RTC_CLKIN */
     },
     .clockout      =
     {
-      .source      = SCG_CLOCKOUT_SRC_FIRC, /* SCG CLKOUTSEL */
-      .initialize  = true, /* Initialize */
+      .source      = SCG_CLOCKOUT_SRC_FIRC,            /* SCG CLKOUTSEL */
+      .initialize  = true,                             /* Initialize */
     },
     .clockmode     =
     {
-      .rccr        = /* RCCR - Run Clock Control Register */
+      .rccr        =                                   /* RCCR - Run Clock Control Register */
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_FIRC, /* SCS */
-        .divslow   = 2, /* DIVSLOW, range 1..16 */
-        .divbus    = 2, /* DIVBUS, range 1..16 */
-        .divcore   = 1, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_FIRC,        /* SCS */
+        .divslow   = 2,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 2,                                /* DIVBUS, range 1..16 */
+        .divcore   = 1,                                /* DIVCORE, range 1..16 */
       },
-      .vccr        = /* VCCR - VLPR Clock Control Register */
+      .vccr        =                                   /* VCCR - VLPR Clock Control Register */
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC, /* SCS */
-        .divslow   = 4, /* DIVSLOW, range 1..16 */
-        .divbus    = 1, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC,        /* SCS */
+        .divslow   = 4,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 1,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
-      .initialize  = true, /* Initialize */
+      .initialize  = true,                             /* Initialize */
     },
   },
   .sim             =
   {
-    .clockout      = /* Clock Out configuration. */
+    .clockout      =                                   /* Clock Out configuration. */
     {
       .source      = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT, /* CLKOUTSEL */
-      .divider     = 1,     /* CLKOUTDIV, range 1..8 */
-      .initialize  = true,  /* Initialize */
-      .enable      = false, /* CLKOUTEN */
+      .divider     = 1,                                /* CLKOUTDIV, range 1..8 */
+      .initialize  = true,                             /* Initialize */
+      .enable      = false,                            /* CLKOUTEN */
     },
-    .lpoclk        = /* Low Power Clock configuration. */
+    .lpoclk        =                                   /* Low Power Clock configuration. */
     {
-      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
-      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
-      .initialize  = true, /* Initialize */
-      .lpo32k      = true, /* LPO32KCLKEN */
-      .lpo1k       = true, /* LPO1KCLKEN */
+      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK,      /* RTCCLKSEL */
+      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,         /* LPOCLKSEL */
+      .initialize  = true,                             /* Initialize */
+      .lpo32k      = true,                             /* LPO32KCLKEN */
+      .lpo1k       = true,                             /* LPO1KCLKEN */
     },
-    .tclk          = /* TCLK CLOCK configuration. */
+    .tclk          =                                   /* TCLK CLOCK configuration. */
     {
-      .tclkfreq[0] = 0,    /* TCLK0 */
-      .tclkfreq[1] = 0,    /* TCLK1 */
-      .tclkfreq[2] = 0,    /* TCLK2 */
-      .initialize  = true, /* Initialize */
+      .tclkfreq[0] = 0,                                /* TCLK0 */
+      .tclkfreq[1] = 0,                                /* TCLK1 */
+      .tclkfreq[2] = 0,                                /* TCLK2 */
+      .initialize  = true,                             /* Initialize */
     },
-    .platgate      = /* Platform Gate Clock configuration. */
+    .platgate      =                                   /* Platform Gate Clock configuration. */
     {
-      .initialize  = true, /* Initialize */
-      .mscm        = true, /* CGCMSCM */
-      .mpu         = true, /* CGCMPU */
-      .dma         = true, /* CGCDMA */
-      .erm         = true, /* CGCERM */
-      .eim         = true, /* CGCEIM */
+      .initialize  = true,                             /* Initialize */
+      .mscm        = true,                             /* CGCMSCM */
+      .mpu         = true,                             /* CGCMPU */
+      .dma         = true,                             /* CGCDMA */
+      .erm         = true,                             /* CGCERM */
+      .eim         = true,                             /* CGCEIM */
     },
-    .traceclk      = /* Debug trace Clock Configuration. */
+    .traceclk      =                                   /* Debug trace Clock Configuration. */
     {
-      .source      = CLOCK_TRACE_SRC_CORE_CLK, /* TRACECLK_SEL */
-      .divider     = 1,     /* TRACEDIV, range 1..8 */
-      .initialize  = true,  /* Initialize */
-      .enable      = true,  /* TRACEDIVEN */
-      .fraction    = false, /* TRACEFRAC */
+      .source      = CLOCK_TRACE_SRC_CORE_CLK,         /* TRACECLK_SEL */
+      .divider     = 1,                                /* TRACEDIV, range 1..8 */
+      .initialize  = true,                             /* Initialize */
+      .enable      = true,                             /* TRACEDIVEN */
+      .fraction    = false,                            /* TRACEFRAC */
     },
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
-    .pclks         = g_peripheral_clockconfig0,  /* Peripheral clock configurations */
+    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
+    .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =
   {
-    .lpoclk        = /* Low Power Clock configuration. */
+    .lpoclk        =                                   /* Low Power Clock configuration. */
     {
-      .trim        = 0,    /* Trimming value for LPO */
-      .initialize  = true, /* Initialize */
-      .enable      = true, /* Enable/disable LPO */
+      .trim        = 0,                                /* Trimming value for LPO */
+      .initialize  = true,                             /* Initialize */
+      .enable      = true,                             /* Enable/disable LPO */
     },
   },
 };

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
@@ -77,132 +77,123 @@ const struct clock_configuration_s g_initial_clkconfig =
 {
   .scg =
   {
-    .sirc               =
+    .sirc          =
     {
-      .range            = SCG_SIRC_RANGE_HIGH,       /* RANGE - High range (8 MHz) */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SIRCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SIRCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /* SIRCSTEN */
-      .lowpower         = true,        /* SIRCLPEN */
-      .locked           = false,       /* LK */
+      .range       = SCG_SIRC_RANGE_HIGH,      /* RANGE - High range (8 MHz) */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .stopmode    = false, /* SIRCSTEN */
+      .lowpower    = true,  /* SIRCLPEN */
+      .locked      = false, /* LK */
     },
-    .firc               =
+    .firc          =
     {
-      .range            = SCG_FIRC_RANGE_48M,        /* RANGE */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* FIRCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* FIRCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .lowpower         = false,       /*  */
-      .regulator        = true,        /* FIRCREGOFF */
-      .locked           = false,       /* LK */
+      .range       = SCG_FIRC_RANGE_48M,       /* RANGE */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .regulator   = true,  /* FIRCREGOFF */
+      .locked      = false, /* LK */
     },
-    .sosc               =
+    .sosc          =
     {
-      .mode             = SCG_SOSC_MONITOR_DISABLE,  /* SOSCCM */
-      .gain             = SCG_SOSC_GAIN_LOW,         /* HGO */
-      .range            = SCG_SOSC_RANGE_HIGH,       /* RANGE */
-      .extref           = SCG_SOSC_REF_OSC,          /* EREFS */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SOSCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SOSCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .lowpower         = false,       /*  */
-      .locked           = false,       /* LK */
+      .mode        = SCG_SOSC_MONITOR_DISABLE, /* SOSCCM */
+      .gain        = SCG_SOSC_GAIN_LOW,        /* HGO */
+      .range       = SCG_SOSC_RANGE_HIGH,      /* RANGE */
+      .extref      = SCG_SOSC_REF_OSC,         /* EREFS */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .locked      = false, /* LK */
     },
-    .rtc                =
+    .rtc           =
     {
-      .initialize       = true,        /* Initialize */
-      .clkin            = 0            /* RTC_CLKIN */
+      .initialize  = true, /* Initialize */
+      .clkin       = 0,    /* RTC_CLKIN */
     },
-    .clockout           =
+    .clockout      =
     {
-      .source           = SCG_CLOCKOUT_SRC_FIRC,  /* SCG CLKOUTSEL */
-      .initialize       = true,        /* Initialize */
+      .source      = SCG_CLOCKOUT_SRC_FIRC, /* SCG CLKOUTSEL */
+      .initialize  = true, /* Initialize */
     },
-    .clockmode          =
+    .clockmode     =
     {
-      .rccr             =              /* RCCR - Run Clock Control Register */
+      .rccr        = /* RCCR - Run Clock Control Register */
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_FIRC,  /* SCS */
-        .divslow        = 2,           /* DIVSLOW, range 1..16 */
-        .divbus         = 2,           /* DIVBUS, range 1..16 */
-        .divcore        = 1            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_FIRC, /* SCS */
+        .divslow   = 2, /* DIVSLOW, range 1..16 */
+        .divbus    = 2, /* DIVBUS, range 1..16 */
+        .divcore   = 1, /* DIVCORE, range 1..16 */
       },
-      .vccr             =              /* VCCR - VLPR Clock Control Register */
+      .vccr        = /* VCCR - VLPR Clock Control Register */
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SIRC,  /* SCS */
-        .divslow        = 4,           /* DIVSLOW, range 1..16 */
-        .divbus         = 1,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC, /* SCS */
+        .divslow   = 4, /* DIVSLOW, range 1..16 */
+        .divbus    = 1, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-
-      /* .altclk */
-
-      .initialize       = true,        /* Initialize */
+      .initialize  = true, /* Initialize */
     },
   },
-  .sim                  =
+  .sim             =
   {
-    .clockout           =              /* Clock Out configuration. */
+    .clockout      = /* Clock Out configuration. */
     {
-      .source           = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT,  /* CLKOUTSEL */
-      .divider          = 1,           /* CLKOUTDIV, range 1..8 */
-      .initialize       = true,        /* Initialize */
-      .enable           = false,       /* CLKOUTEN */
+      .source      = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT, /* CLKOUTSEL */
+      .divider     = 1,     /* CLKOUTDIV, range 1..8 */
+      .initialize  = true,  /* Initialize */
+      .enable      = false, /* CLKOUTEN */
     },
-    .lpoclk             =              /* Low Power Clock configuration. */
+    .lpoclk        = /* Low Power Clock configuration. */
     {
-      .rtc_source       = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
-      .lpo_source       = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
-      .initialize       = true,        /* Initialize */
-      .lpo32k           = true,        /* LPO32KCLKEN */
-      .lpo1k            = true,        /* LPO1KCLKEN */
+      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
+      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
+      .initialize  = true, /* Initialize */
+      .lpo32k      = true, /* LPO32KCLKEN */
+      .lpo1k       = true, /* LPO1KCLKEN */
     },
-    .tclk               =              /* TCLK CLOCK configuration. */
+    .tclk          = /* TCLK CLOCK configuration. */
     {
-      .tclkfreq[0]      = 0,           /* TCLK0 */
-      .tclkfreq[1]      = 0,           /* TCLK1 */
-      .tclkfreq[2]      = 0,           /* TCLK2 */
-      .initialize       = true,        /* Initialize */
+      .tclkfreq[0] = 0,    /* TCLK0 */
+      .tclkfreq[1] = 0,    /* TCLK1 */
+      .tclkfreq[2] = 0,    /* TCLK2 */
+      .initialize  = true, /* Initialize */
     },
-    .platgate           =              /* Platform Gate Clock configuration. */
+    .platgate      = /* Platform Gate Clock configuration. */
     {
-      .initialize       = true,        /* Initialize */
-      .mscm             = true,        /* CGCMSCM */
-      .mpu              = true,        /* CGCMPU */
-      .dma              = true,        /* CGCDMA */
-      .erm              = true,        /* CGCERM */
-      .eim              = true,        /* CGCEIM */
+      .initialize  = true, /* Initialize */
+      .mscm        = true, /* CGCMSCM */
+      .mpu         = true, /* CGCMPU */
+      .dma         = true, /* CGCDMA */
+      .erm         = true, /* CGCERM */
+      .eim         = true, /* CGCEIM */
     },
-    .traceclk           =              /* Debug trace Clock Configuration. */
+    .traceclk      = /* Debug trace Clock Configuration. */
     {
-      .source           = CLOCK_TRACE_SRC_CORE_CLK,  /* TRACECLK_SEL */
-      .divider          = 1,           /* TRACEDIV, range 1..8 */
-      .initialize       = true,        /* Initialize */
-      .enable           = true,        /* TRACEDIVEN */
-      .fraction         = false,       /* TRACEFRAC */
+      .source      = CLOCK_TRACE_SRC_CORE_CLK, /* TRACECLK_SEL */
+      .divider     = 1,     /* TRACEDIV, range 1..8 */
+      .initialize  = true,  /* Initialize */
+      .enable      = true,  /* TRACEDIVEN */
+      .fraction    = false, /* TRACEFRAC */
     },
-#ifdef CONFIG_S32K1XX_HAVE_QSPI
-    .qspirefclk         =              /* Quad Spi Internal Reference Clock Gating. */
-    {
-      .refclk           = false,       /* Qspi reference clock gating */
-    },
-#endif
   },
-  .pcc                  =
+  .pcc             =
   {
-    .count              = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
-    .pclks              = g_peripheral_clockconfig0   /* Peripheral clock configurations */
+    .count         = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
+    .pclks         = g_peripheral_clockconfig0,  /* Peripheral clock configurations */
   },
-  .pmc                  =
+  .pmc             =
   {
-    .lpoclk             =              /* Low Power Clock configuration. */
+    .lpoclk        = /* Low Power Clock configuration. */
     {
-      .trim             = 0,           /* Trimming value for LPO */
-      .initialize       = true,        /* Initialize */
-      .enable           = true,        /* Enable/disable LPO */
+      .trim        = 0,    /* Trimming value for LPO */
+      .initialize  = true, /* Initialize */
+      .enable      = true, /* Enable/disable LPO */
     },
-  }
+  },
 };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_periphclocks.c
@@ -62,14 +62,6 @@
 #include "s32k118evb.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -80,73 +72,80 @@
 const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
 {
   {
-    .clkname    = ADC0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC_DIV2,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN0_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = DMAMUX0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPI2C0_CLK,
+#ifdef CONFIG_S32K1XX_LPI2C0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPTMR0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC_DIV2,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI0_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC_DIV2,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI1_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC_DIV2,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART0_CLK,
+#ifdef CONFIG_S32K1XX_LPUART0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = PORTA_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART1_CLK,
+#ifdef CONFIG_S32K1XX_LPUART1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = PORTB_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTA_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTC_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTB_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTD_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTC_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTE_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTD_CLK,
+    .clkgate = true,
+  },
+  {
+    .clkname = PORTE_CLK,
+    .clkgate = true,
   },
 };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
@@ -79,135 +79,135 @@ const struct clock_configuration_s g_initial_clkconfig =
   {
     .sirc          =
     {
-      .range       = SCG_SIRC_RANGE_HIGH,      /* RANGE - High range (8 MHz) */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .stopmode    = false, /* SIRCSTEN */
-      .lowpower    = true,  /* SIRCLPEN */
-      .locked      = false, /* LK */
+      .range       = SCG_SIRC_RANGE_HIGH,              /* RANGE - High range (8 MHz) */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .stopmode    = false,                            /* SIRCSTEN */
+      .lowpower    = true,                             /* SIRCLPEN */
+      .locked      = false,                            /* LK */
     },
     .firc          =
     {
-      .range       = SCG_FIRC_RANGE_48M,       /* RANGE */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .regulator   = true,  /* FIRCREGOFF */
-      .locked      = false, /* LK */
+      .range       = SCG_FIRC_RANGE_48M,               /* RANGE */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .regulator   = true,                             /* FIRCREGOFF */
+      .locked      = false,                            /* LK */
     },
     .sosc          =
     {
-      .mode        = SCG_SOSC_MONITOR_DISABLE, /* SOSCCM */
-      .gain        = SCG_SOSC_GAIN_LOW,        /* HGO */
-      .range       = SCG_SOSC_RANGE_HIGH,      /* RANGE */
-      .extref      = SCG_SOSC_REF_OSC,         /* EREFS */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .locked      = false, /* LK */
+      .mode        = SCG_SOSC_MONITOR_DISABLE,         /* SOSCCM */
+      .gain        = SCG_SOSC_GAIN_LOW,                /* HGO */
+      .range       = SCG_SOSC_RANGE_HIGH,              /* RANGE */
+      .extref      = SCG_SOSC_REF_OSC,                 /* EREFS */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SOSCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SOSCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .locked      = false,                            /* LK */
     },
     .spll          =
     {
-      .mode        = SCG_SPLL_MONITOR_DISABLE, /* SPLLCM */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV2 */
-      .prediv      = 1,     /* PREDIV */
-      .mult        = 40,    /* MULT */
-      .src         = 0,     /* SOURCE */
-      .initialize  = true,  /* Initialize */
-      .locked      = false, /* LK */
+      .mode        = SCG_SPLL_MONITOR_DISABLE,         /* SPLLCM */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV2 */
+      .prediv      = 1,                                /* PREDIV */
+      .mult        = 40,                               /* MULT */
+      .src         = 0,                                /* SOURCE */
+      .initialize  = true,                             /* Initialize */
+      .locked      = false,                            /* LK */
     },
     .rtc           =
     {
-      .initialize  = true, /* Initialize */
-      .clkin       = 0,    /* RTC_CLKIN */
+      .initialize  = true,                             /* Initialize */
+      .clkin       = 0,                                /* RTC_CLKIN */
     },
     .clockout      =
     {
-      .source      = SCG_CLOCKOUT_SRC_FIRC, /* SCG CLKOUTSEL */
-      .initialize  = true, /* Initialize */
+      .source      = SCG_CLOCKOUT_SRC_FIRC,            /* SCG CLKOUTSEL */
+      .initialize  = true,                             /* Initialize */
     },
     .clockmode     =
     {
-      .rccr        = /* RCCR - Run Clock Control Register */
+      .rccr        =                                   /* RCCR - Run Clock Control Register */
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
-        .divslow   = 3, /* DIVSLOW, range 1..16 */
-        .divbus    = 2, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,     /* SCS */
+        .divslow   = 3,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 2,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
-      .vccr        = /* VCCR - VLPR Clock Control Register */
+      .vccr        =                                   /* VCCR - VLPR Clock Control Register */
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC, /* SCS */
-        .divslow   = 4, /* DIVSLOW, range 1..16 */
-        .divbus    = 1, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC,        /* SCS */
+        .divslow   = 4,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 1,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
       .hccr        =
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
-        .divslow   = 3, /* DIVSLOW, range 1..16 */
-        .divbus    = 2, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,     /* SCS */
+        .divslow   = 3,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 2,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
-      .initialize  = true, /* Initialize */
+      .initialize  = true,                             /* Initialize */
     },
   },
   .sim             =
   {
-    .clockout      = /* Clock Out configuration. */
+    .clockout      =                                   /* Clock Out configuration. */
     {
       .source      = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT, /* CLKOUTSEL */
-      .divider     = 1,     /* CLKOUTDIV, range 1..8 */
-      .initialize  = true,  /* Initialize */
-      .enable      = false, /* CLKOUTEN */
+      .divider     = 1,                                /* CLKOUTDIV, range 1..8 */
+      .initialize  = true,                             /* Initialize */
+      .enable      = false,                            /* CLKOUTEN */
     },
-    .lpoclk        = /* Low Power Clock configuration. */
+    .lpoclk        =                                   /* Low Power Clock configuration. */
     {
-      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
-      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
-      .initialize  = true, /* Initialize */
-      .lpo32k      = true, /* LPO32KCLKEN */
-      .lpo1k       = true, /* LPO1KCLKEN */
+      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK,      /* RTCCLKSEL */
+      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,         /* LPOCLKSEL */
+      .initialize  = true,                             /* Initialize */
+      .lpo32k      = true,                             /* LPO32KCLKEN */
+      .lpo1k       = true,                             /* LPO1KCLKEN */
     },
-    .tclk          = /* TCLK CLOCK configuration. */
+    .tclk          =                                   /* TCLK CLOCK configuration. */
     {
-      .tclkfreq[0] = 0,    /* TCLK0 */
-      .tclkfreq[1] = 0,    /* TCLK1 */
-      .tclkfreq[2] = 0,    /* TCLK2 */
-      .initialize  = true, /* Initialize */
+      .tclkfreq[0] = 0,                                /* TCLK0 */
+      .tclkfreq[1] = 0,                                /* TCLK1 */
+      .tclkfreq[2] = 0,                                /* TCLK2 */
+      .initialize  = true,                             /* Initialize */
     },
-    .platgate      = /* Platform Gate Clock configuration. */
+    .platgate      =                                   /* Platform Gate Clock configuration. */
     {
-      .initialize  = true, /* Initialize */
-      .mscm        = true, /* CGCMSCM */
-      .mpu         = true, /* CGCMPU */
-      .dma         = true, /* CGCDMA */
-      .erm         = true, /* CGCERM */
-      .eim         = true, /* CGCEIM */
+      .initialize  = true,                             /* Initialize */
+      .mscm        = true,                             /* CGCMSCM */
+      .mpu         = true,                             /* CGCMPU */
+      .dma         = true,                             /* CGCDMA */
+      .erm         = true,                             /* CGCERM */
+      .eim         = true,                             /* CGCEIM */
     },
-    .traceclk      = /* Debug trace Clock Configuration. */
+    .traceclk      =                                   /* Debug trace Clock Configuration. */
     {
-      .source      = CLOCK_TRACE_SRC_CORE_CLK, /* TRACECLK_SEL */
-      .divider     = 1,     /* TRACEDIV, range 1..8 */
-      .initialize  = true,  /* Initialize */
-      .enable      = true,  /* TRACEDIVEN */
-      .fraction    = false, /* TRACEFRAC */
+      .source      = CLOCK_TRACE_SRC_CORE_CLK,         /* TRACECLK_SEL */
+      .divider     = 1,                                /* TRACEDIV, range 1..8 */
+      .initialize  = true,                             /* Initialize */
+      .enable      = true,                             /* TRACEDIVEN */
+      .fraction    = false,                            /* TRACEFRAC */
     },
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
-    .pclks         = g_peripheral_clockconfig0,  /* Peripheral clock configurations */
+    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
+    .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =
   {
-    .lpoclk        = /* Low Power Clock configuration. */
+    .lpoclk        =                                   /* Low Power Clock configuration. */
     {
-      .trim        = 0,    /* Trimming value for LPO */
-      .initialize  = true, /* Initialize */
-      .enable      = true, /* Enable/disable LPO */
+      .trim        = 0,                                /* Trimming value for LPO */
+      .initialize  = true,                             /* Initialize */
+      .enable      = true,                             /* Enable/disable LPO */
     },
   },
 };

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
@@ -77,151 +77,141 @@ const struct clock_configuration_s g_initial_clkconfig =
 {
   .scg =
   {
-    .sirc               =
+    .sirc          =
     {
-      .range            = SCG_SIRC_RANGE_HIGH,       /* RANGE - High range (8 MHz) */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SIRCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SIRCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = true,        /* SIRCSTEN */
-      .lowpower         = true,        /* SIRCLPEN */
-      .locked           = false,       /* LK */
+      .range       = SCG_SIRC_RANGE_HIGH,      /* RANGE - High range (8 MHz) */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .stopmode    = false, /* SIRCSTEN */
+      .lowpower    = true,  /* SIRCLPEN */
+      .locked      = false, /* LK */
     },
-    .firc               =
+    .firc          =
     {
-      .range            = SCG_FIRC_RANGE_48M,        /* RANGE */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* FIRCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* FIRCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .lowpower         = false,       /*  */
-      .regulator        = true,        /* FIRCREGOFF */
-      .locked           = false,       /* LK */
+      .range       = SCG_FIRC_RANGE_48M,       /* RANGE */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .regulator   = true,  /* FIRCREGOFF */
+      .locked      = false, /* LK */
     },
-    .sosc               =
+    .sosc          =
     {
-      .mode             = SCG_SOSC_MONITOR_DISABLE,  /* SOSCCM */
-      .gain             = SCG_SOSC_GAIN_LOW,         /* HGO */
-      .range            = SCG_SOSC_RANGE_MID,        /* RANGE */
-      .extref           = SCG_SOSC_REF_OSC,          /* EREFS */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SOSCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SOSCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .lowpower         = false,       /*  */
-      .locked           = false,       /* LK */
+      .mode        = SCG_SOSC_MONITOR_DISABLE, /* SOSCCM */
+      .gain        = SCG_SOSC_GAIN_LOW,        /* HGO */
+      .range       = SCG_SOSC_RANGE_HIGH,      /* RANGE */
+      .extref      = SCG_SOSC_REF_OSC,         /* EREFS */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .locked      = false, /* LK */
     },
-    .spll               =
+    .spll          =
     {
-      .mode             = SCG_SPLL_MONITOR_DISABLE,  /* SPLLCM */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SPLLDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SPLLDIV2 */
-      .prediv           = 1,           /* PREDIV */
-      .mult             = 40,          /* MULT */
-      .src              = 0,           /* SOURCE */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .locked           = false,       /* LK */
+      .mode        = SCG_SPLL_MONITOR_DISABLE, /* SPLLCM */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV2 */
+      .prediv      = 1,     /* PREDIV */
+      .mult        = 40,    /* MULT */
+      .src         = 0,     /* SOURCE */
+      .initialize  = true,  /* Initialize */
+      .locked      = false, /* LK */
     },
-    .rtc                =
+    .rtc           =
     {
-      .initialize       = true,        /* Initialize */
-      .clkin            = 0            /* RTC_CLKIN */
+      .initialize  = true, /* Initialize */
+      .clkin       = 0,    /* RTC_CLKIN */
     },
-    .clockout           =
+    .clockout      =
     {
-      .source           = SCG_CLOCKOUT_SRC_FIRC,  /* SCG CLKOUTSEL */
-      .initialize       = true,        /* Initialize */
+      .source      = SCG_CLOCKOUT_SRC_FIRC, /* SCG CLKOUTSEL */
+      .initialize  = true, /* Initialize */
     },
-    .clockmode          =
+    .clockmode     =
     {
-      .rccr             =              /* RCCR - Run Clock Control Register */
+      .rccr        = /* RCCR - Run Clock Control Register */
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,  /* SCS */
-        .divslow        = 3,           /* DIVSLOW, range 1..16 */
-        .divbus         = 2,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
+        .divslow   = 3, /* DIVSLOW, range 1..16 */
+        .divbus    = 2, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-      .vccr             =              /* VCCR - VLPR Clock Control Register */
+      .vccr        = /* VCCR - VLPR Clock Control Register */
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SIRC,  /* SCS */
-        .divslow        = 4,           /* DIVSLOW, range 1..16 */
-        .divbus         = 1,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC, /* SCS */
+        .divslow   = 4, /* DIVSLOW, range 1..16 */
+        .divbus    = 1, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-      .hccr             =
+      .hccr        =
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,  /* SCS */
-        .divslow        = 3,           /* DIVSLOW, range 1..16 */
-        .divbus         = 2,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
+        .divslow   = 3, /* DIVSLOW, range 1..16 */
+        .divbus    = 2, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-
-      /* .altclk */
-
-      .initialize       = true,        /* Initialize */
+      .initialize  = true, /* Initialize */
     },
   },
-  .sim                  =
+  .sim             =
   {
-    .clockout           =              /* Clock Out configuration. */
+    .clockout      = /* Clock Out configuration. */
     {
-      .source           = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT,  /* CLKOUTSEL */
-      .divider          = 1,           /* CLKOUTDIV, range 1..8 */
-      .initialize       = true,        /* Initialize */
-      .enable           = false,       /* CLKOUTEN */
+      .source      = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT, /* CLKOUTSEL */
+      .divider     = 1,     /* CLKOUTDIV, range 1..8 */
+      .initialize  = true,  /* Initialize */
+      .enable      = false, /* CLKOUTEN */
     },
-    .lpoclk             =              /* Low Power Clock configuration. */
+    .lpoclk        = /* Low Power Clock configuration. */
     {
-      .rtc_source       = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
-      .lpo_source       = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
-      .initialize       = true,        /* Initialize */
-      .lpo32k           = true,        /* LPO32KCLKEN */
-      .lpo1k            = true,        /* LPO1KCLKEN */
+      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
+      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
+      .initialize  = true, /* Initialize */
+      .lpo32k      = true, /* LPO32KCLKEN */
+      .lpo1k       = true, /* LPO1KCLKEN */
     },
-    .tclk               =              /* TCLK CLOCK configuration. */
+    .tclk          = /* TCLK CLOCK configuration. */
     {
-      .tclkfreq[0]      = 0,           /* TCLK0 */
-      .tclkfreq[1]      = 0,           /* TCLK1 */
-      .tclkfreq[2]      = 0,           /* TCLK2 */
-      .initialize       = true,        /* Initialize */
+      .tclkfreq[0] = 0,    /* TCLK0 */
+      .tclkfreq[1] = 0,    /* TCLK1 */
+      .tclkfreq[2] = 0,    /* TCLK2 */
+      .initialize  = true, /* Initialize */
     },
-    .platgate           =              /* Platform Gate Clock configuration. */
+    .platgate      = /* Platform Gate Clock configuration. */
     {
-      .initialize       = true,        /* Initialize */
-      .mscm             = true,        /* CGCMSCM */
-      .mpu              = true,        /* CGCMPU */
-      .dma              = true,        /* CGCDMA */
-      .erm              = true,        /* CGCERM */
-      .eim              = true,        /* CGCEIM */
+      .initialize  = true, /* Initialize */
+      .mscm        = true, /* CGCMSCM */
+      .mpu         = true, /* CGCMPU */
+      .dma         = true, /* CGCDMA */
+      .erm         = true, /* CGCERM */
+      .eim         = true, /* CGCEIM */
     },
-    .traceclk           =              /* Debug trace Clock Configuration. */
+    .traceclk      = /* Debug trace Clock Configuration. */
     {
-      .source           = CLOCK_TRACE_SRC_CORE_CLK,  /* TRACECLK_SEL */
-      .divider          = 1,           /* TRACEDIV, range 1..8 */
-      .initialize       = true,        /* Initialize */
-      .enable           = true,        /* TRACEDIVEN */
-      .fraction         = false,       /* TRACEFRAC */
+      .source      = CLOCK_TRACE_SRC_CORE_CLK, /* TRACECLK_SEL */
+      .divider     = 1,     /* TRACEDIV, range 1..8 */
+      .initialize  = true,  /* Initialize */
+      .enable      = true,  /* TRACEDIVEN */
+      .fraction    = false, /* TRACEFRAC */
     },
-#ifdef CONFIG_S32K1XX_HAVE_QSPI
-    .qspirefclk         =              /* Quad Spi Internal Reference Clock Gating. */
-    {
-      .refclk           = false,       /* Qspi reference clock gating */
-    },
-#endif
   },
-  .pcc                  =
+  .pcc             =
   {
-    .count              = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
-    .pclks              = g_peripheral_clockconfig0   /* Peripheral clock configurations */
+    .count         = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
+    .pclks         = g_peripheral_clockconfig0,  /* Peripheral clock configurations */
   },
-  .pmc                  =
+  .pmc             =
   {
-    .lpoclk             =              /* Low Power Clock configuration. */
+    .lpoclk        = /* Low Power Clock configuration. */
     {
-      .trim             = 0,           /* Trimming value for LPO */
-      .initialize       = true,        /* Initialize */
-      .enable           = true,        /* Enable/disable LPO */
+      .trim        = 0,    /* Trimming value for LPO */
+      .initialize  = true, /* Initialize */
+      .enable      = true, /* Enable/disable LPO */
     },
-  }
+  },
 };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_periphclocks.c
@@ -62,14 +62,6 @@
 #include "s32k144evb.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -80,108 +72,114 @@
 const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
 {
   {
-    .clkname    = ADC0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN0_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = ADC1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN1_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = LPI2C0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN2_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = LPSPI0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPI2C0_CLK,
+#ifdef CONFIG_S32K1XX_LPI2C0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPSPI1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI0_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPSPI2_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI1_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPTMR0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI2_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI2
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART0_CLK,
+#ifdef CONFIG_S32K1XX_LPUART0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART1_CLK,
+#ifdef CONFIG_S32K1XX_LPUART1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART2_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART2_CLK,
+#ifdef CONFIG_S32K1XX_LPUART2
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = PORTA_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTA_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTB_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTB_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTC_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTC_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTD_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTD_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTE_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
-  }
+    .clkname = PORTE_CLK,
+    .clkgate = true,
+  },
 };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
@@ -79,135 +79,135 @@ const struct clock_configuration_s g_initial_clkconfig =
   {
     .sirc          =
     {
-      .range       = SCG_SIRC_RANGE_HIGH,      /* RANGE - High range (8 MHz) */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .stopmode    = false, /* SIRCSTEN */
-      .lowpower    = true,  /* SIRCLPEN */
-      .locked      = false, /* LK */
+      .range       = SCG_SIRC_RANGE_HIGH,              /* RANGE - High range (8 MHz) */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .stopmode    = false,                            /* SIRCSTEN */
+      .lowpower    = true,                             /* SIRCLPEN */
+      .locked      = false,                            /* LK */
     },
     .firc          =
     {
-      .range       = SCG_FIRC_RANGE_48M,       /* RANGE */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .regulator   = true,  /* FIRCREGOFF */
-      .locked      = false, /* LK */
+      .range       = SCG_FIRC_RANGE_48M,               /* RANGE */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .regulator   = true,                             /* FIRCREGOFF */
+      .locked      = false,                            /* LK */
     },
     .sosc          =
     {
-      .mode        = SCG_SOSC_MONITOR_DISABLE, /* SOSCCM */
-      .gain        = SCG_SOSC_GAIN_LOW,        /* HGO */
-      .range       = SCG_SOSC_RANGE_HIGH,      /* RANGE */
-      .extref      = SCG_SOSC_REF_OSC,         /* EREFS */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .locked      = false, /* LK */
+      .mode        = SCG_SOSC_MONITOR_DISABLE,         /* SOSCCM */
+      .gain        = SCG_SOSC_GAIN_LOW,                /* HGO */
+      .range       = SCG_SOSC_RANGE_HIGH,              /* RANGE */
+      .extref      = SCG_SOSC_REF_OSC,                 /* EREFS */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SOSCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SOSCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .locked      = false,                            /* LK */
     },
     .spll          =
     {
-      .mode        = SCG_SPLL_MONITOR_DISABLE, /* SPLLCM */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV2 */
-      .prediv      = 1,     /* PREDIV */
-      .mult        = 40,    /* MULT */
-      .src         = 0,     /* SOURCE */
-      .initialize  = true,  /* Initialize */
-      .locked      = false, /* LK */
+      .mode        = SCG_SPLL_MONITOR_DISABLE,         /* SPLLCM */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV2 */
+      .prediv      = 1,                                /* PREDIV */
+      .mult        = 40,                               /* MULT */
+      .src         = 0,                                /* SOURCE */
+      .initialize  = true,                             /* Initialize */
+      .locked      = false,                            /* LK */
     },
     .rtc           =
     {
-      .initialize  = true, /* Initialize */
-      .clkin       = 0,    /* RTC_CLKIN */
+      .initialize  = true,                             /* Initialize */
+      .clkin       = 0,                                /* RTC_CLKIN */
     },
     .clockout      =
     {
-      .source      = SCG_CLOCKOUT_SRC_FIRC, /* SCG CLKOUTSEL */
-      .initialize  = true, /* Initialize */
+      .source      = SCG_CLOCKOUT_SRC_FIRC,            /* SCG CLKOUTSEL */
+      .initialize  = true,                             /* Initialize */
     },
     .clockmode     =
     {
-      .rccr        = /* RCCR - Run Clock Control Register */
+      .rccr        =                                   /* RCCR - Run Clock Control Register */
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
-        .divslow   = 3, /* DIVSLOW, range 1..16 */
-        .divbus    = 2, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,     /* SCS */
+        .divslow   = 3,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 2,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
-      .vccr        = /* VCCR - VLPR Clock Control Register */
+      .vccr        =                                   /* VCCR - VLPR Clock Control Register */
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC, /* SCS */
-        .divslow   = 4, /* DIVSLOW, range 1..16 */
-        .divbus    = 1, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC,        /* SCS */
+        .divslow   = 4,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 1,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
       .hccr        =
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
-        .divslow   = 3, /* DIVSLOW, range 1..16 */
-        .divbus    = 2, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,     /* SCS */
+        .divslow   = 3,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 2,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
-      .initialize  = true, /* Initialize */
+      .initialize  = true,                             /* Initialize */
     },
   },
   .sim             =
   {
-    .clockout      = /* Clock Out configuration. */
+    .clockout      =                                   /* Clock Out configuration. */
     {
       .source      = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT, /* CLKOUTSEL */
-      .divider     = 1,     /* CLKOUTDIV, range 1..8 */
-      .initialize  = true,  /* Initialize */
-      .enable      = false, /* CLKOUTEN */
+      .divider     = 1,                                /* CLKOUTDIV, range 1..8 */
+      .initialize  = true,                             /* Initialize */
+      .enable      = false,                            /* CLKOUTEN */
     },
-    .lpoclk        = /* Low Power Clock configuration. */
+    .lpoclk        =                                   /* Low Power Clock configuration. */
     {
-      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
-      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
-      .initialize  = true, /* Initialize */
-      .lpo32k      = true, /* LPO32KCLKEN */
-      .lpo1k       = true, /* LPO1KCLKEN */
+      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK,      /* RTCCLKSEL */
+      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,         /* LPOCLKSEL */
+      .initialize  = true,                             /* Initialize */
+      .lpo32k      = true,                             /* LPO32KCLKEN */
+      .lpo1k       = true,                             /* LPO1KCLKEN */
     },
-    .tclk          = /* TCLK CLOCK configuration. */
+    .tclk          =                                   /* TCLK CLOCK configuration. */
     {
-      .tclkfreq[0] = 0,    /* TCLK0 */
-      .tclkfreq[1] = 0,    /* TCLK1 */
-      .tclkfreq[2] = 0,    /* TCLK2 */
-      .initialize  = true, /* Initialize */
+      .tclkfreq[0] = 0,                                /* TCLK0 */
+      .tclkfreq[1] = 0,                                /* TCLK1 */
+      .tclkfreq[2] = 0,                                /* TCLK2 */
+      .initialize  = true,                             /* Initialize */
     },
-    .platgate      = /* Platform Gate Clock configuration. */
+    .platgate      =                                   /* Platform Gate Clock configuration. */
     {
-      .initialize  = true, /* Initialize */
-      .mscm        = true, /* CGCMSCM */
-      .mpu         = true, /* CGCMPU */
-      .dma         = true, /* CGCDMA */
-      .erm         = true, /* CGCERM */
-      .eim         = true, /* CGCEIM */
+      .initialize  = true,                             /* Initialize */
+      .mscm        = true,                             /* CGCMSCM */
+      .mpu         = true,                             /* CGCMPU */
+      .dma         = true,                             /* CGCDMA */
+      .erm         = true,                             /* CGCERM */
+      .eim         = true,                             /* CGCEIM */
     },
-    .traceclk      = /* Debug trace Clock Configuration. */
+    .traceclk      =                                   /* Debug trace Clock Configuration. */
     {
-      .source      = CLOCK_TRACE_SRC_CORE_CLK, /* TRACECLK_SEL */
-      .divider     = 1,     /* TRACEDIV, range 1..8 */
-      .initialize  = true,  /* Initialize */
-      .enable      = true,  /* TRACEDIVEN */
-      .fraction    = false, /* TRACEFRAC */
+      .source      = CLOCK_TRACE_SRC_CORE_CLK,         /* TRACECLK_SEL */
+      .divider     = 1,                                /* TRACEDIV, range 1..8 */
+      .initialize  = true,                             /* Initialize */
+      .enable      = true,                             /* TRACEDIVEN */
+      .fraction    = false,                            /* TRACEFRAC */
     },
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
-    .pclks         = g_peripheral_clockconfig0,  /* Peripheral clock configurations */
+    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
+    .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =
   {
-    .lpoclk        = /* Low Power Clock configuration. */
+    .lpoclk        =                                   /* Low Power Clock configuration. */
     {
-      .trim        = 0,    /* Trimming value for LPO */
-      .initialize  = true, /* Initialize */
-      .enable      = true, /* Enable/disable LPO */
+      .trim        = 0,                                /* Trimming value for LPO */
+      .initialize  = true,                             /* Initialize */
+      .enable      = true,                             /* Enable/disable LPO */
     },
   },
 };

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
@@ -77,151 +77,141 @@ const struct clock_configuration_s g_initial_clkconfig =
 {
   .scg =
   {
-    .sirc               =
+    .sirc          =
     {
-      .range            = SCG_SIRC_RANGE_HIGH,       /* RANGE - High range (8 MHz) */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SIRCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SIRCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = true,        /* SIRCSTEN */
-      .lowpower         = true,        /* SIRCLPEN */
-      .locked           = false,       /* LK */
+      .range       = SCG_SIRC_RANGE_HIGH,      /* RANGE - High range (8 MHz) */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .stopmode    = false, /* SIRCSTEN */
+      .lowpower    = true,  /* SIRCLPEN */
+      .locked      = false, /* LK */
     },
-    .firc               =
+    .firc          =
     {
-      .range            = SCG_FIRC_RANGE_48M,        /* RANGE */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* FIRCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* FIRCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .lowpower         = false,       /*  */
-      .regulator        = true,        /* FIRCREGOFF */
-      .locked           = false,       /* LK */
+      .range       = SCG_FIRC_RANGE_48M,       /* RANGE */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .regulator   = true,  /* FIRCREGOFF */
+      .locked      = false, /* LK */
     },
-    .sosc               =
+    .sosc          =
     {
-      .mode             = SCG_SOSC_MONITOR_DISABLE,  /* SOSCCM */
-      .gain             = SCG_SOSC_GAIN_LOW,         /* HGO */
-      .range            = SCG_SOSC_RANGE_MID,        /* RANGE */
-      .extref           = SCG_SOSC_REF_OSC,          /* EREFS */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SOSCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SOSCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .lowpower         = false,       /*  */
-      .locked           = false,       /* LK */
+      .mode        = SCG_SOSC_MONITOR_DISABLE, /* SOSCCM */
+      .gain        = SCG_SOSC_GAIN_LOW,        /* HGO */
+      .range       = SCG_SOSC_RANGE_HIGH,      /* RANGE */
+      .extref      = SCG_SOSC_REF_OSC,         /* EREFS */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .locked      = false, /* LK */
     },
-    .spll               =
+    .spll          =
     {
-      .mode             = SCG_SPLL_MONITOR_DISABLE,  /* SPLLCM */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SPLLDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SPLLDIV2 */
-      .prediv           = 1,           /* PREDIV */
-      .mult             = 40,          /* MULT */
-      .src              = 0,           /* SOURCE */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .locked           = false,       /* LK */
+      .mode        = SCG_SPLL_MONITOR_DISABLE, /* SPLLCM */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV2 */
+      .prediv      = 1,     /* PREDIV */
+      .mult        = 40,    /* MULT */
+      .src         = 0,     /* SOURCE */
+      .initialize  = true,  /* Initialize */
+      .locked      = false, /* LK */
     },
-    .rtc                =
+    .rtc           =
     {
-      .initialize       = true,        /* Initialize */
-      .clkin            = 0            /* RTC_CLKIN */
+      .initialize  = true, /* Initialize */
+      .clkin       = 0,    /* RTC_CLKIN */
     },
-    .clockout           =
+    .clockout      =
     {
-      .source           = SCG_CLOCKOUT_SRC_FIRC,  /* SCG CLKOUTSEL */
-      .initialize       = true,        /* Initialize */
+      .source      = SCG_CLOCKOUT_SRC_FIRC, /* SCG CLKOUTSEL */
+      .initialize  = true, /* Initialize */
     },
-    .clockmode          =
+    .clockmode     =
     {
-      .rccr             =              /* RCCR - Run Clock Control Register */
+      .rccr        = /* RCCR - Run Clock Control Register */
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,  /* SCS */
-        .divslow        = 3,           /* DIVSLOW, range 1..16 */
-        .divbus         = 2,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
+        .divslow   = 3, /* DIVSLOW, range 1..16 */
+        .divbus    = 2, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-      .vccr             =              /* VCCR - VLPR Clock Control Register */
+      .vccr        = /* VCCR - VLPR Clock Control Register */
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SIRC,  /* SCS */
-        .divslow        = 4,           /* DIVSLOW, range 1..16 */
-        .divbus         = 1,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC, /* SCS */
+        .divslow   = 4, /* DIVSLOW, range 1..16 */
+        .divbus    = 1, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-      .hccr             =
+      .hccr        =
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,  /* SCS */
-        .divslow        = 3,           /* DIVSLOW, range 1..16 */
-        .divbus         = 2,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
+        .divslow   = 3, /* DIVSLOW, range 1..16 */
+        .divbus    = 2, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-
-      /* .altclk */
-
-      .initialize       = true,        /* Initialize */
+      .initialize  = true, /* Initialize */
     },
   },
-  .sim                  =
+  .sim             =
   {
-    .clockout           =              /* Clock Out configuration. */
+    .clockout      = /* Clock Out configuration. */
     {
-      .source           = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT,  /* CLKOUTSEL */
-      .divider          = 1,           /* CLKOUTDIV, range 1..8 */
-      .initialize       = true,        /* Initialize */
-      .enable           = false,       /* CLKOUTEN */
+      .source      = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT, /* CLKOUTSEL */
+      .divider     = 1,     /* CLKOUTDIV, range 1..8 */
+      .initialize  = true,  /* Initialize */
+      .enable      = false, /* CLKOUTEN */
     },
-    .lpoclk             =              /* Low Power Clock configuration. */
+    .lpoclk        = /* Low Power Clock configuration. */
     {
-      .rtc_source       = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
-      .lpo_source       = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
-      .initialize       = true,        /* Initialize */
-      .lpo32k           = true,        /* LPO32KCLKEN */
-      .lpo1k            = true,        /* LPO1KCLKEN */
+      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
+      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
+      .initialize  = true, /* Initialize */
+      .lpo32k      = true, /* LPO32KCLKEN */
+      .lpo1k       = true, /* LPO1KCLKEN */
     },
-    .tclk               =              /* TCLK CLOCK configuration. */
+    .tclk          = /* TCLK CLOCK configuration. */
     {
-      .tclkfreq[0]      = 0,           /* TCLK0 */
-      .tclkfreq[1]      = 0,           /* TCLK1 */
-      .tclkfreq[2]      = 0,           /* TCLK2 */
-      .initialize       = true,        /* Initialize */
+      .tclkfreq[0] = 0,    /* TCLK0 */
+      .tclkfreq[1] = 0,    /* TCLK1 */
+      .tclkfreq[2] = 0,    /* TCLK2 */
+      .initialize  = true, /* Initialize */
     },
-    .platgate           =              /* Platform Gate Clock configuration. */
+    .platgate      = /* Platform Gate Clock configuration. */
     {
-      .initialize       = true,        /* Initialize */
-      .mscm             = true,        /* CGCMSCM */
-      .mpu              = true,        /* CGCMPU */
-      .dma              = true,        /* CGCDMA */
-      .erm              = true,        /* CGCERM */
-      .eim              = true,        /* CGCEIM */
+      .initialize  = true, /* Initialize */
+      .mscm        = true, /* CGCMSCM */
+      .mpu         = true, /* CGCMPU */
+      .dma         = true, /* CGCDMA */
+      .erm         = true, /* CGCERM */
+      .eim         = true, /* CGCEIM */
     },
-    .traceclk           =              /* Debug trace Clock Configuration. */
+    .traceclk      = /* Debug trace Clock Configuration. */
     {
-      .source           = CLOCK_TRACE_SRC_CORE_CLK,  /* TRACECLK_SEL */
-      .divider          = 1,           /* TRACEDIV, range 1..8 */
-      .initialize       = true,        /* Initialize */
-      .enable           = true,        /* TRACEDIVEN */
-      .fraction         = false,       /* TRACEFRAC */
+      .source      = CLOCK_TRACE_SRC_CORE_CLK, /* TRACECLK_SEL */
+      .divider     = 1,     /* TRACEDIV, range 1..8 */
+      .initialize  = true,  /* Initialize */
+      .enable      = true,  /* TRACEDIVEN */
+      .fraction    = false, /* TRACEFRAC */
     },
-#ifdef CONFIG_S32K1XX_HAVE_QSPI
-    .qspirefclk         =              /* Quad Spi Internal Reference Clock Gating. */
-    {
-      .refclk           = false,       /* Qspi reference clock gating */
-    },
-#endif
   },
-  .pcc                  =
+  .pcc             =
   {
-    .count              = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
-    .pclks              = g_peripheral_clockconfig0   /* Peripheral clock configurations */
+    .count         = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
+    .pclks         = g_peripheral_clockconfig0,  /* Peripheral clock configurations */
   },
-  .pmc                  =
+  .pmc             =
   {
-    .lpoclk             =              /* Low Power Clock configuration. */
+    .lpoclk        = /* Low Power Clock configuration. */
     {
-      .trim             = 0,           /* Trimming value for LPO */
-      .initialize       = true,        /* Initialize */
-      .enable           = true,        /* Enable/disable LPO */
+      .trim        = 0,    /* Trimming value for LPO */
+      .initialize  = true, /* Initialize */
+      .enable      = true, /* Enable/disable LPO */
     },
-  }
+  },
 };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_periphclocks.c
@@ -62,14 +62,6 @@
 #include "s32k146evb.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -80,108 +72,114 @@
 const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
 {
   {
-    .clkname    = ADC0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN0_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = ADC1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN1_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = LPI2C0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN2_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = LPSPI0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPI2C0_CLK,
+#ifdef CONFIG_S32K1XX_LPI2C0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPSPI1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI0_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPSPI2_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI1_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPTMR0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI2_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI2
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART0_CLK,
+#ifdef CONFIG_S32K1XX_LPUART0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART1_CLK,
+#ifdef CONFIG_S32K1XX_LPUART1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART2_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART2_CLK,
+#ifdef CONFIG_S32K1XX_LPUART2
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = PORTA_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTA_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTB_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTB_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTC_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTC_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTD_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTD_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTE_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
-  }
+    .clkname = PORTE_CLK,
+    .clkgate = true,
+  },
 };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k148evb.h
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k148evb.h
@@ -82,7 +82,7 @@
 
 /* Count of peripheral clock user configurations */
 
-#define NUM_OF_PERIPHERAL_CLOCKS_0 14
+#define NUM_OF_PERIPHERAL_CLOCKS_0 18
 
 /****************************************************************************
  * Public Types

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
@@ -79,141 +79,141 @@ const struct clock_configuration_s g_initial_clkconfig =
   {
     .sirc          =
     {
-      .range       = SCG_SIRC_RANGE_HIGH,      /* RANGE - High range (8 MHz) */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .stopmode    = false, /* SIRCSTEN */
-      .lowpower    = true,  /* SIRCLPEN */
-      .locked      = false, /* LK */
+      .range       = SCG_SIRC_RANGE_HIGH,              /* RANGE - High range (8 MHz) */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .stopmode    = false,                            /* SIRCSTEN */
+      .lowpower    = true,                             /* SIRCLPEN */
+      .locked      = false,                            /* LK */
     },
     .firc          =
     {
-      .range       = SCG_FIRC_RANGE_48M,       /* RANGE */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .regulator   = true,  /* FIRCREGOFF */
-      .locked      = false, /* LK */
+      .range       = SCG_FIRC_RANGE_48M,               /* RANGE */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .regulator   = true,                             /* FIRCREGOFF */
+      .locked      = false,                            /* LK */
     },
     .sosc          =
     {
-      .mode        = SCG_SOSC_MONITOR_DISABLE, /* SOSCCM */
-      .gain        = SCG_SOSC_GAIN_LOW,        /* HGO */
-      .range       = SCG_SOSC_RANGE_HIGH,      /* RANGE */
-      .extref      = SCG_SOSC_REF_OSC,         /* EREFS */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV2 */
-      .initialize  = true,  /* Initialize */
-      .locked      = false, /* LK */
+      .mode        = SCG_SOSC_MONITOR_DISABLE,         /* SOSCCM */
+      .gain        = SCG_SOSC_GAIN_LOW,                /* HGO */
+      .range       = SCG_SOSC_RANGE_HIGH,              /* RANGE */
+      .extref      = SCG_SOSC_REF_OSC,                 /* EREFS */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SOSCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SOSCDIV2 */
+      .initialize  = true,                             /* Initialize */
+      .locked      = false,                            /* LK */
     },
     .spll          =
     {
-      .mode        = SCG_SPLL_MONITOR_DISABLE, /* SPLLCM */
-      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV1 */
-      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV2 */
-      .prediv      = 1,     /* PREDIV */
-      .mult        = 40,    /* MULT */
-      .src         = 0,     /* SOURCE */
-      .initialize  = true,  /* Initialize */
-      .locked      = false, /* LK */
+      .mode        = SCG_SPLL_MONITOR_DISABLE,         /* SPLLCM */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV2 */
+      .prediv      = 1,                                /* PREDIV */
+      .mult        = 40,                               /* MULT */
+      .src         = 0,                                /* SOURCE */
+      .initialize  = true,                             /* Initialize */
+      .locked      = false,                            /* LK */
     },
     .rtc           =
     {
-      .initialize  = true, /* Initialize */
-      .clkin       = 0,    /* RTC_CLKIN */
+      .initialize  = true,                             /* Initialize */
+      .clkin       = 0,                                /* RTC_CLKIN */
     },
     .clockout      =
     {
-      .source      = SCG_CLOCKOUT_SRC_FIRC, /* SCG CLKOUTSEL */
-      .initialize  = true, /* Initialize */
+      .source      = SCG_CLOCKOUT_SRC_FIRC,            /* SCG CLKOUTSEL */
+      .initialize  = true,                             /* Initialize */
     },
     .clockmode     =
     {
-      .rccr        = /* RCCR - Run Clock Control Register */
+      .rccr        =                                   /* RCCR - Run Clock Control Register */
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
-        .divslow   = 3, /* DIVSLOW, range 1..16 */
-        .divbus    = 2, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,     /* SCS */
+        .divslow   = 3,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 2,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
-      .vccr        = /* VCCR - VLPR Clock Control Register */
+      .vccr        =                                   /* VCCR - VLPR Clock Control Register */
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC, /* SCS */
-        .divslow   = 4, /* DIVSLOW, range 1..16 */
-        .divbus    = 1, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC,        /* SCS */
+        .divslow   = 4,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 1,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
       .hccr        =
       {
-        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
-        .divslow   = 3, /* DIVSLOW, range 1..16 */
-        .divbus    = 2, /* DIVBUS, range 1..16 */
-        .divcore   = 2, /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,     /* SCS */
+        .divslow   = 3,                                /* DIVSLOW, range 1..16 */
+        .divbus    = 2,                                /* DIVBUS, range 1..16 */
+        .divcore   = 2,                                /* DIVCORE, range 1..16 */
       },
-      .initialize  = true, /* Initialize */
+      .initialize  = true,                             /* Initialize */
     },
   },
   .sim             =
   {
-    .clockout      = /* Clock Out configuration. */
+    .clockout      =                                   /* Clock Out configuration. */
     {
       .source      = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT, /* CLKOUTSEL */
-      .divider     = 1,     /* CLKOUTDIV, range 1..8 */
-      .initialize  = true,  /* Initialize */
-      .enable      = false, /* CLKOUTEN */
+      .divider     = 1,                                /* CLKOUTDIV, range 1..8 */
+      .initialize  = true,                             /* Initialize */
+      .enable      = false,                            /* CLKOUTEN */
     },
-    .lpoclk        = /* Low Power Clock configuration. */
+    .lpoclk        =                                   /* Low Power Clock configuration. */
     {
-      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
-      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
-      .initialize  = true, /* Initialize */
-      .lpo32k      = true, /* LPO32KCLKEN */
-      .lpo1k       = true, /* LPO1KCLKEN */
+      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK,      /* RTCCLKSEL */
+      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,         /* LPOCLKSEL */
+      .initialize  = true,                             /* Initialize */
+      .lpo32k      = true,                             /* LPO32KCLKEN */
+      .lpo1k       = true,                             /* LPO1KCLKEN */
     },
-    .tclk          = /* TCLK CLOCK configuration. */
+    .tclk          =                                   /* TCLK CLOCK configuration. */
     {
-      .tclkfreq[0] = 0,    /* TCLK0 */
-      .tclkfreq[1] = 0,    /* TCLK1 */
-      .tclkfreq[2] = 0,    /* TCLK2 */
-      .initialize  = true, /* Initialize */
+      .tclkfreq[0] = 0,                                /* TCLK0 */
+      .tclkfreq[1] = 0,                                /* TCLK1 */
+      .tclkfreq[2] = 0,                                /* TCLK2 */
+      .initialize  = true,                             /* Initialize */
     },
-    .platgate      = /* Platform Gate Clock configuration. */
+    .platgate      =                                   /* Platform Gate Clock configuration. */
     {
-      .initialize  = true, /* Initialize */
-      .mscm        = true, /* CGCMSCM */
-      .mpu         = true, /* CGCMPU */
-      .dma         = true, /* CGCDMA */
-      .erm         = true, /* CGCERM */
-      .eim         = true, /* CGCEIM */
+      .initialize  = true,                             /* Initialize */
+      .mscm        = true,                             /* CGCMSCM */
+      .mpu         = true,                             /* CGCMPU */
+      .dma         = true,                             /* CGCDMA */
+      .erm         = true,                             /* CGCERM */
+      .eim         = true,                             /* CGCEIM */
     },
-    .traceclk      = /* Debug trace Clock Configuration. */
+    .traceclk      =                                   /* Debug trace Clock Configuration. */
     {
-      .source      = CLOCK_TRACE_SRC_CORE_CLK, /* TRACECLK_SEL */
-      .divider     = 1,     /* TRACEDIV, range 1..8 */
-      .initialize  = true,  /* Initialize */
-      .enable      = true,  /* TRACEDIVEN */
-      .fraction    = false, /* TRACEFRAC */
+      .source      = CLOCK_TRACE_SRC_CORE_CLK,         /* TRACECLK_SEL */
+      .divider     = 1,                                /* TRACEDIV, range 1..8 */
+      .initialize  = true,                             /* Initialize */
+      .enable      = true,                             /* TRACEDIVEN */
+      .fraction    = false,                            /* TRACEFRAC */
     },
 #ifdef CONFIG_S32K1XX_HAVE_QSPI
-    .qspirefclk    = /* Quad SPI Internal Reference Clock Gating. */
+    .qspirefclk    =                                   /* Quad SPI Internal Reference Clock Gating. */
     {
-      .refclk      = false, /* QSPI reference clock gating */
+      .refclk      = false,                            /* QSPI reference clock gating */
     },
 #endif
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
-    .pclks         = g_peripheral_clockconfig0,  /* Peripheral clock configurations */
+    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
+    .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =
   {
-    .lpoclk        = /* Low Power Clock configuration. */
+    .lpoclk        =                                   /* Low Power Clock configuration. */
     {
-      .trim        = 0,    /* Trimming value for LPO */
-      .initialize  = true, /* Initialize */
-      .enable      = true, /* Enable/disable LPO */
+      .trim        = 0,                                /* Trimming value for LPO */
+      .initialize  = true,                             /* Initialize */
+      .enable      = true,                             /* Enable/disable LPO */
     },
   },
 };

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
@@ -77,151 +77,147 @@ const struct clock_configuration_s g_initial_clkconfig =
 {
   .scg =
   {
-    .sirc               =
+    .sirc          =
     {
-      .range            = SCG_SIRC_RANGE_HIGH,       /* RANGE - High range (8 MHz) */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SIRCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SIRCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /* SIRCSTEN */
-      .lowpower         = true,        /* SIRCLPEN */
-      .locked           = false,       /* LK */
+      .range       = SCG_SIRC_RANGE_HIGH,      /* RANGE - High range (8 MHz) */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SIRCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .stopmode    = false, /* SIRCSTEN */
+      .lowpower    = true,  /* SIRCLPEN */
+      .locked      = false, /* LK */
     },
-    .firc               =
+    .firc          =
     {
-      .range            = SCG_FIRC_RANGE_48M,        /* RANGE */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* FIRCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* FIRCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .lowpower         = false,       /*  */
-      .regulator        = false,        /* FIRCREGOFF */
-      .locked           = false,       /* LK */
+      .range       = SCG_FIRC_RANGE_48M,       /* RANGE */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* FIRCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .regulator   = true,  /* FIRCREGOFF */
+      .locked      = false, /* LK */
     },
-    .sosc               =
+    .sosc          =
     {
-      .mode             = SCG_SOSC_MONITOR_DISABLE,  /* SOSCCM */
-      .gain             = SCG_SOSC_GAIN_LOW,         /* HGO */
-      .range            = SCG_SOSC_RANGE_MID,        /* RANGE */
-      .extref           = SCG_SOSC_REF_OSC,          /* EREFS */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SOSCDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SOSCDIV2 */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .lowpower         = false,       /*  */
-      .locked           = false,       /* LK */
+      .mode        = SCG_SOSC_MONITOR_DISABLE, /* SOSCCM */
+      .gain        = SCG_SOSC_GAIN_LOW,        /* HGO */
+      .range       = SCG_SOSC_RANGE_HIGH,      /* RANGE */
+      .extref      = SCG_SOSC_REF_OSC,         /* EREFS */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SOSCDIV2 */
+      .initialize  = true,  /* Initialize */
+      .locked      = false, /* LK */
     },
-    .spll               =
+    .spll          =
     {
-      .mode             = SCG_SPLL_MONITOR_DISABLE,  /* SPLLCM */
-      .div1             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SPLLDIV1 */
-      .div2             = SCG_ASYNC_CLOCK_DIV_BY_1,  /* SPLLDIV2 */
-      .prediv           = 1,           /* PREDIV */
-      .mult             = 40,          /* MULT */
-      .src              = 0,           /* SOURCE */
-      .initialize       = true,        /* Initialize */
-      .stopmode         = false,       /*  */
-      .locked           = false,       /* LK */
+      .mode        = SCG_SPLL_MONITOR_DISABLE, /* SPLLCM */
+      .div1        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV1 */
+      .div2        = SCG_ASYNC_CLOCK_DIV_BY_1, /* SPLLDIV2 */
+      .prediv      = 1,     /* PREDIV */
+      .mult        = 40,    /* MULT */
+      .src         = 0,     /* SOURCE */
+      .initialize  = true,  /* Initialize */
+      .locked      = false, /* LK */
     },
-    .rtc                =
+    .rtc           =
     {
-      .initialize       = true,        /* Initialize */
-      .clkin            = 0            /* RTC_CLKIN */
+      .initialize  = true, /* Initialize */
+      .clkin       = 0,    /* RTC_CLKIN */
     },
-    .clockout           =
+    .clockout      =
     {
-      .source           = SCG_CLOCKOUT_SRC_FIRC,  /* SCG CLKOUTSEL */
-      .initialize       = true,        /* Initialize */
+      .source      = SCG_CLOCKOUT_SRC_FIRC, /* SCG CLKOUTSEL */
+      .initialize  = true, /* Initialize */
     },
-    .clockmode          =
+    .clockmode     =
     {
-      .rccr             =              /* RCCR - Run Clock Control Register */
+      .rccr        = /* RCCR - Run Clock Control Register */
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,  /* SCS */
-        .divslow        = 3,           /* DIVSLOW, range 1..16 */
-        .divbus         = 2,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
+        .divslow   = 3, /* DIVSLOW, range 1..16 */
+        .divbus    = 2, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-      .vccr             =              /* VCCR - VLPR Clock Control Register */
+      .vccr        = /* VCCR - VLPR Clock Control Register */
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SIRC,  /* SCS */
-        .divslow        = 4,           /* DIVSLOW, range 1..16 */
-        .divbus         = 1,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SIRC, /* SCS */
+        .divslow   = 4, /* DIVSLOW, range 1..16 */
+        .divbus    = 1, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-      .hccr             =
+      .hccr        =
       {
-        .src            = SCG_SYSTEM_CLOCK_SRC_SYS_PLL,  /* SCS */
-        .divslow        = 3,           /* DIVSLOW, range 1..16 */
-        .divbus         = 2,           /* DIVBUS, range 1..16 */
-        .divcore        = 2            /* DIVCORE, range 1..16 */
+        .src       = SCG_SYSTEM_CLOCK_SRC_SYS_PLL, /* SCS */
+        .divslow   = 3, /* DIVSLOW, range 1..16 */
+        .divbus    = 2, /* DIVBUS, range 1..16 */
+        .divcore   = 2, /* DIVCORE, range 1..16 */
       },
-
-      /* .altclk */
-
-      .initialize       = true,        /* Initialize */
+      .initialize  = true, /* Initialize */
     },
   },
-  .sim                  =
+  .sim             =
   {
-    .clockout           =              /* Clock Out configuration. */
+    .clockout      = /* Clock Out configuration. */
     {
-      .source           = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT,  /* CLKOUTSEL */
-      .divider          = 1,           /* CLKOUTDIV, range 1..8 */
-      .initialize       = true,        /* Initialize */
-      .enable           = false,       /* CLKOUTEN */
+      .source      = SIM_CLKOUT_SEL_SYSTEM_SCG_CLKOUT, /* CLKOUTSEL */
+      .divider     = 1,     /* CLKOUTDIV, range 1..8 */
+      .initialize  = true,  /* Initialize */
+      .enable      = false, /* CLKOUTEN */
     },
-    .lpoclk             =              /* Low Power Clock configuration. */
+    .lpoclk        = /* Low Power Clock configuration. */
     {
-      .rtc_source       = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
-      .lpo_source       = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
-      .initialize       = true,        /* Initialize */
-      .lpo32k           = true,        /* LPO32KCLKEN */
-      .lpo1k            = true,        /* LPO1KCLKEN */
+      .rtc_source  = SIM_RTCCLK_SEL_SOSCDIV1_CLK, /* RTCCLKSEL */
+      .lpo_source  = SIM_LPO_CLK_SEL_LPO_128K,    /* LPOCLKSEL */
+      .initialize  = true, /* Initialize */
+      .lpo32k      = true, /* LPO32KCLKEN */
+      .lpo1k       = true, /* LPO1KCLKEN */
     },
-    .tclk               =              /* TCLK CLOCK configuration. */
+    .tclk          = /* TCLK CLOCK configuration. */
     {
-      .tclkfreq[0]      = 0,           /* TCLK0 */
-      .tclkfreq[1]      = 0,           /* TCLK1 */
-      .tclkfreq[2]      = 0,           /* TCLK2 */
-      .initialize       = true,        /* Initialize */
+      .tclkfreq[0] = 0,    /* TCLK0 */
+      .tclkfreq[1] = 0,    /* TCLK1 */
+      .tclkfreq[2] = 0,    /* TCLK2 */
+      .initialize  = true, /* Initialize */
     },
-    .platgate           =              /* Platform Gate Clock configuration. */
+    .platgate      = /* Platform Gate Clock configuration. */
     {
-      .initialize       = true,        /* Initialize */
-      .mscm             = true,        /* CGCMSCM */
-      .mpu              = true,        /* CGCMPU */
-      .dma              = true,        /* CGCDMA */
-      .erm              = true,        /* CGCERM */
-      .eim              = true,        /* CGCEIM */
+      .initialize  = true, /* Initialize */
+      .mscm        = true, /* CGCMSCM */
+      .mpu         = true, /* CGCMPU */
+      .dma         = true, /* CGCDMA */
+      .erm         = true, /* CGCERM */
+      .eim         = true, /* CGCEIM */
     },
-    .traceclk           =              /* Debug trace Clock Configuration. */
+    .traceclk      = /* Debug trace Clock Configuration. */
     {
-      .source           = CLOCK_TRACE_SRC_CORE_CLK,  /* TRACECLK_SEL */
-      .divider          = 1,           /* TRACEDIV, range 1..8 */
-      .initialize       = true,        /* Initialize */
-      .enable           = true,        /* TRACEDIVEN */
-      .fraction         = false,       /* TRACEFRAC */
+      .source      = CLOCK_TRACE_SRC_CORE_CLK, /* TRACECLK_SEL */
+      .divider     = 1,     /* TRACEDIV, range 1..8 */
+      .initialize  = true,  /* Initialize */
+      .enable      = true,  /* TRACEDIVEN */
+      .fraction    = false, /* TRACEFRAC */
     },
 #ifdef CONFIG_S32K1XX_HAVE_QSPI
-    .qspirefclk         =              /* Quad Spi Internal Reference Clock Gating. */
+    .qspirefclk    = /* Quad SPI Internal Reference Clock Gating. */
     {
-      .refclk           = false,       /* Qspi reference clock gating */
+      .refclk      = false, /* QSPI reference clock gating */
     },
 #endif
   },
-  .pcc                  =
+  .pcc             =
   {
-    .count              = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
-    .pclks              = g_peripheral_clockconfig0   /* Peripheral clock configurations */
+    .count         = NUM_OF_PERIPHERAL_CLOCKS_0, /* Number peripheral clock configurations */
+    .pclks         = g_peripheral_clockconfig0,  /* Peripheral clock configurations */
   },
-  .pmc                  =
+  .pmc             =
   {
-    .lpoclk             =              /* Low Power Clock configuration. */
+    .lpoclk        = /* Low Power Clock configuration. */
     {
-      .trim             = 0,           /* Trimming value for LPO */
-      .initialize       = true,        /* Initialize */
-      .enable           = true,        /* Enable/disable LPO */
+      .trim        = 0,    /* Trimming value for LPO */
+      .initialize  = true, /* Initialize */
+      .enable      = true, /* Enable/disable LPO */
     },
-  }
+  },
 };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_periphclocks.c
@@ -62,14 +62,6 @@
 #include "s32k148evb.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -80,99 +72,142 @@
 const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
 {
   {
-    .clkname    = ADC0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = ENET0_CLK,
+#ifdef CONFIG_S32K1XX_ENET
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_FIRC_DIV1,
+    .frac    = MULTIPLY_BY_ONE,
+    .divider = 1,
   },
   {
-    .clkname    = ADC1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN0_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = LPTMR0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN1_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = LPUART0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = FLEXCAN2_CLK,
+#ifdef CONFIG_S32K1XX_FLEXCAN
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
   },
   {
-    .clkname    = LPUART1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPI2C0_CLK,
+#ifdef CONFIG_S32K1XX_LPI2C0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = LPUART2_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPI2C1_CLK,
+#ifdef CONFIG_S32K1XX_LPI2C1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = ENET0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_FIRC,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI0_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = RTC0_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPSPI1_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = FTM1_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_SIRC,
+    .clkname = LPSPI2_CLK,
+#ifdef CONFIG_S32K1XX_LPSPI2
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = PORTA_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART0_CLK,
+#ifdef CONFIG_S32K1XX_LPUART0
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = PORTB_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART1_CLK,
+#ifdef CONFIG_S32K1XX_LPUART1
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = PORTC_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = LPUART2_CLK,
+#ifdef CONFIG_S32K1XX_LPUART2
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+    .clksrc  = CLK_SRC_SIRC_DIV2,
   },
   {
-    .clkname    = PORTD_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
+    .clkname = PORTA_CLK,
+    .clkgate = true,
   },
   {
-    .clkname    = PORTE_CLK,
-    .clkgate    = true,
-    .clksrc     = CLK_SRC_OFF,
-    .frac       = MULTIPLY_BY_ONE,
-    .divider    = 1,
-  }
+    .clkname = PORTB_CLK,
+    .clkgate = true,
+  },
+  {
+    .clkname = PORTC_CLK,
+    .clkgate = true,
+  },
+  {
+    .clkname = PORTD_CLK,
+    .clkgate = true,
+  },
+  {
+    .clkname = PORTE_CLK,
+    .clkgate = true,
+  },
+  {
+    .clkname = RTC0_CLK,
+#ifdef CONFIG_S32K1XX_RTC
+    .clkgate = true,
+#else
+    .clkgate = false,
+#endif
+  },
 };
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/


### PR DESCRIPTION
This is the second PR with changes to the S32K clock configuration. This one cleans up the (peripheral) clock configuration of the S32K1XX EVB boards that are supported by NuttX.