### PR TITLE
arch: Fix included directed -> included directly

### DIFF
--- a/arch/arm/include/a1x/a10_irq.h
+++ b/arch/arm/include/a1x/a10_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/a1x/irq.h
+++ b/arch/arm/include/a1x/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/am335x/am335x_irq.h
+++ b/arch/arm/include/am335x/am335x_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/am335x/irq.h
+++ b/arch/arm/include/am335x/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/arch.h
+++ b/arch/arm/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/arm/include/arm/irq.h
+++ b/arch/arm/include/arm/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/arm/syscall.h
+++ b/arch/arm/include/arm/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/armv6-m/syscall.h
+++ b/arch/arm/include/armv6-m/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/armv7-a/syscall.h
+++ b/arch/arm/include/armv7-a/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/armv7-m/syscall.h
+++ b/arch/arm/include/armv7-m/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/armv7-r/syscall.h
+++ b/arch/arm/include/armv7-r/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/arm/include/c5471/irq.h
+++ b/arch/arm/include/c5471/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/cxd56xx/irq.h
+++ b/arch/arm/include/cxd56xx/irq.h
@@ -35,7 +35,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/dm320/irq.h
+++ b/arch/arm/include/dm320/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/efm32/efm32g_irq.h
+++ b/arch/arm/include/efm32/efm32g_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/efm32/efm32gg_irq.h
+++ b/arch/arm/include/efm32/efm32gg_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/efm32/efm32tg_irq.h
+++ b/arch/arm/include/efm32/efm32tg_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/efm32/irq.h
+++ b/arch/arm/include/efm32/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/imx1/irq.h
+++ b/arch/arm/include/imx1/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/imx6/irq.h
+++ b/arch/arm/include/imx6/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  & through nuttx/irq.h
  */
 

--- a/arch/arm/include/imxrt/imxrt102x_irq.h
+++ b/arch/arm/include/imxrt/imxrt102x_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/imxrt/imxrt105x_irq.h
+++ b/arch/arm/include/imxrt/imxrt105x_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/imxrt/imxrt106x_irq.h
+++ b/arch/arm/include/imxrt/imxrt106x_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/imxrt/irq.h
+++ b/arch/arm/include/imxrt/irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/irq.h
+++ b/arch/arm/include/irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/kinetis/irq.h
+++ b/arch/arm/include/kinetis/irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/kinetis/kinetis_k20irq.h
+++ b/arch/arm/include/kinetis/kinetis_k20irq.h
@@ -34,7 +34,7 @@
  *
  *************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/kinetis/kinetis_k28irq.h
+++ b/arch/arm/include/kinetis/kinetis_k28irq.h
@@ -33,7 +33,7 @@
  *
  ********************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/kinetis/kinetis_k40irq.h
+++ b/arch/arm/include/kinetis/kinetis_k40irq.h
@@ -34,7 +34,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/kinetis/kinetis_k60irq.h
+++ b/arch/arm/include/kinetis/kinetis_k60irq.h
@@ -34,7 +34,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/kinetis/kinetis_k64irq.h
+++ b/arch/arm/include/kinetis/kinetis_k64irq.h
@@ -34,7 +34,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/kinetis/kinetis_k66irq.h
+++ b/arch/arm/include/kinetis/kinetis_k66irq.h
@@ -34,7 +34,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/kl/irq.h
+++ b/arch/arm/include/kl/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/lc823450/irq.h
+++ b/arch/arm/include/lc823450/irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/lpc17xx_40xx/irq.h
+++ b/arch/arm/include/lpc17xx_40xx/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/lpc17xx_40xx/lpc176x_irq.h
+++ b/arch/arm/include/lpc17xx_40xx/lpc176x_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/lpc17xx_40xx/lpc178x_40xx_irq.h
+++ b/arch/arm/include/lpc17xx_40xx/lpc178x_40xx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/lpc214x/irq.h
+++ b/arch/arm/include/lpc214x/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/lpc2378/irq.h
+++ b/arch/arm/include/lpc2378/irq.h
@@ -39,7 +39,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/lpc31xx/irq.h
+++ b/arch/arm/include/lpc31xx/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/lpc43xx/irq.h
+++ b/arch/arm/include/lpc43xx/irq.h
@@ -33,7 +33,7 @@
  *
  ********************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/lpc54xx/irq.h
