### PR TITLE
stm32h7:DMA Add BDMA support

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32_bdma.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_bdma.h
@@ -49,17 +49,20 @@
 
 /* Register Offsets *****************************************************************/
 
-#define STM32_BDMA_OFFSET(x)        (0x08+0x14*(x))
 #define STM32_BDMA_ISR_OFFSET       0x0000 /* BDMA interrupt status register */
 #define STM32_BDMA_IFCR_OFFSET      0x0004 /* BDMA interrupt flag clear register */
 
-#define STM32_BDMACH_CCR_OFFSET     0x0008
-#define STM32_BDMACH_CNDTR_OFFSET   0x000C
-#define STM32_BDMACH_CPAR_OFFSET    0x0010
-#define STM32_BDMACH_CM0AR_OFFSET   0x0014
-#define STM32_BDMACH_CM1AR_OFFSET   0x0018
+#define STM32_BDMACH_CCR_OFFSET     0x0008 /* BDMA channel x configuration register */
+#define STM32_BDMACH_CNDTR_OFFSET   0x000C /* BDMA channel x number of data to transfer register */
+#define STM32_BDMACH_CPAR_OFFSET    0x0010 /* BDMA channel x peripheral address register */
+#define STM32_BDMACH_CM0AR_OFFSET   0x0014 /* BDMA channel x memory 0 address register */
+#define STM32_BDMACH_CM1AR_OFFSET   0x0018 /* BDMA channel x memory 1 address register */
 
-#define STM32_BDMA_CCRX_OFFSET(x)   (0x0008+(x*0x0014)) /* BDMA channel x configuration register */
+#define STM32_BDMA_SPACING          0x14
+#define STM32_BDMA_OFFSET(x)        (STM32_BDMA_SPACING * (x))
+
+#define STM32_BDMA_CCRX_OFFSET(x)   (STM32_BDMACH_CCR_OFFSET + \
+                                    STM32_BDMA_OFFSET(x))
 #define STM32_BDMA_CCR0_OFFSET      STM32_BDMA_CCRX_OFFSET(0)
 #define STM32_BDMA_CCR1_OFFSET      STM32_BDMA_CCRX_OFFSET(1)
 #define STM32_BDMA_CCR2_OFFSET      STM32_BDMA_CCRX_OFFSET(2)
@@ -69,7 +72,8 @@
 #define STM32_BDMA_CCR6_OFFSET      STM32_BDMA_CCRX_OFFSET(6)
 #define STM32_BDMA_CCR7_OFFSET      STM32_BDMA_CCRX_OFFSET(7)
 
-#define STM32_BDMA_CNDTRX_OFFSET(x) (0x000C+(x*0x0014)) /* BDMA channel x number of data to transfer register */
+#define STM32_BDMA_CNDTRX_OFFSET(x) (STM32_BDMACH_CNDTR_OFFSET + \
+                                    STM32_BDMA_OFFSET(x))
 #define STM32_BDMA_CNDTR0_OFFSET    STM32_BDMA_CNDTRX_OFFSET(0)
 #define STM32_BDMA_CNDTR1_OFFSET    STM32_BDMA_CNDTRX_OFFSET(1)
 #define STM32_BDMA_CNDTR2_OFFSET    STM32_BDMA_CNDTRX_OFFSET(2)
@@ -79,7 +83,8 @@
 #define STM32_BDMA_CNDTR6_OFFSET    STM32_BDMA_CNDTRX_OFFSET(6)
 #define STM32_BDMA_CNDTR7_OFFSET    STM32_BDMA_CNDTRX_OFFSET(7)
 
-#define STM32_BDMA_CPARX_OFFSET(x)  (0x0010+(x*0x0014)) /* BDMA channel x peripheral address register */
+#define STM32_BDMA_CPARX_OFFSET(x)  (STM32_BDMACH_CPAR_OFFSET + \
+                                    STM32_BDMA_OFFSET(x))
 #define STM32_BDMA_CPAR0_OFFSET     STM32_BDMA_CPARX_OFFSET(0)
 #define STM32_BDMA_CPAR1_OFFSET     STM32_BDMA_CPARX_OFFSET(1)
 #define STM32_BDMA_CPAR2_OFFSET     STM32_BDMA_CPARX_OFFSET(2)
@@ -89,7 +94,8 @@
 #define STM32_BDMA_CPAR6_OFFSET     STM32_BDMA_CPARX_OFFSET(6)
 #define STM32_BDMA_CPAR7_OFFSET     STM32_BDMA_CPARX_OFFSET(7)
 
