### PR TITLE
Revert "sched/sched_releasetcb.c:  Handle custom stack allocations.

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -103,10 +103,9 @@
 #  define TCB_FLAG_SCHED_SPORADIC  (2 << TCB_FLAG_POLICY_SHIFT)  /* Sporadic scheding policy */
 #  define TCB_FLAG_SCHED_OTHER     (3 << TCB_FLAG_POLICY_SHIFT)  /* Other scheding policy */
 #define TCB_FLAG_CPU_LOCKED        (1 << 7)                      /* Bit 7: Locked to this CPU */
-#define TCB_FLAG_CUSTOM_STACK      (1 << 8)                      /* Bit 8: Thread uses a custom stack */
-#define TCB_FLAG_SIGNAL_ACTION     (1 << 9)                      /* Bit 9: In a signal handler */
-#define TCB_FLAG_SYSCALL           (1 << 10)                     /* Bit 10: In a system call */
-#define TCB_FLAG_EXIT_PROCESSING   (1 << 11)                     /* Bit 11: Exitting */
+#define TCB_FLAG_SIGNAL_ACTION     (1 << 8)                      /* Bit 8: In a signal handler */
+#define TCB_FLAG_SYSCALL           (1 << 9)                      /* Bit 9: In a system call */
+#define TCB_FLAG_EXIT_PROCESSING   (1 << 10)                     /* Bit 10: Exitting */
                                                                  /* Bits 11-15: Available */
 
 /* Values for struct task_group tg_flags */
@@ -939,9 +938,6 @@ FAR struct socketlist *nxsched_get_sockets(void);
  *   nature of the created task.  For example:
  *
  *     - Task type may be set in the TCB flags to create kernel thread
- *     - If a custom stack is used, i.e., one allocated, managed, and freed
- *       by the caller, then TCB_FLAG_CUSTOM_STACK should be set in the
- *       TCB flags.
  *
  * Input Parameters:
  *   tcb        - Address of the new task's TCB
@@ -977,8 +973,6 @@ int nxtask_init(FAR struct tcb_s *tcb, const char *name, int priority,
  *   was when a subsequent call to task_activate fails.
  *
  *   Caution:  Freeing of the TCB itself might be an unexpected side-effect.
- *   The stack will also be freed UNLESS TCB_FLAG_CUSTOM_STACK was set in
- *   in the tcb->flags field when nxtask_init() was called.
  *
  * Input Parameters:
  *   tcb - Address of the TCB initialized by task_init()

--- a/sched/sched/sched_releasetcb.c
+++ b/sched/sched/sched_releasetcb.c
@@ -127,12 +127,9 @@ int nxsched_release_tcb(FAR struct tcb_s *tcb, uint8_t ttype)
           nxsched_releasepid(tcb->pid);
         }
 
-      /* Delete the thread's stack if one has been allocated and it is
-       * not some custom stack managed by the caller.
-       */
+      /* Delete the thread's stack if one has been allocated */
 
-      if (tcb->stack_alloc_ptr &&
-          (tcb->flags & TCB_FLAG_CUSTOM_STACK) == 0)
+      if (tcb->stack_alloc_ptr)
         {
           up_release_stack(tcb, ttype);
         }

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -58,9 +58,6 @@
  *   nature of the created task.  For example:
  *
  *     - Task type may be set in the TCB flags to create kernel thread
- *     - If a custom stack is used, i.e., one allocated, managed, and freed
- *       by the caller, then TCB_FLAG_CUSTOM_STACK should be set in the
- *       TCB flags.
  *
  * Input Parameters:
  *   tcb        - Address of the new task's TCB
@@ -156,8 +153,6 @@ errout:
  *   was when a subsequent call to task_activate fails.
  *
  *   Caution:  Freeing of the TCB itself might be an unexpected side-effect.
- *   The stack will also be freed UNLESS TCB_FLAG_CUSTOM_STACK was set in
- *   in the tcb->flags field when nxtask_init() was called.
  *
  * Input Parameters:
  *   tcb - Address of the TCB initialized by task_init()


### PR DESCRIPTION
## Summary
Since up_release_stack auto detect whether the memory come from builtin heap
```
if (ttype == TCB_FLAG_TTYPE_KERNEL)
  {
    if (kmm_heapmember(dtcb->stack_alloc_ptr))
      {
        kmm_free(dtcb->stack_alloc_ptr);
      }
  }
else
  {
    /* Use the user-space allocator if this is a task or pthread */
    if (umm_heapmember(dtcb->stack_alloc_ptr))
      {
        kumm_free(dtcb->stack_alloc_ptr);
      }
  }
```

## Impact
No since nobody set TCB_FLAG_CUSTOM_STACK yet.

## Testing

