### PR TITLE
Fixes build issues associated with ARMv7-m mpu source files.

### DIFF
--- a/arch/arm/src/armv7-m/mpu.h
+++ b/arch/arm/src/armv7-m/mpu.h
@@ -101,9 +101,9 @@
 
 /* MPU Region Base Address Register Bit Definitions */
 
-#define MPU_RBAR_REGION_SHIFT   (0)       /* Bits 0-3: MPU region */
+#define MPU_RBAR_REGION_SHIFT   (0)        /* Bits 0-3: MPU region */
 #define MPU_RBAR_REGION_MASK    (15 << MPU_RBAR_REGION_SHIFT)
-#define MPU_RBAR_VALID          (1 << 4)  /* Bit 4: MPU Region Number valid */
+#define MPU_RBAR_VALID          (1 << 4)   /* Bit 4: MPU Region Number valid */
 #define MPU_RBAR_ADDR_MASK      0xffffffe0 /* Bits N-31:  Region base addrese */
 
 /* MPU Region Attributes and Size Register Bit Definitions */
@@ -204,8 +204,8 @@ uint8_t mpu_log2regionfloor(size_t size);
  *
  * Description:
  *   Given (1) the offset to the beginning of valid data, (2) the size of the
- *   memory to be mapped and (2) the log2 size of the mapping to use, determine
- *   the minimal sub-region set to span that memory region.
+ *   memory to be mapped and (2) the log2 size of the mapping to use,
+ *   determine the minimal sub-region set to span that memory region.
  *
  * Assumption:
  *   l2size has the same properties as the return value from

--- a/arch/arm/src/armv7-m/up_mpu.c
+++ b/arch/arm/src/armv7-m/up_mpu.c
@@ -1,4 +1,4 @@
-/****************************************************************************
+/*****************************************************************************
  * arch/arm/src/armv7-m/up_mpu.c
  *
  *   Copyright (C) 2011, 2013 Gregory Nutt. All rights reserved.
@@ -31,11 +31,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************/
+ *****************************************************************************/
 
-/****************************************************************************
+/*****************************************************************************
  * Included Files
- ****************************************************************************/
+ *****************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -45,19 +45,19 @@
 #include "mpu.h"
 #include "up_internal.h"
 
-/****************************************************************************
+/*****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************/
+ *****************************************************************************/
 
-/* Configuration ************************************************************/
+/* Configuration *************************************************************/
 
 #ifndef CONFIG_ARM_MPU_NREGIONS
 #  define CONFIG_ARM_MPU_NREGIONS 8
 #endif
 
-/****************************************************************************
+/*****************************************************************************
  * Private Data
- ****************************************************************************/
+ *****************************************************************************/
 
 /* These sets represent the set of disabled memory sub-regions.  A bit set
  * corresponds to a disabled sub-region; the LS bit corresponds to the first
@@ -87,11 +87,11 @@ static const uint8_t g_ls_regionmask[9] =
 
 static uint8_t g_region;
 
-/****************************************************************************
+/*****************************************************************************
  * Private Functions
- ****************************************************************************/
+ *****************************************************************************/
 
-/****************************************************************************
+/*****************************************************************************
  * Name: mpu_subregion_ms
  *
  * Description:
@@ -103,7 +103,7 @@ static uint8_t g_region;
  *   l2size has the same properties as the return value from
  *   mpu_log2regionceil()
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 static inline uint32_t mpu_subregion_ms(size_t size, uint8_t l2size)
 {
@@ -122,7 +122,7 @@ static inline uint32_t mpu_subregion_ms(size_t size, uint8_t l2size)
 
   if (l2size < 32)
     {
-      mask  = ((1 << l2size)-1) >> 3; /* Shifted mask */
+      mask  = ((1 << l2size) - 1) >> 3; /* Shifted mask */
     }
 
   /* The 4Gb region size is a special case */
@@ -133,15 +133,15 @@ static inline uint32_t mpu_subregion_ms(size_t size, uint8_t l2size)
        * input.
        */
 
-      mask = 0x1fffffff;         /* Shifted mask */
+      mask = 0x1fffffff;          /* Shifted mask */
     }
 
