### PR TITLE
include/nuttx/sched.h:  Move prototype for sched_releasetcb()

### DIFF
--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -40,7 +40,6 @@ DELIM ?= $(strip /)
 ifeq ($(WINTOOL),y)
 INCDIROPT = -w
 endif
-CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" "$(TOPDIR)$(DELIM)sched"}
 
 # Basic BINFMT source files
 

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * binfmt/binfmt_execmodule.c
  *
- *   Copyright (C) 2009, 2013-2014, 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -48,10 +33,10 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/sched.h>
 #include <nuttx/mm/shm.h>
 #include <nuttx/binfmt/binfmt.h>
 
-#include "sched/sched.h"
 #include "binfmt.h"
 
 #ifndef CONFIG_BINFMT_DISABLE

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1,35 +1,20 @@
 /********************************************************************************
  * include/nuttx/sched.h
  *
- *   Copyright (C) 2007-2016, 2018-2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ********************************************************************************/
 
@@ -103,50 +88,50 @@
 
 /* Values for the struct tcb_s flags bits */
 
-#define TCB_FLAG_TTYPE_SHIFT       (0)       /* Bits 0-1: thread type */
+#define TCB_FLAG_TTYPE_SHIFT       (0)                           /* Bits 0-1: thread type */
 #define TCB_FLAG_TTYPE_MASK        (3 << TCB_FLAG_TTYPE_SHIFT)
-#  define TCB_FLAG_TTYPE_TASK      (0 << TCB_FLAG_TTYPE_SHIFT)  /* Normal user task */
-#  define TCB_FLAG_TTYPE_PTHREAD   (1 << TCB_FLAG_TTYPE_SHIFT)  /* User pthread */
-#  define TCB_FLAG_TTYPE_KERNEL    (2 << TCB_FLAG_TTYPE_SHIFT)  /* Kernel thread */
-#define TCB_FLAG_NONCANCELABLE     (1 << 2)  /* Bit 2: Pthread is non-cancelable */
-#define TCB_FLAG_CANCEL_DEFERRED   (1 << 3)  /* Bit 3: Deferred (vs asynch) cancellation type */
-#define TCB_FLAG_CANCEL_PENDING    (1 << 4)  /* Bit 4: Pthread cancel is pending */
-#define TCB_FLAG_POLICY_SHIFT      (5)       /* Bit 5-6: Scheduling policy */
+#  define TCB_FLAG_TTYPE_TASK      (0 << TCB_FLAG_TTYPE_SHIFT)   /*   Normal user task */
+#  define TCB_FLAG_TTYPE_PTHREAD   (1 << TCB_FLAG_TTYPE_SHIFT)   /*   User pthread */
+#  define TCB_FLAG_TTYPE_KERNEL    (2 << TCB_FLAG_TTYPE_SHIFT)   /*   Kernel thread */
+#define TCB_FLAG_NONCANCELABLE     (1 << 2)                      /* Bit 2: Pthread is non-cancelable */
+#define TCB_FLAG_CANCEL_DEFERRED   (1 << 3)                      /* Bit 3: Deferred (vs asynch) cancellation type */
+#define TCB_FLAG_CANCEL_PENDING    (1 << 4)                      /* Bit 4: Pthread cancel is pending */
+#define TCB_FLAG_POLICY_SHIFT      (5)                           /* Bit 5-6: Scheduling policy */
 #define TCB_FLAG_POLICY_MASK       (3 << TCB_FLAG_POLICY_SHIFT)
