### PR TITLE
fs/vfs/fd_open.c:  fs_fdopen() must not set errno

### DIFF
--- a/fs/vfs/fs_fdopen.c
+++ b/fs/vfs/fs_fdopen.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * fs/vfs/fs_fdopen.c
  *
- *   Copyright (C) 2007-2014, 2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -124,11 +109,11 @@ static inline int fs_checkfd(FAR struct tcb_s *tcb, int fd, int oflags)
  *
  ****************************************************************************/
 
-FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb)
+int fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb,
+              FAR struct file_struct **filep)
 {
   FAR struct streamlist *slist;
   FAR FILE              *stream;
-  int                    errcode = OK;
   int                    ret;
   int                    i;
 
@@ -136,7 +121,7 @@ FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb)
 
   if (fd < 0)
     {
-      errcode = EBADF;
+      ret = -EBADF;
       goto errout;
     }
 
@@ -170,7 +155,7 @@ FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb)
 #else
       /* No networking... it is just a bad descriptor */
 
-      errcode = EBADF;
+      ret = -EBADF;
       goto errout;
 #endif
     }
@@ -190,7 +175,6 @@ FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb)
     {
       /* No... return the reported error */
 
-      errcode = -ret;
       goto errout;
     }
 
@@ -207,7 +191,6 @@ FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb)
   ret = nxsem_wait(&slist->sl_sem);
   if (ret < 0)
     {
-      errcode = -ret;
       goto errout;
     }
 
@@ -235,7 +218,7 @@ FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb)
 
           if (!stream->fs_bufstart)
             {
-              errcode = ENOMEM;
+              ret = -ENOMEM;
               goto errout_with_sem;
             }
 
@@ -262,13 +245,18 @@ FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb)
           stream->fs_oflags  = (uint16_t)oflags;
 
           nxsem_post(&slist->sl_sem);
-          return stream;
+          if (filep != NULL)
+            {
+              *filep = stream;
+            }
+
+          return OK;
         }
     }
 
   /* No free stream available.. report ENFILE */
 
-  errcode = ENFILE;
+  ret = -ENFILE;
 
 #if !defined(CONFIG_STDIO_DISABLE_BUFFERING) && CONFIG_STDIO_BUFFER_SIZE > 0
 errout_with_sem:
@@ -276,6 +264,10 @@ errout_with_sem:
   nxsem_post(&slist->sl_sem);
 
 errout:
-  set_errno(errcode);
-  return NULL;
+  if (filep != NULL)
+    {
+      *filep = NULL;
+    }
+
+  return ret;
 }

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1031,7 +1031,8 @@ int close_blockdriver(FAR struct inode *inode);
 
 #if CONFIG_NFILE_STREAMS > 0
 struct tcb_s; /* Forward reference */
-FAR struct file_struct *fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb);
+int fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb,
+              FAR struct file_struct **filep);
 #endif
 
 /****************************************************************************

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -255,7 +255,7 @@ SYSCALL_LOOKUP(telldir,                    1)
 #endif
 
 #if CONFIG_NFILE_STREAMS > 0
-  SYSCALL_LOOKUP(fs_fdopen,                3)
+  SYSCALL_LOOKUP(fs_fdopen,                4)
   SYSCALL_LOOKUP(nxsched_get_streams,      0)
 #endif
 

--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * libs/libc/stdio/lib_fopen.c
  *
- *   Copyright (C) 2007-2012 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -78,18 +63,23 @@
 
 FAR FILE *fdopen(int fd, FAR const char *mode)
 {
-  FAR FILE *ret = NULL;
+  FAR FILE *filep = NULL;
   int oflags;
+  int ret;
 
   /* Map the open mode string to open flags */
 
   oflags = lib_mode2oflags(mode);
   if (oflags >= 0)
     {
-      ret = fs_fdopen(fd, oflags, NULL);
+      ret = fs_fdopen(fd, oflags, NULL, &filep);
+      if (ret < 0)
+        {
+          _NX_SETERRNO(ret);
+        }
     }
 
-  return ret;
+  return filep;
 }
 
 /****************************************************************************
@@ -98,9 +88,10 @@ FAR FILE *fdopen(int fd, FAR const char *mode)
 
 FAR FILE *fopen(FAR const char *path, FAR const char *mode)
 {
-  FAR FILE *ret = NULL;
+  FAR FILE *filep = NULL;
   int oflags;
   int fd;
+  int ret;
 
   /* Map the open mode string to open flags */
 
