### PR TITLE
arch/arm:  Rename context switching functions from up_ to arm_ 

### DIFF
--- a/arch/arm/src/arm/arm_copyfullstate.c
+++ b/arch/arm/src/arm/arm_copyfullstate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/arm/up_copyfullstate.c
+ * arch/arm/src/arm/arm_copyfullstate.c
  *
  *   Copyright (C) 2007-2009, 2013 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -61,12 +61,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyfullstate
+ * Name: arm_copyfullstate
  ****************************************************************************/
 
 /* A little faster than most memcpy's */
 
-void up_copyfullstate(uint32_t *dest, uint32_t *src)
+void arm_copyfullstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/arm/arm_saveusercontext.S
+++ b/arch/arm/src/arm/arm_saveusercontext.S
@@ -1,5 +1,5 @@
 /**************************************************************************
- * arch/arm/src/arm/up_saveusercontext.S
+ * arch/arm/src/arm/arm_saveusercontext.S
  *
  *   Copyright (C) 2007, 2009 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -69,13 +69,13 @@
  **************************************************************************/
 
 /**************************************************************************
- * Name: up_saveusercontext
+ * Name: arm_saveusercontext
  **************************************************************************/
 
 	.text
-	.globl	up_saveusercontext
-	.type	up_saveusercontext, function
-up_saveusercontext:
+	.globl	arm_saveusercontext
+	.type	arm_saveusercontext, function
+arm_saveusercontext:
 	/* On entry, a1 (r0) holds address of struct xcptcontext.
 	 * Offset to the user region.
 	 */
@@ -115,4 +115,4 @@ up_saveusercontext:
 
 	mov	r0, #0		/* Return value == 0 */
 	mov	pc, lr		/* Return */
-	.size	up_saveusercontext, . - up_saveusercontext
+	.size	arm_saveusercontext, . - arm_saveusercontext

--- a/arch/arm/src/arm/up_assert.c
+++ b/arch/arm/src/arm/up_assert.c
@@ -138,7 +138,7 @@ static inline void up_registerdump(void)
     {
       /* No.. capture user registers by hand */
 
-      up_saveusercontext(s_last_regs);
+      arm_saveusercontext(s_last_regs);
       regs = s_last_regs;
     }
 

--- a/arch/arm/src/arm/up_blocktask.c
+++ b/arch/arm/src/arm/up_blocktask.c
@@ -140,11 +140,11 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
         }
 
       /* Copy the user C context into the TCB at the (old) head of the
-       * ready-to-run Task list. if up_saveusercontext returns a non-zero
+       * ready-to-run Task list. if arm_saveusercontext returns a non-zero
        * value, then this is really the previously running task restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/arm/src/arm/up_releasepending.c
+++ b/arch/arm/src/arm/up_releasepending.c
@@ -94,12 +94,12 @@ void up_release_pending(void)
         }
 
       /* Copy the exception context into the TCB of the task that
-       * was currently active. if up_saveusercontext returns a non-zero
+       * was currently active. if arm_saveusercontext returns a non-zero
        * value, then this is really the previously running task
        * restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/arm/src/arm/up_reprioritizertr.c
+++ b/arch/arm/src/arm/up_reprioritizertr.c
@@ -149,12 +149,12 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
             }
 
           /* Copy the exception context into the TCB at the (old) head of the
-           * ready-to-run Task list. if up_saveusercontext returns a non-zero
+           * ready-to-run Task list. if arm_saveusercontext returns a non-zero
            * value, then this is really the previously running task
            * restarting!
            */
 
-          else if (!up_saveusercontext(rtcb->xcp.regs))
+          else if (!arm_saveusercontext(rtcb->xcp.regs))
             {
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.

--- a/arch/arm/src/arm/up_reprioritizertr.c
+++ b/arch/arm/src/arm/up_reprioritizertr.c
@@ -148,9 +148,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
               up_restorestate(rtcb->xcp.regs);
             }
 
-          /* Copy the exception context into the TCB at the (old) head of the
-           * ready-to-run Task list. if arm_saveusercontext returns a non-zero
-           * value, then this is really the previously running task
+          /* Copy the exception context into the TCB at the (old) head of
+           * the ready-to-run Task list. if arm_saveusercontext returns a
+           * non-zero value, then this is really the previously running task
            * restarting!
            */
 

--- a/arch/arm/src/arm/up_sigdeliver.c
+++ b/arch/arm/src/arm/up_sigdeliver.c
@@ -87,7 +87,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copyfullstate(regs, rtcb->xcp.regs);
+  arm_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always

--- a/arch/arm/src/arm/up_unblocktask.c
+++ b/arch/arm/src/arm/up_unblocktask.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/arm/up_unblocktask.c
  *
- *   Copyright (C) 2007-2009, 2013-2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -125,8 +110,8 @@ void up_unblock_task(struct tcb_s *tcb)
 
       /* We are not in an interrupt handler.  Copy the user C context
        * into the TCB of the task that was previously active.  if
-       * arm_saveusercontext returns a non-zero value, then this is really the
-       * previously running task restarting!
+       * arm_saveusercontext returns a non-zero value, then this is really
+       * the previously running task restarting!
        */
 
       else if (!arm_saveusercontext(rtcb->xcp.regs))

--- a/arch/arm/src/arm/up_unblocktask.c
+++ b/arch/arm/src/arm/up_unblocktask.c
@@ -125,11 +125,11 @@ void up_unblock_task(struct tcb_s *tcb)
 
       /* We are not in an interrupt handler.  Copy the user C context
        * into the TCB of the task that was previously active.  if
-       * up_saveusercontext returns a non-zero value, then this is really the
+       * arm_saveusercontext returns a non-zero value, then this is really the
        * previously running task restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the new task that is ready to
            * run (probably tcb).  This is the new rtcb at the head of the

--- a/arch/arm/src/armv6-m/arm_copyfullstate.c
+++ b/arch/arm/src/armv6-m/arm_copyfullstate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv6-m/up_copyfullstate.c
+ * arch/arm/src/armv6-m/arm_copyfullstate.c
  *
  *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -61,12 +61,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyfullstate
+ * Name: arm_copyfullstate
  ****************************************************************************/
 
 /* A little faster than most memcpy's */
 
-void up_copyfullstate(uint32_t *dest, uint32_t *src)
+void arm_copyfullstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv6-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv6-m/arm_saveusercontext.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv6-m/up_saveusercontext.S
+ * arch/arm/src/armv6-m/arm_saveusercontext.S
  *
  *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -52,7 +52,7 @@
  ************************************************************************************/
 
 	.cpu	cortex-m0
-	.file	"up_saveusercontext.S"
+	.file	"arm_saveusercontext.S"
 
 /************************************************************************************
  * Macros
@@ -63,12 +63,12 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_saveusercontext
+ * Name: arm_saveusercontext
  *
  * Description:
  *   Save the current thread context.  Full prototype is:
  *
- *   int  up_saveusercontext(uint32_t *saveregs);
+ *   int  arm_saveusercontext(uint32_t *saveregs);
  *
  * Returned Value:
  *   0: Normal return
@@ -80,9 +80,9 @@
 	.align	2
 	.code	16
 	.thumb_func
-	.globl	up_saveusercontext
-	.type	up_saveusercontext, function
-up_saveusercontext:
+	.globl	arm_saveusercontext
+	.type	arm_saveusercontext, function
+arm_saveusercontext:
 
 	/* Perform the System call with R0=0 and R1=regs */
 