-  asize = (size + mask) & ~mask; /* Adjusted size */
-  nsrs  = asize >> (l2size-3);   /* Number of subregions */
+  asize = (size + mask) & ~mask;  /* Adjusted size */
+  nsrs  = asize >> (l2size - 3);  /* Number of subregions */
   return g_ms_regionmask[nsrs];
 }
 
-/****************************************************************************
+/*****************************************************************************
  * Name: mpu_subregion_ls
  *
  * Description:
@@ -154,7 +154,7 @@ static inline uint32_t mpu_subregion_ms(size_t size, uint8_t l2size)
  *   l2size has the same properties as the return value from
  *   mpu_log2regionceil()
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
 {
@@ -184,19 +184,19 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
        * input.
        */
 
-      mask = 0x1fffffff;           /* Shifted mask */
+      mask = 0x1fffffff;              /* Shifted mask */
     }
 
-  aoffset = offset & ~mask;        /* Adjusted offset */
-  nsrs    = aoffset >> (l2size-3); /* Number of subregions */
+  aoffset = offset & ~mask;           /* Adjusted offset */
+  nsrs    = aoffset >> (l2size - 3);  /* Number of subregions */
   return g_ls_regionmask[nsrs];
 }
 
-/****************************************************************************
+/*****************************************************************************
  * Public Functions
- ****************************************************************************/
+ *****************************************************************************/
 
-/****************************************************************************
+/*****************************************************************************
  * Name: mpu_allocregion
  *
  * Description:
@@ -207,7 +207,7 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
  *   - Regions are only allocated early in initialization, so no special
  *     protection against re-entrancy is required;
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 unsigned int mpu_allocregion(void)
 {
@@ -215,7 +215,7 @@ unsigned int mpu_allocregion(void)
   return (unsigned int)g_region++;
 }
 
-/****************************************************************************
+/*****************************************************************************
  * Name: mpu_log2regionceil
  *
  * Description:
@@ -224,7 +224,7 @@ unsigned int mpu_allocregion(void)
  *
  *   size <= (1 << l2size)
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 uint8_t mpu_log2regionceil(size_t size)
 {
@@ -236,7 +236,7 @@ uint8_t mpu_log2regionceil(size_t size)
   return l2size;
 }
 
-/****************************************************************************
+/*****************************************************************************
  * Name: mpu_log2regionfloor
  *
  * Description:
@@ -245,7 +245,7 @@ uint8_t mpu_log2regionceil(size_t size)
  *
  *   size >= (1 << l2size)
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 uint8_t mpu_log2regionfloor(size_t size)
 {
@@ -259,7 +259,7 @@ uint8_t mpu_log2regionfloor(size_t size)
   return l2size;
 }
 
-/****************************************************************************
+/*****************************************************************************
  * Name: mpu_subregion
  *
  * Description:
@@ -271,7 +271,7 @@ uint8_t mpu_log2regionfloor(size_t size)
  *   l2size has the same properties as the return value from
  *   mpu_log2regionceil()
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
 {

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -73,8 +73,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif
@@ -113,13 +117,11 @@ CHIP_CSRCS += imxrt_gpioirq.c
 endif
 
 ifeq ($(CONFIG_ARM_MPU),y)
-ifneq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c
-endif
 CHIP_CSRCS += imxrt_mpuinit.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CHIP_CSRCS += imxrt_userspace.c
-endif
 endif
 
 ifeq ($(CONFIG_IMXRT_EDMA),y)

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -71,8 +71,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -76,8 +76,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -64,8 +64,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -64,8 +64,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -80,8 +80,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -75,8 +75,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif

--- a/arch/arm/src/stm32/stm32_allocateheap.c
+++ b/arch/arm/src/stm32/stm32_allocateheap.c
@@ -1,4 +1,4 @@
-/****************************************************************************
+/******************************************************************************
  * arch/arm/src/stm32/stm32_allocateheap.c
  *
  *   Copyright (C) 2011-2013, 2015 Gregory Nutt. All rights reserved.
@@ -31,11 +31,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************/
+ ******************************************************************************/
 
-/****************************************************************************
+/******************************************************************************
  * Included Files
- ****************************************************************************/
+ ******************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -60,9 +60,10 @@
 
 #include "stm32_mpuinit.h"
 
