### PR TITLE
Add support for the ST7735 TFT Controller

### DIFF
--- a/boards/arm/sam34/arduino-due/src/sam_mmcsd.c
+++ b/boards/arm/sam34/arduino-due/src/sam_mmcsd.c
@@ -93,7 +93,7 @@
 
 /* Calibration value for timing loop */
 
-#define SPI_BITBAND_LOOPSPERMSEC CONFIG_BOARD_LOOPSPERMSEC
+#define SPI_BITBANG_LOOPSPERMSEC CONFIG_BOARD_LOOPSPERMSEC
 
 /* SPI_PERBIT_NSEC is the minimum time to transfer one bit.  This determines
  * the maximum frequency and is also used to calculate delays to achieve
@@ -275,7 +275,8 @@ int sam_sdinitialize(int minor)
   ret = mmcsd_spislotinitialize(minor, SAM34_MMCSDSLOTNO, spi);
   if (ret < 0)
     {
-      ferr("ERROR: Failed to bind  bit bang SPI device to MMC/SD slot %d: %d\n",
+      ferr("ERROR: Failed to bind bit bang SPI device"
+            " to MMC/SD slot %d: %d\n",
             SAM34_MMCSDSLOTNO, ret);
       return ret;
     }

--- a/boards/arm/sam34/arduino-due/src/sam_touchscreen.c
+++ b/boards/arm/sam34/arduino-due/src/sam_touchscreen.c
@@ -108,7 +108,7 @@
 
 /* Calibration value for timing loop */
 
-#define SPI_BITBAND_LOOPSPERMSEC CONFIG_BOARD_LOOPSPERMSEC
+#define SPI_BITBANG_LOOPSPERMSEC CONFIG_BOARD_LOOPSPERMSEC
 
 /* SPI_PERBIT_NSEC is the minimum time to transfer one bit.  This determines
  * the maximum frequency and is also used to calculate delays to achieve

--- a/boards/arm/stm32/olimex-stm32-p407/include/board.h
+++ b/boards/arm/stm32/olimex-stm32-p407/include/board.h
@@ -349,11 +349,11 @@
 #define BOARD_DHTXX_GPIO_OUTPUT  GPIO_DHTXX_PIN_OUTPUT
 #define BOARD_DHTXX_FRTIMER      1  /* Free-run timer 1 */
 
-/* SPI3 DMA -- As used for I2S DMA transfer with the audio configuration */
+/* SPI3 - As present in the UEXT header */
 
-#define GPIO_SPI3_MISO    GPIO_SPI3_MISO_1
-#define GPIO_SPI3_MOSI    GPIO_SPI3_MOSI_1
-#define GPIO_SPI3_SCK     GPIO_SPI3_SCK_1
+#define GPIO_SPI3_MISO    GPIO_SPI3_MISO_2
+#define GPIO_SPI3_MOSI    GPIO_SPI3_MOSI_2
+#define GPIO_SPI3_SCK     GPIO_SPI3_SCK_2
 
 #define DMACHAN_SPI3_RX   DMAMAP_SPI3_RX_1
 #define DMACHAN_SPI3_TX   DMAMAP_SPI3_TX_1

--- a/boards/arm/stm32/olimex-stm32-p407/src/Make.defs
+++ b/boards/arm/stm32/olimex-stm32-p407/src/Make.defs
@@ -35,7 +35,7 @@
 
 include $(TOPDIR)/Make.defs
 
-CSRCS = stm32_boot.c stm32_bringup.c
+CSRCS = stm32_boot.c stm32_bringup.c stm32_spi.c stm32_st7735.c
 
 ifeq ($(CONFIG_ARCH_LEDS),y)
   CSRCS += stm32_autoleds.c

--- a/boards/arm/stm32/olimex-stm32-p407/src/olimex-stm32-p407.h
+++ b/boards/arm/stm32/olimex-stm32-p407/src/olimex-stm32-p407.h
@@ -207,6 +207,15 @@
 #  define CS4344_I2S_BUS      3
 #endif
 
+/* External ST7735 Pins */
+
+#define GPIO_ST7735_CS     (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz|\
+                            GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN6)
+#define GPIO_ST7735_AO     (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz|\
+                            GPIO_OUTPUT_SET|GPIO_PORTG|GPIO_PIN10)
+#define GPIO_ST7735_RST    (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz|\
+                            GPIO_OUTPUT_SET|GPIO_PORTG|GPIO_PIN12)
+
 #ifndef __ASSEMBLY__
 
 /****************************************************************************
@@ -228,6 +237,17 @@
  ****************************************************************************/
 
 int stm32_bringup(void);
+
+/****************************************************************************
+ * Name: stm32_spidev_initialize
+ *
+ * Description:
+ *   Called to configure SPI chip select GPIO pins for the olimex-stm32-p407
+ *   board.
+ *
+ ****************************************************************************/
+
+void weak_function stm32_spidev_initialize(void);
 
 /****************************************************************************
  * Name: stm32_stram_configure

--- a/boards/arm/stm32/olimex-stm32-p407/src/stm32_boot.c
+++ b/boards/arm/stm32/olimex-stm32-p407/src/stm32_boot.c
@@ -55,9 +55,10 @@
  * Name: stm32_boardinitialize
  *
  * Description:
- *   All STM32 architectures must provide the following entry point.  This entry point
- *   is called early in the initialization -- after all memory has been configured
- *   and mapped but before any devices have been initialized.
+ *   All STM32 architectures must provide the following entry point.
+ *   This entry point is called early in the initialization -- after all
+ *   memory has been configured and mapped but before any devices have been
+ *   initialized.
  *
  ****************************************************************************/
 
@@ -70,10 +71,10 @@ void stm32_boardinitialize(void)
 #endif
 
 #ifdef CONFIG_STM32_OTGFS
-  /* Initialize USB if the 1) OTG FS controller is in the configuration and 2)
-   * disabled, and 3) the weak function stm32_usb_configure() has been brought
-   * into the build. Presumably either CONFIG_USBDEV or CONFIG_USBHOST is also
-   * selected.
+  /* Initialize USB if the 1) OTG FS controller is in the configuration
+   * and 2) disabled, and 3) the weak function stm32_usb_configure() has been
+   * brought into the build. Presumably either CONFIG_USBDEV or
+   * CONFIG_USBHOST is also selected.
    */
 
   stm32_usb_configure();
@@ -90,6 +91,18 @@ void stm32_boardinitialize(void)
 #ifdef CONFIG_ARCH_BUTTONS
   board_button_initialize();
 #endif
