### PR TITLE
drivers/analog/ and include/nuttx/analog: Fix typos and nxstyle issues.

### DIFF
--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -119,13 +119,15 @@ static int adc_open(FAR struct file *filep)
   uint8_t               tmp;
   int                   ret;
 
-  /* If the port is the middle of closing, wait until the close is finished */
+  /* If the port is the middle of closing, wait until the close is
+   * finished.
+   */
 
   ret = nxsem_wait(&dev->ad_closesem);
   if (ret >= 0)
     {
-      /* Increment the count of references to the device.  If this the first
-       * time that the driver has been opened for this device, then
+      /* Increment the count of references to the device.  If this is the
+       * first time that the driver has been opened for this device, then
        * initialize the device.
        */
 
@@ -237,7 +239,7 @@ static ssize_t adc_read(FAR struct file *filep, FAR char *buffer,
 
   ainfo("buflen: %d\n", (int)buflen);
 
-  /* Determine size of the messages to return.
+  /* Determine the size of the messages to return.
    *
    * REVISIT:  What if buflen is 8 does that mean 4 messages of size 2?  Or
    * 2 messages of size 4?  What if buflen is 12.  Does that mean 3 at size
@@ -389,7 +391,7 @@ static ssize_t adc_read(FAR struct file *filep, FAR char *buffer,
         }
       while (dev->ad_recv.af_head != dev->ad_recv.af_tail);
 
-      /* All on the messages have bee transferred.  Return the number of
+      /* All of the messages have been transferred.  Return the number of
        * bytes that were read.
        */
 

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -98,7 +98,7 @@ static const struct comp_callback_s g_comp_callback =
  * Name: comp_pollnotify
  *
  * Description:
- *   This function is called to notificy any waiters of poll-reated events.
+ *   This function is called to notify any waiters of poll-reated events.
  *
  ****************************************************************************/
 
@@ -190,7 +190,7 @@ static int comp_poll(FAR struct file *filep, FAR struct pollfd *fds,
       if (i >= CONFIG_DEV_COMP_NPOLLWAITERS)
         {
           fds->priv   = NULL;
-          ret          = -EBUSY;
+          ret         = -EBUSY;
           goto errout;
         }
     }
@@ -223,8 +223,8 @@ errout:
  * Name: comp_notify
  *
  * Description:
- *   This function is called from the lower half driver to notify
- *   the change of the comparator output.
+ *   This function is called from the lower half driver to notify the change
+ *   of the comparator output.
  *
  ****************************************************************************/
 
@@ -255,13 +255,15 @@ static int comp_open(FAR struct file *filep)
   uint8_t                tmp;
   int                    ret;
 
-  /* If the port is the middle of closing, wait until the close is finished */
+  /* If the port is the middle of closing, wait until the close is
+   * finished.
+   */
 
   ret = nxsem_wait(&dev->ad_sem);
   if (ret >= 0)
     {
-      /* Increment the count of references to the device.  If this the first
-       * time that the driver has been opened for this device, then
+      /* Increment the count of references to the device.  If this is the
+       * first time that the driver has been opened for this device, then
        * initialize the device.
        */
 

--- a/drivers/analog/dac.c
+++ b/drivers/analog/dac.c
@@ -114,13 +114,15 @@ static int dac_open(FAR struct file *filep)
   uint8_t               tmp;
   int                   ret;
 
-  /* If the port is the middle of closing, wait until the close is finished */
+  /* If the port is in the middle of closing, wait until the close is
+   * finished.
+   */
 
   ret = nxsem_wait(&dev->ad_closesem);
   if (ret >= 0)
     {
-      /* Increment the count of references to the device.  If this the first
-       * time that the driver has been opened for this device, then
+      /* Increment the count of references to the device.  If this is the
+       * first time that the driver has been opened for this device, then
        * initialize the device.
        */
 
@@ -332,13 +334,13 @@ static ssize_t dac_write(FAR struct file *filep, FAR const char *buffer,
           nexttail = 0;
         }
 
-      /* If the XMIT fifo becomes full, then wait for space to become
+      /* If the XMIT FIFO becomes full, then wait for space to become
        * available.
        */
 
       while (nexttail == fifo->af_head)
         {
-          /* The transmit FIFO is full  -- was non-blocking mode selected? */
+          /* The transmit FIFO is full -- was non-blocking mode selected? */
 
           if (filep->f_oflags & O_NONBLOCK)
             {
@@ -354,7 +356,7 @@ static ssize_t dac_write(FAR struct file *filep, FAR const char *buffer,
               goto return_with_irqdisabled;
             }
 
-          /* If the FIFO was empty when we started, then we will have
+          /* If the FIFO was empty when we started, then we will have to
            * start the XMIT sequence to clear the FIFO.
            */
 
@@ -503,6 +505,22 @@ int dac_txdone(FAR struct dac_dev_s *dev)
 
   return ret;
 }
+
+/****************************************************************************
+ * Name: dac_register
+ *
+ * Description:
+ *   Register a dac driver.
+ *
+ * Input Parameters:
+ *    path - The full path to the DAC device to be registered.  This could
+ *      be, as an example, "/dev/dac0"
+ *    dev - An instance of the device-specific DAC interface
+ *
+ * Returned Value:
+ *    Zero on success; A negated errno value on failure.
+ *
+ ****************************************************************************/
 
 int dac_register(FAR const char *path, FAR struct dac_dev_s *dev)
 {

--- a/drivers/analog/opamp.c
+++ b/drivers/analog/opamp.c
@@ -98,13 +98,15 @@ static int opamp_open(FAR struct file *filep)
   uint8_t                tmp;
   int                    ret;
 
-  /* If the port is the middle of closing, wait until the close is finished */
+  /* If the port is the middle of closing, wait until the close is
+   * finished.
+   */
 
   ret = nxsem_wait(&dev->ad_closesem);
   if (ret >= 0)
     {
-      /* Increment the count of references to the device.  If this the first
-       * time that the driver has been opened for this device, then
+      /* Increment the count of references to the device.  If this is the
+       * first time that the driver has been opened for this device, then
        * initialize the device.
        */
 
@@ -117,7 +119,9 @@ static int opamp_open(FAR struct file *filep)
         }
       else
         {
-          /* Check if this is the first time that the driver has been opened. */
+          /* Check if this is the first time that the driver has been
+           * opened.
+           */
 
           if (tmp == 1)
             {

--- a/include/nuttx/analog/adc.h
+++ b/include/nuttx/analog/adc.h
@@ -95,8 +95,8 @@
 struct adc_dev_s;
 struct adc_callback_s
 {
-  /* This method is called from the lower half, platform-specific ADC logic when
-   * new ADC sample data is available.
+  /* This method is called from the lower half, platform-specific ADC logic
+   * when new ADC sample data is available.
    *
    * Input Parameters:
    *   dev  - The ADC device structure that was previously registered by
@@ -108,7 +108,8 @@ struct adc_callback_s
    *   Zero on success; a negated errno value on failure.
    */
 
-  CODE int (*au_receive)(FAR struct adc_dev_s *dev, uint8_t ch, int32_t data);
+  CODE int (*au_receive)(FAR struct adc_dev_s *dev, uint8_t ch,
+                         int32_t data);
 };
 
 /* This describes on ADC message */
@@ -130,7 +131,7 @@ struct adc_fifo_s
   struct adc_msg_s af_buffer[CONFIG_ADC_FIFOSIZE];
 };
 
-/* This structure defines all of the operations providd by the architecture
+/* This structure defines all of the operations provided by the architecture
  * specific logic.  All fields must be provided with non-NULL function
  * pointers by the caller of adc_register().
  */
@@ -138,8 +139,8 @@ struct adc_fifo_s
 struct adc_dev_s;
 struct adc_ops_s
 {
-  /* Bind the upper-half driver callbacks to the lower-half implementation.  This
-   * must be called early in order to receive ADC event notifications.
+  /* Bind the upper-half driver callbacks to the lower-half implementation.
+   * This must be called early in order to receive ADC event notifications.
    */
 
   CODE int (*ao_bind)(FAR struct adc_dev_s *dev,
@@ -153,14 +154,14 @@ struct adc_ops_s
 
   /* Configure the ADC. This method is called the first time that the ADC
    * device is opened.  This will occur when the port is first opened.
-   * This setup includes configuring and attaching ADC interrupts.  Interrupts
-   * are all disabled upon return.
+   * This setup includes configuring and attaching ADC interrupts.
+   * Interrupts are all disabled upon return.
    */
 
   CODE int (*ao_setup)(FAR struct adc_dev_s *dev);
 
   /* Disable the ADC.  This method is called when the ADC device is closed.
-   * This method reverses the operation the setup method.
+   * This method reverses the operation of the setup method.
    */
 
   CODE void (*ao_shutdown)(FAR struct adc_dev_s *dev);
@@ -171,12 +172,13 @@ struct adc_ops_s
 
   /* All ioctl calls will be routed through this method */
 
-  CODE int (*ao_ioctl)(FAR struct adc_dev_s *dev, int cmd, unsigned long arg);
+  CODE int (*ao_ioctl)(FAR struct adc_dev_s *dev, int cmd,
+                       unsigned long arg);
 };
 
 /* This is the device structure used by the driver.  The caller of
  * adc_register() must allocate and initialize this structure.  The calling
- * logic need only set all fields to zero except:
+ * logic needs to set all fields to zero except:
  *
  *   The elements of 'ad_ops', and 'ad_priv'
  *
@@ -195,7 +197,7 @@ struct adc_dev_s
   struct adc_fifo_s           ad_recv;       /* Describes receive FIFO */
 
   /* The following is a list of poll structures of threads waiting for
-   * driver events. The 'struct pollfd' reference for each open is also
+   * driver events.  The 'struct pollfd' reference for each open is also
    * retained in the f_priv field of the 'struct file'.
    */
 

--- a/include/nuttx/analog/comp.h
+++ b/include/nuttx/analog/comp.h
@@ -65,7 +65,8 @@ struct comp_callback_s
    * comparator output state changes.
    *
    * Input Parameters:
-   *   dev - The COMP device structure that was previously registered by adc_register()
+   *   dev - The COMP device structure that was previously registered by
+   *         adc_register()
    *   val - The actual value of the comparator output.
    *
    * Returned Value:
@@ -79,7 +80,6 @@ struct comp_ops_s
 {
   /* Bind the upper-half driver callbacks to the lower-half implementation.  This
    * must be called early in order to receive COMP event notifications.
-
    */
 
   CODE int (*ao_bind)(FAR struct comp_dev_s *dev,
@@ -94,7 +94,7 @@ struct comp_ops_s
   CODE int (*ao_setup)(FAR struct comp_dev_s *dev);
 
   /* Disable the COMP.  This method is called when the COMP device is closed.
-   * This method reverses the operation the setup method.
+   * This method reverses the operation of the setup method.
    * Works only if COMP device is not locked.
    */
 
@@ -114,10 +114,10 @@ struct comp_dev_s
 #ifdef CONFIG_COMP
   /* Fields managed by common upper half COMP logic */
 
-  uint8_t ad_ocount;            /* The number of times the device has been opened */
+  uint8_t ad_ocount;           /* The number of times the device has been opened */
   uint8_t val;                 /* Comparator value after output transition event */
-  sem_t   ad_sem;               /* Used to serialize access  */
-  sem_t   ad_readsem;           /* Blocking read */
+  sem_t   ad_sem;              /* Used to serialize access  */
+  sem_t   ad_readsem;          /* Blocking read */
 
   /* pollfd's for output transition events */
 
@@ -131,7 +131,7 @@ struct comp_dev_s
 };
 
 /************************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ************************************************************************************/
 
 #if defined(__cplusplus)

--- a/include/nuttx/analog/dac.h
+++ b/include/nuttx/analog/dac.h
@@ -96,7 +96,7 @@ struct dac_fifo_s
   struct dac_msg_s af_buffer[CONFIG_DAC_FIFOSIZE];
 };
 
-/* This structure defines all of the operations providd by the architecture
+/* This structure defines all of the operations provided by the architecture
  * specific logic.  All fields must be provided with non-NULL function
  * pointers by the caller of dac_register().
  */
@@ -119,8 +119,9 @@ struct dac_ops_s
   CODE int (*ao_setup)(FAR struct dac_dev_s *dev);
 
   /* Disable the DAC.  This method is called when the DAC device is closed.
-   * This method reverses the operation the setup method.
+   * This method reverses the operation of the setup method.
    */
+
   CODE void (*ao_shutdown)(FAR struct dac_dev_s *dev);
 
   /* Call to enable or disable TX interrupts */
@@ -133,12 +134,13 @@ struct dac_ops_s
 
   /* All ioctl calls will be routed through this method */
 
-  CODE int (*ao_ioctl)(FAR struct dac_dev_s *dev, int cmd, unsigned long arg);
+  CODE int (*ao_ioctl)(FAR struct dac_dev_s *dev, int cmd,
+                       unsigned long arg);
 };
 
 /* This is the device structure used by the driver.  The caller of
  * dac_register() must allocate and initialize this structure.  The
- * calling logic need only set all fields to zero except:
+ * calling logic needs to set all fields to zero except:
  *
  *   The elements of 'ad_ops', and 'ad_priv'
  *
@@ -162,7 +164,7 @@ struct dac_dev_s
  ****************************************************************************/
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 #if defined(__cplusplus)

--- a/include/nuttx/analog/opamp.h
+++ b/include/nuttx/analog/opamp.h
@@ -66,7 +66,7 @@ struct opamp_ops_s
   CODE int (*ao_setup)(FAR struct opamp_dev_s *dev);
 
   /* Disable the OPAMP.  This method is called when the OPAMP device is closed.
-   * This method reverses the operation the setup method.
+   * This method reverses the operation of the setup method.
    * Works only if OPAMP device is not locked.
    */
 
@@ -93,7 +93,7 @@ struct opamp_dev_s
 };
 
 /************************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ************************************************************************************/
 
 #if defined(__cplusplus)


### PR DESCRIPTION
## Summary
Only typos and style fixes, no functional change.
## Impact
None.
## Testing

