### PR TITLE
arch/arm/src/nrf52/nrf52_idle.c: disable WFI in up_idle

### DIFF
--- a/arch/arm/src/nrf52/nrf52_idle.c
+++ b/arch/arm/src/nrf52/nrf52_idle.c
@@ -176,10 +176,16 @@ void up_idle(void)
 
   up_idlepm();
 
-  /* Sleep until an interrupt occurs to save power */
+  /* Sleep until an interrupt occurs to save power
+   *
+   * REVISIT: The SysTick's clock will only tick when the CPU is
+   * running (not in WFE/WFI) or when the system is in debug interface mode.
+   */
 
+#if 0
   BEGIN_IDLE();
   asm("WFI");
   END_IDLE();
+#endif
 #endif
 }


### PR DESCRIPTION
## Summary
The SysTick's clock in NRF52 doesn't work in WFE/WFI so we shouldn't enter sleep mode in idle until another system clock is supported

## Impact
The system doesn't freeze without a debugger.

## Testing

