### PR TITLE
ez80:  Fix ez80 build problems.

### DIFF
--- a/arch/z80/src/Makefile
+++ b/arch/z80/src/Makefile
@@ -37,7 +37,6 @@
 
 include $(TOPDIR)/Make.defs
 include chip/Make.defs
-include board/Make.defs
 
 # Compiler-Dependent Make:  SDCC or ZiLOG ZDS-II
 

--- a/arch/z80/src/ez80/Toolchain.defs
+++ b/arch/z80/src/ez80/Toolchain.defs
@@ -71,7 +71,7 @@ else
 
   # Escaped versions
 
-  ETOPDIR := ${shell echo "$(WTOPDIR)" | sed -e "s/ /%20/g"}
+  ETOPDIR := ${shell echo $(WTOPDIR) | sed -e "s/ /%20/g"}
   EZDSSTDINCDIR := ${shell echo "$(WZDSSTDINCDIR)" | sed -e "s/ /%20/g"}
   EZDSZILOGINCDIR := ${shell echo "$(WZDSZILOGINCDIR)" | sed -e "s/ /%20/g"}
 endif

--- a/tools/incdir.c
+++ b/tools/incdir.c
@@ -399,8 +399,8 @@ int main(int argc, char **argv, char **envp)
 
       if (compiler == COMPILER_ZDSII)
         {
-          /* FORM:  -stdinc: 'dir1;dir2;...;dirN'
-           *        -usrinc: 'dir1;dir2;...;dirN'
+          /* FORM:  -stdinc:'dir1;dir2;...;dirN'
+           *        -usrinc:'dir1;dir2;...;dirN'
            */
 
           /* Treat the first directory differently */
@@ -409,11 +409,11 @@ int main(int argc, char **argv, char **envp)
             {
               if (i == ndirs - 1)
                 {
-                  ret = my_asprintf(&segment, "%s '%s'", cmdarg, incpath);
+                  ret = my_asprintf(&segment, "%s'%s'", cmdarg, incpath);
                 }
               else
                 {
-                  ret = my_asprintf(&segment, "%s '%s", cmdarg, incpath);
+                  ret = my_asprintf(&segment, "%s'%s", cmdarg, incpath);
                 }
             }
           else


### PR DESCRIPTION
## Summary

arch/z80/src/Makefile:  Correct inclusion of non-existent file.  This was not a problem before because there was '-' before the include.  Problem revealed with '-' removed.

arch/z80/src/ez80/Toolchain.defs:  Apparently there are not too many '"' in path definition.

tools/incdir.c:  No space between -usrinc:  or -sysinc:  and the list of paths.

There is at least one more outstanding ez80 build problem that I need to fix when I get a chance.