### PR TITLE
STM32L4 clock options and regulator power

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_pwr.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwr.c
@@ -226,3 +226,46 @@ bool stm32l4_pwr_enableusv(bool set)
 
   return was_set;
 }
+
+/************************************************************************************
+ * Name: stm32_pwr_setvos
+ *
+ * Description:
+ *   Set voltage scaling for Vcore
+ *
+ * Input Parameters:
+ *   vos - Either 1 or 2, to set to Range 1 or 2, respectively
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   At present, this function is called only from initialization logic.  If used
+ *   for any other purpose that protection to assure that its operation is atomic
+ *   will be required.
+ *
+ ************************************************************************************/
+
+void stm32_pwr_setvos(int vos)
+{
+  uint32_t regval;
+
+  if (vos != 1 && vos != 2)
+    {
+      return;
+    }
+
+  regval  = getreg32(STM32L4_PWR_CR1);
+  regval &= ~PWR_CR1_VOS_MASK;
+
+  if (vos == 1)
+    {
+      regval |= PWR_CR1_VOS_RANGE1;
+    }
+  else
+    {
+      regval |= PWR_CR1_VOS_RANGE2;
+    }
+
+  putreg32(regval, STM32L4_PWR_CR1);
+}

--- a/arch/arm/src/stm32l4/stm32l4_pwr.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwr.c
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32l4/stm32l4_pwr.c
  *
  *   Copyright (C) 2011 Uros Platise. All rights reserved.
@@ -34,11 +34,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/arch.h>
@@ -51,9 +51,9 @@
 #include "stm32l4_pwr.h"
 #include "stm32l4_rcc.h"
 
-/************************************************************************************
+/****************************************************************************
  * Private Functions
- ************************************************************************************/
+ ****************************************************************************/
 
 static inline uint16_t stm32l4_pwr_getreg(uint8_t offset)
 {
@@ -65,22 +65,25 @@ static inline void stm32l4_pwr_putreg(uint8_t offset, uint16_t value)
   putreg32((uint32_t)value, STM32L4_PWR_BASE + (uint32_t)offset);
 }
 
-static inline void stm32l4_pwr_modifyreg(uint8_t offset, uint16_t clearbits, uint16_t setbits)
+static inline void stm32l4_pwr_modifyreg(uint8_t offset, uint16_t clearbits,
+                                         uint16_t setbits)
 {
-  modifyreg32(STM32L4_PWR_BASE + (uint32_t)offset, (uint32_t)clearbits, (uint32_t)setbits);
+  modifyreg32(STM32L4_PWR_BASE + (uint32_t)offset,
+              (uint32_t)clearbits, (uint32_t)setbits);
 }
 
