### PR TITLE
Check return from nxsem_wait_uninterruptible()

### DIFF
--- a/arch/arm/src/am335x/am335x_i2c.c
+++ b/arch/arm/src/am335x/am335x_i2c.c
@@ -238,7 +238,7 @@ static inline void am335x_i2c_modifyreg(FAR struct am335x_i2c_priv_s *priv,
                                         uint32_t setbits);
 static inline int am335x_i2c_sem_wait(FAR struct am335x_i2c_priv_s *priv);
 static int
-  am335x_i2c_sem_wait_uninterruptible(FAR struct am335x_i2c_priv_s *priv);
+  am335x_i2c_sem_wait_noncancelable(FAR struct am335x_i2c_priv_s *priv);
 
 #ifdef CONFIG_AM335X_I2C_DYNTIMEO
 static useconds_t am335x_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
@@ -471,7 +471,7 @@ static inline int am335x_i2c_sem_wait(FAR struct am335x_i2c_priv_s *priv)
 }
 
 /****************************************************************************
- * Name: am335x_i2c_sem_wait_uninterruptible
+ * Name: am335x_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary.
@@ -479,7 +479,7 @@ static inline int am335x_i2c_sem_wait(FAR struct am335x_i2c_priv_s *priv)
  ****************************************************************************/
 
 static int
-  am335x_i2c_sem_wait_uninterruptible(FAR struct am335x_i2c_priv_s *priv)
+  am335x_i2c_sem_wait_noncancelable(FAR struct am335x_i2c_priv_s *priv)
 {
   return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
@@ -1574,7 +1574,7 @@ static int am335x_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  ret = am335x_i2c_sem_wait_uninterruptible(priv);
+  ret = am335x_i2c_sem_wait_noncancelable(priv);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/efm32/efm32_i2c.c
+++ b/arch/arm/src/efm32/efm32_i2c.c
@@ -281,7 +281,7 @@ static inline void efm32_i2c_modifyreg(FAR struct efm32_i2c_priv_s *priv,
                                        uint32_t setbits);
 static inline int efm32_i2c_sem_wait(FAR struct efm32_i2c_priv_s *priv);
 static int
-  efm32_i2c_sem_wait_uninterruptible(FAR struct efm32_i2c_priv_s *priv);
+  efm32_i2c_sem_wait_noncancelable(FAR struct efm32_i2c_priv_s *priv);
 
 #ifdef CONFIG_EFM32_I2C_DYNTIMEOUT
 static useconds_t efm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
@@ -493,7 +493,7 @@ static inline int efm32_i2c_sem_wait(FAR struct efm32_i2c_priv_s *priv)
 }
 
 /****************************************************************************
- * Name: efm32_i2c_sem_wait_uninterruptible
+ * Name: efm32_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary
@@ -501,7 +501,7 @@ static inline int efm32_i2c_sem_wait(FAR struct efm32_i2c_priv_s *priv)
  ****************************************************************************/
 
 static int
