### PR TITLE
drivers: wireless: Fix buffer overrun in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -325,7 +325,7 @@ static uint16_t _to_uint16(char *str)
   uint16_t ret = 0;
   int n;
 
-  n = sscanf(str, "%04d", &ret);
+  n = sscanf(str, "%04hu", &ret);
   ASSERT(1 == n);
   return ret;
 }


### PR DESCRIPTION
## Summary

- This PR fixes a buffer overrun error reported by CodeSonar

## Impact

- This PR affects gs2200 driver only.

## Testing

- I tested this PR with spresense:wifi. (e.g. renew/telnetd/webserver)