-#define STM32_BDMA_CM0ARX_OFFSET(x) (0x0014+(x*0x0014)) /* BDMA channel x memory 0 address register */
+#define STM32_BDMA_CM0ARX_OFFSET(x) (STM32_BDMACH_CM0AR_OFFSET + \
+                                    STM32_BDMA_OFFSET(x))
 #define STM32_BDMA_CM0AR0_OFFSET    STM32_BDMA_CM0ARX_OFFSET(0)
 #define STM32_BDMA_CM0AR1_OFFSET    STM32_BDMA_CM0ARX_OFFSET(1)
 #define STM32_BDMA_CM0AR2_OFFSET    STM32_BDMA_CM0ARX_OFFSET(2)
@@ -99,7 +105,8 @@
 #define STM32_BDMA_CM0AR6_OFFSET    STM32_BDMA_CM0ARX_OFFSET(6)
 #define STM32_BDMA_CM0AR7_OFFSET    STM32_BDMA_CM0ARX_OFFSET(7)
 
-#define STM32_BDMA_CM1ARX_OFFSET(x) (0x0018+(x*0x0014)) /* BDMA channel x memory 1 address register */
+#define STM32_BDMA_CM1ARX_OFFSET(x) (STM32_BDMACH_CM1AR_OFFSET + \
+                                    STM32_BDMA_OFFSET(x))
 #define STM32_BDMA_CM1AR0_OFFSET    STM32_BDMA_CM1ARX_OFFSET(0)
 #define STM32_BDMA_CM1AR1_OFFSET    STM32_BDMA_CM1ARX_OFFSET(1)
 #define STM32_BDMA_CM1AR2_OFFSET    STM32_BDMA_CM1ARX_OFFSET(2)
@@ -172,6 +179,7 @@
 #define BDMA_CHAN_TCIF             (1 << 1) /* Bit 1: Transfer complete flag */
 #define BDMA_CHAN_HTIF             (1 << 2) /* Bit 2: half transfer complete flag */
 #define BDMA_CHAN_TEIF             (1 << 3) /* Bit 3: Transfer error flag */
+#define BDMA_CCR_ALLINTS           (BDMA_CHAN_TCIF | BDMA_CHAN_HTIF | BDMA_CHAN_TEIF)
 
 /* BDMA interrupt status register */
 
@@ -240,20 +248,20 @@
 #  define BDMA_CCR_PSIZE_8BITS     (0 << BDMA_CCR_PSIZE_SHIFT) /* 00: 8-bits */
 #  define BDMA_CCR_PSIZE_16BITS    (1 << BDMA_CCR_PSIZE_SHIFT) /* 01: 16-bits */
 #  define BDMA_CCR_PSIZE_32BITS    (2 << BDMA_CCR_PSIZE_SHIFT) /* 10: 32-bits */
-#define BDMA_CCR_MSIZE_SHIFT       (10)      /* Bits 10-11: Memory size*/
+#define BDMA_CCR_MSIZE_SHIFT       (10)                        /* Bits 10-11: Memory size*/
 #define BDMA_CCR_MSIZE_MASK        (3 << BDMA_CCR_MSIZE_SHIFT)
 #  define BDMA_CCR_MSIZE_8BITS     (0 << BDMA_CCR_MSIZE_SHIFT) /* 00: 8-bits */
 #  define BDMA_CCR_MSIZE_16BITS    (1 << BDMA_CCR_MSIZE_SHIFT) /* 01: 16-bits */
 #  define BDMA_CCR_MSIZE_32BITS    (2 << BDMA_CCR_MSIZE_SHIFT) /* 10: 32-bits */
-#define BDMA_CCR_PL_SHIFT          (12)      /* Bits 12-13: Priority level */
+#define BDMA_CCR_PL_SHIFT          (12)                        /* Bits 12-13: Priority level */
 #define BDMA_CCR_PL_MASK           (3 << BDMA_CCR_PL_SHIFT)
 #  define BDMA_CCR_PRILO           (0 << BDMA_CCR_PL_SHIFT) /* 00: Low */
 #  define BDMA_CCR_PRIMED          (1 << BDMA_CCR_PL_SHIFT) /* 01: Medium */
 #  define BDMA_CCR_PRIHI           (2 << BDMA_CCR_PL_SHIFT) /* 10: High */
 #  define BDMA_CCR_PRIVERYHI       (3 << BDMA_CCR_PL_SHIFT) /* 11: Very high */
