### PR TITLE
Make more OS internal names consistent

### DIFF
--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * boards/sim/sim/sim/src/sam_bringup.c
  *
- *   Copyright (C) 2015, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -161,7 +146,9 @@ int sim_bringup(void)
           smart_initialize(0, mtd, NULL);
 
 #elif defined(CONFIG_FS_SPIFFS)
-          /* Register the MTD driver so that it can be accessed from the VFS */
+          /* Register the MTD driver so that it can be accessed from the
+           * VFS.
+           */
 
           ret = register_mtddriver("/dev/rammtd", mtd, 0755, NULL);
           if (ret < 0)
@@ -181,7 +168,9 @@ int sim_bringup(void)
             }
 
 #elif defined(CONFIG_FS_LITTLEFS)
-          /* Register the MTD driver so that it can be accessed from the VFS */
+          /* Register the MTD driver so that it can be accessed from the
+           * VFS.
+           */
 
           ret = register_mtddriver("/dev/rammtd", mtd, 0755, NULL);
           if (ret < 0)
@@ -192,7 +181,8 @@ int sim_bringup(void)
 
           /* Mount the LittleFS file system */
 
-          ret = mount("/dev/rammtd", "/mnt/lfs", "littlefs", 0, "forceformat");
+          ret = mount("/dev/rammtd", "/mnt/lfs", "littlefs", 0,
+                      "forceformat");
           if (ret < 0)
             {
               syslog(LOG_ERR,
@@ -227,7 +217,7 @@ int sim_bringup(void)
 #ifdef CONFIG_CPULOAD_ONESHOT
       /* Configure the oneshot timer to support CPU load measurement */
 
-      sched_oneshot_extclk(oneshot);
+      nxsched_oneshot_extclk(oneshot);
 
 #else
       /* Initialize the simulated oneshot driver */
@@ -235,7 +225,8 @@ int sim_bringup(void)
       ret = oneshot_register("/dev/oneshot", oneshot);
       if (ret < 0)
         {
-          syslog(LOG_ERR, "ERROR: Failed to register oneshot at /dev/oneshot: %d\n",
+          syslog(LOG_ERR,
+                 "ERROR: Failed to register oneshot at /dev/oneshot: %d\n",
                  ret);
         }
 #endif

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -1,36 +1,20 @@
 /****************************************************************************
  * include/nuttx/clock.h
  *
- *   Copyright (C) 2007-2009, 2011-2012, 2014, 2016-2018, 2020 Gregory Nutt.
- *     All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -453,7 +437,7 @@ int clock_cpuload(int pid, FAR struct cpuload_s *cpuload);
 #endif
 
 /****************************************************************************
- * Name:  sched_oneshot_extclk
+ * Name:  nxsched_oneshot_extclk
  *
  * Description:
  *   Configure to use a oneshot timer as described in
@@ -471,11 +455,11 @@ int clock_cpuload(int pid, FAR struct cpuload_s *cpuload);
 
 #ifdef CONFIG_CPULOAD_ONESHOT
 struct oneshot_lowerhalf_s;
-void sched_oneshot_extclk(FAR struct oneshot_lowerhalf_s *lower);
+void nxsched_oneshot_extclk(FAR struct oneshot_lowerhalf_s *lower);
 #endif
 
 /****************************************************************************
- * Name:  sched_period_extclk
+ * Name:  nxsched_period_extclk
  *
  * Description:
  *   Configure to use a period timer as described in
@@ -493,7 +477,7 @@ void sched_oneshot_extclk(FAR struct oneshot_lowerhalf_s *lower);
 
 #ifdef CONFIG_CPULOAD_PERIOD
 struct timer_lowerhalf_s;
-void sched_period_extclk(FAR struct timer_lowerhalf_s *lower);
+void nxsched_period_extclk(FAR struct timer_lowerhalf_s *lower);
 #endif
 
 #undef EXTERN

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -850,7 +850,7 @@ config CPULOAD_ONESHOT
 		oneshot timer must be configured by board specific logic which must
 		then call:
 
-			void sched_oneshot_extclk(FAR struct oneshot_lowerhalf_s *lower);
+			void nxsched_oneshot_extclk(FAR struct oneshot_lowerhalf_s *lower);
 
 		To start the CPU load measurement. See include/nuttx/clock.h
 
@@ -868,7 +868,7 @@ config CPULOAD_PERIOD
 		period timer must be configured by board specific logic which must
 		then call:
 
-			void sched_period_extclk(FAR struct timer_lowerhalf_s *lower);
+			void nxsched_period_extclk(FAR struct timer_lowerhalf_s *lower);
 
 		To start the CPU load measurement. See include/nuttx/clock.h
 

--- a/sched/sched/sched_cpuload_oneshot.c
+++ b/sched/sched/sched_cpuload_oneshot.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/sched/sched_cpuload_oneshot.c
  *
- *   Copyright (C) 2016-2017, 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -245,7 +230,7 @@ static void nxsched_oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
  ****************************************************************************/
 
 /****************************************************************************
- * Name:  sched_oneshot_extclk
+ * Name:  nxsched_oneshot_extclk
  *
  * Description:
  *   Configure to use a oneshot timer as described in
@@ -261,7 +246,7 @@ static void nxsched_oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-void sched_oneshot_extclk(FAR struct oneshot_lowerhalf_s *lower)
+void nxsched_oneshot_extclk(FAR struct oneshot_lowerhalf_s *lower)
 {
 #if CONFIG_CPULOAD_ENTROPY > 0
   struct timespec ts;

--- a/sched/sched/sched_cpuload_period.c
+++ b/sched/sched/sched_cpuload_period.c
@@ -168,7 +168,9 @@ static bool nxsched_period_callback(FAR uint32_t *next_interval_us,
 
   DEBUGASSERT(*next_interval_us > 0); /* Check for overflow to negative or zero */
 
-  /* Make sure that the accumulated value does not exceed the maximum timeout */
+  /* Make sure that the accumulated value does not exceed the maximum
+   * timeout.
+   */
 
   if (*next_interval_us > g_sched_period.maxtimeout)
     {
@@ -201,7 +203,7 @@ static bool nxsched_period_callback(FAR uint32_t *next_interval_us,
  ****************************************************************************/
 
 /****************************************************************************
- * Name:  sched_period_extclk
+ * Name:  nxsched_period_extclk
  *
  * Description:
  *   Configure to use a period timer as described in
@@ -217,7 +219,7 @@ static bool nxsched_period_callback(FAR uint32_t *next_interval_us,
  *
  ****************************************************************************/
 
-void sched_period_extclk(FAR struct timer_lowerhalf_s *lower)
+void nxsched_period_extclk(FAR struct timer_lowerhalf_s *lower)
 {
   DEBUGASSERT(lower != NULL && lower->ops != NULL);
   DEBUGASSERT(lower->ops->setcallback != NULL);

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -235,7 +235,7 @@ static inline void nxsem_findandfreeholder(sem_t *sem,
   FAR struct semholder_s *pholder = nxsem_findholder(sem, htcb);
 
   /* When no more counts are held, remove the holder from the list.  The
-   * count was decremented in nxsem_releaseholder.
+   * count was decremented in nxsem_release_holder.
    */
 
   if (pholder != NULL && pholder->counts <= 0)
@@ -685,7 +685,7 @@ static int nxsem_restoreholderprio_self(FAR struct semholder_s *pholder,
 }
 
 /****************************************************************************
- * Name: nxsem_restorebaseprio_irq
+ * Name: nxsem_restore_baseprio_irq
  *
  * Description:
  *   This function is called after an interrupt handler posts a count on
@@ -716,8 +716,8 @@ static int nxsem_restoreholderprio_self(FAR struct semholder_s *pholder,
  *
  ****************************************************************************/
 
-static inline void nxsem_restorebaseprio_irq(FAR struct tcb_s *stcb,
-                                             FAR sem_t *sem)
+static inline void nxsem_restore_baseprio_irq(FAR struct tcb_s *stcb,
+                                              FAR sem_t *sem)
 {
   /* Perform the following actions only if a new thread was given a count.
    * The thread that received the count should be the highest priority
@@ -746,7 +746,7 @@ static inline void nxsem_restorebaseprio_irq(FAR struct tcb_s *stcb,
 }
 
 /****************************************************************************
- * Name: nxsem_restorebaseprio_task
+ * Name: nxsem_restore_baseprio_task
  *
  * Description:
  *   This function is called after the current running task releases a
@@ -777,8 +777,8 @@ static inline void nxsem_restorebaseprio_irq(FAR struct tcb_s *stcb,
  *
  ****************************************************************************/
 
-static inline void nxsem_restorebaseprio_task(FAR struct tcb_s *stcb,
-                                              FAR sem_t *sem)
+static inline void nxsem_restore_baseprio_task(FAR struct tcb_s *stcb,
+                                               FAR sem_t *sem)
 {
   FAR struct tcb_s *rtcb = this_task();
 
@@ -831,7 +831,7 @@ static inline void nxsem_restorebaseprio_task(FAR struct tcb_s *stcb,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxsem_initholders
+ * Name: nxsem_initialize_holders
  *
  * Description:
  *   Called from nxsem_initialize() to set up semaphore holder information.
@@ -846,7 +846,7 @@ static inline void nxsem_restorebaseprio_task(FAR struct tcb_s *stcb,
  *
  ****************************************************************************/
 
-void nxsem_initholders(void)
+void nxsem_initialize_holders(void)
 {
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
   int i;
@@ -920,7 +920,7 @@ void nxsem_destroyholder(FAR sem_t *sem)
 }
 
 /****************************************************************************
- * Name: nxsem_addholder_tcb
+ * Name: nxsem_add_holder_tcb
  *
  * Description:
  *   Called from nxsem_wait() when the calling thread obtains the semaphore;
@@ -938,7 +938,7 @@ void nxsem_destroyholder(FAR sem_t *sem)
  *
  ****************************************************************************/
 
-void nxsem_addholder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
+void nxsem_add_holder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
 {
   FAR struct semholder_s *pholder;
 
@@ -965,7 +965,7 @@ void nxsem_addholder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
 }
 
 /****************************************************************************
- * Name: nxsem_addholder
+ * Name: nxsem_add_holder
  *
  * Description:
  *   Called from nxsem_wait() when the calling thread obtains the semaphore
@@ -981,13 +981,13 @@ void nxsem_addholder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
  *
  ****************************************************************************/
 
-void nxsem_addholder(FAR sem_t *sem)
+void nxsem_add_holder(FAR sem_t *sem)
 {
-  nxsem_addholder_tcb(this_task(), sem);
+  nxsem_add_holder_tcb(this_task(), sem);
 }
 
 /****************************************************************************
- * Name: void nxsem_boostpriority(sem_t *sem)
+ * Name: void nxsem_boost_priority(sem_t *sem)
  *
  * Description:
  *
@@ -1002,7 +1002,7 @@ void nxsem_addholder(FAR sem_t *sem)
  *
  ****************************************************************************/
 
-void nxsem_boostpriority(FAR sem_t *sem)
+void nxsem_boost_priority(FAR sem_t *sem)
 {
   FAR struct tcb_s *rtcb = this_task();
 
@@ -1015,7 +1015,7 @@ void nxsem_boostpriority(FAR sem_t *sem)
 }
 
 /****************************************************************************
- * Name: nxsem_releaseholder
+ * Name: nxsem_release_holder
  *
  * Description:
  *   Called from sem_post() after a thread releases one count on the
@@ -1031,7 +1031,7 @@ void nxsem_boostpriority(FAR sem_t *sem)
  *
  ****************************************************************************/
 
-void nxsem_releaseholder(FAR sem_t *sem)
+void nxsem_release_holder(FAR sem_t *sem)
 {
   FAR struct tcb_s *rtcb = this_task();
   FAR struct semholder_s *pholder;
@@ -1042,7 +1042,7 @@ void nxsem_releaseholder(FAR sem_t *sem)
   if (pholder != NULL && pholder->counts > 0)
     {
       /* Decrement the counts on this holder -- the holder will be freed
-       * later in nxsem_restorebaseprio.
+       * later in nxsem_restore_baseprio.
        */
 
       pholder->counts--;
@@ -1050,7 +1050,7 @@ void nxsem_releaseholder(FAR sem_t *sem)
 }
 
 /****************************************************************************
- * Name: nxsem_restorebaseprio
+ * Name: nxsem_restore_baseprio
  *
  * Description:
  *   This function is called after the current running task releases a
@@ -1082,7 +1082,7 @@ void nxsem_releaseholder(FAR sem_t *sem)
  *
  ****************************************************************************/
 
-void nxsem_restorebaseprio(FAR struct tcb_s *stcb, FAR sem_t *sem)
+void nxsem_restore_baseprio(FAR struct tcb_s *stcb, FAR sem_t *sem)
 {
 #if 0  /* DSA: sometimes crashes when Telnet calls external cmd (i.e. 'i2c') */
   /* Check our assumptions */
@@ -1101,11 +1101,11 @@ void nxsem_restorebaseprio(FAR struct tcb_s *stcb, FAR sem_t *sem)
 
   if (up_interrupt_context())
     {
-      nxsem_restorebaseprio_irq(stcb, sem);
+      nxsem_restore_baseprio_irq(stcb, sem);
     }
   else
     {
-      nxsem_restorebaseprio_task(stcb, sem);
+      nxsem_restore_baseprio_task(stcb, sem);
     }
 }
 

--- a/sched/semaphore/sem_initialize.c
+++ b/sched/semaphore/sem_initialize.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/semaphore/sem_initialize.c
  *
- *   Copyright (C) 2007, 2009, 2012, 2014 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -71,7 +56,7 @@ void nxsem_initialize(void)
 {
   /* Initialize holder structures needed to support priority inheritance */
 
-  nxsem_initholders();
+  nxsem_initialize_holders();
 }
 
 #endif /* CONFIG_PRIORITY_INHERITANCE */

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * sched/semaphore/sem_post.c
  *
- *   Copyright (C) 2007-2009, 2012-2013, 2016-2017 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -113,7 +97,7 @@ int nxsem_post(FAR sem_t *sem)
        *
        * NOTE:  When semaphores are used for signaling purposes, the holder
        * of the semaphore may not be this thread!  In this case,
-       * nxsem_releaseholder() will do nothing.
+       * nxsem_release_holder() will do nothing.
        *
        * In the case of a mutex this could be simply resolved since there is
        * only one holder but for the case of counting semaphores, there may
@@ -125,7 +109,7 @@ int nxsem_post(FAR sem_t *sem)
        * initialized if the semaphore is to used for signaling purposes.
        */
 
-      nxsem_releaseholder(sem);
+      nxsem_release_holder(sem);
       sem->semcount++;
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
@@ -161,7 +145,7 @@ int nxsem_post(FAR sem_t *sem)
                * it is awakened.
                */
 
-              nxsem_addholder_tcb(stcb, sem);
+              nxsem_add_holder_tcb(stcb, sem);
 
               /* It is, let the task take the semaphore */
 
@@ -187,7 +171,7 @@ int nxsem_post(FAR sem_t *sem)
        */
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-      nxsem_restorebaseprio(stcb, sem);
+      nxsem_restore_baseprio(stcb, sem);
       sched_unlock();
 #endif
       ret = OK;

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -95,7 +95,7 @@ int nxsem_wait(FAR sem_t *sem)
           /* It is, let the task take the semaphore. */
 
           sem->semcount--;
-          nxsem_addholder(sem);
+          nxsem_add_holder(sem);
           rtcb->waitsem = NULL;
           ret = OK;
         }
@@ -135,7 +135,7 @@ int nxsem_wait(FAR sem_t *sem)
            * semaphore.
            */
 
-          nxsem_boostpriority(sem);
+          nxsem_boost_priority(sem);
 #endif
           /* Set the errno value to zero (preserving the original errno)
            * value).  We reuse the per-thread errno to pass information
@@ -178,7 +178,7 @@ int nxsem_wait(FAR sem_t *sem)
            * sem_timedwait().
            *
            * If we were not awakened by a signal or a timeout, then
-           * nxsem_addholder() was called by logic in sem_wait() fore this
+           * nxsem_add_holder() was called by logic in sem_wait() fore this
            * thread was restarted.
            */
 

--- a/sched/semaphore/semaphore.h
+++ b/sched/semaphore/semaphore.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/semaphore/semaphore.h
  *
- *   Copyright (C) 2007, 2009-2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -86,22 +71,22 @@ void nxsem_recover(FAR struct tcb_s *tcb);
  */
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-void nxsem_initholders(void);
+void nxsem_initialize_holders(void);
 void nxsem_destroyholder(FAR sem_t *sem);
-void nxsem_addholder(FAR sem_t *sem);
-void nxsem_addholder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem);
-void nxsem_boostpriority(FAR sem_t *sem);
-void nxsem_releaseholder(FAR sem_t *sem);
-void nxsem_restorebaseprio(FAR struct tcb_s *stcb, FAR sem_t *sem);
+void nxsem_add_holder(FAR sem_t *sem);
+void nxsem_add_holder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem);
+void nxsem_boost_priority(FAR sem_t *sem);
+void nxsem_release_holder(FAR sem_t *sem);
+void nxsem_restore_baseprio(FAR struct tcb_s *stcb, FAR sem_t *sem);
 void nxsem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem);
 #else
-#  define nxsem_initholders()
+#  define nxsem_initialize_holders()
 #  define nxsem_destroyholder(sem)
-#  define nxsem_addholder(sem)
-#  define nxsem_addholder_tcb(htcb,sem)
-#  define nxsem_boostpriority(sem)
-#  define nxsem_releaseholder(sem)
-#  define nxsem_restorebaseprio(stcb,sem)
+#  define nxsem_add_holder(sem)
+#  define nxsem_add_holder_tcb(htcb,sem)
+#  define nxsem_boost_priority(sem)
+#  define nxsem_release_holder(sem)
+#  define nxsem_restore_baseprio(stcb,sem)
 #  define nxsem_canceled(stcb,sem)
 #endif
 


### PR DESCRIPTION
## Summary

1. Internal scheduler functions should begin with nxsched_, not sched_
2. Follow the consistent naming patter of https://cwiki.apache.org/confluence/display/NUTTX/Naming+of+OS+Internal+Functions

    // clock_systimer -> clock_systime_tick
    // clock_systimespec -> clock_systime_timespec
    sched_oneshot_extclk -> nxsched_oneshot_extclk
    sched_period_extclk -> nxsched_period_extclk
    // nxsem_setprotocol -> nxsem_set_protocol
    // nxsem_getprotocol -> nxsem_get_protocol
    // nxsem_getvalue -> nxsem_get_value
    nxsem_initholders -> nxsem_initialize_holders
    nxsem_addholder -> nxsem_add_holder
    nxsem_addholder_tcb -> nxsem_add_holder_tcb
    nxsem_boostpriority -> nxsem_boost_priority
    nxsem_releaseholder -> nxsem_release_holder
    nxsem_restorebaseprio -> nxsem_restore_baseprio

Some planned name changed were skipped for now because they effect too many files (and would require many hours of coding style fixups).

## Impact

Name changes only... Should have no impact.

## Testing

N/A

