### PR TITLE
Revert "Don't generate .depend anymore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.depend
 Make.dep
 *.o
 *.a

--- a/arch/arm/src/.gitignore
+++ b/arch/arm/src/.gitignore
@@ -1,3 +1,4 @@
+/.depend
 /Make.dep
 /locked.r
 /board

--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -207,14 +207,15 @@ endif
 
 # Dependencies
 
-Make.dep: Makefile chip$(DELIM)Make.defs $(SRCS)
+.depend: Makefile chip$(DELIM)Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) $(patsubst %,--dep-path %,$(subst :, ,$(VPATH))) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -230,5 +231,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/avr/src/.gitignore
+++ b/arch/avr/src/.gitignore
@@ -1,3 +1,4 @@
+/.depend
 /Make.dep
 /locked.r
 /board

--- a/arch/avr/src/Makefile
+++ b/arch/avr/src/Makefile
@@ -163,14 +163,15 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-Make.dep: Makefile chip/Make.defs $(SRCS)
+.depend: Makefile chip/Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -184,5 +185,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/hc/src/.gitignore
+++ b/arch/hc/src/.gitignore
@@ -1,3 +1,4 @@
+/.depend
 /Make.dep
 /board
 /chip

--- a/arch/hc/src/Makefile
+++ b/arch/hc/src/Makefile
@@ -162,14 +162,15 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-Make.dep: Makefile chip/Make.defs $(SRCS)
+.depend: Makefile chip/Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -183,5 +184,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/mips/src/.gitignore
+++ b/arch/mips/src/.gitignore
@@ -1,3 +1,4 @@
+/.depend
 /Make.dep
 /board
 /chip

--- a/arch/mips/src/Makefile
+++ b/arch/mips/src/Makefile
@@ -160,14 +160,15 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-Make.dep: Makefile chip/Make.defs $(SRCS)
+.depend: Makefile chip/Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -181,5 +182,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/misoc/src/.gitignore
+++ b/arch/misoc/src/.gitignore
@@ -1,3 +1,4 @@
+/.depend
 /Make.dep
 /locked.r
 /board

--- a/arch/misoc/src/Makefile
+++ b/arch/misoc/src/Makefile
@@ -164,14 +164,15 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-Make.dep: Makefile chip/Make.defs $(SRCS)
+.depend: Makefile chip/Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -185,5 +186,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/or1k/src/.gitignore
+++ b/arch/or1k/src/.gitignore
@@ -1,3 +1,4 @@
+/.depend
 /Make.dep
 /locked.r
 /board

--- a/arch/or1k/src/Makefile
+++ b/arch/or1k/src/Makefile
@@ -202,14 +202,15 @@ endif
 
 # Dependencies
 
-Make.dep: Makefile chip$(DELIM)Make.defs $(SRCS)
+.depend: Makefile chip$(DELIM)Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) $(patsubst %,--dep-path %,$(subst :, ,$(VPATH))) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -225,5 +226,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/renesas/src/.gitignore
+++ b/arch/renesas/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/arch/renesas/src/Makefile
+++ b/arch/renesas/src/Makefile
@@ -169,13 +169,14 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-Make.dep: Makefile chip/Make.defs $(SRCS)
+.depend: Makefile chip/Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
-	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -189,5 +190,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/risc-v/src/.gitignore
+++ b/arch/risc-v/src/.gitignore
@@ -1,3 +1,4 @@
+/.depend
 /Make.dep
 /locked.r
 /board

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -199,14 +199,15 @@ endif
 
 # Dependencies
 
-Make.dep: Makefile $(SRCS)
+.depend: Makefile $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) $(patsubst %,--dep-path %,$(subst :, ,$(VPATH))) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) > $@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) > Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -223,6 +224,7 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 info:
 	@echo $(HEAD_OBJ)

--- a/arch/sim/src/.gitignore
+++ b/arch/sim/src/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /Cygwin-names.dat
 /Msys-names.dat
 /Linux-names.dat

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -310,13 +310,14 @@ export_startup: board/libboard$(LIBEXT) up_head.o $(HOSTOBJS)
 
 # Dependencies
 
-Make.dep: Makefile $(SRCS)
+.depend: Makefile $(SRCS)
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
 	fi
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 cleanrel:
 	$(Q) rm -f nuttx.rel $(HOSTOS)-names.dat
@@ -334,6 +335,7 @@ distclean: clean
 		$(MAKE) -C board TOPDIR="$(TOPDIR)" distclean ; \
 	fi
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 	$(call DELFILE, hostfs.h)
 	$(Q) rm -rf GNU
 

--- a/arch/x86/src/.gitignore
+++ b/arch/x86/src/.gitignore
@@ -1,3 +1,4 @@
 /chip
 /board
+/.depend
 /Make.dep

--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -168,14 +168,15 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-Make.dep: Makefile chip/Make.defs $(SRCS)
+.depend: Makefile chip/Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -189,5 +190,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/x86_64/src/.gitignore
+++ b/arch/x86_64/src/.gitignore
@@ -1,3 +1,4 @@
 /chip
 /board
