### PR TITLE
SocketCAN: Fixed dropping timestamped frames when running in CAN2.0B

### DIFF
--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -165,6 +165,7 @@ int can_getsockopt(FAR struct socket *psock, int option,
           }
         break;
 
+#ifdef CONFIG_NET_CAN_CANFD
       case CAN_RAW_FD_FRAMES:
         if (*value_len < sizeof(conn->fd_frames))
           {
@@ -183,6 +184,7 @@ int can_getsockopt(FAR struct socket *psock, int option,
             ret                = OK;
           }
         break;
+#endif
 
       case CAN_RAW_JOIN_FILTERS:
         break;

--- a/net/can/can_recvfrom.c
+++ b/net/can/can_recvfrom.c
@@ -436,7 +436,14 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
           if (!conn->fd_frames)
 #endif
             {
+#if defined(CONFIG_NET_TIMESTAMP)
+              if ((conn->psock->s_timestamp && (dev->d_len >
+                  sizeof(struct can_frame) + sizeof(struct timeval)))
+                  || (!conn->psock->s_timestamp && (dev->d_len >
+                   sizeof(struct can_frame))))
+#else
               if (dev->d_len > sizeof(struct can_frame))
+#endif
                 {
                   /* DO WE NEED TO CLEAR FLAGS?? */
 

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -140,6 +140,7 @@ int can_setsockopt(FAR struct socket *psock, int option,
 
         break;
 
+#ifdef CONFIG_NET_CAN_CANFD
       case CAN_RAW_FD_FRAMES:
         if (value_len != sizeof(conn->fd_frames))
           {
@@ -149,6 +150,7 @@ int can_setsockopt(FAR struct socket *psock, int option,
           conn->fd_frames = *(FAR int32_t *)value;
 
           break;
+#endif
 
       case CAN_RAW_JOIN_FILTERS:
         break;


### PR DESCRIPTION
## Summary
Bug fix: In SocketCAN when a timestamped frame was received while in CAN2.0B mode the frame got dropped. This PR fixes by checking whether the socket is in timestamp while checking packet size.

## Impact
net/can

## Testing
Verified on RDDRONE-UAVCANS32K146 normal NuttX and PX4 NuttX
