### PR TITLE
Fix the build break during porting the latest libc++

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -29,6 +29,7 @@
 #include <nuttx/compiler.h>
 
 #include <sys/types.h>
+#include <errno.h>
 #include <stdint.h>
 #include <limits.h>
 
@@ -254,6 +255,21 @@ FAR void *realloc(FAR void *, size_t);
 FAR void *memalign(size_t, size_t);
 FAR void *zalloc(size_t);
 FAR void *calloc(size_t, size_t);
+
+#ifdef __cplusplus
+inline FAR void *aligned_alloc(size_t a, size_t s)
+{
+  return memalign(a, s);
+}
+
+inline int posix_memalign(FAR void **m, size_t a, size_t s)
+{
+  return (*m = memalign(a, s)) ? OK : ENOMEM;
+}
+#else
+#define aligned_alloc(a, s) memalign((a), (s))
+#define posix_memalign(m, a, s) ((*(m) = memalign((a), (s))) ? OK : ENOMEM)
+#endif
 
 struct mallinfo mallinfo(void);
 

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -158,7 +158,15 @@ int       on_exit(CODE void (*func)(int, FAR void *), FAR void *arg);
 /* _Exit() is a stdlib.h equivalent to the unistd.h _exit() function */
 
 void      _exit(int status); /* See unistd.h */
-#define   _Exit(s) _exit(s)
+
+#ifdef __cplusplus
+inline void _Exit(int s)
+{
+  _exit(s);
+}
+#else
+#define _Exit(s) _exit(s)
+#endif
 
 /* System() command is not implemented in the NuttX libc because it is so
  * entangled with shell logic.  There is an experimental version at
@@ -187,13 +195,44 @@ double    strtod(FAR const char *str, FAR char **endptr);
 long double strtold(FAR const char *str, FAR char **endptr);
 #endif
 
-#define atoi(nptr)  ((int)strtol((nptr), NULL, 10))
-#define atol(nptr)  strtol((nptr), NULL, 10)
+#ifdef __cplusplus
+inline int atoi(FAR const char *nptr)
+{
+  return (int)strtol(nptr, NULL, 10);
+}
+#else
+#define atoi(nptr) ((int)strtol((nptr), NULL, 10))
+#endif
+
+#ifdef __cplusplus
+inline int atol(FAR const char *nptr)
+{
+  return strtol(nptr, NULL, 10);
+}
+#else
+#define atol(nptr) strtol((nptr), NULL, 10)
+#endif
+
 #ifdef CONFIG_HAVE_LONG_LONG
+#ifdef __cplusplus
+inline long long atoll(FAR const char *nptr)
+{
+  return strtoll(nptr, NULL, 10);
+}
+#else
 #define atoll(nptr) strtoll((nptr), NULL, 10)
 #endif
+#endif
+
 #ifdef CONFIG_HAVE_DOUBLE
-#define atof(nptr)  strtod((nptr), NULL)
+#ifdef __cplusplus
+inline double atof(FAR const char *nptr)
+{
+  return strtod(nptr, NULL);
+}
+#else
+#define atof(nptr) strtod((nptr), NULL)
+#endif
 #endif
 
 /* Binary to string conversions */

--- a/include/time.h
+++ b/include/time.h
@@ -96,6 +96,10 @@
 
 #define TIMER_ABSTIME      1
 
+/* Time base values for timespec_get.  */
+
+#define TIME_UTC           1
+
 #ifndef CONFIG_LIBC_LOCALTIME
 /* Local time is the same as gmtime in this implementation */
 
@@ -196,6 +200,17 @@ clock_t clock(void);
 int clock_settime(clockid_t clockid, FAR const struct timespec *tp);
 int clock_gettime(clockid_t clockid, FAR struct timespec *tp);
 int clock_getres(clockid_t clockid, FAR struct timespec *res);
+
+#ifdef __cplusplus
+inline int timespec_get(FAR struct timespec *t, int b)
+{
+  return b == TIME_UTC ? (clock_gettime(CLOCK_REALTIME, t), b) : 0;
+}
+
+#else
+#define timespec_get(t, b) \
+  ((b) == TIME_UTC ? (clock_gettime(CLOCK_REALTIME, (t)), (b)) : 0)
+#endif
 
 time_t mktime(FAR struct tm *tp);
 FAR struct tm *gmtime(FAR const time_t *timep);


### PR DESCRIPTION
## Summary

## Impact

## Testing
_Exit generate the false nxstyle alarm:
```
include/stdlib.h:164:12: error: Mixed case identifier found
include/stdlib.h:164:12: error: Mixed case identifier found
```