### PR TITLE
tools/mkdeps: correct dependencies export for source with subdir 

### DIFF
--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -732,7 +732,6 @@ static void do_dependency(const char *file)
     {
       char tmp[NAME_MAX + 6];
       char *dupname;
-      char *objname;
       char *dotptr;
       const char *expanded;
 
@@ -743,15 +742,14 @@ static void do_dependency(const char *file)
           exit(EXIT_FAILURE);
         }
 
-      objname = basename(dupname);
-      dotptr  = strrchr(objname, '.');
+      dotptr  = strrchr(dupname, '.');
       if (dotptr)
         {
           *dotptr = '\0';
         }
 
       snprintf(tmp, NAME_MAX + 6, " -MT %s%c%s%s ",
-               g_objpath, separator, objname, g_suffix);
+               g_objpath, separator, dupname, g_suffix);
       expanded = do_expand(tmp);
 
       cmdlen += strlen(expanded);


### PR DESCRIPTION
## Summary
tools/mkdeps: correct dependencies export for source with subdir 

Generated dependency will be invalid if the compile target with multi-directory level

## Impact

make dependence

Testing

## Testing
make a test file:

```
diff --git a/examples/hello/Makefile b/examples/hello/Makefile
index 96ba358..76ee850 100644
--- a/examples/hello/Makefile
+++ b/examples/hello/Makefile
@@ -42,6 +42,8 @@ PRIORITY  = $(CONFIG_EXAMPLES_HELLO_PRIORITY)
 STACKSIZE = $(CONFIG_EXAMPLES_HELLO_STACKSIZE)
 MODULE    = $(CONFIG_EXAMPLES_HELLO)
 
+CSRCS = testdir/test.c
+
 # Hello, World! Example
 
 MAINSRC = hello_main.c
```

```
apps/examples/hello$ ls testdir/
test.c
```

Check the Make.dep:

Before patch:

```
apps/examples/hello$ ls testdir/
test.c  test.home.archer.code.apps.examples.hello.o
```

```
apps/examples/hello$ cat Make.dep 
test.home.archer.code.apps.examples.hello.o: testdir/test.c \
 /usr/include/stdc-predef.h
```

After patch:

```
apps/examples/hello$ cat Make.dep 
testdir/test.home.archer.code.apps.examples.hello.o: testdir/test.c \
 /usr/include/stdc-predef.h
```
