### PR TITLE
Docs and comments: Change OSX -> macOS

### DIFF
--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -2547,7 +2547,7 @@ Bugfixes include:
     * FAT.  Now returns the correct error value when it is unable to
       recognize the file system.
 
-    * Build.  MAC OS build fixes (submitted by Mike Smith)
+    * Build.  macOS build fixes (submitted by Mike Smith)
 
 And several others.  See the ChangeLog for more details.
 
@@ -26659,11 +26659,11 @@ This is the first release of NuttX as Apache NuttX (Incubating) and represents o
            - NXP S32K11x (Cortex-M0+) and S32K14x (Cortext-M4F): Add support for NXP automotive boards.
            - XMC 4700 (Cortex-M4F)
        * Architectures with significant improvements
-           - ESP32 loadable modules support 
-           - i.MX RT: FLEXIO clock config logic. 
+           - ESP32 loadable modules support
+           - i.MX RT: FLEXIO clock config logic.
            - Fix the clock configuration for the i.MX RT family
-           - i.MX RT: Add ability to run from OCRAM 
-           - SAMA5D27 peripheral support - USB Host working 
+           - i.MX RT: Add ability to run from OCRAM
+           - SAMA5D27 peripheral support - USB Host working
            - z20x: Add W25 bootloader
            - i.MX RT: Add USB Device support
            - STM32, STM32F7, STM32H7 add SPI DMATHRESHOLD

--- a/arch/arm/src/arm/Toolchain.defs
+++ b/arch/arm/src/arm/Toolchain.defs
@@ -142,7 +142,7 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN),DEVKITARM)
   endif
 endif
 
-# Generic GNU EABI toolchain on OS X, Linux or any typical Posix system
+# Generic GNU EABI toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN),GNU_EABIL)
   CROSSDEV ?= arm-none-eabi-

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -168,7 +168,7 @@ ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),DEVKITARM)
   ARCHCPUFLAGS = -mcpu=cortex-m0 -mthumb -mfloat-abi=soft
 endif
 
-# Generic GNU EABI toolchain on OS X, Linux or any typical Posix system
+# Generic GNU EABI toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),GNU_EABIL)
   CROSSDEV ?= arm-none-eabi-

--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -160,7 +160,7 @@ ifeq ($(CONFIG_ARMV7A_TOOLCHAIN),DEVKITARM)
   endif
 endif
 
-# Generic GNU EABI toolchain on OS X, Linux or any typical Posix system
+# Generic GNU EABI toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_ARMV7A_TOOLCHAIN),GNU_EABIL)
   CROSSDEV ?= $(TARGET_ARCH)-none-eabi-

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -231,7 +231,7 @@ ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),DEVKITARM)
   ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
 
-# Generic GNU EABI toolchain on OS X, Linux or any typical Posix system
+# Generic GNU EABI toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),GNU_EABIL)
   CROSSDEV ?= arm-none-eabi-
@@ -252,7 +252,7 @@ ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),GNU_EABIW)
   endif
 endif
 
-# Clang toolchain on OS X, Linux or any typical Posix system
+# Clang toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),CLANGL)
   CROSSDEV ?= arm-none-eabi-

--- a/arch/arm/src/armv7-r/Toolchain.defs
+++ b/arch/arm/src/armv7-r/Toolchain.defs
@@ -142,7 +142,7 @@ ifeq ($(CONFIG_ARMV7R_TOOLCHAIN),DEVKITARM)
   endif
 endif
 
-# Generic GNU EABI toolchain on OS X, Linux or any typical Posix system
+# Generic GNU EABI toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_ARMV7R_TOOLCHAIN),GNU_EABIL)
   CROSSDEV ?= $(TARGET_ARCH)-none-eabi-

--- a/arch/avr/src/avr/Kconfig
+++ b/arch/avr/src/avr/Kconfig
@@ -43,7 +43,7 @@ config AVR_CROSSPACK_TOOLCHAIN
 	bool "CrossPack-AVR"
 	depends on HOST_MACOS
 	---help---
-		For OS X, the AVR CrossPack toolchain is supported:
+		For macOS, the AVR CrossPack toolchain is supported:
 		http://www.obdev.at/products/crosspack/index.html
 
 config AVR_BUILDROOT_TOOLCHAIN

--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -104,7 +104,7 @@ ifeq ($(CONFIG_AVR_TOOLCHAIN),BUILDROOT)
   LDFLAGS += -nostartfiles -nodefaultlibs
 endif
 
-# AVR CrossPack under OS X
+# AVR CrossPack under macOS
 
 ifeq ($(CONFIG_AVR_TOOLCHAIN),CROSSPACK)
   CROSSDEV ?= avr-

--- a/arch/mips/src/mips32/Kconfig
+++ b/arch/mips/src/mips32/Kconfig
@@ -59,7 +59,7 @@ config MIPS32_TOOLCHAIN_PINGUINOW
 	select ARCH_TOOLCHAIN_GNU
 
 config MIPS32_TOOLCHAIN_PINGUINOL
