### PR TITLE
Run CI using image built in incubator-nuttx-testing and enable esp32 build

### DIFF
--- a/.github/actions/ci-container/action.yaml
+++ b/.github/actions/ci-container/action.yaml
@@ -1,3 +1,16 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: ci-container
 runs:
   using: 'docker'

--- a/.github/actions/ci-container/action.yaml
+++ b/.github/actions/ci-container/action.yaml
@@ -1,0 +1,7 @@
+name: ci-container
+runs:
+  using: 'docker'
+  image: 'docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux'
+  args:
+    - "-c"
+    - ${{ inputs.run }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, arm-14, arm-15, mips-riscv-x86, sim, xtensa]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, arm-14, arm-15, mips-riscv-x86-xtensa, sim]
     steps:
     - name: Checkout nuttx repo
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ on:
 jobs:
   check:
     runs-on: ubuntu-18.04
-    container: liuguo09/ubuntu-nuttx:18.04
 
     steps:
     - name: Checkout nuttx repo
@@ -60,12 +59,12 @@ jobs:
 
   build:
     runs-on: ubuntu-18.04
-    container: liuguo09/ubuntu-nuttx:18.04
+    env:
+      DOCKER_BUILDKIT: 1
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, arm-14, arm-15, mips-riscv-x86, sim]
-
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, arm-14, arm-15, mips-riscv-x86, sim, xtensa]
     steps:
     - name: Checkout nuttx repo
       uses: actions/checkout@v2
@@ -91,7 +90,21 @@ jobs:
         repository: apache/incubator-nuttx-testing
         path: testing
 
+    - name: Docker Login
+      uses: azure/docker-login@v1
+      with:
+        login-server: docker.pkg.github.com
+        username: ${GITHUB_ACTOR}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Run Pull Container
+      uses: ./nuttx/.github/actions/ci-container
+
     - name: Run builds
-      run: |
-        cd testing
-        ./cibuild.sh -x testlist/${{matrix.boards}}.dat
+      uses: ./nuttx/.github/actions/ci-container
+      env:
+        BLOBDIR: /tools/blobs
+      with:
+        run: |
+          cd testing
+          ./cibuild.sh -x testlist/${{matrix.boards}}.dat


### PR DESCRIPTION
This updates the GitHub action to use the container that is built by incubator-nuttx-testing.  It also update the ESP32 postbuild step to have the binary blob path be configurable making it easier to use pre-built files rather than expecting the whole esp-idf project to be available.

This does require this PR to be merged first apache/incubator-nuttx-testing#20
