### PR TITLE
boards/sim: Break out the thread loop instead calling pthread_exit

### DIFF
--- a/boards/sim/sim/sim/src/sim_touchscreen.c
+++ b/boards/sim/sim/sim/src/sim_touchscreen.c
@@ -112,7 +112,7 @@ static FAR void *sim_listener(FAR void *arg)
            */
 
           fwarn("WARNING: Lost server connection: %d\n", errno);
-          pthread_exit(NULL);
+          break;
         }
 
       /* If we received a message, we must be connected */
@@ -125,7 +125,7 @@ static FAR void *sim_listener(FAR void *arg)
         }
     }
 
-  return NULL; /* Not-reachable */
+  return NULL;
 }
 
 /****************************************************************************


### PR DESCRIPTION
Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I744d06d7a669067c68b74c69f3961f34673d81a0

## Summary

## Impact

## Testing

