### PR TITLE
libc: Fix a typo error in tmpfile

### DIFF
--- a/libs/libc/stdio/lib_tmpfile.c
+++ b/libs/libc/stdio/lib_tmpfile.c
@@ -39,7 +39,7 @@ FAR FILE *tmpfile(void)
   fd = mkstemp(path);
   if (fd >= 0)
     {
-      unlink(fd);
+      unlink(path);
       fp = fdopen(fd, "w+");
       if (fp == NULL)
         {


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: Ic6db2c76844a5a9d503fc46bb4b930870afbd9ed

## Summary
Typo error by: https://github.com/apache/incubator-nuttx/pull/1176

## Impact

## Testing

