### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12927,9 +12927,9 @@
 	* arch/arm/src/stm32f7:  otgdev fixed typo.  From David Sidrane
 	  (2016-10-28).
 	* arch/xtensa: Basic architectural support for Xtensa processors and
-	  the Expressif. ESP32 added.  Totally untested on initial release
+	  the Espressif. ESP32 added.  Totally untested on initial release
 	  (2016-10-31).
-	* configs/esp32-core: Basic support for Expressif ESP32 Core v2 board
+	* configs/esp32-core: Basic support for Espressif ESP32 Core v2 board
 	  added.  The initial release includes an NSH and an SMP test
 	  configuration.  Totally untested on initial relesae (2016-10-31).
 	* configs/bambino-200e: Add basic support to Micromint Bambino 200E
@@ -13441,7 +13441,7 @@
 	  (2016-12-20).
 	* Xtensa ESP32: Missing prologue/epilogue macros on C callable function
 	  (2016-12-20).
-	* Xtensa ESP32: Update APP CPU startup logic to match current Expressif
+	* Xtensa ESP32: Update APP CPU startup logic to match current Espressif
 	  example code.  Fix errors APP CPU startup (2016-12-20).
 	* fs/procfs: Fix procfs status for SMP case (2016-12-20).
 	* Xtensa ESP32:  Clock frequency is different if running from IRAM or is
@@ -13986,7 +13986,7 @@
 	  BOARD_SIM_CLKDIV2_USBFRAC to the kinetis_clockconfig.  From David
 	  Sidrane (2017-02-27).
 	* Kinetis:  Use BOARD_xxxx to drive system clocking: (1) Shifted the clock
-	  speed of MK20DX128VLH5 to 48 Mhz to be able to uses USB. (2) Set
+	  speed of MK20DX128VLH5 to 48 MHz to be able to uses USB. (2) Set
 	  BOARD_OUTDIV3 to 0 - there is no BOARD_OUTDIV3 on a MK20DX128VLH5 or
 	  K20DX256VLH7, (3) Added BOARD_SOPT2_PLLFLLSEL and BOARD_SOPT2_FREQ along
 	  with settings for BOARD_SIM_CLKDIV2_USBFRAC and BOARD_SIM_CLKDIV2_USBDIV
@@ -14589,10 +14589,10 @@
 	  From Juha Niskanen (2017-04-05).
 	* STM32:  stm32l15xxx_rcc: configure medium performance voltage range
 	  and zero wait-state when allowed by SYSCLK setting.  Zero wait-state
-	  for flash can be configured when:  (1) Range 1 and SYSCLK <= 16 Mhz,
-	  (2) Range 2 and SYSCLK <= 8 Mhz, or (3) Range 3 and SYSCLK <= 4.2
-	  Mhz.  Medium performance voltage range (1.5V) can be configured when
-	  SYSCLK is up to 16 Mhz and PLLVCO up to 48 Mhz.  From Juha Niskanen
+	  for flash can be configured when:  (1) Range 1 and SYSCLK <= 16 MHz,
+	  (2) Range 2 and SYSCLK <= 8 MHz, or (3) Range 3 and SYSCLK <= 4.2
+	  MHz.  Medium performance voltage range (1.5V) can be configured when
+	  SYSCLK is up to 16 MHz and PLLVCO up to 48 MHz.  From Juha Niskanen
 	  (2017-04-05).
 	* wireless/ieee802154:  Initial MAC char driver write functionality.
 	  From Anthony Merlino (2017-04-05).
@@ -15694,7 +15694,7 @@
 	  6LoWPAN compatible port numbers (2017-06-20).
 	* mac802154_req_data() can return without releasing the exclsem
 	  (2017-06-20).
-	* STM32:  Allow clock frequencies > 168 Mhz on stm32f427/429.  We need
+	* STM32:  Allow clock frequencies > 168 MHz on stm32f427/429.  We need
 	  to enable the power overdrive for this case.  This patch allows the
 	  required bits to be set in proper sequence.  It also modifies the
 	  local register access operations to allow more than 16-bit registers.
@@ -17633,7 +17633,7 @@
 	  mode' flag and STM32F7's I2C driver is in more 'ready to use' state.
 
 	  Commit ports the STM32F7 I2C driver to STM32L4. The I2C clock
-	  configuration is kept the same as before (I2CCLK = PCLK1 80 Mhz)
+	  configuration is kept the same as before (I2CCLK = PCLK1 80 MHz)
 	  instead of switching to STM32F7 arch default that is I2CCLK=HSI.
 	  Further work would be to add configuration option for choosing I2C
 	  clock source instead of current hard-coded default.  From Jussi
@@ -27085,7 +27085,7 @@
 	* Add DMA support for STM32L4+ series
 	  - Add DMA support for STM32L4+
 	  - stm32l4xrxx_rcc: enable "Range 1 boost" mode if any PLL freq above
-	    80 Mhz
+	    80 MHz
 	  From Jussi Kivilinna (2019-10-25).
 	* stm32l4_otgfs: enable OTGFS for STM32L4+ series.  The OTGFS peripheral
 	  on stm32l4x6 and stm32l4rxxx reference manual is exactly the same.

--- a/ChangeLog
+++ b/ChangeLog
@@ -15395,8 +15395,8 @@
 	* Fix ELF loader up_checkarch on ARM arch.  From Cristian Condurache
 	  (2017-05-09).
 	* Kinetis:  Disable MPU when not in protected mode.  The hardware reset
-	  state of the the MPU precludes any bus masters other then DMA access
-	  to memory. Unfortunately USB and SDHC have there own DMA and will not
+	  state of the the MPU precludes any bus masters other than DMA access
+	  to memory. Unfortunately USB and SDHC have their own DMA and will not
 	  have access to memory in the default reset state.  This change
 	  disabled the MPU if present on system startup.  From David Sidrane
 	  (2017-06-02).

--- a/Documentation/NuttX.html
+++ b/Documentation/NuttX.html
@@ -1614,7 +1614,7 @@
       <li><a href="#bcm2708">BCM2708</a> <small>(ARM1176JZ)</small></li>
     </ul>
   </li>
-  <li>Expressif
+  <li>Espressif
     <ul>
       <li><a href="#esp32">ESP32</a> <small>(Dual Xtensa LX6)</small></li>
     </ul>
@@ -6819,12 +6819,12 @@ BFD_ASSERT (*plt_offset != (bfd_vma) -1);
   <td>
     <p>
       <b>Xtensa LX6 ESP32 Architectural Support</b>.
-      Basic architectural support for Xtensa LX6 processors and the port for the Expressif ESP32 were added in NuttX-7.19.
+      Basic architectural support for Xtensa LX6 processors and the port for the Espressif ESP32 were added in NuttX-7.19.
       The basic ESP32 port is function in both single CPU and dual CPU SMP configurations.
     </p>
     <p>
-      <b>Expressif ESP32 Core v2 Board</b>
-      The NuttX release includes support for Expressif ESP32 Core v2 board.
+      <b>Espressif ESP32 Core v2 Board</b>
+      The NuttX release includes support for Espressif ESP32 Core v2 board.
       There is an NSH configuration for each CPU configuration and an OS test configuration for verificatin of the port.
     </p>
     <p>

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -15349,8 +15349,8 @@ detailed bugfix information):
     * NXP/Freescale Kinetis:
 
       - Kinetis MPU:  Disable MPU when not in protected mode.  The hardware
