### PR TITLE
sched/group:  On task creation, do not clone uninitialized descriptors.

### DIFF
--- a/net/socket/socket.c
+++ b/net/socket/socket.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * net/socket/socket.c
  *
- *   Copyright (C) 2007-2009, 2012, 2014-2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -64,7 +49,8 @@
  *   domain   (see sys/socket.h)
  *   type     (see sys/socket.h)
  *   protocol (see sys/socket.h)
- *   psock    A pointer to a user allocated socket structure to be initialized.
+ *   psock    A pointer to a user allocated socket structure to be
+ *            initialized.
  *
  * Returned Value:
  *  Returns zero (OK) on success.  On failure, it returns a negated errno
@@ -90,7 +76,8 @@
  *
  ****************************************************************************/
 
-int psock_socket(int domain, int type, int protocol, FAR struct socket *psock)
+int psock_socket(int domain, int type, int protocol,
+                 FAR struct socket *psock)
 {
   FAR const struct sock_intf_s *sockif = NULL;
   int ret;
@@ -217,6 +204,9 @@ int socket(int domain, int type, int protocol)
       goto errout_with_sockfd;
     }
 
+  /* The socket has been successfully initialized */
+
+  psock->s_flags |= _SF_INITD;
   return sockfd;
 
 errout_with_sockfd:

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  sched/group/group_setuptaskfiles.c
  *
- *   Copyright (C) 2007-2008, 2010, 2012-2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -167,13 +152,15 @@ static inline void sched_dupsockets(FAR struct task_tcb_s *tcb)
 
   for (i = 0; i < CONFIG_NSOCKET_DESCRIPTORS; i++)
     {
-      /* Check if this parent socket is allocated.  We can tell if the
-       * socket is allocated because it will have a positive, non-zero
-       * reference count.
+      /* Check if this parent socket is valid.  Valid means both (1)
+       * allocated and (2) successfully initialized.  A complexity in SMP
+       * mode is that a socket my be allocated, but not yet initialized when
+       * the socket is cloned by another pthread.
+       *
+       * Sockets with the close-on-exec flag set should not be cloned either.
        */
 
-      if (parent[i].s_crefs > 0 &&
-          !_SS_ISCLOEXEC(parent[i].s_flags))
+      if (_PS_VALID(&parent[i]) && !_SS_ISCLOEXEC(parent[i].s_flags))
         {
           /* Yes... duplicate it for the child */
 
@@ -213,7 +200,8 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb)
 
   DEBUGASSERT(group);
 #ifndef CONFIG_DISABLE_PTHREAD
-  DEBUGASSERT((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_PTHREAD);
+  DEBUGASSERT((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) !=
+              TCB_FLAG_TTYPE_PTHREAD);
 #endif
 
   /* Initialize file descriptors for the TCB */


### PR DESCRIPTION
## Summary

Sockets are created in two steps:

1. The socket is allocated, then
2. The socket is initialized.

In SMP mode, there is a possibility that a pthread executing one CPU may create a new task while a pthread on another CPU has allocated the socket but not yet initialized it.  This commit updates the socket clone test to assure that the socket is both allocated and initailized before it is cloned.

This SMP issue was reported by me by Xiao Xiang

## Impact

Without the change, it is possible that uninitialized sockets could be cloned, leading to errors later in the newly started task.

## Testing

Normal network operation was verified using the stm32f4discovery:netnsh configuration.  I do not have an SMP setup that I can use to verify correction of the exact race condition that Xiao Xiang reported to me.