@@ -101,5 +101,5 @@ up_saveusercontext:
 	str		r3, [r2, #0]			/* Save return value */
 	bx		lr						/* "normal" return with r0=0 or
 									 * context switch with r0=1 */
-	.size	up_saveusercontext, .-up_saveusercontext
+	.size	arm_saveusercontext, .-arm_saveusercontext
 	.end

--- a/arch/arm/src/armv6-m/arm_switchcontext.S
+++ b/arch/arm/src/armv6-m/arm_switchcontext.S
@@ -1,35 +1,20 @@
 /************************************************************************************
  * arch/arm/src/armv6-m/arm_switchcontext.S
  *
- *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ************************************************************************************/
 

--- a/arch/arm/src/armv6-m/arm_switchcontext.S
+++ b/arch/arm/src/armv6-m/arm_switchcontext.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv6-m/up_switchcontext.S
+ * arch/arm/src/armv6-m/arm_switchcontext.S
  *
  *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -52,7 +52,7 @@
  ************************************************************************************/
 
 	.cpu	cortex-m0
-	.file	"up_switchcontext.S"
+	.file	"arm_switchcontext.S"
 
 /************************************************************************************
  * Macros
@@ -63,13 +63,13 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_switchcontext
+ * Name: arm_switchcontext
  *
  * Description:
  *   Save the current thread context and restore the specified context.
  *   Full prototype is:
  *
- *   void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ *   void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  *
  * Returned Value:
  *   None
@@ -79,9 +79,9 @@
 	.align	2
 	.code	16
 	.thumb_func
-	.globl	up_switchcontext
-	.type	up_switchcontext, function
-up_switchcontext:
+	.globl	arm_switchcontext
+	.type	arm_switchcontext, function
+arm_switchcontext:
 
 	/* Perform the System call with R0=1, R1=saveregs, R2=restoreregs */
 
@@ -93,5 +93,5 @@ up_switchcontext:
 	/*  We will get here only after the rerturn from the context switch */
 
 	bx		lr
-	.size	up_switchcontext, .-up_switchcontext
+	.size	arm_switchcontext, .-arm_switchcontext
 	.end

--- a/arch/arm/src/armv6-m/svcall.h
+++ b/arch/arm/src/armv6-m/svcall.h
@@ -76,7 +76,7 @@
 
 /* SYS call 2:
  *
- * void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ * void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  */
 
 #define SYS_switch_context        (2)

--- a/arch/arm/src/armv6-m/svcall.h
+++ b/arch/arm/src/armv6-m/svcall.h
@@ -62,7 +62,7 @@
 
 /* SYS call 0:
  *
- * int up_saveusercontext(uint32_t *saveregs);
+ * int arm_saveusercontext(uint32_t *saveregs);
  */
 
 #define SYS_save_context          (0)

--- a/arch/arm/src/armv6-m/up_assert.c
+++ b/arch/arm/src/armv6-m/up_assert.c
@@ -171,7 +171,7 @@ static inline void up_registerdump(void)
     {
       /* No.. capture user registers by hand */
 
-      up_saveusercontext(s_last_regs);
+      arm_saveusercontext(s_last_regs);
       regs = s_last_regs;
     }
 

--- a/arch/arm/src/armv6-m/up_blocktask.c
+++ b/arch/arm/src/armv6-m/up_blocktask.c
@@ -150,9 +150,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv6-m/up_blocktask.c
+++ b/arch/arm/src/armv6-m/up_blocktask.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/armv6-m/up_blocktask.c
  *
- *   Copyright (C) 2013, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/armv6-m/up_releasepending.c
+++ b/arch/arm/src/armv6-m/up_releasepending.c
@@ -120,9 +120,9 @@ void up_release_pending(void)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv6-m/up_releasepending.c
+++ b/arch/arm/src/armv6-m/up_releasepending.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv6-m/up_releasepending.c
  *
- *   Copyright (C) 2013, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -70,7 +55,6 @@ void up_release_pending(void)
 
   /* Merge the g_pendingtasks list into the ready-to-run task list */
 
-  /* sched_lock(); */
   if (sched_mergepending())
     {
       /* The currently active task has changed!  We will need to

--- a/arch/arm/src/armv6-m/up_reprioritizertr.c
+++ b/arch/arm/src/armv6-m/up_reprioritizertr.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv6-m/up_reprioritizertr.c
  *
- *   Copyright (C) 2013, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -179,8 +164,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* arm_switchcontext forces a context switch to the task at the
                * head of the ready-to-run list.  It does not 'return' in the
-               * normal sense.  When it does return, it is because the blocked
-               * task is again ready to run and has execution priority.
+               * normal sense.  When it does return, it is because the
+               * blocked task is again ready to run and has execution
+               * priority.
                */
             }
         }

--- a/arch/arm/src/armv6-m/up_reprioritizertr.c
+++ b/arch/arm/src/armv6-m/up_reprioritizertr.c
@@ -175,9 +175,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * ready to run list.
                */
 
-              up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+              arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-              /* up_switchcontext forces a context switch to the task at the
+              /* arm_switchcontext forces a context switch to the task at the
                * head of the ready-to-run list.  It does not 'return' in the
                * normal sense.  When it does return, it is because the blocked
                * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv6-m/up_sigdeliver.c
+++ b/arch/arm/src/armv6-m/up_sigdeliver.c
@@ -91,7 +91,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copyfullstate(regs, rtcb->xcp.regs);
+  arm_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always

--- a/arch/arm/src/armv6-m/up_svcall.c
+++ b/arch/arm/src/armv6-m/up_svcall.c
@@ -199,7 +199,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_switch_context:  This a switch context command:
        *
-       *   void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+       *   void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/arm/src/armv6-m/up_svcall.c
+++ b/arch/arm/src/armv6-m/up_svcall.c
@@ -156,7 +156,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
     {
       /* R0=SYS_save_context:  This is a save context command:
        *
-       *   int up_saveusercontext(uint32_t *saveregs);
+       *   int arm_saveusercontext(uint32_t *saveregs);
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/arm/src/armv6-m/up_unblocktask.c
+++ b/arch/arm/src/armv6-m/up_unblocktask.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv6-m/up_unblocktask.c
  *
- *   Copyright (C) 2013, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/armv6-m/up_unblocktask.c
+++ b/arch/arm/src/armv6-m/up_unblocktask.c
@@ -133,9 +133,9 @@ void up_unblock_task(struct tcb_s *tcb)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv7-a/arm_assert.c
+++ b/arch/arm/src/armv7-a/arm_assert.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/armv7-a/arm_assert.c
  *
- *   Copyright (C) 2013-2016, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -179,7 +164,6 @@ static inline void up_registerdump(void)
       regs = s_last_regs;
     }
 
-
   /* Dump the interrupt registers */
 
   for (reg = REG_R0; reg <= REG_R15; reg += 8)
@@ -293,7 +277,8 @@ static void up_dumpstate(void)
 
   if (rtcb->xcp.kstack)
     {
-      kstackbase = (uint32_t)rtcb->xcp.kstack + CONFIG_ARCH_KERNEL_STACKSIZE - 4;
+      kstackbase = (uint32_t)rtcb->xcp.kstack +
+                   CONFIG_ARCH_KERNEL_STACKSIZE - 4;
 
       _alert("Kernel stack:\n");
       _alert("  base: %08x\n", kstackbase);

--- a/arch/arm/src/armv7-a/arm_assert.c
+++ b/arch/arm/src/armv7-a/arm_assert.c
@@ -175,7 +175,7 @@ static inline void up_registerdump(void)
     {
       /* No.. capture user registers by hand */
 
-      up_saveusercontext(s_last_regs);
+      arm_saveusercontext(s_last_regs);
       regs = s_last_regs;
     }
 

--- a/arch/arm/src/armv7-a/arm_blocktask.c
+++ b/arch/arm/src/armv7-a/arm_blocktask.c
@@ -140,11 +140,11 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
         }
 
       /* Copy the user C context into the TCB at the (old) head of the
-       * ready-to-run Task list. if up_saveusercontext returns a non-zero
+       * ready-to-run Task list. if arm_saveusercontext returns a non-zero
        * value, then this is really the previously running task restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/arm/src/armv7-a/arm_copyarmstate.c
+++ b/arch/arm/src/armv7-a/arm_copyarmstate.c
@@ -52,7 +52,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyarmstate
+ * Name: arm_copyarmstate
  *
  * Description:
  *    Copy the ARM portion of the register save area (omitting the floating
@@ -60,7 +60,7 @@
  *
  ****************************************************************************/
 
-void up_copyarmstate(uint32_t *dest, uint32_t *src)
+void arm_copyarmstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv7-a/arm_copyfullstate.c
+++ b/arch/arm/src/armv7-a/arm_copyfullstate.c
@@ -49,7 +49,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyfullstate
+ * Name: arm_copyfullstate
  *
  * Description:
  *    Copy the entire register save area (including the floating point
@@ -58,7 +58,7 @@
  *
  ****************************************************************************/
 
-void up_copyfullstate(uint32_t *dest, uint32_t *src)
+void arm_copyfullstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv7-a/arm_releasepending.c
+++ b/arch/arm/src/armv7-a/arm_releasepending.c
@@ -93,12 +93,12 @@ void up_release_pending(void)
         }
 
       /* Copy the exception context into the TCB of the task that
-       * was currently active. if up_saveusercontext returns a non-zero
+       * was currently active. if arm_saveusercontext returns a non-zero
        * value, then this is really the previously running task
        * restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/arm/src/armv7-a/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-a/arm_reprioritizertr.c
@@ -149,12 +149,12 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
             }
 
           /* Copy the exception context into the TCB at the (old) head of the
-           * ready-to-run Task list. if up_saveusercontext returns a non-zero
+           * ready-to-run Task list. if arm_saveusercontext returns a non-zero
            * value, then this is really the previously running task
            * restarting!
            */
 
