### PR TITLE
libc: tmpfile shouldn't hardcode the folder to /tmp

### DIFF
--- a/libs/libc/stdio/lib_tmpfile.c
+++ b/libs/libc/stdio/lib_tmpfile.c
@@ -32,7 +32,7 @@
 
 FAR FILE *tmpfile(void)
 {
-  char path[L_tmpnam] = "/tmp/XXXXXX.tmp";
+  char path[L_tmpnam] = P_tmpdir "/XXXXXX.tmp";
   FAR FILE *fp = NULL;
   int fd;
 

--- a/libs/libc/stdlib/lib_mkstemp.c
+++ b/libs/libc/stdlib/lib_mkstemp.c
@@ -38,10 +38,6 @@
  * Pre-processor definitions
  ****************************************************************************/
 
-#ifndef CONFIG_LIBC_TMPDIR
-#  define CONFIG_LIBC_TMPDIR "/tmp"
-#endif
-
 #define MAX_XS        6
 #define MIN_NUMERIC   0    /* 0-9:   Numeric */
 #define MAX_NUMERIC   9

--- a/libs/libc/wchar/lib_mbsnrtowcs.c
+++ b/libs/libc/wchar/lib_mbsnrtowcs.c
@@ -38,6 +38,7 @@
  ****************************************************************************/
 
 #include <sys/types.h>
+#include <string.h>
 #include <wchar.h>
 
 #ifdef CONFIG_LIBC_WCHAR


### PR DESCRIPTION
## Summary

## Impact

## Testing

