### PR TITLE
Revert "Makefile: move INCDIROPT to common place (#625)"

### DIFF
--- a/audio/Makefile
+++ b/audio/Makefile
@@ -36,6 +36,10 @@
 -include $(TOPDIR)/Make.defs
 DELIM ?= $(strip /)
 
+ifeq ($(WINTOOL),y)
+INCDIROPT = -w
+endif
+
 DEPPATH = --dep-path .
 ASRCS =
 CSRCS = audio.c

--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -37,7 +37,10 @@
 -include $(TOPDIR)/Make.defs
 DELIM ?= $(strip /)
 
-CFLAGS += ${shell $(INCDIR) "$(CC)" "$(TOPDIR)$(DELIM)sched"}
+ifeq ($(WINTOOL),y)
+INCDIROPT = -w
+endif
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" "$(TOPDIR)$(DELIM)sched"}
 
 # Basic BINFMT source files
 

--- a/boards/arm/cxd56xx/common/src/Make.defs
+++ b/boards/arm/cxd56xx/common/src/Make.defs
@@ -157,4 +157,4 @@ endif
 
 DEPPATH += --dep-path src
 VPATH += :src
-CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)
+CFLAGS += $(shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)

--- a/boards/arm/cxd56xx/drivers/audio/Make.defs
+++ b/boards/arm/cxd56xx/drivers/audio/Make.defs
@@ -53,4 +53,4 @@ endif
 
 DEPPATH += --dep-path platform$(DELIM)audio
 VPATH += :platform$(DELIM)audio
-CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)platform$(DELIM)audio)
+CFLAGS += $(shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)platform$(DELIM)audio)

--- a/boards/arm/cxd56xx/drivers/camera/Make.defs
+++ b/boards/arm/cxd56xx/drivers/camera/Make.defs
@@ -24,4 +24,4 @@ endif
 
 DEPPATH += --dep-path platform$(DELIM)camera
 VPATH += :platform$(DELIM)camera
-CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)platform$(DELIM)camera)
+CFLAGS += $(shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)platform$(DELIM)camera)

--- a/boards/arm/cxd56xx/drivers/sensors/Make.defs
+++ b/boards/arm/cxd56xx/drivers/sensors/Make.defs
@@ -79,4 +79,4 @@ endif
 
 DEPPATH += --dep-path platform$(DELIM)sensors
 VPATH += :platform$(DELIM)sensors
-CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)platform$(DELIM)sensors)
+CFLAGS += $(shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)platform$(DELIM)sensors)

--- a/boards/arm/cxd56xx/spresense/src/Make.defs
+++ b/boards/arm/cxd56xx/spresense/src/Make.defs
@@ -91,4 +91,4 @@ endif
 
 DEPPATH += --dep-path board
 VPATH += :board
-CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)board)
+CFLAGS += $(shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)board)

--- a/drivers/1wire/Make.defs
+++ b/drivers/1wire/Make.defs
@@ -45,5 +45,5 @@ endif
 
 DEPPATH += --dep-path 1wire
 VPATH += :1wire
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)1wire}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)1wire}
 endif

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -36,6 +36,10 @@
 -include $(TOPDIR)/Make.defs
 DELIM ?= $(strip /)
 
+ifeq ($(WINTOOL),y)
+INCDIROPT = -w
+endif
+
 DEPPATH = --dep-path .
 ASRCS =
 CSRCS =

--- a/drivers/analog/Make.defs
+++ b/drivers/analog/Make.defs
@@ -121,22 +121,22 @@ endif
 ifeq ($(CONFIG_DAC),y)
   DEPPATH += --dep-path analog
   VPATH += :analog
-  CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)analog}
+  CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)analog}
 else
 ifeq ($(CONFIG_ADC),y)
   DEPPATH += --dep-path analog
   VPATH += :analog
-  CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)analog}
+  CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)analog}
 else
 ifeq ($(CONFIG_COMP),y)
   DEPPATH += --dep-path analog
   VPATH += :analog