-#define BDMA_CCR_M2M               (1 << 14) /* Bit 14: Memory-to-memory mode */
-#define BDMA_CCR_DBM               (1 << 15) /* Bit 15: dobule buffer mode*/
-#define BDMA_CCR_CT                (1 << 16) /* Bit 16: Current target */
+#define BDMA_CCR_M2M               (1 << 14)                /* Bit 14: Memory-to-memory mode */
+#define BDMA_CCR_DBM               (1 << 15)                /* Bit 15: dobule buffer mode*/
+#define BDMA_CCR_CT                (1 << 16)                /* Bit 16: Current target */
 
 /* BDMA channel x number of data to transfer register */
 

--- a/arch/arm/src/stm32h7/hardware/stm32_dma.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_dma.h
@@ -47,7 +47,7 @@
  * Pre-processor Definitions
  ************************************************************************************/
 
-/* 2 DMA controllers + 1 MDMA + 1 BDMA*/
+/* 2 DMA controllers + 1 MDMA + 1 BDMA */
 
 #define MDMA                      (0)
 #define DMA1                      (1)
@@ -275,7 +275,7 @@
 #define DMA_STREAM_HTIF_BIT       (1 << 4)  /* Bit 4: Stream Half Transfer flag */
 #define DMA_STREAM_TCIF_BIT       (1 << 5)  /* Bit 5: Stream Transfer Complete flag */
 
-/* DMA interrupt status register and interrupt flag clear register field definitions */
+/* DMA interrupt status and interrupt clear register field definitions */
 
 #define DMA_INT_STREAM0_SHIFT     (0)       /* Bits 0-5:   DMA Stream 0 interrupt */
 #define DMA_INT_STREAM0_MASK      (DMA_STREAM_MASK <<  DMA_INT_STREAM0_SHIFT)
@@ -308,6 +308,7 @@
 #  define DMA_SCR_DIR_P2M         (0 << DMA_SCR_DIR_SHIFT) /* 00: Peripheral-to-memory */
 #  define DMA_SCR_DIR_M2P         (1 << DMA_SCR_DIR_SHIFT) /* 01: Memory-to-peripheral */
 #  define DMA_SCR_DIR_M2M         (2 << DMA_SCR_DIR_SHIFT) /* 10: Memory-to-memory */
+
 #define DMA_SCR_CIRC              (1 << 8)  /* Bit 8:  Circular mode */
 #define DMA_SCR_PINC              (1 << 9)  /* Bit 9:  Peripheral increment mode */
 #define DMA_SCR_MINC              (1 << 10) /* Bit 10: Memory increment mode */
@@ -316,11 +317,13 @@
 #  define DMA_SCR_PSIZE_8BITS     (0 << DMA_SCR_PSIZE_SHIFT) /* 00: 8-bits */
 #  define DMA_SCR_PSIZE_16BITS    (1 << DMA_SCR_PSIZE_SHIFT) /* 01: 16-bits */
 #  define DMA_SCR_PSIZE_32BITS    (2 << DMA_SCR_PSIZE_SHIFT) /* 10: 32-bits */
+
 #define DMA_SCR_MSIZE_SHIFT       (13)      /* Bits 13-14: Memory size */
 #define DMA_SCR_MSIZE_MASK        (3 << DMA_SCR_MSIZE_SHIFT)
 #  define DMA_SCR_MSIZE_8BITS     (0 << DMA_SCR_MSIZE_SHIFT) /* 00: 8-bits */
 #  define DMA_SCR_MSIZE_16BITS    (1 << DMA_SCR_MSIZE_SHIFT) /* 01: 16-bits */
 #  define DMA_SCR_MSIZE_32BITS    (2 << DMA_SCR_MSIZE_SHIFT) /* 10: 32-bits */
+
 #define DMA_SCR_PINCOS            (1 << 15) /* Bit 15: Peripheral increment offset size */
 #define DMA_SCR_PL_SHIFT          (16)      /* Bits 16-17: Stream Priority level */
 #define DMA_SCR_PL_MASK           (3 << DMA_SCR_PL_SHIFT)
@@ -328,6 +331,7 @@
 #  define DMA_SCR_PRIMED          (1 << DMA_SCR_PL_SHIFT) /* 01: Medium */
 #  define DMA_SCR_PRIHI           (2 << DMA_SCR_PL_SHIFT) /* 10: High */
 #  define DMA_SCR_PRIVERYHI       (3 << DMA_SCR_PL_SHIFT) /* 11: Very high */
