### PR TITLE
fs/: Check return of nxsem_wait_uninterruptible.

### DIFF
--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -190,7 +190,12 @@ static int fat_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -517,7 +522,12 @@ static ssize_t fat_read(FAR struct file *filep, FAR char *buffer,
 
   /* Make sure that the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -642,7 +652,8 @@ fat_read_restart:
 
               if (ret == -EFAULT && !force_indirect)
                 {
-                  ferr("ERROR: DMA read alignment error, restarting indirect\n");
+                  ferr("ERROR: DMA read alignment error,"
+                       " restarting indirect\n");
                   force_indirect = true;
                   goto fat_read_restart;
                 }
@@ -763,7 +774,12 @@ static ssize_t fat_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Make sure that the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -902,7 +918,8 @@ fat_write_restart:
 
               if (ret == -EFAULT && !force_indirect)
                 {
-                  ferr("ERROR: DMA write alignment error, restarting indirect\n");
+                  ferr("ERROR: DMA write alignment error,"
+                        " restarting indirect\n");
                   force_indirect = true;
                   goto fat_write_restart;
                 }
@@ -926,7 +943,8 @@ fat_write_restart:
            * There are two cases where we can avoid this read:
            *
            * - If we are performing a whole-sector write that was rejected
-           *   by fat_hwwrite(), i.e. sectorindex == 0 and buflen >= sector size.
+           *   by fat_hwwrite(), i.e. sectorindex == 0 and buflen >= sector
+           *   size.
            *
            * - If the write is aligned to the beginning of the sector and
            *   extends beyond the end of the file, i.e. sectorindex == 0 and
@@ -975,7 +993,8 @@ fat_write_restart:
           else
             {
               /* We will write to the end of the buffer (or beyond).  Bump
-               * up the current sector number (actually the next sector number).
+               * up the current sector number (actually the next sector
+               * number).
                */
 
               ff->ff_sectorsincluster--;
@@ -1089,7 +1108,12 @@ static off_t fat_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Make sure that the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -1297,7 +1321,12 @@ static int fat_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Make sure that the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -1349,7 +1378,12 @@ static int fat_sync(FAR struct file *filep)
 
   /* Make sure that the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -1382,7 +1416,8 @@ static int fat_sync(FAR struct file *filep)
        * in the sector using the saved directory index.
        */
 
-      direntry = &fs->fs_buffer[(ff->ff_dirindex & DIRSEC_NDXMASK(fs)) * DIR_SIZE];
+      direntry = &fs->fs_buffer[(ff->ff_dirindex & DIRSEC_NDXMASK(fs)) *
+                                 DIR_SIZE];
 
       /* Set the archive bit, set the write time, and update
        * anything that may have* changed in the directory
@@ -1457,7 +1492,12 @@ static int fat_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -1567,7 +1607,12 @@ static int fat_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 
   /* Make sure that the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -1616,7 +1661,8 @@ static int fat_opendir(FAR struct inode *mountpt, FAR const char *relpath,
               ((uint32_t)DIR_GETFSTCLUSTHI(direntry) << 16) |
                          DIR_GETFSTCLUSTLO(direntry);
           dir->u.fat.fd_currcluster  = dir->u.fat.fd_startcluster;
-          dir->u.fat.fd_currsector   = fat_cluster2sector(fs, dir->u.fat.fd_currcluster);
+          dir->u.fat.fd_currsector   = fat_cluster2sector(fs,
+                                         dir->u.fat.fd_currcluster);
           dir->u.fat.fd_index        = 2;
         }
     }
@@ -1660,7 +1706,12 @@ static int fat_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -1685,7 +1736,8 @@ static int fat_fstat(FAR const struct file *filep, FAR struct stat *buf)
    * the saved directory index.
    */
 
-  direntry = &fs->fs_buffer[(ff->ff_dirindex & DIRSEC_NDXMASK(fs)) * DIR_SIZE];
+  direntry = &fs->fs_buffer[(ff->ff_dirindex & DIRSEC_NDXMASK(fs)) *
+                             DIR_SIZE];
 
   /* Call fat_stat_file() to create the buf and to save information to
    * it.
@@ -1735,7 +1787,12 @@ static int fat_truncate(FAR struct file *filep, off_t length)
 
   /* Make sure that the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -1840,7 +1897,8 @@ errout_with_semaphore:
  *
  ****************************************************************************/
 
-static int fat_readdir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir)
+static int fat_readdir(FAR struct inode *mountpt,
+                       FAR struct fs_dirent_s *dir)
 {
   FAR struct fat_mountpt_s *fs;
   unsigned int dirindex;
@@ -1862,7 +1920,12 @@ static int fat_readdir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir)
    * REVISIT: What if a forced unmount was done since opendir() was called?
    */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -1936,7 +1999,8 @@ static int fat_readdir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir)
                * entry.
                */
 
-              dirindex = (dir->u.fat.fd_index & DIRSEC_NDXMASK(fs)) * DIR_SIZE;
+              dirindex = (dir->u.fat.fd_index & DIRSEC_NDXMASK(fs)) *
+                          DIR_SIZE;
               direntry = &fs->fs_buffer[dirindex];
 
               /* Then re-read the attributes from the short file name entry */
@@ -1954,8 +2018,8 @@ static int fat_readdir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir)
                   dir->fd_dir.d_type = DTYPE_DIRECTORY;
                 }
 
-              /* Mark the entry found.  We will set up the next directory index,
-               * and then exit with success.
+              /* Mark the entry found.  We will set up the next directory
+               * index, and then exit with success.
                */
 
               found = true;
