### PR TITLE
net/socket/getsockopt.c:  Eliminate warning

### DIFF
--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -359,7 +359,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 int psock_getsockopt(FAR struct socket *psock, int level, int option,
                      FAR void *value, FAR socklen_t *value_len)
 {
-  int ret;
+  int ret = OK;
 
   /* Verify that the sockfd corresponds to valid, allocated socket */
 


### PR DESCRIPTION
## Summary

net/socket/getsockopt.c: Eliminate warning (which is a build error with -Werror):

    socket/getsockopt.c:362:7: error: 'ret' may be used uninitialized in this function [-Werror=maybe-uninitialized]
       int ret;
           ^~~
## Impact

Warning blocks PR checks.

## Testing

PR checks

