### PR TITLE
sched/task/task_spawn.c:  Fix duplicate task_spawn()

### DIFF
--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -244,7 +244,7 @@ static int nxtask_spawn_proxy(int argc, FAR char *argv[])
  ****************************************************************************/
 
 /****************************************************************************
- * Name: task_spawn
+ * Name: task_spawn/_task_spawn
  *
  * Description:
  *   The task_spawn() function will create a new, child task, where the
@@ -308,10 +308,17 @@ static int nxtask_spawn_proxy(int argc, FAR char *argv[])
  *
  ****************************************************************************/
 
+#ifdef CONFIG_LIB_SYSCALL
+static int _task_spawn(FAR pid_t *pid, FAR const char *name, main_t entry,
+                       FAR const posix_spawn_file_actions_t *file_actions,
+                       FAR const posix_spawnattr_t *attr,
+                       FAR char * const argv[], FAR char * const envp[])
+#else
 int task_spawn(FAR pid_t *pid, FAR const char *name, main_t entry,
                FAR const posix_spawn_file_actions_t *file_actions,
                FAR const posix_spawnattr_t *attr,
                FAR char * const argv[], FAR char * const envp[])
+#endif
 {
   struct sched_param param;
   pid_t proxy;
@@ -441,7 +448,7 @@ errout_with_lock:
  * Name: nx_task_spawn
  *
  * Description:
- *   This function de-marshals parameters and invokes task_spawn().
+ *   This function de-marshals parameters and invokes _task_spawn().
  *
  *   task_spawn() and posix_spawn() are NuttX OS interfaces.  In PROTECTED
  *   and KERNEL build modes, then can be reached from applications only via
@@ -463,9 +470,9 @@ errout_with_lock:
 int nx_task_spawn(FAR const struct spawn_syscall_parms_s *parms)
 {
   DEBUGASSERT(parms != NULL);
-  return task_spawn(parms->pid, parms->name, parms->entry,
-                    parms->file_actions, parms->attr,
-                    parms->argv, parms->envp);
+  return _task_spawn(parms->pid, parms->name, parms->entry,
+                     parms->file_actions, parms->attr,
+                     parms->argv, parms->envp);
 }
 #endif
 


### PR DESCRIPTION
## Summary

In the FLAT build if CONFIG_LIB_SYSCALL=y, then the function task_spawn() will be duplicated.:  One version in libs/libc/spawn and one version in sched/task.

The version of task_spawn in lib/libc/spawn exists only if CONFIG_LIB_SYSCALL is selected.  In that case, the one in sched/task/task_spawn.c should be static, at least in the FLAT build.

The version of task_spawn.c in libs/libc/spawn simply marshals the parameters into a structure and calls nx_task_spawn().  If CONFIG_LIB_SYSCALL is defined then nx_task_spawn() will un-marshal the data can call the real task spawn.  This nonsense is only necessary because task_spawn has 8 parameters and the maximum number of parameters in a system call is only 6.

Without syscalls:  Application should call directly in task_spawn() in sched/task/task_spawn.c and, hence, it must not be static

With syscalls:  Application should call the marshalling task_spawn() in libs/libc/spawn/lib_task_spawn.c -> That will call the autogenerated nx_task_spawn() proxy -> And generate a system call -> The system call will the unmarshalling nx_task_spawn() in sched/task/task_spawn.c -> Which will, finally, call the real task_spawn().

The side-effect of making task_spawn() static is that it then cannot be used within the OS.  But as far as I can tell, nothing in the OS itself currently uses task_spawn() so I think it is safe to make it conditionally static.  But that only protects from duplicate symbols in the useless case mentioned above.
