### PR TITLE
Bump DEFAULT_TASK_STACKSIZE for the sim

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -29,6 +29,7 @@ config DEFAULT_SMALL
 
 config DEFAULT_TASK_STACKSIZE
 	int "The default stack size for tasks"
+	default 8192 if ARCH_SIM
 	default 2048
 	---help---
 		The default stack size for tasks.


### PR DESCRIPTION
The sim demands more stack because:
 * It's often 64-bit
 * It calls host OS libraries