### PR TITLE
arch/risc-v/src/k210: Add basic gpiohs support

### DIFF
--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -59,8 +59,8 @@ endif
 # Specify our C code within this directory to be included
 CHIP_CSRCS  = k210_allocateheap.c k210_clockconfig.c
 CHIP_CSRCS += k210_idle.c k210_irq.c k210_irq_dispatch.c
-CHIP_CSRCS += k210_lowputc.c k210_serial.c
-CHIP_CSRCS += k210_start.c k210_timerisr.c
+CHIP_CSRCS += k210_lowputc.c k210_serial.c k210_fpioa.c
+CHIP_CSRCS += k210_start.c k210_timerisr.c k210_gpiohs.c
 
 ifeq ($(CONFIG_SMP), y)
 CHIP_CSRCS += k210_cpuidlestack.c k210_cpuindex.c

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -47,6 +47,7 @@ CMN_CSRCS  += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c
 CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c k210_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
+CMN_CSRCS  += riscv_mdelay.c
 
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c

--- a/arch/risc-v/src/k210/k210_fpioa.c
+++ b/arch/risc-v/src/k210/k210_fpioa.c
@@ -1,9 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/k210/hardware/k210_memorymap.h
- *
- * Derives from software originally provided by Canaan Inc
- *
- *   Copyright 2018 Canaan Inc
+ * arch/risc-v/src/k210/k210_fpioa.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -22,26 +18,28 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_RISCV_SRC_K210_HARDWARE_K210_MEMORYMAP_H
-#define __ARCH_RISCV_SRC_K210_HARDWARE_K210_MEMORYMAP_H
-
 /****************************************************************************
- * Pre-processor Definitions
+ * Included Files
  ****************************************************************************/
 
-/* Register Base Address ****************************************************/
+#include <nuttx/config.h>
 
-#define K210_CLINT_BASE   0x02000000
-#define K210_PLIC_BASE    0x0c000000
+#include <assert.h>
+#include <debug.h>
 
-#ifdef CONFIG_K210_WITH_QEMU
-#define K210_UART0_BASE   0x10010000
-#else
-#define K210_UART0_BASE   0x38000000
-#endif
-#define K210_GPIOHS_BASE  0x38001000
-#define K210_FPIOA_BASE   0x502B0000
+#include "riscv_internal.h"
+#include "riscv_arch.h"
 
-#define K210_SYSCTL_BASE  0x50440000
+#include "k210_memorymap.h"
+#include "k210_fpioa.h"
 
-#endif /* __ARCH_RISCV_SRC_K210_HARDWARE_K210_MEMORYMAP_H */
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void k210_fpioa_config(uint32_t io, uint32_t ioflags)
+{
+  uint32_t *fpioa = (uint32_t *)K210_FPIOA_BASE;
+  DEBUGASSERT(io < K210_IO_NUMBER);
+  putreg32(ioflags, &fpioa[io]);
+}

--- a/arch/risc-v/src/k210/k210_fpioa.h
+++ b/arch/risc-v/src/k210/k210_fpioa.h
@@ -80,8 +80,8 @@
 #define K210_IO_SL             (1 << 19)
 #define K210_IO_ST             (1 << 23)
 
