### PR TITLE
Add missing entries into LICENSE and NOTICE files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -232,7 +232,7 @@ IGMP support, if enabled, adds additional logic by Steve Reynolds:
 The HID Parser in drivers/usbhost
 =================================
 
-  Adapted from the LUFA Library (MIT license):
+  Adapted from the LUFA Library (HPND-sell-variant):
 
     Copyright 2011  Dean Camera (dean [at] fourwalledcubicle [dot] com)
     dean [at] fourwalledcubicle [dot] com, www.lufa-lib.org
@@ -380,3 +380,103 @@ drivers/video/ov2640
   content of those tables and still retain this BSD license.  I am guessing
   so, but I am not a copyright attorney so you should use this driver in
   products at your own risk.
+
+
+include/nuttx/lcd/ili9488.h
+===========================
+
+  Copyright (c) 2011, Atmel Corporation
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+  - Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the disclaimer below.
+
+  - Atmel's name may not be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+  DISCLAIMER: THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+  DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+include/nuttx/input/x11_keysymdef.h
+===================================
+
+  Copyright 1987, 1994, 1998 The Open Group
+
+  Permission to use, copy, modify, distribute, and sell this software and
+  its documentation for any purpose is hereby granted without fee, provided
+  that the above copyright notice appear in all copies and that both that
+  copyright notice and this permission notice appear in supporting
+  documentation.
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE OPEN GROUP BE LIABLE FOR ANY CLAIM, DAMAGES OR
+  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+
+  Except as contained in this notice, the name of The Open Group shall
+  not be used in advertising or otherwise to promote the sale, use or
+  other dealings in this Software without prior written authorization
+  from The Open Group.
+
+  Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts
+
+  All Rights Reserved
+
+  Permission to use, copy, modify, and distribute this software and its
+  documentation for any purpose and without fee is hereby granted,
+  provided that the above copyright notice appear in all copies and that
+  both that copyright notice and this permission notice appear in
+  supporting documentation, and that the name of Digital not be
+  used in advertising or publicity pertaining to distribution of the
+  software without specific, written prior permission.
+
+  DIGITAL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL
+  DIGITAL BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR
+  ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+  SOFTWARE.
+
+arch/xtensa/src/esp32/chip_macros.h
+===================================
+
+  Copyright (c) 2006-2015 Cadence Design Systems Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -36,5 +36,25 @@ FAT Long File Names
 
   So you have been forewarned:  Use the long filename at your own risk!
 
+
+NXP Restriction for SPIFI code
+==============================
+
+  NOTE: Code supporting spifi for the LCP43xx has restricted usage by NXP
+  FILES:
+    arch/arm/src/lpc43xx/hardware/lpc43_spifi.h
+    arch/arm/src/lpc43xx/spifi/inc/spifilib_api.h
+    arch/arm/src/lpc43xx/spifi/inc/spifilib_dev.h
+    arch/arm/src/lpc43xx/spifi/inc/private/spifilib_chiphw.h
+    arch/arm/src/lpc43xx/spifi/src/spifilib_dev_common.c
+    arch/arm/src/lpc43xx/spifi/src/spifilib_fam_standard_cmd.c
+
+   Permission to use, copy, modify, and distribute this software and its
+   documentation is hereby granted, under NXP Semiconductors' and its
+   licensor's relevant copyrights in the software, without fee, provided that it
+   is used in conjunction with NXP Semiconductors microcontrollers. This
+   copyright, permission, and disclaimer notice must appear in all copies of
+   this code.
+
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
These changes add some of the missing entries in the license file that were identified with Fossology.

This also includes an addition to the NOTICE for the usage limitation in the SPIFI code from NXP.  We will likely need to remove this code eventually as it is not in compliance with Apache requirements.

We should also include this in the 9.0 release.