### PR TITLE
arch/arm: Rename up_savestate and up_restorestate

### DIFF
--- a/arch/arm/src/arm/arm_blocktask.c
+++ b/arch/arm/src/arm/arm_blocktask.c
@@ -120,7 +120,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -136,7 +136,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* Copy the user C context into the TCB at the (old) head of the

--- a/arch/arm/src/arm/arm_releasepending.c
+++ b/arch/arm/src/arm/arm_releasepending.c
@@ -74,7 +74,7 @@ void up_release_pending(void)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+           arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -90,7 +90,7 @@ void up_release_pending(void)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* Copy the exception context into the TCB of the task that

--- a/arch/arm/src/arm/arm_reprioritizertr.c
+++ b/arch/arm/src/arm/arm_reprioritizertr.c
@@ -129,7 +129,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the CURRENT_REGS into the OLD rtcb.
                */
 
-               up_savestate(rtcb->xcp.regs);
+               arm_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -145,7 +145,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * changes will be made when the interrupt returns.
                */
 
-              up_restorestate(rtcb->xcp.regs);
+              arm_restorestate(rtcb->xcp.regs);
             }
 
           /* Copy the exception context into the TCB at the (old) head of

--- a/arch/arm/src/arm/arm_schedulesigaction.c
+++ b/arch/arm/src/arm/arm_schedulesigaction.c
@@ -155,7 +155,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * is the same as the interrupt return context.
                */
 
-              up_savestate(tcb->xcp.regs);
+              arm_savestate(tcb->xcp.regs);
             }
         }
 

--- a/arch/arm/src/arm/arm_unblocktask.c
+++ b/arch/arm/src/arm/arm_unblocktask.c
@@ -89,7 +89,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -105,7 +105,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* We are not in an interrupt handler.  Copy the user C context

--- a/arch/arm/src/armv6-m/arm_blocktask.c
+++ b/arch/arm/src/armv6-m/arm_blocktask.c
@@ -104,7 +104,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -118,7 +118,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv6-m/arm_releasepending.c
+++ b/arch/arm/src/armv6-m/arm_releasepending.c
@@ -73,7 +73,7 @@ void up_release_pending(void)
            * CURRENT_REGS into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+           arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -87,7 +87,7 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv6-m/arm_reprioritizertr.c
+++ b/arch/arm/src/armv6-m/arm_reprioritizertr.c
@@ -129,7 +129,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the CURRENT_REGS into the OLD rtcb.
                */
 
-               up_savestate(rtcb->xcp.regs);
+               arm_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -143,7 +143,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
-              up_restorestate(rtcb->xcp.regs);
+              arm_restorestate(rtcb->xcp.regs);
             }
 
           /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -157,7 +157,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * as the interrupt return context.
                */
 
-              up_savestate(tcb->xcp.regs);
+              arm_savestate(tcb->xcp.regs);
             }
         }
 

--- a/arch/arm/src/armv6-m/arm_unblocktask.c
+++ b/arch/arm/src/armv6-m/arm_unblocktask.c
@@ -87,7 +87,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -101,7 +101,7 @@ void up_unblock_task(struct tcb_s *tcb)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv7-a/arm_blocktask.c
+++ b/arch/arm/src/armv7-a/arm_blocktask.c
@@ -120,7 +120,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -136,7 +136,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* Copy the user C context into the TCB at the (old) head of the

--- a/arch/arm/src/armv7-a/arm_cpupause.c
+++ b/arch/arm/src/armv7-a/arm_cpupause.c
@@ -142,7 +142,7 @@ int up_cpu_paused(int cpu)
    * of the assigned task list for this CPU.
    */
 
-  up_savestate(tcb->xcp.regs);
+  arm_savestate(tcb->xcp.regs);
 
   /* Release the g_cpu_puased spinlock to synchronize with the
    * requesting CPU.
@@ -176,7 +176,7 @@ int up_cpu_paused(int cpu)
    * will be made when the interrupt returns.
    */
 
-  up_restorestate(tcb->xcp.regs);
+  arm_restorestate(tcb->xcp.regs);
   spin_unlock(&g_cpu_wait[cpu]);
 
   return OK;

