### PR TITLE
make/export: copy incdir.c for export build

### DIFF
--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -195,6 +195,7 @@ fi
 # Copy the depends script
 
 cp "${TOPDIR}/tools/mkdeps.c" "${EXPORTDIR}/tools/."
+cp "${TOPDIR}/tools/incdir.c" "${EXPORTDIR}/tools/."
 
 # Copy the default linker script
 


### PR DESCRIPTION
## Summary

make/export: copy incdir.c for export build

export build break by commit 5555070fc3320d91876391bc24f0a7283d31841c

## Impact

make export

Depends on: https://github.com/apache/incubator-nuttx-apps/pull/312

## Testing

Before patch:

```
$ cd $(NUTTX_DIR)
$ ./tools/configure.sh stm32f429i-disco:nsh
$ make export -j12

$ cd $(APPS_DIR)
$ ./tools/mkimport.sh -x $(NUTTX_DIR)/nuttx-export-9.1.0.zip
$ make import -j12
...
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
/bin/sh: 1: /home/archer/code/apps/import/tools/incdir: not found
```
After patch:

```
$ cd $(NUTTX_DIR)
$ ./tools/configure.sh stm32f429i-disco:nsh
$ make export -j12

$ cd $(APPS_DIR)
$ ./tools/mkimport.sh -x $(NUTTX_DIR)/nuttx-export-9.1.0.zip
$ make import -j12
...
LD: nuttx
make[1]: Leaving directory '/home/archer/code/apps/import'
```
