### PR TITLE
tools/pic32: update pic32 scripts to fix jobserver unavailable warning

### DIFF
--- a/tools/pic32/Config.mk
+++ b/tools/pic32/Config.mk
@@ -28,11 +28,9 @@
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 
 define POSTBUILD
-	$(Q)echo "Converting the hex file"; 
+	$(Q)echo "Converting the hex file"
 
-	$(Q) if [ ! -f "tools/pic32/mkpichex" ] ; then \
-		$(MAKE) -C $(TOPDIR)$(DELIM)tools$(DELIM)pic32 -f Makefile.host; \
-	fi
+	+$(Q) $(MAKE) -C $(TOPDIR)$(DELIM)tools$(DELIM)pic32 -f Makefile.host
 	tools$(DELIM)pic32$(DELIM)mkpichex$(HOSTEXEEXT) $(PWD)
 	$(Q)([ $$? -eq 0 ] && echo "Done.")
 endef

--- a/tools/pic32/Makefile.host
+++ b/tools/pic32/Makefile.host
@@ -28,7 +28,7 @@ CFLAGS = -O2 -Wall -I.
 
 # mkpichex - Convert virtual addresses in nuttx.hex to physical addresses
 
-mkconfig: mkpichex.c mkpichex.c
+mkpichex: mkpichex.c
 	@gcc $(CFLAGS) -o mkpichex mkpichex.c
 
 clean:


### PR DESCRIPTION

## Summary
Add + make to fix jobserver unavailable warning. And always build mkpichex to make sure it newest, also correct target name.

## Impact

## Testing
Test and verify with flipnclick-pic32mz:nsh
