### PR TITLE
net/sockopt: change the socket option style from Linux to BSD 

### DIFF
--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -375,11 +375,11 @@ int psock_getsockopt(FAR struct socket *psock, int level, int option,
 
   switch (level)
     {
-      case SOL_SOCKET: /* Socket-level options (see include/sys/socket.h) */
+      case SOL_SOCKET:   /* Socket-level options (see include/sys/socket.h) */
        ret = psock_socketlevel_option(psock, option, value, value_len);
        break;
 
-      case SOL_TCP:    /* TCP protocol socket options (see include/netinet/tcp.h) */
+      case IPPROTO_TCP:  /* TCP protocol socket options (see include/netinet/tcp.h) */
 #ifdef CONFIG_NET_TCPPROTO_OPTIONS
        ret = tcp_getsockopt(psock, option, value, value_len);
        break;
@@ -395,13 +395,13 @@ int psock_getsockopt(FAR struct socket *psock, int level, int option,
        * implemented.
        */
 
-      case SOL_IP:     /* TCP protocol socket options (see include/netinet/ip.h) */
-      case SOL_IPV6:   /* TCP protocol socket options (see include/netinet/ip6.h) */
-      case SOL_UDP:    /* TCP protocol socket options (see include/netinit/udp.h) */
+      case IPPROTO_IP:   /* TCP protocol socket options (see include/netinet/ip.h) */
+      case IPPROTO_IPV6: /* TCP protocol socket options (see include/netinet/ip6.h) */
+      case IPPROTO_UDP:  /* TCP protocol socket options (see include/netinit/udp.h) */
         ret = -ENOSYS;
        break;
 
-      default:         /* The provided level is invalid */
+      default:           /* The provided level is invalid */
         ret = -EINVAL;
        break;
     }

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -399,26 +399,26 @@ int psock_setsockopt(FAR struct socket *psock, int level, int option,
         ret = psock_socketlevel_option(psock, option, value, value_len);
         break;
 
-      case SOL_TCP:    /* TCP protocol socket options (see include/netinet/tcp.h) */
+      case IPPROTO_TCP:/* TCP protocol socket options (see include/netinet/tcp.h) */
 #ifdef CONFIG_NET_TCPPROTO_OPTIONS
         ret = tcp_setsockopt(psock, option, value, value_len);
         break;
 #endif
 
-      case SOL_UDP:    /* UDP protocol socket options (see include/netinet/udp.h) */
+      case IPPROTO_UDP:/* UDP protocol socket options (see include/netinet/udp.h) */
 #ifdef CONFIG_NET_UDPPROTO_OPTIONS
         ret = udp_setsockopt(psock, option, value, value_len);
         break;
 #endif
 
 #ifdef CONFIG_NET_IPv4
-      case SOL_IP:     /* TCP protocol socket options (see include/netinet/in.h) */
+      case IPPROTO_IP:/* TCP protocol socket options (see include/netinet/in.h) */
         ret = ipv4_setsockopt(psock, option, value, value_len);
         break;
 #endif
 
 #ifdef CONFIG_NET_IPv6
-      case SOL_IPV6:   /* TCP protocol socket options (see include/netinet/in.h) */
+      case IPPROTO_IPV6:/* TCP protocol socket options (see include/netinet/in.h) */
         ret = ipv6_setsockopt(psock, option, value, value_len);
         break;
 #endif


### PR DESCRIPTION
## Summary

net/sockopt: change the socket option style from Linux to BSD 

```
Linux Programmer's Manual
...
IP(7)
...
NOTES
...
    Using the SOL_IP socket options level isn't portable;
    BSD-based stacks use the IPPROTO_IP level.
```
## Impact

https://github.com/apache/incubator-nuttx/pull/1291
https://github.com/apache/incubator-nuttx-apps/pull/311

## Testing
CI check is enough.
