### PR TITLE
sim: CMODULEFLAGS fixes for Linux

### DIFF
--- a/boards/sim/sim/sim/configs/cxxtest/Make.defs
+++ b/boards/sim/sim/sim/configs/cxxtest/Make.defs
@@ -82,6 +82,12 @@ AFLAGS = $(CFLAGS) -D__ASSEMBLY__
 CMODULEFLAGS = $(CFLAGS)
 # -fno-pic to avoid GOT relocations
 CMODULEFLAGS += -fno-pic
+# It seems macOS/x86_64 loads the program text around 00000001_xxxxxxxx.
+# The gcc default (-mcmodel=small) would produce out-of-range 32-bit
+# relocations.
+# Even on Linux, NuttX modules are loaded into the NuttX heap, which
+# can be out of range with -mcmodel=small.
+CMODULEFLAGS += -mcmodel=large
 
 LDMODULEFLAGS = -r -e module_initialize
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
@@ -97,10 +103,6 @@ ifeq ($(CONFIG_HOST_MACOS),y)
   MODULECC = x86_64-elf-gcc
   MODULELD = x86_64-elf-ld
   MODULESTRIP = x86_64-elf-strip --strip-unneeded
-  # It seems macOS/x86_64 loads the program text around 00000001_xxxxxxxx.
-  # The gcc default (-mcmodel=small) would produce out-of-range 32-bit
-  # relocations.
-  CMODULEFLAGS += -mcmodel=large
 endif
 
 # ELF module definitions

--- a/boards/sim/sim/sim/configs/cxxtest/Make.defs
+++ b/boards/sim/sim/sim/configs/cxxtest/Make.defs
@@ -88,6 +88,10 @@ CMODULEFLAGS += -fno-pic
 # Even on Linux, NuttX modules are loaded into the NuttX heap, which
 # can be out of range with -mcmodel=small.
 CMODULEFLAGS += -mcmodel=large
+# On Linux, we (ab)use the host compiler to compile binaries for NuttX.
+# Explicitly disable features which might be default on the host while
+# not available on NuttX.
+CMODULEFLAGS += -fno-stack-protector
 
 LDMODULEFLAGS = -r -e module_initialize
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -77,6 +77,12 @@ AFLAGS = $(CFLAGS) -D__ASSEMBLY__
 CMODULEFLAGS = $(CFLAGS)
 # -fno-pic to avoid GOT relocations
 CMODULEFLAGS += -fno-pic
+# It seems macOS/x86_64 loads the program text around 00000001_xxxxxxxx.
+# The gcc default (-mcmodel=small) would produce out-of-range 32-bit
+# relocations.
+# Even on Linux, NuttX modules are loaded into the NuttX heap, which
+# can be out of range with -mcmodel=small.
+CMODULEFLAGS += -mcmodel=large
 
 LDMODULEFLAGS = -r -e module_initialize
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
@@ -92,10 +98,6 @@ ifeq ($(CONFIG_HOST_MACOS),y)
   MODULECC = x86_64-elf-gcc
   MODULELD = x86_64-elf-ld
   MODULESTRIP = x86_64-elf-strip --strip-unneeded
-  # It seems macOS/x86_64 loads the program text around 00000001_xxxxxxxx.
-  # The gcc default (-mcmodel=small) would produce out-of-range 32-bit
-  # relocations.
-  CMODULEFLAGS += -mcmodel=large
 endif
 
 # ELF module definitions

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -83,6 +83,10 @@ CMODULEFLAGS += -fno-pic
 # Even on Linux, NuttX modules are loaded into the NuttX heap, which
 # can be out of range with -mcmodel=small.
 CMODULEFLAGS += -mcmodel=large
+# On Linux, we (ab)use the host compiler to compile binaries for NuttX.
+# Explicitly disable features which might be default on the host while
+# not available on NuttX.
+CMODULEFLAGS += -fno-stack-protector
 
 LDMODULEFLAGS = -r -e module_initialize
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)


### PR DESCRIPTION
## Summary
Sync Linux CMODULEFLAGS with macOS.
Namely, always use -mcmodel=large.

NuttX modules are loaded into the NuttX heap, which can be out of
range for 32-bit relocations generated with -mcmodel=small.

A possible alternative would be to use MAP_32BIT to allocate sim heap.
But I prefer this approach because it's very convenient for me to
be able to share modules between Linux and macOS sim.

Also, disable stack protector:

On Linux, we (ab)use the host compiler to compile binaries for NuttX.
Explicitly disable features which might be default on the host while
not available on NuttX.

On macOS, this is not necessary because we use a cross compiler,
which has safer defaults for our purpose, to build binaries to
run on NuttX. But this doesn't hurt either.

## Impact
Linux sim

## Testing
manually tested with my local app.