-          else if (!up_saveusercontext(rtcb->xcp.regs))
+          else if (!arm_saveusercontext(rtcb->xcp.regs))
             {
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.

--- a/arch/arm/src/armv7-a/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-a/arm_reprioritizertr.c
@@ -148,9 +148,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
               up_restorestate(rtcb->xcp.regs);
             }
 
-          /* Copy the exception context into the TCB at the (old) head of the
-           * ready-to-run Task list. if arm_saveusercontext returns a non-zero
-           * value, then this is really the previously running task
+          /* Copy the exception context into the TCB at the (old) head of
+           * the ready-to-run Task list. if arm_saveusercontext returns a
+           * non-zero value, then this is really the previously running task
            * restarting!
            */
 

--- a/arch/arm/src/armv7-a/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-a/arm_saveusercontext.S
@@ -46,7 +46,7 @@
  * Public Symbols
  ****************************************************************************/
 
-	.globl	up_saveusercontext
+	.globl	arm_saveusercontext
 
 /****************************************************************************
  * Public Functions
@@ -55,13 +55,13 @@
 	.text
 
 /****************************************************************************
- * Name: up_saveusercontext
+ * Name: arm_saveusercontext
  ****************************************************************************/
 
-	.globl	up_saveusercontext
-	.type	up_saveusercontext, function
+	.globl	arm_saveusercontext
+	.type	arm_saveusercontext, function
 
-up_saveusercontext:
+arm_saveusercontext:
 
 	/* On entry, a1 (r0) holds address of struct xcptcontext */
 
@@ -129,5 +129,5 @@ up_saveusercontext:
 	mov		r0, #1			/* Return value == 1 */
 	mov		pc, lr			/* Return */
 
-	.size	up_saveusercontext, . - up_saveusercontext
+	.size	arm_saveusercontext, . - arm_saveusercontext
 	.end

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -96,7 +96,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copyfullstate(regs, rtcb->xcp.regs);
+  arm_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented

--- a/arch/arm/src/armv7-a/arm_unblocktask.c
+++ b/arch/arm/src/armv7-a/arm_unblocktask.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  arch/arm/src/armv7-a/arm_unblocktask.c
  *
- *   Copyright (C) 2013-2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -142,8 +127,8 @@ void up_unblock_task(struct tcb_s *tcb)
 
       /* We are not in an interrupt handler.  Copy the user C context
        * into the TCB of the task that was previously active.  if
-       * arm_saveusercontext returns a non-zero value, then this is really the
-       * previously running task restarting!
+       * arm_saveusercontext returns a non-zero value, then this is really
+       * the previously running task restarting!
        */
 
       else if (!arm_saveusercontext(rtcb->xcp.regs))

--- a/arch/arm/src/armv7-a/arm_unblocktask.c
+++ b/arch/arm/src/armv7-a/arm_unblocktask.c
@@ -142,11 +142,11 @@ void up_unblock_task(struct tcb_s *tcb)
 
       /* We are not in an interrupt handler.  Copy the user C context
        * into the TCB of the task that was previously active.  if
-       * up_saveusercontext returns a non-zero value, then this is really the
+       * arm_saveusercontext returns a non-zero value, then this is really the
        * previously running task restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the new task that is ready to
            * run (probably tcb).  This is the new rtcb at the head of the

--- a/arch/arm/src/armv7-m/arm_copyarmstate.c
+++ b/arch/arm/src/armv7-m/arm_copyarmstate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv7-m/up_copyarmstate.c
+ * arch/arm/src/armv7-m/arm_copyarmstate.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -37,7 +37,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyarmstate
+ * Name: arm_copyarmstate
  *
  * Description:
  *    Copy the ARM portion of the register save area (omitting the floating
@@ -45,7 +45,7 @@
  *
  ****************************************************************************/
 
