### PR TITLE
libs/libxx: add .cpp files build support

### DIFF
--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -83,9 +83,10 @@ endif
 AOBJS = $(ASRCS:.S=$(OBJEXT))
 COBJS = $(CSRCS:.c=$(OBJEXT))
 CXXOBJS = $(CXXSRCS:.cxx=$(OBJEXT))
+CPPOBJS = $(CPPSRCS:.cpp=$(OBJEXT))
 
-SRCS = $(ASRCS) $(CSRCS) $(CXXSRCS)
-OBJS = $(AOBJS) $(COBJS) $(CXXOBJS)
+SRCS = $(ASRCS) $(CSRCS) $(CXXSRCS) $(CPPSRCS)
+OBJS = $(AOBJS) $(COBJS) $(CXXOBJS) $(CPPOBJS)
 
 BIN = libxx$(LIBEXT)
 
@@ -99,6 +100,9 @@ $(COBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
 $(CXXOBJS): %$(OBJEXT): %.cxx
+	$(call COMPILEXX, $<, $@)
+
+$(CPPOBJS): %$(OBJEXT): %.cpp
 	$(call COMPILEXX, $<, $@)
 
 $(BIN):	$(OBJS)


### PR DESCRIPTION
libcxx project has .cpp files inside, so add .cpp files build support
here.

Change-Id: Icd3bcb42f4ceafa5e07a9977149cb08d555a9ade
Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>

## Summary

## Impact

## Testing

