### PR TITLE
x86_64: Set kernel entry to 1M to avoid EPT Violation

### DIFF
--- a/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
+++ b/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
@@ -22,7 +22,7 @@ OUTPUT_ARCH(i386:x86-64)
 ENTRY(__pmode_entry)
 SECTIONS
 {
-    . = 0x4M;
+    . = 0x1M;
     _kernel_physical_start = .;
 
     .loader.text : {


### PR DESCRIPTION
## Summary
When running inside of qemu via KVM ostest configuration fails to run triggering a reboot right after leaving grub.  Using trace-cmd and kernelshark it was determined that a Tripple Fault was being triggered because of too many EPT_VIOLATIONS. 

Using bochs this behaviour is not seen if some of the fault triggers are disabled.

QEMU is started via this command with a delay triggered by grub.
```
qemu-system-x86_64  -cpu host,+pcid,+x2apic,+tsc-deadline,+xsave,+rdrand --enable-kvm -smp 1 -m 2G -cdrom boot.iso -serial mon:stdio -d in_asm -D qemu.log -s -no-reboot
```

In another window kvm tracing is started.  The kernel is selected in GRUB in QEMU.  When QEMU terminates the trace is also sent a TERM signal.
```
❯ sudo trace-cmd record -b 20000 -e kvm
[sudo] password for bashton: 
Hit Ctrl^C to stop recording
^CCPU0 data recorded at offset=0x73b000
    1863680 bytes in size
CPU1 data recorded at offset=0x902000
    97107968 bytes in size
CPU2 data recorded at offset=0x659e000
    5685248 bytes in size
CPU3 data recorded at offset=0x6b0a000
    1699840 bytes in size
```
Looking at the end of the trace we can see the fault prior to QEMU terminating
![ept_violation](https://user-images.githubusercontent.com/173245/80860768-e4937d00-8c1e-11ea-90bb-d456d498cb0e.png)

Once the entry point was changed from 4M to the standard 1M the ostest passed.

## Impact
x86_64 configurations do not run correctly on QEMU with kvm enabled which is required to fully function.

## Testing
The ostest configuration was run in qemu (with kvm) and bochs
