### PR TITLE
vfs: fix support for PTY when CONFIG_NET is not enabled

### DIFF
--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -271,8 +271,11 @@ int nx_vopen(FAR const char *path, int oflags, va_list ap)
        */
 
       fd = (int)OPEN_GETFD(ret);
-      DEBUGASSERT((unsigned)fd < (CONFIG_NFILE_DESCRIPTORS +
-                                  CONFIG_NSOCKET_DESCRIPTORS));
+      DEBUGASSERT((unsigned)fd < (CONFIG_NFILE_DESCRIPTORS
+#ifdef CONFIG_NET
+                                  + CONFIG_NSOCKET_DESCRIPTORS
+#endif
+      ));
     }
 #endif
 


### PR DESCRIPTION
## Summary
Fixes a build error when enabling PTY support without having networking enabled.

## Impact
It is an assertion call so no effect should be expected

## Testing
Tested with the pts app