-/************************************************************************************
+/****************************************************************************
  * Public Functions
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Name: enableclk
  *
  * Description:
- *   Enable/disable the clock to the power control peripheral.  Enabling must be done
- *   after the APB1 clock is validly configured, and prior to using any functionality
- *   controlled by the PWR block (i.e. much of anything else provided by this module).
+ *   Enable/disable the clock to the power control peripheral.  Enabling
+ *   must be done after the APB1 clock is validly configured, and prior to
+ *   using any functionality controlled by the PWR block (i.e. much of
+ *   anything else provided by this module).
  *
  * Input Parameters:
  *   enable - True: enable the clock to the Power control (PWR) block.
@@ -88,7 +91,7 @@ static inline void stm32l4_pwr_modifyreg(uint8_t offset, uint16_t clearbits, uin
  * Returned Value:
  *   True:  the PWR block was previously enabled.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 bool stm32l4_pwr_enableclk(bool enable)
 {
@@ -118,12 +121,12 @@ bool stm32l4_pwr_enableclk(bool enable)
   return wasenabled;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32l4_pwr_enablebkp
  *
  * Description:
- *   Enables access to the backup domain (RTC registers, RTC backup data registers
- *   and backup SRAM).
+ *   Enables access to the backup domain (RTC registers, RTC backup data
+ *   registers and backup SRAM).
  *
  * Input Parameters:
  *   writable - True: enable ability to write to backup domain registers
@@ -131,7 +134,7 @@ bool stm32l4_pwr_enableclk(bool enable)
  * Returned Value:
  *   True: The backup domain was previously writable.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 bool stm32l4_pwr_enablebkp(bool writable)
 {
@@ -167,21 +170,21 @@ bool stm32l4_pwr_enablebkp(bool writable)
   return waswritable;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32l4_pwr_enableusv
  *
  * Description:
- *   Enables or disables the USB Supply Valid monitoring.  Setting this bit is
- *   mandatory to use the USB OTG FS peripheral.
+ *   Enables or disables the USB Supply Valid monitoring.  Setting this bit
+ *   is mandatory to use the USB OTG FS peripheral.
  *
  * Input Parameters:
- *   set - True: Vddusb is valid; False: Vddusb is not present. Logical and electrical
- *         isolation is applied to ignore this supply.
+ *   set - True: Vddusb is valid; False: Vddusb is not present. Logical and
+ *         electrical isolation is applied to ignore this supply.
  *
  * Returned Value:
  *   True: The bit was previously set.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 bool stm32l4_pwr_enableusv(bool set)
 {
@@ -227,7 +230,7 @@ bool stm32l4_pwr_enableusv(bool set)
   return was_set;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_setvos
  *
  * Description:
@@ -240,11 +243,11 @@ bool stm32l4_pwr_enableusv(bool set)
  *   None
  *
  * Assumptions:
- *   At present, this function is called only from initialization logic.  If used
- *   for any other purpose that protection to assure that its operation is atomic
- *   will be required.
+ *   At present, this function is called only from initialization logic.
+ *   If used for any other purpose that protection to assure that its
+ *   operation is atomic will be required.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_setvos(int vos)
 {

--- a/arch/arm/src/stm32l4/stm32l4_pwr.h
+++ b/arch/arm/src/stm32l4/stm32l4_pwr.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32l4/stm32l4_pwr.h
  *
  *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
@@ -31,14 +31,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32L4_STM32L4_PWR_H
 #define __ARCH_ARM_SRC_STM32L4_STM32L4_PWR_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -47,9 +47,9 @@
 #include "chip.h"
 #include "hardware/stm32l4_pwr.h"
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 
@@ -62,17 +62,18 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Name: enableclk
  *
  * Description:
- *   Enable/disable the clock to the power control peripheral.  Enabling must be done
- *   after the APB1 clock is validly configured, and prior to using any functionality
- *   controlled by the PWR block (i.e. much of anything else provided by this module).
+ *   Enable/disable the clock to the power control peripheral.  Enabling
+ *   must be done after the APB1 clock is validly configured, and prior to
+ *   using any functionality controlled by the PWR block (i.e. much of
+ *   anything else provided by this module).
  *
  * Input Parameters:
  *   enable - True: enable the clock to the Power control (PWR) block.
@@ -80,16 +81,16 @@ extern "C"
  * Returned Value:
  *   True:  the PWR block was previously enabled.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 bool stm32l4_pwr_enableclk(bool enable);
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32l4_pwr_enablebkp
  *
  * Description:
- *   Enables access to the backup domain (RTC registers, RTC backup data registers
- *   and backup SRAM).
+ *   Enables access to the backup domain (RTC registers, RTC backup data
+ *   registers and backup SRAM).
  *
  * Input Parameters:
  *   writable - True: enable ability to write to backup domain registers
@@ -97,29 +98,29 @@ bool stm32l4_pwr_enableclk(bool enable);
  * Returned Value:
  *   True: The backup domain was previously writable.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 bool stm32l4_pwr_enablebkp(bool writable);
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32l4_pwr_enableusv
  *
  * Description:
- *   Enables or disables the USB Supply Valid monitoring.  Setting this bit is
- *   mandatory to use the USB OTG FS peripheral.
+ *   Enables or disables the USB Supply Valid monitoring.  Setting this bit
+ *   is mandatory to use the USB OTG FS peripheral.
  *
  * Input Parameters:
- *   set - True: Vddusb is valid; False: Vddusb is not present. Logical and electrical
- *         isolation is applied to ignore this supply.
+ *   set - True: Vddusb is valid; False: Vddusb is not present. Logical and
+ *         electrical isolation is applied to ignore this supply.
  *
  * Returned Value:
  *   True: The bit was previously set.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 bool stm32l4_pwr_enableusv(bool set);
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_setvos
  *
  * Description:
@@ -132,11 +133,11 @@ bool stm32l4_pwr_enableusv(bool set);
  *   None
  *
  * Assumptions:
- *   At present, this function is called only from initialization logic.  If used
- *   for any other purpose that protection to assure that its operation is atomic
- *   will be required.
+ *   At present, this function is called only from initialization logic.
+ *   If used for any other purpose that protection to assure that its
+ *   operation is atomic will be required.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_setvos(int vos);
 

--- a/arch/arm/src/stm32l4/stm32l4_pwr.h
+++ b/arch/arm/src/stm32l4/stm32l4_pwr.h
@@ -119,6 +119,27 @@ bool stm32l4_pwr_enablebkp(bool writable);
 
 bool stm32l4_pwr_enableusv(bool set);
 
+/************************************************************************************
+ * Name: stm32_pwr_setvos
+ *
+ * Description:
+ *   Set voltage scaling for Vcore
+ *
+ * Input Parameters:
+ *   vos - Either 1 or 2, to set to Range 1 or 2, respectively
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   At present, this function is called only from initialization logic.  If used
+ *   for any other purpose that protection to assure that its operation is atomic
+ *   will be required.
+ *
+ ************************************************************************************/
+
+void stm32_pwr_setvos(int vos);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/arch/arm/src/stm32l4/stm32l4x6xx_rcc.c
+++ b/arch/arm/src/stm32l4/stm32l4x6xx_rcc.c
@@ -726,7 +726,8 @@ static void stm32l4_stdclockconfig(void)
   /* setting MSIRANGE */
 
   regval  = getreg32(STM32L4_RCC_CR);
