### PR TITLE
STM32L4: fix 48MHz MSI clock selection logic 

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_i2c.c
+++ b/arch/arm/src/stm32l4/stm32l4_i2c.c
@@ -1288,11 +1288,11 @@ static void stm32l4_i2c_setclock(FAR struct stm32l4_i2c_priv_s *priv,
 {
   int i2cclk_mhz;
   uint32_t pe;
-  uint8_t presc;
-  uint8_t scl_delay;
-  uint8_t sda_delay;
-  uint8_t scl_h_period;
-  uint8_t scl_l_period;
+  uint8_t presc = 0;
+  uint8_t scl_delay = 0;
+  uint8_t sda_delay = 0;
+  uint8_t scl_h_period = 0;
+  uint8_t scl_l_period = 0;
 
   if (frequency != priv->frequency)
     {
@@ -1306,6 +1306,8 @@ static void stm32l4_i2c_setclock(FAR struct stm32l4_i2c_priv_s *priv,
 
 #if defined(STM32L4_I2C_USE_HSI16) || (STM32L4_PCLK1_FREQUENCY == 16000000)
       i2cclk_mhz = 16;
+#elif STM32L4_PCLK1_FREQUENCY == 48000000
+      i2cclk_mhz = 48;
 #elif STM32L4_PCLK1_FREQUENCY == 80000000
       i2cclk_mhz = 80;
 #elif STM32L4_PCLK1_FREQUENCY == 120000000
@@ -1457,6 +1459,33 @@ static void stm32l4_i2c_setclock(FAR struct stm32l4_i2c_priv_s *priv,
               scl_l_period = 162;
             }
         }
+      else if (i2cclk_mhz == 48)
+      {
+        if (frequency == 100000)
+          {
+            presc        = 2;
+            scl_delay    = 10;
+            sda_delay    = 0;
+            scl_h_period = 62;
+            scl_l_period = 85;
+          }
+        else if (frequency == 400000)
+          {
+            presc        = 1;
+            scl_delay    = 8;
+            sda_delay    = 0;
+            scl_h_period = 12;
+            scl_l_period = 33;
+          }
+        else if (frequency == 1000000)
+          {
+            presc        = 0;
+            scl_delay    = 5;
+            sda_delay    = 0;
+            scl_h_period = 8;
+            scl_l_period = 22;
+          }
+      }
       else
         {
           DEBUGPANIC();

--- a/arch/arm/src/stm32l4/stm32l4_i2c.c
+++ b/arch/arm/src/stm32l4/stm32l4_i2c.c
@@ -1460,32 +1460,32 @@ static void stm32l4_i2c_setclock(FAR struct stm32l4_i2c_priv_s *priv,
             }
         }
       else if (i2cclk_mhz == 48)
-      {
-        if (frequency == 100000)
-          {
-            presc        = 2;
-            scl_delay    = 10;
-            sda_delay    = 0;
-            scl_h_period = 62;
-            scl_l_period = 85;
-          }
-        else if (frequency == 400000)
-          {
-            presc        = 1;
-            scl_delay    = 8;
-            sda_delay    = 0;
-            scl_h_period = 12;
-            scl_l_period = 33;
-          }
-        else if (frequency == 1000000)
-          {
-            presc        = 0;
-            scl_delay    = 5;
-            sda_delay    = 0;
-            scl_h_period = 8;
-            scl_l_period = 22;
-          }
-      }
+        {
+          if (frequency == 100000)
+            {
+              presc        = 2;
+              scl_delay    = 10;
+              sda_delay    = 0;
+              scl_h_period = 62;
+              scl_l_period = 85;
+            }
+          else if (frequency == 400000)
+            {
+              presc        = 1;
+              scl_delay    = 8;
+              sda_delay    = 0;
+              scl_h_period = 12;
+              scl_l_period = 33;
+            }
+          else if (frequency == 1000000)
+            {
+              presc        = 0;
+              scl_delay    = 5;
+              sda_delay    = 0;
+              scl_h_period = 8;
+              scl_l_period = 22;
+            }
+        }
       else
         {
           DEBUGPANIC();

--- a/arch/arm/src/stm32l4/stm32l4x6xx_rcc.c
+++ b/arch/arm/src/stm32l4/stm32l4x6xx_rcc.c
@@ -731,26 +731,26 @@ static void stm32l4_stdclockconfig(void)
   putreg32(regval, STM32L4_RCC_CR);
 
   if (!(regval & RCC_CR_MSION))
-  {
-    /* Enable MSI */
+    {
+      /* Enable MSI */
 
-    regval  = getreg32(STM32L4_RCC_CR);
-    regval |= RCC_CR_MSION;
-    putreg32(regval, STM32L4_RCC_CR);
+      regval  = getreg32(STM32L4_RCC_CR);
+      regval |= RCC_CR_MSION;
+      putreg32(regval, STM32L4_RCC_CR);
 
-    /* Wait until the MSI is ready (or until a timeout elapsed) */
+      /* Wait until the MSI is ready (or until a timeout elapsed) */
 
-    for (timeout = MSIRDY_TIMEOUT; timeout > 0; timeout--)
-      {
-        /* Check if the MSIRDY flag is the set in the CR */
+      for (timeout = MSIRDY_TIMEOUT; timeout > 0; timeout--)
+        {
+          /* Check if the MSIRDY flag is the set in the CR */
 
-        if ((getreg32(STM32L4_RCC_CR) & RCC_CR_MSIRDY) != 0)
-          {
-            /* If so, then break-out with timeout > 0 */
+          if ((getreg32(STM32L4_RCC_CR) & RCC_CR_MSIRDY) != 0)
+            {
+              /* If so, then break-out with timeout > 0 */
 
-            break;
-          }
-      }
+              break;
+            }
+        }
     }
 
 #elif defined(STM32L4_BOARD_USEHSE)
@@ -797,7 +797,7 @@ static void stm32l4_stdclockconfig(void)
           stm32l4_pwr_enableclk(true);
           stm32_pwr_setvos(1);
 #endif
-      }
+        }
       else
         {
           /* Select regulator voltage output Scale 2 mode for


### PR DESCRIPTION
## Summary
When MSI clock is selected at 48MHz this change is needed to avoid a hang on boot. It appears that setting the MSION bit when already on brought this problem.  
At the same time, using this higher clock value triggered the selection of the range 1 for core regulator and this also hung during boot. I could not find out why this problem occurs but since this is the default behavior it should introduce any different behavior.
Finally, with this clock speed there wasn't a matching case for the I2C clocking computations. I used ST's tool to get the values for this case. This now allows using I2C with MSI@48MHz as SYSCLK

## Impact
Selection of MSI clock at 48MHz frequency as system clock 

## Testing
I'm using I2C at 48MHz with MSI on STM32L476 and can communicate correctly