-  CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)analog}
+  CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)analog}
 else
 ifeq ($(CONFIG_OPAMP),y)
   DEPPATH += --dep-path analog
   VPATH += :analog
-  CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)analog}
+  CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)analog}
 endif
 endif
 endif

--- a/drivers/bch/Make.defs
+++ b/drivers/bch/Make.defs
@@ -45,6 +45,6 @@ CSRCS += bchdev_driver.c
 
 DEPPATH += --dep-path bch
 VPATH += :bch
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)bch}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)bch}
 
 endif

--- a/drivers/can/Make.defs
+++ b/drivers/can/Make.defs
@@ -47,5 +47,5 @@ endif
 
 DEPPATH += --dep-path can
 VPATH += :can
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)can}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)can}
 endif

--- a/drivers/contactless/Make.defs
+++ b/drivers/contactless/Make.defs
@@ -49,5 +49,5 @@ endif
 
 DEPPATH += --dep-path contactless
 VPATH += :contactless
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)contactless}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)contactless}
 endif

--- a/drivers/crypto/Make.defs
+++ b/drivers/crypto/Make.defs
@@ -43,4 +43,4 @@ endif
 
 DEPPATH += --dep-path crypto
 VPATH += :crypto
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)crypto}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)crypto}

--- a/drivers/i2c/Make.defs
+++ b/drivers/i2c/Make.defs
@@ -54,6 +54,6 @@ endif
 
 DEPPATH += --dep-path i2c
 VPATH += :i2c
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)i2c}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)i2c}
 
 endif  # CONFIG_I2C

--- a/drivers/input/Make.defs
+++ b/drivers/input/Make.defs
@@ -103,5 +103,5 @@ endif
 
 DEPPATH += --dep-path input
 VPATH += :input
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)input}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)input}
 endif

--- a/drivers/ioexpander/Make.defs
+++ b/drivers/ioexpander/Make.defs
@@ -75,7 +75,7 @@ ifeq ($(CONFIG_IOEXPANDER),y)
 
 DEPPATH += --dep-path ioexpander
 VPATH += :ioexpander
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)ioexpander}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)ioexpander}
 
 else ifeq ($(CONFIG_DEV_GPIO),y)
 
@@ -83,6 +83,6 @@ else ifeq ($(CONFIG_DEV_GPIO),y)
 
 DEPPATH += --dep-path ioexpander
 VPATH += :ioexpander
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)ioexpander}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)ioexpander}
 
 endif

--- a/drivers/lcd/Make.defs
+++ b/drivers/lcd/Make.defs
@@ -157,13 +157,13 @@ endif
 ifeq ($(CONFIG_LCD),y)
   DEPPATH += --dep-path lcd
   VPATH += :lcd
-  CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)lcd}
+  CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)lcd}
 else ifeq ($(CONFIG_SLCD),y)
   DEPPATH += --dep-path lcd
   VPATH += :lcd
-  CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)lcd}
+  CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)lcd}
 else ifeq ($(CONFIG_LCD_OTHER),y)
   DEPPATH += --dep-path lcd
   VPATH += :lcd
-  CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)lcd}
+  CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)lcd}
 endif

--- a/drivers/loop/Make.defs
+++ b/drivers/loop/Make.defs
@@ -49,6 +49,6 @@ CSRCS += losetup.c
 
 DEPPATH += --dep-path loop
 VPATH += :loop
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)loop}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)loop}
 
 endif

--- a/drivers/mmcsd/Make.defs
+++ b/drivers/mmcsd/Make.defs
@@ -49,6 +49,6 @@ endif
 
 DEPPATH += --dep-path mmcsd
 VPATH += :mmcsd
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)mmcsd}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)mmcsd}
 
 endif

--- a/drivers/modem/Make.defs
+++ b/drivers/modem/Make.defs
@@ -45,6 +45,6 @@ include modem$(DELIM)altair$(DELIM)Make.defs
 
 DEPPATH += --dep-path modem
 VPATH += :modem
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)modem}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)modem}
 
 endif

