### PR TITLE
Fix typos in comments and documentation.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1987,7 +1987,7 @@
 	  There is no real substance in the initial check-in; only the directory
 	  structure and skeleton files (Code complete on 8/15/11).
 	* arch/arm/include/armv7-m, arch/arm/src/armv7-m, etc.: Rename all cortexm3
-	  directories and files to armv7-m; Change name of of all CORTEXM3 constants
+	  directories and files to armv7-m; Change name of all CORTEXM3 constants
 	  to ARMV7M.  This is a major namespace change needed to cleanly support the
 	  ARM Cortex-M4 which is also in the ARMv7 M Series (specifically, ARMv7E-M).
 	* sched/sig_initialize.c, sig_received.c, and mq_waitirq.c.  Fixed several
@@ -2566,7 +2566,7 @@
 	* configs/pic32-starterkit/nsh2:  Add a PIC32 Ethernet Starter Kit NSH
 	  configuration that has no serial console; all interaction is done via
 	  Telnet.
-	* net/netdev_sem.c:  Correct a deadlock condition by making a seamphore
+	* net/netdev_sem.c:  Correct a deadlock condition by making a semaphore
 	  recursive.  To my knowledge this deadlock only occurs when running the
 	  NSH command ifconfig over Telnet.  In that case the function netdev_foreach
 	  takes the network device semaphore, but so does the telnet logic causing
@@ -2822,7 +2822,7 @@
 	  to done in that case.
 	* arch/arc/src/stm32_otgfsdev.c:  Fixed some status settings in queuing of write
 	  messages. Added a "hack" to work around missing TxFIFO empty interrupts.  The
-	  hack is basically to poll for space in the TxFIFO instead of of setting up
+	  hack is basically to poll for space in the TxFIFO instead of setting up
 	  the interrupt.
 	* arch/arm/src/stm32/stm32f2* and chip/stm32f2*:  Update all STM32 F2 file so
 	  that they are equivalent to F4 files.  This is kind of a maintenance nightmare.
@@ -7602,7 +7602,7 @@
 	* include/unistd.h: Some POSIX_* and _POSIX_* macros are defined
 	  without value, whereas (as far as I can tell) the newer versions
 	  of the standard require them to have the value corresponding to
-	  the standard version implemented, like 200809L. Are the any plans
+	  the standard version implemented, like 200809L. Are there any plans
 	  to clean this up? For now I've put together a quick patch that
 	  defines those macros to 1, consistent with the rest of unistd.h.
 	  From Kosma Moczek (2014-6-30)
@@ -9217,7 +9217,7 @@
 	  but the received characters never arrive in the reader thread.
 	  The problem was fixed by re-initializing the semaphores on the last
 	  uart_close() on the device. From Harald Welte (2014-12-13).
-	* sched/semaphore/sem_recover.c, Make.defs, seamphore.c,
+	* sched/semaphore/sem_recover.c, Make.defs, semaphore.c,
 	  sched/wdog/wd_recover.c, Make.defs, wdog.h, sched/task/task_recover.c:
 	  Add logic to clean up after task_delete() or pthread_cancel() if the
 	  task happens to be waiting on a semaphore when it is cancelled
@@ -13393,7 +13393,7 @@
 	  often half-works and does weird things...).  From Angus Gratton
 	  (2016-12-14).
 	* Xtensa ESP32: Add missing ENTRY() and RET() macros in C callable
-	  assembly language.  At one time I though the that the ESP32 support the
+	  assembly language.  At one time I thought that the ESP32 supported the
 	  CALL0 ABI.  I was mistaken so there may be a few more like this
 	  (2016-12-14).
 	* Xtensa ESP32: Fix a couple of bugs associated with handling of CPU
@@ -22262,7 +22262,7 @@
 	* arch/arm/src/stm32:  Add support for DMA v1 CSELR support.  From
 	  Mateusz Szafoni (2018-12-19).
 	* Brings in initial WIP support for the STML0.  This initial commit is
-	  unverified and, hence it it marked "EXPERIMENTAL."  From Mateusz
+	  unverified and, hence it is marked "EXPERIMENTAL."  From Mateusz
 	  Szafoni (2018-12-19).
 	* configs/:  Hook new STM32L0 boards into the configuration system.
 	  nucleo boards use as default ST LINK MCO as clock input from MCU and
@@ -22284,7 +22284,7 @@
 	* mm/mm_heap/mm_sem.c:  This is a candidate replacement for the reverted
 	  change 91aa26774b291fa553f701ce5222e56a6156c323.  This change adds a
 	  check to mm_trysemaphore() (the root implementation of both
-	  kmm_trysemaphore() and umm_trysemaphore()).  It checks if the that task
+	  kmm_trysemaphore() and umm_trysemaphore()).  It checks if the task
 	  that is apparently executing is marked as RUNNING.  If not, how could
 	  the non-running task be trying to get the MM semaphore?  I think only
 	  in the exact scenario that Eunbong Song has described.  So I think the
@@ -25986,7 +25986,7 @@
 	    conditional logic.  Precedence of operators problem.
 	  - arch/arm/src/s32k1xx/s32k1xx_clockconfig.c:  Fix another problem
 	    related to whether a divider is pre-decremented or not.  The answer
-	    must be the divder values are never pre-decremented.  They are
+	    must be the divider values are never pre-decremented.  They are
 	    decremented just before being written to hardware.
 	  - arch/arm/src/s32k1xx/s32k1xx_periphclocks.c and related files:  Fix
 	    yet another case of confusion between pre-decremented and

--- a/Documentation/NuttShell.html
+++ b/Documentation/NuttShell.html
@@ -2477,7 +2477,7 @@ mkdir &lt;path&gt;
 <p>
   <b>Synopsis</b>.
   Create the directory at <code>&lt;path&gt;</code>.
-  All components of of <code>&lt;path&gt;</code> except the final directory name must exist on a mounted file
+  All components of <code>&lt;path&gt;</code> except the final directory name must exist on a mounted file
   system; the final directory must not.
 </p>
 <p>
@@ -4366,7 +4366,7 @@ set FOOBAR ABC_${FOO}_${BAR}
         </li>
         <li>
           <code>CONFIG_NSH_USBCONSOLE</code>.
-          If defined, then the an arbitrary USB device may be used to as the NSH console.
+          If defined, then an arbitrary USB device may be used to as the NSH console.
           In this case, <code>CONFIG_NSH_USBCONDEV</code> must be defined to indicate which USB device to use as the console.
           The advantage of using a device other that <code>/dev/console</code> is that normal debug output can then use <code>/dev/console</code> while NSH uses <code>CONFIG_NSH_USBCONDEV</code>.
           <p>

--- a/Documentation/NuttXDemandPaging.html
+++ b/Documentation/NuttXDemandPaging.html
@@ -161,7 +161,7 @@
   <dt><code>g_pftcb</code></dt>
     <dd>A variable that holds a reference to the TCB of the thread that is currently be re-filled.</dd>
   <dt><code>g_pgworker</code></dt>
-    <dd>The <i>process</i> ID of of the thread that will perform the page fills.</dd>
+    <dd>The <i>process</i> ID of the thread that will perform the page fills.</dd>
   <dt><code>pg_callback()</code></dt>
     <dd>The callback function that is invoked from a driver when the fill is complete.</dd>
   <dt><code>pg_miss()</code></dt>
@@ -190,7 +190,7 @@
      </li>
      <li>
        <b><code>g_pgworker</code></b>.
-       The <i>process</i> ID of of the thread that will perform the page fills
+       The <i>process</i> ID of the thread that will perform the page fills
      </li>
    </ul>
 </p>

