### PR TITLE
Fix a fatal typo in a recent change

### DIFF
--- a/fs/inode/fs_inoderelease.c
+++ b/fs/inode/fs_inoderelease.c
@@ -61,7 +61,7 @@ void inode_release(FAR struct inode *node)
            * reference count would be wrong.
            */
 
-          DEBUGASSERT(ret = OK || ret == -ECANCELED);
+          DEBUGASSERT(ret == OK || ret == -ECANCELED);
         }
       while (ret < 0);
 


### PR DESCRIPTION
A typo in:
    commit ae401cecdd3c076974184bd6cc02c93cada5fc64
    ("Check return from nxsem_wait_initialize()")