### PR TITLE
tools/checkpatch.sh: use 'git diff' instead of 'git show' to fix duplicate print

### DIFF
--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -90,7 +90,7 @@ check_patch() {
 }
 
 check_commit() {
-  diffs=`git show $1`
+  diffs=`git diff $1`
   check_ranges <<< "$diffs"
 }
 


### PR DESCRIPTION
## Summary
Use 'git diff' instead of 'git show' to fix checkpatch show duplicate print issue. Also fix the rename file not open issue in checkpatch.

## Impact

## Testing
Fix https://github.com/apache/incubator-nuttx/pull/990 PR checkpatch rename file fail issue
