### PR TITLE
cxx: Remove CONFIG_NET guard from [get|set]hostname

### DIFF
--- a/include/cxx/cunistd
+++ b/include/cxx/cunistd
@@ -122,10 +122,8 @@ namespace std
 
   // Networking
 
-#ifdef CONFIG_NET
   using ::gethostname;
   using ::sethostname;
-#endif
 }
 
 #endif // __INCLUDE_CXX_CUNISTD


### PR DESCRIPTION
since these two functions is always implemented now

## Summary

## Impact
No functionality change

## Testing

