### PR TITLE
For NuttX-9.1 backport: Document new support for STM32G474 and B-G474E-DPOW1

### DIFF
--- a/Documentation/NuttX.html
+++ b/Documentation/NuttX.html
@@ -1797,6 +1797,7 @@
       <li><a href="#stm32f433x">STMicro STM32 F433</a> <small>(STM32 F4 family, ARM Cortex-M4)</small></li>
       <li><a href="#stm32f446x">STMicro STM32 F446</a> <small>(STM32 F4 family, ARM Cortex-M4)</small></li>
       <li><a href="#stm32f46xxx">STMicro STM32 F46xx</a> <small>(STM32 F4 family, ARM Cortex-M4)</small></li>
+      <li><a href="#stm32g474x">STMicro STM32 G474x</a> <small>(STM32 G4 family, ARM Cortex-M4)</small></li>
       <li><a href="#stm32l4x2">STMicro STM32 L4x2</a> <small>(STM32 L4 family, ARM Cortex-M4)</small></li>
       <li><a href="#stm32l475">STMicro STM32 L475</a> <small>(STM32 L4 family, ARM Cortex-M4)</small></li>
       <li><a href="#stm32l476">STMicro STM32 L476</a> <small>(STM32 L4 family, ARM Cortex-M4)</small></li>
@@ -4842,6 +4843,35 @@ nsh>
       <a name="stm32f46xxx"><b>STMicro STM32 F46xx</b>.</a>
       Architecture-only support is available for the STM32 F46xx family (meaning that the parts are supported, but there is no example board supported in the system).
       This support was contributed by Paul Alexander Patienc and made available in NuttX-7.15.
+    </p>
+  </td>
+</tr>
+
+<tr>
+  <td><br></td>
+  <td><hr></td>
+</tr>
+<tr>
+  <td><br></td>
+  <td>
+    <p>
+      <a name="stm32g474x"><b>STMicro STM32 G474</b>.</a>
+      One board is supported in this family:
+    </p>
+    <ul>
+      <li>
+        <p>
+          <b>B-G474E-DPOW1 Discovery Kit</b>.
+          Initial board support for the STMicro B-G474E-DPOW1 board from ST Micro was added in NuttX-9.1.  See the <a href="https://www.st.com/content/st_com/en/products/evaluation-tools/product-evaluation-tools/mcu-mpu-eval-tools/stm32-mcu-mpu-eval-tools/stm32-discovery-kits/b-g474e-dpow1.html" target="_blank">STMicro website</a> and the board <a href="https://github.com/apache/incubator-nuttx/blob/master/boards/arm/stm32/b-g474e-dpow1/README.txt" target="_blank">README</a> file for further information.
+        </p>
+      </li>
+    </ul>
+
+  <p><b>Status</b>:</p>
+  <ul>
+    <p>
+      <b>NuttX-9.1</b>.
+      Initial support for booting NuttX to a functional NSH prompt on this board.
     </p>
   </td>
 </tr>

--- a/Documentation/README.html
+++ b/Documentation/README.html
@@ -232,6 +232,8 @@ nuttx/
  |   |   |- stm32/
  |   |   |   |- axoloti/
  |   |   |   |   `- <a href="https://bitbucket.org/nuttx/nuttx/src/master/boards/arm/stm32/axoloti/README.txt" target="_blank"><b><i>README.txt</i></b></a>
+ |   |   |   |- b-g474e-dpow1/
+ |   |   |   |   `- <a href="https://bitbucket.org/nuttx/nuttx/src/master/boards/arm/stm32/b-g474e-dpow1/README.txt" target="_blank"><b><i>README.txt</i></b></a>
  |   |   |   |- clicker2-stm32/
  |   |   |   |   `- <a href="https://bitbucket.org/nuttx/nuttx/src/master/boards/arm/stm32/clicker2-stm32/README.txt" target="_blank"><b><i>README.txt</i></b></a>
  |   |   |   |- cloudctrl/

--- a/README.txt
+++ b/README.txt
@@ -2112,6 +2112,8 @@ nuttx/
  |   |   |- stm32/
  |   |   |   |- axoloti/
  |   |   |   |   `- README.txt
+ |   |   |   |- b-g474e-dpow1/
+ |   |   |   |   `- README.txt
  |   |   |   |- clicker2-stm32/
  |   |   |   |   `- README.txt
  |   |   |   |- cloudctrl/

--- a/boards/README.txt
+++ b/boards/README.txt
@@ -188,6 +188,10 @@ boards/arm/stm32/axoloti
   Support for the Axoloti synthesizer board based on the STMicro
   STM32F427IGH6 MCU.  See: http://www.axoloti.com/
 
+boards/arm/stm32/b-g474e-dpow1
+  Initial support for booting NuttX to a functional NSH prompt on the
+  STMicro B-G474E-DPOW1 Discovery kit with STM32G474RE MCU.
+
 boards/arm/stm32f0l0g0/b-l072z-lrwan1
   STMicro STM32L0 Discovery kit with LoRa/SigFox based on STM32L072CZ MCU.
 


### PR DESCRIPTION
## Summary

    Documentation/NuttX.html:
    Documentation/README.html:
    README.txt:
    boards/README.txt:

        Document initial support for the STM32G474 MCU and
        B-G474E-DPOW1 Discovery kit was added in NuttX-9.1.

## Impact

## Testing

Tested in web browser. Added links are working.
