### PR TITLE
Move mallinfo from stdlib.h to malloc.h

### DIFF
--- a/include/malloc.h
+++ b/include/malloc.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * include/malloc.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_MALLOC_H
+#define __INCLUDE_MALLOC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct mallinfo
+{
+  int arena;    /* This is the total size of memory allocated
+                 * for use by malloc in bytes. */
+  int ordblks;  /* This is the number of free (not in use) chunks */
+  int mxordblk; /* Size of the largest free (not in use) chunk */
+  int uordblks; /* This is the total size of memory occupied by
+                 * chunks handed out by malloc. */
+  int fordblks; /* This is the total size of memory occupied
+                 * by free (not in use) chunks. */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+struct mallinfo mallinfo(void);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __INCLUDE_MALLOC_H */

--- a/include/nuttx/kmalloc.h
+++ b/include/nuttx/kmalloc.h
@@ -28,6 +28,7 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
+#include <malloc.h>
 #include <stdbool.h>
 #include <stdlib.h>
 

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -30,6 +30,7 @@
 
 #include <sys/types.h>
 #include <errno.h>
+#include <malloc.h>
 #include <stdint.h>
 #include <limits.h>
 
@@ -70,18 +71,6 @@
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
-
-struct mallinfo
-{
-  int arena;    /* This is the total size of memory allocated
-                 * for use by malloc in bytes. */
-  int ordblks;  /* This is the number of free (not in use) chunks */
-  int mxordblk; /* Size of the largest free (not in use) chunk */
-  int uordblks; /* This is the total size of memory occupied by
-                 * chunks handed out by malloc. */
-  int fordblks; /* This is the total size of memory occupied
-                 * by free (not in use) chunks. */
-};
 
 /* Structure type returned by the div() function. */
 
@@ -273,8 +262,6 @@ static inline int posix_memalign(FAR void **m, size_t a, size_t s)
 #define aligned_alloc(a, s) memalign((a), (s))
 #define posix_memalign(m, a, s) ((*(m) = memalign((a), (s))) ? OK : ENOMEM)
 #endif
-
-struct mallinfo mallinfo(void);
 
 /* Pseudo-Terminals */
 

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -30,7 +30,6 @@
 
 #include <sys/types.h>
 #include <errno.h>
-#include <malloc.h>
 #include <stdint.h>
 #include <limits.h>
 

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -39,7 +39,7 @@
 
 #include <nuttx/config.h>
 
-#include <stdlib.h>
+#include <malloc.h>
 #include <assert.h>
 #include <debug.h>
 

--- a/mm/umm_heap/umm_mallinfo.c
+++ b/mm/umm_heap/umm_mallinfo.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#include <stdlib.h>
+#include <malloc.h>
 
 #include <nuttx/mm/mm.h>
 


### PR DESCRIPTION
mallinfo is meant to be API compatible with Linux,
where it's provided by malloc.h.
Make stdlib.h include malloc.h for now, until all users
are updated.

(I think the API actually originated with System V. I don't remember
how it was there though.  Anyway, I guess the compatibility with Linux
is more important than System V these days.)

## Summary

## Impact

## Testing

