### PR TITLE
doc: Update a few wiki references

### DIFF
--- a/Documentation/NuttxUserGuide.html
+++ b/Documentation/NuttxUserGuide.html
@@ -2223,7 +2223,7 @@ priority of the calling task is returned.
       <b>NOTE:</b>
       Behavior of features related to <i>task group</i>s depend of NuttX configuration settings.
       See the discussion of &quot;Parent and Child Tasks,&quot; below.
-      See also the <a href="http://www.nuttx.org/doku.php?id=wiki:nxinternal:nxtasking">NuttX Threading Wiki</a> page and the <a href="http://www.nuttx.org/doku.php?id=wiki:nxinternal:tasksnthreads">Tasks vs. Threads FAQ</a> for additional information on tasks and threads in NuttX.
+      See also the <a href="https://cwiki.apache.org/confluence/display/NUTTX/NuttX+Tasking">NuttX Tasking</a> page and the <a href="https://cwiki.apache.org/confluence/display/NUTTX/Tasks+vs.+Threads+FAQ">Tasks vs. Threads FAQ</a> for additional information on tasks and threads in NuttX.
     </small></blockquote>
     <p>
       A <i>task group</i> terminates when the last thread within the group exits.
@@ -4936,7 +4936,7 @@ interface of the same name.
 <blockquote><small>
   <b>NOTE:</b>
   Behavior of features related to <i>task group</i>s depend of NuttX configuration settings.
-  See the <a href="http://www.nuttx.org/doku.php?id=wiki:nxinternal:nxtasking">NuttX Threading Wiki</a> page and the <a href="http://www.nuttx.org/doku.php?id=wiki:nxinternal:tasksnthreads">Tasks vs. Threads FAQ</a> for additional information on tasks and threads in NuttX.
+  See also the <a href="https://cwiki.apache.org/confluence/display/NUTTX/NuttX+Tasking">NuttX Tasking</a> page and the <a href="https://cwiki.apache.org/confluence/display/NUTTX/Tasks+vs.+Threads+FAQ">Tasks vs. Threads FAQ</a> for additional information on tasks and threads in NuttX.
 </small></blockquote>
 <p>
   <b>Signaling Multi-threaded Task Groups</b>.
@@ -5750,7 +5750,7 @@ be sent.
 <blockquote><small>
   <b>NOTE:</b>
   Behavior of features related to <i>task group</i>s depend of NuttX configuration settings.
-  See the <a href="http://www.nuttx.org/doku.php?id=wiki:nxinternal:nxtasking">NuttX Threading Wiki</a> page and the <a href="http://www.nuttx.org/doku.php?id=wiki:nxinternal:tasksnthreads">Tasks vs. Threads FAQ</a> for additional information on tasks and threads in NuttX.
+  See also the <a href="https://cwiki.apache.org/confluence/display/NUTTX/NuttX+Tasking">NuttX Tasking</a> page and the <a href="https://cwiki.apache.org/confluence/display/NUTTX/Tasks+vs.+Threads+FAQ">Tasks vs. Threads FAQ</a> for additional information on tasks and threads in NuttX.
 </small></blockquote>
 <p>
   The following pthread interfaces are supported in some form by NuttX:


### PR DESCRIPTION
It's my best guess because the old wiki URLs don't work anymore.