### PR TITLE
libc: Unify the selection of inline or macro

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -1,7 +1,8 @@
 /****************************************************************************
  * include/ctype.h
  *
- *   Copyright (C) 2007-2009, 2011, 2014, 2016 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2011, 2014, 2016 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -61,7 +62,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isspace(int c)
 {
   return c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
@@ -82,7 +83,7 @@ static inline int isspace(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isascii(int c)
 {
   return c >= 0 && c <= 0x7f;
@@ -99,7 +100,7 @@ static inline int isascii(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isprint(int c)
 {
   return c >= 0x20 && c < 0x7f;
@@ -116,7 +117,7 @@ static inline int isprint(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isgraph(int c)
 {
   return c > 0x20 && c < 0x7f;
@@ -133,7 +134,7 @@ static inline int isgraph(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int iscntrl(int c)
 {
   return !isprint(c);
@@ -150,7 +151,7 @@ static inline int iscntrl(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int islower(int c)
 {
   return c >= 'a' && c <= 'z';
@@ -167,7 +168,7 @@ static inline int islower(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isupper(int c)
 {
   return c >= 'A' && c <= 'Z';
@@ -184,7 +185,7 @@ static inline int isupper(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isalpha(int c)
 {
   return islower(c) || isupper(c);
@@ -201,7 +202,7 @@ static inline int isalpha(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isblank(int c)
 {
   return c == ' ' || c == '\t';
@@ -218,7 +219,7 @@ static inline int isblank(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isdigit(int c)
 {
   return c >= '0' && c <= '9';
@@ -235,7 +236,7 @@ static inline int isdigit(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isalnum(int c)
 {
   return isalpha(c) || isdigit(c);
@@ -253,7 +254,7 @@ static inline int isalnum(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int ispunct(int c)
 {
   return isgraph(c) && !isalnum(c);
@@ -270,7 +271,7 @@ static inline int ispunct(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int isxdigit(int c)
 {
   return (c >= '0' && c <= '9') ||
@@ -292,7 +293,7 @@ static inline int isxdigit(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int toupper(int c)
 {
   return (c >= 'a' && c <= 'z') ? c - 'a' + 'A' : c;
@@ -310,7 +311,7 @@ static inline int toupper(int c)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 static inline int tolower(int c)
 {
   return (c >= 'A' && c <= 'Z') ? (c - 'A' + 'a') : c;
@@ -322,10 +323,6 @@ static inline int tolower(int c)
 
 /****************************************************************************
  * Public Type Definitions
- ****************************************************************************/
-
-/****************************************************************************
- * Public Functions
  ****************************************************************************/
 
 #ifdef __cplusplus

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -210,6 +210,7 @@ int    vdprintf(int fd, FAR const IPTR char *fmt, va_list ap);
 
 /* Operations on paths */
 
+FAR FILE *tmpfile(void);
 FAR char *tmpnam(FAR char *s);
 FAR char *tempnam(FAR const char *dir, FAR const char *pfx);
 int       remove(FAR const char *path);

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -160,8 +160,8 @@ int       on_exit(CODE void (*func)(int, FAR void *), FAR void *arg);
 
 void      _exit(int status); /* See unistd.h */
 
-#ifdef __cplusplus
-inline void _Exit(int s)
+#ifdef CONFIG_HAVE_INLINE
+static inline void _Exit(int s)
 {
   _exit(s);
 }
@@ -196,8 +196,8 @@ double    strtod(FAR const char *str, FAR char **endptr);
 long double strtold(FAR const char *str, FAR char **endptr);
 #endif
 
-#ifdef __cplusplus
-inline int atoi(FAR const char *nptr)
+#ifdef CONFIG_HAVE_INLINE
+static inline int atoi(FAR const char *nptr)
 {
   return (int)strtol(nptr, NULL, 10);
 }
@@ -205,8 +205,8 @@ inline int atoi(FAR const char *nptr)
 #define atoi(nptr) ((int)strtol((nptr), NULL, 10))
 #endif
 
-#ifdef __cplusplus
-inline int atol(FAR const char *nptr)
+#ifdef CONFIG_HAVE_INLINE
+static inline int atol(FAR const char *nptr)
 {
   return strtol(nptr, NULL, 10);
 }
@@ -215,8 +215,8 @@ inline int atol(FAR const char *nptr)
 #endif
 
 #ifdef CONFIG_HAVE_LONG_LONG
-#ifdef __cplusplus
-inline long long atoll(FAR const char *nptr)
+#ifdef CONFIG_HAVE_INLINE
+static inline long long atoll(FAR const char *nptr)
 {
   return strtoll(nptr, NULL, 10);
 }
@@ -226,8 +226,8 @@ inline long long atoll(FAR const char *nptr)
 #endif
 
 #ifdef CONFIG_HAVE_DOUBLE
-#ifdef __cplusplus
-inline double atof(FAR const char *nptr)
+#ifdef CONFIG_HAVE_INLINE
+static inline double atof(FAR const char *nptr)
 {
   return strtod(nptr, NULL);
 }
