### PR TITLE
Check return from nxsem_wait_initialize()

### DIFF
--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -214,8 +214,8 @@ struct mbr3108_dev_s
 };
 
 /****************************************************************************
-* Private Function Prototypes
-*****************************************************************************/
+ * Private Function Prototypes
+ ****************************************************************************/
 
 static int mbr3108_open(FAR struct file *filep);
 static int mbr3108_close(FAR struct file *filep);
@@ -227,8 +227,8 @@ static int mbr3108_poll(FAR struct file *filep, FAR struct pollfd *fds,
                         bool setup);
 
 /****************************************************************************
-* Private Data
-****************************************************************************/
+ * Private Data
+ ****************************************************************************/
 
 static const struct file_operations g_mbr3108_fileops =
 {
@@ -242,8 +242,8 @@ static const struct file_operations g_mbr3108_fileops =
 };
 
 /****************************************************************************
-* Private Functions
-****************************************************************************/
+ * Private Functions
+ ****************************************************************************/
 
 static int mbr3108_i2c_write(FAR struct mbr3108_dev_s *dev, uint8_t reg,
                              const uint8_t *buf, size_t buflen)
@@ -265,11 +265,13 @@ static int mbr3108_i2c_write(FAR struct mbr3108_dev_s *dev, uint8_t reg,
       .length    = buflen
     }
   };
+
   int ret = -EIO;
   int retries;
 
   /* MBR3108 will respond with NACK to address when in low-power mode. Host
-   * needs to retry address selection multiple times to get MBR3108 to wake-up.
+   * needs to retry address selection multiple times to get MBR3108 to
+   * wake-up.
    */
 
   for (retries = 0; retries < MBR3108_I2C_RETRIES; retries++)
@@ -317,11 +319,13 @@ static int mbr3108_i2c_read(FAR struct mbr3108_dev_s *dev, uint8_t reg,
       .length    = buflen
     }
   };
+
   int ret = -EIO;
   int retries;
 
   /* MBR3108 will respond with NACK to address when in low-power mode. Host
-   * needs to retry address selection multiple times to get MBR3108 to wake-up.
+   * needs to retry address selection multiple times to get MBR3108 to
+   * wake-up.
    */
 
   for (retries = 0; retries < MBR3108_I2C_RETRIES; retries++)
@@ -371,7 +375,9 @@ static int mbr3108_check_cmd_status(FAR struct mbr3108_dev_s *dev)
   const uint8_t start_reg = MBR3108_CTRL_CMD;
   const uint8_t last_reg = MBR3108_CTRL_CMD_ERR;
   uint8_t readbuf[MBR3108_CTRL_CMD_ERR - MBR3108_CTRL_CMD + 1];
-  uint8_t cmd, cmd_status, cmd_err;
+  uint8_t cmd;
+  uint8_t cmd_status;
+  uint8_t cmd_err;
   int ret;
 
   DEBUGASSERT(last_reg - start_reg + 1 == sizeof(readbuf));
@@ -483,7 +489,8 @@ static int mbr3108_clear_latched(FAR struct mbr3108_dev_s *dev)
   ret = mbr3108_i2c_write(dev, reg, &cmd, 1);
   if (ret < 0)
     {
-      mbr3108_dbg("MBR3108_CTRL_CMD:MBR3108_CMD_CLEAR_LATCHED write failed.\n");
+      mbr3108_dbg("MBR3108_CTRL_CMD:  "
+                  "MBR3108_CMD_CLEAR_LATCHED write failed.\n");
       return ret;
     }
 
@@ -526,8 +533,9 @@ static int mbr3108_debug_setup(FAR struct mbr3108_dev_s *dev,
   return ret;
 }
 