+
 #define DMA_SCR_DBM               (1 << 18) /* Bit 15: Double buffer mode */
 #define DMA_SCR_CT                (1 << 19) /* Bit 19: Current target */
                                             /* Bit 20: Reserved */
@@ -337,13 +341,14 @@
 #  define DMA_SCR_PBURST_INCR4    (1 << DMA_SCR_PBURST_SHIFT) /* 01: Incremental burst of 4 beats */
 #  define DMA_SCR_PBURST_INCR8    (2 << DMA_SCR_PBURST_SHIFT) /* 10: Incremental burst of 8 beats */
 #  define DMA_SCR_PBURST_INCR16   (3 << DMA_SCR_PBURST_SHIFT) /* 11: Incremental burst of 16 beats */
+
 #define DMA_SCR_MBURST_SHIFT      (23)      /* Bits 23-24: Memory burst transfer configuration */
 #define DMA_SCR_MBURST_MASK       (3 << DMA_SCR_MBURST_SHIFT)
 #  define DMA_SCR_MBURST_SINGLE   (0 << DMA_SCR_MBURST_SHIFT) /* 00: Single transfer */
 #  define DMA_SCR_MBURST_INCR4    (1 << DMA_SCR_MBURST_SHIFT) /* 01: Incremental burst of 4 beats */
 #  define DMA_SCR_MBURST_INCR8    (2 << DMA_SCR_MBURST_SHIFT) /* 10: Incremental burst of 8 beats */
 #  define DMA_SCR_MBURST_INCR16   (3 << DMA_SCR_MBURST_SHIFT) /* 11: Incremental burst of 16 beats */
-                                            /* Bits 25-31: Reserved */
+                                                              /* Bits 25-31: Reserved */
 
 #define DMA_SCR_ALLINTS           (DMA_SCR_DMEIE|DMA_SCR_TEIE|DMA_SCR_HTIE|DMA_SCR_TCIE)
 
@@ -360,6 +365,7 @@
 #  define DMA_SFCR_FTH_HALF       (1 << DMA_SFCR_FTH_SHIFT) /* 1/2 full FIFO */
 #  define DMA_SFCR_FTH_3QUARTER   (2 << DMA_SFCR_FTH_SHIFT) /* 3/4 full FIFO */
 #  define DMA_SFCR_FTH_FULL       (3 << DMA_SFCR_FTH_SHIFT) /* full FIFO */
+
 #define DMA_SFCR_DMDIS            (1 << 2)  /* Bit 2:  Direct mode disable */
 #define DMA_SFCR_FS_SHIFT         (3)       /* Bits 3-5: FIFO status */
 #define DMA_SFCR_FS_MASK          (7 << DMA_SFCR_FS_SHIFT)
@@ -369,8 +375,8 @@
 #  define DMA_SFCR_FS_ALMOSTFULL  (3 << DMA_SFCR_FS_SHIFT) /* 3/4 = fifo_level < full */
 #  define DMA_SFCR_FS_EMPTY       (4 << DMA_SFCR_FS_SHIFT) /* FIFO is empty */
 #  define DMA_SFCR_FS_FULL        (5 << DMA_SFCR_FS_SHIFT) /* FIFO is full */
-                                            /* Bit 6:  Reserved */
-#define DMA_SFCR_FEIE             (1 << 7)  /* Bit 7:  FIFO error interrupt enable */
-                                            /* Bits 8-31: Reserved */
+                                                           /* Bit 6:  Reserved */
+#define DMA_SFCR_FEIE             (1 << 7)                 /* Bit 7:  FIFO error interrupt enable */
+                                                           /* Bits 8-31: Reserved */
 
 #endif /* __ARCH_ARM_SRC_STM32H7_HARDWARE_STM32_DMA_H */


### PR DESCRIPTION
## Summary

This adds BDMA support for the STM32F7.  It preserves the (s)DMA API by mapping the DMA config bits to the BDMA config bits and BDMA status back to DMA status. 

## Impact

You can uses BDMA now!  All drivers that use DMA can now use BDMA (if applicable i.e. IP blocks are in D3 power domain) with NO code changes except for locating DMA buffers in sram4. 

## Testing

Using a nucleo-h743zi  I sent and received data on SPI6. 
Connect CN7-12 (miso) to CN7-14 (mosi) 

tx data was 0x0-0x63 (0 - 100).

After transfer (verifying BDMA calls) the RX data in SRAM4 matches that TX data!

![image](https://user-images.githubusercontent.com/1945821/83916840-b8da4a00-a72a-11ea-8e9b-5893e264c15e.png)

