### PR TITLE
libc/locale: Add the mininal support for locale_t operation

### DIFF
--- a/include/locale.h
+++ b/include/locale.h
@@ -47,13 +47,24 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define LC_ALL      0
-#define LC_COLLATE  1
-#define LC_CTYPE    2
-#define LC_MONETARY 3
-#define LC_NUMERIC  4
-#define LC_TIME     5
-#define LC_MESSAGES 6
+#define LC_ALL           0
+#define LC_COLLATE       1
+#define LC_CTYPE         2
+#define LC_MONETARY      3
+#define LC_NUMERIC       4
+#define LC_TIME          5
+#define LC_MESSAGES      6
+
+#define LC_COLLATE_MASK  (1 << LC_COLLATE)
+#define LC_CTYPE_MASK    (1 << LC_CTYPE)
+#define LC_MONETARY_MASK (1 << LC_MONETARY)
+#define LC_NUMERIC_MASK  (1 << LC_NUMERIC)
+#define LC_TIME_MASK     (1 << LC_TIME)
+#define LC_MESSAGES_MASK (1 << LC_MESSAGES)
+
+#define LC_ALL_MASK      (LC_COLLATE_MASK  | LC_CTYPE_MASK   | \
+                          LC_MONETARY_MASK | LC_NUMERIC_MASK | \
+                          LC_TIME_MASK     | LC_MESSAGES_MASK)
 
 /****************************************************************************
  * Public Type Definitions
@@ -111,6 +122,12 @@ extern "C"
 
 FAR char *setlocale(int category, FAR const char *locale);
 FAR struct lconv *localeconv(void);
+
+locale_t newlocale(int category_mask, FAR const char *locale, locale_t base);
+locale_t duplocale(locale_t locobj);
+void freelocale(locale_t locobj);
+
+locale_t uselocale(locale_t newloc);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/libs/libc/locale/Make.defs
+++ b/libs/libc/locale/Make.defs
@@ -37,7 +37,8 @@ ifeq ($(CONFIG_LIBC_LOCALE),y)
 
 # Add the locale files to the build
 
-CSRCS += lib_setlocale.c lib_localeconv.c
+CSRCS += lib_duplocale.c lib_freelocale.c lib_localeconv.c
+CSRCS += lib_newlocale.c lib_setlocale.c lib_uselocale.c
 
 # Add the locale directory to the build
 

--- a/libs/libc/locale/lib_duplocale.c
+++ b/libs/libc/locale/lib_duplocale.c
@@ -1,0 +1,47 @@
+/****************************************************************************
+ * libs/libc/locale/lib_duplocale.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <locale.h>
+
+#ifdef CONFIG_LIBC_LOCALE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: duplocale
+ *
+ * Description:
+ *   locales are not supported by NuttX
+ *
+ ****************************************************************************/
+
+locale_t duplocale(locale_t locobj)
+{
+  return localeconv();
+}
+#endif

--- a/libs/libc/locale/lib_freelocale.c
+++ b/libs/libc/locale/lib_freelocale.c
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * libs/libc/locale/lib_freelocale.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <locale.h>
+
+#ifdef CONFIG_LIBC_LOCALE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: freelocale
+ *
+ * Description:
+ *   locales are not supported by NuttX
+ *
+ ****************************************************************************/
+
+void freelocale(locale_t locobj)
+{
+}
+#endif

--- a/libs/libc/locale/lib_newlocale.c
+++ b/libs/libc/locale/lib_newlocale.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * libs/libc/locale/lib_newlocale.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <locale.h>
+#include <string.h>
+
+#ifdef CONFIG_LIBC_LOCALE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: newlocale
+ *
+ * Description:
+ *   locales are not supported by NuttX
+ *
+ ****************************************************************************/
+
+locale_t newlocale(int category_mask, FAR const char *locale, locale_t base)
+{
+  return !locale || !strcmp(locale, "POSIX") ||
+         !strcmp(locale, "C") || !strcmp(locale, "") ? localeconv() : NULL;
+}
+#endif

--- a/libs/libc/locale/lib_uselocale.c
+++ b/libs/libc/locale/lib_uselocale.c
@@ -1,0 +1,47 @@
+/****************************************************************************
+ * libs/libc/locale/lib_uselocale.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <locale.h>
+
+#ifdef CONFIG_LIBC_LOCALE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: uselocale
+ *
+ * Description:
+ *   locales are not supported by NuttX
+ *
+ ****************************************************************************/
+
+locale_t uselocale(locale_t newloc)
+{
+  return localeconv();
+}
+#endif


### PR DESCRIPTION
include duplocale, freelocale, newlocale and uselocale

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I9912003847dec660ae5c62836d4d56ebe0718869

## Summary

## Impact

## Testing

