### PR TITLE
sched: Change tcb_s to task_tcb_s for nxtask_[un]init

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -156,7 +156,7 @@ int exec_module(FAR const struct binary_s *binp)
 
   /* Initialize the task */
 
-  ret = nxtask_init((FAR struct tcb_s *)tcb, binp->filename, binp->priority,
+  ret = nxtask_init(tcb, binp->filename, binp->priority,
                     NULL, binp->stacksize, binp->entrypt, binp->argv);
   if (ret < 0)
     {

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -963,7 +963,7 @@ FAR struct socketlist *nxsched_get_sockets(void);
  *
  ********************************************************************************/
 
-int nxtask_init(FAR struct tcb_s *tcb, const char *name, int priority,
+int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 FAR void *stack, uint32_t stack_size, main_t entry,
                 FAR char * const argv[]);
 
@@ -988,7 +988,7 @@ int nxtask_init(FAR struct tcb_s *tcb, const char *name, int priority,
  *
  ********************************************************************************/
 
-void nxtask_uninit(FAR struct tcb_s *tcb);
+void nxtask_uninit(FAR struct task_tcb_s *tcb);
 
 /********************************************************************************
  * Name: nxtask_activate

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -72,13 +72,13 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
                            int priority, int stack_size, main_t entry,
                            FAR char * const argv[])
 {
-  FAR struct tcb_s *tcb;
+  FAR struct task_tcb_s *tcb;
   pid_t pid;
   int ret;
 
   /* Allocate a TCB for the new task. */
 
-  tcb = (FAR struct tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
+  tcb = (FAR struct task_tcb_s *)kmm_zalloc(sizeof(struct task_tcb_s));
   if (!tcb)
     {
       serr("ERROR: Failed to allocate TCB\n");
@@ -87,7 +87,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Setup the task type */
 
-  tcb->flags = ttype;
+  tcb->cmn.flags = ttype;
 
   /* Initialize the task */
 
@@ -100,11 +100,11 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Get the assigned pid before we start the task */
 
-  pid = tcb->pid;
+  pid = tcb->cmn.pid;
 
   /* Activate the task */
 
-  nxtask_activate(tcb);
+  nxtask_activate(&tcb->cmn);
 
   return (int)pid;
 }


### PR DESCRIPTION
## Summary
since these functions can just work with task not thread.

## Impact
No functionality change.

## Testing

