### PR TITLE
syslog: correct to #ifdef CONFIG_SYSLOG_RPMSG to call syslog_rpmsg_init

### DIFF
--- a/drivers/syslog/syslog_initialize.c
+++ b/drivers/syslog/syslog_initialize.c
@@ -102,7 +102,7 @@ int syslog_initialize(void)
   syslog_register();
 #endif
 
-#ifdef CONFIG_SYSLOG_CHARDEV
+#ifdef CONFIG_SYSLOG_RPMSG
   syslog_rpmsg_init();
 #endif
 


### PR DESCRIPTION
## Summary

Same as syslog/Make.defs to use #ifdef CONFIG_SYSLOG_RPMSG to build syslog_rpmsg.c
in which syslog_rpmsg_init defined.
