### PR TITLE
sched/sched/sched_note.c:  Implement interrupt/syscall support

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -99,7 +99,8 @@ enum note_type_e
 #endif
 #ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
   ,
-  NOTE_IRQHANDLER      = 20
+  NOTE_IRQ_ENTER       = 20,
+  NOTE_IRQ_LEAVE       = 21
 #endif
 };
 
@@ -239,7 +240,6 @@ struct note_syscall_enter_s
 {
   struct note_common_s nsc_cmn; /* Common note parameters */
   int nsc_nr;                   /* System call number */
-  bool nsc_enter;               /* true:  Entering system call */
 };
 
 struct note_syscall_leave_s
@@ -247,18 +247,16 @@ struct note_syscall_leave_s
   struct note_common_s nsc_cmn; /* Common note parameters */
   uintptr_t nsc_result;         /* Result of the system call */
   int nsc_nr;                   /* System call number */
-  bool nsc_enter;               /* false:  Leaving system call */
 };
 #endif /* CONFIG_SCHED_INSTRUMENTATION_SYSCALL */
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
-/* This is the specific form of the NOTE_IRQHANDLER note */
+/* This is the specific form of the NOTE_IRQ_ENTER/LEAVE notes */
 
 struct note_irqhandler_s
 {
   struct note_common_s nih_cmn; /* Common note parameters */
   int nih_irq;                  /* IRQ number */
-  bool nih_enter;               /* true:  Entering handler */
 };
 #endif /* CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER */
 #endif /* CONFIG_SCHED_INSTRUMENTATION_BUFFER */

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1026,7 +1026,7 @@ config SCHED_NOTE_BUFSIZE
 		bytes).
 
 config SCHED_NOTE_GET
-	bool "Callable interface to get instrumentatin data"
+	bool "Callable interface to get instrumentation data"
 	default n
 	depends on !SCHED_INSTRUMENTATION_CSECTION && (!SCHED_INSTRUMENTATION_SPINLOCK || !SMP)
 	---help---

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/sched/sched_note.c
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -52,10 +37,6 @@
 #include "sched/sched.h"
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_BUFFER
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
 
 /****************************************************************************
  * Private Types
@@ -591,6 +572,59 @@ void sched_note_spinunlock(FAR struct tcb_s *tcb,
 void sched_note_spinabort(FAR struct tcb_s *tcb, FAR volatile void *spinlock)
 {
   note_spincommon(tcb, spinlock, NOTE_SPINLOCK_ABORT);
+}
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+void sched_note_syscall_enter(int nr, int argc, ...)
+{
+  struct note_syscall_enter_s note;
+  FAR struct tcb_s *tcb = this_task();
+
+  /* Format the note */
+
+  note_common(tcb, &note.nsc_cmn, sizeof(struct note_syscall_enter_s),
+              NOTE_CSECTION_ENTER);
+  note.nsc_nr = nr;
+
+  /* Add the note to circular buffer */
+
+  note_add((FAR const uint8_t *)&note, sizeof(struct note_syscall_enter_s));
+}
+
+void sched_note_syscall_leave(int nr, uintptr_t result)
+{
+  struct note_syscall_leave_s note;
+  FAR struct tcb_s *tcb = this_task();
+
+  /* Format the note */
+
+  note_common(tcb, &note.nsc_cmn, sizeof(struct note_syscall_leave_s),
+              NOTE_CSECTION_LEAVE);
+  note.nsc_result = result;
+  note.nsc_nr     = nr;
+
+  /* Add the note to circular buffer */
+
+  note_add((FAR const uint8_t *)&note, sizeof(struct note_syscall_leave_s));
+}
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
+{
+  struct note_irqhandler_s note;
+  FAR struct tcb_s *tcb = this_task();
+
+  /* Format the note */
+
+  note_common(tcb, &note.nih_cmn, sizeof(struct note_irqhandler_s),
+              enter ? NOTE_IRQ_ENTER : NOTE_IRQ_LEAVE);
+  note.nih_irq = irq;
+
+  /* Add the note to circular buffer */
+
+  note_add((FAR const uint8_t *)&note, sizeof(struct note_irqhandler_s));
 }
 #endif
 


### PR DESCRIPTION
## Summary

A previous PR added interrupt and system call scheduler notes.  This PR addresses buffering support for those notes.

## Impact

There should be none.  Not really usable without changes to apps/.

## Testing

Tested with sim:nsh

