### PR TITLE
sched/task/task_init.c:  Add nxtask_uninit()

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -945,6 +945,27 @@ int nxtask_init(FAR struct tcb_s *tcb, const char *name, int priority,
                 FAR char * const argv[]);
 
 /********************************************************************************
+ * Name: nxtask_uninit
+ *
+ * Description:
+ *   Undo all operations on a TCB performed by task_init() and release the
+ *   TCB by calling kmm_free().  This is intended primarily to support
+ *   error recovery operations after a successful call to task_init() such
+ *   was when a subsequent call to task_activate fails.
+ *
+ *   Caution:  Freeing of the TCB itself might be an unexpected side-effect.
+ *
+ * Input Parameters:
+ *   tcb - Address of the TCB initialized by task_init()
+ *
+ * Returned Value:
+ *   OK on success; negative error value on failure appropriately.
+ *
+ ********************************************************************************/
+
+void nxtask_uninit(FAR struct tcb_s *tcb);
+
+/********************************************************************************
  * Name: nxtask_activate
  *
  * Description:

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -136,7 +136,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
   ret = group_initialize(tcb);
   if (ret < 0)
     {
-      goto errout_with_tcb;
+      goto errout_with_active;
     }
 
   /* Get the assigned pid before we start the task */
@@ -148,15 +148,17 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
   ret = nxtask_activate((FAR struct tcb_s *)tcb);
   if (ret < OK)
     {
-      /* The TCB was added to the active task list by
-       * nxtask_setup_scheduler()
-       */
-
-      dq_rem((FAR dq_entry_t *)tcb, (FAR dq_queue_t *)&g_inactivetasks);
-      goto errout_with_tcb;
+      goto errout_with_active;
     }
 
   return pid;
+
+errout_with_active:
+  /* The TCB was added to the inactive task list by
+   * nxtask_setup_scheduler().
+   */
+
+  dq_rem((FAR dq_entry_t *)tcb, (FAR dq_queue_t *)&g_inactivetasks);
 
 errout_with_tcb:
   nxsched_release_tcb((FAR struct tcb_s *)tcb, ttype);


### PR DESCRIPTION
## Summary

1. sched/task/task_init.c:  Add nxtask_uninit()

Add trivial function nxtask_uninit().  This function will undo all operations on a TCB performed by task_init() and release the TCB by calling kmm_free().  This is intended primarily to support error recovery operations after a successful call to task_init() such was when a subsequent call to task_activate fails.

That error recovery is trivial but not obvious.  This helper function should eliminate confusion about what to do to recover after calling nxtask_init()

2.  sched/task/task_create.c:  Correct logic in error handling

After nxtask_setup_arguments() is called, the task must be removed from the active task list in order to properly recover from any error condition.

## Impact

None anticipated

## Testing

sim:nsh

