### PR TITLE
tools/testbuild.sh: Make blacklist work on macOS

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -198,8 +198,8 @@ function build {
 function dotest {
   echo "===================================================================================="
   config=`echo $1 | cut -d',' -f1`
-  re=\\b${config/\//:}\\b
-  if [[ $blacklist =~ $re ]]; then
+  re="-${config/\//:}[[:space:]]"
+  if [[ "${blacklist} " =~ $re ]]; then
     echo "Skipping: $1"
   else
     echo "Configuration/Tool: $1"


### PR DESCRIPTION
I couldn't find where "\b" was documented.
I guess it's a zero-width word boundary or something like that.
Anyway, it doesn't seem to work on macOS.