+/.depend
 /Make.dep

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -157,14 +157,15 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-Make.dep: Makefile chip/Make.defs $(SRCS)
+.depend: Makefile chip/Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -178,5 +179,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/xtensa/src/.gitignore
+++ b/arch/xtensa/src/.gitignore
@@ -1,3 +1,4 @@
+/.depend
 /Make.dep
 /board
 /chip

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -161,14 +161,15 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-Make.dep: Makefile chip/Make.defs $(SRCS)
+.depend: Makefile chip/Make.defs $(SRCS)
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
-	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
@@ -182,5 +183,6 @@ ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/z16/src/.gitignore
+++ b/arch/z16/src/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /board
 /chip
 /nuttx.linkcmd

--- a/arch/z16/src/Makefile
+++ b/arch/z16/src/Makefile
@@ -133,7 +133,7 @@ nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT) nuttx.linkcmd
 	@echo "LD:  nuttx$(EXEEXT)"
 	$(Q) $(LD) $(LDFLAGS)
 
-Make.dep: Makefile chip/Make.defs $(DEPSRCS)
+.depend: Makefile chip/Make.defs $(DEPSRCS)
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" depend )
 else
@@ -141,7 +141,8 @@ else
 		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
 	fi
 endif
-	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >$@
+	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
+	$(Q) touch $@
 
 # This is part of the top-level export target
 
@@ -159,7 +160,7 @@ endif
 
 # Dependencies
 
-depend: Make.dep
+depend: .depend
 
 clean:
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
@@ -187,5 +188,6 @@ else
 	fi
 endif
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/z80/src/.gitignore
+++ b/arch/z80/src/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /up_mem.h
 /asm_mem.h
 /board

--- a/arch/z80/src/Makefile.sdccl
+++ b/arch/z80/src/Makefile.sdccl
@@ -208,13 +208,14 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Build dependencies
 
-Make.dep: Makefile asm_mem.h chip/Make.defs $(DEPSRCS)
+.depend: Makefile asm_mem.h chip/Make.defs $(DEPSRCS)
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
 	fi
-	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >$@
+	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(Q) if [ -e board/Makefile ]; then \
@@ -230,5 +231,6 @@ distclean: clean
 		$(MAKE) -C board TOPDIR="$(TOPDIR)" distclean ; \
 	fi
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/z80/src/Makefile.sdccw
+++ b/arch/z80/src/Makefile.sdccw
@@ -202,11 +202,12 @@ export_startup: board\libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Build dependencies
 
-Make.dep: Makefile asm_mem.h chip\Make.defs $(DEPSRCS)
+.depend: Makefile asm_mem.h chip\Make.defs $(DEPSRCS)
 	$(Q) if exist board\Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" depend )
-	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >$@
+	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(Q) if exist board\Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" clean )
@@ -218,5 +219,6 @@ clean:
 distclean: clean
 	$(Q) if exist board\Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean )
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/z80/src/Makefile.zdsiil
+++ b/arch/z80/src/Makefile.zdsiil
@@ -139,11 +139,12 @@ nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) nuttx.linkcmd
 	@echo "LD:  nuttx$(EXEEXT)"
 	$(Q) "$(LD)" $(LDFLAGS)
 
-Make.dep: Makefile chip$(DELIM)Make.defs $(DEPSRCS)
+.depend: Makefile chip$(DELIM)Make.defs $(DEPSRCS)
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
 		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
 	fi
-	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >$@
+	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
+	$(Q) touch $@
 
 # This is part of the top-level export target
 
@@ -157,7 +158,7 @@ export_startup: board$(DELIM)libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
@@ -175,5 +176,6 @@ distclean: clean
 		$(MAKE) -C board TOPDIR="$(TOPDIR)" distclean ; \
 	fi
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/arch/z80/src/Makefile.zdsiiw
+++ b/arch/z80/src/Makefile.zdsiiw
@@ -128,9 +128,10 @@ nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) nuttx.linkcmd
 	@echo "LD:  nuttx$(EXEEXT)"
 	$(Q) "$(LD)" $(LDFLAGS)
 
-Make.dep: Makefile chip$(DELIM)Make.defs $(DEPSRCS)
+.depend: Makefile chip$(DELIM)Make.defs $(DEPSRCS)
 	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" depend )
-	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >$@
+	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
+	$(Q) touch $@
 
 # This is part of the top-level export target
 
