### PR TITLE
Check return from nxsem_wait_initialize()

### DIFF
--- a/boards/arm/samv7/samv71-xult/src/sam_ili9488.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_ili9488.c
@@ -204,7 +204,7 @@
 #  define CONFIG_SAMV71XULT_LCD_BGCOLOR 0
 #endif
 
-/* Display/Color Properties **************************************************/
+/* Display/Color Properties *************************************************/
 
 /* Display Resolution */
 
@@ -228,7 +228,7 @@
 #define RGB_BLUE(rgb)         RGB16BLUE(rgb)
 #define RGB_COLOR(r,g,b)      RGBTO16(r,g,b)
 
-/* SAMV7-XULT LCD Hardware Definitions ***************************************/
+/* SAMV7-XULT LCD Hardware Definitions **************************************/
 
 /* LCD /CS is NCS3 */
 
@@ -286,7 +286,7 @@
 #  define LCD_RUNBUFFER_PIXELS SAM_XRES
 #endif
 
-/* Debug *********************************************************************/
+/* Debug ********************************************************************/
 
 #ifdef CONFIG_DEBUG_DMA
 #  define SAMPLENDX_BEFORE_SETUP  0
@@ -422,7 +422,8 @@ static int  sam_getplaneinfo(FAR struct lcd_dev_s *dev, unsigned int planeno,
 static int  sam_getpower(FAR struct lcd_dev_s *dev);
 static int  sam_setpower(FAR struct lcd_dev_s *dev, int power);
 static int  sam_getcontrast(FAR struct lcd_dev_s *dev);
-static int  sam_setcontrast(FAR struct lcd_dev_s *dev, unsigned int contrast);
+static int  sam_setcontrast(FAR struct lcd_dev_s *dev,
+              unsigned int contrast);
 
 /* Initialization */
 
@@ -458,26 +459,27 @@ static const uint32_t g_lcdpin[] =
  * if there are multiple LCD devices, they must each have unique run buffers.
  */
 
-static uint16_t g_runbuffer[LCD_RUNBUFFER_BYTES] __attribute__((aligned(LCD_ALIGN)));
+static uint16_t g_runbuffer[LCD_RUNBUFFER_BYTES]
+  __attribute__((aligned(LCD_ALIGN)));
 
 /* This structure describes the overall LCD video controller */
 
 static const struct fb_videoinfo_s g_videoinfo =
 {
-  .fmt     = SAM_COLORFMT,         /* Color format: RGB16-565: RRRR RGGG GGGB BBBB */
-  .xres    = SAM_XRES,             /* Horizontal resolution in pixel columns */
-  .yres    = SAM_YRES,             /* Vertical resolution in pixel rows */
-  .nplanes = 1,                    /* Number of color planes supported */
+  .fmt     = SAM_COLORFMT,              /* Color format: RGB16-565: RRRR RGGG GGGB BBBB */
+  .xres    = SAM_XRES,                  /* Horizontal resolution in pixel columns */
+  .yres    = SAM_YRES,                  /* Vertical resolution in pixel rows */
+  .nplanes = 1,                         /* Number of color planes supported */
 };
 
 /* This is the standard, NuttX Plane information object */
 
 static const struct lcd_planeinfo_s g_planeinfo =
 {
-  .putrun = sam_putrun,            /* Put a run into LCD memory */
-  .getrun = sam_getrun,            /* Get a run from LCD memory */
-  .buffer = (uint8_t*)g_runbuffer, /* Run scratch buffer */
-  .bpp    = SAM_BPP,               /* Bits-per-pixel */
+  .putrun = sam_putrun,                 /* Put a run into LCD memory */
+  .getrun = sam_getrun,                 /* Get a run from LCD memory */
+  .buffer = (FAR uint8_t *)g_runbuffer, /* Run scratch buffer */
+  .bpp    = SAM_BPP,                    /* Bits-per-pixel */
 };
 
 /* This is the ILI9488 LCD driver object */
@@ -751,7 +753,8 @@ static void sam_disable_backlight(void)
  * Name:  sam_set_backlight
  *
  * Description:
- *   The the backlight to the level associated with the specified power value.
+ *   The the backlight to the level associated with the specified power
+ *   value.
  *
  ****************************************************************************/
 
@@ -994,7 +997,11 @@ static int sam_lcd_dmawait(FAR struct sam_dev_s *priv, uint32_t timeout)
        * incremented and there will be no wait.
        */
 
-      nxsem_wait_uninterruptible(&priv->waitsem);
+      ret = nxsem_wait_uninterruptible(&priv->waitsem);
+      if (ret < 0)
+        {
+          return ret;
+        }
     }
 
   /* Dump the collect DMA sample data */
