### PR TITLE
FlexCAN support NETDEV_LATEINIT

### DIFF
--- a/arch/arm/src/kinetis/kinetis.h
+++ b/arch/arm/src/kinetis/kinetis.h
@@ -777,7 +777,7 @@ int kinetis_netinitialize(int intf);
  * Assumptions:
  *
  ************************************************************************************/
-#ifdef CONFIG_KINETIS_CAN
+#ifdef CONFIG_KINETIS_FLEXCAN
 int kinetis_caninitialize(int intf)
 #endif
 

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.h
@@ -55,7 +55,7 @@
 #define EMAC_INTF 0
 
 /************************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ************************************************************************************/
 
 #ifndef __ASSEMBLY__
@@ -68,6 +68,8 @@ extern "C"
 #else
 #define EXTERN extern
 #endif
+
+#if !defined(CONFIG_NETDEV_LATEINIT)
 
 /************************************************************************************
  * Function: arm_netinitialize
@@ -90,6 +92,29 @@ extern "C"
  ************************************************************************************/
 
 void arm_netinitialize(void);
+
+#else
+
+/************************************************************************************
+ * Function: s32k1xx_netinitialize
+ *
+ * Description:
+ *   Initialize the Ethernet controller and driver
+ *
+ * Input Parameters:
+ *   intf - In the case where there are multiple EMACs, this value
+ *          identifies which EMAC is to be initialized.
+ *
+ * Returned Value:
+ *   OK on success; Negated errno on failure.
+ *
+ * Assumptions:
+ *
+ ************************************************************************************/
+
+int s32k1xx_netinitialize(int intf);
+
+#endif
 
 /************************************************************************************
  * Function: s32k1xx_phy_boardinitialize

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1698,14 +1698,14 @@ static void s32k1xx_reset(struct s32k1xx_driver_s *priv)
  ****************************************************************************/
 
 /****************************************************************************
- * Function: s32k1xx_netinitialize
+ * Function: s32k1xx_caninitialize
  *
  * Description:
- *   Initialize the Ethernet controller and driver
+ *   Initialize the CAN controller and driver
  *
  * Input Parameters:
- *   intf - In the case where there are multiple EMACs, this value
- *          identifies which EMAC is to be initialized.
+ *   intf - In the case where there are multiple CAN devices, this value
+ *          identifies which CAN device is to be initialized.
  *
  * Returned Value:
  *   OK on success; Negated errno on failure.
@@ -1714,7 +1714,7 @@ static void s32k1xx_reset(struct s32k1xx_driver_s *priv)
  *
  ****************************************************************************/
 
