### PR TITLE
Check return from nxsem_wait_initialize()

### DIFF
--- a/arch/arm/src/lc823450/lc823450_i2c.c
+++ b/arch/arm/src/lc823450/lc823450_i2c.c
@@ -126,8 +126,14 @@ struct lc823450_i2c_config_s
 
 struct lc823450_i2c_priv_s
 {
-  FAR const struct i2c_ops_s *ops; /* Standard I2C operations */
-  FAR const struct lc823450_i2c_config_s *config;  /* Port configuration */
+  /* Standard I2C operations */
+
+  FAR const struct i2c_ops_s *ops;
+
+  /* Port configuration */
+
+  FAR const struct lc823450_i2c_config_s *config;
+
   int   refs;                      /* Referernce count */
   sem_t sem_excl;                  /* Mutual exclusion semaphore */
 #ifndef CONFIG_I2C_POLLED
@@ -150,20 +156,31 @@ struct lc823450_i2c_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static inline void lc823450_i2c_sem_wait(FAR struct lc823450_i2c_priv_s *priv);
-static inline void lc823450_i2c_sem_post(FAR struct lc823450_i2c_priv_s *priv);
-static inline int  lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv);
+static inline int
+  lc823450_i2c_sem_wait(FAR struct lc823450_i2c_priv_s *priv);
+static inline void
+  lc823450_i2c_sem_post(FAR struct lc823450_i2c_priv_s *priv);
+static inline int
+  lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv);
 
 #ifndef CONFIG_I2C_POLLED
-static inline void lc823450_i2c_enableirq(FAR struct lc823450_i2c_priv_s *priv);
-static inline void lc823450_i2c_disableirq(FAR struct lc823450_i2c_priv_s *priv);
+static inline void
+  lc823450_i2c_enableirq(FAR struct lc823450_i2c_priv_s *priv);
+static inline void
+  lc823450_i2c_disableirq(FAR struct lc823450_i2c_priv_s *priv);
 #endif
-static inline bool lc823450_i2c_checkirq(FAR struct lc823450_i2c_priv_s *priv);
-static inline bool lc823450_i2c_checkbusy(FAR struct lc823450_i2c_priv_s *priv);
-static inline void lc823450_i2c_prepxfer(FAR struct lc823450_i2c_priv_s *priv);
-static inline void lc823450_i2c_sendstart(FAR struct lc823450_i2c_priv_s *priv);
-static inline void lc823450_i2c_sendstop(FAR struct lc823450_i2c_priv_s *priv);
-static inline uint32_t lc823450_i2c_readdata(FAR struct lc823450_i2c_priv_s *priv);
+static inline bool
+  lc823450_i2c_checkirq(FAR struct lc823450_i2c_priv_s *priv);
+static inline bool
+  lc823450_i2c_checkbusy(FAR struct lc823450_i2c_priv_s *priv);
+static inline void
+  lc823450_i2c_prepxfer(FAR struct lc823450_i2c_priv_s *priv);
+static inline void
+  lc823450_i2c_sendstart(FAR struct lc823450_i2c_priv_s *priv);
+static inline void
+  lc823450_i2c_sendstop(FAR struct lc823450_i2c_priv_s *priv);
+static inline uint32_t
+  lc823450_i2c_readdata(FAR struct lc823450_i2c_priv_s *priv);
 static void lc823450_i2c_starttransfer(FAR struct lc823450_i2c_priv_s *priv);
 
 static int lc823450_i2c_poll(FAR struct lc823450_i2c_priv_s *priv);
@@ -172,7 +189,8 @@ static int lc823450_i2c_isr(int irq, FAR void *context, FAR void *arg);
 #endif
 
 static int lc823450_i2c_init(FAR struct lc823450_i2c_priv_s *priv, int port);
-static int lc823450_i2c_deinit(FAR struct lc823450_i2c_priv_s *priv, int port);
+static int
+  lc823450_i2c_deinit(FAR struct lc823450_i2c_priv_s *priv, int port);
 
 static int lc823450_i2c_transfer(FAR struct i2c_master_s *dev,
                                  FAR struct i2c_msg_s *msgs, int count);
@@ -255,13 +273,14 @@ static struct lc823450_i2c_priv_s lc823450_i2c1_priv =
  * Name: lc823450_i2c_sem_wait
  *
  * Description:
- *   Take the exclusive access, waiting as necessary
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by
+ *   a signal.
  *
  ****************************************************************************/
 
-static inline void lc823450_i2c_sem_wait(FAR struct lc823450_i2c_priv_s *priv)
+static inline int lc823450_i2c_sem_wait(FAR struct lc823450_i2c_priv_s *priv)
 {
-  nxsem_wait_uninterruptible(&priv->sem_excl);
+  return nxsem_wait(&priv->sem_excl);
 }
 
 /****************************************************************************
@@ -272,7 +291,8 @@ static inline void lc823450_i2c_sem_wait(FAR struct lc823450_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline void lc823450_i2c_sem_post(FAR struct lc823450_i2c_priv_s *priv)
+static inline void
+  lc823450_i2c_sem_post(FAR struct lc823450_i2c_priv_s *priv)
 {
   nxsem_post(&priv->sem_excl);
 }
@@ -286,7 +306,8 @@ static inline void lc823450_i2c_sem_post(FAR struct lc823450_i2c_priv_s *priv)
  ****************************************************************************/
 
 #ifndef CONFIG_I2C_POLLED
-static inline int lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv)
+static inline int
+  lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv)
 {
   struct timespec abstime;
   int ret;
@@ -317,10 +338,10 @@ static inline int lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv
       ret = nxsem_timedwait_uninterruptible(&priv->sem_isr, &abstime);
       if (ret < 0)
         {
-
           /* Break out of the loop on irrecoverable errors.  This would
            * include timeouts and mystery errors reported by nxsem_timedwait.
            */
+
           break;
         }
     }
@@ -333,7 +354,8 @@ static inline int lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv
   return ret;
 }
 #else
-static inline int lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv)
+static inline int
+  lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv)
 {
   uint32_t timeout;
   clock_t start;
@@ -388,8 +410,11 @@ static inline int lc823450_i2c_sem_waitdone(FAR struct lc823450_i2c_priv_s *priv
 static void lc823450_i2c_prepxfer(FAR struct lc823450_i2c_priv_s *priv)
 {
   uint32_t base = priv->config->base;
-  putreg32(((lc823450_get_systemfreq() / priv->msgv->frequency + 7) / 8) & 0xffff, base + I2CCKS);
-  putreg32((priv->msgv->addr << 1) | (priv->msgv->flags & I2C_M_READ), base + I2CTXD);
+  putreg32(((lc823450_get_systemfreq() / priv->msgv->frequency + 7) / 8) &
+           0xffff,
+           base + I2CCKS);
+  putreg32((priv->msgv->addr << 1) | (priv->msgv->flags & I2C_M_READ),
+           base + I2CTXD);
 }
 
 /****************************************************************************
@@ -400,7 +425,8 @@ static void lc823450_i2c_prepxfer(FAR struct lc823450_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline bool lc823450_i2c_checkbusy(FAR struct lc823450_i2c_priv_s *priv)
+static inline bool
+  lc823450_i2c_checkbusy(FAR struct lc823450_i2c_priv_s *priv)
 {
   return (getreg32(priv->config->base + I2CSTR) & I2C_STR_BBSY) != 0;
 }
@@ -413,7 +439,8 @@ static inline bool lc823450_i2c_checkbusy(FAR struct lc823450_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline bool lc823450_i2c_checkirq(FAR struct lc823450_i2c_priv_s *priv)
+static inline bool
+  lc823450_i2c_checkirq(FAR struct lc823450_i2c_priv_s *priv)
 {
   return (getreg32(priv->config->base + I2CSTR) & I2C_STR_IREQ) != 0;
 }
@@ -426,7 +453,8 @@ static inline bool lc823450_i2c_checkirq(FAR struct lc823450_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline bool lc823450_i2c_checkack(FAR struct lc823450_i2c_priv_s *priv)
+static inline bool
+  lc823450_i2c_checkack(FAR struct lc823450_i2c_priv_s *priv)
 {
   return (getreg32(priv->config->base + I2CSTR) & I2C_STR_ACKD) != 0;
 }
@@ -439,7 +467,8 @@ static inline bool lc823450_i2c_checkack(FAR struct lc823450_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline void lc823450_i2c_sendstart(FAR struct lc823450_i2c_priv_s *priv)
+static inline void
+  lc823450_i2c_sendstart(FAR struct lc823450_i2c_priv_s *priv)
 {
   modifyreg32(priv->config->base + I2CCTL, I2C_CTL_TRX, I2C_CTL_TRX);
   modifyreg32(priv->config->base + I2CCTL, I2C_CTL_ST, I2C_CTL_ST);
@@ -453,7 +482,8 @@ static inline void lc823450_i2c_sendstart(FAR struct lc823450_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline void lc823450_i2c_sendstop(FAR struct lc823450_i2c_priv_s *priv)
+static inline void
+  lc823450_i2c_sendstop(FAR struct lc823450_i2c_priv_s *priv)
 {
   modifyreg32(priv->config->base + I2CSTR, I2C_STR_IREQ, 0);
   modifyreg32(priv->config->base + I2CCTL, I2C_CTL_TRX, I2C_CTL_TRX);
@@ -502,7 +532,8 @@ static int lc823450_i2c_reset(FAR struct i2c_master_s *dev)
  ****************************************************************************/
 
 #ifndef CONFIG_I2C_POLLED
-static inline void lc823450_i2c_enableirq(FAR struct lc823450_i2c_priv_s *priv)
+static inline void
+  lc823450_i2c_enableirq(FAR struct lc823450_i2c_priv_s *priv)
 {
   modifyreg32(priv->config->base + I2CCTL, I2C_CTL_IREQEN, I2C_CTL_IREQEN);
 }
@@ -517,7 +548,8 @@ static inline void lc823450_i2c_enableirq(FAR struct lc823450_i2c_priv_s *priv)
  ****************************************************************************/
 
 #ifndef CONFIG_I2C_POLLED
-static inline void lc823450_i2c_disableirq(FAR struct lc823450_i2c_priv_s *priv)
+static inline void
+  lc823450_i2c_disableirq(FAR struct lc823450_i2c_priv_s *priv)
 {
   modifyreg32(priv->config->base + I2CCTL, I2C_CTL_IREQEN, 0);
 }
@@ -531,7 +563,8 @@ static inline void lc823450_i2c_disableirq(FAR struct lc823450_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline uint32_t lc823450_i2c_readdata(FAR struct lc823450_i2c_priv_s *priv)
+static inline uint32_t
+  lc823450_i2c_readdata(FAR struct lc823450_i2c_priv_s *priv)
 {
   return getreg32(priv->config->base + I2CRXD);
 }
@@ -558,8 +591,10 @@ static void lc823450_i2c_starttransfer(FAR struct lc823450_i2c_priv_s *priv)
         {
           /* If the next byte to be received is not final, we have to send ACK. */
 
-          modifyreg32(priv->config->base + I2CCTL, I2C_CTL_ACK, I2C_CTL_ACK);
-          modifyreg32(priv->config->base + I2CCTL, I2C_CTL_BTRIG, I2C_CTL_BTRIG);
+          modifyreg32(priv->config->base + I2CCTL, I2C_CTL_ACK,
+                      I2C_CTL_ACK);
+          modifyreg32(priv->config->base + I2CCTL, I2C_CTL_BTRIG,
+                      I2C_CTL_BTRIG);
         }
       else if (priv->dcnt == 1)
         {
@@ -567,19 +602,20 @@ static void lc823450_i2c_starttransfer(FAR struct lc823450_i2c_priv_s *priv)
 
           if (priv->msgc > 0 && priv->msgv->flags & I2C_M_READ)
             {
-
-              /* But if there is a next message and the direction is READ, we have
-               * to send ACK.
+              /* But if there is a next message and the direction is READ,
+               * we have to send ACK.
                */
 
-              modifyreg32(priv->config->base + I2CCTL, I2C_CTL_ACK, I2C_CTL_ACK);
+              modifyreg32(priv->config->base + I2CCTL, I2C_CTL_ACK,
+                          I2C_CTL_ACK);
             }
           else
             {
               modifyreg32(priv->config->base + I2CCTL, I2C_CTL_ACK, 0);
             }
 
-          modifyreg32(priv->config->base + I2CCTL, I2C_CTL_BTRIG, I2C_CTL_BTRIG);
+          modifyreg32(priv->config->base + I2CCTL, I2C_CTL_BTRIG,
+                      I2C_CTL_BTRIG);
         }
 
       priv->irqstate = IRQSTATE_WRECV;
@@ -589,8 +625,10 @@ static void lc823450_i2c_starttransfer(FAR struct lc823450_i2c_priv_s *priv)
       if (priv->dcnt > 0)
         {
           putreg32(*priv->ptr, priv->config->base + I2CTXD);
-          modifyreg32(priv->config->base +  I2CCTL, I2C_CTL_BTRIG, I2C_CTL_BTRIG);
+          modifyreg32(priv->config->base +  I2CCTL,
+                      I2C_CTL_BTRIG, I2C_CTL_BTRIG);
         }
+
       priv->irqstate = IRQSTATE_WSEND;
     }
 }
@@ -660,7 +698,9 @@ static int lc823450_i2c_poll(FAR struct lc823450_i2c_priv_s *priv)
 
               priv->msgv++;
               priv->msgc--;
-              i2cinfo("WSTART (dcnt=%d flags=%xh msgc=%d)\n", priv->dcnt, priv->flags, priv->msgc);
+
+              i2cinfo("WSTART (dcnt=%d flags=%xh msgc=%d)\n",
+                      priv->dcnt, priv->flags, priv->msgc);
 
               lc823450_i2c_starttransfer(priv);
             }