-#  define TCB_FLAG_SCHED_FIFO      (0 << TCB_FLAG_POLICY_SHIFT) /* FIFO scheding policy */
-#  define TCB_FLAG_SCHED_RR        (1 << TCB_FLAG_POLICY_SHIFT) /* Round robin scheding policy */
-#  define TCB_FLAG_SCHED_SPORADIC  (2 << TCB_FLAG_POLICY_SHIFT) /* Sporadic scheding policy */
-#  define TCB_FLAG_SCHED_OTHER     (3 << TCB_FLAG_POLICY_SHIFT) /* Other scheding policy */
-#define TCB_FLAG_CPU_LOCKED        (1 << 7)  /* Bit 7: Locked to this CPU */
-#define TCB_FLAG_SIGNAL_ACTION     (1 << 8)  /* Bit 8: In a signal handler */
-#define TCB_FLAG_SYSCALL           (1 << 9)  /* Bit 9: In a system call */
-#define TCB_FLAG_EXIT_PROCESSING   (1 << 10) /* Bit 10: Exitting */
-                                             /* Bits 11-15: Available */
+#  define TCB_FLAG_SCHED_FIFO      (0 << TCB_FLAG_POLICY_SHIFT)  /* FIFO scheding policy */
+#  define TCB_FLAG_SCHED_RR        (1 << TCB_FLAG_POLICY_SHIFT)  /* Round robin scheding policy */
+#  define TCB_FLAG_SCHED_SPORADIC  (2 << TCB_FLAG_POLICY_SHIFT)  /* Sporadic scheding policy */
+#  define TCB_FLAG_SCHED_OTHER     (3 << TCB_FLAG_POLICY_SHIFT)  /* Other scheding policy */
+#define TCB_FLAG_CPU_LOCKED        (1 << 7)                      /* Bit 7: Locked to this CPU */
+#define TCB_FLAG_SIGNAL_ACTION     (1 << 8)                      /* Bit 8: In a signal handler */
+#define TCB_FLAG_SYSCALL           (1 << 9)                      /* Bit 9: In a system call */
+#define TCB_FLAG_EXIT_PROCESSING   (1 << 10)                     /* Bit 10: Exitting */
+                                                                 /* Bits 11-15: Available */
 
 /* Values for struct task_group tg_flags */
 
-#define GROUP_FLAG_NOCLDWAIT       (1 << 0) /* Bit 0: Do not retain child exit status */
-#define GROUP_FLAG_ADDRENV         (1 << 1) /* Bit 1: Group has an address environment */
-#define GROUP_FLAG_PRIVILEGED      (1 << 2) /* Bit 2: Group is privileged */
-#define GROUP_FLAG_DELETED         (1 << 3) /* Bit 3: Group has been deleted but not yet freed */
-                                            /* Bits 4-7: Available */
+#define GROUP_FLAG_NOCLDWAIT       (1 << 0)                      /* Bit 0: Do not retain child exit status */
+#define GROUP_FLAG_ADDRENV         (1 << 1)                      /* Bit 1: Group has an address environment */
+#define GROUP_FLAG_PRIVILEGED      (1 << 2)                      /* Bit 2: Group is privileged */
+#define GROUP_FLAG_DELETED         (1 << 3)                      /* Bit 3: Group has been deleted but not yet freed */
+                                                                 /* Bits 4-7: Available */
 
 /* Values for struct child_status_s ch_flags */
 
-#define CHILD_FLAG_TTYPE_SHIFT     (0)      /* Bits 0-1: child thread type */
+#define CHILD_FLAG_TTYPE_SHIFT     (0)                           /* Bits 0-1: child thread type */
 #define CHILD_FLAG_TTYPE_MASK      (3 << CHILD_FLAG_TTYPE_SHIFT)
 #  define CHILD_FLAG_TTYPE_TASK    (0 << CHILD_FLAG_TTYPE_SHIFT) /* Normal user task */
 #  define CHILD_FLAG_TTYPE_PTHREAD (1 << CHILD_FLAG_TTYPE_SHIFT) /* User pthread */
 #  define CHILD_FLAG_TTYPE_KERNEL  (2 << CHILD_FLAG_TTYPE_SHIFT) /* Kernel thread */
-#define CHILD_FLAG_EXITED          (1 << 2) /* Bit 2: The child thread has exit'ed */
-                                            /* Bits 3-7: Available */
+#define CHILD_FLAG_EXITED          (1 << 2)                      /* Bit 2: The child thread has exit'ed */
+                                                                 /* Bits 3-7: Available */
 
 /* Sporadic scheduler flags */
 
