### PR TITLE
Makefile: Set the default goal to a target that prints what's going on.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,9 @@
 #
 
 ifeq ($(wildcard .config),)
-.DEFAULT:
+.DEFAULT default:
 	@echo "Nuttx has not been configured:"
 	@echo "  tools/configure.sh <target>"
-
-clean distclean:
-	@:
 else
 include .config
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)


### PR DESCRIPTION
## Summary
When make is invoked with no specific target it defaults to the "clean distclean" target that prints nothing.
With this PR:
`.DEFAULT` will be used when make is invoked with any target (as all don't exist when .config is not present)
`default` is a dummy target that acts as the default goal when make is invoked with no specific target.
## Impact

## Testing