--- a/arch/arm/src/armv7-a/arm_cpustart.c
+++ b/arch/arm/src/armv7-a/arm_cpustart.c
@@ -128,7 +128,7 @@ int arm_start_handler(int irq, FAR void *context, FAR void *arg)
    * be the CPUs NULL task.
    */
 
-  up_restorestate(tcb->xcp.regs);
+  arm_restorestate(tcb->xcp.regs);
   return OK;
 }
 

--- a/arch/arm/src/armv7-a/arm_releasepending.c
+++ b/arch/arm/src/armv7-a/arm_releasepending.c
@@ -73,7 +73,7 @@ void up_release_pending(void)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+           arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -89,7 +89,7 @@ void up_release_pending(void)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* Copy the exception context into the TCB of the task that

--- a/arch/arm/src/armv7-a/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-a/arm_reprioritizertr.c
@@ -129,7 +129,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the CURRENT_REGS into the OLD rtcb.
                */
 
-               up_savestate(rtcb->xcp.regs);
+               arm_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -145,7 +145,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * changes will be made when the interrupt returns.
                */
 
-              up_restorestate(rtcb->xcp.regs);
+              arm_restorestate(rtcb->xcp.regs);
             }
 
           /* Copy the exception context into the TCB at the (old) head of

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/armv7-a/arm_schedulesigaction.c
  *
- *   Copyright (C) 2013, 2015-2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -154,7 +139,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               CURRENT_REGS[REG_PC]    = (uint32_t)arm_sigdeliver;
-              CURRENT_REGS[REG_CPSR]  = (PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT);
+              CURRENT_REGS[REG_CPSR]  = (PSR_MODE_SVC | PSR_I_BIT |
+                                         PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
               CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
 #endif
@@ -163,7 +149,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * as the interrupt return context.
                */
 
-              up_savestate(tcb->xcp.regs);
+              arm_savestate(tcb->xcp.regs);
             }
         }
 
@@ -268,8 +254,9 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
                   /* Now tcb on the other CPU can be accessed safely */
 
-                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be restored
-                   * by the signal trampoline after the signal has been delivered.
+                  /* Copy tcb->xcp.regs to tcp.xcp.saved. These will be
+                   * restored by the signal trampoline after the signal has
+                   * been delivered.
                    */
 
                   tcb->xcp.sigdeliver      = sigdeliver;
@@ -281,7 +268,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    */
 
                   tcb->xcp.regs[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT);