--- a/Documentation/NuttxPortingGuide.html
+++ b/Documentation/NuttxPortingGuide.html
@@ -2069,11 +2069,10 @@ The specific environmental definitions are unique for each board but should incl
 <p><b>Input Parameters:</b></p>
 <ul>
   <li><code>tcb</code>: Refers to a task in the ready-to-run list (normally
-    the task at the head of the list).  It most be
-    stopped, its context saved and moved into one of the
-    waiting task lists.  It it was the task at the head
-    of the ready-to-run list, then a context to the new
-    ready to run task must be performed.
+    the task at the head of the list).  It must be stopped, its context saved
+    and moved into one of the waiting task lists.  If it was the task at the
+    head of the ready-to-run list, then a context switch to the new ready to
+    run task must be performed.
   </li>
   <li><code>task_state</code>: Specifies which waiting task list should be
     hold the blocked task TCB.
@@ -6742,7 +6741,7 @@ int syslog_initialize(void);
 </li>
 <li>
   <p><b>Serialization Buffer</b>.
-    A final option is the use the an <i>interrupt buffer</i> to buffer the interrupt level SYSLOG output.  In this case:
+    A final option is the use of an <i>interrupt buffer</i> to buffer the interrupt level SYSLOG output.  In this case:
   </p>
   <ul>
     <li>

--- a/INVIOLABLES.txt
+++ b/INVIOLABLES.txt
@@ -81,7 +81,7 @@ All Users Matter
     Others?
   o No changes to build system should limit use of NuttX by any user.
   o Simplifying things for one user does not justify excluding another user.
-  o We should seek to expand the the NuttX user base, not to limit it for
+  o We should seek to expand the NuttX user base, not to limit it for
     reasons of preference or priority.
   o We must resist the pull to make NuttX into a Linux-only, GCC-only, and
     ARM-only solution.

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -9053,7 +9053,7 @@ detailed bugfix information):
         to the specific pthread and no other.
       - uint32_t callbacks: Update the type passed to watchdog timer
         handlers.  Using uint32_t is a problem for 64-bit machines because
-        it it too small to pass a pointer.  uintptr_t is a more appropriate
+        it is too small to pass a pointer.  uintptr_t is a more appropriate
         type.
       - mq_timedreceive(): move the location where the errno value is set;
         the ETIMEDOUT errno setting was being overwritten by subsequent

--- a/TODO
+++ b/TODO
@@ -1033,7 +1033,7 @@ o Kernel/Protected Build
                tls_info_s.  Then the PID could be obtained without a system call.
                TLS is not very useful in the FLAT build, however.  TLS works by
                putting per-thread data at the bottom of an aligned stack.  The
-               current stack pointer is the ANDed with the alignment mask to
+               current stack pointer is then ANDed with the alignment mask to
                obtain the per-thread data address.
 
                There are problems with this in the FLAT and PROTECTED builds:

--- a/arch/arm/src/arm/up_blocktask.c
+++ b/arch/arm/src/arm/up_blocktask.c
@@ -58,19 +58,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -84,11 +83,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/arm/src/arm/up_head.S
+++ b/arch/arm/src/arm/up_head.S
@@ -589,7 +589,7 @@ __start:
 	bcc		.Lbssinit
 
 	/* If the .data section is in a separate, uninitialized address space,
-	 * then we will also need to copy the initial values of of the .data
+	 * then we will also need to copy the initial values of the .data
 	 * section from the .text region into that .data region.  This would
 	 * be the case if we are executing from FLASH and the .data section
 	 * lies in a different physical address region OR if we are support

--- a/arch/arm/src/armv6-m/up_blocktask.c
+++ b/arch/arm/src/armv6-m/up_blocktask.c
@@ -58,17 +58,17 @@
  *
  * Description:
  *   The currently executing task at the head of the ready to run list must
- *   be stopped.  Save its context and move it to the inactive list specified
- *   by task_state.
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
  *   tcb: Refers to a task in the ready-to-run list (normally the task at
- *     the head of the list).  It most be stopped, its context saved and
- *     moved into one of the waiting task lists.  It it was the task at the
- *     head of the ready-to-run list, then a context to the new ready to run
- *     task must be performed.
- *   task_state: Specifies which waiting task list should be hold the
- *     blocked task TCB.
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
+ *     ready to run task must be performed.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -82,11 +82,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/arm/src/armv7-a/arm_addrenv.c
+++ b/arch/arm/src/armv7-a/arm_addrenv.c
@@ -188,7 +188,7 @@ static int up_addrenv_initdata(uintptr_t l2table)
   up_invalidate_dcache((uintptr_t)virtptr,
                        (uintptr_t)virtptr + sizeof(uint32_t));
 
-  /* Get the physical address of the first page of of .bss/.data */
+  /* Get the physical address of the first page of .bss/.data */
 
   paddr = (uintptr_t)(*virtptr) & PTE_SMALL_PADDR_MASK;
   DEBUGASSERT(paddr);

--- a/arch/arm/src/armv7-a/arm_blocktask.c
+++ b/arch/arm/src/armv7-a/arm_blocktask.c
@@ -58,19 +58,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -84,11 +83,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/arm/src/armv7-a/arm_head.S
+++ b/arch/arm/src/armv7-a/arm_head.S
@@ -694,7 +694,7 @@ arm_data_initialize:
 
 #ifdef CONFIG_BOOT_RUNFROMFLASH
 	/* If the .data section is in a separate, uninitialized address space,
-	 * then we will also need to copy the initial values of of the .data
+	 * then we will also need to copy the initial values of the .data
 	 * section from the .text region into that .data region.  This would
 	 * be the case if we are executing from FLASH and the .data section
 	 * lies in a different physical address region OR if we are support

--- a/arch/arm/src/armv7-a/arm_pghead.S
+++ b/arch/arm/src/armv7-a/arm_pghead.S
@@ -725,7 +725,7 @@ arm_data_initialize:
 
 #ifdef CONFIG_BOOT_RUNFROMFLASH
 	/* If the .data section is in a separate, uninitialized address space,
-	 * then we will also need to copy the initial values of of the .data
+	 * then we will also need to copy the initial values of the .data
 	 * section from the .text region into that .data region.  This would
 	 * be the case if we are executing from FLASH and the .data section
 	 * lies in a different physical address region OR if we are support

--- a/arch/arm/src/armv7-m/up_blocktask.c
+++ b/arch/arm/src/armv7-m/up_blocktask.c
@@ -57,19 +57,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -83,11 +82,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/arm/src/armv7-r/arm_blocktask.c
+++ b/arch/arm/src/armv7-r/arm_blocktask.c
@@ -58,19 +58,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -84,11 +83,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/arm/src/armv7-r/arm_head.S
+++ b/arch/arm/src/armv7-r/arm_head.S
@@ -423,7 +423,7 @@ arm_data_initialize:
 
 #ifdef CONFIG_BOOT_RUNFROMFLASH
 	/* If the .data section is in a separate, uninitialized address space,
-	 * then we will also need to copy the initial values of of the .data
+	 * then we will also need to copy the initial values of the .data
 	 * section from the .text region into that .data region.  This would
 	 * be the case if we are executing from FLASH and the .data section
 	 * lies in a different physical address region OR if we are support

--- a/arch/arm/src/cxd56xx/cxd56_irq.c
+++ b/arch/arm/src/cxd56xx/cxd56_irq.c
@@ -328,7 +328,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/cxd56xx/cxd56_udmac.h
+++ b/arch/arm/src/cxd56xx/cxd56_udmac.h
@@ -47,7 +47,7 @@
  ****************************************************************************/
 
 /* Bit encoded input parameter to cxd56_channel(). These encodings must fit
- * in the an unsigned integer of type dma_config_t.
+ * in an unsigned integer of type dma_config_t.
  *
  * Current limitations/assumptions in the encoding:
  *

--- a/arch/arm/src/dm320/dm320_usbdev.c
+++ b/arch/arm/src/dm320/dm320_usbdev.c
@@ -1753,7 +1753,7 @@ static void dm320_epreset(unsigned int index)
 static inline void dm320_epinitialize(struct dm320_usbdev_s *priv)
 {
   uint16_t  offset;     /* Full USB buffer offset */