+++ b/arch/arm/include/lpc54xx/irq.h
@@ -33,7 +33,7 @@
  *
  ********************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/max326xx/irq.h
+++ b/arch/arm/include/max326xx/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/max326xx/max32620_30_irq.h
+++ b/arch/arm/include/max326xx/max32620_30_irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/max326xx/max32660_irq.h
+++ b/arch/arm/include/max326xx/max32660_irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/moxart/irq.h
+++ b/arch/arm/include/moxart/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/nrf52/irq.h
+++ b/arch/arm/include/nrf52/irq.h
@@ -33,7 +33,7 @@
  *
  ********************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/nuc1xx/irq.h
+++ b/arch/arm/include/nuc1xx/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/nuc1xx/nuc120_irq.h
+++ b/arch/arm/include/nuc1xx/nuc120_irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/s32k1xx/irq.h
+++ b/arch/arm/include/s32k1xx/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/s32k1xx/s32k11x_irq.h
+++ b/arch/arm/include/s32k1xx/s32k11x_irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/s32k1xx/s32k14x_irq.h
+++ b/arch/arm/include/s32k1xx/s32k14x_irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sam34/irq.h
+++ b/arch/arm/include/sam34/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sam34/sam3u_irq.h
+++ b/arch/arm/include/sam34/sam3u_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sam34/sam3x_irq.h
+++ b/arch/arm/include/sam34/sam3x_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sam34/sam4cm_irq.h
+++ b/arch/arm/include/sam34/sam4cm_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sam34/sam4e_irq.h
+++ b/arch/arm/include/sam34/sam4e_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sam34/sam4l_irq.h
+++ b/arch/arm/include/sam34/sam4l_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sam34/sam4s_irq.h
+++ b/arch/arm/include/sam34/sam4s_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sama5/irq.h
+++ b/arch/arm/include/sama5/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sama5/sama5d2_irq.h
+++ b/arch/arm/include/sama5/sama5d2_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sama5/sama5d3_irq.h
+++ b/arch/arm/include/sama5/sama5d3_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/sama5/sama5d4_irq.h
+++ b/arch/arm/include/sama5/sama5d4_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samd2l2/irq.h
+++ b/arch/arm/include/samd2l2/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samd2l2/samd20_irq.h
+++ b/arch/arm/include/samd2l2/samd20_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samd2l2/samd21_irq.h
+++ b/arch/arm/include/samd2l2/samd21_irq.h
@@ -37,7 +37,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samd2l2/saml21_irq.h
+++ b/arch/arm/include/samd2l2/saml21_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samd5e5/irq.h
+++ b/arch/arm/include/samd5e5/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samd5e5/samd5e5_irq.h
+++ b/arch/arm/include/samd5e5/samd5e5_irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samv7/irq.h
+++ b/arch/arm/include/samv7/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samv7/same70_irq.h
+++ b/arch/arm/include/samv7/same70_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/samv7/samv71_irq.h
+++ b/arch/arm/include/samv7/samv71_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32/irq.h
+++ b/arch/arm/include/stm32/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32/stm32f10xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f10xxx_irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32/stm32f20xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f20xxx_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F20XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F20XXX_IRQ_H

--- a/arch/arm/include/stm32/stm32f30xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f30xxx_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F30XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F30XXX_IRQ_H

--- a/arch/arm/include/stm32/stm32f33xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f33xxx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F33XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F33XXX_IRQ_H

--- a/arch/arm/include/stm32/stm32f37xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f37xxx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F37XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F37XXX_IRQ_H

--- a/arch/arm/include/stm32/stm32f40xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f40xxx_irq.h
@@ -36,7 +36,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32/stm32l15xxx_irq.h
+++ b/arch/arm/include/stm32/stm32l15xxx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32FL15XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32FL15XXX_IRQ_H

--- a/arch/arm/include/stm32f0l0g0/irq.h
+++ b/arch/arm/include/stm32f0l0g0/irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32f0l0g0/stm32f0_irq.h
+++ b/arch/arm/include/stm32f0l0g0/stm32f0_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32f0l0g0/stm32g0_irq.h
+++ b/arch/arm/include/stm32f0l0g0/stm32g0_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32F0L0G0_STM32G0_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32F0L0G0_STM32G0_IRQ_H