-        reset state of the the MPU precludes any bus masters other then DMA
-        access to memory. Unfortunately USB and SDHC have there own DMA and
+        reset state of the the MPU precludes any bus masters other than DMA
+        access to memory. Unfortunately USB and SDHC have their own DMA and
         will not have access to memory in the default reset state.  This change
         disabled the MPU if present on system startup.  From David Sidrane.
       - Kinetis MPU:  Fixed warning for kinetis_mpudisable. Missing header

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -12528,7 +12528,7 @@ Additional new features and extended functionality:
     * Xtensa/ESP32
 
       - Xtensa ESP32:  Basic architectural support for Xtensa processors and
-        the Expressif. ESP32 added.
+        the Espressif. ESP32 added.
       - Xtensa ESP32:  Add EXPERIMENTAL hooks to support lazy Xtensa
         co-processor state restore in the future.
       - Xtensa ESP32:  Basic port is function in both single CPU and dual CPU
@@ -12540,7 +12540,7 @@ Additional new features and extended functionality:
 
     * Xtensa/ESP32 Boards:
 
-      - ESP32 Core v2:  Basic support for Expressif ESP32 Core v2 board
+      - ESP32 Core v2:  Basic support for Espressif ESP32 Core v2 board
         added.  The initial release includes an NSH and an SMP test
         configuration.
       - ESP32 Core v2:  Add configuration to support linking NuttX for
@@ -13769,10 +13769,10 @@ Additional new features and extended functionality:
       - STM32 L1:  stm32l15xxx_rcc: configure medium performance voltage
         range and zero wait-state when allowed by SYSCLK setting.  Zero
         wait-state for flash can be configured when:  (1) Range 1 and
-        SYSCLK <= 16 Mhz, (2) Range 2 and SYSCLK <= 8 Mhz, or (3) Range 3
-        and SYSCLK <= 4.2 Mhz.  Medium performance voltage range (1.5V)
-        can be configured when SYSCLK is up to 16 Mhz and PLLVCO up to
-        48 Mhz.  From Juha Niskanen.
+        SYSCLK <= 16 MHz, (2) Range 2 and SYSCLK <= 8 MHz, or (3) Range 3
+        and SYSCLK <= 4.2 MHz.  Medium performance voltage range (1.5V)
+        can be configured when SYSCLK is up to 16 MHz and PLLVCO up to
+        48 MHz.  From Juha Niskanen.
       - STM32 F0: Add basic support for STM32F0.  From Alan Carvalho de
         Assis.
       - STM32 F0:  Add basic support for STM32F07x family.
@@ -14778,7 +14778,7 @@ Additional new features and extended functionality:
 
       - STM32 L4:  Add support for the STM32L475 family.
       - STM32 L4 RCC:  Enable ADC clock source.  From Juha Niskanen.
-      - STM32:  Allow clock frequencies > 168 Mhz on stm32f427/429.  We need
+      - STM32:  Allow clock frequencies > 168 MHz on stm32f427/429.  We need
         to enable the power overdrive for this case.  This change allows the
         required bits to be set in proper sequence.  It also modifies the
         local register access operations to allow more than 16-bit registers.
@@ -15297,7 +15297,7 @@ detailed bugfix information):
         has not caused problems in the past, but seeing it set in the PC is
         unnerving.
 
-    * Expressif ESP32:
+    * Espressif ESP32:
 
       - Fix ESP32 gpio enable reg and default UART pin. Modify default UART
         pin for ESP-WROOM-32. Fix gpio enable reg.  From Sungki Kim.
@@ -15957,7 +15957,7 @@ Additional new features and extended functionality:
         drivers.  The peripheral on STM32F7 and STM32L4 are identical except
         for L4's 'wakeup from stop mode' flag and STM32F7's I2C driver is in
         more 'ready to use' state.  The I2C clock configuration is kept the
-        same as before (I2CCLK = PCLK1 80 Mhz) instead of switching to
+        same as before (I2CCLK = PCLK1 80 MHz) instead of switching to
         STM32F7 arch default that is I2CCLK=HSI. Further work would be to
         add configuration option for choosing I2C clock source instead of
         current hard-coded default.  From Jussi Kivilinna.
@@ -22578,7 +22578,7 @@ detailed bugfix information):
         Raised DEBUGASSERT in armv7-m/up_ramvec_initialize.c line: 144.
         From Mateusz Szafoni.
 
-    * Expressif ESP32 Drivers:
+    * Espressif ESP32 Drivers:
 
       - ESP32 Timer ISR:  Fix backward comparison.  From Gregory Nutt.
       - ESP32 Serial:  Fix some backward arguments.   Correct 2-stop bit
@@ -25894,7 +25894,7 @@ Additional new features and extended functionality:
       - STM32 L4+ DMA:  Add DMA support for STM32L4+ series.  From Jussi
         Kivilinna.
       - STM32 L4 Clocking:  Enable "Range 1 boost" mode if any PLL freq
-        above 80 Mhz.  From Jussi Kivilinna.
+        above 80 MHz.  From Jussi Kivilinna.
       - STM32 L4 LPTIM:  Add support for LPTIM timers on the STM32L4 as PWM
         outputs.  From Matias N.
       - STM32 H7 Progmem: Add FLASH progmem support.  From David Sidrane.

--- a/arch/README.txt
+++ b/arch/README.txt
@@ -268,7 +268,7 @@ arch/xtensa
     LX6 DPU support:
       arch/xtensa/include/lx6 and arch/xtensa/xtensa/lx6
 
-    Expressif ESP32 implementation of the LX6 DPU:
+    Espressif ESP32 implementation of the LX6 DPU:
       arch/xtensa/include/esp32 and arch/xtensa/xtensa/esp32
 
 arch/z16 - ZiLOG 16-bit processors

--- a/arch/arm/src/imxrt/imxrt_clockconfig.c
+++ b/arch/arm/src/imxrt/imxrt_clockconfig.c
@@ -605,7 +605,7 @@ void imxrt_clockconfig(void)
   reg |= IMXRT_LPI2C_CLK_SELECT;
   putreg32(reg, IMXRT_CCM_CSCDR2);
 
-  /* Set LPI2C divider to 5  for 12 Mhz */
+  /* Set LPI2C divider to 5  for 12 MHz */
 
   reg  = getreg32(IMXRT_CCM_CSCDR2);
   reg &= ~CCM_CSCDR2_LPI2C_CLK_PODF_MASK;

--- a/arch/arm/src/lpc17xx_40xx/hardware/lpc176x_syscon.h
+++ b/arch/arm/src/lpc17xx_40xx/hardware/lpc176x_syscon.h
@@ -197,7 +197,7 @@
 #  define SYSCON_FLASHCFG_TIM_3           (2 << SYSCON_FLASHCFG_TIM_SHIFT) /* 3 CPU clock <= 60 MHz CPU clock */
 #  define SYSCON_FLASHCFG_TIM_4           (3 << SYSCON_FLASHCFG_TIM_SHIFT) /* 4 CPU clock <= 80 MHz CPU clock */
 #  define SYSCON_FLASHCFG_TIM_5           (4 << SYSCON_FLASHCFG_TIM_SHIFT) /* 5 CPU clock <= 100 MHz CPU clock