-#define SPORADIC_FLAG_ALLOCED      (1 << 0)  /* Bit 0: Timer is allocated */
-#define SPORADIC_FLAG_MAIN         (1 << 1)  /* Bit 1: The main timer */
-#define SPORADIC_FLAG_REPLENISH    (1 << 2)  /* Bit 2: Replenishment cycle */
-                                             /* Bits 3-7: Available */
+#define SPORADIC_FLAG_ALLOCED      (1 << 0)                      /* Bit 0: Timer is allocated */
+#define SPORADIC_FLAG_MAIN         (1 << 1)                      /* Bit 1: The main timer */
+#define SPORADIC_FLAG_REPLENISH    (1 << 2)                      /* Bit 2: Replenishment cycle */
+                                                                 /* Bits 3-7: Available */
 
 /* Most internal nxsched_* interfaces are not available in the user space in
  * PROTECTED and KERNEL builds.  In that context, the application semaphore
@@ -273,7 +258,7 @@ typedef CODE void (*atexitfunc_t)(void);
 typedef CODE void (*onexitfunc_t)(int exitcode, FAR void *arg);
 #endif
 
-/* struct sporadic_s *************************************************************/
+/* struct sporadic_s ************************************************************/
 
 #ifdef CONFIG_SCHED_SPORADIC
 
@@ -319,7 +304,7 @@ struct sporadic_s
 
 #endif /* CONFIG_SCHED_SPORADIC */
 
-/* struct child_status_s *********************************************************/
+/* struct child_status_s ********************************************************/
 
 /* This structure is used to maintain information about child tasks.  pthreads
  * work differently, they have join information.  This is only for child tasks.
@@ -336,7 +321,7 @@ struct child_status_s
 };
 #endif
 
-/* struct pthread_cleanup_s ******************************************************/
+/* struct pthread_cleanup_s *****************************************************/
 
 /* This structure describes one element of the pthread cleanup stack */
 
@@ -348,7 +333,7 @@ struct pthread_cleanup_s
 };
 #endif
 
-/* type pthread_keyset_t *********************************************************/
+/* type pthread_keyset_t ********************************************************/
 
 /* Smallest addressable type that can hold the entire configured number of keys */
 
@@ -364,13 +349,13 @@ struct pthread_cleanup_s
 #  endif
 #endif
 
-/* type grpid_t ******************************************************************/
+/* type grpid_t *****************************************************************/
 
 /* The task group ID */
 
 typedef int16_t grpid_t;
 
-/* struct dspace_s ***************************************************************/
+/* struct dspace_s **************************************************************/
 
 /* This structure describes a reference counted D-Space region.  This must be a
  * separately allocated "break-away" structure that can be owned by a task and
@@ -397,11 +382,12 @@ struct dspace_s
 };
 #endif
 
-/* struct task_group_s ***********************************************************/
+/* struct task_group_s **********************************************************/
 
-/* All threads created by pthread_create belong in the same task group (along with
- * the thread of the original task).  struct task_group_s is a shared structure
- * referenced by the TCB of each thread that is a member of the task group.
+/* All threads created by pthread_create belong in the same task group (along
+ * with the thread of the original task).  struct task_group_s is a shared
+ * structure referenced by the TCB of each thread that is a member of the task
+ * group.
  *
  * This structure should contain *all* resources shared by tasks and threads that
  * belong to the same task group:
@@ -460,17 +446,17 @@ struct task_group_s
 #endif
 
 #if defined(CONFIG_SCHED_ATEXIT) && !defined(CONFIG_SCHED_ONEXIT)
-  /* atexit support ************************************************************/
+  /* atexit support *************************************************************/
 
 # if defined(CONFIG_SCHED_ATEXIT_MAX) && CONFIG_SCHED_ATEXIT_MAX > 1
   atexitfunc_t tg_atexitfunc[CONFIG_SCHED_ATEXIT_MAX];
 # else
-  atexitfunc_t tg_atexitfunc;       /* Called when exit is called.             */
+  atexitfunc_t tg_atexitfunc;       /* Called when exit is called.              */
 # endif
 #endif
 
 #ifdef CONFIG_SCHED_ONEXIT
