### PR TITLE
Revert "tools/testbuild.sh: suppress lots of stdout log from configur…

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -157,7 +157,7 @@ function distclean {
 
 function configure {
   echo "  Configuring..."
-  ./tools/configure.sh ${HOPTION} $config 1>/dev/null
+  ./tools/configure.sh ${HOPTION} $config
 
   if [ "X$toolchain" != "X" ]; then
     setting=`grep _TOOLCHAIN_ $nuttx/.config | grep -v CONFIG_ARCH_TOOLCHAIN_* | grep =y`


### PR DESCRIPTION
…e.sh"

https://github.com/apache/incubator-nuttx/pull/615 f6fc87bc3677b7d733ae371cfecdb740821432ad commit silence configure.sh
make output defautly, so revert it.

This reverts commit f0267aff33d52363372a055b2d21ad975ac0abb3.