### PR TITLE
Check return from nxsem_wait_uninterruptible()

### DIFF
--- a/arch/arm/src/samv7/sam_ssc.c
+++ b/arch/arm/src/samv7/sam_ssc.c
@@ -847,7 +847,8 @@ static void ssc_dump_queues(struct sam_transport_s *xpt, const char *msg)
  *   priv - A reference to the SSC peripheral state
  *
  * Returned Value:
- *  None
+ *   Normally OK, but may return -ECANCELED in the rare event that the task
+ *   has been canceled.
  *
  ****************************************************************************/
 
@@ -866,7 +867,8 @@ static int ssc_exclsem_take(struct sam_ssc_s *priv)
  *   priv - A reference to the SSC peripheral state
  *
  * Returned Value:
- *  None
+ *   Normally OK, but may return -ECANCELED in the rare event that the task
+ *   has been canceled.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
Resolution of Issue 619 will require multiple steps, this part of the first step in that resolution:  Every call to nxsem_wait_uninterruptible() must handle the return value from nxsem_wait_uninterruptible properly.  This commit is for all I2S/SSC drivers under arch/.