-  /* on_exit support ***********************************************************/
+  /* on_exit support ************************************************************/
 
 # if defined(CONFIG_SCHED_ONEXIT_MAX) && CONFIG_SCHED_ONEXIT_MAX > 1
   onexitfunc_t tg_onexitfunc[CONFIG_SCHED_ONEXIT_MAX];
@@ -519,6 +505,7 @@ struct task_group_s
   /* Pthreads *******************************************************************/
 
                                     /* Pthread join Info:                       */
+
   sem_t tg_joinsem;                 /*   Mutually exclusive access to join data */
   FAR struct join_s *tg_joinhead;   /*   Head of a list of join data            */
   FAR struct join_s *tg_jointail;   /*   Tail of a list of join data            */
@@ -600,7 +587,7 @@ struct task_group_s
 #endif
 };
 
-/* struct tcb_s ******************************************************************/
+/* struct tcb_s *****************************************************************/
 
 /* This is the common part of the task control block (TCB).  The TCB is the heart
  * of the NuttX task-control logic.  Each task or thread is represented by a TCB
@@ -712,6 +699,7 @@ struct tcb_s
   int pterrno;                           /* Current per-thread errno            */
 
   /* State save areas ***********************************************************/
+
   /* The form and content of these fields are platform-specific.                */
 
   struct xcptcontext xcp;                /* Interrupt register save area        */
@@ -721,7 +709,7 @@ struct tcb_s
 #endif
 };
 
-/* struct task_tcb_s *************************************************************/
+/* struct task_tcb_s ************************************************************/
 
 /* This is the particular form of the task control block (TCB) structure used by
  * tasks (and kernel threads).  There are two TCB forms:  one for pthreads and
@@ -750,15 +738,15 @@ struct task_tcb_s
   FAR char **argv;                       /* Name+start-up parameters            */
 };
 
-/* struct pthread_tcb_s **********************************************************/
+/* struct pthread_tcb_s *********************************************************/
 
 /* This is the particular form of the task control block (TCB) structure used by
  * pthreads.  There are two TCB forms:  one for pthreads and one for tasks.  Both
  * share the common TCB fields (which must appear at the top of the structure)
- * plus additional fields unique to tasks and threads.  Having separate structures
- * for tasks and pthreads adds some complexity,  but saves memory in that it
- * prevents pthreads from being burdened with the overhead required for tasks
- * (and vice versa).
+ * plus additional fields unique to tasks and threads.  Having separate
+ * structures for tasks and pthreads adds some complexity,  but saves memory in
+ * that it prevents pthreads from being burdened with the overhead required for
+ * tasks (and vice versa).
  */
 
 #ifndef CONFIG_DISABLE_PTHREAD
@@ -828,24 +816,71 @@ EXTERN uint32_t g_crit_max[1];
  * Public Function Prototypes
  ********************************************************************************/
 
-/* TCB helpers ******************************************************************/
-
-/* sched_self() returns the TCB of the currently running task (i.e., the
- * caller)
- */
+/********************************************************************************
+ * Name: sched_self
+ *
+ * Description:
+ *   Return the current threads TCB.  Basically, this function just wraps the
+ *   head of the ready-to-run list and manages access to the TCB from outside
+ *   of the sched/ sub-directory.
+ *
+ ********************************************************************************/
 
 FAR struct tcb_s *sched_self(void);
 
-/* sched_foreach will enumerate over each task and provide the TCB of each task
- * or thread to a callback function.  Interrupts will be disabled throughout
- * this enumeration!
- */
+/********************************************************************************
+ * Name: sched_foreach
+ *
+ * Description:
+ *   Enumerate over each task and provide the TCB of each task to a user
+ *   callback functions.
+ *
+ *   NOTE:  This function examines the TCB and calls each handler within a
+ *   critical section.  However, that critical section is released and
+ *   reacquired for each TCB.  When it is released, there may be changes in
+ *   tasking.  If the caller requires absolute stability through the
+ *   traversal, then the caller should establish the critical section BEFORE
+ *   calling this function.
+ *
+ * Input Parameters:
+ *   handler - The function to be called with the TCB of
+ *     each task
+ *
+ * Returned Value:
+ *   None
+ *
+ ********************************************************************************/
 
 void sched_foreach(sched_foreach_t handler, FAR void *arg);
 
