### PR TITLE
Add possibility to add identifier whitelist to "block comments" of file…

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -68,6 +68,7 @@ static volatile spinlock_t g_appcpu_interlock SP_SECTION;
 
 /****************************************************************************
  * ROM function prototypes
+ * <nxs whitelist="Cache_Flush, Cache_Read_Enable" />
  ****************************************************************************/
 
 void Cache_Flush(int cpu);
@@ -184,7 +185,7 @@ void xtensa_appcpu_start(void)
   sched_note_cpu_started(tcb);
 #endif
 
-  /* Handle interlock*/
+  /* Handle interlock */
 
   g_appcpu_started = true;
   spin_unlock(&g_appcpu_interlock);


### PR DESCRIPTION
… under test.

Attention this is **experimental**.
This PR is not supposed to be merged but a base for discussions on whitelisting inside the file under test.
esp32_cpustart.c is used as example:
```
<nxs whitelist="Cache_Flush, Cache_Read_Enable" />
```

The control comments could perhaps be used for some more, e.g.:
```
<nxs ignore="1" />
```
This could ignore file at all if used early (right after license header).

For sure, usage of these control comments need to be restricted within the coding standard.