### PR TITLE
boards: Fix Kconfig for maix-bit with QEMU

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -549,7 +549,7 @@ config ARCH_BOARD_LX_CPU
 config ARCH_BOARD_MAIX_BIT
 	bool "Sipeed Maix Bit board"
 	depends on ARCH_CHIP_K210
-	select ARCH_HAVE_LEDS
+	select ARCH_HAVE_LEDS if !K210_WITH_QEMU
 	---help---
 		This is the board configuration for the port of NuttX to the
 		Sipeed Maix Bit board. This board features the RISC-V K210


### PR DESCRIPTION
## Summary

- This PR fixes Kconfig for maix-bit with QEMU

## Impact

- This PR only affects for Sipeed maix-bit board

## Testing

- I tested this PR both with QEMU and without QEMU (i.e. maix-bit board)
