### PR TITLE
Create release artifacts for release branches

### DIFF
--- a/.github/workflows/releasepackage.yml
+++ b/.github/workflows/releasepackage.yml
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Release Packaging
+
+on:
+  push:
+    branches:
+      - 'releases/*'  # Only try to package releases branches
+    tags:
+      - 'nuttx-*'
+
+jobs:
+  package:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout nuttx repo
+      uses: actions/checkout@v2
+      with:
+        repository: apache/incubator-nuttx
+        path: nuttx
+        ref: ${{ github.ref }}
+        fetch-depth: 1
+    - name: Checkout apps repo
+      uses: actions/checkout@v2
+      with:
+        repository: apache/incubator-nuttx-apps
+        path: apps
+        ref: ${{ github.ref }}  # Use a matching ref for apps
+        fetch-depth: 1
+    - name: Perform packaging
+      id: package
+      shell: bash
+      run: |
+        shopt -s extglob
+        BRANCH_VER=${GITHUB_REF##*/}
+        pushd nuttx
+        git fetch --tags
+        RELEASE_VER=`./tools/gitver.sh $BRANCH_VER`
+        popd
+        echo "Packaging release $RELEASE_VER"
+        ./nuttx/tools/zipme.sh $RELEASE_VER
+        mkdir output
+        mv !(nuttx|apps|output) ./output
+        echo ::set-output name=release_ver::$RELEASE_VER
+    - uses: actions/upload-artifact@v1
+      with:
+        name: release-bundle-nuttx-${{ steps.package.outputs.release_ver }}
+        path: ./output/

--- a/tools/README.txt
+++ b/tools/README.txt
@@ -1137,3 +1137,22 @@ zipme.sh
         Same as above but use the key-id XXXXXX to sign the tarballs
       ./tools/zipme.sh -e "*.swp tmp" 9.0.0
         Create the tarballs but exclude any .swp file and the "tmp" directory.
+
+gitver.sh
+---------
+
+  This script will attempt to generate a semver version based on the git tags
+  and the supplied target version as either major.minor or major.minor.patch
+  If there is not yet a tag for Version 0.1 and 0.1 is supplied it will
+  return the version 0.1.0 If a tag exists of 0.1.2-RC1 it would return
+  version 0.1.2 to standard out if 0.1 or 0.1.2 is supplied.
+  
+  This is helpful for generating a version string for a release tarball on a
+  release branch that has a version of major.minor Even if the first tag has not
+  been made on this branch it will create the version string as the first patch
+  number.  If there is already a tag with the major.minor version of the branch
+  it will use that.
+
+  Example usage:
+  $ ./gitver.sh 0.1
+    0.1.2

--- a/tools/gitver.sh
+++ b/tools/gitver.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#****************************************************************************
+# tools/gitver.sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#****************************************************************************
+
+# Example usage:
+# $ ./gitver.sh 0.1
+#   0.1.2
+
+if [ $# -ne 1 ]
+then
+    echo "Missing version argument" 1>&2
+    exit -1
+fi 
+
+NUTTX_VERSION=$1
+
+# Closest Tag of this Version
+VER_TAG=`git describe --abbrev=0 --match "nuttx-$NUTTX_VERSION" --match "nuttx-$NUTTX_VERSION-*" --match "nuttx-$NUTTX_VERSION.[0-9]*"  2>/dev/null`
+if [ $? -ne 0 ]
+then
+    VER_TAG=nuttx-$NUTTX_VERSION
+fi
+
+
+# Remove nuttx and possible RC
+VER_TAG=`echo $VER_TAG | cut -d'-' --fields=2`
+
+# If version does not have a patch add one
+if [ `expr match $VER_TAG '.'` -eq 1 ]
+then
+    VER_TAG=${VER_TAG}.0
+fi
+
+SEMVER_REGEX="([0-9]+).([0-9]+).([0-9]+)"
+if [[ $VER_TAG =~ $SEMVER_REGEX ]]
+then
+    major="${BASH_REMATCH[1]}"
+    minor="${BASH_REMATCH[2]}"
+    patch="${BASH_REMATCH[3]}"
+else
+    echo "Unexpected Version format: $VER_TAG"  1>&2
+    exit -1
+fi
+
+echo ${major}.${minor}.${patch}


### PR DESCRIPTION
This extends the CI system to generate release bundles for the pushes to the `releases/<ver>` branch.
Right now we have the release branch as something like nuttx-0.9 I would highly recommend moving to the `releases/` structure as it is much easier to script around.  This also pulls the coresponding branch on apps so it needs to be created there as well.

You can see an example of the run here against `release/0.9` fake branch I created including the resulting artifact.
https://github.com/btashton/incubator-nuttx/actions/runs/74119132