### PR TITLE
drivers: wireless: Fix pkt_q_cnt overflow in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -188,7 +188,7 @@ struct gs2200m_dev_s
   struct work_s        irq_work;
   sem_t                dev_sem;
   dq_queue_t           pkt_q[16];
-  uint8_t              pkt_q_cnt[16];
+  uint16_t             pkt_q_cnt[16];
   uint16_t             valid_cid_bits;
   uint16_t             aip_cid_bits;
   uint8_t              tx_buff[MAX_PKT_LEN];


### PR DESCRIPTION
## Summary

- I noticed that pkt_q_cnt overflows during http audio streaming.
- This PR fixes pkt_q_cnt overflow in gs2200m.c

## Impact

- This PR affects gs2200m wifi driver only.

## Testing

- I tested this PR with spresense:wifi and run nxplayer for http audio streaming.
