### PR TITLE
Implements TLS for unaligned stacks.

### DIFF
--- a/arch/arm/include/tls.h
+++ b/arch/arm/include/tls.h
@@ -99,8 +99,24 @@ static inline uint32_t up_getsp(void)
 
 static inline FAR struct tls_info_s *up_tls_info(void)
 {
+#ifdef CONFIG_TLS_ALIGNED
   DEBUGASSERT(!up_interrupt_context());
   return TLS_INFO((uintptr_t)up_getsp());
+#else
+  FAR struct tls_info_s *info = NULL;
+  struct stackinfo_s stackinfo;
+  int ret;
+  
+  DEBUGASSERT(!up_interrupt_context());
+
+  ret = sched_get_stackinfo(0, &stackinfo);
+  if (ret == OK)
+    {
+      info = (FAR struct tsl_info_s *)stackinfo.adj_stack_ptr;
+    }
+
+  return info;
+#endif
 }
 
 #endif /* CONFIG_TLS */

--- a/arch/arm/include/tls.h
+++ b/arch/arm/include/tls.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/include/tls.h
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -97,27 +82,15 @@ static inline uint32_t up_getsp(void)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_TLS_ALIGNED
 static inline FAR struct tls_info_s *up_tls_info(void)
 {
-#ifdef CONFIG_TLS_ALIGNED
   DEBUGASSERT(!up_interrupt_context());
   return TLS_INFO((uintptr_t)up_getsp());
-#else
-  FAR struct tls_info_s *info = NULL;
-  struct stackinfo_s stackinfo;
-  int ret;
-  
-  DEBUGASSERT(!up_interrupt_context());
-
-  ret = sched_get_stackinfo(0, &stackinfo);
-  if (ret == OK)
-    {
-      info = (FAR struct tsl_info_s *)stackinfo.adj_stack_ptr;
-    }
-
-  return info;
-#endif
 }
+#else
+#  define up_tls_info() tls_get_info()
+#endif
 
 #endif /* CONFIG_TLS */
 #endif /* __ARCH_ARM_INCLUDE_TLS_H */

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -92,7 +92,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS
+#ifdef CONFIG_TLS_ALIGNED
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */

--- a/arch/arm/src/common/arm_createstack.c
+++ b/arch/arm/src/common/arm_createstack.c
@@ -107,6 +107,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   stack_size += sizeof(struct tls_info_s);
 
+#ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
    */
@@ -116,6 +117,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
+#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -139,7 +141,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * If TLS is enabled, then we must allocate aligned stacks.
        */
 
-#ifdef CONFIG_TLS
+#ifdef CONFIG_TLS_ALIGNED
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
@@ -157,7 +159,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
             (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
-#else /* CONFIG_TLS */
+#else /* CONFIG_TLS_ALIGNED */
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
@@ -172,7 +174,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
           tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
-#endif /* CONFIG_TLS */
+#endif /* CONFIG_TLS_ALIGNED */
 
 #ifdef CONFIG_DEBUG_FEATURES
       /* Was the allocation successful? */

--- a/arch/arm/src/common/arm_usestack.c
+++ b/arch/arm/src/common/arm_usestack.c
@@ -90,7 +90,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   size_t top_of_stack;
   size_t size_of_stack;
 
-#ifdef CONFIG_TLS
+#ifdef CONFIG_TLS_ALIGNED
   /* Make certain that the user provided stack is properly aligned */
 
   DEBUGASSERT(((uintptr_t)stack & TLS_STACK_MASK) == 0);

--- a/arch/sim/include/tls.h
+++ b/arch/sim/include/tls.h
@@ -81,7 +81,23 @@
 
 static inline FAR struct tls_info_s *up_tls_info(void)
 {
+#ifdef CONFIG_TLS_ALIGNED
   return TLS_INFO((uintptr_t)__builtin_frame_address(0));
+#else
+  FAR struct tls_info_s *info = NULL;
+  struct stackinfo_s stackinfo;
+  int ret;
+  
+  DEBUGASSERT(!up_interrupt_context());
+
+  ret = sched_get_stackinfo(0, &stackinfo);
+  if (ret == OK)
+    {
+      info = (FAR struct tsl_info_s *)stackinfo.adj_stack_ptr;
+    }
+
+  return info;
+#endif
 }
 
 #endif /* CONFIG_TLS */

--- a/arch/sim/src/sim/up_checkstack.c
+++ b/arch/sim/src/sim/up_checkstack.c
@@ -89,7 +89,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS
+#ifdef CONFIG_TLS_ALIGNED
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */

--- a/arch/sim/src/sim/up_createstack.c
+++ b/arch/sim/src/sim/up_createstack.c
@@ -111,6 +111,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   stack_size += sizeof(struct tls_info_s);
 
+#ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
    */
@@ -121,6 +122,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       stack_size = TLS_MAXSTACK;
     }
 #endif
+#endif
 
   /* Move up to next even word boundary if necessary */
 