-  efm32_i2c_sem_wait_uninterruptible(FAR struct efm32_i2c_priv_s *priv)
+  efm32_i2c_sem_wait_noncancelable(FAR struct efm32_i2c_priv_s *priv)
 {
   return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
@@ -1625,7 +1625,7 @@ int efm32_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  ret = efm32_i2c_sem_wait_uninterruptible(priv);
+  ret = efm32_i2c_sem_wait_noncancelable(priv);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/imxrt/imxrt_ehci.c
+++ b/arch/arm/src/imxrt/imxrt_ehci.c
@@ -434,7 +434,7 @@ static int ehci_wait_usbsts(uint32_t maskbits, uint32_t donebits,
 /* Semaphores ***************************************************************/
 
 static int imxrt_takesem(sem_t *sem);
-static int imxrt_takesem_uninterruptible(sem_t *sem);
+static int imxrt_takesem_noncancelable(sem_t *sem);
 #define imxrt_givesem(s) nxsem_post(s);
 
 /* Allocators ***************************************************************/
@@ -1078,7 +1078,7 @@ static int imxrt_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: imxrt_takesem_uninterruptible
+ * Name: imxrt_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -1087,7 +1087,7 @@ static int imxrt_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int imxrt_takesem_uninterruptible(sem_t *sem)
+static int imxrt_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -2591,7 +2591,7 @@ static ssize_t imxrt_transfer_wait(struct imxrt_epinfo_s *epinfo)
    * this upon return.
    */
 
-  ret2 = imxrt_takesem_uninterruptible(&g_ehci.exclsem);
+  ret2 = imxrt_takesem_noncancelable(&g_ehci.exclsem);
   if (ret >= 0 && ret2 < 0)
     {
       ret = ret2;
@@ -2615,7 +2615,7 @@ static ssize_t imxrt_transfer_wait(struct imxrt_epinfo_s *epinfo)
     }
 #endif
 
-  /* Did imxrt_ioc_wait() or imxrt_takesem_uninterruptible() report an
+  /* Did imxrt_ioc_wait() or imxrt_takesem_noncancelable() report an
    * error?
    */
 
@@ -3338,7 +3338,7 @@ static void imxrt_ehci_bottomhalf(FAR void *arg)
    * real option (other than to reschedule and delay).
    */
 
-  imxrt_takesem_uninterruptible(&g_ehci.exclsem);
+  imxrt_takesem_noncancelable(&g_ehci.exclsem);
 
   /* Handle all unmasked interrupt sources
    * USB Interrupt (USBINT)

--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -240,7 +240,7 @@ static inline void imxrt_lpi2c_modifyreg(FAR struct imxrt_lpi2c_priv_s *priv,
                                          uint32_t setbits);
 static inline int imxrt_lpi2c_sem_wait(FAR struct imxrt_lpi2c_priv_s *priv);
 static int
-  imxrt_lpi2c_sem_wait_uninterruptible(FAR struct imxrt_lpi2c_priv_s *priv);
+  imxrt_lpi2c_sem_wait_noncancelable(FAR struct imxrt_lpi2c_priv_s *priv);
 
 #ifdef CONFIG_IMXRT_LPI2C_DYNTIMEO
 static useconds_t imxrt_lpi2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
@@ -536,7 +536,7 @@ static inline int imxrt_lpi2c_sem_wait(FAR struct imxrt_lpi2c_priv_s *priv)
 }
 
 /****************************************************************************
- * Name: imxrt_lpi2c_sem_wait_uninterruptible
+ * Name: imxrt_lpi2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary.
@@ -544,7 +544,7 @@ static inline int imxrt_lpi2c_sem_wait(FAR struct imxrt_lpi2c_priv_s *priv)
  ****************************************************************************/
 
 static int
-  imxrt_lpi2c_sem_wait_uninterruptible(FAR struct imxrt_lpi2c_priv_s *priv)
+  imxrt_lpi2c_sem_wait_noncancelable(FAR struct imxrt_lpi2c_priv_s *priv)
 {
   return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
@@ -1795,7 +1795,7 @@ static int imxrt_lpi2c_reset(FAR struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  ret = imxrt_lpi2c_sem_wait_uninterruptible(priv);
+  ret = imxrt_lpi2c_sem_wait_noncancelable(priv);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/kinetis/kinetis_i2c.c
+++ b/arch/arm/src/kinetis/kinetis_i2c.c
@@ -153,7 +153,7 @@ static inline void
   kinetis_i2c_sem_destroy(FAR struct kinetis_i2cdev_s *priv);
 static inline int kinetis_i2c_sem_wait(FAR struct kinetis_i2cdev_s *priv);
 static int
-  kinetis_i2c_sem_wait_uninterruptible(FAR struct kinetis_i2cdev_s *priv);
+  kinetis_i2c_sem_wait_noncancelable(FAR struct kinetis_i2cdev_s *priv);
 static inline void kinetis_i2c_sem_post(struct kinetis_i2cdev_s *priv);
 
 /* Signal Helper */
@@ -364,7 +364,7 @@ static inline int kinetis_i2c_sem_wait(FAR struct kinetis_i2cdev_s *priv)
 }
 
 /****************************************************************************
- * Name: kinetis_i2c_sem_wait_uninterruptible
+ * Name: kinetis_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary
@@ -372,7 +372,7 @@ static inline int kinetis_i2c_sem_wait(FAR struct kinetis_i2cdev_s *priv)
  ****************************************************************************/
 
 static int
-  kinetis_i2c_sem_wait_uninterruptible(FAR struct kinetis_i2cdev_s *priv)
+  kinetis_i2c_sem_wait_noncancelable(FAR struct kinetis_i2cdev_s *priv)
 {
   return nxsem_wait_uninterruptible(&priv->mutex);
 }
@@ -1280,7 +1280,7 @@ static int kinetis_i2c_reset(struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  ret = kinetis_i2c_sem_wait_uninterruptible(priv);
+  ret = kinetis_i2c_sem_wait_noncancelable(priv);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_usbhost.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_usbhost.c
@@ -289,7 +289,7 @@ static void lpc17_40_putreg(uint32_t val, uint32_t addr);
 /* Semaphores ***************************************************************/
 
 static int lpc17_40_takesem(sem_t *sem);
-static int lpc17_40_takesem_uninterruptible(sem_t *sem);
+static int lpc17_40_takesem_noncancelable(sem_t *sem);
 #define lpc17_40_givesem(s) nxsem_post(s);
 
 /* Byte stream access helper functions **************************************/
@@ -596,7 +596,7 @@ static int lpc17_40_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: lpc17_40_takesem_uninterruptible
+ * Name: lpc17_40_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -605,7 +605,7 @@ static int lpc17_40_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int lpc17_40_takesem_uninterruptible(sem_t *sem)
+static int lpc17_40_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -2587,7 +2587,7 @@ static int lpc17_40_free(struct usbhost_driver_s *drvr, uint8_t *buffer)
 
   /* We must have exclusive access to the transfer buffer pool */
 
-  ret = lpc17_40_takesem_uninterruptible(&priv->exclsem);
+  ret = lpc17_40_takesem_noncancelable(&priv->exclsem);
   lpc17_40_tbfree(buffer);
   lpc17_40_givesem(&priv->exclsem);
   return ret;

--- a/arch/arm/src/lpc31xx/lpc31_ehci.c
+++ b/arch/arm/src/lpc31xx/lpc31_ehci.c
@@ -419,7 +419,7 @@ static int ehci_wait_usbsts(uint32_t maskbits, uint32_t donebits,
 /* Semaphores ***************************************************************/
 
 static int lpc31_takesem(sem_t *sem);
-static int lpc31_takesem_uninterruptible(sem_t *sem);
+static int lpc31_takesem_noncancelable(sem_t *sem);
 #define lpc31_givesem(s) nxsem_post(s);
 
 /* Allocators ***************************************************************/
@@ -1064,7 +1064,7 @@ static int lpc31_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: lpc31_takesem_uninterruptible
+ * Name: lpc31_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -1073,7 +1073,7 @@ static int lpc31_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int lpc31_takesem_uninterruptible(sem_t *sem)
+static int lpc31_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -2575,7 +2575,7 @@ static ssize_t lpc31_transfer_wait(struct lpc31_epinfo_s *epinfo)
    * this upon return.
    */
 
-  ret2 = lpc31_takesem_uninterruptible(&g_ehci.exclsem);
+  ret2 = lpc31_takesem_noncancelable(&g_ehci.exclsem);
   if (ret2 < 0)
     {
       ret = ret2;
@@ -2599,7 +2599,7 @@ static ssize_t lpc31_transfer_wait(struct lpc31_epinfo_s *epinfo)
     }
 #endif
 
-  /* Did lpc31_ioc_wait() or lpc31_takesem_uninterruptible() report an
+  /* Did lpc31_ioc_wait() or lpc31_takesem_noncancelable() report an
    * error?
    */
 
@@ -3322,7 +3322,7 @@ static void lpc31_ehci_bottomhalf(FAR void *arg)
    * real option (other than to reschedule and delay).
    */
 
-  lpc31_takesem_uninterruptible(&g_ehci.exclsem);
+  lpc31_takesem_noncancelable(&g_ehci.exclsem);
 
   /* Handle all unmasked interrupt sources */
 

--- a/arch/arm/src/lpc43xx/lpc43_ehci.c
+++ b/arch/arm/src/lpc43xx/lpc43_ehci.c
@@ -421,7 +421,7 @@ static int ehci_wait_usbsts(uint32_t maskbits, uint32_t donebits,
 /* Semaphores ***************************************************************/
 
 static int lpc43_takesem(sem_t *sem);
-static int lpc43_takesem_uninterruptible(sem_t *sem);
+static int lpc43_takesem_noncancelable(sem_t *sem);
 #define lpc43_givesem(s) nxsem_post(s);
 
 /* Allocators ***************************************************************/
@@ -1054,7 +1054,7 @@ static int lpc43_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: lpc43_takesem_uninterruptible
+ * Name: lpc43_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -1063,7 +1063,7 @@ static int lpc43_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int lpc43_takesem_uninterruptible(sem_t *sem)
+static int lpc43_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -2462,13 +2462,13 @@ static ssize_t lpc43_transfer_wait(struct lpc43_epinfo_s *epinfo)
    * this upon return.
    */
 
-  ret2 = lpc43_takesem_uninterruptible(&g_ehci.exclsem);
+  ret2 = lpc43_takesem_noncancelable(&g_ehci.exclsem);
   if (ret2 < 0)
     {
       ret = ret2;
     }
 
-  /* Did lpc43_ioc_wait() or lpc43_takesem_uninterruptible()report an
+  /* Did lpc43_ioc_wait() or lpc43_takesem_noncancelable()report an
    * error?
    */
 
@@ -3160,7 +3160,7 @@ static void lpc43_ehci_bottomhalf(FAR void *arg)
    * real option (other than to reschedule and delay).
    */
 
-  lpc43_takesem_uninterruptible(&g_ehci.exclsem);
+  lpc43_takesem_noncancelable(&g_ehci.exclsem);
 
   /* Handle all unmasked interrupt sources */
 

--- a/arch/arm/src/lpc54xx/lpc54_usb0_ohci.c
+++ b/arch/arm/src/lpc54xx/lpc54_usb0_ohci.c
@@ -370,7 +370,7 @@ static void lpc54_putreg(uint32_t val, uint32_t addr);
 /* Semaphores ***************************************************************/
 
 static int  lpc54_takesem(sem_t *sem);
-static int  lpc54_takesem_uninterruptible(sem_t *sem);
+static int  lpc54_takesem_noncancelable(sem_t *sem);
 #define lpc54_givesem(s) nxsem_post(s);
 
 /* Byte stream access helper functions **************************************/
@@ -692,7 +692,7 @@ static int lpc54_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: lpc54_takesem_uninterruptible
+ * Name: lpc54_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -701,7 +701,7 @@ static int lpc54_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int lpc54_takesem_uninterruptible(sem_t *sem)
+static int lpc54_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -2672,7 +2672,7 @@ static int lpc54_free(struct usbhost_driver_s *drvr, uint8_t *buffer)
 
   /* We must have exclusive access to the transfer buffer pool */
 
-  ret = lpc54_takesem_uninterruptible(&priv->exclsem);
+  ret = lpc54_takesem_noncancelable(&priv->exclsem);
   lpc54_tbfree(buffer);
   lpc54_givesem(&priv->exclsem);
   return ret;

--- a/arch/arm/src/sama5/sam_can.c
+++ b/arch/arm/src/sama5/sam_can.c
@@ -65,17 +65,18 @@
 #include "up_internal.h"
 #include "up_arch.h"
 
-
 #include "hardware/sam_pinmap.h"
 #include "sam_periphclks.h"
 #include "sam_pio.h"
 #include "sam_can.h"
 
-#if defined(CONFIG_CAN) && (defined(CONFIG_SAMA5_CAN0) || defined(CONFIG_SAMA5_CAN1))
+#if defined(CONFIG_CAN) && (defined(CONFIG_SAMA5_CAN0) || \
+    defined(CONFIG_SAMA5_CAN1))
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Common definitions *******************************************************/
 
 #ifndef MIN
@@ -99,6 +100,7 @@
 #endif
 
 /* Interrupts ***************************************************************/
+
 /* If debug is enabled, then print some diagnostic info if any of these
  * events occur:
  *
@@ -114,7 +116,8 @@
  *
  * CAN_INT_CERR      YES    Bit 24: Mailbox CRC Error
  * CAN_INT_SERR      YES    Bit 25: Mailbox Stuffing Error
- * CAN_INT_AERR      NO     Bit 26: Acknowledgment Error (uusally means no CAN bus)
+ * CAN_INT_AERR      NO     Bit 26: Acknowledgment Error (usally means no
+ *                                  CAN bus)
  * CAN_INT_FERR      YES    Bit 27: Form Error
  *
  * CAN_INT_BERR      YES    Bit 28: Bit Error
@@ -130,6 +133,7 @@
 /****************************************************************************
  * Private Types
  ****************************************************************************/
+
 /* This structure describes receive mailbox filtering */
 
 struct sam_filter_s
@@ -164,7 +168,10 @@ struct sam_config_s
 
 struct sam_can_s
 {
-  const struct sam_config_s *config; /* The constant configuration */
+  /* The constant configuration */
+
+  const struct sam_config_s *config;
+
   bool initialized;         /* TRUE: Device has been initialized */
   uint8_t freemb;           /* Rhe set of unalloated mailboxes */
   uint8_t rxmbset;          /* The set of mailboxes configured for receive */
@@ -187,9 +194,11 @@ struct sam_can_s
 /* CAN Register access */
 
 static uint32_t can_getreg(FAR struct sam_can_s *priv, int offset);
-static void can_putreg(FAR struct sam_can_s *priv, int offset, uint32_t regval);
+static void can_putreg(FAR struct sam_can_s *priv, int offset,
+              uint32_t regval);
 #ifdef CONFIG_SAMA5_CAN_REGDEBUG
-static void can_dumpctrlregs(FAR struct sam_can_s *priv, FAR const char *msg);
+static void can_dumpctrlregs(FAR struct sam_can_s *priv,
+              FAR const char *msg);
 static void can_dumpmbregs(FAR struct sam_can_s *priv, FAR const char *msg);
 #else
 #  define can_dumpctrlregs(priv,msg)
@@ -421,7 +430,8 @@ static uint32_t can_getreg(FAR struct sam_can_s *priv, int offset)
  ****************************************************************************/
 
 #ifdef CONFIG_SAMA5_CAN_REGDEBUG
-static void can_putreg(FAR struct sam_can_s *priv, int offset, uint32_t regval)
+static void can_putreg(FAR struct sam_can_s *priv, int offset,
+                       uint32_t regval)
 {
   FAR const struct sam_config_s *config = priv->config;
   uintptr_t regaddr = config->base + offset;
@@ -436,7 +446,8 @@ static void can_putreg(FAR struct sam_can_s *priv, int offset, uint32_t regval)
 }
 
 #else
-static void can_putreg(FAR struct sam_can_s *priv, int offset, uint32_t regval)
+static void can_putreg(FAR struct sam_can_s *priv, int offset,
+                       uint32_t regval)
 {
   FAR const struct sam_config_s *config = priv->config;
   putreg32(regval, config->base + offset);
@@ -830,7 +841,8 @@ static int can_setup(FAR struct can_dev_s *dev)
   ret = can_hwinitialize(priv);
   if (ret < 0)
     {
-      canerr("ERROR: CAN%d H/W initialization failed: %d\n", config->port, ret);
+      canerr("ERROR: CAN%d H/W initialization failed: %d\n",
+             config->port, ret);
       return ret;
     }
 
@@ -842,7 +854,8 @@ static int can_setup(FAR struct can_dev_s *dev)
   ret = irq_attach(config->pid, can_interrupt, dev);
   if (ret < 0)
     {
-      canerr("ERROR: Failed to attach CAN%d IRQ (%d)", config->port, config->pid);
+      canerr("ERROR: Failed to attach CAN%d IRQ (%d)",
+             config->port, config->pid);
       return ret;
     }
 
@@ -851,7 +864,8 @@ static int can_setup(FAR struct can_dev_s *dev)
   ret = can_recvsetup(priv);
   if (ret < 0)
     {
-      canerr("ERROR: CAN%d H/W initialization failed: %d\n", config->port, ret);
+      canerr("ERROR: CAN%d H/W initialization failed: %d\n",
+             config->port, ret);
       return ret;
     }
 
@@ -1100,10 +1114,12 @@ static int can_send(FAR struct can_dev_s *dev, FAR struct can_msg_s *msg)
 #ifdef CONFIG_CAN_EXTID
   DEBUGASSERT(msg->cm_hdr.ch_extid);
   DEBUGASSERT(msg->cm_hdr.ch_id < (1 << 29));
-  can_putreg(priv, SAM_CAN_MnID_OFFSET(mbndx), CAN_MID_EXTID(msg->cm_hdr.ch_id));
+  can_putreg(priv, SAM_CAN_MnID_OFFSET(mbndx),
+             CAN_MID_EXTID(msg->cm_hdr.ch_id));
 #else
   DEBUGASSERT(msg->cm_hdr.ch_id < (1 << 11));
-  can_putreg(priv, SAM_CAN_MnID_OFFSET(mbndx), CAN_MID_STDID(msg->cm_hdr.ch_id));
+  can_putreg(priv, SAM_CAN_MnID_OFFSET(mbndx),
+             CAN_MID_STDID(msg->cm_hdr.ch_id));
 #endif
 
   /* Enable transmit mode */
@@ -1118,7 +1134,8 @@ static int can_send(FAR struct can_dev_s *dev, FAR struct can_msg_s *msg)
    * message data length in the CAN_MCRx register.
    */
 
-  DEBUGASSERT((can_getreg(priv, SAM_CAN_MnSR_OFFSET(mbndx)) & CAN_MSR_MRDY) != 0);
+  DEBUGASSERT((can_getreg(priv, SAM_CAN_MnSR_OFFSET(mbndx)) &
+               CAN_MSR_MRDY) != 0);
 
   /* Bytes are received/sent on the bus in the following order:
    *
@@ -1139,10 +1156,12 @@ static int can_send(FAR struct can_dev_s *dev, FAR struct can_msg_s *msg)
   /* The message buffer is probably not properaly aligned for 32-bit accesses */
 
   ptr    = msg->cm_data;
-  regval = CAN_MDL0(ptr[0]) | CAN_MDL1(ptr[1]) | CAN_MDL2(ptr[2]) | CAN_MDL3(ptr[3]);
+  regval = CAN_MDL0(ptr[0]) | CAN_MDL1(ptr[1]) | CAN_MDL2(ptr[2]) |
+           CAN_MDL3(ptr[3]);
   can_putreg(priv, SAM_CAN_MnDL_OFFSET(mbndx), regval);
 
-  regval = CAN_MDH4(ptr[4]) | CAN_MDH5(ptr[5]) | CAN_MDH6(ptr[6]) | CAN_MDH7(ptr[7]);
+  regval = CAN_MDH4(ptr[4]) | CAN_MDH5(ptr[5]) | CAN_MDH6(ptr[6]) |
+           CAN_MDH7(ptr[7]);
   can_putreg(priv, SAM_CAN_MnDH_OFFSET(mbndx), regval);
 
   /* Set the DLC value in the CAN_MCRx register.  Set the MTCR register
@@ -1270,10 +1289,10 @@ static inline void can_rxinterrupt(FAR struct can_dev_s *dev, int mbndx,
   md[0] = can_getreg(priv, SAM_CAN_MnDH_OFFSET(mbndx));
   md[1] = can_getreg(priv, SAM_CAN_MnDL_OFFSET(mbndx));
 
-  /* Get the ID associated with the newly received message: )nce a new message
-   * is received, its ID is masked with the CAN_MAMx value and compared
-   * with the CAN_MIDx value. If accepted, the message ID is copied to the
-   * CAN_MIDx register.
+  /* Get the ID associated with the newly received message: )nce a new
+   * message is received, its ID is masked with the CAN_MAMx value and
+   * compared with the CAN_MIDx value. If accepted, the message ID is
+   * copied to the CAN_MIDx register.
    */
 
   mid = can_getreg(priv, SAM_CAN_MnID_OFFSET(mbndx));
@@ -1401,7 +1420,8 @@ static inline void can_mbinterrupt(FAR struct can_dev_s *dev, int mbndx)
           case CAN_MMR_MOT_CONSUMER: /* Consumer Mailbox */
           case CAN_MMR_MOT_PRODUCER: /* Producer Mailbox */
           case CAN_MMR_MOT_DISABLED: /* Mailbox is disabled */
-            canerr("ERROR: CAN%d MB%d: Unsupported or invalid mailbox type\n",
+            canerr("ERROR: CAN%d MB%d: Unsupported or "
+                    "invalid mailbox type\n",
                    priv->config->port, mbndx);
             canerr("       MSR: %08x MMR: %08x\n", msr, mmr);
             break;
@@ -1438,8 +1458,9 @@ static void can_interrupt(int irq, void *context, FAR void *arg)
   /* Get the set of pending interrupts.
    *
    * All interrupts are cleared by clearing the interrupt source except for
-   * the internal timer counter overflow interrupt and the timestamp interrupt.
-   * These interrupts are cleared by reading the CAN_SR register.
+   * the internal timer counter overflow interrupt and the timestamp
+   * interrupt. * These interrupts are cleared by reading the CAN_SR
+   * register.
    */
 
   sr      = can_getreg(priv, SAM_CAN_SR_OFFSET);
@@ -1677,7 +1698,8 @@ static int can_bittiming(struct sam_can_s *priv)
 
   if ((propag + phase1 + phase2) != (uint32_t)(tq - 4))
     {
-      canerr("CAN%d ERROR: Could not realize baud %d\n", config->port, config->baud);
+      canerr("CAN%d ERROR: Could not realize baud %d\n",
+             config->port, config->baud);
       return -EINVAL;
     }
 
@@ -1730,11 +1752,11 @@ static int can_autobaud(struct sam_can_s *priv)
 #warning Missing Logic
 
       /* Autobaud Mode. The autobaud feature is enabled by setting the ABM
-       * field in the CAN_MR register. In this mode, the CAN controller is only
-       * listening to the line without acknowledging the received messages. It
-       * can not send any message. The errors flags are updated. The bit timing
-       * can be adjusted until no error occurs (good configuration found). In
-       * this mode, the error counters are frozen.
+       * field in the CAN_MR register. In this mode, the CAN controller is
+       * only listening to the line without acknowledging the received
+       * messages. It can not send any message. The errors flags are
+       * updated. The bit timing can be adjusted until no error occurs (good
+       * configuration found).  In this mode, the error counters are frozen.
        */
 
       regval  = can_getreg(priv, SAM_CAN_MR_OFFSET);

--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -297,7 +297,7 @@ static int ehci_wait_usbsts(uint32_t maskbits, uint32_t donebits,
 /* Semaphores ***************************************************************/
 
 static int  sam_takesem(sem_t *sem);
-static int  sam_takesem_uninterruptible(sem_t *sem);
+static int  sam_takesem_noncancelable(sem_t *sem);
 #define sam_givesem(s) nxsem_post(s);
 
 /* Allocators ***************************************************************/
@@ -810,7 +810,7 @@ static int sam_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: sam_takesem_uninterruptible
+ * Name: sam_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -819,7 +819,7 @@ static int sam_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int sam_takesem_uninterruptible(sem_t *sem)
+static int sam_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -2336,7 +2336,7 @@ static ssize_t sam_transfer_wait(struct sam_epinfo_s *epinfo)
    * this upon return.
    */
 
-  ret2 = sam_takesem_uninterruptible(&g_ehci.exclsem);
+  ret2 = sam_takesem_noncancelable(&g_ehci.exclsem);
   if (ret2 < 0)
     {
       ret = ret2;
@@ -2360,7 +2360,7 @@ static ssize_t sam_transfer_wait(struct sam_epinfo_s *epinfo)
     }
 #endif
 
-  /* Did sam_ioc_wait() or sam_takesem_uninterruptible() report an error? */
+  /* Did sam_ioc_wait() or sam_takesem_noncancelable() report an error? */
 
   if (ret < 0)
     {
@@ -3070,7 +3070,7 @@ static void sam_ehci_bottomhalf(FAR void *arg)
    * real option (other than to reschedule and delay).
    */
 
-  sam_takesem_uninterruptible(&g_ehci.exclsem);
+  sam_takesem_noncancelable(&g_ehci.exclsem);
 
   /* Handle all unmasked interrupt sources */
 

--- a/arch/arm/src/sama5/sam_nand.c
+++ b/arch/arm/src/sama5/sam_nand.c
@@ -137,6 +137,7 @@
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
+
 /* Low-level HSMC Helpers */
 
 #if NAND_NBANKS > 1
@@ -265,6 +266,7 @@ static void     nand_reset(struct sam_nandcs_s *priv);
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
 /* These pre-allocated structures hold the state of the MTD driver for NAND
  * on CS0..3 as configured.
  */
@@ -648,8 +650,10 @@ static void nand_nfc_cleale(struct sam_nandcs_s *priv, uint8_t mode,
     }
 
   cmd = (rw | regval | NFCADDR_CMD_CSID(priv->cs) | acycle |
-         (((mode & HSMC_CLE_VCMD2_EN) == HSMC_CLE_VCMD2_EN) ? NFCADDR_CMD_VCMD2 : 0) |
-         (cmd1 << NFCADDR_CMD_CMD1_SHIFT) | (cmd2 << NFCADDR_CMD_CMD2_SHIFT));
+         (((mode & HSMC_CLE_VCMD2_EN) == HSMC_CLE_VCMD2_EN) ?
+         NFCADDR_CMD_VCMD2 : 0) |
+         (cmd1 << NFCADDR_CMD_CMD1_SHIFT) |
+         (cmd2 << NFCADDR_CMD_CMD2_SHIFT));
 
   nand_nfc_cmdsend(priv, cmd, acycle1234, acycle0);
 }
@@ -974,10 +978,6 @@ static uint32_t nand_nfc_poll(void)
 
   sr = nand_getreg(SAM_HSMC_SR);
 
-#ifndef CONFIG_SAMA5_NAND_REGDEBUG
-  // finfo("sr=%08x\n", sr);
-#endif
-
   /* When set to one, this XFRDONE indicates that the NFC has terminated
    * the data transfer. This flag is reset after the status read.
    */
@@ -1000,10 +1000,10 @@ static uint32_t nand_nfc_poll(void)
       g_nand.cmddone = true;
     }
 
-  /* If set to one, the RBEDGE0 flag indicates that an edge has been detected
-   * on the Ready/Busy Line x. Depending on the EDGE CTRL field located in the
-   * SMC_CFG register, only rising or falling edge is detected. This flag is
-   * reset after the status read.
+  /* If set to one, the RBEDGE0 flag indicates that an edge has been
+   * detected on the Ready/Busy Line x. Depending on the EDGE CTRL field
+   * located in the SMC_CFG register, only rising or falling edge is
+   * detected. This flag is reset after the status read.
    */
 
   if ((sr & HSMC_NFCINT_RBEDGE0) != 0)
@@ -1074,10 +1074,10 @@ static int hsmc_interrupt(int irq, void *context, FAR void *arg)
       nand_putreg(SAM_HSMC_IDR, HSMC_NFCINT_CMDDONE);
     }
 
-  /* If set to one, the RBEDGE0 flag indicates that an edge has been detected
-   * on the Ready/Busy Line x. Depending on the EDGE CTRL field located in the
-   * SMC_CFG register, only rising or falling edge is detected. This flag is
-   * reset after the status read.
+  /* If set to one, the RBEDGE0 flag indicates that an edge has been
+   * detected on the Ready/Busy Line x. Depending on the EDGE CTRL field
+   * located in the SMC_CFG register, only rising or falling edge is
+   * detected. This flag is reset after the status read.
    */
 
   if (g_nand.rbedge && (imr & HSMC_NFCINT_RBEDGE0) != 0)
@@ -1146,17 +1146,21 @@ static void nand_dma_sampledone(struct sam_nandcs_s *priv, int result)
   sam_dmasample(priv->dma, &priv->dmaregs[DMA_END_TRANSFER]);
 
   /* Then dump the sampled DMA registers */
+
   /* Initial register values */
 
-  sam_dmadump(priv->dma, &priv->dmaregs[DMA_INITIAL], "Initial Registers");
+  sam_dmadump(priv->dma, &priv->dmaregs[DMA_INITIAL],
+              "Initial Registers");
 
   /* Register values after DMA setup */
 
-  sam_dmadump(priv->dma, &priv->dmaregs[DMA_AFTER_SETUP], "After DMA Setup");
+  sam_dmadump(priv->dma, &priv->dmaregs[DMA_AFTER_SETUP],
+              "After DMA Setup");
 
   /* Register values after DMA start */
 
-  sam_dmadump(priv->dma, &priv->dmaregs[DMA_AFTER_START], "After DMA Start");
+  sam_dmadump(priv->dma, &priv->dmaregs[DMA_AFTER_START],
+              "After DMA Start");
 
   /* Register values at the time of the TX and RX DMA callbacks
    * -OR- DMA timeout.
@@ -1169,15 +1173,18 @@ static void nand_dma_sampledone(struct sam_nandcs_s *priv, int result)
 #if 0 /* No timeout */
   if (result == -ETIMEDOUT || result == -EINTR)
     {
-      sam_dmadump(priv->dma, &priv->dmaregs[DMA_TIMEOUT], "At DMA timeout");
+      sam_dmadump(priv->dma, &priv->dmaregs[DMA_TIMEOUT],
+                  "At DMA timeout");
     }
   else
 #endif
     {
-      sam_dmadump(priv->dma, &priv->dmaregs[DMA_CALLBACK], "At DMA callback");
+      sam_dmadump(priv->dma, &priv->dmaregs[DMA_CALLBACK],
+                  "At DMA callback");
     }
 
-  sam_dmadump(priv->dma, &priv->dmaregs[DMA_END_TRANSFER], "At End-of-Transfer");
+  sam_dmadump(priv->dma, &priv->dmaregs[DMA_END_TRANSFER],
+              "At End-of-Transfer");
 }
 #endif
 
@@ -1372,9 +1379,10 @@ static int nand_dma_write(struct sam_nandcs_s *priv,
   sam_dmaconfig(priv->dma, dmaflags);
 
   /* Setup the Memory-to-Memory DMA.  The semantics of the DMA module are
-   * awkward here.  We will treat the NAND (dest) as the peripheral destination
-   * and memory as the source.  Internally, the DMA module will realize that
-   * this is a memory to memory transfer and should do the right thing.
+   * awkward here.  We will treat the NAND (dest) as the peripheral
+   * destination and memory as the source.  Internally, the DMA module will
+   * realize that this is a memory to memory transfer and should do the
+   * right thing.
    */
 
   ret = sam_dmatxsetup(priv->dma, pdest, psrc, nbytes);
@@ -1452,7 +1460,8 @@ static int nand_nfcsram_read(struct sam_nandcs_s *priv, uint8_t *buffer,
 
       /* Transfer using DMA */
 
-      ret = nand_dma_read(priv, src, (uintptr_t)buffer, buflen, NFCSRAM_DMA_FLAGS);
+      ret = nand_dma_read(priv, src, (uintptr_t)buffer, buflen,
+                          NFCSRAM_DMA_FLAGS);
     }
   else
 #endif
@@ -1479,8 +1488,9 @@ static int nand_nfcsram_read(struct sam_nandcs_s *priv, uint8_t *buffer,
  * Name: nand_read
  *
  * Description:
- *   Read data directly from the NAND data address.  Currently this only used
- *   by the PMECC logic which I could not get working if I read from NFC SRAM.
+ *   Read data directly from the NAND data address.  Currently this only
+ *   used by the PMECC logic which I could not get working if I read from
+ *   NFC SRAM.
  *
  * Input Parameters:
  *   priv     - Lower-half, private NAND FLASH device state
@@ -1536,7 +1546,8 @@ static int nand_read(struct sam_nandcs_s *priv, uint8_t *buffer,
       remaining = buflen;
       if (buswidth == 16)
         {
-          volatile uint16_t *src16  = (volatile uint16_t *)priv->raw.dataaddr;
+          volatile uint16_t *src16  =
+            (volatile uint16_t *)priv->raw.dataaddr;
           uint16_t *dest16 = (uint16_t *)buffer;
 
           DEBUGASSERT(((uintptr_t)buffer & 1) == 0);
@@ -1659,7 +1670,8 @@ static int nand_read_pmecc(struct sam_nandcs_s *priv, off_t block,
 
 #if 0 /* Don't use NFC SRAM */
   nand_nfc_cleale(priv,
-                  HSMC_ALE_COL_EN | HSMC_ALE_ROW_EN | HSMC_CLE_VCMD2_EN | HSMC_CLE_DATA_EN,
+                  HSMC_ALE_COL_EN | HSMC_ALE_ROW_EN | HSMC_CLE_VCMD2_EN |
+                  HSMC_CLE_DATA_EN,
                   COMMAND_READ_1, COMMAND_READ_2, 0, rowaddr);
 #else
   nand_setup_rbedge(priv);
@@ -1751,11 +1763,13 @@ static int nand_nfcsram_write(struct sam_nandcs_s *priv, uint8_t *buffer,
 
   if (priv->dma && buflen > CONFIG_SAMA5_NAND_DMA_THRESHOLD)
     {
-      DEBUGASSERT(((uintptr_t)buffer & 3) == 0 && ((uintptr_t)dest & 3) == 0);
+      DEBUGASSERT(((uintptr_t)buffer & 3) == 0 &&
+                  ((uintptr_t)dest & 3) == 0);
 
       /* Transfer using DMA */
 
-      ret = nand_dma_write(priv, (uintptr_t)buffer, dest, buflen, NFCSRAM_DMA_FLAGS);
+      ret = nand_dma_write(priv, (uintptr_t)buffer, dest, buflen,
+                           NFCSRAM_DMA_FLAGS);
     }
   else
 #endif
@@ -1894,7 +1908,8 @@ static int nand_readpage_noecc(struct sam_nandcs_s *priv, off_t block,
   off_t coladdr;
   int ret;
 
-  finfo("block=%d page=%d data=%p spare=%p\n", (int)block, page, data, spare);
+  finfo("block=%d page=%d data=%p spare=%p\n",
+        (int)block, page, data, spare);
   DEBUGASSERT(priv && (data || spare));
 
   /* Get page and spare sizes */
@@ -1933,8 +1948,9 @@ static int nand_readpage_noecc(struct sam_nandcs_s *priv, off_t block,
 
   /* Configure the SMC */
 
-  regval |= (HSMC_CFG_RBEDGE | HSMC_CFG_DTOCYC(15) | HSMC_CFG_DTOMUL_1048576 |
-             HSMC_CFG_NFCSPARESIZE((sparesize - 1) >> 2));
+  regval |= HSMC_CFG_RBEDGE | HSMC_CFG_DTOCYC(15) |
+            HSMC_CFG_DTOMUL_1048576 |
+            HSMC_CFG_NFCSPARESIZE((sparesize - 1) >> 2);
   nand_putreg(SAM_HSMC_CFG, regval);
 
   /* Calculate actual address of the page */
@@ -1946,7 +1962,8 @@ static int nand_readpage_noecc(struct sam_nandcs_s *priv, off_t block,
 
   nand_setup_xfrdone(priv);
   nand_nfc_cleale(priv,
-                  HSMC_ALE_COL_EN | HSMC_ALE_ROW_EN | HSMC_CLE_VCMD2_EN | HSMC_CLE_DATA_EN,
+                  HSMC_ALE_COL_EN | HSMC_ALE_ROW_EN | HSMC_CLE_VCMD2_EN |
+                  HSMC_CLE_DATA_EN,
                   COMMAND_READ_1, COMMAND_READ_2, coladdr, rowaddr);
   nand_wait_xfrdone(priv);
 
@@ -1973,7 +1990,8 @@ static int nand_readpage_noecc(struct sam_nandcs_s *priv, off_t block,
       ret = nand_nfcsram_read(priv, (uint8_t *)spare, sparesize, offset);
       if (ret < 0)
         {
-          ferr("ERROR: nand_nfcsram_read for spare region failed: %d\n", ret);
+          ferr("ERROR: nand_nfcsram_read for spare region failed: %d\n",
+               ret);
           return ret;
         }
     }
@@ -2041,6 +2059,7 @@ static int nand_readpage_pmecc(struct sam_nandcs_s *priv, off_t block,
   if (regval)
     {
       /* Bad sectors.  Check if this is because spare area has been erased */
+
       /* First, re-read the spare area.  REVISIT:  Is this necessary? */
 
       ret = nand_readpage_noecc(priv, block, page, NULL, priv->raw.spare);
@@ -2129,7 +2148,8 @@ static int nand_writepage_noecc(struct sam_nandcs_s *priv, off_t block,
   off_t rowaddr;
   int ret = OK;
 
-  finfo("block=%d page=%d data=%p spare=%p\n", (int)block, page, data, spare);
+  finfo("block=%d page=%d data=%p spare=%p\n",
+        (int)block, page, data, spare);
 
   /* Get page and spare sizes */
 
@@ -2167,8 +2187,9 @@ static int nand_writepage_noecc(struct sam_nandcs_s *priv, off_t block,
 
   /* Configure the SMC */
 
-  regval |= (HSMC_CFG_RBEDGE | HSMC_CFG_DTOCYC(15) | HSMC_CFG_DTOMUL_1048576 |
-             HSMC_CFG_NFCSPARESIZE((sparesize - 1) >> 2));
+  regval |= HSMC_CFG_RBEDGE | HSMC_CFG_DTOCYC(15) |
+            HSMC_CFG_DTOMUL_1048576 |
+            HSMC_CFG_NFCSPARESIZE((sparesize - 1) >> 2);
 
   if (spare)
     {
@@ -2190,16 +2211,19 @@ static int nand_writepage_noecc(struct sam_nandcs_s *priv, off_t block,
       ret = nand_nfcsram_write(priv, (uint8_t *)data, pagesize, 0);
       if (ret < 0)
         {
-          ferr("ERROR: nand_nfcsram_write for data region failed: %d\n", ret);
+          ferr("ERROR: nand_nfcsram_write for data region failed: %d\n",
+               ret);
           return ret;
         }
 
       if (spare)
         {
-          ret = nand_nfcsram_write(priv, (uint8_t *)spare, sparesize, pagesize);
+          ret = nand_nfcsram_write(priv, (uint8_t *)spare, sparesize,
+                                   pagesize);
           if (ret < 0)
             {
-              ferr("ERROR: nand_nfcsram_write for data region failed: %d\n", ret);
+              ferr("ERROR: nand_nfcsram_write for data region failed: %d\n",
+                   ret);
               return ret;
             }
         }
@@ -2322,7 +2346,8 @@ static int nand_writepage_pmecc(struct sam_nandcs_s *priv, off_t block,
   ret = nand_nfcsram_write(priv, (uint8_t *)data, pagesize, 0);
   if (ret < 0)
     {
-      ferr("ERROR: Block %d page %d nand_nfcsram_write for data region failed: %d\n",
+      ferr("ERROR: Block %d page %d nand_nfcsram_write for data region "
+           "failed: %d\n",
            block, page, ret);
       goto errout;
     }
@@ -2444,7 +2469,8 @@ static int nand_writepage_pmecc(struct sam_nandcs_s *priv, off_t block,
   ret = nand_write(priv, (uint8_t *)g_nand.ecctab, eccsize, 0);
   if (ret < 0)
     {
-      ferr("ERROR: Block %d page %d nand_write for spare region failed: %d\n",
+      ferr("ERROR: Block %d page %d nand_write for spare region "
+           "failed: %d\n",
            block, page, ret);
       goto errout;
     }
@@ -2968,6 +2994,7 @@ struct mtd_dev_s *sam_nand_initialize(int cs)
           return NULL;
         }
 #endif
+
       /* Disable all interrupts at the HSMC */
 
       nand_putreg(SAM_HSMC_IDR, HSMC_NFCINT_ALL);
@@ -2981,14 +3008,16 @@ struct mtd_dev_s *sam_nand_initialize(int cs)
     }
 
   /* Initialize the NAND hardware for this CS */
-  /* Perform board-specific SMC initialization for this CS.  This should include:
+
+  /* Perform board-specific SMC initialization for this CS.  This should
+   * include:
    *
    *   1. Enabling of clocking to the HSMC
    *   2. Configuration of timing for the HSMC NAND CS
    *   3. Configuration of PIO pins
    *
-   * Other than enabling the HSMC, these are all things that the board-cognizant
-   * logic is best prepared to handle.
+   * Other than enabling the HSMC, these are all things that the board-
+   * cognizant logic is best prepared to handle.
    */
 
   ret = board_nandflash_config(cs);
@@ -3037,7 +3066,8 @@ struct mtd_dev_s *sam_nand_initialize(int cs)
  * Name: nand_checkreg
  *
  * Description:
- *   Check if the current HSMC register access is a duplicate of the preceding.
+ *   Check if the current HSMC register access is a duplicate of the
+ *   preceding.
  *
  * Input Parameters:
  *   regval   - The value to be written

--- a/arch/arm/src/sama5/sam_ohci.c
+++ b/arch/arm/src/sama5/sam_ohci.c
@@ -344,7 +344,7 @@ static void sam_putreg(uint32_t val, uint32_t addr);
 /* Semaphores ***************************************************************/
 
 static int  sam_takesem(sem_t *sem);
-static int  sam_takesem_uninterruptible(sem_t *sem);
+static int  sam_takesem_noncancelable(sem_t *sem);
 #define sam_givesem(s) nxsem_post(s);
 
 /* Byte stream access helper functions **************************************/
@@ -640,7 +640,7 @@ static int sam_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: sam_takesem_uninterruptible
+ * Name: sam_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -649,7 +649,7 @@ static int sam_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int sam_takesem_uninterruptible(sem_t *sem)
+static int sam_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -1929,7 +1929,7 @@ static int sam_ctrltd(struct sam_rhport_s *rhport,
        * this upon return.
        */
 
-      ret2 = sam_takesem_uninterruptible(&g_ohci.exclsem);
+      ret2 = sam_takesem_noncancelable(&g_ohci.exclsem);
       if (ret2 < 0)
         {
           ret = ret2;
@@ -2285,7 +2285,7 @@ static void sam_ohci_bottomhalf(void *arg)
    * real option (other than to reschedule and delay).
    */
 
-  sam_takesem_uninterruptible(&g_ohci.exclsem);
+  sam_takesem_noncancelable(&g_ohci.exclsem);
 
   /* Root hub status change interrupt */
 
@@ -2912,7 +2912,7 @@ static int sam_epfree(struct usbhost_driver_s *drvr, usbhost_ep_t ep)
    * periodic list and the interrupt table.
    */
 
-  ret2 = sam_takesem_uninterruptible(&g_ohci.exclsem);
+  ret2 = sam_takesem_noncancelable(&g_ohci.exclsem);
 
   /* Remove the ED to the correct list depending on the transfer type */
 
@@ -3045,7 +3045,7 @@ static int sam_free(struct usbhost_driver_s *drvr, uint8_t *buffer)
 
   /* We must have exclusive access to the transfer buffer pool */
 
-  ret = sam_takesem_uninterruptible(&g_ohci.exclsem);
+  ret = sam_takesem_noncancelable(&g_ohci.exclsem);
   sam_tbfree(buffer);
   sam_givesem(&g_ohci.exclsem);
   return ret;

--- a/arch/arm/src/sama5/sam_pmecc.c
+++ b/arch/arm/src/sama5/sam_pmecc.c
@@ -1273,14 +1273,15 @@ int pmecc_configure(struct sam_nandcs_s *priv, bool protected)
  *   None
  *
  * Returned Value:
- *   None
+ *  Normally success (OK) is returned, but the error -ECANCELED may be
+ *  return in the event that task has been canceled.
  *
  ****************************************************************************/
 
 #if NAND_NPMECC_BANKS > 1
-void pmecc_lock(void)
+int pmecc_lock(void)
 {
-  nxsem_wait_uninterruptible(&g_pmecc.exclsem);
+  return nxsem_wait_uninterruptible(&g_pmecc.exclsem);
 }
 #endif
 

--- a/arch/arm/src/sama5/sam_pmecc.c
+++ b/arch/arm/src/sama5/sam_pmecc.c
@@ -72,6 +72,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Number of bits of correction.  These much match the (unshifted) values
  * in the SMC_PMECCFG register BCH_ERR field.
  */
@@ -89,6 +90,7 @@
 /****************************************************************************
  * Private Types
  ****************************************************************************/
+
 /* This is the form of the PMECC descriptor that is passed to the ECC
  * detection correction algorithm in ROM.  The binary for of this structure
  * cannot be altered!
@@ -118,7 +120,8 @@ struct pmecc_desc_s
 
   /* 468-: Sigma table */
 
-  int16_t smu[PMECC_MAX_CORRECTABILITY + 2][2 * PMECC_MAX_CORRECTABILITY + 1];
+  int16_t smu[PMECC_MAX_CORRECTABILITY + 2]
+             [2 * PMECC_MAX_CORRECTABILITY + 1];
 
   /* Polynomial order */
 
@@ -142,7 +145,7 @@ struct sam_pmecc_s
 
 /* This is the type of the ROM detection/correction function
  *
- * REVISIT:  Whare are the types Pmecc and Pmerrloc?
+ * REVISIT:  Where are the types Pmecc and Pmerrloc?
  */
 
 #ifdef CONFIG_SAMA5_PMECC_EMBEDDEDALGO
@@ -165,13 +168,19 @@ static uint32_t pmecc_correctionalgo(uint32_t isr, uintptr_t data);
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
 /* PMECC state data */
 
 static struct sam_pmecc_s g_pmecc;
 
-/* Maps BCH_ERR correctability register value to number of errors per sector */
+/* Maps BCH_ERR correctability register value to number of errors per
+ * sector.
+ */
 
-static const uint8_t g_correctability[5] = {2, 4, 8, 12, 24};
+static const uint8_t g_correctability[5] =
+{
+  2, 4, 8, 12, 24
+};
 
 /****************************************************************************
  * Private Functions
@@ -243,6 +252,7 @@ static uint32_t pmecc_substitute(void)
     }
 
   /* Computation 2t syndromes based on S(x) */
+
   /* Odd syndromes */
 
   for (i = 1; i <= 2 * g_pmecc.desc.tt - 1; i = i + 2)
@@ -298,9 +308,9 @@ static uint32_t pmecc_getsigma(void)
   int16_t *lmu = g_pmecc.desc.lmu;
   int16_t *si = g_pmecc.desc.si;
   int16_t tt = g_pmecc.desc.tt;
-  int32_t mu[PMECC_MAX_CORRECTABILITY+1];       /* Mu */
-  int32_t dmu[PMECC_MAX_CORRECTABILITY+1];      /* Discrepancy */
-  int32_t delta[PMECC_MAX_CORRECTABILITY+1];    /* Delta order   */
+  int32_t mu[PMECC_MAX_CORRECTABILITY + 1];     /* Mu */
+  int32_t dmu[PMECC_MAX_CORRECTABILITY + 1];    /* Discrepancy */
+  int32_t delta[PMECC_MAX_CORRECTABILITY + 1];  /* Delta order   */
   int32_t largest;
   int32_t diff;
   int ro;                                       /* Index of largest delta */
@@ -311,6 +321,7 @@ static uint32_t pmecc_getsigma(void)
   dmu0count = 0;
 
   /* First Row */
+
   /* Mu */
 
   mu[0] = -1; /* Actually -1/2 */
@@ -337,6 +348,7 @@ static uint32_t pmecc_getsigma(void)
   delta[0] = (mu[0] * 2 - lmu[0]) >> 1;
 
   /* Second row */
+
   /* Mu */
 
   mu[1]  = 0;
@@ -371,10 +383,11 @@ static uint32_t pmecc_getsigma(void)
 
   for (i = 1; i <= tt; i++)
     {
-      mu[i+1] = i << 1;
+      mu[i + 1] = i << 1;
 
       /* Compute Sigma (Mu+1) and L(mu). */
-      /* check if discrepancy is set to 0 */
+
+      /* Check if discrepancy is set to 0 */
 
       if (dmu[i] == 0)
         {
@@ -385,8 +398,9 @@ static uint32_t pmecc_getsigma(void)
                 {
                   for (j = 0; j <= (lmu[i] >> 1) + 1; j++)
                     {
-                      g_pmecc.desc.smu[tt+1][j] = g_pmecc.desc.smu[i][j];
+                      g_pmecc.desc.smu[tt + 1][j] = g_pmecc.desc.smu[i][j];
                     }
+
                   lmu[tt + 1] = lmu[i];
                   return 0;
                 }
@@ -399,6 +413,7 @@ static uint32_t pmecc_getsigma(void)
                     {
                       g_pmecc.desc.smu[tt + 1][j] = g_pmecc.desc.smu[i][j];
                     }
+
                   lmu[tt + 1] = lmu[i];
                   return 0;
                 }
@@ -451,9 +466,9 @@ static uint32_t pmecc_getsigma(void)
 
           /* Init smu[i+1] with 0 */
 
-          for (k = 0; k < (2 * PMECC_MAX_CORRECTABILITY+1); k ++)
+          for (k = 0; k < (2 * PMECC_MAX_CORRECTABILITY + 1); k ++)
             {
-              g_pmecc.desc.smu[i+1][k] = 0;
+              g_pmecc.desc.smu[i + 1][k] = 0;
             }
 
           /* Compute smu[i+1] */
@@ -465,17 +480,19 @@ static uint32_t pmecc_getsigma(void)
                    g_pmecc.desc.smu[i + 1][k + diff] =
                      g_pmecc.desc.alphato[(g_pmecc.desc.indexof[dmu[i]] +
                      (g_pmecc.desc.nn - g_pmecc.desc.indexof[dmu[ro]]) +
-                     g_pmecc.desc.indexof[g_pmecc.desc.smu[ro][k]]) % g_pmecc.desc.nn];
+                     g_pmecc.desc.indexof[g_pmecc.desc.smu[ro][k]]) %
+                                          g_pmecc.desc.nn];
                 }
             }
 
           for (k = 0; k <= lmu[i] >> 1; k++)
             {
-              g_pmecc.desc.smu[i+1][k] ^= g_pmecc.desc.smu[i][k];
+              g_pmecc.desc.smu[i + 1][k] ^= g_pmecc.desc.smu[i][k];
             }
         }
 
       /* End Compute Sigma (Mu+1) and L(mu) */
+
       /* In either case compute delta */
 
       delta[i + 1]  = (mu[i + 1] * 2 - lmu[i + 1]) >> 1;
@@ -491,13 +508,18 @@ static uint32_t pmecc_getsigma(void)
                   dmu[i + 1] = si[2 * (i - 1) + 3];
                 }
 
-              /* Check if one operand of the multiplier is null, its index is -1 */
+              /* Check if one operand of the multiplier is null, its index
+               * is -1
+               */
 
-              else if (g_pmecc.desc.smu[i + 1][k] && si[2 * (i - 1) + 3 - k])
+              else if (g_pmecc.desc.smu[i + 1][k] &&
+                       si[2 * (i - 1) + 3 - k])
                 {
                   dmu[i + 1] =
-                    g_pmecc.desc.alphato[(g_pmecc.desc.indexof[g_pmecc.desc.smu[i + 1][k]] +
-                    g_pmecc.desc.indexof[si[2 * (i - 1) + 3 - k]]) % g_pmecc.desc.nn] ^ dmu[i + 1];
+                    g_pmecc.desc.alphato[
+                      (g_pmecc.desc.indexof[g_pmecc.desc.smu[i + 1][k]] +
+                    g_pmecc.desc.indexof[si[2 * (i - 1) + 3 - k]]) %
+                      g_pmecc.desc.nn] ^ dmu[i + 1];
                 }
             }
         }
@@ -637,22 +659,27 @@ static uint32_t pmecc_errorcorrection(uintptr_t sectorbase,
 
               if (*(uint8_t *)(sectorbase + bytepos) & (1 << bitpos))
                 {
-                  *(uint8_t *)(sectorbase + bytepos) &= (0xff ^ (1 << bitpos));
+                  *(uint8_t *)(sectorbase + bytepos) &=
+                    (0xff ^ (1 << bitpos));
                 }
               else
                 {
-                  *(uint8_t *)(sectorbase + bytepos) |= (1 << bitpos);
+                  *(uint8_t *)(sectorbase + bytepos) |=
+                    (1 << bitpos);
                 }
             }
           else
             {
-              if (*(uint8_t *)(sectorbase + bytepos + eccsize) & (1 << bitpos))
+              if (*(uint8_t *)(sectorbase + bytepos + eccsize) &
+                  (1 << bitpos))
                 {
-                  *(uint8_t *)(sectorbase + bytepos + eccsize) &= (0xff ^ (1 << bitpos));
+                  *(uint8_t *)(sectorbase + bytepos + eccsize) &=
+                    (0xff ^ (1 << bitpos));
                 }
               else
                 {
-                  *(uint8_t *)(sectorbase + bytepos + eccsize) |= (1 << bitpos);
+                  *(uint8_t *)(sectorbase + bytepos + eccsize) |=
+                    (1 << bitpos);
                 }
             }
         }
@@ -721,7 +748,8 @@ static uint32_t pmecc_correctionalgo(uint32_t isr, uintptr_t data)
 
           /* Number of bits of the sector + ecc */
 
-          nerrors = pmecc_errorlocation((sectorsz * 8) + (g_pmecc.desc.tt * mm));
+          nerrors = pmecc_errorlocation((sectorsz * 8) +
+                    (g_pmecc.desc.tt * mm));
           if (nerrors == -1)
             {
               return 1;
@@ -850,7 +878,7 @@ static int pmecc_bcherr1k(uint8_t nsectors, uint16_t eccsize)
 static int pmecc_pagelayout(uint16_t datasize, uint16_t eccsize)
 {
   uint16_t correctability512;
-  uint16_t correctability1K;
+  uint16_t correctability1k;
   uint8_t nsectors512;
   uint8_t nsectors1k;
   uint8_t bcherr;
@@ -922,11 +950,11 @@ static int pmecc_pagelayout(uint16_t datasize, uint16_t eccsize)
       case 3:  /* Both 512B and 1KB sectors possible */
         {
           correctability512 = nsectors512 * g_correctability[bcherr512];
-          correctability1K  = nsectors1k * g_correctability[bcherr1k];
+          correctability1k  = nsectors1k * g_correctability[bcherr1k];
 
           /* Use 512B sectors unless we can do better with 1K sectors */
 
-          if (correctability512 >= correctability1K)
+          if (correctability512 >= correctability1k)
             {
               g_pmecc.sector1k = false;
               g_pmecc.nsectors = nsectors512;
@@ -1072,12 +1100,18 @@ int pmecc_configure(struct sam_nandcs_s *priv, bool protected)
       g_pmecc.desc.sectorsz = HSMC_PMECCFG_SECTORSZ_1024;
       sectorsperpage        = (priv->raw.model.pagesize >> 10);
       g_pmecc.desc.mm       = 14;
-#if defined (CONFIG_SAMA5_PMECC_GALOIS_TABLE1024_ROMADDR) && defined (CONFIG_SAMA5_PMECC_GALOIS_ROMTABLES)
-      g_pmecc.desc.alphato  = (int16_t *)&(pmecc_gf1024[PMECC_GF_SIZEOF_1024]);
-      g_pmecc.desc.indexof  = (int16_t *)&(pmecc_gf1024[0]);
+
+#if defined (CONFIG_SAMA5_PMECC_GALOIS_TABLE1024_ROMADDR) && \
+    defined (CONFIG_SAMA5_PMECC_GALOIS_ROMTABLES)
+      g_pmecc.desc.alphato  =
+        (int16_t *)&(pmecc_gf1024[PMECC_GF_SIZEOF_1024]);
+      g_pmecc.desc.indexof  =
+        (int16_t *)&(pmecc_gf1024[0]);
 #else
-      g_pmecc.desc.alphato  = (int16_t *)&(pmecc_gf1024[PMECC_GF_ALPHA_TO]);
-      g_pmecc.desc.indexof  = (int16_t *)&(pmecc_gf1024[PMECC_GF_INDEX_OF]);
+      g_pmecc.desc.alphato  =
+        (int16_t *)&(pmecc_gf1024[PMECC_GF_ALPHA_TO]);
+      g_pmecc.desc.indexof  =
+        (int16_t *)&(pmecc_gf1024[PMECC_GF_INDEX_OF]);
 #endif
     }
   else
@@ -1087,12 +1121,18 @@ int pmecc_configure(struct sam_nandcs_s *priv, bool protected)
       g_pmecc.desc.sectorsz = HSMC_PMECCFG_SECTORSZ_512;
       sectorsperpage        = (priv->raw.model.pagesize >> 9);
       g_pmecc.desc.mm       = 13;
-#if defined (CONFIG_SAMA5_PMECC_GALOIS_TABLE512_ROMADDR) && defined (CONFIG_SAMA5_PMECC_GALOIS_ROMTABLES)
-      g_pmecc.desc.alphato  = (int16_t *)&(pmecc_gf512[PMECC_GF_SIZEOF_512]);
-      g_pmecc.desc.indexof  = (int16_t *)&(pmecc_gf512[0]);
+
+#if defined (CONFIG_SAMA5_PMECC_GALOIS_TABLE512_ROMADDR) && \
+    defined (CONFIG_SAMA5_PMECC_GALOIS_ROMTABLES)
+      g_pmecc.desc.alphato  =
+        (int16_t *)&(pmecc_gf512[PMECC_GF_SIZEOF_512]);
+      g_pmecc.desc.indexof  =
+        (int16_t *)&(pmecc_gf512[0]);
 #else
-      g_pmecc.desc.alphato  = (int16_t *)&(pmecc_gf512[PMECC_GF_ALPHA_TO]);
-      g_pmecc.desc.indexof  = (int16_t *)&(pmecc_gf512[PMECC_GF_INDEX_OF]);
+      g_pmecc.desc.alphato  =
+        (int16_t *)&(pmecc_gf512[PMECC_GF_ALPHA_TO]);
+      g_pmecc.desc.indexof  =
+        (int16_t *)&(pmecc_gf512[PMECC_GF_INDEX_OF]);
 #endif
     }
 
@@ -1133,7 +1173,8 @@ int pmecc_configure(struct sam_nandcs_s *priv, bool protected)
   else
     {
       g_pmecc.desc.eccsize =
-        (((g_pmecc.desc.mm * g_pmecc.correctability) >> 3) + 1) * sectorsperpage;
+        (((g_pmecc.desc.mm * g_pmecc.correctability) >> 3) + 1) *
+        sectorsperpage;
     }
 
   finfo("mm=%d correctability=%d eccsize=%d\n",
@@ -1162,8 +1203,11 @@ int pmecc_configure(struct sam_nandcs_s *priv, bool protected)
 
   g_pmecc.desc.sparesize = priv->raw.model.sparesize;
 
-  //g_pmecc.desc.nandwr = PMECC_CFG_NANDWR;  /* NAND write access */
-  g_pmecc.desc.nandwr = 0;  /* NAND Read access */
+#if 0
+  g_pmecc.desc.nandwr = PMECC_CFG_NANDWR;  /* NAND write access */
+#else
+  g_pmecc.desc.nandwr = 0;                 /* NAND Read access */
+#endif
   if (protected)
     {
       g_pmecc.desc.sparena = HSMC_PMECCFG_SPARE_ENABLE;
@@ -1185,7 +1229,7 @@ int pmecc_configure(struct sam_nandcs_s *priv, bool protected)
   g_pmecc.desc.clkctrl   = 2;
   g_pmecc.desc.interrupt = 0;
 
-   /* Disable ECC module */
+  /* Disable ECC module */
 
   nand_putreg(SAM_HSMC_PMECCTRL, HSMC_PMECCTRL_DISABLE);
 
@@ -1283,8 +1327,9 @@ void pmecc_unlock(void)
 int pmecc_correction(uint32_t isr, uintptr_t data)
 {
 #ifdef CONFIG_SAMA5_PMECC_EMBEDDEDALGO
-  /* REVISIT:  Whare are the types Pmecc and Pmerrloc? */
-  /* REVISIT:  Check returned value */
+  /* REVISIT:  Whare are the types Pmecc and Pmerrloc?
+   * REVISIT:  Check returned value
+   */
 
   return pmecc_correctionalgo(??, ??, &g_pmecc, isr, data);
 #else
@@ -1458,22 +1503,21 @@ void pmecc_buildgf(uint32_t mm, int16_t *indexof, int16_t *alphato)
     {
       /* Check if the msb bit of the lfsr is set */
 
-      if (alphato[i-1] & mask)
+      if (alphato[i - 1] & mask)
         {
           /* Feedback loop is set */
 
-          alphato[i] = alphato[mm] ^ ((alphato[i-1] ^ mask) << 1);
+          alphato[i] = alphato[mm] ^ ((alphato[i - 1] ^ mask) << 1);
         }
       else
         {
           /* Only shift is enabled */
 
-          alphato[i] = alphato[i-1] << 1;
+          alphato[i] = alphato[i - 1] << 1;
         }
 
       /* lookup table */
 
-      //indexof[alphato[i]] = i;
       indexof[alphato[i]] = i % nn;
     }
 

--- a/arch/arm/src/sama5/sam_pmecc.h
+++ b/arch/arm/src/sama5/sam_pmecc.h
@@ -55,7 +55,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* Block checking and H/W ECC support must be enabled for PMECC */
 
 #ifndef CONFIG_MTD_NAND_HWECC
@@ -216,7 +218,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
@@ -229,14 +231,15 @@ extern "C"
  *   None
  *
  * Returned Value:
- *   None
+ *  Normally success (OK) is returned, but the error -ECANCELED may be
+ *  return in the event that task has been canceled.
  *
  ****************************************************************************/
 
 #if NAND_NPMECC_BANKS > 1
-void pmecc_lock(void);
+int pmecc_lock(void);
 #else
-#  define pmecc_lock()
+#  define pmecc_lock() (0)
 #endif
 
 /****************************************************************************
@@ -394,7 +397,7 @@ uint32_t pmecc_get_pagesize(void);
  ****************************************************************************/
 
 #ifdef CONFIG_SAMA5_PMECC_GALOIS_CUSTOM
-void pmecc_buildgf(uint32_t mm, int16_t* indexof, int16_t* alphato);
+void pmecc_buildgf(uint32_t mm, int16_t *indexof, int16_t *alphato);
 #endif
 
 #undef EXTERN
@@ -403,7 +406,9 @@ void pmecc_buildgf(uint32_t mm, int16_t* indexof, int16_t* alphato);
 #endif
 
 #else /* CONFIG_SAMA5_HAVE_PMECC */
+
 /****************************************************************************/
+
 /* Stub definitions to minimize conditional compilation when PMECC is
  * disabled
  */

--- a/arch/arm/src/samd2l2/sam_i2c_master.c
+++ b/arch/arm/src/samd2l2/sam_i2c_master.c
@@ -202,7 +202,7 @@ static void i2c_putreg32(struct sam_i2c_dev_s *priv, uint32_t regval,
                          unsigned int offset);
 
 static int i2c_takesem(sem_t * sem);
-static int i2c_takesem_uninterruptible(sem_t * sem);
+static int i2c_takesem_noncancelable(sem_t * sem);
 #define i2c_givesem(sem) (nxsem_post(sem))
 
 #ifdef CONFIG_SAM_I2C_REGDEBUG
@@ -468,7 +468,7 @@ static int i2c_takesem(sem_t *sem)
 }
 
 /*******************************************************************************
- * Name: i2c_takesem_uninterruptible
+ * Name: i2c_takesem_noncancelable
  *
  * Description:
  *   Take the wait semaphore (handling false alarm wake-ups due to the receipt
@@ -482,7 +482,7 @@ static int i2c_takesem(sem_t *sem)
  *
  *******************************************************************************/
 
-static int i2c_takesem_uninterruptible(sem_t *sem)
+static int i2c_takesem_noncancelable(sem_t *sem)
 {
   return nxsem_wait_uninterruptible(sem);
 }
@@ -1453,7 +1453,7 @@ int sam_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Get exclusive access to the I2C device */
 
-  ret = i2c_takesem_uninterruptible(&priv->exclsem);
+  ret = i2c_takesem_noncancelable(&priv->exclsem);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/samd5e5/sam_i2c_master.c
+++ b/arch/arm/src/samd5e5/sam_i2c_master.c
@@ -190,7 +190,7 @@ static void i2c_putreg32(struct sam_i2c_dev_s *priv, uint32_t regval,
                          unsigned int offset);
 
 static int i2c_takesem(sem_t * sem);
-static int i2c_takesem_uninterruptible(sem_t * sem);
+static int i2c_takesem_noncancelable(sem_t * sem);
 #define i2c_givesem(sem) (nxsem_post(sem))
 
 #ifdef CONFIG_SAM_I2C_REGDEBUG
@@ -493,7 +493,7 @@ static int i2c_takesem(sem_t *sem)
 }
 
 /*******************************************************************************
- * Name: i2c_takesem_uninterruptible
+ * Name: i2c_takesem_noncancelable
  *
  * Description:
  *   Take the wait semaphore (handling false alarm wake-ups due to the receipt
@@ -507,7 +507,7 @@ static int i2c_takesem(sem_t *sem)
  *
  *******************************************************************************/
 
-static int i2c_takesem_uninterruptible(sem_t *sem)
+static int i2c_takesem_noncancelable(sem_t *sem)
 {
   return nxsem_wait_uninterruptible(sem);
 }
@@ -1492,7 +1492,7 @@ int sam_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Get exclusive access to the I2C device */
 
-  ret = i2c_takesem_uninterruptible(&priv->exclsem);
+  ret = i2c_takesem_noncancelable(&priv->exclsem);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/samv7/sam_mcan.c
+++ b/arch/arm/src/samv7/sam_mcan.c
@@ -1,41 +1,27 @@
 /****************************************************************************
  * arch/arm/src/samv7/sam_mcan.c
  *
- *   Copyright (C) 2015-2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * References:
- *   SAMV7D3 Series Data Sheet
- *   Atmel sample code
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX, Atmel, nor the names of its contributors may
- *    be used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
+
+/* References:
+ *   SAMV7D3 Series Data Sheet
+ *   Atmel sample code
+ */
 
 /****************************************************************************
  * Included Files
@@ -71,6 +57,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Common definitions *******************************************************/
 
 #ifndef MIN
@@ -110,6 +97,7 @@
   (SAMV7_MCAN_CLKSRC_FREQUENCY / CONFIG_SAMV7_MCAN_CLKSRC_PRESCALER)
 
 /* Buffer Alignment *********************************************************/
+
 /* Buffer Alignment.
  *
  * The MCAN peripheral does not require any data be aligned.  However, if
@@ -703,6 +691,7 @@
 #define MAILBOX_ADDRESS(a)        ((uint32_t)(a) & 0x0000fffc)
 
 /* Interrupts ***************************************************************/
+
 /* Common interrupts
  *
  *   MCAN_INT_TSW  - Timestamp Wraparound
@@ -785,6 +774,7 @@
 #define MCAN_ANYERR_INTS (MCAN_CMNERR_INTS | MCAN_RXERR_INTS | MCAN_TXERR_INTS)
 
 /* Debug ********************************************************************/
+
 /* Debug configurations that may be enabled just for testing MCAN */
 
 #ifndef CONFIG_DEBUG_CAN_INFO
@@ -877,7 +867,10 @@ struct sam_config_s
 
 struct sam_mcan_s
 {
-  const struct sam_config_s *config; /* The constant configuration */
+  /* The constant configuration */
+
+  const struct sam_config_s *config;
+
   uint8_t state;            /* See enum can_state_s */
 #ifdef CONFIG_CAN_EXTID
   uint8_t nextalloc;        /* Number of allocated extended filters */
@@ -1008,10 +1001,14 @@ static const struct sam_config_s g_mcan0const =
   .txpinset         = GPIO_MCAN0_TX,
   .base             = SAM_MCAN0_BASE,
   .baud             = CONFIG_SAMV7_MCAN0_BITRATE,
-  .btp              = MCAN_BTP_BRP(MCAN0_BRP) | MCAN_BTP_TSEG1(MCAN0_TSEG1) |
-                      MCAN_BTP_TSEG2(MCAN0_TSEG2) | MCAN_BTP_SJW(MCAN0_SJW),
-  .fbtp             = MCAN_FBTP_FBRP(MCAN0_FBRP) | MCAN_FBTP_FTSEG1(MCAN0_FTSEG1) |
-                      MCAN_FBTP_FTSEG2(MCAN0_FTSEG2) | MCAN_FBTP_FSJW(MCAN0_FSJW),
+  .btp              = MCAN_BTP_BRP(MCAN0_BRP) |
+                      MCAN_BTP_TSEG1(MCAN0_TSEG1) |
+                      MCAN_BTP_TSEG2(MCAN0_TSEG2) |
+                      MCAN_BTP_SJW(MCAN0_SJW),
+  .fbtp             = MCAN_FBTP_FBRP(MCAN0_FBRP) |
+                      MCAN_FBTP_FTSEG1(MCAN0_FTSEG1) |
+                      MCAN_FBTP_FTSEG2(MCAN0_FTSEG2) |
+                      MCAN_FBTP_FSJW(MCAN0_FSJW),
   .port             = 0,
   .pid              = SAM_PID_MCAN00,
   .irq0             = SAM_IRQ_MCAN00,
@@ -1084,10 +1081,14 @@ static const struct sam_config_s g_mcan1const =
   .txpinset         = GPIO_MCAN1_TX,
   .base             = SAM_MCAN1_BASE,
   .baud             = CONFIG_SAMV7_MCAN1_BITRATE,
-  .btp              = MCAN_BTP_BRP(MCAN1_BRP) | MCAN_BTP_TSEG1(MCAN1_TSEG1) |
-                      MCAN_BTP_TSEG2(MCAN1_TSEG2) | MCAN_BTP_SJW(MCAN1_SJW),
-  .fbtp             = MCAN_FBTP_FBRP(MCAN1_FBRP) | MCAN_FBTP_FTSEG1(MCAN1_FTSEG1) |
-                      MCAN_FBTP_FTSEG2(MCAN1_FTSEG2) | MCAN_FBTP_FSJW(MCAN1_FSJW),
+  .btp              = MCAN_BTP_BRP(MCAN1_BRP) |
+                      MCAN_BTP_TSEG1(MCAN1_TSEG1) |
+                      MCAN_BTP_TSEG2(MCAN1_TSEG2) |
+                      MCAN_BTP_SJW(MCAN1_SJW),
+  .fbtp             = MCAN_FBTP_FBRP(MCAN1_FBRP) |
+                      MCAN_FBTP_FTSEG1(MCAN1_FTSEG1) |
+                      MCAN_FBTP_FTSEG2(MCAN1_FTSEG2) |
+                      MCAN_FBTP_FSJW(MCAN1_FSJW),
   .port             = 1,
   .pid              = SAM_PID_MCAN10,
   .irq0             = SAM_IRQ_MCAN10,
@@ -1240,7 +1241,8 @@ static uint32_t mcan_getreg(FAR struct sam_mcan_s *priv, int offset)
  ****************************************************************************/
 
 #ifdef CONFIG_SAMV7_MCAN_REGDEBUG
-static void mcan_putreg(FAR struct sam_mcan_s *priv, int offset, uint32_t regval)
+static void mcan_putreg(FAR struct sam_mcan_s *priv, int offset,
+                        uint32_t regval)
 {
   FAR const struct sam_config_s *config = priv->config;
   uintptr_t regaddr = config->base + offset;
@@ -1255,7 +1257,8 @@ static void mcan_putreg(FAR struct sam_mcan_s *priv, int offset, uint32_t regval
 }
 
 #else
-static void mcan_putreg(FAR struct sam_mcan_s *priv, int offset, uint32_t regval)
+static void mcan_putreg(FAR struct sam_mcan_s *priv, int offset,
+                        uint32_t regval)
 {
   FAR const struct sam_config_s *config = priv->config;
   putreg32(regval, config->base + offset);
@@ -1814,7 +1817,10 @@ static int mcan_add_extfilter(FAR struct sam_mcan_s *priv,
 
               /* Wait for initialization mode to take effect */
 
-              while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) & MCAN_CCCR_INIT) == 0);
+              while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) &
+                     MCAN_CCCR_INIT) == 0)
+                {
+                }
 
               /* Enable writing to configuration registers */
 
@@ -1925,7 +1931,10 @@ static int mcan_del_extfilter(FAR struct sam_mcan_s *priv, int ndx)
 
       /* Wait for initialization mode to take effect */
 
-      while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) & MCAN_CCCR_INIT) == 0);
+      while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) &
+             MCAN_CCCR_INIT) == 0)
+        {
+        }
 
       /* Enable writing to configuration registers */
 
@@ -2065,7 +2074,10 @@ static int mcan_add_stdfilter(FAR struct sam_mcan_s *priv,
 
               /* Wait for initialization mode to take effect */
 
-              while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) & MCAN_CCCR_INIT) == 0);
+              while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) &
+                     MCAN_CCCR_INIT) == 0)
+                {
+                }
 
               /* Enable writing to configuration registers */
 
@@ -2174,7 +2186,10 @@ static int mcan_del_stdfilter(FAR struct sam_mcan_s *priv, int ndx)
 
       /* Wait for initialization mode to take effect */
 
-      while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) & MCAN_CCCR_INIT) == 0);
+      while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) &
+              MCAN_CCCR_INIT) == 0)
+        {
+        }
 
       /* Enable writing to configuration registers */
 
