### PR TITLE
dps.h: Remove CONFIG_LIBM and CONFIG_ARCH_MATH_H

### DIFF
--- a/include/dsp.h
+++ b/include/dsp.h
@@ -68,10 +68,6 @@
 #  define CONFIG_LIBDSP_PRECISION 0
 #endif
 
-#if !defined(CONFIG_LIBM) && !defined(CONFIG_ARCH_MATH_H)
-#  error math.h not defined!
-#endif
-
 /* Phase rotation direction */
 
 #define DIR_CW   (1.0f)


### PR DESCRIPTION
since the user may use math library from toolchain directly

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I67ccc4830403e3c15a84a8f9b1420d9a10894ddf

## Summary

## Impact

## Testing

