### PR TITLE
Check return from nxsem_wait_initialize()

### DIFF
--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -1,20 +1,35 @@
 /****************************************************************************
  * drivers/eeprom/i2c_xx24xx.c
  *
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ *   Copyright (C) 2018 Sebastien Lorquet. All rights reserved.
+ *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
 

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -36,7 +36,8 @@
  *              24xx128    16384     64   2     1010AAA
  *              24xx256    32768     64   2     1010AAA
  *              24xx512    65536    128   2     1010AAA
- *              24xx1025  131072    128   2     1010PAA Special case: address bit is shifted.
+ *              24xx1025  131072    128   2     1010PAA Special case: address
+ *                                                      bit is shifted.
  *              24xx1026  131072    128   2     1010AAP
  *
  * Atmel
@@ -58,7 +59,8 @@
  *              M24C04       512    16    1     1010AAP
  *              M24C08      1024    16    1     1010APP
  *              M24C16      2048    16    1     1010PPP
- *              M24C32      4096    32    2     1010AAA ID pages supported as a separate device
+ *              M24C32      4096    32    2     1010AAA ID pages supported
+ *                                                      as a separate device
  *              M24C64      8192    32    2     1010AAA
  *              M24128     16384    64    2     1010AAA
  *              M24256     32768    64    2     1010AAA
@@ -273,7 +275,8 @@ static int ee24xx_waitwritecomplete(FAR struct ee24xx_dev_s *eedev,
   uint32_t addr_hi = (memaddr >> (eedev->addrlen << 3));
 
   msgs[0].frequency = eedev->freq;
-  msgs[0].addr      = eedev->addr | (addr_hi & ((1 << eedev->haddrbits) - 1));
+  msgs[0].addr      = eedev->addr | \
+                      (addr_hi & ((1 << eedev->haddrbits) - 1));
   msgs[0].flags     = I2C_M_READ;
   msgs[0].buffer    = &adr;
   msgs[0].length    = 1;
@@ -310,7 +313,8 @@ static int ee24xx_writepage(FAR struct ee24xx_dev_s *eedev, uint32_t memaddr,
   maddr[1] = memaddr &  0xff;
 
   msgs[0].frequency = eedev->freq;
-  msgs[0].addr      = eedev->addr | (addr_hi & ((1 << eedev->haddrbits) - 1));
+  msgs[0].addr      = eedev->addr | \
+                      (addr_hi & ((1 << eedev->haddrbits) - 1));
   msgs[0].flags     = 0;
   msgs[0].buffer    = eedev->addrlen == 2 ? &maddr[0] : &maddr[1];
   msgs[0].length    = eedev->addrlen;
@@ -556,7 +560,8 @@ static ssize_t ee24xx_read(FAR struct file *filep, FAR char *buffer,
   addr[1]           = (filep->f_pos) &  0xff;
 
   msgs[0].frequency = eedev->freq;
-  msgs[0].addr      = eedev->addr | (addr_hi & ((1 << eedev->haddrbits) - 1));
+  msgs[0].addr      = eedev->addr | \
+                      (addr_hi & ((1 << eedev->haddrbits) - 1));
   msgs[0].flags     = 0;
   msgs[0].buffer    = eedev->addrlen == 2 ? &addr[0] : &addr[1];
   msgs[0].length    = eedev->addrlen;

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * drivers/eeprom/i2c_xx24xx.c
  *
- *   Copyright (C) 2018 Sebastien Lorquet. All rights reserved.
- *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -182,27 +167,62 @@ static const struct ee24xx_geom_s g_ee24xx_devices[] =
 {
   /* Microchip devices */
 
