### PR TITLE
Implement fseeko and ftello

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -158,8 +158,10 @@ FAR FILE *freopen(FAR const char *path, FAR const char *mode,
          FAR FILE *stream);
 int    fscanf(FAR FILE *stream, FAR const IPTR char *fmt, ...);
 int    fseek(FAR FILE *stream, long int offset, int whence);
+int    fseeko(FAR FILE *stream, off_t offset, int whence);
 int    fsetpos(FAR FILE *stream, FAR fpos_t *pos);
 long   ftell(FAR FILE *stream);
+off_t  ftello(FAR FILE *stream);
 size_t fwrite(FAR const void *ptr, size_t size, size_t n_items,
          FAR FILE *stream);
 ssize_t getdelim(FAR char **lineptr, size_t *n, int delimiter,

--- a/libs/libc/stdio/Make.defs
+++ b/libs/libc/stdio/Make.defs
@@ -51,7 +51,7 @@ endif
 ifneq ($(CONFIG_NFILE_STREAMS),0)
 
 CSRCS += lib_fopen.c lib_freopen.c lib_fclose.c lib_fread.c lib_libfread.c
-CSRCS += lib_fseek.c lib_ftell.c lib_fsetpos.c lib_getdelim.c lib_fgetpos.c
+CSRCS += lib_fseek.c lib_fseeko.c lib_ftell.c lib_ftello.c lib_fsetpos.c lib_getdelim.c lib_fgetpos.c
 CSRCS += lib_fgetc.c lib_fgets.c lib_gets_s.c lib_gets.c lib_libfgets.c
 CSRCS += lib_fwrite.c lib_libfwrite.c lib_fflush.c lib_libflushall.c
 CSRCS += lib_libfflush.c lib_rdflush.c lib_wrflush.c lib_fputc.c lib_puts.c

--- a/libs/libc/stdio/lib_fseeko.c
+++ b/libs/libc/stdio/lib_fseeko.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_fseeko.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int fseeko(FAR FILE *stream, off_t offset, int whence)
+{
+  return fseek(stream, offset, whence);
+}

--- a/libs/libc/stdio/lib_ftello.c
+++ b/libs/libc/stdio/lib_ftello.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_ftello.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+off_t ftello(FAR FILE *stream)
+{
+  return ftell(stream);
+}


### PR DESCRIPTION
## Summary
And declare chmod/fchmod/utimes
Please ignore the false alarm:
```
/home/xiaoxiang/nuttx/nuttx/include/stdlib.h:149:10: error: Mixed case identifier found
/home/xiaoxiang/nuttx/nuttx/libs/libc/stdlib/lib_Exit.c:31:5: error: Mixed case identifier found
```

## Impact

## Testing
