### PR TITLE
Check return from nxsem_wait_initialize()

### DIFF
--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -76,17 +76,20 @@ static
 uint8_t cs43l22_readreg(FAR struct cs43l22_dev_s *priv, uint8_t regaddr);
 static void cs43l22_writereg(FAR struct cs43l22_dev_s *priv, uint8_t regaddr,
                              uint8_t regval);
-static void cs43l22_takesem(sem_t * sem);
+static int  cs43l22_takesem(FAR sem_t *sem);
+static int  cs43l22_forcetake(FAR sem_t *sem);
 #define     cs43l22_givesem(s) nxsem_post(s)
 
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
 static inline uint16_t cs43l22_scalevolume(uint16_t volume, b16_t scale);
-static void cs43l22_setvolume(FAR struct cs43l22_dev_s *priv, uint16_t volume,
-                              bool mute);
+static void cs43l22_setvolume(FAR struct cs43l22_dev_s *priv,
+                              uint16_t volume, bool mute);
 #endif
 #ifndef CONFIG_AUDIO_EXCLUDE_TONE
-static void cs43l22_setbass(FAR struct cs43l22_dev_s *priv, uint8_t bass);
-static void cs43l22_settreble(FAR struct cs43l22_dev_s *priv, uint8_t treble);
+static void cs43l22_setbass(FAR struct cs43l22_dev_s *priv,
+                            uint8_t bass);
+static void cs43l22_settreble(FAR struct cs43l22_dev_s *priv,
+                              uint8_t treble);
 #endif
 
 static void cs43l22_setdatawidth(FAR struct cs43l22_dev_s *priv);
@@ -112,21 +115,25 @@ static void cs43l22_returnbuffers(FAR struct cs43l22_dev_s *priv);
 static int  cs43l22_sendbuffer(FAR struct cs43l22_dev_s *priv);
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-static int  cs43l22_start(FAR struct audio_lowerhalf_s *dev, FAR void *session);
+static int  cs43l22_start(FAR struct audio_lowerhalf_s *dev,
+                          FAR void *session);
 #else
 static int  cs43l22_start(FAR struct audio_lowerhalf_s *dev);
 #endif
 #ifndef CONFIG_AUDIO_EXCLUDE_STOP
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-static int  cs43l22_stop(FAR struct audio_lowerhalf_s *dev, FAR void *session);
+static int  cs43l22_stop(FAR struct audio_lowerhalf_s *dev,
+                         FAR void *session);
 #else
 static int  cs43l22_stop(FAR struct audio_lowerhalf_s *dev);
 #endif
 #endif
 #ifndef CONFIG_AUDIO_EXCLUDE_PAUSE_RESUME
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-static int  cs43l22_pause(FAR struct audio_lowerhalf_s *dev, FAR void *session);
-static int  cs43l22_resume(FAR struct audio_lowerhalf_s *dev, FAR void *session);
+static int  cs43l22_pause(FAR struct audio_lowerhalf_s *dev,
+                          FAR void *session);
+static int  cs43l22_resume(FAR struct audio_lowerhalf_s *dev,
+                           FAR void *session);
 #else
 static int  cs43l22_pause(FAR struct audio_lowerhalf_s *dev);
 static int  cs43l22_resume(FAR struct audio_lowerhalf_s *dev);
