### PR TITLE
fs: Rename link to symlink

### DIFF
--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -51,7 +51,7 @@ endif
 CSRCS += fs_pread.c fs_pwrite.c
 
 ifneq ($(CONFIG_PSEUDOFS_SOFTLINKS),0)
-CSRCS += fs_link.c fs_readlink.c
+CSRCS += fs_symlink.c fs_readlink.c
 endif
 
 # Stream support

--- a/fs/vfs/fs_symlink.c
+++ b/fs/vfs/fs_symlink.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * fs/vfs/fs_link.c
+ * fs/vfs/fs_symlink.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -47,10 +47,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: link
+ * Name: symlink
  *
  * Description:
- *   The link() function will create a new link (directory entry) for the
+ *   The symlink() function will create a new link (directory entry) for the
  *   existing file, path2.  This implementation is simplied for use with
  *   NuttX in these ways:
  *
@@ -72,7 +72,7 @@
  *
  ****************************************************************************/
 
-int link(FAR const char *path1, FAR const char *path2)
+int symlink(FAR const char *path1, FAR const char *path2)
 {
   struct inode_search_s desc;
   FAR struct inode *inode = NULL;

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -246,7 +246,7 @@ SYSCALL_LOOKUP(telldir,                    1)
 #endif
 
 #if defined(CONFIG_PSEUDOFS_SOFTLINKS)
-  SYSCALL_LOOKUP(link,                     2)
+  SYSCALL_LOOKUP(symlink,                  2)
   SYSCALL_LOOKUP(readlink,                 3)
 #endif
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -268,7 +268,7 @@
 
 /* Helpers and legacy compatibility definitions */
 
-#define symlink(p1, p2)                  link((p1), (p2))
+#define link(p1, p2)                     symlink((p1), (p2))
 #define fdatasync(f)                     fsync(f)
 #define getdtablesize(f)                 ((int)sysconf(_SC_OPEN_MAX))
 
@@ -359,7 +359,7 @@ int     unlink(FAR const char *pathname);
 int     truncate(FAR const char *path, off_t length);
 
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
-int     link(FAR const char *path1, FAR const char *path2);
+int     symlink(FAR const char *path1, FAR const char *path2);
 ssize_t readlink(FAR const char *path, FAR char *buf, size_t bufsize);
 #endif
 

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -42,7 +42,7 @@
 "insmod","nuttx/module.h","defined(CONFIG_MODULE)","FAR void *","FAR const char *","FAR const char *"
 "ioctl","sys/ioctl.h","","int","int","int","...","unsigned long"
 "kill","signal.h","","int","pid_t","int"
-"link","unistd.h","defined(CONFIG_PSEUDOFS_SOFTLINKS)","int","FAR const char *","FAR const char *"
+"symlink","unistd.h","defined(CONFIG_PSEUDOFS_SOFTLINKS)","int","FAR const char *","FAR const char *"
 "listen","sys/socket.h","defined(CONFIG_NET)","int","int","int"
 "lseek","unistd.h","","off_t","int","off_t","int"
 "lstat","sys/stat.h","","int","FAR const char *","FAR struct stat *"


### PR DESCRIPTION
since the current implementation is really a symoblic link not hard link, and define link as symlinnk until NuttX support the hard link.

## Summary
Follow up the patch: https://github.com/apache/incubator-nuttx/pull/1279

## Impact
No real functionality change.

## Testing

