### PR TITLE
arch/stackframe: fix heap buffer overflow

### DIFF
--- a/arch/arm/src/common/arm_stackframe.c
+++ b/arch/arm/src/common/arm_stackframe.c
@@ -111,8 +111,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -126,8 +124,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -136,5 +133,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/avr/src/avr/up_stackframe.c
+++ b/arch/avr/src/avr/up_stackframe.c
@@ -99,7 +99,9 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
+  /* Align the frame_size */
+
+  frame_size = STACK_ALIGN_UP(frame_size);
 
   /* Is there already a stack allocated? Is it big enough? */
 
@@ -110,8 +112,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr                = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr     = (FAR void *)topaddr;
+  tcb->adj_stack_ptr     = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size   -= frame_size;
 
   /* Set the initial stack pointer to the "base" of the allocated stack */
@@ -121,5 +122,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint8_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/avr/src/avr32/up_stackframe.c
+++ b/arch/avr/src/avr32/up_stackframe.c
@@ -111,8 +111,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -126,8 +124,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -136,5 +133,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/hc/src/common/up_stackframe.c
+++ b/arch/hc/src/common/up_stackframe.c
@@ -111,8 +111,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -126,8 +124,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -137,5 +134,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint16_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/mips/src/common/mips_stackframe.c
+++ b/arch/mips/src/common/mips_stackframe.c
@@ -114,8 +114,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -129,8 +127,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -139,5 +136,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/misoc/src/lm32/lm32_stackframe.c
+++ b/arch/misoc/src/lm32/lm32_stackframe.c
@@ -107,8 +107,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -122,8 +120,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -132,5 +129,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/misoc/src/minerva/minerva_stackframe.c
+++ b/arch/misoc/src/minerva/minerva_stackframe.c
@@ -107,8 +107,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -122,8 +120,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr = (uintptr_t) tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr = (FAR void *)topaddr;
+  tcb->adj_stack_ptr   = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -132,5 +129,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/or1k/src/common/up_stackframe.c
+++ b/arch/or1k/src/common/up_stackframe.c
@@ -103,8 +103,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -118,8 +116,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -128,5 +125,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/renesas/src/common/up_stackframe.c
+++ b/arch/renesas/src/common/up_stackframe.c
@@ -109,8 +109,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -124,8 +122,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr              = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr   = (FAR void *)topaddr;
+  tcb->adj_stack_ptr   = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* Reset the initial state */
@@ -134,5 +131,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return a pointer to allocated memory */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/renesas/src/common/up_stackframe.c
+++ b/arch/renesas/src/common/up_stackframe.c
@@ -51,6 +51,7 @@
 /****************************************************************************
  * Pre-processor Macros
  ****************************************************************************/
+
 /* The SH stack must be aligned at word (4 byte) boundaries. If necessary
  * frame_size must be rounded up to the next boundary
  */

--- a/arch/risc-v/src/common/riscv_stackframe.c
+++ b/arch/risc-v/src/common/riscv_stackframe.c
@@ -114,8 +114,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -129,8 +127,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -139,5 +136,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr);
+  return tcb->adj_stack_ptr;
 }

--- a/arch/sim/src/sim/up_stackframe.c
+++ b/arch/sim/src/sim/up_stackframe.c
@@ -103,8 +103,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -118,8 +116,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr              = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr   = (FAR void *)topaddr;
+  tcb->adj_stack_ptr   = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* Reset the initial state */
@@ -128,5 +125,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return a pointer to the allocated memory */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/x86/src/i486/up_stackframe.c
+++ b/arch/x86/src/i486/up_stackframe.c
@@ -112,8 +112,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -127,8 +125,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -137,5 +134,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/x86_64/src/intel64/up_stackframe.c
+++ b/arch/x86_64/src/intel64/up_stackframe.c
@@ -97,8 +97,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -112,8 +110,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -122,6 +119,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint64_t));
+  return tcb->adj_stack_ptr;
 }
-

--- a/arch/xtensa/src/common/xtensa_stackframe.c
+++ b/arch/xtensa/src/common/xtensa_stackframe.c
@@ -106,8 +106,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -121,8 +119,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr               = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr    = (FAR void *)topaddr;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size  -= frame_size;
 
   /* Reset the initial stack pointer (A1) */
