### PR TITLE
Do not set oneshot zero timer period

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_oneshot.c
+++ b/arch/arm/src/stm32l4/stm32l4_oneshot.c
@@ -277,7 +277,8 @@ int stm32l4_oneshot_start(FAR struct stm32l4_oneshot_s *oneshot,
   irqstate_t flags;
 
   tmrinfo("handler=%p arg=%p, ts=(%lu, %lu)\n",
-         handler, arg, (unsigned long)ts->tv_sec, (unsigned long)ts->tv_nsec);
+         handler, arg, (unsigned long)ts->tv_sec,
+          (unsigned long)ts->tv_nsec);
   DEBUGASSERT(oneshot && handler && ts);
   DEBUGASSERT(oneshot->tch);
 

--- a/arch/arm/src/stm32l4/stm32l4_oneshot.c
+++ b/arch/arm/src/stm32l4/stm32l4_oneshot.c
@@ -313,6 +313,7 @@ int stm32l4_oneshot_start(FAR struct stm32l4_oneshot_s *oneshot,
   period = (usec * (uint64_t)oneshot->frequency) / USEC_PER_SEC;
 
   tmrinfo("usec=%llu period=%08llx\n", usec, period);
+  DEBUGASSERT(period > 0);
   DEBUGASSERT(period <= UINT32_MAX);
 
   /* Set up to receive the callback when the interrupt occurs */

--- a/drivers/audio/tone.c
+++ b/drivers/audio/tone.c
@@ -328,7 +328,16 @@ static void stop_note(FAR struct tone_upperhalf_s *upper)
 {
   FAR struct pwm_lowerhalf_s *tone = upper->devtone;
 
-  tone->ops->stop(tone);
+#ifdef CONFIG_PWM_MULTICHAN
+  upper->tone.channels[0].channel = upper->channel;
+  upper->tone.channels[0].duty    = 0;
+#else
+  upper->tone.duty                = 0;
+#endif
+
+  /* REVISIT: Should check the return value */
+
+  tone->ops->start(tone, &upper->tone);
 }
 
 /****************************************************************************

--- a/drivers/audio/tone.c
+++ b/drivers/audio/tone.c
@@ -361,12 +361,9 @@ static void start_tune(FAR struct tone_upperhalf_s *upper, const char *tune)
   g_silence_length = 0;
   g_repeat         = false;
 
-  /* Schedule a callback to start playing */
+  /* Start playing tune */
 
-  ts.tv_sec        = 1;
-  ts.tv_nsec       = 0;
-
-  ONESHOT_START(upper->oneshot, oneshot_callback, upper, &ts);
+  next_note(upper);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
The oneshot timer would sets autoreload register to zero when a period equal to zero was requested. This would never be triggered since the ARR needs to be at least 1. This commit changes this case to set a minimum period of zero.
The tone driver had an artificial delay of 1s possibly due to this problem which introduced an undersired lag when trying to play a tune. Since the oneshot is now fixed, this delay is removed and it now works as expected without lag. 

There is one caveat: I found that using stop() would not allow further notes to be played. Looking at the PWM code it would seem that the tone should be stopped setting a duty of zero, which is what I did. But I'm not sure this is a bug in the PWM code. Could someone verify that?  

## Impact
STM32L4 oneshot timer for period == 0. I don't think there are other cases for this scenario currently so it should not affect anything else.

## Testing
Tested the tone driver on STM32L4 and worked as expected without the delay. This was on tickless mode which uses oneshot() for the underlying timer, so this indirectly tests also that.
