### PR TITLE
ioctl should check if int will fit in unsigned long not be exactly unsigned long

### DIFF
--- a/libs/libc/misc/lib_ioctl.c
+++ b/libs/libc/misc/lib_ioctl.c
@@ -91,7 +91,7 @@ int ioctl(int fd, int req, ...)
   /* Get the unsigned long argument.
    *
    * REVISIT:  This could be the cause of the crash down the road if the
-   * actual size of the argument not sizeof(unsigned long).
+   * actual size of the argument is not sizeof(unsigned long).
    * Most small integers will be promoted to 'int'.  ARM should pass the
    * following test with all three types having sizeof(type) == 4 bytes.
    * 'float' should also be tested.  But 'long long' and 'double' are out of

--- a/libs/libc/misc/lib_ioctl.c
+++ b/libs/libc/misc/lib_ioctl.c
@@ -91,7 +91,7 @@ int ioctl(int fd, int req, ...)
   /* Get the unsigned long argument.
    *
    * REVISIT:  This could be the cause of the crash down the road if the
-   * actual size of the argument is anything other than sizeof(unsigned long).
+   * actual size of the argument not sizeof(unsigned long).
    * Most small integers will be promoted to 'int'.  ARM should pass the
    * following test with all three types having sizeof(type) == 4 bytes.
    * 'float' should also be tested.  But 'long long' and 'double' are out of
@@ -102,7 +102,7 @@ int ioctl(int fd, int req, ...)
    * discover cases where something worse happens!
    */
 
-  DEBUGASSERT(sizeof(int)        == sizeof(unsigned long) &&
+  DEBUGASSERT(sizeof(int)        <= sizeof(unsigned long) &&
               sizeof(FAR void *) == sizeof(unsigned long));
 
   va_start(ap, req);


### PR DESCRIPTION
## Summary
This is to address #951 I am not quite sure if there is a side effect that I am not clear on.
This is only changing debugassert so it does not actually change operation outside of debugging.
## Impact
This allows running code that calls ioctl from 64 bit platforms.

## Testing
This was tested against x86_64.

