### PR TITLE
build: make sure nuttx bins generated after both pass1 and pass2 built done

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -369,6 +369,18 @@ include tools/LibTargets.mk
 # is unknown to this makefile unless CONFIG_PASS1_OBJECT is defined.
 
 pass1: $(USERLIBS)
+
+pass2: $(NUTTXLIBS)
+
+# $(BIN)
+#
+# Create the final NuttX executable in a two pass build process.  In the
+# normal case, all pass1 and pass2 dependencies are created then pass1
+# and pass2 targets are built.  However, in some cases, you may need to build
+# pass1 dependencies and pass1 first, then build pass2 dependencies and pass2.
+# in that case, execute 'make pass1 pass2' from the command line.
+
+$(BIN): pass1 pass2
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) if [ -z "$(CONFIG_PASS1_BUILDIR)" ]; then \
 		echo "ERROR: CONFIG_PASS1_BUILDIR not defined"; \
@@ -384,8 +396,6 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 	fi
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
-
-pass2: $(NUTTXLIBS)
 	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f $(BIN) /tftpboot/$(BIN).${CONFIG_ARCH}; \
@@ -411,16 +421,6 @@ ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	fi
 endif
 	$(call POSTBUILD)
-
-# $(BIN)
-#
-# Create the final NuttX executable in a two pass build process.  In the
-# normal case, all pass1 and pass2 dependencies are created then pass1
-# and pass2 targets are built.  However, in some cases, you may need to build
-# pass1 dependencies and pass1 first, then build pass2 dependencies and pass2.
-# in that case, execute 'make pass1 pass2' from the command line.
-
-$(BIN): pass1 pass2
 
 # download
 #

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -347,6 +347,18 @@ include tools/LibTargets.mk
 # is unknown to this makefile unless CONFIG_PASS1_OBJECT is defined.
 
 pass1: $(USERLIBS)
+
+pass2: $(NUTTXLIBS)
+
+# $(BIN)
+#
+# Create the final NuttX executable in a two pass build process.  In the
+# normal case, all pass1 and pass2 dependencies are created then pass1
+# and pass2 targets are built.  However, in some cases, you may need to build
+# pass1 dependencies and pass1 first, then build pass2 dependencies and pass2.
+# in that case, execute 'make pass1 pass2' from the command line.
+
+$(BIN): pass1 pass2
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) if [ -z "$(CONFIG_PASS1_BUILDIR)" ]; then \
 		echo "ERROR: CONFIG_PASS1_BUILDIR not defined"; \
@@ -362,8 +374,6 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 	fi
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
-
-pass2: $(NUTTXLIBS)
 	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: $(NUTTXNAME).hex"
@@ -378,16 +388,6 @@ ifeq ($(CONFIG_RAW_BINARY),y)
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
 endif
 	$(call POSTBUILD)
-
-# $(BIN)
-#
-# Create the final NuttX executable in a two pass build process.  In the
-# normal case, all pass1 and pass2 dependencies are created then pass1
-# and pass2 targets are built.  However, in some cases, you may need to build
-# pass1 dependencies and pass1 first, then build pass2 dependencies and pass2.
-# in that case, execute 'make pass1 pass2' from the command line.
-
-$(BIN): pass1 pass2
 
 # download
 #


### PR DESCRIPTION
## Summary
Create the final NuttX executables after pass1 user libs and pass2 nuttx
libs built finished.

## Impact

## Testing