--- a/arch/arm/include/stm32f0l0g0/stm32l0_irq.h
+++ b/arch/arm/include/stm32f0l0g0/stm32l0_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32F0L0G0_STM32L0_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32F0L0G0_STM32L0_IRQ_H

--- a/arch/arm/include/stm32f7/irq.h
+++ b/arch/arm/include/stm32f7/irq.h
@@ -34,7 +34,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32f7/stm32f72xx73xx_irq.h
+++ b/arch/arm/include/stm32f7/stm32f72xx73xx_irq.h
@@ -38,7 +38,7 @@
  *             for SDMMC2 (IRQ103).
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32F7_STM32F72XX73XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32F7_STM32F72XX73XX_IRQ_H

--- a/arch/arm/include/stm32f7/stm32f74xx75xx_irq.h
+++ b/arch/arm/include/stm32f7/stm32f74xx75xx_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32F7_STM32F74XX75XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32F7_STM32F74XX75XX_IRQ_H

--- a/arch/arm/include/stm32f7/stm32f76xx77xx_irq.h
+++ b/arch/arm/include/stm32f7/stm32f76xx77xx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32F7_STM32F76XX77XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32F7_STM32F76XX77XX_IRQ_H

--- a/arch/arm/include/stm32h7/irq.h
+++ b/arch/arm/include/stm32h7/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32h7/stm32h7x3xx_irq.h
+++ b/arch/arm/include/stm32h7/stm32h7x3xx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32H7_STM32H7X3XX_IRQ_H
 

--- a/arch/arm/include/stm32h7/stm32h7x7xx_irq.h
+++ b/arch/arm/include/stm32h7/stm32h7x7xx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32H7_STM32H7X7XX_IRQ_H
 

--- a/arch/arm/include/stm32l4/irq.h
+++ b/arch/arm/include/stm32l4/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/stm32l4/stm32l4x3xx_irq.h
+++ b/arch/arm/include/stm32l4/stm32l4x3xx_irq.h
@@ -35,7 +35,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_STM32L4X3XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_STM32L4X3XX_IRQ_H

--- a/arch/arm/include/stm32l4/stm32l4x5xx_irq.h
+++ b/arch/arm/include/stm32l4/stm32l4x5xx_irq.h
@@ -36,7 +36,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_STM32L4X5XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_STM32L4X5XX_IRQ_H

--- a/arch/arm/include/stm32l4/stm32l4x6xx_irq.h
+++ b/arch/arm/include/stm32l4/stm32l4x6xx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_STM32L4X6XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_STM32L4X6XX_IRQ_H

--- a/arch/arm/include/stm32l4/stm32l4xrxx_irq.h
+++ b/arch/arm/include/stm32l4/stm32l4xrxx_irq.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_STM32L4XRXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_STM32L4XRXX_IRQ_H

--- a/arch/arm/include/str71x/irq.h
+++ b/arch/arm/include/str71x/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/arm/include/syscall.h
+++ b/arch/arm/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/arm/include/tms570/irq.h
+++ b/arch/arm/include/tms570/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/tms570/tms570ls04x03x_irq.h
+++ b/arch/arm/include/tms570/tms570ls04x03x_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly through
+/* This file should never be included directly but, rather, only indirectly through
  * nuttx/irq.h
  */
 

--- a/arch/arm/include/types.h
+++ b/arch/arm/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/arm/include/xmc4/irq.h
+++ b/arch/arm/include/xmc4/irq.h
@@ -33,7 +33,7 @@
  *
  ********************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/xmc4/xmc4500_irq.h
+++ b/arch/arm/include/xmc4/xmc4500_irq.h
@@ -33,7 +33,7 @@
  *
  ********************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/xmc4/xmc4700_irq.h
+++ b/arch/arm/include/xmc4/xmc4700_irq.h
@@ -18,7 +18,7 @@
  *
  ********************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/arm/include/xmc4/xmc4800_irq.h
+++ b/arch/arm/include/xmc4/xmc4800_irq.h
@@ -18,7 +18,7 @@
  *
  ********************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/avr/include/arch.h
