### PR TITLE
net: tcp: Fix port info in warning message in tcp_input.c

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -591,7 +591,7 @@ found:
 
                 nwarn("WARNING: Listen canceled while waiting for ACK on "
                       "port %d\n",
-                      tcp->destport);
+                      ntohs(tcp->destport));
 
                 /* Free the connection structure */
 


### PR DESCRIPTION
## Summary

- This PR fixes port info in warming message in tcp_input.c

## Impact

- In case of CONFIG_DEBUG_NET_WARN=y and the condition is matched.

## Testing

- Enable CONFIG_DEBUG_NET_WARN=y and disable CONFIG_NET_TCPBACKLOG
- Run ftpd_start on NuttX
- Run ftp client on PC and connect to the ftpd on NuttX
