### PR TITLE
 Rename up_fullcontextrestore to arm_fullcontextrestore

### DIFF
--- a/arch/arm/src/arm/arm_fullcontextrestore.S
+++ b/arch/arm/src/arm/arm_fullcontextrestore.S
@@ -1,5 +1,5 @@
 /**************************************************************************
- * arch/arm/src/arm/up_fullcontextrestore.S
+ * arch/arm/src/arm/arm_fullcontextrestore.S
  *
  *   Copyright (C) 2007, 2009-2010 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -69,12 +69,12 @@
  **************************************************************************/
 
 /**************************************************************************
- * Name: up_fullcontextrestore
+ * Name: arm_fullcontextrestore
  **************************************************************************/
 
-	.globl	up_fullcontextrestore
-	.type	up_fullcontextrestore, function
-up_fullcontextrestore:
+	.globl	arm_fullcontextrestore
+	.type	arm_fullcontextrestore, function
+arm_fullcontextrestore:
 
 	/* On entry, a1 (r0) holds address of the register save area */
 
@@ -108,4 +108,4 @@ up_fullcontextrestore:
 	 */
 
 	ldmia	sp!, {r0-r1, r15}
-	.size up_fullcontextrestore, . - up_fullcontextrestore
+	.size arm_fullcontextrestore, . - arm_fullcontextrestore

--- a/arch/arm/src/arm/up_blocktask.c
+++ b/arch/arm/src/arm/up_blocktask.c
@@ -167,7 +167,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/arm/up_releasepending.c
+++ b/arch/arm/src/arm/up_releasepending.c
@@ -138,7 +138,7 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/arm/up_releasepending.c
+++ b/arch/arm/src/arm/up_releasepending.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/arm/up_releasepending.c
  *
- *   Copyright (C) 2007-2009, 2014-2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -71,7 +56,6 @@ void up_release_pending(void)
 
   /* Merge the g_pendingtasks list into the ready-to-run task list */
 
-  /* sched_lock(); */
   if (sched_mergepending())
     {
       /* The currently active task has changed!  We will need to switch

--- a/arch/arm/src/arm/up_reprioritizertr.c
+++ b/arch/arm/src/arm/up_reprioritizertr.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/arm/up_reprioritizertr.c
  *
- *   Copyright (C) 2007-2009, 2013-2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -165,7 +150,8 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
           /* Copy the exception context into the TCB at the (old) head of the
            * ready-to-run Task list. if up_saveusercontext returns a non-zero
-           * value, then this is really the previously running task restarting!
+           * value, then this is really the previously running task
+           * restarting!
            */
 
           else if (!up_saveusercontext(rtcb->xcp.regs))

--- a/arch/arm/src/arm/up_reprioritizertr.c
+++ b/arch/arm/src/arm/up_reprioritizertr.c
@@ -191,7 +191,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
-              up_fullcontextrestore(rtcb->xcp.regs);
+              arm_fullcontextrestore(rtcb->xcp.regs);
             }
         }
     }

--- a/arch/arm/src/arm/up_sigdeliver.c
+++ b/arch/arm/src/arm/up_sigdeliver.c
@@ -127,5 +127,5 @@ void up_sigdeliver(void)
   /* Then restore the correct state for this thread of execution. */
 
   board_autoled_off(LED_SIGNAL);
-  up_fullcontextrestore(regs);
+  arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/arm/up_unblocktask.c
+++ b/arch/arm/src/arm/up_unblocktask.c
@@ -153,7 +153,7 @@ void up_unblock_task(struct tcb_s *tcb)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/armv6-m/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv6-m/arm_fullcontextrestore.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv6-m/up_fullcontextrestore.S
+ * arch/arm/src/armv6-m/arm_fullcontextrestore.S
  *
  *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -52,7 +52,7 @@
  ************************************************************************************/
 
 	.cpu	cortex-m0
-	.file	"up_fullcontextrestore.S"
+	.file	"arm_fullcontextrestore.S"
 
 /************************************************************************************
  * Macros
@@ -63,12 +63,12 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_fullcontextrestore
+ * Name: arm_fullcontextrestore
  *
  * Description:
  *   Restore the current thread context.  Full prototype is:
  *
- *   void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ *   void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  *
  * Returned Value:
  *   None
@@ -78,9 +78,9 @@
 	.align	2
 	.code	16
 	.thumb_func
-	.globl	up_fullcontextrestore
-	.type	up_fullcontextrestore, function
-up_fullcontextrestore:
+	.globl	arm_fullcontextrestore
+	.type	arm_fullcontextrestore, function
+arm_fullcontextrestore:
 
 	/* Perform the System call with R0=1 and R1=regs */
 
