### PR TITLE
nxstyle: Allow Hz, KHz, GHz in identifiers

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1399,7 +1399,7 @@ int main(int argc, char **argv, char **envp)
                    *   IGMPv2      as an IGMP version number
                    *   [0-9]p[0-9] as a decimal point
                    *   d[0-9]      as a divisor
-                   *   MHz         for frequencies
+                   *   Hz          for frequencies (including KHz, MHz, etc.)
                    */
 
                    if (!have_lower && islower(line[n]))
@@ -1461,9 +1461,8 @@ int main(int argc, char **argv, char **envp)
                              break;
 
                          case 'z':
-                           if (!have_upper || n < 2 ||
-                               line[n - 1] != 'H' ||
-                               line[n - 2] != 'M')
+                           if (!have_upper || n < 1 ||
+                               line[n - 1] != 'H')
                              {
                                have_lower = true;
                              }


### PR DESCRIPTION
## Summary

Per the coding standard, we allow MHz as one of the few allowed
exceptions to the identifier case rules.

However, because this exception specifically looked for "MHz" we
would generate undeserved nxstyle errors for Hz, KHz, GHz.

This change adds recognition of any Hz value by eliminating the
requirement for Hz to be preceded by M.

tools/nxstyle.c:

    * main(): Eliminate requirement for Hz to be preceded by M to
      match the rule for allowed mixed case identifier. Update
      relevant comments.

See:
https://cwiki.apache.org/confluence/display/NUTTX/Coding+Standard#macros

Mailing list discussion archived at:
https://lists.apache.org/thread.html/r481b9d145f439c24c8d70992081bf670bc0e893167149e0017519439%40%3Cdev.nuttx.apache.org%3E

## Impact

Several undeserved nxstyle errors will be eliminated for identifiers such as GPIO_SPEED_400KHz, which are allowed, but were not recognized by the rule because it didn't match «MHz».

## Testing

Confirmed:

- Compiles without errors or warnings.
- No longer produces undeserved errors for GPIO_SPEED_400KHz.
- nxstyle passes nxstyle.
