### PR TITLE
sched/task: unify task initialization

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -117,7 +117,7 @@ int exec_module(FAR const struct binary_s *binp)
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
   save_addrenv_t oldenv;
 #endif
-  FAR uint32_t *stack;
+  FAR void *stack;
   pid_t pid;
   int ret;
 
@@ -157,7 +157,7 @@ int exec_module(FAR const struct binary_s *binp)
    * will need to change if/when we want to support dynamic stack allocation.
    */
 
-  stack = (FAR uint32_t *)kumm_malloc(binp->stacksize);
+  stack = kumm_malloc(binp->stacksize);
   if (!stack)
     {
       ret = -ENOMEM;

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -964,7 +964,7 @@ FAR struct socketlist *nxsched_get_sockets(void);
  ********************************************************************************/
 
 int nxtask_init(FAR struct tcb_s *tcb, const char *name, int priority,
-                FAR uint32_t *stack, uint32_t stack_size, main_t entry,
+                FAR void *stack, uint32_t stack_size, main_t entry,
                 FAR char * const argv[]);
 
 /********************************************************************************

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -72,92 +72,41 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
                            int priority, int stack_size, main_t entry,
                            FAR char * const argv[])
 {
-  FAR struct task_tcb_s *tcb;
+  FAR struct tcb_s *tcb;
   pid_t pid;
   int ret;
 
   /* Allocate a TCB for the new task. */
 
-  tcb = (FAR struct task_tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
+  tcb = (FAR struct tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
   if (!tcb)
     {
       serr("ERROR: Failed to allocate TCB\n");
       return -ENOMEM;
     }
 
-  /* Allocate a new task group with privileges appropriate for the parent
-   * thread type.
-   */
+  /* Setup the task type */
 
-  ret = group_allocate(tcb, ttype);
-  if (ret < 0)
-    {
-      goto errout_with_tcb;
-    }
+  tcb->flags = ttype;
 
-#if 0 /* No... there are side effects */
-  /* Associate file descriptors with the new task.  Exclude kernel threads;
-   * kernel threads do not have file or socket descriptors.  They must use
-   * SYSLOG for output and the low-level psock interfaces for network I/O.
-   */
+  /* Initialize the task */
 
-  if (ttype != TCB_FLAG_TTYPE_KERNEL)
-#endif
-    {
-      ret = group_setuptaskfiles(tcb);
-      if (ret < OK)
-        {
-          goto errout_with_tcb;
-        }
-    }
-
-  /* Allocate the stack for the TCB */
-
-  ret = up_create_stack((FAR struct tcb_s *)tcb, stack_size, ttype);
+  ret = nxtask_init(tcb, name, priority, NULL, stack_size, entry, argv);
   if (ret < OK)
     {
-      goto errout_with_tcb;
-    }
-
-  /* Initialize the task control block */
-
-  ret = nxtask_setup_scheduler(tcb, priority, nxtask_start, entry, ttype);
-  if (ret < OK)
-    {
-      goto errout_with_tcb;
-    }
-
-  /* Setup to pass parameters to the new task */
-
-  nxtask_setup_arguments(tcb, name, argv);
-
-  /* Now we have enough in place that we can join the group */
-
-  ret = group_initialize(tcb);
-  if (ret < 0)
-    {
-      goto errout_with_active;
+      kmm_free(tcb);
+      return ret;
     }
 
   /* Get the assigned pid before we start the task */
 
-  pid = (int)tcb->cmn.pid;
+  pid = tcb->pid;
 
   /* Activate the task */
 
-  nxtask_activate((FAR struct tcb_s *)tcb);
-  return pid;
+  nxtask_activate(tcb);
 
-errout_with_active:
-  /* The TCB was added to the inactive task list by
-   * nxtask_setup_scheduler().
-   */
-
-  dq_rem((FAR dq_entry_t *)tcb, (FAR dq_queue_t *)&g_inactivetasks);
-
-errout_with_tcb:
-  nxsched_release_tcb((FAR struct tcb_s *)tcb, ttype);
-  return ret;
+  return (int)pid;
 }
 
 /****************************************************************************

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -83,7 +83,7 @@
  ****************************************************************************/
 
 int nxtask_init(FAR struct tcb_s *tcb, const char *name, int priority,
-                FAR uint32_t *stack, uint32_t stack_size,
+                FAR void *stack, uint32_t stack_size,
                 main_t entry, FAR char * const argv[])
 {
   FAR struct task_tcb_s *ttcb = (FAR struct task_tcb_s *)tcb;


### PR DESCRIPTION
## Summary
1. sched/task: unify task initialization 
`    nxthread_create() Reduce code duplication`
`    nxtask_init(): support stack allocation from internal`

2. sched/task_init: change the stack pointer type to (void *)
`    change the stack pointer type from (uint32_t *) to (void *)`

3. binfmt/exec: allocate stack from internal
`    Implement of nxtask_init() support stack allocation from internal`


## Impact
nxthread_create()
nxtask_init()
exec_module()

## Testing
./tools/configure.sh sim/loadable
./tools/configure.sh sim/nsh