@@ -2217,17 +2232,19 @@ static int mcan_del_stdfilter(FAR struct sam_mcan_s *priv, int ndx)
  *   This function initiates the BUS-OFF recovery sequence.
  *   CAN Specification Rev. 2.0 or ISO11898-1:2015
  *   According the SAMV71 datasheet:
- *   If the device goes Bus_Off, it will set MCAN_CCCR.INIT of its own accord,
- *   stopping all bus activities. Once MCAN_CCCR.INIT has been cleared by the
- *   processor (application), the device will then wait for 129 occurrences of
- *   Bus Idle (129 * 11 consecutive recessive bits) before resuming normal
- *   operation. At the end of the Bus_Off recovery sequence, the Error
- *   Management Counters will be reset. During the waiting time after the
- *   resetting of MCAN_CCCR.INIT, each time a sequence of 11 recessive bits
- *   has been monitored, a Bit0 Error code is written to MCAN_PSR.LEC, enablin
- *   the processor to readily check up whether the CAN bus is stuck at dominant
- *   or continuously disturbed and to monitor the Bus_Off recovery sequence.
- *   MCAN_ECR.REC is used to count these sequences.
+ *
+ *   "If the device goes Bus_Off, it will set MCAN_CCCR.INIT of its own
+ *    accord, stopping all bus activities. Once MCAN_CCCR.INIT has been
+ *    cleared by the processor (application), the device will then wait for
+ *    129 occurrences of Bus Idle (129 * 11 consecutive recessive bits)
+ *    before resuming normal operation. At the end of the Bus_Off recovery
+ *    sequence, the Error Management Counters will be reset. During the
+ *    waiting time after the resetting of MCAN_CCCR.INIT, each time a
+ *    sequence of 11 recessive bits has been monitored, a Bit0 Error code is
+ *    written to MCAN_PSR.LEC, enabling the processor to readily check up
+ *    whether the CAN bus is stuck at dominant or continuously disturbed and
+ *    to monitor the Bus_Off recovery sequence.  MCAN_ECR.REC is used to
+ *    count these sequences."
  *
  * Input Parameters:
  *   priv - An instance of the MCAN driver state structure.
