### PR TITLE
nxsched_release_tcb: Should release stack in kernel build too

### DIFF
--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -134,22 +134,7 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
       if (tcb->stack_alloc_ptr &&
           (tcb->flags & TCB_FLAG_CUSTOM_STACK) == 0)
         {
-#ifdef CONFIG_BUILD_KERNEL
-          /* If the exiting thread is not a kernel thread, then it has an
-           * address environment.  Don't bother to release the stack memory
-           * in this case... There is no point since the memory lies in the
-           * user memory region that will be destroyed anyway (and the
-           * address environment has probably already been destroyed at
-           * this point.. so we would crash if we even tried it).  But if
-           * this is a privileged group, when we still have to release the
-           * memory using the kernel allocator.
-           */
-
-          if ((tcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
-#endif
-            {
-              up_release_stack(tcb, ttype);
-            }
+          up_release_stack(tcb, ttype);
         }
 
 #ifdef CONFIG_PIC


### PR DESCRIPTION
otherwise the memory can't be reused util the process exit

## Summary
Avoid the memory leak in the kernel mode

## Impact
Only impact the kernel mode

## Testing

