### PR TITLE
sim: Suppress "has no symbols" warnings for macOS

### DIFF
--- a/boards/sim/sim/sim/include/dummy.h
+++ b/boards/sim/sim/sim/include/dummy.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * boards/sim/sim/sim/include/dummy.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_SIM_SIM_SIM_INCLUDE_DUMMY_H
+#define __BOARDS_SIM_SIM_SIM_INCLUDE_DUMMY_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define DUMMY_NAME(name) DUMMY_NAME_(dummy_, name)
+#define DUMMY_NAME_(prefix, name) prefix##name
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* ranlib on macOS will generate "has no symbols" warning if the static
+ * library don't expose any public symbol, so let's always generate a dummy
+ * global function to overcome this issue.
+ */
+
+#ifndef __ASSEMBLY__
+void DUMMY_NAME(CKSUM_SELF)(void)
+{
+}
+#endif
+
+#endif /* __BOARDS_SIM_SIM_SIM_INCLUDE_DUMMY_H */

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -47,6 +47,11 @@ ARCHINCLUDES = -I. -isystem $(TOPDIR)/include
 ARCHINCLUDESXX = -I. -isystem $(TOPDIR)/include -isystem $(TOPDIR)/include/cxx
 ARCHSCRIPT =
 
+ifeq ($(CONFIG_HOST_MACOS),y)
+  ARCHDEFINES  += -DCKSUM_SELF=$(if $<,$(word 1,$(shell cksum $<)))
+  ARCHINCLUDES += -include $(TOPDIR)/boards/sim/sim/sim/include/dummy.h
+endif
+
 # Add -fno-common because macOS "ld -r" doesn't seem to pick objects
 # for common symbols.
 ARCHCPUFLAGS += -fno-common


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

## Summary
Fix the same issue as:
https://github.com/apache/incubator-nuttx/pull/933
But the approach is more general.

## Impact

## Testing