@@ -269,7 +276,6 @@ uint8_t cs43l22_readreg(FAR struct cs43l22_dev_s *priv, uint8_t regaddr)
         }
       else
         {
-
           /* The I2C transfer was successful... break out of the loop and
            * return the value read.
            */
@@ -286,13 +292,13 @@ uint8_t cs43l22_readreg(FAR struct cs43l22_dev_s *priv, uint8_t regaddr)
   return 0;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: cs43l22_writereg
  *
  * Description:
  *   Write the specified 16-bit register to the CS43L22 device.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static void
 cs43l22_writereg(FAR struct cs43l22_dev_s *priv, uint8_t regaddr,
@@ -355,28 +361,65 @@ cs43l22_writereg(FAR struct cs43l22_dev_s *priv, uint8_t regaddr,
     }
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: cs43l22_takesem
  *
  * Description:
- *  Take a semaphore count, handling the nasty EINTR return if we are interrupted
- *  by a signal.
+ *  Take a semaphore count, handling the nasty EINTR return if we are
+ *  interrupted by a signal.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
-static void cs43l22_takesem(sem_t * sem)
+static int cs43l22_takesem(FAR sem_t *sem)
 {
-  nxsem_wait_uninterruptible(sem);
+  return nxsem_wait_uninterruptible(sem);
 }
 
-/************************************************************************************
+/****************************************************************************
+ * Name: cs43l22_forcetake
+ *
+ * Description:
+ *   This is just another wrapper but this one continues even if the thread
+ *   is canceled.  This must be done in certain conditions where were must
+ *   continue in order to clean-up resources.
+ *
+ ****************************************************************************/
+
+static int cs43l22_forcetake(FAR sem_t *sem)
+{
+  int result;
+  int ret = OK;
+
+  do
+    {
+      result = nxsem_wait_uninterruptible(sem);
+
+      /* The only expected error would -ECANCELED meaning that the
+       * parent thread has been canceled.  We have to continue and
+       * terminate the poll in this case.
+       */
+
+      DEBUGASSERT(result == OK || result == -ECANCELED);
+      if (ret == OK && result < 0)
+        {
+          /* Remember the first failure */
+
+          ret = result;
+        }
+    }
+  while (result < 0);
+
+  return ret;
+}
+
+/****************************************************************************
  * Name: cs43l22_scalevolume
  *
  * Description:
- *   Set the right and left volume values in the CS43L22 device based on the current
- *   volume and balance settings.
+ *   Set the right and left volume values in the CS43L22 device based on the
+ *   current volume and balance settings.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
 static inline uint16_t cs43l22_scalevolume(uint16_t volume, b16_t scale)
@@ -385,14 +428,14 @@ static inline uint16_t cs43l22_scalevolume(uint16_t volume, b16_t scale)
 }
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Name: cs43l22_setvolume
  *
  * Description:
- *   Set the right and left volume values in the CS43L22 device based on the current
- *   volume and balance settings.
+ *   Set the right and left volume values in the CS43L22 device based on the
+ *   current volume and balance settings.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
 static void
@@ -420,7 +463,7 @@ cs43l22_setvolume(FAR struct cs43l22_dev_s *priv, uint16_t volume, bool mute)
       leftlevel = ((((1000 - priv->balance) * 100) / 500) * volume) / 100;
     }
 
-/* Calculate the right channel volume level {0..1000} */
+  /* Calculate the right channel volume level {0..1000} */
 
   if (priv->balance >= 500)
     {
@@ -442,10 +485,10 @@ cs43l22_setvolume(FAR struct cs43l22_dev_s *priv, uint16_t volume, bool mute)
 
   /* Set the volume */
 
-   regval = (rightlevel + 0x19) & 0xff;
-   cs43l22_writereg(priv, CS43L22_MS_VOL_CTRL_A, regval);
-   regval = ((leftlevel + 0x19) & 0xff);
-   cs43l22_writereg(priv, CS43L22_MS_VOL_CTRL_B, regval);
+  regval = (rightlevel + 0x19) & 0xff;
+  cs43l22_writereg(priv, CS43L22_MS_VOL_CTRL_A, regval);
+  regval = ((leftlevel + 0x19) & 0xff);
+  cs43l22_writereg(priv, CS43L22_MS_VOL_CTRL_B, regval);
 
 #if 0
   regval = (rightlevel + 0x01) & 0xff;
@@ -474,7 +517,7 @@ cs43l22_setvolume(FAR struct cs43l22_dev_s *priv, uint16_t volume, bool mute)
 }
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
-/************************************************************************************
+/****************************************************************************
  * Name: cs43l22_setbass
  *
  * Description:
@@ -482,7 +525,7 @@ cs43l22_setvolume(FAR struct cs43l22_dev_s *priv, uint16_t volume, bool mute)
  *
  *   The level and range are in whole percentage levels (0-100).
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef CONFIG_AUDIO_EXCLUDE_TONE
 static void cs43l22_setbass(FAR struct cs43l22_dev_s *priv, uint8_t bass)
@@ -492,7 +535,7 @@ static void cs43l22_setbass(FAR struct cs43l22_dev_s *priv, uint8_t bass)
 }
 #endif /* CONFIG_AUDIO_EXCLUDE_TONE */
 
-/************************************************************************************
+/****************************************************************************
  * Name: cs43l22_settreble
  *
  * Description:
@@ -500,7 +543,7 @@ static void cs43l22_setbass(FAR struct cs43l22_dev_s *priv, uint8_t bass)
  *
  *   The level and range are in whole percentage levels (0-100).
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef CONFIG_AUDIO_EXCLUDE_TONE
 static void cs43l22_settreble(FAR struct cs43l22_dev_s *priv, uint8_t treble)
@@ -523,11 +566,13 @@ static void cs43l22_setdatawidth(FAR struct cs43l22_dev_s *priv)
   if (priv->bpsamp == 16)
     {
       /* Reset default default setting */
+
       priv->i2s->ops->i2s_txdatawidth(priv->i2s, 16);
     }
   else
     {
       /* This should select 8-bit with no companding */
+
       priv->i2s->ops->i2s_txdatawidth(priv->i2s, 8);
     }
 }
