### PR TITLE
net/igmp: Fix the compiler warning on 64bit platform

### DIFF
--- a/net/igmp/igmp_timer.c
+++ b/net/igmp/igmp_timer.c
@@ -151,7 +151,7 @@ static void igmp_timeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void igmp_timeout(int argc, uint32_t arg, ...)
+static void igmp_timeout(int argc, wdparm_t arg, ...)
 {
   FAR struct igmp_group_s *group;
   int ret;
@@ -197,7 +197,7 @@ void igmp_startticks(FAR struct igmp_group_s *group, unsigned int ticks)
 
   gtmrinfo("ticks: %d\n", ticks);
 
-  ret = wd_start(group->wdog, ticks, igmp_timeout, 1, (uint32_t)group);
+  ret = wd_start(group->wdog, ticks, igmp_timeout, 1, (wdparm_t)group);
 
   DEBUGASSERT(ret == OK);
   UNUSED(ret);


### PR DESCRIPTION
igmp/igmp_timer.c: In function ‘igmp_timeout’:
igmp/igmp_timer.c:163:11: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
  163 |   group = (FAR struct igmp_group_s *)arg;
      |           ^
igmp/igmp_timer.c: In function ‘igmp_startticks’:
igmp/igmp_timer.c:200:55: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  200 |   ret = wd_start(group->wdog, ticks, igmp_timeout, 1, (uint32_t)group);
      |                                                       ^
igmp/igmp_timer.c:200:38: warning: passing argument 3 of ‘wd_start’ from incompatible pointer type [-Wincompatible-pointer-types]
  200 |   ret = wd_start(group->wdog, ticks, igmp_timeout, 1, (uint32_t)group);
      |                                      ^~~~~~~~~~~~
      |                                      |
      |                                      void (*)(int,  uint32_t, ...) {aka void (*)(int,  unsigned int, ...)}
In file included from igmp/igmp_timer.c:50:
/home/xiaoxiang/mirtos/nuttx/include/nuttx/wdog.h:233:53: note: expected ‘wdentry_t’ {aka ‘void (*)(int,  long unsigned int, ...)’} but argument is of type ‘void (*)(int,  uint32_t, ...)’ {aka ‘void (*)(int,  unsigned int, ...)’}
  233 | int wd_start(WDOG_ID wdog, int32_t delay, wdentry_t wdentry, int argc, ...);

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I153355f85f583f5441d97a0b1278bce167eb3fd0

## Summary

## Impact

## Testing

