### PR TITLE
Adjacent stack pointer fix for RX65N in up_usestack.c

### DIFF
--- a/arch/renesas/src/common/up_usestack.c
+++ b/arch/renesas/src/common/up_usestack.c
@@ -124,7 +124,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->adj_stack_size = top_of_stack;
+  tcb->adj_stack_ptr = top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -234,10 +234,6 @@ static void rtc_periodic_callback(FAR void *priv, int alarmid)
       nxsig_notification(alarminfo->pid, &alarminfo->event,
                          SI_QUEUE, &alarminfo->work);
     }
-
-  /* The alarm is no longer active */
-
-  alarminfo->active = false;
 }
 #endif
 


### PR DESCRIPTION
Fixed adjacent stack pointer issue for RX65N in up_usestack.c