@@ -583,17 +628,20 @@ static int cs43l22_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
         switch (caps->ac_subtype)
           {
             case AUDIO_TYPE_QUERY:
+
               /* We don't decode any formats!  Only something above us in
                * the audio stream can perform decoding on our behalf.
                */
 
               /* The types of audio units we implement */
 
-              caps->ac_controls.b[0] = AUDIO_TYPE_OUTPUT | AUDIO_TYPE_FEATURE |
-                                     AUDIO_TYPE_PROCESSING;
+              caps->ac_controls.b[0] =
+                AUDIO_TYPE_OUTPUT | AUDIO_TYPE_FEATURE |
+                AUDIO_TYPE_PROCESSING;
               break;
 
             case AUDIO_FMT_MIDI:
+
               /* We only support Format 0 */
 
               caps->ac_controls.b[0] = AUDIO_SUBFMT_END;
@@ -618,10 +666,11 @@ static int cs43l22_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* Report the Sample rates we support */
 
-              caps->ac_controls.b[0] = AUDIO_SAMP_RATE_8K | AUDIO_SAMP_RATE_11K |
-                                       AUDIO_SAMP_RATE_16K | AUDIO_SAMP_RATE_22K |
-                                       AUDIO_SAMP_RATE_32K | AUDIO_SAMP_RATE_44K |
-                                       AUDIO_SAMP_RATE_48K;
+              caps->ac_controls.b[0] =
+                AUDIO_SAMP_RATE_8K | AUDIO_SAMP_RATE_11K |
+                AUDIO_SAMP_RATE_16K | AUDIO_SAMP_RATE_22K |
+                AUDIO_SAMP_RATE_32K | AUDIO_SAMP_RATE_44K |
+                AUDIO_SAMP_RATE_48K;
               break;
 
             case AUDIO_FMT_MP3:
@@ -639,19 +688,24 @@ static int cs43l22_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
       case AUDIO_TYPE_FEATURE:
 
-        /* If the sub-type is UNDEF, then report the Feature Units we support */
+        /* If the sub-type is UNDEF, then report the Feature Units we
+         * support.
+         */
 
         if (caps->ac_subtype == AUDIO_FU_UNDEF)
           {
-            /* Fill in the ac_controls section with the Feature Units we have */
+            /* Fill in the ac_controls section with the Feature Units we
+             * have.
+             */
 
-            caps->ac_controls.b[0] = AUDIO_FU_VOLUME | AUDIO_FU_BASS | AUDIO_FU_TREBLE;
+            caps->ac_controls.b[0] = AUDIO_FU_VOLUME | AUDIO_FU_BASS |
+                                     AUDIO_FU_TREBLE;
             caps->ac_controls.b[1] = AUDIO_FU_BALANCE >> 8;
           }
         else
           {
-            /* TODO:  Do we need to provide specific info for the Feature Units,
-             * such as volume setting ranges, etc.?
+            /* TODO:  Do we need to provide specific info for the Feature
+             * Units, such as volume setting ranges, etc.?
              */
           }
 
@@ -664,18 +718,22 @@ static int cs43l22_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
         switch (caps->ac_subtype)
           {
             case AUDIO_PU_UNDEF:
+
               /* Provide the type of Processing Units we support */
 
               caps->ac_controls.b[0] = AUDIO_PU_STEREO_EXTENDER;
               break;
 
             case AUDIO_PU_STEREO_EXTENDER:
+
               /* Provide capabilities of our Stereo Extender */
 
-              caps->ac_controls.b[0] = AUDIO_STEXT_ENABLE | AUDIO_STEXT_WIDTH;
+              caps->ac_controls.b[0] =
+                AUDIO_STEXT_ENABLE | AUDIO_STEXT_WIDTH;
               break;
 
             default:
+
               /* Other types of processing uint we don't support */
 
               break;
@@ -748,7 +806,8 @@ cs43l22_configure(FAR struct audio_lowerhalf_s *dev,
               {
                 /* Scale the volume setting to the range {76..255} */
 
-                cs43l22_setvolume(priv, (179 * volume / 1000) + 76, priv->mute);
+                cs43l22_setvolume(priv, (179 * volume / 1000) + 76,
+                                  priv->mute);
               }
             else
               {
@@ -945,6 +1004,7 @@ cs43l22_senddone(FAR struct i2s_dev_s *i2s,
   priv->inflight--;
 
   /* Save the result of the transfer */
+
   /* REVISIT:  This can be overwritten */
 
   priv->result = result;
@@ -1047,7 +1107,7 @@ static int cs43l22_sendbuffer(FAR struct cs43l22_dev_s *priv)
   irqstate_t flags;
   uint32_t timeout;
   int shift;
-  int ret = OK;
+  int ret;
 
   /* Loop while there are audio buffers to be sent and we have few than
    * CONFIG_CS43L22_INFLIGHT then "in-flight"
@@ -1061,7 +1121,12 @@ static int cs43l22_sendbuffer(FAR struct cs43l22_dev_s *priv)
    * only while accessing 'inflight'.
    */
 
-  cs43l22_takesem(&priv->pendsem);
+  ret = cs43l22_takesem(&priv->pendsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   while (priv->inflight < CONFIG_CS43L22_INFLIGHT &&
          dq_peek(&priv->pendq) != NULL && !priv->paused)
     {
@@ -1128,7 +1193,8 @@ static int cs43l22_sendbuffer(FAR struct cs43l22_dev_s *priv)
  ****************************************************************************/
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-static int cs43l22_start(FAR struct audio_lowerhalf_s *dev, FAR void *session)
+static int cs43l22_start(FAR struct audio_lowerhalf_s *dev,
+           FAR void *session)
 #else
 static int cs43l22_start(FAR struct audio_lowerhalf_s *dev)
 #endif
@@ -1143,6 +1209,7 @@ static int cs43l22_start(FAR struct audio_lowerhalf_s *dev)
   audinfo("Entry\n");
 
   /* Exit reduced power modes of operation */
+
   /* REVISIT */
 
   /* Create a message queue for the worker thread */
@@ -1226,6 +1293,7 @@ static int cs43l22_stop(FAR struct audio_lowerhalf_s *dev)
   priv->threadid = 0;
 
   /* Enter into a reduced power usage mode */
+
   /* REVISIT: */
 
   return OK;
@@ -1242,7 +1310,8 @@ static int cs43l22_stop(FAR struct audio_lowerhalf_s *dev)
 
 #ifndef CONFIG_AUDIO_EXCLUDE_PAUSE_RESUME
 #  ifdef CONFIG_AUDIO_MULTI_SESSION
-static int cs43l22_pause(FAR struct audio_lowerhalf_s *dev, FAR void *session)
+static int cs43l22_pause(FAR struct audio_lowerhalf_s *dev,
+                         FAR void *session)
 #  else
 static int cs43l22_pause(FAR struct audio_lowerhalf_s *dev)
 #  endif
@@ -1272,7 +1341,8 @@ static int cs43l22_pause(FAR struct audio_lowerhalf_s *dev)
 
 #ifndef CONFIG_AUDIO_EXCLUDE_PAUSE_RESUME
 #  ifdef CONFIG_AUDIO_MULTI_SESSION
-static int cs43l22_resume(FAR struct audio_lowerhalf_s *dev, FAR void *session)
+static int cs43l22_resume(FAR struct audio_lowerhalf_s *dev,
+                          FAR void *session)
 #  else
 static int cs43l22_resume(FAR struct audio_lowerhalf_s *dev)
 #  endif
@@ -1314,20 +1384,26 @@ static int cs43l22_enqueuebuffer(FAR struct audio_lowerhalf_s *dev,
   audinfo("Enqueueing: apb=%p curbyte=%d nbytes=%d flags=%04x\n",
           apb, apb->curbyte, apb->nbytes, apb->flags);
 
+  ret = cs43l22_takesem(&priv->pendsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   /* Take a reference on the new audio buffer */
 
   apb_reference(apb);
 
   /* Add the new buffer to the tail of pending audio buffers */
 
-  cs43l22_takesem(&priv->pendsem);
   apb->flags |= AUDIO_APB_OUTPUT_ENQUEUED;
   dq_addlast(&apb->dq_entry, &priv->pendq);
   cs43l22_givesem(&priv->pendsem);
 
-  /* Send a message to the worker thread indicating that a new buffer has been
-   * enqueued.  If mq is NULL, then the playing has not yet started.  In that
-   * case we are just "priming the pump" and we don't need to send any message.
+  /* Send a message to the worker thread indicating that a new buffer has
+   * been enqueued.  If mq is NULL, then the playing has not yet started.
+   * In that case we are just "priming the pump" and we don't need to send
+   * any message.
    */
 
   ret = OK;
@@ -1437,7 +1513,12 @@ static int cs43l22_reserve(FAR struct audio_lowerhalf_s *dev)
 
   /* Borrow the APBQ semaphore for thread sync */
 
-  cs43l22_takesem(&priv->pendsem);
+  ret = cs43l22_takesem(&priv->pendsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (priv->reserved)
     {
       ret = -EBUSY;
@@ -1472,13 +1553,15 @@ static int cs43l22_reserve(FAR struct audio_lowerhalf_s *dev)
  ****************************************************************************/
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-static int cs43l22_release(FAR struct audio_lowerhalf_s *dev, FAR void *session)
+static int cs43l22_release(FAR struct audio_lowerhalf_s *dev,
+                           FAR void *session)
 #else
 static int cs43l22_release(FAR struct audio_lowerhalf_s *dev)
 #endif
 {
   FAR struct cs43l22_dev_s *priv = (FAR struct cs43l22_dev_s *)dev;
-  void *value;
+  FAR void *value;
+  int ret;
 
   /* Join any old worker thread we had created to prevent a memory leak */
 
@@ -1490,14 +1573,14 @@ static int cs43l22_release(FAR struct audio_lowerhalf_s *dev)
 
   /* Borrow the APBQ semaphore for thread sync */
 
-  cs43l22_takesem(&priv->pendsem);
+  ret = cs43l22_forcetake(&priv->pendsem);
 
   /* Really we should free any queued buffers here */
 
   priv->reserved = false;
   cs43l22_givesem(&priv->pendsem);
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************
@@ -1623,6 +1706,7 @@ static void *cs43l22_workerthread(pthread_addr_t pvarg)
 
 #ifndef CONFIG_AUDIO_EXCLUDE_STOP
           case AUDIO_MSG_STOP:
+
             /* Indicate that we are terminating */
 
             audinfo("AUDIO_MSG_STOP: Terminating\n");
@@ -1657,7 +1741,7 @@ static void *cs43l22_workerthread(pthread_addr_t pvarg)
 
   /* Return any pending buffers in our pending queue */
 
-  cs43l22_takesem(&priv->pendsem);
+  cs43l22_forcetake(&priv->pendsem);
   while ((apb = (FAR struct ap_buffer_s *)dq_remfirst(&priv->pendq)) != NULL)
     {
       /* Release our reference to the buffer */
@@ -1722,7 +1806,8 @@ static void cs43l22_audio_output(FAR struct cs43l22_dev_s *priv)
 
   /* SPK always off and HP always on */
 
-  regval = CS43L22_PDN_HPB_ON | CS43L22_PDN_HPA_ON | CS43L22_PDN_SPKB_OFF | CS43L22_PDN_SPKA_OFF;
+  regval = CS43L22_PDN_HPB_ON | CS43L22_PDN_HPA_ON | CS43L22_PDN_SPKB_OFF |
+           CS43L22_PDN_SPKA_OFF;
   cs43l22_writereg(priv, CS43L22_POWER_CTRL2, regval);
 
   /* Clock configuration: Auto detection */
@@ -1841,7 +1926,7 @@ static void cs43l22_reset(FAR struct cs43l22_dev_s *priv)
   priv->nchannels  = CS43L22_DEFAULT_NCHANNELS;
   priv->bpsamp     = CS43L22_DEFAULT_BPSAMP;
 #if !defined(CONFIG_AUDIO_EXCLUDE_VOLUME) && !defined(CONFIG_AUDIO_EXCLUDE_BALANCE)
-  priv->balance    = 500;          // b16HALF; /* Center balance */
+  priv->balance    = 500;          /* b16HALF = Center balance */
 #endif
 
   /* Software reset.  This puts all CS43L22 registers back in their
@@ -1889,10 +1974,9 @@ static void cs43l22_reset(FAR struct cs43l22_dev_s *priv)
  *
  ****************************************************************************/
 
-FAR struct audio_lowerhalf_s *cs43l22_initialize(FAR struct i2c_master_s *i2c,
-                                                 FAR struct i2s_dev_s *i2s,
-                                                 FAR const struct
-                                                 cs43l22_lower_s *lower)
+FAR struct audio_lowerhalf_s *
+  cs43l22_initialize(FAR struct i2c_master_s *i2c, FAR struct i2s_dev_s *i2s,
+                     FAR const struct cs43l22_lower_s *lower)
 {
   FAR struct cs43l22_dev_s *priv;
   uint16_t regval;
@@ -1903,7 +1987,8 @@ FAR struct audio_lowerhalf_s *cs43l22_initialize(FAR struct i2c_master_s *i2c,
 
   /* Allocate a CS43L22 device structure */
 
-  priv = (FAR struct cs43l22_dev_s *)kmm_zalloc(sizeof(struct cs43l22_dev_s));
+  priv = (FAR struct cs43l22_dev_s *)
+    kmm_zalloc(sizeof(struct cs43l22_dev_s));
   if (priv)
     {
       /* Initialize the CS43L22 device structure.  Since we used kmm_zalloc,
@@ -1921,10 +2006,12 @@ FAR struct audio_lowerhalf_s *cs43l22_initialize(FAR struct i2c_master_s *i2c,
 
       /* Initialize I2C */
 
-      audinfo("address=%02x frequency=%d\n", lower->address, lower->frequency);
+      audinfo("address=%02x frequency=%d\n",
+              lower->address, lower->frequency);
 
-      /* Software reset.  This puts all CS43L22 registers back in their default
-       * state. */
+      /* Software reset.  This puts all CS43L22 registers back in their
+       * default state.
+       */
 
       CS43L22_HW_RESET(priv->lower);
 

--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -74,7 +74,8 @@
 static void     wm8776_writereg(FAR struct wm8776_dev_s *priv,
                   uint8_t regaddr, uint16_t regval);
 
-static void     wm8776_takesem(sem_t *sem);
+static int      wm8776_takesem(FAR sem_t *sem);
+static int      wm8776_forcetake(FAR sem_t *sem);
 #define         wm8776_givesem(s) nxsem_post(s)
 
 static int      wm8776_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
@@ -174,13 +175,13 @@ static const struct audio_ops_s g_audioops =
   wm8776_release        /* release        */
 };
 
-/************************************************************************************
+/****************************************************************************
  * Name: wm8776_writereg
  *
  * Description:
  *   Write the specified 16-bit register to the WM8776 device.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static void wm8776_writereg(FAR struct wm8776_dev_s *priv,
                             uint8_t regaddr,
@@ -208,28 +209,65 @@ static void wm8776_writereg(FAR struct wm8776_dev_s *priv,
     }
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: wm8776_takesem
  *
  * Description:
- *  Take a semaphore count, handling the nasty EINTR return if we are interrupted
- *  by a signal.
+ *  Take a semaphore count, handling the nasty EINTR return if we are
+ *  interrupted by a signal.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
-static void wm8776_takesem(sem_t *sem)
+static int wm8776_takesem(sem_t *sem)
 {
-  nxsem_wait_uninterruptible(sem);
+  return nxsem_wait_uninterruptible(sem);
 }
 
-/************************************************************************************
+/****************************************************************************
+ * Name: wm8776_forcetake
+ *
+ * Description:
+ *   This is just another wrapper but this one continues even if the thread
+ *   is canceled.  This must be done in certain conditions where were must
+ *   continue in order to clean-up resources.
+ *
+ ****************************************************************************/
+
+static int wm8776_forcetake(FAR sem_t *sem)
+{
+  int result;
+  int ret = OK;
+
+  do
+    {
+      result = nxsem_wait_uninterruptible(sem);
+
+      /* The only expected error would -ECANCELED meaning that the
+       * parent thread has been canceled.  We have to continue and
+       * terminate the poll in this case.
+       */
+
+      DEBUGASSERT(result == OK || result == -ECANCELED);
+      if (ret == OK && result < 0)
+        {
+          /* Remember the first failure */
+
+          ret = result;
+        }
+    }
+  while (result < 0);
+
+  return ret;
+}
+
+/****************************************************************************
  * Name: wm8776_setvolume
  *
  * Description:
- *   Set the right and left volume values in the WM8776 device based on the current
- *   volume and balance settings.
+ *   Set the right and left volume values in the WM8776 device based on the
+ *   current volume and balance settings.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
 static void wm8776_setvolume(FAR struct wm8776_dev_s *priv, uint16_t volume,
@@ -312,8 +350,9 @@ static int wm8776_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
               /* The types of audio units we implement */
 
-              caps->ac_controls.b[0] = AUDIO_TYPE_OUTPUT | AUDIO_TYPE_FEATURE |
-                                     AUDIO_TYPE_PROCESSING;
+              caps->ac_controls.b[0] =
+                AUDIO_TYPE_OUTPUT | AUDIO_TYPE_FEATURE |
+                AUDIO_TYPE_PROCESSING;
 
               break;
 
@@ -413,13 +452,14 @@ static int wm8776_configure(FAR struct audio_lowerhalf_s *dev,
               {
                 /* Scale the volume setting to the range {0x2f .. 0x79} */
 
-                wm8776_setvolume(priv, (0x4a * volume / 1000) + 0x2f, priv->mute);
+                wm8776_setvolume(priv, (0x4a * volume / 1000) + 0x2f,
+                                 priv->mute);
               }
             else
               {
                 ret = -EDOM;
               }
-           }
+          }
           break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
@@ -537,6 +577,7 @@ static void  wm8776_senddone(FAR struct i2s_dev_s *i2s,
   priv->inflight--;
 
   /* Save the result of the transfer */
+
   /* REVISIT:  This can be overwritten */
 
   priv->result = result;
@@ -639,7 +680,7 @@ static int wm8776_sendbuffer(FAR struct wm8776_dev_s *priv)
   irqstate_t flags;
   uint32_t timeout;
   int shift;
-  int ret = OK;
+  int ret;
 
   /* Loop while there are audio buffers to be sent and we have few than
    * CONFIG_WM8776_INFLIGHT then "in-flight"
@@ -653,7 +694,12 @@ static int wm8776_sendbuffer(FAR struct wm8776_dev_s *priv)
    * only while accessing 'inflight'.
    */
 
-  wm8776_takesem(&priv->pendsem);
+  ret = wm8776_takesem(&priv->pendsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   while (priv->inflight < CONFIG_WM8776_INFLIGHT &&
          dq_peek(&priv->pendq) != NULL && !priv->paused)
     {
@@ -713,6 +759,7 @@ static int wm8776_start(FAR struct audio_lowerhalf_s *dev)
   audinfo("Entry\n");
 
   /* Exit reduced power modes of operation */
+
   /* REVISIT */
 
   /* Create a message queue for the worker thread */
@@ -796,6 +843,7 @@ static int wm8776_stop(FAR struct audio_lowerhalf_s *dev)
   priv->threadid = 0;
 
   /* Enter into a reduced power usage mode */
+
   /* REVISIT: */
 
   return OK;
@@ -837,7 +885,8 @@ static int wm8776_pause(FAR struct audio_lowerhalf_s *dev)
 
 #ifndef CONFIG_AUDIO_EXCLUDE_PAUSE_RESUME
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-static int wm8776_resume(FAR struct audio_lowerhalf_s *dev, FAR void *session)
+static int wm8776_resume(FAR struct audio_lowerhalf_s *dev,
+                         FAR void *session)
 #else
 static int wm8776_resume(FAR struct audio_lowerhalf_s *dev)
 #endif
@@ -878,14 +927,20 @@ static int wm8776_enqueuebuffer(FAR struct audio_lowerhalf_s *dev,
 
   /* Add the new buffer to the tail of pending audio buffers */
 
-  wm8776_takesem(&priv->pendsem);
+  ret = wm8776_takesem(&priv->pendsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   apb->flags |= AUDIO_APB_OUTPUT_ENQUEUED;
   dq_addlast(&apb->dq_entry, &priv->pendq);
   wm8776_givesem(&priv->pendsem);
 
-  /* Send a message to the worker thread indicating that a new buffer has been
-   * enqueued.  If mq is NULL, then the playing has not yet started.  In that
-   * case we are just "priming the pump" and we don't need to send any message.
+  /* Send a message to the worker thread indicating that a new buffer has
+   * been enqueued.  If mq is NULL, then the playing has not yet started.
+   * In that case we are just "priming the pump" and we don't need to send
+   * any message.
    */
 
   ret = OK;
@@ -996,7 +1051,12 @@ static int wm8776_reserve(FAR struct audio_lowerhalf_s *dev)
 
   /* Borrow the APBQ semaphore for thread sync */
 
-  wm8776_takesem(&priv->pendsem);
+  ret = wm8776_takesem(&priv->pendsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (priv->reserved)
     {
       ret = -EBUSY;
@@ -1037,7 +1097,8 @@ static int wm8776_release(FAR struct audio_lowerhalf_s *dev)
 #endif
 {
   FAR struct wm8776_dev_s *priv = (FAR struct wm8776_dev_s *)dev;
-  void  *value;
+  FAR void *value;
+  int ret;
 
   /* Join any old worker thread we had created to prevent a memory leak */
 
@@ -1049,14 +1110,14 @@ static int wm8776_release(FAR struct audio_lowerhalf_s *dev)
 
   /* Borrow the APBQ semaphore for thread sync */
 
-  wm8776_takesem(&priv->pendsem);
+  ret = wm8776_forcetake(&priv->pendsem);
 
   /* Really we should free any queued buffers here */
 
   priv->reserved = false;
   wm8776_givesem(&priv->pendsem);
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************
@@ -1075,11 +1136,12 @@ static int wm8776_release(FAR struct audio_lowerhalf_s *dev)
 
 static void wm8776_audio_output(FAR struct wm8776_dev_s *priv)
 {
-  wm8776_writereg(priv, WM8776_MASTER_ATT, WM8776_UPDATE | 0x58); /* -33db */
-  wm8776_writereg(priv, WM8776_DAC_IF, 0x32);  /* 32bit, I2S, standard pol */
+  wm8776_writereg(priv, WM8776_MASTER_ATT,
+                  WM8776_UPDATE | 0x58);           /* -33db */
+  wm8776_writereg(priv, WM8776_DAC_IF, 0x32);      /* 32bit, I2S, standard pol */
 
 #ifdef CONFIG_WM8776_SWAP_HPOUT
-  wm8776_writereg(priv, WM8776_DAC_CC, 0x62);  /* Swap HPOUT L/R */
+  wm8776_writereg(priv, WM8776_DAC_CC, 0x62);      /* Swap HPOUT L/R */
 #endif
 
   wm8776_writereg(priv, WM8776_MASTER_MODE, 0x00); /* slave mode, 128fs */
@@ -1120,7 +1182,6 @@ static void wm8776_hw_reset(FAR struct wm8776_dev_s *priv)
   /* Configure the WM8776 hardware as an audio input device */
 
   wm8776_audio_output(priv);
-
 }
 
 /****************************************************************************
@@ -1203,6 +1264,7 @@ repeat:
 
 #ifndef CONFIG_AUDIO_EXCLUDE_STOP
           case AUDIO_MSG_STOP:
+
             /* Indicate that we are terminating */
 
             audinfo("AUDIO_MSG_STOP: Terminating\n");
@@ -1238,7 +1300,6 @@ repeat:
         {
           goto repeat;
         }
-
     }
 
   /* Reset the WM8776 hardware */
@@ -1247,7 +1308,7 @@ repeat:
 
   /* Return any pending buffers in our pending queue */
 
-  wm8776_takesem(&priv->pendsem);
+  wm8776_forcetake(&priv->pendsem);
   while ((apb = (FAR struct ap_buffer_s *)dq_remfirst(&priv->pendq)) != NULL)
     {
       /* Release our reference to the buffer */
@@ -1286,7 +1347,6 @@ repeat:
   audinfo("Exit\n");
   return NULL;
 }
-
 
 /****************************************************************************
  * Public Functions

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -166,7 +166,7 @@ struct tun_driver_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static void tun_lock(FAR struct tun_device_s *priv);
+static int  tun_lock(FAR struct tun_device_s *priv);
 static void tun_unlock(FAR struct tun_device_s *priv);
 
 /* Common TX logic */
@@ -249,9 +249,9 @@ static const struct file_operations g_tun_file_ops =
  * Name: tundev_lock
  ****************************************************************************/
 
-static void tundev_lock(FAR struct tun_driver_s *tun)
+static int tundev_lock(FAR struct tun_driver_s *tun)
 {
-  nxsem_wait_uninterruptible(&tun->waitsem);
+  return nxsem_wait_uninterruptible(&tun->waitsem);
 }
 
 /****************************************************************************
@@ -267,9 +267,9 @@ static void tundev_unlock(FAR struct tun_driver_s *tun)
  * Name: tun_lock
  ****************************************************************************/
 
-static void tun_lock(FAR struct tun_device_s *priv)
+static int tun_lock(FAR struct tun_device_s *priv)
 {
-  nxsem_wait_uninterruptible(&priv->waitsem);
+  return nxsem_wait_uninterruptible(&priv->waitsem);
 }
 
 /****************************************************************************
@@ -778,10 +778,21 @@ static void tun_txdone(FAR struct tun_device_s *priv)
 static void tun_poll_work(FAR void *arg)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)arg;
+  int ret;
 
   /* Perform the poll */
 
-  tun_lock(priv);
+  ret = tun_lock(priv);
+  if (ret < 0)
+    {
+      /* This would indicate that the worker thread was canceled.. not a
+       * likely event.
+       */
+
+      DEBUGASSERT(ret == -ECANCELED);
+      return;
+    }
+
   net_lock();
 
   /* Check if there is room in the send another TX packet.  We cannot perform
@@ -930,8 +941,15 @@ static int tun_ifdown(FAR struct net_driver_s *dev)
 static void tun_txavail_work(FAR void *arg)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)arg;
+  int ret;
 
-  tun_lock(priv);
+  ret = tun_lock(priv);
+  if (ret < 0)
+    {
+      /* Thread has been canceled, skip poll-related work */
+
+      return;
+    }
 
   /* Check if there is room to hold another network packet. */
 
@@ -1152,6 +1170,7 @@ static int tun_close(FAR struct file *filep)
   FAR struct tun_driver_s *tun  = inode->i_private;
   FAR struct tun_device_s *priv = filep->f_priv;
   int intf;
+  int ret;
 
   if (priv == NULL)
     {
@@ -1159,13 +1178,16 @@ static int tun_close(FAR struct file *filep)
     }
 
   intf = priv - g_tun_devices;
-  tundev_lock(tun);
+  ret  = tundev_lock(tun);
+  if (ret >= 0)
+    {
+      tun->free_tuns |= (1 << intf);
+      tun_dev_uninit(priv);
 
-  tun->free_tuns |= (1 << intf);
-  tun_dev_uninit(priv);
+      tundev_unlock(tun);
+    }
 
-  tundev_unlock(tun);
-  return OK;
+  return ret;
 }
 
 /****************************************************************************
@@ -1176,17 +1198,26 @@ static ssize_t tun_write(FAR struct file *filep, FAR const char *buffer,
                          size_t buflen)
 {
   FAR struct tun_device_s *priv = filep->f_priv;
-  ssize_t ret;
+  ssize_t nwritten = 0;
+  int ret;
 
   if (priv == NULL || buflen > CONFIG_NET_TUN_PKTSIZE)
     {
       return -EINVAL;
     }
 
-  tun_lock(priv);
-
   for (; ; )
     {
+      /* Write must return immediately if interrupted by a signal (or if the
+       * thread is canceled) and no data has yet been written.
+       */
+
+      ret = nxsem_wait(&priv->waitsem);
+      if (ret < 0)
+        {
+          return nwritten == 0 ? (ssize_t)ret : nwritten;
+        }
+
       /* Check if there are free space to write */
 
       if (priv->write_d_len == 0)
@@ -1200,7 +1231,7 @@ static ssize_t tun_write(FAR struct file *filep, FAR const char *buffer,
           tun_net_receive(priv);
           net_unlock();
 
-          ret = buflen;
+          nwritten = buflen;
           break;
         }
 
@@ -1208,18 +1239,17 @@ static ssize_t tun_write(FAR struct file *filep, FAR const char *buffer,
 
       if ((filep->f_oflags & O_NONBLOCK) != 0)
         {
-          ret = -EAGAIN;
+          nwritten = -EAGAIN;
           break;
         }
 
       priv->write_wait = true;
       tun_unlock(priv);
       nxsem_wait(&priv->write_wait_sem);
-      tun_lock(priv);
     }
 
   tun_unlock(priv);
-  return ret;
+  return nwritten;
 }
 
 /****************************************************************************
@@ -1230,29 +1260,38 @@ static ssize_t tun_read(FAR struct file *filep, FAR char *buffer,
                         size_t buflen)
 {
   FAR struct tun_device_s *priv = filep->f_priv;
-  ssize_t ret;
+  ssize_t nread;
+  int ret;
 
   if (priv == NULL)
     {
       return -EINVAL;
     }
 
-  tun_lock(priv);
-
   for (; ; )
     {
+      /* Read must return immediately if interrupted by a signal (or if the
+       * thread is canceled) and no data has yet been read.
+       */
+
+      ret = nxsem_wait(&priv->waitsem);
+      if (ret < 0)
+        {
+          return nread == 0 ? (ssize_t)ret : nread;
+        }
+
       /* Check if there are data to read in write buffer */
 
       if (priv->write_d_len > 0)
         {
           if (buflen < priv->write_d_len)
             {
-              ret = -EINVAL;
+              nread = -EINVAL;
               break;
             }
 
           memcpy(buffer, priv->write_buf, priv->write_d_len);
-          ret = priv->write_d_len;
+          nread = priv->write_d_len;
           priv->write_d_len = 0;
 
           NETDEV_TXDONE(&priv->dev);
@@ -1266,12 +1305,12 @@ static ssize_t tun_read(FAR struct file *filep, FAR char *buffer,
         {
           if (buflen < priv->read_d_len)
             {
-              ret = -EINVAL;
+              nread = -EINVAL;
               break;
             }
 
           memcpy(buffer, priv->read_buf, priv->read_d_len);
-          ret = priv->read_d_len;
+          nread = priv->read_d_len;
           priv->read_d_len = 0;
 
           net_lock();
@@ -1284,18 +1323,17 @@ static ssize_t tun_read(FAR struct file *filep, FAR char *buffer,
 
       if ((filep->f_oflags & O_NONBLOCK) != 0)
         {
-          ret = -EAGAIN;
+          nread = -EAGAIN;
           break;
         }
 
       priv->read_wait = true;
       tun_unlock(priv);
       nxsem_wait(&priv->read_wait_sem);
-      tun_lock(priv);
     }
 
   tun_unlock(priv);
-  return ret;
+  return nread;
 }
 
 /****************************************************************************
@@ -1306,7 +1344,7 @@ int tun_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
 {
   FAR struct tun_device_s *priv = filep->f_priv;
   pollevent_t eventset;
-  int ret = OK;
+  int ret;
 
   /* Some sanity checking */
 
@@ -1315,7 +1353,11 @@ int tun_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
       return -EINVAL;
     }
 
-  tun_lock(priv);
+  ret = tun_lock(priv);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   if (setup)
     {
@@ -1384,7 +1426,11 @@ static int tun_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           return -EINVAL;
         }
 
-      tundev_lock(tun);
+      ret = tundev_lock(tun);
+      if (ret < 0)
+        {
+          return ret;
+        }
 
       free_tuns = tun->free_tuns;
 

--- a/drivers/rwbuffer.c
+++ b/drivers/rwbuffer.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * drivers/rwbuffer.c
  *
- *   Copyright (C) 2009, 2011, 2013-2014, 2017, 2020 Gregory Nutt. All
- *     rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -79,9 +63,9 @@
  * Name: rwb_semtake
  ****************************************************************************/
 
-static void rwb_semtake(FAR sem_t *sem)
+static int rwb_semtake(FAR sem_t *sem)
 {
-  nxsem_wait_uninterruptible(sem);
+  return nxsem_wait_uninterruptible(sem);
 }
 
 /****************************************************************************
@@ -89,6 +73,34 @@ static void rwb_semtake(FAR sem_t *sem)
  ****************************************************************************/
 
 #define rwb_semgive(s) nxsem_post(s)
+
+/****************************************************************************
+ * Name: rwb_forcetake
+ *
+ * Description:
+ *   This is just another wrapper but this one continues even if the thread
+ *   is canceled.  This must be done in certain conditions where were must
+ *   continue in order to clean-up resources.
+ *
+ ****************************************************************************/
+
+static void rwb_forcetake(FAR sem_t *sem)
+{
+  int ret;
+
+  do
+    {
+      ret = nxsem_wait_uninterruptible(sem);
+
+      /* The only expected error would -ECANCELED meaning that the
+       * parent thread has been canceled.  We have to continue and
+       * terminate the poll in this case.
+       */
+
+      DEBUGASSERT(ret == OK || ret == -ECANCELED);
+    }
+  while (ret < 0);
+}
 
 /****************************************************************************
  * Name: rwb_overlap
@@ -182,7 +194,7 @@ static void rwb_wrtimeout(FAR void *arg)
    * worker thread.
    */
 
-  rwb_semtake(&rwb->wrsem);
+  rwb_forcetake(&rwb->wrsem);
   rwb_wrflush(rwb);
   rwb_semgive(&rwb->wrsem);
 }
@@ -410,7 +422,7 @@ int rwb_invalidate_writebuffer(FAR struct rwbuffer_s *rwb,
 
       finfo("startblock=%d blockcount=%p\n", startblock, blockcount);
 
-      rwb_semtake(&rwb->wrsem);
+      rwb_forcetake(&rwb->wrsem);
 
       /* Now there are five cases:
        *
@@ -547,7 +559,7 @@ int rwb_invalidate_readahead(FAR struct rwbuffer_s *rwb,
 
       finfo("startblock=%d blockcount=%p\n", startblock, blockcount);
 
-      rwb_semtake(&rwb->rhsem);
+      rwb_forcetake(&rwb->rhsem);
 
       /* Now there are five cases:
        *
@@ -781,7 +793,14 @@ static ssize_t rwb_read_(FAR struct rwbuffer_s *rwb, off_t startblock,
 
       /* Loop until we have read all of the requested blocks */
 
-      rwb_semtake(&rwb->rhsem);
+      ret = nxsem_wait(&rwb->rhsem);
+      if (ret < 0)
+        {
+          /* Return EINTR or ECANCELED */
+
+          return ret;
+        }
+
       for (remaining = nblocks; remaining > 0; )
         {
           /* Is there anything in the read-ahead buffer? */


### PR DESCRIPTION
Resolution of Issue 619 will require multiple steps, this part of the first step in that resolution:  Every call to nxsem_wait_uninterruptible() must handle the return value from nxsem_wait_uninterruptible properly.  This commit is only for those files under drivers/audio, drivers/net, and drivers/lcd.