### PR TITLE
sched/: Make more naming consistent

### DIFF
--- a/arch/arm/src/arm/vfork.S
+++ b/arch/arm/src/arm/vfork.S
@@ -71,8 +71,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.  This
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -83,8 +83,8 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/armv6-m/vfork.S
+++ b/arch/arm/src/armv6-m/vfork.S
@@ -72,8 +72,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.  This
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -84,8 +84,8 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/armv7-a/vfork.S
+++ b/arch/arm/src/armv7-a/vfork.S
@@ -58,8 +58,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -70,8 +70,8 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/armv7-m/gnu/vfork.S
+++ b/arch/arm/src/armv7-m/gnu/vfork.S
@@ -58,8 +58,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.  This
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -70,8 +70,8 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/armv7-m/iar/vfork.S
+++ b/arch/arm/src/armv7-m/iar/vfork.S
@@ -59,8 +59,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.  This
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -71,8 +71,8 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/armv7-r/vfork.S
+++ b/arch/arm/src/armv7-r/vfork.S
@@ -58,8 +58,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -70,8 +70,8 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/armv8-m/vfork.S
+++ b/arch/arm/src/armv8-m/vfork.S
@@ -58,8 +58,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.  This
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -70,8 +70,8 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/common/arm_vfork.c
+++ b/arch/arm/src/common/arm_vfork.c
@@ -66,8 +66,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -78,10 +78,10 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
- * nxtask_vforkabort() may be called if an error occurs between steps 3 and
+ * nxtask_abort_vfork() may be called if an error occurs between steps 3 and
  * 6.
  *
  * Input Parameters:
@@ -117,10 +117,10 @@ pid_t up_vfork(const struct vfork_s *context)
 
   /* Allocate and initialize a TCB for the child task. */
 
-  child = nxtask_vforksetup((start_t)(context->lr & ~1), &argsize);
+  child = nxtask_setup_vfork((start_t)(context->lr & ~1), &argsize);
   if (!child)
     {
-      serr("ERROR: nxtask_vforksetup failed\n");
+      serr("ERROR: nxtask_setup_vfork failed\n");
       return (pid_t)ERROR;
     }
 
@@ -140,7 +140,7 @@ pid_t up_vfork(const struct vfork_s *context)
   if (ret != OK)
     {
       serr("ERROR: up_create_stack failed: %d\n", ret);
-      nxtask_vforkabort(child, -ret);
+      nxtask_abort_vfork(child, -ret);
       return (pid_t)ERROR;
     }
 
@@ -250,9 +250,9 @@ pid_t up_vfork(const struct vfork_s *context)
     }
 #endif
 
-  /* And, finally, start the child task.  On a failure, nxtask_vforkstart()
-   * will discard the TCB by calling nxtask_vforkabort().
+  /* And, finally, start the child task.  On a failure, nxtask_start_vfork()
+   * will discard the TCB by calling nxtask_abort_vfork().
    */
 
-  return nxtask_vforkstart(child);
+  return nxtask_start_vfork(child);
 }

--- a/arch/mips/src/mips32/mips_vfork.c
+++ b/arch/mips/src/mips32/mips_vfork.c
@@ -83,8 +83,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      this consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -95,10 +95,10 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
- * nxtask_vforkabort() may be called if an error occurs between steps 3 and 6
+ * nxtask_abort_vfork() may be called if an error occurs between steps 3 and 6
  *
  * Input Parameters:
  *   context - Caller context information saved by vfork()
@@ -151,10 +151,10 @@ pid_t up_vfork(const struct vfork_s *context)
 
   /* Allocate and initialize a TCB for the child task. */
 
-  child = nxtask_vforksetup((start_t)context->ra, &argsize);
+  child = nxtask_setup_vfork((start_t)context->ra, &argsize);
   if (!child)
     {
-      sinfo("nxtask_vforksetup failed\n");
+      sinfo("nxtask_setup_vfork failed\n");
       return (pid_t)ERROR;
     }
 
@@ -174,7 +174,7 @@ pid_t up_vfork(const struct vfork_s *context)
   if (ret != OK)
     {
       serr("ERROR: up_create_stack failed: %d\n", ret);
-      nxtask_vforkabort(child, -ret);
+      nxtask_abort_vfork(child, -ret);
       return (pid_t)ERROR;
     }
 
@@ -254,9 +254,9 @@ pid_t up_vfork(const struct vfork_s *context)
   child->cmn.xcp.regs[REG_GP]  = context->gp;  /* Global pointer */
 #endif
 
-  /* And, finally, start the child task.  On a failure, nxtask_vforkstart()
-   * will discard the TCB by calling nxtask_vforkabort().
+  /* And, finally, start the child task.  On a failure, nxtask_start_vfork()
+   * will discard the TCB by calling nxtask_abort_vfork().
    */
 
-  return nxtask_vforkstart(child);
+  return nxtask_start_vfork(child);
 }

--- a/arch/mips/src/mips32/mips_vfork.c
+++ b/arch/mips/src/mips32/mips_vfork.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/mips/src/mips32/mips_vfork.c
  *
- *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -98,7 +83,8 @@
  *   5) up_vfork() then calls nxtask_start_vfork()
  *   6) nxtask_start_vfork() then executes the child thread.
  *
- * nxtask_abort_vfork() may be called if an error occurs between steps 3 and 6
+ * nxtask_abort_vfork() may be called if an error occurs between steps 3
+ * and 6
  *
  * Input Parameters:
  *   context - Caller context information saved by vfork()

--- a/arch/mips/src/mips32/vfork.S
+++ b/arch/mips/src/mips32/vfork.S
@@ -71,8 +71,8 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.  This
+ *   2) up_vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -83,8 +83,8 @@
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   None

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -936,8 +936,8 @@ void nxtask_starthook(FAR struct task_tcb_s *tcb, starthook_t starthook,
  *
  * 1) User code calls vfork().  vfork() is provided in architecture-specific
  *    code.
- * 2) vfork()and calls nxtask_vforksetup().
- * 3) nxtask_vforksetup() allocates and configures the child task's TCB.  This
+ * 2) vfork()and calls nxtask_setup_vfork().
+ * 3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *    consists of:
  *    - Allocation of the child task's TCB.
  *    - Initialization of file descriptors and streams
@@ -948,16 +948,16 @@ void nxtask_starthook(FAR struct task_tcb_s *tcb, starthook_t starthook,
  *    - Allocate and initialize the stack
  *    - Initialize special values in any CPU registers that were not
  *      already configured by up_initial_state()
- * 5) vfork() then calls nxtask_vforkstart()
- * 6) nxtask_vforkstart() then executes the child thread.
+ * 5) vfork() then calls nxtask_start_vfork()
+ * 6) nxtask_start_vfork() then executes the child thread.
  *
- * nxtask_vforkabort() may be called if an error occurs between steps 3 and 6.
+ * nxtask_abort_vfork() may be called if an error occurs between steps 3 and 6.
  *
  ********************************************************************************/
 
