### PR TITLE
testbuild.sh: Add an option to show the list of configs

### DIFF
--- a/tools/README.txt
+++ b/tools/README.txt
@@ -1002,6 +1002,7 @@ testbuild.sh
          Ubuntu under Windows 10 (u), or Windows native (n).  Default Linux
       -a <appsdir> provides the relative path to the apps/ directory.  Default ../apps
       -t <topdir> provides the absolute path to top nuttx/ directory.  Default $PWD/../nuttx
+      -p only print the list of configs without running any builds
       -j <ncpus> passed on to make.  Default:  No -j make option
       -d enables script debug output
       -x exit on build failures

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -43,6 +43,7 @@ MAKE=make
 unset testfile
 unset HOPTION
 unset JOPTION
+PRINTLISTONLY=0
 
 function showusage {
   echo ""
@@ -57,6 +58,7 @@ function showusage {
   echo "  -j <ncpus> passed on to make.  Default:  No -j make option."
   echo "  -a <appsdir> provides the relative path to the apps/ directory.  Default ../apps"
   echo "  -t <topdir> provides the absolute path to top nuttx/ directory.  Default $PWD/../nuttx"
+  echo "  -p only print the list of configs without running any builds"
   echo "  -h will show this help test and terminate"
   echo "  <testlist-file> selects the list of configurations to test.  No default"
   echo ""
@@ -91,6 +93,9 @@ while [ ! -z "$1" ]; do
   -t )
     shift
     nuttx="$1"
+    ;;
+  -p )
+    PRINTLISTONLY=1
     ;;
   -h )
     showusage
@@ -203,6 +208,9 @@ function dotest {
     echo "Skipping: $1"
   else
     echo "Configuration/Tool: $1"
+    if [ ${PRINTLISTONLY} -eq 1 ]; then
+      return
+    fi
 
     # Parse the next line
 


### PR DESCRIPTION
This was useful for me when tweaking testlists.