### PR TITLE
Stm32 h7 spi fixes

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -826,6 +826,13 @@ config STM32H7_SPI1_DMA_BUFFER
 	---help---
 		Add a properly aligned DMA buffer for RX and TX DMA for SPI1.
 
+config STM32H7_SPI1_COMMTYPE
+	int "SPI1 Operation mode"
+	default 0
+	depends on STM32H7_SPI1
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
+
 config STM32H7_SPI2_DMA
 	bool "SPI2 DMA"
 	default n
@@ -839,6 +846,13 @@ config STM32H7_SPI2_DMA_BUFFER
 	depends on STM32H7_SPI2_DMA
 	---help---
 		Add a properly aligned DMA buffer for RX and TX DMA for SPI2.
+
+config STM32H7_SPI2_COMMTYPE
+	int "SPI2 Operation mode"
+	default 0
+	depends on STM32H7_SPI2
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
 
 config STM32H7_SPI3_DMA
 	bool "SPI3 DMA"
@@ -854,6 +868,13 @@ config STM32H7_SPI3_DMA_BUFFER
 	---help---
 		Add a properly aligned DMA buffer for RX and TX DMA for SPI3.
 
+config STM32H7_SPI3_COMMTYPE
+	int "SPI3 Operation mode"
+	default 0
+	depends on STM32H7_SPI3
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
+
 config STM32H7_SPI4_DMA
 	bool "SPI4 DMA"
 	default n
@@ -867,6 +888,13 @@ config STM32H7_SPI4_DMA_BUFFER
 	depends on STM32H7_SPI4_DMA
 	---help---
 		Add a properly aligned DMA buffer for RX and TX DMA for SPI4.
+
+config STM32H7_SPI4_COMMTYPE
+	int "SPI4 Operation mode"
+	default 0
+	depends on STM32H7_SPI4
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
 
 config STM32H7_SPI5_DMA
 	bool "SPI5 DMA"
@@ -882,6 +910,13 @@ config STM32H7_SPI5_DMA_BUFFER
 	---help---
 		Add a properly aligned DMA buffer for RX and TX DMA for SPI5.
 
+config STM32H7_SPI5_COMMTYPE
+	int "SPI5 Operation mode"
+	default 0
+	depends on STM32H7_SPI5
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
+
 config STM32H7_SPI6_DMA
 	bool "SPI6 DMA"
 	default n
@@ -895,6 +930,13 @@ config STM32H7_SPI6_DMA_BUFFER
 	depends on STM32H7_SPI6_DMA
 	---help---
 		Add a properly aligned DMA buffer for RX and TX DMA for SPI6.
+
+config STM32H7_SPI6_COMMTYPE
+	int "SPI6 Operation mode"
+	default 0
+	depends on STM32H7_SPI6
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
 
 endmenu # "SPI Configuration"
 

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -1527,7 +1527,9 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, clrbits, setbits);
       spi_enable(priv, true);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so the subsequence re-configurations will be
+       * faster
+       */
 
       priv->nbits = savbits;  /* nbits has been clobbered... save the signed value */
     }
@@ -1821,7 +1823,9 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
   size_t nbytes = (priv->nbits > 8) ? nwords << 1 : nwords;
 
 #ifdef CONFIG_STM32H7_SPI_DMATHRESHOLD
-  /* If this is a small SPI transfer, then let spi_exchange_nodma() do the work. */
+  /* If this is a small SPI transfer, then let spi_exchange_nodma() do the
+   * work.
+   */
 
   if (nbytes <= CONFIG_STM32H7_SPI_DMATHRESHOLD)
     {
@@ -2151,7 +2155,9 @@ static int spi_pm_prepare(FAR struct pm_callback_s *cb, int domain,
 
       if (sval <= 0)
         {
-          /* Exclusive lock is held, do not allow entry to deeper PM states. */
+          /* Exclusive lock is held, do not allow entry to deeper PM
+           * states.
+           */
 
           return -EBUSY;
         }

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -1814,7 +1814,6 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
 {
   FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)dev;
   FAR void * xbuffer = rxbuffer;
-  int ret;
 
   DEBUGASSERT(priv != NULL);
 


### PR DESCRIPTION
## Summary

There have been some problems with stm32h7 spi driver:
- when doing only tx or only rx, the dmacapable check doesn't work
- cache clean/invalidate is done in strange way

In addition we needed to also use the SPI in simplex tx & simplex rx modes, so added configuration
options for those

## Impact

## Testing
tested on custom stm32h7 board with cache writeback and cache write-through configurations, in full duplex, simplex tx and simplex rx modes
