### PR TITLE
x86_64: Fix crash around enabling XSAVE and SSE/AVX

### DIFF
--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -580,7 +580,7 @@ extern volatile struct gdt_entry_s *gdt64;
 int up_map_region(void *base, int size, int flags);
 void x86_64_check_and_enable_capability(void);
 
-extern void __enable_sse3(void);
+extern void __enable_sse_avx(void);
 extern void __revoke_low_memory(void);
 extern void __enable_pcid(void);
 

--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -581,6 +581,7 @@ int up_map_region(void *base, int size, int flags);
 void x86_64_check_and_enable_capability(void);
 
 extern void __enable_sse3(void);
+extern void __revoke_low_memory(void);
 extern void __enable_pcid(void);
 
 #ifdef __cplusplus

--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -34,11 +34,12 @@ config ARCH_INTEL64_APIC_FREQ_KHZ
 
 endif
 
-config ARCH_INTEL64_HAVE_SSE3
-    bool "SSE3 support"
+config ARCH_INTEL64_HAVE_XSAVE
+    bool "XSAVE support"
     default y
 	---help---
-		Select to enable the use of SSE3 and FPU functions of x86_64
+		Select to enable the use of XSAVE and FPU/SSE/AVX functions 
+		of x86_64
 
 config ARCH_INTEL64_HAVE_PCID
     bool "PCID support"

--- a/arch/x86_64/src/intel64/intel64_check_capability.c
+++ b/arch/x86_64/src/intel64/intel64_check_capability.c
@@ -67,8 +67,7 @@ void x86_64_check_and_enable_capability(void)
   require |= X86_64_CPUID_01_TSCDEA;
 #endif
 
-#ifdef CONFIG_ARCH_INTEL64_HAVE_SSE3
-  require |= X86_64_CPUID_01_SSE3;
+#ifdef CONFIG_ARCH_INTEL64_HAVE_XSAVE
   require |= X86_64_CPUID_01_XSAVE;
 #endif
 
@@ -90,8 +89,8 @@ void x86_64_check_and_enable_capability(void)
       goto err;
     }
 
-#ifdef CONFIG_ARCH_INTEL64_HAVE_SSE3
-  __enable_sse3();
+#ifdef CONFIG_ARCH_INTEL64_HAVE_XSAVE
+  __enable_sse_avx();
 #endif
 
 #ifdef CONFIG_ARCH_INTEL64_HAVE_PCID

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -65,6 +65,7 @@
     .global     __nxstart
     .global     __enable_sse3
     .global     __enable_pcid
+    .global     __revoke_low_memory
     .global     nx_start                        /* nx_start is defined elsewhere */
     .global     up_lowsetup                     /* up_lowsetup is defined elsewhere */
     .global     g_idle_topstack                 /* The end of the idle stack, the start of the heap */
@@ -133,7 +134,7 @@ start32:
 
     // Popluate the lower 4GB as non-present
     // for ecx = 0...512 * 4 : Loop and setup the page directories
-    mov     $0x800, %ecx // 512 * 3
+    mov     $0x800, %ecx // 512 * 4
 epd_loop: 
     mov     %esi,   %edx
     or      $(X86_PAGE_WR | X86_PAGE_PRESENT), %edx
@@ -244,20 +245,7 @@ start64:
     .type   __nxstart, @function
 
 __nxstart:
-    /* We are now in high memory, revoke the lower 128MB memory mapping */
-    lea     pd_low, %edi
-    mov     $0,     %eax
-
-    // for ecx = 0...64 : Loop and setup 64x 2MB page directories
-    mov     $64,   %ecx
-npd_loop: 
-    mov     %eax, 0(%edi)
-    add     $(HUGE_PAGE_SIZE), %eax
-    add     $(X86_PAGE_ENTRY_SIZE), %edi
-
-    // end for ecx
-    dec     %ecx
-    jnz     npd_loop
+    /* We are now in high memory, will revoke the lower 128MB memory mapping in lowsetup*/
 
     //clear out bss section
     movabs  $_sbss, %rbx