-/* by pg al ab sp      device     bytes page  alen */
-  { 0, 1, 1, 0, 1}, /* 24xx00        16    1     1 Ridiculously small device */
-  { 0, 0, 1, 0, 0}, /* 24xx01       128    8     1 */
-  { 1, 0, 1, 0, 0}, /* 24xx02       256    8     1 */
-  { 2, 1, 1, 1, 0}, /* 24xx04       512   16     1 */
-  { 3, 1, 1, 2, 0}, /* 24xx08      1024   16     1 */
-  { 4, 1, 1, 3, 0}, /* 24xx16      2048   16     1 */
-  { 5, 2, 2, 0, 0}, /* 24xx32      4096   32     2 */
-  { 6, 2, 2, 0, 0}, /* 24xx64      8192   32     2 */
-  { 7, 3, 2, 0, 0}, /* 24xx128    16384   64     2 */
-  { 8, 3, 2, 0, 0}, /* 24xx256    32768   64     2 */
-  { 9, 4, 2, 0, 0}, /* 24xx512    65536  128     2 */
-  {10, 4, 2, 1, 1}, /* 24xx1025  131072  128     2 Shifted address, todo */
-  {10, 4, 2, 1, 0}, /* 24xx1026  131072  128     2 */
-  {11, 5, 2, 2, 0}, /* AT24CM02  262144  256     2 */
+  /* by pg al ab sp  device bytes page  alen */
+
+  {
+    0, 1, 1, 0, 1
+  }, /* 24xx00        16    1     1 Ridiculously small device */
+  {
+    0, 0, 1, 0, 0
+  }, /* 24xx01       128    8     1 */
+  {
+    1, 0, 1, 0, 0
+  }, /* 24xx02       256    8     1 */
+  {
+    2, 1, 1, 1, 0
+  }, /* 24xx04       512   16     1 */
+  {
+    3, 1, 1, 2, 0
+  }, /* 24xx08      1024   16     1 */
+  {
+    4, 1, 1, 3, 0
+  }, /* 24xx16      2048   16     1 */
+  {
+    5, 2, 2, 0, 0
+  }, /* 24xx32      4096   32     2 */
+  {
+    6, 2, 2, 0, 0
+  }, /* 24xx64      8192   32     2 */
+  {
+    7, 3, 2, 0, 0
+  }, /* 24xx128    16384   64     2 */
+  {
+    8, 3, 2, 0, 0
+  }, /* 24xx256    32768   64     2 */
+  {
+    9, 4, 2, 0, 0
+  }, /* 24xx512    65536  128     2 */
+  {
+    10, 4, 2, 1, 1
+  }, /* 24xx1025  131072  128     2 Shifted address, todo */
+  {
+    10, 4, 2, 1, 0
+  }, /* 24xx1026  131072  128     2 */
+  {
+    11, 5, 2, 2, 0
+  }, /* AT24CM02  262144  256     2 */
 
   /* STM devices */
 
-  { 0, 1, 1, 0, 0}, /* M24C01       128   16     1 */
-  { 1, 1, 1, 0, 0}, /* M24C02       256   16     1 */
-  {11, 5, 2, 2, 0}, /* M24M02    262144  256     2 */
+  {
+    0, 1, 1, 0, 0
+  }, /* M24C01       128   16     1 */
+  {
+    1, 1, 1, 0, 0
+  }, /* M24C02       256   16     1 */
+  {
+    11, 5, 2, 2, 0
+  }, /* M24M02    262144  256     2 */
 };
 
 /* Driver operations */
