### PR TITLE
tools/sethost.sh:  Correct error in setting a different host.

### DIFF
--- a/tools/sethost.sh
+++ b/tools/sethost.sh
@@ -1,35 +1,20 @@
 #!/usr/bin/env bash
 # tools/sethost.sh
 #
-#   Copyright (C) 2016-2017 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@nuttx.org>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 
 progname=$0
@@ -142,75 +127,58 @@ fi
 
 if [ "X$host" == "Xlinux" -o "X$host" == "Xmacos" ]; then
 
+  # Disable Windows (to suppress warnings from Window Environment selections)
+
+  kconfig-tweak --file $nuttx/.config --disable CONFIG_HOST_WINDOWS
+
   # Enable Linux or macOS
 
   if [ "X$host" == "Xlinux" ]; then
     echo "  Select CONFIG_HOST_LINUX=y"
 
-    echo "CONFIG_HOST_LINUX=y" >> $nuttx/.config
-    sed -i -e "/CONFIG_HOST_MACOS/d" $nuttx/.config
+    kconfig-tweak --file $nuttx/.config --disable CONFIG_HOST_MACOS
+    kconfig-tweak --file $nuttx/.config --enable CONFIG_HOST_LINUX
   else
     echo "  Select CONFIG_HOST_MACOS=y"
 
-    sed -i -e "/CONFIG_HOST_LINUX/d" $nuttx/.config
-    echo "CONFIG_HOST_MACOS=y" >> $nuttx/.config
+    kconfig-tweak --file $nuttx/.config --disable CONFIG_HOST_LINUX
+    kconfig-tweak --file $nuttx/.config --enable CONFIG_HOST_MACOS
   fi
 
-  # Disable all Windows options
+  # Enable the System V ABI
 
-  sed -i -e "/CONFIG_HOST_WINDOWS/d" $nuttx/.config
-  sed -i -e "/CONFIG_SIM_X8664_MICROSOFT/d" $nuttx/.config
-  echo "CONFIG_SIM_X8664_SYSTEMV=y" >> $nuttx/.config
-
-  sed -i -e "/CONFIG_WINDOWS_NATIVE/d" $nuttx/.config
-  sed -i -e "/CONFIG_WINDOWS_CYGWIN/d" $nuttx/.config
-  sed -i -e "/CONFIG_WINDOWS_UBUNTU/d" $nuttx/.config
-  sed -i -e "/CONFIG_WINDOWS_MSYS/d" $nuttx/.config
-  sed -i -e "/CONFIG_WINDOWS_OTHER/d" $nuttx/.config
+  kconfig-tweak --file $nuttx/.config --enable CONFIG_SIM_X8664_SYSTEMV
 else
   echo "  Select CONFIG_HOST_WINDOWS=y"
 
-  # Enable Windows
+  kconfig-tweak --file $nuttx/.config --disable CONFIG_HOST_LINUX
+  kconfig-tweak --file $nuttx/.config --disable CONFIG_HOST_MACOS
 
-  echo "CONFIG_HOST_WINDOWS=y" >> $nuttx/.config
-  sed -i -e "/CONFIG_HOST_LINUX/d" $nuttx/.config
-  sed -i -e "/CONFIG_HOST_MACOS/d" $nuttx/.config
+  # Enable Windows and the Microsoft ABI
 
-  echo "CONFIG_SIM_X8664_MICROSOFT=y" >> $nuttx/.config
-  sed -i -e "/CONFIG_SIM_X8664_SYSTEMV/d" $nuttx/.config
+  kconfig-tweak --file $nuttx/.config --enable CONFIG_HOST_WINDOWS
+  kconfig-tweak --file $nuttx/.config --enable CONFIG_SIM_X8664_MICROSOFT
 
   # Enable Windows environment
 
-  sed -i -e "/CONFIG_WINDOWS_OTHER/d" $nuttx/.config
   if [ "X$wenv" == "Xcygwin" ]; then
     echo "  Select CONFIG_WINDOWS_CYGWIN=y"
-    echo "CONFIG_WINDOWS_CYGWIN=y" >> $nuttx/.config
-    sed -i -e "/CONFIG_WINDOWS_MSYS/d" $nuttx/.config
-    sed -i -e "/CONFIG_WINDOWS_UBUNTU/d" $nuttx/.config
-    sed -i -e "/CONFIG_WINDOWS_NATIVE/d" $nuttx/.config
+    kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_CYGWIN
   else
