### PR TITLE
Fix warning syslog/rpmsg warning

### DIFF
--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -90,7 +90,8 @@ static const struct syslog_channel_s g_default_channel =
 {
   syslog_rpmsg_putc,
   syslog_rpmsg_putc,
-  syslog_default_flush
+  syslog_rpmsg_flush,
+  syslog_rpmsg_write
 };
 #elif defined(HAVE_LOWPUTC)
 static const struct syslog_channel_s g_default_channel =

--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -72,7 +72,6 @@
 #ifdef NEED_LOWPUTC
 static int syslog_default_putc(int ch);
 #endif
-static int syslog_default_flush(void);
 
 /****************************************************************************
  * Public Data
@@ -83,7 +82,6 @@ static const struct syslog_channel_s g_default_channel =
 {
   ramlog_putc,
   ramlog_putc,
-  syslog_default_flush
 };
 #elif defined(CONFIG_SYSLOG_RPMSG)
 static const struct syslog_channel_s g_default_channel =
@@ -98,14 +96,12 @@ static const struct syslog_channel_s g_default_channel =
 {
   up_putc,
   up_putc,
-  syslog_default_flush
 };
 #else
 static const struct syslog_channel_s g_default_channel =
 {
   syslog_default_putc,
   syslog_default_putc,
-  syslog_default_flush
 };
 #endif
 
@@ -131,11 +127,6 @@ static int syslog_default_putc(int ch)
   return ch;
 }
 #endif
-
-static int syslog_default_flush(void)
-{
-  return OK;
-}
 
 /****************************************************************************
  * Public Functions
@@ -163,8 +154,7 @@ int syslog_channel(FAR const struct syslog_channel_s *channel)
 
   if (channel != NULL)
     {
-      DEBUGASSERT(channel->sc_putc != NULL && channel->sc_force != NULL &&
-                  channel->sc_flush != NULL);
+      DEBUGASSERT(channel->sc_putc != NULL && channel->sc_force != NULL);
 
       g_syslog_channel = channel;
       return OK;

--- a/drivers/syslog/syslog_flush.c
+++ b/drivers/syslog/syslog_flush.c
@@ -91,6 +91,10 @@ int syslog_flush(void)
 
   /* Then flush all of the buffered output to the SYSLOG device */
 
-  DEBUGASSERT(g_syslog_channel->sc_flush != NULL);
-  return g_syslog_channel->sc_flush();
+  if (g_syslog_channel->sc_flush != NULL)
+    {
+      return g_syslog_channel->sc_flush();
+    }
+
+  return OK;
 }

--- a/include/nuttx/syslog/syslog_rpmsg.h
+++ b/include/nuttx/syslog/syslog_rpmsg.h
@@ -59,7 +59,10 @@ extern "C"
 void syslog_rpmsg_init_early(FAR const char *cpu_name, FAR void *buffer,
                              size_t size);
 int syslog_rpmsg_init(void);
+
 int syslog_rpmsg_putc(int ch);
+int syslog_rpmsg_flush(void);
+ssize_t syslog_rpmsg_write(FAR const char *buffer, size_t buflen);
 #endif
 
 #ifdef CONFIG_SYSLOG_RPMSG_SERVER


### PR DESCRIPTION
## Summary
Initialize g_default_channel  syslog_rpmsg_flush and syslog_rpmsg_write and make sc_flush optional

## Impact

## Testing
build rpserver/rpproxy without warning and run successfully
