### PR TITLE
build: parallel clean and distclean subdir build

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -430,3 +430,16 @@ define TESTANDREPLACEFILE
 	fi
 endef
 endif
+
+# Invoke make
+
+define MAKE_template
+	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"
+
+endef
+
+define SDIR_template
+$(1)_$(2):
+	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"
+
+endef

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -85,7 +85,7 @@ COMMON_DIR = $(if $(wildcard $(BOARD_DIR)/common/Makefile),y,)
 ifeq ($(CONFIG_APPS_DIR),)
 CONFIG_APPS_DIR = ../apps
 endif
-APPDIR := ${shell if [ -r $(CONFIG_APPS_DIR)/Makefile ]; then echo "$(CONFIG_APPS_DIR)"; fi}
+APPDIR := $(realpath ${shell if [ -r $(CONFIG_APPS_DIR)/Makefile ]; then echo "$(CONFIG_APPS_DIR)"; fi})
 
 # CONTEXTDIRS include directories that have special, one-time pre-build
 #   requirements.  Normally this includes things like auto-generation of
@@ -544,12 +544,9 @@ export: $(NUTTXLIBS)
 
 depend: pass1dep pass2dep
 
-subdir_clean:
-	$(Q) for dir in $(CLEANDIRS) ; do \
-		if [ -e $$dir/Makefile ]; then \
-			$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" clean ; \
-		fi \
-	done
+$(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
+
+subdir_clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
 	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" clean
@@ -567,12 +564,9 @@ clean: subdir_clean
 	$(call DELFILE, uImage)
 	$(call CLEAN)
 
-subdir_distclean:
-	$(Q) for dir in $(CLEANDIRS) ; do \
-		if [ -e $$dir/Makefile ]; then \
-			$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" distclean ; \
-		fi \
-	done
+$(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
+
+subdir_distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
 
 distclean: clean subdir_distclean clean_context
 ifeq ($(CONFIG_BUILD_2PASS),y)
@@ -611,15 +605,15 @@ endif
 
 apps_preconfig:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(TOPDIR)/$(APPDIR)" TOPDIR="$(TOPDIR)" preconfig
+	$(Q) $(MAKE) -C $(APPDIR) TOPDIR="$(TOPDIR)" preconfig
 endif
 
 apps_clean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(TOPDIR)/$(APPDIR)" TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C $(APPDIR) TOPDIR="$(TOPDIR)" clean
 endif
 
 apps_distclean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(TOPDIR)/$(APPDIR)" TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C $(APPDIR) TOPDIR="$(TOPDIR)" distclean
 endif

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -73,7 +73,7 @@ COMMON_DIR = $(if $(wildcard $(BOARD_DIR)$(DELIM)common$(DELIM)Makefile),y,)
 ifeq ($(CONFIG_APPS_DIR),)
 CONFIG_APPS_DIR = ..\apps
 endif
-APPDIR := ${shell if exist "$(CONFIG_APPS_DIR)\Makefile" echo $(CONFIG_APPS_DIR)}
+APPDIR := $(realpath ${shell if exist "$(CONFIG_APPS_DIR)\Makefile" echo $(CONFIG_APPS_DIR)})
 
 # CONTEXTDIRS include directories that have special, one-time pre-build
 #   requirements.  Normally this includes things like auto-generation of
@@ -497,8 +497,9 @@ export: ${NUTTXLIBS}
 
 depend: pass1dep pass2dep
 
-subdir_clean:
-	$(Q) for %%G in ($(CLEANDIRS)) do ( if exist %%G\Makefile $(MAKE) -C %%G TOPDIR="$(TOPDIR)" clean )
+$(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
+
+subdir_clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
 	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" clean
@@ -516,8 +517,9 @@ clean: subdir_clean
 	$(call DELFILE, uImage)
 	$(call CLEAN)
 
-subdir_distclean:
-	$(Q) for %%G in ($(CLEANDIRS)) do ( if exist %%G\Makefile $(MAKE) -C %%G TOPDIR="$(TOPDIR)" distclean )
+$(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
+
+subdir_distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
 
 distclean: clean subdir_distclean clean_context
 ifeq ($(CONFIG_BUILD_2PASS),y)


### PR DESCRIPTION

## Summary
Parallel clean and distclean subdir in nuttx could save more build time. Meanwhile,
use absolute path for APPDIR which could be used by apps clean and distclean
subdir build. 

## Impact


## Testing