-/* Given a task ID, look up the corresponding TCB */
+/********************************************************************************
+ * Name: sched_gettcb
+ *
+ * Description:
+ *   Given a task ID, this function will return the a pointer to the
+ *   corresponding TCB (or NULL if there is no such task ID).
+ *
+ *   NOTE:  This function holds a critical section while examining TCB data
+ *   data structures but releases that critical section before returning.
+ *   When it is released, the TCB may become unstable.  If the caller
+ *   requires absolute stability while using the TCB, then the caller
+ *   should establish the critical section BEFORE calling this function and
+ *   hold that critical section as long as necessary.
+ *
+ ********************************************************************************/
 
 FAR struct tcb_s *sched_gettcb(pid_t pid);
+
+/********************************************************************************
+ * Name:  nxsched_releasepid
+ *
+ * Description:
+ *   When a task is destroyed, this function must be called to make its
+ *   process ID available for re-use.
+ *
+ ********************************************************************************/
+
+int sched_releasetcb(FAR struct tcb_s *tcb, uint8_t ttype);
 
 /* File system helpers **********************************************************/
 
@@ -914,7 +949,7 @@ FAR struct task_tcb_s *nxtask_vforksetup(start_t retaddr, size_t *argsize);
 pid_t nxtask_vforkstart(FAR struct task_tcb_s *child);
 void nxtask_vforkabort(FAR struct task_tcb_s *child, int errcode);
 
-/****************************************************************************
+/********************************************************************************
  * Name: group_exitinfo
  *
  * Description:
@@ -932,7 +967,7 @@ void nxtask_vforkabort(FAR struct task_tcb_s *child, int errcode);
  *   0 (OK) is returned on success and a negated errno is returned on
  *   failure.
  *
- ****************************************************************************/
+ ********************************************************************************/
 
 #ifdef CONFIG_BINFMT_LOADABLE
 struct binary_s;  /* Forward reference */
@@ -983,7 +1018,7 @@ void sched_suspend_scheduler(FAR struct tcb_s *tcb);
 #  define sched_suspend_scheduler(tcb)
 #endif
 
-/****************************************************************************
+/********************************************************************************
  * Name: nxsched_getparam
  *
  * Description:
@@ -1009,12 +1044,12 @@ void sched_suspend_scheduler(FAR struct tcb_s *tcb);
  *   This function can fail if param is null (EINVAL) or if pid does
  *   not correspond to any task (ESRCH).
  *
- ****************************************************************************/
+ ********************************************************************************/
 
 struct sched_param;  /* Forward reference */
 int nxsched_getparam (pid_t pid, FAR struct sched_param *param);
 
-/****************************************************************************
+/********************************************************************************
  * Name:  nxsched_setparam
  *
  * Description:
@@ -1046,12 +1081,12 @@ int nxsched_getparam (pid_t pid, FAR struct sched_param *param);
  *   EPERM  The calling task does not have appropriate privileges.
  *   ESRCH  The task whose ID is pid could not be found.
  *
- ****************************************************************************/
+ ********************************************************************************/
 
 struct sched_param;  /* Forward reference */
 int nxsched_setparam(pid_t pid, FAR const struct sched_param *param);
 
-/****************************************************************************
+/********************************************************************************
  * Name: nxsched_getscheduler
  *
  * Description:
@@ -1078,11 +1113,11 @@ int nxsched_setparam(pid_t pid, FAR const struct sched_param *param);
  *
  *      ESRCH  The task whose ID is pid could not be found.
  *
- ****************************************************************************/
+ ********************************************************************************/
 
 int nxsched_getscheduler(pid_t pid);
 
