### PR TITLE
fs/vfs/fs_stat.c: fill file size for block inode

### DIFF
--- a/fs/vfs/fs_stat.c
+++ b/fs/vfs/fs_stat.c
@@ -389,7 +389,8 @@ int inode_stat(FAR struct inode *inode, FAR struct stat *buf)
           if ((inode->u.i_bops != NULL) && (inode->u.i_bops->geometry))
             {
               struct geometry geo;
-              if (inode->u.i_bops->geometry(inode, &geo) >= 0 && geo.geo_available)
+              if (inode->u.i_bops->geometry(inode, &geo) >= 0 &&
+                  geo.geo_available)
                 {
                   buf->st_size = geo.geo_nsectors * geo.geo_sectorsize;
                 }

--- a/fs/vfs/fs_stat.c
+++ b/fs/vfs/fs_stat.c
@@ -384,6 +384,17 @@ int inode_stat(FAR struct inode *inode, FAR struct stat *buf)
           /* What is if also has child inodes? */
 
           buf->st_mode |= S_IFBLK;
+
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+          if ((inode->u.i_bops != NULL) && (inode->u.i_bops->geometry))
+            {
+              struct geometry geo;
+              if (inode->u.i_bops->geometry(inode, &geo) >= 0 && geo.geo_available)
+                {
+                  buf->st_size = geo.geo_nsectors * geo.geo_sectorsize;
+                }
+            }
+#endif
         }
       else /* if (INODE_IS_DRIVER(inode)) */
         {


### PR DESCRIPTION
## Summary
Now when stat() is calling for block device it also set size of file as number of bytes of all sectors related to this block device.
