### PR TITLE
Revert "CI: use 'git diff $commits' as a whole patchset to do checkpatch"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,4 +32,5 @@ jobs:
         cd nuttx
         commits=`git log -1 --merges --pretty=format:%P | awk -F" " '{ print $1 ".." $2 }'`
         git log --oneline $commits
-        git diff $commits | ../nuttx/tools/checkpatch.sh -
+        echo "../nuttx/tools/checkpatch.sh -g $commits"
+        ../nuttx/tools/checkpatch.sh -g $commits


### PR DESCRIPTION
## Summary
This reverts commit 350131d00e1f0dddcd9252ec6a535830b08f0d1c.

If one PR is on a former master code base, using 'git diff $commits' would result in
abnormal checkpatch report sometimes. So revert it anyway.

## Impact

## Testing