@@ -91,5 +91,5 @@ up_fullcontextrestore:
 	/* This call should not return */
 
 	bx		lr							/* Unnecessary ... will not return */
-	.size	up_fullcontextrestore, .-up_fullcontextrestore
+	.size	arm_fullcontextrestore, .-arm_fullcontextrestore
 	.end

--- a/arch/arm/src/armv6-m/svcall.h
+++ b/arch/arm/src/armv6-m/svcall.h
@@ -1,35 +1,20 @@
 /************************************************************************************
  * arch/arm/src/armv6-m/svcall.h
  *
- *   Copyright (C) 2013-2014 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ************************************************************************************/
 
@@ -51,6 +36,7 @@
  ************************************************************************************/
 
 /* Configuration ********************************************************************/
+
 /* This logic uses three system calls {0,1,2} for context switching and one for the
  * syscall return.  So a minimum of four syscall values must be reserved.  If
  * CONFIG_BUILD_PROTECTED is defined, then four more syscall values must be reserved.

--- a/arch/arm/src/armv6-m/svcall.h
+++ b/arch/arm/src/armv6-m/svcall.h
@@ -83,7 +83,7 @@
 
 /* SYS call 1:
  *
- * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_restore_context       (1)

--- a/arch/arm/src/armv6-m/up_sigdeliver.c
+++ b/arch/arm/src/armv6-m/up_sigdeliver.c
@@ -69,7 +69,7 @@
 void up_sigdeliver(void)
 {
   /* NOTE the "magic" guard space added to regs.  This is a little kludge
-   * because up_fullcontextrestore (called below) will do a stack-to-stack
+   * because arm_fullcontextrestore (called below) will do a stack-to-stack
    * copy an may overwrite the regs[] array contents.  Sorry.
    */
 
@@ -137,5 +137,5 @@ void up_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
-  up_fullcontextrestore(regs);
+  arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv6-m/up_svcall.c
+++ b/arch/arm/src/armv6-m/up_svcall.c
@@ -191,7 +191,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_restore_context:  This a restore context command:
        *
-       *   void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+       *   void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/arm/src/armv6-m/up_svcall.c
+++ b/arch/arm/src/armv6-m/up_svcall.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/armv6-m/up_svcall.c
  *
- *   Copyright (C) 2013-2014, 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -191,7 +176,8 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_restore_context:  This a restore context command:
        *
-       *   void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+       *   void arm_fullcontextrestore(uint32_t *restoreregs)
+       *     noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -199,9 +185,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
        *   R1 = restoreregs
        *
        * In this case, we simply need to set CURRENT_REGS to restore register
-       * area referenced in the saved R1. context == CURRENT_REGS is the normal
-       * exception return.  By setting CURRENT_REGS = context[R1], we force
-       * the return to the saved context referenced in R1.
+       * area referenced in the saved R1. context == CURRENT_REGS is the
+       * normal exception return.  By setting CURRENT_REGS = context[R1], we
+       * force the return to the saved context referenced in R1.
        */
 
       case SYS_restore_context:
@@ -265,8 +251,8 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
           regs[REG_EXC_RETURN] = rtcb->xcp.syscall[index].excreturn;
           rtcb->xcp.nsyscalls  = index;
 
-          /* The return value must be in R0-R1.  dispatch_syscall() temporarily
-           * moved the value for R0 into R2.
+          /* The return value must be in R0-R1.  dispatch_syscall()
+           * temporarily moved the value for R0 into R2.
            */
 
           regs[REG_R0]         = regs[REG_R2];
@@ -283,7 +269,8 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_task_start:  This a user task start
        *
-       *   void up_task_start(main_t taskentry, int argc, FAR char *argv[]) noreturn_function;
+       *   void up_task_start(main_t taskentry, int argc, FAR char *argv[])
+       *     noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -316,7 +303,8 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_pthread_start:  This a user pthread start
        *
-       *   void up_pthread_start(pthread_startroutine_t entrypt, pthread_addr_t arg) noreturn_function;
+       *   void up_pthread_start(pthread_startroutine_t entrypt,
+       *                         pthread_addr_t arg) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -457,7 +445,9 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
         break;
     }
 
