### PR TITLE
Remove CONFIG_TLS

### DIFF
--- a/TODO
+++ b/TODO
@@ -1029,7 +1029,7 @@ o Kernel/Protected Build
                would not be an issue in the more general case.
 
                Update:
-               One solution might be to used CONFIG_TLS, add the PID to struct
+               One solution might be to use TLS, add the PID to struct
                tls_info_s.  Then the PID could be obtained without a system call.
                TLS is not very useful in the FLAT build, however.  TLS works by
                putting per-thread data at the bottom of an aligned stack.  The

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -10,7 +10,6 @@ choice
 config ARCH_ARM
 	bool "ARM"
 	select ARCH_HAVE_INTERRUPTSTACK
-	select ARCH_HAVE_TLS
 	select ARCH_HAVE_VFORK
 	select ARCH_HAVE_STACKCHECK
 	select ARCH_HAVE_CUSTOMOPT
@@ -68,7 +67,6 @@ config ARCH_SIM
 	bool "Simulation"
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_RTC_SUBSECONDS
-	select ARCH_HAVE_TLS
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_POWEROFF
 	select ARCH_HAVE_TESTSET

--- a/arch/arm/include/tls.h
+++ b/arch/arm/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -92,5 +90,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_ARM_INCLUDE_TLS_H */

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -108,6 +108,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
   UNUSED(int_stack);
   start = alloc & ~3;
 #endif
+
   end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */

--- a/arch/arm/src/common/arm_createstack.c
+++ b/arch/arm/src/common/arm_createstack.c
@@ -102,7 +102,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -117,7 +116,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -190,7 +188,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-#if defined(CONFIG_TLS) && defined(CONFIG_STACK_COLORATION)
+#if defined(CONFIG_STACK_COLORATION)
       uintptr_t stack_base;
 #endif
       size_t top_of_stack;
@@ -224,7 +222,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
@@ -242,17 +239,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       arm_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
-#else /* CONFIG_TLS */
-#ifdef CONFIG_STACK_COLORATION
-      /* If stack debug is enabled, then fill the stack with a
-       * recognizable value that we can use later to test for high
-       * water marks.
-       */
-
-      arm_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
-
-#endif /* CONFIG_STACK_COLORATION */
-#endif /* CONFIG_TLS */
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/arm/src/common/arm_usestack.c
+++ b/arch/arm/src/common/arm_usestack.c
@@ -137,24 +137,18 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
 #ifdef CONFIG_STACK_COLORATION
   /* If stack debug is enabled, then fill the stack with a recognizable
    * value that we can use later to test for high water marks.
    */
 
-#ifdef CONFIG_TLS
   arm_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
                  sizeof(struct tls_info_s)),
                  tcb->adj_stack_size - sizeof(struct tls_info_s));
-#else
-  arm_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
-#endif
 #endif
 
   return OK;

--- a/arch/avr/include/tls.h
+++ b/arch/avr/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -74,5 +72,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_AVR_INCLUDE_TLS_H */

--- a/arch/avr/src/avr/up_createstack.c
+++ b/arch/avr/src/avr/up_createstack.c
@@ -101,7 +101,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -116,7 +115,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -139,6 +137,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * then create a zeroed stack to make stack dumps easier to trace.
        * If TLS is enabled, then we must allocate aligned stacks.
        */
+
 #ifdef CONFIG_TLS_ALIGNED
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
@@ -212,11 +211,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (FAR void *)top_of_stack;
       tcb->adj_stack_size = stack_size;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
 #if defined(ARCH_HAVE_LEDS)
       board_autoled_on(LED_STACKCREATED);

--- a/arch/avr/src/avr/up_usestack.c
+++ b/arch/avr/src/avr/up_usestack.c
@@ -135,11 +135,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (FAR void *)top_of_stack;
   tcb->adj_stack_size = stack_size;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/avr/src/avr32/up_createstack.c