-#define K210_FLAG_GPIOHS  (K210_IO_DS(0xf) | K210_IO_OUTPUT_ENABLE | \
-                           K210_IO_INPUT_ENABLE | K210_IO_ST)
+#define K210_IOFLAG_GPIOHS (K210_IO_DS(0xf) | K210_IO_OUTPUT_ENABLE | \
+                            K210_IO_INPUT_ENABLE | K210_IO_ST)
 
 /****************************************************************************
  * Public Functions Prototypes

--- a/arch/risc-v/src/k210/k210_fpioa.h
+++ b/arch/risc-v/src/k210/k210_fpioa.h
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * arch/risc-v/src/k210/k210_fpioa.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_K210_K210_FPIOA_H
+#define __ARCH_RISCV_SRC_K210_K210_FPIOA_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define K210_IO_NUMBER 48
+
+#define K210_IO_FUNC_UARTHS_RX 18  /* UART High speed Receiver */
+#define K210_IO_FUNC_UARTHS_TX 19  /* UART High speed Transmitter */
+#define K210_IO_FUNC_GPIOHS0   24  /* GPIO High speed 0 */
+#define K210_IO_FUNC_GPIOHS1   25  /* GPIO High speed 1 */
+#define K210_IO_FUNC_GPIOHS2   26  /* GPIO High speed 2 */
+#define K210_IO_FUNC_GPIOHS3   27  /* GPIO High speed 3 */
+#define K210_IO_FUNC_GPIOHS4   28  /* GPIO High speed 4 */
+#define K210_IO_FUNC_GPIOHS5   29  /* GPIO High speed 5 */
+#define K210_IO_FUNC_GPIOHS6   30  /* GPIO High speed 6 */
+#define K210_IO_FUNC_GPIOHS7   31  /* GPIO High speed 7 */
+#define K210_IO_FUNC_GPIOHS8   32  /* GPIO High speed 8 */
+#define K210_IO_FUNC_GPIOHS9   33  /* GPIO High speed 9 */
+#define K210_IO_FUNC_GPIOHS10  34  /* GPIO High speed 10 */
+#define K210_IO_FUNC_GPIOHS11  35  /* GPIO High speed 11 */
+#define K210_IO_FUNC_GPIOHS12  36  /* GPIO High speed 12 */
+#define K210_IO_FUNC_GPIOHS13  37  /* GPIO High speed 13 */
+#define K210_IO_FUNC_GPIOHS14  38  /* GPIO High speed 14 */
+#define K210_IO_FUNC_GPIOHS15  39  /* GPIO High speed 15 */
+#define K210_IO_FUNC_GPIOHS16  40  /* GPIO High speed 16 */
+#define K210_IO_FUNC_GPIOHS17  41  /* GPIO High speed 17 */
+#define K210_IO_FUNC_GPIOHS18  42  /* GPIO High speed 18 */
+#define K210_IO_FUNC_GPIOHS19  43  /* GPIO High speed 19 */
+#define K210_IO_FUNC_GPIOHS20  44  /* GPIO High speed 20 */
+#define K210_IO_FUNC_GPIOHS21  45  /* GPIO High speed 21 */
+#define K210_IO_FUNC_GPIOHS22  46  /* GPIO High speed 22 */
+#define K210_IO_FUNC_GPIOHS23  47  /* GPIO High speed 23 */
+#define K210_IO_FUNC_GPIOHS24  48  /* GPIO High speed 24 */
+#define K210_IO_FUNC_GPIOHS25  49  /* GPIO High speed 25 */
+#define K210_IO_FUNC_GPIOHS26  50  /* GPIO High speed 26 */
+#define K210_IO_FUNC_GPIOHS27  51  /* GPIO High speed 27 */
+#define K210_IO_FUNC_GPIOHS28  52  /* GPIO High speed 28 */
+#define K210_IO_FUNC_GPIOHS29  53  /* GPIO High speed 29 */
+#define K210_IO_FUNC_GPIOHS30  54  /* GPIO High speed 30 */
+#define K210_IO_FUNC_GPIOHS31  55  /* GPIO High speed 31 */
+
+#define K210_IO_DS(x)  (x << 8) /* Driving Selector */
+
+#define K210_IO_OUTPUT_ENABLE  (1 << 12)
+#define K210_IO_OUTPUT_INVERT  (1 << 13)
+#define K210_IO_INPUT_ENABLE   (1 << 20)
+#define K210_IO_INPUT_INVERT   (1 << 21)
+#define K210_IO_PULL_DOWN      (1 << 16)
+#define K210_IO_PULL_UP        (3 << 16)
+#define K210_IO_PULL_UP_STRONG (7 << 16)
+#define K210_IO_SL             (1 << 19)
+#define K210_IO_ST             (1 << 23)
+
+#define K210_FLAG_GPIOHS  (K210_IO_DS(0xf) | K210_IO_OUTPUT_ENABLE | \
+                           K210_IO_INPUT_ENABLE | K210_IO_ST)
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+void k210_fpioa_config(uint32_t io, uint32_t ioflag);
+
+#endif /* __ARCH_RISCV_SRC_K210_K210_FPIOA_H */