@@ -280,7 +300,6 @@ static int ee24xx_waitwritecomplete(FAR struct ee24xx_dev_s *eedev,
 static int ee24xx_writepage(FAR struct ee24xx_dev_s *eedev, uint32_t memaddr,
                             FAR const char *buffer, size_t len)
 {
-
   struct i2c_msg_s msgs[2];
   uint8_t maddr[2];
   uint32_t addr_hi = (memaddr >> (eedev->addrlen << 3));
@@ -316,9 +335,9 @@ static int ee24xx_writepage(FAR struct ee24xx_dev_s *eedev, uint32_t memaddr,
  *
  ****************************************************************************/
 
-static void ee24xx_semtake(FAR struct ee24xx_dev_s *eedev)
+static int ee24xx_semtake(FAR struct ee24xx_dev_s *eedev)
 {
-  nxsem_wait_uninterruptible(&eedev->sem);
+  return nxsem_wait_uninterruptible(&eedev->sem);
 }
 
 /****************************************************************************
@@ -352,7 +371,12 @@ static int ee24xx_open(FAR struct file *filep)
 
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
-  ee24xx_semtake(eedev);
+
+  ret = ee24xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Increment the reference count */
 
@@ -384,7 +408,12 @@ static int ee24xx_close(FAR struct file *filep)
 
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
-  ee24xx_semtake(eedev);
+
+  ret = ee24xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Decrement the reference count. I want the entire close operation
    * to be atomic wrt other driver operations.
@@ -419,7 +448,12 @@ static off_t ee24xx_seek(FAR struct file *filep, off_t offset, int whence)
 
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
-  ee24xx_semtake(eedev);
+
+  ret = ee24xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Determine the new, requested file position */
 
@@ -438,6 +472,7 @@ static off_t ee24xx_seek(FAR struct file *filep, off_t offset, int whence)
       break;
 
     default:
+
       /* Return EINVAL if the whence argument is invalid */
 
       ee24xx_semgive(eedev);
@@ -490,7 +525,11 @@ static ssize_t ee24xx_read(FAR struct file *filep, FAR char *buffer,
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
 
-  ee24xx_semtake(eedev);
+  ret = ee24xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* trim len if read would go beyond end of device */
 
@@ -564,7 +603,11 @@ static ssize_t at24cs_read_uuid(FAR struct file *filep, FAR char *buffer,
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee24xx_dev_s *)inode->i_private;
 
-  ee24xx_semtake(eedev);
+  ret = ee24xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* trim len if read would go beyond end of device */
 
@@ -660,7 +703,11 @@ static ssize_t ee24xx_write(FAR struct file *filep, FAR const char *buffer,
 
   savelen = len; /* save number of bytes written */
 
-  ee24xx_semtake(eedev);
+  ret = ee24xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Writes can't happen in a row like the read does.
    * The EEPROM is made of pages, and write sequences
@@ -823,7 +870,7 @@ int ee24xx_initialize(FAR struct i2c_master_s *bus, uint8_t devaddr,
 
   if (g_ee24xx_devices[devtype].special)
     {
-      if (devtype == EEPROM_24xx00)
+      if (devtype == EEPROM_24XX00)
         {
           /* Ultra small 16-byte EEPROM */
 
@@ -835,7 +882,7 @@ int ee24xx_initialize(FAR struct i2c_master_s *bus, uint8_t devaddr,
 
           eedev->pgsize = 1;
         }
-      else if (devtype == EEPROM_24xx1025)
+      else if (devtype == EEPROM_24XX1025)
         {
           /* Microchip alien part where the address MSB is << 2 bits */
 

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -290,7 +290,7 @@ static int ee24xx_waitwritecomplete(FAR struct ee24xx_dev_s *eedev,
   uint32_t addr_hi = (memaddr >> (eedev->addrlen << 3));
 
   msgs[0].frequency = eedev->freq;
-  msgs[0].addr      = eedev->addr | \
+  msgs[0].addr      = eedev->addr |
                       (addr_hi & ((1 << eedev->haddrbits) - 1));
   msgs[0].flags     = I2C_M_READ;
   msgs[0].buffer    = &adr;
@@ -328,7 +328,7 @@ static int ee24xx_writepage(FAR struct ee24xx_dev_s *eedev, uint32_t memaddr,
   maddr[1] = memaddr &  0xff;
 
   msgs[0].frequency = eedev->freq;
-  msgs[0].addr      = eedev->addr | \
+  msgs[0].addr      = eedev->addr |
                       (addr_hi & ((1 << eedev->haddrbits) - 1));
   msgs[0].flags     = 0;
   msgs[0].buffer    = eedev->addrlen == 2 ? &maddr[0] : &maddr[1];
@@ -575,7 +575,7 @@ static ssize_t ee24xx_read(FAR struct file *filep, FAR char *buffer,
   addr[1]           = (filep->f_pos) &  0xff;
 
   msgs[0].frequency = eedev->freq;
-  msgs[0].addr      = eedev->addr | \
+  msgs[0].addr      = eedev->addr |
                       (addr_hi & ((1 << eedev->haddrbits) - 1));
   msgs[0].flags     = 0;
   msgs[0].buffer    = eedev->addrlen == 2 ? &addr[0] : &addr[1];

--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * drivers/eeprom/spi_xx25xx.c
  *
- *   Copyright (C) 2014, 2017 Gregory Nutt. All rights reserved.
- *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -220,29 +205,63 @@ static const struct ee25xx_geom_s g_ee25xx_devices[] =
 {
   /* Microchip devices */
 
-  { 0, 1, 1, 0}, /* 25xx010A     128   16     1 */
-  { 1, 1, 1, 0}, /* 25xx020A     256   16     1 */
-  { 2, 1, 1, 1}, /* 25xx040      512   16     1+bit */
-  { 3, 1, 1, 0}, /* 25xx080     1024   16     1 */
-  { 3, 2, 2, 0}, /* 25xx080B    1024   32     2 */
-  { 4, 1, 2, 0}, /* 25xx160     2048   16     2 */
-  { 4, 2, 2, 0}, /* 25xx160B/D  2048   32     2 */
-  { 5, 2, 2, 0}, /* 25xx320     4096   32     2 */
-  { 6, 2, 2, 0}, /* 25xx640     8192   32     2 */
-  { 7, 3, 2, 0}, /* 25xx128    16384   64     2 */
-  { 8, 3, 2, 0}, /* 25xx256    32768   64     2 */
-  { 9, 4, 2, 0}, /* 25xx512    65536  128     2 */
-  {10, 5, 3, 0}, /* 25xx1024  131072  256     3 */
+  {
+    0, 1, 1, 0
+  }, /* 25xx010A     128   16     1 */
+  {
+    1, 1, 1, 0
+  }, /* 25xx020A     256   16     1 */
+  {
+    2, 1, 1, 1
+  }, /* 25xx040      512   16     1+bit */
+  {
+    3, 1, 1, 0
+  }, /* 25xx080     1024   16     1 */
+  {
+    3, 2, 2, 0
+  }, /* 25xx080B    1024   32     2 */
+  {
+    4, 1, 2, 0
+  }, /* 25xx160     2048   16     2 */
+  {
+    4, 2, 2, 0
+  }, /* 25xx160B/D  2048   32     2 */
+  {
+    5, 2, 2, 0
+  }, /* 25xx320     4096   32     2 */
+  {
+    6, 2, 2, 0
+  }, /* 25xx640     8192   32     2 */
+  {
+    7, 3, 2, 0
+  }, /* 25xx128    16384   64     2 */
+  {
+    8, 3, 2, 0
+  }, /* 25xx256    32768   64     2 */
+  {
+    9, 4, 2, 0
+  }, /* 25xx512    65536  128     2 */
+  {
+    10, 5, 3, 0
+  }, /* 25xx1024  131072  256     3 */
 
   /* Atmel devices */
 
-  { 0, 0, 1, 0}, /* AT25010B     128    8     1 */
-  { 1, 0, 1, 0}, /* AT25020B     256    8     1 */
-  { 2, 0, 1, 1}, /* AT25040B     512    8     1+bit */
+  {
+    0, 0, 1, 0
+  }, /* AT25010B     128    8     1 */
+  {
+    1, 0, 1, 0
+  }, /* AT25020B     256    8     1 */
+  {
+    2, 0, 1, 1
+  }, /* AT25040B     512    8     1+bit */
 
   /* STM devices */
 
-  {11, 5, 3, 0}, /* M95M02    262144  256     3 */
+  {
+    11, 5, 3, 0
+  }, /* M95M02    262144  256     3 */
 };
 
 /* Driver operations */
@@ -437,9 +456,9 @@ static void ee25xx_writepage(FAR struct ee25xx_dev_s *eedev, uint32_t devaddr,
  *
  ****************************************************************************/
 
-static void ee25xx_semtake(FAR struct ee25xx_dev_s *eedev)
+static int ee25xx_semtake(FAR struct ee25xx_dev_s *eedev)
 {
-  nxsem_wait_uninterruptible(&eedev->sem);
+  return nxsem_wait_uninterruptible(&eedev->sem);
 }
 
 /****************************************************************************
@@ -473,7 +492,12 @@ static int ee25xx_open(FAR struct file *filep)
 
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
-  ee25xx_semtake(eedev);
+
+  ret = ee25xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Increment the reference count */
 
@@ -505,7 +529,12 @@ static int ee25xx_close(FAR struct file *filep)
 
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
-  ee25xx_semtake(eedev);
+
+  ret = ee25xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Decrement the reference count. I want the entire close operation
    * to be atomic wrt other driver operations.
@@ -540,7 +569,12 @@ static off_t ee25xx_seek(FAR struct file *filep, off_t offset, int whence)
 
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
-  ee25xx_semtake(eedev);
+
+  ret = ee25xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Determine the new, requested file position */
 
@@ -559,6 +593,7 @@ static off_t ee25xx_seek(FAR struct file *filep, off_t offset, int whence)
       break;
 
     default:
+
       /* Return EINVAL if the whence argument is invalid */
 
       ee25xx_semgive(eedev);
@@ -605,7 +640,11 @@ static ssize_t ee25xx_read(FAR struct file *filep, FAR char *buffer,
   DEBUGASSERT(inode && inode->i_private);
   eedev = (FAR struct ee25xx_dev_s *)inode->i_private;
 
-  ee25xx_semtake(eedev);
+  ret = ee25xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* trim len if read would go beyond end of device */
 
@@ -678,7 +717,11 @@ static ssize_t ee25xx_write(FAR struct file *filep, FAR const char *buffer,
 
   ret = len; /* save number of bytes written */
 
-  ee25xx_semtake(eedev);
+  ret = ee25xx_semtake(eedev);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Writes can't happen in a row like the read does.
    * The EEPROM is made of pages, and write sequences
@@ -780,7 +823,7 @@ int ee25xx_initialize(FAR struct spi_dev_s *dev, FAR char *devname,
   if ((devtype < 0) ||
       (devtype >= sizeof(g_ee25xx_devices) / sizeof(g_ee25xx_devices[0])))
     {
-     return -EINVAL;
+      return -EINVAL;
     }
 
   eedev = kmm_zalloc(sizeof(struct ee25xx_dev_s));

--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -1,20 +1,35 @@
 /****************************************************************************
  * drivers/eeprom/spi_xx25xx.c
  *
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The
- * ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ *   Copyright (C) 2018 Sebastien Lorquet. All rights reserved.
+ *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
 

--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -434,8 +434,10 @@ static void ee25xx_writeenable(FAR struct spi_dev_s *spi, int enable)
  *
  ****************************************************************************/
 
-static void ee25xx_writepage(FAR struct ee25xx_dev_s *eedev, uint32_t devaddr,
-                             FAR const char *data, size_t len)
+static void ee25xx_writepage(FAR struct ee25xx_dev_s *eedev,
+                             uint32_t devaddr,
+                             FAR const char *data,
+                             size_t len)
 {
   ee25xx_lock(eedev->spi);
   SPI_SELECT(eedev->spi, SPIDEV_EEPROM(0), true);
@@ -602,15 +604,16 @@ static off_t ee25xx_seek(FAR struct file *filep, off_t offset, int whence)
 
   /* Opengroup.org:
    *
-   *  "The lseek() function shall allow the file offset to be set beyond the end
-   *   of the existing data in the file. If data is later written at this point,
-   *   subsequent reads of data in the gap shall return bytes with the value 0
-   *   until data is actually written into the gap."
+   *  "The lseek() function shall allow the file offset to be set beyond the
+   *  end of the existing data in the file. If data is later written at this
+   *  point, subsequent reads of data in the gap shall return bytes with the
+   *  value 0 until data is actually written into the gap."
    *
-   * We can conform to the first part, but not the second.  But return EINVAL if
+   * We can conform to the first part, but not the second.
+   * But return EINVAL if
    *
-   *  "...the resulting file offset would be negative for a regular file, block
-   *   special file, or directory."
+   *  "...the resulting file offset would be negative for a regular file,
+   *  block special file, or directory."
    */
 
   if (newpos >= 0)

--- a/include/nuttx/eeprom/i2c_xx24xx.h
+++ b/include/nuttx/eeprom/i2c_xx24xx.h
@@ -1,35 +1,20 @@
- /****************************************************************************
+/****************************************************************************
  * include/nuttx/eeprom/i2c_xx24xx.h
  *
- *   Copyright (C) 2018 Sebastien Lorquet. All rights reserved.
- *   Author: Sebastien Lorquet <sebastien@lorquet.fr>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -46,20 +31,20 @@ enum eeprom_24xx_e
 {
   /* Microchip geometries */
 
-  EEPROM_24xx00,
-  EEPROM_24xx01,
-  EEPROM_24xx02,
-  EEPROM_24xx04,
-  EEPROM_24xx08,
-  EEPROM_24xx16,
-  EEPROM_24xx32,
-  EEPROM_24xx64,
-  EEPROM_24xx128,
-  EEPROM_24xx256,
-  EEPROM_24xx512,
-  EEPROM_24xx1025,
-  EEPROM_24xx1026,
-  EEPROM_24cm02,
+  EEPROM_24XX00,
+  EEPROM_24XX01,
+  EEPROM_24XX02,
+  EEPROM_24XX04,
+  EEPROM_24XX08,
+  EEPROM_24XX16,
+  EEPROM_24XX32,
+  EEPROM_24XX64,
+  EEPROM_24XX128,
+  EEPROM_24XX256,
+  EEPROM_24XX512,
+  EEPROM_24XX1025,
+  EEPROM_24XX1026,
+  EEPROM_24CM02,
 
   /* Atmel geometries - none... */
 
@@ -71,28 +56,28 @@ enum eeprom_24xx_e
 
   /* Aliases (devices similar to previously defined ones) */
 
-  EEPROM_AT24C01   = EEPROM_24xx01,
-  EEPROM_AT24C02   = EEPROM_24xx02,
-  EEPROM_AT24C04   = EEPROM_24xx04,
-  EEPROM_AT24C08   = EEPROM_24xx08,
-  EEPROM_AT24C16   = EEPROM_24xx16,
-  EEPROM_AT24C32   = EEPROM_24xx32,
-  EEPROM_AT24C64   = EEPROM_24xx64,
-  EEPROM_AT24C128  = EEPROM_24xx128,
-  EEPROM_AT24C256  = EEPROM_24xx256,
-  EEPROM_AT24C512  = EEPROM_24xx512,
-  EEPROM_AT24C1024 = EEPROM_24xx1026,
-  EEPROM_AT24CM02  = EEPROM_24cm02,
+  EEPROM_AT24C01   = EEPROM_24XX01,
+  EEPROM_AT24C02   = EEPROM_24XX02,
+  EEPROM_AT24C04   = EEPROM_24XX04,
+  EEPROM_AT24C08   = EEPROM_24XX08,
+  EEPROM_AT24C16   = EEPROM_24XX16,
+  EEPROM_AT24C32   = EEPROM_24XX32,
+  EEPROM_AT24C64   = EEPROM_24XX64,
+  EEPROM_AT24C128  = EEPROM_24XX128,
+  EEPROM_AT24C256  = EEPROM_24XX256,
+  EEPROM_AT24C512  = EEPROM_24XX512,
+  EEPROM_AT24C1024 = EEPROM_24XX1026,
+  EEPROM_AT24CM02  = EEPROM_24CM02,
 
-  EEPROM_M24C04    = EEPROM_24xx04,
-  EEPROM_M24C08    = EEPROM_24xx08,
-  EEPROM_M24C16    = EEPROM_24xx16,
-  EEPROM_M24C32    = EEPROM_24xx32,
-  EEPROM_M24C64    = EEPROM_24xx64,
-  EEPROM_M24128    = EEPROM_24xx128,
-  EEPROM_M24256    = EEPROM_24xx256,
-  EEPROM_M24512    = EEPROM_24xx512,
-  EEPROM_M24M01    = EEPROM_24xx1026,
+  EEPROM_M24C04    = EEPROM_24XX04,
+  EEPROM_M24C08    = EEPROM_24XX08,
+  EEPROM_M24C16    = EEPROM_24XX16,
+  EEPROM_M24C32    = EEPROM_24XX32,
+  EEPROM_M24C64    = EEPROM_24XX64,
+  EEPROM_M24128    = EEPROM_24XX128,
+  EEPROM_M24256    = EEPROM_24XX256,
+  EEPROM_M24512    = EEPROM_24XX512,
+  EEPROM_M24M01    = EEPROM_24XX1026,
 };
 
 /****************************************************************************


### PR DESCRIPTION
Resolution of Issue 619 will require multiple steps,
this part of the first step in that resolution:
Every call to nxsem_wait_uninterruptible() must handle the return
value from nxsem_wait_uninterruptible properly.

This commit is only for those files under drivers/eeprom.