-  /* Report what happened.  That might difficult in the case of a context switch */
+  /* Report what happened.  That might difficult in the case of a context
+   * switch.
+   */
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
 # ifndef CONFIG_DEBUG_SVCALL

--- a/arch/arm/src/armv7-a/arm_blocktask.c
+++ b/arch/arm/src/armv7-a/arm_blocktask.c
@@ -167,7 +167,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/armv7-a/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-a/arm_fullcontextrestore.S
@@ -49,29 +49,29 @@
  * Public Symbols
  ****************************************************************************/
 
-	.globl	up_fullcontextrestore
+	.globl	arm_fullcontextrestore
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_fullcontextrestore
+ * Name: arm_fullcontextrestore
  *
  * Description:
  *   Restore the specified task context. Full prototype is:
  *
- *     void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ *     void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  *
  * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-	.globl	up_fullcontextrestore
-	.type	up_fullcontextrestore, function
+	.globl	arm_fullcontextrestore
+	.type	arm_fullcontextrestore, function
 
-up_fullcontextrestore:
+arm_fullcontextrestore:
 
 	/* On entry, a1 (r0) holds address of the register save area.  All other
 	 * registers are available for use.
@@ -157,4 +157,4 @@ up_fullcontextrestore:
 
 #endif
 
-	.size up_fullcontextrestore, . - up_fullcontextrestore
+	.size arm_fullcontextrestore, . - arm_fullcontextrestore

--- a/arch/arm/src/armv7-a/arm_releasepending.c
+++ b/arch/arm/src/armv7-a/arm_releasepending.c
@@ -137,7 +137,7 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/armv7-a/arm_releasepending.c
+++ b/arch/arm/src/armv7-a/arm_releasepending.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv7-a/arm_releasepending.c
  *
- *   Copyright (C) 2013-2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -70,7 +55,6 @@ void up_release_pending(void)
 
   /* Merge the g_pendingtasks list into the ready-to-run task list */
 
-  /* sched_lock(); */
   if (sched_mergepending())
     {
       /* The currently active task has changed!  We will need to

--- a/arch/arm/src/armv7-a/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-a/arm_reprioritizertr.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv7-a/arm_reprioritizertr.c
  *
- *   Copyright (C) 2013-2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -165,7 +150,8 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
           /* Copy the exception context into the TCB at the (old) head of the
            * ready-to-run Task list. if up_saveusercontext returns a non-zero
-           * value, then this is really the previously running task restarting!
+           * value, then this is really the previously running task
+           * restarting!
            */
 
           else if (!up_saveusercontext(rtcb->xcp.regs))

--- a/arch/arm/src/armv7-a/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-a/arm_reprioritizertr.c
@@ -191,7 +191,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
-              up_fullcontextrestore(rtcb->xcp.regs);
+              arm_fullcontextrestore(rtcb->xcp.regs);
             }
         }
     }

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -135,7 +135,7 @@ void up_sigdeliver(void)
    * errno that is needed by the user logic (it is probably EINTR).
    *
    * I would prefer that all interrupts are disabled when
-   * up_fullcontextrestore() is called, but that may not be necessary.
+   * arm_fullcontextrestore() is called, but that may not be necessary.
    */
 
   sinfo("Resuming\n");
@@ -194,5 +194,5 @@ void up_sigdeliver(void)
   /* Then restore the correct state for this thread of execution. */
 
   board_autoled_off(LED_SIGNAL);
-  up_fullcontextrestore(regs);
+  arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -232,7 +232,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       /* R0=SYS_context_restore:  Restore task context
        *
-       * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+       * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv7-a/arm_syscall.c
  *
- *   Copyright (C) 2013-2014, 2016, 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -199,16 +184,16 @@ uint32_t *arm_syscall(uint32_t *regs)
 #ifdef CONFIG_BUILD_KERNEL
           regs[REG_CPSR]      = rtcb->xcp.syscall[index].cpsr;
 #endif
-          /* The return value must be in R0-R1.  dispatch_syscall() temporarily
-           * moved the value for R0 into R2.
+          /* The return value must be in R0-R1.  dispatch_syscall()
+           * temporarily moved the value for R0 into R2.
            */
 
           regs[REG_R0]         = regs[REG_R2];
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
-          /* If this is the outermost SYSCALL and if there is a saved user stack
-           * pointer, then restore the user stack pointer on this final return to
-           * user code.
+          /* If this is the outermost SYSCALL and if there is a saved user
+           * stack pointer, then restore the user stack pointer on this
+           * final return to user code.
            */
 
           if (index == 0 && rtcb->xcp.ustkptr != NULL)