@@ -259,13 +259,13 @@ FAR void *memalign(size_t, size_t);
 FAR void *zalloc(size_t);
 FAR void *calloc(size_t, size_t);
 
-#ifdef __cplusplus
-inline FAR void *aligned_alloc(size_t a, size_t s)
+#ifdef CONFIG_HAVE_INLINE
+static inline FAR void *aligned_alloc(size_t a, size_t s)
 {
   return memalign(a, s);
 }
 
-inline int posix_memalign(FAR void **m, size_t a, size_t s)
+static inline int posix_memalign(FAR void **m, size_t a, size_t s)
 {
   return (*m = memalign(a, s)) ? OK : ENOMEM;
 }

--- a/include/strings.h
+++ b/include/strings.h
@@ -48,11 +48,13 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if !defined(CONFIG_HAVE_INLINE) && !defined(__cplusplus)
+#ifndef CONFIG_HAVE_INLINE
 /* Compatibility definitions
  *
- * Marked LEGACY in Open Group Base Specifications Issue 6/IEEE Std 1003.1-2004
- * Removed from Open Group Base Specifications Issue 7/IEEE Std 1003.1-2008
+ * Marked LEGACY in Open Group Base Specifications Issue 6/
+ * IEEE Std 1003.1-2004
+ * Removed from Open Group Base Specifications Issue 7/
+ * IEEE Std 1003.1-2008
  */
 
 #  define bcmp(b1,b2,len)  memcmp(b1,b2,(size_t)len)
@@ -61,7 +63,7 @@
 #  define index(s,c)       strchr(s,c)
 #  define rindex(s,c)      strrchr(s,c)
 
-#endif /* !CONFIG_HAVE_INLINE && !__cplusplus */
+#endif /* !CONFIG_HAVE_INLINE */
 
 /****************************************************************************
  * Inline Functions
@@ -76,11 +78,13 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#if defined(CONFIG_HAVE_INLINE) || defined(__cplusplus)
+#ifdef CONFIG_HAVE_INLINE
 /* Compatibility inline functions.
  *
- * Marked LEGACY in Open Group Base Specifications Issue 6/IEEE Std 1003.1-2004
- * Removed from Open Group Base Specifications Issue 7/IEEE Std 1003.1-2008
+ * Marked LEGACY in Open Group Base Specifications Issue 6/
+ * IEEE Std 1003.1-2004
+ * Removed from Open Group Base Specifications Issue 7/
+ * IEEE Std 1003.1-2008
  */
 
 static inline int bcmp(FAR const void *b1, FAR const void *b2, size_t len)
@@ -107,7 +111,7 @@ static inline FAR char *rindex(FAR const char *s, int c)
 {
   return strrchr(s, c);
 }
-#endif /* CONFIG_HAVE_INLINE || __cplusplus */
+#endif /* CONFIG_HAVE_INLINE */
 
 /****************************************************************************
  * Public Function Prototypes

--- a/include/time.h
+++ b/include/time.h
@@ -201,8 +201,8 @@ int clock_settime(clockid_t clockid, FAR const struct timespec *tp);
 int clock_gettime(clockid_t clockid, FAR struct timespec *tp);
 int clock_getres(clockid_t clockid, FAR struct timespec *res);
 
-#ifdef __cplusplus
-inline int timespec_get(FAR struct timespec *t, int b)
+#ifdef CONFIG_HAVE_INLINE
+static inline int timespec_get(FAR struct timespec *t, int b)
 {
   return b == TIME_UTC ? (clock_gettime(CLOCK_REALTIME, t), b) : 0;
 }

--- a/libs/libc/stdio/Make.defs
+++ b/libs/libc/stdio/Make.defs
@@ -60,7 +60,7 @@ CSRCS += lib_stdinstream.c lib_stdoutstream.c lib_stdsistream.c
 CSRCS += lib_stdsostream.c lib_perror.c lib_feof.c lib_ferror.c
 CSRCS += lib_rawinstream.c lib_rawoutstream.c lib_rawsistream.c
 CSRCS += lib_rawsostream.c lib_remove.c lib_clearerr.c lib_scanf.c
-CSRCS += lib_fscanf.c lib_vfscanf.c
+CSRCS += lib_fscanf.c lib_vfscanf.c lib_tmpfile.c
 
 endif
 

--- a/libs/libc/stdio/lib_tmpfile.c
+++ b/libs/libc/stdio/lib_tmpfile.c
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_tmpfile.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR FILE *tmpfile(void)
+{
+  char path[L_tmpnam] = "/tmp/XXXXXX.tmp";
+  FAR FILE *fp = NULL;
+  int fd;
+
+  fd = mkstemp(path);
+  if (fd >= 0)
+    {
+      unlink(fd);
+      fp = fdopen(fd, "w+");
+      if (fp == NULL)
+        {
+          close(fd);
+        }
+    }
+
+  return fp;
+}


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I44a26550ff856af07d2d96a6f0a6066f988d6da3

## Summary

## Impact

## Testing
nxstyle false alarm by L_tmpnam and _Exit:
```
libs/libc/stdio/lib_tmpfile.c:35:12: error: Mixed case identifier found
include/stdlib.h:164:19: error: Mixed case identifier found
```