--- a/arch/risc-v/src/k210/k210_gpiohs.c
+++ b/arch/risc-v/src/k210/k210_gpiohs.c
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * arch/risc-v/src/k210/k210_gpiohs.h
+ *
+ * Derives from software originally provided by Canaan Inc
+ *
+ *   Copyright 2018 Canaan Inc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "riscv_arch.h"
+
+#include "k210_memorymap.h"
+#include "k210_gpiohs.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define GPIOHS_INPUT_VAL_OFFSET    0x00
+#define GPIOHS_INPUT_EN_OFFSET     0x04
+#define GPIOHS_OUTPUT_EN_OFFSET    0x08
+#define GPIOHS_OUTPUT_VAL_OFFSET   0x0c
+#define GPIOHS_PULLUP_EN_OFFSET    0x10
+#define GPIOHS_DRIVE_OFFSET        0x14
+
+#define GPIOHS_INPUT      (K210_GPIOHS_BASE + GPIOHS_INPUT_VAL_OFFSET)
+#define GPIOHS_INPUT_EN   (K210_GPIOHS_BASE + GPIOHS_INPUT_EN_OFFSET)
+#define GPIOHS_OUTPUT     (K210_GPIOHS_BASE + GPIOHS_OUTPUT_VAL_OFFSET)
+#define GPIOHS_OUTPUT_EN  (K210_GPIOHS_BASE + GPIOHS_OUTPUT_EN_OFFSET)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void k210_gpiohs_set_direction(uint32_t io, bool dir)
+{
+  uint32_t outbit = dir << io;
+  uint32_t inbit  = (!dir) << io;
+  modifyreg32(GPIOHS_OUTPUT_EN, inbit, outbit);
+  modifyreg32(GPIOHS_INPUT_EN, outbit, inbit);
+}
+
+void k210_gpiohs_set_value(uint32_t io, bool val)
+{
+  uint32_t setbit = val << io;
+  uint32_t clrbit  = (!val) << io;
+  modifyreg32(GPIOHS_OUTPUT, clrbit, setbit);
+}
+
+bool k210_gpiohs_get_value(uint32_t io)
+{
+  uint32_t reg = getreg32(GPIOHS_INPUT);
+
+  if (reg & (1 << io))
+    {
+      return true;
+    }
+  else
+    {
+      return false;
+    }
+}

--- a/arch/risc-v/src/k210/k210_gpiohs.h
+++ b/arch/risc-v/src/k210/k210_gpiohs.h
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * arch/risc-v/src/k210/k210_gpiohs.h
+ *
+ * Derives from software originally provided by Canaan Inc
+ *
+ *   Copyright 2018 Canaan Inc
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_K210_K210_GPIOHS_H
+#define __ARCH_RISCV_SRC_K210_K210_GPIOHS_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: k210_gpiohs_set_direction
+ *
+ * Description:
+ *   Set gpiohs direction
+ *
+ * Input Parameters:
+ *   io  - IO number
+ *   dir - true for output, false for input
+ *
+ ****************************************************************************/
+
+void k210_gpiohs_set_direction(uint32_t io, bool dir);
+
+/****************************************************************************
+ * Name: k210_gpiohs_set_value
+ *
+ * Description:
+ *   Set gpiohs direction
+ *
+ * Input Parameters:
+ *   io  - IO number
+ *   dir - true for high level, false for low level
+ *
+ ****************************************************************************/
+
+void k210_gpiohs_set_value(uint32_t io, bool val);
+
+/****************************************************************************
+ * Name: k210_gpiohs_get_value
+ *
+ * Description:
+ *   Get gpiohs level
+ *
+ * Input Parameters:
+ *   io  - IO number
+ *
+ * Returned Value:
+ *   true for high level, false for low level
+ *
+ ****************************************************************************/
+
+bool k210_gpiohs_get_value(uint32_t io);
+
+#endif /* __ARCH_RISCV_SRC_K210_K210_GPIOHS_H */

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -549,6 +549,7 @@ config ARCH_BOARD_LX_CPU
 config ARCH_BOARD_MAIX_BIT
 	bool "Sipeed Maix Bit board"
 	depends on ARCH_CHIP_K210
