### PR TITLE
Add missing Elf_Addr typedef

### DIFF
--- a/include/elf32.h
+++ b/include/elf32.h
@@ -165,6 +165,7 @@ typedef struct
   } d_un;
 } Elf32_Dyn;
 
+typedef Elf32_Addr  Elf_Addr;
 typedef Elf32_Ehdr  Elf_Ehdr;
 typedef Elf32_Rel   Elf_Rel;
 typedef Elf32_Rela  Elf_Rela;

--- a/include/elf64.h
+++ b/include/elf64.h
@@ -147,6 +147,7 @@ typedef struct
   } d_un;
 } Elf64_Dyn;
 
+typedef Elf64_Addr  Elf_Addr;
 typedef Elf64_Ehdr  Elf_Ehdr;
 typedef Elf64_Rel   Elf_Rel;
 typedef Elf64_Rela  Elf_Rela;


### PR DESCRIPTION
## Summary
This fixes a compilation error when exceptions are enabled, as it
depends on the Elf_Addr symbol.