-/****************************************************************************
+/******************************************************************************
  * Pre-processor Definitions
- ****************************************************************************/
+ ******************************************************************************/
+
 /* Internal SRAM is available in all members of the STM32 family. The
  * following definitions must be provided to specify the size and
  * location of internal(system) SRAM:
@@ -76,9 +77,9 @@
  *
  * CONFIG_STM32_CCMEXCLUDE    : Exclude CCM SRAM from the HEAP
  *
- * In addition to internal SRAM, external RAM may also be available through the
- * FMC/FSMC. To use external RAM, the following things need to be present in
- * the NuttX configuration file:
+ * In addition to internal SRAM, external RAM may also be available through
+ * the FMC/FSMC. To use external RAM, the following things need to be present
+ * in the NuttX configuration file:
  *
  * CONFIG_STM32_FSMC=y         : Enables the FSMC
  * CONFIG_STM32_FMC=y          : Enables the FMC
@@ -95,17 +96,20 @@
 #  undef CONFIG_STM32_EXTERNAL_RAM
 #endif
 
-/* The STM32L15xxx family has only internal SRAM.  The heap is in one contiguous
- * block starting at g_idle_topstack and extending through CONFIG_RAM_END.
+/* The STM32L15xxx family has only internal SRAM.  The heap is in one
+ * contiguous block starting at g_idle_topstack and extending through
+ * CONFIG_RAM_END.
  */
 
 #if defined(CONFIG_STM32_STM32L15XX)
 
-   /* Set the end of system SRAM */
+  /* Set the end of system SRAM */
 
 #  define SRAM1_END CONFIG_RAM_END
 
-   /* There is no FSMC (Other EnergyLite STM32's do have an FSMC, but not the STM32L15X */
+   /* There is no FSMC (Other EnergyLite STM32's do have an FSMC, but not
+    * the STM32L15X
+    */
 
 #  undef CONFIG_STM32_EXTERNAL_RAM
 
@@ -120,9 +124,10 @@
 #    error "CONFIG_MM_REGIONS > 1.  The STM32L15X has only one memory region."
 #  endif
 
-/* For the STM312F10xxx family, all internal SRAM is in one contiguous block
- * starting at g_idle_topstack and extending through CONFIG_RAM_END (my apologies
- * for the bad naming).  In addition, external FSMC SRAM may be available.
+/* For the STM312F10xxx family, all internal SRAM is in one contiguous
+ * block starting at g_idle_topstack and extending through CONFIG_RAM_END
+ * (my apologies for the bad naming).  In addition, external FSMC SRAM
+ * may be available.
  */
 
 #elif defined(CONFIG_STM32_STM32F10XX)
@@ -184,44 +189,44 @@
     *                  CONFIG_STM32_CCMEXCLUDE NOT defined
     */
 
-#    if CONFIG_MM_REGIONS < 2
+#  if CONFIG_MM_REGIONS < 2
 
-       /* Only one memory region.  Force Configuration 1 */
+     /* Only one memory region.  Force Configuration 1 */
 
-#      ifndef CONFIG_STM32_CCMEXCLUDE
-#        ifdef CONFIG_STM32_HAVE_CCM
-#          warning "CCM SRAM excluded from the heap"
-#        endif
-#        define CONFIG_STM32_CCMEXCLUDE 1
+#    ifndef CONFIG_STM32_CCMEXCLUDE
+#      ifdef CONFIG_STM32_HAVE_CCM
+#        warning "CCM SRAM excluded from the heap"
 #      endif
+#      define CONFIG_STM32_CCMEXCLUDE 1
+#    endif
 
    /* CONFIG_MM_REGIONS may be 2 if CCM SRAM is included in the head */
 
-#    elif CONFIG_MM_REGIONS >= 2
-#      if CONFIG_MM_REGIONS > 2
-#         error "No more than two memory regions can be supported (CONFIG_MM_REGIONS)"
-#         undef CONFIG_MM_REGIONS
-#         define CONFIG_MM_REGIONS 2
-#      endif
+#  elif CONFIG_MM_REGIONS >= 2
+#    if CONFIG_MM_REGIONS > 2
+#       error "No more than two memory regions can be supported (CONFIG_MM_REGIONS)"
+#       undef CONFIG_MM_REGIONS
+#       define CONFIG_MM_REGIONS 2
+#    endif
 
