### PR TITLE
tools/testbuild.sh: suppress lots of stdout log from configure.sh

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -157,7 +157,7 @@ function distclean {
 
 function configure {
   echo "  Configuring..."
-  ./tools/configure.sh ${HOPTION} $config
+  ./tools/configure.sh ${HOPTION} $config 1>/dev/null
 
   if [ "X$toolchain" != "X" ]; then
     setting=`grep _TOOLCHAIN_ $nuttx/.config | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y`


### PR DESCRIPTION
Redirect configure.sh stdout to /dev/null to suppress lots of log
since configure.sh behaviour updated.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>