### PR TITLE
drivers/serial/pty.c:  Correct returned number of bytes.

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -673,6 +673,10 @@ static ssize_t pty_write(FAR struct file *filep,
                * How would we ripple the O_NONBLOCK characteristic to the
                * contained sink pipe?  file_vfcntl()?  Or FIONSPACE?  See the
                * TODO comment at the top of this file.
+               *
+               * NOTE: The newline is not included in total number of bytes
+               * written.  Otherwise, we would return more than the
+               * requested number of bytes.
                */
 
               nwritten = file_write(&dev->pd_sink, &cr, 1);
@@ -681,10 +685,6 @@ static ssize_t pty_write(FAR struct file *filep,
                   ntotal = nwritten;
                   break;
                 }
-
-              /* Update the count of bytes transferred */
-
-              ntotal++;
             }
 
           /* Transfer the (possibly translated) character..  This will block


### PR DESCRIPTION
## Summary

Reported by 권석근 <kwonsksj@gmail.com>:

I found a bug at "pty.c" during ssh server implementation.

When I turn on CONFIG_SERIAL_TERMIOS and OPOST|ONLCR on pty device
for nsh console's stdin/stdout (ssh shell service), I've got system crash.

Bugs at line 687 of pty.c, pty_write()
ntotal++;

when converting '\n' to '\r\n', pty_write() will return more than requested
(+1, for example) length. and this will break caller lib_fflush(), line 150
of lib_libfflush.c.
When she get (libfflush()) bytes_nwritten which is greater than nbuffer,
nbuffer goes to negative at line 150 and eventually destroys
*stream->fs_bufpos at line 163 of lib_libflush.c

Removing ntotal++;  line 687 of pty.c will fix this bug.

BTW, nsh using ptm/pty as a ssh shell service works great with libssh +
mbedtls.
