### PR TITLE
Make task_init() and task_activate() internal OS functions.

### DIFF
--- a/Documentation/NuttxPortingGuide.html
+++ b/Documentation/NuttxPortingGuide.html
@@ -1919,7 +1919,7 @@ The specific environmental definitions are unique for each board but should incl
 
 <p><b>Description</b>.
   Setup up stack-related information in the TCB using pre-allocated stack memory.
-  This function is called only from <code>task_init()</code> when a task or kernel thread is started (never for pthreads).
+  This function is called only from <code>nxtask_init()</code> when a task or kernel thread is started (never for pthreads).
 </p>
 <p>
   The following TCB fields must be initialized:

--- a/Documentation/NuttxUserGuide.html
+++ b/Documentation/NuttxUserGuide.html
@@ -14,7 +14,7 @@
       <h1><big><font color="#3c34ec"><i>NuttX Operating System<p>User's Manual</i></font></big></h1>
       <p><small>by</small></p>
       <p>Gregory Nutt<p>
-      <p>Last Updated: October 16, 2019</p>
+      <p>Last Updated: May 25, 2020</p>
     </td>
   </tr>
 </table>
@@ -200,10 +200,8 @@ paragraphs.
 </p>
 <ul>
   <li><a href="#taskcreate">2.1.1 task_create</a></li>
-  <li><a href="#taskinit">2.1.2 task_init</a></li>
-  <li><a href="#taskactivate">2.1.3 task_activate</a></li>
-  <li><a href="#taskdelete">2.1.4 task_delete</a></li>
-  <li><a href="#taskrestart">2.1.5 task_restart</a></li>
+  <li><a href="#taskdelete">2.1.2 task_delete</a></li>
+  <li><a href="#taskrestart">2.1.3 task_restart</a></li>
 </ul>
 <p>
   Non-standard extensions to VxWorks-like interfaces to support POSIX <a href="http://www.nuttx.org/doku.php?id=wiki:nxinternal:cancellation-points">Cancellation Points</a>.
@@ -345,127 +343,7 @@ VxWorks provides the following similar interface:
 <li>A variable number of parameters can be passed to a task (VxWorks supports ten).
 </ul>
 
