### PR TITLE
Don't need monitor IOB buffer empty event for POLLOUT implementation

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -130,9 +130,6 @@ struct tcp_poll_s
   FAR struct socket *psock;        /* Needed to handle loss of connection */
   struct pollfd *fds;              /* Needed to handle poll events */
   FAR struct devif_callback_s *cb; /* Needed to teardown the poll */
-#if defined(CONFIG_NET_TCP_WRITE_BUFFERS) && defined(CONFIG_IOB_NOTIFIER)
-  int16_t key;                     /* Needed to cancel pending notification */
-#endif
 };
 
 struct tcp_conn_s
@@ -159,10 +156,10 @@ struct tcp_conn_s
    *   TCP_NEWDATA - May be cleared to indicate that the data was consumed
    *                 and that no further process of the new data should be
    *                 attempted.
-   *   TCP_SNDACK  - If TCP_NEWDATA is cleared, then TCP_SNDACK may be set
-   *                 to indicate that an ACK should be included in the response.
-   *                 (In TCP_NEWDATA is cleared bu TCP_SNDACK is not set, then
-   *                 dev->d_len should also be cleared).
+   *   TCP_SNDACK  - If TCP_NEWDATA is cleared, then TCP_SNDACK may be set to
+   *                 indicate that an ACK should be included in the response.
+   *                 (In TCP_NEWDATA is cleared bu TCP_SNDACK is not set,
+   *                 then dev->d_len should also be cleared).
    */
 
   FAR struct devif_callback_s *list;
@@ -282,7 +279,8 @@ struct tcp_conn_s
    */
 
   FAR void *accept_private;
-  int (*accept)(FAR struct tcp_conn_s *listener, FAR struct tcp_conn_s *conn);
+  int (*accept)(FAR struct tcp_conn_s *listener,
+                FAR struct tcp_conn_s *conn);
 
   /* The following is a list of poll structures of threads waiting for
    * socket events.
@@ -550,7 +548,8 @@ int tcp_bind(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr);
  *
  ****************************************************************************/
 
-int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr);
+int tcp_connect(FAR struct tcp_conn_s *conn,
+                FAR const struct sockaddr *addr);
 
 /****************************************************************************
  * Name: psock_tcp_connect
@@ -559,7 +558,7 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr);
  *   Perform a TCP connection
  *
  * Input Parameters:
- *   psock - A reference to the socket structure of the socket to be connected
+ *   psock - A reference to the structure of the socket to be connected
  *   addr  - The address of the remote server to connect to
  *
  * Returned Value:
@@ -1251,7 +1250,8 @@ int tcp_backlogdelete(FAR struct tcp_conn_s *conn,
  * Input Parameters:
  *   psock    The listening TCP socket structure
  *   addr     Receives the address of the connecting client
- *   addrlen  Input: allocated size of 'addr', Return: returned size of 'addr'
+ *   addrlen  Input: allocated size of 'addr'
+ *            Return: returned size of 'addr'
  *   newconn  The new, accepted TCP connection structure
  *
  * Returned Value:

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -107,9 +107,6 @@ struct udp_poll_s
   FAR struct net_driver_s *dev;    /* Needed to free the callback structure */
   struct pollfd *fds;              /* Needed to handle poll events */
   FAR struct devif_callback_s *cb; /* Needed to teardown the poll */
-#if defined(CONFIG_NET_UDP_WRITE_BUFFERS) && defined(CONFIG_IOB_NOTIFIER)
-  int16_t key;                     /* Needed to cancel pending notification */
-#endif
 };
 
 struct udp_conn_s
@@ -298,7 +295,8 @@ int udp_bind(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr);
  *
  ****************************************************************************/
 
-int udp_connect(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr);
+int udp_connect(FAR struct udp_conn_s *conn,
+                FAR const struct sockaddr *addr);
 
 /****************************************************************************
  * Name: udp_close
@@ -688,9 +686,9 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR void *buf,
  *
  ****************************************************************************/
 
-ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
-                         size_t len, int flags, FAR const struct sockaddr *to,
-                         socklen_t tolen);
+ssize_t psock_udp_sendto(FAR struct socket *psock,
+                         FAR const void *buf, size_t len, int flags,
+                         FAR const struct sockaddr *to, socklen_t tolen);
 
 /****************************************************************************
  * Name: udp_pollsetup
@@ -797,8 +795,8 @@ int udp_writebuffer_notifier_setup(worker_t worker,
  *
  * Description:
  *   Eliminate a UDP read-ahead notification previously setup by
- *   udp_readahead_notifier_setup().  This function should only be called if the
- *   notification should be aborted prior to the notification.  The
+ *   udp_readahead_notifier_setup().  This function should only be called if
+ *   the notification should be aborted prior to the notification.  The
  *   notification will automatically be torn down after the notification.
  *
  * Input Parameters:
@@ -825,7 +823,7 @@ int udp_notifier_teardown(int key);
  *   When read-ahead data becomes available, *all* of the workers waiting
  *   for read-ahead data will be executed.  If there are multiple workers
  *   waiting for read-ahead data then only the first to execute will get the
- *   data.  Others will need to call udp_readahead_notifier_setup() once again.
+ *   data. Others will need to call udp_readahead_notifier_setup once again.
  *
  * Input Parameters:
  *   conn  - The UDP connection where read-ahead data was just buffered.


### PR DESCRIPTION
## Summary
It's enough to check the buffer available in the net event handler since the net driver will notify the uppler layer once it finish to send one frame.
This patch also fix the crash bug happen somtime like this:
1.user close the socket immediately after poll
2.iob_notifier_teardown remove the pending notifer work from list
3.but the notifer work may already queue but not execute
then the work may touch the released resource when the work get the chance to run.