### PR TITLE
arch: Move the up_assert declaration from assert.h to arch.h

### DIFF
--- a/Documentation/NuttxPortingGuide.html
+++ b/Documentation/NuttxPortingGuide.html
@@ -2147,7 +2147,7 @@ The specific environmental definitions are unique for each board but should incl
 
 <h3><a name="upassert">4.2.13 <code>up_assert()</code></a></h3>
 <p><b>Function Prototype</b>:<br>
-  <code>void up_assert(FAR const uint8_t *filename, int linenum);</code>
+  <code>void up_assert(FAR const char *filename, int linenum);</code>
 </p>
 
 <p><b>Description</b>.

--- a/arch/arm/src/arm/arm_assert.c
+++ b/arch/arm/src/arm/arm_assert.c
@@ -342,7 +342,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/arm/src/armv6-m/arm_assert.c
+++ b/arch/arm/src/armv6-m/arm_assert.c
@@ -399,7 +399,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/arm/src/armv7-a/arm_assert.c
+++ b/arch/arm/src/armv7-a/arm_assert.c
@@ -423,7 +423,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/arm/src/armv7-m/arm_assert.c
+++ b/arch/arm/src/armv7-m/arm_assert.c
@@ -412,7 +412,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/arm/src/armv7-r/arm_assert.c
+++ b/arch/arm/src/armv7-r/arm_assert.c
@@ -392,7 +392,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -412,7 +412,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/avr/src/common/up_assert.c
+++ b/arch/avr/src/common/up_assert.c
@@ -145,7 +145,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/hc/src/m9s12/m9s12_assert.c
+++ b/arch/hc/src/m9s12/m9s12_assert.c
@@ -327,7 +327,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/mips/src/mips32/mips_assert.c
+++ b/arch/mips/src/mips32/mips_assert.c
@@ -144,7 +144,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/misoc/src/lm32/lm32_assert.c
+++ b/arch/misoc/src/lm32/lm32_assert.c
@@ -149,7 +149,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/misoc/src/minerva/minerva_assert.c
+++ b/arch/misoc/src/minerva/minerva_assert.c
@@ -149,7 +149,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t * filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/or1k/src/common/up_assert.c
+++ b/arch/or1k/src/common/up_assert.c
@@ -405,7 +405,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/renesas/src/common/up_assert.c
+++ b/arch/renesas/src/common/up_assert.c
@@ -144,7 +144,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -344,7 +344,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/risc-v/src/rv64gc/riscv_assert.c
+++ b/arch/risc-v/src/rv64gc/riscv_assert.c
@@ -359,7 +359,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/sim/src/sim/up_head.c
+++ b/arch/sim/src/sim/up_head.c
@@ -108,7 +108,7 @@ int main(int argc, char **argv, char **envp)
  *
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int line)
+void up_assert(const char *filename, int line)
 {
   /* Show the location of the failed assertion */
 

--- a/arch/x86/src/common/up_assert.c
+++ b/arch/x86/src/common/up_assert.c
@@ -288,7 +288,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/x86_64/src/common/up_assert.c
+++ b/arch/x86_64/src/common/up_assert.c
@@ -240,7 +240,7 @@ static void _up_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = this_task();

--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -163,7 +163,7 @@ static void xtensa_assert(int errorcode)
  * Name: up_assert
  ****************************************************************************/
 
-void up_assert(const uint8_t *filename, int lineno)
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();

--- a/arch/z16/src/common/z16_assert.c
+++ b/arch/z16/src/common/z16_assert.c
@@ -128,11 +128,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_FILENAME
-void up_assert(const uint8_t *filename, int lineno)
-#else
-void up_assert(void)
-#endif
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();
@@ -144,20 +140,12 @@ void up_assert(void)
 
   syslog_flush();
 
-#ifdef CONFIG_HAVE_FILENAME
 #if CONFIG_TASK_NAME_SIZE > 0
   _alert("Assertion failed at file:%s line: %d task: %s\n",
         filename, lineno, rtcb->name);
 #else
   _alert("Assertion failed at file:%s line: %d\n",
         filename, lineno);
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
-  _alert("Assertion failed: task: %s\n", rtcb->name);
-#else
-  _alert("Assertion failed\n");
-#endif
 #endif
 
   z16_registerdump();

--- a/arch/z80/src/common/z80_assert.c
+++ b/arch/z80/src/common/z80_assert.c
@@ -127,11 +127,7 @@ static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
  * Name: up_assert
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_FILENAME
-void up_assert(const uint8_t *filename, int lineno)
-#else
-void up_assert(void)
-#endif
+void up_assert(const char *filename, int lineno)
 {
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   struct tcb_s *rtcb = running_task();
@@ -143,20 +139,12 @@ void up_assert(void)
 
   syslog_flush();
 
-#ifdef CONFIG_HAVE_FILENAME
 #if CONFIG_TASK_NAME_SIZE > 0
   _alert("Assertion failed at file:%s line: %d task: %s\n",
         filename, lineno, rtcb->name);
 #else
   _alert("Assertion failed at file:%s line: %d\n",
         filename, lineno);
-#endif
-#else
-#if CONFIG_TASK_NAME_SIZE > 0
-  _alert("Assertion failed: task: %s\n", rtcb->name);
-#else
-  _alert("Assertion failed\n");
-#endif
 #endif
 
   REGISTER_DUMP();

--- a/include/assert.h
+++ b/include/assert.h
@@ -1,7 +1,8 @@
 /****************************************************************************
  * include/assert.h
  *
- *   Copyright (C) 2007-2009, 2011-2013, 2015-2016 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2011-2013, 2015-2016 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  *   Copyright (C) 2016 Omni Hoverboards Inc. All rights reserved.
@@ -60,9 +61,9 @@
 #undef DEBUGVERIFY  /* Like VERIFY, but only if CONFIG_DEBUG_ASSERTIONS is defined */
 
 #ifdef CONFIG_HAVE_FILENAME
-#  define PANIC()        up_assert((const uint8_t *)__FILE__, (int)__LINE__)
+#  define PANIC()        up_assert(__FILE__, __LINE__)
 #else
-#  define PANIC()        up_assert()
+#  define PANIC()        up_assert("unknown", 0)
 #endif
 
 #define ASSERT(f)        do { if (!(f)) PANIC(); } while (0)
@@ -116,12 +117,6 @@ extern "C"
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
-
-#ifdef CONFIG_HAVE_FILENAME
-void up_assert(FAR const uint8_t *filename, int linenum) noreturn_function;
-#else
-void up_assert(void) noreturn_function;
-#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -476,7 +476,7 @@ void up_exit() noreturn_function;
  *
  ****************************************************************************/
 
-/* Prototype is in assert.h */
+void up_assert(FAR const char *filename, int linenum) noreturn_function;
 
 /****************************************************************************
  * Name: up_schedule_sigaction

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -177,7 +177,7 @@
 "uname","sys/utsname.h","","int","FAR struct utsname *"
 "unlink","unistd.h","!defined(CONFIG_DISABLE_MOUNTPOINT)","int","FAR const char *"
 "unsetenv","stdlib.h","!defined(CONFIG_DISABLE_ENVIRON)","int","FAR const char *"
-"up_assert","assert.h","","void","FAR const uint8_t *","int"
+"up_assert","nuttx/arch.h","","void","FAR const char *","int"
 "vfork","unistd.h","defined(CONFIG_SCHED_WAITPID) && defined(CONFIG_ARCH_HAVE_VFORK)","pid_t"
 "wait","sys/wait.h","defined(CONFIG_SCHED_WAITPID) && defined(CONFIG_SCHED_HAVE_PARENT)","pid_t","FAR int *"
 "waitid","sys/wait.h","defined(CONFIG_SCHED_WAITPID) && defined(CONFIG_SCHED_HAVE_PARENT)","int","idtype_t","id_t"," FAR siginfo_t *","int"


### PR DESCRIPTION
and change the 1st argument from "const uint8_t *" to "const char *"

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I86487d57210ab63109148232da71dbc4d60a563b

## Summary

## Impact

## Testing

