### PR TITLE
Check return from nxsem_wait_initialize()

### DIFF
--- a/graphics/vnc/server/vnc_fbdev.c
+++ b/graphics/vnc/server/vnc_fbdev.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * graphics/vnc/server/vnc_fbdev.c
  *
- *   Copyright (C) 2016-2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -174,7 +159,8 @@ static int up_getvideoinfo(FAR struct fb_vtable_s *vtable,
   DEBUGASSERT(fbinfo != NULL && vinfo != NULL);
   if (fbinfo != NULL && vinfo != NULL)
     {
-      DEBUGASSERT(fbinfo->display >= 0 && fbinfo->display < RFB_MAX_DISPLAYS);
+      DEBUGASSERT(fbinfo->display >= 0 &&
+                  fbinfo->display < RFB_MAX_DISPLAYS);
       session = g_vnc_sessions[fbinfo->display];
 
       if (session == NULL || session->state != VNCSERVER_RUNNING)
@@ -215,7 +201,8 @@ static int up_getplaneinfo(FAR struct fb_vtable_s *vtable, int planeno,
   DEBUGASSERT(fbinfo != NULL && pinfo != NULL && planeno == 0);
   if (fbinfo != NULL && pinfo != NULL && planeno == 0)
     {
-      DEBUGASSERT(fbinfo->display >= 0 && fbinfo->display < RFB_MAX_DISPLAYS);
+      DEBUGASSERT(fbinfo->display >= 0 &&
+                  fbinfo->display < RFB_MAX_DISPLAYS);
       session = g_vnc_sessions[fbinfo->display];
 
       if (session == NULL || session->state != VNCSERVER_RUNNING)
@@ -262,7 +249,8 @@ static int up_getcmap(FAR struct fb_vtable_s *vtable,
 
   if (fbinfo != NULL && cmap != NULL)
     {
-      DEBUGASSERT(fbinfo->display >= 0 && fbinfo->display < RFB_MAX_DISPLAYS);
+      DEBUGASSERT(fbinfo->display >= 0 &&
+                  fbinfo->display < RFB_MAX_DISPLAYS);
       session = g_vnc_sessions[fbinfo->display];
 
       if (session == NULL || session->state != VNCSERVER_RUNNING)
@@ -287,7 +275,8 @@ static int up_getcmap(FAR struct fb_vtable_s *vtable,
  ****************************************************************************/
 
 #ifdef CONFIG_FB_CMAP
-static int up_putcmap(FAR struct fb_vtable_s *vtable, FAR const struct fb_cmap_s *cmap)
+static int up_putcmap(FAR struct fb_vtable_s *vtable,
+                      FAR const struct fb_cmap_s *cmap)
 {
   FAR struct vnc_fbinfo_s *fbinfo = (FAR struct vnc_fbinfo_s *)vtable;
   FAR struct vnc_session_s *session;
@@ -299,7 +288,8 @@ static int up_putcmap(FAR struct fb_vtable_s *vtable, FAR const struct fb_cmap_s
 
   if (fbinfo != NULL && cmap != NULL)
     {
-      DEBUGASSERT(fbinfo->display >= 0 && fbinfo->display < RFB_MAX_DISPLAYS);
+      DEBUGASSERT(fbinfo->display >= 0 &&
+                  fbinfo->display < RFB_MAX_DISPLAYS);
       session = g_vnc_sessions[fbinfo->display];
 
       if (session == NULL || session->state != VNCSERVER_RUNNING)
@@ -337,7 +327,8 @@ static int up_getcursor(FAR struct fb_vtable_s *vtable,
 
   if (fbinfo != NULL && attrib != NULL)
     {
-      DEBUGASSERT(fbinfo->display >= 0 && fbinfo->display < RFB_MAX_DISPLAYS);
+      DEBUGASSERT(fbinfo->display >= 0 &&
+                  fbinfo->display < RFB_MAX_DISPLAYS);
       session = g_vnc_sessions[fbinfo->display];
 
       if (session == NULL || session->state != VNCSERVER_RUNNING)
@@ -374,7 +365,8 @@ static int up_setcursor(FAR struct fb_vtable_s *vtable,
 
   if (fbinfo != NULL && settings != NULL)
     {
-      DEBUGASSERT(fbinfo->display >= 0 && fbinfo->display < RFB_MAX_DISPLAYS);
+      DEBUGASSERT(fbinfo->display >= 0 &&
+                  fbinfo->display < RFB_MAX_DISPLAYS);
       session = g_vnc_sessions[fbinfo->display];
 
       if (session == NULL || session->state != VNCSERVER_RUNNING)
@@ -395,12 +387,14 @@ static int up_setcursor(FAR struct fb_vtable_s *vtable,
 #warning Missing logic
         }
 #endif
+
 #ifdef CONFIG_FB_HWCURSORIMAGE
       if ((settings->flags & FB_CUR_SETIMAGE) != 0)
         {
 #warning Missing logic
         }
 #endif
+
       return OK;
     }
 
@@ -485,6 +479,8 @@ static int vnc_start_server(int display)
 
 static inline int vnc_wait_start(int display)
 {
+  int ret;
+
   /* Check if there has been a session allocated yet.  This is one of the
    * first things that the VNC server will do with the kernel thread is
    * started.  But we might be here before the thread has gotten that far.
@@ -494,8 +490,8 @@ static inline int vnc_wait_start(int display)
    * has been allocated and fully initialized.
    */
 
- while (g_vnc_sessions[display] == NULL ||
-        g_vnc_sessions[display]->state == VNCSERVER_UNINITIALIZED)
+  while (g_vnc_sessions[display] == NULL ||
+         g_vnc_sessions[display]->state == VNCSERVER_UNINITIALIZED)
     {
       /* The server is not yet running.  Wait for the server to post the FB
        * semaphore.  In certain error situations, the server may post the
@@ -503,7 +499,11 @@ static inline int vnc_wait_start(int display)
        * conditions here, but I think none that are fatal.
        */
 
-      nxsem_wait_uninterruptible(&g_fbstartup[display].fbinit);
+      ret = nxsem_wait_uninterruptible(&g_fbstartup[display].fbinit);
+      if (ret < 0)
+        {
+          return ret;
+        }
     }
 
   return OK;
@@ -542,8 +542,8 @@ static inline int vnc_wait_connect(int display)
    * messages and to perform remote framebuffer updates.
    */
 
- while (g_vnc_sessions[display] == NULL ||
-        g_vnc_sessions[display]->state != VNCSERVER_RUNNING)
+  while (g_vnc_sessions[display] == NULL ||
+         g_vnc_sessions[display]->state != VNCSERVER_RUNNING)
     {
       /* The server is not yet running.  Wait for the server to post the FB
        * semaphore.  In certain error situations, the server may post the
@@ -574,9 +574,11 @@ static inline int vnc_wait_connect(int display)
           else
             {
               DEBUGASSERT(g_vnc_sessions[display] != NULL &&
-                          g_vnc_sessions[display]->state == VNCSERVER_RUNNING);
+                          g_vnc_sessions[display]->state ==
+                          VNCSERVER_RUNNING);
             }
 #endif
+
           return ret;
         }
     }
@@ -726,7 +728,8 @@ int vnc_fbinitialize(int display, vnc_kbdout_t kbdout,
  *
  * Description:
  *   Return a a reference to the framebuffer object for the specified video
- *   plane of the specified plane.  Many OSDs support multiple planes of video.
+ *   plane of the specified plane.  Many OSDs support multiple planes of
+ *   video.
  *
  * Input Parameters:
  *   display - In the case of hardware with multiple displays, this

--- a/graphics/vnc/server/vnc_updater.c
+++ b/graphics/vnc/server/vnc_updater.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * graphics/vnc/vnc_updater.c
  *
- *   Copyright (C) 2016-2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -126,8 +111,16 @@ static void vnc_sem_debug(FAR struct vnc_session_s *session,
   int queuecount;
   int freewaiting;
   int queuewaiting;
+  int ret;
 
-  nxsem_wait_uninterruptible(&g_errsem);
+  ret = nxsem_wait_uninterruptible(&g_errsem);
+  if (ret < 0)
+    {
+      /* Should happen only on task cancellation */
+
+      DEBUGASSERT(ret == -ECANCELED);
+      return;
+    }
 
   /* Count structures in the list */
 
@@ -445,7 +438,8 @@ int vnc_start_updater(FAR struct vnc_session_s *session)
   session->state = VNCSERVER_RUNNING;
 
   DEBUGVERIFY(pthread_attr_init(&attr));
-  DEBUGVERIFY(pthread_attr_setstacksize(&attr, CONFIG_VNCSERVER_UPDATER_STACKSIZE));
+  DEBUGVERIFY(pthread_attr_setstacksize(&attr,
+                                        CONFIG_VNCSERVER_UPDATER_STACKSIZE));
 
   param.sched_priority = CONFIG_VNCSERVER_UPDATER_PRIO;
   DEBUGVERIFY(pthread_attr_setschedparam(&attr, &param));

--- a/mm/mm_gran/mm_gran.h
+++ b/mm/mm_gran/mm_gran.h
@@ -116,11 +116,12 @@ struct gran_s
  *   priv - Pointer to the gran state
  *
  * Returned Value:
- *   None
+ *   gran_enter_critical() may return any error reported by
+ *   nxsem_wait_uninterruptible()
  *
  ****************************************************************************/
 
-void gran_enter_critical(FAR struct gran_s *priv);
+int  gran_enter_critical(FAR struct gran_s *priv);
 void gran_leave_critical(FAR struct gran_s *priv);
 
 /****************************************************************************

--- a/mm/mm_gran/mm_granalloc.c
+++ b/mm/mm_gran/mm_granalloc.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * mm/mm_gran/mm_granalloc.c
  *
- *   Copyright (C) 2012, 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -84,6 +69,7 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
   int          gatidx;
   int          bitidx;
   int          shift;
+  int          ret;
 
   DEBUGASSERT(priv != NULL && size <= 32 * (1 << priv->log2gran));
 
@@ -91,7 +77,11 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
     {
       /* Get exclusive access to the GAT */
 
-      gran_enter_critical(priv);
+      ret = gran_enter_critical(priv);
+      if (ret < 0)
+        {
+          return NULL;
+        }
 
       /* How many contiguous granules we we need to find? */
 
@@ -147,7 +137,8 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
           alloc = priv->heapstart + (granidx << priv->log2gran);
 
           for (bitidx = 0;
-               bitidx < 32 && (granidx + bitidx + ngranules) <= priv->ngranules;
+               bitidx < 32 &&
+               (granidx + bitidx + ngranules) <= priv->ngranules;
               )
             {
               /* Break out if there are no further free bits in 'curr'.
@@ -199,8 +190,8 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
                   shift = 4;
                 }
 
-              /* We know that the first free bit is now within the lower 4 bits
-               * of 'curr'.  Is it in the upper or lower pair?
+              /* We know that the first free bit is now within the lower 4
+               * bits of 'curr'.  Is it in the upper or lower pair?
                */
 
               else if ((curr & 0x000003) == 0x00000003)
@@ -212,9 +203,9 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
                   shift = 2;
                 }
 
-              /* We know that the first free bit is now within the lower 4 bits
-               * of 'curr'.  Check if we have the allocation at this bit
-               * position.
+              /* We know that the first free bit is now within the lower 4
+               * bits of 'curr'.  Check if we have the allocation at this
+               * bit position.
                */
 
               else if ((curr & mask) == 0)

--- a/mm/mm_gran/mm_grancritical.c
+++ b/mm/mm_gran/mm_grancritical.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * mm/mm_gran/mm_grancritical.c
  *
- *   Copyright (C) 2012, 2016-2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -64,16 +49,18 @@
  *   priv - Pointer to the gran state
  *
  * Returned Value:
- *   None
+ *   gran_enter_critical() may return any error reported by
+ *   nxsem_wait_uninterruptible()
  *
  ****************************************************************************/
 
-void gran_enter_critical(FAR struct gran_s *priv)
+int gran_enter_critical(FAR struct gran_s *priv)
 {
 #ifdef CONFIG_GRAN_INTR
   priv->irqstate = enter_critical_section();
+  return OK;
 #else
-  nxsem_wait_uninterruptible(&priv->exclsem);
+  return nxsem_wait_uninterruptible(&priv->exclsem);
 #endif
 }
 

--- a/mm/mm_gran/mm_granfree.c
+++ b/mm/mm_gran/mm_granfree.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * mm/mm_gran/mm_granfree.c
  *
- *   Copyright (C) 2012, 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -76,12 +61,20 @@ void gran_free(GRAN_HANDLE handle, FAR void *memory, size_t size)
   unsigned int ngranules;
   unsigned int avail;
   uint32_t     gatmask;
+  int          ret;
 
   DEBUGASSERT(priv != NULL && memory && size <= 32 * (1 << priv->log2gran));
 
   /* Get exclusive access to the GAT */
 
-  gran_enter_critical(priv);
+  ret = gran_enter_critical(priv);
+  if (ret < 0)
+    {
+      /* Should happen only on task cancellation */
+
+      DEBUGASSERT(ret == -ECANCELED);
+      return;
+    }
 
   /* Determine the granule number of the first granule in the allocation */
 

--- a/mm/mm_gran/mm_graninfo.c
+++ b/mm/mm_gran/mm_graninfo.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * mm/mm_gran/mm_graninfo.c
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -73,53 +58,115 @@ struct valinfo_s
 
 static const struct nibble_info_s g_0bit_info[1] =
 {
-  { 0, 0, 0, 0}   /*  0 xxxx */
+  {               /*  0 xxxx */
+    0, 0, 0, 0
+  }
 };
 
 static const struct nibble_info_s g_1bit_info[2] =
 {
-  { 1, 1, 0, 0},  /*  0 xxx0 */
-  { 0, 0, 0, 0}   /*  1 xxx1 */
+  {               /*  0 xxx0 */
+    1, 1, 0, 0
+  },
+  {               /*  1 xxx1 */
+    0, 0, 0, 0
+  }
 };
 
 static const struct nibble_info_s g_2bit_info[4] =
 {
-  { 2, 2, 0, 0},  /*  0 xx00 */
-  { 1, 0, 1, 0},  /*  1 xx01 */
-  { 1, 1, 0, 0},  /*  2 xx10 */
-  { 0, 0, 0, 0}   /*  3 xx11 */
+  {               /*  0 xx00 */
+    2, 2, 0, 0
+  },
+  {               /*  1 xx01 */
+    1, 0, 1, 0
+  },
+  {               /*  2 xx10 */
+    1, 1, 0, 0
+  },
+  {               /*  3 xx11 */
+    0, 0, 0, 0
+  }
 };
 
 static const struct nibble_info_s g_3bit_info[8] =
 {
-  { 3, 3, 0, 0},  /*  0 x000 */
-  { 2, 0, 2, 0},  /*  1 x001 */
-  { 2, 1, 1, 0},  /*  2 x010 */
-  { 1, 0, 1, 0},  /*  3 x011 */
-  { 2, 2, 0, 0},  /*  4 x100 */
-  { 1, 0, 0, 1},  /*  5 x101 */
-  { 1, 1, 0, 0},  /*  6 x110 */
-  { 0, 0, 0, 0}   /*  7 x111 */
+  {               /*  0 x000 */
+    3, 3, 0, 0
+  },
+  {               /*  1 x001 */
+    2, 0, 2, 0
+  },
+  {               /*  2 x010 */
+    2, 1, 1, 0
+  },
+  {               /*  3 x011 */
+    1, 0, 1, 0
+  },
+  {               /*  4 x100 */
+    2, 2, 0, 0
+  },
+  {               /*  5 x101 */
+    1, 0, 0, 1
+  },
+  {               /*  6 x110 */
+    1, 1, 0, 0
+  },
+  {               /*  7 x111 */
+    0, 0, 0, 0
+  }
 };
 
 static const struct nibble_info_s g_4bit_info[16] =
 {
-  { 4, 4, 0, 0},  /*  0 0000 */
-  { 3, 0, 3, 0},  /*  1 0001 */
-  { 3, 1, 2, 0},  /*  2 0010 */
-  { 2, 0, 2, 0},  /*  3 0011 */
-  { 3, 2, 1, 0},  /*  4 0100 */
-  { 2, 0, 1, 1},  /*  5 0101 */
-  { 2, 1, 1, 0},  /*  6 0110 */
-  { 1, 0, 1, 0},  /*  7 0111 */
-  { 3, 3, 0, 0},  /*  8 1000 */
-  { 2, 0, 0, 2},  /*  9 1001 */
-  { 2, 1, 0, 1},  /* 10 1010 */
-  { 1, 0, 0, 1},  /* 11 1011 */
-  { 2, 2, 0, 0},  /* 12 1100 */
-  { 1, 0, 0, 1},  /* 13 1101 */
-  { 1, 1, 0, 0},  /* 14 1110 */
-  { 0, 0, 0, 0}   /* 15 1111 */
+  {               /*  0 0000 */
+    4, 4, 0, 0
+  },
+  {               /*  1 0001 */
+    3, 0, 3, 0
+  },
+  {               /*  2 0010 */
+    3, 1, 2, 0
+  },
+  {               /*  3 0011 */
+    2, 0, 2, 0
+  },
+  {               /*  4 0100 */
+    3, 2, 1, 0
+  },
+  {               /*  5 0101 */
+    2, 0, 1, 1
+  },
+  {               /*  6 0110 */
+    2, 1, 1, 0
+  },
+  {               /*  7 0111 */
+    1, 0, 1, 0
+  },
+  {               /*  8 1000 */
+    3, 3, 0, 0
+  },
+  {               /*  9 1001 */
+    2, 0, 0, 2
+  },
+  {               /* 10 1010 */
+    2, 1, 0, 1
+  },
+  {               /* 11 1011 */
+    1, 0, 0, 1
+  },
+  {               /* 12 1100 */
+    2, 2, 0, 0
+  },
+  {               /* 13 1101 */
+    1, 0, 0, 1
+  },
+  {               /* 14 1110 */
+    1, 1, 0, 0
+  },
+  {               /* 15 1111 */
+    0, 0, 0, 0
+  }
 };
 
 static const struct nibble_info_s *g_info_table[5] =
@@ -442,6 +489,7 @@ void gran_info(GRAN_HANDLE handle, FAR struct graninfo_s *info)
   unsigned int nbits;
   unsigned int granidx;
   unsigned int gatidx;
+  int ret;
 
   DEBUGASSERT(priv != NULL && info != NULL);
 
@@ -453,7 +501,14 @@ void gran_info(GRAN_HANDLE handle, FAR struct graninfo_s *info)
 
   /* Get exclusive access to the GAT */
 
-  gran_enter_critical(priv);
+  ret = gran_enter_critical(priv);
+  if (ret < 0)
+    {
+      /* Should happen only on task cancellation */
+
+      DEBUGASSERT(ret == -ECANCELED);
+      return;
+    }
 
   /* Traverse the granule allocation  */
 

--- a/net/route/net_cacheroute.c
+++ b/net/route/net_cacheroute.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * net/route/net_cacheroute.c
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -785,34 +770,42 @@ int net_foreachcache_ipv6(route_handler_ipv6_t handler, FAR void *arg)
 #ifdef CONFIG_ROUTE_IPv4_CACHEROUTE
 void net_flushcache_ipv4(void)
 {
+  int ret;
+
   /* Get exclusive access to the cache */
 
-  net_lock_ipv4_cache();
+  ret = net_lock_ipv4_cache();
+  if (ret >= 0)
+    {
+      /* Reset the cache */
 
-  /* Reset the cache */
+      net_reset_ipv4_cache();
 
-  net_reset_ipv4_cache();
+      /* Unlock the cache */
 
-  /* Unlock the cache */
-
-  net_unlock_ipv4_cache();
+      net_unlock_ipv4_cache();
+    }
 }
 #endif
 
 #ifdef CONFIG_ROUTE_IPv6_CACHEROUTE
 void net_flushcache_ipv6(void)
 {
+  int ret;
+
   /* Get exclusive access to the cache */
 
-  net_lock_ipv6_cache();
+  ret = net_lock_ipv6_cache();
+  if (ret >= 0)
+    {
+      /* Reset the cache */
 
-  /* Reset the cache */
+      net_reset_ipv6_cache();
 
-  net_reset_ipv6_cache();
+      /* Unlock the cache */
 
-  /* Unlock the cache */
-
-  net_unlock_ipv6_cache();
+      net_unlock_ipv6_cache();
+    }
 }
 #endif
 

--- a/sched/task/spawn.h
+++ b/sched/task/spawn.h
@@ -110,7 +110,7 @@ extern struct spawn_parms_s g_spawn_parms;
  *
  ****************************************************************************/
 
-void spawn_semtake(FAR sem_t *sem);
+int spawn_semtake(FAR sem_t *sem);
 #define spawn_semgive(sem) nxsem_post(sem)
 
 /****************************************************************************

--- a/sched/task/task_posixspawn.c
+++ b/sched/task/task_posixspawn.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/task/task_posixspawn.c
  *
- *   Copyright (C) 2013, 2018-2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -371,7 +356,12 @@ int posix_spawn(FAR pid_t *pid, FAR const char *path,
 
   /* Get exclusive access to the global parameter structure */
 
-  spawn_semtake(&g_spawn_parmsem);
+  ret = spawn_semtake(&g_spawn_parmsem);
+  if (ret < 0)
+    {
+      serr("ERROR: spawn_semtake failed: %d\n", ret);
+      return -ret;
+    }
 
   /* Populate the parameter structure */
 
@@ -420,14 +410,25 @@ int posix_spawn(FAR pid_t *pid, FAR const char *path,
   /* Wait for the proxy to complete its job */
 
 #ifdef CONFIG_SCHED_WAITPID
+  /* REVISIT: This should not call waitpid() directly.  waitpid is a
+   * cancellation point and modifies the errno value.  It is inappropriate
+   * for use within the OS.
+   */
+
   ret = waitpid(proxy, &status, 0);
   if (ret < 0)
     {
-      serr("ERROR: waitpid() failed: %d\n", errno);
+      ret = -get_errno();
+      serr("ERROR: waitpid() failed: %d\n", ret);
       goto errout_with_lock;
     }
 #else
-  spawn_semtake(&g_spawn_execsem);
+  ret = spawn_semtake(&g_spawn_execsem);
+  if (ret < 0)
+    {
+      serr("ERROR: spawn_semtake() failed: %d\n", ret);
+      goto errout_with_lock;
+    }
 #endif
 
   /* Get the result and relinquish our access to the parameter structure */

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/task/task_spawn.c
  *
- *   Copyright (C) 2013, 2018-2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -362,7 +347,12 @@ int task_spawn(FAR pid_t *pid, FAR const char *name, main_t entry,
 
   /* Get exclusive access to the global parameter structure */
 
-  spawn_semtake(&g_spawn_parmsem);
+  ret = spawn_semtake(&g_spawn_parmsem);
+  if (ret < 0)
+    {
+      serr("ERROR: spawn_semtake failed: %d\n", ret);
+      return -ret;
+    }
 
   /* Populate the parameter structure */
 
@@ -414,14 +404,25 @@ int task_spawn(FAR pid_t *pid, FAR const char *name, main_t entry,
   /* Wait for the proxy to complete its job */
 
 #ifdef CONFIG_SCHED_WAITPID
+  /* REVISIT: This should not call waitpid() directly.  waitpid is a
+   * cancellation point and modifies the errno value.  It is inappropriate
+   * for use within the OS.
+   */
+
   ret = waitpid(proxy, &status, 0);
   if (ret < 0)
     {
-      serr("ERROR: waitpid() failed: %d\n", errno);
+      ret = -get_errno();
+      serr("ERROR: waitpid() failed: %d\n", ret);
       goto errout_with_lock;
     }
 #else
-  spawn_semtake(&g_spawn_execsem);
+  ret = spawn_semtake(&g_spawn_execsem);
+  if (ret < 0)
+    {
+      serr("ERROR: g_spawn_execsem() failed: %d\n", ret);
+      goto errout_with_lock;
+    }
 #endif
 
   /* Get the result and relinquish our access to the parameter structure */

--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/task/task_spawnparms.c
  *
- *   Copyright (C) 2013, 2015, 2017-2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -167,13 +152,13 @@ static inline int nxspawn_open(FAR struct spawn_open_file_action_s *action)
  *   sem - The semaphore to act on.
  *
  * Returned Value:
- *   None
+ *   See nxsem_wait_uninterruptible
  *
  ****************************************************************************/
 
-void spawn_semtake(FAR sem_t *sem)
+int spawn_semtake(FAR sem_t *sem)
 {
-  nxsem_wait_uninterruptible(sem);
+  return nxsem_wait_uninterruptible(sem);
 }
 
 /****************************************************************************

--- a/wireless/bluetooth/bt_conn.c
+++ b/wireless/bluetooth/bt_conn.c
@@ -12,29 +12,31 @@
  *   All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  *
  * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from this
- *    software without specific prior written permission.
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
@@ -147,9 +149,14 @@ static int conn_tx_kthread(int argc, FAR char *argv[])
     {
       /* Wait until the controller can accept ACL packets */
 
-      wlinfo("calling nxsem_wait\n");
+      wlinfo("calling nxsem_wait_uninterruptible()\n");
 
-      nxsem_wait_uninterruptible(&g_btdev.le_pkts_sem);
+      ret = nxsem_wait_uninterruptible(&g_btdev.le_pkts_sem);
+      if (ret < 0)
+        {
+          wlerr("nxsem_wait_uninterruptible() failed: %d\n", ret);
+          break;
+        }
 
       /* Check for disconnection */
 
@@ -292,6 +299,7 @@ void bt_conn_receive(FAR struct bt_conn_s *conn, FAR struct bt_buf_s *buf,
   switch (flags)
     {
       case 0x02:
+
         /* First packet */
 
         hdr = (void *)buf->data;
@@ -316,6 +324,7 @@ void bt_conn_receive(FAR struct bt_conn_s *conn, FAR struct bt_buf_s *buf,
         break;
 
       case 0x01:
+
         /* Continuation */
 
         if (!conn->rx_len)
@@ -560,40 +569,47 @@ void bt_conn_set_state(FAR struct bt_conn_s *conn,
           int ret;
 
           ret = bt_queue_open(BT_CONN_TX, O_RDWR | O_CREAT,
-                              CONFIG_BLUETOOTH_TXCONN_NMSGS, &conn->tx_queue);
+                              CONFIG_BLUETOOTH_TXCONN_NMSGS,
+                              &conn->tx_queue);
           DEBUGASSERT(ret >= 0 && g_btdev.tx_queue != 0);
           UNUSED(ret);
 
-          /* Get exclusive access to the handoff structure.  The count will be
-           * zero when we complete this.
+          /* Get exclusive access to the handoff structure.  The count will
+           * be zero when we complete this.
            */
 
-          nxsem_wait_uninterruptible(&g_conn_handoff.sync_sem);
+          ret = nxsem_wait_uninterruptible(&g_conn_handoff.sync_sem);
+          if (ret >= 0)
+            {
+              /* Start the Tx connection kernel thread */
 
-          /* Start the Tx connection kernel thread */
+              g_conn_handoff.conn = bt_conn_addref(conn);
+              pid = kthread_create("BT Conn Tx",
+                                   CONFIG_BLUETOOTH_TXCONN_PRIORITY,
+                                   CONFIG_BLUETOOTH_TXCONN_STACKSIZE,
+                                   conn_tx_kthread, NULL);
+              DEBUGASSERT(pid > 0);
+              UNUSED(pid);
 
-          g_conn_handoff.conn = bt_conn_addref(conn);
-          pid = kthread_create("BT Conn Tx", CONFIG_BLUETOOTH_TXCONN_PRIORITY,
-                               CONFIG_BLUETOOTH_TXCONN_STACKSIZE,
-                               conn_tx_kthread, NULL);
-          DEBUGASSERT(pid > 0);
-          UNUSED(pid);
+              /* Take the semaphore again.  This will force us to wait with
+               * the sem_count at -1.  It will be zero again when we
+               * continue.
+               */
 
-          /* Take the semaphore again.  This will force us to wait with the
-           * sem_count at -1.  It will be zero again when we continue.
-           */
-
-          nxsem_wait_uninterruptible(&g_conn_handoff.sync_sem);
-          nxsem_post(&g_conn_handoff.sync_sem);
+              ret = nxsem_wait_uninterruptible(&g_conn_handoff.sync_sem);
+              nxsem_post(&g_conn_handoff.sync_sem);
+          }
         }
         break;
 
       case BT_CONN_DISCONNECTED:
-        /* Send dummy buffer to wake up and stop the Tx thread for states where it
-         * was running.
+
+        /* Send dummy buffer to wake up and stop the Tx thread for states
+         * where it was running.
          */
 
-        if (old_state == BT_CONN_CONNECTED || old_state == BT_CONN_DISCONNECT)
+        if (old_state == BT_CONN_CONNECTED ||
+           old_state == BT_CONN_DISCONNECT)
           {
             bt_queue_send(conn->tx_queue, bt_buf_alloc(BT_DUMMY, NULL, 0),
                           BT_NORMAL_PRIO);
@@ -809,18 +825,18 @@ FAR const bt_addr_le_t *bt_conn_get_dst(FAR const struct bt_conn_s *conn)
  * Name: bt_conn_security
  *
  * Description:
- *   This function enable security (encryption) for a connection. If device is
- *   already paired with sufficiently strong key encryption will be enabled. If
- *   link is already encrypted with sufficiently strong key this function does
- *   nothing.
+ *   This function enable security (encryption) for a connection. If device
+ *   is already paired with sufficiently strong key encryption will be
+ *   enabled. If link is already encrypted with sufficiently strong key this
+ *   function does nothing.
  *
- *   If device is not paired pairing will be initiated. If device is paired and
- *   keys are too weak but input output capabilities allow for strong enough keys
- *   pairing will be initiated.
+ *   If device is not paired pairing will be initiated. If device is paired
+ *   and keys are too weak but input output capabilities allow for strong
+ *   enough keys pairing will be initiated.
  *
- *   This function may return error if required level of security is not possible
- *   to achieve due to local or remote device limitation (eg input output
- *   capabilities).
+ *   This function may return error if required level of security is not
+ *   possible to achieve due to local or remote device limitation (eg input
+ *   output capabilities).
  *
  * Input Parameters:
  *   conn - Connection object.
@@ -1058,7 +1074,8 @@ int bt_conn_le_conn_update(FAR struct bt_conn_s *conn, uint16_t min,
       return -ENOBUFS;
     }
 
-  conn_update                      = bt_buf_extend(buf, sizeof(*conn_update));
+  conn_update                      = bt_buf_extend(buf,
+                                                   sizeof(*conn_update));
   memset(conn_update, 0, sizeof(*conn_update));
   conn_update->handle              = BT_HOST2LE16(conn->handle);
   conn_update->conn_interval_min   = BT_HOST2LE16(min);

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -12,29 +12,31 @@
  *   All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  *
  * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from this
- *    software without specific prior written permission.
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
@@ -164,7 +166,8 @@ static void bt_enqueue_bufwork(FAR struct bt_bufferlist_s *list,
  *
  ****************************************************************************/
 
-static FAR struct bt_buf_s *bt_dequeue_bufwork(FAR struct bt_bufferlist_s *list)
+static FAR struct bt_buf_s *
+  bt_dequeue_bufwork(FAR struct bt_bufferlist_s *list)
 {
   FAR struct bt_buf_s *buf;
   irqstate_t flags;
@@ -248,7 +251,8 @@ static void hci_acl(FAR struct bt_buf_s *buf)
 
   if (buf->len != len)
     {
-      wlerr("ERROR:  ACL data length mismatch (%u != %u)\n", buf->len, len);
+      wlerr("ERROR:  ACL data length mismatch (%u != %u)\n",
+             buf->len, len);
       bt_buf_release(buf);
       return;
     }
@@ -256,7 +260,8 @@ static void hci_acl(FAR struct bt_buf_s *buf)
   conn = bt_conn_lookup_handle(buf->u.acl.handle);
   if (!conn)
     {
-      wlerr("ERROR:  Unable to find conn for handle %u\n", buf->u.acl.handle);
+      wlerr("ERROR:  Unable to find conn for handle %u\n",
+            buf->u.acl.handle);
       bt_buf_release(buf);
       return;
     }
@@ -362,8 +367,8 @@ static void hci_cmd_complete(FAR struct bt_buf_s *buf)
 
   bt_buf_consume(buf, sizeof(*evt));
 
-  /* All command return parameters have a 1-byte status in the beginning, so we
-   * can safely make this generalization.
+  /* All command return parameters have a 1-byte status in the beginning, so
+   * we can safely make this generalization.
    */
 
   status = buf->data;
@@ -445,7 +450,8 @@ static void hci_num_completed_packets(FAR struct bt_buf_s *buf)
 
 static void hci_encrypt_key_refresh_complete(FAR struct bt_buf_s *buf)
 {
-  FAR struct bt_hci_evt_encrypt_key_refresh_complete_s *evt = (FAR void *)buf->data;
+  FAR struct bt_hci_evt_encrypt_key_refresh_complete_s *evt =
+    (FAR void *)buf->data;
   FAR struct bt_conn_s *conn;
   uint16_t handle;
 
@@ -512,8 +518,8 @@ static int bt_hci_start_scanning(uint8_t scan_type, uint8_t scan_filter)
   memset(set_param, 0, sizeof(*set_param));
   set_param->scan_type = scan_type;
 
-  /* for the rest parameters apply default values according to spec 4.2, vol2,
-   * part E, 7.8.10
+  /* for the rest parameters apply default values according to spec 4.2,
+   * vol2, part E, 7.8.10
    */
 
   set_param->interval      = BT_HOST2LE16(0x0010);
@@ -522,7 +528,8 @@ static int bt_hci_start_scanning(uint8_t scan_type, uint8_t scan_filter)
   set_param->addr_type     = 0x00;
 
   bt_hci_cmd_send(BT_HCI_OP_LE_SET_SCAN_PARAMS, buf);
-  buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_SCAN_ENABLE, sizeof(*scan_enable));
+  buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_SCAN_ENABLE,
+                          sizeof(*scan_enable));
   if (buf == NULL)
     {
       wlerr("ERROR:  Failed to create buffer\n");
@@ -628,7 +635,8 @@ static void hci_disconn_complete(FAR struct bt_buf_s *buf)
   uint16_t handle = BT_LE162HOST(evt->handle);
   FAR struct bt_conn_s *conn;
 
-  wlinfo("status %u handle %u reason %u\n", evt->status, handle, evt->reason);
+  wlinfo("status %u handle %u reason %u\n",
+         evt->status, handle, evt->reason);
 
   if (evt->status)
     {
@@ -700,8 +708,8 @@ static void le_conn_complete(FAR struct bt_buf_s *buf)
 
       bt_conn_set_state(conn, BT_CONN_DISCONNECTED);
 
-      /* Drop the reference got by lookup call in CONNECT state. We are now in
-       * DISCONNECTED state since no successful LE link been made.
+      /* Drop the reference got by lookup call in CONNECT state. We are now
+       * in the DISCONNECTED state since no successful LE link been made.
        */
 
       bt_conn_release(conn);
@@ -824,7 +832,8 @@ static void le_adv_report(FAR struct bt_buf_s *buf)
        * according to spec 4.2, Vol 2, Part E, 7.7.65.2.
        */
 
-      info = bt_buf_consume(buf, sizeof(*info) + info->length + sizeof(rssi));
+      info = bt_buf_consume(buf,
+                            sizeof(*info) + info->length + sizeof(rssi));
     }
 }
 
@@ -977,7 +986,12 @@ static int hci_tx_kthread(int argc, FAR char *argv[])
 
       /* Wait until ncmd > 0 */
 
-      nxsem_wait_uninterruptible(&g_btdev.ncmd_sem);
+      ret = nxsem_wait_uninterruptible(&g_btdev.ncmd_sem);
+      if (ret < 0)
+        {
+          wlerr("nxsem_wait_uninterruptible() failed: %d\n", ret);
+          return EXIT_FAILURE;
+        }
 
       /* Get next command - wait if necessary */
 
@@ -1525,7 +1539,8 @@ void bt_driver_unregister(FAR const struct bt_driver_s *btdev)
  * Description:
  *   Called by the Bluetooth low-level driver when new data is received from
  *   the radio.  This may be called from the low-level driver and is part of
- *   the driver interface prototyped in include/nuttx/wireless/bluetooth/bt_driver.h
+ *   the driver interface prototyped in
+ *   include/nuttx/wireless/bluetooth/bt_driver.h
  *
  *   NOTE:  This function will defer all real work to the low or to the high
  *   priority work queues.  Therefore, this function may safely be called


### PR DESCRIPTION
Resolution of Issue 619 will require multiple steps, this part of the first step in that resolution:  Every call to nxsem_wait_uninterruptible() must handle the return value from nxsem_wait_uninterruptible properly.  This commit is only for those files under graphics/, mm/, net/, sched/, wireless/bluetooth.