### PR TITLE
libc: Add the remaining wscanf series declaration

### DIFF
--- a/include/wchar.h
+++ b/include/wchar.h
@@ -176,8 +176,12 @@ int               swprintf(FAR wchar_t *, size_t, FAR const wchar_t *, ...);
 int               swscanf(FAR const wchar_t *, FAR const wchar_t *, ...);
 wint_t            ungetwc(wint_t, FILE *);
 int               vfwprintf(FILE *, FAR const wchar_t *, va_list);
+int               vfwscanf(FILE *, FAR const wchar_t *, va_list);
 int               vwprintf(FAR const wchar_t *, va_list);
-int               vswprintf(wchar_t *, size_t, FAR const wchar_t *,
+int               vwscanf(FAR const wchar_t *, va_list);
+int               vswprintf(FAR wchar_t *, size_t, FAR const wchar_t *,
+                      va_list);
+int               vswscanf(FAR const wchar_t *, FAR const wchar_t *,
                       va_list);
 size_t            wcrtomb(FAR char *, wchar_t, FAR mbstate_t *);
 FAR wchar_t      *wcscat(FAR wchar_t *, FAR const wchar_t *);


### PR DESCRIPTION
The function isn't implemented like other wide printf/scanf

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I0b26bb5174d1a9295fe2454d0e33f8227b8cbf8a

## Summary
libc++ don't really use these functions, but declare them in cwchar like this:
```
using ::fwprintf;
using ::fwscanf;
using ::swprintf;
using ::vfwprintf;
using ::vswprintf;
using ::swscanf;
using ::vfwscanf;
using ::vswscanf;
```

## Impact

## Testing

