### PR TITLE
include/errno.h: Add ELAST macro definition

### DIFF
--- a/include/errno.h
+++ b/include/errno.h
@@ -312,6 +312,7 @@
 #define ESTRPIPE_STR        "Streams pipe error"
 
 #define __ELASTERROR        2000                        /* Users can add values starting here */
+#define ELAST               __ELASTERROR
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
like FreeBSD:
https://github.com/freebsd/freebsd/blob/master/sys/sys/errno.h

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
Change-Id: I89fc7e417a31e4890b31a6c2a3d4b910981482e1

## Summary

## Impact

## Testing