-FAR struct task_tcb_s *nxtask_vforksetup(start_t retaddr, size_t *argsize);
-pid_t nxtask_vforkstart(FAR struct task_tcb_s *child);
-void nxtask_vforkabort(FAR struct task_tcb_s *child, int errcode);
+FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr, size_t *argsize);
+pid_t nxtask_start_vfork(FAR struct task_tcb_s *child);
+void nxtask_abort_vfork(FAR struct task_tcb_s *child, int errcode);
 
 /********************************************************************************
  * Name: group_exitinfo

--- a/sched/group/group.h
+++ b/sched/group/group.h
@@ -1,36 +1,20 @@
 /****************************************************************************
  * sched/group/group.h
  *
- *   Copyright (C) 2007-2013, 2015, 2018-2019 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -105,8 +89,8 @@ int  group_join(FAR struct pthread_tcb_s *tcb);
 #endif
 void group_leave(FAR struct tcb_s *tcb);
 #if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_SCHED_HAVE_PARENT)
-void group_addwaiter(FAR struct task_group_s *group);
-void group_delwaiter(FAR struct task_group_s *group);
+void group_add_waiter(FAR struct task_group_s *group);
+void group_del_waiter(FAR struct task_group_s *group);
 #endif
 
 #if defined(HAVE_GROUP_MEMBERS) || defined(CONFIG_ARCH_ADDRENV)
@@ -117,9 +101,9 @@ FAR struct task_group_s *group_findby_grpid(grpid_t grpid);
 FAR struct task_group_s *group_findbypid(pid_t pid);
 int group_foreachchild(FAR struct task_group_s *group,
                        foreachchild_t handler, FAR void *arg);
-int group_killchildren(FAR struct task_tcb_s *tcb);
+int group_kill_children(FAR struct task_tcb_s *tcb);
 #ifdef CONFIG_SIG_SIGSTOP_ACTION
-int group_suspendchildren(FAR struct tcb_s *tcb);
+int group_suspend_children(FAR struct tcb_s *tcb);
 int group_continue(FAR struct tcb_s *tcb);
 #endif
 #endif
@@ -144,16 +128,16 @@ int group_signal(FAR struct task_group_s *group, FAR siginfo_t *siginfo);
 int task_reparent(pid_t ppid, pid_t chpid);
 
 #ifdef CONFIG_SCHED_CHILD_STATUS
-FAR struct child_status_s *group_allocchild(void);
-void group_freechild(FAR struct child_status_s *status);
-void group_addchild(FAR struct task_group_s *group,
-                    FAR struct child_status_s *child);
-FAR struct child_status_s *group_exitchild(FAR struct task_group_s *group);
-FAR struct child_status_s *group_findchild(FAR struct task_group_s *group,
-                                           pid_t pid);
-FAR struct child_status_s *group_removechild(FAR struct task_group_s *group,
-                                             pid_t pid);
-void group_removechildren(FAR struct task_group_s *group);
+FAR struct child_status_s *group_alloc_child(void);
+void group_free_child(FAR struct child_status_s *status);
+void group_add_child(FAR struct task_group_s *group,
+                     FAR struct child_status_s *child);
+FAR struct child_status_s *group_exit_child(FAR struct task_group_s *group);
+FAR struct child_status_s *group_find_child(FAR struct task_group_s *group,
+                                            pid_t pid);
+FAR struct child_status_s *group_remove_child(FAR struct task_group_s *group,
+                                              pid_t pid);
+void group_remove_children(FAR struct task_group_s *group);
 
 #endif /* CONFIG_SCHED_CHILD_STATUS */
 #endif /* CONFIG_SCHED_HAVE_PARENT */

