### PR TITLE
net/conn: generate port base dynamically

### DIFF
--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -778,7 +778,9 @@ int udp_bind(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr)
 
       net_lock();
 
-      /* Is any other UDP connection already bound to this address and port? */
+      /* Is any other UDP connection already bound to this address
+       * and port ?
+       */
 
       if (udp_find_conn(conn->domain, &conn->u, portno) == NULL)
         {


### PR DESCRIPTION
## Summary
In some extreme scenarios(eg. crash, reboot, reset, etc...),
an established connection cannot guarantee that the port can be
closed properly, if we try to reconnect quickly after reset, the
connection will fail since the current port is same as the
previous one, the previous port connection has been hold on server side.

dynamically apply for the port base to avoid duplication.

