### PR TITLE
boards/mips: restore OUTPUT_FORMAT and OUTPUT_ARCH for mips link scripts

### DIFF
--- a/boards/mips/pic32mx/mirtoo/scripts/c32-debug.ld
+++ b/boards/mips/pic32mx/mirtoo/scripts/c32-debug.ld
@@ -88,6 +88,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/mirtoo/scripts/c32-release.ld
+++ b/boards/mips/pic32mx/mirtoo/scripts/c32-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/mirtoo/scripts/mips-elf-debug.ld
+++ b/boards/mips/pic32mx/mirtoo/scripts/mips-elf-debug.ld
@@ -88,6 +88,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/mirtoo/scripts/mips-elf-release.ld
+++ b/boards/mips/pic32mx/mirtoo/scripts/mips-elf-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/mirtoo/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mx/mirtoo/scripts/pinguino-debug.ld
@@ -88,6 +88,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/mirtoo/scripts/xc32-debug.ld
+++ b/boards/mips/pic32mx/mirtoo/scripts/xc32-debug.ld
@@ -88,6 +88,8 @@ MEMORY
     kseg1_data_mem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/mirtoo/scripts/xc32-release.ld
+++ b/boards/mips/pic32mx/mirtoo/scripts/xc32-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_data_mem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/pic32mx-starterkit/scripts/c32-release.ld
+++ b/boards/mips/pic32mx/pic32mx-starterkit/scripts/c32-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 128K - 512
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/pic32mx-starterkit/scripts/mips-release.ld
+++ b/boards/mips/pic32mx/pic32mx-starterkit/scripts/mips-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 128K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/pic32mx-starterkit/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mx/pic32mx-starterkit/scripts/pinguino-debug.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 128K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/pic32mx7mmb/scripts/c32-release.ld
+++ b/boards/mips/pic32mx/pic32mx7mmb/scripts/c32-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 128K - 512
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/pic32mx7mmb/scripts/mips-release.ld
+++ b/boards/mips/pic32mx/pic32mx7mmb/scripts/mips-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 128K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/pic32mx7mmb/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mx/pic32mx7mmb/scripts/pinguino-debug.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 128K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/sure-pic32mx/scripts/c32-release.ld
+++ b/boards/mips/pic32mx/sure-pic32mx/scripts/c32-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/sure-pic32mx/scripts/mips-release.ld
+++ b/boards/mips/pic32mx/sure-pic32mx/scripts/mips-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/sure-pic32mx/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mx/sure-pic32mx/scripts/pinguino-debug.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/ubw32/scripts/c32-release.ld
+++ b/boards/mips/pic32mx/ubw32/scripts/c32-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/ubw32/scripts/mips-release.ld
+++ b/boards/mips/pic32mx/ubw32/scripts/mips-release.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mx/ubw32/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mx/ubw32/scripts/pinguino-debug.ld
@@ -90,6 +90,8 @@ MEMORY
     kseg1_datamem (w!x) : ORIGIN = 0xa0000200, LENGTH = 32K - 512
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mz/flipnclick-pic32mz/scripts/c32-debug.ld
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/scripts/c32-debug.ld
@@ -104,6 +104,8 @@ MEMORY
     kseg1_datamem (rw!x) : ORIGIN = 0xa0000200, LENGTH = 512K - 640
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mz)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mz/flipnclick-pic32mz/scripts/mips-debug.ld
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/scripts/mips-debug.ld
@@ -104,6 +104,8 @@ MEMORY
     kseg1_datamem (rw!x) : ORIGIN = 0xa0000200, LENGTH = 512K - 640
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mz/flipnclick-pic32mz/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/scripts/pinguino-debug.ld
@@ -104,6 +104,8 @@ MEMORY
     kseg1_datamem (rw!x) : ORIGIN = 0xa0000200, LENGTH = 512K - 640
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mz/flipnclick-pic32mz/scripts/xc32-debug.ld
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/scripts/xc32-debug.ld
@@ -104,6 +104,8 @@ MEMORY
     kseg1_data_mem (rw!x) : ORIGIN = 0xa0000200, LENGTH = 512K - 640
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mz/pic32mz-starterkit/scripts/c32-debug.ld
+++ b/boards/mips/pic32mz/pic32mz-starterkit/scripts/c32-debug.ld
@@ -104,6 +104,8 @@ MEMORY
     kseg1_datamem (rw!x) : ORIGIN = 0xa0000200, LENGTH = 512K - 640
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mz)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mz/pic32mz-starterkit/scripts/mips-debug.ld
+++ b/boards/mips/pic32mz/pic32mz-starterkit/scripts/mips-debug.ld
@@ -104,6 +104,8 @@ MEMORY
     kseg1_datamem (rw!x) : ORIGIN = 0xa0000200, LENGTH = 512K - 640
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mz/pic32mz-starterkit/scripts/pinguino-debug.ld
+++ b/boards/mips/pic32mz/pic32mz-starterkit/scripts/pinguino-debug.ld
@@ -104,6 +104,8 @@ MEMORY
     kseg1_datamem (rw!x) : ORIGIN = 0xa0000200, LENGTH = 512K - 640
 }
 
+OUTPUT_FORMAT("elf32-littlemips")
+OUTPUT_ARCH(mips)
 ENTRY(__start)
 
 SECTIONS

--- a/boards/mips/pic32mz/pic32mz-starterkit/scripts/xc32-debug.ld
+++ b/boards/mips/pic32mz/pic32mz-starterkit/scripts/xc32-debug.ld
@@ -104,6 +104,8 @@ MEMORY
     kseg1_data_mem (rw!x) : ORIGIN = 0xa0000200, LENGTH = 512K - 640
 }
 
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
 ENTRY(__start)
 
 SECTIONS


### PR DESCRIPTION
## Summary
Restore OUTPUT_FORMAT and OUTPUT_ARCH for mips link scripts to fix Nightly build break logs:

p32-ld: pic32mx_head.o: compiled for a little endian system and target is big endian
p32-ld: pic32mx_head.o: endianness incompatible with that of the selected emulation
p32-ld: failed to merge target specific data of file pic32mx_head.o

https://builds.apache.org/view/Incubator%20Projects/job/NuttX-Nightly-Build/179/consoleFull

## Impact
Check builds do not cover mips configs since PINGUINOL toolchain doesn't provide macOS binaries with the same name as in Linux.

## Testing
mips pic32mx-starterkit:nsh2 etc configs
