### PR TITLE
Char drivers should return -ENOTTY if CMD is not recognized

### DIFF
--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -97,7 +97,8 @@ static void pn532_unlock(FAR struct spi_dev_s *spi);
 
 static int     _open(FAR struct file *filep);
 static int     _close(FAR struct file *filep);
-static ssize_t _read(FAR struct file *filep, FAR char *buffer, size_t buflen);
+static ssize_t _read(FAR struct file *filep,
+                     FAR char *buffer, size_t buflen);
 static ssize_t _write(FAR struct file *filep, FAR const char *buffer,
                       size_t buflen);
 static int     _ioctl(FAR struct file *filep, int cmd, unsigned long arg);
@@ -134,7 +135,7 @@ static const struct file_operations g_pn532fops =
 
 static const uint8_t pn532ack[] =
 {
-  0x00, 0x00, 0xFF, 0x00, 0xFF, 0x00
+  0x00, 0x00, 0xff, 0x00, 0xff, 0x00
 };
 
 /****************************************************************************
@@ -218,7 +219,7 @@ static void pn532_frame_init(FAR struct pn532_frame *frame, uint8_t cmd)
 static void pn532_frame_finish(FAR struct pn532_frame *frame)
 {
   frame->lcs = pn532_checksum(frame->len);
-  frame->data[frame->len-1] = pn532_data_checksum(&frame->tfi, frame->len);
+  frame->data[frame->len - 1] = pn532_data_checksum(&frame->tfi, frame->len);
   frame->data[frame->len]   = PN532_POSTAMBLE;
 }
 
@@ -266,10 +267,10 @@ bool pn532_rx_frame_is_valid(FAR struct pn532_frame *f, bool check_data)
   if (check_data)
     {
       chk = pn532_data_checksum(&f->tfi, f->len);
-      if (chk != f->data[f->len-1])
+      if (chk != f->data[f->len - 1])
         {
           ctlserr("ERROR: Frame data checksum failed: calc=0x%X != 0x%X",
-                   chk, f->data[f->len-1]);
+                   chk, f->data[f->len - 1]);
           return false;
         }
     }
@@ -397,7 +398,8 @@ int pn532_read(FAR struct pn532_dev_s *dev, FAR uint8_t *buff, uint8_t n)
   return n;
 }
 
-int pn532_read_more(FAR struct pn532_dev_s *dev, FAR uint8_t *buff, uint8_t n)
+int pn532_read_more(FAR struct pn532_dev_s *dev,
+                    FAR uint8_t *buff, uint8_t n)
 {
   pn532_lock(dev->spi);
   pn532_select(dev);
@@ -650,14 +652,14 @@ uint32_t pn532_write_passive_data(FAR struct pn532_dev_s *dev,
                                   uint8_t address, FAR uint8_t *data,
                                   uint8_t len)
 {
-  uint8_t cmd_buffer[8+7];
+  uint8_t cmd_buffer[8 + 7];
   FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;
   uint8_t resp[20];
   uint32_t res = -EIO;
 
   pn532_frame_init(f, PN532_COMMAND_INDATAEXCHANGE);
   f->data[1] = 1;       /* max n cards at once */
-  f->data[2] = 0xA2;    /* command WRITE */
+  f->data[2] = 0xa2;    /* command WRITE */
   f->data[3] = address; /* ADDRESS, 0 = serial */
   memcpy(&f->data[4], data, len);
   f->len += 7;