-void up_copyarmstate(uint32_t *dest, uint32_t *src)
+void arm_copyarmstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv7-m/arm_copyfullstate.c
+++ b/arch/arm/src/armv7-m/arm_copyfullstate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/armv7-m/up_copyfullstate.c
+ * arch/arm/src/armv7-m/arm_copyfullstate.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -34,7 +34,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyfullstate
+ * Name: arm_copyfullstate
  *
  * Description:
  *    Copy the entire register save area (including the floating point
@@ -43,7 +43,7 @@
  *
  ****************************************************************************/
 
-void up_copyfullstate(uint32_t *dest, uint32_t *src)
+void arm_copyfullstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv7-m/gnu/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-m/gnu/arm_saveusercontext.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv7-m/gnu/up_saveusercontext.S
+ * arch/arm/src/armv7-m/gnu/arm_saveusercontext.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -38,7 +38,7 @@
 
 	.syntax	unified
 	.thumb
-	.file	"up_saveusercontext.S"
+	.file	"arm_saveusercontext.S"
 
 /************************************************************************************
  * Macros
@@ -49,12 +49,12 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_saveusercontext
+ * Name: arm_saveusercontext
  *
  * Description:
  *   Save the current thread context.  Full prototype is:
  *
- *   int  up_saveusercontext(uint32_t *saveregs);
+ *   int  arm_saveusercontext(uint32_t *saveregs);
  *
  * Returned Value:
  *   0: Normal return
@@ -64,9 +64,9 @@
 
 	.text
 	.thumb_func
-	.globl	up_saveusercontext
-	.type	up_saveusercontext, function
-up_saveusercontext:
+	.globl	arm_saveusercontext
+	.type	arm_saveusercontext, function
+arm_saveusercontext:
 
 	/* Perform the System call with R0=0 and R1=regs */
 
@@ -84,5 +84,5 @@ up_saveusercontext:
 	str		r3, [r2, #0]
 	bx		lr						/* "normal" return with r0=0 or
 									 * context switch with r0=1 */
-	.size	up_saveusercontext, .-up_saveusercontext
+	.size	arm_saveusercontext, .-arm_saveusercontext
 	.end

--- a/arch/arm/src/armv7-m/gnu/arm_switchcontext.S
+++ b/arch/arm/src/armv7-m/gnu/arm_switchcontext.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv7-m/iar/up_switchcontext.S
+ * arch/arm/src/armv7-m/gnu/arm_switchcontext.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -28,9 +28,6 @@
 #include "nvic.h"
 #include "svcall.h"
 
-	MODULE up_switchcontext
-	SECTION .text:CODE:NOROOT(2)
-
 /************************************************************************************
  * Pre-processor Definitions
  ************************************************************************************/
@@ -39,7 +36,9 @@
  * Public Symbols
  ************************************************************************************/
 
-	PUBLIC up_switchcontext
+	.syntax	unified
+	.thumb
+	.file	"arm_switchcontext.S"
 
 /************************************************************************************
  * Macros
@@ -50,22 +49,23 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_switchcontext
+ * Name: arm_switchcontext
  *
  * Description:
  *   Save the current thread context and restore the specified context.
  *   Full prototype is:
  *
- *   void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ *   void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  *
  * Returned Value:
  *   None
  *
  ************************************************************************************/
 
-	THUMB
-
-up_switchcontext:
+	.thumb_func
+	.globl	arm_switchcontext
+	.type	arm_switchcontext, function
+arm_switchcontext:
 
 	/* Perform the System call with R0=1, R1=saveregs, R2=restoreregs */
 
@@ -77,5 +77,5 @@ up_switchcontext:
 	/* We will get here only after the rerturn from the context switch */
 
 	bx		lr
-
-	END
+	.size	arm_switchcontext, .-arm_switchcontext
+	.end

--- a/arch/arm/src/armv7-m/iar/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-m/iar/arm_saveusercontext.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv7-m/iar/up_saveusercontext.S
+ * arch/arm/src/armv7-m/iar/arm_saveusercontext.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -28,7 +28,7 @@
 #include "nvic.h"
 #include "svcall.h"
 
-	MODULE up_saveusercontext
+	MODULE arm_saveusercontext
 	SECTION .text:CODE:NOROOT(2)
 
 /************************************************************************************
@@ -39,7 +39,7 @@
  * Public Symbols
  ************************************************************************************/
 
-	PUBLIC up_saveusercontext
+	PUBLIC arm_saveusercontext
 
 /************************************************************************************
  * Macros
@@ -50,12 +50,12 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_saveusercontext
+ * Name: arm_saveusercontext
  *
  * Description:
  *   Save the current thread context.  Full prototype is:
  *
- *   int  up_saveusercontext(uint32_t *saveregs);
+ *   int  arm_saveusercontext(uint32_t *saveregs);
  *
  * Returned Value:
  *   0: Normal return
@@ -65,7 +65,7 @@
 
 	THUMB
 
-up_saveusercontext:
+arm_saveusercontext:
 
 	/* Perform the System call with R0=0 and R1=regs */
 

--- a/arch/arm/src/armv7-m/iar/arm_switchcontext.S
+++ b/arch/arm/src/armv7-m/iar/arm_switchcontext.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/arm/src/armv7-m/gnu/up_switchcontext.S
+ * arch/arm/src/armv7-m/iar/arm_switchcontext.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -28,6 +28,9 @@
 #include "nvic.h"
 #include "svcall.h"
 
+	MODULE arm_switchcontext
+	SECTION .text:CODE:NOROOT(2)
+
 /************************************************************************************
  * Pre-processor Definitions
  ************************************************************************************/
@@ -36,9 +39,7 @@
  * Public Symbols
  ************************************************************************************/
 
-	.syntax	unified
-	.thumb
-	.file	"up_switchcontext.S"
+	PUBLIC arm_switchcontext
 
 /************************************************************************************
  * Macros
@@ -49,23 +50,22 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_switchcontext
+ * Name: arm_switchcontext
  *
  * Description:
  *   Save the current thread context and restore the specified context.
  *   Full prototype is:
  *
- *   void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ *   void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  *
  * Returned Value:
  *   None
  *
  ************************************************************************************/
 
-	.thumb_func
-	.globl	up_switchcontext
-	.type	up_switchcontext, function
-up_switchcontext:
+	THUMB
+
+arm_switchcontext:
 
 	/* Perform the System call with R0=1, R1=saveregs, R2=restoreregs */
 
@@ -77,5 +77,5 @@ up_switchcontext:
 	/* We will get here only after the rerturn from the context switch */
 
 	bx		lr
-	.size	up_switchcontext, .-up_switchcontext
-	.end
+
+	END

--- a/arch/arm/src/armv7-m/svcall.h
+++ b/arch/arm/src/armv7-m/svcall.h
@@ -76,7 +76,7 @@
 
 /* SYS call 2:
  *
- * void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ * void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  */
 
 #define SYS_switch_context        (2)

--- a/arch/arm/src/armv7-m/svcall.h
+++ b/arch/arm/src/armv7-m/svcall.h
@@ -62,7 +62,7 @@
 
 /* SYS call 0:
  *
- * int up_saveusercontext(uint32_t *saveregs);
+ * int arm_saveusercontext(uint32_t *saveregs);
  */
 
 #define SYS_save_context          (0)

--- a/arch/arm/src/armv7-m/up_assert.c
+++ b/arch/arm/src/armv7-m/up_assert.c
@@ -159,7 +159,7 @@ static inline void up_registerdump(void)
     {
       /* No.. capture user registers by hand */
 
-      up_saveusercontext(s_last_regs);
+      arm_saveusercontext(s_last_regs);
       regs = s_last_regs;
     }
 

--- a/arch/arm/src/armv7-m/up_blocktask.c
+++ b/arch/arm/src/armv7-m/up_blocktask.c
@@ -135,9 +135,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv7-m/up_releasepending.c
+++ b/arch/arm/src/armv7-m/up_releasepending.c
@@ -108,9 +108,9 @@ void up_release_pending(void)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv7-m/up_reprioritizertr.c
+++ b/arch/arm/src/armv7-m/up_reprioritizertr.c
@@ -160,9 +160,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * ready to run list.
                */
 
-              up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+              arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-              /* up_switchcontext forces a context switch to the task at the
+              /* arm_switchcontext forces a context switch to the task at the
                * head of the ready-to-run list.  It does not 'return' in the
                * normal sense.  When it does return, it is because the
                * blocked task is again ready to run and has execution

--- a/arch/arm/src/armv7-m/up_sigdeliver.c
+++ b/arch/arm/src/armv7-m/up_sigdeliver.c
@@ -80,7 +80,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copyfullstate(regs, rtcb->xcp.regs);
+  arm_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented

--- a/arch/arm/src/armv7-m/up_svcall.c
+++ b/arch/arm/src/armv7-m/up_svcall.c
@@ -163,7 +163,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
     {
       /* R0=SYS_save_context:  This is a save context command:
        *
-       *   int up_saveusercontext(uint32_t *saveregs);
+       *   int arm_saveusercontext(uint32_t *saveregs);
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/arm/src/armv7-m/up_svcall.c
+++ b/arch/arm/src/armv7-m/up_svcall.c
@@ -210,7 +210,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* R0=SYS_switch_context:  This a switch context command:
        *
-       *   void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+       *   void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/arm/src/armv7-m/up_unblocktask.c
+++ b/arch/arm/src/armv7-m/up_unblocktask.c
@@ -119,9 +119,9 @@ void up_unblock_task(struct tcb_s *tcb)
            * ready to run list.
            */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          arm_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* arm_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/arm/src/armv7-r/arm_assert.c
+++ b/arch/arm/src/armv7-r/arm_assert.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/armv7-r/arm_assert.c
  *
- *   Copyright (C) 2015-2016, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -285,7 +270,8 @@ static void up_dumpstate(void)
 
   if (rtcb->xcp.kstack)
     {
-      kstackbase = (uint32_t)rtcb->xcp.kstack + CONFIG_ARCH_KERNEL_STACKSIZE - 4;
+      kstackbase = (uint32_t)rtcb->xcp.kstack +
+                   CONFIG_ARCH_KERNEL_STACKSIZE - 4;
 
       _alert("Kernel stack:\n");
       _alert("  base: %08x\n", kstackbase);

--- a/arch/arm/src/armv7-r/arm_assert.c
+++ b/arch/arm/src/armv7-r/arm_assert.c
@@ -172,7 +172,7 @@ static inline void up_registerdump(void)
     {
       /* No.. capture user registers by hand */
 
-      up_saveusercontext(s_last_regs);
+      arm_saveusercontext(s_last_regs);
       regs = s_last_regs;
     }
 

--- a/arch/arm/src/armv7-r/arm_blocktask.c
+++ b/arch/arm/src/armv7-r/arm_blocktask.c
@@ -138,11 +138,11 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
         }
 
       /* Copy the user C context into the TCB at the (old) head of the
-       * ready-to-run Task list. if up_saveusercontext returns a non-zero
+       * ready-to-run Task list. if arm_saveusercontext returns a non-zero
        * value, then this is really the previously running task restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/arm/src/armv7-r/arm_copyarmstate.c
+++ b/arch/arm/src/armv7-r/arm_copyarmstate.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/armv7-r/arm_copyarmstate.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -46,6 +31,10 @@
 #include "up_internal.h"
 
 #ifdef CONFIG_ARCH_FPU
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 /****************************************************************************
  * Name: arm_copyarmstate

--- a/arch/arm/src/armv7-r/arm_copyarmstate.c
+++ b/arch/arm/src/armv7-r/arm_copyarmstate.c
@@ -48,7 +48,7 @@
 #ifdef CONFIG_ARCH_FPU
 
 /****************************************************************************
- * Name: up_copyarmstate
+ * Name: arm_copyarmstate
  *
  * Description:
  *    Copy the ARM portion of the register save area (omitting the floating
@@ -56,7 +56,7 @@
  *
  ****************************************************************************/
 
-void up_copyarmstate(uint32_t *dest, uint32_t *src)
+void arm_copyarmstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv7-r/arm_copyfullstate.c
+++ b/arch/arm/src/armv7-r/arm_copyfullstate.c
@@ -61,7 +61,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyfullstate
+ * Name: arm_copyfullstate
  *
  * Description:
  *    Copy the entire register save area (including the floating point
@@ -70,7 +70,7 @@
  *
  ****************************************************************************/
 
-void up_copyfullstate(uint32_t *dest, uint32_t *src)
+void arm_copyfullstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv7-r/arm_copyfullstate.c
+++ b/arch/arm/src/armv7-r/arm_copyfullstate.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/armv7-r/arm_copyfullstate.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -43,18 +28,6 @@
 #include <arch/irq.h>
 
 #include "up_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Private Data
- ****************************************************************************/
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
 
 /****************************************************************************
  * Public Functions

--- a/arch/arm/src/armv7-r/arm_releasepending.c
+++ b/arch/arm/src/armv7-r/arm_releasepending.c
@@ -94,12 +94,12 @@ void up_release_pending(void)
         }
 
       /* Copy the exception context into the TCB of the task that
-       * was currently active. if up_saveusercontext returns a non-zero
+       * was currently active. if arm_saveusercontext returns a non-zero
        * value, then this is really the previously running task
        * restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/arm/src/armv7-r/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-r/arm_reprioritizertr.c
@@ -149,12 +149,12 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
             }
 
           /* Copy the exception context into the TCB at the (old) head of the
-           * ready-to-run Task list. if up_saveusercontext returns a non-zero
+           * ready-to-run Task list. if arm_saveusercontext returns a non-zero
            * value, then this is really the previously running task
            * restarting!
            */
 
-          else if (!up_saveusercontext(rtcb->xcp.regs))
+          else if (!arm_saveusercontext(rtcb->xcp.regs))
             {
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.

--- a/arch/arm/src/armv7-r/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-r/arm_reprioritizertr.c
@@ -148,9 +148,9 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
               up_restorestate(rtcb->xcp.regs);
             }
 
-          /* Copy the exception context into the TCB at the (old) head of the
-           * ready-to-run Task list. if arm_saveusercontext returns a non-zero
-           * value, then this is really the previously running task
+          /* Copy the exception context into the TCB at the (old) head of
+           * the ready-to-run Task list. if arm_saveusercontext returns a
+           * non-zero value, then this is really the previously running task
            * restarting!
            */
 

--- a/arch/arm/src/armv7-r/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-r/arm_saveusercontext.S
@@ -44,7 +44,7 @@
  * Public Symbols
  ****************************************************************************/
 
-	.globl	up_saveusercontext
+	.globl	arm_saveusercontext
 
 #ifdef CONFIG_ARCH_FPU
 	.cpu	cortex-r4f
@@ -61,13 +61,13 @@
 	.text
 
 /****************************************************************************
- * Name: up_saveusercontext
+ * Name: arm_saveusercontext
  ****************************************************************************/
 
-	.globl	up_saveusercontext
-	.type	up_saveusercontext, function
+	.globl	arm_saveusercontext
+	.type	arm_saveusercontext, function
 
-up_saveusercontext:
+arm_saveusercontext:
 
 	/* On entry, a1 (r0) holds address of struct xcptcontext */
 
@@ -128,5 +128,5 @@ up_saveusercontext:
 
 	mov		r0, #0			/* Return value == 0 */
 	mov		pc, lr			/* Return */
-	.size	up_saveusercontext, . - up_saveusercontext
+	.size	arm_saveusercontext, . - arm_saveusercontext
 	.end

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -86,7 +86,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copyfullstate(regs, rtcb->xcp.regs);
+  arm_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always

--- a/arch/arm/src/armv7-r/arm_unblocktask.c
+++ b/arch/arm/src/armv7-r/arm_unblocktask.c
@@ -122,11 +122,11 @@ void up_unblock_task(struct tcb_s *tcb)
 
       /* We are not in an interrupt handler.  Copy the user C context
        * into the TCB of the task that was previously active.  if
-       * up_saveusercontext returns a non-zero value, then this is really the
+       * arm_saveusercontext returns a non-zero value, then this is really the
        * previously running task restarting!
        */
 
-      else if (!up_saveusercontext(rtcb->xcp.regs))
+      else if (!arm_saveusercontext(rtcb->xcp.regs))
         {
           /* Restore the exception context of the new task that is ready to
            * run (probably tcb).  This is the new rtcb at the head of the

--- a/arch/arm/src/armv7-r/arm_unblocktask.c
+++ b/arch/arm/src/armv7-r/arm_unblocktask.c
@@ -122,8 +122,8 @@ void up_unblock_task(struct tcb_s *tcb)
 
       /* We are not in an interrupt handler.  Copy the user C context
        * into the TCB of the task that was previously active.  if
-       * arm_saveusercontext returns a non-zero value, then this is really the
-       * previously running task restarting!
+       * arm_saveusercontext returns a non-zero value, then this is really
+       * the previously running task restarting!
        */
 
       else if (!arm_saveusercontext(rtcb->xcp.regs))

--- a/arch/arm/src/armv8-m/arm_copyarmstate.c
+++ b/arch/arm/src/armv8-m/arm_copyarmstate.c
@@ -37,7 +37,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyarmstate
+ * Name: arm_copyarmstate
  *
  * Description:
  *    Copy the ARM portion of the register save area (omitting the floating
@@ -45,7 +45,7 @@
  *
  ****************************************************************************/
 
-void up_copyarmstate(uint32_t *dest, uint32_t *src)
+void arm_copyarmstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv8-m/arm_copyfullstate.c
+++ b/arch/arm/src/armv8-m/arm_copyfullstate.c
@@ -34,7 +34,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyfullstate
+ * Name: arm_copyfullstate
  *
  * Description:
  *    Copy the entire register save area (including the floating point
@@ -43,7 +43,7 @@
  *
  ****************************************************************************/
 
-void up_copyfullstate(uint32_t *dest, uint32_t *src)
+void arm_copyfullstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -80,7 +80,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copyfullstate(regs, rtcb->xcp.regs);
+  arm_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented

--- a/arch/arm/src/armv8-m/doit.sh
+++ b/arch/arm/src/armv8-m/doit.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+FILELIST=`ls -1 up_*.S`
+
+for file in $FILELIST; do
+  newname=`echo $file | sed -e "s/up_/arm_/g"`
+  echo "### $file->$newname"
+  git mv $file $newname
+
+#  oldbase=`basename $file`
+#  newbase=`basename $newname`
+#  sed -i -e "s/${oldbase}/${newbase}/g" $file
+done
+

--- a/arch/arm/src/c5471/Make.defs
+++ b/arch/arm/src/c5471/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = up_nommuhead.S
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S vfork.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c up_doirq.c

--- a/arch/arm/src/c5471/Make.defs
+++ b/arch/arm/src/c5471/Make.defs
@@ -37,7 +37,7 @@ HEAD_ASRC = up_nommuhead.S
 
 CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S vfork.S
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c up_doirq.c
 CMN_CSRCS += up_exit.c up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_prefetchabort.c up_releasepending.c up_releasestack.c

--- a/arch/arm/src/common/up_internal.h
+++ b/arch/arm/src/common/up_internal.h
@@ -301,7 +301,7 @@ void arm_copyarmstate(uint32_t *dest, uint32_t *src);
 void up_decodeirq(uint32_t *regs);
 int  arm_saveusercontext(uint32_t *saveregs);
 void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
-void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+void arm_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
 
 /* Signal handling **********************************************************/
 

--- a/arch/arm/src/common/up_internal.h
+++ b/arch/arm/src/common/up_internal.h
@@ -93,7 +93,7 @@
 #  if defined(CONFIG_ARCH_FPU) && defined(CONFIG_ARMV7M_LAZYFPU)
 #    define up_savestate(regs)  up_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
-#    define up_savestate(regs)  up_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
+#    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
 #  define up_restorestate(regs) (CURRENT_REGS = regs)
 
@@ -110,7 +110,7 @@
 #  if defined(CONFIG_ARCH_FPU)
 #    define up_savestate(regs)  up_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
-#    define up_savestate(regs)  up_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
+#    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
 #  define up_restorestate(regs) (CURRENT_REGS = regs)
 
@@ -129,9 +129,9 @@
 #  if defined(CONFIG_ARCH_FPU)
 #    define up_savestate(regs)  up_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
-#    define up_savestate(regs)  up_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
+#    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
-#  define up_restorestate(regs) up_copyfullstate((uint32_t*)CURRENT_REGS, regs)
+#  define up_restorestate(regs) arm_copyfullstate((uint32_t*)CURRENT_REGS, regs)
 
 #endif
 
@@ -294,7 +294,7 @@ void arm_boot(void);
 
 /* Context switching */
 
-void up_copyfullstate(uint32_t *dest, uint32_t *src);
+void arm_copyfullstate(uint32_t *dest, uint32_t *src);
 #ifdef CONFIG_ARCH_FPU
 void up_copyarmstate(uint32_t *dest, uint32_t *src);
 #endif

--- a/arch/arm/src/common/up_internal.h
+++ b/arch/arm/src/common/up_internal.h
@@ -91,7 +91,7 @@
    */
 
 #  if defined(CONFIG_ARCH_FPU) && defined(CONFIG_ARMV7M_LAZYFPU)
-#    define up_savestate(regs)  up_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
+#    define up_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
 #    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
@@ -108,7 +108,7 @@
    */
 
 #  if defined(CONFIG_ARCH_FPU)
-#    define up_savestate(regs)  up_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
+#    define up_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
 #    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
@@ -127,7 +127,7 @@
    */
 
 #  if defined(CONFIG_ARCH_FPU)
-#    define up_savestate(regs)  up_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
+#    define up_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
 #    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
@@ -296,7 +296,7 @@ void arm_boot(void);
 
 void arm_copyfullstate(uint32_t *dest, uint32_t *src);
 #ifdef CONFIG_ARCH_FPU
-void up_copyarmstate(uint32_t *dest, uint32_t *src);
+void arm_copyarmstate(uint32_t *dest, uint32_t *src);
 #endif
 void up_decodeirq(uint32_t *regs);
 int  up_saveusercontext(uint32_t *saveregs);

--- a/arch/arm/src/common/up_internal.h
+++ b/arch/arm/src/common/up_internal.h
@@ -299,7 +299,7 @@ void arm_copyfullstate(uint32_t *dest, uint32_t *src);
 void arm_copyarmstate(uint32_t *dest, uint32_t *src);
 #endif
 void up_decodeirq(uint32_t *regs);
-int  up_saveusercontext(uint32_t *saveregs);
+int  arm_saveusercontext(uint32_t *saveregs);
 void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
 void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
 

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -46,7 +46,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -37,7 +37,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -83,9 +83,9 @@ endif
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
 ifneq ($(CONFIG_ARMV7M_CMNVECTOR),y)
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 else ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 endif
 

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -37,7 +37,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/dm320/Make.defs
+++ b/arch/arm/src/dm320/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = up_head.S
 
-CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
+CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S arm_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
 
 CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c

--- a/arch/arm/src/dm320/Make.defs
+++ b/arch/arm/src/dm320/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC = up_head.S
 CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_dataabort.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_prefetchabort.c up_releasepending.c up_releasestack.c

--- a/arch/arm/src/efm32/Make.defs
+++ b/arch/arm/src/efm32/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/efm32/Make.defs
+++ b/arch/arm/src/efm32/Make.defs
@@ -79,7 +79,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_ARMV7M_ITMSYSLOG),y)

--- a/arch/arm/src/efm32/Make.defs
+++ b/arch/arm/src/efm32/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/efm32/Make.defs
+++ b/arch/arm/src/efm32/Make.defs
@@ -47,7 +47,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_doirq.c up_exit.c up_hardfault.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_itm.c up_mdelay.c up_memfault.c up_modifyreg8.c

--- a/arch/arm/src/imx1/Make.defs
+++ b/arch/arm/src/imx1/Make.defs
@@ -37,7 +37,7 @@ HEAD_ASRC = up_head.S
 
 CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_dataabort.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_prefetchabort.c up_releasepending.c up_releasestack.c

--- a/arch/arm/src/imx1/Make.defs
+++ b/arch/arm/src/imx1/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = up_head.S
 
-CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
+CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S arm_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
 CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_dataabort.c up_mdelay.c up_udelay.c up_exit.c

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -47,7 +47,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -91,7 +91,7 @@ CMN_CSRCS += up_cache.c
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 # Required i.MX RT files

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC  =
 
 # Common ARM and Cortex-M7 files
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC  =
 
 # Common ARM and Cortex-M7 files
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -97,7 +97,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_ARMV7M_ITMSYSLOG),y)

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -47,7 +47,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_mdelay.c up_udelay.c up_exit.c up_initialize.c up_memfault.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_modifyreg8.c
 CMN_CSRCS += up_modifyreg16.c up_modifyreg32.c up_releasestack.c

--- a/arch/arm/src/kl/Make.defs
+++ b/arch/arm/src/kl/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC =
 
-CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
+CMN_ASRCS  = up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c

--- a/arch/arm/src/kl/Make.defs
+++ b/arch/arm/src/kl/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_puts.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/kl/Make.defs
+++ b/arch/arm/src/kl/Make.defs
@@ -36,7 +36,7 @@
 HEAD_ASRC =
 
 CMN_ASRCS  = up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
-CMN_ASRCS += up_switchcontext.S vfork.S
+CMN_ASRCS += arm_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -40,7 +40,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -40,7 +40,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -49,7 +49,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -98,7 +98,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 # Required LPC17xx files

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -42,7 +42,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -51,7 +51,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_mdelay.c up_udelay.c up_exit.c up_initialize.c up_memfault.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_modifyreg8.c
 CMN_CSRCS += up_modifyreg16.c up_modifyreg32.c up_releasepending.c

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -42,7 +42,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc214x/Make.defs
+++ b/arch/arm/src/lpc214x/Make.defs
@@ -36,7 +36,7 @@
 
 HEAD_ASRC = lpc214x_head.S
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c

--- a/arch/arm/src/lpc214x/Make.defs
+++ b/arch/arm/src/lpc214x/Make.defs
@@ -39,7 +39,7 @@ HEAD_ASRC = lpc214x_head.S
 CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c
 CMN_CSRCS += up_exit.c up_initialize.c up_initialstate.c
 CMN_CSRCS += up_interruptcontext.c up_prefetchabort.c up_releasepending.c

--- a/arch/arm/src/lpc2378/Make.defs
+++ b/arch/arm/src/lpc2378/Make.defs
@@ -42,7 +42,7 @@ HEAD_ASRC = lpc23xx_head.S
 
 CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c
 CMN_CSRCS += up_exit.c up_initialize.c up_initialstate.c
 CMN_CSRCS += up_interruptcontext.c up_prefetchabort.c up_releasepending.c

--- a/arch/arm/src/lpc2378/Make.defs
+++ b/arch/arm/src/lpc2378/Make.defs
@@ -40,7 +40,7 @@
 
 HEAD_ASRC = lpc23xx_head.S
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c

--- a/arch/arm/src/lpc31xx/Make.defs
+++ b/arch/arm/src/lpc31xx/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC = up_head.S
 CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_dataabort.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/lpc31xx/Make.defs
+++ b/arch/arm/src/lpc31xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = up_head.S
 
-CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S up_saveusercontext.S
+CMN_ASRCS  = up_cache.S arm_fullcontextrestore.S arm_saveusercontext.S
 CMN_ASRCS += up_vectors.S up_vectoraddrexcptn.S up_vectortab.S vfork.S
 
 CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -44,7 +44,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_hardfault.c up_initialize.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_mdelay.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -80,7 +80,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 CHIP_ASRCS  =

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -44,7 +44,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_hardfault.c up_initialize.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_mdelay.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -80,7 +80,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 CHIP_ASRCS  =

--- a/arch/arm/src/max326xx/Make.defs
+++ b/arch/arm/src/max326xx/Make.defs
@@ -46,7 +46,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_doirq.c up_exit.c up_hardfault.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_mdelay.c up_memfault.c up_modifyreg8.c up_modifyreg16.c

--- a/arch/arm/src/max326xx/Make.defs
+++ b/arch/arm/src/max326xx/Make.defs
@@ -37,7 +37,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/max326xx/Make.defs
+++ b/arch/arm/src/max326xx/Make.defs
@@ -37,7 +37,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/max326xx/Make.defs
+++ b/arch/arm/src/max326xx/Make.defs
@@ -78,7 +78,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 # Common MAX326XX Source Files

--- a/arch/arm/src/moxart/Make.defs
+++ b/arch/arm/src/moxart/Make.defs
@@ -40,7 +40,7 @@ HEAD_ASRC = moxart_head.S
 
 CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += up_nommuhead.S vfork.S
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c
 CMN_CSRCS += up_exit.c up_initialstate.c up_initialize.c
 CMN_CSRCS += up_interruptcontext.c up_prefetchabort.c up_releasepending.c

--- a/arch/arm/src/moxart/Make.defs
+++ b/arch/arm/src/moxart/Make.defs
@@ -38,7 +38,7 @@
 
 HEAD_ASRC = moxart_head.S
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += up_nommuhead.S vfork.S
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -76,7 +76,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 CHIP_ASRCS  =

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -44,7 +44,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_doirq.c up_exit.c up_hardfault.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_memfault.c up_mdelay.c up_modifyreg8.c up_modifyreg16.c

--- a/arch/arm/src/nuc1xx/Make.defs
+++ b/arch/arm/src/nuc1xx/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC =
 
-CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
+CMN_ASRCS  = up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c

--- a/arch/arm/src/nuc1xx/Make.defs
+++ b/arch/arm/src/nuc1xx/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/nuc1xx/Make.defs
+++ b/arch/arm/src/nuc1xx/Make.defs
@@ -36,7 +36,7 @@
 HEAD_ASRC =
 
 CMN_ASRCS  = up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
-CMN_ASRCS += up_switchcontext.S vfork.S
+CMN_ASRCS += arm_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c

--- a/arch/arm/src/s32k1xx/s32k11x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k11x/Make.defs
@@ -36,7 +36,7 @@
 # Source files specific to the Cortex-M0+
 
 CMN_ASRCS += up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
-CMN_ASRCS += up_switchcontext.S vfork.S
+CMN_ASRCS += arm_switchcontext.S vfork.S
 
 CMN_CSRCS += up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_initialstate.c up_releasepending.c up_reprioritizertr.c

--- a/arch/arm/src/s32k1xx/s32k11x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k11x/Make.defs
@@ -35,7 +35,7 @@
 
 # Source files specific to the Cortex-M0+
 
-CMN_ASRCS += up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
+CMN_ASRCS += up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS += up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c

--- a/arch/arm/src/s32k1xx/s32k11x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k11x/Make.defs
@@ -38,7 +38,7 @@
 CMN_ASRCS += up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
-CMN_CSRCS += up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS += up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_initialstate.c up_releasepending.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_systemreset.c
 CMN_CSRCS += up_unblocktask.c up_doirq.c up_hardfault.c up_svcall.c

--- a/arch/arm/src/s32k1xx/s32k14x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k14x/Make.defs
@@ -35,7 +35,7 @@
 
 # Source files specific to the Cortex-M4F
 
-CMN_ASRCS += up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS += arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/s32k1xx/s32k14x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k14x/Make.defs
@@ -44,7 +44,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS += up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS += up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_hardfault.c up_initialstate.c up_memfault.c
 CMN_CSRCS += up_releasepending.c up_reprioritizertr.c up_schedulesigaction.c
 CMN_CSRCS += up_sigdeliver.c up_svcall.c up_trigger_irq.c up_unblocktask.c

--- a/arch/arm/src/s32k1xx/s32k14x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k14x/Make.defs
@@ -68,7 +68,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 # Source file specific to the S32k11x family

--- a/arch/arm/src/s32k1xx/s32k14x/Make.defs
+++ b/arch/arm/src/s32k1xx/s32k14x/Make.defs
@@ -35,7 +35,7 @@
 
 # Source files specific to the Cortex-M4F
 
-CMN_ASRCS += arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS += arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -92,7 +92,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_STACK_COLORATION),y)

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -52,7 +52,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_hardfault.c up_initialize.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_mdelay.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/samd2l2/Make.defs
+++ b/arch/arm/src/samd2l2/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC =
 
-CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
+CMN_ASRCS  = up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c

--- a/arch/arm/src/samd2l2/Make.defs
+++ b/arch/arm/src/samd2l2/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/samd2l2/Make.defs
+++ b/arch/arm/src/samd2l2/Make.defs
@@ -36,7 +36,7 @@
 HEAD_ASRC =
 
 CMN_ASRCS  = up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
-CMN_ASRCS += up_switchcontext.S vfork.S
+CMN_ASRCS += arm_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c

--- a/arch/arm/src/samd5e5/Make.defs
+++ b/arch/arm/src/samd5e5/Make.defs
@@ -81,7 +81,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_STACK_COLORATION),y)

--- a/arch/arm/src/samd5e5/Make.defs
+++ b/arch/arm/src/samd5e5/Make.defs
@@ -51,7 +51,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_exit.c up_initialize.c up_initialstate.c
 CMN_CSRCS += up_interruptcontext.c up_mdelay.c up_memfault.c up_modifyreg8.c
 CMN_CSRCS += up_modifyreg16.c up_modifyreg32.c up_releasepending.c

--- a/arch/arm/src/samd5e5/Make.defs
+++ b/arch/arm/src/samd5e5/Make.defs
@@ -42,7 +42,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/samd5e5/Make.defs
+++ b/arch/arm/src/samd5e5/Make.defs
@@ -42,7 +42,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -82,7 +82,7 @@ CMN_CSRCS += up_cache.c
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -52,7 +52,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_hardfault.c up_initialize.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_mdelay.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -47,7 +47,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_exit.c up_hardfault.c up_initialize.c up_initialstate.c
 CMN_CSRCS += up_interruptcontext.c up_mdelay.c up_memfault.c up_modifyreg8.c
 CMN_CSRCS += up_modifyreg16.c up_modifyreg32.c up_releasepending.c

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -91,7 +91,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_ARMV7M_ITMSYSLOG),y)

