### PR TITLE
x86_64: Resolve linking and compiler warning issues

### DIFF
--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -231,7 +231,7 @@
 # define IOAPIC_REG_ID          0x00       /* Register index: ID */
 # define IOAPIC_REG_VER         0x01       /* Register index: version */
 # define IOAPIC_REG_TABLE       0x10       /* Redirection table base */
-#  define IOAPIC_PIN_DISABLE           (1 << 16)  /* Disable */
+# define IOAPIC_PIN_DISABLE     (1 << 16)  /* Disable */
 
 /* PIC related Definitions */
 
@@ -257,8 +257,9 @@
 /* IDT data structures ******************************************************
  *
  * The Interrupt Descriptor Table (IDT) is a data structure used by the x86
- * architecture to implement an interrupt vector table. The IDT is used by the
- * processor to determine the correct response to interrupts and exceptions.
+ * architecture to implement an interrupt vector table. The IDT is used by
+ * the processor to determine the correct response to interrupts and
+ * exceptions.
  */
 
 begin_packed_struct struct idt_entry_s
@@ -286,7 +287,8 @@ begin_packed_struct struct idt_ptr_s
  *
  * The Global Descriptor Table (GDT) is a data structure used by the x86
  * architecture to implement segments and privilege levels. The GDT is used
- * by the processor to determine current privilege level and memory access right.
+ * by the processor to determine current privilege level and memory access
+ * right.
  */
 
 begin_packed_struct struct gdt_entry_s
@@ -321,8 +323,8 @@ begin_packed_struct struct gdt_ptr_s
 /* IST data structures ******************************************************
  *
  * The Interrupt Stack Table (GDT) is a data structure used by the x86-64
- * architecture to automatically switch stack on interrupt and privilege change.
- * It allows setting up to 7 different stack for interrupts.
+ * architecture to automatically switch stack on interrupt and privilege
+ * change. It allows setting up to 7 different stack for interrupts.
  */
 
 begin_packed_struct struct ist_s
@@ -342,7 +344,7 @@ begin_packed_struct struct ist_s
   uint64_t reserved3;            /* reserved */
   uint64_t reserved4;            /* reserved */
   uint16_t reserved5;            /* reserved */
-  uint16_t IOPB_offset;          /* IOPB_offset */
+  uint16_t IOPB_OFFSET;          /* IOPB_offset */
 } end_packed_struct;
 
 /****************************************************************************
@@ -560,7 +562,9 @@ extern volatile uint8_t gdt64_low;
 extern volatile uint8_t gdt64_ist_low;
 extern volatile uint8_t gdt64_low_end;
 
-/* The actual address of the page table and gdt/ist after mapping the kernel in high address*/
+/* The actual address of the page table and gdt/ist after mapping the kernel
+ * in high address
+ */
 
 extern volatile uint64_t *pdpt;
 extern volatile uint64_t *pd;

--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -562,12 +562,12 @@ extern volatile uint8_t gdt64_low_end;
 
 /* The actual address of the page table and gdt/ist after mapping the kernel in high address*/
 
-volatile uint64_t *pdpt;
-volatile uint64_t *pd;
-volatile uint64_t *pt;
+extern volatile uint64_t *pdpt;
+extern volatile uint64_t *pd;
+extern volatile uint64_t *pt;
 