-     /* Two memory regions is okay if CCM SRAM is not disabled. */
+       /* Two memory regions is okay if CCM SRAM is not disabled. */
 
-#      ifdef CONFIG_STM32_CCMEXCLUDE
+#    ifdef CONFIG_STM32_CCMEXCLUDE
 
-         /* Configuration 1: CONFIG_MM_REGIONS should have been 2 */
+       /* Configuration 1: CONFIG_MM_REGIONS should have been 2 */
 
-#        error "CONFIG_MM_REGIONS >= 2 but but CCM SRAM is excluded (CONFIG_STM32_CCMEXCLUDE)"
-#        undef CONFIG_MM_REGIONS
-#        define CONFIG_MM_REGIONS 1
-#      else
+#      error "CONFIG_MM_REGIONS >= 2 but but CCM SRAM is excluded (CONFIG_STM32_CCMEXCLUDE)"
+#      undef CONFIG_MM_REGIONS
+#      define CONFIG_MM_REGIONS 1
+#    else
 
-         /* Configuration 2: DMA should be disabled */
+       /* Configuration 2: DMA should be disabled */
 
-#        ifdef CONFIG_ARCH_DMA
-#          warning "CCM SRAM is included in the heap AND DMA is enabled"
-#        endif
+#      ifdef CONFIG_ARCH_DMA
+#        warning "CCM SRAM is included in the heap AND DMA is enabled"
 #      endif
 #    endif
+#  endif
 
 /* All members of the STM32F33xxx families have 16 Kbi ram and 4 KB CCM SRAM.
  * No external RAM is supported (the F3 family has no FSMC).
@@ -254,43 +259,43 @@
     *                  CONFIG_STM32_CCMEXCLUDE NOT defined
     */
 
-#    if CONFIG_MM_REGIONS < 2
+#  if CONFIG_MM_REGIONS < 2
 
-       /* Only one memory region.  Force Configuration 1 */
+     /* Only one memory region.  Force Configuration 1 */
 
-#      ifndef CONFIG_STM32_CCMEXCLUDE
-#        ifdef CONFIG_STM32_HAVE_CCM
-#          warning "CCM SRAM excluded from the heap"
-#        endif
-#        define CONFIG_STM32_CCMEXCLUDE 1
+#    ifndef CONFIG_STM32_CCMEXCLUDE
+#      ifdef CONFIG_STM32_HAVE_CCM
+#        warning "CCM SRAM excluded from the heap"
 #      endif
+#      define CONFIG_STM32_CCMEXCLUDE 1
+#    endif
 
    /* CONFIG_MM_REGIONS may be 2 if CCM SRAM is included in the head */
 
-#    elif CONFIG_MM_REGIONS >= 2
-#      if CONFIG_MM_REGIONS > 2
-#         error "No more than two memory regions can be supported (CONFIG_MM_REGIONS)"
-#         undef CONFIG_MM_REGIONS
-#         define CONFIG_MM_REGIONS 2
-#      endif
+#  elif CONFIG_MM_REGIONS >= 2
+#    if CONFIG_MM_REGIONS > 2
+#      error "No more than two memory regions can be supported (CONFIG_MM_REGIONS)"
+#      undef CONFIG_MM_REGIONS
+#      define CONFIG_MM_REGIONS 2
+#    endif
 
      /* Two memory regions is okay if CCM SRAM is not disabled. */
 
-#      ifdef CONFIG_STM32_CCMEXCLUDE
+#    ifdef CONFIG_STM32_CCMEXCLUDE
 
-         /* Configuration 1: CONFIG_MM_REGIONS should have been 2 */
+       /* Configuration 1: CONFIG_MM_REGIONS should have been 2 */
 
-#        error "CONFIG_MM_REGIONS >= 2 but but CCM SRAM is excluded (CONFIG_STM32_CCMEXCLUDE)"
-#        undef CONFIG_MM_REGIONS
-#        define CONFIG_MM_REGIONS 1
-#      else
+#      error "CONFIG_MM_REGIONS >= 2 but but CCM SRAM is excluded (CONFIG_STM32_CCMEXCLUDE)"
+#      undef CONFIG_MM_REGIONS
+#      define CONFIG_MM_REGIONS 1
+#    else
 
