### PR TITLE
b-g474e-dpow1: Apply recent build script changes

### DIFF
--- a/boards/arm/stm32/b-g474e-dpow1/scripts/Make.defs
+++ b/boards/arm/stm32/b-g474e-dpow1/scripts/Make.defs
@@ -22,16 +22,16 @@ include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include $(TOPDIR)/arch/arm/src/armv7-m/Toolchain.defs
 
+ARCHINCLUDES += ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include}
+ARCHXXINCLUDES += ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include}
+ARCHXXINCLUDES += ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include$(DELIM)cxx}
+
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   # Windows-native toolchains
-  ARCHINCLUDES = -I. -isystem "${shell cygpath -w $(TOPDIR)/include}"
-  ARCHXXINCLUDES = -I. -isystem "${shell cygpath -w $(TOPDIR)/include}" -isystem "${shell cygpath -w $(TOPDIR)/include/cxx}"
-  ARCHSCRIPT = -T "${shell cygpath -w $(TOPDIR)/boards/$(CONFIG_ARCH)/$(CONFIG_ARCH_CHIP)/$(CONFIG_ARCH_BOARD)/scripts/ld.script}"
+  ARCHSCRIPT = -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)ld.script}"
 else
   # Linux/Cygwin-native toolchain
-  ARCHINCLUDES = -I. -isystem $(TOPDIR)/include
-  ARCHXXINCLUDES = -I. -isystem $(TOPDIR)/include -isystem $(TOPDIR)/include/cxx
-  ARCHSCRIPT = -T$(TOPDIR)/boards/$(CONFIG_ARCH)/$(CONFIG_ARCH_CHIP)/$(CONFIG_ARCH_BOARD)/scripts/ld.script
+  ARCHSCRIPT = -T$(BOARD_DIR)$(DELIM)scripts$(DELIM)ld.script
 endif
 
 CC = $(CROSSDEV)gcc


### PR DESCRIPTION
boards/arm/stm32/b-g474e-dpow1/scripts/Make.defs:

    * Apply the recent build script changes introduced in the
      following git commits:
      - 7e5b0f81e93c7e879ce8434d57e8bf4e2319c1c0 and
      - e83c1400b65c65cbdf59c5abcf2ae368f540faef
      to this board. Namely, factor the definitions of ARCHINCLUDES
      and ARCHXXINCLUDES out of CONFIG_CYGWIN_WINTOOL conditional,
      and use new build variable BOARD_DIR to simplify ARCHSCRIPT.

## Summary

Recent changes to the build scripts were made to many boards. However, this board was left out of those changes. This PR applies similar changes to this board.

## Impact

Simplifies build for this board to match changes recently introduced for many other boards.

## Testing

Build testing on b-g474e-dpow1:nsh configuration, which is the only configuration potentially affected by this change.