### PR TITLE
Remove the residual files in distclean

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -220,6 +220,7 @@ distclean: clean
 	$(Q) $(MAKE) -C ubin distclean TOPDIR=$(TOPDIR)
 	$(Q) $(MAKE) -C kbin distclean TOPDIR=$(TOPDIR)
 	$(Q) $(MAKE) -C zoneinfo distclean TOPDIR=$(TOPDIR) BIN=$(BIN)
+	$(call DELFILE, exec_symtab.c)
 	$(call DELFILE, bin/Make.dep)
 	$(call DELFILE, ubin/Make.dep)
 	$(call DELFILE, kbin/Make.dep)

--- a/tools/Makefile.host
+++ b/tools/Makefile.host
@@ -293,4 +293,5 @@ clean:
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) rm -rf *.dSYM
 endif
+	$(Q) $(MAKE) -C pic32 -f Makefile.host TOPDIR="$(TOPDIR)" clean
 	$(call CLEAN)


### PR DESCRIPTION
## Summary
Fix Apache Nightly Build clean up issue with the following log:

Ignored files:
  (use "git add -f <file>..." to include in what will be committed)

	libs/libc/exec_symtab.c
	tools/pic32/mkpichex

## Impact

## Testing
 Test and verify with lx_cpu:nsh and pic32mz-starterkit:nsh configs.