--- a/sched/group/group_childstatus.c
+++ b/sched/group/group_childstatus.c
@@ -38,10 +38,10 @@
  ****************************************************************************/
 
 /* Note that there cannot be more that CONFIG_MAX_TASKS tasks in total.
- * However, the number of child status structures may need to be significantly
- * larger because this number includes the maximum number of tasks that are
- * running PLUS the number of tasks that have exit'ed without having their
- * exit status reaped (via wait(), waitid(), or waitpid()).
+ * However, the number of child status structures may need to be
+ * significantly larger because this number includes the maximum number of
+ * tasks that are running PLUS the number of tasks that have exit'ed without
+ * having their exit status reaped (via wait(), waitid(), or waitpid()).
  *
  * Obviously, if tasks spawn children indefinitely and never have the exit
  * status reaped, then you have a memory leak!
@@ -165,7 +165,8 @@ void task_initialize(void)
  *
  * Returned Value:
  *   On success, a non-NULL pointer to a child status structure.  NULL is
- *   returned if there are no remaining, pre-allocated child status structures.
+ *   returned if there are no remaining, pre-allocated child status
+ *   structures.
  *
  * Assumptions:
  *   Called during task creation in a safe context.  No special precautions
@@ -413,7 +414,9 @@ void group_remove_children(FAR struct task_group_s *group)
   FAR struct child_status_s *curr;
   FAR struct child_status_s *next;
 
-  /* Remove all child structures for the TCB and return them to the freelist  */
+  /* Remove all child structures for the TCB and return them to the
+   * freelist.
+   */
 
   for (curr = group->tg_children; curr; curr = next)
     {

--- a/sched/group/group_childstatus.c
+++ b/sched/group/group_childstatus.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  sched/group/group_childstatus.c
  *
- *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -94,7 +79,7 @@ static struct child_pool_s g_child_pool;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: group_dumpchildren
+ * Name: group_dump_children
  *
  * Description:
  *   Dump all of the children when the part TCB list is modified.
@@ -111,8 +96,8 @@ static struct child_pool_s g_child_pool;
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_CHILDSTATUS
-static void group_dumpchildren(FAR struct task_group_s *group,
-                               FAR const char *msg)
+static void group_dump_children(FAR struct task_group_s *group,
+                                FAR const char *msg)
 {
   FAR struct child_status_s *child;
   int i;
@@ -125,7 +110,7 @@ static void group_dumpchildren(FAR struct task_group_s *group,
     }
 }
 #else
-#  define group_dumpchildren(t,m)
+#  define group_dump_children(t,m)
 #endif
 
 /****************************************************************************
@@ -169,7 +154,7 @@ void task_initialize(void)
 }
 
 /****************************************************************************
- * Name: group_allocchild
+ * Name: group_alloc_child
  *
  * Description:
  *   Allocate a child status structure by removing the next entry from a
@@ -188,7 +173,7 @@ void task_initialize(void)
  *
  ****************************************************************************/
 
-FAR struct child_status_s *group_allocchild(void)
+FAR struct child_status_s *group_alloc_child(void)
 {
   FAR struct child_status_s *ret;
 
@@ -205,7 +190,7 @@ FAR struct child_status_s *group_allocchild(void)
 }
 
 /****************************************************************************
- * Name: group_freechild
+ * Name: group_free_child
  *
  * Description:
  *   Release a child status structure by returning it to a free list.
@@ -222,7 +207,7 @@ FAR struct child_status_s *group_allocchild(void)
  *
  ****************************************************************************/
 
-void group_freechild(FAR struct child_status_s *child)
+void group_free_child(FAR struct child_status_s *child)
 {
   /* Return the child status structure to the free list  */
 
@@ -234,7 +219,7 @@ void group_freechild(FAR struct child_status_s *child)
 }
 
 /****************************************************************************
- * Name: group_addchild
+ * Name: group_add_child
  *
  * Description:
  *   Add a child status structure in the given TCB.
@@ -252,19 +237,19 @@ void group_freechild(FAR struct child_status_s *child)
  *
  ****************************************************************************/
 
-void group_addchild(FAR struct task_group_s *group,
-                    FAR struct child_status_s *child)
+void group_add_child(FAR struct task_group_s *group,
+                     FAR struct child_status_s *child)
 {
   /* Add the entry into the TCB list of children */
 
   child->flink  = group->tg_children;
   group->tg_children = child;
 
-  group_dumpchildren(group, "group_addchild");
+  group_dump_children(group, "group_add_child");
 }
 
 /****************************************************************************
- * Name: group_findchild
+ * Name: group_find_child
  *
  * Description:
  *   Find a child status structure in the given task group.  A reference to
@@ -280,13 +265,13 @@ void group_addchild(FAR struct task_group_s *group,
  *   returned if there is child status structure for that pid in the TCB.
  *
  * Assumptions:
- *   Called during SIGCHLD processing in a safe context.  No special precautions
- *   are required here.
+ *   Called during SIGCHLD processing in a safe context.  No special
+ *   precautions are required here.
  *
  ****************************************************************************/
 
-FAR struct child_status_s *group_findchild(FAR struct task_group_s *group,
-                                           pid_t pid)
+FAR struct child_status_s *group_find_child(FAR struct task_group_s *group,
+                                            pid_t pid)
 {
   FAR struct child_status_s *child;
 
@@ -306,10 +291,10 @@ FAR struct child_status_s *group_findchild(FAR struct task_group_s *group,
 }
 
 /****************************************************************************
- * Name: group_exitchild
+ * Name: group_exit_child
  *
  * Description:
- *   Search for any child that has exitted.
+ *   Search for any child that has exited.
  *
  * Input Parameters:
  *   tcb - The TCB of the parent task to containing the child status.
@@ -319,12 +304,12 @@ FAR struct child_status_s *group_findchild(FAR struct task_group_s *group,
  *   exited child.  NULL is returned if not child has exited.
  *
  * Assumptions:
- *   Called during SIGCHLD processing in a safe context.  No special precautions
- *   are required here.
+ *   Called during SIGCHLD processing in a safe context.  No special
+ *   precautions are required here.
  *
  ****************************************************************************/
 
-FAR struct child_status_s *group_exitchild(FAR struct task_group_s *group)
+FAR struct child_status_s *group_exit_child(FAR struct task_group_s *group)
 {
   FAR struct child_status_s *child;
 
@@ -342,11 +327,11 @@ FAR struct child_status_s *group_exitchild(FAR struct task_group_s *group)
 }
 
 /****************************************************************************
- * Name: group_removechild
+ * Name: group_remove_child
  *
  * Description:
  *   Remove one child structure from a task group.  The child is removed, but
- *   is not yet freed.  group_freechild must be called in order to free the
+ *   is not yet freed.  group_free_child must be called in order to free the
  *   child status structure.
  *
  * Input Parameters:
@@ -358,13 +343,13 @@ FAR struct child_status_s *group_exitchild(FAR struct task_group_s *group)
  *   returned if there is child status structure for that pid in the TCB.
  *
  * Assumptions:
- *   Called during SIGCHLD processing in a safe context.  No special precautions
- *   are required here.
+ *   Called during SIGCHLD processing in a safe context.  No special
+ *   precautionsare required here.
  *
  ****************************************************************************/
 
-FAR struct child_status_s *group_removechild(FAR struct task_group_s *group,
-                                             pid_t pid)
+FAR struct child_status_s *group_remove_child(FAR struct task_group_s *group,
+                                              pid_t pid)
 {
   FAR struct child_status_s *curr;
   FAR struct child_status_s *prev;
@@ -399,14 +384,14 @@ FAR struct child_status_s *group_removechild(FAR struct task_group_s *group,
         }
 
       curr->flink = NULL;
-      group_dumpchildren(group, "group_removechild");
+      group_dump_children(group, "group_remove_child");
     }
 
   return curr;
 }
 
 /****************************************************************************
- * Name: group_removechildren
+ * Name: group_remove_children
  *
  * Description:
  *   Remove and free all child structure from the task group.
@@ -423,7 +408,7 @@ FAR struct child_status_s *group_removechild(FAR struct task_group_s *group,
  *
  ****************************************************************************/
 
-void group_removechildren(FAR struct task_group_s *group)
+void group_remove_children(FAR struct task_group_s *group)
 {
   FAR struct child_status_s *curr;
   FAR struct child_status_s *next;
@@ -433,11 +418,11 @@ void group_removechildren(FAR struct task_group_s *group)
   for (curr = group->tg_children; curr; curr = next)
     {
       next = curr->flink;
-      group_freechild(curr);
+      group_free_child(curr);
     }
 
   group->tg_children = NULL;
-  group_dumpchildren(group, "group_removechildren");
+  group_dump_children(group, "group_remove_children");
 }
 
 #endif /* CONFIG_SCHED_HAVE_PARENT && CONFIG_SCHED_CHILD_STATUS */

--- a/sched/group/group_killchildren.c
+++ b/sched/group/group_killchildren.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  sched/group/group_killchildren.c
  *
- *   Copyright (C) 2013, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -56,7 +41,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: group_killchildren_handler
+ * Name: group_kill_children_handler
  *
  * Description:
  *   Callback from group_foreachchild that handles one member of the group.
@@ -70,7 +55,7 @@
  *
  ****************************************************************************/
 
-static int group_killchildren_handler(pid_t pid, FAR void *arg)
+static int group_kill_children_handler(pid_t pid, FAR void *arg)
 {
   FAR struct tcb_s *rtcb;
   int ret;
@@ -126,7 +111,7 @@ static int group_killchildren_handler(pid_t pid, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: group_killchildren
+ * Name: group_kill_children
  *
  * Description:
  *   Delete all children of a task except for the specified task.  This is
@@ -142,7 +127,7 @@ static int group_killchildren_handler(pid_t pid, FAR void *arg)
  *
  ****************************************************************************/
 
-int group_killchildren(FAR struct task_tcb_s *tcb)
+int group_kill_children(FAR struct task_tcb_s *tcb)
 {
   int ret;
 
@@ -151,8 +136,8 @@ int group_killchildren(FAR struct task_tcb_s *tcb)
    */
 
   sched_lock();
-  ret = group_foreachchild(tcb->cmn.group, group_killchildren_handler,
-                          (FAR void *)((uintptr_t)tcb->cmn.pid));
+  ret = group_foreachchild(tcb->cmn.group, group_kill_children_handler,
+                           (FAR void *)((uintptr_t)tcb->cmn.pid));
   sched_unlock();
   return ret;
 }

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  sched/group/group_leave.c
  *
- *   Copyright (C) 2013-2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -145,7 +130,7 @@ static inline void group_release(FAR struct task_group_s *group)
 #if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS)
   /* Free all un-reaped child exit status */
 
-  group_removechildren(group);
+  group_remove_children(group);
 #endif
 
   /* Release pending signals */

--- a/sched/group/group_suspendchildren.c
+++ b/sched/group/group_suspendchildren.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  *  sched/group/group_suspendchildren.c
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -56,7 +41,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: group_suspendchildren_handler
+ * Name: group_suspend_children_handler
  *
  * Description:
  *   Callback from group_foreachchild that handles one member of the group.
@@ -70,7 +55,7 @@
  *
  ****************************************************************************/
 
-static int group_suspendchildren_handler(pid_t pid, FAR void *arg)
+static int group_suspend_children_handler(pid_t pid, FAR void *arg)
 {
   FAR struct tcb_s *rtcb;
 
@@ -97,7 +82,7 @@ static int group_suspendchildren_handler(pid_t pid, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: group_suspendchildren
+ * Name: group_suspend_children
  *
  * Description:
  *   Suspend all children of a task except for the specified task.  This is
@@ -112,7 +97,7 @@ static int group_suspendchildren_handler(pid_t pid, FAR void *arg)
  *
  ****************************************************************************/
 
-int group_suspendchildren(FAR struct tcb_s *tcb)
+int group_suspend_children(FAR struct tcb_s *tcb)
 {
   int ret;
 
@@ -121,8 +106,8 @@ int group_suspendchildren(FAR struct tcb_s *tcb)
    */
 
   sched_lock();
-  ret = group_foreachchild(tcb->group, group_suspendchildren_handler,
-                          (FAR void *)((uintptr_t)tcb->pid));
+  ret = group_foreachchild(tcb->group, group_suspend_children_handler,
+                           (FAR void *)((uintptr_t)tcb->pid));
   sched_unlock();
   return ret;
 }

--- a/sched/group/group_waiter.c
+++ b/sched/group/group_waiter.c
@@ -51,7 +51,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name:  group_addwaiter
+ * Name:  group_add_waiter
  *
  * Description:
  *   Increment the number of instances of waitpid that are waiting for this
@@ -62,14 +62,14 @@
  *
  ****************************************************************************/
 
-void group_addwaiter(FAR struct task_group_s *group)
+void group_add_waiter(FAR struct task_group_s *group)
 {
   group->tg_nwaiters++;
   DEBUGASSERT(group->tg_nwaiters > 0);
 }
 
 /****************************************************************************
- * Name:  group_addwaiter
+ * Name:  group_add_waiter
  *
  * Description:
  *   Decrement the number of instances of waitpid that are waiting for this
@@ -81,7 +81,7 @@ void group_addwaiter(FAR struct task_group_s *group)
  *
  ****************************************************************************/
 
-void group_delwaiter(FAR struct task_group_s *group)
+void group_del_waiter(FAR struct task_group_s *group)
 {
   DEBUGASSERT(group->tg_nwaiters > 0);
   group->tg_nwaiters--;

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -197,7 +197,7 @@ static inline void nx_workqueues(void)
    * halves.
    */
 
-  work_hpstart();
+  work_start_highpri();
 
 #endif /* CONFIG_SCHED_HPWORK */
 
@@ -206,7 +206,7 @@ static inline void nx_workqueues(void)
    * tasks
    */
 
-  work_lpstart();
+  work_start_lowpri();
 
 #endif /* CONFIG_SCHED_LPWORK */
 

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -1,39 +1,20 @@
 /****************************************************************************
  * sched/init/nx_bringup.c
  *
- *   Copyright (C) 2011-2012, 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * With extensions by:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Author: Uros Platise <uros.platise@isotel.eu>
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -202,8 +183,8 @@ static inline void nx_workqueues(void)
 #endif /* CONFIG_SCHED_HPWORK */
 
 #ifdef CONFIG_SCHED_LPWORK
-  /* Start the low-priority worker thread for other, non-critical continuation
-   * tasks
+  /* Start the low-priority worker thread for other, non-critical
+   * continuation tasks
    */
 
   work_start_lowpri();

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -95,8 +95,8 @@ struct pthread_tcb_s; /* Forward reference */
 struct task_group_s;  /* Forward reference */
 
 void weak_function pthread_initialize(void);
-int pthread_schedsetup(FAR struct pthread_tcb_s *tcb, int priority,
-                       start_t start, pthread_startroutine_t entry);
+int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
+                            start_t start, pthread_startroutine_t entry);
 
 #ifdef CONFIG_PTHREAD_CLEANUP
 void pthread_cleanup_popall(FAR struct pthread_tcb_s *tcb);

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -420,7 +420,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
 
   /* Initialize the task control block */
 
-  ret = pthread_schedsetup(ptcb, param.sched_priority, pthread_start,
+  ret = pthread_setup_scheduler(ptcb, param.sched_priority, pthread_start,
                            start_routine);
   if (ret != OK)
     {
@@ -429,7 +429,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
     }
 
 #ifdef CONFIG_SMP
-  /* pthread_schedsetup() will set the affinity mask by inheriting the
+  /* pthread_setup_scheduler() will set the affinity mask by inheriting the
    * setting from the parent task.  We need to override this setting
    * with the value from the pthread attributes unless that value is
    * zero:  Zero is the default value and simply means to inherit the

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * sched/pthread/pthread_create.c
  *
- *   Copyright (C) 2007-2009, 2011, 2013-2018 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -421,7 +405,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
   /* Initialize the task control block */
 
   ret = pthread_setup_scheduler(ptcb, param.sched_priority, pthread_start,
-                           start_routine);
+                                start_routine);
   if (ret != OK)
     {
       errcode = EBUSY;

--- a/sched/sched/sched_suspend.c
+++ b/sched/sched/sched_suspend.c
@@ -43,7 +43,7 @@
  *
  * Description:
  *   Suspend/pause the specified thread.  This is normally calling indirectly
- *   via group_suspendchildren();
+ *   via group_suspend_children();
  *
  ****************************************************************************/
 

--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -83,8 +83,8 @@ static void exited_child(FAR struct tcb_s *rtcb,
 
   /* Discard the child entry */
 
-  group_removechild(rtcb->group, child->ch_pid);
-  group_freechild(child);
+  group_remove_child(rtcb->group, child->ch_pid);
+  group_free_child(child);
 }
 #endif
 
@@ -182,7 +182,7 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
         {
           /* Check if this specific pid has allocated child status? */
 
-          if (group_findchild(rtcb->group, (pid_t)id) == NULL)
+          if (group_find_child(rtcb->group, (pid_t)id) == NULL)
             {
               /* This specific pid is not a child */
 
@@ -237,7 +237,7 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
         {
           /* We are waiting for any child to exit */
 
-          if (retains && (child = group_exitchild(rtcb->group)) != NULL)
+          if (retains && (child = group_exit_child(rtcb->group)) != NULL)
             {
               /* A child has exited.  Apparently we missed the signal.
                * Return the exit status and break out of the loop.
@@ -256,7 +256,7 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
         {
           /* Yes ... Get the current status of the child task. */
 
-          child = group_findchild(rtcb->group, (pid_t)id);
+          child = group_find_child(rtcb->group, (pid_t)id);
           DEBUGASSERT(child);
 
           /* Did the child exit? */

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -92,7 +92,7 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
   /* Lock this group so that it cannot be deleted until the wait completes */
 
-  group_addwaiter(group);
+  group_add_waiter(group);
 
   /* "If more than one thread is suspended in waitpid() awaiting termination
    * of the same process, exactly one thread will return the process status
@@ -132,7 +132,7 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
       ret = nxsem_wait(&group->tg_exitsem);
     }
 
-  group_delwaiter(group);
+  group_del_waiter(group);
 
   if (ret < 0)
     {
@@ -247,7 +247,7 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
         {
           /* Yes.. Check if this specific pid has allocated child status? */
 
-          if (group_findchild(rtcb->group, pid) == NULL)
+          if (group_find_child(rtcb->group, pid) == NULL)
             {
               ret = -ECHILD;
               goto errout;
@@ -303,7 +303,7 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
            */
 
           DEBUGASSERT(!retains || rtcb->group->tg_children);
-          if (retains && (child = group_exitchild(rtcb->group)) != NULL)
+          if (retains && (child = group_exit_child(rtcb->group)) != NULL)
             {
               /* A child has exited.  Apparently we missed the signal.
                * Return the saved exit status.
@@ -315,8 +315,8 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
               /* Discard the child entry and break out of the loop */
 
-              group_removechild(rtcb->group, child->ch_pid);
-              group_freechild(child);
+              group_remove_child(rtcb->group, child->ch_pid);
+              group_free_child(child);
               break;
             }
         }
@@ -329,7 +329,7 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
         {
           /* Get the current status of the child task. */
 
-          child = group_findchild(rtcb->group, pid);
+          child = group_find_child(rtcb->group, pid);
           DEBUGASSERT(child);
 
           /* Did the child exit? */
@@ -342,8 +342,8 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
               /* Discard the child entry and break out of the loop */
 
-              group_removechild(rtcb->group, pid);
-              group_freechild(child);
+              group_remove_child(rtcb->group, pid);
+              group_free_child(child);
               break;
             }
         }
@@ -415,15 +415,15 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
             {
               /* Recover the exiting child */
 
-              child = group_exitchild(rtcb->group);
+              child = group_exit_child(rtcb->group);
               DEBUGASSERT(child != NULL);
 
               /* Discard the child entry, if we have one */
 
               if (child != NULL)
                 {
-                  group_removechild(rtcb->group, child->ch_pid);
-                  group_freechild(child);
+                  group_remove_child(rtcb->group, child->ch_pid);
+                  group_free_child(child);
                 }
             }
 #endif /* CONFIG_SCHED_CHILD_STATUS */

--- a/sched/signal/sig_action.c
+++ b/sched/signal/sig_action.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * sched/signal/sig_action.c
  *
- *   Copyright (C) 2007-2009, 2013, 2016-2018 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -267,7 +251,7 @@ int nxsig_action(int signo, FAR const struct sigaction *act,
 
       /* Free all pending exit status */
 
-      group_removechildren(rtcb->group);
+      group_remove_children(rtcb->group);
       leave_critical_section(flags);
     }
 #endif

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -273,7 +273,7 @@ static void nxsig_abnormal_termination(int signo)
    * task group if this_task is a pthread.
    */
 
-  group_killchildren((FAR struct task_tcb_s *)rtcb);
+  group_kill_children((FAR struct task_tcb_s *)rtcb);
 #endif
 
 #ifndef CONFIG_DISABLE_PTHREAD
@@ -333,7 +333,7 @@ static void nxsig_stop_task(int signo)
    * main thread of the task group if this_task is a pthread.
    */
 
-  group_suspendchildren(rtcb);
+  group_suspend_children(rtcb);
 #endif
 
   /* Lock the scheduler so this thread is not pre-empted until after we

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * sched/exit.c
  *
- *   Copyright (C) 2007-2008, 2011-2012, 2018 Gregory Nutt. All rights
- *     reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -95,7 +79,9 @@ void exit(int status)
 
   nxtask_exithook(tcb, status, false);
 
-  /* Then "really" exit.  Only the lower 8 bits of the exit status are used. */
+  /* Then "really" exit.  Only the lower 8 bits of the exit status are
+   * used.
+   */
 
   _exit(status);
 }

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -83,7 +83,7 @@ void exit(int status)
    * exit through a different mechanism.
    */
 
-  group_killchildren((FAR struct task_tcb_s *)tcb);
+  group_kill_children((FAR struct task_tcb_s *)tcb);
 #endif
 
   /* Perform common task termination logic.  This will get called again later

--- a/sched/task/task.h
+++ b/sched/task/task.h
@@ -57,9 +57,9 @@ struct tcb_s; /* Forward reference */
 /* Task start-up */
 
 void nxtask_start(void);
-int  nxtask_schedsetup(FAR struct task_tcb_s *tcb, int priority,
+int  nxtask_setup_scheduler(FAR struct task_tcb_s *tcb, int priority,
        start_t start, main_t main, uint8_t ttype);
-int  nxtask_argsetup(FAR struct task_tcb_s *tcb, FAR const char *name,
+int  nxtask_setup_arguments(FAR struct task_tcb_s *tcb, FAR const char *name,
        FAR char * const argv[]);
 
 /* Task exit */

--- a/sched/task/task_activate.c
+++ b/sched/task/task_activate.c
@@ -54,7 +54,7 @@
  * Name: task_activate
  *
  * Description:
- *   This function activates tasks initialized by nxtask_schedsetup().
+ *   This function activates tasks initialized by nxtask_setup_scheduler().
  *   Without activation, a task is ineligible for execution by the
  *   scheduler.
  *

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -148,7 +148,9 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
   ret = task_activate((FAR struct tcb_s *)tcb);
   if (ret < OK)
     {
-      /* The TCB was added to the active task list by nxtask_setup_scheduler() */
+      /* The TCB was added to the active task list by
+       * nxtask_setup_scheduler()
+       */
 
       dq_rem((FAR dq_entry_t *)tcb, (FAR dq_queue_t *)&g_inactivetasks);
       goto errout_with_tcb;

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -121,7 +121,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Initialize the task control block */
 
-  ret = nxtask_schedsetup(tcb, priority, nxtask_start, entry, ttype);
+  ret = nxtask_setup_scheduler(tcb, priority, nxtask_start, entry, ttype);
   if (ret < OK)
     {
       goto errout_with_tcb;
@@ -129,7 +129,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Setup to pass parameters to the new task */
 
-  nxtask_argsetup(tcb, name, argv);
+  nxtask_setup_arguments(tcb, name, argv);
 
   /* Now we have enough in place that we can join the group */
 
@@ -148,7 +148,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
   ret = task_activate((FAR struct tcb_s *)tcb);
   if (ret < OK)
     {
-      /* The TCB was added to the active task list by nxtask_schedsetup() */
+      /* The TCB was added to the active task list by nxtask_setup_scheduler() */
 
       dq_rem((FAR dq_entry_t *)tcb, (FAR dq_queue_t *)&g_inactivetasks);
       goto errout_with_tcb;

--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -1,36 +1,20 @@
 /****************************************************************************
  * sched/task/task_exit.c
  *
- *   Copyright (C) 2008-2009, 2012-2014, 2016, 2018 Gregory Nutt. All
- *     rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -228,7 +228,7 @@ static inline void nxtask_exitstatus(FAR struct task_group_s *group,
     {
       /* No.. Find the exit status entry for this task in the parent TCB */
 
-      child = group_findchild(group, getpid());
+      child = group_find_child(group, getpid());
       if (child)
         {
 #ifndef HAVE_GROUP_MEMBERS
@@ -272,7 +272,7 @@ static inline void nxtask_groupexit(FAR struct task_group_s *group)
     {
       /* No.. Find the exit status entry for this task in the parent TCB */
 
-      child = group_findchild(group, getpid());
+      child = group_find_child(group, getpid());
       if (child)
         {
           /* Mark that all members of the child task group has exited */

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -66,7 +66,7 @@
  *
  * Returned Value:
  *   OK on success; negative error value on failure appropriately.  (See
- *   nxtask_schedsetup() for possible failure conditions).  On failure, the
+ *   nxtask_setup_scheduler() for possible failure conditions).  On failure, the
  *   caller is responsible for freeing the stack memory and for calling
  *   nxsched_release_tcb() to free the TCB (which could be in most any
  *   state).
@@ -109,7 +109,7 @@ int task_init(FAR struct tcb_s *tcb, const char *name, int priority,
 
   /* Initialize the task control block */
 
-  ret = nxtask_schedsetup(ttcb, priority, nxtask_start, entry,
+  ret = nxtask_setup_scheduler(ttcb, priority, nxtask_start, entry,
                           TCB_FLAG_TTYPE_TASK);
   if (ret < OK)
     {
@@ -118,7 +118,7 @@ int task_init(FAR struct tcb_s *tcb, const char *name, int priority,
 
   /* Setup to pass parameters to the new task */
 
-  nxtask_argsetup(ttcb, name, argv);
+  nxtask_setup_arguments(ttcb, name, argv);
 
   /* Now we have enough in place that we can join the group */
 

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -66,8 +66,8 @@
  *
  * Returned Value:
  *   OK on success; negative error value on failure appropriately.  (See
- *   nxtask_setup_scheduler() for possible failure conditions).  On failure, the
- *   caller is responsible for freeing the stack memory and for calling
+ *   nxtask_setup_scheduler() for possible failure conditions).  On failure,
+ *   the caller is responsible for freeing the stack memory and for calling
  *   nxsched_release_tcb() to free the TCB (which could be in most any
  *   state).
  *

--- a/sched/task/task_reparent.c
+++ b/sched/task/task_reparent.c
@@ -144,7 +144,7 @@ int task_reparent(pid_t ppid, pid_t chpid)
 #ifdef CONFIG_SCHED_CHILD_STATUS
   /* Remove the child status entry from old parent task group */
 
-  child = group_removechild(ogrp, chpid);
+  child = group_remove_child(ogrp, chpid);
   if (child)
     {
       /* Has the new parent's task group suppressed child exit status? */
@@ -153,13 +153,13 @@ int task_reparent(pid_t ppid, pid_t chpid)
         {
           /* No.. Add the child status entry to the new parent's task group */
 
-          group_addchild(pgrp, child);
+          group_add_child(pgrp, child);
         }
       else
         {
           /* Yes.. Discard the child status entry */
 
-          group_freechild(child);
+          group_free_child(child);
         }
 
       /* Either case is a success */
@@ -259,7 +259,7 @@ int task_reparent(pid_t ppid, pid_t chpid)
 #ifdef CONFIG_SCHED_CHILD_STATUS
   /* Remove the child status entry from old parent TCB */
 
-  child = group_removechild(otcb->group, chpid);
+  child = group_remove_child(otcb->group, chpid);
   if (child)
     {
       /* Has the new parent's task group suppressed child exit status? */
@@ -268,13 +268,13 @@ int task_reparent(pid_t ppid, pid_t chpid)
         {
           /* No.. Add the child status entry to the new parent's task group */
 
-          group_addchild(ptcb->group, child);
+          group_add_child(ptcb->group, child);
         }
       else
         {
           /* Yes.. Discard the child status entry */
 
-          group_freechild(child);
+          group_free_child(child);
         }
 
       /* Either case is a success */

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -127,7 +127,7 @@ int task_restart(pid_t pid)
   /* Kill any children of this thread */
 
 #ifdef HAVE_GROUP_MEMBERS
-  group_killchildren(tcb);
+  group_kill_children(tcb);
 #endif
 
   /* Remove the TCB from whatever list it is in.  After this point, the TCB

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -63,7 +63,7 @@ static const char g_noname[] = "<noname>";
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxtask_assignpid
+ * Name: nxtask_assign_pid
  *
  * Description:
  *   This function assigns the next unique task ID to a task.
@@ -76,7 +76,7 @@ static const char g_noname[] = "<noname>";
  *
  ****************************************************************************/
 
-static int nxtask_assignpid(FAR struct tcb_s *tcb)
+static int nxtask_assign_pid(FAR struct tcb_s *tcb)
 {
   pid_t next_pid;
   int   hash_ndx;
@@ -167,7 +167,7 @@ static inline void nxtask_inherit_affinity(FAR struct tcb_s *tcb)
 #endif
 
 /****************************************************************************
- * Name: nxtask_saveparent
+ * Name: nxtask_save_parent
  *
  * Description:
  *   Save the task ID of the parent task in the child task's group and
@@ -188,7 +188,7 @@ static inline void nxtask_inherit_affinity(FAR struct tcb_s *tcb)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_HAVE_PARENT
-static inline void nxtask_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
+static inline void nxtask_save_parent(FAR struct tcb_s *tcb, uint8_t ttype)
 {
   DEBUGASSERT(tcb != NULL && tcb->group != NULL);
 
@@ -234,13 +234,13 @@ static inline void nxtask_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
            * the parent TCB.  There should not be.
            */
 
-          child = group_findchild(rtcb->group, tcb->pid);
+          child = group_find_child(rtcb->group, tcb->pid);
           DEBUGASSERT(child == NULL);
           if (child == NULL)
             {
               /* Allocate a new status structure  */
 
-              child = group_allocchild();
+              child = group_alloc_child();
             }
 
           /* Did we successfully find/allocate the child status structure? */
@@ -256,7 +256,7 @@ static inline void nxtask_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
 
               /* Add the entry into the group's list of children */
 
-              group_addchild(rtcb->group, child);
+              group_add_child(rtcb->group, child);
             }
         }
 
@@ -272,11 +272,11 @@ static inline void nxtask_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
     }
 }
 #else
-#  define nxtask_saveparent(tcb,ttype)
+#  define nxtask_save_parent(tcb,ttype)
 #endif
 
 /****************************************************************************
- * Name: nxtask_dupdspace
+ * Name: nxtask_dup_dspace
  *
  * Description:
  *   When a new task or thread is created from a PIC module, then that
@@ -296,7 +296,7 @@ static inline void nxtask_saveparent(FAR struct tcb_s *tcb, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_PIC
-static inline void nxtask_dupdspace(FAR struct tcb_s *tcb)
+static inline void nxtask_dup_dspace(FAR struct tcb_s *tcb)
 {
   FAR struct tcb_s *rtcb = this_task();
   if (rtcb->dspace != NULL)
@@ -311,18 +311,18 @@ static inline void nxtask_dupdspace(FAR struct tcb_s *tcb)
     }
 }
 #else
-#  define nxtask_dupdspace(tcb)
+#  define nxtask_dup_dspace(tcb)
 #endif
 
 /****************************************************************************
- * Name: nxthread_schedsetup
+ * Name: nxthread_setup_scheduler
  *
  * Description:
  *   This functions initializes the common portions of the Task Control Block
  *   (TCB) in preparation for starting a new thread.
  *
- *   nxthread_schedsetup() is called from nxtask_schedsetup() and
- *   pthread_schedsetup().
+ *   nxthread_setup_scheduler() is called from nxtask_setup_scheduler() and
+ *   pthread_setup_scheduler().
  *
  * Input Parameters:
  *   tcb        - Address of the new task's TCB
@@ -339,15 +339,15 @@ static inline void nxtask_dupdspace(FAR struct tcb_s *tcb)
  *
  ****************************************************************************/
 
-static int nxthread_schedsetup(FAR struct tcb_s *tcb, int priority,
-                               start_t start, CODE void *entry,
-                               uint8_t ttype)
+static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
+                                    start_t start, CODE void *entry,
+                                    uint8_t ttype)
 {
   int ret;
 
   /* Assign a unique task ID to the task. */
 
-  ret = nxtask_assignpid(tcb);
+  ret = nxtask_assign_pid(tcb);
   if (ret == OK)
     {
       /* Save task priority and entry point in the TCB */
@@ -378,7 +378,7 @@ static int nxthread_schedsetup(FAR struct tcb_s *tcb, int priority,
        * a child status structure.
        */
 
-      nxtask_saveparent(tcb, ttype);
+      nxtask_save_parent(tcb, ttype);
 
 #ifdef CONFIG_SMP
       /* exec(), task_create(), and vfork() all inherit the affinity mask
@@ -408,7 +408,7 @@ static int nxthread_schedsetup(FAR struct tcb_s *tcb, int priority,
        * state setup will take the PIC address base into account.
        */
 
-      nxtask_dupdspace(tcb);
+      nxtask_dup_dspace(tcb);
 
       /* Initialize the processor-specific portion of the TCB */
 
@@ -426,7 +426,7 @@ static int nxthread_schedsetup(FAR struct tcb_s *tcb, int priority,
 }
 
 /****************************************************************************
- * Name: nxtask_namesetup
+ * Name: nxtask_setup_name
  *
  * Description:
  *   Assign the task name.
@@ -441,8 +441,8 @@ static int nxthread_schedsetup(FAR struct tcb_s *tcb, int priority,
  ****************************************************************************/
 
 #if CONFIG_TASK_NAME_SIZE > 0
-static void nxtask_namesetup(FAR struct task_tcb_s *tcb,
-                             FAR const char *name)
+static void nxtask_setup_name(FAR struct task_tcb_s *tcb,
+                              FAR const char *name)
 {
   /* Give a name to the unnamed tasks */
 
@@ -457,14 +457,14 @@ static void nxtask_namesetup(FAR struct task_tcb_s *tcb,
   tcb->cmn.name[CONFIG_TASK_NAME_SIZE] = '\0';
 }
 #else
-#  define nxtask_namesetup(t,n)
+#  define nxtask_setup_name(t,n)
 #endif /* CONFIG_TASK_NAME_SIZE */
 
 /****************************************************************************
- * Name: nxtask_stackargsetup
+ * Name: nxtask_setup_stackargs
  *
  * Description:
- *   This functions is called only from nxtask_argsetup()  It will allocate
+ *   This functions is called only from nxtask_setup_arguments()  It will allocate
  *   space on the new task's stack and will copy the argv[] array and all
  *   strings to the task's stack where it is readily accessible to the
  *   task.  Data on the stack, on the other hand, is guaranteed to be
@@ -481,8 +481,8 @@ static void nxtask_namesetup(FAR struct task_tcb_s *tcb,
  *
  ****************************************************************************/
 
-static inline int nxtask_stackargsetup(FAR struct task_tcb_s *tcb,
-                                       FAR char * const argv[])
+static inline int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
+                                         FAR char * const argv[])
 {
   FAR char **stackargv;
   FAR const char *name;
@@ -601,13 +601,13 @@ static inline int nxtask_stackargsetup(FAR struct task_tcb_s *tcb,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxtask_schedsetup
+ * Name: nxtask_setup_scheduler
  *
  * Description:
  *   This functions initializes a Task Control Block (TCB) in preparation
  *   for starting a new task.
  *
- *   nxtask_schedsetup() is called from task_init() and nxtask_start().
+ *   nxtask_setup_scheduler() is called from task_init() and nxtask_start().
  *
  * Input Parameters:
  *   tcb        - Address of the new task's TCB
@@ -624,23 +624,23 @@ static inline int nxtask_stackargsetup(FAR struct task_tcb_s *tcb,
  *
  ****************************************************************************/
 
-int nxtask_schedsetup(FAR struct task_tcb_s *tcb, int priority,
-                      start_t start, main_t main, uint8_t ttype)
+int nxtask_setup_scheduler(FAR struct task_tcb_s *tcb, int priority,
+                           start_t start, main_t main, uint8_t ttype)
 {
   /* Perform common thread setup */
 
-  return nxthread_schedsetup((FAR struct tcb_s *)tcb, priority, start,
-                             (CODE void *)main, ttype);
+  return nxthread_setup_scheduler((FAR struct tcb_s *)tcb, priority, start,
+                                  (CODE void *)main, ttype);
 }
 
 /****************************************************************************
- * Name: pthread_schedsetup
+ * Name: pthread_setup_scheduler
  *
  * Description:
  *   This functions initializes a Task Control Block (TCB) in preparation
  *   for starting a new pthread.
  *
- *   pthread_schedsetup() is called from pthread_create(),
+ *   pthread_setup_scheduler() is called from pthread_create(),
  *
  * Input Parameters:
  *   tcb      - Address of the new task's TCB
@@ -658,24 +658,24 @@ int nxtask_schedsetup(FAR struct task_tcb_s *tcb, int priority,
  ****************************************************************************/
 
 #ifndef CONFIG_DISABLE_PTHREAD
-int pthread_schedsetup(FAR struct pthread_tcb_s *tcb, int priority,
-                       start_t start, pthread_startroutine_t entry)
+int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
+                            start_t start, pthread_startroutine_t entry)
 {
   /* Perform common thread setup */
 
-  return nxthread_schedsetup((FAR struct tcb_s *)tcb, priority, start,
-                             (CODE void *)entry, TCB_FLAG_TTYPE_PTHREAD);
+  return nxthread_setup_scheduler((FAR struct tcb_s *)tcb, priority, start,
+                                  (CODE void *)entry, TCB_FLAG_TTYPE_PTHREAD);
 }
 #endif
 
 /****************************************************************************
- * Name: nxtask_argsetup
+ * Name: nxtask_setup_arguments
  *
  * Description:
  *   This functions sets up parameters in the Task Control Block (TCB) in
  *   preparation for starting a new thread.
  *
- *   nxtask_argsetup() is called only from task_init() and nxtask_start() to
+ *   nxtask_setup_arguments() is called only from task_init() and nxtask_start() to
  *   create a new task.  In the "normal" case, the argv[] array is a
  *   structure in the TCB, the arguments are cloned via strdup.
  *
@@ -697,17 +697,17 @@ int pthread_schedsetup(FAR struct pthread_tcb_s *tcb, int priority,
  *
  ****************************************************************************/
 
-int nxtask_argsetup(FAR struct task_tcb_s *tcb, FAR const char *name,
-                    FAR char * const argv[])
+int nxtask_setup_arguments(FAR struct task_tcb_s *tcb, FAR const char *name,
+                           FAR char * const argv[])
 {
   /* Setup the task name */
 
-  nxtask_namesetup(tcb, name);
+  nxtask_setup_name(tcb, name);
 
   /* Copy the argv[] array and all strings are to the task's stack.  Data on
    * the stack is guaranteed to be accessible by the ask no matter what
    * privilege mode the task runs in.
    */
 
-  return nxtask_stackargsetup(tcb, argv);
+  return nxtask_setup_stackargs(tcb, argv);
 }

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -464,10 +464,10 @@ static void nxtask_setup_name(FAR struct task_tcb_s *tcb,
  * Name: nxtask_setup_stackargs
  *
  * Description:
- *   This functions is called only from nxtask_setup_arguments()  It will allocate
- *   space on the new task's stack and will copy the argv[] array and all
- *   strings to the task's stack where it is readily accessible to the
- *   task.  Data on the stack, on the other hand, is guaranteed to be
+ *   This functions is called only from nxtask_setup_arguments()  It will
+ *   allocate space on the new task's stack and will copy the argv[] array
+ *   and all strings to the task's stack where it is readily accessible to
+ *   the task.  Data on the stack, on the other hand, is guaranteed to be
  *   accessible no matter what privilege mode the task runs in.
  *
  * Input Parameters:
@@ -629,8 +629,8 @@ int nxtask_setup_scheduler(FAR struct task_tcb_s *tcb, int priority,
 {
   /* Perform common thread setup */
 
-  return nxthread_setup_scheduler((FAR struct tcb_s *)tcb, priority, start,
-                                  (CODE void *)main, ttype);
+  return nxthread_setup_scheduler((FAR struct tcb_s *)tcb, priority,
+                                  start, (CODE void *)main, ttype);
 }
 
 /****************************************************************************
@@ -663,8 +663,9 @@ int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
 {
   /* Perform common thread setup */
 
-  return nxthread_setup_scheduler((FAR struct tcb_s *)tcb, priority, start,
-                                  (CODE void *)entry, TCB_FLAG_TTYPE_PTHREAD);
+  return nxthread_setup_scheduler((FAR struct tcb_s *)tcb, priority,
+                                  start, (CODE void *)entry,
+                                  TCB_FLAG_TTYPE_PTHREAD);
 }
 #endif
 
@@ -675,9 +676,9 @@ int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
  *   This functions sets up parameters in the Task Control Block (TCB) in
  *   preparation for starting a new thread.
  *
- *   nxtask_setup_arguments() is called only from task_init() and nxtask_start() to
- *   create a new task.  In the "normal" case, the argv[] array is a
- *   structure in the TCB, the arguments are cloned via strdup.
+ *   nxtask_setup_arguments() is called only from task_init() and
+ *   nxtask_start() to create a new task.  In the "normal" case, the argv[]
+ *   array is a structure in the TCB, the arguments are cloned via strdup.
  *
  *   In the kernel build case, the argv[] array and all strings are copied
  *   to the task's stack.  This is done because the TCB (and kernel allocated

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/task/task_vfork
  *
- *   Copyright (C) 2013-2014, 2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -73,7 +58,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxvfork_namesetup
+ * Name: nxvfork_setup_name
  *
  * Description:
  *   Copy the task name.
@@ -88,19 +73,19 @@
  ****************************************************************************/
 
 #if CONFIG_TASK_NAME_SIZE > 0
-static inline void nxvfork_namesetup(FAR struct tcb_s *parent,
-                                     FAR struct task_tcb_s *child)
+static inline void nxvfork_setup_name(FAR struct tcb_s *parent,
+                                      FAR struct task_tcb_s *child)
 {
   /* Copy the name from the parent into the child TCB */
 
   strncpy(child->cmn.name, parent->name, CONFIG_TASK_NAME_SIZE);
 }
 #else
-#  define nxvfork_namesetup(p,c)
+#  define nxvfork_setup_name(p,c)
 #endif /* CONFIG_TASK_NAME_SIZE */
 
 /****************************************************************************
- * Name: nxvfork_stackargsetup
+ * Name: nxvfork_setup_stackargs
  *
  * Description:
  *   Clone the task arguments in the same relative positions on the child's
@@ -115,8 +100,8 @@ static inline void nxvfork_namesetup(FAR struct tcb_s *parent,
  *
  ****************************************************************************/
 
-static inline int nxvfork_stackargsetup(FAR struct tcb_s *parent,
-                                        FAR struct task_tcb_s *child)
+static inline int nxvfork_setup_stackargs(FAR struct tcb_s *parent,
+                                          FAR struct task_tcb_s *child)
 {
   /* Is the parent a task? or a pthread?  Only tasks (and kernel threads)
    * have command line arguments.
@@ -169,7 +154,7 @@ static inline int nxvfork_stackargsetup(FAR struct tcb_s *parent,
 }
 
 /****************************************************************************
- * Name: nxvfork_argsetup
+ * Name: nxvfork_setup_arguments
  *
  * Description:
  *   Clone the argument list from the parent to the child.
@@ -183,20 +168,20 @@ static inline int nxvfork_stackargsetup(FAR struct tcb_s *parent,
  *
  ****************************************************************************/
 
-static inline int nxvfork_argsetup(FAR struct tcb_s *parent,
-                                   FAR struct task_tcb_s *child)
+static inline int nxvfork_setup_arguments(FAR struct tcb_s *parent,
+                                          FAR struct task_tcb_s *child)
 {
   /* Clone the task name */
 
-  nxvfork_namesetup(parent, child);
+  nxvfork_setup_name(parent, child);
 
   /* Adjust and copy the argv[] array. */
 
-  return nxvfork_stackargsetup(parent, child);
+  return nxvfork_setup_stackargs(parent, child);
 }
 
 /****************************************************************************
- * Name: nxvfork_argsize
+ * Name: nxvfork_sizeof_arguments
  *
  * Description:
  *   Get the parent's argument size.
@@ -209,7 +194,7 @@ static inline int nxvfork_argsetup(FAR struct tcb_s *parent,
  *
  ****************************************************************************/
 
-static inline size_t nxvfork_argsize(FAR struct tcb_s *parent)
+static inline size_t nxvfork_sizeof_arguments(FAR struct tcb_s *parent)
 {
   if ((parent->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_PTHREAD)
     {
@@ -239,7 +224,7 @@ static inline size_t nxvfork_argsize(FAR struct tcb_s *parent)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxtask_vforksetup
+ * Name: nxtask_setup_vfork
  *
  * Description:
  *   The vfork() function has the same effect as fork(), except that the
@@ -255,8 +240,8 @@ static inline size_t nxvfork_argsize(FAR struct tcb_s *parent)
  *
  *   1) User code calls vfork().  vfork() is provided in
  *      architecture-specific code.
- *   2) vfork()and calls nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.
+ *   2) vfork()and calls nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -267,21 +252,21 @@ static inline size_t nxvfork_argsize(FAR struct tcb_s *parent)
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) up_vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) up_vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   retaddr - Return address
  *   argsize - Location to return the argument size
  *
  * Returned Value:
- *   Upon successful completion, nxtask_vforksetup() returns a pointer to
+ *   Upon successful completion, nxtask_setup_vfork() returns a pointer to
  *   newly allocated and initialized child task's TCB.  NULL is returned
  *   on any failure and the errno is set appropriately.
  *
  ****************************************************************************/
 
-FAR struct task_tcb_s *nxtask_vforksetup(start_t retaddr, size_t *argsize)
+FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr, size_t *argsize)
 {
   FAR struct tcb_s *parent = this_task();
   FAR struct task_tcb_s *child;
@@ -343,7 +328,7 @@ FAR struct task_tcb_s *nxtask_vforksetup(start_t retaddr, size_t *argsize)
   /* Initialize the task control block.  This calls up_initial_state() */
 
   sinfo("Child priority=%d start=%p\n", priority, retaddr);
-  ret = nxtask_schedsetup(child, priority, retaddr, parent->entry.main,
+  ret = nxtask_setup_scheduler(child, priority, retaddr, parent->entry.main,
                           ttype);
   if (ret < OK)
     {
@@ -352,7 +337,7 @@ FAR struct task_tcb_s *nxtask_vforksetup(start_t retaddr, size_t *argsize)
 
   /* Return the argument size */
 
-  *argsize = nxvfork_argsize(parent);
+  *argsize = nxvfork_sizeof_arguments(parent);
 
   sinfo("parent=%p, returning child=%p\n", parent, child);
   return child;
@@ -364,7 +349,7 @@ errout_with_tcb:
 }
 
 /****************************************************************************
- * Name: nxtask_vforkstart
+ * Name: nxtask_start_vfork
  *
  * Description:
  *   The vfork() function has the same effect as fork(), except that the
@@ -380,8 +365,8 @@ errout_with_tcb:
  *
  *   1) User code calls vfork()
  *   2) Architecture-specific code provides vfork()and calls
- *      nxtask_vforksetup().
- *   3) nxtask_vforksetup() allocates and configures the child task's TCB.
+ *      nxtask_setup_vfork().
+ *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
@@ -392,8 +377,8 @@ errout_with_tcb:
  *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
- *   5) vfork() then calls nxtask_vforkstart()
- *   6) nxtask_vforkstart() then executes the child thread.
+ *   5) vfork() then calls nxtask_start_vfork()
+ *   6) nxtask_start_vfork() then executes the child thread.
  *
  * Input Parameters:
  *   retaddr - The return address from vfork() where the child task
@@ -407,7 +392,7 @@ errout_with_tcb:
  *
  ****************************************************************************/
 
-pid_t nxtask_vforkstart(FAR struct task_tcb_s *child)
+pid_t nxtask_start_vfork(FAR struct task_tcb_s *child)
 {
   FAR struct tcb_s *parent = this_task();
   pid_t pid;
@@ -419,10 +404,10 @@ pid_t nxtask_vforkstart(FAR struct task_tcb_s *child)
 
   /* Duplicate the original argument list in the forked child TCB */
 
-  ret = nxvfork_argsetup(parent, child);
+  ret = nxvfork_setup_arguments(parent, child);
   if (ret < 0)
     {
-      nxtask_vforkabort(child, -ret);
+      nxtask_abort_vfork(child, -ret);
       return ERROR;
     }
 
@@ -431,7 +416,7 @@ pid_t nxtask_vforkstart(FAR struct task_tcb_s *child)
   ret = group_initialize(child);
   if (ret < 0)
     {
-      nxtask_vforkabort(child, -ret);
+      nxtask_abort_vfork(child, -ret);
       return ERROR;
     }
 
@@ -452,7 +437,7 @@ pid_t nxtask_vforkstart(FAR struct task_tcb_s *child)
   ret = task_activate((FAR struct tcb_s *)child);
   if (ret < OK)
     {
-      nxtask_vforkabort(child, -ret);
+      nxtask_abort_vfork(child, -ret);
       sched_unlock();
       return ERROR;
     }
@@ -491,19 +476,19 @@ pid_t nxtask_vforkstart(FAR struct task_tcb_s *child)
 }
 
 /****************************************************************************
- * Name: nxtask_vforkabort
+ * Name: nxtask_abort_vfork
  *
  * Description:
- *   Recover from any errors after nxtask_vforksetup() was called.
+ *   Recover from any errors after nxtask_setup_vfork() was called.
  *
  * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-void nxtask_vforkabort(FAR struct task_tcb_s *child, int errcode)
+void nxtask_abort_vfork(FAR struct task_tcb_s *child, int errcode)
 {
-  /* The TCB was added to the active task list by nxtask_schedsetup() */
+  /* The TCB was added to the active task list by nxtask_setup_scheduler() */
 
   dq_rem((FAR dq_entry_t *)child, (FAR dq_queue_t *)&g_inactivetasks);
 

--- a/sched/wqueue/kwork_hpthread.c
+++ b/sched/wqueue/kwork_hpthread.c
@@ -115,7 +115,7 @@ static int work_hpthread(int argc, char *argv[])
  ****************************************************************************/
 
 /****************************************************************************
- * Name: work_hpstart
+ * Name: work_start_highpri
  *
  * Description:
  *   Start the high-priority, kernel-mode worker thread(s)
@@ -129,7 +129,7 @@ static int work_hpthread(int argc, char *argv[])
  *
  ****************************************************************************/
 
-int work_hpstart(void)
+int work_start_highpri(void)
 {
   pid_t pid;
   int wndx;

--- a/sched/wqueue/kwork_lpthread.c
+++ b/sched/wqueue/kwork_lpthread.c
@@ -115,7 +115,7 @@ static int work_lpthread(int argc, char *argv[])
  ****************************************************************************/
 
 /****************************************************************************
- * Name: work_lpstart
+ * Name: work_start_lowpri
  *
  * Description:
  *   Start the low-priority, kernel-mode worker thread(s)
@@ -129,7 +129,7 @@ static int work_lpthread(int argc, char *argv[])
  *
  ****************************************************************************/
 
-int work_lpstart(void)
+int work_start_lowpri(void)
 {
   pid_t pid;
   int wndx;

--- a/sched/wqueue/wqueue.h
+++ b/sched/wqueue/wqueue.h
@@ -114,7 +114,7 @@ extern struct lp_wqueue_s g_lpwork;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: work_hpstart
+ * Name: work_start_highpri
  *
  * Description:
  *   Start the high-priority, kernel-mode work queue.
@@ -129,11 +129,11 @@ extern struct lp_wqueue_s g_lpwork;
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_HPWORK
-int work_hpstart(void);
+int work_start_highpri(void);
 #endif
 
 /****************************************************************************
- * Name: work_lpstart
+ * Name: work_start_lowpri
  *
  * Description:
  *   Start the low-priority, kernel-mode worker thread(s)
@@ -148,7 +148,7 @@ int work_hpstart(void);
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_LPWORK
-int work_lpstart(void);
+int work_start_lowpri(void);
 #endif
 
 /****************************************************************************
@@ -172,7 +172,7 @@ int work_lpstart(void);
 void work_process(FAR struct kwork_wqueue_s *wqueue, int wndx);
 
 /****************************************************************************
- * Name: work_notifier_initialize
+ * Name: work_initialize_notifier
  *
  * Description:
  *   Set up the notification data structures for normal operation.
@@ -180,7 +180,7 @@ void work_process(FAR struct kwork_wqueue_s *wqueue, int wndx);
  ****************************************************************************/
 
 #ifdef CONFIG_WQUEUE_NOTIFIER
-void work_notifier_initialize(void);
+void work_initialize_notifier(void);
 #endif
 
 #endif /* CONFIG_SCHED_WORKQUEUE */


### PR DESCRIPTION
## Summary

Rename various functions per the quidelines of https://cwiki.apache.org/confluence/display/NUTTX/Naming+of+OS+Internal+Functions

1. nxtask_schedsetup -> nxtask_setup_scheduler
2. nxtask_argsetup -> nxtask_setup_arguments
3. nxtask_assignpid -> nxtask_assign_pid
4. nxtask_saveparent -> nxtask_save_parent
5. nxtask_dupdspace -> nxtask_dup_dspace
6. nxtask_namesetup -> nxtask_setup_name
7. nxtask_stackargsetup -> nxtask_setup_stackargs
8. pthread_schedsetup -> pthread_setup_scheduler
9. nxthread_schedsetup -> nxthread_setup_scheduler
10. work_notifier_initialize -> work_initialize_notifier
11. work_lpstart -> work_start_lowpri
12. work_hpstart -> work_start_highpri
13. group_addwaiter -> group_add_waiter
14. group_delwaiter -> group_del_waiter
15. group_killchildren -> group_kill_children
16. group_suspendchildren -> group_suspend_children
17. group_freechild -> group_free_child
18. group_addchild -> group_add_child
19. group_exitchild -> group_exit_child
20. group_findchild -> group_find_child
21. group_removechild -> group_remove_child

## Impact

None

## Testing

N/A
