### PR TITLE
mm: mm_heap: Fix deadlock in mm_trysemaphore in SMP mode

### DIFF
--- a/mm/mm_heap/mm_sem.c
+++ b/mm/mm_heap/mm_sem.c
@@ -179,7 +179,8 @@ int mm_trysemaphore(FAR struct mm_heap_s *heap)
 
   if (my_pid < 0)
     {
-      return my_pid;
+      ret = my_pid;
+      goto errout;
     }
 
   /* Does the current task already hold the semaphore?  Is the current


### PR DESCRIPTION
### Summary

- During checking the latest master code, I noticed that smp test application caused deadlock.
- Finally I found the root cause of this issue which was introduced in https://github.com/apache/incubator-nuttx/pull/761
- Actually the above PR did not call leave_critical_section() when exiting the function.
- This PR sets the return value and jumps to the errout so that leave_critical_section() can be called in SMP mode.

### Impact

- This PR affects mm_trysemaphore() in SMP mode only.

### Testing

- Run smp and ostest applications for maix-bit:smp and esp32-core:smp on qemu.