+	select ARCH_HAVE_LEDS
 	---help---
 		This is the board configuration for the port of NuttX to the
 		Sipeed Maix Bit board. This board features the RISC-V K210

--- a/boards/risc-v/k210/maix-bit/include/board.h
+++ b/boards/risc-v/k210/maix-bit/include/board.h
@@ -48,6 +48,28 @@
 
 #include "k210.h"
 
+#include "k210_fpioa.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BOARD_LED_PAD     14 /* Connected to red led */
+
+/* Map pad 14 to gpiohs io 0 */
+
+#define BOARD_LED_IO_FUNC K210_IO_FUNC_GPIOHS0
+#define BOARD_LED_IO      0
+
+#define LED_STARTED       0  /* N/C */
+#define LED_HEAPALLOCATE  1  /* N/C */
+#define LED_IRQSENABLED   2  /* N/C */
+#define LED_STACKCREATED  3  /* N/C */
+#define LED_INIRQ         4  /* N/C */
+#define LED_SIGNAL        5  /* N/C */
+#define LED_ASSERTION     6  /* N/C */
+#define LED_PANIC         7  /* blink */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/boards/risc-v/k210/maix-bit/src/Makefile
+++ b/boards/risc-v/k210/maix-bit/src/Makefile
@@ -41,4 +41,8 @@ ifeq ($(CONFIG_LIB_BOARDCTL),y)
 CSRCS += k210_appinit.c
 endif
 
+ifeq ($(CONFIG_ARCH_LEDS),y)
+CSRCS += k210_leds.c
+endif
+
 include $(TOPDIR)/boards/Board.mk

--- a/boards/risc-v/k210/maix-bit/src/k210_boot.c
+++ b/boards/risc-v/k210/maix-bit/src/k210_boot.c
@@ -41,6 +41,7 @@
 
 #include <debug.h>
 
+#include <nuttx/board.h>
 #include <arch/board/board.h>
 
 /****************************************************************************
@@ -68,4 +69,5 @@
 
 void k210_boardinitialize(void)
 {
+  board_autoled_initialize();
 }

--- a/boards/risc-v/k210/maix-bit/src/k210_leds.c
+++ b/boards/risc-v/k210/maix-bit/src/k210_leds.c
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * boards/risc-v/k210/maix-bit/src/k210_leds.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/board.h>
+
+#include <arch/board/board.h>
+
+#include "k210_fpioa.h"
+#include "k210_gpiohs.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void board_autoled_initialize(void)
+{
+  k210_fpioa_config(BOARD_LED_PAD, BOARD_LED_IO_FUNC | K210_IOFLAG_GPIOHS);
+  k210_gpiohs_set_direction(BOARD_LED_IO, true);
+  k210_gpiohs_set_value(BOARD_LED_IO, true); /* LED off */
+}
+
+void board_autoled_on(int led)
+{
+  if (led == LED_PANIC)
+    {
+      k210_gpiohs_set_value(BOARD_LED_IO, false);
+    }
+}
+
+void board_autoled_off(int led)
+{
+  if (led == LED_PANIC)
+    {
+      k210_gpiohs_set_value(BOARD_LED_IO, true);
+    }
+}


### PR DESCRIPTION
## Summary
Add basic fpioa and gpiohs driver,  without interrupt support

## Impact

## Testing
This PR tested with Maix bit board.
