### PR TITLE
syscall/prctl: fix PR_SET_NAME failure if without <pid> arg

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -207,10 +207,10 @@
  */
 
 #define pthread_setname_np(thread, name) \
-  prctl((int)PR_SET_NAME, (char*)name, (int)thread)
+  prctl((int)PR_SET_NAME_EXT, (char*)name, (int)thread)
 
 #define pthread_getname_np(thread, name) \
-  prctl((int)PR_GET_NAME, (char*)name, (int)thread)
+  prctl((int)PR_GET_NAME_EXT, (char*)name, (int)thread)
 
 /********************************************************************************
  * Public Type Definitions

--- a/include/sys/prctl.h
+++ b/include/sys/prctl.h
@@ -47,26 +47,47 @@
 /* Supported prctl() commands.
  *
  *  PR_SET_NAME
+ *    Set the name of the calling thread, using the value in the location
+ *    pointed to by (char *) arg2. The name can be up to
+ *    CONFIG_TASK_NAME_SIZE long, including the terminating null byte.
+ *    (If the length of the string, including the terminating null byte,
+ *    exceeds CONFIG_TASK_NAME_SIZE bytes, the string is silently truncated.)
+ *    As an example:
+ *
+ *      prctl(PR_SET_NAME, "MyName");
+ *
+ *  PR_GET_NAME
+ *    Return the name of the calling thread, in the buffer pointed to by
+ *    (char *) arg2.  The buffer should allow space for up to
+ *    CONFIG_TASK_NAME_SIZE bytes; the returned string will be
+ *    null-terminated. As an example:
+ *
+ *      char myname[CONFIG_TASK_NAME_SIZE];
+ *      prctl(PR_GET_NAME, myname);
+ *
+ *  PR_SET_NAME_EXT
  *    Set the task (or thread) name for the thread whose ID is in required
  *    arg2 (int), using the value in the location pointed to by required arg1
  *    (char*).  The name can be up to CONFIG_TASK_NAME_SIZE long (including
  *    any null termination).  The thread ID of 0 will set the name of the
  *    calling thread. As an example:
  *
- *      prctl(PR_SET_NAME, "MyName", 0);
+ *      prctl(PR_SET_NAME_EXT, "MyName", pid);
  *
- *  PR_GET_NAME
+ *  PR_GET_NAME_EXT
  *    Return the task (or thread) name for the for the thread whose ID is
- *    optional arg2 (int), in the buffer pointed to by optional arg1 (char *).
- *    The buffer must be CONFIG_TASK_NAME_SIZE long (including any null
- *    termination). As an example:
+ *    optional arg2 (int), in the buffer pointed to by optional arg1
+ *    (char *). The buffer must be CONFIG_TASK_NAME_SIZE long (including
+ *    any null termination). As an example:
  *
  *      char myname[CONFIG_TASK_NAME_SIZE];
- *      prctl(PR_GET_NAME, myname, 0);
+ *      prctl(PR_GET_NAME_EXT, myname, pid);
  */
 
-#define PR_SET_NAME 1
-#define PR_GET_NAME 2
+#define PR_SET_NAME     1
+#define PR_GET_NAME     2
+#define PR_SET_NAME_EXT 3
+#define PR_GET_NAME_EXT 4
 
 /****************************************************************************
  * Public Type Definitions

--- a/sched/task/task_prctl.c
+++ b/sched/task/task_prctl.c
@@ -84,13 +84,21 @@ int prctl(int option, ...)
     {
       case PR_SET_NAME:
       case PR_GET_NAME:
+      case PR_SET_NAME_EXT:
+      case PR_GET_NAME_EXT:
 #if CONFIG_TASK_NAME_SIZE > 0
         {
           /* Get the prctl arguments */
 
           FAR char *name = va_arg(ap, FAR char *);
-          int pid  = va_arg(ap, int);
           FAR struct tcb_s *tcb;
+          int pid = 0;
+
+          if (option == PR_SET_NAME_EXT ||
+              option == PR_GET_NAME_EXT)
+            {
+              pid = va_arg(ap, int);
+            }
 
           /* Get the TCB associated with the PID (handling the special case
            * of pid==0 meaning "this thread")
@@ -127,7 +135,7 @@ int prctl(int option, ...)
 
           /* Now get or set the task name */
 
-          if (option == PR_SET_NAME)
+          if (option == PR_SET_NAME || option == PR_SET_NAME_EXT)
             {
               /* Ensure that tcb->name will be null-terminated, truncating if
                * necessary.


### PR DESCRIPTION
## Summary

syscall/prctl: fix PR_SET_NAME failure if without pid arg

add PR_SET_NAME_EXT/PR_GET_NAME_EXT extension to avoid semantic
conflicts, use extened version for pthread_setname_np/pthread_getname_np

```
PRCTL(2)                              

NAME
       prctl - operations on a process
....
DESCRIPTION
....
PR_SET_NAME (since Linux 2.6.9)
       Set  the  name  of the calling thread, using the value in the location pointed to by (char *) arg2. 
       The name can be up to 16 bytes long, including the terminating null byte.
       (If the length of the string, including the terminating null byte, exceeds 16 bytes, the string is silently truncated.)
```


## Impact

prctl(PR_SET_NAME, "test name")

## Testing

Set the specified name to self and pause the current process:

```
$ git diff .
diff --git a/examples/hello/hello_main.c b/examples/hello/hello_main.c
index 953597a..f21b74b 100644
--- a/examples/hello/hello_main.c
+++ b/examples/hello/hello_main.c
@@ -50,6 +50,9 @@
 
 int main(int argc, FAR char *argv[])
 {
+  prctl(PR_SET_NAME, "test name");
   printf("Hello, World!!\n");
+  pause();
   return 0;
 }
```

Before patch:

```
$ hello &
Hello, World!!
$ ps
  PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK COMMAND
    0     0   0 FIFO     Kthread N-- Ready              00000000 004096 Idle Task
    2     1 100 FIFO     Task    --- Running            00000000 008160 /system/bin/nsh
    3     2 100 FIFO     Task    --- Waiting  Signal    00000000 008176 hello
```

After patch:

```
$ hello &
Hello, World!!
$ ps
  PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK COMMAND
    0     0   0 FIFO     Kthread N-- Ready              00000000 004096 Idle Task
    2     1 100 FIFO     Task    --- Running            00000000 008160 /system/bin/nsh
    3     2 100 FIFO     Task    --- Waiting  Signal    00000000 008176 test name
```