--- a/drivers/modem/altair/Make.defs
+++ b/drivers/modem/altair/Make.defs
@@ -45,6 +45,6 @@ endif
 
 DEPPATH += --dep-path modem$(DELIM)altair
 VPATH += :modem$(DELIM)altair
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)modem}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)modem}
 
 endif

--- a/drivers/power/Make.defs
+++ b/drivers/power/Make.defs
@@ -62,7 +62,7 @@ endif
 
 POWER_DEPPATH := --dep-path power
 POWER_VPATH := :power
-POWER_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
+POWER_CFLAGS := ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
 
 endif
 
@@ -74,7 +74,7 @@ CSRCS += smps.c
 
 POWER_DEPPATH := --dep-path power
 POWER_VPATH := :power
-POWER_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
+POWER_CFLAGS := ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
 
 endif
 
@@ -86,7 +86,7 @@ CSRCS += powerled.c
 
 POWER_DEPPATH := --dep-path power
 POWER_VPATH := :power
-POWER_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
+POWER_CFLAGS := ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
 
 endif
 
@@ -98,7 +98,7 @@ CSRCS += motor.c
 
 POWER_DEPPATH := --dep-path power
 POWER_VPATH := :power
-POWER_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
+POWER_CFLAGS := ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
 
 endif
 
@@ -136,7 +136,7 @@ endif
 
 POWER_DEPPATH := --dep-path power
 POWER_VPATH := :power
-POWER_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
+POWER_CFLAGS := ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
 
 endif
 
@@ -162,7 +162,7 @@ endif
 
 POWER_DEPPATH := --dep-path power
 POWER_VPATH := :power
-POWER_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
+POWER_CFLAGS := ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
 
 endif
 
@@ -188,7 +188,7 @@ endif
 
 POWER_DEPPATH := --dep-path power
 POWER_VPATH := :power
-POWER_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
+POWER_CFLAGS := ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)power}
 
 endif
 

--- a/drivers/rptun/Make.defs
+++ b/drivers/rptun/Make.defs
@@ -41,5 +41,5 @@ CSRCS += rptun.c
 
 DEPPATH += --dep-path rptun
 VPATH += :rptun
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)rptun}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)rptun}
 endif

--- a/drivers/sensors/Make.defs
+++ b/drivers/sensors/Make.defs
@@ -295,6 +295,6 @@ endif
 
 DEPPATH += --dep-path sensors
 VPATH += :sensors
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)sensors}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)sensors}
 
 endif # CONFIG_SENSORS

--- a/drivers/spi/Make.defs
+++ b/drivers/spi/Make.defs
@@ -54,5 +54,5 @@ endif
 
 DEPPATH += --dep-path spi
 VPATH += :spi
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)spi}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)spi}
 endif

--- a/drivers/usbdev/Make.defs
+++ b/drivers/usbdev/Make.defs
@@ -75,5 +75,5 @@ CSRCS += usbdev_trace.c usbdev_trprintf.c
 
 DEPPATH += --dep-path usbdev
 VPATH += :usbdev
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)usbdev}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)usbdev}
 endif

--- a/drivers/usbhost/Make.defs
+++ b/drivers/usbhost/Make.defs
@@ -89,4 +89,4 @@ endif
 
 DEPPATH += --dep-path usbhost
 VPATH += :usbhost
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)usbhost}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)usbhost}

--- a/drivers/usbmisc/Make.defs
+++ b/drivers/usbmisc/Make.defs
@@ -49,5 +49,5 @@ endif
 
 DEPPATH += --dep-path usbmisc
 VPATH += :usbmisc
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)usbmisc}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)usbmisc}
 endif

--- a/drivers/usbmonitor/Make.defs
+++ b/drivers/usbmonitor/Make.defs
@@ -45,6 +45,6 @@ CSRCS += usbmonitor.c
 
 DEPPATH += --dep-path usbmonitor
 VPATH += :usbmonitor
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)usbmonitor}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)usbmonitor}
 
 endif

--- a/drivers/video/Make.defs
+++ b/drivers/video/Make.defs
@@ -69,6 +69,6 @@ endif
 
 DEPPATH += --dep-path video
 VPATH += :video
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)video}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)video}
 
 endif

