### PR TITLE
libc: sysconf support _SC_NPROCESSORS_CONF/_SC_NPROCESSORS_ONLN

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -255,6 +255,9 @@
 #define _SC_XOPEN_UNIX                   0x0079
 #define _SC_XOPEN_VERSION                0x007a
 
+#define _SC_NPROCESSORS_CONF             0x007b
+#define _SC_NPROCESSORS_ONLN             0x007c
+
 /* The following symbolic constants must be defined for file streams: */
 
 #define STDERR_FILENO                    2       /* File number of stderr */

--- a/libs/libc/unistd/lib_sysconf.c
+++ b/libs/libc/unistd/lib_sysconf.c
@@ -233,6 +233,14 @@ long sysconf(int name)
         return 0;
 #endif
 
+      case _SC_NPROCESSORS_CONF:
+      case _SC_NPROCESSORS_ONLN:
+#ifdef CONFIG_SMP_NCPUS
+        return CONFIG_SMP_NCPUS;
+#else
+        return 1;
+#endif
+
       default:
 #if 0 /* Assume valid but not implemented for the time being */
         errcode = EINVAL;


### PR DESCRIPTION
## Summary
sysconf: Add support for _SC_NPROCESSORS_CONF/_SC_NPROCESSORS_ONLN
(https://www.man7.org/linux/man-pages/man3/sysconf.3.html)
## Impact

## Testing

