### PR TITLE
x86_64: Jailhouse support

### DIFF
--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -52,4 +52,12 @@ config ARCH_INTEL64_HAVE_RDRAND
 	---help---
 		Select to enable the use of RDRAND for /dev/random
 
+config ARCH_INTEL64_DISABLE_INT_INIT
+    bool "Disable Initialization of 8259/APIC/IO-APIC"
+    default n
+	---help---
+		Select to disable all initialization related to interrupt 
+		controllers. This is necessary if those are already
+		initialized, i.e. Jailhouse system.
+
 endif

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -106,6 +106,38 @@ header_start:
 #endif
 header_end:
 
+	.code16
+	.section ".realmode", "ax"
+
+    .type   __reset_entry, @function
+__reset_entry:
+    // Load a GDT for protected mode
+    movl $loader_gdt_ptr, %ebx
+	lgdtl (%ebx)
+
+    // enable protected mode in CR0
+	mov %cr0,%eax
+	or $X86_CR0_PE,%al
+	mov %eax,%cr0
+
+    // Long jump into protected mode
+    // Hardcode the address
+	ljmpl $0x8,$0x400000
+
+    // Loader GDT and GDTR
+	.align(16)
+	.global loader_gdt
+loader_gdt:
+	.quad	0
+	.quad	0x00cf9a000000ffff
+	.quad	0x00cf92000000ffff
+
+loader_gdt_ptr:
+	.short	loader_gdt_ptr - loader_gdt - 1
+	.long	loader_gdt
+
+    .size	__reset_entry, . - __reset_entry
+
 
 /****************************************************************************
  * .text
@@ -122,6 +154,11 @@ header_end:
  *   Function to transit protected mode to 64-bit long mode
  *
  ****************************************************************************/
+
+start32_0:
+    mov $0x10, %ax
+    mov %ax, %ss
+    mov %ax, %ds
 
     .type   __pmode_entry, @function
 __pmode_entry:

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -88,11 +88,11 @@
     .set    HEADER_LENGTH, header_end - header_start
     .set    CHECKSUM, -(MULTIBOOT2_HEADER_MAGIC + MULTIBOOT_ARCHITECTURE_I386 + HEADER_LENGTH)
 
-#ifndef CONFIG_ARCH_EXCLUDE_MULTIBOOT
     .section ".multiboot", "a"
     .align    8
 
 header_start:
+#ifndef CONFIG_ARCH_EXCLUDE_MULTIBOOT
     .long MULTIBOOT2_HEADER_MAGIC
     .long MULTIBOOT_ARCHITECTURE_I386
     .long HEADER_LENGTH
@@ -103,9 +103,9 @@ header_start:
     .short MULTIBOOT_HEADER_TAG_END
     .short 0    // flags, none set
     .long 8     // size, including itself (short + short + long)
+#endif
 header_end:
 
-#endif
 
 /****************************************************************************
  * .text

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -122,7 +122,7 @@ __reset_entry:
 
     // Long jump into protected mode
     // Hardcode the address
-	ljmpl $0x8,$0x400000
+	ljmpl $0x8,$0x100000
 
     // Loader GDT and GDTR
 	.align(16)

--- a/arch/x86_64/src/intel64/up_irq.c
+++ b/arch/x86_64/src/intel64/up_irq.c
@@ -53,7 +53,6 @@
  ****************************************************************************/
 
 static void up_apic_init(void);
-static void up_ioapic_init(void);
 static void up_idtentry(unsigned int index, uint64_t base, uint16_t sel,
                         uint8_t flags, uint8_t ist);
 static inline void up_idtinit(void);
@@ -211,6 +210,7 @@ static void up_ist_init(void)
  *
  ****************************************************************************/
 
+#ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
 static void up_deinit_8259(void)
 {
   /* First do an initialization to for any pending interrupt to vanish */
@@ -247,6 +247,7 @@ static void up_deinit_8259(void)
   outb(X86_PIC_EOI, X86_IO_PORT_PIC1_CMD);
   outb(X86_PIC_EOI, X86_IO_PORT_PIC2_CMD);
 }