@@ -2361,7 +2378,8 @@ static int mcan_setup(FAR struct can_dev_s *dev)
   ret = mcan_hw_initialize(priv);
   if (ret < 0)
     {
-      canerr("ERROR: MCAN%d H/W initialization failed: %d\n", config->port, ret);
+      canerr("ERROR: MCAN%d H/W initialization failed: %d\n",
+             config->port, ret);
       return ret;
     }
 
@@ -2393,7 +2411,8 @@ static int mcan_setup(FAR struct can_dev_s *dev)
   mcan_dumpregs(priv, "After receive setup");
 
   /* Enable the interrupts at the NVIC (they are still disabled at the MCAN
-   * peripheral). */
+   * peripheral).
+   */
 
   up_enable_irq(config->irq0);
   up_enable_irq(config->irq1);
@@ -2569,11 +2588,11 @@ static int mcan_ioctl(FAR struct can_dev_s *dev, int cmd, unsigned long arg)
       /* CANIOC_GET_BITTIMING:
        *   Description:    Return the current bit timing settings
        *   Argument:       A pointer to a write-able instance of struct
-       *                   canioc_bittiming_s in which current bit timing values
-       *                   will be returned.
-       *   Returned Value: Zero (OK) is returned on success.  Otherwise -1 (ERROR)
-       *                   is returned with the errno variable set to indicate the
-       *                   nature of the error.
+       *                   canioc_bittiming_s in which current bit timing
+       *                   values will be returned.
+       *   Returned Value: Zero (OK) is returned on success.  Otherwise -1
+       *                   (ERROR) is returned with the errno variable set
+       *                   to indicate the nature of the error.
        *   Dependencies:   None
        */
 
