### PR TITLE
arch/stack: fix check stack breakage

### DIFF
--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -92,22 +92,19 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS_ALIGNED
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
 
+#ifdef CONFIG_TLS_ALIGNED
       DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
+#endif
       start = alloc + sizeof(struct tls_info_s);
     }
   else
     {
       start = alloc & ~3;
     }
-#else
-  UNUSED(int_stack);
-  start = alloc & ~3;
-#endif
 
   end   = (alloc + size + 3) & ~3;
 

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -97,22 +97,19 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS_ALIGNED
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
 
+#ifdef CONFIG_TLS_ALIGNED
       DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
+#endif
       start = alloc + sizeof(struct tls_info_s);
     }
   else
     {
       start = alloc & ~3;
     }
-#else
-  UNUSED(int_stack);
-  start = alloc & ~3;
-#endif
 
   end   = (alloc + size + 3) & ~3;
 

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -91,22 +91,19 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS_ALIGNED
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
 
+#ifdef CONFIG_TLS_ALIGNED
       DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
+#endif
       start = alloc + sizeof(struct tls_info_s);
     }
   else
     {
       start = alloc & ~3;
     }
-#else
-  UNUSED(int_stack);
-  start = alloc & ~3;
-#endif
 
   end   = (alloc + size + 3) & ~3;
 

--- a/arch/sim/src/sim/up_checkstack.c
+++ b/arch/sim/src/sim/up_checkstack.c
@@ -89,22 +89,20 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-#ifdef CONFIG_TLS_ALIGNED
   if (!int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
 
+#ifdef CONFIG_TLS_ALIGNED
       DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
+#endif
       start = alloc + sizeof(struct tls_info_s);
     }
   else
     {
       start = alloc & ~3;
     }
-#else
-  UNUSED(int_stack);
-  start = alloc & ~3;
-#endif
+
   end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -89,18 +89,14 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
       return 0;
     }
 
-  /* Get aligned addresses of the top and bottom of the stack */
+  /* Get aligned addresses of the top and bottom of the stack
+   * Skip over the TLS data structure at the bottom of the stack
+   */
 
 #ifdef CONFIG_TLS_ALIGNED
-
-  /* Skip over the TLS data structure at the bottom of the stack */
-
   DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
-  start = alloc + sizeof(struct tls_info_s);
-#else
-  start = alloc & ~3;
 #endif
-
+  start = alloc + sizeof(struct tls_info_s);
   end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */


### PR DESCRIPTION
## Summary
remove the TLS alignment check

Regression by:

--------------------------------------------------------
commit a6da3c2cb6a214b642fa09c48638f1442fdf9117
Author: Ouss4 <abdelatif.guettouche@gmail.com>
Date:   Thu May 7 18:50:07 2020 +0100

    arch/*/*_checkstack.c: Get aligned address only when
    CONFIG_TLS_ALIGNED is enabled.

--------------------------------------------------------
commit c2244a2382cf9c62937cc558cc947fae9f211b81
Author: Gregory Nutt <gnutt@nuttx.org>
Date:   Thu May 7 09:46:47 2020 -0600

    Remove CONFIG_TLS

    A first step in implementing the user-space error is
    force TLS to be enabled at all times.  It is no longer optional

Signed-off-by: chao.an <anchao@xiaomi.com>