@@ -217,6 +202,7 @@ uint32_t *arm_syscall(uint32_t *regs)
               rtcb->xcp.ustkptr = NULL;
             }
 #endif
+
           /* Save the new SYSCALL nesting level */
 
           rtcb->xcp.nsyscalls   = index;
@@ -232,7 +218,8 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       /* R0=SYS_context_restore:  Restore task context
        *
-       * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+       * void arm_fullcontextrestore(uint32_t *restoreregs)
+       *   noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -256,7 +243,8 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       /* R0=SYS_task_start:  This a user task start
        *
-       *   void up_task_start(main_t taskentry, int argc, FAR char *argv[]) noreturn_function;
+       *   void up_task_start(main_t taskentry, int argc, FAR char *argv[])
+       *     noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -290,7 +278,8 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       /* R0=SYS_pthread_start:  This a user pthread start
        *
-       *   void up_pthread_start(pthread_startroutine_t entrypt, pthread_addr_t arg) noreturn_function;
+       *   void up_pthread_start(pthread_startroutine_t entrypt,
+       *                         pthread_addr_t arg) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -309,7 +298,6 @@ uint32_t *arm_syscall(uint32_t *regs)
            *   PC   = entrypt
            *   CSPR = user mode
            */
-
 
           regs[REG_PC]   = regs[REG_R1];
           regs[REG_R0]   = regs[REG_R2];
