### PR TITLE
Don't check position of comments right of code when separated by prep…

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1014,7 +1014,12 @@ int main(int argc, char **argv, char **envp)
 
           /* Propagate rhcomment over preprocessor lines Issue #120 */
 
-          rhcomment = prevrhcmt;
+          if (prevrhcmt != 0)
+            {
+              /* Don't check position */
+
+              rhcomment = -1;
+            }
 
           lptr = strstr(line, "/*");
           if (lptr != NULL)


### PR DESCRIPTION
…rocessor line without comment.
Please see #585 
It allows imxrt_usbotg.h:275
```
#define USBDEV_USBCMD_ITC_SHIFT              (16)      /* Bits 16-23: Interrupt threshold control */
#define USBDEV_USBCMD_ITC_MASK               (255 << USBDEV_USBCMD_ITC_SHIFT)
#  define USBDEV_USBCMD_ITCIMME              (0  << USBDEV_USBCMD_ITC_SHIFT) /* Immediate (no threshold) */
```
but not imxrt_usbotg.h:284
```
#  define USBDEV_USBCMD_ITC32UF              (32 << USBDEV_USBCMD_ITC_SHIFT) /* 32 micro frames */
#  define USBDEV_USBCMD_ITC64UF              (64 << USBDEV_USBCMD_ITC_SHIFT) /* 64 micro frames */
#define USBDEV_USBCMD_ATDTW                  (1 << 14) /* Bit 14: Add dTD trip wire */
```

Btw: How do I request a review?
@patacongo would you please comment?