### PR TITLE
Fix some long single line comments.

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_sdhci.c
+++ b/arch/arm/src/cxd56xx/cxd56_sdhci.c
@@ -794,7 +794,9 @@ static void cxd56_dataconfig(struct cxd56_sdiodev_s *priv, bool bwrite,
 {
   uint32_t regval = 0;
 
-  /* Set the data timeout value in the SDHCI_SYSCTL field to the selected value */
+  /* Set the data timeout value in the SDHCI_SYSCTL field to the selected
+   * value.
+   */
 
   regval  = getreg32(CXD56_SDHCI_SYSCTL);
   regval &= ~SDHCI_SYSCTL_DTOCV_MASK;
@@ -825,7 +827,9 @@ static void cxd56_datadisable(void)
 {
   uint32_t regval;
 
-  /* Set the data timeout value in the SDHCI_SYSCTL field to the maximum value */
+  /* Set the data timeout value in the SDHCI_SYSCTL field to the maximum
+   * value.
+   */
 
   regval  = getreg32(CXD56_SDHCI_SYSCTL);
   regval &= ~SDHCI_SYSCTL_DTOCV_MASK;
@@ -1187,7 +1191,9 @@ static int cxd56_interrupt(int irq, FAR void *context, FAR void *arg)
   mcinfo("IRQSTAT: %08x IRQSIGEN %08x enabled: %08x\n",
           getreg32(CXD56_SDHCI_IRQSTAT), regval, enabled);
 
-  /* Disable card interrupts to clear the card interrupt to the host system. */
+  /* Disable card interrupts to clear the card interrupt to the host
+   * system.
+   */
 
   regval &= ~(SDHCI_INT_CINT | enabled);
   putreg32(regval, CXD56_SDHCI_IRQSIGEN);
@@ -2016,7 +2022,9 @@ static int cxd56_sdio_recvsetup(FAR struct sdio_dev_s *dev,
   cxd56_sampleinit();
   cxd56_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = nbytes;
@@ -2937,7 +2945,9 @@ static int cxd56_sdio_dmarecvsetup(FAR struct sdio_dev_s *dev,
   cxd56_sampleinit();
   cxd56_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = buflen;

--- a/arch/arm/src/imxrt/imxrt_usdhc.c
+++ b/arch/arm/src/imxrt/imxrt_usdhc.c
@@ -1736,7 +1736,9 @@ static void imxrt_clock(FAR struct sdio_dev_s *dev, enum sdio_clock_e rate)
 
         mcinfo("IDMODE\n");
 
-        /* Put out an additional 80 clocks in case this is a power-up sequence */
+        /* Put out an additional 80 clocks in case this is a power-up
+         * sequence.
+         */
 
         regval |= (BOARD_USDHC_IDMODE_PRESCALER |
                    BOARD_USDHC_IDMODE_DIVISOR |
@@ -2042,7 +2044,9 @@ static int imxrt_sendcmd(FAR struct sdio_dev_s *dev, uint32_t cmd,
   mcrregval |= USDHC_MC_DMAEN;
 #endif
 
-  /* Check for abort. TODO: Check Suspend/Resume bits too in XFR_TYP::CMDTYP */
+  /* Check for abort. TODO: Check Suspend/Resume bits too in
+   * XFR_TYP::CMDTYP.
+   */
 
   if (cmd & MMCSD_STOPXFR)
     {
@@ -2379,9 +2383,11 @@ static int imxrt_waitresponse(FAR struct sdio_dev_s *dev, uint32_t cmd)
   enerrors = getreg32(priv->addr + IMXRT_USDHC_IRQSTAT_OFFSET) & errors;
   if (enerrors != 0)
     {
-      mcerr("ERROR: cmd: %08x errors: %08x, fired %08x IRQSTAT: %08x\n", cmd, \
-        errors, enerrors, getreg32(priv->addr + IMXRT_USDHC_IRQSTAT_OFFSET));
-        ret = -EIO;
+      mcerr("ERROR: cmd: %08x errors: %08x, fired %08x IRQSTAT: %08x\n",
+            cmd, errors, enerrors,
+            getreg32(priv->addr + IMXRT_USDHC_IRQSTAT_OFFSET));
+
+      ret = -EIO;
     }
 
   return ret;

--- a/arch/arm/src/kinetis/kinetis_sdhc.c
+++ b/arch/arm/src/kinetis/kinetis_sdhc.c
@@ -658,7 +658,9 @@ static void kinetis_dataconfig(struct kinetis_dev_s *priv, bool bwrite,
   unsigned int watermark;
   uint32_t regval = 0;
 
-  /* Set the data timeout value in the SDHC_SYSCTL field to the selected value */
+  /* Set the data timeout value in the SDHC_SYSCTL field to the selected
+   * value.
+   */
 
   regval  = getreg32(KINETIS_SDHC_SYSCTL);
   regval &= ~SDHC_SYSCTL_DTOCV_MASK;
@@ -729,7 +731,9 @@ static void kinetis_datadisable(void)
 {
   uint32_t regval;
 
-  /* Set the data timeout value in the SDHC_SYSCTL field to the maximum value */
+  /* Set the data timeout value in the SDHC_SYSCTL field to the maximum
+   * value.
+   */
 
   regval  = getreg32(KINETIS_SDHC_SYSCTL);
   regval &= ~SDHC_SYSCTL_DTOCV_MASK;
@@ -1088,7 +1092,9 @@ static int kinetis_interrupt(int irq, void *context, FAR void *arg)
   mcinfo("IRQSTAT: %08x IRQSIGEN %08x enabled: %08x\n",
          getreg32(KINETIS_SDHC_IRQSTAT), regval, enabled);
 
-  /* Disable card interrupts to clear the card interrupt to the host system. */
+  /* Disable card interrupts to clear the card interrupt to the host
+   * system.
+   */
 
   regval &= ~SDHC_INT_CINT;
   putreg32(regval, KINETIS_SDHC_IRQSIGEN);
@@ -1958,7 +1964,9 @@ static int kinetis_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
   kinetis_sampleinit();
   kinetis_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = nbytes;
@@ -2667,7 +2675,9 @@ static int kinetis_dmarecvsetup(FAR struct sdio_dev_s *dev,
   kinetis_sampleinit();
   kinetis_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = buflen;

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_sdcard.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_sdcard.c
@@ -206,7 +206,9 @@
 #define SDCARD_WAITALL_ICR   (SDCARD_CMDDONE_ICR | SDCARD_RESPDONE_ICR | \
                               SDCARD_XFRDONE_ICR)
 
-/* Let's wait until we have both SD card transfer complete and DMA complete. */
+/* Let's wait until we have both SD card transfer complete and DMA
+ * complete.
+ */
 
 #define SDCARD_XFRDONE_FLAG  (1)
 #define SDCARD_DMADONE_FLAG  (2)
@@ -1799,7 +1801,9 @@ static int lpc17_40_recvsetup(FAR struct sdio_dev_s *dev,
   lpc17_40_sampleinit();
   lpc17_40_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = nbytes;
@@ -2099,7 +2103,9 @@ static int lpc17_40_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
 #endif
     }
 
-  /* Clear all pending message completion events and return the R1/R6 response */
+  /* Clear all pending message completion events and return the R1/R6
+   * response.
+   */
 
   putreg32(SDCARD_RESPDONE_ICR | SDCARD_CMDDONE_ICR, LPC17_40_SDCARD_CLEAR);
   *rshort = getreg32(LPC17_40_SDCARD_RESP0);
@@ -2516,7 +2522,9 @@ static int lpc17_40_dmarecvsetup(FAR struct sdio_dev_s *dev,
       lpc17_40_sampleinit();
       lpc17_40_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-      /* Save the destination buffer information for use by the interrupt handler */
+      /* Save the destination buffer information for use by the interrupt
+       * handler.
+       */
 
       priv->buffer    = (uint32_t *)buffer;
       priv->remaining = buflen;
@@ -2595,7 +2603,9 @@ static int lpc17_40_dmasendsetup(FAR struct sdio_dev_s *dev,
       lpc17_40_sampleinit();
       lpc17_40_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-      /* Save the source buffer information for use by the interrupt handler */
+      /* Save the source buffer information for use by the interrupt
+       * handler.
+       */
 
       priv->buffer    = (uint32_t *)buffer;
       priv->remaining = buflen;

--- a/arch/arm/src/lpc43xx/lpc43_sdmmc.c
+++ b/arch/arm/src/lpc43xx/lpc43_sdmmc.c
@@ -188,7 +188,9 @@
 #define SDCARD_WAITALL_CLEAR    (SDCARD_CMDDONE_CLEAR | SDCARD_RESPDONE_CLEAR | \
                                  SDCARD_XFRDONE_CLEAR)
 
-/* Let's wait until we have both SD card transfer complete and DMA complete. */
+/* Let's wait until we have both SD card transfer complete and DMA
+ * complete.
+ */
 
 #define SDCARD_XFRDONE_FLAG     (1)
 #define SDCARD_DMADONE_FLAG     (2)
@@ -1736,7 +1738,9 @@ static int lpc43_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
   DEBUGASSERT(priv != NULL && buffer != NULL && nbytes > 0);
   DEBUGASSERT(((uint32_t)buffer & 3) == 0);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = nbytes;

--- a/arch/arm/src/lpc54xx/lpc54_sdmmc.c
+++ b/arch/arm/src/lpc54xx/lpc54_sdmmc.c
@@ -192,7 +192,9 @@
 #define SDCARD_WAITALL_CLEAR    (SDCARD_CMDDONE_CLEAR | SDCARD_RESPDONE_CLEAR | \
                                  SDCARD_XFRDONE_CLEAR)
 
-/* Let's wait until we have both SD card transfer complete and DMA complete. */
+/* Let's wait until we have both SD card transfer complete and DMA
+ * complete.
+ */
 
 #define SDCARD_XFRDONE_FLAG     (1)
 #define SDCARD_DMADONE_FLAG     (2)
@@ -1736,7 +1738,9 @@ static int lpc54_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
   DEBUGASSERT(priv != NULL && buffer != NULL && nbytes > 0);
   DEBUGASSERT(((uint32_t)buffer & 3) == 0);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = nbytes;
@@ -2490,7 +2494,9 @@ static int lpc54_dmarecvsetup(FAR struct sdio_dev_s *dev,
 
   lpc54_putreg(SDMMC_BMOD_SWR, LPC54_SDMMC_BMOD);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = buflen;

--- a/arch/arm/src/sam34/sam_hsmci.c
+++ b/arch/arm/src/sam34/sam_hsmci.c
@@ -1288,7 +1288,9 @@ static int sam_interrupt(int irq, void *context, FAR void *arg)
       pending = enabled & priv->xfrmask;
       if (pending != 0)
         {
-          /* Yes.. the transfer is complete.  Did it complete with an error? */
+          /* Yes.. the transfer is complete.  Did it complete with an
+           * error?
+           */
 
           if ((pending & HSMCI_DATA_ERRORS) != 0)
             {
@@ -1540,7 +1542,9 @@ static void sam_widebus(FAR struct sdio_dev_s *dev, bool wide)
   struct sam_dev_s *priv = (struct sam_dev_s *)dev;
   uint32_t regval;
 
-  /* Set 1-bit or 4-bit bus by configuring the SDCBUS field of the SDCR register */
+  /* Set 1-bit or 4-bit bus by configuring the SDCBUS field of the SDCR
+   * register.
+   */
 
   regval  = getreg32(SAM_HSMCI_SDCR);
   regval &= ~HSMCI_SDCR_SDCBUS_MASK;
@@ -1878,7 +1882,9 @@ static int sam_cancel(FAR struct sdio_dev_s *dev)
 
   sam_notransfer(priv);
 
-  /* Clearing (most) pending interrupt status by reading the status register */
+  /* Clearing (most) pending interrupt status by reading the status
+   * register.
+   */
 
   getreg32(SAM_HSMCI_SR);
 

--- a/arch/arm/src/sama5/sam_hsmci.c
+++ b/arch/arm/src/sama5/sam_hsmci.c
@@ -1232,7 +1232,9 @@ static void sam_dmacallback(DMA_HANDLE handle, void *arg, int result)
 
       sam_putreg(priv, 0, SAM_HSMCI_DMA_OFFSET);
 
-      /* Terminate the transfer with an I/O error in the event of a DMA failure */
+      /* Terminate the transfer with an I/O error in the event of a DMA
+       * failure.
+       */
 
       if (result < 0)
         {
@@ -1584,7 +1586,9 @@ static int sam_hsmci_interrupt(int irq, void *context, void *arg)
                 }
             }
 
-          /* Otherwise it must be a DMA transfer that completed successfully */
+          /* Otherwise it must be a DMA transfer that completed
+           * successfully.
+           */
 
           else
             {
@@ -1803,7 +1807,9 @@ static void sam_widebus(FAR struct sdio_dev_s *dev, bool wide)
   struct sam_dev_s *priv = (struct sam_dev_s *)dev;
   uint32_t regval;
 
-  /* Set 1-bit or 4-bit bus by configuring the SDCBUS field of the SDCR register */
+  /* Set 1-bit or 4-bit bus by configuring the SDCBUS field of the SDCR
+   * register.
+   */
 
   regval  = sam_getreg(priv, SAM_HSMCI_SDCR_OFFSET);
   regval &= ~HSMCI_SDCR_SDCBUS_MASK;
@@ -1836,7 +1842,9 @@ static void sam_clock(FAR struct sdio_dev_s *dev, enum sdio_clock_e rate)
   uint32_t regval;
   bool enable = true;
 
-  /* Fetch the current mode register and mask out the clkdiv+clockodd (and pwsdiv) */
+  /* Fetch the current mode register and mask out the clkdiv+clockodd (and
+   * pwsdiv).
+   */
 
   regval = sam_getreg(priv, SAM_HSMCI_MR_OFFSET);
   regval &= ~(HSMCI_MR_CLKDIV_MASK | HSMCI_MR_PWSDIV_MASK | HSMCI_MR_CLKODD);
@@ -2172,7 +2180,9 @@ static int sam_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
   priv->xfrbusy = true;
   priv->txbusy  = false;
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = buflen;
@@ -2296,7 +2306,9 @@ static int sam_cancel(FAR struct sdio_dev_s *dev)
 
   sam_notransfer(priv);
 
-  /* Clearing (most) pending interrupt status by reading the status register */
+  /* Clearing (most) pending interrupt status by reading the status
+   * register.
+   */
 
   sam_getreg(priv, SAM_HSMCI_SR_OFFSET);
 

--- a/arch/arm/src/samv7/sam_hsmci.c
+++ b/arch/arm/src/samv7/sam_hsmci.c
@@ -1168,7 +1168,9 @@ static void sam_dmacallback(DMA_HANDLE handle, void *arg, int result)
 
       sam_putreg(priv, 0, SAM_HSMCI_DMA_OFFSET);
 
-      /* Terminate the transfer with an I/O error in the event of a DMA failure */
+      /* Terminate the transfer with an I/O error in the event of a DMA
+       * failure.
+       */
 
       if (result < 0)
         {
@@ -1569,7 +1571,9 @@ static int sam_hsmci_interrupt(int irq, void *context, void *arg)
                 }
             }
 
-          /* Otherwise it must be a DMA transfer that completed successfully */
+          /* Otherwise it must be a DMA transfer that completed
+           * successfully.
+           */
 
           else
             {
@@ -1788,7 +1792,9 @@ static void sam_widebus(FAR struct sdio_dev_s *dev, bool wide)
   struct sam_dev_s *priv = (struct sam_dev_s *)dev;
   uint32_t regval;
 
-  /* Set 1-bit or 4-bit bus by configuring the SDCBUS field of the SDCR register */
+  /* Set 1-bit or 4-bit bus by configuring the SDCBUS field of the SDCR
+   * register.
+   */
 
   regval  = sam_getreg(priv, SAM_HSMCI_SDCR_OFFSET);
   regval &= ~HSMCI_SDCR_SDCBUS_MASK;
@@ -1821,7 +1827,9 @@ static void sam_clock(FAR struct sdio_dev_s *dev, enum sdio_clock_e rate)
   uint32_t regval;
   bool enable = true;
 
-  /* Fetch the current mode register and mask out the clkdiv+clockodd (and pwsdiv) */
+  /* Fetch the current mode register and mask out the clkdiv+clockodd (and
+   * pwsdiv).
+   */
 
   regval = sam_getreg(priv, SAM_HSMCI_MR_OFFSET);
   regval &= ~(HSMCI_MR_CLKDIV_MASK | HSMCI_MR_PWSDIV_MASK | HSMCI_MR_CLKODD);
@@ -2160,7 +2168,9 @@ static int sam_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
   priv->xfrbusy = true;
   priv->txbusy  = false;
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = buflen;
@@ -2339,7 +2349,9 @@ static int sam_cancel(FAR struct sdio_dev_s *dev)
 
   sam_notransfer(priv);
 
-  /* Clearing (most) pending interrupt status by reading the status register */
+  /* Clearing (most) pending interrupt status by reading the status
+   * register.
+   */
 
   sam_getreg(priv, SAM_HSMCI_SR_OFFSET);
 

--- a/arch/arm/src/samv7/sam_twihs.c
+++ b/arch/arm/src/samv7/sam_twihs.c
@@ -704,7 +704,9 @@ static int twi_interrupt(int irq, FAR void *context, FAR void *arg)
             }
           else
             {
-              /* No.. just switch to the next message and continue sending.  */
+              /* No.. just switch to the next message and continue
+               * sending.
+               */
 
               DEBUGASSERT((next->flags & I2C_M_READ) == 0);
               priv->msg = next;

--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -1969,7 +1969,9 @@ static int stm32_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
   stm32_sampleinit();
   stm32_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = nbytes;
@@ -2286,7 +2288,9 @@ static int stm32_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
 #endif
     }
 
-  /* Clear all pending message completion events and return the R1/R6 response */
+  /* Clear all pending message completion events and return the R1/R6
+   * response.
+   */
 
   putreg32(SDIO_RESPDONE_ICR | SDIO_CMDDONE_ICR, STM32_SDIO_ICR);
   *rshort = getreg32(STM32_SDIO_RESP1);
@@ -2776,7 +2780,9 @@ static int stm32_dmarecvsetup(FAR struct sdio_dev_s *dev,
   stm32_sampleinit();
   stm32_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = buflen;

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -2261,7 +2261,9 @@ static int stm32_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
   stm32_sampleinit();
   stm32_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = nbytes;
@@ -2563,7 +2565,9 @@ static int stm32_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
 #endif
     }
 
-  /* Clear all pending message completion events and return the R1/R6 response */
+  /* Clear all pending message completion events and return the R1/R6
+   * response.
+   */
 
   sdmmc_putreg32(priv, STM32_SDMMC_RESPDONE_ICR | STM32_SDMMC_CMDDONE_ICR,
                  STM32_SDMMC_ICR_OFFSET);
@@ -3067,7 +3071,9 @@ static int stm32_dmarecvsetup(FAR struct sdio_dev_s *dev,
   stm32_sampleinit();
   stm32_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = buflen;

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -2467,7 +2467,9 @@ static int stm32_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
 #endif
     }
 
-  /* Clear all pending message completion events and return the R1/R6 response */
+  /* Clear all pending message completion events and return the R1/R6
+   * response.
+   */
 
   sdmmc_putreg32(priv, STM32_SDMMC_RESPDONE_ICR | STM32_SDMMC_CMDDONE_ICR,
                  STM32_SDMMC_ICR_OFFSET);
@@ -2978,7 +2980,9 @@ static int stm32_dmarecvsetup(FAR struct sdio_dev_s *dev,
   stm32_sampleinit();
   stm32_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer      = (uint32_t *)buffer;
   priv->remaining  = buflen;

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -2057,7 +2057,9 @@ static int stm32_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
   stm32_sampleinit();
   stm32_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = nbytes;
@@ -2852,7 +2854,9 @@ static int stm32_dmarecvsetup(FAR struct sdio_dev_s *dev,
   stm32_sampleinit();
   stm32_sample(priv, SAMPLENDX_BEFORE_SETUP);
 
-  /* Save the destination buffer information for use by the interrupt handler */
+  /* Save the destination buffer information for use by the interrupt
+   * handler.
+   */
 
   priv->buffer    = (uint32_t *)buffer;
   priv->remaining = buflen;


### PR DESCRIPTION
This commit fixes some long single line comments.  This effort was primarily intended to verify the change to tools/nxstyle of PR #743 further.  This took the files changed with 1501d284c33d073dbdac5767de1cb859ae27726d and ran them through nxstyle again.  The files in the commit previously passed the old nxstyle test with no complaints.  The current nxstyle, on the other hand, reported 49 long single line comments.  Each of those were verified and the file was updated.  The nxstyle change appears completely reliable.