### PR TITLE
arch/sim: Fix multiple definition of `g_cpu_wait' and `g_cpu_paused'

### DIFF
--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -211,8 +211,8 @@
  * so that it will be ready for the next pause operation.
  */
 
-volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS] SP_SECTION;
-volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS] SP_SECTION;
+extern volatile spinlock_t g_cpu_wait[CONFIG_SMP_NCPUS] SP_SECTION;
+extern volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS] SP_SECTION;
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I62d81582d58c9156ee8a56207b479dad7d6d18df

## Summary

## Impact

## Testing