@@ -681,9 +721,9 @@ static int lc823450_i2c_poll(FAR struct lc823450_i2c_priv_s *priv)
     }
   else if (priv->irqstate == IRQSTATE_WRECV)
     {
-      /* When the master is receiver, it shall send ACK instead of the slave when
-       * it receives data. In this case, it don't have to check if ACK comes,
-       * because the slave does not send ACK.
+      /* When the master is receiver, it shall send ACK instead of the slave
+       * when it receives data. In this case, it don't have to check if
+       * ACK comes, because the slave does not send ACK.
        */
 
       *priv->ptr++ = lc823450_i2c_readdata(priv);
@@ -743,24 +783,25 @@ static int lc823450_i2c_poll(FAR struct lc823450_i2c_priv_s *priv)
             }
           else
             {
-              /* We need restart from START condition. If transfer direction is different
-               * between current message and next message, restart is necessary.
+              /* We need restart from START condition. If transfer direction
+               * is different between current message and next message,
+               * restart is necessary.
                */
 
               i2cinfo("re-START condition\n");
 
 #ifdef CONFIG_I2C_RESET
-              /* Reset I2C bus by softreset. There is not description of the reset,
-               * but in order to recover I2C bus busy, it must be done.
-               * Please refer to macaron's code.
+              /* Reset I2C bus by softreset. There is not description of the
+               * reset, but in order to recover I2C bus busy, it must be
+               * done.  Please refer to macaron's code.
                */
 
               lc823450_i2c_reset((FAR struct i2c_master_s *)priv);
 #endif
 
 #ifndef CONFIG_I2C_POLLED
-              /* We have to enable interrupt again, because all registers are reset by
-               * lc823450_i2c_reset().
+              /* We have to enable interrupt again, because all registers
+               * are reset by lc823450_i2c_reset().
                */
 
               lc823450_i2c_enableirq(priv);
@@ -774,8 +815,8 @@ static int lc823450_i2c_poll(FAR struct lc823450_i2c_priv_s *priv)
         }
       else if (priv->msgv)
         {
-          /* There are no other message. We send STOP condition because all messages
-           * are transferred.
+          /* There are no other message. We send STOP condition because all
+           * messages are transferred.
            */
 
           i2cinfo("STOP condition\n");
@@ -881,7 +922,8 @@ static int lc823450_i2c_init(FAR struct lc823450_i2c_priv_s *priv, int port)
  *
  ****************************************************************************/
 
-static int lc823450_i2c_deinit(FAR struct lc823450_i2c_priv_s *priv, int port)
+static int lc823450_i2c_deinit(FAR struct lc823450_i2c_priv_s *priv,
+                               int port)
 {
   /* Disable I2C */
 
@@ -962,9 +1004,13 @@ static int lc823450_i2c_transfer(FAR struct i2c_master_s *dev,
       return -EINVAL;
     }
 
-   /* ensure that address or flags don't change meanwhile */
+  /* Ensure that address or flags don't change meanwhile */
 
-  lc823450_i2c_sem_wait(priv);
+  ret = lc823450_i2c_sem_wait(priv);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   priv->timedout = false;
 
@@ -1008,7 +1054,6 @@ static int lc823450_i2c_transfer(FAR struct i2c_master_s *dev,
 
   if (lc823450_i2c_sem_waitdone(priv) < 0)
     {
-
       irqs = enter_critical_section();
 
       ret = -ETIMEDOUT;
@@ -1032,7 +1077,8 @@ static int lc823450_i2c_transfer(FAR struct i2c_master_s *dev,
         }
       else
         {
-          i2cerr("No need of timeout handling. It may be done in irq handler\n");
+          i2cerr("No need of timeout handling. "
+                 "It may be done in irq handler\n");
 
           leave_critical_section(irqs);
         }
@@ -1058,7 +1104,6 @@ exit:
   lc823450_i2c_sem_post(priv);
 
   return ret;
-
 }
 
 /****************************************************************************
@@ -1185,7 +1230,8 @@ int lc823450_i2cbus_uninitialize(FAR struct i2c_master_s *dev)
  * Name: lc823450_i2cbus_changetimeout
  ****************************************************************************/
 
-void lc823450_i2cbus_changetimeout(FAR struct i2c_master_s *dev, uint32_t timeoms)
+void lc823450_i2cbus_changetimeout(FAR struct i2c_master_s *dev,
+                                   uint32_t timeoms)
 {
   FAR struct lc823450_i2c_priv_s *priv = (struct lc823450_i2c_priv_s *)dev;
   priv->timeoms = timeoms;

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -166,11 +166,11 @@ enum s32k1xx_trace_e
 
 struct s32k1xx_trace_s
 {
-  uint32_t status;             /* I2C 32-bit SR2|SR1 status */
-  uint32_t count;              /* Interrupt count when status change */
+  uint32_t status;               /* I2C 32-bit SR2|SR1 status */
+  uint32_t count;                /* Interrupt count when status change */
   enum s32k1xx_intstate_e event; /* Last event that occurred with this status */
-  uint32_t parm;               /* Parameter associated with the event */
-  clock_t time;                /* First of event or first status */
+  uint32_t parm;                 /* Parameter associated with the event */
+  clock_t time;                  /* First of event or first status */
 };
 
 /* I2C Device hardware configuration */
@@ -193,8 +193,14 @@ struct s32k1xx_lpi2c_config_s
 
 struct s32k1xx_lpi2c_priv_s
 {
-  const struct i2c_ops_s *ops; /* Standard I2C operations */
-  const struct s32k1xx_lpi2c_config_s *config; /* Port configuration */
+  /* Standard I2C operations */
+
+  const struct i2c_ops_s *ops;
+
+  /* Port configuration */
+
+  const struct s32k1xx_lpi2c_config_s *config;
+
   int refs;                    /* Reference count */
   sem_t sem_excl;              /* Mutual exclusion semaphore */
 #ifndef CONFIG_I2C_POLLED
@@ -227,41 +233,58 @@ struct s32k1xx_lpi2c_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static inline uint32_t s32k1xx_lpi2c_getreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                          uint16_t offset);
-static inline void s32k1xx_lpi2c_putreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                      uint16_t offset, uint32_t value);
-static inline void s32k1xx_lpi2c_modifyreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                         uint16_t offset, uint32_t clearbits,
-                                         uint32_t setbits);
-static inline void s32k1xx_lpi2c_sem_wait(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static inline uint32_t
+  s32k1xx_lpi2c_getreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
+                       uint16_t offset);
+static inline void
+  s32k1xx_lpi2c_putreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
+                       uint16_t offset, uint32_t value);
+static inline void
+  s32k1xx_lpi2c_modifyreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
+                          uint16_t offset, uint32_t clearbits,
+                          uint32_t setbits);
+static inline int
+  s32k1xx_lpi2c_sem_wait(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static int
+  s32k1xx_lpi2c_sem_wait_uninterruptible(
+    FAR struct s32k1xx_lpi2c_priv_s *priv);
 
 #ifdef CONFIG_S32K1XX_I2C_DYNTIMEO
-static useconds_t s32k1xx_lpi2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
+static useconds_t
+  s32k1xx_lpi2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
 #endif /* CONFIG_S32K1XX_I2C_DYNTIMEO */
 
-static inline int  s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *priv);
-static inline void s32k1xx_lpi2c_sem_waitstop(FAR struct s32k1xx_lpi2c_priv_s *priv);
-static inline void s32k1xx_lpi2c_sem_post(FAR struct s32k1xx_lpi2c_priv_s *priv);
-static inline void s32k1xx_lpi2c_sem_init(FAR struct s32k1xx_lpi2c_priv_s *priv);
-static inline void s32k1xx_lpi2c_sem_destroy(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static inline int
+  s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static inline void
+  s32k1xx_lpi2c_sem_waitstop(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static inline void
+  s32k1xx_lpi2c_sem_post(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static inline void
+  s32k1xx_lpi2c_sem_init(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static inline void
+  s32k1xx_lpi2c_sem_destroy(FAR struct s32k1xx_lpi2c_priv_s *priv);
 
 #ifdef CONFIG_I2C_TRACE
 static void s32k1xx_lpi2c_tracereset(FAR struct s32k1xx_lpi2c_priv_s *priv);
 static void s32k1xx_lpi2c_tracenew(FAR struct s32k1xx_lpi2c_priv_s *priv,
                                  uint32_t status);
 static void s32k1xx_lpi2c_traceevent(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                   enum s32k1xx_trace_e event, uint32_t parm);
+                                     enum s32k1xx_trace_e event,
+                                     uint32_t parm);
 static void s32k1xx_lpi2c_tracedump(FAR struct s32k1xx_lpi2c_priv_s *priv);
 #endif /* CONFIG_I2C_TRACE */
 
 static uint32_t s32k1xx_lpi2c_pckfreq(uintptr_t base);
 static void s32k1xx_lpi2c_setclock(FAR struct s32k1xx_lpi2c_priv_s *priv,
                                uint32_t frequency);
-static inline void s32k1xx_lpi2c_sendstart(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                         uint8_t address);
-static inline void s32k1xx_lpi2c_sendstop(FAR struct s32k1xx_lpi2c_priv_s *priv);
-static inline uint32_t s32k1xx_lpi2c_getstatus(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static inline void
+  s32k1xx_lpi2c_sendstart(FAR struct s32k1xx_lpi2c_priv_s *priv,
+                          uint8_t address);
+static inline void
+  s32k1xx_lpi2c_sendstop(FAR struct s32k1xx_lpi2c_priv_s *priv);
+static inline uint32_t
+  s32k1xx_lpi2c_getstatus(FAR struct s32k1xx_lpi2c_priv_s *priv);
 
 static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s * priv);
 
@@ -389,8 +412,9 @@ static struct s32k1xx_lpi2c_priv_s s32k1xx_lpi2c1_priv =
  *
  ****************************************************************************/
 
-static inline uint32_t s32k1xx_lpi2c_getreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                          uint16_t offset)
+static inline uint32_t
+  s32k1xx_lpi2c_getreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
+                       uint16_t offset)
 {
   return getreg32(priv->config->base + offset);
 }
@@ -403,8 +427,9 @@ static inline uint32_t s32k1xx_lpi2c_getreg(FAR struct s32k1xx_lpi2c_priv_s *pri
  *
  ****************************************************************************/
 
-static inline void s32k1xx_lpi2c_putreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                      uint16_t offset, uint32_t value)
+static inline void
+  s32k1xx_lpi2c_putreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
+                       uint16_t offset, uint32_t value)
 {
   putreg32(value, priv->config->base + offset);
 }
@@ -417,9 +442,10 @@ static inline void s32k1xx_lpi2c_putreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
  *
  ****************************************************************************/
 
-static inline void s32k1xx_lpi2c_modifyreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                         uint16_t offset, uint32_t clearbits,
-                                         uint32_t setbits)
+static inline void
+  s32k1xx_lpi2c_modifyreg(FAR struct s32k1xx_lpi2c_priv_s *priv,
+                          uint16_t offset, uint32_t clearbits,
+                          uint32_t setbits)
 {
   modifyreg32(priv->config->base + offset, clearbits, setbits);
 }
