### PR TITLE
esp32-core/README: Use the default partition table offset

### DIFF
--- a/boards/xtensa/esp32/esp32-core/README.txt
+++ b/boards/xtensa/esp32/esp32-core/README.txt
@@ -470,11 +470,14 @@ OpenOCD for the ESP32
   this:
 
     esptool.py --chip esp32 elf2image --flash_mode dio --flash_size 4MB -o nuttx.bin nuttx
-    esptool.py --chip esp32 --port COMx write_flash 0x1000 bootloader.bin 0x4000 partition_table.bin 0x10000 nuttx.bin
+    esptool.py --chip esp32 --port COMx write_flash 0x1000 bootloader.bin 0x8000 partition_table.bin 0x10000 nuttx.bin
 
   The first step converts an ELF image into an ESP32-compatible binary
   image format, and the second step flashes it (along with bootloader image and
   partition table binary.)
+  The offset for the partition table may vary, depending on ESP-IDF
+  configuration, CONFIG_PARTITION_TABLE_OFFSET, which is by default 0x8000
+  as of writing this.
 
   To put the ESP32 into serial flashing mode, it needs to be reset with IO0 held
   low.  On the Core boards this can be accomplished by holding the button marked


### PR DESCRIPTION
And mention the relevant ESP-IDF config.