### PR TITLE
tools/nxstyle.c:  All Public Function Prototypes in C files

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -176,7 +176,7 @@ static const struct file_section_s g_section_info[] =
   },
   {
     " * Public Function Prototypes\n",  /* Index: PUBLIC_FUNCTION_PROTOTYPES */
-    C_HEADER
+    C_SOURCE | C_HEADER
   }
 };
 


### PR DESCRIPTION
Allow "Public Function Prototypes" sections in .c files.  Per the coding standard, all public function prototypes belong in .c files.  However, there are some situations when the public function prototype is needed in a .c file and it shoudld, most correctly, be placed in a "Public Function Prototypes" section.