-<H3><a name="taskinit">2.1.2 task_init</a></H3>
-
-<p>
-<b>Function Prototype:</b>
-<pre>
-   #include &lt;sched.h&gt;
-   int task_init(struct tcb_s *tcb, char *name, int priority, uint32_t *stack, uint32_t stack_size,
-                 maint_t entry, char * const argv[]);
-</pre>
-
-<p>
-<b>Description:</b>
-<p>
-  This function initializes a Task Control Block (TCB)
-  in preparation for starting a new thread.  It performs a subset
-  of the functionality of <code>task_create()</code> (see above).
-</P>
-<p>
-  Unlike task_create(), task_init() does not activate the task.
-  This must be done by calling task_activate().
-</P>
-<p>
-<b>Input Parameters:</b>
-  <ul>
-    <li><code>tcb</code>. Address of the new task's TCB
-    <li><code>name</code>. Name of the new task (not used)
-    <li><code>priority</code>. Priority of the new task
-    <li><code>stack</code>. Start of the pre-allocated stack
-    <li><code>stack_size</code>. size (in bytes) of the pre-allocated stack
-    <li><code>entry</code>. Entry point of a new task
-    <li><code>argv</code>. A pointer to an array of input parameters.
-       The array should be terminated with a NULL argv[] value.
-       If no parameters are required, argv may be NULL.
-  </ul>
-</p>
-<p>
-<b>Returned Value:</b>
-</p>
-<ul>
-  <li><p>OK, or ERROR if the task cannot be initialized.</P>
-  <p>This function can only failure is it is unable to assign
-    a new, unique task ID to the TCB (<a href="#ErrnoAccess"><code>errno</code></a> is not set).</P>
-</ul>
-<p>
-<b>Assumptions/Limitations:</b>
-<ul>
-<li>task_init() is provided to support internal OS functionality.  It is
-<b>not recommended</b> for normal usage.  task_create() is the preferred
-mechanism to initialize and start a new task.
-</ul>
-<p>
-<b>POSIX Compatibility:</b> This is a NON-POSIX interface.
-VxWorks provides the following similar interface:
-<pre>
-   STATUS taskInit(WIND_TCB *pTcb, char *name, int priority, int options, uint32_t *pStackBase, int stackSize,
-                   FUNCPTR entryPt, int arg1, int arg2, int arg3, int arg4, int arg5,
-                   int arg6, int arg7, int arg8, int arg9, int arg10);
-</pre>
-
-<p>
-  The NuttX task_init() differs from VxWorks' taskInit() in the
-  following ways:
-</p>
-<ul>
-<li>Interface name
-<li>Various differences in types or arguments
-<li>There is no options argument.
-<li>A variable number of parameters can be passed to a task (VxWorks supports ten).
-</ul>
-
-<H3><a name="taskactivate">2.1.3 task_activate</a></H3>
-
-<p>
-<b>Function Prototype:</b>
-<pre>
-    #include &lt;sched.h&gt;
-    int task_activate(struct tcb_s *tcb);
-</pre>
-
-<p>
-<b>Description:</b> This function activates tasks created by task_init().
-Without activation, a task is ineligible for execution by the
-scheduler.
-<p>
-<b>Input Parameters:</b>
-<ul>
-<li><code>tcb</code>. The TCB for the task for the task (same as the
-task_init argument).
-</ul>
-
-<p>
-<b>Returned Value:</b>
-<ul>
-<li>OK, or ERROR if the task cannot be activated (<a href="#ErrnoAccess"><code>errno</code></a> is not set).
-</ul>
-
-<p>
-<b>Assumptions/Limitations:</b>
-<ul>
-<li>task_activate() is provided to support internal OS functionality.  It is
-<b>not recommended</b> for normal usage.  task_create() is the preferred
-mechanism to initialize and start a new task.
-</ul>
-<p>
-<b>POSIX Compatibility:</b> This is a NON-POSIX interface.
-VxWorks provides the following similar interface:
-<pre>
-    STATUS taskActivate(int tid);
-</pre>
-
-<p>
-  The NuttX task_activate() differs from VxWorks' taskActivate() in the
-  following ways:
-</p>
-<ul>
-<li>Function name
-<li>With VxWork's taskActivate, the pid argument is supposed to be
-the pointer to the WIND_TCB cast to an integer.
-</ul>
-
-<H3><a name="taskdelete">2.1.4 task_delete</a></H3>
+<H3><a name="taskdelete">2.1.2 task_delete</a></H3>
 
 <p>
 <b>Function Prototype:</b>
@@ -534,7 +412,7 @@ STATUS taskDelete(int tid);
   <li>Deletion of self is supported, but only because <code>task_delete()</code> will re-direct processing to <code>exit()</code>.
 </ul>
 
-<H3><a name="taskrestart">2.1.5 task_restart</a></H3>
+<H3><a name="taskrestart">2.1.3 task_restart</a></H3>
 <p>
 <b>Function Prototype:</b>
 <ul><pre>
@@ -10691,15 +10569,13 @@ notify a task when a message is available on a queue.
   <li><a href="#standardio">stdio.h</a></li>
   <li><a href="#drvselectops">sys/select.h</a></li>
   <li><a href="#drvrioctlops">sys/ioctl.h</a></li>
-  <li><a href="#taskactivate">task_activate</a></li>
   <li><a href="#Task_Control">Task Control Interfaces</a>
   <li><a href="#taskcreate">task_create</a></li>
   <li><a href="#taskdelete">task_delete</a></li>
-  <li><a href="#taskinit">task_init</a></li>
   <li><a href="#taskrestart">task_restart</a></li>
   <li><a href="#Task_Schedule">Task Scheduling Interfaces</a>
   <li><a href="#tasksetcancelstate">task_setcancelstate</a></li>
-  <li><a href="#tasksetcanceltype>task_setcanceltype</a></li>
+  <li><a href="#tasksetcanceltype">task_setcanceltype</a></li>
   <li><a href="#task_spawn">task_spawn</a></li>
   <li><a href="#task_spawnattr_getstacksize">task_spawnattr_getstacksize</a></li>
   <li><a href="#task_spawnattr_setstacksize">task_spawnattr_setstacksize</a></li>

--- a/TODO
+++ b/TODO
@@ -273,7 +273,7 @@ o Task/Scheduler (sched/)
                  message queue used in the OS.  I am keeping this issue
                  open because (1) there are some known remaining calls that
                  that will modify the errno (such as dup(), dup2(),
-                 task_activate(), kthread_create(), exec(), mq_open(),
+                 nxtask_activate(), kthread_create(), exec(), mq_open(),
                  mq_close(), and others) and (2) there may still be calls that
                  create cancellation points.  Need to check things like open(),
                  close(), read(), write(), and possibly others.

