### PR TITLE
[Backport-1300] libs: rv64: Fix _calc_imm() in arch_elf.c 

### DIFF
--- a/libs/libc/machine/risc-v/rv64/arch_elf.c
+++ b/libs/libc/machine/risc-v/rv64/arch_elf.c
@@ -150,7 +150,7 @@ static void _calc_imm(long offset, long *imm_hi, long *imm_lo)
     {
       hi++;
     }
-  else if (r <= -2048)
+  else if (r < -2048)
     {
       hi--;
     }


### PR DESCRIPTION
## Summary
This is a backport of #1300 that affects elf loading for RISCV-64.