### PR TITLE
sim: Add host mmap and perror support

### DIFF
--- a/arch/sim/src/nuttx-names.dat
+++ b/arch/sim/src/nuttx-names.dat
@@ -53,6 +53,7 @@ memcpy         NXmemcpy
 memset         NXmemset
 mkfifo         NXmkfifo
 mktime         NXmktime
+mmap           NXmmap
 mq_close       NXmq_close
 mkdir          NXmkdir
 mount          NXmount
@@ -62,6 +63,7 @@ optarg         NXoptarg
 optind         NXoptind
 optopt         NXoptopt
 nanosleep      NXnanosleep
+perror         NXperror
 pipe           NXpipe
 poll           NXpoll
 printf         NXprintf


### PR DESCRIPTION
## Summary
Add host mmap and perror to nuttx-names.dat for sim to fix crash in up_hostmemory.c if with CONFIG_LIBC_MODLIB and CONFIG_BINFMT_LOADABLE enabled.

## Impact
In a493c92826fd0918231cbfe470e1cf9b48e96de3 commit: sim: Use executable memory for the heap
It uses the  up_hostmemory.c with mmap and perror.

## Testing
Tested and verfied in our inner project sim config in which with CONFIG_BINFMT_LOADABLE enabled.
