### PR TITLE
nxsem_wait_uninterruptible:  Now returns if the task is canceled.

### DIFF
--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -26,7 +26,6 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <nuttx/compiler.h>
 
 #include <errno.h>
 #include <semaphore.h>
@@ -523,29 +522,13 @@ int sem_setprotocol(FAR sem_t *sem, int protocol);
  *   sem - Semaphore descriptor.
  *
  * Return Value:
- *   Zero(OK) - On success
- *   EINVAL - Invalid attempt to get the semaphore
+ *   Zero(OK)  - On success
+ *   EINVAL    - Invalid attempt to get the semaphore
+ *   ECANCELED - May be returned if the thread is canceled while waiting.
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
-static inline int nxsem_wait_uninterruptible(FAR sem_t *sem)
-{
-  int ret;
-
-  do
-    {
-      /* Take the semaphore (perhaps waiting) */
-
-      ret = nxsem_wait(sem);
-    }
-  while (ret == -EINTR || ret == -ECANCELED);
-
-  return ret;
-}
-#else
 int nxsem_wait_uninterruptible(FAR sem_t *sem);
-#endif
 
 /****************************************************************************
  * Name: nxsem_timedwait_uninterruptible
@@ -570,27 +553,8 @@ int nxsem_wait_uninterruptible(FAR sem_t *sem);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
-static inline int
-  nxsem_timedwait_uninterruptible(FAR sem_t *sem,
-                                  FAR const struct timespec *abstime)
-{
-  int ret;
-
-  do
-    {
-      /* Take the semaphore (perhaps waiting) */
-
-      ret = nxsem_timedwait(sem, abstime);
-    }
-  while (ret == -EINTR);
-
-  return ret;
-}
-#else
 int nxsem_timedwait_uninterruptible(FAR sem_t *sem,
                                     FAR const struct timespec *abstime);
-#endif
 
 /****************************************************************************
  * Name: nxsem_tickwait_uninterruptible
@@ -619,27 +583,8 @@ int nxsem_timedwait_uninterruptible(FAR sem_t *sem,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
-static inline int
-  nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start,
-                                 uint32_t delay)
-{
-  int ret;
-
-  do
-    {
-      /* Take the semaphore (perhaps waiting) */
-
-      ret = nxsem_tickwait(sem, start, delay);
-    }
-  while (ret == -EINTR);
-
-  return ret;
-}
-#else
 int nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start,
                                    uint32_t delay);
-#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -189,7 +189,6 @@ errout_with_irqdisabled:
  *
  ****************************************************************************/
 
-#ifndef CONFIG_HAVE_INLINE
 int nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start,
                                    uint32_t delay)
 {
@@ -205,5 +204,4 @@ int nxsem_tickwait_uninterruptible(FAR sem_t *sem, clock_t start,
 
   return ret;
 }
-#endif
 

--- a/sched/semaphore/sem_timedwait.c
+++ b/sched/semaphore/sem_timedwait.c
@@ -221,7 +221,6 @@ errout_with_irqdisabled:
  *
  ****************************************************************************/
 
-#ifndef CONFIG_HAVE_INLINE
 int nxsem_timedwait_uninterruptible(FAR sem_t *sem,
                                     FAR const struct timespec *abstime)
 {
@@ -237,7 +236,6 @@ int nxsem_timedwait_uninterruptible(FAR sem_t *sem,
 
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: sem_timedwait

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/semaphore/sem_wait.c
  *
- *   Copyright (C) 2007-2013, 2016, 2020 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -172,22 +157,22 @@ int nxsem_wait(FAR sem_t *sem)
 
           /* When we resume at this point, either (1) the semaphore has been
            * assigned to this thread of execution, or (2) the semaphore wait
-           * has been interrupted by a signal or a timeout.  We can detect these
-           * latter cases be examining the per-thread errno value.
+           * has been interrupted by a signal or a timeout.  We can detect
+           * these latter cases be examining the per-thread errno value.
            *
-           * In the event that the semaphore wait was interrupted by a signal or
-           * a timeout, certain semaphore clean-up operations have already been
-           * performed (see sem_waitirq.c).  Specifically:
+           * In the event that the semaphore wait was interrupted by a
+           * signal or a timeout, certain semaphore clean-up operations have
+           * already been performed (see sem_waitirq.c).  Specifically:
            *
            * - nxsem_canceled() was called to restore the priority of all
            *   threads that hold a reference to the semaphore,
            * - The semaphore count was decremented, and
            * - tcb->waitsem was nullifed.
            *
-           * It is necesaary to do these things in sem_waitirq.c because a long
-           * time may elapse between the time that the signal was issued and
-           * this thread is awakened and this leaves a door open to several
-           * race conditions.
+           * It is necessary to do these things in sem_waitirq.c because a
+           * long time may elapse between the time that the signal was issued
+           * and this thread is awakened and this leaves a door open to
+           * several race conditions.
            */
 
           /* Check if an error occurred while we were sleeping.  Expected
@@ -217,19 +202,19 @@ int nxsem_wait(FAR sem_t *sem)
  * Name: nxsem_wait_uninterruptible
  *
  * Description:
- *   This function is wrapped version of nxsem_wait(), which is uninterruptible
- *   and convenient for use.
+ *   This function is wrapped version of nxsem_wait(), which is
+ *   uninterruptible and convenient for use.
  *
  * Parameters:
  *   sem - Semaphore descriptor.
  *
  * Return Value:
- *   Zero(OK) - On success
- *   EINVAL - Invalid attempt to get the semaphore
+ *   Zero(OK)  - On success
+ *   EINVAL    - Invalid attempt to get the semaphore
+ *   ECANCELED - May be returned if the thread is canceled while waiting.
  *
  ****************************************************************************/
 
-#ifndef CONFIG_HAVE_INLINE
 int nxsem_wait_uninterruptible(FAR sem_t *sem)
 {
   int ret;
@@ -240,11 +225,10 @@ int nxsem_wait_uninterruptible(FAR sem_t *sem)
 
       ret = nxsem_wait(sem);
     }
-  while (ret == -EINTR || ret == -ECANCELED);
+  while (ret == -EINTR);
 
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: sem_wait


### PR DESCRIPTION
See Issue 619.

Also removed inline functions from include/nuttx/semaphore.h.  They just cause too many problems.