+++ b/arch/avr/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/avr/include/at32uc3/irq.h
+++ b/arch/avr/include/at32uc3/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/avr/include/at90usb/irq.h
+++ b/arch/avr/include/at90usb/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/avr/include/atmega/irq.h
+++ b/arch/avr/include/atmega/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/avr/include/avr/irq.h
+++ b/arch/avr/include/avr/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h.
  */
 

--- a/arch/avr/include/avr/syscall.h
+++ b/arch/avr/include/avr/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/avr/include/avr/types.h
+++ b/arch/avr/include/avr/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through stdint.h
  */
 

--- a/arch/avr/include/avr32/irq.h
+++ b/arch/avr/include/avr32/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/avr/include/avr32/syscall.h
+++ b/arch/avr/include/avr32/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/avr/include/avr32/types.h
+++ b/arch/avr/include/avr32/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through stdint.h
  */
 

--- a/arch/avr/include/irq.h
+++ b/arch/avr/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/avr/include/syscall.h
+++ b/arch/avr/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/avr/include/types.h
+++ b/arch/avr/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through stdint.h
  */
 

--- a/arch/avr/include/xmega/xmegac_irq.h
+++ b/arch/avr/include/xmega/xmegac_irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/hc/include/arch.h
+++ b/arch/hc/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/hc/include/hc12/irq.h
+++ b/arch/hc/include/hc12/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/hc/include/hc12/types.h
+++ b/arch/hc/include/hc12/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/hc/include/hcs12/irq.h
+++ b/arch/hc/include/hcs12/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/hc/include/hcs12/types.h
+++ b/arch/hc/include/hcs12/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/hc/include/irq.h
+++ b/arch/hc/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/hc/include/m9s12/irq.h
+++ b/arch/hc/include/m9s12/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/hc/include/syscall.h
+++ b/arch/hc/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/hc/include/types.h
+++ b/arch/hc/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/mips/include/arch.h
+++ b/arch/mips/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/mips/include/irq.h
+++ b/arch/mips/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/mips32/irq.h
+++ b/arch/mips/include/mips32/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/pic32mx/irq.h
+++ b/arch/mips/include/pic32mx/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/pic32mx/irq_1xx2xx.h
+++ b/arch/mips/include/pic32mx/irq_1xx2xx.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/pic32mx/irq_3xx4xx.h
+++ b/arch/mips/include/pic32mx/irq_3xx4xx.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/pic32mx/irq_5xx6xx7xx.h
+++ b/arch/mips/include/pic32mx/irq_5xx6xx7xx.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/pic32mz/irq.h
+++ b/arch/mips/include/pic32mz/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/pic32mz/irq_pic32mzxxxec.h
+++ b/arch/mips/include/pic32mz/irq_pic32mzxxxec.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/pic32mz/irq_pic32mzxxxef.h
+++ b/arch/mips/include/pic32mz/irq_pic32mzxxxef.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/mips/include/types.h
+++ b/arch/mips/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through stdint.h
  */
 

--- a/arch/misoc/include/irq.h
+++ b/arch/misoc/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/misoc/include/lm32/syscall.h
+++ b/arch/misoc/include/lm32/syscall.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/misoc/include/minerva/irq.h
+++ b/arch/misoc/include/minerva/irq.h
@@ -35,7 +35,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/misoc/include/minerva/syscall.h
+++ b/arch/misoc/include/minerva/syscall.h
@@ -34,7 +34,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/misoc/include/syscall.h
+++ b/arch/misoc/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/misoc/include/types.h
+++ b/arch/misoc/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through stdint.h
  */
 

--- a/arch/or1k/include/arch.h
+++ b/arch/or1k/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/or1k/include/irq.h
+++ b/arch/or1k/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/or1k/include/mor1kx/irq.h
+++ b/arch/or1k/include/mor1kx/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/or1k/include/types.h
+++ b/arch/or1k/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/renesas/include/arch.h
+++ b/arch/renesas/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/renesas/include/irq.h
+++ b/arch/renesas/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/renesas/include/m16c/irq.h
+++ b/arch/renesas/include/m16c/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/renesas/include/m16c/types.h
+++ b/arch/renesas/include/m16c/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly\
+/* This file should never be included directly but, rather, only indirectly\
  * through sys/types.h
  */
 

