### PR TITLE
arch: x86_64: remove leftover debug output

### DIFF
--- a/arch/x86_64/src/intel64/up_sigdeliver.c
+++ b/arch/x86_64/src/intel64/up_sigdeliver.c
@@ -113,8 +113,6 @@ void up_sigdeliver(void)
 
   /* Deliver the signals */
 
-  _err("Deliver signal to %llx: %llx\n", rtcb, rtcb->xcp.sigdeliver);
-
   sighandler(rtcb);
 
   /* Output any debug messages BEFORE restoring errno (because they may


### PR DESCRIPTION
## Summary

Remove a potential source of race condition in x86_64 up_sigdeliver.

I left a piece of debug output in the up_sigdeliver function during porting.

## Impact

No more race condition around multiple signals.

## Testing

Ostest and nsh of x86_64 qemu port should work as normally without the removed verbose output message during signal handling.

However, these still being affected by Issue #955