### PR TITLE
Call c++ global variables in nxtask_startup

### DIFF
--- a/boards/arm/imxrt/imxrt1050-evk/kernel/imxrt_userspace.c
+++ b/boards/arm/imxrt/imxrt1050-evk/kernel/imxrt_userspace.c
@@ -71,8 +71,8 @@
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -108,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/imxrt/imxrt1060-evk/kernel/imxrt_userspace.c
+++ b/boards/arm/imxrt/imxrt1060-evk/kernel/imxrt_userspace.c
@@ -71,8 +71,8 @@
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -108,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/lc823450/lc823450-xgevk/kernel/lc823450_userspace.c
+++ b/boards/arm/lc823450/lc823450-xgevk/kernel/lc823450_userspace.c
@@ -68,14 +68,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -111,7 +111,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/kernel/lpc17_40_userspace.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/kernel/lpc17_40_userspace.c
@@ -108,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/kernel/lpc17_40_userspace.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/kernel/lpc17_40_userspace.c
@@ -108,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/lpc17xx_40xx/open1788/kernel/lpc17_40_userspace.c
+++ b/boards/arm/lpc17xx_40xx/open1788/kernel/lpc17_40_userspace.c
@@ -65,14 +65,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
+/* These 'addresses' of these values are setup by the linker script. They are
  * not actual uint32_t storage locations! They are only used meaningfully in
  * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -108,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/lpc17xx_40xx/pnev5180b/kernel/lpc17_40_userspace.c
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/kernel/lpc17_40_userspace.c
@@ -70,14 +70,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
+/* These 'addresses' of these values are setup by the linker script. They are
  * not actual uint32_t storage locations! They are only used meaningfully in
  * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -113,7 +113,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/lpc43xx/bambino-200e/kernel/lpc43_userspace.c
+++ b/boards/arm/lpc43xx/bambino-200e/kernel/lpc43_userspace.c
@@ -66,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
+/* These 'addresses' of these values are setup by the linker script. They are
  * not actual uint32_t storage locations! They are only used meaningfully in
  * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -109,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/sam34/sam3u-ek/kernel/sam_userspace.c
+++ b/boards/arm/sam34/sam3u-ek/kernel/sam_userspace.c
@@ -71,8 +71,8 @@
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -108,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/samv7/same70-xplained/kernel/sam_userspace.c
+++ b/boards/arm/samv7/same70-xplained/kernel/sam_userspace.c
@@ -71,8 +71,8 @@
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -108,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/samv7/samv71-xult/kernel/sam_userspace.c
+++ b/boards/arm/samv7/samv71-xult/kernel/sam_userspace.c
@@ -50,6 +50,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #ifndef CONFIG_NUTTX_USERSPACE
@@ -64,14 +65,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -107,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32/clicker2-stm32/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/clicker2-stm32/kernel/stm32_userspace.c
@@ -66,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -109,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32/mikroe-stm32f4/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/mikroe-stm32f4/kernel/stm32_userspace.c
@@ -50,6 +50,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #ifndef CONFIG_NUTTX_USERSPACE
@@ -64,14 +65,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -107,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32/olimex-stm32-p407/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/olimex-stm32-p407/kernel/stm32_userspace.c
@@ -51,6 +51,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #ifndef CONFIG_NUTTX_USERSPACE
@@ -65,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -108,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32/omnibusf4/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/omnibusf4/kernel/stm32_userspace.c
@@ -74,8 +74,8 @@
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -111,7 +111,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32/stm3240g-eval/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/stm3240g-eval/kernel/stm32_userspace.c
@@ -50,6 +50,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #ifndef CONFIG_NUTTX_USERSPACE
@@ -64,14 +65,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declareion extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recoved the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -107,7 +108,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32/stm32f4discovery/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/stm32f4discovery/kernel/stm32_userspace.c
@@ -51,6 +51,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #ifndef CONFIG_NUTTX_USERSPACE
@@ -65,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -108,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32f7/stm32f746g-disco/kernel/stm32_userspace.c
+++ b/boards/arm/stm32f7/stm32f746g-disco/kernel/stm32_userspace.c
@@ -66,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -109,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32f7/stm32f769i-disco/kernel/stm32_userspace.c
+++ b/boards/arm/stm32f7/stm32f769i-disco/kernel/stm32_userspace.c
@@ -66,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -109,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32h7/nucleo-h743zi/kernel/stm32_userspace.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/kernel/stm32_userspace.c
@@ -66,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -109,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32h7/stm32h747i-disco/kernel/stm32_userspace.c
+++ b/boards/arm/stm32h7/stm32h747i-disco/kernel/stm32_userspace.c
@@ -66,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -109,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32l4/stm32l476vg-disco/kernel/stm32l4_userspace.c
+++ b/boards/arm/stm32l4/stm32l476vg-disco/kernel/stm32l4_userspace.c
@@ -66,14 +66,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -109,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/kernel/stm32l4_userspace.c
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/kernel/stm32l4_userspace.c
@@ -72,8 +72,8 @@
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -109,7 +109,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/arm/tiva/lm3s6965-ek/kernel/lm_userspace.c
+++ b/boards/arm/tiva/lm3s6965-ek/kernel/lm_userspace.c
@@ -51,14 +51,14 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They are
- * not actual uint32_t storage locations! They are only used meaningfully in the
- * following way:
+/* These 'addresses' of these values are setup by the linker script. They are
+ * not actual uint32_t storage locations! They are only used meaningfully in
+ * the following way:
  *
  *  - The linker script defines, for example, the symbol_sdata.
  *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it is
- *    not!).
+ *    that the value _sdata is the address of a uint32_t variable _data (it
+ *    is not!).
  *  - We can recover the linker value then by simply taking the address of
  *    of _data.  like:  uint32_t *pdata = &_sdata;
  */