--- a/drivers/wireless/Make.defs
+++ b/drivers/wireless/Make.defs
@@ -82,5 +82,5 @@ endif
 
 DEPPATH += --dep-path wireless
 VPATH += :wireless
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless}
 endif

--- a/drivers/wireless/bluetooth/Make.defs
+++ b/drivers/wireless/bluetooth/Make.defs
@@ -63,6 +63,6 @@ endif
 
 DEPPATH += --dep-path wireless$(DELIM)bluetooth
 VPATH += :wireless$(DELIM)bluetooth
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)bluetooth}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)bluetooth}
 
 endif # CONFIG_DRIVERS_BLUETOOTH

--- a/drivers/wireless/ieee80211/bcm43xxx/Make.defs
+++ b/drivers/wireless/ieee80211/bcm43xxx/Make.defs
@@ -60,6 +60,6 @@ endif
 
 DEPPATH += --dep-path wireless$(DELIM)ieee80211$(DELIM)bcm43xxx
 VPATH += :wireless$(DELIM)ieee80211$(DELIM)bcm43xxx
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee80211$(DELIM)bcm43xxx}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee80211$(DELIM)bcm43xxx}
 
 endif # CONFIG_IEEE80211_BROADCOM_FULLMAC

--- a/drivers/wireless/ieee802154/Make.defs
+++ b/drivers/wireless/ieee802154/Make.defs
@@ -49,6 +49,6 @@ include wireless$(DELIM)ieee802154$(DELIM)xbee$(DELIM)Make.defs
 
 DEPPATH += --dep-path wireless$(DELIM)ieee802154
 VPATH += :wireless$(DELIM)ieee802154
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee802154}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee802154}
 
 endif # CONFIG_DRIVERS_IEEE802154

--- a/drivers/wireless/ieee802154/at86rf23x/Make.defs
+++ b/drivers/wireless/ieee802154/at86rf23x/Make.defs
@@ -43,6 +43,6 @@ CSRCS += at86rf23x.c
 
 DEPPATH += --dep-path wireless$(DELIM)ieee802154$(DELIM)at86rf23x
 VPATH += :wireless$(DELIM)ieee802154$(DELIM)at86rf23x
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee802154$(DELIM)at86rf23x}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee802154$(DELIM)at86rf23x}
 
 endif # CONFIG_IEEE802154_AT86RF233

--- a/drivers/wireless/ieee802154/mrf24j40/Make.defs
+++ b/drivers/wireless/ieee802154/mrf24j40/Make.defs
@@ -44,6 +44,6 @@ CSRCS += mrf24j40_regops.c mrf24j40.c
 
 DEPPATH += --dep-path wireless$(DELIM)ieee802154$(DELIM)mrf24j40
 VPATH += :wireless$(DELIM)ieee802154$(DELIM)mrf24j40
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee802154$(DELIM)mrf24j40}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee802154$(DELIM)mrf24j40}
 
 endif # CONFIG_IEEE802154_MRF24J40

--- a/drivers/wireless/ieee802154/xbee/Make.defs
+++ b/drivers/wireless/ieee802154/xbee/Make.defs
@@ -43,6 +43,6 @@ CSRCS += xbee_ioctl.c xbee_mac.c xbee_netdev.c xbee.c
 
 DEPPATH += --dep-path wireless$(DELIM)ieee802154$(DELIM)xbee
 VPATH += :wireless$(DELIM)ieee802154$(DELIM)xbee
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee802154$(DELIM)xbee}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)ieee802154$(DELIM)xbee}
 
 endif # CONFIG_IEEE802154_XBEE

--- a/drivers/wireless/lpwan/sx127x/Make.defs
+++ b/drivers/wireless/lpwan/sx127x/Make.defs
@@ -43,6 +43,6 @@ CSRCS += sx127x.c
 
 DEPPATH += --dep-path wireless$(DELIM)lpwan$(DELIM)sx127x
 VPATH += :wireless$(DELIM)lpwan$(DELIM)sx127x
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)lpwan$(DELIM)sx127x}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)lpwan$(DELIM)sx127x}
 
 endif # CONFIG_LPWAN_SX127X

