### PR TITLE
arch: x86: Set the idle task stack to prevent get/set errno on idle task resulting NULL reference

### DIFF
--- a/arch/x86_64/src/common/up_initialize.c
+++ b/arch/x86_64/src/common/up_initialize.c
@@ -43,6 +43,7 @@
 
 #include <arch/board/board.h>
 
+#include "sched/sched.h"
 #include "up_arch.h"
 #include "up_internal.h"
 
@@ -100,6 +101,12 @@ static void up_calibratedelay(void)
 
 void up_initialize(void)
 {
+  struct tcb_s *rtcb = this_task();
+
+  rtcb->adj_stack_size = CONFIG_IDLETHREAD_STACKSIZE;
+  rtcb->stack_alloc_ptr =
+    (void *)(g_idle_topstack - CONFIG_IDLETHREAD_STACKSIZE);
+
   /* Initialize global variables */
 
   g_current_regs = NULL;
@@ -119,8 +126,8 @@ void up_initialize(void)
 #endif
 
 #ifdef CONFIG_ARCH_DMA
-  /* Initialize the DMA subsystem if the weak function up_dma_initialize has been
-   * brought into the build
+  /* Initialize the DMA subsystem if the weak function up_dma_initialize
+   * has been brought into the build
    */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS


### PR DESCRIPTION
## Summary

In response to the recent TLS implementation.

Architecture should set the idle task task attributes in the TCB, otherwise get/set errno on idle task will crash.

This patch sets the x86_64 idle task TCB's stack attributes in up_initialize().

## Impact

Application should stop crashing, e.g. on sigdeliver(), where get/set errno is called with idle task.

## Testing

Standard ostest.