-	bool "Pinguino mips-elf toolchain under OS X or Linux"
+	bool "Pinguino mips-elf toolchain under macOS or Linux"
 	depends on HOST_LINUX || HOST_MACOS
 	select ARCH_TOOLCHAIN_GNU
 

--- a/arch/mips/src/mips32/Toolchain.defs
+++ b/arch/mips/src/mips32/Toolchain.defs
@@ -144,7 +144,7 @@ else
   MIPS_MICROMIPS =
 endif
 
-# Generic GNU mip32 toolchain on OS X or Linux
+# Generic GNU mip32 toolchain on macOS or Linux
 
 ifeq ($(CONFIG_MIPS32_TOOLCHAIN),GNU_ELF)
   CROSSDEV ?= mips-elf-

--- a/arch/misoc/src/lm32/Toolchain.defs
+++ b/arch/misoc/src/lm32/Toolchain.defs
@@ -84,7 +84,7 @@ ifeq ($(CONFIG_LM32_TOOLCHAIN),BUILDROOT)
   MAXOPTIMIZATION ?= -Os
 endif
 
-# Generic GNU toolchain on OS X, Linux or any typical Posix system
+# Generic GNU toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_LM32_TOOLCHAIN),GNUL)
   CROSSDEV ?= lm32-elf-

--- a/arch/or1k/src/mor1kx/Toolchain.defs
+++ b/arch/or1k/src/mor1kx/Toolchain.defs
@@ -59,7 +59,7 @@ ifeq ($(CONFIG_ARCH_OR1K_MOR1KX),y)
 else
 endif
 
-# Generic GNU or1k toolchain on OS X or Linux
+# Generic GNU or1k toolchain on macOS or Linux
 
 #ifeq ($(CONFIG_OR1K_TOOLCHAIN),GNU_ELF)
 CROSSDEV ?= or1k-elf-

--- a/arch/risc-v/src/rv32im/Toolchain.defs
+++ b/arch/risc-v/src/rv32im/Toolchain.defs
@@ -74,7 +74,7 @@ ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
   MAXOPTIMIZATION := $(CONFIG_DEBUG_OPTLEVEL)
 endif
 
-# Generic GNU RVG toolchain on OS X, Linux or any typical Posix system
+# Generic GNU RVG toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVGL)
   CROSSDEV ?= riscv64-unknown-elf-

--- a/arch/risc-v/src/rv64gc/Toolchain.defs
+++ b/arch/risc-v/src/rv64gc/Toolchain.defs
@@ -70,7 +70,7 @@ ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
   MAXOPTIMIZATION := $(CONFIG_DEBUG_OPTLEVEL)
 endif
 
-# Generic GNU RVG toolchain on OS X, Linux or any typical Posix system
+# Generic GNU RVG toolchain on macOS, Linux or any typical Posix system
 
 ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVGL)
   CROSSDEV ?= riscv64-unknown-elf-

--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -67,7 +67,7 @@ config SIM_X8664_SYSTEMV
 	bool "System V AMD64 ABI"
 	---help---
 		The calling convention of the System V AMD64 ABI is followed on Solaris,
-		Linux, FreeBSD, Mac OS X, and other UNIX-like or POSIX-compliant operating
+		Linux, FreeBSD, macOS, and other UNIX-like or POSIX-compliant operating
 		systems. The first six integer or pointer arguments are passed in registers
 		RDI, RSI, RDX, RCX, R8, and R9, while XMM0, XMM1, XMM2, XMM3, XMM4, XMM5,
 		XMM6 and XMM7 are used for floating point arguments. For system calls, R10