--- a/arch/arm/src/stm32f0l0g0/Make.defs
+++ b/arch/arm/src/stm32f0l0g0/Make.defs
@@ -36,7 +36,7 @@
 
 HEAD_ASRC =
 
-CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
+CMN_ASRCS  = up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c

--- a/arch/arm/src/stm32f0l0g0/Make.defs
+++ b/arch/arm/src/stm32f0l0g0/Make.defs
@@ -39,7 +39,7 @@ HEAD_ASRC =
 CMN_ASRCS  = up_exception.S up_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += up_switchcontext.S vfork.S
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c
 CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_puts.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/stm32f0l0g0/Make.defs
+++ b/arch/arm/src/stm32f0l0g0/Make.defs
@@ -37,7 +37,7 @@
 HEAD_ASRC =
 
 CMN_ASRCS  = up_exception.S arm_saveusercontext.S arm_fullcontextrestore.S
-CMN_ASRCS += up_switchcontext.S vfork.S
+CMN_ASRCS += arm_switchcontext.S vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_mdelay.c up_udelay.c up_exit.c

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -82,7 +82,7 @@ CMN_CSRCS += up_cache.c
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -52,7 +52,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_hardfault.c up_initialize.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_mdelay.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -52,7 +52,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_hardfault.c  up_initialize.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_mdelay.c up_memfault.c
 CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -77,7 +77,7 @@ CMN_CSRCS += up_vectors.c
 CMN_CSRCS += up_cache.c
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -43,7 +43,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -44,7 +44,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -53,7 +53,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_hardfault.c up_initialize.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_mdelay.c up_memfault.c
 CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -44,7 +44,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -77,7 +77,7 @@ CMN_CSRCS += up_vectors.c
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)

