### PR TITLE
Fix typo in arch/arm/src/lpc17xx_40xx/Kconfig

### DIFF
--- a/arch/arm/src/lpc17xx_40xx/Kconfig
+++ b/arch/arm/src/lpc17xx_40xx/Kconfig
@@ -284,7 +284,7 @@ config LPC17_40_SSP1
 	default n
 
 config LPC17_40_SSP2
-	bool "SSP1"
+	bool "SSP2"
 	default n
 	depends on ARCH_FAMILY_LPC177X || ARCH_FAMILY_LPC178X || ARCH_FAMILY_LPC407X || ARCH_FAMILY_LPC408X
 


### PR DESCRIPTION
## Summary
Fixes a typo in the description of the SSP2 bool
