### PR TITLE
make/version: correct the version generation 

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -31,7 +31,7 @@ endif
 
 # In case we cannot get version information from GIT
 
-ifneq ($(GIT_PRESENT),true)
+ifeq ($(GIT_PRESENT),)
 -include $(TOPDIR)/.version
 
 # In case the version file does not exist


### PR DESCRIPTION
## Summary
make/version: correct the version generation 

incorrect version generation by commit 3ec12a84c29d549d3de1e077f05bfb07ff315de5

## Impact

## Testing

`./tools/configure.sh stm32f429i-disco:nsh V=1`

Before patch:

```
$ cat .version 
#!/bin/bash

CONFIG_VERSION_STRING="0.0.0"
CONFIG_VERSION_MAJOR=0
CONFIG_VERSION_MINOR=0
CONFIG_VERSION_PATCH=0
CONFIG_VERSION_BUILD="0"
```

After patch:

```
$ cat .version
#!/bin/bash

CONFIG_VERSION_STRING="9.1.0"
CONFIG_VERSION_MAJOR=9
CONFIG_VERSION_MINOR=1
CONFIG_VERSION_PATCH=0
CONFIG_VERSION_BUILD="58dd6aa"
```

