### PR TITLE
Refactor audio

### DIFF
--- a/drivers/audio/audio_null.c
+++ b/drivers/audio/audio_null.c
@@ -737,6 +737,7 @@ static int null_cancelbuffer(FAR struct audio_lowerhalf_s *dev,
 static int null_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
                         unsigned long arg)
 {
+  int ret = OK;
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
   FAR struct ap_buffer_info_s *bufinfo;
 #endif
@@ -771,11 +772,12 @@ static int null_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
 #endif
 
       default:
+        ret = -ENOTTY;
         break;
     }
 
   audinfo("Return OK\n");
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -1449,6 +1449,7 @@ static int cs43l22_cancelbuffer(FAR struct audio_lowerhalf_s *dev,
 static int cs43l22_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
                          unsigned long arg)
 {
+  int ret = OK;
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
   FAR struct ap_buffer_info_s *bufinfo;
 #endif
@@ -1486,11 +1487,12 @@ static int cs43l22_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
 #endif
 
       default:
+        ret = -ENOTTY;
         audinfo("Ignored\n");
         break;
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/drivers/audio/cxd56.c
+++ b/drivers/audio/cxd56.c
@@ -3307,6 +3307,7 @@ static int cxd56_cancelbuffer(FAR struct audio_lowerhalf_s *lower,
 static int cxd56_ioctl(FAR struct audio_lowerhalf_s *lower, int cmd,
                  unsigned long arg)
 {
+  int ret = OK;
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
   FAR struct ap_buffer_info_s *bufinfo;
 #endif
@@ -3329,11 +3330,12 @@ static int cxd56_ioctl(FAR struct audio_lowerhalf_s *lower, int cmd,
 #endif
 
       default:
+        ret = -ENOTTY;
         audinfo("Unhandled ioctl: %d\n", cmd);
         break;
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/drivers/audio/vs1053.c
+++ b/drivers/audio/vs1053.c
@@ -1716,6 +1716,7 @@ static int vs1053_cancelbuffer(FAR struct audio_lowerhalf_s *lower,
 static int vs1053_ioctl(FAR struct audio_lowerhalf_s *lower, int cmd,
                   unsigned long arg)
 {
+  int ret = OK;
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
   FAR struct ap_buffer_info_s *bufinfo;
 #endif
@@ -1744,10 +1745,11 @@ static int vs1053_ioctl(FAR struct audio_lowerhalf_s *lower, int cmd,
 #endif
 
       default:
+        ret = -ENOTTY;
         break;
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -988,6 +988,7 @@ static int wm8776_cancelbuffer(FAR struct audio_lowerhalf_s *dev,
 static int wm8776_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
                         unsigned long arg)
 {
+  int ret = OK;
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
   FAR struct ap_buffer_info_s *bufinfo;
 #endif
@@ -1025,11 +1026,12 @@ static int wm8776_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
 #endif
 
       default:
+        ret = -ENOTTY;
         audinfo("Ignored\n");
         break;
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -1832,6 +1832,7 @@ static int wm8904_cancelbuffer(FAR struct audio_lowerhalf_s *dev,
 static int wm8904_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
                         unsigned long arg)
 {
+  int ret = OK;
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
   FAR struct ap_buffer_info_s *bufinfo;
 #endif
@@ -1869,11 +1870,12 @@ static int wm8904_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
 #endif
 
       default:
+        ret = -ENOTTY;
         audinfo("Ignored\n");
         break;
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -408,13 +408,11 @@ struct audio_info_s
  * so this info is queried from the lower-half driver.
  */
 
-#ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
 struct ap_buffer_info_s
 {
   apb_samp_t  nbuffers;     /* Preferred qty of buffers */
   apb_samp_t  buffer_size;  /* Preferred size of the buffers */
 };
-#endif
 
 /* This structure describes an Audio Pipeline Buffer */
 


### PR DESCRIPTION
## Summary

- This PR consists 2 commits to refactor nuttx audio drivers. 
- The first commit is audio.h so that we can use struct ap_buffer_info_s without CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
- The second commit is to return -EINVAL in xxx_ioctl() if not handled.

## Impact

- This PR affects all audio drivers.

## Testing

- I tested this PR with nxplayer on both lc823450-xgevk which has wm8776.c and spresense which has cxd56.c but should work for other audio drivers.
