### PR TITLE
stm32: nxstyle fixes

### DIFF
--- a/arch/arm/src/stm32/stm32_gpio.c
+++ b/arch/arm/src/stm32/stm32_gpio.c
@@ -341,8 +341,8 @@ int stm32_configgpio(uint32_t cfgset)
 
   if (!input)
     {
-      /* It is an output or an alternate function.  We have to look at the CNF
-       * bits to know which.
+      /* It is an output or an alternate function.  We have to look at
+       * the CNF bits to know which.
        */
 
       unsigned int cnf = (cfgset & GPIO_CNF_MASK);
@@ -410,7 +410,8 @@ int stm32_configgpio(uint32_t cfgset)
 #endif
 
 /****************************************************************************
- * Name: stm32_configgpio (for the STM32L15xxx, STM32F20xxx and STM32F40xxx family)
+ * Name: stm32_configgpio (for the STM32L15xxx, STM32F20xxx and STM32F40xxx
+ * family)
  ****************************************************************************/
 
 #if defined(CONFIG_STM32_STM32L15XX) || defined(CONFIG_STM32_STM32F20XX) || \
@@ -456,7 +457,10 @@ int stm32_configgpio(uint32_t cfgset)
         break;
 
       case GPIO_OUTPUT:     /* General purpose output mode */
-        stm32_gpiowrite(cfgset, (cfgset & GPIO_OUTPUT_SET) != 0); /* Set the initial output value */
+
+        /* Set the initial output value */
+
+        stm32_gpiowrite(cfgset, (cfgset & GPIO_OUTPUT_SET) != 0);
         pinmode = GPIO_MODER_OUTPUT;
         break;
 
@@ -608,18 +612,22 @@ int stm32_configgpio(uint32_t cfgset)
 
   putreg32(regval, base + STM32_GPIO_OTYPER_OFFSET);
 
-  /* Otherwise, it is an input pin.  Should it configured as an EXTI interrupt? */
+  /* Otherwise, it is an input pin.  Should it configured as an EXTI
+   * interrupt?
+   */
 
   if (pinmode != GPIO_MODER_OUTPUT && (cfgset & GPIO_EXTI) != 0)
     {
-      /* "In STM32 F1 the selection of the EXTI line source is performed through
-       *  the EXTIx bits in the AFIO_EXTICRx registers, while in F2 series this
-       *  selection is done through the EXTIx bits in the SYSCFG_EXTICRx registers.
+      /* "In STM32 F1 the selection of the EXTI line source is performed
+       *  through the EXTIx bits in the AFIO_EXTICRx registers, while in F2
+       *  series this selection is done through the EXTIx bits in the
+       *  SYSCFG_EXTICRx registers.
        *
-       * "Only the mapping of the EXTICRx registers has been changed, without any
-       *  changes to the meaning of the EXTIx bits. However, the range of EXTI
-       *  bits values has been extended to 0b1000 to support the two ports added
-       *  in F2, port H and I (in F1 series the maximum value is 0b0110)."
+       * "Only the mapping of the EXTICRx registers has been changed,
+       *  without any changes to the meaning of the EXTIx bits. However,
+       *  the range of EXTI bits values has been extended to 0b1000 to
+       *  support the two ports added in F2, port H and I (in F1 series
+       *  the maximum value is 0b0110)."
        */
 
       uint32_t regaddr;
@@ -645,14 +653,15 @@ int stm32_configgpio(uint32_t cfgset)
  * Name: stm32_unconfiggpio
  *
  * Description:
- *   Unconfigure a GPIO pin based on bit-encoded description of the pin, set it
- *   into default HiZ state (and possibly mark it's unused) and unlock it whether
- *   it was previsouly selected as alternative function (GPIO_ALT|GPIO_CNF_AFPP|...).
+ *   Unconfigure a GPIO pin based on bit-encoded description of the pin, set
+ *   it into default HiZ state (and possibly mark it's unused) and unlock it
+ *   whether it was previously selected as alternative function
+ *   (GPIO_ALT|GPIO_CNF_AFPP|...).
  *
- *   This is a safety function and prevents hardware from schocks, as unexpected
- *   write to the Timer Channel Output GPIO to fixed '1' or '0' while it should
- *   operate in PWM mode could produce excessive on-board currents and trigger
- *   over-current/alarm function.
+ *   This is a safety function and prevents hardware from schocks, as
+ *   unexpected write to the Timer Channel Output GPIO to fixed '1' or '0'
+ *   while it should operate in PWM mode could produce excessive on-board
+ *   currents and trigger over-current/alarm function.
  *
  * Returned Value:
  *  OK on success
@@ -788,10 +797,11 @@ bool stm32_gpioread(uint32_t pinset)
  *   By default the I/O compensation cell is not used. However when the I/O
  *   output buffer speed is configured in 50 MHz or 100 MHz mode, it is
  *   recommended to use the compensation cell for slew rate control on I/O
- *   tf(IO)out)/tr(IO)out commutation to reduce the I/O noise on power supply.
+ *   tf(IO)out)/tr(IO)out commutation to reduce the I/O noise on power
+ *   supply.
  *
- *   The I/O compensation cell can be used only when the supply voltage ranges
- *   from 2.4 to 3.6 V.
+ *   The I/O compensation cell can be used only when the supply voltage
+ *   ranges from 2.4 to 3.6 V.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/stm32/stm32_rcc.c
+++ b/arch/arm/src/stm32/stm32_rcc.c
@@ -70,7 +70,7 @@
 #define HSERDY_TIMEOUT (100 * CONFIG_BOARD_LOOPSPERMSEC)
 
 /****************************************************************************
- * Private Functions
+ * Included Files
  ****************************************************************************/
 
 /* Include chip-specific clocking initialization logic */
@@ -93,6 +93,10 @@
 #  error "Unsupported STM32 chip"
 #endif
 
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
 #if defined(CONFIG_STM32_STM32L15XX)
 # define STM32_RCC_XXX       STM32_RCC_CSR
 # define RCC_XXX_YYYRST      RCC_CSR_RTCRST
@@ -110,9 +114,9 @@
  *
  * Description:
  *   The RTC needs to reset the Backup Domain to change RTCSEL and resetting
- *   the Backup Domain renders to disabling the LSE as consequence.   In order
- *   to avoid resetting the Backup Domain when we already configured LSE we
- *   will reset the Backup Domain early (here).
+ *   the Backup Domain renders to disabling the LSE as consequence.
+ *   In order to avoid resetting the Backup Domain when we already
+ *   configured LSE we will reset the Backup Domain early (here).
  *
  * Input Parameters:
  *   None
@@ -164,8 +168,8 @@ static inline void rcc_resetbkp(void)
  *   configuration file.
  *
  *   If CONFIG_ARCH_BOARD_STM32_CUSTOM_CLOCKCONFIG is defined, then clocking
- *   will be enabled by an externally provided, board-specific function called
- *   stm32_board_clockconfig().
+ *   will be enabled by an externally provided, board-specific function
+ *   called stm32_board_clockconfig().
  *
  * Input Parameters:
  *   None
@@ -193,7 +197,9 @@ void stm32_clockconfig(void)
 
 #else
 
-  /* Invoke standard, fixed clock configuration based on definitions in board.h */
+  /* Invoke standard, fixed clock configuration based on definitions
+   * in board.h
+   */
 
   stm32_stdclockconfig();
 
@@ -210,22 +216,22 @@ void stm32_clockconfig(void)
   rcc_enableperipherals();
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_clockenable
  *
  * Description:
- *   Re-enable the clock and restore the clock settings based on settings in board.h.
- *   This function is only available to support low-power modes of operation:  When
- *   re-awakening from deep-sleep modes, it is necessary to re-enable/re-start the
- *   PLL
+ *   Re-enable the clock and restore the clock settings based on settings
+ *   in board.h. This function is only available to support low-power
+ *   modes of operation:  When re-awakening from deep-sleep modes, it is
+ *   necessary to re-enable/re-start the PLL
  *
  *   This functional performs a subset of the operations performed by
- *   stm32_clockconfig():  It does not reset any devices, and it does not reset the
- *   currently enabled peripheral clocks.
+ *   stm32_clockconfig():  It does not reset any devices, and it does not
+ *   reset the currently enabled peripheral clocks.
  *
- *   If CONFIG_ARCH_BOARD_STM32_CUSTOM_CLOCKCONFIG is defined, then clocking will
- *   be enabled by an externally provided, board-specific function called
- *   stm32_board_clockconfig().
+ *   If CONFIG_ARCH_BOARD_STM32_CUSTOM_CLOCKCONFIG is defined, then clocking
+ *   will be enabled by an externally provided, board-specific function
+ *   called stm32_board_clockconfig().
  *
  * Input Parameters:
  *   None
@@ -233,7 +239,7 @@ void stm32_clockconfig(void)
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_PM
 void stm32_clockenable(void)
@@ -246,7 +252,9 @@ void stm32_clockenable(void)
 
 #else
 
-  /* Invoke standard, fixed clock configuration based on definitions in board.h */
+  /* Invoke standard, fixed clock configuration based on definitions
+   * in board.h
+   */
 
   stm32_stdclockconfig();
 

--- a/arch/arm/src/stm32/stm32_rcc.h
+++ b/arch/arm/src/stm32/stm32_rcc.h
@@ -103,8 +103,8 @@ extern uint32_t _vectors[];
  * Name: stm32_mco1config
  *
  * Description:
- *   Selects the clock source to output on MCO1 pin (PA8). PA8 should be configured in
- *   alternate function mode.
+ *   Selects the clock source to output on MCO1 pin (PA8). PA8 should be
+ *   configured in alternate function mode.
  *
  * Input Parameters:
  *   source - One of the definitions for the RCC_CFGR_MCO1 definitions from
@@ -125,7 +125,7 @@ static inline void stm32_mco1config(uint32_t source, uint32_t div)
   uint32_t regval;
 
   regval = getreg32(STM32_RCC_CFGR);
-  regval &= ~(RCC_CFGR_MCO1_MASK|RCC_CFGR_MCO1PRE_MASK);
+  regval &= ~(RCC_CFGR_MCO1_MASK | RCC_CFGR_MCO1PRE_MASK);
   regval |= (source | div);
   putreg32(regval, STM32_RCC_CFGR);
 }
@@ -204,8 +204,8 @@ static inline void stm32_mcodivconfig(uint32_t source, uint32_t divider)
  * Name: stm32_mco2config
  *
  * Description:
- *   Selects the clock source to output on MCO2 pin (PC9). PC9 should be configured in
- *   alternate function mode.
+ *   Selects the clock source to output on MCO2 pin (PC9). PC9 should be
+ *   configured in alternate function mode.
  *
  * Input Parameters:
  *   source - One of the definitions for the RCC_CFGR_MCO2 definitions from
@@ -226,7 +226,7 @@ static inline void stm32_mco2config(uint32_t source, uint32_t div)
   uint32_t regval;
 
   regval = getreg32(STM32_RCC_CFGR);
-  regval &= ~(RCC_CFGR_MCO2_MASK|RCC_CFGR_MCO2PRE_MASK);
+  regval &= ~(RCC_CFGR_MCO2_MASK | RCC_CFGR_MCO2PRE_MASK);
   regval |= (source | div);
   putreg32(regval, STM32_RCC_CFGR);
 }
@@ -317,23 +317,23 @@ void stm32_clockenable(void);
 
 void stm32_rcc_enablelse(void);
 
-/****************************************************************************
+/************************************************************************************
  * Name: stm32_rcc_enablelsi
  *
  * Description:
  *   Enable the Internal Low-Speed (LSI) RC Oscillator.
  *
- ****************************************************************************/
+ ************************************************************************************/
 
 void stm32_rcc_enablelsi(void);
 
-/****************************************************************************
+/************************************************************************************
  * Name: stm32_rcc_disablelsi
  *
  * Description:
  *   Disable the Internal Low-Speed (LSI) RC Oscillator.
  *
- ****************************************************************************/
+ ************************************************************************************/
 
 void stm32_rcc_disablelsi(void);
 


### PR DESCRIPTION
## Summary

arch/arm/src/stm32/stm32_gpio.c
arch/arm/src/stm32/stm32_rcc.c
arch/arm/src/stm32/stm32_rcc.h

    * nxstyle fixes, mostly long lines

## Impact

Removes numerous nxstyle errors.

## Testing

Passes nxstyle