@@ -338,6 +326,7 @@ uint32_t *arm_syscall(uint32_t *regs)
       case SYS_signal_handler:
         {
           FAR struct tcb_s *rtcb = sched_self();
+
           /* Remember the caller's return address */
 
           DEBUGASSERT(rtcb->xcp.sigreturn == 0);
@@ -370,7 +359,8 @@ uint32_t *arm_syscall(uint32_t *regs)
 
           if (rtcb->xcp.kstack != NULL)
             {
-              DEBUGASSERT(rtcb->xcp.kstkptr == NULL && rtcb->xcp.ustkptr != NULL);
+              DEBUGASSERT(rtcb->xcp.kstkptr == NULL &&
+                          rtcb->xcp.ustkptr != NULL);
 
               rtcb->xcp.kstkptr = (FAR uint32_t *)regs[REG_SP];
               regs[REG_SP]      = (uint32_t)rtcb->xcp.ustkptr;
@@ -474,9 +464,11 @@ uint32_t *arm_syscall(uint32_t *regs)
           if (index == 0 && rtcb->xcp.kstack != NULL)
             {
               rtcb->xcp.ustkptr = (FAR uint32_t *)regs[REG_SP];
-              regs[REG_SP]      = (uint32_t)rtcb->xcp.kstack + ARCH_KERNEL_STACKSIZE;
+              regs[REG_SP]      = (uint32_t)rtcb->xcp.kstack +
+                                  ARCH_KERNEL_STACKSIZE;
             }
 #endif
+
           /* Save the new SYSCALL nesting level */
 
           rtcb->xcp.nsyscalls   = index + 1;

--- a/arch/arm/src/armv7-a/arm_unblocktask.c
+++ b/arch/arm/src/armv7-a/arm_unblocktask.c
@@ -174,7 +174,7 @@ void up_unblock_task(struct tcb_s *tcb)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/armv7-a/svcall.h
+++ b/arch/arm/src/armv7-a/svcall.h
@@ -1,35 +1,20 @@
 /************************************************************************************
  * arch/arm/src/armv7-a/svcall.h
  *
- *   Copyright (C) 2014 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ************************************************************************************/
 
@@ -53,6 +38,7 @@
  ************************************************************************************/
 
 /* Configuration ********************************************************************/
+
 /* This logic uses one system call for the syscall return.  So a minimum of one
  * syscall values must be reserved.  If CONFIG_BUILD_KERNEL is defined, then four
  * more syscall values must be reserved.

--- a/arch/arm/src/armv7-a/svcall.h
+++ b/arch/arm/src/armv7-a/svcall.h
@@ -84,7 +84,7 @@
 #ifdef CONFIG_BUILD_KERNEL
 /* SYS call 1:
  *
- * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_context_restore       (1)

--- a/arch/arm/src/armv7-m/gnu/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-m/gnu/arm_fullcontextrestore.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv7-m/gnu/up_fullcontextrestore.S
+ * arch/arm/src/armv7-m/gnu/arm_fullcontextrestore.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -38,7 +38,7 @@
 
 	.syntax	unified
 	.thumb
-	.file	"up_fullcontextrestore.S"
+	.file	"arm_fullcontextrestore.S"
 
 /************************************************************************************
  * Macros
@@ -49,12 +49,12 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_fullcontextrestore
+ * Name: arm_fullcontextrestore
  *
  * Description:
  *   Restore the current thread context.  Full prototype is:
  *
- *   void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ *   void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  *
  * Returned Value:
  *   None
@@ -62,9 +62,9 @@
  ************************************************************************************/
 
 	.thumb_func
-	.globl	up_fullcontextrestore
-	.type	up_fullcontextrestore, function
-up_fullcontextrestore:
+	.globl	arm_fullcontextrestore
+	.type	arm_fullcontextrestore, function
+arm_fullcontextrestore:
 
 	/* Perform the System call with R0=1 and R1=regs */
 
@@ -75,5 +75,5 @@ up_fullcontextrestore:
 	/* This call should not return */
 
 	bx		lr							/* Unnecessary ... will not return */
-	.size	up_fullcontextrestore, .-up_fullcontextrestore
+	.size	arm_fullcontextrestore, .-arm_fullcontextrestore
 	.end

--- a/arch/arm/src/armv7-m/iar/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-m/iar/arm_fullcontextrestore.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv7-m/iar/up_fullcontextrestore.S
+ * arch/arm/src/armv7-m/iar/arm_fullcontextrestore.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -28,7 +28,7 @@
 #include "nvic.h"
 #include "svcall.h"
 
-	MODULE up_fullcontextrestore
+	MODULE arm_fullcontextrestore
 	SECTION .text:CODE:NOROOT(2)
 
 /************************************************************************************
@@ -39,7 +39,7 @@
  * Public Symbols
  ************************************************************************************/
 
-	PUBLIC up_fullcontextrestore
+	PUBLIC arm_fullcontextrestore
 
 /************************************************************************************
  * Macros
@@ -50,12 +50,12 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_fullcontextrestore
+ * Name: arm_fullcontextrestore
  *
  * Description:
  *   Restore the current thread context.  Full prototype is:
  *
- *   void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ *   void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  *
  * Returned Value:
  *   None
@@ -64,7 +64,7 @@
 
 	THUMB
 
-up_fullcontextrestore:
+arm_fullcontextrestore:
 
 	/* Perform the System call with R0=1 and R1=regs */
 

--- a/arch/arm/src/armv7-m/svcall.h
+++ b/arch/arm/src/armv7-m/svcall.h
@@ -69,7 +69,7 @@
 
 /* SYS call 1:
  *
- * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_restore_context       (1)

--- a/arch/arm/src/armv7-m/up_sigdeliver.c
+++ b/arch/arm/src/armv7-m/up_sigdeliver.c
@@ -123,7 +123,7 @@ void up_sigdeliver(void)
    * errno that is needed by the user logic (it is probably EINTR).
    *
    * I would prefer that all interrupts are disabled when
-   * up_fullcontextrestore() is called, but that may not be necessary.
+   * arm_fullcontextrestore() is called, but that may not be necessary.
    */
 
   sinfo("Resuming\n");
@@ -192,5 +192,5 @@ void up_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
-  up_fullcontextrestore(regs);
+  arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv7-m/up_svcall.c
+++ b/arch/arm/src/armv7-m/up_svcall.c
@@ -186,7 +186,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_restore_context:  This a restore context command:
        *
-       *   void up_fullcontextrestore(uint32_t *restoreregs)
+       *   void arm_fullcontextrestore(uint32_t *restoreregs)
        *          noreturn_function;
        *
        * At this point, the following values are saved in context:

--- a/arch/arm/src/armv7-r/arm_blocktask.c
+++ b/arch/arm/src/armv7-r/arm_blocktask.c
@@ -156,7 +156,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/armv7-r/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-r/arm_fullcontextrestore.S
@@ -52,7 +52,7 @@
  * Public Symbols
  ****************************************************************************/
 
-	.globl	up_fullcontextrestore
+	.globl	arm_fullcontextrestore
 
 #ifdef CONFIG_ARCH_FPU
 	.cpu	cortex-r4f
@@ -68,22 +68,22 @@
 	.text
 
 /****************************************************************************
- * Name: up_fullcontextrestore
+ * Name: arm_fullcontextrestore
  *
  * Description:
  *   Restore the specified task context. Full prototype is:
  *
- *     void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ *     void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  *
  * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-	.globl	up_fullcontextrestore
-	.type	up_fullcontextrestore, function
+	.globl	arm_fullcontextrestore
+	.type	arm_fullcontextrestore, function
 
-up_fullcontextrestore:
+arm_fullcontextrestore:
 
 	/* On entry, a1 (r0) holds address of the register save area.  All other
 	 * registers are available for use.
@@ -163,4 +163,4 @@ up_fullcontextrestore:
 	ldmia		sp!, {r0-r1, pc}^
 #endif
 
-	.size up_fullcontextrestore, . - up_fullcontextrestore
+	.size arm_fullcontextrestore, . - arm_fullcontextrestore

--- a/arch/arm/src/armv7-r/arm_releasepending.c
+++ b/arch/arm/src/armv7-r/arm_releasepending.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv7-r/arm_releasepending.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -71,7 +56,6 @@ void up_release_pending(void)
 
   /* Merge the g_pendingtasks list into the ready-to-run task list */
 
-  /* sched_lock(); */
   if (sched_mergepending())
     {
       /* The currently active task has changed!  We will need to

--- a/arch/arm/src/armv7-r/arm_releasepending.c
+++ b/arch/arm/src/armv7-r/arm_releasepending.c
@@ -129,7 +129,7 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/armv7-r/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-r/arm_reprioritizertr.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv7-r/arm_reprioritizertr.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -165,7 +150,8 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
           /* Copy the exception context into the TCB at the (old) head of the
            * ready-to-run Task list. if up_saveusercontext returns a non-zero
-           * value, then this is really the previously running task restarting!
+           * value, then this is really the previously running task
+           * restarting!
            */
 
           else if (!up_saveusercontext(rtcb->xcp.regs))

--- a/arch/arm/src/armv7-r/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-r/arm_reprioritizertr.c
@@ -182,7 +182,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
-              up_fullcontextrestore(rtcb->xcp.regs);
+              arm_fullcontextrestore(rtcb->xcp.regs);
             }
         }
     }

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -126,5 +126,5 @@ void up_sigdeliver(void)
   /* Then restore the correct state for this thread of execution. */
 
   board_autoled_off(LED_SIGNAL);
