### PR TITLE
make/export: enhance make export

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -421,7 +421,7 @@ ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 		cp -f uImage /tftpboot/uImage; \
 	fi
 endif
-	$(call POSTBUILD)
+	$(call POSTBUILD, $(TOPDIR))
 
 # download
 #

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -117,7 +117,7 @@ LINKLIBS = $(patsubst staging/%,%,$(NUTTXLIBS))
 # Export tool definitions
 
 MKEXPORT= tools/mkexport.sh
-MKEXPORT_ARGS = -w$(CONFIG_CYGWIN_WINTOOL) -t "$(TOPDIR)"
+MKEXPORT_ARGS = -w$(CONFIG_CYGWIN_WINTOOL) -t "$(TOPDIR)" -b "$(BOARD_DIR)"
 
 ifneq ($(CONFIG_BUILD_FLAT),y)
 MKEXPORT_ARGS += -u

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -381,7 +381,7 @@ ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: $(NUTTXNAME).bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
 endif
-	$(call POSTBUILD)
+	$(call POSTBUILD, $(TOPDIR))
 
 # download
 #

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -39,6 +39,7 @@ unset TOPDIR
 unset LIBLIST
 unset TGZ
 unset APPDIR
+unset BOARDDIR
 
 USRONLY=n
 WINTOOL=n
@@ -49,6 +50,10 @@ while [ ! -z "$1" ]; do
   -a )
     shift
     APPDIR="$1"
+    ;;
+  -b )
+    shift
+    BOARDDIR="$1"
     ;;
   -d )
     set -x
@@ -200,6 +205,12 @@ cp "${TOPDIR}/tools/incdir.c" "${EXPORTDIR}/tools/."
 # Copy the default linker script
 
 cp -f "${TOPDIR}/binfmt/libelf/gnu-elf.ld" "${EXPORTDIR}/scripts/."
+
+# Copy the board config script
+
+if [ -f "${BOARDDIR}/scripts/Config.mk" ]; then
+  cp -f "${BOARDDIR}/scripts/Config.mk" "${EXPORTDIR}/scripts/."
+fi
 
 # Is there a linker script in this configuration?
 

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -260,7 +260,7 @@ echo "HOSTINCLUDES     = ${HOSTINCLUDES}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "HOSTCFLAGS       = ${HOSTCFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "HOSTLDFLAGS      = ${HOSTLDFLAGS}" >>"${EXPORTDIR}/scripts/Make.defs"
 echo "HOSTEXEEXT       = ${HOSTEXEEXT}" >>"${EXPORTDIR}/scripts/Make.defs"
-echo "LDSCRIPT         = ${LDSCRIPT}" >>"${EXPORTDIR}/scripts/Make.defs"
+echo "LDNAME           = ${LDNAME}" >>"${EXPORTDIR}/scripts/Make.defs"
 
 # Additional compilation options when the kernel is built
 


### PR DESCRIPTION
## Summary

1. make/POSTBUILD: make BIN directory configurable
enhance the post build can support configurable BIN directory

2. make/export: export post build script
post build processing is also necessary for import compile

3. make/export: use LDNAME instead of LDSCRIPT
use LDNAME instead of LDSCRIPT to avoid invalid native path exported to the import build

## Impact
make export

## Testing

```
$ cd $(NUTTX_DIR)
$ ./tools/configure.sh stm32f429i-disco:nsh
$ make export -j12

$ cd $(APPS_DIR)
$ ./tools/mkimport.sh -x $(NUTTX_DIR)/nuttx-export-9.1.0.zip
$ make import -j12
...
LD: nuttx
make[1]: Leaving directory '/home/archer/code/apps/import'

```