### PR TITLE
sim: Hide getopt related globals

### DIFF
--- a/arch/sim/src/nuttx-names.dat
+++ b/arch/sim/src/nuttx-names.dat
@@ -58,6 +58,9 @@ mkdir          NXmkdir
 mount          NXmount
 open           NXopen
 opendir        NXopendir
+optarg         NXoptarg
+optind         NXoptind
+optopt         NXoptopt
 nanosleep      NXnanosleep
 pipe           NXpipe
 poll           NXpoll


### PR DESCRIPTION
Right now this is rather theorethic as we don't actually
use getopt though.