### PR TITLE
stm32h7:SPI Add buffers for DMA & and FIX DMA

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -633,6 +633,90 @@ config STM32H7_SPI_DMATHRESHOLD
 		by polling logic.  But we need a threshold value to determine what
 		is small.
 
+config STM32H7_SPI1_DMA
+	bool "SPI1 DMA"
+	default n
+	depends on STM32H7_SPI1 && STM32H7_SPI_DMA
+	---help---
+		Use DMA to improve SPI1 transfer performance.
+
+config STM32H7_SPI1_DMA_BUFFER
+	int "SPI1 DMA buffer size"
+	default 0
+	depends on STM32H7_SPI1_DMA
+	---help---
+		Add a properly aligned DMA buffer for RX and TX DMA for SPI1.
+
+config STM32H7_SPI2_DMA
+	bool "SPI2 DMA"
+	default n
+	depends on STM32H7_SPI2 && STM32H7_SPI_DMA
+	---help---
+		Use DMA to improve SPI2 transfer performance.
+
+config STM32H7_SPI2_DMA_BUFFER
+	int "SPI2 DMA buffer size"
+	default 0
+	depends on STM32H7_SPI2_DMA
+	---help---
+		Add a properly aligned DMA buffer for RX and TX DMA for SPI2.
+
+config STM32H7_SPI3_DMA
+	bool "SPI3 DMA"
+	default n
+	depends on STM32H7_SPI3 && STM32H7_SPI_DMA
+	---help---
+		Use DMA to improve SPI3 transfer performance.
+
+config STM32H7_SPI3_DMA_BUFFER
+	int "SPI3 DMA buffer size"
+	default 0
+	depends on STM32H7_SPI3_DMA
+	---help---
+		Add a properly aligned DMA buffer for RX and TX DMA for SPI3.
+
+config STM32H7_SPI4_DMA
+	bool "SPI4 DMA"
+	default n
+	depends on STM32H7_SPI4 && STM32H7_SPI_DMA
+	---help---
+		Use DMA to improve SPI4 transfer performance.
+
+config STM32H7_SPI4_DMA_BUFFER
+	int "SPI4 DMA buffer size"
+	default 0
+	depends on STM32H7_SPI4_DMA
+	---help---
+		Add a properly aligned DMA buffer for RX and TX DMA for SPI4.
+
+config STM32H7_SPI5_DMA
+	bool "SPI5 DMA"
+	default n
+	depends on STM32H7_SPI5 && STM32H7_SPI_DMA
+	---help---
+		Use DMA to improve SPI5 transfer performance.
+
+config STM32H7_SPI5_DMA_BUFFER
+	int "SPI5 DMA buffer size"
+	default 0
+	depends on STM32H7_SPI5_DMA
+	---help---
+		Add a properly aligned DMA buffer for RX and TX DMA for SPI5.
+
+config STM32H7_SPI6_DMA
+	bool "SPI6 DMA"
+	default n
+	depends on STM32H7_SPI6 && STM32H7_SPI_DMA
+	---help---
+		Use DMA to improve SPI6 transfer performance.
+
+config STM32H7_SPI6_DMA_BUFFER
+	int "SPI6 DMA buffer size"
+	default 0
+	depends on STM32H7_SPI6_DMA
+	---help---
+		Add a properly aligned DMA buffer for RX and TX DMA for SPI6.
+
 endmenu # "SPI Configuration"
 
 menu "U[S]ART Configuration"


### PR DESCRIPTION
This add an optional ability to have buffering in the SPI driver for DMA. 

If a SPI Bus uses an "in driver buffers" we will incur 2 copies,  The copy cost is << less the non DMA transfer time and having the buffer in the driver ensures DMA can be used. 

This is needed for because the SPI API does not support passing the buffer extent, so the only extent is buffer + the transfer size.  This is an issue on H7 with caching. These can sizes be less than the cache line size, and not aligned and typically greater then 4 bytes, which is about the break even point for the DMA IO overhead.


The SPI driver was violating the DMA/SPI setup as described in 49.4.14 Communication using DMA (direct memory addressing) of RM0433 Rev 6. The result was that the TX DMA operation would always return FIFO overrun/underrun (FEIFx) indicating a FIFO error event occurred on the stream.

This PR fixes this issue.

