### PR TITLE
build: incdir.sh shouldn't check whether the path exist

### DIFF
--- a/tools/incdir.bat
+++ b/tools/incdir.bat
@@ -98,11 +98,6 @@ if "%1" == "" (
   goto :End
 )
 
-if not exist %1 (
-  echo ERROR: Path %1 does not exist
-  goto :Usage
-)
-
 if "%fmt%"=="zds" goto :GenerateZdsPath
 if "%response%"=="" goto :FirstStdPath
 if "%pathtype%"=="system" goto :NextStdSystemPath

--- a/tools/incdir.sh
+++ b/tools/incdir.sh
@@ -191,14 +191,6 @@ fi
 unset response
 for dir in $dirlist; do
 
-  # Verify that the include directory exists
-
-  if [ ! -d $dir ]; then
-    echo "Include path '$dir' does not exist"
-    echo $showusage
-    exit 1
-  fi
-
   # Check if the path needs to be extended for Windows-based tools under Cygwin
   # windows=yes:  We are building for a windows platform
   # wintool=y:    The platform is Cygwin and we are using a windows native tool


### PR DESCRIPTION
since compiler never complain that the path(by -I) doesn't exist

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

## Summary

## Impact

## Testing

