### PR TITLE
MODLIB_SYSTEM_SYMTAB: Rename the generated file

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -124,12 +124,12 @@ endif
 
 ifeq ($(CONFIG_MODLIB_SYSTEM_SYMTAB),y)
 
-modlib_symtab.c : $(CSVFILES) $(MKSYMTAB)
+modlib_sys_symtab.c : $(CSVFILES) $(MKSYMTAB)
 	$(Q) cat $(CSVFILES) | LC_ALL=C sort >$@.csv
 	$(Q) $(MKSYMTAB) $@.csv $@ $(CONFIG_MODLIB_SYMTAB_ARRAY) $(CONFIG_MODLIB_NSYMBOLS_VAR)
 	$(Q) rm -f $@.csv
 
-CSRCS += modlib_symtab.c
+CSRCS += modlib_sys_symtab.c
 
 endif
 


### PR DESCRIPTION
To avoid conflict with ./libs/libc/modlib/modlib_symtab.c