### PR TITLE
fs/nfs/nfs_proto.h: Use of uint64_t in the data types breaks NFS func…

### DIFF
--- a/fs/nfs/nfs_proto.h
+++ b/fs/nfs/nfs_proto.h
@@ -426,7 +426,7 @@ struct LOOKUP3resok
 struct READ3args
 {
   struct file_handle fhandle;      /* Variable length */
-  uint64_t           offset;
+  nfsuint64          offset;
   uint32_t           count;
 };
 
@@ -449,7 +449,7 @@ struct READ3resok
 struct nfs_wrhdr_s
 {
   struct file_handle fhandle;     /* Variable length */
-  uint64_t           offset;
+  nfsuint64          offset;
   uint32_t           count;
   uint32_t           stable;
   uint32_t           length;

--- a/fs/nfs/nfs_proto.h
+++ b/fs/nfs/nfs_proto.h
@@ -58,106 +58,106 @@
  * Specification"
  */
 
-#define NFS_PORT                2049
-#define NFS_PROG                100003
-#define NFS_VER2                2
-#define NFS_VER3                3
-#define NFS_VER4                4
-#define NFS_MAXDGRAMDATA        32768
-#define MAXBSIZE                64000
-#define NFS_MAXDATA             MAXBSIZE
-#define NFS_MAXPATHLEN          1024
-#define NFS_MAXNAMLEN           255
-#define NFS_MAXPKTHDR           404
-#define NFS_MAXPACKET           (NFS_MAXPKTHDR + NFS_MAXDATA)
-#define NFS_MINPACKET           20
-#define NFS_FABLKSIZE           512   /* Size in bytes of a block wrt fa_blocks */
+#define NFS_PORT                  2049
+#define NFS_PROG                  100003
+#define NFS_VER2                  2
+#define NFS_VER3                  3
+#define NFS_VER4                  4
+#define NFS_MAXDGRAMDATA          32768
+#define MAXBSIZE                  64000
+#define NFS_MAXDATA               MAXBSIZE
+#define NFS_MAXPATHLEN            1024
+#define NFS_MAXNAMLEN             255
+#define NFS_MAXPKTHDR             404
+#define NFS_MAXPACKET             (NFS_MAXPKTHDR + NFS_MAXDATA)
+#define NFS_MINPACKET             20
+#define NFS_FABLKSIZE             512   /* Size in bytes of a block wrt fa_blocks */
 
 /* Stat numbers for rpc returns (version 2 and 3) */
 
-#define NFS_OK                  0
-#define NFSERR_PERM             1
-#define NFSERR_NOENT            2
-#define NFSERR_IO               5
-#define NFSERR_NXIO             6
-#define NFSERR_ACCES            13
-#define NFSERR_EXIST            17
-#define NFSERR_XDEV             18    /* Version 3 only */
-#define NFSERR_NODEV            19
-#define NFSERR_NOTDIR           20
-#define NFSERR_ISDIR            21
-#define NFSERR_INVAL            22    /* Version 3 only */
-#define NFSERR_FBIG             27
-#define NFSERR_NOSPC            28
-#define NFSERR_ROFS             30
-#define NFSERR_MLINK            31    /* Version 3 only */
-#define NFSERR_NAMETOL          63
-#define NFSERR_NOTEMPTY         66
-#define NFSERR_DQUOT            69
-#define NFSERR_STALE            70
-#define NFSERR_REMOTE           71    /* Version 3 only */
-#define NFSERR_WFLUSH           99    /* Version 2 only */
-#define NFSERR_BADHANDLE        10001 /* The rest Version 3 only */
-#define NFSERR_NOT_SYNC         10002
-#define NFSERR_BAD_COOKIE       10003
-#define NFSERR_NOTSUPP          10004
-#define NFSERR_TOOSMALL         10005
-#define NFSERR_SERVERFAULT      10006
-#define NFSERR_BADTYPE          10007
-#define NFSERR_JUKEBOX          10008
-#define NFSERR_TRYLATER         NFSERR_JUKEBOX
-#define NFSERR_STALEWRITEVERF   30001 /* Fake return for nfs_commit() */
+#define NFS_OK                    0
+#define NFSERR_PERM               1
+#define NFSERR_NOENT              2
+#define NFSERR_IO                 5
+#define NFSERR_NXIO               6
+#define NFSERR_ACCES              13
+#define NFSERR_EXIST              17
+#define NFSERR_XDEV               18    /* Version 3 only */
+#define NFSERR_NODEV              19
+#define NFSERR_NOTDIR             20
+#define NFSERR_ISDIR              21
+#define NFSERR_INVAL              22    /* Version 3 only */
+#define NFSERR_FBIG               27
+#define NFSERR_NOSPC              28
+#define NFSERR_ROFS               30
+#define NFSERR_MLINK              31    /* Version 3 only */
+#define NFSERR_NAMETOL            63
+#define NFSERR_NOTEMPTY           66
+#define NFSERR_DQUOT              69
+#define NFSERR_STALE              70
+#define NFSERR_REMOTE             71    /* Version 3 only */
+#define NFSERR_WFLUSH             99    /* Version 2 only */
+#define NFSERR_BADHANDLE          10001 /* The rest Version 3 only */
+#define NFSERR_NOT_SYNC           10002
+#define NFSERR_BAD_COOKIE         10003
+#define NFSERR_NOTSUPP            10004
+#define NFSERR_TOOSMALL           10005
+#define NFSERR_SERVERFAULT        10006
+#define NFSERR_BADTYPE            10007
+#define NFSERR_JUKEBOX            10008
+#define NFSERR_TRYLATER           NFSERR_JUKEBOX
+#define NFSERR_STALEWRITEVERF     30001 /* Fake return for nfs_commit() */
 
-#define NFSERR_RETVOID          0x20000000    /* Return void, not error */
-#define NFSERR_AUTHERR          0x40000000    /* Mark an authentication error */
-#define NFSERR_RETERR           0x80000000    /* Mark an error return for V3 */
+#define NFSERR_RETVOID            0x20000000    /* Return void, not error */
+#define NFSERR_AUTHERR            0x40000000    /* Mark an authentication error */
+#define NFSERR_RETERR             0x80000000    /* Mark an error return for V3 */
 
 /* Sizes in bytes of various NFS RPC components */
 
-#define NFSX_UNSIGNED           4
+#define NFSX_UNSIGNED             4
 
 /* Specific to NFS Version 3 */
 
-#define NFSX_V3FH               (sizeof(struct fhandle))  /* size this server uses */
-#define NFSX_V3FHMAX            64    /* max. allowed by protocol */
-#define NFSX_V3FATTR            84
-#define NFSX_V3SATTR            60    /* max. all fields filled in */
-#define NFSX_V3SRVSATTR         (sizeof (struct nfsv3_sattr))
-#define NFSX_V3POSTOPATTR       (NFSX_V3FATTR + NFSX_UNSIGNED)
-#define NFSX_V3WCCDATA          (NFSX_V3POSTOPATTR + 7 * NFSX_UNSIGNED)
-#define NFSX_V3COOKIEVERF       8
-#define NFSX_V3WRITEVERF        8
-#define NFSX_V3CREATEVERF       8
-#define NFSX_V3STATFS           52
-#define NFSX_V3FSINFO           48
-#define NFSX_V3PATHCONF         24
+#define NFSX_V3FH                 (sizeof(struct fhandle))                /* size this server uses */
+#define NFSX_V3FHMAX              64                                      /* max. allowed by protocol */
+#define NFSX_V3FATTR              84
+#define NFSX_V3SATTR              60                                      /* max. all fields filled in */
+#define NFSX_V3SRVSATTR           (sizeof (struct nfsv3_sattr))
+#define NFSX_V3POSTOPATTR         (NFSX_V3FATTR + NFSX_UNSIGNED)
+#define NFSX_V3WCCDATA            (NFSX_V3POSTOPATTR + 7 * NFSX_UNSIGNED)
+#define NFSX_V3COOKIEVERF         8
+#define NFSX_V3WRITEVERF          8
+#define NFSX_V3CREATEVERF         8
+#define NFSX_V3STATFS             52
+#define NFSX_V3FSINFO             48
+#define NFSX_V3PATHCONF           24
 
 /* NFS RPC procedure numbers (before version mapping) */
 
-#define NFSPROC_NULL            0
-#define NFSPROC_GETATTR         1
-#define NFSPROC_SETATTR         2
-#define NFSPROC_LOOKUP          3
-#define NFSPROC_ACCESS          4
-#define NFSPROC_READLINK        5
-#define NFSPROC_READ            6
-#define NFSPROC_WRITE           7
-#define NFSPROC_CREATE          8
-#define NFSPROC_MKDIR           9
-#define NFSPROC_SYMLINK         10
-#define NFSPROC_MKNOD           11
-#define NFSPROC_REMOVE          12
-#define NFSPROC_RMDIR           13
-#define NFSPROC_RENAME          14
-#define NFSPROC_LINK            15
-#define NFSPROC_READDIR         16
-#define NFSPROC_READDIRPLUS     17
-#define NFSPROC_FSSTAT          18
-#define NFSPROC_FSINFO          19
-#define NFSPROC_PATHCONF        20
-#define NFSPROC_COMMIT          21
-#define NFSPROC_NOOP            22
-#define NFS_NPROCS              23
+#define NFSPROC_NULL              0
+#define NFSPROC_GETATTR           1
+#define NFSPROC_SETATTR           2
+#define NFSPROC_LOOKUP            3
+#define NFSPROC_ACCESS            4
+#define NFSPROC_READLINK          5
+#define NFSPROC_READ              6
+#define NFSPROC_WRITE             7
+#define NFSPROC_CREATE            8
+#define NFSPROC_MKDIR             9
+#define NFSPROC_SYMLINK           10
+#define NFSPROC_MKNOD             11
+#define NFSPROC_REMOVE            12
+#define NFSPROC_RMDIR             13
+#define NFSPROC_RENAME            14
+#define NFSPROC_LINK              15
+#define NFSPROC_READDIR           16
+#define NFSPROC_READDIRPLUS       17
+#define NFSPROC_FSSTAT            18
+#define NFSPROC_FSINFO            19
+#define NFSPROC_PATHCONF          20
+#define NFSPROC_COMMIT            21
+#define NFSPROC_NOOP              22
+#define NFS_NPROCS                23
 
 /* Constants used by the Version 3 protocol for various RPCs */
 
@@ -165,44 +165,44 @@
 #define NFSV3SATTRTIME_TOSERVER   1
 #define NFSV3SATTRTIME_TOCLIENT   2
 
-#define NFSV3ACCESS_READ         0x01
-#define NFSV3ACCESS_LOOKUP       0x02
-#define NFSV3ACCESS_MODIFY       0x04
-#define NFSV3ACCESS_EXTEND       0x08
-#define NFSV3ACCESS_DELETE       0x10
-#define NFSV3ACCESS_EXECUTE      0x20
+#define NFSV3ACCESS_READ          0x01
+#define NFSV3ACCESS_LOOKUP        0x02
+#define NFSV3ACCESS_MODIFY        0x04
+#define NFSV3ACCESS_EXTEND        0x08
+#define NFSV3ACCESS_DELETE        0x10
+#define NFSV3ACCESS_EXECUTE       0x20
 
-#define NFSV3WRITE_UNSTABLE      0
-#define NFSV3WRITE_DATASYNC      1
-#define NFSV3WRITE_FILESYNC      2
+#define NFSV3WRITE_UNSTABLE       0
+#define NFSV3WRITE_DATASYNC       1
+#define NFSV3WRITE_FILESYNC       2
 
-#define NFSV3CREATE_UNCHECKED    0
-#define NFSV3CREATE_GUARDED      1
-#define NFSV3CREATE_EXCLUSIVE    2
+#define NFSV3CREATE_UNCHECKED     0
+#define NFSV3CREATE_GUARDED       1
+#define NFSV3CREATE_EXCLUSIVE     2
 
-#define NFSV3FSINFO_LINK         0x01
-#define NFSV3FSINFO_SYMLINK      0x02
-#define NFSV3FSINFO_HOMOGENEOUS  0x08
-#define NFSV3FSINFO_CANSETTIME   0x10
+#define NFSV3FSINFO_LINK          0x01
+#define NFSV3FSINFO_SYMLINK       0x02
+#define NFSV3FSINFO_HOMOGENEOUS   0x08
+#define NFSV3FSINFO_CANSETTIME    0x10
 
 /* Mode bit values */
 
-#define NFSMODE_IXOTH            (1 << 0)      /* Execute permission for others on a file */
-#define NFSMODE_IWOTH            (1 << 1)      /* Write permission for others */
-#define NFSMODE_IROTH            (1 << 2)      /* Read permission for others */
-#define NFSMODE_IXGRP            (1 << 3)      /* Execute permission for group on a file */
-#define NFSMODE_IWGRP            (1 << 4)      /* Write permission for group */
-#define NFSMODE_IRGRP            (1 << 5)      /* Read permission for group */
-#define NFSMODE_IXUSR            (1 << 6)      /* Execute permission for owner on a file */
-#define NFSMODE_IWUSR            (1 << 7)      /* Write permission for owner */
-#define NFSMODE_IRUSR            (1 << 8)      /* Read permission for owner */
-#define NFSMODE_SAVETEXT         (1 << 9)      /* Save swapped text */
-#define NFSMODE_ISGID            (1 << 10)     /* Set group ID on execution */
-#define NFSMODE_ISUID            (1 << 11)     /* Set user ID on execution */
+#define NFSMODE_IXOTH             (1 << 0)      /* Execute permission for others on a file */
+#define NFSMODE_IWOTH             (1 << 1)      /* Write permission for others */
+#define NFSMODE_IROTH             (1 << 2)      /* Read permission for others */
+#define NFSMODE_IXGRP             (1 << 3)      /* Execute permission for group on a file */
+#define NFSMODE_IWGRP             (1 << 4)      /* Write permission for group */
+#define NFSMODE_IRGRP             (1 << 5)      /* Read permission for group */
+#define NFSMODE_IXUSR             (1 << 6)      /* Execute permission for owner on a file */
+#define NFSMODE_IWUSR             (1 << 7)      /* Write permission for owner */
+#define NFSMODE_IRUSR             (1 << 8)      /* Read permission for owner */
+#define NFSMODE_SAVETEXT          (1 << 9)      /* Save swapped text */
+#define NFSMODE_ISGID             (1 << 10)     /* Set group ID on execution */
+#define NFSMODE_ISUID             (1 << 11)     /* Set user ID on execution */
 
 /* File identifier */
 
-#define MAXFIDSZ                 16
+#define MAXFIDSZ                  16
 
 /****************************************************************************
  * Public Types
@@ -345,9 +345,9 @@ struct wcc_attr
 
 struct wcc_data
 {
-  uint32_t           wcc_attr_follows;       /* True if data follows */
+  uint32_t           wcc_attr_follows;          /* True if data follows */
   struct wcc_attr    before;
-  uint32_t           nfs_attr_follow;        /* True if attributes present */
+  uint32_t           nfs_attr_follow;           /* True if attributes present */
   struct nfs_fattr   after;
 };
 
