### PR TITLE
Use NuttX's signal set functions inside the OS.

### DIFF
--- a/drivers/modem/altair/altmdm_sys.c
+++ b/drivers/modem/altair/altmdm_sys.c
@@ -42,6 +42,8 @@
 #include <nuttx/irq.h>
 #include <signal.h>
 
+#include <nuttx/signal.h>
+
 #include "altmdm_dev.h"
 #include "altmdm_sys.h"
 
@@ -443,7 +445,8 @@ int altmdm_sys_waitflag(FAR struct altmdm_sys_flag_s *handle,
         }
 
       abs_time.tv_sec = timeout_ms / 1000;
-      abs_time.tv_nsec = (timeout_ms - (abs_time.tv_sec * 1000)) * 1000 * 1000;
+      abs_time.tv_nsec = (timeout_ms - (abs_time.tv_sec * 1000)) *
+                          1000 * 1000;
 
       abs_time.tv_sec += curr_time.tv_sec;
       abs_time.tv_nsec += curr_time.tv_nsec;
@@ -557,7 +560,8 @@ int altmdm_sys_waitflag(FAR struct altmdm_sys_flag_s *handle,
  *
  ****************************************************************************/
 
-int altmdm_sys_setflag(FAR struct altmdm_sys_flag_s *handle, uint32_t pattern)
+int altmdm_sys_setflag(FAR struct altmdm_sys_flag_s *handle,
+                       uint32_t pattern)
 {
   int ret;
   irqstate_t flags;
@@ -665,7 +669,7 @@ timer_t altmdm_sys_starttimer(int first_ms, int interval_ms,
     }
 
   sigemptyset(&mask);
-  sigaddset(&mask, MY_TIMER_SIGNAL);
+  nxsig_addset(&mask, MY_TIMER_SIGNAL);
 
   ret = sigprocmask(SIG_UNBLOCK, &mask, NULL);
   if (ret != OK)
@@ -677,7 +681,7 @@ timer_t altmdm_sys_starttimer(int first_ms, int interval_ms,
   sa.sa_sigaction = handler;
   sa.sa_flags = SA_SIGINFO;
   sigfillset(&sa.sa_mask);
-  sigdelset(&sa.sa_mask, MY_TIMER_SIGNAL);
+  nxsig_delset(&sa.sa_mask, MY_TIMER_SIGNAL);
 
   ret = sigaction(MY_TIMER_SIGNAL, &sa, NULL);
   if (ret != OK)

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -183,7 +183,7 @@ static int rptun_thread(int argc, FAR char *argv[])
   priv = (FAR struct rptun_priv_s *)((uintptr_t)strtoul(argv[2], NULL, 0));
 
   sigemptyset(&set);
-  sigaddset(&set, SIGUSR1);
+  nxsig_addset(&set, SIGUSR1);
   nxsig_procmask(SIG_BLOCK, &set, NULL);
 
   while (1)

--- a/include/nuttx/signal.h
+++ b/include/nuttx/signal.h
@@ -113,6 +113,79 @@ struct sigwork_s
 struct timespec;  /* Forward reference */
 
 /****************************************************************************
+ * Name: nxsig_ismember
+ *
+ * Description:
+ *   This function tests whether the signal specified by signo is a member
+ *   of the set specified by set.
+ *
+ * Input Parameters:
+ *   set - Signal set to test
+ *   signo - Signal to test for
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   On success, it returns 0 if the signal is not a member, 1 if the signal
+ *   is a member of the set.
+ *   A negated errno value is returned on failure.
+ *
+ *    EINVAL - The signo argument is invalid.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int nxsig_ismember(FAR const sigset_t *set, int signo);
+
+/****************************************************************************
+ * Name: nxsig_addset
+ *
+ * Description:
+ *   This function adds the signal specified by signo to the signal set
+ *   specified by set.
+ *
+ * Input Parameters:
+ *   set - Signal set to add signal to
+ *   signo - Signal to add
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   It follows the NuttX internal error return policy:  Zero (OK) is
+ *   returned on success.  A negated errno value is returned on failure.
+ *
+ *    EINVAL - The signo argument is invalid.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int nxsig_addset(FAR sigset_t *set, int signo);
+
+/****************************************************************************
+ * Name: nxsig_delset
+ *
+ * Description:
+ *   This function deletes the signal specified by signo from the signal
+ *   set specified by the 'set' argument.
+ *
+ * Input Parameters:
+ *   set - Signal set to delete the signal from
+ *   signo - Signal to delete
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   It follows the NuttX internal error return policy:  Zero (OK) is
+ *   returned on success.  A negated errno value is returned on failure.
+ *
+ *    EINVAL - The signo argument is invalid.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int nxsig_delset(FAR sigset_t *set, int signo);
+
+/****************************************************************************
  * Name: nxsig_procmask
  *
  * Description:

--- a/libs/libc/signal/sig_addset.c
+++ b/libs/libc/signal/sig_addset.c
@@ -45,6 +45,45 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: nxsig_addset
+ *
+ * Description:
+ *   This function adds the signal specified by signo to the signal set
+ *   specified by set.
+ *
+ * Input Parameters:
+ *   set - Signal set to add signal to
+ *   signo - Signal to add
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   It follows the NuttX internal error return policy:  Zero (OK) is
+ *   returned on success.  A negated errno value is returned on failure.
+ *
+ *    EINVAL - The signo argument is invalid.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int nxsig_addset(FAR sigset_t *set, int signo)
+{
+  /* Verify the signal */
+
+  if (!GOOD_SIGNO(signo))
+    {
+      return -EINVAL;
+    }
+  else
+    {
+      /* Add the signal to the set */
+
+      *set |= SIGNO2SET(signo);
+      return OK;
+    }
+}
+
+/****************************************************************************
  * Name: sigaddset
  *
  * Description:
@@ -64,18 +103,16 @@
 
 int sigaddset(FAR sigset_t *set, int signo)
 {
-  /* Verify the signal */
+  int ret;
 
-  if (!GOOD_SIGNO(signo))
+  /* Let nxsig_addset do all the work. */
+
+  ret = nxsig_addset(set, signo);
+  if (ret < 0)
     {
       set_errno(EINVAL);
-      return ERROR;
+      ret = ERROR;
     }
-  else
-    {
-      /* Add the signal to the set */
 
-      *set |= SIGNO2SET(signo);
-      return OK;
-    }
+  return ret;
 }

--- a/libs/libc/signal/sig_delset.c
+++ b/libs/libc/signal/sig_delset.c
@@ -45,6 +45,45 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: nxsig_delset
+ *
+ * Description:
+ *   This function deletes the signal specified by signo from the signal
+ *   set specified by the 'set' argument.
+ *
+ * Input Parameters:
+ *   set - Signal set to delete the signal from
+ *   signo - Signal to delete
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   It follows the NuttX internal error return policy:  Zero (OK) is
+ *   returned on success.  A negated errno value is returned on failure.
+ *
+ *    EINVAL - The signo argument is invalid.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int nxsig_delset(FAR sigset_t *set, int signo)
+{
+  /* Verify the signal */
+
+  if (!GOOD_SIGNO(signo))
+    {
+      return -EINVAL;
+    }
+  else
+    {
+      /* Remove the signal from the set */
+
+      *set &= ~SIGNO2SET(signo);
+      return OK;
+    }
+}
+
+/****************************************************************************
  * Name: sigdelset
  *
  * Description:
@@ -64,18 +103,16 @@
 
 int sigdelset(FAR sigset_t *set, int signo)
 {
-  /* Verify the signal */
+  int ret;
 
-  if (!GOOD_SIGNO(signo))
+  /* Let nxseg_delset do all the work. */
+
+  ret = nxsig_delset(set, signo);
+  if (ret < 0)
     {
       set_errno(EINVAL);
-      return ERROR;
+      ret = ERROR;
     }
-  else
-    {
-      /* Remove the signal from the set */
 
-      *set &= ~SIGNO2SET(signo);
-      return OK;
-    }
+  return ret;
 }