--- a/drivers/wireless/spirit/drivers/Make.defs
+++ b/drivers/wireless/spirit/drivers/Make.defs
@@ -43,7 +43,7 @@ CSRCS += spirit_netdev.c
 
 DEPPATH += --dep-path wireless$(DELIM)spirit$(DELIM)drivers
 VPATH += :wireless$(DELIM)spirit$(DELIM)drivers
-CFLAGS += ${shell $(INCDIR) "$(CC)" \
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" \
   $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)spirit$(DELIM)drivers}
 
 endif # CONFIG_SPIRIT_NETDEV

--- a/drivers/wireless/spirit/include/Make.defs
+++ b/drivers/wireless/spirit/include/Make.defs
@@ -35,5 +35,5 @@
 
 # Add path to include Spirit header files in CFLAGS
 
-CFLAGS += ${shell $(INCDIR) "$(CC)" \
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" \
   $(TOPDIR)$(DELIM)drivers$(DELIM)wireless$(DELIM)spirit$(DELIM)include}

--- a/fs/spiffs/Make.defs
+++ b/fs/spiffs/Make.defs
@@ -44,6 +44,6 @@ CSRCS += spiffs_cache.c spiffs_check.c spiffs_mtd.c
 
 DEPPATH += --dep-path spiffs/src
 VPATH += :spiffs/src
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)fs$(DELIM)spiffs$(DELIM)src}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)fs$(DELIM)spiffs$(DELIM)src}
 
 endif

--- a/graphics/Makefile
+++ b/graphics/Makefile
@@ -38,6 +38,10 @@
 
 DEPPATH = --dep-path .
 
+ifeq ($(WINTOOL),y)
+INCDIROPT = -w
+endif
+
 ASRCS =
 CSRCS =
 VPATH =

--- a/graphics/nxbe/Make.defs
+++ b/graphics/nxbe/Make.defs
@@ -51,5 +51,5 @@ CSRCS += nxbe_cursor.c
 endif
 
 DEPPATH += --dep-path nxbe
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)/graphics/nxbe}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)/graphics/nxbe}
 VPATH += :nxbe

--- a/graphics/nxglib/Make.defs
+++ b/graphics/nxglib/Make.defs
@@ -111,6 +111,6 @@ CSRCS += nxglib_cursor_backup_24bpp.c nxglib_cursor_backup_32bpp.c
 endif
 
 DEPPATH += --dep-path nxglib
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)/graphics/nxglib}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)/graphics/nxglib}
 #VPATH += :nxglib
 VPATH = nxglib

--- a/graphics/nxmu/Make.defs
+++ b/graphics/nxmu/Make.defs
@@ -39,5 +39,5 @@ CSRCS += nxmu_sendclient.c nxmu_sendclientwindow.c nxmu_server.c
 CSRCS += nxmu_start.c
 
 DEPPATH += --dep-path nxmu
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)/graphics/nxmu}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)/graphics/nxmu}
 VPATH += :nxmu

--- a/graphics/nxterm/Make.defs
+++ b/graphics/nxterm/Make.defs
@@ -52,7 +52,7 @@ CSRCS += nxterm_sem.c
 endif
 
 DEPPATH += --dep-path nxterm
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)/graphics/nxterm}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)/graphics/nxterm}
 VPATH += :nxterm
 
 endif

--- a/graphics/vnc/client/Make.defs
+++ b/graphics/vnc/client/Make.defs
@@ -36,7 +36,7 @@
 ifeq ($(CONFIG_VNCCLIENT),y)
 
 DEPPATH += --dep-path vnc/client
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)/graphics/vnc/client}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)/graphics/vnc/client}
 VPATH += :vnc/client
 
 endif