--- a/arch/arm/src/common/arm_usestack.c
+++ b/arch/arm/src/common/arm_usestack.c
@@ -62,7 +62,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/avr/src/avr/up_usestack.c
+++ b/arch/avr/src/avr/up_usestack.c
@@ -68,7 +68,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/avr/src/avr32/up_usestack.c
+++ b/arch/avr/src/avr32/up_usestack.c
@@ -67,7 +67,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/hc/src/common/up_usestack.c
+++ b/arch/hc/src/common/up_usestack.c
@@ -66,7 +66,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/mips/src/common/mips_usestack.c
+++ b/arch/mips/src/common/mips_usestack.c
@@ -87,7 +87,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/renesas/src/common/up_usestack.c
+++ b/arch/renesas/src/common/up_usestack.c
@@ -67,7 +67,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/risc-v/src/common/riscv_usestack.c
+++ b/arch/risc-v/src/common/riscv_usestack.c
@@ -87,7 +87,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/sim/src/sim/up_usestack.c
+++ b/arch/sim/src/sim/up_usestack.c
@@ -73,7 +73,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/x86/src/i486/up_usestack.c
+++ b/arch/x86/src/i486/up_usestack.c
@@ -67,7 +67,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/x86_64/src/intel64/up_usestack.c
+++ b/arch/x86_64/src/intel64/up_usestack.c
@@ -52,7 +52,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/xtensa/src/common/xtensa_usestack.c
+++ b/arch/xtensa/src/common/xtensa_usestack.c
@@ -79,7 +79,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/z16/src/common/z16_usestack.c
+++ b/arch/z16/src/common/z16_usestack.c
@@ -52,7 +52,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/arch/z80/src/common/z80_usestack.c
+++ b/arch/z80/src/common/z80_usestack.c
@@ -51,7 +51,7 @@
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -166,11 +166,11 @@ int exec_module(FAR const struct binary_s *binp)
 
   /* Initialize the task */
 
-  ret = task_init((FAR struct tcb_s *)tcb, binp->filename, binp->priority,
-                  stack, binp->stacksize, binp->entrypt, binp->argv);
+  ret = nxtask_init((FAR struct tcb_s *)tcb, binp->filename, binp->priority,
+                    stack, binp->stacksize, binp->entrypt, binp->argv);
   if (ret < 0)
     {
-      berr("task_init() failed: %d\n", ret);
+      berr("nxtask_init() failed: %d\n", ret);
       kumm_free(stack);
       goto errout_with_addrenv;
     }
@@ -254,10 +254,10 @@ int exec_module(FAR const struct binary_s *binp)
 
   /* Then activate the task at the provided priority */
 
-  ret = task_activate((FAR struct tcb_s *)tcb);
+  ret = nxtask_activate((FAR struct tcb_s *)tcb);
   if (ret < 0)
     {
-      berr("task_activate() failed: %d\n", ret);
+      berr("nxtask_activate() failed: %d\n", ret);
       goto errout_with_tcbinit;
     }
 

--- a/include/cxx/csched
+++ b/include/cxx/csched
@@ -1,35 +1,20 @@
 //***************************************************************************
-// include/cxx/cfcntl
+// include/cxx/csched
 //
-//   Copyright (C) 2012 Gregory Nutt. All rights reserved.
-//   Author: Gregory Nutt <gnutt@nuttx.org>
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The
+// ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the
+// License.  You may obtain a copy of the License at
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
-// 1. Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-// 3. Neither the name NuttX nor the names of its contributors may be
-//    used to endorse or promote products derived from this software
-//    without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
 //
 //***************************************************************************
 
@@ -49,8 +34,6 @@
 namespace std
 {
   using ::sched_param;
-  using ::task_init;
-  using ::task_activate;
   using ::task_create;
   using ::task_delete;
   using ::task_restart;

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * include/nuttx/arch.h
  *
- *   Copyright (C) 2007-2019 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -280,7 +265,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype);
  *
  * Description:
  *   Setup up stack-related information in the TCB using pre-allocated stack