@@ -2587,11 +2606,15 @@ static int mcan_ioctl(FAR struct can_dev_s *dev, int cmd, unsigned long arg)
           DEBUGASSERT(bt != NULL);
 
           regval       = mcan_getreg(priv, SAM_MCAN_BTP_OFFSET);
-          bt->bt_sjw   = ((regval & MCAN_BTP_SJW_MASK) >> MCAN_BTP_SJW_SHIFT) + 1;
-          bt->bt_tseg1 = ((regval & MCAN_BTP_TSEG1_MASK) >> MCAN_BTP_TSEG1_SHIFT) + 1;
-          bt->bt_tseg2 = ((regval & MCAN_BTP_TSEG2_MASK) >> MCAN_BTP_TSEG2_SHIFT) + 1;
+          bt->bt_sjw   = ((regval & MCAN_BTP_SJW_MASK) >>
+                          MCAN_BTP_SJW_SHIFT) + 1;
+          bt->bt_tseg1 = ((regval & MCAN_BTP_TSEG1_MASK) >>
+                          MCAN_BTP_TSEG1_SHIFT) + 1;
+          bt->bt_tseg2 = ((regval & MCAN_BTP_TSEG2_MASK) >>
+                          MCAN_BTP_TSEG2_SHIFT) + 1;
 
