### PR TITLE
tmpfs: Fix tmpfs_foreach recursively removing files in directories

### DIFF
--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -662,7 +662,9 @@ static int tmpfs_create_file(FAR struct tmpfs_s *fs,
       name   = copy;
       parent = (FAR struct tmpfs_directory_s *)fs->tfs_root.tde_object;
 
-      /* Lock the root directory to emulate the behavior of tmpfs_find_directory() */
+      /* Lock the root directory to emulate the behavior of
+       * tmpfs_find_directory()
+       */
 
       ret = tmpfs_lock_directory(parent);
       if (ret < 0)
@@ -1175,7 +1177,9 @@ static int tmpfs_statfs_callout(FAR struct tmpfs_directory_s *tdo,
 
   DEBUGASSERT(to != NULL);
 
-  /* Accumulate statistics.  Save the total memory allocated for this object. */
+  /* Accumulate statistics.  Save the total memory allocated
+   * for this object.
+   */
 
   tmpbuf->tsf_alloc += to->to_alloc;
 
@@ -1271,7 +1275,7 @@ static int tmpfs_free_callout(FAR struct tmpfs_directory_s *tdo,
 
       if (tfo->tfo_refs > 0)
         {
-          /* Yes.. We cannot delete the file now.  Just mark it as unlinked. */
+          /* Yes.. We cannot delete the file now. Just mark it as unlinked. */
 
           tfo->tfo_flags |= TFO_FLAG_UNLINKED;
           return TMPFS_UNLINKED;

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1322,7 +1322,7 @@ static int tmpfs_foreach(FAR struct tmpfs_directory_s *tdo,
            * action will be to delete the directory.
            */
 
-          ret = tmpfs_foreach(next, tmpfs_free_callout, NULL);
+          ret = tmpfs_foreach(next, callout, arg);
           if (ret < 0)
             {
               return -ECANCELED;


### PR DESCRIPTION
Fixes #912

## Summary

This PR fixes `tmpfs_foreach` unconditionally and recursively removing files in directories of any mounted TMPFS. It is ok when it called from `tmpfs_unbind` op, but it shouldn't delete any files if called from `tmpfs_statfs`.

## Impact

- TMPFS usage statistics analysis (statfs) operation.
- TMPFS umount (unbind) operation.

## Testing

Tested `tmpfs_statfs` case only, which is called when running `df` command or reading `/proc/fs/usage`. It seems like values in `/proc/fs/usage` are increasing now if more files created and all files remains unchanged in any directory of TMPFS.