### PR TITLE
net/sockopt: do not set the errno to SO_ERROR

### DIFF
--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -92,7 +92,8 @@
  ****************************************************************************/
 
 static int psock_socketlevel_option(FAR struct socket *psock, int option,
-                                    FAR void *value, FAR socklen_t *value_len)
+                                    FAR void *value,
+                                    FAR socklen_t *value_len)
 {
   /* Verify that the socket option if valid (but might not be supported ) */
 
@@ -121,7 +122,8 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           default:          /* Other options are passed to usrsock daemon. */
             {
-              return usrsock_getsockopt(conn, SOL_SOCKET, option, value, value_len);
+              return usrsock_getsockopt(conn, SOL_SOCKET,
+                                        option, value, value_len);
             }
         }
     }
@@ -276,7 +278,9 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
         }
         break;
 
-      /* The following are not yet implemented (return values other than {0,1) */
+      /* The following are not yet implemented
+       * (return values other than {0,1})
+       */
 
       case SO_LINGER:     /* Lingers on a close() if data is present */
       case SO_RCVBUF:     /* Sets receive buffer size */
@@ -431,7 +435,8 @@ int psock_getsockopt(FAR struct socket *psock, int level, int option,
  *
  ****************************************************************************/
 
-int getsockopt(int sockfd, int level, int option, void *value, socklen_t *value_len)
+int getsockopt(int sockfd, int level, int option,
+               void *value, socklen_t *value_len)
 {
   FAR struct socket *psock;
   int ret;

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -445,7 +445,7 @@ int getsockopt(int sockfd, int level, int option, void *value, socklen_t *value_
   ret = psock_getsockopt(psock, level, option, value, value_len);
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       return ERROR;
     }
 

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -470,7 +470,7 @@ int setsockopt(int sockfd, int level, int option, const void *value,
   ret = psock_setsockopt(psock, level, option, value, value_len);
   if (ret < 0)
     {
-      _SO_SETERRNO(psock, -ret);
+      set_errno(-ret);
       return ERROR;
     }
 

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -87,7 +87,8 @@
  ****************************************************************************/
 
 static int psock_socketlevel_option(FAR struct socket *psock, int option,
-                                    FAR const void *value, socklen_t value_len)
+                                    FAR const void *value,
+                                    socklen_t value_len)
 {
   /* Verify that the socket option if valid (but might not be supported ) */
 
@@ -259,7 +260,9 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           net_lock();
 
-          /* Set or clear the linger option bit and linger time (in deciseconds) */
+          /* Set or clear the linger option bit and linger time
+           * (in deciseconds)
+           */
 
           if (setting->l_onoff)
             {
@@ -315,8 +318,8 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
  *   See <sys/socket.h> a complete list of values for the socket level
  *   'option' argument.
  *
- *   Protocol level options, such as SOL_TCP, are defined in protocol-specific
- *   header files, for example include/netinet/tcp.h
+ *   Protocol level options, such as SOL_TCP, are defined in
+ *   protocol-specific header files, for example include/netinet/tcp.h
  *
  * Input Parameters:
  *   psock     Socket structure of socket to operate on
@@ -419,8 +422,8 @@ int psock_setsockopt(FAR struct socket *psock, int level, int option,
  *   See <sys/socket.h> a complete list of values for the socket level
  *   'option' argument.
  *
- *   Protocol level options, such as SOL_TCP, are defined in protocol-specific
- *   header files, for example include/netinet/tcp.h
+ *   Protocol level options, such as SOL_TCP, are defined in
+ *   protocol-specific header files, for example include/netinet/tcp.h
  *
  * Input Parameters:
  *   sockfd    Socket descriptor of socket


### PR DESCRIPTION
## Summary
SO_ERROR is used to report asynchronous errors that are the result
of events within the network stack and not synchronous errors that
are the result of a library call(send/recv/connect)

Synchronous results are reported via errno.

Linux Programmer's Manual
...
NAME
       getsockopt, setsockopt - get and set options on sockets
...
RETURN VALUE
...
       On error, -1 is returned, and errno is set appropriately
