### PR TITLE
Fix heap corruption

### DIFF
--- a/boards/risc-v/k210/maix-bit/README-qemu.txt
+++ b/boards/risc-v/k210/maix-bit/README-qemu.txt
@@ -37,6 +37,11 @@
 
   $ qemu-system-riscv64 -nographic -machine sifive_u -bios ./nuttx
 
+  NOTE: To run nuttx for kostest, gdb needs to be used to load both nuttx_user.elf and nuttx
+
+  $ qemu-system-riscv64 -nographic -machine sifive_u -s -S
+  $ riscv64-unknown-elf-gdb -ex 'target extended-remot:1234' -ex 'load nuttx_user.elf' -ex 'load nuttx' -ex 'c'
+
 6. TODO
 
   Support FPU

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -211,12 +211,10 @@ struct mm_freenode_s
   FAR struct mm_freenode_s *blink;
 };
 
-#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
 struct mm_delaynode_s
 {
   struct mm_delaynode_s *flink;
 };
-#endif
 
 /* What is the size of the freenode? */
 
@@ -258,11 +256,9 @@ struct mm_heap_s
 
   struct mm_freenode_s mm_nodelist[MM_NNODES];
 
-#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   /* Free delay list, for some situation can't do free immdiately */
 
   struct mm_delaynode_s *mm_delaylist;
-#endif
 };
 
 /****************************************************************************

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -175,11 +175,9 @@ void mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart,
   heap->mm_nregions = 0;
 #endif
 
-#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   /* Initialize mm_delaylist */
 
   heap->mm_delaylist = NULL;
-#endif
 
   /* Initialize the node array */
 


### PR DESCRIPTION
## Description

**Describe problem solved by the PR**

During testing maix-bit:kostest, I found a heap corruption which destroys USR_HEAP->mm_delaylist which was introduced in https://github.com/apache/incubator-nuttx/pull/761. This PR fixes this heap corruption.

**Describe your solution**

```struct mm_delaynode_s *mm_delaylist``` is included in CONFIG_BUILD_PROTECTED. Actually, it is not accessed from userland but from kernel in protected build mode. However, ```sizeof(struct mm_heap_s)``` must be correct in userland to avoid heap corruption by accessing to adjacent memory area.

**Describe possible alternatives**

I have no ideas so far.

**Additional context**

Please see https://github.com/apache/incubator-nuttx/pull/761 as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Build and run maix-bit:kostst on qemu

The instructions are also updated in this PR.

**Test Configuration**:

* Nuttx board/config: maix-bit:kostest, maix-bit:smp
* Hardware: qemu-system-riscv64
* Toolchain: riscv64-unknown-elf-gcc 8.3.0

## Checklist:

- [x] My code follows the style guidelines of this project (NEED link to how to run checkpatch)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings (NEED link to how to run checkpatch spelling)