--- a/graphics/vnc/server/Make.defs
+++ b/graphics/vnc/server/Make.defs
@@ -43,7 +43,7 @@ CSRCS += vnc_keymap.c
 endif
 
 DEPPATH += --dep-path vnc/server
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)/graphics/vnc/server}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)/graphics/vnc/server}
 VPATH += :vnc/server
 
 endif

--- a/libs/libc/zoneinfo/Makefile
+++ b/libs/libc/zoneinfo/Makefile
@@ -36,6 +36,10 @@
 -include $(TOPDIR)/.config
 -include $(TOPDIR)/Make.defs
 
+ifeq ($(WINTOOL),y)
+INCDIROPT = -w
+endif
+
 # Zoneinfo database
 
 ASRCS =

--- a/mm/iob/Make.defs
+++ b/mm/iob/Make.defs
@@ -56,6 +56,6 @@ endif
 
 DEPPATH += --dep-path iob
 VPATH += :iob
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)mm$(DELIM)iob}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)mm$(DELIM)iob}
 
 endif # CONFIG_MM_IOB

--- a/pass1/Makefile
+++ b/pass1/Makefile
@@ -36,6 +36,10 @@
 -include $(TOPDIR)/Make.defs
 DELIM ?= $(strip /)
 
+ifeq ($(WINTOOL),y)
+INCDIROPT = -w
+endif
+
 DEPPATH = --dep-path .
 
 ASRCS = $(wildcard *.S)

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -95,9 +95,6 @@ endif
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   DEFINE = "$(TOPDIR)\tools\define.bat"
   INCDIR = "$(TOPDIR)\tools\incdir.bat"
-else ifeq ($(WINTOOL),y)
-  DEFINE = "$(TOPDIR)/tools/define.sh"
-  INCDIR = "$(TOPDIR)/tools/incdir.sh" -w
 else
   DEFINE = "$(TOPDIR)/tools/define.sh"
   INCDIR = "$(TOPDIR)/tools/incdir.sh"

--- a/wireless/Makefile
+++ b/wireless/Makefile
@@ -36,6 +36,10 @@
 -include $(TOPDIR)/Make.defs
 DELIM ?= $(strip /)
 
+ifeq ($(WINTOOL),y)
+INCDIROPT = -w
+endif
+
 # Add files to the build
 
 DEPPATH = --dep-path .

--- a/wireless/bluetooth/Make.defs
+++ b/wireless/bluetooth/Make.defs
@@ -43,6 +43,6 @@ CSRCS += bt_uuid.c
 
 DEPPATH += --dep-path bluetooth
 VPATH += :bluetooth
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)wireless$(DELIM)bluetooth}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)wireless$(DELIM)bluetooth}
 
 endif # CONFIG_WIRELESS_BLUETOOTH

--- a/wireless/ieee802154/Make.defs
+++ b/wireless/ieee802154/Make.defs
@@ -66,6 +66,6 @@ endif
 
 DEPPATH += --dep-path ieee802154
 VPATH += :ieee802154
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)wireless$(DELIM)ieee802154}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)wireless$(DELIM)ieee802154}
 
 endif # CONFIG_WIRELESS_IEEE802154

--- a/wireless/pktradio/Make.defs
+++ b/wireless/pktradio/Make.defs
@@ -45,6 +45,6 @@ endif
 
 DEPPATH += --dep-path pktradio
 VPATH += :pktradio
-CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)wireless$(DELIM)pktradio}
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)wireless$(DELIM)pktradio}
 
 endif # CONFIG_WIRELESS_PKTRADIO


### PR DESCRIPTION
This reverts commit b9ace36fcc7ccb55d1541231be07689d557628f4.

This change was added by PR 625 but has a serious logic flaw.  It removes all occurrences of INCDIROPT and replaces it with a definition in tools/Config.mk:

    else ifeq ($(WINTOOL),y)
      DEFINE = "$(TOPDIR)/tools/define.sh"
      INCDIR = "$(TOPDIR)/tools/incdir.sh" -w

This logic flaw is the Config.mk is included in all Make.defs files BEFORE WINTOOL is defined.  As a result, the definition is wrong in many places when building under Cygwin with a Windows native toolchain.