-         /* Configuration 2: DMA should be disabled */
+       /* Configuration 2: DMA should be disabled */
 
-#        ifdef CONFIG_ARCH_DMA
-#          warning "CCM SRAM is included in the heap AND DMA is enabled"
-#        endif
+#      ifdef CONFIG_ARCH_DMA
+#        warning "CCM SRAM is included in the heap AND DMA is enabled"
 #      endif
+#    endif
 #  endif
 
 /* All members of the STM32F37xxx families have 16-32 Kib ram in a single
@@ -323,19 +328,19 @@
  *   1) 112KiB of System SRAM beginning at address 0x2000:0000
  *   2)  16KiB of System SRAM beginning at address 0x2001:c000
  *
- * The STM32F401 family is an exception and has only 64KiB or 96Kib total on one
- * bank:
+ * The STM32F401 family is an exception and has only 64KiB or 96Kib total
+ * on one bank:
  *
- *   3) 64KiB (STM32F401xB/C) or 96KiB (STM32401xD/E) of System SRAM beginning
- *      at address 0x2000:0000
+ *   3) 64KiB (STM32F401xB/C) or 96KiB (STM32401xD/E) of System SRAM
+ *      beginning at address 0x2000:0000
  *
  * Members of the STM32F40xxx family have an additional 64Kib of CCM RAM
  * for a total of 192KB.
  *
  *   4) 64Kib of CCM SRAM beginning at address 0x1000:0000
  *
- * The STM32F427/437/429/439 parts have another 64KiB of System SRAM for a total
- * of 256KiB.
+ * The STM32F427/437/429/439 parts have another 64KiB of System SRAM for
+ * a total of 256KiB.
  *
  *   5) 64Kib of System SRAM beginning at address 0x2002:0000
  *
@@ -344,9 +349,10 @@
  * regions are contiguous and treated as one in this logic that extends to
  * 0x2002:0000 (or 0x2003:0000 for the F427/F437/F429/F439).
  *
- * As a complication, CCM SRAM cannot be used for DMA.  So, if STM32 DMA is enabled,
- * CCM SRAM should probably be excluded from the heap or the application must take
- * extra care to ensure that DMA buffers are not allocated in CCM SRAM.
+ * As a complication, CCM SRAM cannot be used for DMA.  So, if STM32 DMA is
+ * enabled, CCM SRAM should probably be excluded from the heap or the
+ * application must take extra care to ensure that DMA buffers are not
+ * allocated in CCM SRAM.
  *
  * In addition, external FSMC SRAM may be available.
  */
@@ -409,9 +415,9 @@
 
 #  if defined(CONFIG_STM32_EXTERNAL_RAM)
 
-   /* Configuration 3 or 4. External SRAM is available.  CONFIG_MM_REGIONS
-    * should be at least 2.
-    */
+     /* Configuration 3 or 4. External SRAM is available.  CONFIG_MM_REGIONS
+      * should be at least 2.
+      */
 
 #    if CONFIG_MM_REGIONS < 2
 
@@ -422,7 +428,7 @@
 #      undef CONFIG_STM32_CCMEXCLUDE
 #      define CONFIG_STM32_CCMEXCLUDE 1
 
-   /* CONFIG_MM_REGIONS may be 3 if CCM SRAM is included in the head */
+     /* CONFIG_MM_REGIONS may be 3 if CCM SRAM is included in the head */
 
 #    elif CONFIG_MM_REGIONS > 2
 
@@ -454,9 +460,9 @@
 #        endif
 #      endif
 
-   /* CONFIG_MM_REGIONS is exactly 2.  We cannot support both CCM SRAM and
-    * FSMC SRAM.
-    */
+     /* CONFIG_MM_REGIONS is exactly 2.  We cannot support both CCM SRAM and
+      * FSMC SRAM.
+      */
 
 #    elif !defined(CONFIG_STM32_CCMEXCLUDE)
 #      error "CONFIG_MM_REGIONS == 2, cannot support both CCM SRAM and FSMC SRAM"
