### PR TITLE
libs/libc/netdb/lib_dnsaddserver.c: Fix wrong fopen() mode.

### DIFF
--- a/libs/libc/netdb/lib_dnsaddserver.c
+++ b/libs/libc/netdb/lib_dnsaddserver.c
@@ -87,7 +87,7 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
   int status;
   int ret;
 
-  stream = fopen(CONFIG_NETDB_RESOLVCONF_PATH, "at");
+  stream = fopen(CONFIG_NETDB_RESOLVCONF_PATH, "r");
   if (stream == NULL)
     {
       int errcode = get_errno();

--- a/libs/libc/netdb/lib_dnsaddserver.c
+++ b/libs/libc/netdb/lib_dnsaddserver.c
@@ -111,7 +111,8 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
         {
           FAR struct sockaddr_in *in4 = (FAR struct sockaddr_in *)addr;
 
-          if (inet_ntop(AF_INET, &in4->sin_addr, addrstr, DNS_MAX_ADDRSTR) == NULL)
+          if (inet_ntop(AF_INET, &in4->sin_addr, addrstr,
+                        DNS_MAX_ADDRSTR) == NULL)
             {
               ret = -errno;
               nerr("ERROR: inet_ntop failed: %d\n", errcode);
@@ -143,7 +144,8 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
         {
           FAR struct sockaddr_in6 *in6 = (FAR struct sockaddr_in6 *)addr;
 
-          if (inet_ntop(AF_INET6, &in6->sin6_addr, addrstr, DNS_MAX_ADDRSTR) == NULL)
+          if (inet_ntop(AF_INET6, &in6->sin6_addr, addrstr,
+                        DNS_MAX_ADDRSTR) == NULL)
             {
               ret = -errno;
               nerr("ERROR: inet_ntop failed: %d\n", errcode);


### PR DESCRIPTION
dns_add_nameserver(): As reported by Surya Prakash Verma, call to
fopen() used nonexistent file open mode "at"; changed this to "r"
per Surya's analysis. See Surya's email to dev@ on 12 Mar 2020,
archived here: [https://lists.apache.org/thread.html/rbbbee93f79dd8f4224969bb03bf093d8c96421380a1d955167a2f661%40%3Cdev.nuttx.apache.org%3E].