### PR TITLE
STM32H7 Use BDMA on SPI6

### DIFF
--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -57,6 +57,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/compiler.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/spi/spi.h>
 #include <nuttx/power/pm.h>
@@ -709,10 +710,11 @@ static const struct spi_ops_s g_sp6iops =
 };
 
 #if defined(SPI6_DMABUFSIZE_ADJUSTED)
-static uint8_t g_spi6_txbuf[SPI6_DMABUFSIZE_ADJUSTED] SPI6_DMABUFSIZE_ALGN;
-static uint8_t g_spi6_rxbuf[SPI6_DMABUFSIZE_ADJUSTED] SPI6_DMABUFSIZE_ALGN;
+static uint8_t g_spi6_txbuf[SPI6_DMABUFSIZE_ADJUSTED] SPI6_DMABUFSIZE_ALGN
+                                                      locate_data(".sram4");
+static uint8_t g_spi6_rxbuf[SPI6_DMABUFSIZE_ADJUSTED] SPI6_DMABUFSIZE_ALGN
+                                                      locate_data(".sram4");
 #endif
-
 static struct stm32_spidev_s g_spi6dev =
 {
   .spidev   =

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
@@ -185,6 +185,12 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
+    /* Emit the the D3 power domain section for locating BDMA data */
+
+    .sram4 :
+    {
+    } > sram4
+
     /* Stabs debugging sections. */
 
     .stab 0 : { *(.stab) }

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
@@ -94,6 +94,12 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > ksram
 
+    /* Emit the the D3 power domain section for locating BDMA data */
+
+    .sram4 :
+    {
+    } > sram4
+
     /* Stabs debugging sections */
 
     .stab 0 : { *(.stab) }

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
@@ -183,6 +183,12 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
+    /* Emit the the D3 power domain section for locating BDMA data */
+
+    .sram4 :
+    {
+    } > sram4
+
     /* Stabs debugging sections. */
 
     .stab 0 : { *(.stab) }

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
@@ -94,6 +94,13 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > ksram
 
+    /* Emit the the D3 power domain section for locating BDMA data */
+
+    .sram4 :
+    {
+    } > sram4
+
+
     /* Stabs debugging sections */
 
     .stab 0 : { *(.stab) }


### PR DESCRIPTION
## Summary

This enables BDMA on the the STM32H7 SPI6 channel.

## Impact

Dependent on https://github.com/apache/incubator-nuttx/pull/1203 to actually work. But will not break the build without it. 

## Testing

see https://github.com/apache/incubator-nuttx/pull/1203 

```
  ****************************************************************************/
@@ -146,6 +148,28 @@ int stm32_bringup(void)
 
+   static struct spi_dev_s *spidev;
+   spidev = stm32_spibus_initialize(6);
+   SPI_SETFREQUENCY(spidev, 1000000);
+   SPI_SETMODE(spidev, 3);
+   SPI_SETBITS(spidev, 8);
+   SPI_SELECT(spidev, 0, true);
+   uint8_t send[100];
+   uint8_t recv[100];
+   for (int i = 0; i < 100; i++)
+     {
+       send[i] = i;
+       recv[i] = i;
+     }
+   /* do the transfer */
+   SPI_EXCHANGE(spidev, send, recv, 100);
+
+   /* and clean up */
+   SPI_SELECT(spidev, 0, false);
+
```
