### PR TITLE
Fix syscall lookup table

### DIFF
--- a/syscall/syscall_lookup.h
+++ b/syscall/syscall_lookup.h
@@ -315,8 +315,8 @@ SYSCALL_LOOKUP(up_assert,                  2, STUB_up_assert)
   SYSCALL_LOOKUP(pthread_setschedprio,     2, STUB_pthread_setschedprio)
   SYSCALL_LOOKUP(pthread_setspecific,      2, STUB_pthread_setspecific)
 #ifdef CONFIG_SMP
-  SYSCALL_LOOKUP(pthread_setaffinity,      3, STUB_pthread_setaffinity)
-  SYSCALL_LOOKUP(pthread_getaffinity,      3, STUB_pthread_getaffinity)
+  SYSCALL_LOOKUP(pthread_setaffinity_np,   3, STUB_pthread_setaffinity_np)
+  SYSCALL_LOOKUP(pthread_getaffinity_np,   3, STUB_pthread_getaffinity_np)
 #endif
   SYSCALL_LOOKUP(pthread_cond_timedwait,   3, STUB_pthread_cond_timedwait)
   SYSCALL_LOOKUP(pthread_kill,             2, STUB_pthread_kill)

--- a/syscall/syscall_stublookup.c
+++ b/syscall/syscall_stublookup.c
@@ -320,9 +320,9 @@ uintptr_t STUB_pthread_setschedprio(int nbr, uintptr_t parm1,
 uintptr_t STUB_pthread_setspecific(int nbr, uintptr_t parm1,
             uintptr_t parm2);
 
-uintptr_t STUB_pthread_setaffinity(int nbr, uintptr_t parm1,
+uintptr_t STUB_pthread_setaffinity_np(int nbr, uintptr_t parm1,
             uintptr_t parm2, uintptr_t parm3);
-uintptr_t STUB_pthread_getaffinity(int nbr, uintptr_t parm1,
+uintptr_t STUB_pthread_getaffinity_np(int nbr, uintptr_t parm1,
             uintptr_t parm2, uintptr_t parm3);
 
 uintptr_t STUB_pthread_cond_timedwait(int nbr, uintptr_t parm1,


### PR DESCRIPTION
## Summary
This PR fixes syscall names in the syscall lookup table. 

## Impact
Affected in PROTECTED or KERNEL build with SMP.
At this moment there is no such existing configuration.

## Testing
Tested by enabling CONFIG_SMP to existing PROTECTED configuration.
Build break due to the syscall name was fixed.