### PR TITLE
boards/Board.mk:  Fix MSYS build problem w/ ZDS-II Toolchain

### DIFF
--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -76,12 +76,12 @@ ifneq ($(CONFIG_ARCH_FAMILY),)
 endif
 
 ifneq ($(ZDSVERSION),)
-ifeq ($(WINTOOL),y)
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+  USRINCLUDES = -usrinc:".;$(SCHEDSRCDIR);$(ARCHSRCDIR)$(DELIM)chip;$(ARCHSRCDIR)$(DELIM)common"
+else
   WSCHEDSRCDIR = ${shell cygpath -w $(SCHEDSRCDIR)}
   WARCHSRCDIR = ${shell cygpath -w $(ARCHSRCDIR)}
   USRINCLUDES = -usrinc:'.;$(WSCHEDSRCDIR);$(WARCHSRCDIR)\chip;$(WARCHSRCDIR)\common'
-else
-  USRINCLUDES = -usrinc:".;$(SCHEDSRCDIR);$(ARCHSRCDIR)$(DELIM)chip;$(ARCHSRCDIR)$(DELIM)common"
 endif
 else
 ifeq ($(WINTOOL),y)


### PR DESCRIPTION
## Summary

POSIX style paths must always be converted to Windows style paths when
using the ZDS-II Toolchain with Cygwin or MSYS

## Impact

Only effects platforms using ZiLOG ZDS-II Toolchain

## Testing

makerlisp:ez80
