### PR TITLE
arch: k210: Fix cpu1 hangup during boot with qemu

### DIFF
--- a/arch/risc-v/src/k210/k210_start.c
+++ b/arch/risc-v/src/k210/k210_start.c
@@ -87,8 +87,6 @@ void __k210_start(uint32_t mhartid)
   const uint32_t *src;
   uint32_t *dest;
 
-  g_serial_ok = false;
-
   if (0 < mhartid)
     {
       goto cpu1;


### PR DESCRIPTION
## Summary

- I noticed that sometimes cpu1 hangs during boot with qemu.
- In boot up process, cpu1 needs to wait for g_serial_ok is set to true which means that cpu0 finished serial driver initialization.
- However previous logic initializes g_serial_ok to false by each cpu which caused cpu1 hang up.
- This PR simply removes such an incorrect logic.

## Impact

- This PR affects k210 only.

## Testing

- I tested this PR for both k210 and qemu.