-  up_fullcontextrestore(regs);
+  arm_fullcontextrestore(regs);
 }

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -230,7 +230,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       /* R0=SYS_context_restore:  Restore task context
        *
-       * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+       * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv7-r/arm_syscall.c
  *
- *   Copyright (C) 2015, 20-19 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -197,16 +182,16 @@ uint32_t *arm_syscall(uint32_t *regs)
 #ifdef CONFIG_BUILD_PROTECTED
           regs[REG_CPSR]      = rtcb->xcp.syscall[index].cpsr;
 #endif
-          /* The return value must be in R0-R1.  dispatch_syscall() temporarily
-           * moved the value for R0 into R2.
+          /* The return value must be in R0-R1.  dispatch_syscall()
+           * temporarily moved the value for R0 into R2.
            */
 
           regs[REG_R0]         = regs[REG_R2];
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
-          /* If this is the outermost SYSCALL and if there is a saved user stack
-           * pointer, then restore the user stack pointer on this final return to
-           * user code.
+          /* If this is the outermost SYSCALL and if there is a saved user
+           * stack pointer, then restore the user stack pointer on this
+           * final return to user code.
            */
 
           if (index == 0 && rtcb->xcp.ustkptr != NULL)
@@ -215,6 +200,7 @@ uint32_t *arm_syscall(uint32_t *regs)
               rtcb->xcp.ustkptr = NULL;
             }
 #endif
+
           /* Save the new SYSCALL nesting level */
 
           rtcb->xcp.nsyscalls   = index;
@@ -230,7 +216,8 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       /* R0=SYS_context_restore:  Restore task context
        *
-       * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+       * void arm_fullcontextrestore(uint32_t *restoreregs)
+       *   noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -254,7 +241,8 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       /* R0=SYS_task_start:  This a user task start
        *
-       *   void up_task_start(main_t taskentry, int argc, FAR char *argv[]) noreturn_function;
+       *   void up_task_start(main_t taskentry, int argc, FAR char *argv[])
+       *     noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -288,7 +276,8 @@ uint32_t *arm_syscall(uint32_t *regs)
 
       /* R0=SYS_pthread_start:  This a user pthread start
        *
-       *   void up_pthread_start(pthread_startroutine_t entrypt, pthread_addr_t arg) noreturn_function;
+       *   void up_pthread_start(pthread_startroutine_t entrypt,
+       *                         pthread_addr_t arg) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -307,7 +296,6 @@ uint32_t *arm_syscall(uint32_t *regs)
            *   PC   = entrypt
            *   CSPR = user mode
            */
