### PR TITLE
sched/init/nx_start.c: Reinstate logic to remove compiler warning

### DIFF
--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -545,6 +545,8 @@ void nx_start(void)
 
   nxsem_initialize();
 
+#if defined(MM_KERNEL_USRHEAP_INIT) || defined(CONFIG_MM_KERNEL_HEAP) || \
+    defined(CONFIG_MM_PGALLOC)
   /* Initialize the memory manager */
 
     {
@@ -579,6 +581,7 @@ void nx_start(void)
       mm_pginitialize(heap_start, heap_size);
 #endif
     }
+#endif
 
 #ifdef CONFIG_ARCH_USE_MODULE_TEXT
   up_module_text_init();


### PR DESCRIPTION
Revert a portion of eca70597858bc619d3114901d16e4a30f1ebffbe that
causes compiler warnings about unused variables if nx_start() is not
initializing any of the user-mode heap, kernel-mode heap, or page
allocator:

    init/nx_start.c: In function 'nx_start':
    init/nx_start.c:552:14: warning: unused variable 'heap_size'
    [-Wunused-variable]
           size_t heap_size;
                  ^~~~~~~~~
    init/nx_start.c:551:17: warning: unused variable 'heap_start'
    [-Wunused-variable]
           FAR void *heap_start;
                     ^~~~~~~~~~

See dev@nuttx.apache.org mailing list discussion "New unused variables
warning in nx_start()" starting 6 May 2020, archived here:

[https://lists.apache.org/thread.html/r3900727e6a06f4445d6eb881d065119ba6647daab89600c3d45d1424%40%3Cdev.nuttx.apache.org%3E](https://lists.apache.org/thread.html/r3900727e6a06f4445d6eb881d065119ba6647daab89600c3d45d1424%40%3Cdev.nuttx.apache.org%3E)

## Summary

sched/init/nx_start.c:

    * If none of MM_KERNEL_USRHEAP_INIT, CONFIG_MM_KERNEL_HEAP, or
      CONFIG_MM_PGALLOC are defined, the variables heap_start and
      heap_size were declared but never used.

    * This change reinstates wrapping the block with a preprocessor
      conditional to prevent the variables being declared if they will
      not be used. This preprocessor condition was removed in the
      above-mentioned commit.

## Impact

Please note that if you **accidentally** don't have `__KERNEL__` defined when it should be (e.g., because your custom board's Make.defs file uses EXTRADEFINES instead of EXTRAFLAGS, which happened to me), then MM_KERNEL_USRHEAP_INIT won't be defined when it should in sched/init/nx_start.c. With this conditional logic reinstated, you won't see the warning about the unused variables, which is what alerted me to the problem, culminating in finding the error in my Make.defs.

## Testing

I built my custom board configuration with this change and the compiler warning is eliminated.
