### PR TITLE
arch/sim/src/nuttx-names.dat:  Add __errno()

### DIFF
--- a/arch/sim/src/nuttx-names.dat
+++ b/arch/sim/src/nuttx-names.dat
@@ -1,3 +1,4 @@
+__errno        NX__errno
 _exit          NX_exit
 accept         NXaccept
 asprintf       NXasprintf


### PR DESCRIPTION
## Summary

Needed to avoid collision with the host on simulator build.

## Impact

Needed for reliable simulator build.

## Testing

sim:nsh

