### PR TITLE
K210 pll

### DIFF
--- a/arch/risc-v/src/k210/hardware/k210_sysctl.h
+++ b/arch/risc-v/src/k210/hardware/k210_sysctl.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/k210/hardware/k210_memorymap.h
+ * arch/risc-v/src/k210/hardware/k210_sysctl.h
  *
  * Derives from software originally provided by Canaan Inc
  *
@@ -22,25 +22,27 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_RISCV_SRC_K210_HARDWARE_K210_MEMORYMAP_H
-#define __ARCH_RISCV_SRC_K210_HARDWARE_K210_MEMORYMAP_H
+#ifndef __ARCH_RISCV_SRC_K210_HARDWARE_K210_SYSCTL_H
+#define __ARCH_RISCV_SRC_K210_HARDWARE_K210_SYSCTL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Register Base Address ****************************************************/
+#define K210_SYSCTL_PLL0  (K210_SYSCTL_BASE + 0x08)
 
-#define K210_CLINT_BASE   0x02000000
-#define K210_PLIC_BASE    0x0c000000
+#define PLL_CLK_R(n)  (n & 0x00000f)
+#define PLL_CLK_F(n)  ((n & 0x0003f0) >> 4)
+#define PLL_CLK_OD(n) ((n & 0x003c00) >> 10)
 
-#ifdef CONFIG_K210_WITH_QEMU
-#define K210_UART0_BASE   0x10010000
-#else
-#define K210_UART0_BASE   0x38000000
-#endif
-#define K210_GPIO_BASE    0x38001000
+#define K210_SYSCTL_CLKSEL0  (K210_SYSCTL_BASE + 0x20)
 
-#define K210_SYSCTL_BASE  0x50440000
+#define CLKSEL0_ACLK_SEL(n) (n & 0x00000001)
 
-#endif /* __ARCH_RISCV_SRC_K210_HARDWARE_K210_MEMORYMAP_H */
+#endif /* __ARCH_RISCV_SRC_K210_HARDWARE_K210_SYSCTL_H */

--- a/arch/risc-v/src/k210/k210_clockconfig.c
+++ b/arch/risc-v/src/k210/k210_clockconfig.c
@@ -1,35 +1,24 @@
 /****************************************************************************
  * arch/risc-v/src/k210/k210_clockconfig.c
  *
- *   Copyright (C) 2019 Masayuki Ishikawa. All rights reserved.
- *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>
+ * Derives from software originally provided by Canaan Inc
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   Copyright 2018 Canaan Inc
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -53,6 +42,14 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define OSC_FREQ 26000000
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static uint32_t g_cpu_clock = 416000000;
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -63,8 +60,29 @@
 
 uint32_t k210_get_cpuclk(void)
 {
-  return 416000000; /* TODO */
+  return g_cpu_clock;
 }
+
+/****************************************************************************
+ * Name: k210_get_pll0clk
+ ****************************************************************************/
+
+#ifndef CONFIG_K210_WITH_QEMU
+uint32_t k210_get_pll0clk(void)
+{
+  uint32_t pll0;
+  uint32_t nr;
+  uint32_t nf;
+  uint32_t od;
+
+  pll0 = getreg32(K210_SYSCTL_PLL0);
+  nr   = PLL_CLK_R(pll0)  + 1;
+  nf   = PLL_CLK_F(pll0)  + 1;
+  od   = PLL_CLK_OD(pll0) + 1;
+
+  return OSC_FREQ / nr * nf / od;
+}
+#endif
 
 /****************************************************************************
  * Name: k210_clockconfig
@@ -72,5 +90,24 @@ uint32_t k210_get_cpuclk(void)
 
 void k210_clockconfig(void)
 {
-  /* TODO */
+#ifndef CONFIG_K210_WITH_QEMU
+  uint32_t clksel0;
+
+  /* Obtain clock selector for ACLK */
+
+  clksel0 = getreg32(K210_SYSCTL_CLKSEL0);
+
+  if (1 == CLKSEL0_ACLK_SEL(clksel0))
+    {
+      /* PLL0 selected */
+
+      g_cpu_clock = k210_get_pll0clk() / 2;
+    }
+  else
+    {
+      /* OSC selected */
+
+      g_cpu_clock = OSC_FREQ;
+    }
+#endif
 }

--- a/arch/risc-v/src/k210/k210_clockconfig.h
+++ b/arch/risc-v/src/k210/k210_clockconfig.h
@@ -65,10 +65,11 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 EXTERN uint32_t k210_get_cpuclk(void);
+EXTERN uint32_t k210_get_pll0clk(void);
 EXTERN void k210_clockconfig(void);
 
 #if defined(__cplusplus)

--- a/arch/risc-v/src/k210/k210_memorymap.h
+++ b/arch/risc-v/src/k210/k210_memorymap.h
@@ -41,6 +41,7 @@
 #include "hardware/k210_uart.h"
 #include "hardware/k210_clint.h"
 #include "hardware/k210_plic.h"
+#include "hardware/k210_sysctl.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/boards/risc-v/k210/maix-bit/README.txt
+++ b/boards/risc-v/k210/maix-bit/README.txt
@@ -27,10 +27,13 @@
   (gdb) load nuttx
   (gdb) c
 
-5. TODO
+5. Write nuttx.bin to SPI-Flash
 
-  PLL setting (currently CPU clock freq is assumed to be 416MHz)
-  Boot from SPI-Flash
+  $ pip3 install kflash
+  $ kflash -p /dev/ttyUSB0 -b 1500000 ./nuttx/nuttx.bin
+
+6. TODO
+
   Support peripherals such as GPIO/SPI/I2C/...
   Support FPU
-  Support RISC-V User mode
+  Support memory protection for user mode


### PR DESCRIPTION
## Summary

- This PR includes K210 PLL support
- Some logics are derived from kendryte-standalone-sdk for which Canaan Inc has copyright and the license is Apache 2.0.

## Impact

- This PR affects K210 only.

## Testing

- I tested this PR with both K210 and QEMU.