-/****************************************************************************
+/********************************************************************************
  * Name: nxsched_setscheduler
  *
  * Description:
@@ -1114,12 +1149,12 @@ int nxsched_getscheduler(pid_t pid);
  *   EINVAL The scheduling policy is not one of the recognized policies.
  *   ESRCH  The task whose ID is pid could not be found.
  *
- ****************************************************************************/
+ ********************************************************************************/
 
 int nxsched_setscheduler(pid_t pid, int policy,
                          FAR const struct sched_param *param);
 
-/****************************************************************************
+/********************************************************************************
  * Name: nxsched_getaffinity
  *
  * Description:
@@ -1146,13 +1181,13 @@ int nxsched_setscheduler(pid_t pid, int policy,
  *
  *     ESRCH  The task whose ID is pid could not be found.
  *
- ****************************************************************************/
+ ********************************************************************************/
 
 #ifdef CONFIG_SMP
 int nxsched_getaffinity(pid_t pid, size_t cpusetsize, FAR cpu_set_t *mask);
 #endif
 
-/****************************************************************************
+/********************************************************************************
  * Name: nxsched_setaffinity
  *
  * Description:
@@ -1182,7 +1217,7 @@ int nxsched_getaffinity(pid_t pid, size_t cpusetsize, FAR cpu_set_t *mask);
  *
  *     ESRCH  The task whose ID is pid could not be found.
  *
- ****************************************************************************/
+ ********************************************************************************/
 
 #ifdef CONFIG_SMP
 int nxsched_setaffinity(pid_t pid, size_t cpusetsize,

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/sched/sched.h
  *
- *   Copyright (C) 2007-2014, 2016, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -354,9 +339,9 @@ extern volatile uint32_t g_cpuload_total;
  *    locked.
  * 2. Scheduling logic would set the bit associated with the cpu in
  *    'g_cpu_lockset' when the TCB at the head of the g_assignedtasks[cpu]
- *    list transitions has 'lockcount' > 0. This might happen when sched_lock()
- *    is called, or after a context switch that changes the TCB at the
- *    head of the g_assignedtasks[cpu] list.
+ *    list transitions has 'lockcount' > 0. This might happen when
+ *    sched_lock() is called, or after a context switch that changes the
+ *    TCB at the head of the g_assignedtasks[cpu] list.
  * 3. Similarly, the cpu bit in the global 'g_cpu_lockset' would be cleared
  *    when the TCB at the head of the g_assignedtasks[cpu] list has
  *    'lockcount' == 0. This might happen when sched_unlock() is called, or
@@ -507,6 +492,5 @@ void sched_critmon_suspend(FAR struct tcb_s *tcb);
 /* TCB operations */
 
 bool sched_verifytcb(FAR struct tcb_s *tcb);
-int  sched_releasetcb(FAR struct tcb_s *tcb, uint8_t ttype);
 
 #endif /* __SCHED_SCHED_SCHED_H */

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * sched/task/task_create.c
  *
- *   Copyright (C) 2007-2010, 2013-2014, 2016, 2018-2019 Gregory Nutt. All
- *     rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -47,6 +31,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/sched.h>
 #include <nuttx/kthread.h>
 
 #include "sched/sched.h"

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/task/task_init.c
  *
- *   Copyright (C) 2007, 2009, 2013-2014 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -45,6 +30,7 @@
 #include <errno.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/sched.h>
 
 #include "sched/sched.h"
 #include "group/group.h"

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * sched/task/task_setup.c
  *
- *   Copyright (C) 2007-2014, 2016-2017, 2019 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -48,6 +32,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/sched.h>
 #include <nuttx/signal.h>
 
 #include "sched/sched.h"


### PR DESCRIPTION
Move the prototype for the internal OS from from sched/sched/sched.h to include/nuttx/sched.h.  This was done because binfmt/binfmt/excecmodule.c requires the prototype for sched_releasetcb() and was illegally including sched/sched/sched.h.  That is a blatant violation of the OS modular design and the person that did this should be hung up by their thumbs.  Oh... I did that back in a bad moment in 2014.  Now that is made right.