### PR TITLE
stm32h7 progmem fixes

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -297,6 +297,20 @@ config STM32H7_FLASH_OVERRIDE_I
 
 endchoice # "Override Flash Size Designator"
 
+config STM32H7_FLASH_CR_PSIZE
+	int "Flash program size width"
+	depends on ARCH_CHIP_STM32H7
+	default 3
+	range 0 3
+	---help---
+		On some hardware the fastest 64 bit wide flash writes cause too
+		high power consumption which may compromize the system stability.
+		This option can be used to reduce the program size. The options are:
+		0: 8 bits
+		1: 16 bits
+		2: 32 bits
+		3: 64 bits (default)
+
 config STM32H7_AXI_SRAM_CORRUPTION_WAR
 	bool "Errata 2.2.9 Reading from AXI SRAM data read corruption Workaround"
 	default y

--- a/arch/arm/src/stm32h7/stm32_flash.c
+++ b/arch/arm/src/stm32h7/stm32_flash.c
@@ -140,6 +140,12 @@
 
 #endif
 
+#ifndef CONFIG_STM32H7_FLASH_CR_PSIZE
+#define FLASH_CR_PSIZE FLASH_CR_PSIZE_X64
+#else
+#define FLASH_CR_PSIZE (CONFIG_STM32H7_FLASH_CR_PSIZE << FLASH_CR_PSIZE_SHIFT)
+#endif
+
 #define FLASH_KEY1           0x45670123
 #define FLASH_KEY2           0xcdef89ab
 #define FLASH_OPTKEY1        0x08192a3b
@@ -871,7 +877,7 @@ ssize_t up_progmem_write(size_t addr, const void *buf, size_t count)
   stm32h7_unlock_flash(priv);
 
   stm32h7_flash_modifyreg32(priv, STM32_FLASH_CR1_OFFSET,
-                            FLASH_CR_PSIZE_MASK, FLASH_CR_PSIZE_X32);
+                            FLASH_CR_PSIZE_MASK, FLASH_CR_PSIZE);
 
   stm32h7_flash_modifyreg32(priv, STM32_FLASH_CR1_OFFSET, 0, FLASH_CR_PG);
 


### PR DESCRIPTION
## Summary

This pull request fixes the progmem driver for stm32h7 to be usable. Current version has the following problems:
- It doesn't compile at all
- Writing the flash doesn't work properly, also it mixes the eraseblock size & page size information which makes it impossible to use on upper levels.

## Impact

## Testing
Tested on stm32h743zi evaluation board.