-          brp          = ((regval & MCAN_BTP_BRP_MASK) >> MCAN_BTP_BRP_SHIFT) + 1;
+          brp          = ((regval & MCAN_BTP_BRP_MASK) >>
+                          MCAN_BTP_BRP_SHIFT) + 1;
           bt->bt_baud  = SAMV7_MCANCLK_FREQUENCY / brp /
                          (bt->bt_tseg1 + bt->bt_tseg2 + 1);
           ret = OK;
@@ -2601,18 +2624,18 @@ static int mcan_ioctl(FAR struct can_dev_s *dev, int cmd, unsigned long arg)
       /* CANIOC_SET_BITTIMING:
        *   Description:    Set new current bit timing values
        *   Argument:       A pointer to a read-able instance of struct
-       *                   canioc_bittiming_s in which the new bit timing values
-       *                   are provided.
-       *   Returned Value: Zero (OK) is returned on success.  Otherwise -1 (ERROR)
-       *                   is returned with the errno variable set to indicate the
-       *                   nature of the error.
+       *                   canioc_bittiming_s in which the new bit timing
+       *                   values are provided.
+       *   Returned Value: Zero (OK) is returned on success.  Otherwise -1
+       *                   (ERROR) is returned with the errno variable set
+       *                   to indicate the nature of the error.
        *   Dependencies:   None
        *
-       * REVISIT: There is probably a limitation here:  If there are multiple
-       * threads trying to send CAN packets, when one of these threads reconfigures
-       * the bitrate, the MCAN hardware will be reset and the context of operation
-       * will be lost.  Hence, this IOCTL can only safely be executed in quiescent
-       * time periods.
+       * REVISIT: There is probably a limitation here:  If there are
+       * multiple threads trying to send CAN packets, when one of these
+       * threads reconfigures the bitrate, the MCAN hardware will be reset
+       * and the context of operation will be lost.  Hence, this IOCTL can
+       * only safely be executed in quiescent time periods.
        */
 
       case CANIOC_SET_BITTIMING:
