### PR TITLE
mkdeps: Quote CFLAGS to be safe with the shell

### DIFF
--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -352,8 +352,7 @@ static const char *do_shquote(const char *argument)
     {
       fprintf(stderr,
               "ERROR: Truncated during shquote string is too long"
-              "[%lu/%zu]\n", (unsigned long)strlen(argument),
-              sizeof(g_shquote));
+              "[%zu/%zu]\n", strlen(argument), sizeof(g_shquote));
       exit(EXIT_FAILURE);
     }
 
@@ -590,7 +589,7 @@ static const char *do_expand(const char *argument)
         {
           fprintf(stderr,
                   "ERROR: Truncated during expansion string is too long"
-                  "[%lu/%u]\n", (unsigned long)strlen(argument), MAX_EXPAND);
+                  "[%zu/%u]\n", strlen(argument), MAX_EXPAND);
           exit(EXIT_FAILURE);
         }
 
@@ -662,8 +661,7 @@ static const char *convert_path(const char *path)
                              NULL, 0);
       if (size > (MAX_PATH - 3))
         {
-          fprintf(stderr, "# ERROR: POSIX path too long: %lu\n",
-                  (unsigned long)size);
+          fprintf(stderr, "# ERROR: POSIX path too long: %zd\n", size);
           exit(EXIT_FAILURE);
         }
 


### PR DESCRIPTION
mkdeps uses system() thus a shell to execute cc.
it doesn't work if you have something like

    CFLAGS   += -DMBEDTLS_USER_CONFIG_FILE="<mbedtls/user_config.h>"

because the shell interprets "<" as a redirect.

to fix it, we should do either

    * make it shell-quote arguments

    * or, stop using system()

this commit implements the former.

some platforms provide easy ways to do the former.
eg. https://netbsd.gw.com/cgi-bin/man-cgi?shquote++NetBSD-current
but unfortunately none of them seems available widely.

i guess the latter approach is more common.
eg. https://github.com/NetBSD/src/blob/4464250282160188d09bef1ac67ec944b9a8a828/usr.bin/mkdep/mkdep.c#L137-L154
but i might be a burden for windows. (i don't know)

## Summary

## Impact

## Testing