@@ -94,7 +94,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/boards/risc-v/k210/maix-bit/kernel/k210_userspace.c
+++ b/boards/risc-v/k210/maix-bit/kernel/k210_userspace.c
@@ -94,7 +94,7 @@ const struct userspace_s userspace __attribute__ ((section (".userspace"))) =
 
   /* Task/thread startup routines */
 
-  .task_startup     = task_startup,
+  .task_startup     = nxtask_startup,
 #ifndef CONFIG_DISABLE_PTHREAD
   .pthread_startup  = pthread_startup,
 #endif

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -1034,6 +1034,26 @@ void nxtask_starthook(FAR struct task_tcb_s *tcb, starthook_t starthook,
 #endif
 
 /********************************************************************************
+ * Name: nxtask_startup
+ *
+ * Description:
+ *   This function is the user-space, task startup function.  It is called
+ *   from up_task_start() in user-mode.
+ *
+ * Input Parameters:
+ *   entrypt - The user-space address of the task entry point
+ *   argc and argv - Standard arguments for the task entry point
+ *
+ * Returned Value:
+ *   None.  This function does not return.
+ *
+ ********************************************************************************/
+
+#ifndef CONFIG_BUILD_KERNEL
+void nxtask_startup(main_t entrypt, int argc, FAR char *argv[]);
+#endif
+
+/********************************************************************************
  * Internal vfork support.  The overall sequence is:
  *
  * 1) User code calls vfork().  vfork() is provided in architecture-specific

--- a/include/nuttx/userspace.h
+++ b/include/nuttx/userspace.h
@@ -153,7 +153,7 @@ extern "C"
  ****************************************************************************/
 
 /****************************************************************************
- * Name: task_startup
+ * Name: nxtask_startup
  *
  * Description:
  *   This function is the user-space, task startup function.  It is called
@@ -169,7 +169,7 @@ extern "C"
  ****************************************************************************/
 
 #ifndef __KERNEL__
-void task_startup(main_t entrypt, int argc, FAR char *argv[])
+void nxtask_startup(main_t entrypt, int argc, FAR char *argv[])
        noreturn_function;
 #endif
 

--- a/include/nuttx/userspace.h
+++ b/include/nuttx/userspace.h
@@ -117,8 +117,7 @@ struct userspace_s
 
   /* Task/thread startup routines */
 
-  CODE void (*task_startup)(main_t entrypt, int argc, FAR char *argv[])
-    noreturn_function;
+  CODE void (*task_startup)(main_t entrypt, int argc, FAR char *argv[]);
 #ifndef CONFIG_DISABLE_PTHREAD
   CODE void (*pthread_startup)(pthread_startroutine_t entrypt,
     pthread_addr_t arg);
@@ -151,27 +150,6 @@ extern "C"
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
-
-/****************************************************************************
- * Name: nxtask_startup
- *
- * Description:
- *   This function is the user-space, task startup function.  It is called
- *   from up_task_start() in user-mode.
- *
- * Input Parameters:
- *   entrypt - The user-space address of the task entry point
- *   argc and argv - Standard arguments for the task entry point
- *
- * Returned Value:
- *   None.  This function does not return.
- *
- ****************************************************************************/
-
-#ifndef __KERNEL__
-void nxtask_startup(main_t entrypt, int argc, FAR char *argv[])
-       noreturn_function;
-#endif
 
 /****************************************************************************
  * Name: pthread_startup

--- a/libs/libc/sched/Make.defs
+++ b/libs/libc/sched/Make.defs
@@ -45,7 +45,7 @@ ifeq ($(CONFIG_SMP),y)
 CSRCS += sched_cpucount.c
 endif
 
-ifeq ($(CONFIG_BUILD_PROTECTED),y)
+ifneq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += task_startup.c
 endif
 

--- a/libs/libc/sched/task_startup.c
+++ b/libs/libc/sched/task_startup.c
@@ -39,12 +39,94 @@
 
 #include <nuttx/config.h>
 
+#include <sched.h>
 #include <stdlib.h>
 #include <assert.h>
 
-#include <nuttx/userspace.h>
+#ifndef CONFIG_BUILD_KERNEL
 
-#if defined(CONFIG_BUILD_PROTECTED) && !defined(__KERNEL__)
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* This type defines one entry in initialization array */
+
+typedef CODE void (*initializer_t)(void);
+
+/****************************************************************************
+ * External References
+ ****************************************************************************/
+
+/* _sinit and _einit are symbols exported by the linker script that mark the
+ * beginning and the end of the C++ initialization section.
+ */
+
+extern initializer_t _sinit;
+extern initializer_t _einit;
+
+/* _stext and _etext are symbols exported by the linker script that mark the
+ * beginning and the end of text.
+ */
+
+extern uintptr_t _stext;
+extern uintptr_t _etext;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: cxx_initialize
+ *
+ * Description:
+ *   If C++ and C++ static constructors are supported, then this function
+ *   must be provided by board-specific logic in order to perform
+ *   initialization of the static C++ class instances.
+ *
+ *   This function should then be called in the application-specific
+ *   user_start logic in order to perform the C++ initialization.  NOTE
+ *   that no component of the core NuttX RTOS logic is involved; this
+ *   function definition only provides the 'contract' between application
+ *   specific C++ code and platform-specific toolchain support.
+ *
+ ****************************************************************************/
+
+static void cxx_initialize(void)
+{
+#ifdef CONFIG_HAVE_CXXINITIALIZE
+  static int inited = 0;
+
+  if (inited == 0)
+    {
+      initializer_t *initp;
+
+      sinfo("_sinit: %p _einit: %p _stext: %p _etext: %p\n",
+            &_sinit, &_einit, &_stext, &_etext);
+
+      /* Visit each entry in the initialization table */
+
+      for (initp = &_sinit; initp != &_einit; initp++)
+        {
+          initializer_t initializer = *initp;
+          sinfo("initp: %p initializer: %p\n", initp, initializer);
+
+          /* Make sure that the address is non-NULL and lies in the text
+           * region defined by the linker script.  Some toolchains may put
+           * NULL values or counts in the initialization table.
+           */
+
+          if ((FAR void *)initializer >= (FAR void *)&_stext &&
+              (FAR void *)initializer < (FAR void *)&_etext)
+            {
+              sinfo("Calling %p\n", initializer);
+              initializer();
+            }
+        }
+
+      inited = 1;
+    }
+#endif
+}
 
 /****************************************************************************
  * Public Functions
@@ -70,6 +152,12 @@ void nxtask_startup(main_t entrypt, int argc, FAR char *argv[])
 {
   DEBUGASSERT(entrypt);
 
+  /* If C++ initialization for static constructors is supported, then do
+   * that first
+   */
+
+  cxx_initialize();
+
   /* Call the 'main' entry point passing argc and argv, calling exit()
    * if/when the task returns.
    */
@@ -77,4 +165,4 @@ void nxtask_startup(main_t entrypt, int argc, FAR char *argv[])
   exit(entrypt(argc, argv));
 }
 
