### PR TITLE
vpnkit: set mac address when available

### DIFF
--- a/arch/sim/src/sim/up_vpnkit.c
+++ b/arch/sim/src/sim/up_vpnkit.c
@@ -111,6 +111,7 @@ static int vpnkit_connect(void)
   INFO("Successfully negotiated with vpnkit");
   g_vpnkit_fd = fd;
   g_connect_warned = false;
+  netdriver_setmacaddr(g_vifinfo.mac);
   return 0;
 }
 
@@ -138,7 +139,6 @@ static void vpnkit_disconnect(void)
 void vpnkit_init(void)
 {
   vpnkit_connect();
-  netdriver_setmacaddr(g_vifinfo.mac);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
up_vpnkit network driver gets its mac address from the vpnkit.
it isn't available until a successful negotiation with the vpnkit.

## Impact

## Testing
locally tested on macos
