### PR TITLE
Add LED support to stm32f411-minimum board

### DIFF
--- a/boards/arm/stm32/stm32f411-minimum/configs/nsh/defconfig
+++ b/boards/arm/stm32/stm32f411-minimum/configs/nsh/defconfig
@@ -6,7 +6,6 @@
 # modifications.
 #
 # CONFIG_ARCH_FPU is not set
-# CONFIG_ARCH_LEDS is not set
 # CONFIG_DISABLE_OS_API is not set
 # CONFIG_NSH_ARGCAT is not set
 # CONFIG_NSH_CMDOPT_HEXDUMP is not set

--- a/boards/arm/stm32/stm32f411-minimum/include/board.h
+++ b/boards/arm/stm32/stm32f411-minimum/include/board.h
@@ -297,6 +297,17 @@
  * The STM32F411-Minimum (aka BlackPill) has a LED on PC13 pin.
  */
 
+/* The board has only one controllable LED */
+
+#define LED_STARTED       0  /* No LEDs */
+#define LED_HEAPALLOCATE  1  /* LED1 on */
+#define LED_IRQSENABLED   2  /* LED1 on */
+#define LED_STACKCREATED  3  /* LED1 on */
+#define LED_INIRQ         4  /* LED1 on */
+#define LED_SIGNAL        5  /* LED1 on */
+#define LED_ASSERTION     6  /* LED1 on */
+#define LED_PANIC         7  /* LED1 blinking */
+
 /* LED index values for use with board_userled() */
 
 #define BOARD_LED1        0

--- a/boards/arm/stm32/stm32f411-minimum/src/Make.defs
+++ b/boards/arm/stm32/stm32f411-minimum/src/Make.defs
@@ -23,11 +23,15 @@ include $(TOPDIR)/Make.defs
 CSRCS = stm32_boot.c stm32_bringup.c
 
 ifeq ($(CONFIG_NSH_LIBRARY),y)
-CSRCS += stm32_appinit.c
+  CSRCS += stm32_appinit.c
+endif
+
+ifeq ($(CONFIG_ARCH_LEDS),y)
+  CSRCS += stm32_autoleds.c
 endif
 
 ifeq ($(CONFIG_STM32_OTGFS),y)
-CSRCS += stm32_usb.c
+  CSRCS += stm32_usb.c
 endif
 
 DEPPATH += --dep-path board

--- a/boards/arm/stm32/stm32f411-minimum/src/stm32_autoleds.c
+++ b/boards/arm/stm32/stm32f411-minimum/src/stm32_autoleds.c
@@ -69,7 +69,7 @@ void board_autoled_initialize(void)
 
 void board_autoled_on(int led)
 {
-  ledinfo("board_autoled_on(%d)\n",led);
+  ledinfo("board_autoled_on(%d)\n", led);
 
   switch (led)
     {
@@ -83,6 +83,7 @@ void board_autoled_on(int led)
       break;
 
     case LED_PANIC:
+
       /* For panic state, the LED is blinking */
 
       set_led(true);
@@ -99,6 +100,7 @@ void board_autoled_off(int led)
   switch (led)
     {
     case LED_PANIC:
+
       /* For panic state, the LED is blinking */
 
       set_led(false);

--- a/boards/arm/stm32/stm32f411-minimum/src/stm32_autoleds.c
+++ b/boards/arm/stm32/stm32f411-minimum/src/stm32_autoleds.c
@@ -1,0 +1,109 @@
+/****************************************************************************
+ * boards/arm/stm32/stm32f411-minimum/src/stm32_autoleds.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <debug.h>
+
+#include <nuttx/board.h>
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include "arm_arch.h"
+#include "arm_internal.h"
+#include "stm32.h"
+#include "stm32f411-minimum.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static inline void set_led(bool v)
+{
+  ledinfo("Turn LED %s\n", v? "on":"off");
+  stm32_gpiowrite(GPIO_LED1, !v);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_autoled_initialize
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_LEDS
+void board_autoled_initialize(void)
+{
+  /* Configure LED GPIO for output */
+
+  stm32_configgpio(GPIO_LED1);
+}
+
+/****************************************************************************
+ * Name: board_autoled_on
+ ****************************************************************************/
+
+void board_autoled_on(int led)
+{
+  ledinfo("board_autoled_on(%d)\n",led);
+
+  switch (led)
+    {
+    case LED_STARTED:
+    case LED_HEAPALLOCATE:
+      /* As the board provides only one soft controllable LED, we simply
+       * turn it on when the board boots.
+       */
+
+      set_led(true);
+      break;
+
+    case LED_PANIC:
+      /* For panic state, the LED is blinking */
+
+      set_led(true);
+      break;
+    }
+}
+
+/****************************************************************************
+ * Name: board_autoled_off
+ ****************************************************************************/
+
+void board_autoled_off(int led)
+{
+  switch (led)
+    {
+    case LED_PANIC:
+      /* For panic state, the LED is blinking */
+
+      set_led(false);
+      break;
+    }
+}
+
+#endif /* CONFIG_ARCH_LEDS */

--- a/boards/arm/stm32/stm32f411-minimum/src/stm32f411-minimum.h
+++ b/boards/arm/stm32/stm32f411-minimum/src/stm32f411-minimum.h
@@ -39,12 +39,12 @@
 /* LED.  User LED1: the blue LED is a user LED connected to board LED C13
  * corresponding to MCU I/O PC13.
  *
- * - When the I/O is HIGH value, the LED is on.
- * - When the I/O is LOW, the LED is off.
+ * - When the I/O is LOW value, the LED is on.
+ * - When the I/O is HIGH, the LED is off.
  */
 
 #define GPIO_LED1 \
-  (GPIO_PORTC | GPIO_PIN13 | GPIO_OUTPUT_CLEAR | GPIO_OUTPUT | GPIO_PULLUP | \
+  (GPIO_PORTC | GPIO_PIN13 | GPIO_OUTPUT_SET | GPIO_OUTPUT | GPIO_PULLUP | \
    GPIO_SPEED_50MHz)
 
 /* Buttons


### PR DESCRIPTION
## Summary
Add LED support to stm32f411-minimum board
## Impact
Minor/None
## Testing