@@ -360,9 +360,9 @@ struct file_handle
 
 struct diropargs3
 {
-  struct file_handle fhandle;                  /* Variable length */
-  uint32_t           length;                   /* Size of name[] */
-  uint32_t           name[(NAME_MAX+3) >> 2];  /* Variable length */
+  struct file_handle fhandle;                   /* Variable length */
+  uint32_t           length;                    /* Size of name[]  */
+  uint32_t           name[(NAME_MAX + 3) >> 2]; /* Variable length */
 };
 
 struct CREATE3args
@@ -393,25 +393,26 @@ struct SETATTR3resok
   struct wcc_data         wcc_data;
 };
 
-/* The actual size of the lookup argument is variable.  These structures are, therefore,
- * only useful in setting aside maximum memory usage for the LOOKUP arguments.
+/* The actual size of the lookup argument is variable.
+ * These structures are, therefore, only useful in setting
+ * aside maximum memory usage for the LOOKUP arguments.
  */
 
 struct LOOKUP3filename
 {
-  uint32_t           namelen;                  /* Size of name[] */
-  uint32_t           name[(NAME_MAX+3) >> 2];  /* Variable length */
+  uint32_t           namelen;                   /* Size of name[]  */
+  uint32_t           name[(NAME_MAX + 3) >> 2]; /* Variable length */
 };
 
 struct LOOKUP3args
 {
-  struct file_handle     dirhandle;            /* Variable length */
-  struct LOOKUP3filename name;                 /* Variable length  */
+  struct file_handle     dirhandle;             /* Variable length */
+  struct LOOKUP3filename name;                  /* Variable length */
 };
 
 /* Actual size of LOOKUP3args */
 
