### PR TITLE
arm/gic: Don't pirnt log in arm_decodeirq

### DIFF
--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -109,7 +109,6 @@ void arm_gic0_initialize(void)
 
   for (irq = GIC_IRQ_SPI; irq < nlines; irq += 16)
     {
-    //putreg32(0xffffffff, GIC_ICDICFR(irq));  /* SPIs edge sensitive */
       putreg32(0x55555555, GIC_ICDICFR(irq));  /* SPIs level sensitive */
     }
 
@@ -122,7 +121,7 @@ void arm_gic0_initialize(void)
     }
 
 #ifdef CONFIG_SMP
-  /* Attach SGI interrupt handlers.  This attaches the handler for all CPUs. */
+  /* Attach SGI interrupt handlers. This attaches the handler to all CPUs. */
 
   DEBUGVERIFY(irq_attach(GIC_IRQ_SGI1, arm_start_handler, NULL));
   DEBUGVERIFY(irq_attach(GIC_IRQ_SGI2, arm_pause_handler, NULL));
@@ -179,9 +178,9 @@ void arm_gic_initialize(void)
    * field; the value n (n=0-6) specifies that bits (n+1) through bit 7 are
    * used in the comparison for interrupt pre-emption.  A GIC supports a
    * minimum of 16 and a maximum of 256 priority levels so not all binary
-   * point settings may be meaningul. The special value n=7 (GIC_ICCBPR_NOPREMPT)
-   * disables pre-emption.  We disable all pre-emption here to prevent nesting
-   * of interrupt handling.
+   * point settings may be meaningul. The special value n=7
+   * (GIC_ICCBPR_NOPREMPT) disables pre-emption.  We disable all pre-emption
+   * here to prevent nesting of interrupt handling.
    */
 
   putreg32(GIC_ICCBPR_NOPREMPT, GIC_ICCBPR);
@@ -190,7 +189,7 @@ void arm_gic_initialize(void)
 
   putreg32(GIC_ICCPMR_MASK, GIC_ICCPMR);
 
- /* Configure the  CPU Interface Control Register */
+  /* Configure the  CPU Interface Control Register */
 
   iccicr  = getreg32(GIC_ICCICR);
 
@@ -207,7 +206,7 @@ void arm_gic_initialize(void)
   /* Clear non-secure state ICCICR bits to be configured below */
 
   iccicr &= ~(GIC_ICCICRS_EOIMODENS | GIC_ICCICRU_ENABLEGRP1 |
-              GIC_ICCICRU_FIQBYPDISGRP1 |GIC_ICCICRU_IRQBYPDISGRP1);
+              GIC_ICCICRU_FIQBYPDISGRP1 | GIC_ICCICRU_IRQBYPDISGRP1);
 
 #endif
 
@@ -218,7 +217,7 @@ void arm_gic_initialize(void)
    * REVISIT: Do I need to do this?
    */
 
-  //iccicr |= GIC_ICCICRS_FIQEN;
+  /* iccicr |= GIC_ICCICRS_FIQEN; */
 
 #elif defined(CONFIG_ARCH_TRUSTZONE_BOTH)
   /* Set FIQn=1 if secure interrupts are to signal using nfiq_c.
@@ -240,7 +239,7 @@ void arm_gic_initialize(void)
    * I need this setting in this configuration.
    */
 
-   iccicr |= GIC_ICCICRS_ACKTCTL;
+  iccicr |= GIC_ICCICRS_ACKTCTL;
 
 #elif defined(CONFIG_ARCH_TRUSTZONE_BOTH)
   /* Program the AckCtl bit to select the required interrupt acknowledge
@@ -250,7 +249,7 @@ void arm_gic_initialize(void)
    * state.
    */
 
-   iccicr |= GIC_ICCICRS_ACKTCTL;
+  iccicr |= GIC_ICCICRS_ACKTCTL;
 
   /* Program the SBPR bit to select the required binary pointer behavior.
    *
@@ -258,7 +257,7 @@ void arm_gic_initialize(void)
    * state.
    */
 
-   iccicr |= GIC_ICCICRS_CBPR;
+  iccicr |= GIC_ICCICRS_CBPR;
 #endif
 
 #if defined(CONFIG_ARCH_TRUSTZONE_SECURE) || defined(CONFIG_ARCH_TRUSTZONE_BOTH)
@@ -387,8 +386,6 @@ uint32_t *arm_decodeirq(uint32_t *regs)
   regval = getreg32(GIC_ICCIAR);
   irq    = (regval & GIC_ICCIAR_INTID_MASK) >> GIC_ICCIAR_INTID_SHIFT;
 
-  irqinfo("irq=%d\n", irq);
-
   /* Ignore spurions IRQs.  ICCIAR will report 1023 if there is no pending
    * interrupt.
    */
@@ -418,8 +415,8 @@ uint32_t *arm_decodeirq(uint32_t *regs)
  *
  *   This function implements enabling of the device specified by 'irq'
  *   at the interrupt controller level if supported by the architecture
- *   (up_irq_restore() supports the global level, the device level is hardware
- *   specific).
+ *   (up_irq_restore() supports the global level, the device level is
+ *   hardware specific).
  *
  *   Since this API is not supported on all architectures, it should be
  *   avoided in common implementations where possible.


### PR DESCRIPTION
it is unsafe place to do this

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I47fdb1a34a7f1d5c5d3c4f3c0030a60bf01c43c2

## Summary
Dissuss here: https://github.com/apache/incubator-nuttx/issues/802

## Impact

## Testing

