### PR TITLE
tools/nxstyle.c: handle scientific notation with a negative exponent

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -2033,6 +2033,19 @@ int main(int argc, char **argv, char **envp)
                       check_spaces_leftright(line, lineno, n, n + 1);
                       n++;
                     }
+
+                  /* Scientific notation with a negative exponent (eg. 10e-10)
+                   * REVISIT: This fails for cases where the variable name
+                   *          ends with 'e' preceded by a digit:
+                   *          a = abc1e-10;
+                   *          a = ABC1E-10;
+                   */
+
+                  else if ((line[n - 1] == 'e' || line[n - 1] == 'E') &&
+                           isdigit(line[n + 1]) && isdigit(line[n - 2]))
+                    {
+                      n++;
+                    }
                   else
                     {
                       /* '-' may function as a unary operator and snuggle


### PR DESCRIPTION
Tested with the folowing code:

```
int test(void)
{
  /* [OK] OK */

  int i = 10e12;
  int i = 10E12;
  int j = 10e-1;
  int j = 10E-1;
  int e = 9e-10;
  int e = 9E-10;

  /* [OK] FAIL */

  k = e-j;
  k = E-j;

  /* [OK] FAIL */

  e = ee-eee;
  e = EE-EEE;

  /* [FALSE POSITIVE] OK but should FAIL  */

  a = abc1e-10;
  a = ABC1E-10;

  /* [OK] FAIL */

  j = e-10;
  j = E-10;

  /* [OK] FAIL */

  j = 10-e;
  j = 10-E;

  /* [OK] OK */

  e = ee - eee;
  E = EE - EEE;

  /* [OK] OK */

  j = e - 10;
  j = E - 10;

  /* [OK] OK */

  i = e - j;
  i = E - j;

  /* [OK] OK */

  k = 10e-1;
  k = 10E-1;

  /* [OK] OK */

  k = 23e12;
  k = 23E12;
}
```