- *   memory.  This function is called only from task_init() when a task or
+ *   memory.  This function is called only from nxtask_init() when a task or
  *   kernel thread is started (never for pthreads).
  *
  *   The following TCB fields must be initialized:

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -908,6 +908,62 @@ FAR struct socketlist *nxsched_get_sockets(void);
 #endif
 
 /********************************************************************************
+ * Name: nxtask_init
+ *
+ * Description:
+ *   This function initializes a Task Control Block (TCB) in preparation for
+ *   starting a new thread.  It performs a subset of the functionality of
+ *   task_create()
+ *
+ *   Unlike task_create():
+ *     1. Allocate the TCB.  The pre-allocated TCB is passed in argv.
+ *     2. Allocate the stack.  The pre-allocated stack is passed in argv.
+ *     3. Activate the task. This must be done by calling nxtask_activate().
+ *
+ * Input Parameters:
+ *   tcb        - Address of the new task's TCB
+ *   name       - Name of the new task (not used)
+ *   priority   - Priority of the new task
+ *   stack      - Start of the pre-allocated stack
+ *   stack_size - Size (in bytes) of the stack allocated
+ *   entry      - Application start point of the new task
+ *   argv       - A pointer to an array of input parameters.  The array
+ *                should be terminated with a NULL argv[] value. If no
+ *                parameters are required, argv may be NULL.
+ *
+ * Returned Value:
+ *   OK on success; negative error value on failure appropriately.  (See
+ *   nxtask_setup_scheduler() for possible failure conditions).  On failure,
+ *   the caller is responsible for freeing the stack memory and for calling
+ *   nxsched_release_tcb() to free the TCB (which could be in most any
+ *   state).
+ *
+ ********************************************************************************/
+
+int nxtask_init(FAR struct tcb_s *tcb, const char *name, int priority,
+                FAR uint32_t *stack, uint32_t stack_size, main_t entry,
+                FAR char * const argv[]);
+
+/********************************************************************************
+ * Name: nxtask_activate
+ *
+ * Description:
+ *   This function activates tasks initialized by nxtask_setup_scheduler().
+ *   Without activation, a task is ineligible for execution by the
+ *   scheduler.
+ *
+ * Input Parameters:
+ *   tcb - The TCB for the task for the task (same as the nxtask_init
+ *         argument).
+ *
+ * Returned Value:
+ *   Always returns OK
+ *
+ ********************************************************************************/
+
+int nxtask_activate(FAR struct tcb_s *tcb);
+
+/********************************************************************************
  * Name: nxtask_starthook
  *
  * Description:

--- a/include/sched.h
+++ b/include/sched.h
@@ -218,11 +218,6 @@ extern "C"
 
 /* Task Control Interfaces (non-standard) */
 
-int    task_init(FAR struct tcb_s *tcb, const char *name, int priority,
-                 FAR uint32_t *stack, uint32_t stack_size, main_t entry,
-                 FAR char * const argv[]);
-int    task_activate(FAR struct tcb_s *tcb);
-
 #ifndef CONFIG_BUILD_KERNEL
 int    task_create(FAR const char *name, int priority, int stack_size,
                    main_t entry, FAR char * const argv[]);

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -78,7 +78,7 @@ static const char g_pthreadname[] = "<pthread>";
  *   This functions sets up parameters in the Task Control Block (TCB) in
  *   preparation for starting a new thread.
  *
- *   pthread_argsetup() is called from task_init() and nxtask_start() to
+ *   pthread_argsetup() is called from nxtask_init() and nxtask_start() to
  *   create a new task (with arguments cloned via strdup) or pthread_create()
  *   which has one argument passed by value (distinguished by the pthread
  *   boolean argument).
@@ -553,7 +553,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
   sched_lock();
   if (ret == OK)
     {
-      ret = task_activate((FAR struct tcb_s *)ptcb);
+      ret = nxtask_activate((FAR struct tcb_s *)ptcb);
     }
 
   if (ret == OK)

--- a/sched/task/task_activate.c
+++ b/sched/task/task_activate.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/task/task_activate.c
  *
- *   Copyright (C) 2007-2009, 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -43,6 +28,7 @@
 #include <debug.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/sched.h>
 #include <nuttx/arch.h>
 #include <nuttx/sched_note.h>
 
@@ -51,7 +37,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: task_activate
+ * Name: nxtask_activate
  *
  * Description:
  *   This function activates tasks initialized by nxtask_setup_scheduler().