+                  tcb->xcp.regs[REG_CPSR]  = (PSR_MODE_SVC | PSR_I_BIT |
+                                              PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
                   tcb->xcp.regs[REG_CPSR] |= PSR_T_BIT;
 #endif
@@ -290,10 +278,10 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                 {
                   /* tcb is running on the same CPU */
 
-                  /* Save the return PC, CPSR and either the BASEPRI or PRIMASK
-                   * registers (and perhaps also the LR).  These will be
-                   * restored by the signal trampoline after the signal has been
-                   * delivered.
+                  /* Save the return PC, CPSR and either the BASEPRI or
+                   * PRIMASK registers (and perhaps also the LR).  These will
+                   * be restored by the signal trampoline after the signal
+                   * has been delivered.
                    */
 
                   tcb->xcp.sigdeliver      = (FAR void *)sigdeliver;
@@ -306,20 +294,21 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    */
 
                   CURRENT_REGS[REG_PC]    = (uint32_t)arm_sigdeliver;
-                  CURRENT_REGS[REG_CPSR]  = (PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT);
+                  CURRENT_REGS[REG_CPSR]  = (PSR_MODE_SVC | PSR_I_BIT |
+                                             PSR_F_BIT);
 #ifdef CONFIG_ARM_THUMB
                   CURRENT_REGS[REG_CPSR] |= PSR_T_BIT;
 #endif
 
-                  /* And make sure that the saved context in the TCB is the same
-                   * as the interrupt return context.
+                  /* And make sure that the saved context in the TCB is the
+                   * same as the interrupt return context.
                    */
 
-                  up_savestate(tcb->xcp.regs);
+                  arm_savestate(tcb->xcp.regs);
                 }
 
-              /* Increment the IRQ lock count so that when the task is restarted,
-               * it will hold the IRQ spinlock.
+              /* Increment the IRQ lock count so that when the task is
+               * restarted, it will hold the IRQ spinlock.
                */
 
               DEBUGASSERT(tcb->irqcount < INT16_MAX);
@@ -327,9 +316,10 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
               /* In an SMP configuration, the interrupt disable logic also
                * involves spinlocks that are configured per the TCB irqcount
-               * field.  This is logically equivalent to enter_critical_section().
-               * The matching call to leave_critical_section() will be
-               * performed in arm_sigdeliver().
+               * field.  This is logically equivalent to
+               * enter_critical_section().  The matching call to
+               * leave_critical_section() will be performed in
+               * arm_sigdeliver().
                */
 
               spin_setbit(&g_cpu_irqset, cpu, &g_cpu_irqsetlock,

--- a/arch/arm/src/armv7-a/arm_unblocktask.c
+++ b/arch/arm/src/armv7-a/arm_unblocktask.c
@@ -102,7 +102,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -122,7 +122,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* We are not in an interrupt handler.  Copy the user C context

--- a/arch/arm/src/armv7-m/arm_blocktask.c
+++ b/arch/arm/src/armv7-m/arm_blocktask.c
@@ -104,7 +104,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -118,7 +118,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv7-m/arm_releasepending.c
+++ b/arch/arm/src/armv7-m/arm_releasepending.c
@@ -77,7 +77,7 @@ void up_release_pending(void)
            * CURRENT_REGS into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+           arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -91,7 +91,7 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv7-m/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-m/arm_reprioritizertr.c
@@ -129,7 +129,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the CURRENT_REGS into the OLD rtcb.
                */
 
-               up_savestate(rtcb->xcp.regs);
+               arm_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -143,7 +143,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
-              up_restorestate(rtcb->xcp.regs);
+              arm_restorestate(rtcb->xcp.regs);
             }
 
           /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -159,7 +159,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * as the interrupt return context.
                */
 
-              up_savestate(tcb->xcp.regs);
+              arm_savestate(tcb->xcp.regs);
             }
         }
 
@@ -352,7 +352,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * same as the interrupt return context.
                    */
 
-                  up_savestate(tcb->xcp.regs);
+                  arm_savestate(tcb->xcp.regs);
                 }
 
               /* Increment the IRQ lock count so that when the task is

--- a/arch/arm/src/armv7-m/arm_unblocktask.c
+++ b/arch/arm/src/armv7-m/arm_unblocktask.c
@@ -88,7 +88,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -102,7 +102,7 @@ void up_unblock_task(struct tcb_s *tcb)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv7-r/arm_blocktask.c
+++ b/arch/arm/src/armv7-r/arm_blocktask.c
@@ -120,7 +120,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -134,7 +134,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts. */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* Copy the user C context into the TCB at the (old) head of the

--- a/arch/arm/src/armv7-r/arm_releasepending.c
+++ b/arch/arm/src/armv7-r/arm_releasepending.c
@@ -74,7 +74,7 @@ void up_release_pending(void)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+           arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -90,7 +90,7 @@ void up_release_pending(void)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* Copy the exception context into the TCB of the task that

--- a/arch/arm/src/armv7-r/arm_reprioritizertr.c
+++ b/arch/arm/src/armv7-r/arm_reprioritizertr.c
@@ -129,7 +129,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the CURRENT_REGS into the OLD rtcb.
                */
 
-               up_savestate(rtcb->xcp.regs);
+               arm_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -145,7 +145,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * changes will be made when the interrupt returns.
                */
 
-              up_restorestate(rtcb->xcp.regs);
+              arm_restorestate(rtcb->xcp.regs);
             }
 
           /* Copy the exception context into the TCB at the (old) head of

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/armv7-r/arm_schedulesigaction.c
  *
- *   Copyright (C) 2015-2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -149,7 +134,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                */
 
               CURRENT_REGS[REG_PC]      = (uint32_t)arm_sigdeliver;
