### PR TITLE
sched: Unify the main thread and pthread behaivour

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -714,6 +714,12 @@ struct tcb_s
   FAR struct mqueue_inode_s *msgwaitq;   /* Waiting for this message queue      */
 #endif
 
+  /* Robust mutex support *******************************************************/
+
+#if !defined(CONFIG_DISABLE_PTHREAD) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
+  FAR struct pthread_mutex_s *mhead;     /* List of mutexes held by thread      */
+#endif
+
   /* Clean-up stack *************************************************************/
 
 #ifdef CONFIG_PTHREAD_CLEANUP
@@ -796,12 +802,6 @@ struct pthread_tcb_s
 
   pthread_addr_t arg;                    /* Startup argument                    */
   FAR void *joininfo;                    /* Detach-able info to support join    */
-
-  /* Robust mutex support *******************************************************/
-
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-  FAR struct pthread_mutex_s *mhead;     /* List of mutexes held by thread      */
-#endif
 };
 #endif /* !CONFIG_DISABLE_PTHREAD */
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -714,6 +714,17 @@ struct tcb_s
   FAR struct mqueue_inode_s *msgwaitq;   /* Waiting for this message queue      */
 #endif
 
+  /* Clean-up stack *************************************************************/
+
+#ifdef CONFIG_PTHREAD_CLEANUP
+  /* tos   - The index to the next available entry at the top of the stack.
+   * stack - The pre-allocated clean-up stack memory.
+   */
+
+  uint8_t tos;
+  struct pthread_cleanup_s stack[CONFIG_PTHREAD_CLEANUP_STACKSIZE];
+#endif
+
   /* Pre-emption monitor support ************************************************/
 
 #ifdef CONFIG_SCHED_CRITMONITOR
@@ -790,17 +801,6 @@ struct pthread_tcb_s
 
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
   FAR struct pthread_mutex_s *mhead;     /* List of mutexes held by thread      */
-#endif
-
-  /* Clean-up stack *************************************************************/
-
-#ifdef CONFIG_PTHREAD_CLEANUP
-  /* tos   - The index to the next available entry at the top of the stack.
-   * stack - The pre-allocated clean-up stack memory.
-   */
-
-  uint8_t tos;
-  struct pthread_cleanup_s stack[CONFIG_PTHREAD_CLEANUP_STACKSIZE];
 #endif
 };
 #endif /* !CONFIG_DISABLE_PTHREAD */

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -121,7 +121,7 @@ int pthread_mutex_take(FAR struct pthread_mutex_s *mutex,
                        FAR const struct timespec *abs_timeout, bool intr);
 int pthread_mutex_trytake(FAR struct pthread_mutex_s *mutex);
 int pthread_mutex_give(FAR struct pthread_mutex_s *mutex);
-void pthread_mutex_inconsistent(FAR struct pthread_tcb_s *tcb);
+void pthread_mutex_inconsistent(FAR struct tcb_s *tcb);
 #else
 #  define pthread_mutex_take(m,abs_timeout,i)  pthread_sem_take(&(m)->sem,(abs_timeout),(i))
 #  define pthread_mutex_trytake(m)             pthread_sem_trytake(&(m)->sem)

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -99,7 +99,7 @@ int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
                             start_t start, pthread_startroutine_t entry);
 
 #ifdef CONFIG_PTHREAD_CLEANUP
-void pthread_cleanup_popall(FAR struct pthread_tcb_s *tcb);
+void pthread_cleanup_popall(FAR struct tcb_s *tcb);
 #endif
 
 int pthread_completejoin(pid_t pid, FAR void *exit_value);

--- a/sched/pthread/pthread_cancel.c
+++ b/sched/pthread/pthread_cancel.c
@@ -141,7 +141,7 @@ int pthread_cancel(pthread_t thread)
    * function will be unable to unlock its own mutexes.
    */
 
-  pthread_cleanup_popall(tcb);
+  pthread_cleanup_popall((FAR struct tcb_s *)tcb);
 #endif
 
   /* Complete pending join operations */

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -124,7 +124,7 @@ void pthread_exit(FAR void *exit_value)
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
   /* Recover any mutexes still held by the canceled thread */
 
-  pthread_mutex_inconsistent((FAR struct pthread_tcb_s *)tcb);
+  pthread_mutex_inconsistent(tcb);
 #endif
 
   /* Perform common task termination logic.  This will get called again later

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * sched/pthread/pthread_exit.c
  *
- *   Copyright (C) 2007, 2009, 2011-2013, 2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007, 2009, 2011-2013, 2017 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -105,7 +106,7 @@ void pthread_exit(FAR void *exit_value)
 #ifdef CONFIG_PTHREAD_CLEANUP
   /* Perform any stack pthread clean-up callbacks */
 
-  pthread_cleanup_popall((FAR struct pthread_tcb_s *)tcb);
+  pthread_cleanup_popall(tcb);
 #endif
 
   /* Complete pending join operations */

--- a/sched/pthread/pthread_mutexinconsistent.c
+++ b/sched/pthread/pthread_mutexinconsistent.c
@@ -71,7 +71,7 @@
  *
  ****************************************************************************/
 
-void pthread_mutex_inconsistent(FAR struct pthread_tcb_s *tcb)
+void pthread_mutex_inconsistent(FAR struct tcb_s *tcb)
 {
   FAR struct pthread_mutex_s *mutex;
   irqstate_t flags;
@@ -80,7 +80,7 @@ void pthread_mutex_inconsistent(FAR struct pthread_tcb_s *tcb)
 
   sched_lock();
 
-  /* Remove and process each mutex from the list of mutexes held by this task */
+  /* Remove and process each mutex held by this task */
 
   while (tcb->mhead != NULL)
     {

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -93,6 +93,12 @@ void exit(int status)
   pthread_cleanup_popall(tcb);
 #endif
 
+#if !defined(CONFIG_DISABLE_PTHREAD) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
+  /* Recover any mutexes still held by the canceled thread */
+
+  pthread_mutex_inconsistent(tcb);
+#endif
+
   /* Perform common task termination logic.  This will get called again later
    * through logic kicked off by _exit().  However, we need to call it before
    * calling _exit() in order to handle atexit() and on_exit() callbacks and

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -34,6 +34,7 @@
 #include "task/task.h"
 #include "group/group.h"
 #include "sched/sched.h"
+#include "pthread/pthread.h"
 
 /****************************************************************************
  * Public Functions
@@ -84,6 +85,12 @@ void exit(int status)
    */
 
   group_kill_children((FAR struct task_tcb_s *)tcb);
+#endif
+
+#ifdef CONFIG_PTHREAD_CLEANUP
+  /* Perform any stack pthread clean-up callbacks */
+
+  pthread_cleanup_popall(tcb);
 #endif
 
   /* Perform common task termination logic.  This will get called again later


### PR DESCRIPTION
## Summary
1.Make pthread_cleanup_[push|pop] callable from the main thread
2.Robust mutex also support in main thread now

## Impact

## Testing
nxstyle error can be ignored(mixed case and file rename):
```
include/stdlib.h:166:19: error: Mixed case identifier found
sched/task/task_atexit.c: fatal: Failed to open
sched/task/task_onexit.c: fatal: Failed to open
```