### PR TITLE
stm32f7/h7 spi add missing ret declaration

### DIFF
--- a/arch/arm/src/stm32f7/stm32_spi.c
+++ b/arch/arm/src/stm32f7/stm32_spi.c
@@ -1786,6 +1786,8 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
 {
   FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)dev;
   FAR void * xbuffer = rxbuffer;
+  int ret;
+
   DEBUGASSERT(priv != NULL);
 
   /* Convert the number of word to a number of bytes */

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -1812,6 +1812,8 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
 {
   FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)dev;
   FAR void * xbuffer = rxbuffer;
+  int ret;
+
   DEBUGASSERT(priv != NULL);
 
   /* Convert the number of word to a number of bytes */


### PR DESCRIPTION
Fixes compile failure when SPI DMA is enabled.