### PR TITLE
stm32: nxstyle fixes

### DIFF
--- a/arch/arm/include/stm32/irq.h
+++ b/arch/arm/include/stm32/irq.h
@@ -77,6 +77,10 @@
 
 #define STM32_IRQ_FIRST         (16) /* Vector number of the first external interrupt */
 
+/************************************************************************************
+ * Included Files
+ ************************************************************************************/
+
 #if defined(CONFIG_STM32_STM32L15XX)
 #  include <arch/stm32/stm32l15xxx_irq.h>
 #elif defined(CONFIG_STM32_STM32F10XX)
@@ -113,7 +117,7 @@ extern "C"
 #endif
 
 /************************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ************************************************************************************/
 
 #undef EXTERN

--- a/arch/arm/src/stm32/hardware/stm32_dma_v1.h
+++ b/arch/arm/src/stm32/hardware/stm32_dma_v1.h
@@ -54,8 +54,9 @@
 #define DMA1                       (0)
 #define DMA2                       (1)
 
-/* These definitions apply to both the STM32 F1 and F3 families */
-/* 12 Channels Total: 7 DMA1 Channels(1-7) and 5 DMA2 channels (1-5) */
+/* These definitions apply to both the STM32 F1 and F3 families
+ * 12 Channels Total: 7 DMA1 Channels(1-7) and 5 DMA2 channels (1-5)
+ */
 
 #define DMA_CHAN1                  (0)
 #define DMA_CHAN2                  (1)
@@ -257,31 +258,31 @@
 
 /* DMA channel configuration register */
 
-#define DMA_CCR_EN                (1 << 0)  /* Bit 0: Channel enable */
-#define DMA_CCR_TCIE              (1 << 1)  /* Bit 1: Transfer complete interrupt enable */
-#define DMA_CCR_HTIE              (1 << 2)  /* Bit 2: Half Transfer interrupt enable */
-#define DMA_CCR_TEIE              (1 << 3)  /* Bit 3: Transfer error interrupt enable */
-#define DMA_CCR_DIR               (1 << 4)  /* Bit 4: Data transfer direction */
-#define DMA_CCR_CIRC              (1 << 5)  /* Bit 5: Circular mode */
-#define DMA_CCR_PINC              (1 << 6)  /* Bit 6: Peripheral increment mode */
-#define DMA_CCR_MINC              (1 << 7)  /* Bit 7: Memory increment mode */
-#define DMA_CCR_PSIZE_SHIFT       (8)       /* Bits 8-9: Peripheral size */
+#define DMA_CCR_EN                (1 << 0)                   /* Bit 0: Channel enable */
+#define DMA_CCR_TCIE              (1 << 1)                   /* Bit 1: Transfer complete interrupt enable */
+#define DMA_CCR_HTIE              (1 << 2)                   /* Bit 2: Half Transfer interrupt enable */
+#define DMA_CCR_TEIE              (1 << 3)                   /* Bit 3: Transfer error interrupt enable */
+#define DMA_CCR_DIR               (1 << 4)                   /* Bit 4: Data transfer direction */
+#define DMA_CCR_CIRC              (1 << 5)                   /* Bit 5: Circular mode */
+#define DMA_CCR_PINC              (1 << 6)                   /* Bit 6: Peripheral increment mode */
+#define DMA_CCR_MINC              (1 << 7)                   /* Bit 7: Memory increment mode */
+#define DMA_CCR_PSIZE_SHIFT       (8)                        /* Bits 8-9: Peripheral size */
 #define DMA_CCR_PSIZE_MASK        (3 << DMA_CCR_PSIZE_SHIFT)
 #  define DMA_CCR_PSIZE_8BITS     (0 << DMA_CCR_PSIZE_SHIFT) /* 00: 8-bits */
 #  define DMA_CCR_PSIZE_16BITS    (1 << DMA_CCR_PSIZE_SHIFT) /* 01: 16-bits */
 #  define DMA_CCR_PSIZE_32BITS    (2 << DMA_CCR_PSIZE_SHIFT) /* 10: 32-bits */
-#define DMA_CCR_MSIZE_SHIFT       (10)      /* Bits 10-11: Memory size */
+#define DMA_CCR_MSIZE_SHIFT       (10)                       /* Bits 10-11: Memory size */
 #define DMA_CCR_MSIZE_MASK        (3 << DMA_CCR_MSIZE_SHIFT)
 #  define DMA_CCR_MSIZE_8BITS     (0 << DMA_CCR_MSIZE_SHIFT) /* 00: 8-bits */
 #  define DMA_CCR_MSIZE_16BITS    (1 << DMA_CCR_MSIZE_SHIFT) /* 01: 16-bits */
 #  define DMA_CCR_MSIZE_32BITS    (2 << DMA_CCR_MSIZE_SHIFT) /* 10: 32-bits */