@@ -131,5 +128,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return the pointer to the allocated region */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/z16/src/common/z16_stackframe.c
+++ b/arch/z16/src/common/z16_stackframe.c
@@ -88,8 +88,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -103,8 +101,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr                 = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr      = (FAR void *)topaddr;
+  tcb->adj_stack_ptr      = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size    -= frame_size;
 
   /* Reset the initial stack pointer */
@@ -113,5 +110,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return a pointer to the allocated memory */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }

--- a/arch/z80/src/common/z80_stackframe.c
+++ b/arch/z80/src/common/z80_stackframe.c
@@ -87,8 +87,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  uintptr_t topaddr;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -102,8 +100,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  topaddr              = (uintptr_t)tcb->adj_stack_ptr - frame_size;
-  tcb->adj_stack_ptr   = (FAR void *)topaddr;
+  tcb->adj_stack_ptr   = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* Reset the initial state */
@@ -112,5 +109,5 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* And return a pointer to the allocated memory */
 
-  return (FAR void *)(topaddr + sizeof(uint32_t));
+  return tcb->adj_stack_ptr;
 }


### PR DESCRIPTION
## Summary
arch/stackframe: fix heap buffer overflow

ASAN trace:
...
==32087==ERROR: AddressSanitizer: heap-buffer-overflow on address 0xf4502120 at pc 0x56673ca3 bp 0xff9b6a08 sp 0xff9b69f8
WRITE of size 1 at 0xf4502120 thread T0
    #0 0x56673ca2 in strcpy string/lib_strcpy.c:64

0xf4502120 is located 0 bytes to the right of 8224-byte region [0xf4500100,0xf4502120)
allocated by thread T0 here:
    #0 0xf7a60f54 in malloc (/usr/lib32/libasan.so.4+0xe5f54)
    #1 0x5667725d in up_create_stack sim/up_createstack.c:135
    #2 0x56657ed8 in nxthread_create task/task_create.c:125
    #3 0x566580bb in kthread_create task/task_create.c:297
    #4 0x5665935f in work_start_highpri wqueue/kwork_hpthread.c:149
    #5 0x56656f31 in nx_workqueues init/nx_bringup.c:181
    #6 0x56656fc6 in nx_bringup init/nx_bringup.c:436
    #7 0x56656e95 in nx_start init/nx_start.c:809
    #8 0x566548d4 in main sim/up_head.c:95
    #9 0xf763ae80 in __libc_start_main (/lib/i386-linux-gnu/libc.so.6+0x18e80)

CALLSTACK:
    #8  0xf79de7a5 in __asan_report_store1 () from /usr/lib32/libasan.so.4
    #9  0x565fd4d7 in strcpy (dest=0xf4a02121 "", src=0xf5c00895 "k") at string/lib_strcpy.c:64
    #10 0x565e4eb2 in nxtask_setup_stackargs (tcb=0xf5c00810, argv=0x0) at task/task_setup.c:570
    #11 0x565e50ff in nxtask_setup_arguments (tcb=0xf5c00810, name=0x5679e580 "hpwork", argv=0x0) at task/task_setup.c:714
    #12 0x565e414e in nxthread_create (name=0x5679e580 "hpwork", ttype=2 '\002', priority=224, stack=0x0, stack_size=8192, entry=0x565e54e1 <work_hpthread>, argv=0x0) at task/task_create.c:143
    #13 0x565e42e3 in kthread_create (name=0x5679e580 "hpwork", priority=224, stack_size=8192, entry=0x565e54e1 <work_hpthread>, argv=0x0) at task/task_create.c:297
    #14 0x565e5557 in work_start_highpri () at wqueue/kwork_hpthread.c:149
    #15 0x565e3e32 in nx_workqueues () at init/nx_bringup.c:181
    #16 0x565e3ec7 in nx_bringup () at init/nx_bringup.c:436
    #17 0x565e3d96 in nx_start () at init/nx_start.c:809
    #18 0x565e3195 in main (argc=1, argv=0xffe6b954, envp=0xffe6b95c) at sim/up_head.c:95