### PR TITLE
xtensa_user_handler: Save PS correctly

### DIFF
--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -196,7 +196,7 @@ _xtensa_user_handler:
 	mov		a0, sp							/* sp == a1 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
-	rsr		a0, EPS							/* Save interruptee's PS */
+	rsr		a0, PS							/* Save interruptee's PS */
 	s32i	a0, sp, (4 * REG_PS)
 	rsr		a0, EPC_1						/* Save interruptee's PC */
 	s32i	a0, sp, (4 * REG_PC)


### PR DESCRIPTION
"EPS" is not a real register. It's just a base value of EPS_{2..7}.