### PR TITLE
arch/sim: Fix hostfs.h No such file or directory in makedep

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -38,6 +38,7 @@ include $(TOPDIR)/Make.defs
 
 ARCH_SRCDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src
 
+INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)}
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)chip}
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)sched}
 


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

## Summary
regression by commit:
https://github.com/apache/incubator-nuttx/commit/7e5b0f81e93c7e879ce8434d57e8bf4e2319c1c0

## Impact

## Testing

