### PR TITLE
libs/libc/netdb/lib_dnsaddserver.c: Fix wrong fopen() mode.

### DIFF
--- a/libs/libc/netdb/lib_dnsaddserver.c
+++ b/libs/libc/netdb/lib_dnsaddserver.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * libs/libc/netdb/lib_dnsaddserver.c
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -87,7 +72,7 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
   int status;
   int ret;
 
-  stream = fopen(CONFIG_NETDB_RESOLVCONF_PATH, "at");
+  stream = fopen(CONFIG_NETDB_RESOLVCONF_PATH, "a+");
   if (stream == NULL)
     {
       int errcode = get_errno();
@@ -111,7 +96,8 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
         {
           FAR struct sockaddr_in *in4 = (FAR struct sockaddr_in *)addr;
 
-          if (inet_ntop(AF_INET, &in4->sin_addr, addrstr, DNS_MAX_ADDRSTR) == NULL)
+          if (inet_ntop(AF_INET, &in4->sin_addr, addrstr,
+                        DNS_MAX_ADDRSTR) == NULL)
             {
               ret = -errno;
               nerr("ERROR: inet_ntop failed: %d\n", errcode);
@@ -143,7 +129,8 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
         {
           FAR struct sockaddr_in6 *in6 = (FAR struct sockaddr_in6 *)addr;
 
-          if (inet_ntop(AF_INET6, &in6->sin6_addr, addrstr, DNS_MAX_ADDRSTR) == NULL)
+          if (inet_ntop(AF_INET6, &in6->sin6_addr, addrstr,
+                        DNS_MAX_ADDRSTR) == NULL)
             {
               ret = -errno;
               nerr("ERROR: inet_ntop failed: %d\n", errcode);


### PR DESCRIPTION
dns_add_nameserver(): As reported by Surya Prakash Verma, call to
fopen() used nonexistent file open mode "at"; changed this to "r"
per Surya's analysis. See Surya's email to dev@ on 12 Mar 2020,
archived here: https://lists.apache.org/thread.html/rbbbee93f79dd8f4224969bb03bf093d8c96421380a1d955167a2f661%40%3Cdev.nuttx.apache.org%3E