### PR TITLE
arch/arm/src/armv8-m:  Rename files to correspond to naming conventions.

### DIFF
--- a/arch/arm/src/armv7-m/ram_vectors.h
+++ b/arch/arm/src/armv7-m/ram_vectors.h
@@ -52,7 +52,7 @@
 /* If CONFIG_ARCH_RAMVECTORS is defined, then the ARM logic must provide
  * ARM-specific implementations of irq_initialize(), irq_attach(), and
  * irq_dispatch.  In this case, it is also assumed that the ARM vector
- * table resides in RAM, has the name up_ram_vectors, and has been
+ * table resides in RAM, has the name g_ram_vectors, and has been
  * properly positioned and aligned in memory by the linker script.
  *
  * REVISIT: Can this alignment requirement vary from core-to-core?  Yes, it

--- a/arch/arm/src/armv7-m/up_ramvec_initialize.c
+++ b/arch/arm/src/armv7-m/up_ramvec_initialize.c
@@ -88,7 +88,7 @@
 /* If CONFIG_ARCH_RAMVECTORS is defined, then the ARM logic must provide
  * ARM-specific implementations of up_ramvec_initialize(), irq_attach(), and
  * irq_dispatch.  In this case, it is also assumed that the ARM vector
- * table resides in RAM, has the name up_ram_vectors, and has been
+ * table resides in RAM, has the name g_ram_vectors, and has been
  * properly positioned and aligned in memory by the linker script.
  *
  * REVISIT: Can this alignment requirement vary from core-to-core?  Yes, it

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -159,7 +159,7 @@ static inline void up_registerdump(void)
     {
       /* No.. capture user registers by hand */
 
-      up_saveusercontext(s_last_regs);
+      arm_saveusercontext(s_last_regs);
       regs = s_last_regs;
     }
 

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_assert.c
+ * arch/arm/src/armv8-m/arm_assert.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_blocktask.c
+++ b/arch/arm/src/armv8-m/arm_blocktask.c
@@ -135,9 +135,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv8-m/arm_blocktask.c
+++ b/arch/arm/src/armv8-m/arm_blocktask.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_blocktask.c
+ * arch/arm/src/armv8-m/arm_blocktask.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_cache.c
+++ b/arch/arm/src/armv8-m/arm_cache.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_cache.c
+ * arch/arm/src/armv8-m/arm_cache.c
  *
  *   Copyright (C) 2015, 2018-2019 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/arm/src/armv8-m/arm_doirq.c
+++ b/arch/arm/src/armv8-m/arm_doirq.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_doirq.c
+ * arch/arm/src/armv8-m/arm_doirq.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_exception.S
+++ b/arch/arm/src/armv8-m/arm_exception.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv8-m/gnu/up_exception.S
+ * arch/arm/src/armv8-m/gnu/arm_exception.S
  *
  *   Copyright (C) 2009-2013, 2015-2016, 2018 Gregory Nutt. All rights reserved.
  *   Copyright (C) 2012 Michael Smith. All rights reserved.
@@ -88,7 +88,7 @@
 
 	.syntax		unified
 	.thumb
-	.file		"up_exception.S"
+	.file		"arm_exception.S"
 
 /************************************************************************************
  * Macro Definitions

--- a/arch/arm/src/armv8-m/arm_fetchadd.S
+++ b/arch/arm/src/armv8-m/arm_fetchadd.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/gnu/up_fetchadd.S
+ * arch/arm/src/armv8-m/gnu/arm_fetchadd.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -26,7 +26,7 @@
 
 	.syntax		unified
 	.thumb
-	.file	"up_fetchadd.S"
+	.file	"arm_fetchadd.S"
 
 /****************************************************************************
  * Public Functions

--- a/arch/arm/src/armv8-m/arm_fpu.S
+++ b/arch/arm/src/armv8-m/arm_fpu.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv8-m/gnu/up_fpu.S
+ * arch/arm/src/armv8-m/gnu/arm_fpu.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -46,7 +46,7 @@
 
 	.syntax		unified
 	.thumb
-	.file		"up_fpu.S"
+	.file		"arm_fpu.S"
 
 /************************************************************************************
  * Public Functions

--- a/arch/arm/src/armv8-m/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv8-m/arm_fullcontextrestore.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv8-m/gnu/up_saveusercontext.S
+ * arch/arm/src/armv8-m/gnu/arm_fullcontextrestore.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -38,7 +38,7 @@
 
 	.syntax	unified
 	.thumb
-	.file	"up_saveusercontext.S"
+	.file	"arm_fullcontextrestore.S"
 
 /************************************************************************************
  * Macros
@@ -49,40 +49,31 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_saveusercontext
+ * Name: arm_fullcontextrestore
  *
  * Description:
- *   Save the current thread context.  Full prototype is:
+ *   Restore the current thread context.  Full prototype is:
  *
- *   int  up_saveusercontext(uint32_t *saveregs);
+ *   void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  *
  * Returned Value:
- *   0: Normal return
- *   1: Context switch return
+ *   None
  *
  ************************************************************************************/
 