-
 
           regs[REG_PC]   = regs[REG_R1];
           regs[REG_R0]   = regs[REG_R2];
@@ -336,6 +324,7 @@ uint32_t *arm_syscall(uint32_t *regs)
       case SYS_signal_handler:
         {
           FAR struct tcb_s *rtcb = sched_self();
+
           /* Remember the caller's return address */
 
           DEBUGASSERT(rtcb->xcp.sigreturn == 0);
@@ -368,7 +357,8 @@ uint32_t *arm_syscall(uint32_t *regs)
 
           if (rtcb->xcp.kstack != NULL)
             {
-              DEBUGASSERT(rtcb->xcp.kstkptr == NULL && rtcb->xcp.ustkptr != NULL);
+              DEBUGASSERT(rtcb->xcp.kstkptr == NULL &&
+                          rtcb->xcp.ustkptr != NULL);
 
               rtcb->xcp.kstkptr = (FAR uint32_t *)regs[REG_SP];
               regs[REG_SP]      = (uint32_t)rtcb->xcp.ustkptr;
@@ -472,9 +462,11 @@ uint32_t *arm_syscall(uint32_t *regs)
           if (index == 0 && rtcb->xcp.kstack != NULL)
             {
               rtcb->xcp.ustkptr = (FAR uint32_t *)regs[REG_SP];
-              regs[REG_SP]      = (uint32_t)rtcb->xcp.kstack + ARCH_KERNEL_STACKSIZE;
+              regs[REG_SP]      = (uint32_t)rtcb->xcp.kstack +
+                                   ARCH_KERNEL_STACKSIZE;
             }
 #endif
+
           /* Save the new SYSCALL nesting level */
 
           rtcb->xcp.nsyscalls   = index + 1;

--- a/arch/arm/src/armv7-r/arm_unblocktask.c
+++ b/arch/arm/src/armv7-r/arm_unblocktask.c
@@ -156,7 +156,7 @@ void up_unblock_task(struct tcb_s *tcb)
 
           /* Then switch contexts */
 
-          up_fullcontextrestore(rtcb->xcp.regs);
+          arm_fullcontextrestore(rtcb->xcp.regs);
         }
     }
 }

--- a/arch/arm/src/armv7-r/arm_unblocktask.c
+++ b/arch/arm/src/armv7-r/arm_unblocktask.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv7-r/arm_unblocktask.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/armv7-r/svcall.h
+++ b/arch/arm/src/armv7-r/svcall.h
@@ -84,7 +84,7 @@
 #ifdef CONFIG_BUILD_PROTECTED
 /* SYS call 1:
  *
- * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_context_restore       (1)

--- a/arch/arm/src/armv7-r/svcall.h
+++ b/arch/arm/src/armv7-r/svcall.h
@@ -1,35 +1,20 @@
 /************************************************************************************
  * arch/arm/src/armv7-r/svcall.h
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ************************************************************************************/
 
@@ -53,6 +38,7 @@
  ************************************************************************************/
 
 /* Configuration ********************************************************************/
+
 /* This logic uses one system call for the syscall return.  So a minimum of one
  * syscall values must be reserved.  If CONFIG_BUILD_PROTECTED is defined, then four
  * more syscall values must be reserved.

--- a/arch/arm/src/c5471/Make.defs
+++ b/arch/arm/src/c5471/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = up_nommuhead.S
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S vfork.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c up_doirq.c

--- a/arch/arm/src/common/up_exit.c
+++ b/arch/arm/src/common/up_exit.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * common/up_exit.c
  *
- *   Copyright (C) 2007-2009, 201-2014, 2017-2018 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/common/up_exit.c
+++ b/arch/arm/src/common/up_exit.c
@@ -187,9 +187,5 @@ void _exit(int status)
 
   /* Then switch contexts */
 
-#ifdef CONFIG_ARCH_ARMV8M
   arm_fullcontextrestore(tcb->xcp.regs);
-#else
-  up_fullcontextrestore(tcb->xcp.regs);
-#endif
 }

