### PR TITLE
sim: Suppress "has no symbols" warnings for macOS

### DIFF
--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -47,6 +47,7 @@ BINFMT_ASRCS  =
 BINFMT_CSRCS  = binfmt_globals.c binfmt_initialize.c binfmt_register.c binfmt_unregister.c
 BINFMT_CSRCS += binfmt_loadmodule.c binfmt_unloadmodule.c binfmt_execmodule.c
 BINFMT_CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_dumpmodule.c
+BINFMT_CSRCS += dummy.c
 
 ifeq ($(CONFIG_BINFMT_LOADABLE),y)
 BINFMT_CSRCS += binfmt_exit.c

--- a/binfmt/dummy.c
+++ b/binfmt/dummy.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * binfmt/dummy.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* Just to ensure that this library has some symbols.
+ * Some tools complain about a library with no symbols.
+ * E.g. macOS ranlib.
+ */
+
+int __binfmt_dummy;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/boards/sim/sim/sim/configs/cxxtest/Make.defs
+++ b/boards/sim/sim/sim/configs/cxxtest/Make.defs
@@ -62,10 +62,11 @@ CPP = $(CROSSDEV)cc -E
 LD = $(CROSSDEV)ld
 ifeq ($(CONFIG_HOST_MACOS),y)
 STRIP = $(CROSSDEV)strip
+AR = $(TOPDIR)/tools/xcode-silent-ar-rcs
 else
 STRIP = $(CROSSDEV)strip --strip-unneeded
-endif
 AR = $(CROSSDEV)ar rcs
+endif
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -64,10 +64,11 @@ CPP = $(CROSSDEV)cc -E -P -x c
 LD = $(CROSSDEV)ld
 ifeq ($(CONFIG_HOST_MACOS),y)
 STRIP = $(CROSSDEV)strip
+AR = $(TOPDIR)/tools/xcode-silent-ar-rcs
 else
 STRIP = $(CROSSDEV)strip --strip-unneeded
-endif
 AR = $(CROSSDEV)ar rcs
+endif
 NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump

--- a/boards/sim/sim/sim/src/dummy.c
+++ b/boards/sim/sim/sim/src/dummy.c
@@ -1,1 +1,38 @@
+/****************************************************************************
+ * boards/sim/sim/sim/src/dummy.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
 
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* Just to ensure that this library has some symbols.
+ * Some tools complain about a library with no symbols.
+ * E.g. macOS ranlib.
+ */
+
+int __board_dummy;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/tools/xcode-silent-ar-rcs
+++ b/tools/xcode-silent-ar-rcs
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an "ar rcs" equivalent without "has no symbols" warnings.
+# Unfortunately, ar doesn't have a -no_warning_for_no_symbols equivalent.
+
+set -e
+ar rcS "$@"
+ranlib -no_warning_for_no_symbols "$1"


### PR DESCRIPTION
## Summary
https://github.com/apache/incubator-nuttx/issues/920

## Impact

## Testing

