### PR TITLE
Add retry to pull docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,14 @@ jobs:
         login-server: docker.pkg.github.com
         username: ${GITHUB_ACTOR}
         password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Docker Pull
+      uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        retry_wait_seconds: 10
+        command: docker pull docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux
 
     - name: Run builds
       uses: ./testing/.github/actions/ci-container


### PR DESCRIPTION
This should cause the docker pull step to retry after a delay to hopefully handle the issues with the GitHub package registry.

NOTE:  The container will not be pulled again in the next step because it already exists.  There is almost zero cost to doing this pull here instead of directly in the run.