@@ -672,9 +674,10 @@ uint32_t pn532_write_passive_data(FAR struct pn532_dev_s *dev,
             {
               dev->state = PN532_STATE_IDLE;
               f = (FAR struct pn532_frame *) resp;
-              tracerx("passive target id resp:", (FAR uint8_t *)f, f->len+6);
+              tracerx("passive target id resp:", (FAR uint8_t *)f,
+                      f->len + 6);
 
-              if (f->data[0] == PN532_COMMAND_INDATAEXCHANGE+1)
+              if (f->data[0] == PN532_COMMAND_INDATAEXCHANGE + 1)
                 {
                   res = f->data[1];
                 }
@@ -685,10 +688,11 @@ uint32_t pn532_write_passive_data(FAR struct pn532_dev_s *dev,
   return res;
 }
 
-uint32_t pn532_read_passive_data(FAR struct pn532_dev_s *dev, uint8_t address,
-                                 FAR uint8_t *data, uint8_t len)
+uint32_t pn532_read_passive_data(FAR struct pn532_dev_s *dev,
+                                 uint8_t address, FAR uint8_t *data,
+                                 uint8_t len)
 {
-  uint8_t cmd_buffer[4+7];
+  uint8_t cmd_buffer[4 + 7];
   FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;
   uint8_t resp[30];
   uint32_t res = -1;
@@ -704,13 +708,15 @@ uint32_t pn532_read_passive_data(FAR struct pn532_dev_s *dev, uint8_t address,
     {
       if (dev->state == PN532_STATE_DATA_READY)
         {
-          if (pn532_read_frame(dev, (FAR struct pn532_frame *)resp, 25) == OK)
+          if (pn532_read_frame(dev,
+                               (FAR struct pn532_frame *)resp, 25) == OK)
             {
               dev->state = PN532_STATE_IDLE;
               f = (FAR struct pn532_frame *) resp;
-              tracerx("passive target id resp:", (FAR uint8_t *)f, f->len+6);
+              tracerx("passive target id resp:", (FAR uint8_t *)f,
+                      f->len + 6);
 
-              if (f->data[0] == PN532_COMMAND_INDATAEXCHANGE+1)
+              if (f->data[0] == PN532_COMMAND_INDATAEXCHANGE + 1)
                 {
                   if (f->data[1] == 0 && data && len)
                     {
@@ -729,7 +735,7 @@ uint32_t pn532_read_passive_data(FAR struct pn532_dev_s *dev, uint8_t address,
 uint32_t pn532_read_passive_target_id(FAR struct pn532_dev_s *dev,
                                       uint8_t baudrate)
 {
-  uint8_t cmd_buffer[4+7];
+  uint8_t cmd_buffer[4 + 7];
   FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;
   uint8_t resp[20];
   uint32_t res = -EAGAIN;
@@ -746,9 +752,9 @@ uint32_t pn532_read_passive_target_id(FAR struct pn532_dev_s *dev,
           f = (FAR struct pn532_frame *) resp;
           r = (FAR struct pn_poll_response *) &f->data[1];
 
-          tracerx("passive target id resp:", (FAR uint8_t *)f, f->len+6);
+          tracerx("passive target id resp:", (FAR uint8_t *)f, f->len + 6);
 
-          if (f->data[0] == PN532_COMMAND_INLISTPASSIVETARGET+1)
+          if (f->data[0] == PN532_COMMAND_INLISTPASSIVETARGET + 1)
             {
               uint32_t cid = 0;
 
@@ -783,13 +789,12 @@ uint32_t pn532_read_passive_target_id(FAR struct pn532_dev_s *dev,
     }
 
   return res;
-
 }
 
 static int pn532_read_passive_target(FAR struct pn532_dev_s *dev,
                                      uint8_t baudrate)
 {
-  uint8_t cmd_buffer[4+7];
+  uint8_t cmd_buffer[4 + 7];
   FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;
 
   pn532_frame_init(f, PN532_COMMAND_INLISTPASSIVETARGET);
@@ -800,16 +805,17 @@ static int pn532_read_passive_target(FAR struct pn532_dev_s *dev,
   return pn532_write_frame(dev, f);
 }
 
-bool pn532_set_rf_config(struct pn532_dev_s *dev, struct pn_rf_config_s *conf)
+bool pn532_set_rf_config(struct pn532_dev_s * dev,
+                         struct pn_rf_config_s * conf)
 {
   bool res = false;
-  uint8_t cmd_buffer[15+7];
+  uint8_t cmd_buffer[15 + 7];
   FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;
 
   pn532_frame_init(f, PN532_COMMAND_RFCONFIGURATION);
   f->data[1] = conf->cfg_item;
   memcpy(&f->data[2], conf->config, conf->data_size);
-  f->len += conf->data_size+1;
+  f->len += conf->data_size + 1;
   pn532_frame_finish(f);
 
   if (pn532_write_frame(dev, f) == OK)
@@ -943,7 +949,7 @@ static ssize_t _read(FAR struct file *filep, FAR char *buffer, size_t buflen)
   dev = inode->i_private;
 
   uint32_t id = pn532_read_passive_target_id(dev, PN532_MIFARE_ISO14443A);
-  if (id != 0xFFFFFFFF)
+  if (id != 0xffffffff)
     {
       if (buffer)
         {
@@ -1102,7 +1108,7 @@ static int _ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
     default:
       ctlserr("ERROR: Unrecognized cmd: %d\n", cmd);
-      ret = -EINVAL;
+      ret = -ENOTTY;
       break;
     }
 

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -828,7 +828,7 @@ static int ee24xx_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   switch (cmd)
     {
       default:
-        ret = -EINVAL;
+        ret = -ENOTTY;
     }
 
   return ret;

--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -812,7 +812,7 @@ static int ee25xx_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   switch (cmd)
     {
       default:
-        ret = -EINVAL;
+        ret = -ENOTTY;
     }
 
   return ret;

--- a/drivers/modem/altair/altmdm.c
+++ b/drivers/modem/altair/altmdm.c
@@ -368,6 +368,7 @@ static int altmdm_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
     default:
       m_err("Unrecognized cmd: 0x%08x\n", cmd);
+      ret = -ENOTTY;
       break;
     }
 

--- a/drivers/modem/u-blox.c
+++ b/drivers/modem/u-blox.c
@@ -56,6 +56,7 @@
  ****************************************************************************/
 
 /* Debug ********************************************************************/
+
 /* Non-standard debug that may be enabled just for testing the modem driver */
 
 #ifdef CONFIG_MODEM_U_BLOX_DEBUG
@@ -74,29 +75,29 @@
 
 struct ubxmdm_upper
 {
-  FAR char* path;     /* Registration path */
+  FAR char * path;     /* Registration path */
 
   /* The contained lower-half driver. */
 
-  FAR struct ubxmdm_lower* lower;
+  FAR struct ubxmdm_lower * lower;
 };
 
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
 
-static ssize_t ubxmdm_read (FAR struct file* filep,
-                            FAR char* buffer,
+static ssize_t ubxmdm_read (FAR struct file * filep,
+                            FAR char * buffer,
                             size_t buflen);
-static ssize_t ubxmdm_write(FAR struct file* filep,
-                            FAR const char* buffer,
+static ssize_t ubxmdm_write(FAR struct file * filep,
+                            FAR const char * buffer,
                             size_t buflen);
-static int     ubxmdm_ioctl(FAR struct file* filep,
+static int     ubxmdm_ioctl(FAR struct file * filep,
                             int cmd,
                             unsigned long arg);
 
-static int     ubxmdm_poll (FAR struct file* filep,
-                            FAR struct pollfd* fds,
+static int     ubxmdm_poll (FAR struct file * filep,
+                            FAR struct pollfd * fds,
                             bool setup);
 
 /****************************************************************************
@@ -118,29 +119,29 @@ static const struct file_operations ubxmdm_fops =
  * Private Functions
  ****************************************************************************/
 
-static ssize_t ubxmdm_read(FAR struct file* filep,
-                           FAR char* buffer,
+static ssize_t ubxmdm_read(FAR struct file * filep,
+                           FAR char * buffer,
                            size_t len)
 {
   return 0; /* Return EOF */
 }
 
-static ssize_t ubxmdm_write(FAR struct file* filep,
-                            FAR const char* buffer,
+static ssize_t ubxmdm_write(FAR struct file * filep,
+                            FAR const char * buffer,
                             size_t len)
 {
   return len; /* Say that everything was written */
 }
 
-static int ubxmdm_ioctl(FAR struct file* filep,
+static int ubxmdm_ioctl(FAR struct file * filep,
                         int cmd,
                         unsigned long arg)
 {
-  FAR struct inode*         inode = filep->f_inode;
-  FAR struct ubxmdm_upper*  upper;
-  FAR struct ubxmdm_lower*  lower;
-  int                       ret;
-  FAR struct ubxmdm_status* status;
+  FAR struct inode *         inode = filep->f_inode;
+  FAR struct ubxmdm_upper *  upper;
+  FAR struct ubxmdm_lower *  lower;
+  int                        ret;
+  FAR struct ubxmdm_status * status;
 
   m_info("cmd: %d arg: %ld\n", cmd, arg);
   upper = inode->i_private;
@@ -209,7 +210,7 @@ static int ubxmdm_ioctl(FAR struct file* filep,
     case MODEM_IOC_GETSTATUS:
       if (lower->ops->getstatus)
         {
-          status = (FAR struct ubxmdm_status*) ((uintptr_t) arg);
+          status = (FAR struct ubxmdm_status *) ((uintptr_t) arg);
           if (status)
             {
               ret = lower->ops->getstatus(lower, status);
@@ -239,7 +240,7 @@ static int ubxmdm_ioctl(FAR struct file* filep,
         }
       else
         {
-          ret = -ENOSYS;
+          ret = -ENOTTY;
         }
 
       break;
@@ -248,8 +249,8 @@ static int ubxmdm_ioctl(FAR struct file* filep,
   return ret;
 }
 
-static int ubxmdm_poll(FAR struct file* filep,
-                       FAR struct pollfd* fds,
+static int ubxmdm_poll(FAR struct file * filep,
+                       FAR struct pollfd * fds,
                        bool setup)
 {
   if (setup)
@@ -268,15 +269,15 @@ static int ubxmdm_poll(FAR struct file* filep,
  * Public Functions
  ****************************************************************************/
 
-FAR void* ubxmdm_register(FAR const char *path,
-                          FAR struct ubxmdm_lower *lower)
+FAR void * ubxmdm_register(FAR const char * path,
+                          FAR struct ubxmdm_lower * lower)
 {
   FAR struct ubxmdm_upper *upper;
   int ret;
 
   DEBUGASSERT(path && lower);
 
-  upper = (FAR struct ubxmdm_upper*)
+  upper = (FAR struct ubxmdm_upper *)
     kmm_zalloc(sizeof(struct ubxmdm_upper));
   if (!upper)
     {
@@ -299,7 +300,7 @@ FAR void* ubxmdm_register(FAR const char *path,
       goto errout_with_path;
     }
 
-  return (FAR void*) upper;
+  return (FAR void *) upper;
 
 errout_with_path:
   kmm_free(upper->path);
@@ -316,7 +317,7 @@ void ubxmdm_unregister(FAR void *handle)
   FAR struct ubxmdm_upper *upper;
   FAR struct ubxmdm_lower *lower;
 
-  upper = (FAR struct ubxmdm_upper*) handle;
+  upper = (FAR struct ubxmdm_upper *) handle;
   DEBUGASSERT(upper != NULL);
   lower = upper->lower;
   DEBUGASSERT(lower != NULL);

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -153,8 +153,9 @@ static const struct file_operations mtdconfig_fops =
  *
  ****************************************************************************/
 
-static int mtdconfig_readbytes(FAR struct mtdconfig_struct_s *dev, int offset,
-                               FAR uint8_t *pdata, int readlen)
+static int mtdconfig_readbytes(FAR struct mtdconfig_struct_s *dev,
+                               int offset, FAR uint8_t *pdata,
+                               int readlen)
 {
   off_t  bytestoread = readlen;
   off_t  bytesthisblock;
@@ -194,7 +195,8 @@ static int mtdconfig_readbytes(FAR struct mtdconfig_struct_s *dev, int offset,
 
       while (bytestoread > 0)
         {
-          if (bytesthisblock < dev->blocksize || bytestoread < dev->blocksize)
+          if (bytesthisblock < dev->blocksize ||
+              bytestoread < dev->blocksize)
             {
               /* Copy to temp buffer first...don't need the whole block */
 
@@ -269,7 +271,7 @@ static int mtdconfig_writebytes(FAR struct mtdconfig_struct_s *dev,
   else
 #endif
 
-    /* Perform the write using the block write method of the MTD */
+  /* Perform the write using the block write method of the MTD */
 
     {
       uint16_t  block;
@@ -681,8 +683,8 @@ static off_t mtdconfig_ramconsolidate(FAR struct mtdconfig_struct_s *dev)
 
               /* Now write the item to the current dst_offset location. */
 
-              ret = mtdconfig_writebytes(dev, dst_offset, (FAR uint8_t *)phdr,
-                                         sizeof(hdr));
+              ret = mtdconfig_writebytes(dev, dst_offset,
+                                         (FAR uint8_t *)phdr, sizeof(hdr));
               if (ret != sizeof(hdr))
                 {
                   /* I/O Error! */
@@ -707,8 +709,9 @@ static off_t mtdconfig_ramconsolidate(FAR struct mtdconfig_struct_s *dev)
 
               /* Test if enough space in dst block for another header */
 
-              if (dst_offset + sizeof(hdr) >= (dst_block + 1) * dev->erasesize ||
-                  dst_offset == (dst_block + 1) * dev->erasesize)
+              if ((dst_offset + sizeof(hdr) >= (dst_block + 1) *
+                  dev->erasesize) || (dst_offset == (dst_block + 1) *
+                  dev->erasesize))
                 {
                   dst_block++;
                   dst_offset = dst_block * dev->erasesize +
@@ -840,7 +843,8 @@ static off_t  mtdconfig_consolidate(FAR struct mtdconfig_struct_s *dev)
       /* Scan all headers and move them to the src_offset */
 
 retry_relocate:
-      bytes = MTD_READ(dev->mtd, src_offset, sizeof(hdr), (FAR uint8_t *)&hdr);
+      bytes = MTD_READ(dev->mtd, src_offset,
+                       sizeof(hdr), (FAR uint8_t *)&hdr);
       if (bytes != sizeof(hdr))
         {
           /* I/O Error! */
@@ -870,13 +874,17 @@ retry_relocate:
             }
           else
             {
-              /* Test if this entry will fit in the current destination block */
+              /* Test if this entry will fit in the current destination
+               * block.
+               */
 
               bytes_left_in_block = (dst_block + 1) * dev->erasesize -
                                     dst_offset;
               if (hdr.len + sizeof(hdr) > bytes_left_in_block)
                 {
-                  /* Item doesn't fit in the block.  Advance to the next one */
+                  /* Item doesn't fit in the block. Advance to the next
+                   * one.
+                   */
 
                   /* Update control variables */
 
@@ -893,8 +901,8 @@ retry_relocate:
 
               /* Copy this entry to the destination */
 
-              ret = mtdconfig_writebytes(dev, dst_offset, (FAR uint8_t *)&hdr,
-                                         sizeof(hdr));
+              ret = mtdconfig_writebytes(dev, dst_offset,
+                                         (FAR uint8_t *)&hdr, sizeof(hdr));
               if (ret != sizeof(hdr))
                 {
                   /* I/O Error! */
@@ -987,10 +995,13 @@ retry_relocate:
 
       if (dst_offset + sizeof(hdr) >= (dst_block + 1) * dev->erasesize)
         {
-          /* No room at end of dst block for another header.  Go to next block. */
+          /* No room at end of dst block for another header.
+           * Go to next block.
+           */
 
           dst_block++;
-          dst_offset = dst_block * dev->erasesize + CONFIGDATA_BLOCK_HDR_SIZE;
+          dst_offset = dst_block * dev->erasesize +
+                       CONFIGDATA_BLOCK_HDR_SIZE;
           DEBUGASSERT(dst_block != src_block);
         }
     }
@@ -1349,7 +1360,8 @@ retry_find:
       hdr.len = pdata->len;
       hdr.flags = MTD_ERASED_FLAGS;
 
-      ret = mtdconfig_writebytes(dev, offset, (FAR uint8_t *)&hdr, sizeof(hdr));
+      ret = mtdconfig_writebytes(dev, offset,
+                                 (FAR uint8_t *)&hdr, sizeof(hdr));
       if (ret != sizeof(hdr))
         {
           /* Cannot write even header! */
@@ -1444,6 +1456,7 @@ static int mtdconfig_getconfig(FAR struct mtdconfig_struct_s *dev,
     }
 
 errout:
+
   /* Free the buffer */
 
   kmm_free(dev->buffer);
@@ -1510,7 +1523,7 @@ static int mtdconfig_ioctl(FAR struct file *filep, int cmd,
   FAR struct config_data_s *pdata;
   struct mtdconfig_header_s hdr;
   off_t bytes_to_read;
-  int ret = -ENOSYS;
+  int ret = -ENOTTY;
 
   switch (cmd)
     {
@@ -1531,6 +1544,7 @@ static int mtdconfig_ioctl(FAR struct file *filep, int cmd,
         break;
 
       case CFGDIOC_DELCONFIG:
+
         /* Set the config item */
 
         pdata = (FAR struct config_data_s *)arg;
@@ -1538,6 +1552,7 @@ static int mtdconfig_ioctl(FAR struct file *filep, int cmd,
         break;
 
       case CFGDIOC_FIRSTCONFIG:
+
         /* Get the the first config item */
 
         pdata = (FAR struct config_data_s *)arg;
@@ -1585,6 +1600,7 @@ static int mtdconfig_ioctl(FAR struct file *filep, int cmd,
         break;
 
       case CFGDIOC_NEXTCONFIG:
+
         /* Get the next config item */
 
         pdata = (FAR struct config_data_s *)arg;
@@ -1601,7 +1617,8 @@ static int mtdconfig_ioctl(FAR struct file *filep, int cmd,
         /* Test if the config item is valid */
 
 #ifdef CONFIG_MTD_CONFIG_NAMED
-        if (dev->readoff != 0 && hdr.name[0] != CONFIG_MTD_CONFIG_ERASEDVALUE)
+        if (dev->readoff != 0 &&
+            hdr.name[0] != CONFIG_MTD_CONFIG_ERASEDVALUE)
 #else
         if (dev->readoff != 0 && hdr.id != MTD_ERASED_ID)
 #endif
@@ -1639,6 +1656,7 @@ static int mtdconfig_ioctl(FAR struct file *filep, int cmd,
         break;
 
       case MTDIOC_BULKERASE:
+
         /* Call the MTD's ioctl for this */
 
         if (dev->mtd->ioctl)
@@ -1703,7 +1721,8 @@ int mtdconfig_register(FAR struct mtd_dev_s *mtd)
        * from the size of a pointer).
        */
 
-      ret = MTD_IOCTL(mtd, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geo));
+      ret = MTD_IOCTL(mtd, MTDIOC_GEOMETRY,
+                      (unsigned long)((uintptr_t)&geo));
       if (ret < 0)
         {
           ferr("ERROR: MTD ioctl(MTDIOC_GEOMETRY) failed: %d\n", ret);

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -1464,7 +1464,7 @@ static int tun_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       return OK;
     }
 
-  return -EBADFD;
+  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/drivers/timers/timer.c
+++ b/drivers/timers/timer.c
@@ -116,7 +116,7 @@ static const struct file_operations g_timerops =
  * Private Functions
  ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Name: timer_notifier
  *
  * Description:
@@ -124,7 +124,7 @@ static const struct file_operations g_timerops =
  *
  * REVISIT: This function prototype is insufficient to support signaling
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static bool timer_notifier(FAR uint32_t *next_interval_us, FAR void *arg)
 {
@@ -141,13 +141,13 @@ static bool timer_notifier(FAR uint32_t *next_interval_us, FAR void *arg)
   return true;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: timer_open
  *
  * Description:
  *   This function is called whenever the timer device is opened.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static int timer_open(FAR struct file *filep)
 {
@@ -192,13 +192,13 @@ errout:
   return ret;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: timer_close
  *
  * Description:
  *   This function is called when the timer device is closed.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static int timer_close(FAR struct file *filep)
 {
@@ -229,28 +229,29 @@ static int timer_close(FAR struct file *filep)
   return OK;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: timer_read
  *
  * Description:
  *   A dummy read method.  This is provided only to satisfy the VFS layer.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
-static ssize_t timer_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
+static ssize_t timer_read(FAR struct file *filep, FAR char *buffer,
+                          size_t buflen)
 {
   /* Return zero -- usually meaning end-of-file */
 
   return 0;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: timer_write
  *
  * Description:
  *   A dummy write method.  This is provided only to satisfy the VFS layer.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static ssize_t timer_write(FAR struct file *filep, FAR const char *buffer,
                            size_t buflen)
@@ -258,14 +259,14 @@ static ssize_t timer_write(FAR struct file *filep, FAR const char *buffer,
   return 0;
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: timer_ioctl
  *
  * Description:
  *   The standard ioctl method.  This is where ALL of the timer work is
  *   done.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
@@ -393,7 +394,8 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         if (notify != NULL)
           {
             memcpy(&upper->notify, notify, sizeof(*notify));
-            ret = timer_setcallback((FAR void *)upper, timer_notifier, upper);
+            ret = timer_setcallback((FAR void *)upper,
+                                    timer_notifier, upper);
           }
         else
           {
@@ -422,7 +424,9 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       }
       break;
 
-    /* Any unrecognized IOCTL commands might be platform-specific ioctl commands */
+    /* Any unrecognized IOCTL commands might be platform-specific ioctl
+     * commands
+     */
 
     default:
       {
@@ -439,7 +443,7 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           }
         else
           {
-            ret = -ENOSYS;
+            ret = -ENOTTY;
           }
       }
       break;

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -183,7 +183,8 @@ static void watchdog_automonitor_idle(FAR struct pm_callback_s *cb,
 #endif
 
 #ifdef CONFIG_WATCHDOG_AUTOMONITOR
-static void watchdog_automonitor_start(FAR struct watchdog_upperhalf_s *upper)
+static void watchdog_automonitor_start(FAR struct watchdog_upperhalf_s
+                                       *upper)
 {
   FAR struct watchdog_lowerhalf_s *lower = upper->lower;
 
@@ -549,7 +550,7 @@ static int wdog_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           }
         else
           {
-            ret = -ENOSYS;
+            ret = -ENOTTY;
           }
       }
       break;

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -2199,7 +2199,7 @@ static int usbhost_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
     default:
 
-      ret = -EINVAL;
+      ret = -ENOTTY;
       goto errout;
     }
 


### PR DESCRIPTION
## Summary
There are some char drivers that were returning -EINVAL instead -ENOTTY, let fix it
## Impact
Minor/None
## Testing

