### PR TITLE
arch/arm: include chip.h in up_checkstack.c/up_initialize.c

### DIFF
--- a/arch/arm/src/common/up_checkstack.c
+++ b/arch/arm/src/common/up_checkstack.c
@@ -51,6 +51,7 @@
 
 #include "sched/sched.h"
 #include "up_internal.h"
+#include "chip.h"
 
 #ifdef CONFIG_STACK_COLORATION
 

--- a/arch/arm/src/common/up_initialize.c
+++ b/arch/arm/src/common/up_initialize.c
@@ -58,6 +58,7 @@
 
 #include "up_arch.h"
 #include "up_internal.h"
+#include "chip.h"
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
to get up_intstack_base definition in SMP case

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I4b995e0e68c783bf8aac9cd9820cfaf717d6de16