### PR TITLE
Introduce CONFIG_DEFAULT_TASK_STACKSIZE

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -27,6 +27,12 @@ config DEFAULT_SMALL
 		have already been selected in your configuration file.  This applies
 		only to new settings that require a default value.
 
+config DEFAULT_TASK_STACKSIZE
+	int "The default stack size for tasks"
+	default 2048
+	---help---
+		The default stack size for tasks.
+
 choice
 	prompt "Build Host Platform"
 	default HOST_LINUX

--- a/binfmt/libelf/Kconfig
+++ b/binfmt/libelf/Kconfig
@@ -17,7 +17,7 @@ config ELF_ALIGN_LOG2
 
 config ELF_STACKSIZE
 	int "ELF Stack Size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		This is the default stack size that will be used when starting ELF binaries.
 

--- a/boards/sim/sim/sim/Kconfig
+++ b/boards/sim/sim/sim/Kconfig
@@ -16,7 +16,7 @@ comment "NX Server Options"
 
 config SIM_LISTENER_STACKSIZE
 	int "NX Server/Listener Stack Size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		The stacksize to use when creating the NX server.  Default 2048
 

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -40,7 +40,7 @@ config NET_RPMSG_PRIORITY
 
 config NET_RPMSG_STACKSIZE
 	int "net rpmsg stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		The stack size allocated for the net rpmsg task.
 

--- a/libs/libc/unistd/Kconfig
+++ b/libs/libc/unistd/Kconfig
@@ -105,7 +105,7 @@ config POSIX_SPAWN_PROXY_STACKSIZE
 
 config TASK_SPAWN_DEFAULT_STACKSIZE
 	int "Default task_spawn Stack Size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	depends on !ARCH_ADDRENV
 	---help---
 		The actual size to use for the child task's stack can be set with

--- a/libs/libc/wqueue/Kconfig
+++ b/libs/libc/wqueue/Kconfig
@@ -23,7 +23,7 @@ config LIB_USRWORKPRIORITY
 
 config LIB_USRWORKSTACKSIZE
 	int "User mode worker thread stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		The stack size allocated for the lower priority worker thread.  Default: 2K.
 

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -184,9 +184,9 @@ config SLIP_NINTERFACES
 
 config SLIP_STACKSIZE
 	int "SLIP stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
-		Select the stack size of the SLIP RX and TX tasks.  Default: 2048
+		Select the stack size of the SLIP RX and TX tasks.
 
 config SLIP_DEFPRIO
 	int "SLIP priority"

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -329,7 +329,7 @@ config SMP_NCPUS
 
 config SMP_IDLETHREAD_STACKSIZE
 	int "CPU IDLE stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		Each CPU will have its own IDLE task.  System initialization occurs
 		on CPU0 and uses CONFIG_IDLETHREAD_STACKSIZE which will probably be
@@ -1272,7 +1272,7 @@ if BOARD_LATE_INITIALIZE
 
 config BOARD_INITTHREAD_STACKSIZE
 	int "Board initialization thread stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		The size of the stack to allocate when starting the board
 		initialization thread.
@@ -1656,7 +1656,7 @@ config SCHED_HPWORKPRIORITY
 
 config SCHED_HPWORKSTACKSIZE
 	int "High priority worker thread stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		The stack size allocated for the worker thread.  Default: 2K.
 
@@ -1755,7 +1755,7 @@ config SCHED_LPWORKPRIOMAX
 
 config SCHED_LPWORKSTACKSIZE
 	int "Low priority worker thread stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		The stack size allocated for the lower priority worker thread.  Default: 2K.
 
@@ -1775,7 +1775,7 @@ config IDLETHREAD_STACKSIZE
 
 config USERMAIN_STACKSIZE
 	int "Main thread stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		The size of the stack to allocate for the user initialization thread
 		that is started as soon as the OS completes its initialization.
@@ -1788,7 +1788,7 @@ config PTHREAD_STACK_MIN
 
 config PTHREAD_STACK_DEFAULT
 	int "Default pthread stack size"
-	default 2048
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		Default pthread stack size
 


### PR DESCRIPTION
* The appropriate size of stack varies among archs.
  E.g. for 64-bit sim, 2048 is way too small, especially when the task
  happens to use host OS functionalities.
  I plan to allow an arch provide its own default.

* I plan to use this to replace hardcoded "STACKSIZE = 2048" in APPDIR.