### PR TITLE
sched/Kconfig:  Add interrupt and system call instrumentation

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -284,6 +284,14 @@ config ARCH_GLOBAL_IRQDISABLE
 		interrupts as well so that no context switches can occur on the CPU
 		that disabled "local" interrupts.
 
+config ARCH_HAVE_SYSCALL_HOOKS
+	bool
+	default n
+	---help---
+		Indicates that the architecture supports the system call hooks as
+		required if CONFIG_SCHED_INSTRUMENTATION_SYSCALL is enabled.  Refer
+		to sched/Kconfig for additional information.
+
 config ARCH_FPU
 	bool "FPU support"
 	default y

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -45,6 +45,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdarg.h>
 
 #include <nuttx/sched.h>
 
@@ -305,6 +306,20 @@ void sched_note_spinabort(FAR struct tcb_s *tcb, FAR volatile void *spinlock);
 #  define sched_note_spinabort(t,s)
 #endif
 
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+void sched_note_syscall_enter(int nr, int argc, ...);
+void sched_note_syscall_leave(int nr, uintptr_t result);
+#else
+#  define sched_note_syscall_enter(n,a...)
+#  define sched_note_syscall_leave(n,r)
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+void sched_note_irqhandler(int irq, FAR void *handler, bool enter);
+#else
+#  define sched_note_irqhandler(i,h,e)
+#endif
+
 /****************************************************************************
  * Name: sched_note_get
  *
@@ -387,6 +402,9 @@ int note_register(void);
 #  define sched_note_spinlocked(t,s)
 #  define sched_note_spinunlock(t,s)
 #  define sched_note_spinabort(t,s)
+#  define sched_note_syscall_enter(n,a...)
+#  define sched_note_syscall_leave(n,r)
+#  define sched_note_irqhandler(i,h,e)
 
 #endif /* CONFIG_SCHED_INSTRUMENTATION */
 #endif /* __INCLUDE_NUTTX_SCHED_NOTE_H */

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -972,6 +972,25 @@ config SCHED_INSTRUMENTATION_SPINLOCKS
 			void sched_note_spinunlock(FAR struct tcb_s *tcb, bool state);
 			void sched_note_spinabort(FAR struct tcb_s *tcb, bool state);
 
+config SCHED_INSTRUMENTATION_SYSCALL
+	bool "System call monitor hooks"
+	default n
+	---help---
+		Enables additional hooks for entry and exit from system call.
+		Board-specific logic must provide this additional logic.
+
+			void sched_note_syscall_enter(int nr, int argc, ...);
+			void sched_note_syscall_leave(int nr, uintptr_t result);
+
+config SCHED_INSTRUMENTATION_IRQHANDLER
+	bool "Interrupt handler monitor hooks"
+	default n
+	---help---
+		Enables additional hooks for interrupt handler. Board-specific logic
+		must provide this additional logic.
+
+			void sched_note_irqhandler(int irq, FAR void *handler, bool enter);
+
 config SCHED_INSTRUMENTATION_BUFFER
 	bool "Buffer instrumentation data in memory"
 	default n

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -975,6 +975,7 @@ config SCHED_INSTRUMENTATION_SPINLOCKS
 config SCHED_INSTRUMENTATION_SYSCALL
 	bool "System call monitor hooks"
 	default n
+	depends on LIB_SYSCALL && ARCH_HAVE_SYSCALL_HOOKS
 	---help---
 		Enables additional hooks for entry and exit from system call.
 		Board-specific logic must provide this additional logic.

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -43,6 +43,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 #include <nuttx/random.h>
+#include <nuttx/sched_note.h>
 
 #include "irq/irq.h"
 #include "clock/clock.h"
@@ -171,10 +172,22 @@ void irq_dispatch(int irq, FAR void *context)
   add_irq_randomness(irq);
 #endif
 
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+  /* Notify that we are entering into the interrupt handler */
+
+  sched_note_irqhandler(irq, vector, true);
+#endif
+
   /* Then dispatch to the interrupt handler */
 
   CALL_VECTOR(ndx, vector, irq, context, arg);
   UNUSED(ndx);
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+  /* Notify that we are leaving from the interrupt handler */
+
+  sched_note_irqhandler(irq, vector, false);
+#endif
 
   /* Record the new "running" task.  g_running_tasks[] is only used by
    * assertion logic for reporting crashes.


### PR DESCRIPTION
## Summary

This PR brings in the system call and interrupt instrumentation from https://github.com/YuuichiNakamura/incubator-nuttx (feature/task-tracer branch).

## Impact

These are not currently used in the code base but are used by users of the OS.  There should be no impact if the features are not enabled.

## Testing

N/A.  These are enabling hooks for features, but not testable features themselves.