@@ -428,13 +454,30 @@ static inline void s32k1xx_lpi2c_modifyreg(FAR struct s32k1xx_lpi2c_priv_s *priv
  * Name: s32k1xx_lpi2c_sem_wait
  *
  * Description:
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by
+ *   a signal.
+ *
+ ****************************************************************************/
+
+static inline int
+  s32k1xx_lpi2c_sem_wait(FAR struct s32k1xx_lpi2c_priv_s *priv)
+{
+  return nxsem_wait(&priv->sem_excl);
+}
+
+/****************************************************************************
+ * Name: s32k1xx_lpi2c_sem_wait_uninterruptible
+ *
+ * Description:
  *   Take the exclusive access, waiting as necessary
  *
  ****************************************************************************/
 
-static inline void s32k1xx_lpi2c_sem_wait(FAR struct s32k1xx_lpi2c_priv_s *priv)
+static int
+  s32k1xx_lpi2c_sem_wait_uninterruptible(
+    FAR struct s32k1xx_lpi2c_priv_s *priv)
 {
-  nxsem_wait_uninterruptible(&priv->sem_excl);
+  return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
 
 /****************************************************************************
@@ -476,7 +519,8 @@ static useconds_t s32k1xx_lpi2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs)
  ****************************************************************************/
 
 #ifndef CONFIG_I2C_POLLED
-static inline int s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *priv)
+static inline int
+  s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *priv)
 {
   struct timespec abstime;
   irqstate_t flags;
@@ -531,7 +575,9 @@ static inline int s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *pr
       /* Add a value proportional to the number of bytes in the transfer */
 
 #ifdef CONFIG_S32K1XX_I2C_DYNTIMEO
-      abstime.tv_nsec += 1000 * s32k1xx_lpi2c_tousecs(priv->msgc, priv->msgv);
+      abstime.tv_nsec +=
+        1000 * s32k1xx_lpi2c_tousecs(priv->msgc, priv->msgv);
+
       if (abstime.tv_nsec >= 1000 * 1000 * 1000)
         {
           abstime.tv_sec++;
@@ -588,7 +634,8 @@ static inline int s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *pr
   return ret;
 }
 #else
-static inline int s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *priv)
+static inline int
+  s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *priv)
 {
   clock_t timeout;
   clock_t start;
@@ -647,7 +694,8 @@ static inline int s32k1xx_lpi2c_sem_waitdone(FAR struct s32k1xx_lpi2c_priv_s *pr
  *
  ****************************************************************************/
 
-static inline void s32k1xx_lpi2c_sem_waitstop(FAR struct s32k1xx_lpi2c_priv_s *priv)
+static inline void
+  s32k1xx_lpi2c_sem_waitstop(FAR struct s32k1xx_lpi2c_priv_s *priv)
 {
   clock_t start;
   clock_t elapsed;
@@ -748,7 +796,8 @@ static inline void s32k1xx_lpi2c_sem_post(struct s32k1xx_lpi2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline void s32k1xx_lpi2c_sem_init(FAR struct s32k1xx_lpi2c_priv_s *priv)
+static inline void
+  s32k1xx_lpi2c_sem_init(FAR struct s32k1xx_lpi2c_priv_s *priv)
 {
   nxsem_init(&priv->sem_excl, 0, 1);
 
@@ -770,7 +819,8 @@ static inline void s32k1xx_lpi2c_sem_init(FAR struct s32k1xx_lpi2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline void s32k1xx_lpi2c_sem_destroy(FAR struct s32k1xx_lpi2c_priv_s *priv)
+static inline void
+  s32k1xx_lpi2c_sem_destroy(FAR struct s32k1xx_lpi2c_priv_s *priv)
 {
   nxsem_destroy(&priv->sem_excl);
 #ifndef CONFIG_I2C_POLLED
@@ -886,8 +936,10 @@ static void s32k1xx_lpi2c_tracedump(FAR struct s32k1xx_lpi2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %s(%2d) PARM: %08x TIME: %d\n",
-             i + 1, trace->status, trace->count, g_trace_names[trace->event],
+             "%2d. STATUS: %08x COUNT: %3d EVENT: %s(%2d) PARM: %08x "
+             "TIME: %d\n",
+             i + 1, trace->status, trace->count,
+             g_trace_names[trace->event],
              trace->event, trace->parm, trace->time - priv->start_time);
     }
 }
@@ -1090,8 +1142,9 @@ static void s32k1xx_lpi2c_setclock(FAR struct s32k1xx_lpi2c_priv_s *priv,
  *
  ****************************************************************************/
 
-static inline void s32k1xx_lpi2c_sendstart(FAR struct s32k1xx_lpi2c_priv_s *priv,
-                                         uint8_t address)
+static inline void
+  s32k1xx_lpi2c_sendstart(FAR struct s32k1xx_lpi2c_priv_s *priv,
+                          uint8_t address)
 {
   uint32_t txcount = 0;
   uint32_t status = 0;
@@ -1141,7 +1194,8 @@ static inline void s32k1xx_lpi2c_sendstart(FAR struct s32k1xx_lpi2c_priv_s *priv
  *
  ****************************************************************************/
 
-static inline void s32k1xx_lpi2c_sendstop(FAR struct s32k1xx_lpi2c_priv_s *priv)
+static inline void
+  s32k1xx_lpi2c_sendstop(FAR struct s32k1xx_lpi2c_priv_s *priv)
 {
   s32k1xx_lpi2c_putreg(priv, S32K1XX_LPI2C_MTDR_OFFSET, LPI2C_MTDR_CMD_STOP);
 }
@@ -1154,7 +1208,8 @@ static inline void s32k1xx_lpi2c_sendstop(FAR struct s32k1xx_lpi2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline uint32_t s32k1xx_lpi2c_getstatus(FAR struct s32k1xx_lpi2c_priv_s *priv)
+static inline uint32_t
+  s32k1xx_lpi2c_getstatus(FAR struct s32k1xx_lpi2c_priv_s *priv)
 {
   return s32k1xx_lpi2c_getreg(priv, S32K1XX_LPI2C_MSR_OFFSET);
 }
@@ -1185,7 +1240,8 @@ static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s *priv)
 
   /* Check if there is more bytes to send */
 
-  else if (((priv->flags & I2C_M_READ) == 0) && (status & LPI2C_MSR_TDF) != 0)
+  else if (((priv->flags & I2C_M_READ) == 0) &&
+           (status & LPI2C_MSR_TDF) != 0)
     {
       if (priv->dcnt > 0)
         {
@@ -1204,7 +1260,8 @@ static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s *priv)
 
   /* Check if there is more bytes to read */
 
-  else if (((priv->flags & I2C_M_READ) != 0) && (status & LPI2C_MSR_RDF) != 0)
+  else if (((priv->flags & I2C_M_READ) != 0) &&
+           (status & LPI2C_MSR_RDF) != 0)
     {
       /* Read a byte, if dcnt goes < 0, then read dummy bytes to ack ISRs */
 
@@ -1222,8 +1279,10 @@ static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s *priv)
 
           /* Receive a byte */
 
-          *priv->ptr++ = s32k1xx_lpi2c_getreg(priv, S32K1XX_LPI2C_MRDR_OFFSET) &
-                         LPI2C_MRDR_DATA_MASK;
+          *priv->ptr++ =
+            s32k1xx_lpi2c_getreg(priv, S32K1XX_LPI2C_MRDR_OFFSET) &
+            LPI2C_MRDR_DATA_MASK;
+
           priv->dcnt--;
 
 #ifdef CONFIG_I2C_POLLED
@@ -1516,13 +1575,17 @@ static int s32k1xx_lpi2c_transfer(FAR struct i2c_master_s *dev,
                                 FAR struct i2c_msg_s *msgs, int count)
 {
   FAR struct s32k1xx_lpi2c_priv_s *priv = (struct s32k1xx_lpi2c_priv_s *)dev;
-  int ret = 0;
+  int ret;
 
   DEBUGASSERT(count > 0);
 
   /* Ensure that address or flags don't change meanwhile */
 
-  s32k1xx_lpi2c_sem_wait(priv);
+  ret = s32k1xx_lpi2c_sem_wait(priv);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Clear any pending error interrupts */
 
@@ -1625,13 +1688,14 @@ static int s32k1xx_lpi2c_transfer(FAR struct i2c_master_s *dev,
 #ifdef CONFIG_I2C_RESET
 static int s32k1xx_lpi2c_reset(FAR struct i2c_master_s *dev)
 {
-  FAR struct s32k1xx_lpi2c_priv_s *priv = (FAR struct s32k1xx_lpi2c_priv_s *)dev;
+  FAR struct s32k1xx_lpi2c_priv_s *priv =
+    (FAR struct s32k1xx_lpi2c_priv_s *)dev;
   unsigned int clock_count;
   unsigned int stretch_count;
   uint32_t scl_gpio;
   uint32_t sda_gpio;
   uint32_t frequency;
-  int ret = ERROR;
+  int ret;
 
   DEBUGASSERT(dev);
 
@@ -1641,7 +1705,13 @@ static int s32k1xx_lpi2c_reset(FAR struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  s32k1xx_lpi2c_sem_wait(priv);
+  ret = s32k1xx_lpi2c_sem_wait_uninterruptible(priv);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = -EIO;
 
   /* Save the current frequency */
 

--- a/arch/arm/src/samd2l2/sam_i2c_master.c
+++ b/arch/arm/src/samd2l2/sam_i2c_master.c
@@ -163,12 +163,12 @@ struct i2c_attr_s
 
 struct sam_i2c_dev_s
 {
-  struct i2c_master_s dev;    /* I2C master device */
-  const struct i2c_attr_s *attr;  /* Invariant attributes of I2C device */
-  struct i2c_msg_s *msg;      /* Current message being processed */
-  uint32_t frequency;         /* I2C transfer clock frequency */
-  uint16_t flags;             /* Transfer flags */
-  uint16_t nextflags;         /* Next message flags */
+  struct i2c_master_s dev;       /* I2C master device */
+  const struct i2c_attr_s *attr; /* Invariant attributes of I2C device */
+  struct i2c_msg_s *msg;         /* Current message being processed */
+  uint32_t frequency;            /* I2C transfer clock frequency */
+  uint16_t flags;                /* Transfer flags */
+  uint16_t nextflags;            /* Next message flags */
 
   sem_t exclsem;              /* Only one thread can access at a time */
   sem_t waitsem;              /* Wait for I2C transfer completion */
@@ -201,7 +201,8 @@ static uint32_t i2c_getreg32(struct sam_i2c_dev_s *priv, unsigned int offset);
 static void i2c_putreg32(struct sam_i2c_dev_s *priv, uint32_t regval,
                          unsigned int offset);
 
-static void i2c_takesem(sem_t * sem);
+static int i2c_takesem(sem_t * sem);
+static int i2c_takesem_uninterruptible(sem_t * sem);
 #define i2c_givesem(sem) (nxsem_post(sem))
 
 #ifdef CONFIG_SAM_I2C_REGDEBUG
@@ -363,7 +364,7 @@ struct i2c_ops_s g_i2cops =
 };
 
 /*******************************************************************************
- * Low-level Helpers
+ * Private Functions
  *******************************************************************************/
 
 /*******************************************************************************
@@ -451,8 +452,7 @@ static void i2c_putreg32(struct sam_i2c_dev_s *priv, uint32_t regval,
  * Name: i2c_takesem
  *
  * Description:
- *   Take the wait semaphore (handling false alarm wake-ups due to the receipt
- *   of signals).
+ *   Take the wait semaphore.  May be interrupted by a signal.
  *
  * Input Parameters:
  *   dev - Instance of the SDIO device driver state structure.
@@ -462,9 +462,29 @@ static void i2c_putreg32(struct sam_i2c_dev_s *priv, uint32_t regval,
  *
  *******************************************************************************/
 
-static void i2c_takesem(sem_t *sem)
+static int i2c_takesem(sem_t *sem)
 {
-  nxsem_wait_uninterruptible(sem);
+  return nxsem_wait(sem);
+}
+
+/*******************************************************************************
+ * Name: i2c_takesem_uninterruptible
+ *
+ * Description:
+ *   Take the wait semaphore (handling false alarm wake-ups due to the receipt
+ *   of signals).  May be interrupted by a signal.
+ *
+ * Input Parameters:
+ *   dev - Instance of the SDIO device driver state structure.
+ *
+ * Returned Value:
+ *   None
+ *
+ *******************************************************************************/
+
+static int i2c_takesem_uninterruptible(sem_t *sem)
+{
+  return nxsem_wait_uninterruptible(sem);
 }
 
 /*******************************************************************************
@@ -703,6 +723,7 @@ static int i2c_interrupt(int irq, FAR void *context, FAR void *arg)
           i2c_wait_synchronization(priv);
 
           /* STOP */
+
           if ((priv->nextflags & I2C_M_NOSTART) == 0)
             {
               regval  = i2c_getreg32(priv, SAM_I2C_CTRLB_OFFSET);
@@ -737,7 +758,6 @@ static int i2c_interrupt(int irq, FAR void *context, FAR void *arg)
           /* Cancel timeout */
 
           i2c_wakeup(priv, OK);
-          // i2cinfo("Got data = 0x%02X\n", msg->buffer[0]);
         }
 
       i2c_putreg8(priv, I2C_INT_SB, SAM_I2C_INTFLAG_OFFSET);
@@ -941,7 +961,7 @@ static int sam_i2c_transfer(FAR struct i2c_master_s *dev,
   irqstate_t flags;
   unsigned int size;
   int i;
-  int ret = -EBUSY;
+  int ret;
 
   DEBUGASSERT(dev != NULL && msgs != NULL && count > 0);
 
@@ -970,9 +990,15 @@ static int sam_i2c_transfer(FAR struct i2c_master_s *dev,
 
   /* Get exclusive access to the device */
 
-  i2c_takesem(&priv->exclsem);
+  ret = i2c_takesem(&priv->exclsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Initiate the message transfer */
+
+  ret = -BUSY;
 
   /* Initiate the transfer.  The rest will be handled from interrupt logic.
    * Interrupts must be disabled to prevent re-entrance from the interrupt
@@ -1039,8 +1065,6 @@ static uint32_t sam_i2c_setfrequency(struct sam_i2c_dev_s *priv,
   uint32_t baud = 0;
   uint32_t baud_hs = 0;
   uint32_t ctrla;
-
-  // i2cinfo("sercom=%d frequency=%d\n", priv->attr->sercom, frequency);
 
   /* Check if the configured BAUD is within the valid range */
 
@@ -1429,7 +1453,11 @@ int sam_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Get exclusive access to the I2C device */
 
-  i2c_takesem(&priv->exclsem);
+  ret = i2c_takesem_uninterruptible(&priv->exclsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Disable I2C interrupts */
 

--- a/arch/arm/src/samd5e5/sam_i2c_master.c
+++ b/arch/arm/src/samd5e5/sam_i2c_master.c
@@ -151,12 +151,12 @@ struct i2c_attr_s
 
 struct sam_i2c_dev_s
 {
-  struct i2c_master_s dev;    /* I2C master device */
-  const struct i2c_attr_s *attr;  /* Invariant attributes of I2C device */
-  struct i2c_msg_s *msg;      /* Current message being processed */
-  uint32_t frequency;         /* I2C transfer clock frequency */
-  uint16_t flags;             /* Transfer flags */
-  uint16_t nextflags;         /* Next message flags */
+  struct i2c_master_s dev;       /* I2C master device */
+  const struct i2c_attr_s *attr; /* Invariant attributes of I2C device */
+  struct i2c_msg_s *msg;         /* Current message being processed */
+  uint32_t frequency;            /* I2C transfer clock frequency */
+  uint16_t flags;                /* Transfer flags */
+  uint16_t nextflags;            /* Next message flags */
 
   sem_t exclsem;              /* Only one thread can access at a time */
   sem_t waitsem;              /* Wait for I2C transfer completion */
@@ -189,7 +189,8 @@ static uint32_t i2c_getreg32(struct sam_i2c_dev_s *priv, unsigned int offset);
 static void i2c_putreg32(struct sam_i2c_dev_s *priv, uint32_t regval,
                          unsigned int offset);
 
-static void i2c_takesem(sem_t * sem);
+static int i2c_takesem(sem_t * sem);
+static int i2c_takesem_uninterruptible(sem_t * sem);
 #define i2c_givesem(sem) (nxsem_post(sem))
 
 #ifdef CONFIG_SAM_I2C_REGDEBUG
@@ -476,6 +477,25 @@ static void i2c_putreg32(struct sam_i2c_dev_s *priv, uint32_t regval,
  * Name: i2c_takesem
  *
  * Description:
+ *   Take the wait semaphore.  May be interrupted by a signal.
+ *
+ * Input Parameters:
+ *   dev - Instance of the SDIO device driver state structure.
+ *
+ * Returned Value:
+ *   None
+ *
+ *******************************************************************************/
+
+static int i2c_takesem(sem_t *sem)
+{
+  return nxsem_wait(sem);
+}
+
+/*******************************************************************************
+ * Name: i2c_takesem_uninterruptible
+ *
+ * Description:
  *   Take the wait semaphore (handling false alarm wake-ups due to the receipt
  *   of signals).
  *
@@ -487,9 +507,9 @@ static void i2c_putreg32(struct sam_i2c_dev_s *priv, uint32_t regval,
  *
  *******************************************************************************/
 
-static void i2c_takesem(sem_t *sem)
+static int i2c_takesem_uninterruptible(sem_t *sem)
 {
-  nxsem_wait_uninterruptible(sem);
+  return nxsem_wait_uninterruptible(sem);
 }
 
 /*******************************************************************************
@@ -719,6 +739,7 @@ static int i2c_interrupt(int irq, FAR void *context, FAR void *arg)
           i2c_wait_synchronization(priv);
 
           /* STOP */
+
           if ((priv->nextflags & I2C_M_NOSTART) == 0)
             {
               regval  = i2c_getreg32(priv, SAM_I2C_CTRLB_OFFSET);
@@ -753,7 +774,6 @@ static int i2c_interrupt(int irq, FAR void *context, FAR void *arg)
           /* Cancel timeout */
 
           i2c_wakeup(priv, OK);
-          // i2cinfo("Got data = 0x%02X\n", msg->buffer[0]);
         }
 
       i2c_putreg8(priv, I2C_INT_SB, SAM_I2C_INTFLAG_OFFSET);
@@ -957,7 +977,7 @@ static int sam_i2c_transfer(FAR struct i2c_master_s *dev,
   irqstate_t flags;
   unsigned int size;
   int i;
-  int ret = -EBUSY;
+  int ret;
 
   DEBUGASSERT(dev != NULL && msgs != NULL && count > 0);
 
@@ -986,9 +1006,15 @@ static int sam_i2c_transfer(FAR struct i2c_master_s *dev,
 
   /* Get exclusive access to the device */
 
-  i2c_takesem(&priv->exclsem);
+  ret = i2c_takesem(&priv->exclsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Initiate the message transfer */
+
+  ret = -EBUSY;
 
   /* Initiate the transfer.  The rest will be handled from interrupt logic.
    * Interrupts must be disabled to prevent re-entrance from the interrupt
@@ -1051,8 +1077,6 @@ static uint32_t sam_i2c_setfrequency(struct sam_i2c_dev_s *priv,
   uint32_t baud = 0;
   uint32_t baud_hs = 0;
   uint32_t ctrla;
-
-  // i2cinfo("sercom=%d frequency=%d\n", priv->attr->sercom, frequency);
 
   /* Check if the configured BAUD is within the valid range */
 
@@ -1168,7 +1192,8 @@ static void i2c_hw_initialize(struct sam_i2c_dev_s *priv, uint32_t frequency)
   regval = i2c_getreg32(priv, SAM_I2C_CTRLA_OFFSET);
   if (regval & I2C_CTRLA_ENABLE)
     {
-      i2cerr("ERROR: Cannot initialize I2C because it is already initialized!\n");
+      i2cerr("ERROR: Cannot initialize I2C "
+             "because it is already initialized!\n");
       return;
     }
 
@@ -1467,7 +1492,11 @@ int sam_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Get exclusive access to the I2C device */
 
-  i2c_takesem(&priv->exclsem);
+  ret = i2c_takesem_uninterruptible(&priv->exclsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Disable I2C interrupts */
 

--- a/arch/arm/src/stm32/stm32f40xxx_i2c.c
+++ b/arch/arm/src/stm32/stm32f40xxx_i2c.c
@@ -100,8 +100,9 @@
 #if defined(CONFIG_STM32_I2C1) || defined(CONFIG_STM32_I2C2) || \
     defined(CONFIG_STM32_I2C3)
 
-/* This implementation is for the STM32 F1, F2, and F4 only */
-/* Experimentally enabled for STM32L15XX */
+/* This implementation is for the STM32 F1, F2, and F4 only.
+ * Experimentally enabled for STM32L15XX.
+ */
 
 #if defined(CONFIG_STM32_STM32L15XX) || defined(CONFIG_STM32_STM32F10XX) || \
     defined(CONFIG_STM32_STM32F20XX) || defined(CONFIG_STM32_STM32F4XXX)
@@ -109,7 +110,9 @@
 /************************************************************************************
  * Pre-processor Definitions
  ************************************************************************************/
+
 /* Configuration ********************************************************************/
+
 /* CONFIG_I2C_POLLED may be set so that I2C interrupts will not be used.  Instead,
  * CPU-intensive polling will be used.
  */
@@ -197,6 +200,7 @@
 /************************************************************************************
  * Private Types
  ************************************************************************************/
+
 /* Interrupt state */
 
 enum stm32_intstate_e
@@ -253,8 +257,14 @@ struct stm32_i2c_config_s
 
 struct stm32_i2c_priv_s
 {
-  const struct i2c_ops_s *ops; /* Standard I2C operations */
-  const struct stm32_i2c_config_s *config; /* Port configuration */
+  /* Standard I2C operations */
+
+  const struct i2c_ops_s *ops;
+
+  /* Port configuration */
+
+  const struct stm32_i2c_config_s *config;
+
   int refs;                    /* Referernce count */
   sem_t sem_excl;              /* Mutual exclusion semaphore */
 #ifndef CONFIG_I2C_POLLED
@@ -268,7 +278,7 @@ struct stm32_i2c_priv_s
   uint32_t frequency;          /* Current I2C frequency */
   volatile int dcnt;           /* Current message length */
   uint16_t flags;              /* Current message flags */
-  bool check_addr_ACK;         /* Flag to signal if on next interrupt address has ACKed */
+  bool check_addr_ack;         /* Flag to signal if on next interrupt address has ACKed */
 
   /* I2C trace support */
 
@@ -299,12 +309,13 @@ struct stm32_i2c_priv_s
 
 static inline uint16_t stm32_i2c_getreg(FAR struct stm32_i2c_priv_s *priv,
                                         uint8_t offset);
-static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint16_t value);
+static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv,
+                                    uint8_t offset, uint16_t value);
 static inline void stm32_i2c_modifyreg(FAR struct stm32_i2c_priv_s *priv,
                                        uint8_t offset, uint16_t clearbits,
                                        uint16_t setbits);
-static inline void stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv);
+static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv);
+static int stm32_i2c_sem_wait_uninterruptible(FAR struct stm32_i2c_priv_s *priv);
 
 #ifdef CONFIG_STM32_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
@@ -344,8 +355,8 @@ static int stm32_i2c_isr(int irq, void *context, FAR void *arg);
 
 static int stm32_i2c_init(FAR struct stm32_i2c_priv_s *priv);
 static int stm32_i2c_deinit(FAR struct stm32_i2c_priv_s *priv);
-static int stm32_i2c_transfer(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                              int count);
+static int stm32_i2c_transfer(FAR struct i2c_master_s *dev,
+                              FAR struct i2c_msg_s *msgs, int count);
 #ifdef CONFIG_I2C_RESET
 static int stm32_i2c_reset(FAR struct i2c_master_s *dev);
 #endif
@@ -528,8 +539,8 @@ static inline uint16_t stm32_i2c_getreg(FAR struct stm32_i2c_priv_s *priv,
  *
  ************************************************************************************/
 
-static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint16_t value)
+static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv,
+                                    uint8_t offset, uint16_t value)
 {
   putreg16(value, priv->config->base + offset);
 }
@@ -553,13 +564,28 @@ static inline void stm32_i2c_modifyreg(FAR struct stm32_i2c_priv_s *priv,
  * Name: stm32_i2c_sem_wait
  *
  * Description:
- *   Take the exclusive access, waiting as necessary
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by a
+ *   signal.
  *
  ************************************************************************************/
 
-static inline void stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv)
+static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv)
 {
-  nxsem_wait_uninterruptible(&priv->sem_excl);
+  return nxsem_wait(&priv->sem_excl);
+}
+
+/************************************************************************************
+ * Name: stm32_i2c_sem_wait_uninterruptible
+ *
+ * Description:
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by a
+ *   signal.
+ *
+ ************************************************************************************/
+
+static int stm32_i2c_sem_wait_uninterruptible(FAR struct stm32_i2c_priv_s *priv)
+{
+  return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
 
 /************************************************************************************
@@ -786,7 +812,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
         {
           return;
         }
-
     }
 
   /* Loop until the stop is complete or a timeout occurs. */
@@ -894,7 +919,7 @@ static void stm32_i2c_tracenew(FAR struct stm32_i2c_priv_s *priv, uint32_t statu
         {
           /* Yes.. bump up the trace index (unless we are out of trace entries) */
 
-          if (priv->tndx >= (CONFIG_I2C_NTRACE-1))
+          if (priv->tndx >= (CONFIG_I2C_NTRACE - 1))
             {
               i2cerr("ERROR: Trace table overflow\n");
               return;
@@ -935,7 +960,7 @@ static void stm32_i2c_traceevent(FAR struct stm32_i2c_priv_s *priv,
 
       /* Bump up the trace index (unless we are out of trace entries) */
 
-      if (priv->tndx >= (CONFIG_I2C_NTRACE-1))
+      if (priv->tndx >= (CONFIG_I2C_NTRACE - 1))
         {
           i2cerr("ERROR: Trace table overflow\n");
           return;
@@ -959,7 +984,7 @@ static void stm32_i2c_tracedump(FAR struct stm32_i2c_priv_s *priv)
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
              "%2d. STATUS: %08x COUNT: %3d EVENT: %s(%2d) PARM: %08x TIME: %d\n",
-             i+1, trace->status, trace->count, g_trace_names[trace->event],
+             i + 1, trace->status, trace->count, g_trace_names[trace->event],
              trace->event, trace->parm, trace->time - priv->start_time);
     }
 }
@@ -1289,18 +1314,20 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
   if (priv->dcnt == -1 && priv->msgc > 0)
     {
-     /* Any new message should begin with "Start" condition
-      * However there were 2 situations where that was not true
-      * Situation 1: Next message continue transmission sequence of previous message
-      *
-      * Situation 2: If an error is injected that looks like a STOP the
-      * interrupt will be reentered with some status that will be incorrect. This
-      * will ensure that the error handler will clear the interrupt enables and
-      * return the error to the waiting task.
-      */
+      /* Any new message should begin with "Start" condition
+       * However there were 2 situations where that was not true
+       * Situation 1: Next message continue transmission sequence of previous message
+       *
+       * Situation 2: If an error is injected that looks like a STOP the
+       * interrupt will be reentered with some status that will be incorrect. This
+       * will ensure that the error handler will clear the interrupt enables and
+       * return the error to the waiting task.
+       */
 
-      if (((priv->msgv[0].flags & I2C_M_NOSTART) != 0 && (status & I2C_SR1_TXE) == 0) ||
-          ((priv->msgv[0].flags & I2C_M_NOSTART) == 0 && (status & I2C_SR1_SB) == 0))
+      if (((priv->msgv[0].flags & I2C_M_NOSTART) != 0 &&
+           (status & I2C_SR1_TXE) == 0) ||
+          ((priv->msgv[0].flags & I2C_M_NOSTART) == 0 &&
+           (status & I2C_SR1_SB) == 0))
         {
 #if defined(CONFIG_STM32_I2C_DMA) || defined(CONFIG_I2C_POLLED)
           return OK;
@@ -1392,14 +1419,15 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
           stm32_i2c_putreg(priv, STM32_I2C_DR_OFFSET,
                            (priv->flags & I2C_M_TEN) ?
-                           0 :((priv->msgv->addr << 1) | (priv->flags & I2C_M_READ)));
+                           0 : ((priv->msgv->addr << 1) |
+                           (priv->flags & I2C_M_READ)));
 
           i2cinfo("Address sent. Addr=%#02x Write/Read bit=%i\n",
                   priv->msgv->addr, (priv->flags & I2C_M_READ));
 
           /* Flag that address has just been sent */
 
-          priv->check_addr_ACK = true;
+          priv->check_addr_ack = true;
 
           stm32_i2c_traceevent(priv, I2CEVENT_SENDADDR, priv->msgv->addr);
         }
@@ -1407,7 +1435,8 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
         {
           /* TODO: untested!! */
 
-          i2cwarn(" An empty message has been detected, ignoring and passing to next message.\n");
+          i2cwarn(" An empty message has been detected, "
+                  "ignoring and passing to next message.\n");
 
           /* Trace event */
 
@@ -1432,7 +1461,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
    * received the address is valid and transmission can continue.
    */
 
-  /* Check for NACK after an address*/
+  /* Check for NACK after an address */
 
 #ifndef CONFIG_I2C_POLLED
   /* When polling the i2c ISR it's not possible to determine when
@@ -1453,7 +1482,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
    * Note: this commentary is found in both places.
    */
 
-  else if ((status & I2C_SR1_ADDR) == 0 && priv->check_addr_ACK)
+  else if ((status & I2C_SR1_ADDR) == 0 && priv->check_addr_ack)
     {
       i2cinfo("Invalid Address. Setting stop bit and clearing message\n");
       i2cinfo("status %i\n", status);
@@ -1467,7 +1496,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
       /* Reset flag to check for valid address */
 
-      priv->check_addr_ACK = false;
+      priv->check_addr_ack = false;
 
       /* Send stop bit to clear bus */
 
@@ -1479,14 +1508,14 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
     }
 #endif
 
-    /* ACK in read mode, ACK in write mode is handled separately */
+  /* ACK in read mode, ACK in write mode is handled separately */
 
   else if ((priv->flags & I2C_M_READ) != 0 && (status & I2C_SR1_ADDR) != 0 &&
-           priv->check_addr_ACK)
+           priv->check_addr_ack)
     {
       /* Reset check addr flag as we are handling this event */
 
-      priv->check_addr_ACK = false;
+      priv->check_addr_ack = false;
 
       /* Note:
        *
@@ -1584,13 +1613,14 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
            * The DMAEN bit must be set in the I2C_CR2 register before the ADDR event.
            */
 
-          stm32_dmasetup(priv->rxdma, priv->config->base+STM32_I2C_DR_OFFSET,
-            (uint32_t) priv->ptr, priv->dcnt,
-            DMA_SCR_DIR_P2M |
-            DMA_SCR_MSIZE_8BITS |
-            DMA_SCR_PSIZE_8BITS |
-            DMA_SCR_MINC |
-            I2C_DMA_PRIO);
+          stm32_dmasetup(priv->rxdma,
+                         priv->config->base + STM32_I2C_DR_OFFSET,
+                         (uint32_t)priv->ptr, priv->dcnt,
+                         DMA_SCR_DIR_P2M |
+                         DMA_SCR_MSIZE_8BITS |
+                         DMA_SCR_PSIZE_8BITS |
+                         DMA_SCR_MINC |
+                         I2C_DMA_PRIO);
 
           /* Do not enable the ITBUFEN bit in the I2C_CR2 register if DMA is
            * used.
@@ -1702,7 +1732,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
       /* Address has cleared so don't check on next call */
 
-      priv->check_addr_ACK = false;
+      priv->check_addr_ack = false;
 
       /* Check if we have transmitted the whole message or we are after
        * the last byte where the stop condition or else(according to the
@@ -1723,13 +1753,14 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
            * before the ADDR event.
            */
 
-          stm32_dmasetup(priv->txdma, priv->config->base+STM32_I2C_DR_OFFSET,
+          stm32_dmasetup(priv->txdma,
+                         priv->config->base + STM32_I2C_DR_OFFSET,
                          (uint32_t) priv->ptr, priv->dcnt,
                          DMA_SCR_DIR_M2P |
                          DMA_SCR_MSIZE_8BITS |
                          DMA_SCR_PSIZE_8BITS |
                          DMA_SCR_MINC |
-                         I2C_DMA_PRIO );
+                         I2C_DMA_PRIO);
 
           /* Do not enable the ITBUFEN bit in the I2C_CR2 register if DMA is
            * used.
@@ -1796,12 +1827,13 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
               stm32_i2c_modifyreg(priv, STM32_I2C_CR2_OFFSET, 0, I2C_CR2_ITBUFEN);
             }
 #endif
+
           if (priv->dcnt == 0 &&
               priv->msgc > 0 && (priv->msgv->flags & I2C_M_NOSTART) != 0)
             {
               /* Set condition to get to next message */
 
-              priv->dcnt =- 1;
+              priv->dcnt = -1;
               stm32_i2c_traceevent(priv, I2CEVENT_WRITE_NO_RESTART, priv->dcnt);
             }
         }
@@ -1839,7 +1871,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
            (status & (I2C_SR1_RXNE | I2C_SR1_BTF)) != 0)
     {
       /* When read flag is set and the receive buffer is not empty
-       *(RXNE is set) then the driver can read from the data register.
+       * (RXNE is set) then the driver can read from the data register.
        */
 
       status |= (stm32_i2c_getreg(priv, STM32_I2C_SR2_OFFSET) << 16);
@@ -1924,7 +1956,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
    * device wasn't ready yet.
    */
 
-   else
+  else
     {
 #ifdef CONFIG_I2C_POLLED
       stm32_i2c_traceevent(priv, I2CEVENT_POLL_DEV_NOT_RDY, 0);
@@ -2034,13 +2066,13 @@ static int stm32_i2c_isr(int irq, void *context, FAR void *arg)
 }
 #endif
 
-/*****************************************************************************
+/************************************************************************************
  * Name: stm32_i2c_dmarxcallback
  *
  * Description:
  *   Called when the RX DMA completes
  *
- *****************************************************************************/
+ ************************************************************************************/
 
 #ifdef CONFIG_STM32_I2C_DMA
 static void stm32_i2c_dmarxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
@@ -2088,13 +2120,13 @@ static void stm32_i2c_dmarxcallback(DMA_HANDLE handle, uint8_t status, void *arg
 }
 #endif /* ifdef CONFIG_STM32_I2C_DMA */
 
-/*****************************************************************************
+/************************************************************************************
  * Name: stm32_i2c_dmarxcallback
  *
  * Description:
  *   Called when the RX DMA completes
  *
- *****************************************************************************/
+ ************************************************************************************/
 
 #ifdef CONFIG_STM32_I2C_DMA
 static void stm32_i2c_dmatxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
@@ -2244,21 +2276,28 @@ static int stm32_i2c_deinit(FAR struct stm32_i2c_priv_s *priv)
  *
  ************************************************************************************/
 
-static int stm32_i2c_transfer(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                              int count)
+static int stm32_i2c_transfer(FAR struct i2c_master_s *dev,
+                              FAR struct i2c_msg_s *msgs, int count)
 {
   FAR struct stm32_i2c_priv_s *priv = (struct stm32_i2c_priv_s *)dev;
   uint32_t status = 0;
 #ifdef I2C1_FSMC_CONFLICT
   uint32_t ahbenr;
 #endif
-  int ret = 0;
+  int ret;
 
   DEBUGASSERT(count);
-  stm32_i2c_sem_wait(priv);   /* Ensure that address or flags don't change meanwhile */
+
+  /* Ensure that address or flags don't change meanwhile */
+
+  ret = stm32_i2c_sem_wait(priv);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
 #ifdef CONFIG_STM32_I2C_DMA
-  /* stop DMA just in case */
+  /* Stop DMA just in case */
 
   stm32_i2c_modifyreg(priv, STM32_I2C_CR2_OFFSET, I2C_CR2_DMAEN, 0);
   stm32_dmastop(priv->rxdma);
@@ -2472,7 +2511,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s *dev)
   uint32_t scl_gpio;
   uint32_t sda_gpio;
   uint32_t frequency;
-  int ret = ERROR;
+  int ret;
 
   DEBUGASSERT(dev);
 
@@ -2482,7 +2521,13 @@ static int stm32_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  stm32_i2c_sem_wait(priv);
+  ret = stm32_i2c_sem_wait_uninterruptible(priv);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = -EIO;
 
   /* Save the current frequency */
 
@@ -2642,17 +2687,18 @@ FAR struct i2c_master_s *stm32_i2cbus_initialize(int port)
       stm32_i2c_init(priv);
 
 #ifdef CONFIG_STM32_I2C_DMA
-  /* Get DMA channels.  NOTE: stm32_dmachannel() will always assign the DMA channel.
-   * if the channel is not available, then stm32_dmachannel() will block and wait
-   * until the channel becomes available.  WARNING: If you have another device sharing
-   * a DMA channel with SPI and the code never releases that channel, then the call
-   * to stm32_dmachannel()  will hang forever in this function!  Don't let your
-   * design do that!
-   */
+      /* Get DMA channels.  NOTE: stm32_dmachannel() will always assign the DMA
+       * channel.  If the channel is not available, then stm32_dmachannel() will
+       * block and wait until the channel becomes available.  WARNING: If you
+       * have another device sharing a DMA channel with SPI and the code never
+       * releases that channel, then the call to stm32_dmachannel()  will hang
+       * forever in this function!  Don't let your design do that!
+       */
+
       priv->rxdma = stm32_dmachannel(priv->rxch);
       priv->txdma = stm32_dmachannel(priv->txch);
       DEBUGASSERT(priv->rxdma && priv->txdma);
-#endif /* #ifdef CONFIG_STM32_I2C_DMA */
+#endif /* CONFIG_STM32_I2C_DMA */
     }
 
   leave_critical_section(flags);

--- a/arch/arm/src/stm32f0l0g0/stm32_i2c.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_i2c.c
@@ -163,16 +163,19 @@
  *    CONFIG_STM32F0L0G0_I2C3
  *    CONFIG_STM32F0L0G0_I2C4
  *
- *  To configure the ISR timeout using fixed values (CONFIG_STM32F0L0G0_I2C_DYNTIMEO=n):
+ *  To configure the ISR timeout using fixed values
+ *  (CONFIG_STM32F0L0G0_I2C_DYNTIMEO=n):
  *
  *    CONFIG_STM32F0L0G0_I2CTIMEOSEC   (Timeout in seconds)
  *    CONFIG_STM32F0L0G0_I2CTIMEOMS    (Timeout in milliseconds)
  *    CONFIG_STM32F0L0G0_I2CTIMEOTICKS (Timeout in ticks)
  *
- *  To configure the ISR timeout using dynamic values (CONFIG_STM32F0L0G0_I2C_DYNTIMEO=y):
+ *  To configure the ISR timeout using dynamic values
+ *  (CONFIG_STM32F0L0G0_I2C_DYNTIMEO=y):
  *
  *    CONFIG_STM32F0L0G0_I2C_DYNTIMEO_USECPERBYTE  (Timeout in microseconds per byte)
- *    CONFIG_STM32F0L0G0_I2C_DYNTIMEO_STARTSTOP    (Timeout for start/stop in milliseconds)
+ *    CONFIG_STM32F0L0G0_I2C_DYNTIMEO_STARTSTOP    (Timeout for start/stop in
+ *                                                  milliseconds)
  *
  *  Debugging output enabled with:
  *
@@ -292,7 +295,7 @@
 
 /* Unused bit in I2c_ISR used to communicate a bad state has occurred in
  * the isr processing
-*/
+ */
 
 #define I2C_INT_BAD_STATE 0x8000000
 
@@ -388,8 +391,12 @@ struct stm32_i2c_config_s
 
 struct stm32_i2c_priv_s
 {
-  const struct stm32_i2c_config_s *config; /* Port configuration */
+  /* Port configuration */
+
+  const struct stm32_i2c_config_s *config;
+
   int refs;                    /* Reference count */
+
   sem_t sem_excl;              /* Mutual exclusion semaphore */
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
@@ -436,14 +443,15 @@ struct stm32_i2c_inst_s
 
 static inline uint16_t stm32_i2c_getreg(FAR struct stm32_i2c_priv_s *priv,
                                         uint8_t offset);
-static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint16_t value);
-static inline void stm32_i2c_putreg32(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint32_t value);
+static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv,
+                                    uint8_t offset, uint16_t value);
+static inline void stm32_i2c_putreg32(FAR struct stm32_i2c_priv_s *priv,
+                                      uint8_t offset, uint32_t value);
 static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits);
-static inline void stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
+static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
+static int stm32_i2c_sem_wait_uninterruptble(FAR struct i2c_master_s *dev);
 #ifdef CONFIG_STM32F0L0G0_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
 #endif /* CONFIG_STM32F0L0G0_I2C_DYNTIMEO */
@@ -471,10 +479,10 @@ static int stm32_i2c_isr(int irq, void *context, FAR void *arg);
 static int stm32_i2c_init(FAR struct stm32_i2c_priv_s *priv);
 static int stm32_i2c_deinit(FAR struct stm32_i2c_priv_s *priv);
 
-static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                             int count);
-static int stm32_i2c_transfer(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                              int count);
+static int stm32_i2c_process(FAR struct i2c_master_s *dev,
+                             FAR struct i2c_msg_s *msgs, int count);
+static int stm32_i2c_transfer(FAR struct i2c_master_s *dev,
+                              FAR struct i2c_msg_s *msgs, int count);
 #ifdef CONFIG_I2C_RESET
 static int stm32_i2c_reset(FAR struct i2c_master_s * dev);
 #endif
@@ -661,8 +669,8 @@ static inline uint32_t stm32_i2c_getreg32(FAR struct stm32_i2c_priv_s *priv,
  *
  ************************************************************************************/
 
-static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint16_t value)
+static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv,
+                                    uint8_t offset, uint16_t value)
 {
   putreg16(value, priv->config->base + offset);
 }
@@ -680,7 +688,6 @@ static inline void stm32_i2c_putreg32(FAR struct stm32_i2c_priv_s *priv,
 {
   putreg32(value, priv->config->base + offset);
 }
-
 
 /************************************************************************************
  * Name: stm32_i2c_modifyreg32
@@ -701,13 +708,28 @@ static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
  * Name: stm32_i2c_sem_wait
  *
  * Description:
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by a
+ *   signal.
+ *
+ ************************************************************************************/
+
+static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
+{
+  return nxsem_wait(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
+}
+
+/************************************************************************************
+ * Name: stm32_i2c_sem_wait_uninterruptble
+ *
+ * Description:
  *   Take the exclusive access, waiting as necessary
  *
  ************************************************************************************/
 
-static inline void stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
+static int stm32_i2c_sem_wait_uninterruptble(FAR struct i2c_master_s *dev)
 {
-  nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
+  return
+    nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
 }
 
 /************************************************************************************
@@ -750,7 +772,8 @@ static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs)
 #ifndef CONFIG_I2C_POLLED
 static inline void stm32_i2c_enableinterrupts(struct stm32_i2c_priv_s *priv)
 {
-    stm32_i2c_modifyreg32(priv, STM32_I2C_CR1_OFFSET, 0, (I2C_CR1_TXRX | I2C_CR1_NACKIE));
+    stm32_i2c_modifyreg32(priv, STM32_I2C_CR1_OFFSET, 0,
+                          (I2C_CR1_TXRX | I2C_CR1_NACKIE));
 }
 #endif
 
@@ -816,6 +839,7 @@ static inline int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
           abstime.tv_nsec -= 1000 * 1000 * 1000;
         }
 #endif
+
       /* Wait until either the transfer is complete or the timeout expires */
 
       ret = nxsem_timedwait_uninterruptible(&priv->sem_isr, &abstime);
@@ -907,7 +931,7 @@ static inline void
 stm32_i2c_set_7bit_address(FAR struct stm32_i2c_priv_s *priv)
 {
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR2_OFFSET, I2C_CR2_SADD7_MASK,
-                        ((priv->msgv->addr & 0x7F) << I2C_CR2_SADD7_SHIFT));
+                        ((priv->msgv->addr & 0x7f) << I2C_CR2_SADD7_SHIFT));
 }
 
 /************************************************************************************
@@ -977,7 +1001,6 @@ stm32_i2c_disable_reload(FAR struct stm32_i2c_priv_s *priv)
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR2_OFFSET, I2C_CR2_RELOAD, 0);
 }
 
-
 /************************************************************************************
  * Name: stm32_i2c_sem_waitstop
  *
@@ -1026,7 +1049,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
         {
           return;
         }
-
     }
 
   /* Loop until the stop is complete or a timeout occurs. */
@@ -1135,7 +1157,7 @@ static void stm32_i2c_tracenew(FAR struct stm32_i2c_priv_s *priv,
         {
           /* Yes.. bump up the trace index (unless we are out of trace entries) */
 
-          if (priv->tndx >= (CONFIG_I2C_NTRACE-1))
+          if (priv->tndx >= (CONFIG_I2C_NTRACE - 1))
             {
               i2cerr("ERROR: Trace table overflow\n");
               return;
@@ -1176,7 +1198,7 @@ static void stm32_i2c_traceevent(FAR struct stm32_i2c_priv_s *priv,
 
       /* Bump up the trace index (unless we are out of trace entries) */
 
-      if (priv->tndx >= (CONFIG_I2C_NTRACE-1))
+      if (priv->tndx >= (CONFIG_I2C_NTRACE - 1))
         {
           i2cerr("ERROR: Trace table overflow\n");
           return;
@@ -1200,7 +1222,7 @@ static void stm32_i2c_tracedump(FAR struct stm32_i2c_priv_s *priv)
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
              "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
-             i+1, trace->status, trace->count,  trace->event, trace->parm,
+             i + 1, trace->status, trace->count,  trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }
 }
@@ -1273,7 +1295,6 @@ static void stm32_i2c_setclock(FAR struct stm32_i2c_priv_s *priv, uint32_t frequ
 
   if (frequency != priv->frequency)
     {
-
       /*  The Speed and timing calculation are based on the following
        *  fI2CCLK = HSI and is 16Mhz
        *  Analog filter is on,
@@ -1282,39 +1303,38 @@ static void stm32_i2c_setclock(FAR struct stm32_i2c_priv_s *priv, uint32_t frequ
        *  Mode is FastMode
        */
 
-        if (frequency == 100000)
-          {
-            presc        = 0;
-            scl_delay    = 5;
-            sda_delay    = 0;
-            scl_h_period = 61;
-            scl_l_period = 89;
-
-          }
-        else if (frequency == 400000)
-           {
-             presc        = 0;
-             scl_delay    = 3;
-             sda_delay    = 0;
-             scl_h_period = 6;
-             scl_l_period = 24;
-           }
-         else if (frequency == 1000000)
-            {
-              presc        = 0;
-              scl_delay    = 2;
-              sda_delay    = 0;
-              scl_h_period = 1;
-              scl_l_period = 5;
-            }
-        else
-          {
-            presc        = 7;
-            scl_delay    = 0;
-            sda_delay    = 0;
-            scl_h_period = 35;
-            scl_l_period = 162;
-          }
+      if (frequency == 100000)
+        {
+          presc        = 0;
+          scl_delay    = 5;
+          sda_delay    = 0;
+          scl_h_period = 61;
+          scl_l_period = 89;
+        }
+      else if (frequency == 400000)
+        {
+          presc        = 0;
+          scl_delay    = 3;
+          sda_delay    = 0;
+          scl_h_period = 6;
+          scl_l_period = 24;
+        }
+      else if (frequency == 1000000)
+        {
+          presc        = 0;
+          scl_delay    = 2;
+          sda_delay    = 0;
+          scl_h_period = 1;
+          scl_l_period = 5;
+        }
+      else
+        {
+          presc        = 7;
+          scl_delay    = 0;
+          sda_delay    = 0;
+          scl_h_period = 35;
+          scl_l_period = 162;
+        }
 
       uint32_t timingr =
         (presc << I2C_TIMINGR_PRESC_SHIFT) |
@@ -1588,10 +1608,8 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
   if (status & I2C_INT_NACK)
     {
-
       if (priv->astart == true)
         {
-
           /* NACK received on first (address) byte: address is invalid */
 
           i2cinfo("NACK: Address invalid: dcnt=%i msgc=%i status=0x%08x\n",
@@ -1653,7 +1671,6 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
   else if ((priv->flags & (I2C_M_READ)) == 0 && (status & (I2C_ISR_TXIS)) != 0)
     {
-
       /* TXIS interrupt occurred, address valid, ready to transmit */
 
       stm32_i2c_traceevent(priv, I2CEVENT_WRITE, 0);
@@ -1884,7 +1901,6 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->msgv++;
 
           stm32_i2c_sendstart(priv);
-
         }
       else
         {
@@ -1970,7 +1986,8 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->flags  = priv->msgv->flags;
 
           /* if this is the last message, disable reload so the
-           * TC event fires next time */
+           * TC event fires next time.
+           */
 
           if (priv->msgc == 0)
             {
@@ -2097,7 +2114,8 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
       stm32_i2c_traceevent(priv, I2CEVENT_ISR_SHUTDOWN, 0);
 
       /* clear pointer to message content to reflect we are done
-       * with the current transaction */
+       * with the current transaction.
+       */
 
       priv->msgv = NULL;
 
@@ -2262,7 +2280,8 @@ static int stm32_i2c_deinit(FAR struct stm32_i2c_priv_s *priv)
  *
  ************************************************************************************/
 
-static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs, int count)
+static int stm32_i2c_process(FAR struct i2c_master_s *dev,
+                             FAR struct i2c_msg_s *msgs, int count)
 {
   struct stm32_i2c_inst_s     *inst = (struct stm32_i2c_inst_s *)dev;
   FAR struct stm32_i2c_priv_s *priv = inst->priv;
@@ -2354,12 +2373,12 @@ static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s 
 
       errval = ETIMEDOUT;
       i2cerr("ERROR: Waitdone timed out CR1: 0x%08x CR2: 0x%08x status: 0x%08x\n",
-             cr1, cr2,status);
+             cr1, cr2, status);
     }
   else
     {
       i2cinfo("Waitdone success: CR1: 0x%08x CR2: 0x%08x status: 0x%08x\n",
-             cr1, cr2,status );
+             cr1, cr2, status);
     }
 
   UNUSED(cr1);
@@ -2458,7 +2477,7 @@ static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s 
        */
 
       clock_t start = clock_systimer();
-      clock_t timeout = USEC2TICK(USEC_PER_SEC/priv->frequency) + 1;
+      clock_t timeout = USEC2TICK(USEC_PER_SEC / priv->frequency) + 1;
 
       status = stm32_i2c_getstatus(priv);
 
@@ -2491,11 +2510,20 @@ static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s 
  *
  ************************************************************************************/
 
-static int stm32_i2c_transfer(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                              int count)
+static int stm32_i2c_transfer(FAR struct i2c_master_s *dev,
+                              FAR struct i2c_msg_s *msgs, int count)
 {
-  stm32_i2c_sem_wait(dev);   /* ensure that address or flags don't change meanwhile */
-  return stm32_i2c_process(dev, msgs, count);
+  int ret;
+
+  /* Ensure that address or flags don't change meanwhile */
+
+  ret = stm32_i2c_sem_wait(dev);
+  if (ret >= 0)
+    {
+      ret = stm32_i2c_process(dev, msgs, count);
+    }
+
+  return ret;
 }
 
 /************************************************************************************
@@ -2515,7 +2543,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
   uint32_t scl_gpio;
   uint32_t sda_gpio;
   uint32_t frequency;
-  int ret = ERROR;
+  int ret;
 
   DEBUGASSERT(dev);
 
@@ -2529,7 +2557,13 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
 
   /* Lock out other clients */
 
-  stm32_i2c_sem_wait(dev);
+  ret = stm32_i2c_sem_wait_uninterruptble(dev);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = -EIO;
 
   /* Save the current frequency */
 
@@ -2676,6 +2710,7 @@ static int stm32_i2c_pm_prepare(FAR struct pm_callback_s *cb, int domain,
 
     case PM_STANDBY:
     case PM_SLEEP:
+
       /* Check if exclusive lock for I2C bus is held. */
 
       if (nxsem_getvalue(&priv->sem_excl, &sval) < 0)
@@ -2694,6 +2729,7 @@ static int stm32_i2c_pm_prepare(FAR struct pm_callback_s *cb, int domain,
       break;
 
     default:
+
       /* Should not get here */
 
       break;
@@ -2726,8 +2762,8 @@ FAR struct i2c_master_s *stm32_i2cbus_initialize(int port)
 
 #if 0                           /* REVISIT: this is not true for all STM32 M0 */
 #if STM32_HSI_FREQUENCY != 8000000 || defined(INVALID_CLOCK_SOURCE)
-#   warning STM32_I2C_INIT: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
-    return NULL;
+#  warning STM32_I2C_INIT: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
+  return NULL;
 #endif
 #endif
 
@@ -2846,4 +2882,4 @@ int stm32_i2cbus_uninitialize(FAR struct i2c_master_s * dev)
 }
 
 #endif /* CONFIG_STM32F0L0G0_I2C1 || CONFIG_STM32F0L0G0_I2C2 || \
-          CONFIG_STM32F0L0G0_I2C3 || CONFIG_STM32F0L0G0_I2C4 */
+        * CONFIG_STM32F0L0G0_I2C3 || CONFIG_STM32F0L0G0_I2C4 */

--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -181,10 +181,12 @@
  *    CONFIG_STM32F7_I2CTIMEOMS    (Timeout in milliseconds)
  *    CONFIG_STM32F7_I2CTIMEOTICKS (Timeout in ticks)
  *
- *  To configure the ISR timeout using dynamic values (CONFIG_STM32F7_I2C_DYNTIMEO=y):
+ *  To configure the ISR timeout using dynamic values
+ *  (CONFIG_STM32F7_I2C_DYNTIMEO=y):
  *
  *    CONFIG_STM32F7_I2C_DYNTIMEO_USECPERBYTE  (Timeout in microseconds per byte)
- *    CONFIG_STM32F7_I2C_DYNTIMEO_STARTSTOP    (Timeout for start/stop in milliseconds)
+ *    CONFIG_STM32F7_I2C_DYNTIMEO_STARTSTOP    (Timeout for start/stop in
+ *                                              milliseconds)
  *
  *  Debugging output enabled with:
  *
@@ -328,7 +330,7 @@
 
 /* Unused bit in I2c_ISR used to communicate a bad state has occurred in
  * the isr processing
-*/
+ */
 
 #define I2C_INT_BAD_STATE 0x8000000
 
@@ -425,7 +427,10 @@ struct stm32_i2c_config_s
 
 struct stm32_i2c_priv_s
 {
-  const struct stm32_i2c_config_s *config; /* Port configuration */
+  /* Port configuration */
+
+  const struct stm32_i2c_config_s *config;
+
   int refs;                    /* Reference count */
   sem_t sem_excl;              /* Mutual exclusion semaphore */
 #ifndef CONFIG_I2C_POLLED
@@ -473,14 +478,15 @@ struct stm32_i2c_inst_s
 
 static inline uint16_t stm32_i2c_getreg(FAR struct stm32_i2c_priv_s *priv,
                                         uint8_t offset);
-static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint16_t value);
-static inline void stm32_i2c_putreg32(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint32_t value);
+static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv,
+                                    uint8_t offset, uint16_t value);
+static inline void stm32_i2c_putreg32(FAR struct stm32_i2c_priv_s *priv,
+                                      uint8_t offset, uint32_t value);
 static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits);
-static inline void stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
+static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
+static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev);
 #ifdef CONFIG_STM32F7_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
 #endif /* CONFIG_STM32F7_I2C_DYNTIMEO */
@@ -508,10 +514,10 @@ static int stm32_i2c_isr(int irq, void *context, FAR void *arg);
 static int stm32_i2c_init(FAR struct stm32_i2c_priv_s *priv);
 static int stm32_i2c_deinit(FAR struct stm32_i2c_priv_s *priv);
 
-static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                             int count);
-static int stm32_i2c_transfer(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                              int count);
+static int stm32_i2c_process(FAR struct i2c_master_s *dev,
+                             FAR struct i2c_msg_s *msgs, int count);
+static int stm32_i2c_transfer(FAR struct i2c_master_s *dev,
+                              FAR struct i2c_msg_s *msgs, int count);
 #ifdef CONFIG_I2C_RESET
 static int stm32_i2c_reset(FAR struct i2c_master_s * dev);
 #endif
@@ -702,8 +708,8 @@ static inline uint32_t stm32_i2c_getreg32(FAR struct stm32_i2c_priv_s *priv,
  *
  ************************************************************************************/
 
-static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint16_t value)
+static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv,
+                                    uint8_t offset, uint16_t value)
 {
   putreg16(value, priv->config->base + offset);
 }
@@ -721,7 +727,6 @@ static inline void stm32_i2c_putreg32(FAR struct stm32_i2c_priv_s *priv,
 {
   putreg32(value, priv->config->base + offset);
 }
-
 
 /************************************************************************************
  * Name: stm32_i2c_modifyreg32
@@ -742,13 +747,29 @@ static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
  * Name: stm32_i2c_sem_wait
  *
  * Description:
- *   Take the exclusive access, waiting as necessary
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by a
+ *   signal.
  *
  ************************************************************************************/
 
-static inline void stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
+static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
 {
-  nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
+  return nxsem_wait(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
+}
+
+/************************************************************************************
+ * Name: stm32_i2c_sem_wait_uninterruptible
+ *
+ * Description:
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by a
+ *   signal.
+ *
+ ************************************************************************************/
+
+static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev)
+{
+  return
+    nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
 }
 
 /************************************************************************************
@@ -791,7 +812,8 @@ static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs)
 #ifndef CONFIG_I2C_POLLED
 static inline void stm32_i2c_enableinterrupts(struct stm32_i2c_priv_s *priv)
 {
-    stm32_i2c_modifyreg32(priv, STM32_I2C_CR1_OFFSET, 0, (I2C_CR1_TXRX | I2C_CR1_NACKIE));
+    stm32_i2c_modifyreg32(priv, STM32_I2C_CR1_OFFSET, 0,
+                          (I2C_CR1_TXRX | I2C_CR1_NACKIE));
 }
 #endif
 
@@ -857,6 +879,7 @@ static inline int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
           abstime.tv_nsec -= 1000 * 1000 * 1000;
         }
 #endif
+
       /* Wait until either the transfer is complete or the timeout expires */
 
       ret = nxsem_timedwait_uninterruptible(&priv->sem_isr, &abstime);
@@ -948,7 +971,7 @@ static inline void
 stm32_i2c_set_7bit_address(FAR struct stm32_i2c_priv_s *priv)
 {
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR2_OFFSET, I2C_CR2_SADD7_MASK,
-                        ((priv->msgv->addr & 0x7F) << I2C_CR2_SADD7_SHIFT));
+                        ((priv->msgv->addr & 0x7f) << I2C_CR2_SADD7_SHIFT));
 }
 
 /************************************************************************************
@@ -1018,7 +1041,6 @@ stm32_i2c_disable_reload(FAR struct stm32_i2c_priv_s *priv)
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR2_OFFSET, I2C_CR2_RELOAD, 0);
 }
 
-
 /************************************************************************************
  * Name: stm32_i2c_sem_waitstop
  *
@@ -1067,7 +1089,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
         {
           return;
         }
-
     }
 
   /* Loop until the stop is complete or a timeout occurs. */
@@ -1176,7 +1197,7 @@ static void stm32_i2c_tracenew(FAR struct stm32_i2c_priv_s *priv,
         {
           /* Yes.. bump up the trace index (unless we are out of trace entries) */
 
-          if (priv->tndx >= (CONFIG_I2C_NTRACE-1))
+          if (priv->tndx >= (CONFIG_I2C_NTRACE - 1))
             {
               i2cerr("ERROR: Trace table overflow\n");
               return;
@@ -1217,7 +1238,7 @@ static void stm32_i2c_traceevent(FAR struct stm32_i2c_priv_s *priv,
 
       /* Bump up the trace index (unless we are out of trace entries) */
 
-      if (priv->tndx >= (CONFIG_I2C_NTRACE-1))
+      if (priv->tndx >= (CONFIG_I2C_NTRACE - 1))
         {
           i2cerr("ERROR: Trace table overflow\n");
           return;
@@ -1241,7 +1262,7 @@ static void stm32_i2c_tracedump(FAR struct stm32_i2c_priv_s *priv)
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
              "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
-             i+1, trace->status, trace->count,  trace->event, trace->parm,
+             i + 1, trace->status, trace->count,  trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }
 }
@@ -1314,7 +1335,6 @@ static void stm32_i2c_setclock(FAR struct stm32_i2c_priv_s *priv, uint32_t frequ
 
   if (frequency != priv->frequency)
     {
-
       /*  The Speed and timing calculation are based on the following
        *  fI2CCLK = HSI and is 16Mhz
        *  Analog filter is on,
@@ -1323,39 +1343,38 @@ static void stm32_i2c_setclock(FAR struct stm32_i2c_priv_s *priv, uint32_t frequ
        *  Mode is FastMode
        */
 
-        if (frequency == 100000)
-          {
-            presc        = 0;
-            scl_delay    = 5;
-            sda_delay    = 0;
-            scl_h_period = 61;
-            scl_l_period = 89;
-
-          }
-        else if (frequency == 400000)
-           {
-             presc        = 0;
-             scl_delay    = 3;
-             sda_delay    = 0;
-             scl_h_period = 6;
-             scl_l_period = 24;
-           }
-         else if (frequency == 1000000)
-            {
-              presc        = 0;
-              scl_delay    = 2;
-              sda_delay    = 0;
-              scl_h_period = 1;
-              scl_l_period = 5;
-            }
-        else
-          {
-            presc        = 7;
-            scl_delay    = 0;
-            sda_delay    = 0;
-            scl_h_period = 35;
-            scl_l_period = 162;
-          }
+      if (frequency == 100000)
+        {
+          presc        = 0;
+          scl_delay    = 5;
+          sda_delay    = 0;
+          scl_h_period = 61;
+          scl_l_period = 89;
+        }
+      else if (frequency == 400000)
+        {
+          presc        = 0;
+          scl_delay    = 3;
+          sda_delay    = 0;
+          scl_h_period = 6;
+          scl_l_period = 24;
+        }
+      else if (frequency == 1000000)
+        {
+          presc        = 0;
+          scl_delay    = 2;
+          sda_delay    = 0;
+          scl_h_period = 1;
+          scl_l_period = 5;
+        }
+      else
+        {
+          presc        = 7;
+          scl_delay    = 0;
+          sda_delay    = 0;
+          scl_h_period = 35;
+          scl_l_period = 162;
+        }
 
       uint32_t timingr =
         (presc << I2C_TIMINGR_PRESC_SHIFT) |
@@ -1629,10 +1648,8 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
   if (status & I2C_INT_NACK)
     {
-
       if (priv->astart == true)
         {
-
           /* NACK received on first (address) byte: address is invalid */
 
           i2cinfo("NACK: Address invalid: dcnt=%i msgc=%i status=0x%08x\n",
@@ -1694,7 +1711,6 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
   else if ((priv->flags & (I2C_M_READ)) == 0 && (status & (I2C_ISR_TXIS)) != 0)
     {
-
       /* TXIS interrupt occurred, address valid, ready to transmit */
 
       stm32_i2c_traceevent(priv, I2CEVENT_WRITE, 0);
@@ -1925,7 +1941,6 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->msgv++;
 
           stm32_i2c_sendstart(priv);
-
         }
       else
         {
@@ -2011,7 +2026,8 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->flags  = priv->msgv->flags;
 
           /* if this is the last message, disable reload so the
-           * TC event fires next time */
+           * TC event fires next time.
+           */
 
           if (priv->msgc == 0)
             {
@@ -2138,7 +2154,8 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
       stm32_i2c_traceevent(priv, I2CEVENT_ISR_SHUTDOWN, 0);
 
       /* clear pointer to message content to reflect we are done
-       * with the current transaction */
+       * with the current transaction.
+       */
 
       priv->msgv = NULL;
 
@@ -2307,7 +2324,8 @@ static int stm32_i2c_deinit(FAR struct stm32_i2c_priv_s *priv)
  *
  ************************************************************************************/
 
-static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs, int count)
+static int stm32_i2c_process(FAR struct i2c_master_s *dev,
+                             FAR struct i2c_msg_s *msgs, int count)
 {
   struct stm32_i2c_inst_s     *inst = (struct stm32_i2c_inst_s *)dev;
   FAR struct stm32_i2c_priv_s *priv = inst->priv;
@@ -2399,12 +2417,12 @@ static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s 
 
       errval = ETIMEDOUT;
       i2cerr("ERROR: Waitdone timed out CR1: 0x%08x CR2: 0x%08x status: 0x%08x\n",
-             cr1, cr2,status);
+             cr1, cr2, status);
     }
   else
     {
       i2cinfo("Waitdone success: CR1: 0x%08x CR2: 0x%08x status: 0x%08x\n",
-             cr1, cr2,status );
+             cr1, cr2, status);
     }
 
   UNUSED(cr1);
@@ -2503,7 +2521,7 @@ static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s 
        */
 
       clock_t start = clock_systimer();
-      clock_t timeout = USEC2TICK(USEC_PER_SEC/priv->frequency) + 1;
+      clock_t timeout = USEC2TICK(USEC_PER_SEC / priv->frequency) + 1;
 
       status = stm32_i2c_getstatus(priv);
 
@@ -2536,11 +2554,20 @@ static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s 
  *
  ************************************************************************************/
 
-static int stm32_i2c_transfer(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                              int count)
+static int stm32_i2c_transfer(FAR struct i2c_master_s *dev,
+                              FAR struct i2c_msg_s *msgs, int count)
 {
-  stm32_i2c_sem_wait(dev);   /* ensure that address or flags don't change meanwhile */
-  return stm32_i2c_process(dev, msgs, count);
+  int ret;
+
+  /* Ensure that address or flags don't change meanwhile */
+
+  ret = stm32_i2c_sem_wait(dev);
+  if (ret >= 0)
+    {
+      ret = stm32_i2c_process(dev, msgs, count);
+    }
+
+  return ret;
 }
 
 /************************************************************************************
@@ -2560,7 +2587,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
   uint32_t scl_gpio;
   uint32_t sda_gpio;
   uint32_t frequency;
-  int ret = ERROR;
+  int ret;
 
   DEBUGASSERT(dev);
 
@@ -2574,7 +2601,13 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
 
   /* Lock out other clients */
 
-  stm32_i2c_sem_wait(dev);
+  ret = stm32_i2c_sem_wait_uninterruptible(dev);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = -EIO;
 
   /* Save the current frequency */
 
@@ -2721,6 +2754,7 @@ static int stm32_i2c_pm_prepare(FAR struct pm_callback_s *cb, int domain,
 
     case PM_STANDBY:
     case PM_SLEEP:
+
       /* Check if exclusive lock for I2C bus is held. */
 
       if (nxsem_getvalue(&priv->sem_excl, &sval) < 0)
@@ -2739,6 +2773,7 @@ static int stm32_i2c_pm_prepare(FAR struct pm_callback_s *cb, int domain,
       break;
 
     default:
+
       /* Should not get here */
 
       break;
@@ -2770,8 +2805,8 @@ FAR struct i2c_master_s *stm32_i2cbus_initialize(int port)
 #endif
 
 #if STM32_HSI_FREQUENCY != 16000000 || defined(INVALID_CLOCK_SOURCE)
-#   warning STM32_I2C_INIT: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
-    return NULL;
+# warning STM32_I2C_INIT: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
+  return NULL;
 #endif
 
   /* Get I2C private structure */
@@ -2889,4 +2924,4 @@ int stm32_i2cbus_uninitialize(FAR struct i2c_master_s * dev)
 }
 
 #endif /* CONFIG_STM32F7_I2C1 || CONFIG_STM32F7_I2C2 || \
-          CONFIG_STM32F7_I2C3 || CONFIG_STM32F7_I2C4 */
+        * CONFIG_STM32F7_I2C3 || CONFIG_STM32F7_I2C4 */

--- a/arch/arm/src/stm32h7/stm32_i2c.c
+++ b/arch/arm/src/stm32h7/stm32_i2c.c
@@ -178,7 +178,8 @@
  *    CONFIG_STM32H7_I2CTIMEOMS    (Timeout in milliseconds)
  *    CONFIG_STM32H7_I2CTIMEOTICKS (Timeout in ticks)
  *
- *  To configure the ISR timeout using dynamic values (CONFIG_STM32H7_I2C_DYNTIMEO=y):
+ *  To configure the ISR timeout using dynamic values
+ *  (CONFIG_STM32H7_I2C_DYNTIMEO=y):
  *
  *    CONFIG_STM32H7_I2C_DYNTIMEO_USECPERBYTE  (Timeout in microseconds per byte)
  *    CONFIG_STM32H7_I2C_DYNTIMEO_STARTSTOP    (Timeout for start/stop in msec)
@@ -379,7 +380,10 @@ struct stm32_i2c_config_s
 
 struct stm32_i2c_priv_s
 {
-  const struct stm32_i2c_config_s *config; /* Port configuration */
+  /* Port configuration */
+
+  const struct stm32_i2c_config_s *config;
+
   int refs;                    /* Referernce count */
   sem_t sem_excl;              /* Mutual exclusion semaphore */
 #ifndef CONFIG_I2C_POLLED
@@ -434,7 +438,8 @@ static inline void stm32_i2c_putreg32(FAR struct stm32_i2c_priv_s *priv,
 static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits);
-static inline void stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
+static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
+static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev);
 #ifdef CONFIG_STM32H7_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
 #endif /* CONFIG_STM32H7_I2C_DYNTIMEO */
@@ -462,8 +467,8 @@ static int stm32_i2c_isr(int irq, void *context, FAR void *arg);
 static int stm32_i2c_init(FAR struct stm32_i2c_priv_s *priv);
 static int stm32_i2c_deinit(FAR struct stm32_i2c_priv_s *priv);
 
-static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                             int count);
+static int stm32_i2c_process(FAR struct i2c_master_s *dev,
+                             FAR struct i2c_msg_s *msgs, int count);
 static int stm32_i2c_transfer(FAR struct i2c_master_s *dev,
                               FAR struct i2c_msg_s *msgs, int count);
 #ifdef CONFIG_I2C_RESET
@@ -656,8 +661,8 @@ static inline uint32_t stm32_i2c_getreg32(FAR struct stm32_i2c_priv_s *priv,
  *
  ************************************************************************************/
 
-static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv, uint8_t offset,
-                                    uint16_t value)
+static inline void stm32_i2c_putreg(FAR struct stm32_i2c_priv_s *priv,
+                                    uint8_t offset, uint16_t value)
 {
   putreg16(value, priv->config->base + offset);
 }
@@ -695,13 +700,29 @@ static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
  * Name: stm32_i2c_sem_wait
  *
  * Description:
- *   Take the exclusive access, waiting as necessary
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by a
+ *   signal.
  *
  ************************************************************************************/
 
-static inline void stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
+static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
 {
-  nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
+  return nxsem_wait(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
+}
+
+/************************************************************************************
+ * Name: stm32_i2c_sem_wait_uninterruptible
+ *
+ * Description:
+ *   Take the exclusive access, waiting as necessary.  May be interrupted by a
+ *   signal.
+ *
+ ************************************************************************************/
+
+static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev)
+{
+  return
+    nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
 }
 
 /************************************************************************************
@@ -811,6 +832,7 @@ static inline int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
           abstime.tv_nsec -= 1000 * 1000 * 1000;
         }
 #endif
+
       /* Wait until either the transfer is complete or the timeout expires */
 
       ret = nxsem_timedwait_uninterruptible(&priv->sem_isr, &abstime);
@@ -902,7 +924,7 @@ static inline void
 stm32_i2c_set_7bit_address(FAR struct stm32_i2c_priv_s *priv)
 {
   stm32_i2c_modifyreg32(priv, STM32_I2C_CR2_OFFSET, I2C_CR2_SADD7_MASK,
-                        ((priv->msgv->addr & 0x7F) << I2C_CR2_SADD7_SHIFT));
+                        ((priv->msgv->addr & 0x7f) << I2C_CR2_SADD7_SHIFT));
 }
 
 /************************************************************************************
@@ -1020,7 +1042,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
         {
           return;
         }
-
     }
 
   /* Loop until the stop is complete or a timeout occurs. */
@@ -1129,7 +1150,7 @@ static void stm32_i2c_tracenew(FAR struct stm32_i2c_priv_s *priv,
         {
           /* Yes.. bump up the trace index (unless we are out of trace entries) */
 
-          if (priv->tndx >= (CONFIG_I2C_NTRACE-1))
+          if (priv->tndx >= (CONFIG_I2C_NTRACE - 1))
             {
               i2cerr("ERROR: Trace table overflow\n");
               return;
@@ -1170,7 +1191,7 @@ static void stm32_i2c_traceevent(FAR struct stm32_i2c_priv_s *priv,
 
       /* Bump up the trace index (unless we are out of trace entries) */
 
-      if (priv->tndx >= (CONFIG_I2C_NTRACE-1))
+      if (priv->tndx >= (CONFIG_I2C_NTRACE - 1))
         {
           i2cerr("ERROR: Trace table overflow\n");
           return;
@@ -1194,7 +1215,7 @@ static void stm32_i2c_tracedump(FAR struct stm32_i2c_priv_s *priv)
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
              "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
-             i+1, trace->status, trace->count,  trace->event, trace->parm,
+             i + 1, trace->status, trace->count,  trace->event, trace->parm,
              trace->time - priv->start_time);
     }
 }
@@ -1278,39 +1299,38 @@ static void stm32_i2c_setclock(FAR struct stm32_i2c_priv_s *priv, uint32_t frequ
        *  Mode is FastMode
        */
 
-        if (frequency == 100000)
-          {
-            presc        = 0;
-            scl_delay    = 5;
-            sda_delay    = 0;
-            scl_h_period = 61;
-            scl_l_period = 89;
-
-          }
-        else if (frequency == 400000)
-           {
-             presc        = 0;
-             scl_delay    = 3;
-             sda_delay    = 0;
-             scl_h_period = 6;
-             scl_l_period = 24;
-           }
-         else if (frequency == 1000000)
-            {
-              presc        = 0;
-              scl_delay    = 2;
-              sda_delay    = 0;
-              scl_h_period = 1;
-              scl_l_period = 5;
-            }
-        else
-          {
-            presc        = 7;
-            scl_delay    = 0;
-            sda_delay    = 0;
-            scl_h_period = 35;
-            scl_l_period = 162;
-          }
+      if (frequency == 100000)
+        {
+          presc        = 0;
+          scl_delay    = 5;
+          sda_delay    = 0;
+          scl_h_period = 61;
+          scl_l_period = 89;
+        }
+      else if (frequency == 400000)
+        {
+          presc        = 0;
+          scl_delay    = 3;
+          sda_delay    = 0;
+          scl_h_period = 6;
+          scl_l_period = 24;
+        }
+      else if (frequency == 1000000)
+        {
+          presc        = 0;
+          scl_delay    = 2;
+          sda_delay    = 0;
+          scl_h_period = 1;
+          scl_l_period = 5;
+        }
+      else
+        {
+          presc        = 7;
+          scl_delay    = 0;
+          sda_delay    = 0;
+          scl_h_period = 35;
+          scl_l_period = 162;
+        }
 
       uint32_t timingr =
         (presc << I2C_TIMINGR_PRESC_SHIFT) |
@@ -1586,10 +1606,8 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
   if (status & I2C_INT_NACK)
     {
-
       if (priv->astart == true)
         {
-
           /* NACK received on first (address) byte: address is invalid */
 
           i2cinfo("NACK: Address invalid: dcnt=%i msgc=%i status=0x%08x\n",
@@ -1651,7 +1669,6 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
 
   else if ((priv->flags & (I2C_M_READ)) == 0 && (status & (I2C_ISR_TXIS)) != 0)
     {
-
       /* TXIS interrupt occurred, address valid, ready to transmit */
 
       stm32_i2c_traceevent(priv, I2CEVENT_WRITE, 0);
@@ -1877,7 +1894,6 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->msgv++;
 
           stm32_i2c_sendstart(priv);
-
         }
       else
         {
@@ -2253,8 +2269,8 @@ static int stm32_i2c_deinit(FAR struct stm32_i2c_priv_s *priv)
  *
  ************************************************************************************/
 
-static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s *msgs,
-                             int count)
+static int stm32_i2c_process(FAR struct i2c_master_s *dev,
+                             FAR struct i2c_msg_s *msgs, int count)
 {
   struct stm32_i2c_inst_s     *inst = (struct stm32_i2c_inst_s *)dev;
   FAR struct stm32_i2c_priv_s *priv = inst->priv;
@@ -2450,7 +2466,7 @@ static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s 
        */
 
       uint32_t start = clock_systimer();
-      uint32_t timeout = USEC2TICK(USEC_PER_SEC/priv->frequency) + 1;
+      uint32_t timeout = USEC2TICK(USEC_PER_SEC / priv->frequency) + 1;
 
       status = stm32_i2c_getstatus(priv);
 
@@ -2486,8 +2502,17 @@ static int stm32_i2c_process(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s 
 static int stm32_i2c_transfer(FAR struct i2c_master_s *dev,
                               FAR struct i2c_msg_s *msgs, int count)
 {
-  stm32_i2c_sem_wait(dev);   /* ensure that address or flags don't change meanwhile */
-  return stm32_i2c_process(dev, msgs, count);
+  int ret;
+
+  /* Ensure that address or flags don't change meanwhile */
+
+  ret = stm32_i2c_sem_wait(dev);
+  if (ret >= 0)
+    {
+      ret = stm32_i2c_process(dev, msgs, count);
+    }
+
+  return ret;
 }
 
 /************************************************************************************
@@ -2507,7 +2532,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
   uint32_t scl_gpio;
   uint32_t sda_gpio;
   uint32_t frequency;
-  int ret = ERROR;
+  int ret;
 
   DEBUGASSERT(dev);
 
@@ -2521,7 +2546,13 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
 
   /* Lock out other clients */
 
-  stm32_i2c_sem_wait(dev);
+  ret = stm32_i2c_sem_wait_uninterruptible(dev);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = -EIO;
 
   /* Save the current frequency */
 
@@ -2668,6 +2699,7 @@ static int stm32_i2c_pm_prepare(FAR struct pm_callback_s *cb, int domain,
 
     case PM_STANDBY:
     case PM_SLEEP:
+
       /* Check if exclusive lock for I2C bus is held. */
 
       if (nxsem_getvalue(&priv->sem_excl, &sval) < 0)
@@ -2713,7 +2745,7 @@ FAR struct i2c_master_s *stm32_i2cbus_initialize(int port)
 
 #if STM32_HSI_FREQUENCY != 16000000 || defined(INVALID_CLOCK_SOURCE)
 #   warning STM32_I2C_INIT: Peripheral clock is HSI and it must be 16mHz or the speed/timing calculations need to be redone.
-    return NULL;
+  return NULL;
 #endif
 
   /* Get I2C private structure */
@@ -2831,4 +2863,4 @@ int stm32_i2cbus_uninitialize(FAR struct i2c_master_s * dev)
 }
 
 #endif /* CONFIG_STM32H7_I2C1 || CONFIG_STM32H7_I2C2 || \
-          CONFIG_STM32H7_I2C3 || CONFIG_STM32H7_I2C4 */
+        * CONFIG_STM32H7_I2C3 || CONFIG_STM32H7_I2C4 */

--- a/arch/mips/src/pic32mz/pic32mz-i2c.c
+++ b/arch/mips/src/pic32mz/pic32mz-i2c.c
@@ -99,7 +99,7 @@
             TICK2USEC(CONFIG_PIC32MZ_I2CTIMEOTICKS)
 #endif
 
-/* Debug *********************************************************************/
+/* Debug ********************************************************************/
 
 /* I2C event trace logic. */
 
@@ -192,22 +192,29 @@ struct pic32mz_i2c_config_s
 
 struct pic32mz_i2c_priv_s
 {
-  const struct i2c_ops_s *ops; /* Standard I2C operations */
-  const struct pic32mz_i2c_config_s *config; /* Port configuration */
-  int refs;                    /* Referernce count */
-  sem_t sem_excl;              /* Mutual exclusion semaphore */
+  /* Standard I2C operations */
+
+  const struct i2c_ops_s *ops;
+
+  /* Port configuration */
+
+  const struct pic32mz_i2c_config_s *config;
+
+  int refs;                       /* Reference count */
+  sem_t sem_excl;                 /* Mutual exclusion semaphore */
 #ifndef CONFIG_I2C_POLLED
-  sem_t sem_isr;               /* Interrupt wait semaphore */
+  sem_t sem_isr;                  /* Interrupt wait semaphore */
 #endif
-  volatile uint8_t intstate;   /* Interrupt handshake (see enum pic32mz_intstate_e) */
+  volatile uint8_t intstate;      /* Interrupt handshake (see enum
+                                   * pic32mz_intstate_e) */
   volatile uint8_t process_state; /* State of the isr process */
 
-  uint8_t msgc;                /* Message count */
-  struct i2c_msg_s *msgv;      /* Message list */
-  uint8_t *ptr;                /* Current message buffer */
-  uint32_t frequency;          /* Current I2C frequency */
-  int dcnt;                    /* Current message length */
-  uint16_t flags;              /* Current message flags */
+  uint8_t msgc;                   /* Message count */
+  struct i2c_msg_s *msgv;         /* Message list */
+  uint8_t *ptr;                   /* Current message buffer */
+  uint32_t frequency;             /* Current I2C frequency */
+  int dcnt;                       /* Current message length */
+  uint16_t flags;                 /* Current message flags */
 
   /* I2C trace support */
 
@@ -227,14 +234,14 @@ struct pic32mz_i2c_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static inline uint32_t pic32mz_i2c_getreg(FAR struct pic32mz_i2c_priv_s *priv,
-                                          uint8_t offset);
+static inline uint32_t
+  pic32mz_i2c_getreg(FAR struct pic32mz_i2c_priv_s *priv,
+                     uint8_t offset);
 static inline void pic32mz_i2c_putreg(FAR struct pic32mz_i2c_priv_s *priv,
                                       uint8_t offset, uint32_t value);
 static inline void pic32mz_i2c_modifyreg(FAR struct pic32mz_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits);
-static inline void pic32mz_i2c_sem_wait(FAR struct pic32mz_i2c_priv_s *priv);
 
 #ifdef CONFIG_PICM32MZ_I2C_DYNTIMEO
 static useconds_t pic32mz_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
@@ -253,16 +260,19 @@ static inline void
 static void pic32mz_i2c_tracereset(FAR struct pic32mz_i2c_priv_s *priv);
 static void pic32mz_i2c_tracenew(FAR struct pic32mz_i2c_priv_s *priv,
                                  uint32_t status);
-static void pic32mz_i2c_traceevent(FAR struct pic32mz_i2c_priv_s *priv,
-                                   enum pic32mz_trace_e event, uint32_t parm);
+static void
+  pic32mz_i2c_traceevent(FAR struct pic32mz_i2c_priv_s *priv,
+                         enum pic32mz_trace_e event, uint32_t parm);
 static void pic32mz_i2c_tracedump(FAR struct pic32mz_i2c_priv_s *priv);
 #endif /* CONFIG_I2C_TRACE */
 
-static inline int pic32mz_i2c_setbaudrate(FAR struct pic32mz_i2c_priv_s *priv,
-                                          uint32_t frequency);
+static inline int
+  pic32mz_i2c_setbaudrate(FAR struct pic32mz_i2c_priv_s *priv,
+                          uint32_t frequency);
 static inline void
   pic32mz_i2c_send_start(FAR struct pic32mz_i2c_priv_s *priv);
-static inline void pic32mz_i2c_send_stop(FAR struct pic32mz_i2c_priv_s *priv);
+static inline void
+  pic32mz_i2c_send_stop(FAR struct pic32mz_i2c_priv_s *priv);
 static inline void
   pic32mz_i2c_send_repeatedstart(FAR struct pic32mz_i2c_priv_s *priv);
 static inline void pic32mz_i2c_send_ack(FAR struct pic32mz_i2c_priv_s *priv,
@@ -586,8 +596,8 @@ static void pic32mz_i2c_tracedump(FAR struct pic32mz_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline uint32_t pic32mz_i2c_getreg(FAR struct pic32mz_i2c_priv_s *priv,
-                                          uint8_t offset)
+static inline uint32_t
+  pic32mz_i2c_getreg(FAR struct pic32mz_i2c_priv_s *priv, uint8_t offset)
 {
   return getreg32(priv->config->base + offset);
 }
@@ -619,19 +629,6 @@ static inline void pic32mz_i2c_modifyreg(FAR struct pic32mz_i2c_priv_s *priv,
                                          uint32_t setbits)
 {
   modifyreg32(priv->config->base + offset, clearbits, setbits);
-}
-
-/****************************************************************************
- * Name: pic32mz_i2c_sem_wait
- *
- * Description:
- *   Take the exclusive access, waiting as necessary
- *
- ****************************************************************************/
-
-static inline void pic32mz_i2c_sem_wait(FAR struct pic32mz_i2c_priv_s *priv)
-{
-  nxsem_wait_uninterruptible(&priv->sem_excl);
 }
 
 /****************************************************************************
@@ -1315,8 +1312,9 @@ static int pic32mz_i2c_isr(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static inline int pic32mz_i2c_setbaudrate(FAR struct pic32mz_i2c_priv_s *priv,
-                                          uint32_t frequency)
+static inline int
+  pic32mz_i2c_setbaudrate(FAR struct pic32mz_i2c_priv_s *priv,
+                          uint32_t frequency)
 {
   uint32_t baudrate;
 
@@ -1602,12 +1600,16 @@ static int pic32mz_i2c_transfer(FAR struct i2c_master_s *dev,
                                 FAR struct i2c_msg_s *msgs, int count)
 {
   FAR struct pic32mz_i2c_priv_s *priv = (struct pic32mz_i2c_priv_s *)dev;
-  int ret = OK;
   uint32_t status = 0;
+  int ret;
 
   /* Acquire the semaphore. */
 
-  pic32mz_i2c_sem_wait(priv);
+  ret = nxsem_wait(&priv->sem_excl);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Wait for the bus to be in an idle state. */
 
@@ -1732,7 +1734,11 @@ static int pic32mz_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  pic32mz_i2c_sem_wait(priv);
+  ret = nxsem_wait_uninterruptible(&priv->sem_excl);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Save the current frequency */
 


### PR DESCRIPTION
 Resolution of Issue 619 will require multiple steps, this part of the first step in that resolution:  Every call to nxsem_wait_uninterruptible() must handle the return value from nxsem_wait_uninterruptible properly.  This commit is for all I2C drivers under arch/.