-#define DMA_CCR_PL_SHIFT          (12)      /* Bits 12-13: Channel Priority level */
+#define DMA_CCR_PL_SHIFT          (12)                       /* Bits 12-13: Channel Priority level */
 #define DMA_CCR_PL_MASK           (3 << DMA_CCR_PL_SHIFT)
-#  define DMA_CCR_PRILO           (0 << DMA_CCR_PL_SHIFT) /* 00: Low */
-#  define DMA_CCR_PRIMED          (1 << DMA_CCR_PL_SHIFT) /* 01: Medium */
-#  define DMA_CCR_PRIHI           (2 << DMA_CCR_PL_SHIFT) /* 10: High */
-#  define DMA_CCR_PRIVERYHI       (3 << DMA_CCR_PL_SHIFT) /* 11: Very high */
-#define DMA_CCR_MEM2MEM           (1 << 14) /* Bit 14: Memory to memory mode */
+#  define DMA_CCR_PRILO           (0 << DMA_CCR_PL_SHIFT)    /* 00: Low */
+#  define DMA_CCR_PRIMED          (1 << DMA_CCR_PL_SHIFT)    /* 01: Medium */
+#  define DMA_CCR_PRIHI           (2 << DMA_CCR_PL_SHIFT)    /* 10: High */
+#  define DMA_CCR_PRIVERYHI       (3 << DMA_CCR_PL_SHIFT)    /* 11: Very high */
+#define DMA_CCR_MEM2MEM           (1 << 14)                  /* Bit 14: Memory to memory mode */
 
 #define DMA_CCR_ALLINTS           (DMA_CCR_TEIE|DMA_CCR_HTIE|DMA_CCR_TCIE)
 

--- a/arch/arm/src/stm32/hardware/stm32_i2c.h
+++ b/arch/arm/src/stm32/hardware/stm32_i2c.h
@@ -36,6 +36,10 @@
 #ifndef __ARCH_ARM_SRC_STM32_HARDWARE_STM32_I2C_H
 #define __ARCH_ARM_SRC_STM32_HARDWARE_STM32_I2C_H
 
+/************************************************************************************
+ * Included Files
+ ************************************************************************************/
+
 /* There are 2 main types of I2C IP cores among STM32 chips:
  *   1. STM32 I2C IPv1 - F1, F2, F4 and L1
  *   2. STM32 I2C IPv2 - G0, L0, F0, F3, F7, H7 and L4

--- a/arch/arm/src/stm32/hardware/stm32_pinmap.h
+++ b/arch/arm/src/stm32/hardware/stm32_pinmap.h
@@ -74,8 +74,9 @@
 #    include "hardware/stm32f103c_pinmap.h"
 
 /* STM32 F103 High Density Family */
-/* STM32F103RC, STM32F103RD, and STM32F103RE are all provided in 64 pin packages and differ
- * only in the available FLASH and SRAM.
+
+/* STM32F103RC, STM32F103RD, and STM32F103RE are all provided in 64 pin
+ * packages and differ only in the available FLASH and SRAM.
  */
 
 #  elif defined(CONFIG_ARCH_CHIP_STM32F103RB) || \
@@ -85,15 +86,15 @@
         defined(CONFIG_ARCH_CHIP_STM32F103RG)
 #    include "hardware/stm32f103r_pinmap.h"
 
-/* STM32F103VC, STM32F103VD, and STM32F103VE are all provided in 100 pin packages and differ
- * only in the available FLASH and SRAM.
+/* STM32F103VC, STM32F103VD, and STM32F103VE are all provided in 100 pin
+ * packages and differ only in the available FLASH and SRAM.
  */
 
 #  elif defined(CONFIG_ARCH_CHIP_STM32F103VC) || defined(CONFIG_ARCH_CHIP_STM32F103VE)
 #    include "hardware/stm32f103v_pinmap.h"
 
-/* STM32F103ZC, STM32F103ZD, and STM32F103ZE are all provided in 144 pin packages and differ
- * only in the available FLASH and SRAM.
+/* STM32F103ZC, STM32F103ZD, and STM32F103ZE are all provided in 144 pin
+ * packages and differ only in the available FLASH and SRAM.
  */
 #  elif defined(CONFIG_ARCH_CHIP_STM32F103ZE)
 #    include "hardware/stm32f103z_pinmap.h"

