### PR TITLE
 sim: fix compile error caused by race condition

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -280,7 +280,7 @@ board/libboard$(LIBEXT):
 nuttx-names.dat: nuttx-names.in
 	$(call PREPROCESS, $<, $@)
 
-nuttx.rel : libarch$(LIBEXT) board/libboard$(LIBEXT) nuttx-names.dat $(LINKOBJS)
+nuttx.rel: libarch$(LIBEXT) board/libboard$(LIBEXT) nuttx-names.dat $(LINKOBJS)
 	$(Q) echo "LD:  nuttx.rel"
 	$(Q) $(LD) -r $(LDLINKFLAGS) $(RELPATHS) $(EXTRA_LIBPATHS) -o $@ $(REQUIREDOBJS) $(LDSTARTGROUP) $(RELLIBS) $(EXTRA_LIBS) $(LDENDGROUP) $(LDUNEXPORTSYMBOLS)
 ifneq ($(HOSTOS),Darwin)
@@ -316,7 +316,8 @@ export_startup: board/libboard$(LIBEXT) up_head.o $(HOSTOBJS)
 depend: .depend
 
 cleanrel:
-	$(Q) rm -f nuttx.rel nuttx-names.dat
+	$(call DELFILE, nuttx-names.dat)
+	$(call DELFILE, nuttx.rel)
 
 clean: cleanrel
 	$(Q) if [ -e board/Makefile ]; then \


### PR DESCRIPTION
## Summary
 sim: fix compile error caused by race condition

```
LD: nuttx.rel
objcopy: couldn't open symbol redefinition file nuttx-names.dat (error: No such file or directory)
Makefile: 297: recipe for target 'nuttx.rel' failed
```

## Impact

## Testing
```
./tools/configure.sh sim/nsh
make -j16
```
