### PR TITLE
tools/Makefiles: Fix use of unbuilt incdir binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,24 @@
 ############################################################################
 # Makefile
 #
-#   Copyright (C) 2012, 2018 Gregory Nutt. All rights reserved.
-#   Author: Gregory Nutt <gnutt@nuttx.org>
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in
-#    the documentation and/or other materials provided with the
-#    distribution.
-# 3. Neither the name NuttX nor the names of its contributors may be
-#    used to endorse or promote products derived from this software
-#    without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
 #
 ############################################################################
 
-# This is a top-level "kludge" Makefile that just includes the correct
-# Makefile.  If you already know the Makefile that you want, you can skip
-# this nonsense using:
-#
-#   make -f tools/Makefile.unix, OR
-#   make -f tools/Makefile.win
-#
+# Check if the system has been configured
 
 ifeq ($(wildcard .config),)
 .DEFAULT default:
@@ -47,6 +26,16 @@ ifeq ($(wildcard .config),)
 	@echo "  tools/configure.sh <target>"
 else
 include .config
+
+# Build any necessary tools needed early in the build.
+# incdir - Is needed immediately by all Make.defs file.
+
+TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
+DUMMY  := ${shell $(MAKE) -C tools -f Makefile.host incdir \
+          INCDIR="$(TOPDIR)/tools/incdir.sh"}
+
+# Include the correct Makefile for the selected architecture.
+
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 include tools/Makefile.win
 else

--- a/tools/Makefile.host
+++ b/tools/Makefile.host
@@ -285,10 +285,10 @@ clean:
 	$(call DELFILE, nxstyle.exe)
 	$(call DELFILE, rmcr)
 	$(call DELFILE, rmcr.exe)
-	$(call DELFILE, incdir)
-	$(call DELFILE, incdir.exe)
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) rm -rf *.dSYM
 endif
 	$(Q) $(MAKE) -C pic32 -f Makefile.host TOPDIR="$(TOPDIR)" clean
+	$(call DELFILE, incdir)
+	$(call DELFILE, incdir.exe)
 	$(call CLEAN)

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -523,7 +523,6 @@ depend: pass1dep pass2dep
 $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
 
 subdir_clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" clean
 endif
@@ -563,6 +562,7 @@ endif
 	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board
 	$(Q) $(DIRUNLINK) $(ARCH_SRC)/chip
 	$(Q) $(DIRUNLINK) $(TOPDIR)/drivers/platform
+	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps/ directory is included with NuttX,

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -355,11 +355,6 @@ clean_context:
 
 include tools/LibTargets.mk
 
-# Build the incdir tools need for all builds
-
-tools/incdir$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" incdir$(HOSTEXEEXT)
-
 # pass1 and pass2
 #
 # If the 2 pass build option is selected, then this pass1 target is
@@ -370,9 +365,9 @@ tools/incdir$(HOSTEXEEXT):
 # is an archive.  Exactly what is performed during pass1 or what it generates
 # is unknown to this makefile unless CONFIG_PASS1_OBJECT is defined.
 
-pass1: tools/incdir$(HOSTEXEEXT) $(USERLIBS)
+pass1: $(USERLIBS)
 
-pass2: tools/incdir$(HOSTEXEEXT) $(NUTTXLIBS)
+pass2: $(NUTTXLIBS)
 
 # $(BIN)
 #

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -330,13 +330,6 @@ clean_context:
 # execution will then be built from those libraries.  The following targets
 # build those libraries.
 
-include tools/LibTargets.mk
-
-# Build the incdir tools need for all builds
-
-tools\incdir$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" incdir$(HOSTEXEEXT)
-
 # pass1 and pass2
 #
 # If the 2 pass build option is selected, then this pass1 target is
@@ -347,9 +340,9 @@ tools\incdir$(HOSTEXEEXT):
 # is an archive.  Exactly what is performed during pass1 or what it generates
 # is unknown to this makefile unless CONFIG_PASS1_OBJECT is defined.
 
-pass1: tools\incdir$(HOSTEXEEXT) $(USERLIBS)
+pass1: $(USERLIBS)
 
-pass2: tools\incdir$(HOSTEXEEXT) $(NUTTXLIBS)
+pass2: $(NUTTXLIBS)
 
 # $(BIN)
 #

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -479,7 +479,6 @@ depend: pass1dep pass2dep
 $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
 
 subdir_clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" clean
 endif
@@ -518,6 +517,7 @@ endif
 	$(call DIRUNLINK, $(ARCH_SRC)\board)
 	$(call DIRUNLINK, $(ARCH_SRC)\chip)
 	$(call DIRUNLINK, $(TOPDIR)\drivers\platform)
+	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps\ directory is included with NuttX,


### PR DESCRIPTION
## Summary

There were several cases where there were attempts to use the tools/incdir binary before it was used.  You can see these in the PR checks.  They do not seem to fail the build, but there are many of these errors in the build.

This resolves that issue but adds a significant amount to the build time.