-  uint8_t addrhi;     /* MS bytes of ofset */
+  uint8_t addrhi;     /* MS bytes of offset */
   uint8_t addrlo;     /* LS bytes of offset */
   int     i;
 
@@ -1765,7 +1765,7 @@ static inline void dm320_epinitialize(struct dm320_usbdev_s *priv)
   dm320_putreg8(USB_CSR2_FLFIFO, DM320_USB_CSR2);
   dm320_putreg8(USB_CSR2_FLFIFO, DM320_USB_CSR2);
 
-  /* EP0 Fifo size/address (ofset == 0) */
+  /* EP0 Fifo size/address (offset == 0) */
 
   dm320_putreg8(0x00, DM320_USB_TXFIFO1);
   dm320_putreg8(0x00, DM320_USB_RXFIFO1);

--- a/arch/arm/src/efm32/efm32_irq.c
+++ b/arch/arm/src/efm32/efm32_irq.c
@@ -343,7 +343,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/imxrt/imxrt_edma.c
+++ b/arch/arm/src/imxrt/imxrt_edma.c
@@ -773,7 +773,7 @@ void weak_function up_dma_initialize(void)
 
   nxsem_setprotocol(&g_edma.dsem, SEM_PRIO_NONE);
 
-  /* Initialize the list of of free TCDs from the pool of pre-allocated TCDs. */
+  /* Initialize the list of free TCDs from the pool of pre-allocated TCDs. */
 
   imxrt_tcd_initialize();
 #endif

