### PR TITLE
tools/: Hook incdir.c into build system.

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -16,5 +16,6 @@
 /mkversion
 /nxstyle
 /rmcr
+/incdir
 /.k2h-body.dat
 /.k2h-apndx.dat

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -179,10 +179,10 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   INCDIR ?= "$(TOPDIR)\tools\incdir.bat"
 else ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   DEFINE ?= "$(TOPDIR)/tools/define.sh" -w
-  INCDIR ?= "$(TOPDIR)/tools/incdir.sh" -w
+  INCDIR ?= "$(TOPDIR)/tools/incdir$(HOSTEXEEXT)" -w
 else
   DEFINE ?= "$(TOPDIR)/tools/define.sh"
-  INCDIR ?= "$(TOPDIR)/tools/incdir.sh"
+  INCDIR ?= "$(TOPDIR)/tools/incdir$(HOSTEXEEXT)"
 endif
 
 # PREPROCESS - Default macro to run the C pre-processor

--- a/tools/Makefile.host
+++ b/tools/Makefile.host
@@ -285,6 +285,8 @@ clean:
 	$(call DELFILE, nxstyle.exe)
 	$(call DELFILE, rmcr)
 	$(call DELFILE, rmcr.exe)
+	$(call DELFILE, incdir)
+	$(call DELFILE, incdir.exe)
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) rm -rf *.dSYM
 endif

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -1,36 +1,20 @@
 ############################################################################
 # tools/Makefile.unix
 #
-#   Copyright (C) 2007-2012, 2014-2015, 2018-2019 Gregory Nutt. All rights
-#      reserved.
-#   Author: Gregory Nutt <gnutt@nuttx.org>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 
@@ -371,6 +355,11 @@ clean_context:
 
 include tools/LibTargets.mk
 
+# Build the incdir tools need for all builds
+
+tools/incdir$(HOSTEXEEXT):
+	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" incdir$(HOSTEXEEXT)
+
 # pass1 and pass2
 #
 # If the 2 pass build option is selected, then this pass1 target is
@@ -381,9 +370,9 @@ include tools/LibTargets.mk
 # is an archive.  Exactly what is performed during pass1 or what it generates
 # is unknown to this makefile unless CONFIG_PASS1_OBJECT is defined.
 
-pass1: $(USERLIBS)
+pass1: tools/incdir$(HOSTEXEEXT) $(USERLIBS)
 
-pass2: $(NUTTXLIBS)
+pass2: tools/incdir$(HOSTEXEEXT) $(NUTTXLIBS)
 
 # $(BIN)
 #

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -1,35 +1,20 @@
 ############################################################################
 # tools/Makefile.win
 #
-#   Copyright (C) 2012, 2015, 2018 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@nuttx.org>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 
@@ -347,6 +332,11 @@ clean_context:
 
 include tools/LibTargets.mk
 
+# Build the incdir tools need for all builds
+
+tools\incdir$(HOSTEXEEXT):
+	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" incdir$(HOSTEXEEXT)
+
 # pass1 and pass2
 #
 # If the 2 pass build option is selected, then this pass1 target is
@@ -357,9 +347,9 @@ include tools/LibTargets.mk
 # is an archive.  Exactly what is performed during pass1 or what it generates
 # is unknown to this makefile unless CONFIG_PASS1_OBJECT is defined.
 
-pass1: $(USERLIBS)
+pass1: tools\incdir$(HOSTEXEEXT) $(USERLIBS)
 
-pass2: $(NUTTXLIBS)
+pass2: tools\incdir$(HOSTEXEEXT) $(NUTTXLIBS)
 
 # $(BIN)
 #


### PR DESCRIPTION
## Summary

1. incdir.c was added in PR 1148.  This PR hooks it into the build system.
2.  tools/Makefile.host:  Add incdir binary to Makefile.host.  This was missed in PR 1148

## Impact

This has the potential to break builds.  Significant testing has been and is being performed on individual builds.  Running the change through the PR checks will be the best, final test.

## Testing

The PR checks for this PR is the final verification of this change.