@@ -2698,17 +2721,20 @@ static int mcan_ioctl(FAR struct can_dev_s *dev, int cmd, unsigned long arg)
       case CANIOC_ADD_EXTFILTER:
         {
           DEBUGASSERT(arg != 0);
-          ret = mcan_add_extfilter(priv, (FAR struct canioc_extfilter_s *)arg);
+
+          ret = mcan_add_extfilter(priv,
+                                   (FAR struct canioc_extfilter_s *)arg);
         }
         break;
 
       /* CANIOC_DEL_EXTFILTER:
-       *   Description:    Remove an address filter for a standard 29 bit address.
+       *   Description:    Remove an address filter for a standard 29 bit
+       *                   address.
        *   Argument:       The filter index previously returned by the
        *                   CANIOC_ADD_EXTFILTER command
-       *   Returned Value: Zero (OK) is returned on success.  Otherwise -1 (ERROR)
-       *                   is returned with the errno variable set to indicate the
-       *                   nature of the error.
+       *   Returned Value: Zero (OK) is returned on success.  Otherwise -1
+       *                   (ERROR) is returned with the errno variable set
+       *                   to indicate the nature of the error.
        */
 
       case CANIOC_DEL_EXTFILTER:
@@ -2731,17 +2757,20 @@ static int mcan_ioctl(FAR struct can_dev_s *dev, int cmd, unsigned long arg)
       case CANIOC_ADD_STDFILTER:
         {
           DEBUGASSERT(arg != 0);
-          ret = mcan_add_stdfilter(priv, (FAR struct canioc_stdfilter_s *)arg);
+
+          ret = mcan_add_stdfilter(priv,
+                                   (FAR struct canioc_stdfilter_s *)arg);
         }
         break;
 
       /* CANIOC_DEL_STDFILTER:
-       *   Description:    Remove an address filter for a standard 11 bit address.
+       *   Description:    Remove an address filter for a standard 11 bit
+       *                   address.
        *   Argument:       The filter index previously returned by the
        *                   CANIOC_ADD_STDFILTER command
-       *   Returned Value: Zero (OK) is returned on success.  Otherwise -1 (ERROR)
-       *                   is returned with the errno variable set to indicate the
-       *                   nature of the error.
+       *   Returned Value: Zero (OK) is returned on success.  Otherwise -1
+       *                   (ERROR) is returned with the errno variable set
+       *                   to indicate the nature of the error.
        */
 
       case CANIOC_DEL_STDFILTER:
@@ -2754,9 +2783,9 @@ static int mcan_ioctl(FAR struct can_dev_s *dev, int cmd, unsigned long arg)
       /* CANIOC_BUSOFF_RECOVERY:
        *   Description : Initiates the BUS - OFF recovery sequence
        *   Argument : None
-       *   Returned Value : Zero (OK) is returned on success. Otherwise - 1 (ERROR)
-       *                    is returned with the errno variable set to indicate the
-       *                    nature of the error.
+       *   Returned Value : Zero (OK) is returned on success. Otherwise -1
+       *                    (ERROR) is returned with the errno variable set
+       *                    to indicate the nature of the error.
        *   Dependencies : None
        */
 
@@ -3105,7 +3134,8 @@ static bool mcan_txempty(FAR struct can_dev_s *dev)
  ****************************************************************************/
 
 #if 0 /* Not Used */
-bool mcan_dedicated_rxbuffer_available(FAR struct sam_mcan_s *priv, int bufndx)
+bool mcan_dedicated_rxbuffer_available(FAR struct sam_mcan_s *priv,
+                                       int bufndx)
 {
   if (bufndx < 32)
     {
@@ -3191,8 +3221,9 @@ static void mcan_error(FAR struct can_dev_s *dev, uint32_t status)
 
   if ((status & (MCAN_INT_RF0L | MCAN_INT_RF1L)) != 0)
     {
-      /* Receive FIFO 0 Message Lost */
-      /* Receive FIFO 1 Message Lost */
+      /* Receive FIFO 0/1 Message Lost
+       * Receive FIFO 1 Message Lost
+       */
 
       errbits |= CAN_ERROR_CONTROLLER;
       data[1] |= CAN_ERROR1_RXOVERFLOW;
@@ -3215,8 +3246,9 @@ static void mcan_error(FAR struct can_dev_s *dev, uint32_t status)
 
   if ((status & (MCAN_INT_MRAF | MCAN_INT_ELO)) != 0)
     {
-      /* Message RAM Access Failure */
-      /* Error Logging Overflow */
+      /* Message RAM Access Failure
+       * Error Logging Overflow
+       */
 
       errbits |= CAN_ERROR_CONTROLLER;
       data[1] |= CAN_ERROR1_UNSPEC;
@@ -3315,6 +3347,7 @@ static void mcan_receive(FAR struct can_dev_s *dev, FAR uint32_t *rxbuffer,
   up_invalidate_dcache((uintptr_t)rxbuffer, (uintptr_t)rxbuffer + nbytes);
 
   /* Format the CAN header */
+
   /* Work R0 contains the CAN ID */
 
   regval = *rxbuffer++;
@@ -3339,12 +3372,14 @@ static void mcan_receive(FAR struct can_dev_s *dev, FAR uint32_t *rxbuffer,
     {
       /* Save the extended ID of the newly received message */
 
-      hdr.ch_id    = (regval & BUFFER_R0_EXTID_MASK) >> BUFFER_R0_EXTID_SHIFT;
+      hdr.ch_id    = (regval & BUFFER_R0_EXTID_MASK) >>
+                     BUFFER_R0_EXTID_SHIFT;
       hdr.ch_extid = true;
     }
   else
     {
-      hdr.ch_id    = (regval & BUFFER_R0_STDID_MASK) >> BUFFER_R0_STDID_SHIFT;
+      hdr.ch_id    = (regval & BUFFER_R0_STDID_MASK) >>
+                     BUFFER_R0_STDID_SHIFT;
       hdr.ch_extid = false;
     }
 
@@ -3552,7 +3587,7 @@ static int mcan_interrupt(int irq, void *context, FAR void *arg)
 #if 0 /* Not used */
       /* Check if a message has been stored to the dedicated RX buffer (DRX) */
 
-      if ((pending & MCAN_INT_DRX) != 0))
+      if ((pending & MCAN_INT_DRX) != 0)
         {
           int i;
 
@@ -3583,11 +3618,13 @@ static int mcan_interrupt(int irq, void *context, FAR void *arg)
 
                   if (i < 32)
                     {
-                      sam_putreg(priv, SAM_MCAN_NDAT1_OFFSET, (1 << i);
+                      sam_putreg(priv, SAM_MCAN_NDAT1_OFFSET,
+                                 (1 << i);
                     }
                   else
                     {
-                      sam_putreg(priv, SAM_MCAN_NDAT1_OFFSET, (1 << (i - 32));
+                      sam_putreg(priv, SAM_MCAN_NDAT1_OFFSET,
+                                 (1 << (i - 32));
                     }
                 }
             }
@@ -3651,6 +3688,7 @@ static int mcan_interrupt(int irq, void *context, FAR void *arg)
         }
 
       /* Check for successful reception of a new message in RX FIFO0 */
+
       /* Clear the RX FIFO0 new message interrupt */
 
       mcan_putreg(priv, SAM_MCAN_IR_OFFSET, MCAN_INT_RF0N);
@@ -3829,6 +3867,7 @@ static int mcan_hw_initialize(struct sam_mcan_s *priv)
   mcan_putreg(priv, SAM_MCAN_TXESC_OFFSET, regval);
 
   /* Configure Message Filters */
+
   /* Disable all standard filters */
 
   msgram = config->msgram.stdfilters;
@@ -3895,7 +3934,8 @@ static int mcan_hw_initialize(struct sam_mcan_s *priv)
 #if 0 /* Not necessary in initialization mode */
   /* Wait for the mode to take effect */
 
-  while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) & (MCAN_CCCR_FDBS | MCAN_CCCR_FDO)) != 0);
+  while ((mcan_getreg(priv, SAM_MCAN_CCCR_OFFSET) &
+         (MCAN_CCCR_FDBS | MCAN_CCCR_FDO)) != 0);
 #endif
 
   /* Enable FIFO/Queue mode
@@ -3932,6 +3972,7 @@ static int mcan_hw_initialize(struct sam_mcan_s *priv)
 #endif
 
   /* Configure interrupt lines */
+
   /* Select RX-related interrupts */
 
 #if 0 /* Dedicated RX buffers are not used by this driver */
@@ -4002,7 +4043,8 @@ FAR struct can_dev_s *sam_mcan_initialize(int port)
    * use PCK5 to derive bit rate.
    */
 
-  regval = PMC_PCK_PRES(CONFIG_SAMV7_MCAN_CLKSRC_PRESCALER - 1) | SAMV7_MCAN_CLKSRC;
+  regval = PMC_PCK_PRES(CONFIG_SAMV7_MCAN_CLKSRC_PRESCALER - 1) |
+           SAMV7_MCAN_CLKSRC;
   putreg32(regval, SAM_PMC_PCK5);
 
   /* Enable PCK5 */
@@ -4024,7 +4066,8 @@ FAR struct can_dev_s *sam_mcan_initialize(int port)
 
       regval  = getreg32(SAM_MATRIX_CAN0);
       regval &= MATRIX_CAN0_RESERVED;
-      regval |= (uint32_t)config->msgram.stdfilters & MATRIX_CAN0_CAN0DMABA_MASK;
+      regval |= (uint32_t)config->msgram.stdfilters &
+                MATRIX_CAN0_CAN0DMABA_MASK;
       putreg32(regval, SAM_MATRIX_CAN0);
     }
   else
@@ -4042,7 +4085,8 @@ FAR struct can_dev_s *sam_mcan_initialize(int port)
 
       regval  = getreg32(SAM_MATRIX_CCFG_SYSIO);
       regval &= ~MATRIX_CCFG_CAN1DMABA_MASK;
-      regval |= (uint32_t)config->msgram.stdfilters & MATRIX_CCFG_CAN1DMABA_MASK;
+      regval |= (uint32_t)config->msgram.stdfilters &
+                MATRIX_CCFG_CAN1DMABA_MASK;
       putreg32(regval, SAM_MATRIX_CCFG_SYSIO);
     }
   else

--- a/arch/arm/src/samv7/sam_spi_slave.c
+++ b/arch/arm/src/samv7/sam_spi_slave.c
@@ -128,7 +128,7 @@ static void     spi_dumpregs(struct sam_spidev_s *priv, const char *msg);
 #endif
 
 static int      spi_semtake(struct sam_spidev_s *priv);
-static void     spi_semtake_uninterruptible(struct sam_spidev_s *priv);
+static void     spi_semtake_noncancelable(struct sam_spidev_s *priv);
 #define         spi_semgive(priv) (nxsem_post(&(priv)->spisem))
 
 /* Interrupt Handling */
@@ -351,7 +351,7 @@ static int spi_semtake(struct sam_spidev_s *priv)
 }
 
 /****************************************************************************
- * Name: spi_semtake_uninterruptible
+ * Name: spi_semtake_noncancelable
  *
  * Description:
  *   Take the semaphore that enforces mutually exclusive access to SPI
@@ -365,7 +365,7 @@ static int spi_semtake(struct sam_spidev_s *priv)
  *
  ****************************************************************************/
 
-static void spi_semtake_uninterruptible(struct sam_spidev_s *priv)
+static void spi_semtake_noncancelable(struct sam_spidev_s *priv)
 {
   int ret;
 
@@ -881,7 +881,7 @@ static void spi_unbind(struct spi_sctrlr_s *sctrlr)
 
   /* Get exclusive access to the SPI device */
 
-  spi_semtake_uninterruptible(priv);
+  spi_semtake_noncancelable(priv);
 
   /* Disable SPI interrupts (still enabled at the NVIC) */
 
@@ -1069,7 +1069,7 @@ static void spi_qflush(struct spi_sctrlr_s *sctrlr)
 
   /* Get exclusive access to the SPI device */
 
-  spi_semtake_uninterruptible(priv);
+  spi_semtake_noncancelable(priv);
 
   /* Mark the buffer empty, momentarily disabling interrupts */
 

--- a/arch/arm/src/stm32/stm32_i2c.c
+++ b/arch/arm/src/stm32/stm32_i2c.c
@@ -290,7 +290,7 @@ static inline void stm32_i2c_modifyreg(FAR struct stm32_i2c_priv_s *priv,
                                        uint8_t offset, uint16_t clearbits,
                                        uint16_t setbits);
 static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv);
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct stm32_i2c_priv_s *priv);
+static int stm32_i2c_sem_wait_noncancelable(FAR struct stm32_i2c_priv_s *priv);
 
 #ifdef CONFIG_STM32_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
@@ -520,14 +520,14 @@ static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv)
 }
 
 /************************************************************************************
- * Name: stm32_i2c_sem_wait_uninterruptible
+ * Name: stm32_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary
  *
  ************************************************************************************/
 
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct stm32_i2c_priv_s *priv)
+static int stm32_i2c_sem_wait_noncancelable(FAR struct stm32_i2c_priv_s *priv)
 {
   return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
@@ -1826,7 +1826,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  ret = stm32_i2c_sem_wait_uninterruptible(priv);
+  ret = stm32_i2c_sem_wait_noncancelable(priv);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/stm32/stm32_i2c_alt.c
+++ b/arch/arm/src/stm32/stm32_i2c_alt.c
@@ -320,7 +320,7 @@ static inline void stm32_i2c_modifyreg(FAR struct stm32_i2c_priv_s *priv,
                                        uint8_t offset, uint16_t clearbits,
                                        uint16_t setbits);
 static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv);
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct stm32_i2c_priv_s *priv);
+static int stm32_i2c_sem_wait_noncancelable(FAR struct stm32_i2c_priv_s *priv);
 
 #ifdef CONFIG_STM32_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
