### PR TITLE
sched: Remove SCHED_EXIT_KILL_CHILDREN option

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -616,18 +616,6 @@ config SCHED_WAITPID
 		compliant) and will enable the waitid() and wait() interfaces as
 		well.
 
-config SCHED_EXIT_KILL_CHILDREN
-	bool "Enable kill all children when exit"
-	default n
-	depends on SCHED_HAVE_PARENT && SCHED_CHILD_STATUS
-	---help---
-		When a task exits, all of its child threads will be killed.
-
-		Caution:  This selection should not be used unless you are certain
-		of what you are doing.  Uninformed of this option can often lead to
-		memory leaks since, for example, memory allocations held by threads
-		are not automatically freed!
-
 config SCHED_USER_IDENTITY
 	bool "Support per-task User Identity"
 	default n

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -77,7 +77,7 @@ void exit(int status)
 
   status &= 0xff;
 
-#ifdef CONFIG_SCHED_EXIT_KILL_CHILDREN
+#ifdef HAVE_GROUP_MEMBERS
   /* Kill all of the children of the group, preserving only this thread.
    * exit() is normally called from the main thread of the task.  pthreads
    * exit through a different mechanism.


### PR DESCRIPTION
## Summary
All standard indicate exit should terminate the whole process/task:
https://pubs.opengroup.org/onlinepubs/007904975/functions/exit.html
https://en.cppreference.com/w/c/program/exit
https://linux.die.net/man/2/exit
so let's remove the option and trust the caller know the difference:
1.exit terminate all threads belong the current process/task
2.pthread_exit only terminate the current(main/pthread) thread

## Impact

## Testing

