### PR TITLE
arch/mips/src/common/mips_usestack.c: Include tls.h header.

### DIFF
--- a/arch/mips/src/common/mips_usestack.c
+++ b/arch/mips/src/common/mips_usestack.c
@@ -46,6 +46,7 @@
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/arch.h>
+#include <nuttx/tls.h>
 
 #include "mips_internal.h"
 


### PR DESCRIPTION
## Summary
An include was missing from the mips_usestack.c file.

## Impact

## Testing

