### PR TITLE
tools/nxstyle: Fix AddressSanitizer error

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -352,7 +352,7 @@ static int block_comment_width(char *line)
 
   /* Skip over any trailing whitespace at the end of the line */
 
-  for (e = strlen(line) - 1; isspace(line[e]); e--)
+  for (e = strlen(line) - 1; e >= 0 && isspace(line[e]); e--)
     {
     }
 


### PR DESCRIPTION
## Summary
Here is the asan output:
```
=================================================================
==2474==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7fffb7e59b5f at pc 0x561fffec79f6 bp 0x7fffb7e59ac0 sp 0x7fffb7e59ab0
READ of size 1 at 0x7fffb7e59b5f thread T0
    #0 0x561fffec79f5 in block_comment_width /home/xiaoxiang/mirtos/nuttx/tools/nxstyle.c:355

Address 0x7fffb7e59b5f is located in stack of thread T0 at offset 31 in frame
    #0 0x561fffec7b90 in get_line_width /home/xiaoxiang/mirtos/nuttx/tools/nxstyle.c:419

  This frame has 1 object(s):
    [32, 544) 'line' (line 420) <== Memory access at offset 31 underflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-underflow /home/xiaoxiang/mirtos/nuttx/tools/nxstyle.c:355 in block_comment_width
Shadow bytes around the buggy address:
  0x100076fc3310: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100076fc3320: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100076fc3330: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100076fc3340: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100076fc3350: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x100076fc3360: 00 00 00 00 00 00 00 00 f1 f1 f1[f1]00 00 00 00
  0x100076fc3370: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100076fc3380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100076fc3390: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100076fc33a0: 00 00 00 00 00 00 00 00 00 00 00 00 f3 f3 f3 f3
  0x100076fc33b0: f3 f3 f3 f3 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==2474==ABORTING
```

## Impact

## Testing

