### PR TITLE
arch/arm: Fix linker error: undefined reference to `g_intstackalloc'

### DIFF
--- a/arch/arm/src/common/up_checkstack.c
+++ b/arch/arm/src/common/up_checkstack.c
@@ -211,9 +211,15 @@ ssize_t up_check_stack_remain(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
+#ifdef CONFIG_SMP
+  return do_stackcheck(up_intstack_base(),
+                       (CONFIG_ARCH_INTERRUPTSTACK & ~3),
+                       true);
+#else
   return do_stackcheck((uintptr_t)&g_intstackalloc,
                        (CONFIG_ARCH_INTERRUPTSTACK & ~3),
                        true);
+#endif
 }
 
 size_t up_check_intstack_remain(void)

--- a/arch/arm/src/common/up_checkstack.c
+++ b/arch/arm/src/common/up_checkstack.c
@@ -140,7 +140,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
       int j;
 
       ptr = (FAR uint32_t *)start;
-      for (i = 0; i < size; i += 4*64)
+      for (i = 0; i < size; i += 4 * 64)
         {
           for (j = 0; j < 64; j++)
             {

--- a/arch/arm/src/common/up_initialize.c
+++ b/arch/arm/src/common/up_initialize.c
@@ -75,7 +75,11 @@
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
 static inline void up_color_intstack(void)
 {
+#ifdef CONFIG_SMP
+  uint32_t *ptr = (uint32_t *)up_intstack_base();
+#else
   uint32_t *ptr = (uint32_t *)&g_intstackalloc;
+#endif
   ssize_t size;
 
   for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);

--- a/arch/arm/src/common/up_initialize.c
+++ b/arch/arm/src/common/up_initialize.c
@@ -139,8 +139,8 @@ void up_initialize(void)
 #endif
 
 #ifdef CONFIG_ARCH_DMA
-  /* Initialize the DMA subsystem if the weak function up_dma_initialize has been
-   * brought into the build
+  /* Initialize the DMA subsystem if the weak function up_dma_initialize has
+   * been brought into the build
    */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS

--- a/arch/arm/src/imx6/Make.defs
+++ b/arch/arm/src/imx6/Make.defs
@@ -75,6 +75,10 @@ CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_syscall.c
 CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c
 
+ifeq ($(CONFIG_ARM_SEMIHOSTING_HOSTFS),y)
+CMN_CSRCS += up_hostfs.c
+endif
+
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += imx_idle.c
 endif


### PR DESCRIPTION
when CONFIG_ARCH_INTERRUPTSTACK, CONFIG_SMP and CONFIG_STACK_COLORATION are true

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>