### PR TITLE
esp32: Remove the unecessary PREPROCESS call to fix build warning

### DIFF
--- a/boards/xtensa/esp32/esp32-core/src/Makefile
+++ b/boards/xtensa/esp32/esp32-core/src/Makefile
@@ -58,7 +58,6 @@ EXTRA_DISTCLEAN = $(call DELFILE, $(SCRIPTOUT))
 include $(TOPDIR)/boards/Board.mk
 
 $(SCRIPTOUT): $(SCRIPTIN) $(CONFIGFILE)
-	# $(call PREPROCESS, $(SCRIPTIN), $@)
 	$(Q) $(CC) -isystem $(TOPDIR)/include -C -P -x c -E $(SCRIPTIN) -o $@
 
 context: $(SCRIPTOUT)


### PR DESCRIPTION
xtensa-esp32-elf-gcc: warning: /home/jenkins/jenkins-slave/workspace/NuttX-Nightly-Build/nuttx/boards/xtensa/esp32/esp32-core/scripts/esp32.template: linker input file unused because linking not done.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>