@@ -128,7 +130,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   /* Allocate the memory for the stack */
 
-#ifdef CONFIG_TLS
+#ifdef CONFIG_TLS_ALIGNED
   stack_alloc_ptr = (FAR uint8_t *)kumm_memalign(TLS_STACK_ALIGN,
                                                  adj_stack_size);
 #else /* CONFIG_TLS */

--- a/arch/sim/src/sim/up_usestack.c
+++ b/arch/sim/src/sim/up_usestack.c
@@ -101,7 +101,7 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
   uintptr_t adj_stack_addr;
   size_t adj_stack_size;
 
-#ifdef CONFIG_TLS
+#ifdef CONFIG_TLS_ALIGNED
   /* Make certain that the user provided stack is properly aligned */
 
   DEBUGASSERT(((uintptr_t)stack & TLS_STACK_MASK) == 0);

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * include/nuttx/tls.h
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -140,6 +125,27 @@ uintptr_t tls_get_element(int elem);
  ****************************************************************************/
 
 void tls_set_element(int elem, uintptr_t value);
+
+/****************************************************************************
+ * Name: tls_get_info
+ *
+ * Description:
+ *   Return a reference to the tls_info_s structure.  This is used as part
+ *   of the internal implementation of tls_get/set_elem() and ONLY for the
+ *   where CONFIG_TLS_ALIGNED is *not* defined
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   A reference to the thread-specific tls_info_s structure is return on
+ *   success.  NULL would be returned in the event of any failure.
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_TLS_ALIGNED
+FAR struct tls_info_s *tls_get_info(void);
+#endif
 
 #endif /* CONFIG_TLS */
 #endif /* __INCLUDE_NUTTX_TLS_H */

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -51,8 +51,10 @@
  ****************************************************************************/
 /* Configuration ************************************************************/
 
-#ifndef CONFIG_TLS_LOG2_MAXSTACK
-#  error CONFIG_TLS_LOG2_MAXSTACK is not defined
+#ifdef CONFIG_TLS_ALIGNED
+#  ifndef CONFIG_TLS_LOG2_MAXSTACK
+#    error CONFIG_TLS_LOG2_MAXSTACK is not defined
+#  endif
 #endif
 
 #ifndef CONFIG_TLS_NELEM
@@ -68,14 +70,17 @@
 
 /* TLS Definitions **********************************************************/
 
-#define TLS_STACK_ALIGN   (1L << CONFIG_TLS_LOG2_MAXSTACK)
-#define TLS_STACK_MASK    (TLS_STACK_ALIGN - 1)
-#define TLS_MAXSTACK      (TLS_STACK_ALIGN)
-#define TLS_INFO(sp)      ((FAR struct tls_info_s *)((sp) & ~TLS_STACK_MASK))
+#ifdef CONFIG_TLS_ALIGNED
+#  define TLS_STACK_ALIGN  (1L << CONFIG_TLS_LOG2_MAXSTACK)
+#  define TLS_STACK_MASK   (TLS_STACK_ALIGN - 1)
+#  define TLS_MAXSTACK     (TLS_STACK_ALIGN)
+#  define TLS_INFO(sp)     ((FAR struct tls_info_s *)((sp) & ~TLS_STACK_MASK))
+#endif
 
 /****************************************************************************
  * Public Types
  ****************************************************************************/
+
 /* When TLS is enabled, up_createstack() will align allocated stacks to the
  * TLS_STACK_ALIGN value.  An instance of the following structure will be
  * implicitly positioned at the "lower" end of the stack.  Assuming a

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -34,6 +34,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -99,10 +100,10 @@ struct tls_info_s
  *   elem - Index of TLS element to return
  *
  * Returned Value:
- *   The value of TLS element associated with 'elem'. Errors are not reported.
- *   Aero is returned in the event of an error, but zero may also be valid
- *   value and returned when there is no error.  The only possible error would
- *   be if elemn < 0 or elem >=CONFIG_TLS_NELEM.
+ *   The value of TLS element associated with 'elem'. Errors are not
+ *   reported.  Zero is returned in the event of an error, but zero may also
+ *   be valid value and returned when there is no error.  The only possible
+ *   error would be if elem < 0 or elem >=CONFIG_TLS_NELEM.
  *
  ****************************************************************************/
 

--- a/libs/libc/tls/Kconfig
+++ b/libs/libc/tls/Kconfig
@@ -26,23 +26,23 @@ config TLS_ALIGNED
 	default y if BUILD_KERNEL
 	default n if !BUILD_KERNEL
 	---help---
-		Aligned TLS works by fetch thread information from the beginning
+		Aligned TLS works by fetching thread information from the beginning
 		of the stack memory allocation.  In order to do this, the memory
 		must be aligned in such a way that the executing logic can simply
 		mask the current stack pointer to get the beginning of the stack
 		allocation.
 
 		The advantage of using an aligned stack is no OS interface need
