### PR TITLE
bmp280: support reading temperature

### DIFF
--- a/drivers/sensors/bmp280.c
+++ b/drivers/sensors/bmp280.c
@@ -549,6 +549,33 @@ static uint32_t bmp280_getpressure(FAR struct bmp280_dev_s *priv)
 }
 
 /****************************************************************************
+ * Name: bmp280_gettemp
+ *
+ * Description:
+ *   Read temperature only
+ *
+ ****************************************************************************/
+
+static uint32_t bmp280_gettemp(FAR struct bmp280_dev_s *priv)
+{
+  uint8_t buf[3];
+  int32_t temp;
+
+  bmp280_getregs(priv, BMP280_TEMP_MSB, buf, 3);
+
+  temp = COMBINE(buf);
+
+  sninfo("temp = %d\n", temp);
+
+  if (priv->compensated == ENABLE_COMPENSATED)
+  {
+    temp = bmp280_compensate_temp(priv, temp);
+  }
+
+  return temp;
+}
+
+/****************************************************************************
  * Name: bmp280_open
  *
  * Description:
@@ -640,6 +667,9 @@ static int bmp280_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       case SNIOC_SETSTB:
         ret = bmp280_set_standby(priv, arg);
         break;
+
+      case SNIOC_GET_TEMP:
+        *(uint32_t*)arg = bmp280_gettemp(priv);
 
       default:
         snerr("Unrecognized cmd: %d\n", cmd);

--- a/drivers/sensors/bmp280.c
+++ b/drivers/sensors/bmp280.c
@@ -163,7 +163,8 @@ struct bmp280_dev_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static uint8_t bmp280_getreg8(FAR struct bmp280_dev_s *priv, uint8_t regaddr);
+static uint8_t bmp280_getreg8(FAR struct bmp280_dev_s *priv,
+                              uint8_t regaddr);
 static void bmp280_putreg8(FAR struct bmp280_dev_s *priv, uint8_t regaddr,
                            uint8_t regval);
 static uint32_t bmp280_getpressure(FAR struct bmp280_dev_s *priv);
@@ -568,9 +569,9 @@ static uint32_t bmp280_gettemp(FAR struct bmp280_dev_s *priv)
   sninfo("temp = %d\n", temp);
 
   if (priv->compensated == ENABLE_COMPENSATED)
-  {
-    temp = bmp280_compensate_temp(priv, temp);
-  }
+    {
+      temp = bmp280_compensate_temp(priv, temp);
+    }
 
   return temp;
 }
@@ -669,7 +670,7 @@ static int bmp280_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         break;
 
       case SNIOC_GET_TEMP:
-        *(uint32_t*)arg = bmp280_gettemp(priv);
+        *(uint32_t *)arg = bmp280_gettemp(priv);
 
       default:
         snerr("Unrecognized cmd: %d\n", cmd);

--- a/include/nuttx/sensors/bmp280.h
+++ b/include/nuttx/sensors/bmp280.h
@@ -112,6 +112,13 @@ extern "C"
 
 #define SNIOC_SETSTB               _SNIOC(0x0003)
 
+/* Get temperature value
+ *
+ * Arg: Pointer to uint32_t (raw value)
+ */
+
+#define SNIOC_GET_TEMP             _SNIOC(0x0004)
+
 struct bmp280_press_adj_s
 {
   uint16_t  dig_p1; /* calibration P1 data */

--- a/include/nuttx/sensors/bmp280.h
+++ b/include/nuttx/sensors/bmp280.h
@@ -36,6 +36,10 @@
 #ifndef __INCLUDE_NUTTX_SENSORS_BMP280_H
 #define __INCLUDE_NUTTX_SENSORS_BMP280_H
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
 #include <nuttx/config.h>
 
 #if defined(CONFIG_I2C) && (defined(CONFIG_SENSORS_BMP280) || defined(CONFIG_SENSORS_BMP280_SCU))


### PR DESCRIPTION
## Summary
Adds capability to get temperature via ioctl()

## Impact
Feature addition

## Testing
Tested using BMP280