@@ -466,9 +472,9 @@
 
 #  elif !defined(CONFIG_STM32_CCMEXCLUDE)
 
-   /* Configuration 2: FSMC SRAM is not used, but CCM SRAM is requested.  DMA
-    * should be disabled and CONFIG_MM_REGIONS should be 2.
-    */
+     /* Configuration 2: FSMC SRAM is not used, but CCM SRAM is requested.
+      * DMA should be disabled and CONFIG_MM_REGIONS should be 2.
+      */
 
 #    ifdef CONFIG_ARCH_DMA
 #      warning "CCM SRAM is included in the heap AND DMA is enabled"
@@ -503,17 +509,17 @@
 #  endif
 #endif
 
-/****************************************************************************
+/******************************************************************************
  * Private Functions
- ****************************************************************************/
+ ******************************************************************************/
 
-/****************************************************************************
+/******************************************************************************
  * Name: up_heap_color
  *
  * Description:
  *   Set heap memory to a known, non-zero state to checking heap usage.
  *
- ****************************************************************************/
+ ******************************************************************************/
 
 #ifdef CONFIG_HEAP_COLORATION
 static inline void up_heap_color(FAR void *start, size_t size)
@@ -524,11 +530,11 @@ static inline void up_heap_color(FAR void *start, size_t size)
 #  define up_heap_color(start,size)
 #endif
 
-/****************************************************************************
+/******************************************************************************
  * Public Functions
- ****************************************************************************/
+ ******************************************************************************/
 
-/****************************************************************************
+/******************************************************************************
  * Name: up_allocate_heap
  *
  * Description:
@@ -550,16 +556,16 @@ static inline void up_heap_color(FAR void *start, size_t size)
  *
  *   The following memory map is assumed for the kernel build:
  *
- *     Kernel .data region.  Size determined at link time.
- *     Kernel .bss  region  Size determined at link time.
- *     Kernel IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
+ *     Kernel .data region       Size determined at link time
+ *     Kernel .bss  region       Size determined at link time
+ *     Kernel IDLE thread stack  Size determined by CONFIG_IDLETHREAD_STACKSIZE
  *     Padding for alignment
- *     User .data region.  Size determined at link time.
- *     User .bss region  Size determined at link time.
- *     Kernel heap.  Size determined by CONFIG_MM_KERNEL_HEAPSIZE.
- *     User heap.  Extends to the end of SRAM.
+ *     User .data region         Size determined at link time
+ *     User .bss region          Size determined at link time
+ *     Kernel heap               Size determined by CONFIG_MM_KERNEL_HEAPSIZE
+ *     User heap                 Extends to the end of SRAM
  *
- ****************************************************************************/
+ ******************************************************************************/
 
 void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 {
@@ -569,7 +575,8 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+    CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = SRAM1_END - ubase;
   int       log2;
 
@@ -598,7 +605,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 
   /* Allow user-mode access to the user heap memory */
 
-   stm32_mpu_uheap((uintptr_t)ubase, usize);
+  stm32_mpu_uheap((uintptr_t)ubase, usize);
 #else
 
   /* Return the heap settings */
@@ -613,7 +620,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 #endif
 }
 
-/****************************************************************************
+/******************************************************************************
  * Name: up_allocate_kheap
  *
  * Description:
@@ -621,7 +628,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  *   user-space heaps (CONFIG_MM_KERNEL_HEAP=y), this function allocates
  *   (and protects) the kernel-space heap.
  *
- ****************************************************************************/
+ ******************************************************************************/
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
 void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
@@ -631,7 +638,8 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+    CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = SRAM1_END - ubase;
   int       log2;
 
@@ -657,14 +665,14 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
 }
 #endif
 
-/****************************************************************************
+/******************************************************************************
  * Name: up_addregion
  *
  * Description:
  *   Memory may be added in non-contiguous chunks.  Additional chunks are
  *   added by calling this function.
  *
- ****************************************************************************/
+ ******************************************************************************/
 
 #if CONFIG_MM_REGIONS > 1
 void up_addregion(void)
@@ -674,17 +682,17 @@ void up_addregion(void)
 
   /* Allow user-mode access to the STM32F20xxx/STM32F40xxx CCM SRAM heap */
 
