### PR TITLE
sched: Avoid call up_initial_state for idle thread twice

### DIFF
--- a/sched/init/nx_smpstart.c
+++ b/sched/init/nx_smpstart.c
@@ -168,11 +168,7 @@ int nx_smp_start(void)
           return ret;
         }
 
-      /* Reinitialize the processor-specific portion of the TCB.  This is
-       * the second time this has been called for this CPU, but the stack
-       * was not yet initialized on the first call so we need to do it
-       * again.
-       */
+      /* Initialize the processor-specific portion of the TCB */
 
       up_initial_state(tcb);
     }

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -528,9 +528,14 @@ void nx_start(void)
 
       g_running_tasks[cpu] = &g_idletcb[cpu].cmn;
 
-      /* Initialize the processor-specific portion of the TCB */
+      /* Initialize the 1st processor-specific portion of the TCB
+       * Note: other idle thread get initialized in nx_smpstart
+       */
 
-      up_initial_state(&g_idletcb[cpu].cmn);
+      if (cpu == 0)
+        {
+          up_initial_state(&g_idletcb[cpu].cmn);
+        }
     }
 
   /* Task lists are initialized */


### PR DESCRIPTION
## Summary
The current implementation call up_initial_state twice for each idle thread running on the secondary CPUs. This patch ensure each idle tcb_s is initialized by up_initial_state only once.

## Impact
Only impact idle threads run on the secondary CPUs.

## Testing
Test on sim with SMP