--- a/arch/arm/src/str71x/Make.defs
+++ b/arch/arm/src/str71x/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC = str71x_head.S
 CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
 
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copyfullstate.c
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c
 CMN_CSRCS += up_createstack.c up_dataabort.c up_mdelay.c up_udelay.c
 CMN_CSRCS += up_exit.c up_initialize.c up_initialstate.c
 CMN_CSRCS += up_interruptcontext.c up_prefetchabort.c up_releasepending.c

--- a/arch/arm/src/str71x/Make.defs
+++ b/arch/arm/src/str71x/Make.defs
@@ -35,7 +35,7 @@
 
 HEAD_ASRC = str71x_head.S
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_vectors.S
 CMN_ASRCS += vfork.S
 
 CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c arm_copyfullstate.c

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -72,7 +72,7 @@ CMN_CSRCS += up_vectors.c
 
 ifeq ($(CONFIG_ARCH_FPU),y)
   CMN_ASRCS += up_fpu.S
-  CMN_CSRCS += up_copyarmstate.c
+  CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -36,7 +36,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S  vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -36,7 +36,7 @@
 
 HEAD_ASRC  =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S  vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -45,7 +45,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_hardfault.c up_initialize.c
 CMN_CSRCS += up_initialstate.c up_interruptcontext.c up_mdelay.c
 CMN_CSRCS += up_memfault.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -97,7 +97,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += up_fpu.S
-CMN_CSRCS += up_copyarmstate.c
+CMN_CSRCS += arm_copyarmstate.c
 endif
 
 ifeq ($(CONFIG_ARMV7M_ITMSYSLOG),y)

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S arm_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -47,7 +47,7 @@ CMN_ASRCS += up_setjmp.S
 endif
 endif
 
-CMN_CSRCS  = up_assert.c up_blocktask.c up_copyfullstate.c up_createstack.c
+CMN_CSRCS  = up_assert.c up_blocktask.c arm_copyfullstate.c up_createstack.c
 CMN_CSRCS += up_doirq.c up_exit.c up_initialize.c up_initialstate.c
 CMN_CSRCS += up_hardfault.c up_interruptcontext.c up_memfault.c up_mdelay.c
 CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -38,7 +38,7 @@ HEAD_ASRC =
 CMN_UASRCS =
 CMN_UCSRCS =
 
