### PR TITLE
drivers: wireless: Add WPA2-PSK in AP mode for gs2200m

### DIFF
--- a/boards/arm/cxd56xx/spresense/README.txt
+++ b/boards/arm/cxd56xx/spresense/README.txt
@@ -95,8 +95,12 @@ Configuration sub-directories
     (2) Access Point (AP) mode
 
     To run the module in AP mode, you need to specify SSID to advertise and
-    WEP-key. (NOTE: in AP mode, you can also specify channel number to use)
+    WPA2-PSK passphrase or WEP-key. (NOTE: in AP mode, you can also specify
+    channel number to use. Also, you need to set CONFIG_WL_GS2200M_ENABLE_WEP=y
+    if you want to use WEP instead of WPA2-PSK)
 
+      nsh> gs2200m -a ssid-to-advertise 8-to-63-wpa2-psk-passphrase &
+      or
       nsh> gs2200m -a ssid-to-advertise 10-hex-digits-wep-key &
 
     If the module was initialized in AP mode, you can see a new IP address is
@@ -106,5 +110,5 @@ Configuration sub-directories
       eth0    Link encap:Ethernet HWaddr 3c:95:09:00:69:93 at UP
       inet    addr:192.168.11.1 DRaddr:192.168.11.1 Mask:255.255.255.0
 
-    Now you can connect your PC to the AP with the above SSID and WEP-key
-    which you specified.
+    Now you can connect your PC to the AP with the above SSID and WPA2-PSK
+    passphrase or WEP-key which you specified.

--- a/drivers/wireless/Kconfig
+++ b/drivers/wireless/Kconfig
@@ -37,6 +37,10 @@ config WL_GS2200M
 
 if WL_GS2200M
 
+config WL_GS2200M_ENABLE_WEP
+	bool "WEP support in AP mode"
+	default false
+
 config WL_GS2200M_SPI_FREQUENCY
 	int "SPI frequency for GS2200M"
 	default 4000000


### PR DESCRIPTION
## Summary

- This PR adds WPA2-PSK support in AP mode for gs2200m
- NOTE: By default, WPA2-PSK is used instead of WEP.
- Also updated README.txt

## Impact

- This PR affects gs2200m driver in AP mode.

## Testing

- I tested this PR with spresense:wifi and run gs2200m in AP mode.
- Then I connected my MacBook Pro to the gs2200m.