-		be called to get the beginning of the stack.  It is simply and
+		be called to get the beginning of the stack.  It is simply an
 		AND operation on the current stack pointer.  The disadvantages
-		are that the alignment (1) causes memory fragmentation which
+		are that the alignment (1) causes memory fragmentation which can
 		be a serious problem for memory limited systems, and (2) limits
 		the maximum size of the stack.  Any mask places a limit on the
 		maximum size of the stack; stack sizes about that would map to
 		an incorrect address.
 
 		In general, CONFIG_TLS_ALIGNED is preferred for the KERNEL
-		build where the virtualized stack address an be aligned with
+		build where the virtualized stack address can be aligned with
 		no implications to physical memory.  In other builds, the
 		unaligned stack implementation is usually superior.
 

--- a/libs/libc/tls/Kconfig
+++ b/libs/libc/tls/Kconfig
@@ -21,17 +21,37 @@ config TLS
 
 if TLS
 
+config TLS_ALIGNED
+	bool "Require stack alignment"
+	default y if BUILD_KERNEL
+	default n if !BUILD_KERNEL
+	---help---
+		Aligned TLS works by fetch thread information from the beginning
+		of the stack memory allocation.  In order to do this, the memory
+		must be aligned in such a way that the executing logic can simply
+		mask the current stack pointer to get the beginning of the stack
+		allocation.
+
+		The advantage of using an aligned stack is no OS interface need
+		be called to get the beginning of the stack.  It is simply and
+		AND operation on the current stack pointer.  The disadvantages
+		are that the alignment (1) causes memory fragmentation which
+		be a serious problem for memory limited systems, and (2) limits
+		the maximum size of the stack.  Any mask places a limit on the
+		maximum size of the stack; stack sizes about that would map to
+		an incorrect address.
+
+		In general, CONFIG_TLS_ALIGNED is preferred for the KERNEL
+		build where the virtualized stack address an be aligned with
+		no implications to physical memory.  In other builds, the
+		unaligned stack implementation is usually superior.
+
 config TLS_LOG2_MAXSTACK
 	int "Maximum stack size (log2)"
 	default 13
 	range 11 24
+	depends on TLS_ALIGNED
 	---help---
-		Stack based TLS works by fetch thread information from the beginning
-		of the stack memory allocation.  In order to do this, the memory
-		must be aligned in such a way that the executing logic can simply
-		masking the current stack pointer to get the beginning of the stack
-		allocation.
-
 		This setting specifies the alignment of the stack as a power of 2:
 		11=2KB, 12=4KB, 13=8KB, etc.  The exact alignment is not so critical
 		except that (1) a very large value can cause you to run out of

--- a/libs/libc/tls/Make.defs
+++ b/libs/libc/tls/Make.defs
@@ -1,41 +1,30 @@
 ############################################################################
 # libs/libc/tls/Make.defs
 #
-#   Copyright (C) 2016 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@nuttx.org>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 
 ifeq ($(CONFIG_TLS),y)
 
 CSRCS += tls_setelem.c tls_getelem.c
+
+ifneq ($(CONFIG_TLS_ALIGNED),y)
+CSRCS += tls_getinfo.c
+endif
 
 # Include tls build support
 

--- a/libs/libc/tls/tls_getelem.c
+++ b/libs/libc/tls/tls_getelem.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * libs/libc/fixedmath/tls_getelem.c
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/libs/libc/tls/tls_getelem.c
+++ b/libs/libc/tls/tls_getelem.c
@@ -47,10 +47,10 @@
  *   elem - Index of TLS element to return
  *
  * Returned Value:
- *   The value of TLS element associated with 'elem'. Errors are not reported.
- *   Aero is returned in the event of an error, but zero may also be valid
- *   value and returned when there is no error.  The only possible error would
- *   be if elem >=CONFIG_TLS_NELEM.
+ *   The value of TLS element associated with 'elem'. Errors are not
+ *   reported.  Zero is returned in the event of an error, but zero may also
+ *   be valid value and returned when there is no error.  The only possible
+ *   error would be if elem < 0 or elem >=CONFIG_TLS_NELEM.
  *
  ****************************************************************************/
 

--- a/libs/libc/tls/tls_setelem.c
+++ b/libs/libc/tls/tls_setelem.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * libs/libc/fixedmath/tls_setelem.c
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

TLS has been in NuttX for a long time, but has only been truly usable in the KERNEL build mode.  That was due primarily large stack alignement that was required for TLS to work.

This PR implements TLS using an unaligned stack.  This is less efficient since it does involve a system call to get the base stack address.  However, it can now be generalized to all build modes.

This is an initial step in implementing an errno that supports read/write access in all build modes.

## Impact

Since TLS is not currently used in any configuration, there should be no impact of this change.

## Testing

The change was verified using the sim:ostest configuration.  The configuration was modified to enable TLS.  This enables the TLS test at apps/testing/ostest/tls.c

