### PR TITLE
nuttx compiler.h: Add location directive

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -103,9 +103,17 @@
 
 #  define farcall_function __attribute__ ((long_call))
 
+/* Code locate */
+
+#  define locate_code(n) __attribute__ ((section(n)))
+
 /* Data alignment */
 
 #  define aligned_data(n) __attribute__ ((aligned(n)))
+
+/* Data location */
+
+#  define locate_data(n) __attribute__ ((section(n)))
 
 /* The packed attribute informs GCC that the structure elements are packed,
  * ignoring other alignment rules.
@@ -336,7 +344,9 @@
  */
 
 #  define noreturn_function
+#  define locate_code(n)
 #  define aligned_data(n)
+#  define locate_data(n)
 #  define begin_packed_struct
 #  define end_packed_struct
 
@@ -475,6 +485,8 @@
 
 #  define noreturn_function
 #  define aligned_data(n)
+#  define locate_code(n)
+#  define locate_data(n)
 #  define begin_packed_struct
 #  define end_packed_struct
 #  define naked_function
@@ -575,7 +587,9 @@
 #  define weak_const_function
 #  define noreturn_function
 #  define farcall_function
+#  define locate_code(n)
 #  define aligned_data(n)
+#  define locate_data(n)
 #  define begin_packed_struct  __packed
 #  define end_packed_struct
 #  define reentrant_function
@@ -628,6 +642,8 @@
 #  define noreturn_function
 #  define farcall_function
 #  define aligned_data(n)
+#  define locate_code(n)
+#  define locate_data(n)
 #  define begin_packed_struct
 #  define end_packed_struct
 #  define reentrant_function


### PR DESCRIPTION
## Summary

   The ability to locate data in different sections
   is becoming critical and common place in cores with multiple
   bus matrices and power domains, where DMA can be limited to
   a specific memory.

## Impact
  None.
## Testing
By inspection

`make && arm-none-eabi-nm nuttx | grep spi`
```
24000070 d g_spi6dev
38000080 d g_spi6_rxbuf
38000000 d g_spi6_txbuf
```
The test case will be in a following PR if this is accepted upstream
