### PR TITLE
libc: Refine the inline handling

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -62,7 +62,7 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isspace(int c)
 {
   return c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
@@ -83,7 +83,7 @@ static inline int isspace(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isascii(int c)
 {
   return c >= 0 && c <= 0x7f;
@@ -100,7 +100,7 @@ static inline int isascii(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isprint(int c)
 {
   return c >= 0x20 && c < 0x7f;
@@ -117,7 +117,7 @@ static inline int isprint(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isgraph(int c)
 {
   return c > 0x20 && c < 0x7f;
@@ -134,7 +134,7 @@ static inline int isgraph(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int iscntrl(int c)
 {
   return !isprint(c);
@@ -151,7 +151,7 @@ static inline int iscntrl(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int islower(int c)
 {
   return c >= 'a' && c <= 'z';
@@ -168,7 +168,7 @@ static inline int islower(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isupper(int c)
 {
   return c >= 'A' && c <= 'Z';
@@ -185,7 +185,7 @@ static inline int isupper(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isalpha(int c)
 {
   return islower(c) || isupper(c);
@@ -202,7 +202,7 @@ static inline int isalpha(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isblank(int c)
 {
   return c == ' ' || c == '\t';
@@ -219,7 +219,7 @@ static inline int isblank(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isdigit(int c)
 {
   return c >= '0' && c <= '9';
@@ -236,7 +236,7 @@ static inline int isdigit(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isalnum(int c)
 {
   return isalpha(c) || isdigit(c);
@@ -254,7 +254,7 @@ static inline int isalnum(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int ispunct(int c)
 {
   return isgraph(c) && !isalnum(c);
@@ -271,7 +271,7 @@ static inline int ispunct(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int isxdigit(int c)
 {
   return (c >= '0' && c <= '9') ||
@@ -293,7 +293,7 @@ static inline int isxdigit(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int toupper(int c)
 {
   return (c >= 'a' && c <= 'z') ? c - 'a' + 'A' : c;
@@ -311,7 +311,7 @@ static inline int toupper(int c)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_HAVE_INLINE
+#ifdef __cplusplus
 static inline int tolower(int c)
 {
   return (c >= 'A' && c <= 'Z') ? (c - 'A' + 'a') : c;

--- a/include/cxx/cstring
+++ b/include/cxx/cstring
@@ -88,11 +88,6 @@ namespace std
 
   // Declared in legacy strings.h
 
-  using ::bcmp;
-  using ::bcopy;
-  using ::bzero;
-  using ::index;
-  using ::rindex;
   using ::ffs;
   using ::strcasecmp;
   using ::strncasecmp;

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -255,15 +255,6 @@
 #  undef  CONFIG_PTR_IS_NOT_INT
 #endif
 
-/* GCC supports inlined functions for C++ and for C version C99 and above */
-
-#  if defined(__cplusplus) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
-#    define CONFIG_HAVE_INLINE 1
-#  else
-#    undef CONFIG_HAVE_INLINE
-#    define inline
-#  endif
-
 /* ISO C11 supports anonymous (unnamed) structures and unions, added in
  * GCC 4.6 (but might be suppressed with -std= option).  ISO C++11 also
  * adds un-named unions, but NOT unnamed structures (although compilers
@@ -422,10 +413,6 @@
 #  define CONFIG_PTR_IS_NOT_INT 1
 #endif
 
-/* New versions of SDCC supports inline function */
-
-#  define CONFIG_HAVE_INLINE 1
-
 /* SDCC does types long long and float, but not types double and long
  * double.
  */
@@ -543,11 +530,6 @@
 #    endif
 #  endif
 
-/* The Zilog compiler does not support inline functions */
-
-#  undef  CONFIG_HAVE_INLINE
-#  define inline
-
 /* ISO C11 supports anonymous (unnamed) structures and unions.  Zilog does
  * not support C11
  */
@@ -659,8 +641,6 @@
 #  undef  CONFIG_SMALL_MEMORY
 #  undef  CONFIG_LONG_IS_NOT_INT
 #  undef  CONFIG_PTR_IS_NOT_INT
-#  undef  CONFIG_HAVE_INLINE
-#  define inline
 #  undef  CONFIG_HAVE_LONG_LONG
 #  define CONFIG_HAVE_FLOAT 1
 #  undef  CONFIG_HAVE_DOUBLE

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -82,15 +82,6 @@
 #define stdout     (&nxsched_get_streams()->sl_streams[1])
 #define stderr     (&nxsched_get_streams()->sl_streams[2])
 
-/* These APIs are not implemented and/or can be synthesized from
- * supported APIs.
- */
-
-#define putc(c,s)  fputc((c),(s))
-#define putchar(c) fputc(c, stdout)
-#define getc(s)    fgetc(s)
-#define getchar()  fgetc(stdin)
-
 /* Path to the directory where temporary files can be created */
 
 #ifndef CONFIG_LIBC_TMPDIR
@@ -164,6 +155,8 @@ long   ftell(FAR FILE *stream);
 off_t  ftello(FAR FILE *stream);
 size_t fwrite(FAR const void *ptr, size_t size, size_t n_items,
          FAR FILE *stream);
+int     getc(FAR FILE *stream);
+int     getchar(void);
 ssize_t getdelim(FAR char **lineptr, size_t *n, int delimiter,
          FAR FILE *stream);
 ssize_t getline(FAR char **lineptr, size_t *n, FAR FILE *stream);
@@ -180,6 +173,8 @@ int    ungetc(int c, FAR FILE *stream);
 
 void   perror(FAR const char *s);
 int    printf(FAR const IPTR char *fmt, ...);
+int    putc(int c, FAR FILE *stream);
+int    putchar(int c);
 int    puts(FAR const IPTR char *s);
 int    rename(FAR const char *oldpath, FAR const char *newpath);
 int    sprintf(FAR char *buf, FAR const IPTR char *fmt, ...);

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -29,7 +29,6 @@
 #include <nuttx/compiler.h>
 
 #include <sys/types.h>
-#include <errno.h>
 #include <stdint.h>
 #include <limits.h>
 
@@ -146,16 +145,7 @@ int       on_exit(CODE void (*func)(int, FAR void *), FAR void *arg);
 
 /* _Exit() is a stdlib.h equivalent to the unistd.h _exit() function */
 
-void      _exit(int status); /* See unistd.h */
-
-#ifdef CONFIG_HAVE_INLINE
-static inline void _Exit(int s)
-{
-  _exit(s);
-}
-#else
-#define _Exit(s) _exit(s)
-#endif
+void      _Exit(int status) noreturn_function;
 
 /* System() command is not implemented in the NuttX libc because it is so
  * entangled with shell logic.  There is an experimental version at
@@ -186,44 +176,13 @@ double    strtod(FAR const char *str, FAR char **endptr);
 long double strtold(FAR const char *str, FAR char **endptr);
 #endif
 
-#ifdef CONFIG_HAVE_INLINE
-static inline int atoi(FAR const char *nptr)
-{
-  return (int)strtol(nptr, NULL, 10);
-}
-#else
-#define atoi(nptr) ((int)strtol((nptr), NULL, 10))
-#endif
-
-#ifdef CONFIG_HAVE_INLINE
-static inline int atol(FAR const char *nptr)
-{
-  return strtol(nptr, NULL, 10);
-}
-#else
-#define atol(nptr) strtol((nptr), NULL, 10)
-#endif
-
+int atoi(FAR const char *nptr);
+long atol(FAR const char *nptr);
 #ifdef CONFIG_HAVE_LONG_LONG
-#ifdef CONFIG_HAVE_INLINE
-static inline long long atoll(FAR const char *nptr)
-{
-  return strtoll(nptr, NULL, 10);
-}
-#else
-#define atoll(nptr) strtoll((nptr), NULL, 10)
+long long atoll(FAR const char *nptr);
 #endif
-#endif
-
 #ifdef CONFIG_HAVE_DOUBLE
-#ifdef CONFIG_HAVE_INLINE
-static inline double atof(FAR const char *nptr)
-{
-  return strtod(nptr, NULL);
-}
-#else
-#define atof(nptr) strtod((nptr), NULL)
-#endif
+double atof(FAR const char *nptr);
 #endif
 
 /* Binary to string conversions */
@@ -248,21 +207,8 @@ FAR void *realloc(FAR void *, size_t);
 FAR void *memalign(size_t, size_t);
 FAR void *zalloc(size_t);
 FAR void *calloc(size_t, size_t);
-
-#ifdef CONFIG_HAVE_INLINE
-static inline FAR void *aligned_alloc(size_t a, size_t s)
-{
-  return memalign(a, s);
-}
-
-static inline int posix_memalign(FAR void **m, size_t a, size_t s)
-{
-  return (*m = memalign(a, s)) ? OK : ENOMEM;
-}
-#else
-#define aligned_alloc(a, s) memalign((a), (s))
-#define posix_memalign(m, a, s) ((*(m) = memalign((a), (s))) ? OK : ENOMEM)
-#endif
+FAR void *aligned_alloc(size_t, size_t);
+int posix_memalign(FAR void **, size_t, size_t);
 
 /* Pseudo-Terminals */
 

--- a/include/strings.h
+++ b/include/strings.h
@@ -48,7 +48,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef CONFIG_HAVE_INLINE
 /* Compatibility definitions
  *
  * Marked LEGACY in Open Group Base Specifications Issue 6/
@@ -57,13 +56,11 @@
  * IEEE Std 1003.1-2008
  */
 
-#  define bcmp(b1,b2,len)  memcmp(b1,b2,(size_t)len)
-#  define bcopy(b1,b2,len) (void)memmove(b2,b1,len)
-#  define bzero(s,n)       (void)memset(s,0,n)
-#  define index(s,c)       strchr(s,c)
-#  define rindex(s,c)      strrchr(s,c)
-
-#endif /* !CONFIG_HAVE_INLINE */
+#define bcmp(b1,b2,len)  memcmp(b1,b2,(size_t)len)
+#define bcopy(b1,b2,len) (void)memmove(b2,b1,len)
+#define bzero(s,n)       (void)memset(s,0,n)
+#define index(s,c)       strchr(s,c)
+#define rindex(s,c)      strrchr(s,c)
 
 /****************************************************************************
  * Inline Functions
@@ -77,41 +74,6 @@ extern "C"
 #else
 #define EXTERN extern
 #endif
-
-#ifdef CONFIG_HAVE_INLINE
-/* Compatibility inline functions.
- *
- * Marked LEGACY in Open Group Base Specifications Issue 6/
- * IEEE Std 1003.1-2004
- * Removed from Open Group Base Specifications Issue 7/
- * IEEE Std 1003.1-2008
- */
-
-static inline int bcmp(FAR const void *b1, FAR const void *b2, size_t len)
-{
-  return memcmp(b1, b2, len);
-}
-
-static inline void bcopy(FAR const void *b1, FAR void *b2, size_t len)
-{
-  memmove(b2, b1, len);
-}
-
-static inline void bzero(FAR void *s, size_t len)
-{
-  memset(s, 0, len);
-}
-
-static inline FAR char *index(FAR const char *s, int c)
-{
-  return strchr(s, c);
-}
-
-static inline FAR char *rindex(FAR const char *s, int c)
-{
-  return strrchr(s, c);
-}
-#endif /* CONFIG_HAVE_INLINE */
 
 /****************************************************************************
  * Public Function Prototypes

--- a/include/time.h
+++ b/include/time.h
@@ -200,17 +200,7 @@ clock_t clock(void);
 int clock_settime(clockid_t clockid, FAR const struct timespec *tp);
 int clock_gettime(clockid_t clockid, FAR struct timespec *tp);
 int clock_getres(clockid_t clockid, FAR struct timespec *res);
-
-#ifdef CONFIG_HAVE_INLINE
-static inline int timespec_get(FAR struct timespec *t, int b)
-{
-  return b == TIME_UTC ? (clock_gettime(CLOCK_REALTIME, t), b) : 0;
-}
-
-#else
-#define timespec_get(t, b) \
-  ((b) == TIME_UTC ? (clock_gettime(CLOCK_REALTIME, (t)), (b)) : 0)
-#endif
+int timespec_get(FAR struct timespec *t, int b);
 
 time_t mktime(FAR struct tm *tp);
 FAR struct tm *gmtime(FAR const time_t *timep);

--- a/libs/libc/stdio/Make.defs
+++ b/libs/libc/stdio/Make.defs
@@ -51,12 +51,13 @@ endif
 ifneq ($(CONFIG_NFILE_STREAMS),0)
 
 CSRCS += lib_fopen.c lib_freopen.c lib_fclose.c lib_fread.c lib_libfread.c
-CSRCS += lib_fseek.c lib_fseeko.c lib_ftell.c lib_ftello.c lib_fsetpos.c lib_getdelim.c lib_fgetpos.c
-CSRCS += lib_fgetc.c lib_fgets.c lib_gets_s.c lib_gets.c lib_libfgets.c
-CSRCS += lib_fwrite.c lib_libfwrite.c lib_fflush.c lib_libflushall.c
-CSRCS += lib_libfflush.c lib_rdflush.c lib_wrflush.c lib_fputc.c lib_puts.c
-CSRCS += lib_fputs.c lib_ungetc.c lib_vprintf.c lib_fprintf.c lib_vfprintf.c
-CSRCS += lib_stdinstream.c lib_stdoutstream.c lib_stdsistream.c
+CSRCS += lib_fseek.c lib_fseeko.c lib_ftell.c lib_ftello.c lib_fsetpos.c
+CSRCS += lib_getdelim.c lib_fgetpos.c lib_getc.c lib_getchar.c lib_fgetc.c
+CSRCS += lib_fgets.c lib_gets_s.c lib_gets.c lib_libfgets.c lib_fwrite.c
+CSRCS += lib_libfwrite.c lib_fflush.c lib_libflushall.c lib_libfflush.c
+CSRCS += lib_rdflush.c lib_wrflush.c lib_putc.c lib_putchar.c lib_fputc.c
+CSRCS += lib_puts.c lib_fputs.c lib_ungetc.c lib_vprintf.c lib_fprintf.c
+CSRCS += lib_vfprintf.c lib_stdinstream.c lib_stdoutstream.c lib_stdsistream.c
 CSRCS += lib_stdsostream.c lib_perror.c lib_feof.c lib_ferror.c
 CSRCS += lib_rawinstream.c lib_rawoutstream.c lib_rawsistream.c
 CSRCS += lib_rawsostream.c lib_remove.c lib_rewind.c lib_clearerr.c

--- a/libs/libc/stdio/lib_getc.c
+++ b/libs/libc/stdio/lib_getc.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_getc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int getc(FAR FILE *stream)
+{
+  return fgetc(stream);
+}

--- a/libs/libc/stdio/lib_getchar.c
+++ b/libs/libc/stdio/lib_getchar.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_getchar.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int getchar(void)
+{
+  return fgetc(stdin);
+}

--- a/libs/libc/stdio/lib_putc.c
+++ b/libs/libc/stdio/lib_putc.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_putc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int putc(int c, FAR FILE *stream)
+{
+  return fputc(c, stream);
+}

--- a/libs/libc/stdio/lib_putchar.c
+++ b/libs/libc/stdio/lib_putchar.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdio/lib_putchar.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdio.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int putchar(int c)
+{
+  return fputc(c, stdout);
+}

--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -20,12 +20,12 @@
 
 # Add the stdlib C files to the build
 
-CSRCS += lib_abs.c lib_abort.c lib_div.c lib_ldiv.c lib_lldiv.c
-CSRCS += lib_itoa.c lib_labs.c lib_llabs.c lib_realpath.c
-CSRCS += lib_bsearch.c lib_rand.c lib_qsort.c lib_srand.c
-CSRCS += lib_strtol.c lib_strtoll.c lib_strtoul.c lib_strtoull.c
-CSRCS += lib_strtod.c lib_strtof.c lib_strtold.c lib_checkbase.c
-CSRCS += lib_mktemp.c lib_mkstemp.c
+CSRCS += lib_abs.c lib_abort.c lib_aligned_alloc.c lib_atof.c lib_atoi.c
+CSRCS += lib_atol.c lib_atoll.c lib_div.c lib_ldiv.c lib_lldiv.c lib_Exit.c
+CSRCS += lib_itoa.c lib_labs.c lib_llabs.c lib_realpath.c lib_bsearch.c
+CSRCS += lib_rand.c lib_posix_memalign.c lib_qsort.c lib_srand.c lib_strtol.c
+CSRCS += lib_strtoll.c lib_strtoul.c lib_strtoull.c lib_strtod.c lib_strtof.c
+CSRCS += lib_strtold.c lib_checkbase.c lib_mktemp.c lib_mkstemp.c
 
 ifeq ($(CONFIG_LIBC_WCHAR),y)
 CSRCS += lib_mblen.c lib_mbtowc.c lib_wctomb.c

--- a/libs/libc/stdlib/lib_Exit.c
+++ b/libs/libc/stdlib/lib_Exit.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libc/stdlib/lib_Exit.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+#include <unistd.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void _Exit(int status)
+{
+  _exit(status);
+}

--- a/libs/libc/stdlib/lib_aligned_alloc.c
+++ b/libs/libc/stdlib/lib_aligned_alloc.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdlib/lib_aligned_alloc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR void *aligned_alloc(size_t align, size_t size)
+{
+  return memalign(align, size);
+}

--- a/libs/libc/stdlib/lib_atof.c
+++ b/libs/libc/stdlib/lib_atof.c
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * libs/libc/stdlib/lib_atof.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_DOUBLE
+double atof(FAR const char *nptr)
+{
+  return strtod(nptr, NULL);
+}
+#endif

--- a/libs/libc/stdlib/lib_atoi.c
+++ b/libs/libc/stdlib/lib_atoi.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdlib/lib_atoi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int atoi(FAR const char *nptr)
+{
+  return strtol(nptr, NULL, 10);
+}

--- a/libs/libc/stdlib/lib_atol.c
+++ b/libs/libc/stdlib/lib_atol.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/stdlib/lib_atol.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+long atol(FAR const char *nptr)
+{
+  return strtol(nptr, NULL, 10);
+}

--- a/libs/libc/stdlib/lib_atoll.c
+++ b/libs/libc/stdlib/lib_atoll.c
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * libs/libc/stdlib/lib_atoll.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_HAVE_LONG_LONG
+long long atoll(FAR const char *nptr)
+{
+  return strtoll(nptr, NULL, 10);
+}
+#endif

--- a/libs/libc/stdlib/lib_posix_memalign.c
+++ b/libs/libc/stdlib/lib_posix_memalign.c
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * libs/libc/stdlib/lib_posix_memalign.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int posix_memalign(FAR void **mem, size_t align, size_t size)
+{
+  *mem = memalign(align, size);
+  return *mem ? OK : ENOMEM;
+}

--- a/libs/libc/time/Make.defs
+++ b/libs/libc/time/Make.defs
@@ -38,7 +38,7 @@
 
 CSRCS += lib_strftime.c lib_calendar2utc.c lib_daysbeforemonth.c
 CSRCS += lib_gettimeofday.c lib_isleapyear.c lib_settimeofday.c lib_time.c
-CSRCS += lib_nanosleep.c lib_difftime.c lib_dayofweek.c
+CSRCS += lib_timespec_get.c lib_nanosleep.c lib_difftime.c lib_dayofweek.c
 CSRCS += lib_asctime.c lib_asctimer.c lib_ctime.c lib_ctimer.c
 
 ifdef CONFIG_LIBC_LOCALTIME

--- a/libs/libc/time/lib_timespec_get.c
+++ b/libs/libc/time/lib_timespec_get.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * libs/libc/time/lib_timespec_get.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <time.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int timespec_get(FAR struct timespec *t, int b)
+{
+  if (b == TIME_UTC)
+    {
+      return clock_gettime(CLOCK_REALTIME, t) < 0 ? 0 : b;
+    }
+  else
+    {
+      return 0;
+    }
+}

--- a/wireless/bluetooth/bt_atomic.c
+++ b/wireless/bluetooth/bt_atomic.c
@@ -47,13 +47,6 @@
  * Public Functions
  ****************************************************************************/
 
-#ifndef CONFIG_HAVE_INLINE
-void bt_atomic_set(FAR bt_atomic_t *ptr, bt_atomic_t value)
-{
-  *ptr = value;
-}
-#endif
-
 bt_atomic_t bt_atomic_incr(FAR bt_atomic_t *ptr)
 {
   irqstate_t flags;
@@ -105,20 +98,6 @@ bt_atomic_t bt_atomic_clrbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno)
 
   return value;
 }
-
-#ifndef CONFIG_HAVE_INLINE
-bt_atomic_t bt_atomic_get(FAR bt_atomic_t *ptr)
-{
-  return *ptr;
-}
-#endif
-
-#ifndef CONFIG_HAVE_INLINE
-bool bt_atomic_testbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno)
-{
-  return (*ptr & (1 << bitno)) != 0;
-}
-#endif
 
 bool bt_atomic_testsetbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno)
 {

--- a/wireless/bluetooth/bt_atomic.h
+++ b/wireless/bluetooth/bt_atomic.h
@@ -48,52 +48,27 @@
 #include <stdbool.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define bt_atomic_set(ptr, value)     (*(ptr) = (value))
+#define bt_atomic_get(ptr)            (*(ptr))
+#define bt_atomic_testbit(ptr, bitno) ((*(ptr) & (1 << (bitno))) != 0)
+
+/****************************************************************************
  * Public Types
  ****************************************************************************/
 
 typedef uint8_t bt_atomic_t;
 
 /****************************************************************************
- * Inline Functions
- ****************************************************************************/
-
-#ifdef CONFIG_HAVE_INLINE
-/* These operations are inherently atomic */
-
-static inline void bt_atomic_set(FAR bt_atomic_t *ptr, bt_atomic_t value)
-{
-  *ptr = value;
-}
-
-static inline bt_atomic_t bt_atomic_get(FAR bt_atomic_t *ptr)
-{
-  return *ptr;
-}
-
-static inline bool bt_atomic_testbit(FAR bt_atomic_t *ptr,
-                                     bt_atomic_t bitno)
-{
-  return (*ptr & (1 << bitno)) != 0;
-}
-#endif
-
-/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
-
-#ifndef CONFIG_HAVE_INLINE
-void bt_atomic_set(FAR bt_atomic_t *ptr, bt_atomic_t value);
-bt_atomic_t bt_atomic_get(FAR bt_atomic_t *ptr);
-#endif
 
 bt_atomic_t bt_atomic_incr(FAR bt_atomic_t *ptr);
 bt_atomic_t bt_atomic_decr(FAR bt_atomic_t *ptr);
 bt_atomic_t bt_atomic_setbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno);
 bt_atomic_t bt_atomic_clrbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno);
-
-#ifndef CONFIG_HAVE_INLINE
-bool bt_atomic_testbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno);
-#endif
 
 bool bt_atomic_testsetbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno);
 bool bt_atomic_testclrbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno);


### PR DESCRIPTION
## Summary
1.Remove CONFIG_HAVE_INLINE macro
2.Change the ANSI C function to normal function
3.Other simple non ANSI function to macro
Note: only ctype function keep both inline/macro verion for the speed reason, but conditioned by __cplusplus now.

## Impact
No functionality change

## Testing