@@ -59,7 +45,7 @@
  *   scheduler.
  *
  * Input Parameters:
- *   tcb - The TCB for the task for the task (same as the task_init
+ *   tcb - The TCB for the task for the task (same as the nxtask_init
  *         argument).
  *
  * Returned Value:
@@ -67,7 +53,7 @@
  *
  ****************************************************************************/
 
-int task_activate(FAR struct tcb_s *tcb)
+int nxtask_activate(FAR struct tcb_s *tcb)
 {
   irqstate_t flags = enter_critical_section();
 

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -145,7 +145,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Activate the task */
 
-  ret = task_activate((FAR struct tcb_s *)tcb);
+  ret = nxtask_activate((FAR struct tcb_s *)tcb);
   if (ret < OK)
     {
       /* The TCB was added to the active task list by

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -41,7 +41,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: task_init
+ * Name: nxtask_init
  *
  * Description:
  *   This function initializes a Task Control Block (TCB) in preparation for
@@ -51,7 +51,7 @@
  *   Unlike task_create():
  *     1. Allocate the TCB.  The pre-allocated TCB is passed in argv.
  *     2. Allocate the stack.  The pre-allocated stack is passed in argv.
- *     3. Activate the task. This must be done by calling task_activate().
+ *     3. Activate the task. This must be done by calling nxtask_activate().
  *
  * Input Parameters:
  *   tcb        - Address of the new task's TCB
@@ -73,7 +73,7 @@
  *
  ****************************************************************************/
 
-int task_init(FAR struct tcb_s *tcb, const char *name, int priority,
+int nxtask_init(FAR struct tcb_s *tcb, const char *name, int priority,
               FAR uint32_t *stack, uint32_t stack_size,
               main_t entry, FAR char * const argv[])
 {

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -201,7 +201,7 @@ int task_restart(pid_t pid)
 
   /* Activate the task. */
 
-  ret = task_activate((FAR struct tcb_s *)tcb);
+  ret = nxtask_activate((FAR struct tcb_s *)tcb);
   if (ret != OK)
     {
       nxtask_terminate(pid, true);

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -607,7 +607,8 @@ static inline int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
  *   This functions initializes a Task Control Block (TCB) in preparation
  *   for starting a new task.
  *
- *   nxtask_setup_scheduler() is called from task_init() and nxtask_start().
+ *   nxtask_setup_scheduler() is called from nxtask_init() and
+ *   nxtask_start().
  *
  * Input Parameters:
  *   tcb        - Address of the new task's TCB
@@ -676,7 +677,7 @@ int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
  *   This functions sets up parameters in the Task Control Block (TCB) in
  *   preparation for starting a new thread.
  *
- *   nxtask_setup_arguments() is called only from task_init() and
+ *   nxtask_setup_arguments() is called only from nxtask_init() and
  *   nxtask_start() to create a new task.  In the "normal" case, the argv[]
  *   array is a structure in the TCB, the arguments are cloned via strdup.
  *

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -176,9 +176,9 @@ errout:
  *      to perform these operations?
  *   A: Good idea, except that existing nxtask_starthook() implementation
  *      cannot be used here unless we get rid of task_create and, instead,
- *      use task_init() and task_activate().  start_taskhook() could then
- *      be called between task_init() and task_activate().  task_restart()
- *      would still be an issue.
+ *      use nxtask_init() and nxtask_activate().  start_taskhook() could then
+ *      be called between nxtask_init() and nxtask_activate().
+ *      task_restart() would still be an issue.
  *
  * Input Parameters:
  *   Standard task start-up parameters

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -434,7 +434,7 @@ pid_t nxtask_start_vfork(FAR struct task_tcb_s *child)
 
   /* Activate the task */
 
-  ret = task_activate((FAR struct tcb_s *)child);
+  ret = nxtask_activate((FAR struct tcb_s *)child);
   if (ret < OK)
     {
       nxtask_abort_vfork(child, -ret);


### PR DESCRIPTION
##  Summary

-Move task_init() and task_activate() prototypes from include/sched.h to include/nuttx/sched.h.  These are internal OS functions and should not be exposed to the user.
-Remove references to task_init() and task_activate() from the User Manual.
-Rename task_init() to nxtask_init() since since it is an OS internal function
-Rename task_activate() to nxtask_activate since it is an OS internal function

## Impact

None hopefully

## Testing

sim:nsh

