### PR TITLE
include/cxx/cwchar: include wctype.h to fix libcxx build break

### DIFF
--- a/include/cxx/cwchar
+++ b/include/cxx/cwchar
@@ -43,6 +43,7 @@
 #include <nuttx/config.h>
 
 #include <wchar.h>
+#include <wctype.h>
 #include <stdlib.h>
 
 //***************************************************************************


### PR DESCRIPTION
## Summary
Note that iswalnum etc functions defined in wctype.h, and cwchar uses them.
So include wctype.h to fix libcxx build break.

## Impact

## Testing
Test and virify with our sim config with llvm libcxx enabled.