--- a/arch/renesas/include/rx65n/types.h
+++ b/arch/renesas/include/rx65n/types.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly\
+/* This file should never be included directly but, rather, only indirectly\
  * through sys/types.h
  */
 

--- a/arch/renesas/include/sh1/irq.h
+++ b/arch/renesas/include/sh1/irq.h
@@ -33,7 +33,7 @@
  *
  ************************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/renesas/include/sh1/types.h
+++ b/arch/renesas/include/sh1/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly\
+/* This file should never be included directly but, rather, only indirectly\
  * through sys/types.h
  */
 

--- a/arch/renesas/include/sh1Ptypes.h
+++ b/arch/renesas/include/sh1Ptypes.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly\
+/* This file should never be included directly but, rather, only indirectly\
  * through sys/types.h
  */
 

--- a/arch/renesas/include/syscall.h
+++ b/arch/renesas/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/renesas/include/types.h
+++ b/arch/renesas/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/risc-v/include/arch.h
+++ b/arch/risc-v/include/arch.h
@@ -30,7 +30,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/risc-v/include/gap8/chip.h
+++ b/arch/risc-v/include/gap8/chip.h
@@ -31,7 +31,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -30,7 +30,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/risc-v/include/nr5m100/chip.h
+++ b/arch/risc-v/include/nr5m100/chip.h
@@ -30,7 +30,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/risc-v/include/rv32im/csr.h
+++ b/arch/risc-v/include/rv32im/csr.h
@@ -30,7 +30,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/risc-v/include/rv32im/irq.h
+++ b/arch/risc-v/include/rv32im/irq.h
@@ -35,7 +35,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/risc-v/include/rv32im/syscall.h
+++ b/arch/risc-v/include/rv32im/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/risc-v/include/rv64gc/irq.h
+++ b/arch/risc-v/include/rv64gc/irq.h
@@ -35,7 +35,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/risc-v/include/rv64gc/syscall.h
+++ b/arch/risc-v/include/rv64gc/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/risc-v/include/syscall.h
+++ b/arch/risc-v/include/syscall.h
@@ -35,7 +35,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/risc-v/include/types.h
+++ b/arch/risc-v/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/sim/include/arch.h
+++ b/arch/sim/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/sim/include/syscall.h
+++ b/arch/sim/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/sim/include/types.h
+++ b/arch/sim/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through sys/types.h
  */
 

--- a/arch/x86/include/arch.h
+++ b/arch/x86/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through arch/arch.h
  */
 

--- a/arch/x86/include/i486/arch.h
+++ b/arch/x86/include/i486/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/x86/include/i486/io.h
+++ b/arch/x86/include/i486/io.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through arch/io.h
  */
 

--- a/arch/x86/include/i486/irq.h
+++ b/arch/x86/include/i486/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/x86/include/i486/syscall.h
+++ b/arch/x86/include/i486/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/x86/include/i486/types.h
+++ b/arch/x86/include/i486/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only
+/* This file should never be included directly but, rather, only
  * indirectly through arch/types.h (which is, in turn only accessed
  * through sys/types.h or stdint.h).
  */

--- a/arch/x86/include/irq.h
+++ b/arch/x86/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/x86/include/qemu/arch.h
+++ b/arch/x86/include/qemu/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/x86/include/qemu/irq.h
+++ b/arch/x86/include/qemu/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/x86/include/syscall.h
+++ b/arch/x86/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/x86/include/types.h
+++ b/arch/x86/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/x86_64/include/arch.h
+++ b/arch/x86_64/include/arch.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through arch/arch.h
  */
 

--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/x86_64/include/intel64/io.h
+++ b/arch/x86_64/include/intel64/io.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through arch/io.h
  */
 

--- a/arch/x86_64/include/intel64/irq.h
+++ b/arch/x86_64/include/intel64/irq.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/x86_64/include/intel64/syscall.h
+++ b/arch/x86_64/include/intel64/syscall.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/x86_64/include/intel64/types.h
+++ b/arch/x86_64/include/intel64/types.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only
+/* This file should never be included directly but, rather, only
  * indirectly through arch/types.h (which is, in turn only accessed
  * through sys/types.h or stdint.h).
  */

