### PR TITLE
Fix some very minor spacing problems.

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1162,7 +1162,7 @@ int nxsched_get_scheduler(pid_t pid);
  ********************************************************************************/
 
 int nxsched_set_scheduler(pid_t pid, int policy,
-                         FAR const struct sched_param *param);
+                          FAR const struct sched_param *param);
 
 /********************************************************************************
  * Name: nxsched_get_affinity
@@ -1231,7 +1231,7 @@ int nxsched_get_affinity(pid_t pid, size_t cpusetsize, FAR cpu_set_t *mask);
 
 #ifdef CONFIG_SMP
 int nxsched_set_affinity(pid_t pid, size_t cpusetsize,
-                        FAR const cpu_set_t *mask);
+                         FAR const cpu_set_t *mask);
 #endif
 
 /********************************************************************************

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -404,7 +404,7 @@ void nxsched_reassess_timer(void);
 
 #if CONFIG_RR_INTERVAL > 0
 uint32_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, uint32_t ticks,
-                                  bool noswitches);
+                                    bool noswitches);
 #endif
 
 #ifdef CONFIG_SCHED_SPORADIC
@@ -425,7 +425,8 @@ void nxsched_continue(FAR struct tcb_s *tcb);
 #endif
 
 #ifdef CONFIG_SMP
-#if defined(CONFIG_ARCH_GLOBAL_IRQDISABLE) || defined(CONFIG_ARCH_HAVE_FETCHADD)
+#if defined(CONFIG_ARCH_GLOBAL_IRQDISABLE) || \
+    defined(CONFIG_ARCH_HAVE_FETCHADD)
 FAR struct tcb_s *this_task(void);
 #endif
 
@@ -435,7 +436,8 @@ int  nxsched_pause_cpu(FAR struct tcb_s *tcb);
 irqstate_t nxsched_lock_tasklist(void);
 void nxsched_unlock_tasklist(irqstate_t lock);
 
-#if defined(CONFIG_ARCH_HAVE_FETCHADD) && !defined(CONFIG_ARCH_GLOBAL_IRQDISABLE)
+#if defined(CONFIG_ARCH_HAVE_FETCHADD) && \
+   !defined(CONFIG_ARCH_GLOBAL_IRQDISABLE)
 #  define nxsched_islocked_global() \
      (spin_islocked(&g_cpu_schedlock) || g_global_lockcount > 0)
 #else


### PR DESCRIPTION
## Summary

Fix some very minor spacing problems introduced by the renaming.  Standardizing the names is a good thing, but I have to remember to fix up any spacing problems introduced with the length of t a name changes.

## Impact

None

## Testing

N/A

