### PR TITLE
sched/task: add use stack support for kernel thread 

### DIFF
--- a/include/nuttx/kthread.h
+++ b/include/nuttx/kthread.h
@@ -89,7 +89,7 @@ extern "C"
  * Input Parameters:
  *   name       - Name of the new task
  *   priority   - Priority of the new task
- *   stack_size - size (in bytes) of the stack needed
+ *   stack_size - Size (in bytes) of the stack needed
  *   entry      - Entry point of a new task
  *   arg        - A pointer to an array of input parameters.  The array
  *                should be terminated with a NULL argv[] value. If no
@@ -116,7 +116,7 @@ int nxtask_create(FAR const char *name, int priority,
  * Input Parameters:
  *   name       - Name of the new task
  *   priority   - Priority of the new task
- *   stack_size - size (in bytes) of the stack needed
+ *   stack_size - Size (in bytes) of the stack needed
  *   entry      - Entry point of a new task
  *   arg        - A pointer to an array of input parameters.  The array
  *                should be terminated with a NULL argv[] value. If no
@@ -131,6 +131,33 @@ int nxtask_create(FAR const char *name, int priority,
 
 int kthread_create(FAR const char *name, int priority, int stack_size,
                    main_t entry, FAR char * const argv[]);
+
+/********************************************************************************
+ * Name: kthread_create2
+ *
+ * Description:
+ *   An extended version of kthread_create(), use a reserved stack area for
+ *   kernel thread.
+ *
+ * Input Parameters:
+ *   name       - Name of the new task
+ *   priority   - Priority of the new task
+ *   stack      - Pointer to the stack space.
+ *   stack_size - Size (in bytes) of the stack needed
+ *   entry      - Entry point of a new task
+ *   arg        - A pointer to an array of input parameters.  The array
+ *                should be terminated with a NULL argv[] value. If no
+ *                parameters are required, argv may be NULL.
+ *
+ * Returned Value:
+ *   Returns the positive, non-zero process ID of the new task or a negated
+ *   errno value to indicate the nature of any failure.  If memory is
+ *   insufficient or the task cannot be created -ENOMEM will be returned.
+ *
+ ********************************************************************************/
+
+int kthread_create2(FAR const char *name, int priority, FAR void *stack,
+                    int stack_size, main_t entry, FAR char *const argv[]);
 
 /****************************************************************************
  * Name: kthread_delete

--- a/include/nuttx/kthread.h
+++ b/include/nuttx/kthread.h
@@ -105,13 +105,13 @@ extern "C"
 int nxtask_create(FAR const char *name, int priority,
                   int stack_size, main_t entry, FAR char * const argv[]);
 
-/********************************************************************************
+/****************************************************************************
  * Name: kthread_create
  *
  * Description:
- *   This function creates and activates a kernel thread task with kernel-mode
- *   privileges.  It is identical to task_create() except that it configures the
- *   newly started thread to run in kernel model.
+ *   This function creates and activates a kernel thread task with
+ *   kernel-mode privileges.  It is identical to task_create() except that
+ *   it configures the newly started thread to run in kernel model.
  *
  * Input Parameters:
  *   name       - Name of the new task
@@ -127,12 +127,12 @@ int nxtask_create(FAR const char *name, int priority,
  *   errno value to indicate the nature of any failure.  If memory is
  *   insufficient or the task cannot be created -ENOMEM will be returned.
  *
- ********************************************************************************/
+ ****************************************************************************/
 
 int kthread_create(FAR const char *name, int priority, int stack_size,
                    main_t entry, FAR char * const argv[]);
 
-/********************************************************************************
+/****************************************************************************
  * Name: kthread_create2
  *
  * Description:
@@ -154,7 +154,7 @@ int kthread_create(FAR const char *name, int priority, int stack_size,
  *   errno value to indicate the nature of any failure.  If memory is
  *   insufficient or the task cannot be created -ENOMEM will be returned.
  *
- ********************************************************************************/
+ ****************************************************************************/
 
 int kthread_create2(FAR const char *name, int priority, FAR void *stack,
                     int stack_size, main_t entry, FAR char *const argv[]);


### PR DESCRIPTION
## Summary
sched/task: add use stack support for kernel thread 

An extended version of kthread_create(), use a reserved stack area for kernel thread.