-  regval |= (STM32L4_BOARD_MSIRANGE | RCC_CR_MSION);    /* Enable MSI and frequency */
+  regval &= ~RCC_CR_MSIRANGE_MASK;                /* Zero-out current MSIRANGE bits */
+  regval |= (STM32L4_BOARD_MSIRANGE | RCC_CR_MSION | RCC_CR_MSIRGSEL);  /* Enable MSI and frequency */
   putreg32(regval, STM32L4_RCC_CR);
 
   /* Wait until the MSI is ready (or until a timeout elapsed) */

--- a/arch/arm/src/stm32l4/stm32l4x6xx_rcc.c
+++ b/arch/arm/src/stm32l4/stm32l4x6xx_rcc.c
@@ -777,23 +777,26 @@ static void stm32l4_stdclockconfig(void)
 
   if (timeout > 0)
     {
-#warning todo: regulator voltage according to clock freq
-#if 0
       /* Ensure Power control is enabled before modifying it. */
 
-      regval  = getreg32(STM32L4_RCC_APB1ENR);
-      regval |= RCC_APB1ENR_PWREN;
-      putreg32(regval, STM32L4_RCC_APB1ENR);
+      stm32l4_pwr_enableclk(true);
 
-      /* Select regulator voltage output Scale 1 mode to support system
-       * frequencies up to 168 MHz.
-       */
+      if (STM32L4_SYSCLK_FREQUENCY > 24000000ul)
+        {
+          /* Select regulator voltage output Scale 1 mode to support system
+           * frequencies up to 168 MHz.
+           */
 
-      regval  = getreg32(STM32L4_PWR_CR);
-      regval &= ~PWR_CR_VOS_MASK;
-      regval |= PWR_CR_VOS_SCALE_1;
-      putreg32(regval, STM32L4_PWR_CR);
-#endif
+          stm32_pwr_setvos(1);
+        }
+      else
+        {
+          /* Select regulator voltage output Scale 2 mode for
+           * frequencies below 24 MHz
+           */
+
+          stm32_pwr_setvos(2);
+        }
 
       /* Set the HCLK source/divider */
 

--- a/arch/arm/src/stm32l4/stm32l4x6xx_rcc.c
+++ b/arch/arm/src/stm32l4/stm32l4x6xx_rcc.c
@@ -723,11 +723,11 @@ static void stm32l4_stdclockconfig(void)
         }
     }
 
-  /* setting MSIRANGE */
+  /* Enable MSI and choosing frequency */
 
   regval  = getreg32(STM32L4_RCC_CR);
-  regval &= ~RCC_CR_MSIRANGE_MASK;                /* Zero-out current MSIRANGE bits */
-  regval |= (STM32L4_BOARD_MSIRANGE | RCC_CR_MSION | RCC_CR_MSIRGSEL);  /* Enable MSI and frequency */
+  regval &= ~RCC_CR_MSIRANGE_MASK;
+  regval |= (STM32L4_BOARD_MSIRANGE | RCC_CR_MSION | RCC_CR_MSIRGSEL);
   putreg32(regval, STM32L4_RCC_CR);
 
   /* Wait until the MSI is ready (or until a timeout elapsed) */
@@ -949,9 +949,11 @@ static void stm32l4_stdclockconfig(void)
         }
 #endif
 
-      /* TODO: could reduce flash wait states according to vcore range and freq */
-
-      /* Enable FLASH prefetch, instruction cache, data cache, and 4 wait states */
+      /* Enable FLASH prefetch, instruction cache, data cache,
+       * and 4 wait states.
+       * TODO: could reduce flash wait states according to vcore range
+       * and freq
+       */
 
 #ifdef CONFIG_STM32L4_FLASH_PREFETCH
       regval = (FLASH_ACR_LATENCY_4 | FLASH_ACR_ICEN | FLASH_ACR_DCEN |


### PR DESCRIPTION
This includes:
* Interface to select the core regulator voltage according to clock frequency range
* Usage of this interface during clock configuration according to chosen clock frequency
* Little fix that didn not really permit choosing the MSI clock frequency
* Option to choose a different system clock than the main PLL (there is HSI, MSI, HSE and LSE available to use)
* Option to not enable the main PLL which allows for reduced power usage when setting one of the above options as system clock, to do this you should define STM32L4_BOARD_NOPLL on your board header.