### PR TITLE
sched/pthread/pthread_cleanup.c:  Exclude kernel threads.

### DIFF
--- a/sched/pthread/pthread_cleanup.c
+++ b/sched/pthread/pthread_cleanup.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * sched/pthread/pthread_cleanup.c
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -148,7 +133,11 @@ void pthread_cleanup_pop(int execute)
    */
 
   sched_lock();
-  pthread_cleanup_pop_tcb(tcb, execute);
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
+    {
+      pthread_cleanup_pop_tcb(tcb, execute);
+    }
+
   sched_unlock();
 }
 
@@ -165,7 +154,8 @@ void pthread_cleanup_push(pthread_cleanup_t routine, FAR void *arg)
    */
 
   sched_lock();
-  if (tcb->tos < CONFIG_PTHREAD_CLEANUP_STACKSIZE)
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL &&
+      tcb->tos < CONFIG_PTHREAD_CLEANUP_STACKSIZE)
     {
       unsigned int ndx = tcb->tos;
 
@@ -197,20 +187,25 @@ void pthread_cleanup_popall(FAR struct tcb_s *tcb)
 {
   DEBUGASSERT(tcb != NULL);
 
-  /* Pop and execute each cleanup routine/
-   *
-   * sched_lock() should provide sufficient protection.  We only need to
-   * have this TCB stationary; the pthread cleanup stack should never be
-   * modified by interrupt level logic.
-   */
+  /* Kernel threads do not support pthread APIs */
 
-  sched_lock();
-  while (tcb->tos > 0)
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
     {
-      pthread_cleanup_pop_tcb(tcb, 1);
-    }
+      /* Pop and execute each cleanup routine/
+       *
+       * sched_lock() should provide sufficient protection.  We only need to
+       * have this TCB stationary; the pthread cleanup stack should never be
+       * modified by interrupt level logic.
+       */
 
-  sched_unlock();
+      sched_lock();
+      while (tcb->tos > 0)
+        {
+          pthread_cleanup_pop_tcb(tcb, 1);
+        }
+
+      sched_unlock();
+    }
 }
 
 #endif /* CONFIG_PTHREAD_CLEANUP */


### PR DESCRIPTION
## Summary

Prohibit use of pthread_cleanup API's by kernel threads.  The pthread pthread_cleanup functions MUST run in user mode, making them unusable for kernel threads.

See also Issue #1263

## Impact

There should be none.  This just adds the protection.  No one, under any condition, should be using pthread APIs within the OS anyway.

## Testing

Verified on sim:nsh