+#endif
 
 /****************************************************************************
  * Name: up_init_apic
@@ -262,16 +263,19 @@ static void up_apic_init(void)
   uint32_t icrl;
   uint32_t apic_base;
 
+#ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
   /* Enable the APIC in X2APIC MODE */
 
   apic_base = read_msr(MSR_IA32_APIC_BASE) & 0xfffff000;
   write_msr(MSR_IA32_APIC_BASE, apic_base | MSR_IA32_APIC_EN |
                                 MSR_IA32_APIC_X2APIC | MSR_IA32_APIC_BSP);
+#endif
 
   /* Enable the APIC and setup an spurious interrupt vector */
 
   write_msr(MSR_X2APIC_SPIV, MSR_X2APIC_SPIV_EN | IRQ_SPURIOUS);
 
+#ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
   /* Disable the LINT interrupt lines */
 
   write_msr(MSR_X2APIC_LINT0, MSR_X2APIC_MASKED);
@@ -313,6 +317,7 @@ static void up_apic_init(void)
   /* Enable interrupts on the APIC (but not on the processor). */
 
   write_msr(MSR_X2APIC_TPR, 0);
+#endif
 }
 
 /****************************************************************************
@@ -338,6 +343,7 @@ static int __attribute__((unused))
  *
  ****************************************************************************/
 
+#ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
 static void up_ioapic_init(void)
 {
   int i;
@@ -357,6 +363,7 @@ static void up_ioapic_init(void)
 
   return;
 }
+#endif
 
 /****************************************************************************
  * Name: up_idtentry
@@ -480,17 +487,21 @@ void up_irqinitialize(void)
 
   up_ist_init();
 
+#ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
   /* Disable 8259 PIC */
 
   up_deinit_8259();
+#endif
 
   /* Initialize the APIC */
 
   up_apic_init();
 
+#ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
   /* Initialize the IOAPIC */
 
   up_ioapic_init();
+#endif
 
   /* Initialize the IDT */
 
@@ -513,10 +524,12 @@ void up_irqinitialize(void)
 
 void up_disable_irq(int irq)
 {
+#ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
   if (irq >= IRQ0)
     {
       up_ioapic_mask_pin(irq - IRQ0);
     }
+#endif
 }
 
 /****************************************************************************
@@ -529,10 +542,12 @@ void up_disable_irq(int irq)
 
 void up_enable_irq(int irq)
 {
+#ifndef CONFIG_ARCH_INTEL64_DISABLE_INT_INIT
   if (irq >= IRQ0)
     {
       up_ioapic_unmask_pin(irq - IRQ0);
     }
+#endif
 }
 
 /****************************************************************************

--- a/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
+++ b/boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld
@@ -22,12 +22,20 @@ OUTPUT_ARCH(i386:x86-64)
 ENTRY(__pmode_entry)
 SECTIONS
 {
+
+    . = 0x0;
+
+    .realmode : {
+        . = ALIGN(8);
+        KEEP(*(.multiboot))
+        *(.realmode)
+    }
+
     . = 0x1M;
     _kernel_physical_start = .;
 
     .loader.text : {
         . = ALIGN(8);
-        KEEP(*(.multiboot))
         *(.loader.text)
     }
 


### PR DESCRIPTION
## Summary

Jailhouse (https://github.com/siemens/jailhouse) is a partitioning hypervisor based on Linux.

This patch adds ability to make Nuttx bootable as a Jailhouse cell.
It includes 3 parts:
 * Because Jailhouse execute code from 0x0 without a BIOS, a option to remove multiboot header is added
 * Because Jailhouse kickstart the CPU at realmode, a stub to bring the CPU into protected mode is added.
 * Because in a Jailhouse environment, the interrupt controllers are initialized by Linux and IO-APIC related operation are not supported by Jailhouse, an option is added to disable the APIC/IO-APIC/8259 initialization and IO-APIC/8259 related operations. 

## Testing

ostest can run on Jailhouse.

## Other comments

1. I will be glad to provide a example jailhouse cell config if needed.
2. You need to have a PCI/PCI-E based serial device to have an output, because Jailhouse don't support 8259 and IO-APIC, which the legacy COM port is hooked to. (at least I can get it working reliably.)
3. Or you can force the Nuttx 16550 serial driver to output in polling mode, but commenting out the following in `driver/serial/serial.c:1062`. This will allow you to run ostest with legacy COM port, but not nsh because serial RX requires interrupt handling.
```
  1062   if (up_interrupt_context() || sched_idletask())                                                                                                                     
```
4. Maybe we can add a option config to disable TX interrupt of serial interface?
5. I am working on a PCI-E framework and a example serial driver.
