### PR TITLE
sim: Update hostfs after the recent struct stat timespec changes

### DIFF
--- a/arch/sim/src/sim/up_hostfs.c
+++ b/arch/sim/src/sim/up_hostfs.c
@@ -97,18 +97,30 @@ static void host_stat_convert(struct stat *hostbuf, struct nuttx_stat_s *buf)
       buf->st_mode |= NUTTX_S_IFSOCK;
     }
 
-  buf->st_dev     = hostbuf->st_dev;
-  buf->st_ino     = hostbuf->st_ino;
-  buf->st_nlink   = hostbuf->st_nlink;
-  buf->st_uid     = hostbuf->st_uid;
-  buf->st_gid     = hostbuf->st_gid;
-  buf->st_rdev    = hostbuf->st_rdev;
-  buf->st_size    = hostbuf->st_size;
-  buf->st_atim    = hostbuf->st_atime;
-  buf->st_mtim    = hostbuf->st_mtime;
-  buf->st_ctim    = hostbuf->st_ctime;
-  buf->st_blksize = hostbuf->st_blksize;
-  buf->st_blocks  = hostbuf->st_blocks;
+  buf->st_dev          = hostbuf->st_dev;
+  buf->st_ino          = hostbuf->st_ino;
+  buf->st_nlink        = hostbuf->st_nlink;
+  buf->st_uid          = hostbuf->st_uid;
+  buf->st_gid          = hostbuf->st_gid;
+  buf->st_rdev         = hostbuf->st_rdev;
+  buf->st_size         = hostbuf->st_size;
+#if defined(__APPLE__)
+  buf->st_atim.tv_sec  = hostbuf->st_atimespec.tv_sec;
+  buf->st_atim.tv_nsec = hostbuf->st_atimespec.tv_nsec;
+  buf->st_mtim.tv_sec  = hostbuf->st_mtimespec.tv_sec;
+  buf->st_mtim.tv_nsec = hostbuf->st_mtimespec.tv_nsec;
+  buf->st_ctim.tv_sec  = hostbuf->st_ctimespec.tv_sec;
+  buf->st_ctim.tv_nsec = hostbuf->st_ctimespec.tv_nsec;
+#else
+  buf->st_atim.tv_sec  = hostbuf->st_atim.tv_sec;
+  buf->st_atim.tv_nsec = hostbuf->st_atim.tv_nsec;
+  buf->st_mtim.tv_sec  = hostbuf->st_mtim.tv_sec;
+  buf->st_mtim.tv_nsec = hostbuf->st_mtim.tv_nsec;
+  buf->st_ctim.tv_sec  = hostbuf->st_ctim.tv_sec;
+  buf->st_ctim.tv_nsec = hostbuf->st_ctim.tv_nsec;
+#endif
+  buf->st_blksize      = hostbuf->st_blksize;
+  buf->st_blocks       = hostbuf->st_blocks;
 }
 
 /****************************************************************************

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -118,6 +118,12 @@ typedef uintptr_t    nuttx_size_t;
 
 typedef uint32_t     nuttx_time_t;
 
+struct nuttx_timespec
+{
+    nuttx_time_t tv_sec;
+    long tv_nsec;
+};
+
 /* These must exactly match the definition from include/dirent.h: */
 
 struct nuttx_dirent_s
@@ -144,19 +150,19 @@ struct nuttx_statfs_s
 
 struct nuttx_stat_s
 {
-  nuttx_dev_t     st_dev;     /* Device ID of device containing file */
-  nuttx_ino_t     st_ino;     /* File serial number */
-  nuttx_mode_t    st_mode;    /* File type, attributes, and access mode bits */
-  nuttx_nlink_t   st_nlink;   /* Number of hard links to the file */
-  nuttx_uid_t     st_uid;     /* User ID of file */
-  nuttx_gid_t     st_gid;     /* Group ID of file */
-  nuttx_dev_t     st_rdev;    /* Device ID (if file is character or block special) */
-  nuttx_off_t     st_size;    /* Size of file/directory, in bytes */
-  nuttx_time_t    st_atim;    /* Time of last access */
-  nuttx_time_t    st_mtim;    /* Time of last modification */
-  nuttx_time_t    st_ctim;    /* Time of last status change */
-  nuttx_blksize_t st_blksize; /* Block size used for filesystem I/O */
-  nuttx_blkcnt_t  st_blocks;  /* Number of blocks allocated */
+  nuttx_dev_t           st_dev;     /* Device ID of device containing file */
+  nuttx_ino_t           st_ino;     /* File serial number */
+  nuttx_mode_t          st_mode;    /* File type, attributes, and access mode bits */
+  nuttx_nlink_t         st_nlink;   /* Number of hard links to the file */
+  nuttx_uid_t           st_uid;     /* User ID of file */
+  nuttx_gid_t           st_gid;     /* Group ID of file */
+  nuttx_dev_t           st_rdev;    /* Device ID (if file is character or block special) */
+  nuttx_off_t           st_size;    /* Size of file/directory, in bytes */
+  struct nuttx_timespec st_atim;    /* Time of last access */
+  struct nuttx_timespec st_mtim;    /* Time of last modification */
+  struct nuttx_timespec st_ctim;    /* Time of last status change */
+  nuttx_blksize_t       st_blksize; /* Block size used for filesystem I/O */
+  nuttx_blkcnt_t        st_blocks;  /* Number of blocks allocated */
 };
 
 #endif /* __SIM__ */


### PR DESCRIPTION
Fix it after the following change:

    commit bb4458b63f21e2ccbde238a1860b4f75f68b3362
    Author: Ouss4 <abdelatif.guettouche@gmail.com>
    Date:   Thu Apr 30 19:05:12 2020 +0100

        include/sys/stat.h: Per the POSIX standard, the atime, ctime and mtime field
    s
        have changed their type from time_t to struct timespec.

## Summary

## Impact

## Testing

