### PR TITLE
libs: rv64: Fix _calc_imm() in arch_elf.c

### DIFF
--- a/libs/libc/machine/risc-v/rv64/arch_elf.c
+++ b/libs/libc/machine/risc-v/rv64/arch_elf.c
@@ -150,7 +150,7 @@ static void _calc_imm(long offset, long *imm_hi, long *imm_lo)
     {
       hi++;
     }
-  else if (r <= -2048)
+  else if (r < -2048)
     {
       hi--;
     }


### PR DESCRIPTION
## Summary

- I noticed that maix-bit:elf fails due to assertion

```
****************************************************************************
* Executing struct
****************************************************************************

up_assert: Assertion failed at file:machine/risc-v/rv64/arch_elf.c line: 163 task: init
```

- Finally, I found a bug in _calc_imm() which calculates immediate values when loading elf files.

## Impact

- This PR affects elf loading for RISCV-64.

## Testing

- I tested _calc_imm(long offset, ...) where the offset range is from -100000 to +100000.
- Also, I tested maix-bit:elf and maix-bit:posix_spawn with qemu.