--- a/libs/libc/signal/sig_ismember.c
+++ b/libs/libc/signal/sig_ismember.c
@@ -38,10 +38,52 @@
  ****************************************************************************/
 
 #include <signal.h>
+#include <errno.h>
+
+#include <nuttx/signal.h>
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxsig_ismember
+ *
+ * Description:
+ *   This function tests whether the signal specified by signo is a member
+ *   of the set specified by set.
+ *
+ * Input Parameters:
+ *   set - Signal set to test
+ *   signo - Signal to test for
+ *
+ * Returned Value:
+ *   This is an internal OS interface and should not be used by applications.
+ *   On success, it returns 0 if the signal is not a member, 1 if the signal
+ *   is a member of the set.
+ *   A negated errno value is returned on failure.
+ *
+ *    EINVAL - The signo argument is invalid.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int nxsig_ismember(FAR const sigset_t *set, int signo)
+{
+  /* Verify the signal */
+
+  if (!GOOD_SIGNO(signo))
+    {
+      return -EINVAL;
+    }
+  else
+    {
+      /* Check if the signal is in the set */
+
+      return ((*set & SIGNO2SET(signo)) != 0);
+    }
+}
 
 /****************************************************************************
  * Name: sigismember
@@ -65,15 +107,15 @@
 
 int sigismember(FAR const sigset_t *set, int signo)
 {
-  int ret = ERROR;
+  int ret;
 
-  /* Verify the signal */
+  /* Let nxsig_ismember do all of the work */
 