@@ -289,6 +277,29 @@ hang:
     jmp    hang
     .size    __nxstart, . - __nxstart
 
+    .type   __revoke_low_memory, @function
+__revoke_low_memory:
+
+    /* Revoke the lower 128MB memory mapping */
+    lea     pd_low, %edi
+    lea     pt_low, %esi
+
+    // for ecx = 0...64 : Loop and setup 64x 2MB page directories
+    mov     $64,   %ecx
+npd_loop: 
+    mov     %esi,   %edx
+    or      $(X86_PAGE_WR | X86_PAGE_PRESENT), %edx
+    mov     %edx, 0(%edi)
+    add     $(PAGE_SIZE), %esi
+    add     $(X86_PAGE_ENTRY_SIZE), %edi
+
+    // end for ecx
+    dec     %ecx
+    jnz     npd_loop
+
+    ret
+
+    .size    __revoke_low_memory, . - __revoke_low_memory
 
 /****************************************************************************
  * Name: __enable_sse3

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -63,7 +63,7 @@
  ****************************************************************************/
     .global     __pmode_entry                   /* The 32bit protected mode entry */
     .global     __nxstart
-    .global     __enable_sse3
+    .global     __enable_sse_avx
     .global     __enable_pcid
     .global     __revoke_low_memory
     .global     nx_start                        /* nx_start is defined elsewhere */
@@ -302,16 +302,16 @@ npd_loop:
     .size    __revoke_low_memory, . - __revoke_low_memory
 
 /****************************************************************************
- * Name: __enable_sse3
+ * Name: __enable_sse_avx
  *
  * Description:
  *   Do low-level initialization SSE related processor setting
  *
  ****************************************************************************/
 
-    .type   __enable_sse3, @function
+    .type   __enable_sse_avx, @function
 
-__enable_sse3:
+__enable_sse_avx:
     // Enable SSE
     mov     %cr0,   %rax
     mov     $(X86_CR0_EM), %rbx
@@ -330,7 +330,7 @@ __enable_sse3:
 
     ret
 
-    .size    __enable_sse3, . - __enable_sse3
+    .size    __enable_sse_avx, . - __enable_sse_avx
 
 
 /****************************************************************************

--- a/arch/x86_64/src/intel64/intel64_lowsetup.c
+++ b/arch/x86_64/src/intel64/intel64_lowsetup.c
@@ -95,6 +95,7 @@ void up_lowsetup(void)
   x86_64_check_and_enable_capability();
 
   /* Revoke the lower memory */
+
   __revoke_low_memory();
 
   /* perform board-specific initializations */

--- a/arch/x86_64/src/intel64/intel64_lowsetup.c
+++ b/arch/x86_64/src/intel64/intel64_lowsetup.c
@@ -94,6 +94,9 @@ void up_lowsetup(void)
 
   x86_64_check_and_enable_capability();
 
+  /* Revoke the lower memory */
+  __revoke_low_memory();
+
   /* perform board-specific initializations */
 
   x86_64_boardinitialize();


### PR DESCRIPTION
## Summary

If the user chooses to enable SSE related function in config, the OS will check and initialize the FPU during boot.

During the setup of FPU, the LDMXCSR instruction takes a 32 bit memory address, containing the FPU setting. The FPU setting is hardcoded and placed in the binary image.

However, this is conducted after the kernel's lower memoey mapping was revoked, causing a page fault.
Using the high address of the hardcoded FPU setting is not possible because the kernel is mapped above 4GB space (32bit).

The proposed fix it by revoking the lower 128MB mapping at a later stage of booting, after the setup procedure is conducted.

## Impact

No more instant crash during boot with SSE/AVX enabled.

## Testing

Should boot on bochs/qemu with ostest