--- a/arch/x86_64/include/irq.h
+++ b/arch/x86_64/include/irq.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/x86_64/include/syscall.h
+++ b/arch/x86_64/include/syscall.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/x86_64/include/types.h
+++ b/arch/x86_64/include/types.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/xtensa/include/arch.h
+++ b/arch/xtensa/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/arch.h
  */
 

--- a/arch/xtensa/include/esp32/irq.h
+++ b/arch/xtensa/include/esp32/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/xtensa/include/lx6/irq.h
+++ b/arch/xtensa/include/lx6/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h
  */
 

--- a/arch/xtensa/include/syscall.h
+++ b/arch/xtensa/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/xtensa/include/types.h
+++ b/arch/xtensa/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through stdint.h
  */
 

--- a/arch/z16/include/arch.h
+++ b/arch/z16/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h
  */
 

--- a/arch/z16/include/irq.h
+++ b/arch/z16/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/z16/include/syscall.h
+++ b/arch/z16/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/z16/include/types.h
+++ b/arch/z16/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through sys/types.h
  */
 

--- a/arch/z16/include/z16f/arch.h
+++ b/arch/z16/include/z16f/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h (via arch/arch.h)
  */
 

--- a/arch/z16/include/z16f/irq.h
+++ b/arch/z16/include/z16f/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h (via arch/irq.h)
  */
 

--- a/arch/z80/include/arch.h
+++ b/arch/z80/include/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/arch.h
  */
 

--- a/arch/z80/include/ez80/arch.h
+++ b/arch/z80/include/ez80/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h (via arch/arch.h)
  */
 

--- a/arch/z80/include/ez80/io.h
+++ b/arch/z80/include/ez80/io.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through arch/io.h
  */
 

--- a/arch/z80/include/ez80/irq.h
+++ b/arch/z80/include/ez80/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h (via arch/irq.h)
  */
 

--- a/arch/z80/include/ez80/types.h
+++ b/arch/z80/include/ez80/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/z80/include/irq.h
+++ b/arch/z80/include/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
  */
 

--- a/arch/z80/include/syscall.h
+++ b/arch/z80/include/syscall.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through include/syscall.h or include/sys/sycall.h
  */
 

--- a/arch/z80/include/types.h
+++ b/arch/z80/include/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
 * through sys/types.h
  */
 

--- a/arch/z80/include/z180/arch.h
+++ b/arch/z80/include/z180/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/arch.h (via arch/arch.h)
  */
 

--- a/arch/z80/include/z180/io.h
+++ b/arch/z80/include/z180/io.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through arch/io.h
  */
 

--- a/arch/z80/include/z180/irq.h
+++ b/arch/z80/include/z180/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through nuttx/irq.h (via arch/irq.h)
  */
 

--- a/arch/z80/include/z180/types.h
+++ b/arch/z80/include/z180/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/z80/include/z8/arch.h
+++ b/arch/z80/include/z8/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h (via arch/arch.h)
  */
 

--- a/arch/z80/include/z8/irq.h
+++ b/arch/z80/include/z8/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h (via arch/irq.h)
  */
 

--- a/arch/z80/include/z8/types.h
+++ b/arch/z80/include/z8/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 

--- a/arch/z80/include/z80/arch.h
+++ b/arch/z80/include/z80/arch.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/arch.h (via arch/arch.h)
  */
 

--- a/arch/z80/include/z80/io.h
+++ b/arch/z80/include/z80/io.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through arch/io.h
  */
 

--- a/arch/z80/include/z80/irq.h
+++ b/arch/z80/include/z80/irq.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather,
+/* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h (via arch/irq.h)
  */
 

--- a/arch/z80/include/z80/types.h
+++ b/arch/z80/include/z80/types.h
@@ -33,7 +33,7 @@
  *
  ****************************************************************************/
 
-/* This file should never be included directed but, rather, only indirectly
+/* This file should never be included directly but, rather, only indirectly
  * through sys/types.h
  */
 


### PR DESCRIPTION
This fixes a minor typo that had been copied and pasted into numerous irq and syscall headers.

"This file should never be **included directed**..." changed to "**included directly**."

Changes to comments only. No functional changes.