### PR TITLE
boards: arm: cxd56: initilize the video stream driver from the board

### DIFF
--- a/boards/arm/cxd56xx/spresense/src/cxd56_bringup.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_bringup.c
@@ -203,6 +203,9 @@ int cxd56_bringup(void)
 {
   struct pm_cpu_wakelock_s wlock;
   int ret;
+#ifdef CONFIG_VIDEO_ISX012
+  FAR const struct video_devops_s *devops;
+#endif
 
   ret = nsh_cpucom_initialize();
   if (ret < 0)
@@ -359,13 +362,21 @@ int cxd56_bringup(void)
       _err("ERROR: Failed to initialize ISX012 board. %d\n", errno);
     }
 
-  g_video_devops = isx012_initialize();
-  if (g_video_devops == NULL)
+  devops  = isx012_initialize();
+  if (devops == NULL)
     {
       _err("ERROR: Failed to populate ISX012 devops. %d\n", errno);
       ret = ERROR;
     }
 #endif /* CONFIG_VIDEO_ISX012 */
+
+#ifdef CONFIG_VIDEO_STREAM
+  ret = video_initialize("/dev/video", devops);
+  if (ret < 0)
+    {
+      _err("ERROR: Failed to initialize video stream driver. \n");
+    }
+#endif
 
   /* In order to prevent Hi-Z from being input to the SD Card controller,
    * Initialize SDIO pins to GPIO low output with internal pull-down.

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -222,7 +222,7 @@ static int video_s_ext_ctrls(FAR struct video_mng_s *priv,
  * Public Data
  ****************************************************************************/
 
-FAR const struct video_devops_s *g_video_devops;
+static const struct video_devops_s *g_video_devops;
 
 /****************************************************************************
  * Private Data
@@ -1495,7 +1495,8 @@ static int video_unregister(FAR video_mng_t *v_mgr)
  * Public Functions
  ****************************************************************************/
 
-int video_initialize(FAR const char *devpath)
+int video_initialize(FAR const char *devpath,
+                     FAR const struct video_devops_s *devops)
 {
   if (is_initialized)
     {

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -1035,8 +1035,14 @@ static int video_queryctrl(FAR struct v4l2_queryctrl *ctrl)
 
   /* Replace to VIDIOC_QUERY_EXT_CTRL format */
 
-  ext_ctrl.ctrl_class = ctrl->ctrl_class;
-  ext_ctrl.id         = ctrl->id;
+  ext_ctrl.ctrl_class     = ctrl->ctrl_class;
+  ext_ctrl.id             = ctrl->id;
+  ext_ctrl.type           = ctrl->type;
+  ext_ctrl.minimum        = ctrl->minimum;
+  ext_ctrl.maximum        = ctrl->maximum;
+  ext_ctrl.step           = ctrl->step;
+  ext_ctrl.default_value  = ctrl->default_value;
+  ext_ctrl.flags          = ctrl->flags;
 
   ret = video_query_ext_ctrl(&ext_ctrl);
 

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -625,8 +625,6 @@ struct v4l2_ext_controls
  * Public Data
  ****************************************************************************/
 
-extern FAR const struct video_devops_s *g_video_devops;
-
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -639,7 +637,8 @@ extern FAR const struct video_devops_s *g_video_devops;
  *  negative value is returned.
  */
 
-int video_initialize(FAR const char *devpath);
+int video_initialize(FAR const char *devpath,
+                     FAR const struct video_devops_s *devops);
 
 /* Uninitialize video driver.
  *


### PR DESCRIPTION
## Summary
The video stream driver must be initialized from the board to comply with NuttX

## Impact
Spresense board 

NOTE:
Please remove the initalization from any camera example

## Testing
compiled and tested on device