-              CURRENT_REGS[REG_CPSR]    = (PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT);
+              CURRENT_REGS[REG_CPSR]    = (PSR_MODE_SVC | PSR_I_BIT |
+                                           PSR_F_BIT);
 
 #ifdef CONFIG_ENDIAN_BIG
               CURRENT_REGS[REG_CPSR]    |= PSR_E_BIT;
@@ -159,7 +145,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * as the interrupt return context.
                */
 
-              up_savestate(tcb->xcp.regs);
+              arm_savestate(tcb->xcp.regs);
             }
         }
 
@@ -184,7 +170,8 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            */
 
           tcb->xcp.regs[REG_PC]      = (uint32_t)arm_sigdeliver;
-          tcb->xcp.regs[REG_CPSR]    = (PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT);
+          tcb->xcp.regs[REG_CPSR]    = (PSR_MODE_SVC | PSR_I_BIT |
+                                        PSR_F_BIT);
 
 #ifdef CONFIG_ENDIAN_BIG
           tcb->xcp.regs[REG_CPSR]    |= PSR_E_BIT;

--- a/arch/arm/src/armv7-r/arm_unblocktask.c
+++ b/arch/arm/src/armv7-r/arm_unblocktask.c
@@ -101,7 +101,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -117,7 +117,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* We are not in an interrupt handler.  Copy the user C context

--- a/arch/arm/src/armv8-m/arm_blocktask.c
+++ b/arch/arm/src/armv8-m/arm_blocktask.c
@@ -104,7 +104,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -118,7 +118,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv8-m/arm_releasepending.c
+++ b/arch/arm/src/armv8-m/arm_releasepending.c
@@ -77,7 +77,7 @@ void up_release_pending(void)
            * CURRENT_REGS into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+           arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -91,7 +91,7 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv8-m/arm_reprioritizertr.c
+++ b/arch/arm/src/armv8-m/arm_reprioritizertr.c
@@ -129,7 +129,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the CURRENT_REGS into the OLD rtcb.
                */
 
-               up_savestate(rtcb->xcp.regs);
+               arm_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -143,7 +143,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
-              up_restorestate(rtcb->xcp.regs);
+              arm_restorestate(rtcb->xcp.regs);
             }
 
           /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -159,7 +159,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * as the interrupt return context.
                */
 
-              up_savestate(tcb->xcp.regs);
+              arm_savestate(tcb->xcp.regs);
             }
         }
 
@@ -352,7 +352,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * same as the interrupt return context.
                    */
 
-                  up_savestate(tcb->xcp.regs);
+                  arm_savestate(tcb->xcp.regs);
                 }
 
               /* Increment the IRQ lock count so that when the task is

--- a/arch/arm/src/armv8-m/arm_unblocktask.c
+++ b/arch/arm/src/armv8-m/arm_unblocktask.c
@@ -88,7 +88,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          arm_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -102,7 +102,7 @@ void up_unblock_task(struct tcb_s *tcb)
 
           /* Then switch contexts */
 
-          up_restorestate(rtcb->xcp.regs);
+          arm_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -91,11 +91,11 @@
    */
 
 #  if defined(CONFIG_ARCH_FPU) && defined(CONFIG_ARMV7M_LAZYFPU)
-#    define up_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
+#    define arm_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
-#    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
+#    define arm_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
-#  define up_restorestate(regs) (CURRENT_REGS = regs)
+#  define arm_restorestate(regs) (CURRENT_REGS = regs)
 
 /* The Cortex-A and Cortex-R support the same mechanism, but only lazy
  * floating point register save/restore.
@@ -108,11 +108,11 @@
    */
 
 #  if defined(CONFIG_ARCH_FPU)
-#    define up_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
+#    define arm_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
-#    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
+#    define arm_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
-#  define up_restorestate(regs) (CURRENT_REGS = regs)
+#  define arm_restorestate(regs) (CURRENT_REGS = regs)
 
 /* Otherwise, for the ARM7 and ARM9.  The state is copied in full from stack
  * to stack.  This is not very efficient and should be fixed to match
@@ -127,11 +127,11 @@
    */
 
 #  if defined(CONFIG_ARCH_FPU)
