### PR TITLE
x86_64: Use gcc compiler instead of clang for macOS

### DIFF
--- a/boards/x86_64/intel64/qemu-intel64/scripts/Make.defs
+++ b/boards/x86_64/intel64/qemu-intel64/scripts/Make.defs
@@ -56,6 +56,10 @@ ifeq ($(HOSTOS),Cygwin)
 CROSSDEV = i486-nuttx-elf-
 endif
 
+ifeq ($(CONFIG_HOST_MACOS),y)
+CROSSDEV = 86_64-elf-
+endif
+
 CC = $(CROSSDEV)gcc
 CPP = $(CROSSDEV)gcc -E
 LD = $(CROSSDEV)ld


### PR DESCRIPTION
## Summary
macOS tries to force the use of clang which is not currently supported for the x86_64 builds. Giving an error like `clang: error: unknown argument: '-fno-crossjumping'` This will force the use of gcc like we do with the sim builds, this should resolve this PR https://github.com/apache/incubator-nuttx-testing/pull/43
## Impact
Should allow building on macOS

## Testing
Testing should be triggered by CI path after this.  Current configuration is already not able to build on macOS