+
+  /* Configure SPI chip selects if 1) SPI is not disabled, and 2) the weak
+   * function stm32_spidev_initialize() has been brought into the link.
+   */
+
+#if defined(CONFIG_STM32_SPI1) || defined(CONFIG_STM32_SPI2) ||\
+    defined(CONFIG_STM32_SPI3)
+  if (stm32_spidev_initialize)
+    {
+      stm32_spidev_initialize();
+    }
+#endif
 }
 
 /****************************************************************************
@@ -98,10 +111,11 @@ void stm32_boardinitialize(void)
  * Description:
  *   If CONFIG_BOARD_LATE_INITIALIZE is selected, then an additional
  *   initialization call will be performed in the boot-up sequence to a
- *   function called board_late_initialize().  board_late_initialize() will be
- *   called immediately after up_initialize() is called and just before the
- *   initial application is started.  This additional initialization phase
- *   may be used, for example, to initialize board-specific device drivers.
+ *   function called board_late_initialize().  board_late_initialize() will
+ *   be called immediately after up_initialize() is called and just before
+ *   the initial application is started.  This additional initialization
+ *   phase may be used, for example, to initialize board-specific device
+ *   drivers.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/olimex-stm32-p407/src/stm32_spi.c
+++ b/boards/arm/stm32/olimex-stm32-p407/src/stm32_spi.c
@@ -1,0 +1,195 @@
+/****************************************************************************
+ * boards/arm/stm32/olimex-stm32-p407/src/stm32_spi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/spi/spi.h>
+#include <arch/board/board.h>
+
+#include "arm_arch.h"
+#include "chip.h"
+#include "stm32.h"
+
+#include "olimex-stm32-p407.h"
+
+#if defined(CONFIG_STM32_SPI1) || defined(CONFIG_STM32_SPI2) ||\
+    defined(CONFIG_STM32_SPI3)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_spidev_initialize
+ *
+ * Description:
+ *   Called to configure SPI chip select GPIO pins for the olimex
+ *   board.
+ *
+ ****************************************************************************/
+
+void weak_function stm32_spidev_initialize(void)
+{
+  stm32_configgpio(GPIO_ST7735_CS);
+}
+
+/****************************************************************************
+ * Name:  stm32_spi1/2/3select and stm32_spi1/2/3status
+ *
+ * Description:
+ *   The external functions, stm32_spi1/2/3select and stm32_spi1/2/3status
+ *   must be provided by board-specific logic.  They are implementations of
+ *   the select and status methods of the SPI interface defined by struct
+ *   spi_ops_s (see include/nuttx/spi/spi.h). All other methods (including
+ *   stm32_spibus_initialize()) are provided by common STM32 logic.  To use
+ *   this common SPI logic on your board:
+ *
+ *   1. Provide logic in stm32_boardinitialize() to configure SPI chip select
+ *      pins.
+ *   2. Provide stm32_spi1/2/3select() and stm32_spi1/2/3status() functions
+ *      in your board-specific logic.  These functions will perform chip
+ *      selection and status operations using GPIOs in the way your board
+ *      is configured.
+ *   3. Add a call to stm32_spibus_initialize() in your low level application
+ *      initialization logic
+ *   4. The handle returned by stm32_spibus_initialize() may then be used to
+ *      bind the SPI driver to higher level logic (e.g., calling
+ *      mmcsd_spislotinitialize(), for example, will bind the SPI driver to
+ *      the SPI MMC/SD driver).
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_STM32_SPI1
+void stm32_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+                      bool selected)
+{
+  spiinfo("devid: %d CS: %s\n",
+          (int)devid, selected ? "assert" : "de-assert");
+}
+
+uint8_t stm32_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_STM32_SPI2
+void stm32_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+                      bool selected)
+{
+  spiinfo("devid: %d CS: %s\n",
+          (int)devid, selected ? "assert" : "de-assert");
+}
+
+uint8_t stm32_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+#ifdef CONFIG_STM32_SPI3
+void stm32_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+                      bool selected)
+{
+  spiinfo("devid: %d CS: %s\n",
+          (int)devid, selected ? "assert" : "de-assert");
+
+#ifdef CONFIG_LCD_ST7735
+  if (devid == SPIDEV_DISPLAY(0))
+    {
+      stm32_gpiowrite(GPIO_ST7735_CS, !selected);
+    }
+#endif
+}
+
+uint8_t stm32_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+/****************************************************************************
+ * Name: stm32_spi1cmddata
+ *
+ * Description:
+ *   Set or clear the SH1101A A0 or SD1306 D/C n bit to select data (true)
+ *   or command (false). This function must be provided by platform-specific
+ *   logic. This is an implementation of the cmddata method of the SPI
+ *   interface defined by struct spi_ops_s (see include/nuttx/spi/spi.h).
+ *
+ * Input Parameters:
+ *
+ *   spi - SPI device that controls the bus the device that requires the CMD/
+ *         DATA selection.
+ *   devid - If there are multiple devices on the bus, this selects which one
+ *         to select cmd or data.  NOTE:  This design restricts, for example,
+ *         one one SPI display per SPI bus.
+ *   cmd - true: select command; false: select data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_CMDDATA
+#ifdef CONFIG_STM32_SPI1
+int stm32_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  return -ENODEV;
+}
+#endif
+
+#ifdef CONFIG_STM32_SPI2
+int stm32_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  return -ENODEV;
+}
+#endif
+
+#ifdef CONFIG_STM32_SPI3
+int stm32_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  /*  This is the Data/Command control pad which determines whether the
+   *  data bits are data or a command.
+   */
+
+#ifdef CONFIG_LCD_ST7735
+  if (devid == SPIDEV_DISPLAY(0))
+    {
+      stm32_gpiowrite(GPIO_ST7735_AO, !cmd);
+      return OK;
+    }
+#endif
+
+  return -ENODEV;
+}
+#endif
+#endif /* CONFIG_SPI_CMDDATA */
+
+#endif /* CONFIG_STM32_SPI1 || CONFIG_STM32_SPI2 */

