### PR TITLE
arch/arm/stm32: Make SysTick as a Tickless clock source option

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -3421,6 +3421,13 @@ config STM32_EXTERNAL_RAM
 	---help---
 		In addition to internal SRAM, external RAM may be available through the FSMC/FMC.
 
+config STM32_TICKLESS_SYSTICK
+	bool "Tickless via SysTick"
+	default n
+	depends on SCHED_TICKLESS
+	---help---
+		Use SysTick as Tickless clock.
+
 menu "Timer Configuration"
 	depends on STM32_TIM
 
@@ -3430,6 +3437,7 @@ config STM32_TICKLESS_TIMER
 	int "Tickless hardware timer"
 	default 2
 	range 1 14
+	depends on !STM32_TICKLESS_SYSTICK
 	---help---
 		If the Tickless OS feature is enabled, then one clock must be
 		assigned to provided the timer needed by the OS.

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -44,12 +44,20 @@ endif
 
 CMN_CSRCS  = arm_assert.c arm_blocktask.c arm_copyfullstate.c arm_createstack.c
 CMN_CSRCS += arm_exit.c arm_hardfault.c arm_initialize.c arm_initialstate.c
-CMN_CSRCS += arm_interruptcontext.c arm_mdelay.c arm_memfault.c arm_modifyreg8.c
+CMN_CSRCS += arm_interruptcontext.c arm_memfault.c arm_modifyreg8.c
 CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
 CMN_CSRCS += arm_trigger_irq.c arm_unblocktask.c arm_udelay.c arm_usestack.c
 CMN_CSRCS += arm_doirq.c arm_vfork.c
+
+ifeq ($(CONFIG_STM32_TICKLESS_SYSTICK),y)
+CMN_CSRCS += arm_systick.c
+endif
+
+ifneq ($(CONFIG_TIMER_ARCH),y)
+CMN_CSRCS += arm_mdelay.c
+endif
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
@@ -104,10 +112,10 @@ ifeq ($(CONFIG_TIMER),y)
 CHIP_CSRCS += stm32_tim_lowerhalf.c
 endif
 
-ifneq ($(CONFIG_SCHED_TICKLESS),y)
-CHIP_CSRCS += stm32_timerisr.c
-else
+ifdef CONFIG_STM32_TICKLESS_TIMER
 CHIP_CSRCS += stm32_tickless.c
+else
+CHIP_CSRCS += stm32_timerisr.c
 endif
 
 ifeq ($(CONFIG_STM32_ONESHOT),y)


### PR DESCRIPTION
## Summary

Add a option by using SysTick's arch timer driver to support Tickless mode.

## Impact

None

## Testing

Tested on stm32f429zi-disco