### PR TITLE
drivers/lcd/pcf8574_lcd_backpack.c: increase delay for HOME and CLEAR…

### DIFF
--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -68,7 +68,7 @@
 #define DELAY_US_NYBBLE0    20
 #define DELAY_US_NYBBLE1    10
 #define DELAY_US_WRITE      40
-#define DELAY_US_HOMECLEAR  1500
+#define DELAY_US_HOMECLEAR  2000
 
 /* HD44780 commands */
 


### PR DESCRIPTION
… instructions

Some LCD1602 require at least 1.52 ms wait time after "Clear display" and
"Return home" instructions. Make sure we wait enough.