--- a/arch/sim/src/sim/up_setjmp64.S
+++ b/arch/sim/src/sim/up_setjmp64.S
@@ -57,7 +57,7 @@
 #  define REGS %rcx
 
 /* The calling convention of the System V AMD64 ABI is followed on Solaris,
- * Linux, FreeBSD, Mac OS X, and other UNIX-like or POSIX-compliant operating
+ * Linux, FreeBSD, macOS, and other UNIX-like or POSIX-compliant operating
  * systems. The first six integer or pointer arguments are passed in registers
  * RDI, RSI, RDX, RCX, R8, and R9, while XMM0, XMM1, XMM2, XMM3, XMM4, XMM5,
  * XMM6 and XMM7 are used for floating point arguments. For system calls, R10

--- a/boards/arm/am335x/beaglebone-black/scripts/Make.defs
+++ b/boards/arm/am335x/beaglebone-black/scripts/Make.defs
@@ -41,7 +41,7 @@ include ${TOPDIR}/arch/arm/src/armv7-a/Toolchain.defs
 
 LDSCRIPT = sdram.ld
 
-# Setup for Windows vs Linux/Cygwin/OSX environments
+# Setup for Windows vs Linux/Cygwin/macOS environments
 
 ifeq ($(WINTOOL),y)
   # Windows-native toolchains

--- a/boards/arm/samv7/same70-xplained/README.txt
+++ b/boards/arm/samv7/same70-xplained/README.txt
@@ -1087,7 +1087,7 @@ Debugging
 
   This is a simple command line utility for programming ARM-based MCUs
   (currently only Atmel) though CMSIS-DAP SWD interface. It works on Linux,
-  Mac OS X and Windows.  Very useful to around especially if you have the
+  macOS and Windows.  Very useful to around especially if you have the
   following issue:
 
   Booting to FLASH or the ROM Bootloader

--- a/boards/arm/stm32/stm32vldiscovery/README.txt
+++ b/boards/arm/stm32/stm32vldiscovery/README.txt
@@ -215,4 +215,4 @@ Where <subdir> is one of the following:
 
     Default toolchain:
 
-    CONFIG_ARMV7M_TOOLCHAIN_CODESOURCERYL=y  : CodeSourcery under Linux / Mac OS X
+    CONFIG_ARMV7M_TOOLCHAIN_CODESOURCERYL=y  : CodeSourcery under Linux / macOS

--- a/boards/avr/at32uc3/avr32dev1/README.txt
+++ b/boards/avr/at32uc3/avr32dev1/README.txt
@@ -112,7 +112,7 @@ PA17 and PA23 are available from the AVR32DEV1:
 Development Environment
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-  Linux, Mac OS X or Cygwin on Windows can be used for the development environment.
+  Linux, macOS or Cygwin on Windows can be used for the development environment.
   The source has been built only using the GNU toolchain (see below).  Other
   toolchains will likely cause problems. Testing was performed using the Cygwin
   environment.
@@ -142,7 +142,7 @@ WinAVR:
 
 AVR32 Toolchain Builder:
 
-  A third option is to build the toolchain yourself. For OS X and Linux systems,
+  A third option is to build the toolchain yourself. For macOS and Linux systems,
   this Makefile will build a complete gcc-4.4.3 toolchain:
 
     https://github.com/jsnyder/avr32-toolchain

--- a/boards/avr/at90usb/micropendous3/README.txt
+++ b/boards/avr/at90usb/micropendous3/README.txt
@@ -241,9 +241,9 @@ Linux:
   After configuring NuttX, make sure that CONFIG_AVR_LINUXGCC_TOOLCHAIN=y is set in your
   .config file.
 
-Mac OS X:
+macOS:
 
-  For Mac OS X, the CrossPack for AVR toolchain is available from:
+  For macOS, the CrossPack for AVR toolchain is available from:
 
     http://www.obdev.at/products/crosspack/index.html
 

--- a/boards/avr/at90usb/teensy-2.0/README.txt
+++ b/boards/avr/at90usb/teensy-2.0/README.txt
@@ -250,9 +250,9 @@ Linux:
   After configuring NuttX, make sure that CONFIG_AVR_LINUXGCC_TOOLCHAIN=y is set in your
   .config file.
 
-Mac OS X:
+macOS:
 
-  For Mac OS X, the CrossPack for AVR toolchain is available from:
+  For macOS, the CrossPack for AVR toolchain is available from:
 
     http://www.obdev.at/products/crosspack/index.html
 

--- a/boards/avr/atmega/amber/README.txt
+++ b/boards/avr/atmega/amber/README.txt
@@ -228,9 +228,9 @@ Linux:
   After configuring NuttX, make sure that CONFIG_AVR_LINUXGCC_TOOLCHAIN=y is set in your
   .config file.
 
-Mac OS X:
+macOS:
 
-  For Mac OS X, the CrossPack for AVR toolchain is available from:
+  For macOS, the CrossPack for AVR toolchain is available from:
 
     http://www.obdev.at/products/crosspack/index.html
 

--- a/boards/avr/atmega/moteino-mega/README.txt
+++ b/boards/avr/atmega/moteino-mega/README.txt
@@ -123,7 +123,7 @@ the toolchain on the make commandline with CONFIG_AVR_TOOLCHAIN=<toolchain>.
 
 The valid values for <toolchain> are BUILDROOT, CROSSPACK, LINUXGCC and WINAVR.
 
-This port was tested using the OS X / CROSSPACK tool chain, GCC version 4.8.1.
+This port was tested using the macOS / CROSSPACK tool chain, GCC version 4.8.1.
 Please see other NuttX documentation for toolchain details.
 
 MoteinoMEGA Configuration Options

--- a/boards/mips/pic32mx/mirtoo/README.txt
+++ b/boards/mips/pic32mx/mirtoo/README.txt
@@ -395,7 +395,7 @@ Toolchains
   mips-elf toolchain:
 
     CONFIG_MIPS32_TOOLCHAIN_PINGUINOW - Pinguino mips-elf toolchain for Windows
-    CONFIG_MIPS32_TOOLCHAIN_GNU_ELF   - mips-elf toolchain for Linux or OS X
+    CONFIG_MIPS32_TOOLCHAIN_GNU_ELF   - mips-elf toolchain for Linux or macOS
 
   And set the path appropriately in the PATH environment variable.  These tool
   configurations are untested -- expect some additional integration issues.


### PR DESCRIPTION
Mac OS X was renamed to macOS at some point. Update references to OSX, OS X, Mac OS X, Mac OSX, and other permutations, to macOS, in README files and in comments of other files.