### PR TITLE
tools/nxstyle:  Ignore stub names that begin with STUB_*

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1459,7 +1459,8 @@ int main(int argc, char **argv, char **envp)
                    */
 
                   if ((strncmp(&line[ident_index], "PRIx", 4) == 0) ||
-                      (strncmp(&line[ident_index], "SYS_", 4) == 0))
+                      (strncmp(&line[ident_index], "SYS_", 4) == 0) ||
+                      (strncmp(&line[ident_index], "STUB_", 5) == 0))
                     {
                       /* No error */
                     }


### PR DESCRIPTION
The names use for stub functions follows a non-standard convention:  They begin with STUB_