### PR TITLE
semaphore: do not assert if the count exceeds the limit

### DIFF
--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -100,6 +100,14 @@ int nxsem_post(FAR sem_t *sem)
 
       flags = enter_critical_section();
 
+      /* Check the maximum allowable value */
+
+      if (sem->semcount >= SEM_VALUE_MAX)
+        {
+          leave_critical_section(flags);
+          return -EOVERFLOW;
+        }
+
       /* Perform the semaphore unlock operation, releasing this task as a
        * holder then also incrementing the count on the semaphore.
        *
@@ -117,7 +125,6 @@ int nxsem_post(FAR sem_t *sem)
        * initialized if the semaphore is to used for signaling purposes.
        */
 
-      DEBUGASSERT(sem->semcount < SEM_VALUE_MAX);
       nxsem_releaseholder(sem);
       sem->semcount++;
 


### PR DESCRIPTION
## Summary
semaphore: do not assert if the count exceeds the limit

Linux Programmer's Manual:

SEM_POST(3)

NAME
       sem_post - unlock a semaphore
...

ERRORS
...
       EOVERFLOW
              The maximum allowable value for a semaphore would be exceeded.

Change-Id: I57c1a797a5510df4290a10aa2f3106fd01754b37
Signed-off-by: chao.an <anchao@xiaomi.com>