--- a/arch/arm/src/stm32/stm32_dma.c
+++ b/arch/arm/src/stm32/stm32_dma.c
@@ -41,12 +41,8 @@
 
 #include "chip.h"
 
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/* This file is only a thin shell that includes the correct DMA implementation
- * for the selected STM32 IP core:
+/* This file is only a thin shell that includes the correct DMA
+ * implementation for the selected STM32 IP core:
  *   - STM32 DMA IP version 1 - F0, F1, F3, L0, L1, L4
  *   - STM32 DMA IP version 2 - F2, F4, F7, H7
  *
@@ -60,3 +56,7 @@
 #elif defined(CONFIG_STM32_HAVE_IP_DMA_V2)
 #  include "stm32_dma_v2.c"
 #endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/

--- a/arch/arm/src/stm32/stm32_dumpgpio.c
+++ b/arch/arm/src/stm32/stm32_dumpgpio.c
@@ -59,6 +59,7 @@
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
 /* Port letters for prettier debug output */
 
 static const char g_portchar[STM32_NGPIO_PORTS] =

--- a/arch/arm/src/stm32/stm32_gpio.h
+++ b/arch/arm/src/stm32/stm32_gpio.h
@@ -96,9 +96,9 @@
 #define GPIO_OUTPUT                   (0)                        /*         0=Output or alternate function */
 #define GPIO_ALT                      (0)
 
-/* If the pin is a GPIO digital output, then this identifies the initial output value.
- * If the pin is an input, this bit is overloaded to provide the qualifier to\
- * distinguish input pull-up and -down:
+/* If the pin is a GPIO digital output, then this identifies the initial
+ * output value.  If the pin is an input, this bit is overloaded to
+ * provide the qualifier to\ distinguish input pull-up and -down:
  *
  * 1111 1100 0000 0000
  * 5432 1098 7654 3210
@@ -124,7 +124,8 @@
 #  define GPIO_CNF_INFLOAT            (1 << GPIO_CNF_SHIFT)      /* Input floating */
 #  define GPIO_CNF_INPULLUD           (2 << GPIO_CNF_SHIFT)      /* Input pull-up/down general bit, since up is composed of two parts */
 #  define GPIO_CNF_INPULLDWN          (2 << GPIO_CNF_SHIFT)      /* Input pull-down */
-#  define GPIO_CNF_INPULLUP          ((2 << GPIO_CNF_SHIFT) | GPIO_OUTPUT_SET) /* Input pull-up */
+#  define GPIO_CNF_INPULLUP          ((2 << GPIO_CNF_SHIFT) \
+                                      | GPIO_OUTPUT_SET)         /* Input pull-up */
 
 #  define GPIO_CNF_OUTPP              (0 << GPIO_CNF_SHIFT)      /* Output push-pull */
 #  define GPIO_CNF_OUTOD              (1 << GPIO_CNF_SHIFT)      /* Output open-drain */
@@ -205,8 +206,8 @@
       defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX) || \
       defined(CONFIG_STM32_STM32F37XX) || defined(CONFIG_STM32_STM32F4XXX)
 
-/* Each port bit of the general-purpose I/O (GPIO) ports can be individually configured
- * by software in several modes:
+/* Each port bit of the general-purpose I/O (GPIO) ports can be
+ * individually configured by software in several modes:
  *
  *  - Input floating
  *  - Input pull-up
@@ -318,9 +319,9 @@
 #define GPIO_OPENDRAIN                (1 << 9)                   /* Bit9: 1=Open-drain output */
 #define GPIO_PUSHPULL                 (0)                        /* Bit9: 0=Push-pull output */
 
-/* If the pin is a GPIO digital output, then this identifies the initial output value.
- * If the pin is an input, this bit is overloaded to provide the qualifier to
- * distinguish input pull-up and -down:
+/* If the pin is a GPIO digital output, then this identifies the initial
+ * output value.  If the pin is an input, this bit is overloaded to
+ * provide the qualifier to distinguish input pull-up and -down:
  *
  * 1111 1111 1100 0000 0000
  * 9876 5432 1098 7654 3210


### PR DESCRIPTION
## Summary

arch/arm/include/stm32/irq.h:
arch/arm/src/stm32/hardware/stm32_dma_v1.h:
arch/arm/src/stm32/hardware/stm32_i2c.h:
arch/arm/src/stm32/hardware/stm32_pinmap.h:
arch/arm/src/stm32/stm32_dma.c:
arch/arm/src/stm32/stm32_dumpgpio.c:
arch/arm/src/stm32/stm32_gpio.h:

    * nxstyle fixes, mostly long lines

## Impact

No functional changes. Silences numerous nxstyle errors.

## Testing

Changes pass nxstyle.
