### PR TITLE
stm32h7:stm32h7x3xx_rcc Select FDCAN clock source

### DIFF
--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -917,6 +917,15 @@ static void stm32_stdclockconfig(void)
       putreg32(regval, STM32_RCC_D3CCIPR);
 #endif
 
+      /* Configure FDCAN source clock */
+
+#if defined(STM32_RCC_D2CCIP1R_FDCANSEL)
+      regval = getreg32(STM32_RCC_D2CCIP1R);
+      regval &= ~RCC_D2CCIP1R_FDCANSEL_MASK;
+      regval |= STM32_RCC_D2CCIP1R_FDCANSEL;
+      putreg32(regval, STM32_RCC_D2CCIP1R);
+#endif
+
 #if defined(CONFIG_STM32H7_IWDG) || defined(CONFIG_STM32H7_RTC_LSICLOCK)
       /* Low speed internal clock source LSI */
 


### PR DESCRIPTION
## Summary
Make use of FDCANSEL (if defined) to configure FDCAN's clock source

## Testing
Tested with PX4's UAVCAN stm32h7 driver on an Orange Cube (stm32h743)

For additional context see: https://github.com/PX4/Firmware/pull/14967
