### PR TITLE
tools/sethost.sh & tools/configure.c: When no make argument is passed, silence make output.

### DIFF
--- a/tools/configure.c
+++ b/tools/configure.c
@@ -380,12 +380,25 @@ static void parse_args(int argc, char **argv)
 static int run_make(const char *arg)
 {
   char **argv;
+  bool v1 = false;
 
   snprintf(g_buffer, BUFFER_SIZE, "make %s", arg);
+
   for (argv = g_makeargv; *argv; argv++)
     {
-      strncat(g_buffer, " ", BUFFER_SIZE);
-      strncat(g_buffer, *argv, BUFFER_SIZE);
+      strncat(g_buffer, " ", BUFFER_SIZE - 1);
+      strncat(g_buffer, *argv, BUFFER_SIZE - 1);
+      if (strcmp(*argv, "V=1") == 0)
+        {
+          v1 = true;
+        }
+    }
+
+  if (!v1)
+    {
+#ifndef WIN32
+      strncat(g_buffer, " 1>/dev/null", BUFFER_SIZE - 1);
+#endif
     }
 
   return system(g_buffer);
@@ -644,7 +657,7 @@ static void config_search(const char *boarddir,
 
           /* Make a modifiable copy */
 
-          strncpy(g_buffer, boarddir, BUFFER_SIZE);
+          strncpy(g_buffer, boarddir, BUFFER_SIZE - 1);
 
           /* Save the <archdir> */
 

--- a/tools/sethost.sh
+++ b/tools/sethost.sh
@@ -122,7 +122,7 @@ fi
 if [ -x tools/sethost.sh ]; then
   nuttx=$PWD
 else
-  echo "This script must be execute in nuttx/ or nutts/tools directories"
+  echo "This script must be execute in nuttx/ or nuttx/tools directories"
   exit 1
 fi
 
@@ -211,4 +211,9 @@ fi
 sed -i -e "/CONFIG_HOST_OTHER/d" $nuttx/.config
 
 echo "  Refreshing..."
-make olddefconfig $* || { echo "ERROR: failed to refresh"; exit 1; }
+
+if grep -q "V=1" <<< "$*" ; then
+  make olddefconfig $* || { echo "ERROR: failed to refresh"; exit 1; }
+else
+  make olddefconfig $* 1>/dev/null || { echo "ERROR: failed to refresh"; exit 1; }
+fi


### PR DESCRIPTION
With -d option removed in a previous PR, sethost.sh (and configure.c) always print make output, sometimes important information get lost in the middle of all that output.
If this one gets merged I guess #605  will be redundant.