-#endif /* CONFIG_BUILD_PROTECTED && !__KERNEL__ */
+#endif /* !CONFIG_BUILD_KERNEL */

--- a/libs/libc/sched/task_startup.c
+++ b/libs/libc/sched/task_startup.c
@@ -51,7 +51,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: task_startup
+ * Name: nxtask_startup
  *
  * Description:
  *   This function is the user-space, task startup function.  It is called
@@ -66,7 +66,7 @@
  *
  ****************************************************************************/
 
-void task_startup(main_t entrypt, int argc, FAR char *argv[])
+void nxtask_startup(main_t entrypt, int argc, FAR char *argv[])
 {
   DEBUGASSERT(entrypt);
 

--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -22,6 +22,14 @@ config HAVE_CXX
 
 if HAVE_CXX
 
+config HAVE_CXXINITIALIZE
+	bool "Have C++ initialization"
+	default n
+	---help---
+		The platform-specific logic includes support for initialization
+		of static C++ instances for this architecture and for the selected
+		toolchain (via up_cxxinitialize()).
+
 config CXX_EXCEPTION
 	bool
 

--- a/sched/task/task_start.c
+++ b/sched/task/task_start.c
@@ -89,7 +89,7 @@
 void nxtask_start(void)
 {
   FAR struct task_tcb_s *tcb = (FAR struct task_tcb_s *)this_task();
-  int exitcode;
+  int exitcode = EXIT_FAILURE;
   int argc;
 
   DEBUGASSERT((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != \
@@ -138,13 +138,14 @@ void nxtask_start(void)
   if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
     {
       up_task_start(tcb->cmn.entry.main, argc, tcb->argv);
-      exitcode = EXIT_FAILURE; /* Should not get here */
     }
   else
-#endif
     {
       exitcode = tcb->cmn.entry.main(argc, tcb->argv);
     }
+#else
+  nxtask_startup(tcb->cmn.entry.main, argc, tcb->argv);
+#endif
 
   /* Call exit() if/when the task returns */
 


### PR DESCRIPTION
## Summary
To avoid the similar code spread around the apps code space

## Impact

## Testing