-  if (GOOD_SIGNO(signo))
+  ret = nxsig_ismember(set, signo);
+  if (ret < 0)
     {
-      /* Check if the signal is in the set */
-
-      ret = ((*set & SIGNO2SET(signo)) != 0);
+      set_errno(EINVAL);
+      ret = ERROR;
     }
 
   return ret;

--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -202,7 +202,7 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
   /* Create a signal set that contains only SIGCHLD */
 
   sigemptyset(&set);
-  sigaddset(&set, SIGCHLD);
+  nxsig_addset(&set, SIGCHLD);
 
   /* Disable pre-emption so that nothing changes while the loop executes */
 
@@ -314,7 +314,9 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
             }
         }
 
-      /* We are waiting for a specific PID.  Does this task retain child status? */
+      /* We are waiting for a specific PID.  Does this task retain child
+       * status?
+       */
 
       else if (retains)
         {

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -331,7 +331,7 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
   /* Create a signal set that contains only SIGCHLD */
 
   sigemptyset(&set);
-  sigaddset(&set, SIGCHLD);
+  nxsig_addset(&set, SIGCHLD);
 
   /* Disable pre-emption so that nothing changes while the loop executes */
 
@@ -455,7 +455,9 @@ pid_t waitpid(pid_t pid, int *stat_loc, int options)
             }
         }
 
-      /* We are waiting for a specific PID. Does this task retain child status? */
+      /* We are waiting for a specific PID. Does this task retain child
+       * status?
+       */
 
       else if (retains)
         {

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -459,7 +459,7 @@ static void nxsig_setup_default_action(FAR struct task_group_s *group,
 
       /* Indicate that the default signal handler has been attached */
 
-      sigaddset(&group->tg_sigdefault, (int)info->signo);
+      nxsig_addset(&group->tg_sigdefault, (int)info->signo);
     }
 }
 
@@ -495,7 +495,7 @@ bool nxsig_isdefault(FAR struct tcb_s *tcb, int signo)
    * false in all other cases.
    */
 
-  ret = sigismember(&group->tg_sigdefault, signo);
+  ret = nxsig_ismember(&group->tg_sigdefault, signo);
   return ret < 0 ? false : (bool)ret;
 }
 