@@ -1041,7 +1048,8 @@ static void sam_lcd_dmacallback(DMA_HANDLE handle, void *arg, int result)
  ****************************************************************************/
 
 static int sam_lcd_txtransfer(FAR struct sam_dev_s *priv,
-                              FAR const uint16_t *buffer, unsigned int buflen)
+                              FAR const uint16_t *buffer,
+                              unsigned int buflen)
 {
   irqstate_t flags;
   int ret;
@@ -1083,7 +1091,8 @@ static int sam_lcd_txtransfer(FAR struct sam_dev_s *priv,
  ****************************************************************************/
 
 static int sam_lcd_rxtransfer(FAR struct sam_dev_s *priv,
-                              FAR const uint16_t *buffer, unsigned int buflen)
+                              FAR const uint16_t *buffer,
+                              unsigned int buflen)
 {
   irqstate_t flags;
   int ret;
@@ -1415,7 +1424,11 @@ static inline void sam_smc_initialize(void)
 static inline int sam_lcd_initialize(void)
 {
   FAR struct sam_dev_s *priv = &g_lcddev;
-  uint8_t buffer[4] = {0, 0, 0, 0};
+  uint8_t buffer[4] =
+  {
+    0, 0, 0, 0
+  };
+
   uint16_t id;
   uint16_t param;
   int ret;

--- a/crypto/random_pool.c
+++ b/crypto/random_pool.c
@@ -120,9 +120,13 @@ static struct entropy_pool_s entropy_pool;
 #endif
 
 /* Polynomial from paper "The Linux Pseudorandom Number Generator Revisited"
- * x^POOL_SIZE + x^104 + x^76 + x^51 + x^25 + x + 1 */
+ * x^POOL_SIZE + x^104 + x^76 + x^51 + x^25 + x + 1
+ */
 
-static const uint32_t pool_stir[] = { POOL_SIZE, 104, 76, 51, 25, 1 };
+static const uint32_t pool_stir[] =
+{
+  POOL_SIZE, 104, 76, 51, 25, 1
+};
 
 /* Derived from IEEE 802.3 CRC-32 */
 
@@ -198,7 +202,7 @@ static void addentropy(FAR const uint32_t *buf, size_t n, bool inc_new)
         {
           g_rng.rd_newentr += 1;
         }
-   }
+    }
 }
 
 /****************************************************************************
@@ -260,15 +264,18 @@ static void getentropy(FAR blake2s_state *S)
  * number generator (DRBG) as used here. BLAKE2 specification is available
  * at https://blake2.net/
  *
- * BLAKE2Xs here  implementation is based on public-domain/CC0 BLAKE2 reference
- * implementation by Samual Neves, at
- *  https://github.com/BLAKE2/BLAKE2/tree/master/ref
- * Copyright 2012, Samuel Neves <sneves@dei.uc.pt>
+ * BLAKE2Xs here  implementation is based on public-domain/CC0 BLAKE2
+ * reference implementation by Samual Neves, at
+ *
+ *   https://github.com/BLAKE2/BLAKE2/tree/master/ref
+ *   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>
  */
 
 static void rng_reseed(void)
 {
-  blake2s_param P = {};
+  blake2s_param P =
+    {
+    };
 
   /* Reset output node counter. */
 
@@ -336,8 +343,9 @@ static void rng_buf_internal(FAR void *bytes, size_t nbytes)
     }
   else if (g_rng.blake2xs.out_node_offset == UINT32_MAX)
     {
-      /* Maximum BLAKE2Xs output reached (2^32-1 output blocks, maximum 128 GiB
-       * bytes), reseed. */
+      /* Maximum BLAKE2Xs output reached (2^32-1 output blocks, maximum 128
+       * GiB bytes), reseed.
+       */
 
       rng_reseed();
     }
