### PR TITLE
Back port #895 to releases/9.0

### DIFF
--- a/tools/incdir.sh
+++ b/tools/incdir.sh
@@ -200,8 +200,10 @@ for dir in $dirlist; do
   fi
 
   # Check if the path needs to be extended for Windows-based tools under Cygwin
+  # windows=yes:  We are building for a windows platform
+  # wintool=y:    The platform is Cygwin and we are using a windows native tool
 
-  if [ "X$windows" = "Xyes" ]; then
+  if [ "X$windows" = "Xyes" -a "X$wintool" == "Xy" ]; then
     path=`cygpath -w $dir`
   else
     path=$dir


### PR DESCRIPTION
Commit 3b9efc95a2e introduced an error in the generation of include file paths.  The logic that determined if cygpath should be called to create a Windows native path for the case of Cygwin using a native toolchain was incorrect.  This corrects this warning:

 ./tools/configure.sh -c sim:nsh
$ make
<CUT>
make[1]: Entering directory '/home/btashton/apache/apps'
make[2]: Entering directory '/home/btashton/apache/apps/builtin'
./exec_builtin.c:54:10: fatal error: builtin/builtin.h: No such file or directory
   54 | #include "builtin/builtin.h"
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
ERROR: cc failed: 1
       command: cc -MT ./exec_builtin.home.btashton.apache.apps.builtin.o  -M -Wall -Wstrict-prototypes -Wshadow -Wundef -g -fno-builtin -fno-common -I. -isystem /home/btashton/apache/nuttx/include -D__KERNEL__ -pipe -I C:\cygwin64\home\btashton\apache\apps\include ./exec_builtin.c
make[2]: *** [/home/btashton/apache/apps/Application.mk:224: .depend] Error 1
make[2]: Leaving directory '/home/btashton/apache/apps/builtin'
make[1]: *** [Makefile:67: /home/btashton/apache/apps/builtin_depend] Error 2

In this case a Cygwin POSIX toolchain is being used by the path in the CFLAGS to apps/include is incorrectly a Windows native path.  This error is corrected by this change to tools/incdir.sh