@@ -579,22 +579,22 @@ _sa_handler_t nxsig_default(FAR struct tcb_s *tcb, int signo, bool defaction)
       handler = nxsig_default_action(signo);
       if (handler != SIG_IGN)
         {
-          /* sigaddset() is not atomic (but neither is sigaction()) */
+          /* nxsig_addset() is not atomic (but neither is sigaction()) */
 
           flags = spin_lock_irqsave();
-          sigaddset(&group->tg_sigdefault, signo);
+          nxsig_addset(&group->tg_sigdefault, signo);
           spin_unlock_irqrestore(flags);
         }
     }
 
   if (handler == SIG_IGN)
     {
-      /* We are unsetting the default action.  NOTE that sigdelset() is not
+      /* We are unsetting the default action. NOTE that nxsig_delset() is not
        * atomic (but neither is sigaction()).
        */
 
       flags = spin_lock_irqsave();
-      sigdelset(&group->tg_sigdefault, signo);
+      nxsig_delset(&group->tg_sigdefault, signo);
       spin_unlock_irqrestore(flags);
     }
 

--- a/sched/signal/sig_kill.c
+++ b/sched/signal/sig_kill.c
@@ -167,7 +167,7 @@ int kill(pid_t pid, int signo)
 {
   int ret;
 
-  /* Let nxsem_kill() do all of the work */
+  /* Let nxsig_kill() do all of the work */
 
   ret = nxsig_kill(pid, signo);
   if (ret < 0)

--- a/sched/signal/sig_lowest.c
+++ b/sched/signal/sig_lowest.c
@@ -41,6 +41,8 @@
 
 #include <signal.h>
 
+#include <nuttx/signal.h>
+
 #include "signal/signal.h"
 
 /****************************************************************************
@@ -61,7 +63,7 @@ int nxsig_lowest(sigset_t *set)
 
   for (signo = MIN_SIGNO; signo <= MAX_SIGNO; signo++)
     {
-      if (sigismember(set, signo))
+      if (nxsig_ismember(set, signo))
         {
           return signo;
         }

--- a/sched/signal/sig_pending.c
+++ b/sched/signal/sig_pending.c
@@ -43,6 +43,7 @@
 #include <sched.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/signal.h>
 
 #include "sched/sched.h"
 #include "signal/signal.h"
@@ -106,7 +107,7 @@ sigset_t nxsig_pendingset(FAR struct tcb_s *stcb)
   for (sigpend = (FAR sigpendq_t *)group->tg_sigpendingq.head;
        (sigpend); sigpend = sigpend->flink)
     {
-      sigaddset(&sigpendset, sigpend->info.si_signo);
+      nxsig_addset(&sigpendset, sigpend->info.si_signo);
     }
 
   leave_critical_section(flags);

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -406,7 +406,7 @@ int nxsig_timedwait(FAR const sigset_t *set, FAR struct siginfo *info,
            * that we were waiting for?
            */
 
-          if (sigismember(set, rtcb->sigunbinfo.si_signo))
+          if (nxsig_ismember(set, rtcb->sigunbinfo.si_signo))
             {
               /* Yes.. the return value is the number of the signal that
                * awakened us.

--- a/sched/signal/sig_unmaskpendingsignal.c
+++ b/sched/signal/sig_unmaskpendingsignal.c
@@ -41,6 +41,8 @@
 
 #include <sched.h>
 
+#include <nuttx/signal.h>
+
 #include "sched/sched.h"
 #include "signal/signal.h"
 
@@ -101,7 +103,7 @@ bool nxsig_unmask_pendingsignal(void)
            * signal number is pending.
            */
 
-          sigdelset(&unmaskedset, signo);
+          nxsig_delset(&unmaskedset, signo);
 
           /* Remove the pending signal from the list of pending signals */
 

--- a/sched/wqueue/kwork_process.c
+++ b/sched/wqueue/kwork_process.c
@@ -222,7 +222,7 @@ void work_process(FAR struct kwork_wqueue_s *wqueue, int wndx)
       /* Wait indefinitely until signalled with SIGWORK */
 
       sigemptyset(&set);
-      sigaddset(&set, SIGWORK);
+      nxsig_addset(&set, SIGWORK);
 
       wqueue->worker[wndx].busy = false;
       DEBUGVERIFY(nxsig_waitinfo(&set, NULL));


### PR DESCRIPTION
## Summary
Inside the OS use NuttX's signal functions.  These function should not set errno and thus won't interfere with application logic.

## Impact

## Testing

