### PR TITLE
boards/Board.mk: Remove include $(TOPDIR)/Make.defs

### DIFF
--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -35,8 +35,6 @@
 #
 ############################################################################
 
-include $(TOPDIR)/Make.defs
-
 ifneq ($(RCSRCS)$(RCRAWS),)
 ETCDIR := etctmp
 ETCSRC := $(ETCDIR:%=%.c)


### PR DESCRIPTION
This file is already included by most board's Makefile,
remove it to avoid override the board's specific CFLAGS
etc.

Signed-off-by: Huang Qi <huangqi3@xiaomi.com>

## Summary

## Impact

## Testing