-#define SIZEOF_LOOKUP3filename(b) (sizeof(uint32_t) + (((b)+3) & ~3))
+#define SIZEOF_LOOKUP3filename(b) (sizeof(uint32_t) + (((b) + 3) & ~3))
 #define SIZEOF_LOOKUP3args(a,b)   (SIZEOF_file_handle(a) + SIZEOF_LOOKUP3filename(b))
 
 struct LOOKUP3resok
@@ -425,7 +426,7 @@ struct LOOKUP3resok
 
 struct READ3args
 {
-  struct file_handle fhandle;      /* Variable length */
+  struct file_handle fhandle;           /* Variable length */
   nfsuint64          offset;
   uint32_t           count;
 };
@@ -433,22 +434,22 @@ struct READ3args
 struct nfs_rdhdr_s
 {
   uint32_t           attributes_follow;
-  struct nfs_fattr   attributes;   /* Will not be present if attributes_follow == 0 */
-  uint32_t           count;        /* Number of bytes read */
-  uint32_t           eof;          /* Non-zero if at the end of file */
-  uint32_t           length;       /* Length of data (same as count?) */
+  struct nfs_fattr   attributes;        /* Will not be present if attributes_follow == 0 */
+  uint32_t           count;             /* Number of bytes read */
+  uint32_t           eof;               /* Non-zero if at the end of file */
+  uint32_t           length;            /* Length of data (same as count?) */
 };
 
 struct READ3resok
 {
   struct nfs_rdhdr_s hdr;
-  uint8_t            data[1];      /* Actual data size depends on count */
+  uint8_t            data[1];           /* Actual data size depends on count */
 };
 #define SIZEOF_READ3resok(n) (sizeof(struct nfs_rdhdr_s) + (n))
 
 struct nfs_wrhdr_s
 {
-  struct file_handle fhandle;     /* Variable length */
+  struct file_handle fhandle;           /* Variable length */
   nfsuint64          offset;
   uint32_t           count;
   uint32_t           stable;
@@ -458,7 +459,7 @@ struct nfs_wrhdr_s
 struct WRITE3args
 {
   struct nfs_wrhdr_s hdr;
-  uint8_t            data[1]; /* Actual data size depends on count */
+  uint8_t            data[1];           /* Actual data size depends on count */
 };
 #define SIZEOF_WRITE3args(n) (sizeof(struct nfs_wrhdr_s) + (n))
 
@@ -500,10 +501,10 @@ struct MKDIR3args
 
 struct MKDIR3resok
 {
-  uint32_t           handle_follows;           /* True, handle follows */
-  struct file_handle fhandle;                  /* Variable length */
-  uint32_t           attributes_follows;       /* True, attributes follows */
-  struct nfs_fattr   attributes;               /* Directory attributes */
+  uint32_t           handle_follows;                /* True, handle follows */
+  struct file_handle fhandle;                       /* Variable length */
+  uint32_t           attributes_follows;            /* True, attributes follows */
+  struct nfs_fattr   attributes;                    /* Directory attributes */
   struct wcc_data    dir_wcc;
 };
 
@@ -519,14 +520,14 @@ struct RMDIR3resok
 
 struct READDIR3args
 {
-  struct file_handle dir;                      /* Variable length */
+  struct file_handle dir;                           /* Variable length */
   nfsuint64          cookie;
   uint8_t            cookieverf[NFSX_V3COOKIEVERF];
   uint32_t           count;
 };
 
-/* The READDIR reply is variable length and consists of multiple entries, each
- * of form:
+/* The READDIR reply is variable length and consists of multiple entries,
+ *  each of form:
  *
  *  EOF - OR -
  *
@@ -543,7 +544,7 @@ struct READDIR3resok
   struct nfs_fattr   dir_attributes;
   uint8_t            cookieverf[NFSX_V3COOKIEVERF];
   uint32_t           value_follows;
-  uint32_t           reply[1]; /* Variable length reply begins here */
+  uint32_t           reply[1];                      /* Variable length reply begins here */
 };
 
 #define SIZEOF_READDIR3resok(n) \


### PR DESCRIPTION
## Summary
The use of uint64_t primitive type in NFS structures forces the compiler to align data on an 8-byte boundary. 

## Impact
As a result of this, unwanted gaps being created, which causes NFS to fail. (e.g.,nfs_read/initialize the request)

## Testing
I noticed this issue while I was trying to 'cat' a file. The NFS implementation was always failing with 10001. After digging into the problem and sniffing the packages with Wireshark, I saw some garbage data in the read requests. After making this change, the problem disappeared, and everything has started to work as expected.