-  stm32_mpu_uheap((uintptr_t)SRAM2_START, SRAM2_END-SRAM2_START);
+  stm32_mpu_uheap((uintptr_t)SRAM2_START, SRAM2_END - SRAM2_START);
 
 #endif
 
   /* Colorize the heap for debug */
 
-  up_heap_color((FAR void *)SRAM2_START, SRAM2_END-SRAM2_START);
+  up_heap_color((FAR void *)SRAM2_START, SRAM2_END - SRAM2_START);
 
   /* Add the STM32F20xxx/STM32F40xxx CCM SRAM user heap region. */
 
-  kumm_addregion((FAR void *)SRAM2_START, SRAM2_END-SRAM2_START);
+  kumm_addregion((FAR void *)SRAM2_START, SRAM2_END - SRAM2_START);
 #endif
 
 #ifdef CONFIG_STM32_EXTERNAL_RAM
@@ -692,7 +700,7 @@ void up_addregion(void)
 
   /* Allow user-mode access to the FSMC SRAM user heap memory */
 
-   stm32_mpu_uheap((uintptr_t)CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE);
+  stm32_mpu_uheap((uintptr_t)CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE);
 
 #endif
 

--- a/arch/arm/src/stm32/stm32_allocateheap.c
+++ b/arch/arm/src/stm32/stm32_allocateheap.c
@@ -53,12 +53,12 @@
 #include <arch/board/board.h>
 
 #include "chip.h"
-#ifdef CONFIG_ARM_MPU
-#  include "mpu.h"
-#  include "stm32_mpuinit.h"
-#endif
+
+#include "mpu.h"
 #include "up_arch.h"
 #include "up_internal.h"
+
+#include "stm32_mpuinit.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -93,8 +93,12 @@ ifeq ($(CONFIG_ARMV7M_ITMSYSLOG),y)
 CMN_CSRCS += up_itm_syslog.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1102,6 +1102,7 @@ if STM32H7_BKPSRAM
 config STM32H7_BBSRAM
 	bool "BBSRAM File Support"
 	default n
+	select ARM_MPU
 
 config STM32H7_BBSRAM_FILES
 	int "Max Files to support in BBSRAM"

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -92,8 +92,12 @@ ifeq ($(CONFIG_STM32H7_PROGMEM),y)
 CMN_CSRCS += stm32_flash.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif
@@ -130,7 +134,7 @@ endif
 
 ifeq ($(CONFIG_STM32H7_BBSRAM),y)
 ifeq ($(CONFIG_ARMV7M_DCACHE),y)
-ifeq ($(CONFIG_BUILD_PROTECTED),)
+ifeq ($(CONFIG_ARM_MPU),y)
 CMN_CSRCS += up_mpu.c
 endif
 endif

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -84,8 +84,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -83,8 +83,12 @@ ifeq ($(CONFIG_STACK_COLORATION),y)
   CMN_CSRCS += up_checkstack.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-  CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+  CMN_CSRCS += up_task_start.c up_pthread_start.c
   CMN_CSRCS += up_signal_dispatch.c
   CMN_UASRCS += up_signal_handler.S
 else

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -71,8 +71,12 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += up_ramvec_initialize.c up_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CMN_CSRCS += up_mpu.c
+endif
+
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-CMN_CSRCS += up_mpu.c up_task_start.c up_pthread_start.c
+CMN_CSRCS += up_task_start.c up_pthread_start.c
 CMN_CSRCS += up_signal_dispatch.c
 CMN_UASRCS += up_signal_handler.S
 endif


### PR DESCRIPTION
As per the discussion the mailing list, this fixes the build issues associated with non-conditional inclusion of ARMv7-m mpu source files. 

Summary of changes
- inline functions within mpu.h converted to macros or moved to up_mpu.c
- mpu.h and up_mpu.c are now conditionally included in build via CONFIG_ARM_MPU

For each chip, I selected a test config and ran flat builds with and without the mpu enabled. When a configuration existed that allowed me to perform a protected build, I check that this completed successfully as well. 

Chips affected by these changes
- imxrt
- kinetis
- lpc17xx
- lpc43xx
- lpc54xx
- sam34
- stm32
- stm32f7
- stm32h7
- stm32l4
- tiva
- xmc4