+++ b/arch/avr/src/avr32/up_createstack.c
@@ -106,7 +106,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -121,7 +120,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -226,11 +224,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (FAR void *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/avr/src/avr32/up_usestack.c
+++ b/arch/avr/src/avr32/up_usestack.c
@@ -144,11 +144,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (FAR void *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/hc/include/tls.h
+++ b/arch/hc/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -89,5 +87,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_HC_INCLUDE_TLS_H */

--- a/arch/hc/src/common/up_createstack.c
+++ b/arch/hc/src/common/up_createstack.c
@@ -103,7 +103,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -118,7 +117,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -225,11 +223,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/hc/src/common/up_usestack.c
+++ b/arch/hc/src/common/up_usestack.c
@@ -135,11 +135,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/mips/include/tls.h
+++ b/arch/mips/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -89,5 +87,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_MIPS_INCLUDE_TLS_H */

--- a/arch/mips/src/common/mips_createstack.c
+++ b/arch/mips/src/common/mips_createstack.c
@@ -124,7 +124,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -139,7 +138,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -252,11 +250,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/mips/src/common/mips_usestack.c
+++ b/arch/mips/src/common/mips_usestack.c
@@ -161,11 +161,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/misoc/include/tls.h
+++ b/arch/misoc/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -87,5 +85,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_MISOC_INCLUDE_TLS_H */

--- a/arch/misoc/src/lm32/lm32_createstack.c
+++ b/arch/misoc/src/lm32/lm32_createstack.c
@@ -124,7 +124,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -139,7 +138,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -245,11 +243,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (FAR uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/misoc/src/minerva/minerva_createstack.c
+++ b/arch/misoc/src/minerva/minerva_createstack.c
@@ -116,7 +116,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -131,7 +130,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size? Because of
@@ -238,11 +236,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr = (FAR uint32_t *) top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/or1k/include/tls.h
+++ b/arch/or1k/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -91,5 +89,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_OR1K_INCLUDE_TLS_H */

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -97,6 +97,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
+#ifdef CONFIG_TLS_ALIGNED
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
@@ -108,6 +109,10 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
     {
       start = alloc & ~3;
     }
+#else
+  UNUSED(int_stack);
+  start = alloc & ~3;
+#endif
 
   end   = (alloc + size + 3) & ~3;
 

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -97,7 +97,6 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
@@ -109,10 +108,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
     {
       start = alloc & ~3;
     }
-#else
-  UNUSED(int_stack);
-  start = alloc & ~3;
-#endif
+
   end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */

--- a/arch/or1k/src/common/up_createstack.c
+++ b/arch/or1k/src/common/up_createstack.c
@@ -117,7 +117,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -132,7 +131,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -205,7 +203,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-#if defined(CONFIG_TLS) && defined(CONFIG_STACK_COLORATION)
+#if defined(CONFIG_STACK_COLORATION)
       uintptr_t stack_base;
 #endif
       size_t top_of_stack;
@@ -220,7 +218,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
@@ -238,17 +235,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       up_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
-#else /* CONFIG_TLS */
-#ifdef CONFIG_STACK_COLORATION
-      /* If stack debug is enabled, then fill the stack with a
-       * recognizable value that we can use later to test for high
-       * water marks.
-       */
-
-      up_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
-
-#endif /* CONFIG_STACK_COLORATION */
-#endif /* CONFIG_TLS */
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/renesas/include/tls.h
+++ b/arch/renesas/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -74,5 +72,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_RENESAS_INCLUDE_TLS_H */

--- a/arch/renesas/src/common/up_createstack.c
+++ b/arch/renesas/src/common/up_createstack.c
@@ -103,7 +103,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -118,7 +117,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -225,11 +223,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/renesas/src/common/up_usestack.c
+++ b/arch/renesas/src/common/up_usestack.c
@@ -134,11 +134,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr = top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/risc-v/include/tls.h
+++ b/arch/risc-v/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -74,5 +72,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_RISCV_INCLUDE_TLS_H */

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -91,6 +91,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
+#ifdef CONFIG_TLS_ALIGNED
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
@@ -102,6 +103,10 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
     {
       start = alloc & ~3;
     }
+#else
+  UNUSED(int_stack);
+  start = alloc & ~3;
+#endif
 
   end   = (alloc + size + 3) & ~3;
 

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -91,7 +91,6 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
@@ -103,10 +102,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
     {
       start = alloc & ~3;
     }
-#else
-  UNUSED(int_stack);
-  start = alloc & ~3;
-#endif
+
   end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -252,7 +252,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
                    sizeof(struct tls_info_s);
       stack_size = tcb->adj_stack_size -
                    sizeof(struct tls_info_s);
-      riscv_stack_color((FAR void *)stack_base, stack_size);
+      up_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
 

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -124,7 +124,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -139,7 +138,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -212,7 +210,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-#if defined(CONFIG_TLS) && defined(CONFIG_STACK_COLORATION)
+#if defined(CONFIG_STACK_COLORATION)
       uintptr_t stack_base;
 #endif
       size_t top_of_stack;
@@ -240,7 +238,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (FAR uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
@@ -258,16 +255,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       riscv_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
-#else /* CONFIG_TLS */
-#ifdef CONFIG_STACK_COLORATION
-      /* If stack debug is enabled, then fill the stack with a
-       * recognizable value that we can use later to test for high
-       * water marks.
-       */
-
-      up_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
-#endif /* CONFIG_STACK_COLORATION */
-#endif /* CONFIG_TLS */
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/risc-v/src/common/riscv_usestack.c
+++ b/arch/risc-v/src/common/riscv_usestack.c
@@ -155,11 +155,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (uintptr_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/sim/include/tls.h
+++ b/arch/sim/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -73,5 +71,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_SIM_INCLUDE_TLS_H */

--- a/arch/sim/src/sim/up_createstack.c
+++ b/arch/sim/src/sim/up_createstack.c
@@ -106,7 +106,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
   FAR uint8_t *stack_alloc_ptr;
   int ret = ERROR;
 
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -122,7 +121,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       stack_size = TLS_MAXSTACK;
     }
 #endif
-#endif
 
   /* Move up to next even word boundary if necessary */
 
@@ -133,15 +131,15 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 #ifdef CONFIG_TLS_ALIGNED
   stack_alloc_ptr = (FAR uint8_t *)kumm_memalign(TLS_STACK_ALIGN,
                                                  adj_stack_size);
-#else /* CONFIG_TLS */
+#else
   stack_alloc_ptr = (FAR uint8_t *)kumm_malloc(adj_stack_size);
-#endif /* CONFIG_TLS */
+#endif
 
   /* Was the allocation successful? */
 
   if (stack_alloc_ptr)
     {
-#if defined(CONFIG_TLS) && defined(CONFIG_STACK_COLORATION)
+#if defined(CONFIG_STACK_COLORATION)
       uintptr_t stack_base;
 #endif
 
@@ -160,7 +158,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->stack_alloc_ptr = stack_alloc_ptr;
       tcb->adj_stack_ptr   = (FAR void *)adj_stack_addr;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(stack_alloc_ptr, 0, sizeof(struct tls_info_s));
@@ -177,17 +174,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       up_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
-#else /* CONFIG_TLS */
-#ifdef CONFIG_STACK_COLORATION
-      /* If stack debug is enabled, then fill the stack with a
-       * recognizable value that we can use later to test for high
-       * water marks.
-       */
-
-      up_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
-
-#endif /* CONFIG_STACK_COLORATION */
-#endif /* CONFIG_TLS */
 
       ret = OK;
     }

--- a/arch/sim/src/sim/up_usestack.c
+++ b/arch/sim/src/sim/up_usestack.c
@@ -126,11 +126,9 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
   tcb->stack_alloc_ptr = stack;
   tcb->adj_stack_ptr   = (FAR void *)adj_stack_addr;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(stack, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/x86/include/tls.h
+++ b/arch/x86/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -74,5 +72,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_X86_INCLUDE_TLS_H */

--- a/arch/x86/src/i486/up_createstack.c
+++ b/arch/x86/src/i486/up_createstack.c
@@ -105,7 +105,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -120,7 +119,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -225,11 +223,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/x86/src/i486/up_usestack.c
+++ b/arch/x86/src/i486/up_usestack.c
@@ -134,11 +134,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/x86_64/include/tls.h
+++ b/arch/x86_64/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -74,5 +72,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_X86_64_INCLUDE_TLS_H */

--- a/arch/x86_64/src/intel64/up_createstack.c
+++ b/arch/x86_64/src/intel64/up_createstack.c
@@ -90,7 +90,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -105,7 +104,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -213,11 +211,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (uint64_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/x86_64/src/intel64/up_usestack.c
+++ b/arch/x86_64/src/intel64/up_usestack.c
@@ -122,11 +122,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (uint64_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/xtensa/include/tls.h
+++ b/arch/xtensa/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -91,5 +89,4 @@ static inline FAR struct tls_info_s *up_tls_info(void)
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_XTENSA_INCLUDE_TLS_H */

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -91,10 +91,16 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
+#ifdef CONFIG_TLS_ALIGNED
+
   /* Skip over the TLS data structure at the bottom of the stack */
 
   DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
   start = alloc + sizeof(struct tls_info_s);
+#else
+  start = alloc & ~3;
+#endif
+
   end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -91,14 +91,10 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS
   /* Skip over the TLS data structure at the bottom of the stack */
 
   DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
   start = alloc + sizeof(struct tls_info_s);
-#else
-  start = alloc & ~3;
-#endif
   end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -121,7 +121,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
   uintptr_t cpstart;
 #endif
 
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -136,7 +135,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -287,11 +285,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (FAR uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/xtensa/src/common/xtensa_usestack.c
+++ b/arch/xtensa/src/common/xtensa_usestack.c
@@ -147,11 +147,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/z16/include/tls.h
+++ b/arch/z16/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -70,5 +68,4 @@
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_Z16_INCLUDE_TLS_H */

--- a/arch/z16/src/common/z16_createstack.c
+++ b/arch/z16/src/common/z16_createstack.c
@@ -84,7 +84,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -99,7 +98,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -204,11 +202,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/z16/src/common/z16_usestack.c
+++ b/arch/z16/src/common/z16_usestack.c
@@ -119,11 +119,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_size = top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/arch/z80/include/tls.h
+++ b/arch/z80/include/tls.h
@@ -30,8 +30,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -70,5 +68,4 @@
 #  define up_tls_info() tls_get_info()
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __ARCH_Z80_INCLUDE_TLS_H */

--- a/arch/z80/src/common/z80_createstack.c
+++ b/arch/z80/src/common/z80_createstack.c
@@ -88,7 +88,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
   stack_size += sizeof(struct tls_info_s);
@@ -103,7 +102,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
     {
       stack_size = TLS_MAXSTACK;
     }
-#endif
 #endif
 
   /* Is there already a stack allocated of a different size?  Because of
@@ -209,11 +207,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       tcb->adj_stack_ptr  = (FAR uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
       /* Initialize the TLS data structure */
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/z80/src/common/z80_usestack.c
+++ b/arch/z80/src/common/z80_usestack.c
@@ -118,11 +118,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   tcb->adj_stack_size = top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
-#ifdef CONFIG_TLS
   /* Initialize the TLS data structure */
 
   memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
-#endif
 
   return OK;
 }

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1695,14 +1695,12 @@ int up_timer_start(FAR const struct timespec *ts);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_TLS
 /* struct tls_info_s;
  * FAR struct tls_info_s *up_tls_info(void);
  *
  * The actual declaration or definition is provided in arch/tls.h.  The
  * actual implementation may be a MACRO or and inline function.
  */
-#endif
 
 /****************************************************************************
  * Multiple CPU support

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -29,8 +29,6 @@
 
 #include <sys/types.h>
 
-#ifdef CONFIG_TLS
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -148,5 +146,4 @@ void tls_set_element(int elem, uintptr_t value);
 FAR struct tls_info_s *tls_get_info(void);
 #endif
 
-#endif /* CONFIG_TLS */
 #endif /* __INCLUDE_NUTTX_TLS_H */

--- a/libs/libc/tls/Kconfig
+++ b/libs/libc/tls/Kconfig
@@ -3,23 +3,7 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config ARCH_HAVE_TLS
-	bool
-	default n
-	---help---
-		Selected by the configuration system if the current architecture
-		supports TLS.
-
 menu "Thread Local Storage (TLS)"
-	depends on ARCH_HAVE_TLS
-
-config TLS
-	bool "Thread Local Storage (TLS)"
-	default n
-	---help---
-		Build in support for stack based thread local storage (TLS).
-
-if TLS
 
 config TLS_ALIGNED
 	bool "Require stack alignment"
@@ -66,5 +50,4 @@ config TLS_NELEM
 		The number of unique TLS elements.  These can be accessed with
 		the user library functions tls_get_element() and tls_set_element().
 
-endif # TLS
 endmenu # Thread Local Storage (TLS)

--- a/libs/libc/tls/Make.defs
+++ b/libs/libc/tls/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_TLS),y)
+ifneq ($(CONFIG_TLS_NELEM),0)
 
 CSRCS += tls_setelem.c tls_getelem.c
 

--- a/libs/libc/tls/tls_getelem.c
+++ b/libs/libc/tls/tls_getelem.c
@@ -31,7 +31,7 @@
 #include <nuttx/tls.h>
 #include <arch/tls.h>
 
-#ifdef CONFIG_TLS
+#if CONFIG_TLS_NELEM > 0
 
 /****************************************************************************
  * Public Functions
@@ -75,4 +75,4 @@ uintptr_t tls_get_element(int elem)
   return ret;
 }
 
-#endif /* CONFIG_TLS */
+#endif /* CONFIG_TLS_NELEM > 0 */

--- a/libs/libc/tls/tls_setelem.c
+++ b/libs/libc/tls/tls_setelem.c
@@ -31,7 +31,7 @@
 #include <nuttx/tls.h>
 #include <arch/tls.h>
 
-#ifdef CONFIG_TLS
+#if CONFIG_TLS_NELEM > 0
 
 /****************************************************************************
  * Public Functions
@@ -71,4 +71,4 @@ void tls_set_element(int elem, uintptr_t value)
     }
 }
 
-#endif /* CONFIG_TLS */
+#endif /* CONFIG_TLS_NELEM > 0 */


### PR DESCRIPTION
## Summary

A first step in implementing the user-space error is force TLS to be enabled at all times.  It is no longer optional

## Impact

High risk... Effects just about everything.

## Testing

Not yet

