### PR TITLE
arch: Rename _exit to up_exit to follow the naming convention

### DIFF
--- a/Documentation/NuttxPortingGuide.html
+++ b/Documentation/NuttxPortingGuide.html
@@ -78,7 +78,7 @@
       <a href="#upblocktask">4.2.9 <code>up_block_task()</code></a><br>
       <a href="#upreleasepending">4.2.10 <code>up_release_pending()</code></a><br>
       <a href="#upreprioritizertr">4.2.11 <code>up_reprioritize_rtr()</code></a><br>
-      <a href="#_exit">4.2.12 <code>_exit()</code></a><br>
+      <a href="#upexit">4.2.12 <code>up_exit()</code></a><br>
       <a href="#upassert">4.2.13 <code>up_assert()</code></a><br>
       <a href="#upschedulesigaction">4.2.14 <code>up_schedule_sigaction()</code></a><br>
       <a href="#upallocateheap">4.2.15 <code>up_allocate_heap()</code></a><br>
@@ -2131,8 +2131,8 @@ The specific environmental definitions are unique for each board but should incl
   </li>
 </ul>
 
-<h3><a name="_exit">4.2.12 <code>_exit()</code></a></h3>
-<p><b>Function Prototype</b>: <code>void _exit(int status) noreturn_function;</code></p>
+<h3><a name="up_exit">4.2.12 <code>up_exit()</code></a></h3>
+<p><b>Function Prototype</b>: <code>void up_exit(int status) noreturn_function;</code></p>
 
 <p><b>Description</b>.
   This function causes the currently executing task to cease

--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -141,10 +141,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -164,10 +160,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -114,7 +114,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -124,7 +124,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/avr/src/common/up_exit.c
+++ b/arch/avr/src/common/up_exit.c
@@ -156,10 +156,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -179,10 +175,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/avr/src/common/up_exit.c
+++ b/arch/avr/src/common/up_exit.c
@@ -129,7 +129,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -139,7 +139,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/hc/src/common/up_exit.c
+++ b/arch/hc/src/common/up_exit.c
@@ -140,10 +140,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -163,10 +159,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/hc/src/common/up_exit.c
+++ b/arch/hc/src/common/up_exit.c
@@ -113,7 +113,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -123,7 +123,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -131,7 +131,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -141,7 +141,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -158,10 +158,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -181,10 +177,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -151,10 +151,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -174,10 +170,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -124,7 +124,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -134,7 +134,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -122,7 +122,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -132,7 +132,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -149,10 +149,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -172,10 +168,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/or1k/src/common/up_exit.c
+++ b/arch/or1k/src/common/up_exit.c
@@ -156,10 +156,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -179,10 +175,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/or1k/src/common/up_exit.c
+++ b/arch/or1k/src/common/up_exit.c
@@ -129,7 +129,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -139,7 +139,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/renesas/src/common/up_exit.c
+++ b/arch/renesas/src/common/up_exit.c
@@ -140,10 +140,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -163,10 +159,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/renesas/src/common/up_exit.c
+++ b/arch/renesas/src/common/up_exit.c
@@ -113,7 +113,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -123,7 +123,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -131,7 +131,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -141,7 +141,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -158,10 +158,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -181,10 +177,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/sim/src/sim/up_exit.c
+++ b/arch/sim/src/sim/up_exit.c
@@ -69,10 +69,6 @@ void _exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -83,10 +79,6 @@ void _exit(int status)
 
   tcb = this_task();
   sinfo("New Active Task TCB=%p\n", tcb);
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* The way that we handle signals in the simulation is kind of
    * a kludge.  This would be unsafe in a truly multi-threaded, interrupt

--- a/arch/sim/src/sim/up_exit.c
+++ b/arch/sim/src/sim/up_exit.c
@@ -53,7 +53,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -63,7 +63,7 @@
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   FAR struct tcb_s *tcb = this_task();
 

--- a/arch/x86/src/common/up_exit.c
+++ b/arch/x86/src/common/up_exit.c
@@ -140,10 +140,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -163,10 +159,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/x86/src/common/up_exit.c
+++ b/arch/x86/src/common/up_exit.c
@@ -113,7 +113,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease to exist.
@@ -123,7 +123,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/x86_64/src/common/up_exit.c
+++ b/arch/x86_64/src/common/up_exit.c
@@ -135,7 +135,7 @@ void _exit(int status)
    * The IRQ state will be restored when the next task is started.
    */
 
