### PR TITLE
cstdlib:Add missing atox to std namespace

### DIFF
--- a/include/cxx/cstdlib
+++ b/include/cxx/cstdlib
@@ -70,6 +70,9 @@ namespace std
 
   // String to binary conversions
 
+  using ::atof;
+  using ::atoi;
+  using ::atol;
   using ::strtol;
   using ::strtoul;
 #ifdef CONFIG_HAVE_LONG_LONG


### PR DESCRIPTION
## Summary

std::atof was not being resolved as cstdlib was missing ato[fil] using statements.

see https://en.cppreference.com/w/cpp/string/byte/atof

## Impact

Code would not build.

## Testing

Code compiles. 