--- a/boards/arm/stm32/olimex-stm32-p407/src/stm32_st7735.c
+++ b/boards/arm/stm32/olimex-stm32-p407/src/stm32_st7735.c
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * boards/arm/stm32/olimex-stm32-p407/src/stm32_st7735.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/lcd/lcd.h>
+#include <nuttx/lcd/st7735.h>
+
+#include "arm_arch.h"
+#include "arm_internal.h"
+
+#include "stm32_gpio.h"
+#include "stm32_spi.h"
+#include "olimex-stm32-p407.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define LCD_SPI_PORTNO 3
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct spi_dev_s *g_spidev;
+static struct lcd_dev_s *g_lcd = NULL;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  board_lcd_initialize
+ *
+ * Description:
+ *   Initialize the LCD video hardware.  The initial state of the LCD is
+ *   fully initialized, display memory cleared, and the LCD ready to use, but
+ *   with the power setting at 0 (full off).
+ *
+ ****************************************************************************/
+
+int board_lcd_initialize(void)
+{
+  stm32_configgpio(GPIO_ST7735_RST);
+  stm32_configgpio(GPIO_ST7735_AO);
+
+  g_spidev = stm32_spibus_initialize(LCD_SPI_PORTNO);
+  if (!g_spidev)
+    {
+      lcderr("ERROR: Failed to initialize SPI port %d\n", LCD_SPI_PORTNO);
+      return -ENODEV;
+    }
+
+  stm32_gpiowrite(GPIO_ST7735_RST, 0);
+  up_mdelay(1);
+  stm32_gpiowrite(GPIO_ST7735_RST, 1);
+  up_mdelay(120);
+
+  g_lcd = st7735_lcdinitialize(g_spidev);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_getdev
+ *
+ * Description:
+ *   Return a a reference to the LCD object for the specified LCD.  This
+ *   allows support for multiple LCD devices.
+ *
+ ****************************************************************************/
+
+FAR struct lcd_dev_s *board_lcd_getdev(int devno)
+{
+  return g_lcd;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_uninitialize
+ *
+ * Description:
+ *   Uninitialize the LCD support
+ *
+ ****************************************************************************/
+
+void board_lcd_uninitialize(void)
+{
+  /* Turn the display off */
+
+  g_lcd->setpower(g_lcd, 0);
+}

--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -55,7 +55,7 @@ config LCD_EXTERNINIT
 	depends on LCD_FRAMEBUFFER
 	---help---
 		Define to support external LCD initialization by platform-specific
-		code.  This this option is defined, then the LCD framebuffer
+		code.  If this option is defined, then the LCD framebuffer
 		emulation will call board_graphics_setup() to initialize the
 		graphics device.  This option is necessary if display is used that
 		cannot be initialized using the standard LCD interfaces.
@@ -573,6 +573,32 @@ config SSD1351_MSTRCONTRAST
 		Specifies the master contrast ratio in sixteenths.
 
 endif
+
+config LCD_ST7735
+	bool "Sitronix ST7735 TFT Controller"
+	default n
+
+if LCD_ST7735
+	config LCD_ST7735_GM00
+		bool "132x162 Display Resolution"
+		default n
+		---help---
+			Two resolutions are availabe, either the 132x162 or
+			the 128x160
+
+	config LCD_ST7735_BPP
+		int "Bit Per Pixel (12, 16 or 18)"
+		default 16
+
+	config LCD_ST7735_SPIMODE
+		int "SPI Mode"
+		default 0
+
+	config LCD_ST7735_FREQUENCY
+		int "SPI Frequency"
+		default 3000000
+
+endif # LCD_ST7735
 
 config LCD_PCD8544
 	bool "Nokia 5110 LCD Display (Philips PCD8544)"

--- a/drivers/lcd/Make.defs
+++ b/drivers/lcd/Make.defs
@@ -131,6 +131,11 @@ endif
 ifeq ($(CONFIG_LCD_RA8875),y)
   CSRCS += ra8875.c
 endif
+
+ifeq ($(CONFIG_LCD_ST7735),y)
+  CSRCS += st7735.c
+endif
+
 endif # CONFIG_LCD
 
 ifeq ($(CONFIG_SLCD),y)

--- a/drivers/lcd/st7735.c
+++ b/drivers/lcd/st7735.c
@@ -1,0 +1,680 @@
+/****************************************************************************
+ * drivers/lcd/st7735.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/lcd/lcd.h>
+#include <nuttx/lcd/st7735.h>
+
+#include "st7735.h"
+
+#ifdef CONFIG_LCD_ST7735
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Verify that all configuration requirements have been met */
+
+#ifndef CONFIG_LCD_ST7735_SPIMODE
+#  define CONFIG_LCD_ST7735_SPIMODE SPIDEV_MODE0
+#endif
+
+/* SPI frequency */
+
+#ifndef CONFIG_LCD_ST7735_FREQUENCY
+#  define CONFIG_LCD_ST7735_FREQUENCY 3000000
+#endif
+
+/* Check contrast selection */
+
+#if !defined(CONFIG_LCD_MAXCONTRAST)
+#  define CONFIG_LCD_MAXCONTRAST 1
+#endif
+
+/* Check power setting */
+
+#if !defined(CONFIG_LCD_MAXPOWER) || CONFIG_LCD_MAXPOWER < 1
+#  define CONFIG_LCD_MAXPOWER 1
+#endif
+
+#if CONFIG_LCD_MAXPOWER > 255
+#  error "CONFIG_LCD_MAXPOWER must be less than 256 to fit in uint8_t"
+#endif
+
+/* Check orientation */
+
+#if defined(CONFIG_LCD_PORTRAIT)
+#  if defined(CONFIG_LCD_LANDSCAPE) || defined(CONFIG_LCD_RLANDSCAPE) ||\
+      defined(CONFIG_LCD_RPORTRAIT)
+#    error "Cannot define both portrait and any other orientations"
+#  endif
+#elif defined(CONFIG_LCD_RPORTRAIT)
+#  if defined(CONFIG_LCD_LANDSCAPE) || defined(CONFIG_LCD_RLANDSCAPE)
+#    error "Cannot define both rportrait and any other orientations"
+#  endif
+#elif defined(CONFIG_LCD_LANDSCAPE)
+#  ifdef CONFIG_LCD_RLANDSCAPE
+#    error "Cannot define both landscape and any other orientations"
+#  endif
+#elif !defined(CONFIG_LCD_RLANDSCAPE)
+#  define CONFIG_LCD_LANDSCAPE 1
+#endif
+
+/* Display Resolution */
+
+#ifdef CONFIG_LCD_ST7735_GM00
+#  define CONFIG_ST7735_XRES 132
+#  define CONFIG_ST7735_YRES 162
+#  define ST7735_LUT_SIZE    162
+#else
+#  define CONFIG_ST7735_XRES 128
+#  define CONFIG_ST7735_YRES 160
+#  define ST7735_LUT_SIZE    160
+#endif
+
+#if defined(CONFIG_LCD_LANDSCAPE) || defined(CONFIG_LCD_RLANDSCAPE)
+#  define ST7735_XRES       CONFIG_ST7735_YRES
+#  define ST7735_YRES       CONFIG_ST7735_XRES
+#else
+#  define ST7735_XRES       CONFIG_ST7735_XRES
+#  define ST7735_YRES       CONFIG_ST7735_YRES
+#endif
+
+/* Color depth and format */
+
+#ifdef CONFIG_LCD_ST7735_BPP
+#  if (CONFIG_LCD_ST7735_BPP == 12)
+#    define ST7735_BPP           12
+#    define ST7735_COLORFMT      FB_FMT_RGB12_444
+#    define ST7735_BYTESPP       2
+#  elif (CONFIG_LCD_ST7735_BPP == 16)
+#    define ST7735_BPP           16
+#    define ST7735_COLORFMT      FB_FMT_RGB16_565
+#    define ST7735_BYTESPP       2
+#  elif (CONFIG_LCD_ST7735_BPP == 18)
+#    define ST7735_BPP           18
+#    define ST7735_COLORFMT      FB_FMT_RGB16_666
+#    define ST7735_BYTESPP       3
+#  else
+#    define ST7735_BPP           16
+#    define ST7735_COLORFMT      FB_FMT_RGB16_565
+#    define ST7735_BYTESPP       2
+#    warning "Invalid color depth.  Falling back to 16bpp"
+#  endif
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* This structure describes the state of this driver */
+
+struct st7735_dev_s
+{
+  /* Publicly visible device structure */
+
+  struct lcd_dev_s dev;
+
+  /* Private LCD-specific information follows */
+
+  FAR struct spi_dev_s *spi;  /* SPI device */
+  uint8_t bpp;                /* Selected color depth */
+  uint8_t power;              /* Current power setting */
+
+  /* This is working memory allocated by the LCD driver for each LCD device
+   * and for each color plane. This memory will hold one raster line of data.
+   * The size of the allocated run buffer must therefore be at least
+   * (bpp * xres / 8).  Actual alignment of the buffer must conform to the
+   * bitwidth of the underlying pixel type.
+   *
+   * If there are multiple planes, they may share the same working buffer
+   * because different planes will not be operate on concurrently.  However,
+   * if there are multiple LCD devices, they must each have unique run
+   * buffers.
+   */
+
+  uint16_t runbuffer[ST7735_LUT_SIZE];
+};
+
+/****************************************************************************
+ * Private Function Protototypes
+ ****************************************************************************/
+
+/* Misc. Helpers */
+
+static void st7735_select(FAR struct spi_dev_s *spi, int bits);
+static void st7735_deselect(FAR struct spi_dev_s *spi);
+
+static inline void st7735_sendcmd(FAR struct st7735_dev_s *dev, uint8_t cmd);
+static void st7735_sleep(FAR struct st7735_dev_s *dev, bool sleep);
+static void st7735_display(FAR struct st7735_dev_s *dev, bool on);
+static void st7735_setarea(FAR struct st7735_dev_s *dev,
+                           uint16_t x0, uint16_t y0,
+                           uint16_t x1, uint16_t y1);
+static void st7735_bpp(FAR struct st7735_dev_s *dev, int bpp);
+static void st7735_wrram(FAR struct st7735_dev_s *dev,
+                         FAR const uint16_t *buff, size_t size);
+static void st7735_rdram(FAR struct st7735_dev_s *dev,
+                         FAR uint16_t *buff, size_t size);
+static void st7735_fill(FAR struct st7735_dev_s *dev, uint16_t color);
+
+/* LCD Data Transfer Methods */
+
+static int st7735_putrun(fb_coord_t row, fb_coord_t col,
+                         FAR const uint8_t *buffer, size_t npixels);
+#ifndef CONFIG_LCD_NOGETRUN
+static int st7735_getrun(fb_coord_t row, fb_coord_t col,
+                         FAR uint8_t *buffer, size_t npixels);
+#endif
+
+/* LCD Configuration */
+
+static int st7735_getvideoinfo(FAR struct lcd_dev_s *dev,
+                               FAR struct fb_videoinfo_s *vinfo);
+static int st7735_getplaneinfo(FAR struct lcd_dev_s *dev,
+                               unsigned int planeno,
+                               FAR struct lcd_planeinfo_s *pinfo);
+
+/* LCD Specific Controls */
+
+static int st7735_getpower(FAR struct lcd_dev_s *dev);
+static int st7735_setpower(FAR struct lcd_dev_s *dev, int power);
+static int st7735_getcontrast(FAR struct lcd_dev_s *dev);
+static int st7735_setcontrast(FAR struct lcd_dev_s *dev,
+                              unsigned int contrast);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct st7735_dev_s g_lcddev;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: st7735_select
+ *
+ * Description:
+ *   Select the SPI, locking and  re-configuring if necessary
+ *
+ * Input Parameters:
+ *   spi   - Reference to the SPI driver structure
+ *   bits  - Number of SPI bits
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+static void st7735_select(FAR struct spi_dev_s *spi, int bits)
+{
+  /* Select ST7735 chip (locking the SPI bus in case there are multiple
+   * devices competing for the SPI bus
+   */
+
+  SPI_LOCK(spi, true);
+  SPI_SELECT(spi, SPIDEV_DISPLAY(0), true);
+
+  /* Now make sure that the SPI bus is configured for the ST7735 (it
+   * might have gotten configured for a different device while unlocked)
+   */
+
+  SPI_SETMODE(spi, CONFIG_LCD_ST7735_SPIMODE);
+  SPI_SETBITS(spi, bits);
+  SPI_SETFREQUENCY(spi, CONFIG_LCD_ST7735_FREQUENCY);
+}
+
+/****************************************************************************
+ * Name: st7735_deselect
+ *
+ * Description:
+ *   De-select the SPI
+ *
+ * Input Parameters:
+ *   spi  - Reference to the SPI driver structure
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+static void st7735_deselect(FAR struct spi_dev_s *spi)
+{
+  /* De-select ST7735 chip and relinquish the SPI bus. */
+
+  SPI_SELECT(spi, SPIDEV_DISPLAY(0), false);
+  SPI_LOCK(spi, false);
+}
+
+/****************************************************************************
+ * Name: st7735_sendcmd
+ *
+ * Description:
+ *   Send a command to the driver.
+ *
+ ****************************************************************************/
+
+static inline void st7735_sendcmd(FAR struct st7735_dev_s *dev, uint8_t cmd)
+{
+  st7735_select(dev->spi, 8);
+  SPI_CMDDATA(dev->spi, SPIDEV_DISPLAY(0), true);
+  SPI_SEND(dev->spi, cmd);
+  SPI_CMDDATA(dev->spi, SPIDEV_DISPLAY(0), false);
+  st7735_deselect(dev->spi);
+}
+
+/****************************************************************************
+ * Name: st7735_sleep
+ *
+ * Description:
+ *   Sleep or wake up the driver.
+ *
+ ****************************************************************************/
+
+static void st7735_sleep(FAR struct st7735_dev_s *dev, bool sleep)
+{
+  st7735_sendcmd(dev, sleep ? ST7735_SLPIN : ST7735_SLPOUT);
+  up_mdelay(120);
+}
+
+/****************************************************************************
+ * Name: st7735_display
+ *
+ * Description:
+ *   Turn on or off the display.
+ *
+ ****************************************************************************/
+
+static void st7735_display(FAR struct st7735_dev_s *dev, bool on)
+{
+  st7735_sendcmd(dev, on ? ST7735_DISPON : ST7735_DISPOFF);
+}
+
+/****************************************************************************
+ * Name: st7735_setarea
+ *
+ * Description:
+ *   Set the rectangular area for an upcomming read or write from RAM.
+ *
+ ****************************************************************************/
+
+static void st7735_setarea(FAR struct st7735_dev_s *dev,
+                           uint16_t x0, uint16_t y0,
+                           uint16_t x1, uint16_t y1)
+{
+  /* Set row address */
+
+  st7735_sendcmd(dev, ST7735_RASET);
+  st7735_select(dev->spi, 16);
+  SPI_SEND(dev->spi, y0);
+  SPI_SEND(dev->spi, y1);
+  st7735_deselect(dev->spi);
+
+  /* Set column address */
+
+  st7735_sendcmd(dev, ST7735_CASET);
+  st7735_select(dev->spi, 16);
+  SPI_SEND(dev->spi, x0);
+  SPI_SEND(dev->spi, x1);
+  st7735_deselect(dev->spi);
+}
+
+/****************************************************************************
+ * Name: st7735_bpp
+ *
+ * Description:
+ *   Set the color depth of the device.
+ *
+ ****************************************************************************/
+
+static void st7735_bpp(FAR struct st7735_dev_s *dev, int bpp)
+{
+  uint8_t depth;
+
+  /* Don't send any command if the depth hasn't changed. */
+
+  if (dev->bpp != bpp)
+    {
+      /* REVISIT: Works only for 12 and 16 bpp! */
+
+      depth = bpp >> 2 | 1;
+      st7735_sendcmd(dev, ST7735_COLMOD);
+      st7735_select(dev->spi, 8);
+      SPI_SEND(dev->spi, depth);
+      st7735_deselect(dev->spi);
+
+      /* Cache the new BPP */
+
+      dev->bpp = bpp;
+    }
+}
+
+/****************************************************************************
+ * Name: st7735_wrram
+ *
+ * Description:
+ *   Write to the driver's RAM.
+ *
+ ****************************************************************************/
+
+static void st7735_wrram(FAR struct st7735_dev_s *dev,
+                         FAR const uint16_t *buff, size_t size)
+{
+  st7735_sendcmd(dev, ST7735_RAMWR);
+
+  st7735_select(dev->spi, ST7735_BYTESPP * 8);
+  SPI_SNDBLOCK(dev->spi, buff, size);
+  st7735_deselect(dev->spi);
+}
+
+/****************************************************************************
+ * Name: st7735_rdram
+ *
+ * Description:
+ *   Read from the driver's RAM.
+ *
+ ****************************************************************************/
+
+static void st7735_rdram(FAR struct st7735_dev_s *dev,
+                         FAR uint16_t *buff, size_t size)
+{
+  st7735_sendcmd(dev, ST7735_RAMRD);
+
+  st7735_select(dev->spi, ST7735_BYTESPP * 8);
+  SPI_RECVBLOCK(dev->spi, buff, size);
+  st7735_deselect(dev->spi);
+}
+
+/****************************************************************************
+ * Name: st7735_fill
+ *
+ * Description:
+ *   Fill the display with the specified color.
+ *
+ ****************************************************************************/
+
+static void st7735_fill(FAR struct st7735_dev_s *dev, uint16_t color)
+{
+  int i;
+
+  st7735_setarea(dev, 0, 0, ST7735_XRES - 1, ST7735_YRES - 1);
+
+  st7735_sendcmd(dev, ST7735_RAMWR);
+  st7735_select(dev->spi, ST7735_BYTESPP * 8);
+
+  for (i = 0; i < ST7735_XRES * ST7735_YRES; i++)
+    {
+      SPI_SEND(dev->spi, color);
+    }
+
+  st7735_deselect(dev->spi);
+}
+
+/****************************************************************************
+ * Name:  st7735_putrun
+ *
+ * Description:
+ *   This method can be used to write a partial raster line to the LCD:
+ *
+ *   row     - Starting row to write to (range: 0 <= row < yres)
+ *   col     - Starting column to write to (range: 0 <= col <= xres-npixels)
+ *   buffer  - The buffer containing the run to be written to the LCD
+ *   npixels - The number of pixels to write to the LCD
+ *             (range: 0 < npixels <= xres-col)
+ *
+ ****************************************************************************/
+
+static int st7735_putrun(fb_coord_t row, fb_coord_t col,
+                         FAR const uint8_t *buffer, size_t npixels)
+{
+  FAR struct st7735_dev_s *priv = &g_lcddev;
+  FAR const uint16_t *src = (FAR const uint16_t *)buffer;
+
+  ginfo("row: %d col: %d npixels: %d\n", row, col, npixels);
+  DEBUGASSERT(buffer && ((uintptr_t)buffer & 1) == 0);
+
+  st7735_setarea(priv, col, row, col + npixels - 1, row);
+  st7735_wrram(priv, src, npixels);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  st7735_getrun
+ *
+ * Description:
+ *   This method can be used to read a partial raster line from the LCD:
+ *
+ *  row     - Starting row to read from (range: 0 <= row < yres)
+ *  col     - Starting column to read read (range: 0 <= col <= xres-npixels)
+ *  buffer  - The buffer in which to return the run read from the LCD
+ *  npixels - The number of pixels to read from the LCD
+ *            (range: 0 < npixels <= xres-col)
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_LCD_NOGETRUN
+static int st7735_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
+                         size_t npixels)
+{
+  FAR struct st7735_dev_s *priv = &g_lcddev;
+  FAR uint16_t *dest = (FAR uint16_t *)buffer;
+
+  ginfo("row: %d col: %d npixels: %d\n", row, col, npixels);
+  DEBUGASSERT(buffer && ((uintptr_t)buffer & 1) == 0);
+
+  st7735_setarea(priv, col, row, col + npixels - 1, row);
+  st7735_rdram(priv, dest, npixels);
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
+ * Name:  st7735_getvideoinfo
+ *
+ * Description:
+ *   Get information about the LCD video controller configuration.
+ *
+ ****************************************************************************/
+
+static int st7735_getvideoinfo(FAR struct lcd_dev_s *dev,
+                               FAR struct fb_videoinfo_s *vinfo)
+{
+  DEBUGASSERT(dev && vinfo);
+  lcdinfo("fmt: %d xres: %d yres: %d nplanes: 1\n",
+          ST7735_COLORFMT, ST7735_XRES, ST7735_YRES);
+
+  vinfo->fmt     = ST7735_COLORFMT;    /* Color format: RGB16-565: RRRR RGGG GGGB BBBB */
+  vinfo->xres    = ST7735_XRES;        /* Horizontal resolution in pixel columns */
+  vinfo->yres    = ST7735_YRES;        /* Vertical resolution in pixel rows */
+  vinfo->nplanes = 1;                  /* Number of color planes supported */
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  st7735_getplaneinfo
+ *
+ * Description:
+ *   Get information about the configuration of each LCD color plane.
+ *
+ ****************************************************************************/
+
+static int st7735_getplaneinfo(FAR struct lcd_dev_s *dev,
+                               unsigned int planeno,
+                               FAR struct lcd_planeinfo_s *pinfo)
+{
+  FAR struct st7735_dev_s *priv = (FAR struct st7735_dev_s *)dev;
+
+  DEBUGASSERT(dev && pinfo && planeno == 0);
+  lcdinfo("planeno: %d bpp: %d\n", planeno, ST7735_BPP);
+
+  pinfo->putrun = st7735_putrun;                  /* Put a run into LCD memory */
+#ifndef CONFIG_LCD_NOGETRUN
+  pinfo->getrun = st7735_getrun;                  /* Get a run from LCD memory */
+#endif
+  pinfo->buffer = (FAR uint8_t *)priv->runbuffer; /* Run scratch buffer */
+  pinfo->bpp    = priv->bpp;                      /* Bits-per-pixel */
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  st7735_getpower
+ ****************************************************************************/
+
+static int st7735_getpower(FAR struct lcd_dev_s *dev)
+{
+  FAR struct st7735_dev_s *priv = (FAR struct st7735_dev_s *)dev;
+
+  lcdinfo("power: %d\n", priv->power);
+  return priv->power;
+}
+
+/****************************************************************************
+ * Name:  st7735_setpower
+ ****************************************************************************/
+
+static int st7735_setpower(FAR struct lcd_dev_s *dev, int power)
+{
+  FAR struct st7735_dev_s *priv = (FAR struct st7735_dev_s *)dev;
+
+  lcdinfo("power: %d\n", power);
+  DEBUGASSERT((unsigned)power <= CONFIG_LCD_MAXPOWER);
+
+  /* Set new power level */
+
+  if (power > 0)
+    {
+      /* Turn on the display */
+
+      st7735_display(priv, true);
+
+      /* Save the power */
+
+      priv->power = power;
+    }
+  else
+    {
+      /* Turn off the display */
+
+      st7735_display(priv, false);
+
+      /* Save the power */
+
+      priv->power = 0;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  st7735_getcontrast
+ *
+ * Description:
+ *   Get the current contrast setting (0-CONFIG_LCD_MAXCONTRAST).
+ *
+ ****************************************************************************/
+
+static int st7735_getcontrast(FAR struct lcd_dev_s *dev)
+{
+  lcdinfo("Not implemented\n");
+  return -ENOSYS;
+}
+
+/****************************************************************************
+ * Name:  st7735_setcontrast
+ *
+ * Description:
+ *   Set LCD panel contrast (0-CONFIG_LCD_MAXCONTRAST).
+ *
+ ****************************************************************************/
+
+static int st7735_setcontrast(FAR struct lcd_dev_s *dev,
+                              unsigned int contrast)
+{
+  lcdinfo("contrast: %d\n", contrast);
+  return -ENOSYS;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  st7735_initialize
+ *
+ * Description:
+ *   Initialize the ST7735 video hardware.  The initial state of the
+ *   LCD is fully initialized, display memory cleared, and the LCD ready
+ *   to use, but with the power setting at 0 (full off == sleep mode).
+ *
+ * Returned Value:
+ *
+ *   On success, this function returns a reference to the LCD object for
+ *   the specified LCD.  NULL is returned on any failure.
+ *
+ ****************************************************************************/
+
+FAR struct lcd_dev_s *st7735_lcdinitialize(FAR struct spi_dev_s *spi)
+{
+  FAR struct st7735_dev_s *priv = &g_lcddev;
+
+  /* Initialize the driver data structure */
+
+  priv->dev.getvideoinfo = st7735_getvideoinfo;
+  priv->dev.getplaneinfo = st7735_getplaneinfo;
+  priv->dev.getpower     = st7735_getpower;
+  priv->dev.setpower     = st7735_setpower;
+  priv->dev.getcontrast  = st7735_getcontrast;
+  priv->dev.setcontrast  = st7735_setcontrast;
+  priv->spi              = spi;
+
+  /* Init the hardware and clear the display */
+
+  st7735_sleep(priv, false);
+  st7735_bpp(priv, ST7735_BPP);
+  st7735_display(priv, true);
+  st7735_fill(priv, 0xffff);
+
+  return &priv->dev;
+}
+
+#endif /* CONFIG_LCD_ST7735 */
+

--- a/drivers/lcd/st7735.h
+++ b/drivers/lcd/st7735.h
@@ -1,0 +1,53 @@
+/**************************************************************************************
+ * drivers/lcd/st7735.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ **************************************************************************************/
+
+#ifndef __DRIVERS_LCD_ST7735_H
+#define __DRIVERS_LCD_ST7735_H
+
+/**************************************************************************************
+ * Included Files
+ **************************************************************************************/
+
+/**************************************************************************************
+ * Pre-processor Definitions
+ **************************************************************************************/
+
+#define ST7735_NOP       0x00   /* No Operation */
+#define ST7735_SWRESET   0x01   /* Software Reset */
+#define ST7735_RDDID     0x04   /* Read Display ID */
+#define ST7735_RDDST     0x09   /* Read Display Status */
+#define ST7735_RDDPM     0x0a   /* Read Display Power */
+#define ST7735_SLPIN     0x10   /* Sleep In & Booster Off */
+#define ST7735_SLPOUT    0x11   /* Sleep Out & Booster On */
+#define ST7735_PTLON     0x12   /* Partial Mode On */
+#define ST7735_NORON     0x13   /* Partial Mode Off */
+#define ST7735_INVOFF    0x20   /* Display Inversion Off */
+#define ST7735_INVON     0x21   /* Display Inversion On */
+#define ST7735_DISPOFF   0x28   /* Display Off */
+#define ST7735_DISPON    0x29   /* Display On */
+#define ST7735_CASET     0x2a   /* Column Address Set */
+#define ST7735_RASET     0x2b   /* Row Address Set */
+#define ST7735_RAMWR     0x2c   /* Memory Write */
+#define ST7735_RAMRD     0x2e   /* Memory Read */
+#define ST7735_IDMOFF    0x38   /* Idle Mode Off */
+#define ST7735_IDMON     0x39   /* Idle Mode On */
+#define ST7735_COLMOD    0x3a   /* Interface Pixel Format */
+
+#endif /* __DRIVERS_LCD_ST7735_H */

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -55,8 +55,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* This file holds the static, device-independ portion of the generica SPI-
- * bit-bang driver.  The full driver consists of 5 files:
+/* This file holds the static, device-independent portion of the generic
+ * SPI-bit-bang driver.  The full driver consists of 5 files:
  *
  * 1. drivers/spi/spi_bitbang.c:  This file.  This file holds the basic
  *    SPI driver framework and not perform any direct bit-bang operations.
@@ -68,17 +68,17 @@
  * 3. boards/<arch>/<chip>/<board>/src/<file>:  The implementation of the
  *    low-level bit-bang logic resides in some file in the board source
  *    directory.  This board-specific logic includes the bit-bang skeleton
- *    logic provided in include/nuttx/spi/spi_bitband.c.
- * 4. include/nuttx/spi/spi_bitband.c.  Despite the .c extension, this
+ *    logic provided in include/nuttx/spi/spi_bitbang.c.
+ * 4. include/nuttx/spi/spi_bitbang.c.  Despite the .c extension, this is
  *    really an included file.  It is used in this way:  1) The board-
  *    specific logic in boards/<arch>/<chip>/<board>/src/<file> provides
- *    some definitions then 2) includes include/nuttx/spi/spi_bitband.c.
+ *    some definitions then 2) includes include/nuttx/spi/spi_bitbang.c.
  *    That file will then use those definitions to implement the low-level
- *    bit-bang logic.  the board-specific logic then calls
+ *    bit-bang logic.  The board-specific logic then calls
  *    spi_create_bitbang() in this file to instantiate the complete SPI
  *    driver.
  *
- *    See include/nuttx/spi/spi_bitband.c for more detailed usage
+ *    See include/nuttx/spi/spi_bitbang.c for more detailed usage
  *    information.
  */
 

--- a/include/nuttx/lcd/st7735.h
+++ b/include/nuttx/lcd/st7735.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * include/nuttx/lcd/st7735.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_ST7735_H
+#define __INCLUDE_NUTTX_ST7735_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdbool.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  st7735_initialize
+ *
+ * Description:
+ *   Initialize the ST7735 video hardware.  The initial state of the
+ *   LCD is fully initialized, display memory cleared, and the LCD ready
+ *   to use, but with the power setting at 0 (full off == sleep mode).
+ *
+ * Returned Value:
+ *
+ *   On success, this function returns a reference to the LCD object for
+ *   the specified LCD.  NULL is returned on any failure.
+ *
+ ****************************************************************************/
+
+FAR struct lcd_dev_s *st7735_lcdinitialize(FAR struct spi_dev_s *spi);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_ST7735_H */

--- a/include/nuttx/spi/spi_bitbang.c
+++ b/include/nuttx/spi/spi_bitbang.c
@@ -44,7 +44,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Usage ********************************************************************/
+
 /* To use this logic, you should provide a C file that does the following:
  *
  * - Defines SPI_SETSCK and SPI_CLRSCK to set and clear the SCK signal
@@ -53,12 +55,12 @@
  * - Defines SPI_PERBIT_NSEC which is the minimum time to transfer one bit.
  *   This determines the maximum frequency.
  * - Other configuration options:
- *   SPI_BITBAND_LOOPSPERMSEC - Delay loop calibration
+ *   SPI_BITBANG_LOOPSPERMSEC - Delay loop calibration
  *   SPI_BITBANG_DISABLEMODE0 - Define to disable Mode 0 support
  *   SPI_BITBANG_DISABLEMODE1 - Define to disable Mode 1 support
  *   SPI_BITBANG_DISABLEMODE2 - Define to disable Mode 2 support
  *   SPI_BITBANG_DISABLEMODE3 - Define to disable Mode 3 support
- * - Provide implementations of spi_select(), spi_status(), and spi_cmddata().
+ * - Provide implementations of spi_select(), spi_status() and spi_cmddata().
  * - Then include this file
  * - Provide an initialization function that initializes the GPIO pins used
  *   in the bit bang interface and calls spi_create_bitbang().
@@ -115,6 +117,7 @@ static const struct spi_bitbang_ops_s g_spiops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
 /****************************************************************************
  * Name: spi_delay
  *
@@ -122,10 +125,10 @@ static const struct spi_bitbang_ops_s g_spiops =
  *   Delay for a specified number of loops
  *
  * Input Parameters:
- *   count - The number of loops
+ *   holdtime - The number of loops
  *
  * Returned Value:
- *   Returns the actual frequency selected
+ *   None.
  *
  ****************************************************************************/
 
@@ -143,7 +146,7 @@ static void spi_delay(uint32_t holdtime)
  *   Set the SPI frequency.
  *
  * Input Parameters:
- *   dev -       Device-specific state data
+ *   priv -      Device-specific state data
  *   frequency - The SPI frequency requested
  *
  * Returned Value:
@@ -151,7 +154,8 @@ static void spi_delay(uint32_t holdtime)
  *
  ****************************************************************************/
 
-static uint32_t spi_setfrequency(FAR struct spi_bitbang_s *priv, uint32_t frequency)
+static uint32_t spi_setfrequency(FAR struct spi_bitbang_s *priv,
+                                 uint32_t frequency)
 {
   uint32_t pnsec;
 
@@ -160,11 +164,14 @@ static uint32_t spi_setfrequency(FAR struct spi_bitbang_s *priv, uint32_t freque
    * wait, set low, wait, set high, wait, etc.
    *
    * Here we calcalute the half period of the frequency in nanoseconds (i.e.,
-   * the amount of time that the clock should remain in the high or low state).
+   * the amount of time that the clock should remain in the high or low
+   * state).
    *
-   *   frequency = psec / 1 sec                       psec = full period in seconds
+   *   frequency = psec / 1 sec
+   *      psec = full period in seconds
    *   psec      = 1 sec / frequency
-   *   pnsec     = 1000000000 nsec / (2 * frequency)  pnsec = full period in nsec
+   *   pnsec     = 1000000000 nsec / (2 * frequency)
+   *      pnsec = full period in nsec
    *
    * As examples:
    * 1) frequency = 400KHz; SPI_PERBIT_NSEC = 100
@@ -190,41 +197,43 @@ static uint32_t spi_setfrequency(FAR struct spi_bitbang_s *priv, uint32_t freque
 
   pnsec = (pnsec + 1) >> 1;
 
-  /* But what we really want is the hold time in loop counts. We know that
-   * SPI_BITBAND_LOOPSPERMSEC is the number of times through a delay loop
+  /* But what we really want is the hold time in loop counts.  We know that
+   * SPI_BITBANG_LOOPSPERMSEC is the number of times through a delay loop
    * to get 1 millisecond.
    *
-   * SPI_BITBAND_LOOPSPERMSEC / 1000000 is then the number of counts
+   * SPI_BITBANG_LOOPSPERMSEC / 1000000 is then the number of counts
    * to get 1 nanosecond.  In reality, this is a number less than zero.  But
    * then we can use this to calculate:
    *
-   * holdtime loops/hold = pnsec nsec/hold * (SPI_BITBAND_LOOPSPERMSEC / 1000000) loops/nsec
+   * holdtime loops/hold = pnsec nsec/hold * (SPI_BITBANG_LOOPSPERMSEC /
+   *                                          1000000) loops/nsec
    *
    * As examples:
    * 1) frequency = 400KHz; SPI_PERBIT_NSEC = 100; pnsec = 1200;
-   *    SPI_BITBAND_LOOPSPERMSEC = 5000
+   *    SPI_BITBANG_LOOPSPERMSEC = 5000
    *    holdtime  = (1200 * 5000 + 500000) / 1000000 = 6
    * 2) frequency = 20MHz;  SPI_PERBIT_NSEC = 100; pnsec = 0;
-   *    SPI_BITBAND_LOOPSPERMSEC = 5000
+   *    SPI_BITBANG_LOOPSPERMSEC = 5000
    *    holdtime  = (0 * 5000 + 500000) / 1000000 = 0
    */
 
-  priv->holdtime = (pnsec * SPI_BITBAND_LOOPSPERMSEC + 500000) / 1000000;
+  priv->holdtime = (pnsec * SPI_BITBANG_LOOPSPERMSEC + 500000) / 1000000;
 
   /* Let's do our best to calculate the actual frequency
    *
    * As examples:
    * 1) frequency = 400KHz; SPI_PERBIT_NSEC = 100;
-   *    SPI_BITBAND_LOOPSPERMSEC = 5000; holdtime = 6
+   *    SPI_BITBANG_LOOPSPERMSEC = 5000; holdtime = 6
    *    pnsec     = 2 * 1000000 * 6 / 5000 + 100 = 2500 nsec
    *    frequency = 400KHz
    * 2) frequency = 20MHz;  SPI_PERBIT_NSEC = 100; holdtime = 0
-   *    SPI_BITBAND_LOOPSPERMSEC = 5000; holdtime = 0
+   *    SPI_BITBANG_LOOPSPERMSEC = 5000; holdtime = 0
    *    pnsec     = 2 * 0 * 6 / 5000 + 100 = 100 nsec
    *    frequency = 10MHz
    */
 
-  pnsec = 2 * 1000000 * priv->holdtime / SPI_BITBAND_LOOPSPERMSEC + SPI_PERBIT_NSEC;
+  pnsec = 2 * 1000000 * priv->holdtime / SPI_BITBANG_LOOPSPERMSEC +
+          SPI_PERBIT_NSEC;
   frequency = 1000000000ul / pnsec;
   return frequency;
 }
@@ -236,8 +245,8 @@ static uint32_t spi_setfrequency(FAR struct spi_bitbang_s *priv, uint32_t freque
  *   Select the current SPI mode
  *
  * Input Parameters:
- *   dev  - Device-specific state data
- *   mode - the new SPI mode
+ *   priv - Device-specific state data
+ *   mode - The new SPI mode
  *
  * Returned Value:
  *   None
@@ -466,8 +475,8 @@ static uint16_t spi_bitexchange2(uint16_t dataout, uint32_t holdtime)
 {
   uint16_t datain;
 
-  /* Here the clock is is in the resting set (high).  Set MOSI output and wait
-   * for the hold time
+  /* Here the clock is is in the resting set (high).  Set MOSI output and
+   * wait for the hold time
    */
 
   if (dataout != 0)
@@ -568,7 +577,7 @@ static uint16_t spi_bitexchange3(uint16_t dataout, uint32_t holdtime)
  * Name: spi_exchange
  *
  * Description:
- *   Exahange on word of data on SPI
+ *   Exahange one word of data on SPI
  *
  * Input Parameters:
  *   priv     - Device-specific state data
@@ -580,7 +589,8 @@ static uint16_t spi_bitexchange3(uint16_t dataout, uint32_t holdtime)
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_BITBANG_VARWIDTH
-static uint16_t spi_exchange(FAR struct spi_bitbang_s *priv, uint16_t dataout)
+static uint16_t spi_exchange(FAR struct spi_bitbang_s *priv,
+                             uint16_t dataout)
 {
   bitexchange_t exchange = priv->exchange;
   uint32_t holdtime = priv->holdtime;
@@ -609,7 +619,8 @@ static uint16_t spi_exchange(FAR struct spi_bitbang_s *priv, uint16_t dataout)
 }
 
 #else
-static uint16_t spi_exchange(FAR struct spi_bitbang_s *priv, uint16_t dataout)
+static uint16_t spi_exchange(FAR struct spi_bitbang_s *priv,
+                             uint16_t dataout)
 {
   bitexchange_t exchange = priv->exchange;
   uint32_t holdtime = priv->holdtime;

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -52,8 +52,8 @@
  * Pre-processor definitions
  ****************************************************************************/
 
-/* Color format definitions.  The pretty much define the color pixel processing
- * organization of the video controller.
+/* Color format definitions.  This pretty much defines the color pixel
+ * processing organization of the video controller.
  */
 
 /* Monochrome Formats *******************************************************/
@@ -66,7 +66,7 @@
 #define FB_FMT_GREY           FB_FMT_Y8 /* BPP=8 */
 #define FB_FMT_Y800           FB_FMT_Y8 /* BPP=8 */
 
-#define FB_ISMONO(f)          ((f) >= FB_FMT_Y4) && (f) <= FB_FMT_Y16)
+#define FB_ISMONO(f)          (((f) >= FB_FMT_Y4) && (f) <= FB_FMT_Y16)
 
 /* RGB video formats ********************************************************/
 
@@ -92,8 +92,8 @@
 
 #define FB_FMT_RGBRAW         16          /* BPP=? */
 
-/* Raw RGB with arbitrary sample packing within a pixel. Packing and precision
- * of R, G and B components is determined by bit masks for each.
+/* Raw RGB with arbitrary sample packing within a pixel. Packing and
+ * precision of R, G and B components is determined by bit masks for each.
  */
 
 #define FB_FMT_RGBBTFLD16     17          /* BPP=16 */
@@ -110,7 +110,7 @@
 #define FB_FMT_RGBT16         22          /* BPP=16 */
 #define FB_FMT_RGBT32         23          /* BPP=32 */
 
-#define FB_ISRGB(f)           ((f) >= FB_FMT_RGB1) && (f) <= FB_FMT_RGBT32)
+#define FB_ISRGB(f)           (((f) >= FB_FMT_RGB1) && (f) <= FB_FMT_RGBT32)
 
 /* Packed YUV Formats *******************************************************/
 
@@ -148,7 +148,7 @@
 #define FB_FMT_Y42T           44          /* BPP=16  UYVY LSB for transparency */
 #define FB_FMT_YUVP           45          /* BPP=24? YCbCr 4:2:2 Y0U0Y1V0 order */
 
-#define FB_ISYUVPACKED(f)     ((f) >= FB_FMT_AYUV) && (f) <= FB_FMT_YUVP)
+#define FB_ISYUVPACKED(f)     (((f) >= FB_FMT_AYUV) && (f) <= FB_FMT_YUVP)
 
 /* Packed Planar YUV Formats ************************************************/
 
@@ -196,7 +196,7 @@
 #  define FB_CUR_XOR          0x10        /* Use XOR vs COPY ROP on image */
 #endif
 
-/* Hardware overlay acceleration *******************************************/
+/* Hardware overlay acceleration ********************************************/
 
 #ifdef CONFIG_FB_OVERLAY
 #  define FB_ACCL_TRANSP      0x01        /* Hardware tranparency support */
@@ -445,7 +445,9 @@ struct fb_cursorsize_s
 };
 #endif
 
-/* The following are used to get/get the cursor attributes via IOCTL command. */
+/* The following are used to get/get the cursor attributes via IOCTL
+ * command.
+ */
 
 struct fb_cursorattrib_s
 {
@@ -624,7 +626,8 @@ int up_fbinitialize(int display);
  *
  * Description:
  *   Return a a reference to the framebuffer object for the specified video
- *   plane of the specified plane.  Many OSDs support multiple planes of video.
+ *   plane of the specified plane.  Many OSDs support multiple planes of
+ *   video.
  *
  * Input Parameters:
  *   display - In the case of hardware with multiple displays, this


### PR DESCRIPTION
## Summary
Add support for the ST7735 TFT Controller.

## Impact
This also adds the necessary SPI hooks for the Olimex P407 board.
## Testing
Tested with different graphic examples: nxhello, nximg, nxtext..
