### PR TITLE
cstdlib:  mallinfo is no longer in stdlib.h

### DIFF
--- a/include/cxx/cstdlib
+++ b/include/cxx/cstdlib
@@ -103,7 +103,6 @@ namespace std
   using ::memalign;
   using ::zalloc;
   using ::calloc;
-  using ::mallinfo;
 
 #ifdef CONFIG_PSEUDOTERM
   // Pseudo-Terminals


### PR DESCRIPTION
## Summary

C++ build broken by PR #1236.  cstdlib fails because mallinfo is no long defined in stdlib.h.  Fix:  Remove reference from cstdlib.

## Impact

Should fix C++ build problems introduced by PR #1236 

## Testing

PR checks only