-volatile struct ist_s *ist64;
-volatile struct gdt_entry_s *gdt64;
+extern volatile struct ist_s *ist64;
+extern volatile struct gdt_entry_s *gdt64;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -136,8 +136,14 @@ uint64_t *isr_handler(uint64_t *regs, uint64_t irq)
 {
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   board_autoled_on(LED_INIRQ);
-  PANIC(); /* Doesn't return */
-  return regs;               /* To keep the compiler happy */
+
+  /* Doesn't return */
+
+  PANIC();
+
+  /* To keep the compiler happy */
+
+  return regs;
 #else
 
   DEBUGASSERT(g_current_regs == NULL);
@@ -191,8 +197,14 @@ uint64_t *irq_handler(uint64_t *regs, uint64_t irq_no)
 {
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   board_autoled_on(LED_INIRQ);
-  PANIC(); /* Doesn't return */
-  return regs;               /* To keep the compiler happy */
+
+  /* Doesn't return */
+
+  PANIC();
+
+  /* To keep the compiler happy */
+
+  return regs;
 #else
   uint64_t *ret;
   int irq;

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -139,7 +139,6 @@ uint64_t *isr_handler(uint64_t *regs, uint64_t irq)
   PANIC(); /* Doesn't return */
   return regs;               /* To keep the compiler happy */
 #else
-  uint64_t *ret;
 
   DEBUGASSERT(g_current_regs == NULL);
   g_current_regs = regs;

--- a/arch/x86_64/src/intel64/intel64_lowsetup.c
+++ b/arch/x86_64/src/intel64/intel64_lowsetup.c
@@ -38,6 +38,19 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* The actual address of the page table and gdt/ist after mapping the kernel in high address*/
+
+volatile uint64_t *pdpt;
+volatile uint64_t *pd;
+volatile uint64_t *pt;
+
+volatile struct ist_s *ist64;
+volatile struct gdt_entry_s *gdt64;
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -64,16 +77,16 @@ void up_lowsetup(void)
 
   /* Setup pointers for accessing Page table and GDT in high address */
 
-  pdpt = &pdpt_low + X86_64_LOAD_OFFSET;
-  pd   = &pd_low   + X86_64_LOAD_OFFSET;
-  pt   = &pt_low   + X86_64_LOAD_OFFSET;
+  pdpt = (uint64_t *)((uintptr_t)&pdpt_low + X86_64_LOAD_OFFSET);
+  pd   = (uint64_t *)((uintptr_t)&pd_low   + X86_64_LOAD_OFFSET);
+  pt   = (uint64_t *)((uintptr_t)&pt_low   + X86_64_LOAD_OFFSET);
 
-  ist64     = (struct ist_s *)((void *)&ist64_low       + X86_64_LOAD_OFFSET);
-  gdt64     = (struct gdt_entry_s *)((void *)&gdt64_low + X86_64_LOAD_OFFSET);
+  ist64 = (struct ist_s *)((uintptr_t)&ist64_low       + X86_64_LOAD_OFFSET);
+  gdt64 = (struct gdt_entry_s *)((uintptr_t)&gdt64_low + X86_64_LOAD_OFFSET);
 
   /* reload the GDTR with mapped high memory address */
 
-  setgdt(gdt64, (uintptr_t)(&gdt64_low_end - &gdt64_low) - 1);
+  setgdt((void *)gdt64, (uintptr_t)(&gdt64_low_end - &gdt64_low) - 1);
 
   /* Do some checking on CPU compatibilities */
 

--- a/arch/x86_64/src/intel64/intel64_lowsetup.c
+++ b/arch/x86_64/src/intel64/intel64_lowsetup.c
@@ -41,7 +41,9 @@
  * Public Data
  ****************************************************************************/
 
-/* The actual address of the page table and gdt/ist after mapping the kernel in high address*/
+/* The actual address of the page table and gdt/ist after mapping the kernel
+ * in high address.
+ */
 
 volatile uint64_t *pdpt;
 volatile uint64_t *pd;
@@ -69,11 +71,11 @@ volatile struct gdt_entry_s *gdt64;
 
 void up_lowsetup(void)
 {
-  /* we should be in long mode at this point*/
+  /* we should be in long mode at this point */
 
   /* GDT is loaded with 64bit GDT  */
 
-  /* Paging is enabled*/
+  /* Paging is enabled */
 
   /* Setup pointers for accessing Page table and GDT in high address */
 

--- a/arch/x86_64/src/intel64/intel64_rng.c
+++ b/arch/x86_64/src/intel64/intel64_rng.c
@@ -141,7 +141,7 @@ static ssize_t x86_rngread(struct file *filep, char *buffer, size_t buflen)
     {
       unsigned short temp = 0;
 
-      while (_rdrand16_step((unsigned short *)temp))
+      while (_rdrand16_step(&temp))
         {
           sched_yield();
         }

--- a/arch/x86_64/src/intel64/intel64_rng.c
+++ b/arch/x86_64/src/intel64/intel64_rng.c
@@ -70,7 +70,7 @@ static const struct file_operations g_rngops =
 {
   0,               /* open */
   0,               /* close */
-  x86_rngread,   /* read */
+  x86_rngread,     /* read */
   0,               /* write */
   0,               /* seek */
   0                /* ioctl */

--- a/arch/x86_64/src/intel64/up_initialstate.c
+++ b/arch/x86_64/src/intel64/up_initialstate.c
@@ -85,6 +85,7 @@ void up_initial_state(struct tcb_s *tcb)
   /* set page table to share space with current process */
 
   rtcb = this_task();
+  UNUSED(rtcb);
 
   /* Save the initial stack pointer... the value of the stackpointer before
    * the "interrupt occurs."

--- a/arch/x86_64/src/intel64/up_irq.c
+++ b/arch/x86_64/src/intel64/up_irq.c
@@ -190,7 +190,10 @@ static void up_ist_init(void)
   tss_h = (((uintptr_t)ist64 >> 32) & 0xffffffff);  /* High address */
 
   gdt64[X86_GDT_ISTL_SEL_NUM] = tss_l;
-  gdt64[X86_GDT_ISTH_SEL_NUM] = *((struct gdt_entry_s *)&tss_h);
+
+  /* memcpy used to handle type punning compiler warning */
+
+  memcpy((void *)&gdt64[X86_GDT_ISTH_SEL_NUM], (void *)&tss_h, sizeof(gdt64[0]));
 
   ist64->IST1 = (uintptr_t)g_interrupt_stack_end;
   ist64->IST2 = (uintptr_t)g_isr_stack_end;

--- a/arch/x86_64/src/intel64/up_irq.c
+++ b/arch/x86_64/src/intel64/up_irq.c
@@ -176,8 +176,9 @@ static void up_ist_init(void)
   memset(&tss_l, 0, sizeof(tss_l));
   memset(&tss_h, 0, sizeof(tss_h));
 
-  tss_l.limit_low = (((104 - 1) & 0xffff)); /* Segment limit = TSS size - 1 */
-  tss_l.base_low  = ((uintptr_t)ist64 & 0x00ffffff);  /* Low address 1 */
+  tss_l.limit_low = (((104 - 1) & 0xffff));    /* Segment limit = TSS size - 1 */
+
+  tss_l.base_low  = ((uintptr_t)ist64 & 0x00ffffff);          /* Low address 1 */
   tss_l.base_high = (((uintptr_t)ist64 & 0xff000000) >> 24);  /* Low address 2 */
 
   tss_l.P = 1;
@@ -193,7 +194,8 @@ static void up_ist_init(void)
 
   /* memcpy used to handle type punning compiler warning */
 
-  memcpy((void *)&gdt64[X86_GDT_ISTH_SEL_NUM], (void *)&tss_h, sizeof(gdt64[0]));
+  memcpy((void *)&gdt64[X86_GDT_ISTH_SEL_NUM],
+      (void *)&tss_h, sizeof(gdt64[0]));
 
   ist64->IST1 = (uintptr_t)g_interrupt_stack_end;
   ist64->IST2 = (uintptr_t)g_isr_stack_end;
@@ -317,7 +319,8 @@ static void up_apic_init(void)
  * Name: legacy_pic_irq_handler
  *
  * Description:
- *  This function will capture will legacy 8259 PIC IRQ using virtual wire mode
+ *  This function will capture will legacy 8259 PIC IRQ using virtual wire
+ *  mode
  *
  ****************************************************************************/
 
@@ -375,8 +378,8 @@ static void up_idtentry(unsigned int index, uint64_t base, uint16_t sel,
   entry->sel     = sel;
   entry->zero    = 0;
 
-  /* We must uncomment the OR below when we get to using user-mode. It sets the
-   * interrupt gate's privilege level to 3.
+  /* We must uncomment the OR below when we get to using user-mode. It sets
+   * the interrupt gate's privilege level to 3.
    */
 
   entry->flags  = flags; /* | 0x60 */

--- a/arch/x86_64/src/intel64/up_regdump.c
+++ b/arch/x86_64/src/intel64/up_regdump.c
@@ -74,7 +74,6 @@ void print_mem(void *sp, size_t size)
 void backtrace(uint64_t rbp)
 {
   int i;
-  int j;
 
   _alert("Frame Dump (64 bytes):\n");
 
@@ -101,12 +100,8 @@ void backtrace(uint64_t rbp)
 
 void up_registerdump(uint64_t *regs)
 {
-  int i;
-  int j;
   uint64_t mxcsr;
   uint64_t cr2;
-  uint64_t rbp;
-  char buf[9];
 
   asm volatile ("stmxcsr %0"::"m"(mxcsr):"memory");
   asm volatile ("mov %%cr2, %%rax; mov %%rax, %0"::"m"(cr2):"memory", "rax");
@@ -138,11 +133,12 @@ void up_registerdump(uint64_t *regs)
 
   if (regs[REG_RSP] > 0 && regs[REG_RSP] < 0x1000000)
     {
-      print_mem(regs[REG_RSP] - 512, 128 * 0x200000 - regs[REG_RSP] + 512);
+      print_mem((void *)regs[REG_RSP] - 512,
+          128 * 0x200000 - regs[REG_RSP] + 512);
     }
   else
     {
-      print_mem(regs[REG_RSP] - 512, 1024);
+      print_mem((void *)regs[REG_RSP] - 512, 1024);
     }
 
 #ifdef CONFIG_DEBUG_NOOPT

--- a/arch/x86_64/src/intel64/up_releasestack.c
+++ b/arch/x86_64/src/intel64/up_releasestack.c
@@ -79,9 +79,6 @@
 
 void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
-  struct vma_s *ptr;
-  int i;
-
   /* Is there a stack allocated? */
 
   if (dtcb->stack_alloc_ptr)

--- a/boards/x86_64/intel64/qemu-intel64/README.txt
+++ b/boards/x86_64/intel64/qemu-intel64/README.txt
@@ -42,7 +42,7 @@ set timeout=0
 set default=0
 menuentry "kernel" {
   multiboot2 /boot/nuttx.elf
-  }
+}
 ```
 
 ##### Making the disk
@@ -79,7 +79,7 @@ Running QEMU
 
   In the top-level NuttX directory:
 
-    qemu -cpu host -enable-kvm -m 2GB -cdrom boot.iso -nographic -serial mon:stdio
+    qemu-system-x86_64 -cpu host -enable-kvm -m 2G -cdrom boot.iso -nographic -serial mon:stdio
 
   This multiplex the qemu console and COM1 to your console.
   Use control-a 1 and 2 to switch between.


### PR DESCRIPTION
## Summary
x86_64 port has multiple compile issues related to linking as well as some pointer aliasing warnings/errors that prevented this from compiling. This also resolves a bug in the RNG and some related style issues.

```
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_boot.o):(.bss+0x0): multiple definition of `gdt64'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x10): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_boot.o):(.bss+0x8): multiple definition of `ist64'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x18): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_boot.o):(.bss+0x10): multiple definition of `pt'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x20): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_boot.o):(.bss+0x18): multiple definition of `pd'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x28): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_boot.o):(.bss+0x20): multiple definition of `pdpt'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x30): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_freq.o):(.bss+0x0): multiple definition of `gdt64'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x10): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_freq.o):(.bss+0x8): multiple definition of `ist64'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x18): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_freq.o):(.bss+0x10): multiple definition of `pt'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x20): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_freq.o):(.bss+0x18): multiple definition of `pd'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x28): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_freq.o):(.bss+0x20): multiple definition of `pdpt'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x30): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_net.o):(.bss+0x0): multiple definition of `gdt64'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x10): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_net.o):(.bss+0x8): multiple definition of `ist64'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x18): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_net.o):(.bss+0x10): multiple definition of `pt'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x20): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_net.o):(.bss+0x18): multiple definition of `pd'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x28): first defined here
ld: /home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src/board/libboard.a(qemu_net.o):(.bss+0x20): multiple definition of `pdpt'; /home/bashton/nuttx/apache/incubator-nuttx/staging/libsched.a(clock_initialize.o):(.bss+0x30): first defined here
make[1]: *** [Makefile:140: nuttx.elf] Error 1
make[1]: Leaving directory '/home/bashton/nuttx/apache/incubator-nuttx/arch/x86_64/src'
make: *** [tools/Makefile.unix:450: pass2] Error 2
```

