### PR TITLE
fs/vfs/fs_fstat:  Correct fstat() for proxied block and MTD drivers.

### DIFF
--- a/fs/vfs/fs_fstat.c
+++ b/fs/vfs/fs_fstat.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * fs/vfs/fs_fstat.c
  *
- *   Copyright (C) 2017-2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -45,7 +30,106 @@
 #include <errno.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/mtd/mtd.h>
 #include "inode/inode.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: proxy_fstat
+ *
+ * Description:
+ *   Check for special cases where the character driver is really just a
+ *   proxy for the real, underlying MTD or block driver.
+ *
+ *   NOTE:  This must be done here rather than in the the common
+ *   inode_stat() function because the filep reference must be available
+ *   in order to call the character driver ioctl method.
+ *
+ * Input Parameters:
+ *   filep  - File structure instance
+ *   inode  - The inode associated with the file descriptor
+ *   buf    - The caller provide location in which to return information
+ *            about the open file.
+ *
+ * Returned Value:
+ *   Upon successful completion, 0 is returned. Otherwise, a negated errno
+ *   value is returned.
+ *
+ ****************************************************************************/
+
+static int proxy_fstat(FAR struct file *filep, FAR struct inode *inode,
+                       FAR struct stat *buf)
+{
+#ifdef CONFIG_MTD
+  struct mtd_geometry_s mtdgeo;
+#endif
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+  struct geometry blkgeo;
+#endif
+  int ret = -ENOENT;
+
+  /* Check if this is a valid character driver */
+
+  if (INODE_IS_DRIVER(inode) &&
+      inode->u.i_ops != NULL &&
+      inode->u.i_ops->ioctl != NULL)
+    {
+#ifdef CONFIG_MTD
+      /* Check if this is a proxy for an MTD driver.  In this case, both the
+       * MTDIOC_GEOMETRY ioctl and the BIOC_GEOMTRY will be supported by
+       * character driver.
+       */
+
+      if (inode->u.i_ops->ioctl(filep, MTDIOC_GEOMETRY,
+                                (unsigned long)((uintptr_t)&mtdgeo)) >= 0)
+        {
+          memset(buf, 0, sizeof(struct stat));
+          buf->st_mode  = S_IFMTD;
+          buf->st_mode |= S_IROTH | S_IRGRP | S_IRUSR;
+          buf->st_mode |= S_IWOTH | S_IWGRP | S_IWUSR;
+          buf->st_size  = mtdgeo.neraseblocks * mtdgeo.erasesize;
+          ret           = OK;
+        }
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+      else
+#endif
+#endif
+
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+      /* Check if this is a proxy for a block driver.  In this case, only
+       * the BIOC_GEOMETRY ioctl will be supported.
+       */
+
+      if (inode->u.i_ops->ioctl(filep, BIOC_GEOMETRY,
+                                (unsigned long)((uintptr_t)&blkgeo)) >= 0)
+        {
+          memset(buf, 0, sizeof(struct stat));
+          buf->st_mode = S_IFBLK;
+          if (inode->u.i_ops->read)
+            {
+              buf->st_mode |= S_IROTH | S_IRGRP | S_IRUSR;
+            }
+
+          if (inode->u.i_ops->write)
+            {
+              buf->st_mode |= S_IWOTH | S_IWGRP | S_IWUSR;
+            }
+
+          if (blkgeo.geo_available)
+            {
+              buf->st_size = blkgeo.geo_nsectors * blkgeo.geo_sectorsize;
+            }
+
+          ret = OK;
+        }
+#endif
+    }
+
+  return ret;
+}
 
 /****************************************************************************
  * Public Functions
@@ -55,8 +139,8 @@
  * Name: file_fstat
  *
  * Description:
- *   file_fstat() is an internal OS interface.  It is functionally similar to
- *   the standard fstat() interface except:
+ *   file_fstat() is an internal OS interface.  It is functionally similar
+ *   to the standard fstat() interface except:
  *
  *    - It does not modify the errno variable,
  *    - It is not a cancellation point,
@@ -65,8 +149,8 @@
  *
  * Input Parameters:
  *   filep  - File structure instance
- *   buf    - The caller provide location in which to return information about
- *            the open file.
+ *   buf    - The caller provide location in which to return information
+ *            about the open file.
  *
  * Returned Value:
  *   Upon successful completion, 0 shall be returned. Otherwise, -1 shall be
@@ -108,9 +192,15 @@ int file_fstat(FAR struct file *filep, FAR struct stat *buf)
   else
 #endif
     {
-      /* The inode is part of the root pseudo file system. */
+      /* Check if the inode is a proxy for a block or MTD driver */
 
-      ret = inode_stat(inode, buf);
+      ret = proxy_fstat(filep, inode, buf);
+      if (ret < 0)
+        {
+          /* The inode is part of the root pseudo file system. */
+
+          ret = inode_stat(inode, buf);
+        }
     }
 
   return ret;

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -924,7 +924,7 @@ FAR struct socketlist *nxsched_get_sockets(void);
  *   Certain fields of the pre-allocated TCB may be set to change the
  *   nature of the created task.  For example:
  *
- *     - Task type may be set in the TCB flags to create  kernel thread
+ *     - Task type may be set in the TCB flags to create kernel thread
  *     - If a custom stack is used, i.e., one allocated, managed, and freed
  *       by the caller, then TCB_FLAG_CUSTOM_STACK should be set in the
  *       TCB flags.

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * include/sys/stat.h
  *
- *   Copyright (C) 2007-2009, 2012, 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -109,7 +94,7 @@
 #define S_ISSHM(m)  (((m) & s_IFTGT) == S_IFSHM)
 #define S_ISSOCK(m) (((m) & s_IFTGT) == S_IFSOCK)
 #define S_ISMTD(m)  (((m) & s_IFTGT) == S_IFMTD)
-#define S_ISLNK(m)  (((m) & S_IFLNK)   != 0)
+#define S_ISLNK(m)  (((m) & S_IFLNK) != 0)
 
 /* The following macros are required by POSIX to acheive backward
  * compatibility with earlier versions of struct stat.

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -57,7 +57,7 @@
  *   Certain fields of the pre-allocated TCB may be set to change the
  *   nature of the created task.  For example:
  *
- *     - Task type may be set in the TCB flags to create  kernel thread
+ *     - Task type may be set in the TCB flags to create kernel thread
  *     - If a custom stack is used, i.e., one allocated, managed, and freed
  *       by the caller, then TCB_FLAG_CUSTOM_STACK should be set in the
  *       TCB flags.


### PR DESCRIPTION
## Summary

Block and MTD drivers may be opened and managed as though they were character drivers.  But this is really sleight of hand; there is a hidden character driver proxy that mediates the interface to the block and MTD drivers in this case.

fstat(), however, did not account for this.  It would report the characteristics of the proxy character driver, not of the underlying block or MTD driver.

This change corrects that.  fstat now checks if the character driver is such a proxy and, if so, reports the characteristics of the underlying block or MTD driver, not the proxy character driver.

NOTE: Also includes cosmetic-only changes to some related files.

## Impact

Should have no impact other than correcting the information returned by fstat.

## Testing

Testing on sim:nsh with modifications to exercise block and MTD drivers.


