### PR TITLE
arch: Fix up_check_tcbstack() to consider tls_info_s

### DIFF
--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -191,7 +191,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size,
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr +
+                       sizeof(struct tls_info_s),
+                       tcb->adj_stack_size,
                        false);
 }
 

--- a/arch/avr/src/avr/up_checkstack.c
+++ b/arch/avr/src/avr/up_checkstack.c
@@ -184,7 +184,8 @@ ssize_t up_check_stack_remain(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
-  uintptr_t start = (uintptr_t)g_intstackbase - (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+  uintptr_t start = (uintptr_t)g_intstackbase -
+    (CONFIG_ARCH_INTERRUPTSTACK & ~3);
   return do_stackcheck(start, (CONFIG_ARCH_INTERRUPTSTACK & ~3));
 }
 

--- a/arch/avr/src/avr/up_checkstack.c
+++ b/arch/avr/src/avr/up_checkstack.c
@@ -161,7 +161,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size);
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr +
+                       sizeof(struct tls_info_s),
+                       tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -151,7 +151,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size,
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr +
+                       sizeof(struct tls_info_s),
+                       tcb->adj_stack_size,
                        false);
 }
 

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -190,7 +190,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size,
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr +
+                       sizeof(struct tls_info_s),
+                       tcb->adj_stack_size,
                        false);
 }
 

--- a/arch/sim/src/sim/up_checkstack.c
+++ b/arch/sim/src/sim/up_checkstack.c
@@ -187,7 +187,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size,
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr +
+                       sizeof(struct tls_info_s),
+                       tcb->adj_stack_size,
                        false);
 }
 

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -183,7 +183,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size);
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr +
+                       sizeof(struct tls_info_s),
+                       tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)


### PR DESCRIPTION
## Summary

- Recently I noticed that ps command always reports 100.0% stack filled.
- So I tried 'git bisect' and found that it depends https://github.com/apache/incubator-nuttx/pull/995.
- I think that removing CONFIG_TLS means that t_info_s now exists on top of the stack so need to be considered in up_check_tcbstack() as well.

## Impact

- Some architectures such as arm, avr, or1k, risc-v, sim and xtensa with stack coloring.

## Testing

- I only checked this PR with esp32-core (xtensa), maix-bit (riscv64), lm3s6965-ek (cortex-m3) but should work for avr, or1k and sim as well.
