### PR TITLE
libc: Move double_t typedef from sys/types.h to math.h

### DIFF
--- a/include/cxx/cmath
+++ b/include/cxx/cmath
@@ -51,6 +51,10 @@
 
 namespace std
 {
+  using ::float32;
+  using ::double_t;
+  using ::float64;
+
 #ifdef CONFIG_HAVE_FLOAT
   using ::acosf;
   using ::asinf;

--- a/include/cxx/cstddef
+++ b/include/cxx/cstddef
@@ -53,14 +53,6 @@ namespace std
 {
   // Standard types
 
-  using ::float32;
-#ifndef CONFIG_HAVE_DOUBLE
-  using ::double_t;
-  using ::float64;
-#else
-  using ::double_t;
-  using ::float64;
-#endif
   using ::mode_t;
   using ::size_t;
   using ::ssize_t;

--- a/include/nuttx/lib/math.h
+++ b/include/nuttx/lib/math.h
@@ -125,6 +125,21 @@
 #define M_PI_2_F   ((float)M_PI_2)
 
 /****************************************************************************
+ * Type Declarations
+ ****************************************************************************/
+
+/* Floating point types */
+
+typedef float        float32;
+#ifndef CONFIG_HAVE_DOUBLE
+typedef float        double_t;
+typedef float        float64;
+#else
+typedef double       double_t;
+typedef double       float64;
+#endif
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -1,7 +1,8 @@
 /****************************************************************************
  * include/sys/types.h
  *
- *   Copyright (C) 2007-2009, 2011-2012, 2014-2015 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2011-2012, 2014-2015 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -104,17 +105,6 @@
 
 #ifndef __ASSEMBLY__
 
-/* Floating point types */
-
-typedef float        float32;
-#ifndef CONFIG_HAVE_DOUBLE
-typedef float        double_t;
-typedef float        float64;
-#else
-typedef double       double_t;
-typedef double       float64;
-#endif
-
 /* Misc. scalar types */
 
 /* mode_t is an integer type used for file attributes.  mode_t needs
@@ -165,8 +155,8 @@ typedef uint16_t     ino_t;
 
 typedef uint16_t     nlink_t;
 
-/* pid_t is used for process IDs and process group IDs. It must be signed because
- * negative PID values are used to represent invalid PIDs.
+/* pid_t is used for process IDs and process group IDs. It must be signed
+ * because negative PID values are used to represent invalid PIDs.
  */
 
 typedef int16_t      pid_t;
@@ -177,9 +167,9 @@ typedef int16_t      pid_t;
 
 typedef int16_t      id_t;
 
-/* Unix requires a key of type key_t defined in file sys/types.h for requesting
- * resources such as shared memory segments, message queues and semaphores. A key
- * is simply an integer of type key_t
+/* Unix requires a key of type key_t defined in file sys/types.h for
+ * requesting resources such as shared memory segments, message queues and
+ * semaphores. A key is simply an integer of type key_t
  */
 
 typedef int16_t      key_t;

--- a/libs/libc/stdio/legacy_dtoa.c
+++ b/libs/libc/stdio/legacy_dtoa.c
@@ -45,6 +45,7 @@
 
 #include <nuttx/config.h>
 
+#include <math.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -132,7 +133,8 @@ typedef struct bigint_s bigint_t;
  * Options:
  *
  * 1. Allocate on stack.  g_freelist is rather large, however.. around 275
- *    bytes (it could be shrunk a little by using stdint types instead of int.
+ *    bytes (it could be shrunk a little by using stdint types instead of
+ *    int.
  * 2. Semaphore protect the global variables and handle interrupt level
  *    calls as a special case (perhaps refusing them?  Or having a duplicate
  *    set of variables, one for tasks and one for interrupt usage)
@@ -236,6 +238,7 @@ static FAR bigint_t *multadd(FAR bigint_t *b, int m, int a)
           bfree(b);
           b  = b1;
         }
+
       b->x[wds++] = a;
       b->wds      = wds;
     }
@@ -478,11 +481,11 @@ static FAR bigint_t *pow5mult(FAR bigint_t *b, int k)
   FAR bigint_t *b1;
   FAR bigint_t *p5;
   FAR bigint_t *p51;
+  int i;
   static int p05[3] =
   {
     5, 25, 125
   };
-  int i;
 
   if ((i = k & 3) != 0)
     {
@@ -631,14 +634,14 @@ static int cmp(FAR bigint_t *a, FAR bigint_t *b)
 
 #ifdef CONFIG_DEBUG_LIB
   if (i > 1 && a->x[i - 1] == 0)
-   {
-    lerr("ERROR: cmp called with a->x[a->wds-1] == 0\n");
-   }
+    {
+      lerr("ERROR: cmp called with a->x[a->wds-1] == 0\n");
+    }
 
   if (j > 1 && b->x[j - 1] == 0)
-   {
-    lerr("ERROR: cmp called with b->x[b->wds-1] == 0\n");
-   }
+    {
+      lerr("ERROR: cmp called with b->x[b->wds-1] == 0\n");
+    }
 #endif
 
   if (i -= j)
@@ -827,21 +830,23 @@ static FAR bigint_t *d2b(double_t d, int *e, int *bits)
   if ((y = WORD1(d)) != 0)
     {
       if ((k = lo0bits(&y)) != 0)
-        if (k >= 16)
-          {
-            x[0] = y | ((z << (32 - k)) & 0xffff);
-            x[1] = z >> (k - 16) & 0xffff;
-            x[2] = z >> k;
-            i    = 2;
-          }
-        else
-          {
-            x[0] = y & 0xffff;
-            x[1] = (y >> 16) | ((z << (16 - k)) & 0xffff);
-            x[2] = z >> k & 0xffff;
-            x[3] = z >> (k + 16);
-            i    = 3;
-          }
+        {
+          if (k >= 16)
+            {
+              x[0] = y | ((z << (32 - k)) & 0xffff);
+              x[1] = z >> (k - 16) & 0xffff;
+              x[2] = z >> k;
+              i    = 2;
+            }
+          else
+            {
+              x[0] = y & 0xffff;
+              x[1] = (y >> 16) | ((z << (16 - k)) & 0xffff);
+              x[2] = z >> k & 0xffff;
+              x[3] = z >> (k + 16);
+              i    = 3;
+            }
+        }
       else
         {
           x[0] = y & 0xffff;
@@ -859,6 +864,7 @@ static FAR bigint_t *d2b(double_t d, int *e, int *bits)
           lerr("ERROR: Zero passed to d2b\n");
         }
 #endif
+
       k = lo0bits(&z);
       if (k >= 16)
         {
@@ -1550,6 +1556,7 @@ fast_failed:
               d += ds;
             }
 #endif
+
           *st++ = '0' + (int)l;
           if (i == ilim)
             {
@@ -1760,8 +1767,8 @@ one_digit:
           mhi = lshift(mhi, m2);
         }
 
-      /* Compute mlo -- check for special case that d is a normalized power of
-       * 2.
+      /* Compute mlo -- check for special case that d is a normalized power
+       * of 2.
        */
 
       mlo = mhi;
@@ -1776,7 +1783,7 @@ one_digit:
         {
           dig = quorem(b, s) + '0';
 
-          /* Do we yet have the shortest decimal string that will round to d? */
+          /* Have we yet the shortest decimal string that will round to d? */
 
           j     = cmp(b, mlo);
           delta = diff(s, mhi);
@@ -1799,6 +1806,7 @@ one_digit:
               goto ret;
             }
 #endif
+
           if (j < 0 || (j == 0 && !mode
 #ifndef CONFIG_DTOA_ROUND_BIASED
               && ((WORD1(d) & 1) == 0)

--- a/libs/libc/stdio/legacy_libvsprintf.c
+++ b/libs/libc/stdio/legacy_libvsprintf.c
@@ -39,7 +39,7 @@
 
 #include <nuttx/compiler.h>
 
-#include <sys/types.h>
+#include <math.h>
 #include <wchar.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -100,7 +100,7 @@
  * string data cannot be accessed by simply de-referencing the format string
  * pointer.  This might be in the case in Harvard architectures where string
  * data might be stored in instruction space or if string data were stored
- * on some media like EEPROM or external serial FLASH.  In all of these cases,
+ * on some media like EEPROM or external serial FLASH. In all of these cases,
  * string data has to be accessed indirectly using the architecture-supplied
  * up_romgetc().  The following mechanisms attempt to make these different
  * access methods indistinguishable in the following code.
@@ -177,11 +177,14 @@ static int  getlusize(uint8_t fmt, FAR uint16_t flags, unsigned long ln);
 /* Unsigned long long int to ASCII conversions */
 
 #if defined(CONFIG_HAVE_LONG_LONG) && defined(CONFIG_LIBC_LONG_LONG)
-static void llutodec(FAR struct lib_outstream_s *obj, unsigned long long lln);
-static void llutohex(FAR struct lib_outstream_s *obj, unsigned long long lln,
-                     uint8_t a);
-static void llutooct(FAR struct lib_outstream_s *obj, unsigned long long lln);
-static void llutobin(FAR struct lib_outstream_s *obj, unsigned long long lln);
+static void llutodec(FAR struct lib_outstream_s *obj,
+                     unsigned long long lln);
+static void llutohex(FAR struct lib_outstream_s *obj,
+                     unsigned long long lln, uint8_t a);
+static void llutooct(FAR struct lib_outstream_s *obj,
+                     unsigned long long lln);
+static void llutobin(FAR struct lib_outstream_s *obj,
+                     unsigned long long lln);
 static void llutoascii(FAR struct lib_outstream_s *obj, uint8_t fmt,
                        uint16_t flags, unsigned long long lln);
 static void llfixup(uint8_t fmt, FAR uint16_t *flags, FAR long long *lln);
@@ -220,12 +223,12 @@ static const char g_nullstring[] = "(null)";
 static void ptohex(FAR struct lib_outstream_s *obj, uint16_t flags,
                    FAR void *p)
 {
+  uint8_t bits;
   union
   {
     uint32_t  dw;
     FAR void *p;
   } u;
-  uint8_t bits;
 
   /* Check for alternate form */
 
@@ -1210,22 +1213,22 @@ int lib_vsprintf(FAR struct lib_outstream_s *obj, FAR const IPTR char *src,
 
       if (FMT_CHAR != '%')
         {
-           /* Output the character */
+          /* Output the character */
 
-           obj->put(obj, FMT_CHAR);
+          obj->put(obj, FMT_CHAR);
 
-           /* Flush the buffer if a newline is encountered */
+          /* Flush the buffer if a newline is encountered */
 
-           if (FMT_CHAR == '\n')
-             {
-               /* Should return an error on a failure to flush */
+          if (FMT_CHAR == '\n')
+            {
+              /* Should return an error on a failure to flush */
 
-               obj->flush(obj);
-             }
+              obj->flush(obj);
+            }
 
-           /* Process the next character in the format */
+          /* Process the next character in the format */
 
-           continue;
+          continue;
         }
 
       /* We have found a format specifier. Move past it. */
@@ -1263,6 +1266,7 @@ int lib_vsprintf(FAR struct lib_outstream_s *obj, FAR const IPTR char *src,
             {
               justify = FMT_RJUST0;
             }
+
 #if 0
           /* Center justification. */
 

--- a/libs/libc/stdio/lib_dtoa_engine.h
+++ b/libs/libc/stdio/lib_dtoa_engine.h
@@ -40,11 +40,9 @@
  * Included Files
  ****************************************************************************/
 
-#include <sys/types.h>
+#include <math.h>
 #include <stdint.h>
 #include <float.h>
-
-#include <nuttx/lib/float.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -41,9 +41,7 @@
 
 #include <nuttx/compiler.h>
 
-#include <sys/types.h>
-
-#include <sys/types.h>
+#include <math.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/libs/libc/stdlib/lib_srand.c
+++ b/libs/libc/stdlib/lib_srand.c
@@ -39,7 +39,7 @@
 
 #include <nuttx/config.h>
 
-#include <sys/types.h>
+#include <math.h>
 #include <stdlib.h>
 
 #include <nuttx/lib/lib.h>
@@ -120,9 +120,9 @@ static inline unsigned long fgenerate1(void)
 {
   unsigned long randint;
 
-  /* First order congruential generator.  One may be added to the result of the
-   * generated value to avoid the value zero.  This would be fatal for the
-   * first order random number generator.
+  /* First order congruential generator.  One may be added to the result of
+   * the generated value to avoid the value zero.  This would be fatal for
+   * the first order random number generator.
    */
 
   randint    = (RND1_CONSTK * g_randint1) % RND1_CONSTP;
@@ -158,8 +158,8 @@ static inline unsigned long fgenerate2(void)
   g_randint2 = g_randint1;
   g_randint1 = randint;
 
-  /* We cannot permit both values to become zero.  That would be fatal for the
-   * second order random number generator.
+  /* We cannot permit both values to become zero.  That would be fatal for
+   * the second order random number generator.
    */
 
   if (g_randint2 == 0 && g_randint1 == 0)
@@ -200,8 +200,8 @@ static inline unsigned long fgenerate3(void)
   g_randint2 = g_randint1;
   g_randint1 = randint;
 
-  /* We cannot permit all three values to become zero.  That would be fatal for the
-   * third order random number generator.
+  /* We cannot permit all three values to become zero.  That would be fatal
+   * for the third order random number generator.
    */
 
   if (g_randint3 == 0 && g_randint2 == 0 && g_randint1 == 0)


### PR DESCRIPTION
specified here:
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/math.h.html

## Summary
The change make:
1.More confirm to the standard
2.Avoid the confliction with the 3rd party math library

## Impact
No functionality change

## Testing
Please ignore the nxstyle false alarm:
```
libs/libc/stdio/legacy_libvsprintf.c:215:3: warning: #include outside of 'Included Files' section
```