@@ -139,7 +140,7 @@ export_startup: board$(DELIM)libboard$(LIBEXT) $(STARTUP_OBJS)
 
 # Dependencies
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" clean )
@@ -153,5 +154,6 @@ clean:
 distclean: clean
 	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean )
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/audio/.gitignore
+++ b/audio/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/audio/Makefile
+++ b/audio/Makefile
@@ -77,10 +77,11 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -88,5 +89,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/binfmt/.gitignore
+++ b/binfmt/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.src
 /*.obj
 /*.asm

--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -92,10 +92,11 @@ $(BINFMT_COBJS): %$(OBJEXT): %.c
 $(BIN): $(BINFMT_OBJS)
 	$(call ARCHIVE, $@, $(BINFMT_OBJS))
 
-Make.dep: Makefile $(BINFMT_SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(BINFMT_SRCS) >$@
+.depend: Makefile $(BINFMT_SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(BINFMT_SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -103,5 +104,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/boards/.gitignore
+++ b/boards/.gitignore
@@ -1,3 +1,4 @@
+.depend
 Make.dep
 *.o
 *.a
@@ -12,6 +13,7 @@ core
 .cproject
 cscope.out
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -119,17 +119,18 @@ ifneq ($(CXXOBJS),)
 	$(call ARCHIVE, $@, $(CXXOBJS))
 endif
 
-Make.dep: Makefile $(SRCS) $(CXXSRCS)
+.depend: Makefile $(SRCS) $(CXXSRCS)
 ifneq ($(ZDSVERSION),)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
 else
-	$(Q) $(MKDEP) $(DEPPATH) $(CC) -- $(CFLAGS) -- $(SRCS) >$@
+	$(Q) $(MKDEP) $(DEPPATH) $(CC) -- $(CFLAGS) -- $(SRCS) >Make.dep
 endif
 ifneq ($(CXXSRCS),)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(CXXSRCS) >>$@
+	$(Q) $(MKDEP) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(CXXSRCS) >>Make.dep
 endif
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 ifneq ($(BOARD_CONTEXT),y)
 context:
@@ -142,6 +143,7 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 	$(EXTRA_DISTCLEAN)
 
 -include Make.dep

--- a/boards/Makefile
+++ b/boards/Makefile
@@ -103,15 +103,16 @@ $(CXXOBJS): %$(OBJEXT): %.cxx
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
+.depend: Makefile $(SRCS)
 ifneq ($(SRCS),)
-	$(Q) $(MKDEP) --dep-path . "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	$(Q) $(MKDEP) --dep-path . "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
 endif
 ifneq ($(CXXSRCS),)
-	$(Q) $(MKDEP) --dep-path . "$(CXX)" -- $(CXXFLAGS) -- $(CXXSRCS) >>$@
+	$(Q) $(MKDEP) --dep-path . "$(CXX)" -- $(CXXFLAGS) -- $(CXXSRCS) >>Make.dep
 endif
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 $(DUMMY_KCONFIG): $(BOARD_KCONFIG)
 	$(call DELFILE, $(DUMMY_KCONFIG))
@@ -133,5 +134,6 @@ clean: clean_context
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/boards/arm/c5471/c5471evm/src/.gitignore
+++ b/boards/arm/c5471/c5471evm/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/cxd56xx/spresense/src/.gitignore
+++ b/boards/arm/cxd56xx/spresense/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/dm320/ntosd-dm320/src/.gitignore
+++ b/boards/arm/dm320/ntosd-dm320/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/efm32/efm32-g8xx-stk/src/.gitignore
+++ b/boards/arm/efm32/efm32-g8xx-stk/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/efm32/efm32gg-stk3700/src/.gitignore
+++ b/boards/arm/efm32/efm32gg-stk3700/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/efm32/olimex-efm32g880f128-stk/src/.gitignore
+++ b/boards/arm/efm32/olimex-efm32g880f128-stk/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/imxrt/imxrt1020-evk/.gitignore
+++ b/boards/arm/imxrt/imxrt1020-evk/.gitignore
@@ -1,1 +1,3 @@
+/.depend
 /Make.dep
+src/.depend

--- a/boards/arm/imxrt/imxrt1050-evk/kernel/Makefile
+++ b/boards/arm/imxrt/imxrt1050-evk/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/imxrt/imxrt1060-evk/kernel/Makefile
+++ b/boards/arm/imxrt/imxrt1060-evk/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/kinetis/freedom-k28f/src/.gitignore
+++ b/boards/arm/kinetis/freedom-k28f/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/kinetis/kwikstik-k40/src/.gitignore
+++ b/boards/arm/kinetis/kwikstik-k40/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/kinetis/teensy-3.x/src/.gitignore
+++ b/boards/arm/kinetis/teensy-3.x/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/kinetis/twr-k60n512/src/.gitignore
+++ b/boards/arm/kinetis/twr-k60n512/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/kl/freedom-kl25z/src/.gitignore
+++ b/boards/arm/kl/freedom-kl25z/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/kl/freedom-kl26z/src/.gitignore
+++ b/boards/arm/kl/freedom-kl26z/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/kl/teensy-lc/src/.gitignore
+++ b/boards/arm/kl/teensy-lc/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lc823450/lc823450-xgevk/kernel/Makefile
+++ b/boards/arm/lc823450/lc823450-xgevk/kernel/Makefile
@@ -111,7 +111,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) -n nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/lpc17xx_40xx/lincoln60/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/lincoln60/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/kernel/Makefile
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/kernel/Makefile
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/lpcxpresso-lpc1768/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/lpcxpresso-lpc1768/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/lx_cpu/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/mbed/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/mbed/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/mcb1700/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/mcb1700/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/open1788/kernel/Makefile
+++ b/boards/arm/lpc17xx_40xx/open1788/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/lpc17xx_40xx/open1788/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/open1788/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/pnev5180b/kernel/Makefile
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/kernel/Makefile
@@ -114,7 +114,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/lpc17xx_40xx/pnev5180b/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/u-blox-c027/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/u-blox-c027/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc17xx_40xx/zkit-arm-1769/src/.gitignore
+++ b/boards/arm/lpc17xx_40xx/zkit-arm-1769/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc214x/mcu123-lpc214x/src/.gitignore
+++ b/boards/arm/lpc214x/mcu123-lpc214x/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc214x/zp214xpa/src/.gitignore
+++ b/boards/arm/lpc214x/zp214xpa/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc2378/olimex-lpc2378/src/.gitignore
+++ b/boards/arm/lpc2378/olimex-lpc2378/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc31xx/ea3131/locked/Makefile
+++ b/boards/arm/lpc31xx/ea3131/locked/Makefile
@@ -97,7 +97,9 @@ locked.r: ld-locked.inc $(PASS1_LIBBOARD)
 $(PASS1_SRCDIR)$(DELIM)locked.r: locked.r
 	$(Q) cp -a locked.r $(TOPDIR)$(DELIM)$(PASS1_SRCDIR)$(DELIM)locked.r
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, locked.r)

--- a/boards/arm/lpc31xx/ea3131/src/.gitignore
+++ b/boards/arm/lpc31xx/ea3131/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc31xx/ea3152/src/.gitignore
+++ b/boards/arm/lpc31xx/ea3152/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc31xx/olimex-lpc-h3131/src/.gitignore
+++ b/boards/arm/lpc31xx/olimex-lpc-h3131/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc43xx/bambino-200e/kernel/Makefile
+++ b/boards/arm/lpc43xx/bambino-200e/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/lpc43xx/bambino-200e/src/.gitignore
+++ b/boards/arm/lpc43xx/bambino-200e/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc43xx/lpc4330-xplorer/src/.gitignore
+++ b/boards/arm/lpc43xx/lpc4330-xplorer/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc43xx/lpc4337-ws/src/.gitignore
+++ b/boards/arm/lpc43xx/lpc4337-ws/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc43xx/lpc4357-evb/src/.gitignore
+++ b/boards/arm/lpc43xx/lpc4357-evb/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/lpc43xx/lpc4370-link2/src/.gitignore
+++ b/boards/arm/lpc43xx/lpc4370-link2/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/nrf52/nrf52-feather/src/.gitignore
+++ b/boards/arm/nrf52/nrf52-feather/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/nrf52/nrf52832-dk/src/.gitignore
+++ b/boards/arm/nrf52/nrf52832-dk/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/nrf52/nrf52840-dk/src/.gitignore
+++ b/boards/arm/nrf52/nrf52840-dk/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/nrf52/nrf52840-dongle/src/.gitignore
+++ b/boards/arm/nrf52/nrf52840-dongle/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/nuc1xx/nutiny-nuc120/src/.gitignore
+++ b/boards/arm/nuc1xx/nutiny-nuc120/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/s32k1xx/rddrone-uavcan144/src/.gitignore
+++ b/boards/arm/s32k1xx/rddrone-uavcan144/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/s32k1xx/rddrone-uavcan146/src/.gitignore
+++ b/boards/arm/s32k1xx/rddrone-uavcan146/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/s32k1xx/s32k118evb/src/.gitignore
+++ b/boards/arm/s32k1xx/s32k118evb/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/s32k1xx/s32k144evb/src/.gitignore
+++ b/boards/arm/s32k1xx/s32k144evb/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/s32k1xx/s32k146evb/src/.gitignore
+++ b/boards/arm/s32k1xx/s32k146evb/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/s32k1xx/s32k148evb/src/.gitignore
+++ b/boards/arm/s32k1xx/s32k148evb/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/sam34/arduino-due/src/.gitignore
+++ b/boards/arm/sam34/arduino-due/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/sam34/flipnclick-sam3x/src/.gitignore
+++ b/boards/arm/sam34/flipnclick-sam3x/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/sam34/sam3u-ek/kernel/Makefile
+++ b/boards/arm/sam34/sam3u-ek/kernel/Makefile
@@ -103,7 +103,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/sam34/sam3u-ek/src/.gitignore
+++ b/boards/arm/sam34/sam3u-ek/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/sam34/sam4e-ek/src/.gitignore
+++ b/boards/arm/sam34/sam4e-ek/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/sam34/sam4l-xplained/src/.gitignore
+++ b/boards/arm/sam34/sam4l-xplained/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/samd2l2/arduino-m0/src/.gitignore
+++ b/boards/arm/samd2l2/arduino-m0/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/samd2l2/samd20-xplained/src/.gitignore
+++ b/boards/arm/samd2l2/samd20-xplained/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/samd2l2/samd21-xplained/src/.gitignore
+++ b/boards/arm/samd2l2/samd21-xplained/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/samd2l2/saml21-xplained/src/.gitignore
+++ b/boards/arm/samd2l2/saml21-xplained/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/samv7/same70-xplained/kernel/Makefile
+++ b/boards/arm/samv7/same70-xplained/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/samv7/samv71-xult/kernel/Makefile
+++ b/boards/arm/samv7/samv71-xult/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32/axoloti/src/.gitignore
+++ b/boards/arm/stm32/axoloti/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/clicker2-stm32/kernel/Makefile
+++ b/boards/arm/stm32/clicker2-stm32/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32/clicker2-stm32/src/.gitignore
+++ b/boards/arm/stm32/clicker2-stm32/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/cloudctrl/src/.gitignore
+++ b/boards/arm/stm32/cloudctrl/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/fire-stm32v2/src/.gitignore
+++ b/boards/arm/stm32/fire-stm32v2/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/hymini-stm32v/src/.gitignore
+++ b/boards/arm/stm32/hymini-stm32v/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/mikroe-stm32f4/kernel/Makefile
+++ b/boards/arm/stm32/mikroe-stm32f4/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32/mikroe-stm32f4/src/.gitignore
+++ b/boards/arm/stm32/mikroe-stm32f4/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/nucleo-f446re/src/.gitignore
+++ b/boards/arm/stm32/nucleo-f446re/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/olimex-stm32-h407/src/.gitignore
+++ b/boards/arm/stm32/olimex-stm32-h407/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/olimex-stm32-p107/src/.gitignore
+++ b/boards/arm/stm32/olimex-stm32-p107/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/olimex-stm32-p407/kernel/Makefile
+++ b/boards/arm/stm32/olimex-stm32-p407/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32/olimexino-stm32/src/.gitignore
+++ b/boards/arm/stm32/olimexino-stm32/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/omnibusf4/kernel/Makefile
+++ b/boards/arm/stm32/omnibusf4/kernel/Makefile
@@ -111,7 +111,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32/omnibusf4/src/.gitignore
+++ b/boards/arm/stm32/omnibusf4/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/shenzhou/src/.gitignore
+++ b/boards/arm/stm32/shenzhou/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm3210e-eval/src/.gitignore
+++ b/boards/arm/stm32/stm3210e-eval/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm3220g-eval/src/.gitignore
+++ b/boards/arm/stm32/stm3220g-eval/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm3240g-eval/kernel/Makefile
+++ b/boards/arm/stm32/stm3240g-eval/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32/stm3240g-eval/src/.gitignore
+++ b/boards/arm/stm32/stm3240g-eval/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm32_tiny/src/.gitignore
+++ b/boards/arm/stm32/stm32_tiny/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm32f103-minimum/src/.gitignore
+++ b/boards/arm/stm32/stm32f103-minimum/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm32f3discovery/src/.gitignore
+++ b/boards/arm/stm32/stm32f3discovery/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm32f429i-disco/src/.gitignore
+++ b/boards/arm/stm32/stm32f429i-disco/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm32f4discovery/kernel/Makefile
+++ b/boards/arm/stm32/stm32f4discovery/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32/stm32f4discovery/src/.gitignore
+++ b/boards/arm/stm32/stm32f4discovery/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm32ldiscovery/src/.gitignore
+++ b/boards/arm/stm32/stm32ldiscovery/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/stm32vldiscovery/src/.gitignore
+++ b/boards/arm/stm32/stm32vldiscovery/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32/viewtool-stm32f107/src/.gitignore
+++ b/boards/arm/stm32/viewtool-stm32f107/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32f0l0g0/nucleo-f072rb/src/.gitignore
+++ b/boards/arm/stm32f0l0g0/nucleo-f072rb/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32f0l0g0/nucleo-f091rc/src/.gitignore
+++ b/boards/arm/stm32f0l0g0/nucleo-f091rc/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32f0l0g0/stm32f051-discovery/src/.gitignore
+++ b/boards/arm/stm32f0l0g0/stm32f051-discovery/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32f0l0g0/stm32f072-discovery/src/.gitignore
+++ b/boards/arm/stm32f0l0g0/stm32f072-discovery/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32f7/nucleo-144/src/.gitignore
+++ b/boards/arm/stm32f7/nucleo-144/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32f7/stm32f746-ws/src/.gitignore
+++ b/boards/arm/stm32f7/stm32f746-ws/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32f7/stm32f746g-disco/kernel/Makefile
+++ b/boards/arm/stm32f7/stm32f746g-disco/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32f7/stm32f746g-disco/src/.gitignore
+++ b/boards/arm/stm32f7/stm32f746g-disco/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32f7/stm32f769i-disco/kernel/Makefile
+++ b/boards/arm/stm32f7/stm32f769i-disco/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32f7/stm32f769i-disco/src/.gitignore
+++ b/boards/arm/stm32f7/stm32f769i-disco/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32h7/nucleo-h743zi/kernel/Makefile
+++ b/boards/arm/stm32h7/nucleo-h743zi/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32h7/nucleo-h743zi/src/.gitignore
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32h7/stm32h747i-disco/kernel/Makefile
+++ b/boards/arm/stm32h7/stm32h747i-disco/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32h7/stm32h747i-disco/src/.gitignore
+++ b/boards/arm/stm32h7/stm32h747i-disco/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32l4/b-l475e-iot01a/src/.gitignore
+++ b/boards/arm/stm32l4/b-l475e-iot01a/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32l4/nucleo-l452re/src/.gitignore
+++ b/boards/arm/stm32l4/nucleo-l452re/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32l4/nucleo-l496zg/src/.gitignore
+++ b/boards/arm/stm32l4/nucleo-l496zg/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/stm32l4/stm32l476vg-disco/kernel/Makefile
+++ b/boards/arm/stm32l4/stm32l476vg-disco/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/kernel/Makefile
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/kernel/Makefile
@@ -109,7 +109,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/src/.gitignore
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/str71x/olimex-strp711/src/.gitignore
+++ b/boards/arm/str71x/olimex-strp711/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/dk-tm4c129x/src/.gitignore
+++ b/boards/arm/tiva/dk-tm4c129x/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/eagle100/src/.gitignore
+++ b/boards/arm/tiva/eagle100/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/ekk-lm3s9b96/src/.gitignore
+++ b/boards/arm/tiva/ekk-lm3s9b96/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/lm3s6432-s2e/src/.gitignore
+++ b/boards/arm/tiva/lm3s6432-s2e/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/lm3s6965-ek/kernel/Makefile
+++ b/boards/arm/tiva/lm3s6965-ek/kernel/Makefile
@@ -94,7 +94,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/arm/tiva/lm3s6965-ek/src/.gitignore
+++ b/boards/arm/tiva/lm3s6965-ek/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/lm3s8962-ek/src/.gitignore
+++ b/boards/arm/tiva/lm3s8962-ek/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/lm4f120-launchpad/src/.gitignore
+++ b/boards/arm/tiva/lm4f120-launchpad/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/tm4c123g-launchpad/src/.gitignore
+++ b/boards/arm/tiva/tm4c123g-launchpad/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/arm/tiva/tm4c1294-launchpad/src/.gitignore
+++ b/boards/arm/tiva/tm4c1294-launchpad/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/avr/at32uc3/avr32dev1/src/.gitignore
+++ b/boards/avr/at32uc3/avr32dev1/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/avr/at90usb/micropendous3/src/.gitignore
+++ b/boards/avr/at90usb/micropendous3/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/avr/at90usb/teensy-2.0/src/.gitignore
+++ b/boards/avr/at90usb/teensy-2.0/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/avr/atmega/amber/src/.gitignore
+++ b/boards/avr/atmega/amber/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/avr/atmega/arduino-mega2560/src/Makefile
+++ b/boards/avr/atmega/arduino-mega2560/src/Makefile
@@ -81,10 +81,11 @@ $(COBJS) $(LINKOBJS): %$(OBJEXT): %.c
 libboard$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 context:
 
@@ -94,5 +95,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/boards/avr/atmega/moteino-mega/src/.gitignore
+++ b/boards/avr/atmega/moteino-mega/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/hc/m9s12/demo9s12ne64/src/.gitignore
+++ b/boards/hc/m9s12/demo9s12ne64/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/hc/m9s12/ne64badge/src/.gitignore
+++ b/boards/hc/m9s12/ne64badge/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/mips/pic32mx/mirtoo/src/.gitignore
+++ b/boards/mips/pic32mx/mirtoo/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/mips/pic32mx/pic32mx-starterkit/src/.gitignore
+++ b/boards/mips/pic32mx/pic32mx-starterkit/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/mips/pic32mx/pic32mx7mmb/src/.gitignore
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/mips/pic32mx/sure-pic32mx/src/.gitignore
+++ b/boards/mips/pic32mx/sure-pic32mx/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/mips/pic32mx/ubw32/src/.gitignore
+++ b/boards/mips/pic32mx/ubw32/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/mips/pic32mz/flipnclick-pic32mz/src/.gitignore
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/mips/pic32mz/pic32mz-starterkit/src/.gitignore
+++ b/boards/mips/pic32mz/pic32mz-starterkit/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/misoc/lm32/misoc/src/.gitignore
+++ b/boards/misoc/lm32/misoc/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/or1k/mor1kx/or1k/src/.gitignore
+++ b/boards/or1k/mor1kx/or1k/src/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /up_mem.h
 /*.sym
 /*.asm

--- a/boards/renesas/m16c/skp16c26/src/.gitignore
+++ b/boards/renesas/m16c/skp16c26/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/renesas/m16c/skp16c26/src/Makefile
+++ b/boards/renesas/m16c/skp16c26/src/Makefile
@@ -59,10 +59,11 @@ $(COBJS) $(LINKOBJS): %$(OBJEXT): %.c
 libboard$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 context:
 
@@ -72,5 +73,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/boards/renesas/rx65n/rx65n-grrose/src/Makefile
+++ b/boards/renesas/rx65n/rx65n-grrose/src/Makefile
@@ -46,10 +46,11 @@ $(COBJS) $(LINKOBJS): %$(OBJEXT): %.c
 libboard$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, libboard$(LIBEXT))
@@ -57,6 +58,7 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 ifneq ($(BOARD_CONTEXT),y)
 context:

--- a/boards/renesas/rx65n/rx65n-rsk1mb/src/Makefile
+++ b/boards/renesas/rx65n/rx65n-rsk1mb/src/Makefile
@@ -60,10 +60,11 @@ $(COBJS) $(LINKOBJS): %$(OBJEXT): %.c
 libboard$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, libboard$(LIBEXT))
@@ -71,6 +72,7 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 ifneq ($(BOARD_CONTEXT),y)
 context:

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/Makefile
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/Makefile
@@ -46,10 +46,11 @@ $(COBJS) $(LINKOBJS): %$(OBJEXT): %.c
 libboard$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, libboard$(LIBEXT))
@@ -57,6 +58,7 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 ifneq ($(BOARD_CONTEXT),y)
 context:

--- a/boards/renesas/rx65n/rx65n/src/Makefile
+++ b/boards/renesas/rx65n/rx65n/src/Makefile
@@ -61,10 +61,11 @@ $(COBJS) $(LINKOBJS): %$(OBJEXT): %.c
 libboard$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, libboard$(LIBEXT))
@@ -72,6 +73,7 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 ifneq ($(BOARD_CONTEXT),y)
 context:

--- a/boards/renesas/sh1/us7032evb1/src/.gitignore
+++ b/boards/renesas/sh1/us7032evb1/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/renesas/sh1/us7032evb1/src/Makefile
+++ b/boards/renesas/sh1/us7032evb1/src/Makefile
@@ -59,10 +59,11 @@ $(COBJS) $(LINKOBJS): %$(OBJEXT): %.c
 libboard$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(CC) -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, libboard$(LIBEXT))
@@ -70,5 +71,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/boards/risc-v/k210/maix-bit/kernel/Makefile
+++ b/boards/risc-v/k210/maix-bit/kernel/Makefile
@@ -94,7 +94,9 @@ $(TOPDIR)$(DELIM)User.map: nuttx_user.elf
 	$(Q) $(NM) -n nuttx_user.elf >$(TOPDIR)$(DELIM)User.map
 	$(Q) $(CROSSDEV)size nuttx_user.elf
 
-depend:
+.depend:
+
+depend: .depend
 
 clean:
 	$(call DELFILE, nuttx_user.elf)

--- a/boards/sim/sim/sim/src/.gitignore
+++ b/boards/sim/sim/sim/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/x86/qemu/qemu-i486/src/.gitignore
+++ b/boards/x86/qemu/qemu-i486/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/x86_64/intel64/qemu-intel64/src/.gitignore
+++ b/boards/x86_64/intel64/qemu-intel64/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/xtensa/esp32/esp32-core/src/.gitignore
+++ b/boards/xtensa/esp32/esp32-core/src/.gitignore
@@ -1,1 +1,2 @@
+/.depend
 /Make.dep

--- a/boards/z16/z16f/z16f2800100zcog/src/.gitignore
+++ b/boards/z16/z16f/z16f2800100zcog/src/.gitignore
@@ -1,2 +1,3 @@
 /Make.dep
+/.depend
 /*.obj

--- a/boards/z80/ez80/ez80f910200kitg/src/.gitignore
+++ b/boards/z80/ez80/ez80f910200kitg/src/.gitignore
@@ -1,2 +1,3 @@
 /Make.dep
+/.depend
 /*.obj

--- a/boards/z80/ez80/ez80f910200zco/src/.gitignore
+++ b/boards/z80/ez80/ez80f910200zco/src/.gitignore
@@ -1,2 +1,3 @@
 /Make.dep
+/.depend
 /*.obj

--- a/boards/z80/ez80/makerlisp/src/.gitignore
+++ b/boards/z80/ez80/makerlisp/src/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/boards/z80/ez80/z20x/src/.gitignore
+++ b/boards/z80/ez80/z20x/src/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/boards/z80/z180/p112/src/.gitignore
+++ b/boards/z80/z180/p112/src/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /up_mem.h
 /*.sym
 /*.asm

--- a/boards/z80/z8/z8encore000zco/src/.gitignore
+++ b/boards/z80/z8/z8encore000zco/src/.gitignore
@@ -1,2 +1,3 @@
 /Make.dep
+/.depend
 /*.obj

--- a/boards/z80/z8/z8f64200100kit/src/.gitignore
+++ b/boards/z80/z8/z8f64200100kit/src/.gitignore
@@ -1,2 +1,3 @@
 /Make.dep
+/.depend
 /*.obj

--- a/boards/z80/z80/z80sim/src/.gitignore
+++ b/boards/z80/z80/z80sim/src/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /up_mem.h
 /*.sym
 /*.asm

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -93,10 +93,13 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) --dep-path . "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+ifeq ($(CONFIG_CRYPTO),y)
+	$(Q) $(MKDEP) --dep-path . "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+endif
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -104,5 +107,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/drivers/.gitignore
+++ b/drivers/.gitignore
@@ -1,5 +1,6 @@
 /platform
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -128,10 +128,11 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -139,5 +140,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/fs/.gitignore
+++ b/fs/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -99,10 +99,11 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN):	$(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -110,5 +111,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/graphics/.gitignore
+++ b/graphics/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/graphics/Makefile
+++ b/graphics/Makefile
@@ -132,10 +132,11 @@ $(BIN): $(OBJS)
 
 mklibgraphics: $(BIN)
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: gensources Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean_context:
 	$(Q) $(MAKE) -C nxglib -f Makefile.devblit distclean TOPDIR=$(TOPDIR) EXTRADEFINES=$(EXTRADEFINES)
@@ -153,5 +154,6 @@ clean:
 
 distclean: clean clean_context
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/graphics/nxmu/.gitignore
+++ b/graphics/nxmu/.gitignore
@@ -1,4 +1,5 @@
 Make.dep
+.depend
 *.swp
 *.asm
 *.rel

--- a/libs/libc/zoneinfo/Makefile
+++ b/libs/libc/zoneinfo/Makefile
@@ -132,10 +132,11 @@ context: .tzbuilt romfs
 
 # Create dependencies
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(ROOTDEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, .built)
@@ -143,6 +144,7 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 	$(call DELFILE, .tzunpack)
 	$(call DELFILE, .tzbuilt)
 	$(call DELFILE, romfs_zoneinfo.img)

--- a/libs/libdsp/Makefile
+++ b/libs/libdsp/Makefile
@@ -72,10 +72,11 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -83,5 +84,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/libs/libxx/.gitignore
+++ b/libs/libxx/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /uClibc++
 /libcxx
 /*.asm

--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -104,10 +104,11 @@ $(CXXOBJS): %$(OBJEXT): %.cxx
 $(BIN):	$(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -115,5 +116,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/net/.gitignore
+++ b/net/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/net/Makefile
+++ b/net/Makefile
@@ -104,10 +104,13 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+ifeq ($(CONFIG_NET),y)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+endif
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -115,5 +118,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/openamp/Makefile
+++ b/openamp/Makefile
@@ -66,10 +66,11 @@ $(BIN): $(OBJS)
 
 dirlinks::
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(foreach obj,$(OBJS),$(call DELFILE, $(obj)))
@@ -78,5 +79,6 @@ clean:
 
 distclean:: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/pass1/.gitignore
+++ b/pass1/.gitignore
@@ -1,5 +1,6 @@
 /*.c
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/pass1/Makefile
+++ b/pass1/Makefile
@@ -67,10 +67,11 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -78,6 +79,7 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 	$(call DELFILE, *.c)
 	$(call DELFILE, *.S)
 

--- a/sched/.gitignore
+++ b/sched/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/sched/Makefile
+++ b/sched/Makefile
@@ -79,10 +79,11 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -90,5 +91,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/syscall/.gitignore
+++ b/syscall/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /.context
 /*.asm
 /*.obj

--- a/syscall/Makefile
+++ b/syscall/Makefile
@@ -79,11 +79,12 @@ $(BIN1): $(PROXY_OBJS)
 $(BIN2): $(STUB_OBJS)
 	$(call ARCHIVE, $@, $(STUB_OBJS))
 
-Make.dep: Makefile $(SRCS)
+.depend: Makefile $(SRCS)
 	$(Q) $(MKDEP) $(ROOTDEPPATH) $(PROXYDEPPATH) $(STUBDEPPATH) \
-	  "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+	  "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 .context: syscall.csv
 	$(Q) $(MAKE) -C $(TOPDIR)$(DELIM)tools -f Makefile.host mksyscall
@@ -105,6 +106,7 @@ endif
 distclean: clean
 	$(call DELFILE, .context)
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 	$(call DELFILE, proxies$(DELIM)*.c)
 	$(call DELFILE, stubs$(DELIM)*.c)
 

--- a/video/Makefile
+++ b/video/Makefile
@@ -63,10 +63,11 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN):	$(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -74,5 +75,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep

--- a/wireless/.gitignore
+++ b/wireless/.gitignore
@@ -1,4 +1,5 @@
 /Make.dep
+/.depend
 /*.asm
 /*.obj
 /*.rel

--- a/wireless/Makefile
+++ b/wireless/Makefile
@@ -74,10 +74,11 @@ $(COBJS): %$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-Make.dep: Makefile $(SRCS)
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >$@
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
 
-depend: Make.dep
+depend: .depend
 
 clean:
 	$(call DELFILE, $(BIN))
@@ -85,5 +86,6 @@ clean:
 
 distclean: clean
 	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
 
 -include Make.dep


### PR DESCRIPTION
This reverts commit 79af7fbf4ef0185fa501e23a900a2ad933f845a7.

Because:
    
* btashton reported some issues in local builds:
    
  https://github.com/apache/incubator-nuttx/pull/603#issuecomment-602264860
    
* this might be related to the current CI breakage:
    
  > /bin/sh: 1: /__w/incubator-nuttx/incubator-nuttx/nuttx/tools/mkdeps: not found