-  (void)enter_critical_section();
+  enter_critical_section();
 
   sinfo("TCB=%p exiting\n", this_task());
 
@@ -146,7 +146,7 @@ void _exit(int status)
 
   /* Destroy the task at the head of the ready to run list. */
 
-  (void)nxtask_exit();
+  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.
@@ -165,11 +165,10 @@ void _exit(int status)
    * the ready-to-run list.
    */
 
-  (void)group_addrenv(tcb);
+  group_addrenv(tcb);
 #endif
 
   /* Then switch contexts */
 
   up_fullcontextrestore(tcb->xcp.regs);
 }
-

--- a/arch/x86_64/src/common/up_exit.c
+++ b/arch/x86_64/src/common/up_exit.c
@@ -117,7 +117,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease to exist.
@@ -127,7 +127,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb;
 

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -157,10 +157,6 @@ void _exit(int status)
   nxsched_foreach(_xtensa_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
 #if XCHAL_CP_NUM > 0
   /* Disable co-processor support for the task that is exit-ing. */
 
@@ -192,10 +188,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -130,7 +130,7 @@ static void _xtensa_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -140,7 +140,7 @@ static void _xtensa_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   struct tcb_s *tcb = this_task();
 

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -140,10 +140,6 @@ void _exit(int status)
   nxsched_foreach(_z16_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -154,10 +150,6 @@ void _exit(int status)
 
   tcb = this_task();
   sinfo("New Active Task TCB=%p\n", tcb);
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -113,7 +113,7 @@ static void _z16_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -123,7 +123,7 @@ static void _z16_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   FAR struct tcb_s *tcb = this_task();
 

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -115,7 +115,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -125,7 +125,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
  *
  ****************************************************************************/
 
-void _exit(int status)
+void up_exit(int status)
 {
   FAR struct tcb_s *tcb = this_task();
 

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -142,10 +142,6 @@ void _exit(int status)
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
 
-  /* Update scheduler parameters */
-
-  nxsched_suspend_scheduler(tcb);
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
@@ -166,10 +162,6 @@ void _exit(int status)
 
   group_addrenv(tcb);
 #endif
-
-  /* Reset scheduler parameters */
-
-  nxsched_resume_scheduler(tcb);
 
   /* Then switch contexts */
 

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -198,7 +198,7 @@ int exec_module(FAR const struct binary_s *binp)
     }
 #endif
 
-#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_MM_SHM)
+#ifdef CONFIG_MM_SHM
   /* Initialize the shared memory virtual page allocator */
 
   ret = shm_group_initialize(tcb->cmn.group);
@@ -254,12 +254,7 @@ int exec_module(FAR const struct binary_s *binp)
 
   /* Then activate the task at the provided priority */
 
-  ret = nxtask_activate((FAR struct tcb_s *)tcb);
-  if (ret < 0)
-    {
-      berr("nxtask_activate() failed: %d\n", ret);
-      goto errout_with_tcbinit;
-    }
+  nxtask_activate((FAR struct tcb_s *)tcb);
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
   /* Restore the address environment of the caller */
@@ -274,11 +269,13 @@ int exec_module(FAR const struct binary_s *binp)
 
   return (int)pid;
 
+#if defined(CONFIG_ARCH_ADDRENV) || defined(CONFIG_MM_SHM)
 errout_with_tcbinit:
   tcb->cmn.stack_alloc_ptr = NULL;
   nxsched_release_tcb(&tcb->cmn, TCB_FLAG_TTYPE_TASK);
   kumm_free(stack);
   return ret;
+#endif
 
 errout_with_addrenv:
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -450,7 +450,7 @@ void up_release_pending(void);
 void up_reprioritize_rtr(FAR struct tcb_s *tcb, uint8_t priority);
 
 /****************************************************************************
- * Name: _exit
+ * Name: up_exit
  *
  * Description:
  *   This function causes the currently executing task to cease
@@ -463,6 +463,8 @@ void up_reprioritize_rtr(FAR struct tcb_s *tcb, uint8_t priority);
  *   disable interrupts before performing scheduling operations.
  *
  ****************************************************************************/
+
+void up_exit() noreturn_function;
 
 /* Prototype is in unistd.h */
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -989,11 +989,11 @@ void nxtask_uninit(FAR struct tcb_s *tcb);
  *         argument).
  *
  * Returned Value:
- *   Always returns OK
+ *   None
  *
  ********************************************************************************/
 
-int nxtask_activate(FAR struct tcb_s *tcb);
+void nxtask_activate(FAR struct tcb_s *tcb);
 
 /********************************************************************************
  * Name: nxtask_starthook

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -553,11 +553,8 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
   sched_lock();
   if (ret == OK)
     {
-      ret = nxtask_activate((FAR struct tcb_s *)ptcb);
-    }
+      nxtask_activate((FAR struct tcb_s *)ptcb);
 
-  if (ret == OK)
-    {
       /* Wait for the task to actually get running and to register
        * its join structure.
        */

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -40,6 +40,22 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: _exit
+ *
+ * Description:
+ *   This function causes the currently executing task to cease
+ *   to exist.  This is a special case of task_delete() where the task to
+ *   be deleted is the currently executing task.  It is more complex because
+ *   a context switch must be perform to the next ready to run task.
+ *
+ ****************************************************************************/
+
+void _exit(int status)
+{
+  up_exit(status);
+}
+
+/****************************************************************************
  * Name: exit
  *
  * Description:

--- a/sched/task/task_activate.c
+++ b/sched/task/task_activate.c
@@ -49,11 +49,11 @@
  *         argument).
  *
  * Returned Value:
- *   Always returns OK
+ *   None
  *
  ****************************************************************************/
 
-int nxtask_activate(FAR struct tcb_s *tcb)
+void nxtask_activate(FAR struct tcb_s *tcb)
 {
   irqstate_t flags = enter_critical_section();
 
@@ -79,5 +79,4 @@ int nxtask_activate(FAR struct tcb_s *tcb)
 
   up_unblock_task(tcb);
   leave_critical_section(flags);
-  return OK;
 }

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -145,12 +145,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Activate the task */
 
-  ret = nxtask_activate((FAR struct tcb_s *)tcb);
-  if (ret < OK)
-    {
-      goto errout_with_active;
-    }
-
+  nxtask_activate((FAR struct tcb_s *)tcb);
   return pid;
 
 errout_with_active:

--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -84,6 +84,10 @@ int nxtask_exit(void)
   dtcb = this_task();
 #endif
 
+  /* Update scheduler parameters */
+
+  nxsched_suspend_scheduler(dtcb);
+
   /* Remove the TCB of the current task from the ready-to-run list.  A
    * context switch will definitely be necessary -- that must be done
    * by the architecture-specific logic.
@@ -102,13 +106,11 @@ int nxtask_exit(void)
   rtcb = this_task();
 #endif
 
-#ifdef CONFIG_SMP
   /* Because clearing the global IRQ control in nxsched_remove_readytorun()
    * was moved to nxsched_resume_scheduler(). So call the API here.
    */
 
   nxsched_resume_scheduler(rtcb);
-#endif
 
   /* We are now in a bad state -- the head of the ready to run task list
    * does not correspond to the thread that is running.  Disabling pre-

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -73,7 +73,6 @@ int task_restart(pid_t pid)
 #ifdef CONFIG_SMP
   int cpu;
 #endif
-  int ret;
 
   /* Check if the task to restart is the calling task */
 
@@ -188,7 +187,7 @@ int task_restart(pid_t pid)
 
   if (cpu >= 0)
     {
-      ret = up_cpu_resume(cpu);
+      int ret = up_cpu_resume(cpu);
       if (ret < 0)
         {
           errcode = -ret;
@@ -201,14 +200,7 @@ int task_restart(pid_t pid)
 
   /* Activate the task. */
 
-  ret = nxtask_activate((FAR struct tcb_s *)tcb);
-  if (ret != OK)
-    {
-      nxtask_terminate(pid, true);
-      errcode = -ret;
-      goto errout_with_lock;
-    }
-
+  nxtask_activate((FAR struct tcb_s *)tcb);
   return OK;
 
 errout_with_lock:

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -434,13 +434,7 @@ pid_t nxtask_start_vfork(FAR struct task_tcb_s *child)
 
   /* Activate the task */
 
-  ret = nxtask_activate((FAR struct tcb_s *)child);
-  if (ret < OK)
-    {
-      nxtask_abort_vfork(child, -ret);
-      sched_unlock();
-      return ERROR;
-    }
+  nxtask_activate((FAR struct tcb_s *)child);
 
   /* The child task has not yet ran because pre-emption is disabled.
    * The child task has the same priority as the parent task, so that


### PR DESCRIPTION
## Summary

## Impact

## Testing