-                                                                            * (Up to 120 Mhz for LPC1759/69 only */
+                                                                            * (Up to 120 MHz for LPC1759/69 only */
 #  define SYSCON_FLASHCFG_TIM_6           (5 << SYSCON_FLASHCFG_TIM_SHIFT) /* "safe" setting for any conditions */
                                                       /* Bits 16-31:  Reserved */
 

--- a/arch/arm/src/lpc17xx_40xx/hardware/lpc178x_40xx_syscon.h
+++ b/arch/arm/src/lpc17xx_40xx/hardware/lpc178x_40xx_syscon.h
@@ -227,7 +227,7 @@
 #  define SYSCON_FLASHCFG_TIM_2             (2 << SYSCON_FLASHCFG_TIM_SHIFT) /* 3 CPU clock <= 60 MHz CPU clock */
 #  define SYSCON_FLASHCFG_TIM_3             (3 << SYSCON_FLASHCFG_TIM_SHIFT) /* 4 CPU clock <= 80 MHz CPU clock */
 #  define SYSCON_FLASHCFG_TIM_4             (4 << SYSCON_FLASHCFG_TIM_SHIFT) /* 5 CPU clock <= 100 MHz CPU clock
-                                                                              * (Up to 120 Mhz for LPC1788x) */
+                                                                              * (Up to 120 MHz for LPC1788x) */
 #  define SYSCON_FLASHCFG_TIM_5             (5 << SYSCON_FLASHCFG_TIM_SHIFT) /* "safe" setting for any conditions */
                                                       /* Bits 16-31:  Reserved */
 /* Memory Mapping Control register (MEMMAP - 0x400F C040) */

--- a/arch/arm/src/lpc31xx/lpc31_cgu.h
+++ b/arch/arm/src/lpc31xx/lpc31_cgu.h
@@ -1500,7 +1500,7 @@ Nandflash Controller */
 
 #define CGU_HPFINSEL_SHIFT               (0)       /* Bits 0-3: Select input to high HPPLL0 */
 #define CGU_HPFINSEL_MASK                (15 << CGU_HPFINSEL_SHIFT)
-#  define CGU_HPFINSEL_FFAST             (CGU_FREQIN_FFAST     << CGU_HPFINSEL_SHIFT) /* ffast (12 Mhz) */
+#  define CGU_HPFINSEL_FFAST             (CGU_FREQIN_FFAST     << CGU_HPFINSEL_SHIFT) /* ffast (12 MHz) */
 #  define CGU_HPFINSEL_I2SRXBCK0         (CGU_FREQIN_I2SRXBCK0 << CGU_HPFINSEL_SHIFT) /* I2SRX_BCK0 */
 #  define CGU_HPFINSEL_I2SRXWS0          (CGU_FREQIN_I2SRXWS0  << CGU_HPFINSEL_SHIFT) /* I2SRX_WS0 */
 #  define CGU_HPFINSEL_I2SRXBCK1         (CGU_FREQIN_I2SRXBCK1 << CGU_HPFINSEL_SHIFT) /* I2SRX_BCK1 */

--- a/arch/arm/src/lpc43xx/spifi/inc/spifilib_dev.h
+++ b/arch/arm/src/lpc43xx/spifi/inc/spifilib_dev.h
@@ -304,11 +304,11 @@ typedef struct SPIFI_DEVICE_DATA {
 	uint16_t subBlkSize;						/**< size of sub-block */
 	uint16_t pageSize;							/**< page size */
 	uint32_t maxReadSize;						/**< max read allowed in one operation */
-	uint8_t maxClkRate;							/**< (in Mhz) maximum clock rate (max common speed) */
-	uint8_t maxReadRate;						/**< (in Mhz) max clock rate for read (driver may utilize fast read) */
-	uint8_t maxHSReadRate;						/**< (in Mhz) max clock rate for quad / dual read */
-	uint8_t maxProgramRate;						/**< (in Mhz) max clock rate for program */
-	uint8_t maxHSProgramRate;					/**< (in Mhz) max clock rate for quad program */
+	uint8_t maxClkRate;							/**< (in MHz) maximum clock rate (max common speed) */
+	uint8_t maxReadRate;						/**< (in MHz) max clock rate for read (driver may utilize fast read) */
+	uint8_t maxHSReadRate;						/**< (in MHz) max clock rate for quad / dual read */
+	uint8_t maxProgramRate;						/**< (in MHz) max clock rate for program */
+	uint8_t maxHSProgramRate;					/**< (in MHz) max clock rate for quad program */
 	uint8_t initDeInitFxId;					/**< init/DeInit fx_id */
 	uint8_t clearStatusFxId;					/**< clearStatus fx_id */
 	uint8_t getStatusFxId;					/**< getStatus fx_id */

--- a/arch/arm/src/lpc43xx/spifi/src/spifilib_fam_standard_cmd.c
+++ b/arch/arm/src/lpc43xx/spifi/src/spifilib_fam_standard_cmd.c
@@ -1352,7 +1352,7 @@ SPIFI_FAM_NODE_T *spifi_REG_FAMILY_CommonCommandSet(void)
 			0x1000,					/* sub-block size */
 			0x100,					/* page size */
 			MAX_SINGLE_READ,					/* max single read bytes */
-			104,				/* max clock rate in Mhz */
+			104,				/* max clock rate in MHz */
 			104,				/* max read clock rate in MHz */
 			104,				/* max high speed read clock rate in MHz */
 			104,				/* max program clock rate in MHz */

--- a/arch/arm/src/s32k1xx/s32k1xx_clockconfig.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_clockconfig.h
@@ -177,8 +177,8 @@ enum scg_sosc_gain_e
 
 enum scg_sosc_range_e
 {
-  SCG_SOSC_RANGE_MID       = 2,        /* Medium frequency range selected for the crystal OSC (4 Mhz to 8 Mhz). */
-  SCG_SOSC_RANGE_HIGH      = 3,        /* High frequency range selected for the crystal OSC (8 Mhz to 40 Mhz). */
+  SCG_SOSC_RANGE_MID       = 2,        /* Medium frequency range selected for the crystal OSC (4 MHz to 8 MHz). */
+  SCG_SOSC_RANGE_HIGH      = 3,        /* High frequency range selected for the crystal OSC (8 MHz to 40 MHz). */
 };
 
 struct scg_sosc_config_s

--- a/arch/arm/src/sama5/sam_pmecc.c
+++ b/arch/arm/src/sama5/sam_pmecc.c
@@ -1221,7 +1221,7 @@ int pmecc_configure(struct sam_nandcs_s *priv, bool protected)
    * case, the ECC computation takes into account the whole spare area
    * minus the ECC area in the ECC computation operation
    *
-   * NOTE:  At 133 Mhz, the clkctrl field must be programmed with 2,
+   * NOTE:  At 133 MHz, the clkctrl field must be programmed with 2,
    * indicating that the setup time is 3 clock cycles.
    */
 

--- a/arch/arm/src/samv7/sam_clockconfig.c
+++ b/arch/arm/src/samv7/sam_clockconfig.c
@@ -266,13 +266,13 @@ static inline void sam_pmcsetup(void)
 
   if ((getreg32(SAM_PMC_MCKR) & PMC_MCKR_PLLADIV2) != 0)
     {
-      /* Divider = 480 Mhz / 2 / 48 Mhz = 5 */
+      /* Divider = 480 MHz / 2 / 48 MHz = 5 */
 
       regval |=  PMC_USB_USBDIV(4);
     }
   else
     {
-      /* Divider = 480 Mhz / 1 / 48 Mhz = 10 */
+      /* Divider = 480 MHz / 1 / 48 MHz = 10 */
 
       regval |=  PMC_USB_USBDIV(9);
     }

--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -9488,7 +9488,7 @@ config STM32_USB_ITRMP
 		The legacy USB in the F1 series shared interrupt lines with USB
 		device and CAN1.  In the F3 series, a hardware options was added to
 		either retain the legacy F1 behavior or to map the USB interrupts to
-		there own dedicated vectors.  The option is available only for the
+		their own dedicated vectors.  The option is available only for the
 		F3 family and selects the use of the dedicated USB interrupts.
 
 menu "CAN driver configuration"

--- a/arch/arm/src/stm32/stm32f40xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f40xxx_rcc.c
@@ -756,7 +756,7 @@ static void stm32_stdclockconfig(void)
 #if defined(CONFIG_STM32_STM32F429) || defined(CONFIG_STM32_STM32F446) || \
     defined(CONFIG_STM32_STM32F469)
 
-      /* Enable the Over-drive to extend the clock frequency to 180 Mhz */
+      /* Enable the Over-drive to extend the clock frequency to 180 MHz */
 
       regval  = getreg32(STM32_PWR_CR);
       regval |= PWR_CR_ODEN;

--- a/arch/arm/src/stm32f7/stm32f72xx73xx_rcc.c
+++ b/arch/arm/src/stm32f7/stm32f72xx73xx_rcc.c
@@ -806,9 +806,9 @@ static void stm32_stdclockconfig(void)
 
       /* Over-drive is needed if
        *  - Voltage output scale 1 mode is selected and SYSCLK frequency is
-       *    over 180 Mhz.
+       *    over 180 MHz.
        *  - Voltage output scale 2 mode is selected and SYSCLK frequence is
-       *    over 168 Mhz.
+       *    over 168 MHz.
        */
 
       if ((STM32_PWR_VOS_SCALE == PWR_CR1_VOS_SCALE_1 &&
@@ -817,7 +817,7 @@ static void stm32_stdclockconfig(void)
            STM32_SYSCLK_FREQUENCY > 168000000))
         {
           /* Enable the Over-drive to extend the clock frequency up to
-           * 216 Mhz.
+           * 216 MHz.
            */
 
           regval  = getreg32(STM32_PWR_CR1);

--- a/arch/arm/src/stm32f7/stm32f74xx75xx_rcc.c
+++ b/arch/arm/src/stm32f7/stm32f74xx75xx_rcc.c
@@ -803,9 +803,9 @@ static void stm32_stdclockconfig(void)
 
       /* Over-drive is needed if
        *  - Voltage output scale 1 mode is selected and SYSCLK frequency is
-       *    over 180 Mhz.
+       *    over 180 MHz.
        *  - Voltage output scale 2 mode is selected and SYSCLK frequence is
-       *    over 168 Mhz.
+       *    over 168 MHz.
        */
 
       if ((STM32_PWR_VOS_SCALE == PWR_CR1_VOS_SCALE_1 &&
@@ -814,7 +814,7 @@ static void stm32_stdclockconfig(void)
            STM32_SYSCLK_FREQUENCY > 168000000))
         {
           /* Enable the Over-drive to extend the clock frequency up to
-           * 216 Mhz.
+           * 216 MHz.
            */
 
           regval  = getreg32(STM32_PWR_CR1);

--- a/arch/arm/src/stm32f7/stm32f76xx77xx_rcc.c
+++ b/arch/arm/src/stm32f7/stm32f76xx77xx_rcc.c
@@ -820,9 +820,9 @@ static void stm32_stdclockconfig(void)
 
       /* Over-drive is needed if
        *  - Voltage output scale 1 mode is selected and SYSCLK frequency is
-       *    over 180 Mhz.
+       *    over 180 MHz.
        *  - Voltage output scale 2 mode is selected and SYSCLK frequence is
-       *    over 168 Mhz.
+       *    over 168 MHz.
        */
 
       if ((STM32_PWR_VOS_SCALE == PWR_CR1_VOS_SCALE_1 &&
@@ -831,7 +831,7 @@ static void stm32_stdclockconfig(void)
            STM32_SYSCLK_FREQUENCY > 168000000))
         {
           /* Enable the Over-drive to extend the clock frequency up to
-           * 216 Mhz.
+           * 216 MHz.
            */
 
           regval  = getreg32(STM32_PWR_CR1);

--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -818,7 +818,7 @@ static void stm32_stdclockconfig(void)
 
       /* Over-drive is needed if
        *  - Voltage output scale 1 mode is selected and SYSCLK frequency is
-       *    over 400 Mhz.
+       *    over 400 MHz.
        */
 
       if ((STM32_PWR_VOS_SCALE == PWR_D3CR_VOS_SCALE_1) &&
@@ -830,7 +830,7 @@ static void stm32_stdclockconfig(void)
           regval |= RCC_APB4ENR_SYSCFGEN;
           putreg32(regval, STM32_RCC_APB4ENR);
 
-          /* Enable Overdrive to extend the clock frequency up to 480 Mhz. */
+          /* Enable Overdrive to extend the clock frequency up to 480 MHz. */
 
           regval = getreg32(STM32_SYSCFG_PWRCR);
           regval |= SYSCFG_PWRCR_ODEN;

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -814,7 +814,7 @@ static void stm32_stdclockconfig(void)
 
       /* Over-drive is needed if
        *  - Voltage output scale 1 mode is selected and SYSCLK frequency is
-       *    over 400 Mhz.
+       *    over 400 MHz.
        */
 
       if ((STM32_PWR_VOS_SCALE == PWR_D3CR_VOS_SCALE_1) &&
@@ -826,7 +826,7 @@ static void stm32_stdclockconfig(void)
           regval |= RCC_APB4ENR_SYSCFGEN;
           putreg32(regval, STM32_RCC_APB4ENR);
 
-          /* Enable Overdrive to extend the clock frequency up to 480 Mhz. */
+          /* Enable Overdrive to extend the clock frequency up to 480 MHz. */
 
           regval = getreg32(STM32_SYSCFG_PWRCR);
           regval |= SYSCFG_PWRCR_ODEN;

--- a/arch/arm/src/stm32l4/stm32l4_i2c.c
+++ b/arch/arm/src/stm32l4/stm32l4_i2c.c
@@ -79,7 +79,7 @@
  *      Fast-mode (up to 400 kHz)
  *      fI2CCLK clock source selection is based on RCC_CCIPR_I2CxSEL
  *      being set to PCLK and the calculations are based on PCLK frequency
- *      of 80 Mhz
+ *      of 80 MHz
  *
  *  - Multiple instances (shared bus)
  *  - Interrupt based operation
@@ -100,7 +100,7 @@
  *  - Wakeup from Stop mode
  *  - More effective error reporting to higher layers
  *  - Slave operation
- *  - Support of fI2CCLK frequencies other than 80 Mhz and other clock sources
+ *  - Support of fI2CCLK frequencies other than 80 MHz and other clock sources
  *  - Polled operation (code present but untested)
  *  - SMBus support
  *  - Multi-master support
@@ -1349,7 +1349,7 @@ static void stm32l4_i2c_setclock(FAR struct stm32l4_i2c_priv_s *priv,
           /* Default timing calculations from original STM32L4 driver: */
 
           /*  The Speed and timing calculation are based on the following
-           *  fI2CCLK = PCLK and is 80 Mhz
+           *  fI2CCLK = PCLK and is 80 MHz
            *  Analog filter is on,
            *  Digital filter off
            *  Rise Time is 120 ns and fall is 10 ns
@@ -1400,7 +1400,7 @@ static void stm32l4_i2c_setclock(FAR struct stm32l4_i2c_priv_s *priv,
       else if (i2cclk_mhz == 120)
         {
           /*  The Speed and timing calculation are based on the following
-           *  fI2CCLK = PCLK and is 120 Mhz
+           *  fI2CCLK = PCLK and is 120 MHz
            *  Analog filter is on,
            *  Digital filter off
            *  Rise Time is 120 ns and fall is 25 ns
@@ -2378,7 +2378,7 @@ static int stm32l4_i2c_init(FAR struct stm32l4_i2c_priv_s *priv)
 
   /* TODO:
    * - Provide means to set peripheral clock source via RCC_CCIPR_I2CxSEL
-   * - Make clock source Kconfigurable (currently PCLK = 80 Mhz)
+   * - Make clock source Kconfigurable (currently PCLK = 80 MHz)
    */
 
   /* Force a frequency update */

--- a/arch/arm/src/stm32l4/stm32l4xrxx_rcc.c
+++ b/arch/arm/src/stm32l4/stm32l4xrxx_rcc.c
@@ -772,7 +772,7 @@ static void stm32l4_stdclockconfig(void)
 
       /* Switch to Range 1 boost mode to support system frequencies up to
        * 120 MHz.
-       * If any PLL has output frequency higher than 80 Mhz, Range 1 boost
+       * If any PLL has output frequency higher than 80 MHz, Range 1 boost
        * mode needs to be used (RM0432, "6.2.9 Clock source frequency versus
        * voltage scaling").
        * Range 2 is not supported.

--- a/arch/mips/src/pic32mx/pic32mx-ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx-ethernet.c
@@ -2927,7 +2927,7 @@ static inline int pic32mx_phyinit(struct pic32mx_driver_s *priv)
   /* The RMII/MII of operation can be selected by strap options or register
    * control (using the RBR register). For RMII mode, it is required to use
    * the strap option, since it requires a 50 MHz clock instead of the normal
-   * 25 Mhz.
+   * 25 MHz.
    */
 
 #endif

--- a/arch/mips/src/pic32mz/pic32mz-ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz-ethernet.c
@@ -3094,7 +3094,7 @@ static inline int pic32mz_phyinit(struct pic32mz_driver_s *priv)
   /* The RMII/MII of operation can be selected by strap options or register
    * control (using the RBR register). For RMII mode, it is required to use
    * the strap option, since it requires a 50 MHz clock instead of the normal
-   * 25 Mhz.
+   * 25 MHz.
    */
 
 #endif

--- a/arch/mips/src/pic32mz/pic32mz-lowinit.c
+++ b/arch/mips/src/pic32mz/pic32mz-lowinit.c
@@ -217,7 +217,7 @@ static inline void pic32mz_prefetch(void)
     }
   else
     {
-      /* For devices with 252 Mhz SYSCLK */
+      /* For devices with 252 MHz SYSCLK */
 
       nwaits = 4;
       regval = PRECON_PREFEN_CPUID;

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -10,7 +10,7 @@ choice
 	default ARCH_CHIP_ESP32
 
 config ARCH_CHIP_ESP32
-	bool "Expressif ESP32"
+	bool "Espressif ESP32"
 	select ARCH_FAMILY_LX6
 	select XTENSA_HAVE_INTERRUPTS
 	select ARCH_HAVE_MULTICPU
@@ -18,7 +18,7 @@ config ARCH_CHIP_ESP32
 	select ARCH_TOOLCHAIN_GNU
 	select ARCH_GLOBAL_IRQDISABLE
 	---help---
-		The ESP32 is a dual-core system from Expressif with two Harvard
+		The ESP32 is a dual-core system from Espressif with two Harvard
 		architecture Xtensa LX6 CPUs. All embedded memory, external memory
 		and peripherals are located on the data bus and/or the instruction
 		bus of these CPUs. With some minor exceptions, the address mapping

--- a/arch/xtensa/src/esp32/esp32_clockconfig.c
+++ b/arch/xtensa/src/esp32/esp32_clockconfig.c
@@ -6,7 +6,7 @@
  *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Derives from software originally provided by Expressif Systems:
+ * Derives from software originally provided by Espressif Systems:
  *
  * Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
  *

--- a/arch/xtensa/src/esp32/esp32_cpuidlestack.c
+++ b/arch/xtensa/src/esp32/esp32_cpuidlestack.c
@@ -6,7 +6,7 @@
  *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Derives from software originally provided by Expressif Systems:
+ * Derives from software originally provided by Espressif Systems:
  *
  * Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
  *

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -6,7 +6,7 @@
  *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Derivies from sample code provided by Expressif Systems:
+ * Derives from sample code provided by Espressif Systems:
  *
  *   Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
  *

--- a/arch/xtensa/src/esp32/esp32_gpio.h
+++ b/arch/xtensa/src/esp32/esp32_gpio.h
@@ -6,7 +6,7 @@
  *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Derivies in part from sample code provided by Expressif Systems:
+ * Derives in part from sample code provided by Espressif Systems:
  *
  *   Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
  *

--- a/arch/xtensa/src/esp32/hardware/esp32_iomux.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_iomux.h
@@ -6,7 +6,7 @@
  *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Derivies from sample code provided by Expressif Systems:
+ * Derives from sample code provided by Espressif Systems:
  *
  *   Copyright 2015-2016 Espressif Systems (Shanghai) PTE LTD
  *

--- a/arch/xtensa/src/esp32/rom/esp32_gpio.h
+++ b/arch/xtensa/src/esp32/rom/esp32_gpio.h
@@ -6,7 +6,7 @@
  *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Derivies from sample code provided by Expressif Systems:
+ * Derives from sample code provided by Espressif Systems:
  *
  * Copyright 2010-2016 Espressif Systems (Shanghai) PTE LTD
  *

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -179,10 +179,10 @@ config ARCH_BOARD_EKKLM3S9B96
 		an EKK-LM3S9B96 which is a Cortex-M3.
 
 config ARCH_BOARD_ESP32CORE
-	bool "Expressif ESP32 Core board V2"
+	bool "Espressif ESP32 Core board V2"
 	depends on ARCH_CHIP_ESP32
 	---help---
-		The ESP32 is a dual-core system from Expressif with two Harvard
+		The ESP32 is a dual-core system from Espressif with two Harvard
 		architecture Xtensa LX6 CPUs. All embedded memory, external memory
 		and peripherals are located on the data bus and/or the instruction
 		bus of these CPUs. With some minor exceptions, the address mapping
@@ -568,7 +568,7 @@ config ARCH_BOARD_MAKERLISP
 	depends on ARCH_CHIP_EZ80F91
 	select ARCH_HAVE_LEDS
 	---help---
-		ez80Acclaim! Microcontroller.  This port use the MakerLips machine
+		ez80Acclaim! Microcontroller.  This port use the MakerLisp machine
 		based on an eZ80F091 part, and the Zilog ZDS-II Windows command line
 		tools.  The development environment is Cygwin under Windows. A
 		Windows native development environment is available but has not
@@ -1205,13 +1205,13 @@ config ARCH_BOARD_QEMU_I486
 	depends on ARCH_X86 || ARCH_I486
 	---help---
 		Port of NuttX to QEMU in i486 mode.  This port will also run on real i486
-		hardwared (Google the Bifferboard).
+		hardware (Google the Bifferboard).
 
 config ARCH_BOARD_INTEL64_QEMU
 	bool "Intel64 for Qemu simulator"
 	depends on ARCH_X86_64 || ARCH_INTEL64
 	---help---
-		Port of NuttX to QEMU in intel64 mode.  This port will also run on real 
+		Port of NuttX to QEMU in intel64 mode.  This port will also run on real
 		generic Intel64 hardware.
 
 config ARCH_BOARD_RX65N
@@ -1732,7 +1732,7 @@ config ARCH_BOARD_STM32L476_MDK
 	select ARCH_HAVE_IRQBUTTONS
 	---help---
 		Motorola Mods Development Board (MDK) features  STM32L476ME MCU.
-		The STM32L476ME  is a Cortex-M4 optimised for low-power operation
+		The STM32L476ME is a Cortex-M4 optimised for low-power operation
 		at up to 80MHz operation with 1024Kb Flash memory and 96+32Kb SRAM.
 
 config ARCH_BOARD_STM32L_DISCOVERY

--- a/boards/README.txt
+++ b/boards/README.txt
@@ -167,7 +167,7 @@ http://nuttx.org/Documentation/NuttXConfigVariables.html.
 Supported Boards
 ^^^^^^^^^^^^^^^^
 
-boards/avr/atmeta/amber
+boards/avr/atmega/amber
   This is placeholder for the SoC Robotics Amber Web Server that is based
   on the Atmel AVR ATMega128 MCU.  There is not much there yet and what is
   there is untested due to tool-related issues.
@@ -255,12 +255,11 @@ boards/arm/tiva/ekk-lm3s9b96
   an EKK-LM3S9B96 which is a Cortex-M3.
 
 boards/xtensa/esp32/esp-core
-  The ESP32 is a dual-core system from Expressif with two Harvard
-  architecture Xtensa LX6 CPUs. All embedded memory, external memory and
-  nd peripherals are located on the data bus and/or the instruction bus of
-  bus of these CPUs. With some minor exceptions, the address mapping of two
-  CPUs is symmetric, meaning they use the same addresses to access the same
-  memory.
+  The ESP32 is a dual-core system from Espressif with two Harvard architecture
+  Xtensa LX6 CPUs.  All embedded memory, external memory and peripherals are
+  located on the data bus and/or the instruction bus of bus of these CPUs.
+  With some minor exceptions, the address mapping of two CPUs is symmetric,
+  meaning they use the same addresses to access the same memory.
 
 boards/z80/ez80/ez80f0910200kitg
   ez80Acclaim! Microcontroller.  This port use the Zilog ez80f0910200kitg
@@ -278,11 +277,11 @@ boards/arm/stm32/fire-stm32v2
   the boards are supported but only version 2 has been tested.
 
 boards/mips/pic32mz/flipnclick-pic32mz
-  Board support for the Mikroe Flip&Click PIC32MZ board.  This board is an
+  Board support for the Mikroe Flip&Click PIC32MZ board.  This board is a
   chipKit Arduino-compatible board (but can also be used with the Mikroe
   bootloader).  It has with four Mikroe Click bus interfaces in addition to
   standard Arduino connectors.  This board features the Microchip
-  PIC32MZ2048EFH100 MCU running at 200 MHz (252Mhz capable).
+  PIC32MZ2048EFH100 MCU running at 200 MHz (252 MHz capable).
 
 boards/arm/sam34/flipnclick-sam3x
   Board support for the Mikroe Flip&Click STM32X board.  This board is an
@@ -372,7 +371,7 @@ boards/arm/lpc17xx_40xx/lx_cpu
   LPC1788) and Xilinx Spartan 6 XC6SLX9
 
 boards/z80/ez80/makerlisp
-  This port use the MakerLips machine based on an eZ80F091 ez80Acclaim!
+  This port use the MakerLisp machine based on an eZ80F091 ez80Acclaim!
   Microcontroller, and the Zilog ZDS-II Windows command line tools.  The
   development environment is Cygwin under Windows. A Windows native
   development environment is available but has not been verified.
@@ -623,7 +622,7 @@ boards/arm/lpc17xx_40xx/pnev5180b
 
 boards/x86/qemu/qemu-i486
   Port of NuttX to QEMU in i486 mode.  This port will also run on real i486
-  hardwared (Google the Bifferboard).
+  hardware (Google the Bifferboard).
 
 boards/risc-v/nr5m100/nr5m100-nexys4
   Port of NuttX to RISC-V platform on IQ-Analog NR5M100 RISC-V FPGA platform.
@@ -752,7 +751,7 @@ boards/arm/stm32/stm32f103-minimum
   Generic STM32F103C8T6 Minimum ARM Development Board.
 
 boards/arm/stm32/stm32f4discovery
-  STMicro STM32F4-Discovery board based on the STMIcro STM32F407VGT6 MCU.
+  STMicro STM32F4-Discovery board based on the STMicro STM32F407VGT6 MCU.
 
 boards/arm/stm32/stm32f411e-disco
   This is a minimal configuration that supports low-level test of the
@@ -771,7 +770,7 @@ boards/arm/stm32f7/stm32f746g-ws
 
 boards/arm/stm32l4/stm32l476-mdk
   Motorola Mods Development Board (MDK) features  STM32L476ME MCU.
-  The STM32L476ME  is a Cortex-M4 optimised for low-power operation
+  The STM32L476ME is a Cortex-M4 optimised for low-power operation
   at up to 80MHz operation with 1024Kb Flash memory and 96+32Kb SRAM.
 
 boards/arm/stm32f7/stm32f769i-disco
@@ -922,7 +921,7 @@ tools/configure.sh
 
   See tools/README.txt for more information about these scripts.
 
-  And if your application directory is not in the standard loction (../apps
+  And if your application directory is not in the standard location (../apps
   or ../apps-<version>), then you should also specify the location of the
   application directory on the command line like:
 

--- a/boards/arm/imxrt/imxrt1020-evk/include/board.h
+++ b/boards/arm/imxrt/imxrt1020-evk/include/board.h
@@ -63,7 +63,7 @@
  *                        528Mhz  = (24Mhz * 22) / 1
  *
  *     AHB_CLOCK_ROOT             = PLL6fOut / IMXRT_AHB_PODF_DIVIDER
- *     1Hz to 500 Mhz             = Mhz / IMXRT_ARM_CLOCK_DIVIDER
+ *     1Hz to 500 MHz             = MHz / IMXRT_ARM_CLOCK_DIVIDER
  *                        IMXRT_ARM_CLOCK_DIVIDER = 1
  *                        500Mhz  = 500Mhz / 1
  *

--- a/boards/arm/imxrt/imxrt1050-evk/include/board.h
+++ b/boards/arm/imxrt/imxrt1050-evk/include/board.h
@@ -63,7 +63,7 @@
  *                        600Mhz  = (24Mhz * 100/2) / 2
  *
  *     AHB_CLOCK_ROOT             = PLL1fOut / IMXRT_AHB_PODF_DIVIDER
- *     1Hz to 600 Mhz             = 600Mhz / IMXRT_ARM_CLOCK_DIVIDER
+ *     1Hz to 600 MHz             = 600Mhz / IMXRT_ARM_CLOCK_DIVIDER
  *                        IMXRT_ARM_CLOCK_DIVIDER = 1
  *                        600Mhz  = 600Mhz / 1
  *

--- a/boards/arm/imxrt/imxrt1060-evk/include/board.h
+++ b/boards/arm/imxrt/imxrt1060-evk/include/board.h
@@ -63,7 +63,7 @@
  *                        600Mhz  = (24Mhz * 100/2) / 2
  *
  *     AHB_CLOCK_ROOT             = PLL1fOut / IMXRT_AHB_PODF_DIVIDER
- *     1Hz to 600 Mhz             = 600Mhz / IMXRT_ARM_CLOCK_DIVIDER
+ *     1Hz to 600 MHz             = 600Mhz / IMXRT_ARM_CLOCK_DIVIDER
  *                        IMXRT_ARM_CLOCK_DIVIDER = 1
  *                        600Mhz  = 600Mhz / 1
  *

--- a/boards/arm/kinetis/freedom-k64f/include/board.h
+++ b/boards/arm/kinetis/freedom-k64f/include/board.h
@@ -70,8 +70,8 @@
  * a KINETIS_MCG_PLL_REF_MIN >= PLLIN <= KINETIS_MCG_PLL_REF_MIN reference
  * clock to the PLL.
  *
- *   PLL Input frequency:   PLLIN  = REFCLK / PRDIV = 50  Mhz  / 20 = 2.5 MHz
- *   PLL Output frequency:  PLLOUT = PLLIN  * VDIV  = 2.5 Mhz  * 48 = 120 MHz
+ *   PLL Input frequency:   PLLIN  = REFCLK / PRDIV = 50  MHz  / 20 = 2.5 MHz
+ *   PLL Output frequency:  PLLOUT = PLLIN  * VDIV  = 2.5 MHz  * 48 = 120 MHz
  *   MCG Frequency:         PLLOUT = 120 MHz
  *
  * PRDIV register value is the divider minus KINETIS_MCG_C5_PRDIV_BASE.

--- a/boards/arm/kinetis/freedom-k66f/include/board.h
+++ b/boards/arm/kinetis/freedom-k66f/include/board.h
@@ -74,9 +74,9 @@
  * KINETIS_MCG_PLL_REF_MIN >= PLLIN <=KINETIS_MCG_PLL_REF_MAX  reference
  * clock to the PLL.
  *
- *   PLL Input frequency:   PLLIN  = REFCLK / PRDIV = 12 Mhz  / 1  = 12 MHz
- *   PLL Output frequency:  PLLOUT = PLLIN  * VDIV  = 12 Mhz  * 30 = 360 MHz
- *   MCG Frequency:         PLLOUT = 180 Mhz = 360 MHz /
+ *   PLL Input frequency:   PLLIN  = REFCLK / PRDIV = 12 MHz  / 1  = 12 MHz
+ *   PLL Output frequency:  PLLOUT = PLLIN  * VDIV  = 12 MHz  * 30 = 360 MHz
+ *   MCG Frequency:         PLLOUT = 180 MHz = 360 MHz /
  *                                             KINETIS_MCG_PLL_INTERNAL_DIVBY
  *
  * PRDIV register value is the divider minus KINETIS_MCG_C5_PRDIV_BASE.
@@ -114,7 +114,7 @@
 #define BOARD_SOPT2_PLLFLLSEL   SIM_SOPT2_PLLFLLSEL_MCGPLLCLK
 #define BOARD_SOPT2_FREQ        BOARD_MCG_FREQ
 
-/* N.B. The above BOARD_SOPT2_FREQ precludes use of USB with a 12 Mhz Xtal
+/* N.B. The above BOARD_SOPT2_FREQ precludes use of USB with a 12 MHz Xtal
  * Divider output clock = Divider input clock × [ (USBFRAC+1) / (USBDIV+1) ]
  *     SIM_CLKDIV2_FREQ = BOARD_SOPT2_FREQ × [ (USBFRAC+1) / (USBDIV+1) ]
  *                48Mhz = 168Mhz X [(1 + 1) / (6 + 1)]
@@ -131,8 +131,8 @@
 
 /* Divider output clock = Divider input clock * ((PLLFLLFRAC+1)/(PLLFLLDIV+1))
  *  SIM_CLKDIV3_FREQ = BOARD_SOPT2_FREQ × [ (PLLFLLFRAC+1) / (PLLFLLDIV+1)]
- *            90 Mhz = 180 Mhz X [(0 + 1) / (1 + 1)]
- *            90 Mhz = 180 Mhz / (1 + 1) * (0 + 1)
+ *            90 MHz = 180 MHz X [(0 + 1) / (1 + 1)]
+ *            90 MHz = 180 MHz / (1 + 1) * (0 + 1)
  */
 
 #define BOARD_SIM_CLKDIV3_PLLFLLFRAC  1

--- a/boards/arm/kinetis/teensy-3.x/include/board.h
+++ b/boards/arm/kinetis/teensy-3.x/include/board.h
@@ -92,7 +92,7 @@
  *
  * Board can be overclocked at 96MHz (per PJRC.com)
  *   PLL Input frequency:   PLLIN  = REFCLK/PRDIV = 16MHz/8 = 2MHz
- *   PLL Output frequency:  PLLOUT = PLLIN*VDIV   = Mhz*48 = 96MHz
+ *   PLL Output frequency:  PLLOUT = PLLIN*VDIV   = MHz*48 = 96MHz
  *   MCG Frequency:         PLLOUT = 96MHz
  */
 

--- a/boards/arm/kinetis/twr-k64f120m/include/board.h
+++ b/boards/arm/kinetis/twr-k64f120m/include/board.h
@@ -64,7 +64,7 @@
  *
  *   PLL Input frequency:   PLLIN  = REFCLK/PRDIV = 50MHz/20 = 2.5 MHz
  *   PLL Output frequency:  PLLOUT = PLLIN*VDIV   = 2.5Mhz*48 = 120MHz
- *   MCG Frequency:         PLLOUT = 120 Mhz
+ *   MCG Frequency:         PLLOUT = 120 MHz
  */
 
 #define BOARD_PRDIV          20  /* PLL External Reference Divider */

--- a/boards/arm/str71x/olimex-strp711/README.txt
+++ b/boards/arm/str71x/olimex-strp711/README.txt
@@ -46,7 +46,7 @@ Olimex STR-P711
  - Power supply filtering capacitor
  - RESET circuit
  - RESET button
- - 4 Mhz crystal oscillator
+ - 4 MHz crystal oscillator
  - 32768 Hz crystal and RTC
 
  Power Supply

--- a/boards/arm/str71x/olimex-strp711/include/board.h
+++ b/boards/arm/str71x/olimex-strp711/include/board.h
@@ -58,7 +58,7 @@
  * - Power supply filtering capacitor
  * - RESET circuit
  * - RESET button
- * - 4 Mhz crystal oscillator
+ * - 4 MHz crystal oscillator
  * - 32768 Hz crystal and RTC
  *
  ****************************************************************************/

--- a/boards/avr/atmega/amber/README.txt
+++ b/boards/avr/atmega/amber/README.txt
@@ -345,7 +345,7 @@ Build Notes:
      cd avr-lib-1.7.1
 
   3. Configure avr-lib.  Assuming that WinAVR is installed at the following
-     loction:
+     location:
 
      export PATH=/cygdrive/c/WinAVR/bin:$PATH
      ./configure --build=`./config.guess` --host=avr

--- a/boards/risc-v/nr5m100/nr5m100-nexys4/README.txt
+++ b/boards/risc-v/nr5m100/nr5m100-nexys4/README.txt
@@ -67,13 +67,13 @@ Development Environment
   cores require a separate I and D bus with cache SRAM and an external memory cache controller,
   etc.  This in addition to the pipeline registers adds additional gate count.
 
-  The nr5m100-nexys4 core runs at 83.333 Mhz which provides about 18 Mhz effective operating
+  The nr5m100-nexys4 core runs at 83.333 MHz which provides about 18 MHz effective operating
   speed with the multi-clock per instruction architecture.  If you are looking for a higher
   performance platform, you should check out the PULP Platform ( http://www.pulp-platform.org ).
   That is an FPGA design with a 4-stage pipeline RISC-V core, though not currently supported
   by NuttX.  The NR5M100 project will likely pull in the RISC-V core from that design next,
   though this will probably not be available soon.  With a bit of work, it is possible to
-  run the nr5m100-nexys4 core at 170 Mhz with a 6.5 clocks-per-instruction state machine.
+  run the nr5m100-nexys4 core at 170 MHz with a 6.5 clocks-per-instruction state machine.
   This would give an effective performance of about 26Mhz.
 
 Development Environment

--- a/boards/xtensa/esp32/esp32-core/README.txt
+++ b/boards/xtensa/esp32/esp32-core/README.txt
@@ -1,7 +1,7 @@
-README for the Expressif ESP32 Core board (V2)
+README for the Espressif ESP32 Core board (V2)
 ==============================================
 
-  The ESP32 is a dual-core system from Expressif with two Harvard
+  The ESP32 is a dual-core system from Espressif with two Harvard
   architecture Xtensa LX6 CPUs. All embedded memory, external memory and
   peripherals are located on the data bus and/or the instruction bus of
   these CPUs. With some minor exceptions, the address mapping of two CPUs
@@ -173,7 +173,7 @@ Memory Map
   IRAM for PRO cpu:  0x40080000 0x400a0000  RX  iram0_0_seg
     - Interrupt Vectors
     - Low level handlers
-    - Xtensa/Expressif libraries
+    - Xtensa/Espressif libraries
   RTC fast memory:   0x400c0000 0x400c2000  RWX rtc_iram_seg (PRO_CPU only)
     - .rtc.text (unused?)
   FLASH:             0x400d0018 0x40400018  RX  iram0_2_seg  (actually FLASH)
@@ -752,7 +752,7 @@ Things to Do
   1. There is no support for an interrupt stack yet.
 
   2. There is no clock initialization logic in place.  This depends on logic in
-     Expressif libriaries.  The board comes up using that basic 40 Mhz crystal
+     Espressif libraries.  The board comes up using that basic 40 MHz crystal
      for clocking.  Getting to 80 MHz will require clocking initialization in
      esp32_clockconfig.c.
 

--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -720,7 +720,7 @@ static int composite_setup(FAR struct usbdevclass_driver_s *driver,
        * Non-Standard Class Requests
        **********************************************************************/
 
-       /* Class implementations should handle there own interface and endpoint
+       /* Class implementations should handle their own interface and endpoint
         * requests.
         */
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -259,8 +259,8 @@ int bcmf_probe(FAR struct bcmf_sdio_dev_s *sbus)
       goto exit_error;
     }
 
-  /* Default device clock speed is up to 25 Mhz
-   * We could set EHS bit to operate at a clock rate up to 50 Mhz.
+  /* Default device clock speed is up to 25 MHz
+   * We could set EHS bit to operate at a clock rate up to 50 MHz.
    */
 
   SDIO_CLOCK(sbus->sdio_dev, CLOCK_SD_TRANSFER_4BIT);

--- a/drivers/wireless/spirit/lib/spirit_radio.c
+++ b/drivers/wireless/spirit/lib/spirit_radio.c
@@ -90,7 +90,7 @@ static const uint8_t g_vectc_bandval[4] =
   SYNT0_BS_6, SYNT0_BS_12, SYNT0_BS_16, SYNT0_BS_32
 };
 
-/* It represents the available channel bandwidth times 10 for 26 Mhz xtal.
+/* It represents the available channel bandwidth times 10 for 26 MHz xtal.
  * NOTE: The channel bandwidth for others xtal frequencies can be computed
  * since this table multiplying the current table by a factor
  * xtal_frequency/26e6.

--- a/fs/tmpfs/Kconfig
+++ b/fs/tmpfs/Kconfig
@@ -28,7 +28,7 @@ config FS_TMPFS_DIRECTORY_ALLOCGUARD
 	---help---
 		In order to avoid frequent reallocations, a little more memory than
 		needed is always allocated.  This permits the directory to grow
-		without so many realloctions.
+		without so many reallocations.
 
 config FS_TMPFS_DIRECTORY_FREEGUARD
 	int "Directory under free"
@@ -37,7 +37,7 @@ config FS_TMPFS_DIRECTORY_FREEGUARD
 		In order to avoid frequent reallocations, a lot of free memory has
 		to be available before a directory entry shrinks (via reallocation)
 		little more memory than needed is always allocated.  This permits
-		the directory to shrink without so many realloctions.
+		the directory to shrink without so many reallocations.
 
 config FS_TMPFS_FILE_ALLOCGUARD
 	int "Directory object over-allocation"
@@ -45,7 +45,7 @@ config FS_TMPFS_FILE_ALLOCGUARD
 	---help---
 		In order to avoid frequent reallocations, a little more memory than
 		needed is always allocated.  This permits the file to grow without
-		so many realloctions.
+		so many reallocations.
 
 		You will probably want to use smaller value than the default on tiny
 		TMFPS systems.
@@ -57,6 +57,6 @@ config FS_TMPFS_FILE_FREEGUARD
 		In order to avoid frequent reallocations, a lot of free memory has
 		to be available before a directory entry shrinks (via reallocation)
 		little more memory than needed is always allocated.  This permits
-		the file to shrink without so many realloctions.
+		the file to shrink without so many reallocations.
 
 endif

--- a/include/nuttx/wireless/ioctl.h
+++ b/include/nuttx/wireless/ioctl.h
@@ -62,9 +62,9 @@
  */
 
 #define WLIOC_SETRADIOFREQ  _WLCIOC(0x0001)  /* arg: Pointer to uint32_t, frequency
-                                             * value (in Mhz) */
+                                             * value (in MHz) */
 #define WLIOC_GETRADIOFREQ  _WLCIOC(0x0002)  /* arg: Pointer to uint32_t, frequency
-                                             * value (in Mhz) */
+                                             * value (in MHz) */
 #define WLIOC_SETADDR       _WLCIOC(0x0003)  /* arg: Pointer to address value, format
                                              * of the address is driver specific */
 #define WLIOC_GETADDR       _WLCIOC(0x0004)  /* arg: Pointer to address value, format

--- a/include/nuttx/wireless/nrf24l01.h
+++ b/include/nuttx/wireless/nrf24l01.h
@@ -409,7 +409,7 @@ int nrf24l01_setdatarate(FAR struct nrf24l01_dev_s *dev,
  *
  * Input Parameters:
  *   dev Pointer to an nRF24L01 device structure
- *   freq New frequency value  (in Mhz: 2400 to 2525)
+ *   freq New frequency value  (in MHz: 2400 to 2525)
  *
  * Returned Value:
  *   OK
@@ -425,7 +425,7 @@ int nrf24l01_setradiofreq(FAR struct nrf24l01_dev_s *dev, uint32_t freq);
  *   dev Pointer to an nRF24L01 device structure
  *
  * Returned Value:
- *   Radio frequency  (in Mhz)
+ *   Radio frequency  (in MHz)
  *
  ********************************************************************************************/
 

--- a/tools/configure.c
+++ b/tools/configure.c
@@ -990,7 +990,7 @@ static void check_configuration(void)
       g_oldnative = true;
     }
 
-  /* If we are going to some host other then windows native or to a windows
+  /* If we are going to some host other than windows native or to a windows
    * native host, then don't ignore what is in the defconfig file.
    */
 

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -187,7 +187,7 @@ fi
 # (2) The CONFIG_APPS_DIR setting to see if there is a configured location for the
 #     application directory.  This can be overridden from the command line.
 
-# If we are going to some host other then windows native or to a windows
+# If we are going to some host other than windows native or to a windows
 # native host, then don't even check what is in the defconfig file.
 
 oldnative=`grep CONFIG_WINDOWS_NATIVE= ${src_config} | cut -d'=' -f2`


### PR DESCRIPTION
Correct various typos in comments and documentation:

- Expressif -> Espressif
- Mhz -> MHz
- MakerLips -> MakerLisp
- hardwared -> hardware
- STMIcro -> STMicro
- loction -> location
- atmeta -> atmega
- derivies -> derives
- libriaries -> libraries
- realloction -> reallocation
- and others

No functional changes.