-#    define up_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
+#    define arm_savestate(regs)  arm_copyarmstate(regs, (uint32_t*)CURRENT_REGS)
 #  else
-#    define up_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
+#    define arm_savestate(regs)  arm_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #  endif
-#  define up_restorestate(regs) arm_copyfullstate((uint32_t*)CURRENT_REGS, regs)
+#  define arm_restorestate(regs) arm_copyfullstate((uint32_t*)CURRENT_REGS, regs)
 
 #endif
 
@@ -468,8 +468,9 @@ void arm_wdtinit(void);
  * network is enabled yet there is no Ethernet driver to be initialized.
  *
  * Use of common/arm_etherstub.c is deprecated.  The preferred mechanism is
- * to use CONFIG_NETDEV_LATEINIT=y to suppress the call to arm_netinitialize()
- * in up_initialize().  Then this stub would not be needed.
+ * to use CONFIG_NETDEV_LATEINIT=y to suppress the call to
+ * arm_netinitialize() in up_initialize().  Then this stub would not be
+ * needed.
  */
 
 #if defined(CONFIG_NET) && !defined(CONFIG_NETDEV_LATEINIT)

--- a/arch/arm/src/cxd56xx/cxd56_cpupause.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpupause.c
@@ -224,7 +224,7 @@ int up_cpu_paused(int cpu)
    * of the assigned task list for this CPU.
    */
 
-  up_savestate(tcb->xcp.regs);
+  arm_savestate(tcb->xcp.regs);
 
   /* Wait for the spinlock to be released */
 
@@ -251,7 +251,7 @@ int up_cpu_paused(int cpu)
    * will be made when the interrupt returns.
    */
 
-  up_restorestate(tcb->xcp.regs);
+  arm_restorestate(tcb->xcp.regs);
   spin_unlock(&g_cpu_wait[cpu]);
 
   return OK;

--- a/arch/arm/src/lc823450/lc823450_cpupause.c
+++ b/arch/arm/src/lc823450/lc823450_cpupause.c
@@ -155,7 +155,7 @@ int up_cpu_paused(int cpu)
    * of the assigned task list for this CPU.
    */
 
-  up_savestate(tcb->xcp.regs);
+  arm_savestate(tcb->xcp.regs);
 
   /* Wait for the spinlock to be released */
 
@@ -182,7 +182,7 @@ int up_cpu_paused(int cpu)
    * will be made when the interrupt returns.
    */
 
-  up_restorestate(tcb->xcp.regs);
+  arm_restorestate(tcb->xcp.regs);
 
   spin_unlock(&g_cpu_wait[cpu]);
 

--- a/arch/arm/src/sam34/sam4cm_cpupause.c
+++ b/arch/arm/src/sam34/sam4cm_cpupause.c
@@ -156,7 +156,7 @@ int up_cpu_paused(int cpu)
    * of the assigned task list for this CPU.
    */
 
-  up_savestate(tcb->xcp.regs);
+  arm_savestate(tcb->xcp.regs);
 
   /* Wait for the spinlock to be released */
 
@@ -183,7 +183,7 @@ int up_cpu_paused(int cpu)
    * will be made when the interrupt returns.
    */
 
-  up_restorestate(tcb->xcp.regs);
+  arm_restorestate(tcb->xcp.regs);
   spin_unlock(&g_cpu_wait[cpu]);
 
   return OK;


### PR DESCRIPTION
## Summary

The naming standard at https://cwiki.apache.org/confluence/display/NUTTX/Naming+FAQ requires that all MCU-private functions begin with the name of the architecture, not up_.

This PR addresses function-like macro naming that was missing in previous PRs:  up_savestate() and up_restorestate() which must be named arm_savestate() and arm_restorestate().

## Impact

There should be no impact of this change (other that one step toward more consistent naming).

## Testing

stm32f103-minimum:nsh