@@ -2004,7 +2068,12 @@ static int fat_rewinddir(FAR struct inode *mountpt,
    * REVISIT: What if a forced unmount was done since opendir() was called?
    */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -2034,14 +2103,15 @@ static int fat_rewinddir(FAR struct inode *mountpt,
       dir->u.fat.fd_index       = 0;
     }
 
-  /* This is not the root directory.  Here the fd_index is set to 2, skipping over
-   * both the "." and ".." entries.
+  /* This is not the root directory.  Here the fd_index is set to 2, skipping
+   * over both the "." and ".." entries.
    */
 
   else
     {
       dir->u.fat.fd_currcluster  = dir->u.fat.fd_startcluster;
-      dir->u.fat.fd_currsector   = fat_cluster2sector(fs, dir->u.fat.fd_currcluster);
+      dir->u.fat.fd_currsector   = fat_cluster2sector(fs,
+                                     dir->u.fat.fd_currcluster);
       dir->u.fat.fd_index        = 2;
     }
 
@@ -2128,6 +2198,7 @@ static int fat_unbind(FAR void *handle, FAR struct inode **blkdriver,
                       unsigned int flags)
 {
   FAR struct fat_mountpt_s *fs = (FAR struct fat_mountpt_s *)handle;
+  int ret;
 
   if (!fs)
     {
@@ -2136,7 +2207,12 @@ static int fat_unbind(FAR void *handle, FAR struct inode **blkdriver,
 
   /* Check if there are sill any files opened on the filesystem. */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (fs->fs_head)
     {
       /* There are open files.  We umount now unless we are forced with the
@@ -2230,7 +2306,12 @@ static int fat_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret < 0)
     {
@@ -2287,7 +2368,12 @@ static int fat_unlink(FAR struct inode *mountpt, FAR const char *relpath)
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret == OK)
     {
@@ -2340,7 +2426,12 @@ static int fat_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -2446,8 +2537,8 @@ static int fat_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
     }
 
   /* Now create the "." directory entry in the first directory slot.  These
-   * are special directory entries and are not handled by the normal directory
-   * management routines.
+   * are special directory entries and are not handled by the normal
+   * directory management routines.
    */
 
   memset(&direntry[DIR_NAME], ' ', DIR_MAXFNAME);
@@ -2549,13 +2640,18 @@ int fat_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret == OK)
     {
-      /* If the directory is open, the correct behavior is to remove the directory
-       * name, but to keep the directory cluster chain in place until the last
-       * open reference to the directory is closed.
+      /* If the directory is open, the correct behavior is to remove the
+       * directory name, but to keep the directory cluster chain in place
+       * until the last open reference to the directory is closed.
        */
 
       /* Remove the directory.
@@ -2597,7 +2693,12 @@ int fat_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -2860,7 +2961,12 @@ static int fat_stat(FAR struct inode *mountpt, FAR const char *relpath,
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {

--- a/fs/fat/fs_fat32.h
+++ b/fs/fat/fs_fat32.h
@@ -133,9 +133,13 @@
 /****************************************************************************
  * These offsets describes the partition tables in the MBR
  */
-                               /* 446@0: Generally unused and zero; but may
-                                * include IDM Boot Manager menu entry at 8@394 */
-#define PART_ENTRY(n)     (446+((n) << 4)) /* n = 0,1,2,3 */
+
+/* 446@0: Generally unused and zero; but may
+ * include IDM Boot Manager menu entry at 8@394
+ */
+
+#define PART_ENTRY(n)     (446 + ((n) << 4)) /* n = 0,1,2,3 */
+
 #define PART_ENTRY1        446 /* 16@446: Partition table, first entry */
 #define PART_ENTRY2        462 /* 16@462: Partition table, second entry */
 #define PART_ENTRY3        478 /* 16@478: Partition table, third entry */
@@ -281,8 +285,7 @@
 
 #define CLUS_NDXMASK(f)     ((f)->fs_fatsecperclus - 1)
 
-/****************************************************************************
- * The FAT "long" file name (LFN) directory entry */
+/* The FAT "long" file name (LFN) directory entry */
 
 #ifdef CONFIG_FAT_LFN
 
@@ -334,8 +337,7 @@
 # define LDDIR_LFNATTR     0x0f
 #endif
 
-/****************************************************************************
- * File system types */
+/* File system types */
 
 #define FSTYPE_FAT12         0
 #define FSTYPE_FAT16         1
@@ -375,8 +377,8 @@
  * between FAT12, 16, and 32.
  */
 
-/* FAT12: For M$, the calculation is ((1 << 12) - 19).  But we will follow the
- * Linux tradition of allowing slightly more clusters for FAT12.
+/* FAT12: For M$, the calculation is ((1 << 12) - 19).  But we will follow
+ * the Linux tradition of allowing slightly more clusters for FAT12.
  */
 
 #define FAT_MAXCLUST12 ((1 << 12) - 16)
@@ -389,17 +391,16 @@
 #define FAT_MAXCLUST16 (((uint32_t)1 << 16) - 16)
 
 /* FAT32: M$ reserves the MS 4 bits of a FAT32 FAT entry so only 18 bits are
- * available.  For M$, the calculation is ((1 << 28) - 19). (The uint32_t cast
- * is needed for architectures where int is only 16 bits).  M$ also claims
- * that the minimum size is 65,527.
+ * available.  For M$, the calculation is ((1 << 28) - 19). (The uint32_t
+ * cast is needed for architectures where int is only 16 bits).  M$ also
+ * claims that the minimum size is 65,527.
  */
 
 #define FAT_MINCLUST32  65524
 /* #define FAT_MINCLUST32  (FAT_MAXCLUST16 + 1) */
 #define FAT_MAXCLUST32  (((uint32_t)1 << 28) - 16)
 
-/****************************************************************************
- * Access to data in raw sector data */
+/* Access to data in raw sector data */
 
 #define UBYTE_VAL(p,o)            (((uint8_t*)(p))[o])
 #define UBYTE_PTR(p,o)            &UBYTE_VAL(p,o)
@@ -867,9 +868,9 @@
  * Public Types
  ****************************************************************************/
 
-/* This structure represents the overall mountpoint state.  An instance of this
- * structure is retained as inode private data on each mountpoint that is
- * mounted with a fat32 filesystem.
+/* This structure represents the overall mountpoint state.  An instance of
+ * this structure is retained as inode private data on each mountpoint that
+ * is mounted with a fat32 filesystem.
  */
 
 struct fat_file_s;
@@ -879,7 +880,7 @@ struct fat_mountpt_s
   struct fat_file_s *fs_head;      /* A list to all files opened on this mountpoint */
 
   sem_t    fs_sem;                 /* Used to assume thread-safe access */
-  off_t    fs_hwsectorsize;        /* HW: Sector size reported by block driver*/
+  off_t    fs_hwsectorsize;        /* HW: Sector size reported by block driver */
   off_t    fs_hwnsectors;          /* HW: The number of sectors reported by the hardware */
   off_t    fs_fatbase;             /* Logical block of start of filesystem (past resd sectors) */
   off_t    fs_rootbase;            /* MBR: Cluster no. of 1st cluster of root dir */
@@ -899,8 +900,8 @@ struct fat_mountpt_s
   uint8_t  fs_type;                /* FSTYPE_FAT12, FSTYPE_FAT16, or FSTYPE_FAT32 */
   uint8_t  fs_fatnumfats;          /* MBR: Number of FATs (probably 2) */
   uint8_t  fs_fatsecperclus;       /* MBR: Sectors per allocation unit: 2**n, n=0..7 */
-  uint8_t *fs_buffer;              /* This is an allocated buffer to hold one sector
-                                    * from the device */
+  uint8_t *fs_buffer;              /* This is an allocated buffer to hold one
+                                    * sector from the device */
 };
 
 /* This structure represents on open file under the mountpoint.  An instance
@@ -965,7 +966,7 @@ struct fat_dirinfo_s
   /* The file/directory name */
 
 #ifdef CONFIG_FAT_LFN
-  uint8_t fd_lfname[LDIR_MAXFNAME+1]; /* Long filename with terminator */
+  uint8_t fd_lfname[LDIR_MAXFNAME + 1]; /* Long filename with terminator */
 #endif
   uint8_t fd_name[DIR_MAXFNAME];   /* Short 8.3 alias filename (no terminator) */
 
@@ -1011,7 +1012,8 @@ struct fat_dirinfo_s
 #undef EXTERN
 #if defined(__cplusplus)
 #define EXTERN extern "C"
-extern "C" {
+extern "C"
+{
 #else
 #define EXTERN extern
 #endif
@@ -1025,7 +1027,7 @@ EXTERN void   fat_putuint32(uint8_t *ptr, uint32_t value32);
 
 /* Manage the per-mount semaphore that protects access to shared resources */
 
-EXTERN void   fat_semtake(struct fat_mountpt_s *fs);
+EXTERN int    fat_semtake(struct fat_mountpt_s *fs);
 EXTERN void   fat_semgive(struct fat_mountpt_s *fs);
 
 /* Get the current time for FAT creation and write times */
@@ -1047,7 +1049,7 @@ EXTERN int    fat_hwwrite(struct fat_mountpt_s *fs, uint8_t *buffer,
 
 /* Cluster / cluster chain access helpers */
 
-EXTERN off_t  fat_cluster2sector(struct fat_mountpt_s *fs,  uint32_t cluster);
+EXTERN off_t  fat_cluster2sector(struct fat_mountpt_s *fs, uint32_t cluster);
 EXTERN off_t  fat_getcluster(struct fat_mountpt_s *fs, uint32_t clusterno);
 EXTERN int    fat_putcluster(struct fat_mountpt_s *fs, uint32_t clusterno,
                              off_t startsector);
@@ -1058,39 +1060,54 @@ EXTERN int32_t fat_extendchain(struct fat_mountpt_s *fs, uint32_t cluster);
 
 /* Help for traversing directory trees and accessing directory entries */
 
-EXTERN int    fat_nextdirentry(struct fat_mountpt_s *fs, struct fs_fatdir_s *dir);
-EXTERN int    fat_finddirentry(struct fat_mountpt_s *fs, struct fat_dirinfo_s *dirinfo,
+EXTERN int    fat_nextdirentry(struct fat_mountpt_s *fs,
+                               struct fs_fatdir_s *dir);
+EXTERN int    fat_finddirentry(struct fat_mountpt_s *fs,
+                               struct fat_dirinfo_s *dirinfo,
                                const char *path);
-EXTERN int    fat_dirnamewrite(struct fat_mountpt_s *fs, struct fat_dirinfo_s *dirinfo);
-EXTERN int    fat_dirwrite(struct fat_mountpt_s *fs, struct fat_dirinfo_s *dirinfo,
+EXTERN int    fat_dirnamewrite(struct fat_mountpt_s *fs,
+                               struct fat_dirinfo_s *dirinfo);
+EXTERN int    fat_dirwrite(struct fat_mountpt_s *fs,
+                           struct fat_dirinfo_s *dirinfo,
                            uint8_t attributes, uint32_t fattime);
-EXTERN int    fat_allocatedirentry(struct fat_mountpt_s *fs, struct fat_dirinfo_s *dirinfo);
-EXTERN int    fat_freedirentry(struct fat_mountpt_s *fs, struct fat_dirseq_s *seq);
-EXTERN int    fat_dirname2path(struct fat_mountpt_s *fs, struct fs_dirent_s *dir);
+EXTERN int    fat_allocatedirentry(struct fat_mountpt_s *fs,
+                                   struct fat_dirinfo_s *dirinfo);
+EXTERN int    fat_freedirentry(struct fat_mountpt_s *fs,
+                               struct fat_dirseq_s *seq);
+EXTERN int    fat_dirname2path(struct fat_mountpt_s *fs,
+                               struct fs_dirent_s *dir);
 
 /* File creation and removal helpers */
 
-EXTERN int    fat_dirtruncate(struct fat_mountpt_s *fs, FAR uint8_t *direntry);
+EXTERN int    fat_dirtruncate(struct fat_mountpt_s *fs,
+                              FAR uint8_t *direntry);
 EXTERN int    fat_dirshrink(struct fat_mountpt_s *fs, FAR uint8_t *direntry,
                             off_t length);
-EXTERN int    fat_dirextend(FAR struct fat_mountpt_s *fs, FAR struct fat_file_s *ff,
-                            off_t length);
-EXTERN int    fat_dircreate(struct fat_mountpt_s *fs, struct fat_dirinfo_s *dirinfo);
-EXTERN int    fat_remove(struct fat_mountpt_s *fs, const char *relpath, bool directory);
+EXTERN int    fat_dirextend(FAR struct fat_mountpt_s *fs,
+                            FAR struct fat_file_s *ff, off_t length);
+EXTERN int    fat_dircreate(struct fat_mountpt_s *fs,
+                            struct fat_dirinfo_s *dirinfo);
+EXTERN int    fat_remove(struct fat_mountpt_s *fs, const char *relpath,
+                         bool directory);
 
 /* Mountpoint and file buffer cache (for partial sector accesses) */
 
 EXTERN int    fat_fscacheflush(struct fat_mountpt_s *fs);
 EXTERN int    fat_fscacheread(struct fat_mountpt_s *fs, off_t sector);
-EXTERN int    fat_ffcacheflush(struct fat_mountpt_s *fs, struct fat_file_s *ff);
-EXTERN int    fat_ffcacheread(struct fat_mountpt_s *fs, struct fat_file_s *ff, off_t sector);
-EXTERN int    fat_ffcacheinvalidate(struct fat_mountpt_s *fs, struct fat_file_s *ff);
+EXTERN int    fat_ffcacheflush(struct fat_mountpt_s *fs,
+                               struct fat_file_s *ff);
+EXTERN int    fat_ffcacheread(struct fat_mountpt_s *fs,
+                              struct fat_file_s *ff, off_t sector);
+EXTERN int    fat_ffcacheinvalidate(struct fat_mountpt_s *fs,
+                                    struct fat_file_s *ff);
 
 /* FSINFO sector support */
 
 EXTERN int    fat_updatefsinfo(struct fat_mountpt_s *fs);
-EXTERN int    fat_nfreeclusters(struct fat_mountpt_s *fs, off_t *pfreeclusters);
-EXTERN int    fat_currentsector(struct fat_mountpt_s *fs, struct fat_file_s *ff, off_t position);
+EXTERN int    fat_nfreeclusters(struct fat_mountpt_s *fs,
+                                off_t *pfreeclusters);
+EXTERN int    fat_currentsector(struct fat_mountpt_s *fs,
+                                struct fat_file_s *ff, off_t position);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/fs/fat/fs_fat32attrib.c
+++ b/fs/fat/fs_fat32attrib.c
@@ -102,7 +102,12 @@ static int fat_attrib(const char *path, fat_attrib_t *retattrib,
 
   /* Check if the mount is still healthy */
 
-  fat_semtake(fs);
+  ret = fat_semtake(fs);
+  if (ret < 0)
+    {
+      goto errout_with_inode;
+    }
+
   ret = fat_checkmount(fs);
   if (ret != OK)
     {
@@ -197,7 +202,8 @@ int fat_getattrib(const char *path, fat_attrib_t *attrib)
  * Name: fat_setattrib
  ****************************************************************************/
 
-int fat_setattrib(const char *path, fat_attrib_t setbits, fat_attrib_t clearbits)
+int fat_setattrib(const char *path, fat_attrib_t setbits,
+                  fat_attrib_t clearbits)
 {
   return fat_attrib(path, NULL, setbits, clearbits);
 }

--- a/fs/fat/fs_fat32util.c
+++ b/fs/fat/fs_fat32util.c
@@ -288,8 +288,8 @@ static int fat_checkbootrecord(struct fat_mountpt_s *fs)
 uint16_t fat_getuint16(uint8_t *ptr)
 {
   /* NOTE that (1) this operation is independent of endian-ness and that (2)
-   * byte-by-byte transfer is necessary in any case because the address may be
-   * unaligned.
+   * byte-by-byte transfer is necessary in any case because the address may
+   * be unaligned.
    */
 
   return ((uint16_t)ptr[1] << 8) | ptr[0];
@@ -302,8 +302,8 @@ uint16_t fat_getuint16(uint8_t *ptr)
 uint32_t fat_getuint32(uint8_t *ptr)
 {
   /* NOTE that (1) this operation is independent of endian-ness and that (2)
-   * byte-by-byte transfer is necessary in any case because the address may be
-   * unaligned.
+   * byte-by-byte transfer is necessary in any case because the address may
+   * be unaligned.
    */
 
   return ((uint32_t)fat_getuint16(&ptr[2]) << 16) | fat_getuint16(&ptr[0]);
@@ -365,7 +365,7 @@ void fat_putuint32(FAR uint8_t *ptr, uint32_t value32)
  * Name: fat_semtake
  ****************************************************************************/
 
-void fat_semtake(struct fat_mountpt_s *fs)
+int fat_semtake(struct fat_mountpt_s *fs)
 {
   nxsem_wait_uninterruptible(&fs->fs_sem);
 }
@@ -547,8 +547,8 @@ int fat_mount(struct fat_mountpt_s *fs, bool writeable)
    * zero.  This could be either the boot record or a partition that refers
    * to the boot record.
    *
-   * First read sector zero.  This will be the first access to the drive and a
-   * likely failure point.
+   * First read sector zero.  This will be the first access to the drive and
+   * a likely failure point.
    */
 
   fs->fs_fatbase = 0;
@@ -574,12 +574,13 @@ int fat_mount(struct fat_mountpt_s *fs, bool writeable)
       int i;
       for (i = 0; i < 4; i++)
         {
-          /* Check if the partition exists and, if so, get the bootsector for that
-           * partition and see if we can find the boot record there.
+          /* Check if the partition exists and, if so, get the bootsector for
+           * that partition and see if we can find the boot record there.
            */
 
           uint8_t part = PART_GETTYPE(i, fs->fs_buffer);
-          finfo("Partition %d, offset %d, type %d\n", i, PART_ENTRY(i), part);
+          finfo("Partition %d, offset %d, type %d\n",
+                 i, PART_ENTRY(i), part);
 
           if (part == 0)
             {
@@ -707,7 +708,8 @@ int fat_checkmount(struct fat_mountpt_s *fs)
             {
               struct geometry geo;
               int errcode = inode->u.i_bops->geometry(inode, &geo);
-              if (errcode == OK && geo.geo_available && !geo.geo_mediachanged)
+              if (errcode == OK && geo.geo_available &&
+                  !geo.geo_mediachanged)
                 {
                   return OK;
                 }
@@ -905,7 +907,8 @@ off_t fat_getcluster(struct fat_mountpt_s *fs, uint32_t clusterno)
           case FSTYPE_FAT16 :
             {
               unsigned int fatoffset = 2 * clusterno;
-              off_t        fatsector = fs->fs_fatbase + SEC_NSECTORS(fs, fatoffset);
+              off_t        fatsector = fs->fs_fatbase +
+                                       SEC_NSECTORS(fs, fatoffset);
               unsigned int fatindex  = fatoffset & SEC_NDXMASK(fs);
 
               if (fat_fscacheread(fs, fatsector) < 0)
@@ -921,7 +924,8 @@ off_t fat_getcluster(struct fat_mountpt_s *fs, uint32_t clusterno)
           case FSTYPE_FAT32 :
             {
               unsigned int fatoffset = 4 * clusterno;
-              off_t        fatsector = fs->fs_fatbase + SEC_NSECTORS(fs, fatoffset);
+              off_t        fatsector = fs->fs_fatbase +
+                                       SEC_NSECTORS(fs, fatoffset);
               unsigned int fatindex  = fatoffset & SEC_NDXMASK(fs);
 
               if (fat_fscacheread(fs, fatsector) < 0)
@@ -997,7 +1001,8 @@ int fat_putcluster(struct fat_mountpt_s *fs, uint32_t clusterno,
                 {
                   /* Save the LS four bits of the next cluster */
 
-                  value = (fs->fs_buffer[fatindex] & 0x0f) | nextcluster << 4;
+                  value = (fs->fs_buffer[fatindex] & 0x0f) |
+                           nextcluster << 4;
                 }
               else
                 {
@@ -1033,8 +1038,8 @@ int fat_putcluster(struct fat_mountpt_s *fs, uint32_t clusterno,
                     }
                 }
 
-              /* Output the MS byte first handling the 12-bit alignment within
-               * the 16-bits
+              /* Output the MS byte first handling the 12-bit alignment
+               * within the 16-bits
                */
 
               if ((clusterno & 1) != 0)
@@ -1058,7 +1063,8 @@ int fat_putcluster(struct fat_mountpt_s *fs, uint32_t clusterno,
           case FSTYPE_FAT16 :
             {
               unsigned int fatoffset = 2 * clusterno;
-              off_t        fatsector = fs->fs_fatbase + SEC_NSECTORS(fs, fatoffset);
+              off_t        fatsector = fs->fs_fatbase +
+                                       SEC_NSECTORS(fs, fatoffset);
               unsigned int fatindex  = fatoffset & SEC_NDXMASK(fs);
 
               if (fat_fscacheread(fs, fatsector) < 0)
@@ -1075,7 +1081,8 @@ int fat_putcluster(struct fat_mountpt_s *fs, uint32_t clusterno,
           case FSTYPE_FAT32 :
             {
               unsigned int fatoffset = 4 * clusterno;
-              off_t        fatsector = fs->fs_fatbase + SEC_NSECTORS(fs, fatoffset);
+              off_t        fatsector = fs->fs_fatbase +
+                                       SEC_NSECTORS(fs, fatoffset);
               unsigned int fatindex  = fatoffset & SEC_NDXMASK(fs);
               uint32_t     val;
 
@@ -1089,7 +1096,8 @@ int fat_putcluster(struct fat_mountpt_s *fs, uint32_t clusterno,
               /* Keep the top 4 bits */
 
               val = FAT_GETFAT32(fs->fs_buffer, fatindex) & 0xf0000000;
-              FAT_PUTFAT32(fs->fs_buffer, fatindex, val | (nextcluster & 0x0fffffff));
+              FAT_PUTFAT32(fs->fs_buffer, fatindex,
+                           val | (nextcluster & 0x0fffffff));
             }
           break;
 
@@ -1356,9 +1364,9 @@ int fat_nextdirentry(struct fat_mountpt_s *fs, struct fs_fatdir_s *dir)
 
       if (!dir->fd_currcluster)
         {
-          /* For FAT12/16, the boot record tells us number of 32-bit directories
-           * that are contained in the root directory.  This should correspond to
-           * an even number of sectors.
+          /* For FAT12/16, the boot record tells us number of 32-bit
+           * directories that are contained in the root directory.  This
+           * should correspond to an even number of sectors.
            */
 
           if (ndx >= fs->fs_rootentcnt)
@@ -1372,17 +1380,17 @@ int fat_nextdirentry(struct fat_mountpt_s *fs, struct fs_fatdir_s *dir)
         }
       else
         {
-          /* Not a FAT12/16 root directory, check if we have examined the entire
-           * cluster comprising the directory.
+          /* Not a FAT12/16 root directory, check if we have examined the
+           * entire cluster comprising the directory.
            *
-           * The current sector within the cluster is the entry number divided
-           * byte the number of entries per sector
+           * The current sector within the cluster is the entry number
+           * divided byte the number of entries per sector
            */
 
           int sector = ndx / DIRSEC_NDIRS(fs);
 
-          /* We are finished with the cluster when the last sector of the cluster
-           * has been examined.
+          /* We are finished with the cluster when the last sector of the
+           * cluster has been examined.
            */
 
           if ((sector & (fs->fs_fatsecperclus - 1)) == 0)
@@ -1898,7 +1906,8 @@ int fat_ffcacheflush(struct fat_mountpt_s *fs, struct fat_file_s *ff)
  *
  ****************************************************************************/
 
-int fat_ffcacheread(struct fat_mountpt_s *fs, struct fat_file_s *ff, off_t sector)
+int fat_ffcacheread(struct fat_mountpt_s *fs, struct fat_file_s *ff,
+                    off_t sector)
 {
   int ret;
 

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -172,9 +172,9 @@ const struct mountpt_operations hostfs_operations =
  * Name: hostfs_semtake
  ****************************************************************************/
 
-void hostfs_semtake(FAR struct hostfs_mountpt_s *fs)
+int hostfs_semtake(FAR struct hostfs_mountpt_s *fs)
 {
-  nxsem_wait_uninterruptible(fs->fs_sem);
+  return nxsem_wait_uninterruptible(fs->fs_sem);
 }
 
 /****************************************************************************
@@ -275,7 +275,11 @@ static int hostfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Allocate memory for the open file */
 
@@ -360,6 +364,7 @@ static int hostfs_close(FAR struct file *filep)
   FAR struct hostfs_ofile_s   *hf;
   FAR struct hostfs_ofile_s   *nextfile;
   FAR struct hostfs_ofile_s   *prevfile;
+  int ret;
 
   /* Sanity checks */
 
@@ -373,7 +378,11 @@ static int hostfs_close(FAR struct file *filep)
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Check if we are the last one with a reference to the file and
    * only close if we are.
@@ -459,7 +468,11 @@ static ssize_t hostfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Call the host to perform the read */
 
@@ -511,7 +524,11 @@ static ssize_t hostfs_write(FAR struct file *filep, const char *buffer,
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Test the permissions.  Only allow write if the file was opened with
    * write flags.
@@ -561,7 +578,11 @@ static off_t hostfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Call our internal routine to perform the seek */
 
@@ -600,7 +621,11 @@ static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Call our internal routine to perform the ioctl */
 
@@ -623,6 +648,7 @@ static int hostfs_sync(FAR struct file *filep)
   FAR struct inode            *inode;
   FAR struct hostfs_mountpt_s *fs;
   FAR struct hostfs_ofile_s   *hf;
+  int ret;
 
   /* Sanity checks */
 
@@ -638,7 +664,11 @@ static int hostfs_sync(FAR struct file *filep)
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   host_sync(hf->fd);
 
@@ -708,7 +738,11 @@ static int hostfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Call the host to perform the read */
 
@@ -749,7 +783,11 @@ static int hostfs_ftruncate(FAR struct file *filep, off_t length)
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Call the host to perform the truncate */
 
@@ -783,7 +821,11 @@ static int hostfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Append to the host's root directory */
 
@@ -817,6 +859,7 @@ static int hostfs_closedir(FAR struct inode *mountpt,
                            FAR struct fs_dirent_s *dir)
 {
   struct hostfs_mountpt_s  *fs;
+  int ret;
 
   /* Sanity checks */
 
@@ -828,7 +871,11 @@ static int hostfs_closedir(FAR struct inode *mountpt,
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Call the host's closedir function */
 
@@ -861,7 +908,11 @@ static int hostfs_readdir(FAR struct inode *mountpt,
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Call the host OS's readdir function */
 
@@ -910,6 +961,7 @@ static int hostfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   FAR char *options;
   char *ptr, *saveptr;
   int len;
+  int ret;
 
   /* Validate the block driver is NULL */
 
@@ -968,7 +1020,12 @@ static int hostfs_bind(FAR struct inode *blkdriver, FAR const void *data,
     {
       /* Take the semaphore for the mount */
 
-      hostfs_semtake(fs);
+      ret = hostfs_semtake(fs);
+      if (ret < 0)
+        {
+          kmm_free(fs);
+          return ret;
+        }
     }
 
   /* Initialize the allocated mountpt state structure.  The filesystem is
@@ -1022,7 +1079,13 @@ static int hostfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
   /* Check if there are sill any files opened on the filesystem. */
 
   ret = OK; /* Assume success */
-  hostfs_semtake(fs);
+
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (fs->fs_head != NULL)
     {
       /* We cannot unmount now.. there are open files */
@@ -1061,7 +1124,11 @@ static int hostfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   fs = mountpt->i_private;
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Call the host fs to perform the statfs */
 
@@ -1094,7 +1161,11 @@ static int hostfs_unlink(FAR struct inode *mountpt, FAR const char *relpath)
 
   fs = mountpt->i_private;
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Append to the host's root directory */
 
@@ -1130,7 +1201,11 @@ static int hostfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
 
   fs = mountpt->i_private;
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Append to the host's root directory */
 
@@ -1167,7 +1242,11 @@ int hostfs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 
   /* Take the semaphore */
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Append to the host's root directory */
 
@@ -1204,7 +1283,11 @@ int hostfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
 
   fs = mountpt->i_private;
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Append to the host's root directory */
 
@@ -1243,7 +1326,11 @@ static int hostfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
 
   fs = mountpt->i_private;
 
-  hostfs_semtake(fs);
+  ret = hostfs_semtake(fs);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Append to the host's root directory */
 

--- a/fs/hostfs/hostfs.h
+++ b/fs/hostfs/hostfs.h
@@ -80,9 +80,9 @@ struct hostfs_ofile_s
   int                       fd;
 };
 
-/* This structure represents the overall mountpoint state.  An instance of this
- * structure is retained as inode private data on each mountpoint that is
- * mounted with a hostfs filesystem.
+/* This structure represents the overall mountpoint state.  An instance of
+ * this structure is retained as inode private data on each mountpoint that
+ * is mounted with a hostfs filesystem.
  */
 
 struct hostfs_mountpt_s
@@ -98,7 +98,7 @@ struct hostfs_mountpt_s
 
 /* Semaphore access for internal use */
 
-void hostfs_semtake(struct hostfs_mountpt_s *fs);
+int  hostfs_semtake(struct hostfs_mountpt_s *fs);
 void hostfs_semgive(struct hostfs_mountpt_s *fs);
 
 /* Forward references for utility functions */

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -174,7 +174,12 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Check if the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret != OK)
     {
@@ -385,7 +390,12 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Make sure that the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return (ssize_t)ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret != OK)
     {
@@ -476,7 +486,8 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
              sector++;
             }
 
-          finfo("Return %d bytes from sector offset %d\n", bytesread, sectorndx);
+          finfo("Return %d bytes from sector offset %d\n",
+                bytesread, sectorndx);
           memcpy(userbuffer, &rf->rf_buffer[sectorndx], bytesread);
         }
 
@@ -547,7 +558,12 @@ static off_t romfs_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Make sure that the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return (off_t)ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret != OK)
     {
@@ -644,7 +660,12 @@ static int romfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Check if the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret != OK)
     {
@@ -737,7 +758,12 @@ static int romfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Check if the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret >= 0)
     {
@@ -778,7 +804,12 @@ static int romfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
 
   /* Make sure that the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret != OK)
     {
@@ -846,7 +877,12 @@ static int romfs_readdir(FAR struct inode *mountpt,
 
   /* Make sure that the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret != OK)
     {
@@ -883,7 +919,8 @@ static int romfs_readdir(FAR struct inode *mountpt,
 
       /* Save the filename */
 
-      ret = romfs_parsefilename(rm, dir->u.romfs.fr_curroffset, dir->fd_dir.d_name);
+      ret = romfs_parsefilename(rm, dir->u.romfs.fr_curroffset,
+                                dir->fd_dir.d_name);
       if (ret < 0)
         {
           ferr("ERROR: romfs_parsefilename failed: %d\n", ret);
@@ -938,7 +975,12 @@ static int romfs_rewinddir(FAR struct inode *mountpt,
 
   /* Make sure that the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret == OK)
     {
@@ -986,7 +1028,8 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
 
   /* Create an instance of the mountpt state structure */
 
-  rm = (FAR struct romfs_mountpt_s *)kmm_zalloc(sizeof(struct romfs_mountpt_s));
+  rm = (FAR struct romfs_mountpt_s *)
+    kmm_zalloc(sizeof(struct romfs_mountpt_s));
   if (!rm)
     {
       ferr("ERROR: Failed to allocate mountpoint structure\n");
@@ -1064,7 +1107,12 @@ static int romfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
 
   /* Check if there are sill any files opened on the filesystem. */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (rm->rm_head)
     {
       /* We cannot unmount now.. there are open files */
@@ -1092,9 +1140,9 @@ static int romfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
                 }
 
               /* We hold a reference to the block driver but should
-               * not but mucking with inodes in this context.  So, we will just return
-               * our contained reference to the block driver inode and let the umount
-               * logic dispose of it.
+               * not but mucking with inodes in this context.  So, we will
+               * just return our contained reference to the block driver
+               * inode and let the umount logic dispose of it.
                */
 
               if (blkdriver)
@@ -1144,7 +1192,12 @@ static int romfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 
   /* Check if the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret < 0)
     {
@@ -1250,7 +1303,12 @@ static int romfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
 
   /* Check if the mount is still healthy */
 
-  romfs_semtake(rm);
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   ret = romfs_checkmount(rm);
   if (ret != OK)
     {

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -79,7 +79,8 @@
                                 *        to 16 byte boundary. */
 
 /* Bits 0-3 of the rf_next offset provide mode information.  These are the
- * values specified in  */
+ * values specified in
+ */
 
 #define RFNEXT_MODEMASK    7    /* Bits 0-2: Mode; bit 3: Executable */
 #define RFNEXT_ALLMODEMASK 15   /* Bits 0-3: All mode bits */
@@ -129,9 +130,9 @@
  * Public Types
  ****************************************************************************/
 
-/* This structure represents the overall mountpoint state.  An instance of this
- * structure is retained as inode private data on each mountpoint that is
- * mounted with a fat32 filesystem.
+/* This structure represents the overall mountpoint state.  An instance of
+ * this structure is retained as inode private data on each mountpoint that
+ * is mounted with a fat32 filesystem.
  */
 
 struct romfs_file_s;
@@ -141,7 +142,7 @@ struct romfs_mountpt_s
   struct romfs_file_s *rm_head;      /* A list to all files opened on this mountpoint */
 
   bool     rm_mounted;              /* true: The file system is ready */
-  uint16_t rm_hwsectorsize;         /* HW: Sector size reported by block driver*/
+  uint16_t rm_hwsectorsize;         /* HW: Sector size reported by block driver */
   sem_t    rm_sem;                  /* Used to assume thread-safe access */
   uint32_t rm_rootoffset;           /* Saved offset to the first root directory entry */
   uint32_t rm_hwnsectors;           /* HW: The number of sectors reported by the hardware */
@@ -202,7 +203,7 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
-void romfs_semtake(FAR struct romfs_mountpt_s *rm);
+int  romfs_semtake(FAR struct romfs_mountpt_s *rm);
 void romfs_semgive(FAR struct romfs_mountpt_s *rm);
 int  romfs_hwread(FAR struct romfs_mountpt_s *rm, FAR uint8_t *buffer,
        uint32_t sector, unsigned int nsectors);

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -171,9 +171,9 @@ int16_t romfs_devcacheread(struct romfs_mountpt_s *rm, uint32_t offset)
   uint32_t sector;
   int      ret;
 
-  /* rm->rm_cachesector holds the current sector that is buffer in or referenced
-   * by rm->tm_buffer. If the requested sector is the same as this sector,
-   * then we do nothing.
+  /* rm->rm_cachesector holds the current sector that is buffer in or
+   * referenced by rm->tm_buffer. If the requested sector is the same as this
+   * this then we do nothing.
    */
 
   sector = SEC_NSECTORS(rm, offset);
@@ -330,9 +330,9 @@ static inline int romfs_searchdir(struct romfs_mountpt_s *rm,
  * Name: romfs_semtake
  ****************************************************************************/
 
-void romfs_semtake(struct romfs_mountpt_s *rm)
+int romfs_semtake(struct romfs_mountpt_s *rm)
 {
-  nxsem_wait_uninterruptible(&rm->rm_sem);
+  return nxsem_wait_uninterruptible(&rm->rm_sem);
 }
 
 /****************************************************************************
@@ -351,8 +351,8 @@ void romfs_semgive(struct romfs_mountpt_s *rm)
  *
  ****************************************************************************/
 
-int romfs_hwread(struct romfs_mountpt_s *rm, uint8_t *buffer, uint32_t sector,
-                 unsigned int nsectors)
+int romfs_hwread(struct romfs_mountpt_s *rm, uint8_t *buffer,
+                 uint32_t sector, unsigned int nsectors)
 {
   int ret = OK;
 
@@ -415,9 +415,9 @@ int romfs_filecacheread(struct romfs_mountpt_s *rm, struct romfs_file_s *rf,
         sector, rf->rf_cachesector, rm->rm_hwsectorsize,
         rm->rm_xipbase, rf->rf_buffer);
 
-  /* rf->rf_cachesector holds the current sector that is buffer in or referenced
-   * by rf->rf_buffer. If the requested sector is the same as this sector,
-   * then we do nothing.
+  /* rf->rf_cachesector holds the current sector that is buffer in or
+   * referenced by rf->rf_buffer. If the requested sector is the same as this
+   * sector then we do nothing.
    */
 
   if (rf->rf_cachesector != sector)
@@ -458,10 +458,10 @@ int romfs_filecacheread(struct romfs_mountpt_s *rm, struct romfs_file_s *rf,
  * Name: romfs_hwconfigure
  *
  * Description:
- *   This function is called as part of the ROMFS mount operation   It
- *   configures the ROMFS filestem for use on this block driver.  This includes
- *   the accounting for the geometry of the device, setting up any XIP modes
- *   of operation, and/or allocating any cache buffers.
+ *   This function is called as part of the ROMFS mount operation.
+ *   It configures the ROMFS filestem for use on this block driver.  This
+ *   include the accounting for the geometry of the device, setting up any
+ *   XIP modes of operation, and/or allocating any cache buffers.
  *
  ****************************************************************************/
 
@@ -563,9 +563,9 @@ int romfs_hwconfigure(struct romfs_mountpt_s *rm)
  *
  * Description:
  *   This function is called as part of the ROMFS mount operation   It
- *   sets up the mount structure to include configuration information contained
- *   in the ROMFS header.  This is the place where we actually determine if
- *   the media contains a ROMFS filesystem.
+ *   sets up the mount structure to include configuration information
+ *   contained in the ROMFS header.  This is the place where we actually
+ *   determine if the media contains a ROMFS filesystem.
  *
  ****************************************************************************/
 
@@ -575,7 +575,7 @@ int romfs_fsconfigure(struct romfs_mountpt_s *rm)
   int16_t     ndx;
 
   /* Then get information about the ROMFS filesystem on the devices managed
-   * by this block driver.  Read sector zero which contains the volume header.
+   * by this block driver. Read sector zero which contains the volume header.
    */
 
   ndx = romfs_devcacheread(rm, 0);

--- a/fs/smartfs/smartfs.h
+++ b/fs/smartfs/smartfs.h
@@ -53,13 +53,16 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* SMART Definitions ********************************************************/
+
 /* General SMART organization.  The following example assumes 4 logical
  * sectors per FLASH erase block.  The actual relationship is determined by
  * the FLASH geometry reported by the MTD driver.
  *
- * ERASE LOGICAL                   Sectors begin with a sector header.  Sectors may
- * BLOCK SECTOR      CONTENTS      be marked as "released," pending garbage collection
+ * ERASE LOGICAL                   Sectors begin with a sector header.
+ *                                 Sectors may be marked as "released,"
+ * BLOCK SECTOR      CONTENTS      pending garbage collection
  *   n   4*n     --+---------------+
  *             Hdr |LLLLLLLLLLLLLLL| Logical sector number (2 bytes)
  *                 |QQQQQQQQQQQQQQQ| Sequence number (2 bytes)
@@ -150,8 +153,8 @@
  * INODE_STATE_DELETED - The inode has been deleted.
  * Other values        - The inode is bad and has an invalid state.
  *
- * Care is taken so that the VALID to DELETED transition only involves burning
- * bits from the erased to non-erased state.
+ * Care is taken so that the VALID to DELETED transition only involves
+ * burning bits from the erased to non-erased state.
  */
 
 #define INODE_STATE_FILE          (CONFIG_NXFFS_ERASEDSTATE ^ 0x22)
@@ -255,9 +258,9 @@ struct smartfs_entry_s
 struct smartfs_entry_header_s
 {
   uint16_t          flags;        /* Flags, including permissions:
-                                      15:   Empty entry
-                                      14:   Active entry
-                                      12-0: Permissions bits */
+                                   *  15:   Empty entry
+                                   *  14:   Active entry
+                                   *  12-0: Permissions bits */
   int16_t           firstsector;  /* Sector number of the name */
   uint32_t          utc;          /* Time stamp */
   char              name[0];      /* inode name */
@@ -270,23 +273,23 @@ struct smartfs_entry_header_s
 #if defined(CONFIG_MTD_SMART_ENABLE_CRC) && defined(CONFIG_SMART_CRC_32)
 struct smartfs_chain_header_s
 {
-  uint8_t           nextsector[4];/* Next logical sector in the chain */
-  uint8_t           used[4];      /* Number of bytes used in this sector */
-  uint8_t           type;         /* Type of sector entry (file or dir) */
+  uint8_t           nextsector[4]; /* Next logical sector in the chain */
+  uint8_t           used[4];       /* Number of bytes used in this sector */
+  uint8_t           type;          /* Type of sector entry (file or dir) */
 };
 #elif defined(CONFIG_MTD_SMART_ENABLE_CRC) && defined(CONFIG_SMART_CRC_16)
 struct smartfs_chain_header_s
 {
-  uint8_t           type;         /* Type of sector entry (file or dir) */
-  uint8_t           nextsector[2];/* Next logical sector in the chain */
-  uint8_t           used[2];      /* Number of bytes used in this sector */
+  uint8_t           type;          /* Type of sector entry (file or dir) */
+  uint8_t           nextsector[2]; /* Next logical sector in the chain */
+  uint8_t           used[2];       /* Number of bytes used in this sector */
 };
 #else
 struct smartfs_chain_header_s
 {
-  uint8_t           type;         /* Type of sector entry (file or dir) */
-  uint8_t           nextsector[2];/* Next logical sector in the chain */
-  uint8_t           used[2];      /* Number of bytes used in this sector */
+  uint8_t           type;          /* Type of sector entry (file or dir) */
+  uint8_t           nextsector[2]; /* Next logical sector in the chain */
+  uint8_t           used[2];       /* Number of bytes used in this sector */
 };
 #endif
 
@@ -296,43 +299,44 @@ struct smartfs_chain_header_s
 
 struct smartfs_ofile_s
 {
-  struct smartfs_ofile_s   *fnext;      /* Supports a singly linked list */
+  struct smartfs_ofile_s   *fnext;        /* Supports a singly linked list */
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
-  uint8_t*                  buffer;     /* Sector buffer to reduce writes */
-  uint8_t                   bflags;     /* Buffer flags */
+  uint8_t                  *buffer;       /* Sector buffer to reduce writes */
+  uint8_t                   bflags;       /* Buffer flags */
 #endif
-  int16_t                   crefs;      /* Reference count */
-  mode_t                    oflags;     /* Open mode */
-  struct smartfs_entry_s    entry;      /* Describes the SMARTFS inode entry */
-  size_t                    filepos;    /* Current file position */
-  uint16_t                  currsector; /* Current sector of filepos */
-  uint16_t                  curroffset; /* Current offset in sector */
-  uint16_t                  byteswritten;/* Count of bytes written to currsector
-                                          * that have not been recorded in the
-                                          * sector yet.  We delay updating the
-                                          * used field until the file is closed,
-                                          * a seek, or more data is written that
-                                          * causes the sector to change. */
+  int16_t                   crefs;        /* Reference count */
+  mode_t                    oflags;       /* Open mode */
+  struct smartfs_entry_s    entry;        /* Describes the SMARTFS inode entry */
+  size_t                    filepos;      /* Current file position */
+  uint16_t                  currsector;   /* Current sector of filepos */
+  uint16_t                  curroffset;   /* Current offset in sector */
+  uint16_t                  byteswritten; /* Count of bytes written to currsector
+                                           * that have not been recorded in the
+                                           * sector yet.  We delay updating the
+                                           * used field until the file is closed,
+                                           * a seek, or more data is written that
+                                           * causes the sector to change.
+                                           */
 };
 
-/* This structure represents the overall mountpoint state.  An instance of this
- * structure is retained as inode private data on each mountpoint that is
- * mounted with a smartfs filesystem.
+/* This structure represents the overall mountpoint state.  An instance of
+ * this structure is retained as inode private data on each mountpoint that
+ * is mounted with a smartfs filesystem.
  */
 
 struct smartfs_mountpt_s
 {
 #if defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) || defined(CONFIG_FS_PROCFS)
-  struct smartfs_mountpt_s   *fs_next;      /* Pointer to next SMART filesystem */
+  struct smartfs_mountpt_s   *fs_next;       /* Pointer to next SMART filesystem */
 #endif
-  FAR struct inode           *fs_blkdriver; /* Our underlying block device */
-  sem_t                      *fs_sem;       /* Used to assure thread-safe access */
-  FAR struct smartfs_ofile_s *fs_head;      /* A singly-linked list of open files */
-  bool                        fs_mounted;   /* true: The file system is ready */
-  struct smart_format_s       fs_llformat;  /* Low level device format info */
-  char                       *fs_rwbuffer;  /* Read/Write working buffer */
-  char                       *fs_workbuffer;/* Working buffer */
-  uint8_t                     fs_rootsector;/* Root directory sector num */
+  FAR struct inode           *fs_blkdriver;  /* Our underlying block device */
+  sem_t                      *fs_sem;        /* Used to assure thread-safe access */
+  FAR struct smartfs_ofile_s *fs_head;       /* A singly-linked list of open files */
+  bool                        fs_mounted;    /* true: The file system is ready */
+  struct smart_format_s       fs_llformat;   /* Low level device format info */
+  char                       *fs_rwbuffer;   /* Read/Write working buffer */
+  char                       *fs_workbuffer; /* Working buffer */
+  uint8_t                     fs_rootsector; /* Root directory sector num */
 };
 
 /****************************************************************************
@@ -340,12 +344,12 @@ struct smartfs_mountpt_s
  ****************************************************************************/
 
 /****************************************************************************
- * Public Functions
+ * Public Functions Prototypes
  ****************************************************************************/
 
 /* Semaphore access for internal use */
 
-void smartfs_semtake(struct smartfs_mountpt_s *fs);
+int  smartfs_semtake(struct smartfs_mountpt_s *fs);
 void smartfs_semgive(struct smartfs_mountpt_s *fs);
 
 /* Forward references for utility functions */
@@ -363,7 +367,7 @@ int smartfs_finddirentry(FAR struct smartfs_mountpt_s *fs,
         FAR uint16_t *parentdirsector, FAR const char **filename);
 
 int smartfs_createentry(FAR struct smartfs_mountpt_s *fs,
-        uint16_t parentdirsector, FAR const char* filename,
+        uint16_t parentdirsector, FAR const char *filename,
         uint16_t type,
         mode_t mode, FAR struct smartfs_entry_s *direntry,
         uint16_t sectorno, FAR struct smartfs_ofile_s *sf);
@@ -395,11 +399,11 @@ uint32_t smartfs_rdle32(FAR const void *val);
 void smartfs_wrle32(uint8_t *dest, uint32_t val);
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-struct smartfs_mountpt_s* smartfs_get_first_mount(void);
+struct smartfs_mountpt_s *smartfs_get_first_mount(void);
 #endif
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-struct smartfs_mountpt_s* smartfs_get_first_mount(void);
+struct smartfs_mountpt_s *smartfs_get_first_mount(void);
 #endif
 
 struct file;        /* Forward references */

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -925,7 +925,11 @@ static int unionfs_close(FAR struct file *filep)
 
   /* Get exclusive access to the file system data structures */
 
-  unionfs_semtake(ui, false);
+  ret = unionfs_semtake(ui, false);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   DEBUGASSERT(ui != NULL && filep->f_priv != NULL);
   uf = (FAR struct unionfs_file_s *)filep->f_priv;
@@ -1601,7 +1605,11 @@ static int unionfs_closedir(FAR struct inode *mountpt,
 
   /* Get exclusive access to the file system data structures */
 
-  unionfs_semtake(ui, true);
+  ret = unionfs_semtake(ui, true);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   DEBUGASSERT(dir);
   fu = &dir->u.unionfs;
@@ -2046,6 +2054,7 @@ static int unionfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
                           unsigned int flags)
 {
   FAR struct unionfs_inode_s *ui;
+  int ret;
 
   finfo("handle=%p blkdriver=%p flags=%x\n", handle, blkdriver, flags);
 
@@ -2056,7 +2065,11 @@ static int unionfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
 
   /* Get exclusive access to the file system data structures */
 
-  unionfs_semtake(ui, true);
+  ret = unionfs_semtake(ui, true);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Mark the file system as unmounted. */
 


### PR DESCRIPTION
There are two style complaints. One is described in #652 and the other one I don't really understand what the issue is.
It seems like an indentation for a function. That would be a bug. Maybe it's confused with an indentation that we would do after a preprocessor directive?