--- a/arch/arm/src/imxrt/imxrt_ehci.c
+++ b/arch/arm/src/imxrt/imxrt_ehci.c
@@ -2126,7 +2126,7 @@ static int imxrt_async_setup(struct imxrt_rhport_s *rhport,
   toggle = (uint32_t)epinfo->toggle << QTD_TOKEN_TOGGLE_SHIFT;
   ret    = -EIO;
 
-  /* Is the an EP0 SETUP request?  If so, req will be non-NULL and we will
+  /* Is there an EP0 SETUP request?  If so, req will be non-NULL and we will
    * queue two or three qTDs:
    *
    *   1) One for the SETUP phase,
@@ -2795,7 +2795,7 @@ static int imxrt_qh_ioccheck(struct imxrt_qh_s *qh, uint32_t **bp, void *arg)
                QH_TOKEN_HALTED &&
               (token & QH_TOKEN_CERR_MASK) != 0)
             {
-              /* It is a stall,  Note the that the data toggle is reset
+              /* It is a stall,  Note that the data toggle is reset
                * after the stall.
                */
 

--- a/arch/arm/src/imxrt/imxrt_irq.c
+++ b/arch/arm/src/imxrt/imxrt_irq.c
@@ -392,7 +392,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/kinetis/kinetis_irq.c
+++ b/arch/arm/src/kinetis/kinetis_irq.c
@@ -332,7 +332,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/lc823450/lc823450_irq.c
+++ b/arch/arm/src/lc823450/lc823450_irq.c
@@ -504,7 +504,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_irq.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_irq.c
@@ -301,7 +301,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/lpc31xx/lpc31_ehci.c
+++ b/arch/arm/src/lpc31xx/lpc31_ehci.c
@@ -2120,7 +2120,7 @@ static int lpc31_async_setup(struct lpc31_rhport_s *rhport,
   toggle = (uint32_t)epinfo->toggle << QTD_TOKEN_TOGGLE_SHIFT;
   ret    = -EIO;
 
-  /* Is the an EP0 SETUP request?  If so, req will be non-NULL and we will
+  /* Is there an EP0 SETUP request?  If so, req will be non-NULL and we will
    * queue two or three qTDs:
    *
    *   1) One for the SETUP phase,
@@ -2787,7 +2787,7 @@ static int lpc31_qh_ioccheck(struct lpc31_qh_s *qh, uint32_t **bp, void *arg)
           if ((token & (QH_TOKEN_BABBLE | QH_TOKEN_HALTED)) == QH_TOKEN_HALTED &&
               (token & QH_TOKEN_CERR_MASK) != 0)
             {
-              /* It is a stall,  Note the that the data toggle is reset
+              /* It is a stall,  Note that the data toggle is reset
                * after the stall.
                */
 

--- a/arch/arm/src/lpc43xx/lpc43_ehci.c
+++ b/arch/arm/src/lpc43xx/lpc43_ehci.c
@@ -2010,7 +2010,7 @@ static int lpc43_async_setup(struct lpc43_rhport_s *rhport,
   toggle = (uint32_t)epinfo->toggle << QTD_TOKEN_TOGGLE_SHIFT;
   ret    = -EIO;
 
-  /* Is the an EP0 SETUP request?  If so, req will be non-NULL and we will
+  /* Is there an EP0 SETUP request?  If so, req will be non-NULL and we will
    * queue two or three qTDs:
    *
    *   1) One for the SETUP phase,
@@ -2650,7 +2650,7 @@ static int lpc43_qh_ioccheck(struct lpc43_qh_s *qh, uint32_t **bp, void *arg)
           if ((token & (QH_TOKEN_BABBLE | QH_TOKEN_HALTED)) == QH_TOKEN_HALTED &&
               (token & QH_TOKEN_CERR_MASK) != 0)
             {
-              /* It is a stall,  Note the that the data toggle is reset
+              /* It is a stall,  Note that the data toggle is reset
                * after the stall.
                */
 

--- a/arch/arm/src/lpc43xx/lpc43_irq.c
+++ b/arch/arm/src/lpc43xx/lpc43_irq.c
@@ -335,7 +335,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/lpc54xx/lpc54_irq.c
+++ b/arch/arm/src/lpc54xx/lpc54_irq.c
@@ -334,7 +334,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/max326xx/common/max326_irq.c
+++ b/arch/arm/src/max326xx/common/max326_irq.c
@@ -333,7 +333,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/nrf52/nrf52_irq.c
+++ b/arch/arm/src/nrf52/nrf52_irq.c
@@ -339,7 +339,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/s32k1xx/s32k14x/s32k14x_irq.c
+++ b/arch/arm/src/s32k1xx/s32k14x/s32k14x_irq.c
@@ -355,7 +355,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/s32k1xx/s32k1xx_edma.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_edma.c
@@ -741,7 +741,7 @@ void weak_function up_dma_initialize(void)
 
   nxsem_setprotocol(&g_edma.dsem, SEM_PRIO_NONE);
 
-  /* Initialize the list of of free TCDs from the pool of pre-allocated TCDs. */
+  /* Initialize the list of free TCDs from the pool of pre-allocated TCDs. */
 
   s32k1xx_tcd_initialize();
 #endif

--- a/arch/arm/src/sam34/sam4cm_oneshot.c
+++ b/arch/arm/src/sam34/sam4cm_oneshot.c
@@ -468,7 +468,7 @@ int sam_oneshot_cancel(struct sam_oneshot_s *oneshot,
         }
       else
         {
-          /* The total time remaining is the difference.  Convert the that
+          /* The total time remaining is the difference.  Convert that
            * to units of microseconds.
            *
            *   frequency = ticks / second

--- a/arch/arm/src/sam34/sam_irq.c
+++ b/arch/arm/src/sam34/sam_irq.c
@@ -363,7 +363,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -1943,7 +1943,7 @@ static int sam_async_setup(struct sam_rhport_s *rhport,
   toggle = (uint32_t)epinfo->toggle << QTD_TOKEN_TOGGLE_SHIFT;
   ret    = -EIO;
 
-  /* Is the an EP0 SETUP request?  If so, req will be non-NULL and we will
+  /* Is there an EP0 SETUP request?  If so, req will be non-NULL and we will
    * queue two or three qTDs:
    *
    *   1) One for the SETUP phase,
@@ -2610,7 +2610,7 @@ static int sam_qh_ioccheck(struct sam_qh_s *qh, uint32_t **bp, void *arg)
           if ((token & (QH_TOKEN_BABBLE | QH_TOKEN_HALTED)) == QH_TOKEN_HALTED &&
               (token & QH_TOKEN_CERR_MASK) != 0)
             {
-              /* It is a stall,  Note the that the data toggle is reset
+              /* It is a stall,  Note that the data toggle is reset
                * after the stall.
                */
 

--- a/arch/arm/src/sama5/sam_oneshot.c
+++ b/arch/arm/src/sama5/sam_oneshot.c
@@ -480,7 +480,7 @@ int sam_oneshot_cancel(struct sam_oneshot_s *oneshot,
         }
       else
         {
-          /* The total time remaining is the difference.  Convert the that
+          /* The total time remaining is the difference.  Convert that
            * to units of microseconds.
            *
            *   frequency = ticks / second

--- a/arch/arm/src/samd2l2/sam_dmac.h
+++ b/arch/arm/src/samd2l2/sam_dmac.h
@@ -107,7 +107,7 @@
  * PERIPH_RXTRIG    - The RX ID of the peripheral that provides the DMA trigger.  This
  *                    is one of the DMA_TRIGSRC_*[_RX] definitions.  This trigger source
  *                    is selected when sam_dmarxsetup() is called.
- * PERIPH_INCREMENT - Indicates the that peripheral address should be incremented on
+ * PERIPH_INCREMENT - Indicates that the peripheral address should be incremented on
  *                    each "beat"
  * PERIPH_QOS       - Quality of service for peripheral accesses
  */
@@ -128,7 +128,7 @@
 
 /* Memory endpoint characteristics
  *
- * MEM_INCREMENT - Indicates the that memory address should be incremented on each
+ * MEM_INCREMENT - Indicates that the memory address should be incremented on each
  *                 "beat"
  * MEM_QOS       - Quality of service for memory accesses
  */

--- a/arch/arm/src/samd2l2/sam_i2c_master.c
+++ b/arch/arm/src/samd2l2/sam_i2c_master.c
@@ -1439,7 +1439,7 @@ int sam_i2c_reset(FAR struct i2c_master_s *dev)
 
   i2c_putreg32(priv, ctrla & ~I2C_CTRLA_ENABLE, SAM_I2C_CTRLA_OFFSET);
 
-  /* Wait it get sync */
+  /* Wait to get sync */
 
   i2c_wait_synchronization(priv);
 

--- a/arch/arm/src/samd5e5/sam_dmac.h
+++ b/arch/arm/src/samd5e5/sam_dmac.h
@@ -106,7 +106,7 @@
  *                    is one of the DMAC_CHCTRLA_TRIGSRC_*[_TX] definitions.  This trigger source
  *                    is selected when sam_dmatxsetup() is called.
  * PERIPH_TRIGACT   - Trigger action
- * PERIPH_INCREMENT - Indicates the that peripheral address should be incremented on
+ * PERIPH_INCREMENT - Indicates that the peripheral address should be incremented on
  *                    each "beat"
  */
 
@@ -122,7 +122,7 @@
 
 /* Memory endpoint characteristics
  *
- * MEM_INCREMENT - Indicates the that memory address should be incremented on each
+ * MEM_INCREMENT - Indicates that the memory address should be incremented on each
  *                 "beat"
  */
 

--- a/arch/arm/src/samd5e5/sam_i2c_master.c
+++ b/arch/arm/src/samd5e5/sam_i2c_master.c
@@ -1477,7 +1477,7 @@ int sam_i2c_reset(FAR struct i2c_master_s *dev)
 
   i2c_putreg32(priv, ctrla & ~I2C_CTRLA_ENABLE, SAM_I2C_CTRLA_OFFSET);
 
-  /* Wait it get sync */
+  /* Wait to get sync */
 
   i2c_wait_synchronization(priv);
 

--- a/arch/arm/src/samd5e5/sam_irq.c
+++ b/arch/arm/src/samd5e5/sam_irq.c
@@ -441,7 +441,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/samv7/sam_irq.c
+++ b/arch/arm/src/samv7/sam_irq.c
@@ -359,7 +359,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/samv7/sam_oneshot.c
+++ b/arch/arm/src/samv7/sam_oneshot.c
@@ -482,7 +482,7 @@ int sam_oneshot_cancel(struct sam_oneshot_s *oneshot,
         }
       else
         {
-          /* The total time remaining is the difference.  Convert the that
+          /* The total time remaining is the difference.  Convert that
            * to units of microseconds.
            *
            *   frequency = ticks / second

--- a/arch/arm/src/samv7/sam_serial.c
+++ b/arch/arm/src/samv7/sam_serial.c
@@ -294,7 +294,7 @@
 
 /* Pick ttys7. This could be one of USART1-2. It can't be UART0-4
  * or USART 1 because those have already been assigned to ttsyS0-6.
- * One of of USART1-2 could also be the console.
+ * One of USART1-2 could also be the console.
  */
 
 #if defined(CONFIG_SAMV7_USART1) && defined(CONFIG_USART1_SERIALDRIVER) && \

--- a/arch/arm/src/stm32/stm32_irq.c
+++ b/arch/arm/src/stm32/stm32_irq.c
@@ -339,7 +339,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/stm32/stm32_oneshot.c
+++ b/arch/arm/src/stm32/stm32_oneshot.c
@@ -443,7 +443,7 @@ int stm32_oneshot_cancel(struct stm32_oneshot_s *oneshot,
         }
       else
         {
-          /* The total time remaining is the difference.  Convert the that
+          /* The total time remaining is the difference.  Convert that
            * to units of microseconds.
            *
            *   frequency = ticks / second

--- a/arch/arm/src/stm32/stm32_sdadc.c
+++ b/arch/arm/src/stm32/stm32_sdadc.c
@@ -820,7 +820,7 @@ static void sdadc_reset(FAR struct adc_dev_s *dev)
 
   sdadc_rccreset(priv, false);
 
-  /* Enable the SDADC (and wait it stabilizes) */
+  /* Enable the SDADC (and wait until it stabilizes) */
 
   sdadc_enable(priv, true);
 

--- a/arch/arm/src/stm32f7/stm32_irq.c
+++ b/arch/arm/src/stm32f7/stm32_irq.c
@@ -392,7 +392,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/stm32h7/stm32_irq.c
+++ b/arch/arm/src/stm32h7/stm32_irq.c
@@ -417,7 +417,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/stm32l4/stm32l4_irq.c
+++ b/arch/arm/src/stm32l4/stm32l4_irq.c
@@ -327,7 +327,7 @@ void up_irqinitialize(void)
   putreg32(DEFPRIORITY32, NVIC_SYSH8_11_PRIORITY);
   putreg32(DEFPRIORITY32, NVIC_SYSH12_15_PRIORITY);
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports:
    *
    *  0 -> 32 interrupt lines,  8 priority registers

--- a/arch/arm/src/stm32l4/stm32l4_oneshot.c
+++ b/arch/arm/src/stm32l4/stm32l4_oneshot.c
@@ -445,7 +445,7 @@ int stm32l4_oneshot_cancel(FAR struct stm32l4_oneshot_s *oneshot,
         }
       else
         {
-          /* The total time remaining is the difference.  Convert the that
+          /* The total time remaining is the difference.  Convert that
            * to units of microseconds.
            *
            *   frequency = ticks / second

--- a/arch/arm/src/tiva/common/tiva_irq.c
+++ b/arch/arm/src/tiva/common/tiva_irq.c
@@ -393,7 +393,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -940,7 +940,7 @@ static void tiva_txdone(struct tiva_driver_s *priv)
   /* Verify that the Tx FIFO is not in use.  The NEWTX bit initiates an
    * Ethernet transmission once the packet has been placed in the TX FIFO.
    * This bit is cleared once the transmission has been completed.  Since
-   * we get here because of of TXEMP which indicates that the packet was
+   * we get here because of TXEMP which indicates that the packet was
    * transmitted and that the TX FIFO is empty, NEWTX should always be zero
    * at this point.
    */

--- a/arch/arm/src/xmc4/xmc4_irq.c
+++ b/arch/arm/src/xmc4/xmc4_irq.c
@@ -331,7 +331,7 @@ void up_irqinitialize(void)
   int nintlines;
   int i;
 
-  /* The NVIC ICTR register (bits 0-4) holds the number of of interrupt
+  /* The NVIC ICTR register (bits 0-4) holds the number of interrupt
    * lines that the NVIC supports, defined in groups of 32. That is,
    * the total number of interrupt lines is up to (32*(INTLINESNUM+1)).
    *

--- a/arch/avr/src/avr/up_blocktask.c
+++ b/arch/avr/src/avr/up_blocktask.c
@@ -57,19 +57,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -83,11 +82,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
          (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/avr/src/avr32/up_blocktask.c
+++ b/arch/avr/src/avr32/up_blocktask.c
@@ -58,19 +58,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -84,11 +83,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
          (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/hc/src/common/up_blocktask.c
+++ b/arch/hc/src/common/up_blocktask.c
@@ -58,19 +58,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -84,11 +83,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
          (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/mips/src/mips32/up_blocktask.c
+++ b/arch/mips/src/mips32/up_blocktask.c
@@ -59,19 +59,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -85,11 +84,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/mips/src/pic32mz/pic32mz-oneshot.c
+++ b/arch/mips/src/pic32mz/pic32mz-oneshot.c
@@ -434,7 +434,7 @@ int pic32mz_oneshot_cancel(struct pic32mz_oneshot_s *oneshot,
         }
       else
         {
-          /* The total time remaining is the difference.  Convert the that
+          /* The total time remaining is the difference.  Convert that
            * to units of microseconds.
            *
            *   frequency = ticks / second

--- a/arch/misoc/src/lm32/lm32_blocktask.c
+++ b/arch/misoc/src/lm32/lm32_blocktask.c
@@ -60,19 +60,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -86,11 +85,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/misoc/src/minerva/minerva_blocktask.c
+++ b/arch/misoc/src/minerva/minerva_blocktask.c
@@ -60,19 +60,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -87,9 +86,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
   /* Remove the tcb task from the ready-to-run list.  If we are blocking the
-   * task at the head of the task list (the most likely case), then a context
-   * switch to the next ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/or1k/src/common/up_blocktask.c
+++ b/arch/or1k/src/common/up_blocktask.c
@@ -58,19 +58,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -84,11 +83,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/renesas/src/common/up_blocktask.c
+++ b/arch/renesas/src/common/up_blocktask.c
@@ -57,19 +57,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -83,11 +82,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/risc-v/src/rv32im/up_blocktask.c
+++ b/arch/risc-v/src/rv32im/up_blocktask.c
@@ -59,19 +59,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -85,11 +84,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/risc-v/src/rv64gc/up_blocktask.c
+++ b/arch/risc-v/src/rv64gc/up_blocktask.c
@@ -59,19 +59,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -85,11 +84,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/sim/src/sim/up_blocktask.c
+++ b/arch/sim/src/sim/up_blocktask.c
@@ -57,19 +57,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -85,11 +84,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
   //sinfo("Blocking TCB=%p\n", tcb);
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/x86/src/common/up_blocktask.c
+++ b/arch/x86/src/common/up_blocktask.c
@@ -59,17 +59,17 @@
  *
  * Description:
  *   The currently executing task at the head of the ready to run list must
- *   be stopped.  Save its context and move it to the inactive list specified
- *   by task_state.
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally the task at the
- *     head of the list).  It most be stopped, its context saved and moved
- *     into one of the waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new ready to run task
- *     must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
+ *     ready to run task must be performed.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -83,11 +83,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/x86_64/src/common/up_blocktask.c
+++ b/arch/x86_64/src/common/up_blocktask.c
@@ -44,17 +44,17 @@
  *
  * Description:
  *   The currently executing task at the head of the ready to run list must
- *   be stopped.  Save its context and move it to the inactive list specified
- *   by task_state.
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally the task at the
- *     head of the list).  It most be stopped, its context saved and moved
- *     into one of the waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new ready to run task
- *     must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
+ *     ready to run task must be performed.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -68,11 +68,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   ASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
          (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/xtensa/src/common/xtensa_blocktask.c
+++ b/arch/xtensa/src/common/xtensa_blocktask.c
@@ -59,19 +59,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -85,11 +84,10 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
   DEBUGASSERT((tcb->task_state >= FIRST_READY_TO_RUN_STATE) &&
               (tcb->task_state <= LAST_READY_TO_RUN_STATE));
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/z16/src/common/up_blocktask.c
+++ b/arch/z16/src/common/up_blocktask.c
@@ -57,19 +57,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -85,11 +84,10 @@ void up_block_task(FAR struct tcb_s *tcb, tstate_t task_state)
 
   /* sinfo("Blocking TCB=%p\n", tcb); */
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/arch/z80/src/common/up_blocktask.c
+++ b/arch/z80/src/common/up_blocktask.c
@@ -44,19 +44,18 @@
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new
  *     ready to run task must be performed.
- *   task_state: Specifies which waiting task list should be
- *     hold the blocked task TCB.
+ *   task_state: Specifies which waiting task list should hold the blocked
+ *     task TCB.
  *
  ****************************************************************************/
 
@@ -72,11 +71,10 @@ void up_block_task(FAR struct tcb_s *tcb, tstate_t task_state)
 
   /* _info("Blocking TCB=%p\n", tcb); */
 
-  /* Remove the tcb task from the ready-to-run list.  If we
-   * are blocking the task at the head of the task list (the
-   * most likely case), then a context switch to the next
-   * ready-to-run task is needed. In this case, it should
-   * also be true that rtcb == tcb.
+  /* Remove the tcb task from the ready-to-run list.  If we are blocking the
+   * task at the head of the task list (the most likely case), then a
+   * context switch to the next ready-to-run task is needed. In this case,
+   * it should also be true that rtcb == tcb.
    */
 
   switch_needed = sched_removereadytorun(tcb);

--- a/boards/arm/s32k1xx/s32k146evb/README.txt
+++ b/boards/arm/s32k1xx/s32k146evb/README.txt
@@ -32,7 +32,7 @@ Status
     for recovery from this condition at: https://community.nxp.com/thread/505593 .
     But none of those options are working for me.
 
-    Give the success running of of SRAM and the success of the same fixes
+    Give the success running of SRAM and the success of the same fixes
     on the S32K118, I believe that the NSH configuration should now run out
     of FLASH.  Unfortunately, I cannot demonstrate that.
 

--- a/boards/arm/samd2l2/samd20-xplained/README.txt
+++ b/boards/arm/samd2l2/samd20-xplained/README.txt
@@ -37,7 +37,7 @@ STATUS/ISSUES
 
     2. Garbage appears on the display sometimes after a reset (maybe 20% of
        the time) or after a power cycle (less after a power cycle).  I don't
-       understand the cause of of this but most of this can be eliminated by
+       understand the cause of this but most of this can be eliminated by
        simply holding the reset button longer and releasing it cleanly
        (then it fails maybe 5-10% of the time, maybe because of button
        chatter?) (2014-2-18).

--- a/boards/arm/samd5e5/metro-m4/include/board.h
+++ b/boards/arm/samd5e5/metro-m4/include/board.h
@@ -336,7 +336,7 @@
  * CPU frequency = 120MHz / 1 = 120MHz
  */
 
-#define BOARD_MCLK_CPUDIV       1         /* MCLK divder to get CPU frequency */
+#define BOARD_MCLK_CPUDIV       1         /* MCLK divider to get CPU frequency */
 
 /* Peripheral clocking */
 

--- a/boards/arm/samd5e5/same54-xplained-pro/include/board.h
+++ b/boards/arm/samd5e5/same54-xplained-pro/include/board.h
@@ -336,7 +336,7 @@
  * CPU frequency = 120MHz / 1 = 120MHz
  */
 
-#define BOARD_MCLK_CPUDIV       1         /* MCLK divder to get CPU frequency */
+#define BOARD_MCLK_CPUDIV       1         /* MCLK divider to get CPU frequency */
 
 #define BOARD_MCK_FREQUENCY     BOARD_GCLK0_FREQUENCY
 

--- a/boards/arm/samv7/same70-xplained/README.txt
+++ b/boards/arm/samv7/same70-xplained/README.txt
@@ -904,7 +904,7 @@ Click Shield
   click mikroBUSes.  The above discusses on the UNO shield.  I know that the
   serial ports, at least, differ on the two shields.
 
-  UPDATE: And it appears the that Mega shield is *not* compatible with the
+  UPDATE: And it appears that the Mega shield is *not* compatible with the
   SAME70-Xplained.  I am told that the SPI in mikroBUS slots does not connect
   to pins on the  SAME70-Xplained that can support the SPI communications.
   Avoid this triple mikroBUS shield!

--- a/boards/hc/m9s12/demo9s12ne64/README.txt
+++ b/boards/hc/m9s12/demo9s12ne64/README.txt
@@ -370,9 +370,9 @@ Common Configuration Notes
      b. Execute 'make menuconfig' in nuttx/ in order to start the
         reconfiguration process.
 
-  3. By default, all configurations assume the that you are building under
-     under Linux (should work under Windows with Cygwin as well).  This
-     is easily reconfigured:
+  3. By default, all configurations assume that you are building under
+     Linux (should work under Windows with Cygwin as well).  This is
+     easily reconfigured:
 
         CONFIG_HOST_LINUX=y
 

--- a/boards/hc/m9s12/ne64badge/README.txt
+++ b/boards/hc/m9s12/ne64badge/README.txt
@@ -477,9 +477,9 @@ Common Configuration Notes
      b. Execute 'make menuconfig' in nuttx/ in order to start the
         reconfiguration process.
 
-  3. By default, all configurations assume the that you are building under
-     under Linux (should work under Windows with Cygwin as well).  This
-     is easily reconfigured:
+  3. By default, all configurations assume that you are building under
+     Linux (should work under Windows with Cygwin as well).  This is
+     easily reconfigured:
 
         CONFIG_HOST_LINUX=y
 

--- a/drivers/mtd/sst39vf.c
+++ b/drivers/mtd/sst39vf.c
@@ -510,7 +510,7 @@ static int sst39vf_sectorerase(FAR struct sst39vf_dev_s *priv,
 
   /* Use the data toggle delay method.  The typical delay is 18 MSec. The
    * maximum is 25 MSec.  With a 10 MS system timer resolution, this is
-   * the difference of of waiting 20MS vs. 20MS.  So using the data toggle
+   * the difference of waiting 20MS vs. 20MS.  So using the data toggle
    * delay method should give better write performance by about 10MS per
    * block.
    */

--- a/drivers/sensors/README.txt
+++ b/drivers/sensors/README.txt
@@ -128,7 +128,7 @@ open(): This function performs the below actions...
      sensor configuration is specified. (The custom configuration is
      basically an array of (device_reg_address, value) pairs that are
      written to the sensor via "single register write" operations.
-     If a custom sensor configuration was specified, then the that
+     If a custom sensor configuration was specified, then that
      configuration is written to the sensor, otherwise the "default
      sensor configuration" is written to the sensor.
      (A side effect of writing this data may result in interrupts

--- a/drivers/sensors/lsm303agr.c
+++ b/drivers/sensors/lsm303agr.c
@@ -356,7 +356,7 @@ static int lsm303agr_sensor_config(FAR struct lsm303agr_dev_s *priv)
  * Name: lsm303agr_isbitset
  *
  * Description:
- *   Check if bit it set from mask, not bit number.
+ *   Check if bit is set from mask, not bit number.
  *
  ****************************************************************************/
 

--- a/drivers/sensors/lsm6dsl.c
+++ b/drivers/sensors/lsm6dsl.c
@@ -392,7 +392,7 @@ static int lsm6dsl_sensor_config(FAR struct lsm6dsl_dev_s *priv)
  * Name: lsm6dsl_isbitset
  *
  * Description:
- *   Check if bit it set from mask, not bit number.
+ *   Check if bit is set from mask, not bit number.
  *
  ****************************************************************************/
 

--- a/drivers/syslog/README.txt
+++ b/drivers/syslog/README.txt
@@ -262,7 +262,7 @@ SYSLOG Channels
 
   3. Serialization Buffer
   -----------------------
-  A final option is the use the an "interrupt buffer" to buffer the
+  A final option is the use of an "interrupt buffer" to buffer the
   interrupt level SYSLOG output.  In this case:
 
     * SYSLOG output generated from interrupt level process in not sent to

--- a/fs/spiffs/src/spiffs_volume.c
+++ b/fs/spiffs/src/spiffs_volume.c
@@ -462,7 +462,7 @@ void spiffs_fobj_free(FAR struct spiffs_s *fs,
 
       if (curr == fobj)
         {
-          /* Yes, remove it from the list of of file objects */
+          /* Yes, remove it from the list of file objects */
 
           dq_rem((FAR dq_entry_t *)curr, &fs->objq);
           break;

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -399,21 +399,19 @@ void up_unblock_task(FAR struct tcb_s *tcb);
  * Name: up_block_task
  *
  * Description:
- *   The currently executing task at the head of
- *   the ready to run list must be stopped.  Save its context
- *   and move it to the inactive list specified by task_state.
+ *   The currently executing task at the head of the ready to run list must
+ *   be stopped.  Save its context and move it to the inactive list
+ *   specified by task_state.
  *
- *   This function is called only from the NuttX scheduling
- *   logic.  Interrupts will always be disabled when this
- *   function is called.
+ *   This function is called only from the NuttX scheduling logic.
+ *   Interrupts will always be disabled when this function is called.
  *
  * Input Parameters:
- *   tcb: Refers to a task in the ready-to-run list (normally
- *     the task at the head of the list).  It most be
- *     stopped, its context saved and moved into one of the
- *     waiting task lists.  It it was the task at the head
- *     of the ready-to-run list, then a context to the new
- *     ready to run task must be performed.
+ *   tcb: Refers to a task in the ready-to-run list (normally the task at
+ *     the head of the list).  It must be stopped, its context saved and
+ *     moved into one of the waiting task lists.  If it was the task at the
+ *     head of the ready-to-run list, then a context switch to the new ready
+ *     to run task must be performed.
  *   task_state: Specifies which waiting task list should be
  *     hold the blocked task TCB.
  *

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -70,7 +70,7 @@
  *
  * This is only important when compiling libraries (libc or libnx) that are
  * used both by the OS (libkc.a and libknx.a) or by the applications
- * (libuc.a and libunx.a).  The that case, the correct interface must be
+ * (libuc.a and libunx.a).  In that case, the correct interface must be
  * used for the build context.
  *
  * REVISIT:  In the flat build, the same functions must be used both by

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -269,7 +269,7 @@ FAR struct iob_s *iob_tryalloc(bool throttled, enum iob_user_e consumerid);
  * Name: iob_navail
  *
  * Description:
- *   Return the number of of available IOBs.
+ *   Return the number of available IOBs.
  *
  ****************************************************************************/
 

--- a/include/nuttx/mqueue.h
+++ b/include/nuttx/mqueue.h
@@ -65,7 +65,7 @@
  *
  * This is only important when compiling libraries (libc or libnx) that are
  * used both by the OS (libkc.a and libknx.a) or by the applications
- * (libuc.a and libunx.a).  The that case, the correct interface must be
+ * (libuc.a and libunx.a).  In that case, the correct interface must be
  * used for the build context.
  *
  * REVISIT:  In the flat build, the same functions must be used both by

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -67,7 +67,7 @@
  *
  * This is only important when compiling libraries (libc or libnx) that are
  * used both by the OS (libkc.a and libknx.a) or by the applications
- * (libuc.a and libunx.a).  The that case, the correct interface must be
+ * (libuc.a and libunx.a).  In that case, the correct interface must be
  * used for the build context.
  *
  * REVISIT:  In the flat build, the same functions must be used both by

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -156,7 +156,7 @@
  *
  * This is only important when compiling libraries (libc or libnx) that are
  * used both by the OS (libkc.a and libknx.a) or by the applications
- * (libuc.a and libunx.a).  The that case, the correct interface must be
+ * (libuc.a and libunx.a).  In that case, the correct interface must be
  * used for the build context.
  *
  * REVISIT:  In the flat build, the same functions must be used both by

--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -66,7 +66,7 @@
  *
  * This is only important when compiling libraries (libc or libnx) that are
  * used both by the OS (libkc.a and libknx.a) or by the applications
- * (libuc.a and libunx.a).  The that case, the correct interface must be
+ * (libuc.a and libunx.a).  In that case, the correct interface must be
  * used for the build context.
  *
  * REVISIT:  In the flat build, the same functions must be used both by

--- a/include/nuttx/signal.h
+++ b/include/nuttx/signal.h
@@ -81,7 +81,7 @@ struct sigwork_s
  *
  * This is only important when compiling libraries (libc or libnx) that are
  * used both by the OS (libkc.a and libknx.a) or by the applications
- * (libuc.a and libunx.a).  The that case, the correct interface must be
+ * (libuc.a and libunx.a).  In that case, the correct interface must be
  * used for the build context.
  *
  * REVISIT:  In the flat build, the same functions must be used both by

--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -289,7 +289,7 @@ int pwm_register(FAR const char *path, FAR struct pwm_lowerhalf_s *dev);
  *      number of pulses is required, the 'count' value will be nonzero.
  *   2. The lower half driver's start() method must verify that it can
  *      support the request pulse train (frequency, duty, AND pulse count).
- *      It it cannot, it should return an error.  If the pulse count is
+ *      If it cannot, it should return an error.  If the pulse count is
  *      non-zero, it should set up the hardware for that number of pulses
  *      and return success.  NOTE:  That is CONFIG_PWM_PULSECOUNT is
  *      defined, the start() method receives an additional parameter

--- a/include/signal.h
+++ b/include/signal.h
@@ -256,7 +256,7 @@
 #  define SIGEV_THREAD  3 /* A notification function is called */
 #endif
 
-/* Special values of of sa_handler used by sigaction and sigset.  They are all
+/* Special values of sa_handler used by sigaction and sigset.  They are all
  * treated like NULL for now.  This is okay for SIG_DFL and SIG_IGN because
  * in NuttX, the default action for all signals is to ignore them.
  */

--- a/libs/libc/semaphore/sem_init.c
+++ b/libs/libc/semaphore/sem_init.c
@@ -82,7 +82,7 @@ int nxsem_init(FAR sem_t *sem, int pshared, unsigned int value)
 
   if (sem != NULL && value <= SEM_VALUE_MAX)
     {
-      /* Initialize the seamphore count */
+      /* Initialize the semaphore count */
 
       sem->semcount         = (int16_t)value;
 

--- a/libs/libc/wqueue/work_queue.c
+++ b/libs/libc/wqueue/work_queue.c
@@ -61,7 +61,7 @@
  *
  * Description:
  *   Queue work to be performed at a later time.  All queued work will be
- *   performed on the worker thread of of execution (not the caller's).
+ *   performed on the worker thread of execution (not the caller's).
  *
  *   The work structure is allocated by caller, but completely managed by
  *   the work queue logic.  The caller should never modify the contents of
@@ -132,7 +132,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
  *
  * Description:
  *   Queue user-mode work to be performed at a later time.  All queued work
- *   will be performed on the worker thread of of execution (not the caller's).
+ *   will be performed on the worker thread of execution (not the caller's).
  *
  *   The work structure is allocated and must be initialized to all zero by
  *   the caller.  Otherwise, the work structure is completely managed by the

--- a/mm/iob/iob_navail.c
+++ b/mm/iob/iob_navail.c
@@ -53,7 +53,7 @@
  * Name: iob_navail
  *
  * Description:
- *   Return the number of of available IOBs.
+ *   Return the number of available IOBs.
  *
  ****************************************************************************/
 

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -70,7 +70,7 @@ config NET_ETH_PKTSIZE
 		590.
 
 		IPv6 hosts are required to be able to handle an MSS of 1220 octets,
-		resulting in a minimum buffer size of of 1220+20+40+14 = 1294
+		resulting in a minimum buffer size of 1220+20+40+14 = 1294
 
 		To get an MTU of 1500, for example, you would need packet buffer of
 		size 1514.

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -642,7 +642,7 @@ int ipv6_forward(FAR struct net_driver_s *dev, FAR struct ipv6_hdr_s *ipv6)
           /* Nothing other 6LoWPAN forwarding is currently handled and that
            * case was dealt with in ipv6_packet_conversion().
            *
-           * REVISIT: Is the an issue?  Do other use cases make sense?
+           * REVISIT: Is this an issue?  Do other use cases make sense?
            */
 
           nwarn("WARNING: Packet forwarding supported only for 6LoWPAN\n");

--- a/sched/pthread/pthread_findjoininfo.c
+++ b/sched/pthread/pthread_findjoininfo.c
@@ -55,7 +55,7 @@
  *   Find a join structure in a local data set.
  *
  * Input Parameters:
- *   group - The that the pid is (or was) a member of of
+ *   group - The group that the pid is (or was) a member of
  *   pid - The ID of the pthread
  *
  * Returned Value:

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -317,7 +317,7 @@ static int nxsem_boostholderprio(FAR struct semholder_s *pholder,
 
   /* Make sure that the holder thread is still active.  If it exited without
    * releasing its counts, then that would be a bad thing.  But we can take
-   * no real action because we don't know know that the program is doing.
+   * no real action because we don't know what the program is doing.
    * Perhaps its plan is to kill a thread, then destroy the semaphore.
    */
 
@@ -401,7 +401,7 @@ static int nxsem_boostholderprio(FAR struct semholder_s *pholder,
 
 #else
   /* If the priority of the thread that is waiting for a count is less than
-   * of equal to the priority of the thread holding a count, then do nothing
+   * or equal to the priority of the thread holding a count, then do nothing
    * because the thread is already running at a sufficient priority.
    */
 
@@ -436,7 +436,7 @@ static int nxsem_verifyholder(FAR struct semholder_s *pholder,
   FAR struct tcb_s *htcb = (FAR struct tcb_s *)pholder->htcb;
 
   /* Called after a semaphore has been released (incremented), the semaphore
-   * could is non-negative, and there is no thread waiting for the count.
+   * could be non-negative, and there is no thread waiting for the count.
    * In this case, the priority of the holder should not be boosted.
    */
 
@@ -484,7 +484,7 @@ static int nxsem_restoreholderprio(FAR struct tcb_s *htcb,
 
   /* Make sure that the holder thread is still active.  If it exited without
    * releasing its counts, then that would be a bad thing.  But we can take
-   * no real action because we don't know know that the program is doing.
+   * no real action because we don't know what the program is doing.
    * Perhaps its plan is to kill a thread, then destroy the semaphore.
    */
 
@@ -531,7 +531,7 @@ static int nxsem_restoreholderprio(FAR struct tcb_s *htcb,
 
       /* There are multiple pending priority levels. The holder thread's
        * "boosted" priority could greater than or equal to
-       * "stcb->sched_priority" (it could be greater if its priority we
+       * "stcb->sched_priority" (it could be greater if its priority was
        * boosted because it also holds another semaphore).
        */
 
@@ -574,7 +574,7 @@ static int nxsem_restoreholderprio(FAR struct tcb_s *htcb,
         {
           /* The holder thread has been boosted to a higher priority than the
            * waiter task.  The pending priority should be in the list (unless
-           * it was lost because of of list overflow or because the holder
+           * it was lost because of list overflow or because the holder
            * was reprioritized again unbeknownst to the priority inheritance
            * logic).
            *
@@ -668,8 +668,8 @@ static int nxsem_restoreholderprio_self(FAR struct semholder_s *pholder,
 
 #if CONFIG_SEM_PREALLOCHOLDERS == 0
       /* In the case where there are only 2 holders. This step
-       * is necessary to insure we have space. Release the holder
-       * if all counts have been given up. before reprioritizing
+       * is necessary to ensure we have space. Release the holder
+       * if all counts have been given up before reprioritizing
        * causes a context switch.
        */
 
@@ -686,7 +686,7 @@ static int nxsem_restoreholderprio_self(FAR struct semholder_s *pholder,
  * Name: nxsem_restorebaseprio_irq
  *
  * Description:
- *   This function is called after the an interrupt handler posts a count on
+ *   This function is called after an interrupt handler posts a count on
  *   the semaphore.  It will check if we need to drop the priority of any
  *   threads holding a count on the semaphore.  Their priority could have
  *   been boosted while they held the count.
@@ -695,7 +695,7 @@ static int nxsem_restoreholderprio_self(FAR struct semholder_s *pholder,
  *   stcb - The TCB of the task that was just started (if any).  If the
  *     post action caused a count to be given to another thread, then stcb
  *     is the TCB that received the count.  Note, just because stcb received
- *     the count, it does not mean that it it is higher priority than other
+ *     the count, it does not mean that it is higher priority than other
  *     threads.
  *   sem - A reference to the semaphore being posted.
  *     - If the semaphore count is <0 then there are still threads waiting
@@ -756,7 +756,7 @@ static inline void nxsem_restorebaseprio_irq(FAR struct tcb_s *stcb,
  *   stcb - The TCB of the task that was just started (if any).  If the
  *     post action caused a count to be given to another thread, then stcb
  *     is the TCB that received the count.  Note, just because stcb received
- *     the count, it does not mean that it it is higher priority than other
+ *     the count, it does not mean that it is higher priority than other
  *     threads.
  *   sem - A reference to the semaphore being posted.
  *     - If the semaphore count is <0 then there are still threads waiting
@@ -1061,7 +1061,7 @@ void nxsem_releaseholder(FAR sem_t *sem)
  *   stcb - The TCB of the task that was just started (if any).  If the
  *     post action caused a count to be given to another thread, then stcb
  *     is the TCB that received the count.  Note, just because stcb received
- *     the count, it does not mean that it it is higher priority than other
+ *     the count, it does not mean that it is higher priority than other
  *     threads.
  *   sem - A reference to the semaphore being posted.
  *     - If the semaphore count is <0 then there are still threads waiting

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -132,7 +132,7 @@ int nxsem_post(FAR sem_t *sem)
 
       sched_lock();
 #endif
-      /* If the result of of semaphore unlock is non-positive, then
+      /* If the result of semaphore unlock is non-positive, then
        * there must be some task waiting for the semaphore.
        */
 

--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -58,8 +58,8 @@
  *
  * Description:
  *   This function locks the specified semaphore only if the semaphore is
- *   currently not locked.  Otherwise, it locks the semaphore.  In either
- *   case, the call returns without blocking.
+ *   currently not locked.  In either case, the call returns without
+ *   blocking.
  *
  * Input Parameters:
  *   sem - the semaphore descriptor
@@ -129,8 +129,8 @@ int nxsem_trywait(FAR sem_t *sem)
  *
  * Description:
  *   This function locks the specified semaphore only if the semaphore is
- *   currently not locked.  Otherwise, it locks the semaphore.  In either
- *   case, the call returns without blocking.
+ *   currently not locked.  In either case, the call returns without
+ *   blocking.
  *
  * Input Parameters:
  *   sem - the semaphore descriptor

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -268,10 +268,9 @@ static void nxsig_abnormal_termination(int signo)
    */
 
 #ifdef HAVE_GROUP_MEMBERS
-  /* Kill of of the children of the task.  This will not kill the currently
+  /* Kill all of the children of the task.  This will not kill the currently
    * running task/pthread (this_task).  It will kill the main thread of the
-   * task group if the this_task is a
-   * pthread.
+   * task group if this_task is a pthread.
    */
 
   group_killchildren((FAR struct task_tcb_s *)rtcb);
@@ -329,9 +328,9 @@ static void nxsig_stop_task(int signo)
    */
 
 #ifdef HAVE_GROUP_MEMBERS
-  /* Suspend of of the children of the task.  This will not suspend the
+  /* Suspend all of the children of the task.  This will not suspend the
    * currently running task/pthread (this_task).  It will suspend the
-   * main thread of the task group if the this_task is a pthread.
+   * main thread of the task group if this_task is a pthread.
    */
 
   group_suspendchildren(rtcb);

--- a/sched/wqueue/kwork_inherit.c
+++ b/sched/wqueue/kwork_inherit.c
@@ -256,8 +256,8 @@ static void lpwork_restoreworker(pid_t wpid, uint8_t reqprio)
         {
           /* The worker thread has been boosted to a higher priority than the
            * waiter task.  The pending priority should be in the list (unless
-           * it was lost because of of list overflow or because the worker
-           * was reprioritized again unbeknownst to the priority inheritance
+           * it was lost because of list overflow or because the worker was
+           * reprioritized again unbeknownst to the priority inheritance
            * logic).
            *
            * Search the list for the matching priority.

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -47,7 +47,7 @@
  *
  * Description:
  *   Queue work to be performed at a later time.  All queued work will be
- *   performed on the worker thread of of execution (not the caller's).
+ *   performed on the worker thread of execution (not the caller's).
  *
  *   The work structure is allocated by caller, but completely managed by
  *   the work queue logic.  The caller should never modify the contents of
@@ -120,7 +120,7 @@ static void work_qqueue(FAR struct kwork_wqueue_s *wqueue,
  *
  * Description:
  *   Queue kernel-mode work to be performed at a later time.  All queued
- *   work will be performed on the worker thread of of execution (not the
+ *   work will be performed on the worker thread of execution (not the
  *   caller's).
  *
  *   The work structure is allocated and must be initialized to all zero by


### PR DESCRIPTION
This fixes numerous typos, grammar errors, etc., in various docs and many source files (comments only). No functional changes.

I did not run nxstyle against the many files touched by this change. There should not be any new violations. Even if some of the files contain old violations, I think it is best to fix the typos first.