### PR TITLE
rewind: clear the error indicator

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -90,7 +90,6 @@
 #define putchar(c) fputc(c, stdout)
 #define getc(s)    fgetc(s)
 #define getchar()  fgetc(stdin)
-#define rewind(s)  ((void)fseek((s),0,SEEK_SET))
 
 /* Path to the directory where temporary files can be created */
 
@@ -168,6 +167,7 @@ ssize_t getdelim(FAR char **lineptr, size_t *n, int delimiter,
 ssize_t getline(FAR char **lineptr, size_t *n, FAR FILE *stream);
 FAR char *gets(FAR char *s);
 FAR char *gets_s(FAR char *s, rsize_t n);
+void   rewind(FAR FILE *stream);
 void   setbuf(FAR FILE *stream, FAR char *buf);
 int    setvbuf(FAR FILE *stream, FAR char *buffer, int mode, size_t size);
 int    ungetc(int c, FAR FILE *stream);

--- a/libs/libc/stdio/Make.defs
+++ b/libs/libc/stdio/Make.defs
@@ -59,8 +59,8 @@ CSRCS += lib_fputs.c lib_ungetc.c lib_vprintf.c lib_fprintf.c lib_vfprintf.c
 CSRCS += lib_stdinstream.c lib_stdoutstream.c lib_stdsistream.c
 CSRCS += lib_stdsostream.c lib_perror.c lib_feof.c lib_ferror.c
 CSRCS += lib_rawinstream.c lib_rawoutstream.c lib_rawsistream.c
-CSRCS += lib_rawsostream.c lib_remove.c lib_clearerr.c lib_scanf.c
-CSRCS += lib_vscanf.c lib_fscanf.c lib_vfscanf.c lib_tmpfile.c
+CSRCS += lib_rawsostream.c lib_remove.c lib_rewind.c lib_clearerr.c
+CSRCS += lib_scanf.c lib_vscanf.c lib_fscanf.c lib_vfscanf.c lib_tmpfile.c
 
 endif
 

--- a/libs/libc/stdio/lib_rewind.c
+++ b/libs/libc/stdio/lib_rewind.c
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_rewind.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+
+#include "libc.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: rewind
+ ****************************************************************************/
+
+void rewind(FAR FILE *stream)
+{
+  /* Verify that we were provided with a stream */
+
+  if (!stream)
+    {
+      set_errno(EBADF);
+      return;
+    }
+
+  lib_take_semaphore(stream);
+  (void) fseek(stream, 0L, SEEK_SET);
+  stream->fs_flags &= ~__FS_FLAG_ERROR;
+  lib_give_semaphore(stream);
+}


### PR DESCRIPTION
## Summary
Make rewind() clear the error indicator of the stream
as it's specified by the standards.

## Impact
apps relying on the old (wrong) behavior will break. it's quite unlikely though.

## Testing
tested with my local app.