### PR TITLE
Fix some macOS sim warnings.

### DIFF
--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * net/devif/devif_callback.c
  *
- *   Copyright (C) 2008-2009, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -108,7 +93,9 @@ static void devif_callback_free(FAR struct net_driver_s *dev,
 
           for (prev = NULL, curr = dev->d_devcb;
                curr != NULL && curr != cb;
-               prev = curr, curr = curr->nxtdev);
+               prev = curr, curr = curr->nxtdev)
+            {
+            }
 
           /* Remove the structure from the device event list */
 
@@ -136,7 +123,9 @@ static void devif_callback_free(FAR struct net_driver_s *dev,
 
           for (prev = NULL, curr = *list;
                curr && curr != cb;
-               prev = curr, curr = curr->nxtconn);
+               prev = curr, curr = curr->nxtconn)
+            {
+            }
 
           /* Remove the structure from the connection event list */
 

--- a/sched/mqueue/mq_rcvinternal.c
+++ b/sched/mqueue/mq_rcvinternal.c
@@ -286,7 +286,9 @@ ssize_t nxmq_do_receive(mqd_t mqdes, FAR struct mqueue_msg_s *mqmsg,
       flags = enter_critical_section();
       for (btcb = (FAR struct tcb_s *)g_waitingformqnotfull.head;
            btcb && btcb->msgwaitq != msgq;
-           btcb = btcb->flink);
+           btcb = btcb->flink)
+        {
+        }
 
       /* If one was found, unblock it.  NOTE:  There is a race
        * condition here:  the queue might be full again by the

--- a/sched/mqueue/mq_sndinternal.c
+++ b/sched/mqueue/mq_sndinternal.c
@@ -169,7 +169,9 @@ FAR struct mqueue_msg_s *nxmq_alloc_msg(void)
 
           if (mqmsg != NULL)
             {
-              /* Yes... remember that this message was dynamically allocated */
+              /* Yes... remember that this message was dynamically
+               * allocated.
+               */
 
               mqmsg->type = MQ_ALLOC_DYN;
             }
@@ -414,7 +416,9 @@ int nxmq_do_send(mqd_t mqdes, FAR struct mqueue_msg_s *mqmsg,
 
       for (btcb = (FAR struct tcb_s *)g_waitingformqnotempty.head;
            btcb && btcb->msgwaitq != msgq;
-           btcb = btcb->flink);
+           btcb = btcb->flink)
+        {
+        }
 
       /* If one was found, unblock it */
 

--- a/sched/pthread/pthread_mutex.c
+++ b/sched/pthread/pthread_mutex.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/pthread/pthread_mutex.c
  *
- *   Copyright (C) 2017, 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -80,8 +65,8 @@ static void pthread_mutex_add(FAR struct pthread_mutex_s *mutex)
    * consistency logic.  Presumably, when the main thread exits, all of the
    * child pthreads will also terminate.
    *
-   * REVISIT:  NuttX does not support that behavior at present; child pthreads
-   * will persist after the main thread exits.
+   * REVISIT:  NuttX does not support that behavior at present; child
+   * pthreads will persist after the main thread exits.
    */
 
   if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_PTHREAD)
@@ -134,7 +119,9 @@ static void pthread_mutex_remove(FAR struct pthread_mutex_s *mutex)
 
       for (prev = NULL, curr = ptcb->mhead;
            curr != NULL && curr != mutex;
-           prev = curr, curr = curr->flink);
+           prev = curr, curr = curr->flink)
+        {
+        }
 
       DEBUGASSERT(curr == mutex);
 

--- a/sched/sched/sched_mergepending.c
+++ b/sched/sched/sched_mergepending.c
@@ -100,7 +100,9 @@ bool sched_mergepending(void)
 
       for (;
            (rtcb && ptcb->sched_priority <= rtcb->sched_priority);
-           rtcb = rtcb->flink);
+           rtcb = rtcb->flink)
+        {
+        }
 
       /* Add the ptcb to the spot found in the list.  Check if the
        * ptcb goes at the ends of the ready-to-run list. This would be


### PR DESCRIPTION
These warnings fix a class of warnings that I saw during CI checks for macOS sim builds.  For example:

    devif/devif_callback.c:111:49: warning: for loop has empty body [-Wempty-body]
                   prev = curr, curr = curr->nxtdev);
                                                    ^
    devif/devif_callback.c:111:49: note: put the semicolon on a separate line to silence this warning

I did not put the semi-colon on a separate line, but used braces.