### PR TITLE
nxstyle:  Fix distinction be source and header file for long lines.

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -2428,15 +2428,7 @@ int main(int argc, char **argv, char **envp)
 
           if (m > g_maxline && !rhcomment)
             {
-              if (g_file_type == C_SOURCE)
-                {
-                  ERROR("Long line found", lineno, m);
-                }
-              else if (g_file_type == C_HEADER)
-
-                {
-                  WARN("Long line found", lineno, m);
-                }
+              ERROR("Long line found", lineno, m);
             }
         }
 


### PR DESCRIPTION
## Summary

For some unknow reason, long lines were reported as WARNING is header files, but as ERRORS in C source file.  There are errors where ever they occur.

## Impact

None other than a visual difference.  All long lines will be reportes as ERRORs.

## Testing