```
chip/intel64_lowsetup.c: In function ‘up_lowsetup’:
chip/intel64_lowsetup.c:67:8: warning: assignment to ‘volatile uint64_t *’ {aka ‘volatile long long unsigned int *’} from incompatible pointer type ‘volatile uint8_t *’ {aka ‘volatile unsigned char *’} [-Wincompatible-pointer-types]
   67 |   pdpt = &pdpt_low + X86_64_LOAD_OFFSET;
      |        ^       
chip/intel64_lowsetup.c:68:8: warning: assignment to ‘volatile uint64_t *’ {aka ‘volatile long long unsigned int *’} from incompatible pointer type ‘volatile uint8_t *’ {aka ‘volatile unsigned char *’} [-Wincompatible-pointer-types]
   68 |   pd   = &pd_low   + X86_64_LOAD_OFFSET;
      |        ^          
chip/intel64_lowsetup.c:69:8: warning: assignment to ‘volatile uint64_t *’ {aka ‘volatile long long unsigned int *’} from incompatible pointer type ‘volatile uint8_t *’ {aka ‘volatile unsigned char *’} [-Wincompatible-pointer-types]
   69 |   pt   = &pt_low   + X86_64_LOAD_OFFSET;
      |        ^             
chip/intel64_lowsetup.c:76:10: warning: passing argument 1 of ‘setgdt’ discards ‘volatile’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   76 |   setgdt(gdt64, (uintptr_t)(&gdt64_low_end - &gdt64_low) - 1);
      |          ^~~~~                                                         
In file included from /home/bashton/nuttx/apache/incubator-nuttx/include/arch/arch.h:36,
                 from /home/bashton/nuttx/apache/incubator-nuttx/include/arch/chip/irq.h:35,
                 from /home/bashton/nuttx/apache/incubator-nuttx/include/arch/irq.h:38,
                 from /home/bashton/nuttx/apache/incubator-nuttx/include/nuttx/irq.h:123,
                 from /home/bashton/nuttx/apache/incubator-nuttx/include/nuttx/sched.h:40,
                 from /home/bashton/nuttx/apache/incubator-nuttx/include/sched.h:50,
                 from /home/bashton/nuttx/apache/incubator-nuttx/include/nuttx/arch.h:96,
                 from chip/intel64_lowsetup.c:27:
```
## Testing

Build and ran the ostree build in QEMU.  There are more issues that need to be resolved as it frequently will not boot.