@@ -529,14 +529,14 @@ static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv)
 }
 
 /************************************************************************************
- * Name: stm32_i2c_sem_wait_uninterruptible
+ * Name: stm32_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary
  *
  ************************************************************************************/
 
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct stm32_i2c_priv_s *priv)
+static int stm32_i2c_sem_wait_noncancelable(FAR struct stm32_i2c_priv_s *priv)
 {
   return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
@@ -2292,7 +2292,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
 
   /* Lock out other clients */
 
-  ret = stm32_i2c_sem_wait_uninterruptible(priv);
+  ret = stm32_i2c_sem_wait_noncancelable(priv);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/stm32/stm32_i2c_v2.c
+++ b/arch/arm/src/stm32/stm32_i2c_v2.c
@@ -448,7 +448,7 @@ static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits);
 static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev);
+static int stm32_i2c_sem_wait_noncancelable(FAR struct i2c_master_s *dev);
 #ifdef CONFIG_STM32_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
 #endif /* CONFIG_STM32_I2C_DYNTIMEO */
@@ -720,14 +720,14 @@ static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
 }
 
 /************************************************************************************
- * Name: stm32_i2c_sem_wait_uninterruptible
+ * Name: stm32_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary
  *
  ************************************************************************************/
 
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev)
+static int stm32_i2c_sem_wait_noncancelable(FAR struct i2c_master_s *dev)
 {
   return
     nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
@@ -2562,7 +2562,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
 
   /* Lock out other clients */
 
-  ret = stm32_i2c_sem_wait_uninterruptible(dev);
+  ret = stm32_i2c_sem_wait_noncancelable(dev);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/stm32/stm32_otgfshost.c
+++ b/arch/arm/src/stm32/stm32_otgfshost.c
@@ -297,7 +297,7 @@ static inline void stm32_modifyreg(uint32_t addr, uint32_t clrbits,
 /* Semaphores ***************************************************************/
 
 static int  stm32_takesem(sem_t *sem);
-static int  stm32_takesem_uninterruptible(sem_t *sem);
+static int  stm32_takesem_noncancelable(sem_t *sem);
 #define stm32_givesem(s) nxsem_post(s);
 
 /* Byte stream access helper functions **************************************/
@@ -648,7 +648,7 @@ static int stm32_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: stm32_takesem_uninterruptible
+ * Name: stm32_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -657,7 +657,7 @@ static int stm32_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int stm32_takesem_uninterruptible(sem_t *sem)
+static int stm32_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -4244,7 +4244,7 @@ static int stm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 
   /* We must have exclusive access to the USB host hardware and state structures */
 
-  ret = stm32_takesem_uninterruptible(&priv->exclsem);
+  ret = stm32_takesem_noncancelable(&priv->exclsem);
 
   /* A single channel is represent by an index in the range of 0 to
    * STM32_MAX_TX_FIFOS.  Otherwise, the ep must be a pointer to an allocated

--- a/arch/arm/src/stm32/stm32_otghshost.c
+++ b/arch/arm/src/stm32/stm32_otghshost.c
@@ -302,7 +302,7 @@ static inline void stm32_modifyreg(uint32_t addr, uint32_t clrbits,
 /* Semaphores ***************************************************************/
 
 static int  stm32_takesem(sem_t *sem);
-static int  stm32_takesem_uninterruptible(sem_t *sem);
+static int  stm32_takesem_noncancelable(sem_t *sem);
 #define stm32_givesem(s) nxsem_post(s);
 
 /* Byte stream access helper functions **************************************/
@@ -653,7 +653,7 @@ static int stm32_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: stm32_takesem_uninterruptible
+ * Name: stm32_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -662,7 +662,7 @@ static int stm32_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int stm32_takesem_uninterruptible(sem_t *sem)
+static int stm32_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -4244,7 +4244,7 @@ static int stm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 
   /* We must have exclusive access to the USB host hardware and state structures */
 
-  ret = stm32_takesem_uninterruptible(&priv->exclsem);
+  ret = stm32_takesem_noncancelable(&priv->exclsem);
 
   /* A single channel is represent by an index in the range of 0 to
    * STM32_MAX_TX_FIFOS.  Otherwise, the ep must be a pointer to an allocated

--- a/arch/arm/src/stm32/stm32f40xxx_i2c.c
+++ b/arch/arm/src/stm32/stm32f40xxx_i2c.c
@@ -315,7 +315,7 @@ static inline void stm32_i2c_modifyreg(FAR struct stm32_i2c_priv_s *priv,
                                        uint8_t offset, uint16_t clearbits,
                                        uint16_t setbits);
 static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv);
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct stm32_i2c_priv_s *priv);
+static int stm32_i2c_sem_wait_noncancelable(FAR struct stm32_i2c_priv_s *priv);
 
 #ifdef CONFIG_STM32_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
@@ -575,7 +575,7 @@ static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv)
 }
 
 /************************************************************************************
- * Name: stm32_i2c_sem_wait_uninterruptible
+ * Name: stm32_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary.  May be interrupted by a
@@ -583,7 +583,7 @@ static inline int stm32_i2c_sem_wait(FAR struct stm32_i2c_priv_s *priv)
  *
  ************************************************************************************/
 
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct stm32_i2c_priv_s *priv)
+static int stm32_i2c_sem_wait_noncancelable(FAR struct stm32_i2c_priv_s *priv)
 {
   return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
@@ -2521,7 +2521,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s *dev)
 
   /* Lock out other clients */
 
-  ret = stm32_i2c_sem_wait_uninterruptible(priv);
+  ret = stm32_i2c_sem_wait_noncancelable(priv);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -486,7 +486,7 @@ static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits);
 static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev);
+static int stm32_i2c_sem_wait_noncancelable(FAR struct i2c_master_s *dev);
 #ifdef CONFIG_STM32F7_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
 #endif /* CONFIG_STM32F7_I2C_DYNTIMEO */
@@ -758,7 +758,7 @@ static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
 }
 
 /************************************************************************************
- * Name: stm32_i2c_sem_wait_uninterruptible
+ * Name: stm32_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary.  May be interrupted by a
@@ -766,7 +766,7 @@ static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
  *
  ************************************************************************************/
 
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev)
+static int stm32_i2c_sem_wait_noncancelable(FAR struct i2c_master_s *dev)
 {
   return
     nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
@@ -2601,7 +2601,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
 
   /* Lock out other clients */
 
-  ret = stm32_i2c_sem_wait_uninterruptible(dev);
+  ret = stm32_i2c_sem_wait_noncancelable(dev);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/stm32f7/stm32_otghost.c
+++ b/arch/arm/src/stm32f7/stm32_otghost.c
@@ -312,7 +312,7 @@ static inline void stm32_modifyreg(uint32_t addr, uint32_t clrbits,
 /* Semaphores ***************************************************************/
 
 static int  stm32_takesem(sem_t *sem);
-static int  stm32_takesem_uninterruptible(sem_t *sem);
+static int  stm32_takesem_noncancelable(sem_t *sem);
 #define stm32_givesem(s) nxsem_post(s);
 
 /* Byte stream access helper functions **************************************/
@@ -659,7 +659,7 @@ static int stm32_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: stm32_takesem_uninterruptible
+ * Name: stm32_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -668,7 +668,7 @@ static int stm32_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int stm32_takesem_uninterruptible(sem_t *sem)
+static int stm32_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -4234,7 +4234,7 @@ static int stm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 
   /* We must have exclusive access to the USB host hardware and state structures */
 
-  ret = stm32_takesem_uninterruptible(&priv->exclsem);
+  ret = stm32_takesem_noncancelable(&priv->exclsem);
 
   /* A single channel is represent by an index in the range of 0 to
    * STM32_MAX_TX_FIFOS.  Otherwise, the ep must be a pointer to an allocated

--- a/arch/arm/src/stm32h7/stm32_i2c.c
+++ b/arch/arm/src/stm32h7/stm32_i2c.c
@@ -439,7 +439,7 @@ static inline void stm32_i2c_modifyreg32(FAR struct stm32_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits);
 static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev);
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev);
+static int stm32_i2c_sem_wait_noncancelable(FAR struct i2c_master_s *dev);
 #ifdef CONFIG_STM32H7_I2C_DYNTIMEO
 static useconds_t stm32_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
 #endif /* CONFIG_STM32H7_I2C_DYNTIMEO */
@@ -711,7 +711,7 @@ static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
 }
 
 /************************************************************************************
- * Name: stm32_i2c_sem_wait_uninterruptible
+ * Name: stm32_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary.  May be interrupted by a
@@ -719,7 +719,7 @@ static inline int stm32_i2c_sem_wait(FAR struct i2c_master_s *dev)
  *
  ************************************************************************************/
 
-static int stm32_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev)
+static int stm32_i2c_sem_wait_noncancelable(FAR struct i2c_master_s *dev)
 {
   return
     nxsem_wait_uninterruptible(&((struct stm32_i2c_inst_s *)dev)->priv->sem_excl);
@@ -2546,7 +2546,7 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
 
   /* Lock out other clients */
 
-  ret = stm32_i2c_sem_wait_uninterruptible(dev);
+  ret = stm32_i2c_sem_wait_noncancelable(dev);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/stm32h7/stm32_otghost.c
+++ b/arch/arm/src/stm32h7/stm32_otghost.c
@@ -317,7 +317,7 @@ static inline void stm32_modifyreg(uint32_t addr, uint32_t clrbits,
 /* Semaphores ***************************************************************/
 
 static int  stm32_takesem(sem_t *sem);
-static int  stm32_takesem_uninterruptible(sem_t *sem);
+static int  stm32_takesem_noncancelable(sem_t *sem);
 #define stm32_givesem(s) nxsem_post(s);
 
 /* Byte stream access helper functions **************************************/
@@ -664,7 +664,7 @@ static int stm32_takesem(sem_t *sem)
 }
 
 /****************************************************************************
- * Name: stm32_takesem_uninterruptible
+ * Name: stm32_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -673,7 +673,7 @@ static int stm32_takesem(sem_t *sem)
  *
  ****************************************************************************/
 
-static int stm32_takesem_uninterruptible(sem_t *sem)
+static int stm32_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -4240,7 +4240,7 @@ static int stm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 
   /* We must have exclusive access to the USB host hardware and state structures */
 
-  ret = stm32_takesem_uninterruptible(&priv->exclsem);
+  ret = stm32_takesem_noncancelable(&priv->exclsem);
 
   /* A single channel is represent by an index in the range of 0 to
    * STM32_MAX_TX_FIFOS.  Otherwise, the ep must be a pointer to an allocated

--- a/arch/arm/src/stm32l4/stm32l4_i2c.c
+++ b/arch/arm/src/stm32l4/stm32l4_i2c.c
@@ -479,7 +479,7 @@ static inline void stm32l4_i2c_modifyreg32(FAR struct stm32l4_i2c_priv_s *priv,
                                            uint8_t offset, uint32_t clearbits,
                                            uint32_t setbits);
 static inline int stm32l4_i2c_sem_wait(FAR struct i2c_master_s *dev);
-static int stm32l4_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev);
+static int stm32l4_i2c_sem_wait_noncancelable(FAR struct i2c_master_s *dev);
 #ifdef CONFIG_STM32L4_I2C_DYNTIMEO
 static useconds_t stm32l4_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
 #endif /* CONFIG_STM32L4_I2C_DYNTIMEO */
@@ -752,14 +752,14 @@ static inline int stm32l4_i2c_sem_wait(FAR struct i2c_master_s *dev)
 }
 
 /************************************************************************************
- * Name: stm32l4_i2c_sem_wait_uninterruptible
+ * Name: stm32l4_i2c_sem_wait_noncancelable
  *
  * Description:
  *   Take the exclusive access, waiting as necessary
  *
  ************************************************************************************/
 
-static int stm32l4_i2c_sem_wait_uninterruptible(FAR struct i2c_master_s *dev)
+static int stm32l4_i2c_sem_wait_noncancelable(FAR struct i2c_master_s *dev)
 {
   return
     nxsem_wait_uninterruptible(&((struct stm32l4_i2c_inst_s *)dev)->priv->sem_excl);
@@ -2727,7 +2727,7 @@ static int stm32l4_i2c_reset(FAR struct i2c_master_s * dev)
 
   /* Lock out other clients */
 
-  ret = stm32l4_i2c_sem_wait_uninterruptible(dev);
+  ret = stm32l4_i2c_sem_wait_noncancelable(dev);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/stm32l4/stm32l4_otgfshost.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfshost.c
@@ -312,7 +312,7 @@ static inline void stm32l4_modifyreg(uint32_t addr, uint32_t clrbits,
 /* Semaphores ***************************************************************/
 
 static int  stm32l4_takesem(FAR sem_t *sem);
-static int  stm32l4_takesem_uninterruptible(FAR sem_t *sem);
+static int  stm32l4_takesem_noncancelable(FAR sem_t *sem);
 #define stm32l4_givesem(s) nxsem_post(s);
 
 /* Byte stream access helper functions **************************************/
@@ -670,7 +670,7 @@ static int stm32l4_takesem(FAR sem_t *sem)
 }
 
 /****************************************************************************
- * Name: stm32l4_takesem_uninterruptible
+ * Name: stm32l4_takesem_noncancelable
  *
  * Description:
  *   This is just a wrapper to handle the annoying behavior of semaphore
@@ -679,7 +679,7 @@ static int stm32l4_takesem(FAR sem_t *sem)
  *
  ****************************************************************************/
 
-static int stm32l4_takesem_uninterruptible(sem_t *sem)
+static int stm32l4_takesem_noncancelable(sem_t *sem)
 {
   int result;
   int ret = OK;
@@ -4268,7 +4268,7 @@ static int stm32l4_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 
   /* We must have exclusive access to the USB host hardware and state structures */
 
-  ret = stm32l4_takesem_uninterruptible(&priv->exclsem);
+  ret = stm32l4_takesem_noncancelable(&priv->exclsem);
 
   /* A single channel is represent by an index in the range of 0 to
    * STM32L4_MAX_TX_FIFOS.  Otherwise, the ep must be a pointer to an


### PR DESCRIPTION
* Resolution of Issue 619 will require multiple steps, this part of the first step in that resolution:  Every call to nxsem_wait_uninterruptible() must handle the return value from nxsem_wait_uninterruptible properly.  This commit is for all remaining drivers in the Atmel SAM architectures.
* Run nxstyle on the modified files.
* Correct the naming of some new functions.   Several private functions were added with a name ending with _uninterruptible.  That is not correct.  These new functions should be named _noncancelable.