@@ -436,7 +444,8 @@ void up_rngaddentropy(enum rnd_source_t kindof, FAR const uint32_t *buf,
   if (kindof == RND_SRC_IRQ && n > 0)
     {
       /* Ignore interrupt randomness if previous interrupt was from same
-       * source. */
+       * source.
+       */
 
       if (buf[0] == g_rng.rd_prev_irq)
         {
@@ -463,7 +472,8 @@ void up_rngaddentropy(enum rnd_source_t kindof, FAR const uint32_t *buf,
       uint8_t curr_time = ts.tv_sec * 8 + ts.tv_nsec / (NSEC_PER_SEC / 8);
 
       /* Allow interrupts/timers increase entropy counter at max rate
-       * of 8 Hz. */
+       * of 8 Hz.
+       */
 
       if (g_rng.rd_prev_time == curr_time)
         {
@@ -500,14 +510,18 @@ void up_rngaddentropy(enum rnd_source_t kindof, FAR const uint32_t *buf,
 
 void up_rngreseed(void)
 {
-  nxsem_wait_uninterruptible(&g_rng.rd_sem);
+  int ret;
 
-  if (g_rng.rd_newentr >= MIN_SEED_NEW_ENTROPY_WORDS)
+  ret = nxsem_wait_uninterruptible(&g_rng.rd_sem);
+  if (ret >= 0)
     {
-      rng_reseed();
-    }
+      if (g_rng.rd_newentr >= MIN_SEED_NEW_ENTROPY_WORDS)
+        {
+          rng_reseed();
+        }
 
-  nxsem_post(&g_rng.rd_sem);
+      nxsem_post(&g_rng.rd_sem);
+    }
 }
 
 /****************************************************************************
@@ -549,7 +563,12 @@ void up_randompool_initialize(void)
 
 void getrandom(FAR void *bytes, size_t nbytes)
 {
-  nxsem_wait_uninterruptible(&g_rng.rd_sem);
-  rng_buf_internal(bytes, nbytes);
-  nxsem_post(&g_rng.rd_sem);
+  int ret;
+
+  ret = nxsem_wait_uninterruptible(&g_rng.rd_sem);
+  if (ret >= 0)
+    {
+      rng_buf_internal(bytes, nbytes);
+      nxsem_post(&g_rng.rd_sem);
+    }
 }

--- a/fs/aio/aio.h
+++ b/fs/aio/aio.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * fs/aio/aio.h
  *
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -150,11 +135,11 @@ void aio_initialize(void);
  *   None
  *
  * Returned Value:
- *   None
+ *   aio_lock() return -ECANCELED if the calling thread is canceled.
  *
  ****************************************************************************/
 
-void aio_lock(void);
+int aio_lock(void);
 void aio_unlock(void);
 
 /****************************************************************************

--- a/fs/aio/aio_cancel.c
+++ b/fs/aio/aio_cancel.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * fs/aio/aio_cancel.c
  *
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -110,7 +95,7 @@ int aio_cancel(int fildes, FAR struct aiocb *aiocbp)
 
   ret = AIO_ALLDONE;
   sched_lock();
-  aio_lock();
+  ret = aio_lock();
 
   if (aiocbp)
     {

--- a/fs/aio/aioc_contain.c
+++ b/fs/aio/aioc_contain.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * fs/aio/aioc_contain.c
  *
- *   Copyright (C) 2014, 2017-2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -121,29 +106,38 @@ FAR struct aio_container_s *aio_contain(FAR struct aiocb *aiocbp)
 #endif
 
   /* Allocate the AIO control block container, waiting for one to become
-   * available if necessary.  This should never fail.
+   * available if necessary.  This should not fail except for in the case
+   * where the calling thread is canceled.
    */
 
   aioc = aioc_alloc();
-  DEBUGASSERT(aioc);
+  if (aioc != NULL)
+    {
+      /* Initialize the container */
 
-  /* Initialize the container */
-
-  memset(aioc, 0, sizeof(struct aio_container_s));
-  aioc->aioc_aiocbp = aiocbp;
-  aioc->u.ptr = u.ptr;
-  aioc->aioc_pid = getpid();
+      memset(aioc, 0, sizeof(struct aio_container_s));
+      aioc->aioc_aiocbp = aiocbp;
+      aioc->u.ptr       = u.ptr;
+      aioc->aioc_pid    = getpid();
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-  DEBUGVERIFY(nxsched_getparam (aioc->aioc_pid, &param));
-  aioc->aioc_prio = param.sched_priority;
+      DEBUGVERIFY(nxsched_getparam (aioc->aioc_pid, &param));
+      aioc->aioc_prio   = param.sched_priority;
 #endif
 
-  /* Add the container to the pending transfer list. */
+      /* Add the container to the pending transfer list. */
 
-  aio_lock();
-  dq_addlast(&aioc->aioc_link, &g_aio_pending);
-  aio_unlock();
+      ret = aio_lock();
+      if (ret < 0)
+        {
+          aioc_free(aioc);
+          goto errout;
+        }
+
+      dq_addlast(&aioc->aioc_link, &g_aio_pending);
+      aio_unlock();
+    }
+
   return aioc;
 
 errout:
@@ -168,21 +162,26 @@ errout:
 
 FAR struct aiocb *aioc_decant(FAR struct aio_container_s *aioc)
 {
-  FAR struct aiocb *aiocbp;
+  FAR struct aiocb *aiocbp = NULL;
+  int ret;
 
   DEBUGASSERT(aioc);
 
   /* Remove the container to the pending transfer list. */
 
-  aio_lock();
-  dq_rem(&aioc->aioc_link, &g_aio_pending);
+  ret = aio_lock();
+  if (ret >= 0)
+    {
+      dq_rem(&aioc->aioc_link, &g_aio_pending);
 
-  /* De-cant the AIO control block and return the container to the free list */
+      /* De-cant the AIO control block and return the container to the free list */
 
-  aiocbp = aioc->aioc_aiocbp;
-  aioc_free(aioc);
+      aiocbp = aioc->aioc_aiocbp;
+      aioc_free(aioc);
 
-  aio_unlock();
+      aio_unlock();
+    }
+
   return aiocbp;
 }
 

--- a/fs/driver/fs_blockproxy.c
+++ b/fs/driver/fs_blockproxy.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * fs/driver/fs_blockproxy.c
  *
- *   Copyright (C) 2015-2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -101,7 +86,12 @@ static FAR char *unique_chardev(void)
     {
       /* Get the semaphore protecting the path number */
 
-      nxsem_wait_uninterruptible(&g_devno_sem);
+      ret = nxsem_wait_uninterruptible(&g_devno_sem);
+      if (ret < 0)
+        {
+          ferr("ERROR: nxsem_wait_uninterruptible failed: %d\n", ret);
+          return NULL;
+        }
 
       /* Get the next device number and release the semaphore */
 

--- a/fs/driver/fs_mtdproxy.c
+++ b/fs/driver/fs_mtdproxy.c
@@ -96,7 +96,12 @@ static FAR char *unique_blkdev(void)
     {
       /* Get the semaphore protecting the path number */
 
-      nxsem_wait_uninterruptible(&g_devno_sem);
+      ret = nxsem_wait_uninterruptible(&g_devno_sem);
+      if (ret < 0)
+        {
+          ferr("ERROR: nxsem_wait_uninterruptible failed: %d\n", ret);
+          return NULL;
+        }
 
       /* Get the next device number and release the semaphore */
 
@@ -197,9 +202,9 @@ int mtd_proxy(FAR const char *mtddev, int mountflags,
       goto out_with_fltdev;
     }
 
-  /* Unlink and free the block device name.  The driver instance will persist,
-   * provided that CONFIG_DISABLE_PSEUDOFS_OPERATIONS=y (otherwise, we have
-   * a problem here!)
+  /* Unlink and free the block device name.  The driver instance will
+   * persist, provided that CONFIG_DISABLE_PSEUDOFS_OPERATIONS=y (otherwise,
+   * we have a problem here!)
    */
 
 out_with_fltdev:

--- a/fs/inode/fs_inoderelease.c
+++ b/fs/inode/fs_inoderelease.c
@@ -52,16 +52,18 @@ void inode_release(FAR struct inode *node)
     {
       /* Decrement the references of the inode */
 
-      ret = inode_semtake();
-      if (ret < 0)
+      do
         {
-          /* REVISIT:  Reference count will be wrong.  This could only
-           * happen on thread cancellation.
+          ret = inode_semtake();
+
+          /* This only possible error is due to cancellation of the thread.
+           * We need to try again anyway in this case, otherwise the
+           * reference count would be wrong.
            */
 
-          ferr("ERROR: inode_semtake failed: %d\n", ret);
-          return;
+          DEBUGASSERT(ret = OK || ret == -ECANCELED);
         }
+      while (ret < 0);
 
       if (node->i_crefs)
         {

--- a/fs/mqueue/mq_close.c
+++ b/fs/mqueue/mq_close.c
@@ -176,16 +176,17 @@ void mq_inode_release(FAR struct inode *inode)
 
   /* Decrement the reference count on the inode */
 
-  ret = inode_semtake();
-  if (ret < 0)
+  do
     {
-      /* REVISIT:  Should get here only on task cancellation.  The MQ inode
-       * would not not be released in this case.
+      ret = inode_semtake();
+
+      /* The only error that is expected is due to thread cancellation.
+       * At this point, we must continue to free the mqueue anyway.
        */
 
-      ferr("ERROR: inode_semtake() failed: %d\n", ret);
-      return;
+      DEBUGASSERT(ret == OK || ret == -ECANCELED);
     }
+  while (ret < 0);
 
   if (inode->i_crefs > 0)
     {

--- a/fs/nfs/Kconfig
+++ b/fs/nfs/Kconfig
@@ -13,7 +13,7 @@ config NFS
 #if NFS
 
 config NFS_STATISTICS
-	bool "NFS Statics"
+	bool "NFS Statistics"
 	default n
 	depends on NFS
 	---help---

--- a/fs/semaphore/sem_close.c
+++ b/fs/semaphore/sem_close.c
@@ -81,16 +81,17 @@ int sem_close(FAR sem_t *sem)
 
   /* Decrement the reference count on the inode */
 
-  ret = inode_semtake();
-  if (ret < 0)
+  do
     {
-      /* REVISIT:  This failure is probably -ECANCELED meaning that the
-       * thread was canceled.  In this case, the semaphore will not be
-       * closed.
+      ret = inode_semtake();
+
+      /* The only error that is expected is due to thread cancellation.
+       * At this point, we must continue to free the semaphore anyway.
        */
 
-      return ret;
+      DEBUGASSERT(ret == OK || ret == -ECANCELED);
     }
+  while (ret < 0);
 
   if (inode->i_crefs > 0)
     {


### PR DESCRIPTION
Resolution of Issue 619 will require multiple steps, this part of the first step in that resolution:  Every call to nxsem_wait_uninterruptible() must handle the return value from nxsem_wait_uninterruptible properly.  This commit is only for those files under fs/driver, fs/aio, fs/nfs, crypto/, and boards/.

Please note:  The modified file under fs/nfs generates several " Mixed case identifier found" errors.  Please ignore these.  These cannot be fixed without changes to numerous other files.  They also follow a non-standard convention that is used many files:  Using lower case structure names in custom SIZEOF_ definitions.