-int s32k1xx_netinitialize(int intf)
+int s32k1xx_caninitialize(int intf)
 {
   struct s32k1xx_driver_s *priv;
   int ret;
@@ -1894,10 +1894,10 @@ int s32k1xx_netinitialize(int intf)
  * Name: arm_netinitialize
  *
  * Description:
- *   Initialize the first network interface.  If there are more than one
- *   interface in the chip, then board-specific logic will have to provide
- *   this function to determine which, if any, Ethernet controllers should
- *   be initialized.
+ *   Initialize the enabled CAN device interfaces.  If there are more
+ *   different network devices in the chip, then board-specific logic will
+ *   have to provide this function to determine which, if any, network
+ *   devices should be initialized.
  *
  ****************************************************************************/
 
@@ -1905,15 +1905,15 @@ int s32k1xx_netinitialize(int intf)
 void arm_netinitialize(void)
 {
 #ifdef CONFIG_S32K1XX_FLEXCAN0
-  s32k1xx_netinitialize(0);
+  s32k1xx_caninitialize(0);
 #endif
 
 #ifdef CONFIG_S32K1XX_FLEXCAN1
-  s32k1xx_netinitialize(1);
+  s32k1xx_caninitialize(1);
 #endif
 
 #ifdef CONFIG_S32K1XX_FLEXCAN2
-  s32k1xx_netinitialize(2);
+  s32k1xx_caninitialize(2);
 #endif
 }
 #endif

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.h
@@ -65,14 +65,16 @@ extern "C"
 #define EXTERN extern
 #endif
 
+#if !defined(CONFIG_NETDEV_LATEINIT)
+
 /************************************************************************************
  * Function: arm_netinitialize
  *
  * Description:
- *   Initialize the first network interface.  If there are more than one
- *   interface in the chip, then board-specific logic will have to provide
- *   this function to determine which, if any, Ethernet controllers should
- *   be initialized.  Also prototyped in up_internal.h.
+ *   Initialize the enabled CAN device interfaces.  If there are more
+ *   different network devices in the chip, then board-specific logic will
+ *   have to provide this function to determine which, if any, network
+ *   devices should be initialized.
  *
  * Input Parameters:
  *   None
@@ -87,23 +89,28 @@ extern "C"
 
 void arm_netinitialize(void);
 
+#else
+
 /************************************************************************************
- * Function: s32k1xx_phy_boardinitialize
+ * Function: s32k1xx_caninitialize
  *
  * Description:
- *   Some boards require specialized initialization of the PHY before it can be
- *   used.  This may include such things as configuring GPIOs, resetting the PHY,
- *   etc.  If CONFIG_S32K1XX_FLEXCAN_PHYINIT is defined in the configuration then the
- *   board specific logic must provide s32k1xx_phyinitialize();  The i.MX RT Ethernet
- *   driver will call this function one time before it first uses the PHY.
+ *   Initialize the CAN controller and driver
  *
  * Input Parameters:
- *   intf - Always zero for now.
+ *   intf - In the case where there are multiple CAN devices, this value
+ *          identifies which CAN device is to be initialized.
  *
  * Returned Value:
  *   OK on success; Negated errno on failure.
  *
+ * Assumptions:
+ *
  ************************************************************************************/
+
+int s32k1xx_caninitialize(int intf);
+
+#endif
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/arm/src/s32k1xx/s32k1xx_start.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_start.c
@@ -69,6 +69,10 @@
 #include "s32k1xx_progmem.h"
 #endif
 
+#ifdef CONFIG_S32K1XX_EEEPROM
+#include "s32k1xx_eeeprom.h"
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/

--- a/boards/arm/s32k1xx/rddrone-uavcan144/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/rddrone-uavcan144/src/s32k1xx_bringup.c
@@ -159,9 +159,9 @@ int s32k1xx_bringup(void)
 #endif
 
 #ifdef CONFIG_S32K1XX_EEEPROM
-      /* Register EEEPROM block device */
+  /* Register EEEPROM block device */
 
-      s32k1xx_eeeprom_register(0, 4096);
+  s32k1xx_eeeprom_register(0, 4096);
 #endif
 
   return ret;

--- a/boards/arm/s32k1xx/rddrone-uavcan146/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/rddrone-uavcan146/src/s32k1xx_bringup.c
@@ -156,9 +156,9 @@ int s32k1xx_bringup(void)
 #endif
 
 #ifdef CONFIG_S32K1XX_EEEPROM
-      /* Register EEEPROM block device */
+  /* Register EEEPROM block device */
 
-      s32k1xx_eeeprom_register(0, 4096);
+  s32k1xx_eeeprom_register(0, 4096);
 #endif
 
   return ret;

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_bringup.c
@@ -121,9 +121,9 @@ int s32k1xx_bringup(void)
 #endif
 
 #ifdef CONFIG_S32K1XX_EEEPROM
-      /* Register EEEPROM block device */
+  /* Register EEEPROM block device */
 
-      s32k1xx_eeeprom_register(0, 4096);
+  s32k1xx_eeeprom_register(0, 2048);
 #endif
 
   return ret;

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_bringup.c
@@ -153,9 +153,9 @@ int s32k1xx_bringup(void)
 #endif
 
 #ifdef CONFIG_S32K1XX_EEEPROM
-      /* Register EEEPROM block device */
+  /* Register EEEPROM block device */
 
-      s32k1xx_eeeprom_register(0, 4096);
+  s32k1xx_eeeprom_register(0, 4096);
 #endif
 
   return ret;

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_bringup.c
@@ -153,9 +153,9 @@ int s32k1xx_bringup(void)
 #endif
 
 #ifdef CONFIG_S32K1XX_EEEPROM
-      /* Register EEEPROM block device */
+  /* Register EEEPROM block device */
 
-      s32k1xx_eeeprom_register(0, 4096);
+  s32k1xx_eeeprom_register(0, 4096);
 #endif
 
   return ret;

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_bringup.c
@@ -55,6 +55,10 @@
 #  include "s32k1xx_eeeprom.h"
 #endif
 
+#ifdef CONFIG_S32K1XX_FLEXCAN
+#  include "s32k1xx_flexcan.h"
+#endif
+
 #include "s32k148evb.h"
 
 /****************************************************************************
@@ -113,6 +117,26 @@ int s32k1xx_bringup(void)
       /* Register EEEPROM block device */
 
       s32k1xx_eeeprom_register(0, 4096);
+#endif
+
+#ifdef CONFIG_NETDEV_LATEINIT
+
+# ifdef CONFIG_S32K1XX_ENET
+  s32k1xx_netinitialize(0);
+# endif
+
+# ifdef CONFIG_S32K1XX_FLEXCAN0
+  s32k1xx_caninitialize(0);
+# endif
+
+# ifdef CONFIG_S32K1XX_FLEXCAN1
+  s32k1xx_caninitialize(1);
+# endif
+
+# ifdef CONFIG_S32K1XX_FLEXCAN2
+  s32k1xx_caninitialize(2);
+# endif
+
 #endif
 
   return ret;

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_bringup.c
@@ -114,9 +114,9 @@ int s32k1xx_bringup(void)
 #endif
 
 #ifdef CONFIG_S32K1XX_EEEPROM
-      /* Register EEEPROM block device */
+  /* Register EEEPROM block device */
 
-      s32k1xx_eeeprom_register(0, 4096);
+  s32k1xx_eeeprom_register(0, 4096);
 #endif
 
 #ifdef CONFIG_NETDEV_LATEINIT


### PR DESCRIPTION
## Summary
FlexCAN uses arm_netinitialize() to intialize the CAN netdev however this conflicts on boards with both CAN and ENET (S32K148EVB). Thus NETDEV_LATEINIT support is required to let the board-specific initialize handle this.

## Impact
arch/arm/src/s32k1xx
arch/arm/src/kinetis 
boards/arm/s32k1xx/s32k148evb

## Testing
Tested on S32K148EVB with Ethernet addition
