### PR TITLE
Implement WNOHANG for waitpid and waitid

### DIFF
--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -311,6 +311,22 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
         }
 #endif
 
+      if ((options & WNOHANG) != 0)
+        {
+          /* SUSv4 says:
+           *
+           * "If waitid() returns because WNOHANG was specified and status
+           * is not available for any process specified by idtype and id,
+           * then the si_signo and si_pid members of the structure pointed
+           * to by infop shall be set to zero and the values of other
+           * members of the structure are unspecified."
+           */
+
+          info->si_signo = 0;
+          info->si_pid = 0;
+          break;
+        }
+
       /* Wait for any death-of-child signal */
 
       ret = nxsig_waitinfo(&set, info);

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -390,6 +390,12 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
 #endif /* CONFIG_SCHED_CHILD_STATUS */
 
+      if ((options & WNOHANG) != 0)
+        {
+          pid = 0;
+          break;
+        }
+
       /* Wait for any death-of-child signal */
 
       ret = nxsig_waitinfo(&set, &info);


### PR DESCRIPTION
## Summary
Implement WNOHANG for
* (CONFIG_SCHED_HAVE_PARENT=y version of) waitpid
* waitid

## Impact

## Testing
waitpid is tested with my local app.
waitid is build-tested only.
