### PR TITLE
STM32/STM32H7: minor fixes for PWM

### DIFF
--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -433,7 +433,8 @@ static void pwm_modifyreg(struct stm32_pwmtimer_s *priv, uint32_t offset,
                           uint32_t clearbits, uint32_t setbits);
 
 #ifdef CONFIG_DEBUG_PWM_INFO
-static void pwm_dumpregs(struct stm32_pwmtimer_s *priv, FAR const char *msg);
+static void pwm_dumpregs(FAR struct pwm_lowerhalf_s *dev,
+                         FAR const char *msg);
 #else
 #  define pwm_dumpregs(priv,msg)
 #endif
@@ -1997,7 +1998,7 @@ static void pwm_modifyreg(struct stm32_pwmtimer_s *priv, uint32_t offset,
  *   Dump all timer registers.
  *
  * Input Parameters:
- *   priv - A reference to the PWM block status
+ *   dev - A reference to the lower half PWM driver state structure
  *
  * Returned Value:
  *   None
@@ -2005,8 +2006,10 @@ static void pwm_modifyreg(struct stm32_pwmtimer_s *priv, uint32_t offset,
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_PWM_INFO
-static void pwm_dumpregs(struct stm32_pwmtimer_s *priv, FAR const char *msg)
+static void pwm_dumpregs(struct pwm_lowerhalf_s *dev, FAR const char *msg)
 {
+  FAR struct stm32_pwmtimer_s *priv = (FAR struct stm32_pwmtimer_s *)dev;
+
   pwminfo("%s:\n", msg);
   if (priv->timid == 16 || priv->timid == 17)
     {
@@ -2931,7 +2934,7 @@ static int pwm_outputs_enable(FAR struct pwm_lowerhalf_s *dev,
   regval |= ((outputs & STM32_PWM_OUT3N) ? ATIM_CCER_CC3NE : 0);
   regval |= ((outputs & STM32_PWM_OUT4)  ? ATIM_CCER_CC4E  : 0);
 
-  /* NOTE: CC4N does not exist, but some docs show configuration bits for it */
+  /* NOTE: CC4N doesn't exist, but some docs show configuration bits for it */
 
 #ifdef HAVE_IP_TIMERS_V2
   regval |= ((outputs & STM32_PWM_OUT5)  ? ATIM_CCER_CC5E  : 0);
@@ -3446,7 +3449,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
       up_enable_irq(priv->irq);
     }
 
-  pwm_dumpregs(priv, "After starting");
+  pwm_dumpregs(dev, "After starting");
 
 errout:
   return ret;
@@ -3739,7 +3742,7 @@ static int pwm_timer(FAR struct pwm_lowerhalf_s *dev,
 
   pwm_timer_enable(dev, true);
 
-  pwm_dumpregs(priv, "After starting");
+  pwm_dumpregs(dev, "After starting");
 
 errout:
   return ret;
@@ -4127,7 +4130,7 @@ static int pwm_setup(FAR struct pwm_lowerhalf_s *dev)
       goto errout;
     }
 
-  pwm_dumpregs(priv, "Initially");
+  pwm_dumpregs(dev, "Initially");
 
   /* Configure the PWM output pins, but do not start the timer yet */
 
@@ -4135,21 +4138,38 @@ static int pwm_setup(FAR struct pwm_lowerhalf_s *dev)
     {
       if (priv->channels[i].out1.in_use == 1)
         {
-          pincfg = priv->channels[i].out1.pincfg;
-          pwminfo("pincfg: %08x\n", pincfg);
+          /* Do not configure the pin if pincfg is not specified.
+           * This prevents overwriting the PA0 configuration if the
+           * channel is used internally.
+           */
 
-          stm32_configgpio(pincfg);
-          pwm_dumpgpio(pincfg, "PWM setup");
+          pincfg = priv->channels[i].out1.pincfg;
+          if (pincfg != 0)
+            {
+              pwminfo("pincfg: %08x\n", pincfg);
+
+              stm32_configgpio(pincfg);
+              pwm_dumpgpio(pincfg, "PWM setup");
+            }
         }
 
 #ifdef HAVE_PWM_COMPLEMENTARY
       if (priv->channels[i].out2.in_use == 1)
         {
           pincfg = priv->channels[i].out2.pincfg;
-          pwminfo("pincfg: %08x\n", pincfg);
 
-          stm32_configgpio(pincfg);
-          pwm_dumpgpio(pincfg, "PWM setup");
+          /* Do not configure the pin if pincfg is not specified.
+           * This prevents overwriting the PA0 configuration if the
+           * channel is used internally.
+           */
+
+          if (pincfg != 0)
+            {
+              pwminfo("pincfg: %08x\n", pincfg);
+
+              stm32_configgpio(pincfg);
+              pwm_dumpgpio(pincfg, "PWM setup");
+            }
         }
 #endif
     }
@@ -4542,7 +4562,7 @@ static int pwm_stop(FAR struct pwm_lowerhalf_s *dev)
   leave_critical_section(flags);
 
   pwminfo("regaddr: %08x resetbit: %08x\n", regaddr, resetbit);
-  pwm_dumpregs(priv, "After stop");
+  pwm_dumpregs(dev, "After stop");
 
 errout:
   return ret;

--- a/arch/arm/src/stm32/stm32_pwm.h
+++ b/arch/arm/src/stm32/stm32_pwm.h
@@ -932,14 +932,13 @@
 #define PWM_TIM_ENABLE(dev, state)                                                 \
         (dev)->llops->tim_enable((FAR struct pwm_lowerhalf_s *)dev, state)
 #ifdef CONFIG_DEBUG_PWM_INFO
-#  define PWM_DUMP_REGS(dev)                                                       \
-        (dev)->llops->dump_regs((FAR struct pwm_lowerhalf_s *)dev)
+#  define PWM_DUMP_REGS(dev, msg)                                                  \
+        (dev)->llops->dump_regs((FAR struct pwm_lowerhalf_s *)dev, msg)
 #else
-#  define PWM_DUMP_REGS(dev)
+#  define PWM_DUMP_REGS(dev, msg)
 #endif
 #define PWM_DT_UPDATE(dev, dt)                                                     \
         (dev)->llops->dt_update((FAR struct pwm_lowerhalf_s *)dev, dt)
-
 #endif
 
 /************************************************************************************
@@ -1108,7 +1107,7 @@ struct stm32_pwm_ops_s
 #ifdef CONFIG_DEBUG_PWM_INFO
   /* Dump timer registers */
 
-  int (*dump_regs)(FAR struct pwm_lowerhalf_s *dev);
+  void (*dump_regs)(FAR struct pwm_lowerhalf_s *dev, FAR const char *msg);
 #endif
 
 #ifdef HAVE_PWM_COMPLEMENTARY

--- a/arch/arm/src/stm32h7/stm32_pwm.c
+++ b/arch/arm/src/stm32h7/stm32_pwm.c
@@ -1694,7 +1694,6 @@ static void pwm_putreg(struct stm32_pwmtimer_s *priv, int offset,
 static void pwm_modifyreg(struct stm32_pwmtimer_s *priv, uint32_t offset,
                             uint32_t clearbits, uint32_t setbits)
 {
-
   if (pwm_reg_is_32bit(priv->timtype, offset) == true)
     {
       /* 32-bit register */
@@ -1753,7 +1752,7 @@ static void pwm_dumpregs(struct stm32_pwmtimer_s *priv, FAR const char *msg)
               pwm_getreg(priv, STM32_GTIM_EGR_OFFSET),
               pwm_getreg(priv, STM32_GTIM_CCMR1_OFFSET));
     }
-   else
+  else
     {
       pwminfo("   SR: %04x EGR:  %04x CCMR1: %04x CCMR2: %04x\n",
               pwm_getreg(priv, STM32_GTIM_SR_OFFSET),
@@ -1822,7 +1821,6 @@ static void pwm_dumpregs(struct stm32_pwmtimer_s *priv, FAR const char *msg)
 
 static int pwm_ccr_update(FAR struct pwm_lowerhalf_s *dev, uint8_t index,
                           uint32_t ccr)
-
 {
   FAR struct stm32_pwmtimer_s *priv = (FAR struct stm32_pwmtimer_s *)dev;
   uint32_t offset = 0;
@@ -2079,8 +2077,8 @@ static int pwm_frequency_update(FAR struct pwm_lowerhalf_s *dev,
   uint32_t timclk    = 0;
   uint32_t prescaler = 0;
 
-  /* Calculate optimal values for the timer prescaler and for the timer reload
-   * register.  If 'frequency' is the desired frequency, then
+  /* Calculate optimal values for the timer prescaler and for the timer
+   * reload register. If 'frequency' is the desired frequency, then
    *
    *   reload = timclk / frequency
    *   timclk = pclk / presc
@@ -2138,7 +2136,8 @@ static int pwm_frequency_update(FAR struct pwm_lowerhalf_s *dev,
       reload--;
     }
 
-  pwminfo("TIM%u PCLK: %u frequency: %u TIMCLK: %u prescaler: %u reload: %u\n",
+  pwminfo("TIM%u PCLK: %u frequency: %u TIMCLK: %u "
+          "prescaler: %u reload: %u\n",
           priv->timid, priv->pclk, frequency, timclk, prescaler, reload);
 
   /* Set the reload and prescaler values */
@@ -2534,13 +2533,13 @@ static int pwm_output_configure(FAR struct stm32_pwmtimer_s *priv,
 
   /* Configure output polarity (all PWM timers) */
 
-  if (priv->channels[channel-1].out1.pol == STM32_POL_NEG)
+  if (priv->channels[channel - 1].out1.pol == STM32_POL_NEG)
     {
-      ccer |= (GTIM_CCER_CC1P << ((channel-1)*4));
+      ccer |= (GTIM_CCER_CC1P << ((channel - 1) * 4));
     }
   else
     {
-      ccer &= ~(GTIM_CCER_CC1P << ((channel-1)*4));
+      ccer &= ~(GTIM_CCER_CC1P << ((channel - 1) * 4));
     }
 
 #ifdef HAVE_ADVTIM
@@ -2549,36 +2548,36 @@ static int pwm_output_configure(FAR struct stm32_pwmtimer_s *priv,
     {
       /* Configure output IDLE State */
 
-      if (priv->channels[channel-1].out1.idle == STM32_IDLE_ACTIVE)
+      if (priv->channels[channel - 1].out1.idle == STM32_IDLE_ACTIVE)
         {
-          cr2 |= (ATIM_CR2_OIS1 << ((channel-1)*2));
+          cr2 |= (ATIM_CR2_OIS1 << ((channel - 1) * 2));
         }
       else
         {
-          cr2 &= ~(ATIM_CR2_OIS1 << ((channel-1)*2));
+          cr2 &= ~(ATIM_CR2_OIS1 << ((channel - 1) * 2));
         }
 
 #ifdef HAVE_PWM_COMPLEMENTARY
       /* Configure complementary output IDLE state */
 
-      if (priv->channels[channel-1].out2.idle == STM32_IDLE_ACTIVE)
+      if (priv->channels[channel - 1].out2.idle == STM32_IDLE_ACTIVE)
         {
-          cr2 |= (ATIM_CR2_OIS1N << ((channel-1)*2));
+          cr2 |= (ATIM_CR2_OIS1N << ((channel - 1) * 2));
         }
       else
         {
-          cr2 &= ~(ATIM_CR2_OIS1N << ((channel-1)*2));
+          cr2 &= ~(ATIM_CR2_OIS1N << ((channel - 1) * 2));
         }
 
       /* Configure complementary output polarity */
 
-      if (priv->channels[channel-1].out2.pol == STM32_POL_NEG)
+      if (priv->channels[channel - 1].out2.pol == STM32_POL_NEG)
         {
-          ccer |= (ATIM_CCER_CC1NP << ((channel-1)*4));
+          ccer |= (ATIM_CCER_CC1NP << ((channel - 1) * 4));
         }
       else
         {
-          ccer &= ~(ATIM_CCER_CC1NP << ((channel-1)*4));
+          ccer &= ~(ATIM_CCER_CC1NP << ((channel - 1) * 4));
         }
 #endif /* HAVE_PWM_COMPLEMENTARY */
 
@@ -2604,7 +2603,7 @@ static int pwm_output_configure(FAR struct stm32_pwmtimer_s *priv,
        *          which causes an ugly condition above
        */
 
-      ccer &= ~(GTIM_CCER_CC1NP << ((channel-1)*4));
+      ccer &= ~(GTIM_CCER_CC1NP << ((channel - 1) * 4));
     }
 #endif /* HAVE_GTIM_CCXNP */
 
@@ -2729,7 +2728,8 @@ errout:
  *
  ****************************************************************************/
 
-static int pwm_sync_configure(FAR struct stm32_pwmtimer_s *priv, uint8_t trgo)
+static int pwm_sync_configure(FAR struct stm32_pwmtimer_s *priv,
+                              uint8_t trgo)
 {
   uint32_t cr2 = 0;
 
@@ -2830,7 +2830,7 @@ static uint16_t pwm_outputs_from_channels(FAR struct stm32_pwmtimer_s *priv)
 
           if (priv->channels[i].out1.in_use == 1)
             {
-              outputs |= (STM32_PWM_OUT1 << ((channel-1)*2));
+              outputs |= (STM32_PWM_OUT1 << ((channel - 1) * 2));
             }
 
 #ifdef HAVE_PWM_COMPLEMENTARY
@@ -2838,7 +2838,7 @@ static uint16_t pwm_outputs_from_channels(FAR struct stm32_pwmtimer_s *priv)
 
           if (priv->channels[i].out2.in_use == 1)
             {
-              outputs |= (STM32_PWM_OUT1N << ((channel-1)*2));
+              outputs |= (STM32_PWM_OUT1N << ((channel - 1) * 2));
             }
 #endif
         }
@@ -2907,7 +2907,6 @@ static int pwm_break_dt_configure(FAR struct stm32_pwmtimer_s *priv)
       /* Configure BRK2 filter */
 
       bdtr |= (priv->brk.flt2 << ATIM_BDTR_BK2F_SHIFT);
-
     }
 #endif /* HAVE_IP_TIMERS_V2 */
 #endif /* HAVE_BREAK */

--- a/arch/arm/src/stm32h7/stm32_pwm.h
+++ b/arch/arm/src/stm32h7/stm32_pwm.h
@@ -829,10 +829,10 @@
 #define PWM_TIM_ENABLE(dev, state)                                                 \
         (dev)->llops->tim_enable((FAR struct pwm_lowerhalf_s *)dev, state)
 #ifdef CONFIG_DEBUG_PWM_INFO
-#  define PWM_DUMP_REGS(dev)                                                       \
-        (dev)->llops->dump_regs((FAR struct pwm_lowerhalf_s *)dev)
+#  define PWM_DUMP_REGS(dev, msg)                                 \
+  (dev)->llops->dump_regs((FAR struct pwm_lowerhalf_s *)dev, msg)
 #else
-#  define PWM_DUMP_REGS(dev)
+#  define PWM_DUMP_REGS(dev, msg)
 #endif
 #define PWM_DT_UPDATE(dev, dt)                                                     \
         (dev)->llops->dt_update((FAR struct pwm_lowerhalf_s *)dev, dt)
@@ -999,7 +999,7 @@ struct stm32_pwm_ops_s
 #ifdef CONFIG_DEBUG_PWM_INFO
   /* Dump timer registers */
 
-  int (*dump_regs)(FAR struct pwm_lowerhalf_s *dev);
+  void (*dump_regs)(FAR struct pwm_lowerhalf_s *dev, FAR const char *msg);
 #endif
 
 #ifdef HAVE_PWM_COMPLEMENTARY

--- a/arch/arm/src/stm32h7/stm32_pwm.h
+++ b/arch/arm/src/stm32h7/stm32_pwm.h
@@ -55,14 +55,22 @@
 
 #include "chip.h"
 
+#ifdef CONFIG_STM32H7_PWM
+#  include <arch/board/board.h>
+#  include "hardware/stm32_tim.h"
+#endif
+
 /************************************************************************************
  * Pre-processor Definitions
  ************************************************************************************/
+
 /* Configuration ********************************************************************/
+
 /* Timer devices may be used for different purposes.  One special purpose is
- * to generate modulated outputs for such things as motor control.  If CONFIG_STM32H7_TIMn
- * is defined then the CONFIG_STM32H7_TIMn_PWM must also be defined to indicate that
- * timer "n" is intended to be used for pulsed output signal generation.
+ * to generate modulated outputs for such things as motor control.
+ * If CONFIG_STM32H7_TIMn is defined then the CONFIG_STM32H7_TIMn_PWM must also be
+ * defined to indicate that timer "n" is intended to be used for pulsed output
+ * signal generation.
  */
 
 #ifndef CONFIG_STM32H7_TIM1
@@ -110,9 +118,6 @@
 /* Check if PWM support for any channel is enabled. */
 
 #ifdef CONFIG_STM32H7_PWM
-
-#include <arch/board/board.h>
-#include "hardware/stm32_tim.h"
 
 /* PWM driver channels configuration */
 
@@ -915,13 +920,18 @@ enum stm32_pwm_output_e
   STM32_PWM_OUT3  = (1 << 4),
   STM32_PWM_OUT3N = (1 << 5),
   STM32_PWM_OUT4  = (1 << 6),
+
   /* 1 << 7 reserved - no complementary output for CH4 */
+
 #ifdef HAVE_IP_TIMERS_V2
   /* Only available inside micro */
 
   STM32_PWM_OUT5  = (1 << 8),
+
   /* 1 << 9 reserved - no complementary output for CH5 */
+
   STM32_PWM_OUT6  = (1 << 10),
+
   /* 1 << 11 reserved - no complementary output for CH6 */
 #endif
 };
@@ -974,7 +984,8 @@ struct stm32_pwm_ops_s
 
   /* Enable outputs */
 
-  int (*outputs_enable)(FAR struct pwm_lowerhalf_s *dev, uint16_t outputs, bool state);
+  int (*outputs_enable)(FAR struct pwm_lowerhalf_s *dev, uint16_t outputs,
+                        bool state);
 
   /* Software update */
 
@@ -1027,7 +1038,7 @@ extern "C"
 #endif
 
 /************************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ************************************************************************************/
 
 /************************************************************************************


### PR DESCRIPTION
- arch/arm/src/stm32h7/stm32_pwm: nxstyle fixes
- arch/arm/src/stm32h7/stm32_pwm: fix PWM_DUMP_REGS macro
- arch/arm/src/stm32h7/stm32_pwm: prevent the PA0 pin configuration from being overwritten
- arch/arm/src/stm32/stm32_pwm: fix PWM_DUMP_REGS macro
- arch/arm/src/stm32/stm32_pwm: prevent the PA0 pin configuration from being overwritten