--- a/arch/arm/src/common/up_internal.h
+++ b/arch/arm/src/common/up_internal.h
@@ -300,7 +300,7 @@ void up_copyarmstate(uint32_t *dest, uint32_t *src);
 #endif
 void up_decodeirq(uint32_t *regs);
 int  up_saveusercontext(uint32_t *saveregs);
-void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
 void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
 
 /* Signal handling **********************************************************/

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -37,7 +37,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/dm320/Make.defs
+++ b/arch/arm/src/dm320/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = up_head.S
 
-CMN_ASRCS  = up_cache.S up_fullcontextrestore.S up_saveusercontext.S
+CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
 
 CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c

--- a/arch/arm/src/efm32/Make.defs
+++ b/arch/arm/src/efm32/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/imx1/Make.defs
+++ b/arch/arm/src/imx1/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = up_head.S
 
-CMN_ASRCS  = up_cache.S up_fullcontextrestore.S up_saveusercontext.S
+CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
 CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_dataabort.c up_mdelay.c up_udelay.c up_exit.c

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC  =
 
 # Common ARM and Cortex-M7 files
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/kl/Make.defs
+++ b/arch/arm/src/kl/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC =
 
-CMN_ASRCS  = up_exception.S up_saveusercontext.S up_fullcontextrestore.S
+CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -40,7 +40,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -42,7 +42,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc214x/Make.defs
+++ b/arch/arm/src/lpc214x/Make.defs
@@ -36,7 +36,7 @@
 
 HEAD_ASRC = lpc214x_head.S
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_vectors.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c

--- a/arch/arm/src/lpc2378/Make.defs
+++ b/arch/arm/src/lpc2378/Make.defs
@@ -40,7 +40,7 @@
 
 HEAD_ASRC = lpc23xx_head.S
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_vectors.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c

--- a/arch/arm/src/lpc31xx/Make.defs
+++ b/arch/arm/src/lpc31xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = up_head.S
 
-CMN_ASRCS  = up_cache.S up_fullcontextrestore.S up_saveusercontext.S
+CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
 
 CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/max326xx/Make.defs
+++ b/arch/arm/src/max326xx/Make.defs
@@ -37,7 +37,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/moxart/Make.defs
+++ b/arch/arm/src/moxart/Make.defs
@@ -38,7 +38,7 @@
 
 HEAD_ASRC = moxart_head.S
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_vectors.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += up_nommuhead.S vfork.S
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/nuc1xx/Make.defs
+++ b/arch/arm/src/nuc1xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC =
 
-CMN_ASRCS  = up_exception.S up_saveusercontext.S up_fullcontextrestore.S
+CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c

--- a/arch/arm/src/s32k1xx/s32k11x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k11x/Make.defs
@@ -35,7 +35,7 @@
 
 # Source files specific to the Cortex-M0+
 
-CMN_ASRCS += up_exception.S up_saveusercontext.S up_fullcontextrestore.S
+CMN_ASRCS += up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS += up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c

--- a/arch/arm/src/s32k1xx/s32k14x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k14x/Make.defs
@@ -35,7 +35,7 @@
 
 # Source files specific to the Cortex-M4F
 
-CMN_ASRCS += up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS += up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/samd2l2/Make.defs
+++ b/arch/arm/src/samd2l2/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC =
 
-CMN_ASRCS  = up_exception.S up_saveusercontext.S up_fullcontextrestore.S
+CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c

--- a/arch/arm/src/samd5e5/Make.defs
+++ b/arch/arm/src/samd5e5/Make.defs
@@ -42,7 +42,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32f0l0g0/Make.defs
+++ b/arch/arm/src/stm32f0l0g0/Make.defs
@@ -36,7 +36,7 @@
 
 HEAD_ASRC =
 
-CMN_ASRCS  = up_exception.S up_saveusercontext.S up_fullcontextrestore.S
+CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -44,7 +44,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/str71x/Make.defs
+++ b/arch/arm/src/str71x/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = str71x_head.S
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_vectors.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -36,7 +36,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S  vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S up_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)


### PR DESCRIPTION
## Summary

The naming standard at https://cwiki.apache.org/confluence/display/NUTTX/Naming+FAQ requires that all MCU-private interfaces begin with the name of the architecture, not up_.

This replaces PR #916 and answers Issue #915 

## Impact

There should be not impact of this change (other that one step toward more consistent naming).

## Testing

stm32f4discovery:nsh
