### PR TITLE
arch/arm/src/common/up_exit.c: _exit should call arm_fullcontextresto…

### DIFF
--- a/arch/arm/src/common/up_exit.c
+++ b/arch/arm/src/common/up_exit.c
@@ -187,5 +187,9 @@ void _exit(int status)
 
   /* Then switch contexts */
 
+#ifdef CONFIG_ARCH_ARMV8M
+  arm_fullcontextrestore(tcb->xcp.regs);
+#else
   up_fullcontextrestore(tcb->xcp.regs);
+#endif
 }


### PR DESCRIPTION
…re for armv8-m

Since armv8-m now uses arm_fullcontextrestore instead of up_fullcontextrestore, _exit
should call arm_fullcontextrestore for armv8-m accordingly.

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>


