### PR TITLE
Makefile.unix:versioning insure it is a .git dir

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -25,9 +25,13 @@ include $(TOPDIR)/Make.defs
 
 GIT_DIR = $(if $(wildcard $(TOPDIR)$(DELIM).git),y,)
 
+ifeq ($(GIT_DIR),y)
+GIT_PRESENT = `git rev-parse --git-dir 2> /dev/null`
+endif
+
 # In case we cannot get version information from GIT
 
-ifneq ($(GIT_DIR),y)
+ifneq ($(GIT_PRESENT),true)
 -include $(TOPDIR)/.version
 
 # In case the version file does not exist


### PR DESCRIPTION
## Summary

An out-of-tree build may have a .git file that is from a submodule.  Once we find a .git, we need check if this is really a working dir.

## Impact
The tools/version was being passes values that imply the directory is a working dir when it is not.
It this uses git operations that will fail. 
 
## Testing

built in nuttx master and out of tree in a submodule. Both now work.