@@ -121,18 +112,21 @@ FAR FILE *fopen(FAR const char *path, FAR const char *mode)
 
   if (fd >= 0)
     {
-      ret = fs_fdopen(fd, oflags, NULL);
-      if (!ret)
+      ret = fs_fdopen(fd, oflags, NULL, &filep);
+      if (ret < 0)
         {
           /* Don't forget to close the file descriptor if any other
            * failures are reported by fdopen().
            */
 
           close(fd);
+
+          _NX_SETERRNO(ret);
+          filep = NULL;
         }
     }
 
-  return ret;
+  return filep;
 }
 
 /****************************************************************************
@@ -229,7 +223,9 @@ int lib_mode2oflags(FAR const char *mode)
 
                     oflags &= (O_BINARY | O_EXCL);
 
-                    /* Open for write read/access, truncating any existing file */
+                    /* Open for write read/access, truncating any existing
+                     * file.
+                     */
 
                     oflags |= (O_RDWR | O_CREAT | O_TRUNC);
                     state  |= MODE_PLUS;
@@ -242,7 +238,9 @@ int lib_mode2oflags(FAR const char *mode)
 
                     oflags &= (O_BINARY | O_EXCL);
 
-                    /* Read from the beginning of the file; write to the end */
+                    /* Read from the beginning of the file; write to the
+                     * end,
+                     */
 
                     oflags |= (O_RDWR | O_CREAT | O_APPEND);
                     state  |= MODE_PLUS;

--- a/net/socket/net_checksd.c
+++ b/net/socket/net_checksd.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * net/socket/net_checksd.c
  *
- *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -57,9 +42,9 @@
  * Description:
  *   Check if the socket descriptor is valid for the provided TCB and if it
  *   supports the requested access.  This trivial operation is part of the
- *   fdopen() operation when the fdopen() is performed on a socket descriptor.
- *   It simply performs some sanity checking before permitting the socket
- *   descriptor to be wrapped as a C FILE stream.
+ *   fdopen() operation when the fdopen() is performed on a socket
+ *   descriptor.  It simply performs some sanity checking before permitting
+ *   the socket descriptor to be wrapped as a C FILE stream.
  *
  ****************************************************************************/
 

--- a/sched/group/group_setupstreams.c
+++ b/sched/group/group_setupstreams.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/group/group_setupstreams.c
  *
- *   Copyright (C) 2007-2008, 2010-2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -83,9 +68,9 @@ int group_setupstreams(FAR struct task_tcb_s *tcb)
    * fd = 2 is stderr (write-only, append)
    */
 
-  fs_fdopen(0, O_RDONLY,         (FAR struct tcb_s *)tcb);
-  fs_fdopen(1, O_WROK | O_CREAT, (FAR struct tcb_s *)tcb);
-  fs_fdopen(2, O_WROK | O_CREAT, (FAR struct tcb_s *)tcb);
+  fs_fdopen(0, O_RDONLY,         (FAR struct tcb_s *)tcb, NULL);
+  fs_fdopen(1, O_WROK | O_CREAT, (FAR struct tcb_s *)tcb, NULL);
+  fs_fdopen(2, O_WROK | O_CREAT, (FAR struct tcb_s *)tcb, NULL);
 
   return OK;
 }

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -23,7 +23,7 @@
 "execv","unistd.h","!defined(CONFIG_BINFMT_DISABLE) && defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char * const []|FAR char * const *"
 "exit","stdlib.h","","void","int"
 "fcntl","fcntl.h","","int","int","int","...","int"
-"fs_fdopen","nuttx/fs/fs.h","CONFIG_NFILE_STREAMS > 0","FAR struct file_struct *","int","int","FAR struct tcb_s *"
+"fs_fdopen","nuttx/fs/fs.h","CONFIG_NFILE_STREAMS > 0","int","int","int","FAR struct tcb_s *","FAR struct file_struct **"
 "fstat","sys/stat.h","","int","int","FAR struct stat *"
 "fstatfs","sys/statfs.h","","int","int","FAR struct statfs *"
 "fsync","unistd.h","!defined(CONFIG_DISABLE_MOUNTPOINT)","int","int"


### PR DESCRIPTION
## Summary

Functions within the OS must never set the errno value.  fs_fdopen() was setting the errno value.  Now, after some parameter changes, it reports errors via a negated errno integer return value as do most all other internal OS functions.

## Impact

The per-thread errno will not be set by fs_fdopen.  This should correct the error noted in the dev list:  nx_start() logic calls group_setup_idlestreams() which, in turn, call fs_fdopen().  If fs_fdopen() fails it would set the errno value (first bug) and, if the the idle thread stack parameters are not initialized, it could also cause a NULL pointer derefence crash.

## Testing

sim:nsh


