### PR TITLE
arch: esp32: Fix compile error for smp

### DIFF
--- a/arch/xtensa/src/esp32/chip_macros.h
+++ b/arch/xtensa/src/esp32/chip_macros.h
@@ -67,7 +67,7 @@
     movi        \reg, 1
     j           2f
 1:
-    movii       \reg, 0
+    movi        \reg, 0
 2:
     .endm
 


### PR DESCRIPTION
### Summary

- I noticed a compile error occurred for esp32-core:smp and just fixed it.

### Impact

- This PR affects esp32 for smp.

### Testing

-  I tested this PR with QEMU.
