### PR TITLE
mm/mm_heap: fix mm_heap not support BUILD_FLAT

### DIFF
--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -227,7 +227,7 @@ struct mm_freenode_s
   FAR struct mm_freenode_s *blink;
 };
 
-#ifdef __KERNEL__
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 struct mm_delaynode_s
 {
   struct mm_delaynode_s *flink;
@@ -274,10 +274,10 @@ struct mm_heap_s
 
   struct mm_freenode_s mm_nodelist[MM_NNODES];
 
-#ifdef __KERNEL__
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   /* Free delay list, for some situation can't do free immdiately */
 
-  struct mm_delaynode_s mm_delaylist;
+  struct mm_delaynode_s *mm_delaylist;
 #endif
 };
 

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -175,10 +175,10 @@ void mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart,
   heap->mm_nregions = 0;
 #endif
 
-#ifdef __KERNEL__
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   /* Initialize mm_delaylist */
 
-  heap->mm_delaylist.flink = NULL;
+  heap->mm_delaylist = NULL;
 #endif
 
   /* Initialize the node array */

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -59,7 +59,7 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef __KERNEL__
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 static void mm_free_delaylist(FAR struct mm_heap_s *heap)
 {
   FAR struct mm_delaynode_s *tmp;
@@ -69,8 +69,8 @@ static void mm_free_delaylist(FAR struct mm_heap_s *heap)
 
   flags = enter_critical_section();
 
-  tmp = heap->mm_delaylist.flink;
-  heap->mm_delaylist.flink = NULL;
+  tmp = heap->mm_delaylist;
+  heap->mm_delaylist = NULL;
 
   leave_critical_section(flags);
 
@@ -116,7 +116,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
   void *ret = NULL;
   int ndx;
 
-#ifdef __KERNEL__
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   /* Firstly, free mm_delaylist */
 
   mm_free_delaylist(heap);


### PR DESCRIPTION
1. change ifdef __KERNEL__ to:
   if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)

2. change mm_delaylist to *mm_delaylist

3. change FAR struct mm_delaynode_s *new to:
   FAR struct mm_delaynode_s *tmp

4. should check mm_trysemaphore() return values

Change-Id: I57ba991f13c3eaf56dc2d71ac946c11669e32dfa
Signed-off-by: ligd <liguiding@fishsemi.com>