### PR TITLE
arch: x86_64: add no-relax to the linker flags

### DIFF
--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -138,7 +138,7 @@ board/libboard$(LIBEXT):
 nuttx$(EXEEXT): board/libboard$(LIBEXT)
 	@echo "LD: nuttx$(EXEEXT)"
 	$(Q) $(LD) $(LDFLAGS) $(LIBPATHS) -o $(NUTTX) $(EXTRA_OBJS) \
-		$(LDSTARTGROUP) $(LIBGCC) --whole-archive  $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
+		$(LDSTARTGROUP) $(LIBGCC) --whole-archive --no-relax  $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) $(NM) $(NUTTX) | \
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \


### PR DESCRIPTION
## Summary

Using newer gcc toolchains (version 7 and 9), without `--no-relax` linker flags, x86_64 boards failed to build.

## Impact

x86_64 boards failed to build, including the `ostest` example in the repository

## Testing

Following the READMEof x86_64 build, one should be able to build `ostest` binary and successfully run it on qemu or boches emulator.

I might need someone with older distro, e.g. Ubuntu 16.04, to test will the old toolchain be affected by this patch or not.

As I remember, 16.04's gcc 5.4 doesn't have this problem.