-    sed -i -e "/CONFIG_WINDOWS_CYGWIN/d" $nuttx/.config
     if [ "X$wenv" == "Xmsys" ]; then
       echo "  Select CONFIG_WINDOWS_MSYS=y"
-      echo "CONFIG_WINDOWS_MSYS=y" >> $nuttx/.config
-      sed -i -e "/CONFIG_WINDOWS_UBUNTU/d" $nuttx/.config
-      sed -i -e "/CONFIG_WINDOWS_NATIVE/d" $nuttx/.config
+      kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_MSYS
     else
-      sed -i -e "/CONFIG_WINDOWS_MSYS/d" $nuttx/.config
       if [ "X$wenv" == "Xubuntu" ]; then
         echo "  Select CONFIG_WINDOWS_UBUNTU=y"
-        echo "CONFIG_WINDOWS_UBUNTU=y" >> $nuttx/.config
-        sed -i -e "/CONFIG_WINDOWS_NATIVE/d" $nuttx/.config
+        kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_UBUNTU
       else
         echo "  Select CONFIG_WINDOWS_NATIVE=y"
-        sed -i -e "/CONFIG_WINDOWS_UBUNTU/d" $nuttx/.config
-        echo "CONFIG_WINDOWS_NATIVE=y" $nuttx/.config
+        kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_NATIVE
       fi
     fi
   fi
 fi
-
-sed -i -e "/CONFIG_HOST_OTHER/d" $nuttx/.config
 
 echo "  Refreshing..."
 


### PR DESCRIPTION
## Summary

In an older PR, the standard kconfig-tweak calls were replaced with sed edit.  This is an incorrect change and results in invalid configurations.  This change restores the use of kconfig-tweak and always generates correct configurations.

## Impact

This change resolves issue #386

sed edits do not handle all of the dependencies correct and generates invalid configurations.  Most defconfig files specify Linux by default, so you will only see the effect of the corruped configuration when sethost changes changes to a different configuration.  Then, when 'make olddefconfig' is subsequentyly run, the corruption in the defconfig file is reflected by warnings such as:

    $ tools/configure.sh -c stm32f4discovery:nsh
       Copy files
       Select CONFIG_HOST_WINDOWS=y
       Select CONFIG_WINDOWS_CYGWIN=y
       Refreshing...
    .config:62:warning: override: reassigning to symbol HOST_WINDOWS
    .config:62:warning: override: HOST_WINDOWS changes choice state

Those warnings are eliminated by this changed.

## Testing

Tested by repeatedly doing:

    tools/configure.sh -c stm32f4discovery:nsh

I've also tested these configurations and they all work (after one forced push):

    tools/configure.sh -c imxrt1060-evk:nsh  # Linux to Windows Cygwin
    rm .config Make.defs
    tools/configure.sh -l imxrt1060-evk:nsh  # Linux to Linux
    rm .config Make.defs
    tools/configure.sh -g imxrt1060-evk:nsh  # Linux to MSYS
    rm .config Make.defs
    tools/configure.sh -l stm32f4discovery:nsh # Windows to Linux
    rm .config Make.defs
    tools/configure.sh -c stm32f4discovery:nsh # Windows to Windows Cygwin
    rm .config Make.defs
    tools/configure.sh -m stm32f4discovery:nsh # Windows to macOS
    rm .config Make.defs
    tools/configure.sh -g stm32f4discovery:nsh # Windows to Windows MSYS
    rm .config Make.defs
    tools/configure.sh -g sim:nsh  # Linux to Windows MSYS
    rm .config Make.defs
    tools/configure.sh -l sim:nsh  # Linux to Linux
    rm .config Make.defs
    tools/configure.sh -c sim:nsh  # Linux to Windows Cygwin
    rm .config Make.defs
    tools/configure.sh -m sim:nsh   # Linux to macOS
    rm .config Make.defs
    tools/configure.sh -l sim:module  # macOS to Linux
    rm .config Make.defs
    tools/configure.sh -c sim:module # macOS to Windows Cygwin

At this point, I have not come up with any way that results in a corrupted defconfig file or in any warning from 'make olddefconfig'

BTW: If you want to experiment with this, you don't need to have Windows or a macOS. configure.sh doesn't care what platform you are on. So you can configure -l, -g, -c, -m on any plaform, including Linux.
