### PR TITLE
net: netdev: Fix netdev_vioctl()

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1759,7 +1759,7 @@ int netdev_vioctl(int sockfd, int cmd, va_list ap)
 {
   FAR struct socket *psock = sockfd_socket(sockfd);
 
-  return psock_ioctl(psock, cmd, ap);
+  return psock_vioctl(psock, cmd, ap);
 }
 
 /****************************************************************************


### PR DESCRIPTION
##Summary

- Recently I noticed that dhcp client does not work correctly due to https://github.com/apache/incubator-nuttx/pull/965
- Finally I found the root cause was introduced the above commit.
- This PR fixes this issue.

## Impact

- Applications such as dhcp client.

## Testing

- I tested this PR with stm32f4discovery:wifi and lm3s6965-ek:discover with qemu.

