### PR TITLE
arch/arm/: Rename up_intstack_* to arm_intstack_*

### DIFF
--- a/arch/arm/src/armv7-a/arm_assert.c
+++ b/arch/arm/src/armv7-a/arm_assert.c
@@ -247,7 +247,7 @@ static void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #ifdef CONFIG_SMP
-  istackbase = (uint32_t)up_intstack_base();
+  istackbase = (uint32_t)arm_intstack_base();
 #else
   istackbase = (uint32_t)&g_intstackbase;
 #endif
@@ -303,7 +303,7 @@ static void up_dumpstate(void)
        */
 
 #ifdef CONFIG_SMP
-      stackbase = (uint32_t *)up_intstack_base();
+      stackbase = (uint32_t *)arm_intstack_base();
 #else
       stackbase = (uint32_t *)&g_intstackbase;
 #endif

--- a/arch/arm/src/armv7-m/arm_assert.c
+++ b/arch/arm/src/armv7-m/arm_assert.c
@@ -250,7 +250,7 @@ static void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #ifdef CONFIG_SMP
-  istackbase = (uint32_t)up_intstack_base();
+  istackbase = (uint32_t)arm_intstack_base();
 #else
   istackbase = (uint32_t)&g_intstackbase;
 #endif

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -250,7 +250,7 @@ static void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #ifdef CONFIG_SMP
-  istackbase = (uint32_t)up_intstack_base();
+  istackbase = (uint32_t)arm_intstack_base();
 #else
   istackbase = (uint32_t)&g_intstackbase;
 #endif

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -213,7 +213,7 @@ ssize_t up_check_stack_remain(void)
 size_t up_check_intstack(void)
 {
 #ifdef CONFIG_SMP
-  return do_stackcheck(up_intstack_base(),
+  return do_stackcheck(arm_intstack_base(),
                        (CONFIG_ARCH_INTERRUPTSTACK & ~3),
                        true);
 #else

--- a/arch/arm/src/common/arm_initialize.c
+++ b/arch/arm/src/common/arm_initialize.c
@@ -62,7 +62,7 @@
 static inline void up_color_intstack(void)
 {
 #ifdef CONFIG_SMP
-  uint32_t *ptr = (uint32_t *)up_intstack_base();
+  uint32_t *ptr = (uint32_t *)arm_intstack_base();
 #else
   uint32_t *ptr = (uint32_t *)&g_intstackalloc;
 #endif

--- a/arch/arm/src/imx6/chip.h
+++ b/arch/arm/src/imx6/chip.h
@@ -148,7 +148,7 @@
 #ifndef __ASSEMBLY__
 
 /****************************************************************************
- * Name: up_intstack_base
+ * Name: arm_intstack_base
  *
  * Description:
  *   Return a pointer to the "base" the correct interrupt stack allocation
@@ -157,7 +157,7 @@
  ****************************************************************************/
 
 #if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
-static inline uintptr_t up_intstack_base(void)
+static inline uintptr_t arm_intstack_base(void)
 {
   uintptr_t base = (uintptr_t)g_irqstack_alloc;
 #if CONFIG_SMP_NCPUS > 1
@@ -171,7 +171,7 @@ static inline uintptr_t up_intstack_base(void)
 #endif
 
 /****************************************************************************
- * Name: up_intstack_top
+ * Name: arm_intstack_top
  *
  * Description:
  *   Return a pointer to the "top" the correct interrupt stack for the
@@ -180,9 +180,9 @@ static inline uintptr_t up_intstack_base(void)
  ****************************************************************************/
 
 #if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
-static inline uintptr_t up_intstack_top(void)
+static inline uintptr_t arm_intstack_top(void)
 {
-  return up_intstack_base() + INTSTACK_SIZE;
+  return arm_intstack_base() + INTSTACK_SIZE;
 }
 #endif
 

--- a/arch/arm/src/lc823450/chip.h
+++ b/arch/arm/src/lc823450/chip.h
@@ -137,7 +137,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: up_intstack_base
+ * Name: arm_intstack_base
  *
  * Description:
  *   Set the current stack pointer to the "base" the correct interrupt stack
@@ -146,7 +146,7 @@ extern "C"
  ****************************************************************************/
 
 #if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 7
-static inline uintptr_t up_intstack_base(void)
+static inline uintptr_t arm_intstack_base(void)
 {
   uintptr_t base = (uintptr_t)g_instack_alloc;
 #if CONFIG_SMP_NCPUS > 1


### PR DESCRIPTION
## Summary

The naming standard at https://cwiki.apache.org/confluence/display/NUTTX/Naming+FAQ requires that all architecture-private functions begin with the name of the arch, not up_.

This PR addresses only these name changes for the ARM-private functions up_instack_base() and up_instack_top() which should be called arm_instack_base() and arm_instack_top().

## Impact

There should be no impact of this change (other that one step toward more consistent naming).

## Testing

Normal PR checks are sufficient