-static int mbr3108_device_configuration(FAR struct mbr3108_dev_s *dev,
-                                        FAR const struct mbr3108_sensor_conf_s *conf)
+static int
+  mbr3108_device_configuration(FAR struct mbr3108_dev_s *dev,
+                               FAR const struct mbr3108_sensor_conf_s *conf)
 {
   const uint8_t start_reg = MBR3108_SENSOR_EN;
   const uint8_t last_reg = MBR3108_CONFIG_CRC + 1;
@@ -580,7 +588,10 @@ static int mbr3108_device_configuration(FAR struct mbr3108_dev_s *dev,
 static int mbr3108_get_sensor_status(FAR struct mbr3108_dev_s *dev,
                                      FAR void *buf)
 {
-  struct mbr3108_sensor_status_s status = {};
+  struct mbr3108_sensor_status_s status =
+  {
+  };
+
   const uint8_t start_reg = MBR3108_BUTTON_STAT;
   const uint8_t last_reg = MBR3108_LATCHED_PROX_STAT;
   uint8_t readbuf[MBR3108_LATCHED_PROX_STAT - MBR3108_BUTTON_STAT + 1];
@@ -588,7 +599,7 @@ static int mbr3108_get_sensor_status(FAR struct mbr3108_dev_s *dev,
 
   DEBUGASSERT(last_reg - start_reg + 1 == sizeof(readbuf));
 
-  /* Attempt to sensor status registers.*/
+  /* Attempt to sensor status registers. */
 
   ret = mbr3108_i2c_read(dev, start_reg, readbuf, sizeof(readbuf));
   if (ret < 0)
@@ -598,14 +609,17 @@ static int mbr3108_get_sensor_status(FAR struct mbr3108_dev_s *dev,
       return ret;
     }
 
-  status.button = (readbuf[MBR3108_BUTTON_STAT + 0 - start_reg]) |
-                  (readbuf[MBR3108_BUTTON_STAT + 1 - start_reg] << 8);
-  status.proximity = readbuf[MBR3108_PROX_STAT - start_reg];
+  status.button            =
+    (readbuf[MBR3108_BUTTON_STAT + 0 - start_reg]) |
+    (readbuf[MBR3108_BUTTON_STAT + 1 - start_reg] << 8);
+  status.proximity         =
+    readbuf[MBR3108_PROX_STAT - start_reg];
 
-  status.latched_button =
-                  (readbuf[MBR3108_LATCHED_BUTTON_STAT + 0 - start_reg]) |
-                  (readbuf[MBR3108_LATCHED_BUTTON_STAT + 1 - start_reg] << 8);
-  status.latched_proximity = readbuf[MBR3108_LATCHED_PROX_STAT - start_reg];
+  status.latched_button    =
+    (readbuf[MBR3108_LATCHED_BUTTON_STAT + 0 - start_reg]) |
+    (readbuf[MBR3108_LATCHED_BUTTON_STAT + 1 - start_reg] << 8);
+  status.latched_proximity =
+    readbuf[MBR3108_LATCHED_PROX_STAT - start_reg];
 
   memcpy(buf, &status, sizeof(status));
 
@@ -619,13 +633,17 @@ static int mbr3108_get_sensor_status(FAR struct mbr3108_dev_s *dev,
 static int mbr3108_get_sensor_debug_data(FAR struct mbr3108_dev_s *dev,
                                          FAR void *buf)
 {
-  struct mbr3108_sensor_debug_s data = {};
+  struct mbr3108_sensor_debug_s data =
+  {
+  };
+
   const uint8_t start_reg = MBR3108_SYNC_COUNTER1;
   const uint8_t last_reg = MBR3108_SYNC_COUNTER2;
   uint8_t readbuf[MBR3108_SYNC_COUNTER2 - MBR3108_SYNC_COUNTER1 + 1];
+  uint8_t sync1;
+  uint8_t sync2;
   int ret;
   int retries;
-  uint8_t sync1, sync2;
 
   DEBUGASSERT(last_reg - start_reg + 1 == sizeof(readbuf));
 
@@ -692,7 +710,9 @@ static int mbr3108_probe_device(FAR struct mbr3108_dev_s *dev)
 
   DEBUGASSERT(last_reg - start_reg + 1 == sizeof(readbuf));
 
-  /* Attempt to read device identification registers with multi-byte read.*/
+  /* Attempt to read device identification registers with multi-byte
+   * read.
+   */
 
   ret = mbr3108_i2c_read(dev, start_reg, readbuf, sizeof(readbuf));
   if (ret < 0)
@@ -719,11 +739,11 @@ static int mbr3108_probe_device(FAR struct mbr3108_dev_s *dev)
       dev_rev != MBR3108_EXPECTED_DEVICE_REV)
     {
       mbr3108_dbg("Probe failed, dev-id mismatch!\n");
-      mbr3108_dbg(
-          "  Expected: family_id: 0x%02x, device_id: 0x%04x, device_rev: %d\n",
-          MBR3108_EXPECTED_FAMILY_ID,
-          MBR3108_EXPECTED_DEVICE_ID,
-          MBR3108_EXPECTED_DEVICE_REV);
+      mbr3108_dbg("  Expected: family_id: 0x%02x, device_id: "
+                  "0x%04x, device_rev: %d\n",
+                  MBR3108_EXPECTED_FAMILY_ID,
+                  MBR3108_EXPECTED_DEVICE_ID,
+                  MBR3108_EXPECTED_DEVICE_REV);
 
       return -ENXIO;
     }
@@ -874,7 +894,11 @@ static int mbr3108_open(FAR struct file *filep)
   DEBUGASSERT(inode && inode->i_private);
   priv = inode->i_private;
 
-  nxsem_wait_uninterruptible(&priv->devsem);
+  ret = nxsem_wait_uninterruptible(&priv->devsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   use_count = priv->cref + 1;
   if (use_count == 1)
@@ -936,6 +960,7 @@ static int mbr3108_close(FAR struct file *filep)
   FAR struct inode *inode;
   FAR struct mbr3108_dev_s *priv;
   int use_count;
+  int ret;
 
   DEBUGASSERT(filep);
   inode = filep->f_inode;
@@ -943,7 +968,11 @@ static int mbr3108_close(FAR struct file *filep)
   DEBUGASSERT(inode && inode->i_private);
   priv = inode->i_private;
 
-  nxsem_wait_uninterruptible(&priv->devsem);
+  ret = nxsem_wait_uninterruptible(&priv->devsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   use_count = priv->cref - 1;
   if (use_count == 0)
@@ -1025,8 +1054,8 @@ static int mbr3108_poll(FAR struct file *filep, FAR struct pollfd *fds,
           goto out;
         }
 
-      /* This is a request to set up the poll.  Find an available slot for the
-       * poll structure reference.
+      /* This is a request to set up the poll.  Find an available slot for
+       * the poll structure reference.
        */
 
       for (i = 0; i < CONFIG_INPUT_CYPRESS_MBR3108_NPOLLWAITERS; i++)

--- a/drivers/input/ft5x06.h
+++ b/drivers/input/ft5x06.h
@@ -65,76 +65,77 @@
  ****************************************************************************/
 
 /* WARNING: Some definitions may apply only to the FT5336 */
+
 /* FT5x06 maximum number of simultaneously detected touches. */
 
-#define FT5x06_MAX_TOUCHES                (5)
+#define FT5X06_MAX_TOUCHES                (5)
 
 /* FT5x06 raw touch data length. */
 
-#define FT5x06_TOUCH_DATA_LEN             (0x20)
+#define FT5X06_TOUCH_DATA_LEN             (0x20)
 
 /* FT5x06 register addresses */
 
-#define FT5x06_TOUCH_MODE_REG             (0x00) /* Mode register */
-#define FT5x06_TOUCH_GESTID_REG           (0x01) /* Gesture ID register */
-#define FT5x06_TOUCH_STAT_REG             (0x02) /* Touch data status */
+#define FT5X06_TOUCH_MODE_REG             (0x00) /* Mode register */
+#define FT5X06_TOUCH_GESTID_REG           (0x01) /* Gesture ID register */
+#define FT5X06_TOUCH_STAT_REG             (0x02) /* Touch data status */
                                                  /* See struct ft5x06_touch_point_s */
-#define FT5x06_TH_GROUP_REG               (0x80) /* Threshold for touch detection */
-#define FT5x06_TH_DIFF_REG                (0x85) /* Filter function coefficients */
-#define FT5x06_CTRL_REG                   (0x86) /* Control register */
-#define FT5x06_TIMEENTERMONITOR_REG       (0x87) /* Time switching Active to Monitor */
-#define FT5x06_PERIODACTIVE_REG           (0x88) /* Report rate in Active mode */
-#define FT5x06_PERIODMONITOR_REG          (0x89) /* Report rate in Monitor mode */
-#define FT5x06_RADIAN_VALUE_REG           (0x91) /* Minimum allowing angle */
-#define FT5x06_OFFSET_LEFT_RIGHT_REG      (0x92) /* Minimum offset */
-#define FT5x06_OFFSET_UP_DOWN_REG         (0x93) /* Maximum offset */
-#define FT5x06_DISTANCE_LEFT_RIGHT_REG    (0x94) /* Minimum distance */
-#define FT5x06_DISTANCE_UP_DOWN_REG       (0x95) /* Minimum distance */
-#define FT5x06_DISTANCE_ZOOM_REG          (0x96) /* Maximum distance */
-#define FT5x06_LIB_VER_H_REG              (0xa1) /* MS LIB version */
-#define FT5x06_LIB_VER_L_REG              (0xa2) /* LS LIB version */
-#define FT5x06_CIPHER_REG                 (0xa3) /* Chip selecting */
-#define FT5x06_GMODE_REG                  (0xa4) /* Interrupt mode */
-#define FT5x06_PWR_MODE_REG               (0xa5) /* Power mode */
-#define FT5x06_FIRMID_REG                 (0xa6) /* Firmware version */
-#define FT5x06_CHIP_ID_REG                (0xa8) /* Chip ID */
-#define FT5x06_RELEASE_CODE_ID_REG        (0xaf) /* Release code version */
-#define FT5x06_STATE_REG                  (0xbc) /* Current operating mode */
+#define FT5X06_TH_GROUP_REG               (0x80) /* Threshold for touch detection */
+#define FT5X06_TH_DIFF_REG                (0x85) /* Filter function coefficients */
+#define FT5X06_CTRL_REG                   (0x86) /* Control register */
+#define FT5X06_TIMEENTERMONITOR_REG       (0x87) /* Time switching Active to Monitor */
+#define FT5X06_PERIODACTIVE_REG           (0x88) /* Report rate in Active mode */
+#define FT5X06_PERIODMONITOR_REG          (0x89) /* Report rate in Monitor mode */
+#define FT5X06_RADIAN_VALUE_REG           (0x91) /* Minimum allowing angle */
+#define FT5X06_OFFSET_LEFT_RIGHT_REG      (0x92) /* Minimum offset */
+#define FT5X06_OFFSET_UP_DOWN_REG         (0x93) /* Maximum offset */
+#define FT5X06_DISTANCE_LEFT_RIGHT_REG    (0x94) /* Minimum distance */
+#define FT5X06_DISTANCE_UP_DOWN_REG       (0x95) /* Minimum distance */
+#define FT5X06_DISTANCE_ZOOM_REG          (0x96) /* Maximum distance */
+#define FT5X06_LIB_VER_H_REG              (0xa1) /* MS LIB version */
+#define FT5X06_LIB_VER_L_REG              (0xa2) /* LS LIB version */
+#define FT5X06_CIPHER_REG                 (0xa3) /* Chip selecting */
+#define FT5X06_GMODE_REG                  (0xa4) /* Interrupt mode */
+#define FT5X06_PWR_MODE_REG               (0xa5) /* Power mode */
+#define FT5X06_FIRMID_REG                 (0xa6) /* Firmware version */
+#define FT5X06_CHIP_ID_REG                (0xa8) /* Chip ID */
+#define FT5X06_RELEASE_CODE_ID_REG        (0xaf) /* Release code version */
+#define FT5X06_STATE_REG                  (0xbc) /* Current operating mode */
 
-#define FT5x06_TOUCH_DATA_STARTREG        (1)  /* Address where data begins */
+#define FT5X06_TOUCH_DATA_STARTREG        (1)    /* Address where data begins */
 
 /* Possible values of the DEV_MODE register */
 
-#define FT5x06_DEV_MODE_WORKING           (0x00)
-#define FT5x06_DEV_MODE_FACTORY           (0x04)
+#define FT5X06_DEV_MODE_WORKING           (0x00)
+#define FT5X06_DEV_MODE_FACTORY           (0x04)
 
 /* Possible values of the GEST_ID register */
 
-#define FT5x06_GEST_ID_NO_GESTURE         (0x00)
-#define FT5x06_GEST_ID_MOVE_UP            (0x10)
-#define FT5x06_GEST_ID_MOVE_RIGHT         (0x14)
-#define FT5x06_GEST_ID_MOVE_DOWN          (0x18)
-#define FT5x06_GEST_ID_MOVE_LEFT          (0x1C)
-#define FT5x06_GEST_ID_SINGLE_CLICK       (0x20)
-#define FT5x06_GEST_ID_DOUBLE_CLICK       (0x22)
-#define FT5x06_GEST_ID_ROTATE_CLOCKWISE   (0x28)
-#define FT5x06_GEST_ID_ROTATE_C_CLOCKWISE (0x29)
-#define FT5x06_GEST_ID_ZOOM_IN            (0x40)
-#define FT5x06_GEST_ID_ZOOM_OUT           (0x49)
+#define FT5X06_GEST_ID_NO_GESTURE         (0x00)
+#define FT5X06_GEST_ID_MOVE_UP            (0x10)
+#define FT5X06_GEST_ID_MOVE_RIGHT         (0x14)
+#define FT5X06_GEST_ID_MOVE_DOWN          (0x18)
+#define FT5X06_GEST_ID_MOVE_LEFT          (0x1c)
+#define FT5X06_GEST_ID_SINGLE_CLICK       (0x20)
+#define FT5X06_GEST_ID_DOUBLE_CLICK       (0x22)
+#define FT5X06_GEST_ID_ROTATE_CLOCKWISE   (0x28)
+#define FT5X06_GEST_ID_ROTATE_C_CLOCKWISE (0x29)
+#define FT5X06_GEST_ID_ZOOM_IN            (0x40)
+#define FT5X06_GEST_ID_ZOOM_OUT           (0x49)
 
-/* Values related to FT5x06_CTRL_REG */
+/* Values related to FT5X06_CTRL_REG */
 
-#define FT5x06_CTRL_KEEP_ACTIVE_MODE      (0x00)
-#define FT5x06_CTRL_KEEP_AUTO_SWITCH_MONITOR_MODE (0x01)
+#define FT5X06_CTRL_KEEP_ACTIVE_MODE      (0x00)
+#define FT5X06_CTRL_KEEP_AUTO_SWITCH_MONITOR_MODE (0x01)
 
-/* Possible values of FT5x06_GMODE_REG */
+/* Possible values of FT5X06_GMODE_REG */
 
-#define FT5x06_G_MODE_INTERRUPT_POLLING   (0x00)
-#define FT5x06_G_MODE_INTERRUPT_TRIGGER   (0x01)
+#define FT5X06_G_MODE_INTERRUPT_POLLING   (0x00)
+#define FT5X06_G_MODE_INTERRUPT_TRIGGER   (0x01)
 
-/* Possible values of FT5x06_CHIP_ID_REG */
+/* Possible values of FT5X06_CHIP_ID_REG */
 
-#define FT5x06_ID_VALUE                   (0x51)
+#define FT5X06_ID_VALUE                   (0x51)
 
 /* Operations on struct ft5x06_touch_point_s */
 
@@ -149,10 +150,10 @@
 
 enum touch_event_e
 {
-  FT5x06_DOWN    = 0,  /* The state changed to touched */
-  FT5x06_UP      = 1,  /* The state changed to not touched */
-  FT5x06_CONTACT = 2,  /* There is a continuous touch being detected */
-  FT5x06_INVALID = 3   /* No touch information available */
+  FT5X06_DOWN    = 0,  /* The state changed to touched */
+  FT5X06_UP      = 1,  /* The state changed to not touched */
+  FT5X06_CONTACT = 2,  /* There is a continuous touch being detected */
+  FT5X06_INVALID = 3   /* No touch information available */
 };
 
 /* Describes on touchpoint returned by the FT5x06 */
@@ -173,7 +174,7 @@ struct ft5x06_touch_data_s
 {
   uint8_t gestid;      /* Gesture ID */
   uint8_t tdstatus;    /* Touch status */
-  struct ft5x06_touch_point_s touch[FT5x06_MAX_TOUCHES];
+  struct ft5x06_touch_point_s touch[FT5X06_MAX_TOUCHES];
 };
 
 /****************************************************************************

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * drivers/input/mxt.c
  *
- *   Copyright (C) 2014, 2016-2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -75,7 +60,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Driver support ***********************************************************/
+
 /* This format is used to construct the /dev/input[n] device driver path.  It
  * defined here so that it will be used consistently in all places.
  */
@@ -105,6 +92,7 @@
 /****************************************************************************
  * Private Types
  ****************************************************************************/
+
 /* This enumeration describes the state of one contact.
  *
  *                  |
@@ -219,6 +207,7 @@ struct mxt_dev_s
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
+
 /* MXT register access */
 
 static int  mxt_getreg(FAR struct mxt_dev_s *priv, uint16_t regaddr,
@@ -279,6 +268,7 @@ static int  mxt_hwinitialize(FAR struct mxt_dev_s *priv);
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
 /* This the vtable that supports the character driver interface */
 
 static const struct file_operations mxt_fops =
@@ -606,10 +596,10 @@ static void mxt_notify(FAR struct mxt_dev_s *priv)
       nxsem_post(&priv->waitsem);
     }
 
-  /* If there are threads waiting on poll() for maXTouch data to become available,
-   * then wake them up now.  NOTE: we wake up all waiting threads because we
-   * do not know that they are going to do.  If they all try to read the data,
-   * then some make end up blocking after all.
+  /* If there are threads waiting on poll() for maXTouch data to become
+   * available, then wake them up now.  NOTE: we wake up all waiting threads
+   * because we do not know that they are going to do.  If they all try to
+   * read the data, then some make end up blocking after all.
    */
 
   for (i = 0; i < CONFIG_MXT_NPOLLWAITERS; i++)
@@ -708,8 +698,8 @@ static inline int mxt_waitsample(FAR struct mxt_dev_s *priv)
     }
 
   /* Re-acquire the semaphore that manages mutually exclusive access to
-   * the device structure.  We may have to wait here.  But we have our sample.
-   * Interrupts and pre-emption will be re-enabled while we wait.
+   * the device structure.  We may have to wait here.  But we have our
+   * sample.  Interrupts and pre-emption will be re-enabled while we wait.
    */
 
   ret = nxsem_wait(&priv->devsem);
@@ -742,7 +732,7 @@ static void mxt_button_event(FAR struct mxt_dev_s *priv,
    * pressed if the corresponding bit is zero.
    */
 
-   for (i = 0; i < priv->lower->nbuttons; i++)
+  for (i = 0; i < priv->lower->nbuttons; i++)
     {
       uint8_t bit = (MXT_GPIO0_MASK << i);
 
@@ -778,8 +768,10 @@ static void mxt_touch_event(FAR struct mxt_dev_s *priv,
 
   /* Extract the 12-bit X and Y positions */
 
-  x = ((uint16_t)msg->body[1] << 4) | (((uint16_t)msg->body[3] >> 4) & 0x0f);
-  y = ((uint16_t)msg->body[2] << 4) | (((uint16_t)msg->body[3] & 0x0f));
+  x = ((uint16_t)msg->body[1] << 4) |
+      (((uint16_t)msg->body[3] >> 4) & 0x0f);
+  y = ((uint16_t)msg->body[2] << 4) |
+      (((uint16_t)msg->body[3] & 0x0f));
 
   /* Swap X/Y as necessary */
 
@@ -896,8 +888,10 @@ static void mxt_touch_event(FAR struct mxt_dev_s *priv,
            * event?
            */
 
-          xdiff = x > sample->lastx ? (x - sample->lastx) : (sample->lastx - x);
-          ydiff = y > sample->lasty ? (y - sample->lasty) : (sample->lasty - y);
+          xdiff = x > sample->lastx ? (x - sample->lastx) :
+                                      (sample->lastx - x);
+          ydiff = y > sample->lasty ? (y - sample->lasty) :
+                                      (sample->lasty - y);
 
           /* Check the thresholds */
 
@@ -983,7 +977,17 @@ static void mxt_worker(FAR void *arg)
 
   /* Get exclusive access to the MXT driver data structure */
 
-  nxsem_wait_uninterruptible(&priv->devsem);
+  do
+    {
+      ret = nxsem_wait_uninterruptible(&priv->devsem);
+
+      /* This would only fail if something canceled the worker thread?
+       * That is not expected.
+       */
+
+      DEBUGASSERT(ret == OK || ret == -ECANCELED);
+    }
+  while (ret < 0);
 
   /* Loop, processing each message from the maXTouch */
 
@@ -1040,15 +1044,18 @@ static void mxt_worker(FAR void *arg)
         }
 #endif
 
-      /* 0xff marks the end of the messages; any other message IDs are ignored
-       * (after complaining a little).
+      /* 0xff marks the end of the messages; any other message IDs are
+       * ignored (after complaining a little).
        */
 
       else if (msg.id != 0xff)
         {
-          iinfo("Ignored: id=%u message={%02x %02x %02x %02x %02x %02x %02x}\n",
-                msg.id, msg.body[0], msg.body[1], msg.body[2], msg.body[3],
-                msg.body[4], msg.body[5], msg.body[6]);
+          iinfo("Ignored: id=%u message="
+                "{%02x %02x %02x %02x %02x %02x %02x}\n",
+                msg.id,
+                msg.body[0], msg.body[1], msg.body[2],
+                msg.body[3], msg.body[4], msg.body[5],
+                msg.body[6]);
 
           retries++;
         }
@@ -1056,6 +1063,7 @@ static void mxt_worker(FAR void *arg)
   while (id != 0xff && retries < 16);
 
 errout_with_semaphore:
+
   /* Release our lock on the MXT device */
 
   nxsem_post(&priv->devsem);
@@ -1294,7 +1302,7 @@ static ssize_t mxt_read(FAR struct file *filep, FAR char *buffer, size_t len)
         {
           ret = -EAGAIN;
           goto errout;
-       }
+        }
 
       /* Wait for sample data */
 
@@ -1354,7 +1362,8 @@ static ssize_t mxt_read(FAR struct file *filep, FAR char *buffer, size_t len)
 
   if (ncontacts > 0)
     {
-      FAR struct touch_sample_s *report = (FAR struct touch_sample_s *)buffer;
+      FAR struct touch_sample_s *report =
+        (FAR struct touch_sample_s *)buffer;
 
       /* Yes, copy the sample data into the user buffer */
 
@@ -1442,8 +1451,9 @@ static ssize_t mxt_read(FAR struct file *filep, FAR char *buffer, size_t len)
 
                   sample->contact = CONTACT_REPORT;
 
-                  /* A pressure measurement of zero means that pressure is not
-                   * available */
+                  /* A pressure measurement of zero means that pressure is
+                   * not available.
+                   */
 
                   if (point->pressure != 0)
                     {
@@ -1780,8 +1790,8 @@ static int mxt_hwinitialize(FAR struct mxt_dev_s *priv)
   info->ysize = regval;
 
   iinfo("Family: %u variant: %u version: %u.%u.%02x\n",
-        info->family, info->variant, info->version >> 4, info->version & 0x0f,
-        info->build);
+        info->family, info->variant, info->version >> 4,
+        info->version & 0x0f, info->build);
   iinfo("Matrix size: (%u,%u) objects: %u\n",
         info->xsize, info->ysize, info->nobjects);
 


### PR DESCRIPTION
Resolution of Issue 619 will require multiple steps, this part of the first step in that resolution:  Every call to nxsem_wait_uninterruptible() must handle the return value from nxsem_wait_uninterruptible properly.  This commit is only for those files under drivers/input.