-CMN_ASRCS  = up_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
+CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S up_switchcontext.S
 CMN_ASRCS += up_testset.S up_fetchadd.S vfork.S
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/boards/arm/cxd56xx/spresense/src/cxd56_ostest.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_ostest.c
@@ -93,7 +93,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/lpc43xx/bambino-200e/src/lpc43_ostest.c
+++ b/boards/arm/lpc43xx/bambino-200e/src/lpc43_ostest.c
@@ -91,7 +91,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/lpc43xx/bambino-200e/src/lpc43_ostest.c
+++ b/boards/arm/lpc43xx/bambino-200e/src/lpc43_ostest.c
@@ -3,7 +3,7 @@
  *
  *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
- *           Alan Carvalho de Assis acassis@gmail.com [nuttx] <nuttx@googlegroups.com>
+ *           Alan Carvalho de Assis <acassis@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/boards/arm/lpc43xx/lpc4330-xplorer/src/lpc43_ostest.c
+++ b/boards/arm/lpc43xx/lpc4330-xplorer/src/lpc43_ostest.c
@@ -94,7 +94,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/lpc43xx/lpc4357-evb/src/lpc43_ostest.c
+++ b/boards/arm/lpc43xx/lpc4357-evb/src/lpc43_ostest.c
@@ -94,7 +94,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/lpc43xx/lpc4370-link2/src/lpc43_ostest.c
+++ b/boards/arm/lpc43xx/lpc4370-link2/src/lpc43_ostest.c
@@ -94,7 +94,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/sama5/sama5d2-xult/src/sam_ostest.c
+++ b/boards/arm/sama5/sama5d2-xult/src/sam_ostest.c
@@ -79,7 +79,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_ostest.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_ostest.c
@@ -94,7 +94,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_ostest.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_ostest.c
@@ -93,7 +93,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_ostest.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_ostest.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/arm/sama5/sama5d3x-ek/src/sam_ostest.c
  *
- *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -82,6 +67,7 @@ static uint32_t g_saveregs[XCPTCONTEXT_REGS];
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
 /* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will
  * return the current FPU registers.
  */

--- a/boards/arm/sama5/sama5d4-ek/src/sam_ostest.c
+++ b/boards/arm/sama5/sama5d4-ek/src/sam_ostest.c
@@ -94,7 +94,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/stm32/omnibusf4/src/stm32_ostest.c
+++ b/boards/arm/stm32/omnibusf4/src/stm32_ostest.c
@@ -92,7 +92,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/stm32/stm3240g-eval/src/stm32_ostest.c
+++ b/boards/arm/stm32/stm3240g-eval/src/stm32_ostest.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/arm/stm32/stm3240g-eval/src/stm32_ostest.c
  *
- *   Copyright (C) 2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -54,7 +39,8 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-/* Configuration ********************************************************************/
+
+/* Configuration ************************************************************/
 
 #undef HAVE_FPU
 #if defined(CONFIG_ARCH_FPU) && defined(CONFIG_TESTING_OSTEST_FPUSIZE) && \
@@ -81,8 +67,9 @@ static uint32_t g_saveregs[XCPTCONTEXT_REGS];
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will return
- * the current FPU registers.
+
+/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will
+ * return the current FPU registers.
  */
 
 void arch_getfpu(FAR uint32_t *fpusave)

--- a/boards/arm/stm32/stm3240g-eval/src/stm32_ostest.c
+++ b/boards/arm/stm32/stm3240g-eval/src/stm32_ostest.c
@@ -92,7 +92,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_ostest.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_ostest.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/arm/stm32/stm32f429i-disco/src/stm32_ostest.c
  *
- *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -54,7 +39,8 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-/* Configuration ********************************************************************/
+
+/* Configuration ************************************************************/
 
 #undef HAVE_FPU
 #if defined(CONFIG_ARCH_FPU) && !defined(CONFIG_TESTING_OSTEST_FPUTESTDISABLE) && \
@@ -81,8 +67,9 @@ static uint32_t g_saveregs[XCPTCONTEXT_REGS];
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will return
- * the current FPU registers.
+
+/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will
+ * return the current FPU registers.
  */
 
 void arch_getfpu(FAR uint32_t *fpusave)

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_ostest.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_ostest.c
@@ -92,7 +92,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_ostest.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_ostest.c
@@ -90,7 +90,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_ostest.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_ostest.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/arm/stm32/stm32f4discovery/src/stm32_ostest.c
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -55,7 +40,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Configuration ********************************************************************/
+/* Configuration ************************************************************/
 
 #undef HAVE_FPU
 #if defined(CONFIG_ARCH_FPU) && !defined(CONFIG_TESTING_OSTEST_FPUTESTDISABLE) && \
@@ -79,8 +64,8 @@ static uint32_t g_saveregs[XCPTCONTEXT_REGS];
  * Public Functions
  ****************************************************************************/
 
-/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will return
- * the current FPU registers.
+/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will
+ * return the current FPU registers.
  */
 
 void arch_getfpu(FAR uint32_t *fpusave)

--- a/boards/arm/stm32f7/stm32f746g-disco/src/stm32_ostest.c
+++ b/boards/arm/stm32f7/stm32f746g-disco/src/stm32_ostest.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/arm/stm32f7/stm32f746g-disco/src/stm32_ostest.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -54,7 +39,8 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-/* Configuration ********************************************************************/
+
+/* Configuration ************************************************************/
 
 #undef HAVE_FPU
 #if defined(CONFIG_ARCH_FPU) && !defined(CONFIG_TESTING_OSTEST_FPUTESTDISABLE) && \
@@ -81,8 +67,9 @@ static uint32_t g_saveregs[XCPTCONTEXT_REGS];
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will return
- * the current FPU registers.
+
+/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will
+ * return the current FPU registers.
  */
 
 void arch_getfpu(FAR uint32_t *fpusave)

--- a/boards/arm/stm32f7/stm32f746g-disco/src/stm32_ostest.c
+++ b/boards/arm/stm32f7/stm32f746g-disco/src/stm32_ostest.c
@@ -92,7 +92,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/stm32f7/stm32f769i-disco/src/stm32_ostest.c
+++ b/boards/arm/stm32f7/stm32f769i-disco/src/stm32_ostest.c
@@ -93,7 +93,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/stm32f7/stm32f769i-disco/src/stm32_ostest.c
+++ b/boards/arm/stm32f7/stm32f769i-disco/src/stm32_ostest.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/arm/stm32f7/stm32f769i-disco/src/stm32_ostest.c
  *
- *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -54,7 +39,8 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-/* Configuration ********************************************************************/
+
+/* Configuration ************************************************************/
 
 #undef HAVE_FPU
 #if defined(CONFIG_ARCH_FPU) && !defined(CONFIG_TESTING_OSTEST_FPUTESTDISABLE) && \
@@ -82,8 +68,8 @@ static uint32_t g_saveregs[XCPTCONTEXT_REGS];
  * Public Functions
  ****************************************************************************/
 
-/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will return
- * the current FPU registers.
+/* Given an array of size CONFIG_TESTING_OSTEST_FPUSIZE, this function will
+ * return the current FPU registers.
  */
 
 void arch_getfpu(FAR uint32_t *fpusave)
@@ -97,7 +83,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
 
   /* Return only the floating register values */
 
-  memcpy(fpusave, &g_saveregs[REG_S0], (4*SW_FPU_REGS));
+  memcpy(fpusave, &g_saveregs[REG_S0], (4 * SW_FPU_REGS));
   leave_critical_section(flags);
 }
 

--- a/boards/arm/xmc4/xmc4500-relax/src/xmc4_ostest.c
+++ b/boards/arm/xmc4/xmc4500-relax/src/xmc4_ostest.c
@@ -90,7 +90,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_ostest.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_ostest.c
@@ -75,7 +75,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  arm_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 


### PR DESCRIPTION
## Summary

The naming standard at https://cwiki.apache.org/confluence/display/NUTTX/Naming+FAQ requires that all MCU-private interfaces begin with the name of the architecture, not up_.

This PR addresses only these context switching function names:

    up_copyfullstate -> arm_copyfullstate
    up_copyarmstate -> arm_copyarmstate
    up_saveusercontext -> arm_saveusercontext
    up_switchcontext -> arm_switchcontext

## Impact

There should be not impact of this change (other that one step toward more consistent naming).

## Testing

stm32f4discovery:netnsh