-	.text
 	.thumb_func
-	.globl	up_saveusercontext
-	.type	up_saveusercontext, function
-up_saveusercontext:
+	.globl	arm_fullcontextrestore
+	.type	arm_fullcontextrestore, function
+arm_fullcontextrestore:
 
-	/* Perform the System call with R0=0 and R1=regs */
+	/* Perform the System call with R0=1 and R1=regs */
 
-	mov		r1, r0					/* R1: regs */
-	mov		r0, #SYS_save_context	/* R0: save context (also return value) */
-	svc		0						/* Force synchronous SVCall (or Hard Fault) */
+	mov		r1, r0						/* R1: regs */
+	mov		r0, #SYS_restore_context	/* R0: restore context */
+	svc		0							/* Force synchronous SVCall (or Hard Fault) */
 
-	/* There are two return conditions.  On the first return, R0 (the
-	 * return value will be zero.  On the second return we need to
-	 * force R0 to be 1.
-	 */
+	/* This call should not return */
 
-	add		r2, r1, #(4*REG_R0)
-	mov		r3, #1
-	str		r3, [r2, #0]
-	bx		lr						/* "normal" return with r0=0 or
-									 * context switch with r0=1 */
-	.size	up_saveusercontext, .-up_saveusercontext
+	bx		lr							/* Unnecessary ... will not return */
+	.size	arm_fullcontextrestore, .-arm_fullcontextrestore
 	.end

--- a/arch/arm/src/armv8-m/arm_hardfault.c
+++ b/arch/arm/src/armv8-m/arm_hardfault.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_hardfault.c
+ * arch/arm/src/armv8-m/arm_hardfault.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_initialstate.c
+ * arch/arm/src/armv8-m/arm_initialstate.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_itm.c
+++ b/arch/arm/src/armv8-m/arm_itm.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_itm.c
+ * arch/arm/src/armv8-m/arm_itm.c
  *
  *   Copyright (c) 2009 - 2013 ARM LIMITED
  *

--- a/arch/arm/src/armv8-m/arm_itm_syslog.c
+++ b/arch/arm/src/armv8-m/arm_itm_syslog.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_itm_syslog.c
+ * arch/arm/src/armv8-m/arm_itm_syslog.c
  *
  *   Copyright (C) 2014 Pierre-noel Bouteville . All rights reserved.
  *   Copyright (C) 2014, 2016 Gregory Nutt. All rights reserved.

--- a/arch/arm/src/armv8-m/arm_lazyexception.S
+++ b/arch/arm/src/armv8-m/arm_lazyexception.S
@@ -71,7 +71,7 @@
 
 	.syntax		unified
 	.thumb
-	.file		"up_lazyexception.S"
+	.file		"arm_lazyexception.S"
 
 /************************************************************************************************
  * Macro Definitions

--- a/arch/arm/src/armv8-m/arm_memfault.c
+++ b/arch/arm/src/armv8-m/arm_memfault.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_memfault.c
+ * arch/arm/src/armv8-m/arm_memfault.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * arch/arm/src/armv8-m/up_mpu.c
+ * arch/arm/src/armv8-m/arm_mpu.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_ramvec_attach.c
+++ b/arch/arm/src/armv8-m/arm_ramvec_attach.c
@@ -43,7 +43,7 @@
 void exception_common(void);
 
 /****************************************************************************
- * Name: up_ramvec_attach
+ * Name: arm_ramvec_attach
  *
  * Description:
  *   Configure the ram vector table so that IRQ number 'irq' will be
@@ -51,7 +51,7 @@ void exception_common(void);
  *
  ****************************************************************************/
 
-int up_ramvec_attach(int irq, up_vector_t vector)
+int arm_ramvec_attach(int irq, up_vector_t vector)
 {
   int ret = -EINVAL;
 

--- a/arch/arm/src/armv8-m/arm_ramvec_initialize.c
+++ b/arch/arm/src/armv8-m/arm_ramvec_initialize.c
@@ -86,9 +86,9 @@
  ****************************************************************************/
 
 /* If CONFIG_ARCH_RAMVECTORS is defined, then the ARM logic must provide
- * ARM-specific implementations of up_ramvec_initialize(), irq_attach(), and
+ * ARM-specific implementations of arm_ramvec_initialize(), irq_attach(), and
  * irq_dispatch.  In this case, it is also assumed that the ARM vector
- * table resides in RAM, has the name up_ram_vectors, and has been
+ * table resides in RAM, has the name g_ram_vectors, and has been
  * properly positioned and aligned in memory by the linker script.
  *
  * REVISIT: Can this alignment requirement vary from core-to-core?  Yes, it
@@ -105,14 +105,14 @@ up_vector_t g_ram_vectors[ARMV8M_VECTAB_SIZE]
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_ramvec_initialize
+ * Name: arm_ramvec_initialize
  *
  * Description:
  *   Copy vectors to RAM an configure the NVIC to use the RAM vectors.
  *
  ****************************************************************************/
 
-void up_ramvec_initialize(void)
+void arm_ramvec_initialize(void)
 {
   const up_vector_t *src;
   up_vector_t *dest;

--- a/arch/arm/src/armv8-m/arm_ramvec_initialize.c
+++ b/arch/arm/src/armv8-m/arm_ramvec_initialize.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_ramvec_initialize.c
+ * arch/arm/src/armv8-m/arm_ramvec_initialize.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_releasepending.c
+++ b/arch/arm/src/armv8-m/arm_releasepending.c
@@ -108,9 +108,9 @@ void up_release_pending(void)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv8-m/arm_reprioritizertr.c
+++ b/arch/arm/src/armv8-m/arm_reprioritizertr.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  arch/arm/src/armv8-m/up_reprioritizertr.c
+ *  arch/arm/src/armv8-m/arm_reprioritizertr.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_reprioritizertr.c
+++ b/arch/arm/src/armv8-m/arm_reprioritizertr.c
@@ -160,9 +160,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * ready to run list.
                */
 
-              up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+              arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-              /* up_switchcontext forces a context switch to the task at the
+              /* arm_switchcontext forces a context switch to the task at the
                * head of the ready-to-run list.  It does not 'return' in the
                * normal sense.  When it does return, it is because the
                * blocked task is again ready to run and has execution

--- a/arch/arm/src/armv8-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv8-m/arm_saveusercontext.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv8-m/gnu/up_switchcontext.S
+ * arch/arm/src/armv8-m/gnu/arm_saveusercontext.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -38,7 +38,7 @@
 
 	.syntax	unified
 	.thumb
-	.file	"up_switchcontext.S"
+	.file	"arm_saveusercontext.S"
 
 /************************************************************************************
  * Macros
@@ -49,33 +49,40 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_switchcontext
+ * Name: arm_saveusercontext
  *
  * Description:
- *   Save the current thread context and restore the specified context.
- *   Full prototype is:
+ *   Save the current thread context.  Full prototype is:
  *
- *   void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ *   int  arm_saveusercontext(uint32_t *saveregs);
  *
  * Returned Value:
- *   None
+ *   0: Normal return
+ *   1: Context switch return
  *
  ************************************************************************************/
 
+	.text
 	.thumb_func
-	.globl	up_switchcontext
-	.type	up_switchcontext, function
-up_switchcontext:
+	.globl	arm_saveusercontext
+	.type	arm_saveusercontext, function
+arm_saveusercontext:
 
-	/* Perform the System call with R0=1, R1=saveregs, R2=restoreregs */
+	/* Perform the System call with R0=0 and R1=regs */
 
-	mov		r2, r1					/* R2: restoreregs */
-	mov		r1, r0					/* R1: saveregs */
-	mov		r0, #SYS_switch_context	/* R0: context switch */
+	mov		r1, r0					/* R1: regs */
+	mov		r0, #SYS_save_context	/* R0: save context (also return value) */
 	svc		0						/* Force synchronous SVCall (or Hard Fault) */
 
-	/* We will get here only after the rerturn from the context switch */
+	/* There are two return conditions.  On the first return, R0 (the
+	 * return value will be zero.  On the second return we need to
+	 * force R0 to be 1.
+	 */
 
-	bx		lr
-	.size	up_switchcontext, .-up_switchcontext
+	add		r2, r1, #(4*REG_R0)
+	mov		r3, #1
+	str		r3, [r2, #0]
+	bx		lr						/* "normal" return with r0=0 or
+									 * context switch with r0=1 */
+	.size	arm_saveusercontext, .-arm_saveusercontext
 	.end

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_schedulesigaction.c
+ * arch/arm/src/armv8-m/arm_schedulesigaction.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_setjmp.S
+++ b/arch/arm/src/armv8-m/arm_setjmp.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv8-m/gnu/up_setjmp.S
+ * arch/arm/src/armv8-m/gnu/arm_setjmp.S
  *
  *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
  *   Author: David S. Alessio <David@DSA.Consulting>

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_sigdeliver.c
+ * arch/arm/src/armv8-m/arm_sigdeliver.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -123,7 +123,7 @@ void up_sigdeliver(void)
    * errno that is needed by the user logic (it is probably EINTR).
    *
    * I would prefer that all interrupts are disabled when
-   * up_fullcontextrestore() is called, but that may not be necessary.
+   * arm_fullcontextrestore() is called, but that may not be necessary.
    */
 
   sinfo("Resuming\n");
@@ -192,5 +192,5 @@ void up_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
-  up_fullcontextrestore(regs);
+  arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv8-m/arm_signal_dispatch.c
+++ b/arch/arm/src/armv8-m/arm_signal_dispatch.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_signal_dispatch.c
+ * arch/arm/src/armv8-m/arm_signal_dispatch.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_signal_handler.S
+++ b/arch/arm/src/armv8-m/arm_signal_handler.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/gnu/up_testset.S
+ * arch/arm/src/armv8-m/gnu/arm_signal_handler.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -23,86 +23,81 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <arch/spinlock.h>
+
+#include <arch/syscall.h>
+
+#if defined(CONFIG_BUILD_PROTECTED) && !defined(__KERNEL__)
+
+/****************************************************************************
+ * File info
+ ****************************************************************************/
 
 	.syntax		unified
 	.thumb
-	.file	"up_testset.S"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Public Symbols
- ****************************************************************************/
-
-	.globl	up_testset
-
-/****************************************************************************
- * Assembly Macros
- ****************************************************************************/
+	.cpu		cortex-m3
+	.file		"arm_signal_handler.S"
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-	.text
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_testset
+ * Name: up_signal_handler
  *
  * Description:
- *   Perform an atomic test and set operation on the provided spinlock.
+ *   This function is the user-space, signal handler trampoline function.  It
+ *   is called from up_signal_dispatch() in user-mode.
  *
- *   This function must be provided via the architecture-specific logic.
+ *     R0-R3, R11 - volatile registers need not be preserved.
+ *     R4-R10 - static registers must be preserved
+ *     R12-R14 - LR and SP must be preserved
  *
  * Input Parameters:
- *   lock - The address of spinlock object.
+ *   R0 = sighand
+ *     The address user-space signal handling function
+ *   R1-R3 = signo, info, and ucontext
+ *     Standard arguments to be passed to the signal handling function.
  *
  * Returned Value:
- *   The spinlock is always locked upon return.  The value of previous value
- *   of the spinlock variable is returned, either SP_LOCKED if the spinlock
- *   as previously locked (meaning that the test-and-set operation failed to
- *   obtain the lock) or SP_UNLOCKED if the spinlock was previously unlocked
- *   (meaning that we successfully obtained the lock)
+ *   None.  This function does not return in the normal sense.  It returns
+ *   via the SYS_signal_handler_return (see svcall.h)
  *
  ****************************************************************************/
 
-	.globl	up_testset
-	.type	up_testset, %function
+	.text
+	.thumb_func
+	.globl	up_signal_handler
+	.type	up_signal_handler, function
+up_signal_handler:
 
-up_testset:
+	/* Save some register */
 
-	mov		r1, #SP_LOCKED
+	push	{lr}			/* Save LR on the stack */
 
-	/* Test if the spinlock is locked or not */
+	/* Call the signal handler */
 
-1:
-	ldrexb	r2, [r0]			/* Test if spinlock is locked or not */
-	cmp		r2, r1				/* Already locked? */
-	beq		2f					/* If already locked, return SP_LOCKED */
+	mov		ip, r0			/* IP=sighand */
+	mov		r0, r1			/* R0=signo */
+	mov		r1, r2			/* R1=info */
+	mov		r2, r3			/* R2=ucontext */
+	blx		ip				/* Call the signal handler */
 
-	/* Not locked ... attempt to lock it */
+	/* Restore the registers */
 
-	strexb	r2, r1, [r0]		/* Attempt to set the locked state */
-	cmp		r2, r1				/* r2 will be 1 is strexb failed */
-	beq		1b					/* Failed to lock... try again */
+	pop		{r2}			/* Recover LR in R2 */
+	mov		lr, r2			/* Restore LR */
 
-	/* Lock acquired -- return SP_UNLOCKED */
+	/* Execute the SYS_signal_handler_return SVCall (will not return) */
 
-	dmb							/* Required before accessing protected resource */
-	mov		r0, #SP_UNLOCKED
-	bx		lr
+	mov		r0, #SYS_signal_handler_return
+	svc		0
+	nop
 
-	/* Lock not acquired -- return SP_LOCKED */
-
-2:
-	mov		r0, #SP_LOCKED
-	bx		lr
-	.size	up_testset, . - up_testset
+	.size	up_signal_handler, .-up_signal_handler
 	.end
+
+#endif /* CONFIG_BUILD_PROTECTED && !__KERNEL__ */

--- a/arch/arm/src/armv8-m/arm_stackcheck.c
+++ b/arch/arm/src/armv8-m/arm_stackcheck.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_stackcheck.c
+ * arch/arm/src/armv8-m/arm_stackcheck.c
  *
  *   Copyright (c) 2013, 2014 PX4 Development Team. All rights reserved.
  *

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -163,7 +163,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
     {
       /* R0=SYS_save_context:  This is a save context command:
        *
-       *   int up_saveusercontext(uint32_t *saveregs);
+       *   int arm_saveusercontext(uint32_t *saveregs);
        *
        * At this point, the following values are saved in context:
        *
@@ -186,7 +186,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_restore_context:  This a restore context command:
        *
-       *   void up_fullcontextrestore(uint32_t *restoreregs)
+       *   void arm_fullcontextrestore(uint32_t *restoreregs)
        *          noreturn_function;
        *
        * At this point, the following values are saved in context:
@@ -210,7 +210,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_switch_context:  This a switch context command:
        *
-       *   void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+       *   void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
        *
        * At this point, the following values are saved in context:
        *
@@ -237,7 +237,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_syscall_return:  This a syscall return command:
        *
-       *   void up_syscall_return(void);
+       *   void arm_syscall_return(void);
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_svcall.c
+ * arch/arm/src/armv8-m/arm_svcall.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_switchcontext.S
+++ b/arch/arm/src/armv8-m/arm_switchcontext.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv8-m/gnu/up_fullcontextrestore.S
+ * arch/arm/src/armv8-m/gnu/arm_switchcontext.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -38,7 +38,7 @@
 
 	.syntax	unified
 	.thumb
-	.file	"up_fullcontextrestore.S"
+	.file	"arm_switchcontext.S"
 
 /************************************************************************************
  * Macros
@@ -49,12 +49,13 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_fullcontextrestore
+ * Name: arm_switchcontext
  *
  * Description:
- *   Restore the current thread context.  Full prototype is:
+ *   Save the current thread context and restore the specified context.
+ *   Full prototype is:
  *
- *   void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ *   void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  *
  * Returned Value:
  *   None
@@ -62,18 +63,19 @@
  ************************************************************************************/
 
 	.thumb_func
-	.globl	up_fullcontextrestore
-	.type	up_fullcontextrestore, function
-up_fullcontextrestore:
+	.globl	arm_switchcontext
+	.type	arm_switchcontext, function
+arm_switchcontext:
 
-	/* Perform the System call with R0=1 and R1=regs */
+	/* Perform the System call with R0=1, R1=saveregs, R2=restoreregs */
 
-	mov		r1, r0						/* R1: regs */
-	mov		r0, #SYS_restore_context	/* R0: restore context */
-	svc		0							/* Force synchronous SVCall (or Hard Fault) */
+	mov		r2, r1					/* R2: restoreregs */
+	mov		r1, r0					/* R1: saveregs */
+	mov		r0, #SYS_switch_context	/* R0: context switch */
+	svc		0						/* Force synchronous SVCall (or Hard Fault) */
 
-	/* This call should not return */
+	/* We will get here only after the rerturn from the context switch */
 
-	bx		lr							/* Unnecessary ... will not return */
-	.size	up_fullcontextrestore, .-up_fullcontextrestore
+	bx		lr
+	.size	arm_switchcontext, .-arm_switchcontext
 	.end

--- a/arch/arm/src/armv8-m/arm_systemreset.c
+++ b/arch/arm/src/armv8-m/arm_systemreset.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_systemreset.c
+ * arch/arm/src/armv8-m/arm_systemreset.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_systick.c
+++ b/arch/arm/src/armv8-m/arm_systick.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_systick.c
+ * arch/arm/src/armv8-m/arm_systick.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/armv8-m/arm_testset.S
+++ b/arch/arm/src/armv8-m/arm_testset.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/gnu/up_signal_handler.S
+ * arch/arm/src/armv8-m/gnu/arm_testset.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -23,81 +23,86 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-
-#include <arch/syscall.h>
-
-#if defined(CONFIG_BUILD_PROTECTED) && !defined(__KERNEL__)
-
-/****************************************************************************
- * File info
- ****************************************************************************/
+#include <arch/spinlock.h>
 
 	.syntax		unified
 	.thumb
-	.cpu		cortex-m3
-	.file		"up_signal_handler.S"
+	.file	"arm_testset.S"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl	up_testset
+
+/****************************************************************************
+ * Assembly Macros
+ ****************************************************************************/
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+	.text
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_signal_handler
+ * Name: up_testset
  *
  * Description:
- *   This function is the user-space, signal handler trampoline function.  It
- *   is called from up_signal_dispatch() in user-mode.
+ *   Perform an atomic test and set operation on the provided spinlock.
  *
- *     R0-R3, R11 - volatile registers need not be preserved.
- *     R4-R10 - static registers must be preserved
- *     R12-R14 - LR and SP must be preserved
+ *   This function must be provided via the architecture-specific logic.
  *
  * Input Parameters:
- *   R0 = sighand
- *     The address user-space signal handling function
- *   R1-R3 = signo, info, and ucontext
- *     Standard arguments to be passed to the signal handling function.
+ *   lock - The address of spinlock object.
  *
  * Returned Value:
- *   None.  This function does not return in the normal sense.  It returns
- *   via the SYS_signal_handler_return (see svcall.h)
+ *   The spinlock is always locked upon return.  The value of previous value
+ *   of the spinlock variable is returned, either SP_LOCKED if the spinlock
+ *   as previously locked (meaning that the test-and-set operation failed to
+ *   obtain the lock) or SP_UNLOCKED if the spinlock was previously unlocked
+ *   (meaning that we successfully obtained the lock)
  *
  ****************************************************************************/
 
-	.text
-	.thumb_func
-	.globl	up_signal_handler
-	.type	up_signal_handler, function
-up_signal_handler:
+	.globl	up_testset
+	.type	up_testset, %function
 
-	/* Save some register */
+up_testset:
 
-	push	{lr}			/* Save LR on the stack */
+	mov		r1, #SP_LOCKED
 
-	/* Call the signal handler */
+	/* Test if the spinlock is locked or not */
 
-	mov		ip, r0			/* IP=sighand */
-	mov		r0, r1			/* R0=signo */
-	mov		r1, r2			/* R1=info */
-	mov		r2, r3			/* R2=ucontext */
-	blx		ip				/* Call the signal handler */
+1:
+	ldrexb	r2, [r0]			/* Test if spinlock is locked or not */
+	cmp		r2, r1				/* Already locked? */
+	beq		2f					/* If already locked, return SP_LOCKED */
 
-	/* Restore the registers */
+	/* Not locked ... attempt to lock it */
 
-	pop		{r2}			/* Recover LR in R2 */
-	mov		lr, r2			/* Restore LR */
+	strexb	r2, r1, [r0]		/* Attempt to set the locked state */
+	cmp		r2, r1				/* r2 will be 1 is strexb failed */
+	beq		1b					/* Failed to lock... try again */
 
-	/* Execute the SYS_signal_handler_return SVCall (will not return) */
+	/* Lock acquired -- return SP_UNLOCKED */
 
-	mov		r0, #SYS_signal_handler_return
-	svc		0
-	nop
+	dmb							/* Required before accessing protected resource */
+	mov		r0, #SP_UNLOCKED
+	bx		lr
 
-	.size	up_signal_handler, .-up_signal_handler
+	/* Lock not acquired -- return SP_LOCKED */
+
+2:
+	mov		r0, #SP_LOCKED
+	bx		lr
+	.size	up_testset, . - up_testset
 	.end
-
-#endif /* CONFIG_BUILD_PROTECTED && !__KERNEL__ */

--- a/arch/arm/src/armv8-m/arm_unblocktask.c
+++ b/arch/arm/src/armv8-m/arm_unblocktask.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  arch/arm/src/armv8-m/up_releasepending.c
+ *  arch/arm/src/armv8-m/arm_unblocktask.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -30,6 +30,7 @@
 #include <nuttx/sched.h>
 
 #include "sched/sched.h"
+#include "clock/clock.h"
 #include "up_internal.h"
 
 /****************************************************************************
@@ -37,47 +38,57 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_release_pending
+ * Name: up_unblock_task
  *
  * Description:
- *   Release and ready-to-run tasks that have
- *   collected in the pending task list.  This can call a
- *   context switch if a new task is placed at the head of
- *   the ready to run list.
+ *   A task is currently in an inactive task list
+ *   but has been prepped to execute.  Move the TCB to the
+ *   ready-to-run list, restore its context, and start execution.
+ *
+ * Input Parameters:
+ *   tcb: Refers to the tcb to be unblocked.  This tcb is
+ *     in one of the waiting tasks lists.  It must be moved to
+ *     the ready-to-run list and, if it is the highest priority
+ *     ready to run task, executed.
  *
  ****************************************************************************/
 
-void up_release_pending(void)
+void up_unblock_task(struct tcb_s *tcb)
 {
   struct tcb_s *rtcb = this_task();
 
-  sinfo("From TCB=%p\n", rtcb);
+  /* Verify that the context switch can be performed */
 
-  /* Merge the g_pendingtasks list into the ready-to-run task list */
+  DEBUGASSERT((tcb->task_state >= FIRST_BLOCKED_STATE) &&
+              (tcb->task_state <= LAST_BLOCKED_STATE));
 
-#if 0
-  sched_lock();
-#endif
+  /* Remove the task from the blocked task list */
 
-  if (sched_mergepending())
+  sched_removeblocked(tcb);
+
+  /* Add the task in the correct location in the prioritized
+   * ready-to-run task list
+   */
+
+  if (sched_addreadytorun(tcb))
     {
-      /* The currently active task has changed!  We will need to switch
-       * contexts.
+      /* The currently active task has changed! We need to do
+       * a context switch to the new task.
        */
 
       /* Update scheduler parameters */
 
       sched_suspend_scheduler(rtcb);
 
-      /* Are we operating in interrupt context? */
+      /* Are we in an interrupt handler? */
 
       if (CURRENT_REGS)
         {
-          /* Yes, then we have to do things differently. Just copy the
-           * CURRENT_REGS into the OLD rtcb.
+          /* Yes, then we have to do things differently.
+           * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+          up_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/arm/src/armv8-m/arm_unblocktask.c
+++ b/arch/arm/src/armv8-m/arm_unblocktask.c
@@ -119,9 +119,9 @@ void up_unblock_task(struct tcb_s *tcb)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv8-m/arm_vectors.c
+++ b/arch/arm/src/armv8-m/arm_vectors.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv8-m/up_vectors.c
+ * arch/arm/src/armv8-m/arm_vectors.c
  *
  *   Copyright (C) 2012 Michael Smith. All rights reserved.
  *

--- a/arch/arm/src/armv8-m/ram_vectors.h
+++ b/arch/arm/src/armv8-m/ram_vectors.h
@@ -52,7 +52,7 @@
 /* If CONFIG_ARCH_RAMVECTORS is defined, then the ARM logic must provide
  * ARM-specific implementations of irq_initialize(), irq_attach(), and
  * irq_dispatch.  In this case, it is also assumed that the ARM vector
- * table resides in RAM, has the name up_ram_vectors, and has been
+ * table resides in RAM, has the name g_ram_vectors, and has been
  * properly positioned and aligned in memory by the linker script.
  *
  * REVISIT: Can this alignment requirement vary from core-to-core?  Yes, it
@@ -69,14 +69,14 @@ extern up_vector_t g_ram_vectors[ARMV8M_VECTAB_SIZE]
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_ramvec_initialize
+ * Name: arm_ramvec_initialize
  *
  * Description:
  *   Copy vectors to RAM an configure the NVIC to use the RAM vectors.
  *
  ****************************************************************************/
 
-void up_ramvec_initialize(void);
+void arm_ramvec_initialize(void);
 
 /****************************************************************************
  * Name: exception_common
@@ -89,7 +89,7 @@ void up_ramvec_initialize(void);
 void exception_common(void);
 
 /****************************************************************************
- * Name: up_ramvec_attach
+ * Name: arm_ramvec_attach
  *
  * Description:
  *   Configure the ram vector table so that IRQ number 'irq' will be
@@ -97,7 +97,7 @@ void exception_common(void);
  *
  ****************************************************************************/
 
-int up_ramvec_attach(int irq, up_vector_t vector);
+int arm_ramvec_attach(int irq, up_vector_t vector);
 
 #endif /* CONFIG_ARCH_RAMVECTORS */
 #endif /* __ARCH_ARM_SRC_COMMON_ARMV8_M_RAM_VECTORS_H */

--- a/arch/arm/src/armv8-m/svcall.h
+++ b/arch/arm/src/armv8-m/svcall.h
@@ -62,21 +62,21 @@
 
 /* SYS call 0:
  *
- * int up_saveusercontext(uint32_t *saveregs);
+ * int arm_saveusercontext(uint32_t *saveregs);
  */
 
 #define SYS_save_context          (0)
 
 /* SYS call 1:
  *
- * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_restore_context       (1)
 
 /* SYS call 2:
  *
- * void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ * void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  */
 
 #define SYS_switch_context        (2)
@@ -84,7 +84,7 @@
 #ifdef CONFIG_LIB_SYSCALL
 /* SYS call 3:
  *
- * void up_syscall_return(void);
+ * void arm_syscall_return(void);
  */
 
 #define SYS_syscall_return        (3)


### PR DESCRIPTION
This files in the arch/arm/src/armv8-m directory were cloned from arch/arm/src/armv7-m.  Naming standards were created for the architecture files, function, and variable names:  https://cwiki.apache.org/confluence/display/NUTTX/Naming+FAQ

There however were never appliced to arch/arm/src/armv7-m and so this bad naming was inherited by arch/arm/src/armv8-m.  This commit corrects the file naming only and makes it compliant with the Naming FAQ.
