### PR TITLE
libc: Replace nuttx/lib/math.h with math.h

### DIFF
--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -43,6 +43,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <fcntl.h>
@@ -62,7 +63,6 @@
 #include <nuttx/audio/i2s.h>
 #include <nuttx/audio/audio.h>
 #include <nuttx/audio/cs43l22.h>
-#include <nuttx/lib/math.h>
 
 #include "cs43l22.h"
 

--- a/drivers/audio/vs1053.c
+++ b/drivers/audio/vs1053.c
@@ -44,6 +44,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 
+#include <math.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -60,7 +61,6 @@
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/audio/audio.h>
 #include <nuttx/audio/vs1053.h>
-#include <nuttx/lib/math.h>
 
 #include "vs1053.h"
 

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -50,6 +50,7 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <fcntl.h>
@@ -71,7 +72,6 @@
 #include <nuttx/audio/i2s.h>
 #include <nuttx/audio/audio.h>
 #include <nuttx/audio/wm8904.h>
-#include <nuttx/lib/math.h>
 
 #include "wm8904.h"
 


### PR DESCRIPTION
Because user may replace math library with other implementation

## Summary

## Impact
No funtionality change.

## Testing

