### PR TITLE
sched: Don't call nxnotify_cancellation in task_setcancelstate

### DIFF
--- a/sched/task/task_setcancelstate.c
+++ b/sched/task/task_setcancelstate.c
@@ -114,18 +114,7 @@ int task_setcancelstate(int state, FAR int *oldstate)
 #ifdef CONFIG_CANCELLATION_POINTS
           /* If we are using deferred cancellation? */
 
-          if ((tcb->flags & TCB_FLAG_CANCEL_DEFERRED) != 0)
-            {
-              /* Yes.. If we are within a cancellation point, then
-               * notify of the cancellation.
-               */
-
-              if (tcb->cpcount > 0)
-                {
-                  nxnotify_cancellation(tcb);
-                }
-            }
-          else
+          if ((tcb->flags & TCB_FLAG_CANCEL_DEFERRED) == 0)
 #endif
             {
               /* No.. We are using asynchronous cancellation.  If the


### PR DESCRIPTION
since it is impossible that the current running thread is
in the waiting state and then need to wake up self.

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: Ie2ba55c382eb3eb7c8d9f04bba1b9e294aaf6196

## Summary

## Impact

## Testing

