### PR TITLE
ea3131/scripts/pg-ld.script: Rename up_head.o to arm_head.o

### DIFF
--- a/boards/arm/lpc31xx/ea3131/scripts/pg-ld.script
+++ b/boards/arm/lpc31xx/ea3131/scripts/pg-ld.script
@@ -80,16 +80,16 @@ SECTIONS
     .locked : {
         _slocked = ABSOLUTE(.);
         *(.vectors)
-        up_head.o locked.r (.text .text.*)
-        up_head.o locked.r (.fixup)
-        up_head.o locked.r (.gnu.warning)
-        up_head.o locked.r (.rodata .rodata.*)
-        up_head.o locked.r (.gnu.linkonce.t.*)
-        up_head.o locked.r (.glue_7)
-        up_head.o locked.r (.glue_7t)
-        up_head.o locked.r (.got)
-        up_head.o locked.r (.gcc_except_table)
-        up_head.o locked.r (.gnu.linkonce.r.*)
+        arm_head.o locked.r (.text .text.*)
+        arm_head.o locked.r (.fixup)
+        arm_head.o locked.r (.gnu.warning)
+        arm_head.o locked.r (.rodata .rodata.*)
+        arm_head.o locked.r (.gnu.linkonce.t.*)
+        arm_head.o locked.r (.glue_7)
+        arm_head.o locked.r (.glue_7t)
+        arm_head.o locked.r (.got)
+        arm_head.o locked.r (.gcc_except_table)
+        arm_head.o locked.r (.gnu.linkonce.r.*)
         _elocked = ABSOLUTE(.);
     } >locked
 


### PR DESCRIPTION
## Summary
In https://github.com/apache/incubator-nuttx/pull/935, up_head.S has been renamed
to arm_head.S, so update object file here accordingly.

## Impact

## Testing
Tested with:
./tools/configure.sh ea3131:pgnsh and make pass2

Fix the following error:
arm-none-eabi-ld: cannot find up_head.o

