### PR TITLE
Nxstyle

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -751,7 +751,8 @@ int main(int argc, char **argv, char **envp)
                * another right brace, or a pre-processor directive like #endif
                */
 
-              if (strchr(line, '}') == NULL && line[n] != '#' &&
+              if (dnest == 0 &&
+                  strchr(line, '}') == NULL && line[n] != '#' &&
                   strncmp(&line[n], "else", 4) != 0 &&
                   strncmp(&line[n], "while", 5) != 0 &&
                   strncmp(&line[n], "break", 5) != 0)
@@ -967,8 +968,8 @@ int main(int argc, char **argv, char **envp)
 
                   rhcomment = -1;
 
-                  if (ncomment > 0 && (!strncmp(&line[ii], "if", 2)
-                      || !strncmp(&line[ii], "el", 2)))
+                  if (ncomment > 0 && (strncmp(&line[ii], "if", 2) == 0 ||
+                      strncmp(&line[ii], "el", 2) == 0))
                     {
                       /* in #if...  and #el.. */
 
@@ -1608,7 +1609,7 @@ int main(int argc, char **argv, char **envp)
                       {
                         /* REVISIT: dnest is always > 0 here if bfunctions == false */
 
-                        if (dnest == 0 || !bfunctions)
+                        if (dnest == 0 || !bfunctions || lineno == rbrace_lineno)
                           {
                              ERROR("Left bracket not on separate line", lineno,
                                    n);
@@ -1753,6 +1754,13 @@ int main(int argc, char **argv, char **envp)
                                      ERROR("Space precedes semi-colon",
                                            lineno, endx);
                                   }
+                              }
+                            else if (line[endx] == '=')
+                              {
+                                /* There's a struct initialization following */
+
+                                check_spaces_leftright(line, lineno, endx, endx);
+                                dnest = 1;
                               }
                             else
                               {


### PR DESCRIPTION
This change addresses cases like #553 .
```
  struct
  {
    const char *pathname;
    long mode;
    size_t len;
  } open =
  {
    .pathname = pathname,
    .mode = host_flags_to_mode(flags),
    .len = strlen(pathname),
  };
```
And as side effect it relaxes brace rules inside data declarations and assignments.

```
  const struct clock_configuration_s g_initial_clkconfig =
  {
    .scg =
    {
      .sirc =
      {
        .range       = SCG_SIRC_RANGE_HIGH,              /* RANGE - High range (8 MHz) */
        .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SIRCDIV1 */
      },
      .firc =
      {
        .range       = SCG_FIRC_RANGE_48M,               /* RANGE */
        .div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* FIRCDIV1 */
      }
    }
  };
```
This is only relevant for architecture specific directories, but since we don't distinguish it shouldn't throw errors.

I'm open for discussion.

Edit: I forgot to rebase, now there are already pulled commits again in the PR. Should I cancel and resubmit?
I'm still a git newbie.