### PR TITLE
sched/kthread: extend kthread_create() to support configurable stack

### DIFF
--- a/boards/arm/imxrt/imxrt1020-evk/src/imxrt_usbhost.c
+++ b/boards/arm/imxrt/imxrt1020-evk/src/imxrt_usbhost.c
@@ -276,7 +276,7 @@ void imxrt_usbhost_vbusdrive(int rhport, bool enable)
     }
 }
 
-/****************************************************************************
+/*****************************************************************************
  * Name: imxrt_setup_overcurrent
  *
  * Description:
@@ -291,7 +291,7 @@ void imxrt_usbhost_vbusdrive(int rhport, bool enable)
  *   Zero (OK) returned on success; a negated errno value is returned on
  *   failure.
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 #if 0 /* Not ready yet */
 int imxrt_setup_overcurrent(xcpt_t handler, void *arg)

--- a/boards/arm/imxrt/imxrt1020-evk/src/imxrt_usbhost.c
+++ b/boards/arm/imxrt/imxrt1020-evk/src/imxrt_usbhost.c
@@ -221,7 +221,7 @@ int imxrt_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("EHCI Monitor", CONFIG_USBHOST_DEFPRIO,
-                       CONFIG_USBHOST_STACKSIZE,
+                       NULL, CONFIG_USBHOST_STACKSIZE,
                        (main_t)ehci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {

--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_usbhost.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_usbhost.c
@@ -274,7 +274,7 @@ void imxrt_usbhost_vbusdrive(int rhport, bool enable)
     }
 }
 
-/****************************************************************************
+/*****************************************************************************
  * Name: imxrt_setup_overcurrent
  *
  * Description:
@@ -289,7 +289,7 @@ void imxrt_usbhost_vbusdrive(int rhport, bool enable)
  *   Zero (OK) returned on success; a negated errno value is returned on
  *   failure.
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 #if 0 /* Not ready yet */
 int imxrt_setup_overcurrent(xcpt_t handler, void *arg)

--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_usbhost.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_usbhost.c
@@ -219,7 +219,7 @@ int imxrt_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("EHCI Monitor", CONFIG_USBHOST_DEFPRIO,
-                       CONFIG_USBHOST_STACKSIZE,
+                       NULL, CONFIG_USBHOST_STACKSIZE,
                        (main_t)ehci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/src/lpc17_40_bringup.c
@@ -302,7 +302,8 @@ static int nsh_usbhostinitialize(void)
   if (ret != OK)
     {
       syslog(LOG_ERR,
-             "ERROR: Failed to register the CDC/ACM serial class: %d\n", ret);
+             "ERROR: Failed to register the CDC/ACM serial class: %d\n",
+             ret);
     }
 #endif
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/src/lpc17_40_bringup.c
@@ -317,7 +317,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/src/lpc17_40_bringup.c
@@ -338,7 +338,8 @@ static int nsh_usbhostinitialize(void)
   if (ret != OK)
     {
       syslog(LOG_ERR,
-             "ERROR: Failed to register the CDC/ACM serial class: %d\n", ret);
+             "ERROR: Failed to register the CDC/ACM serial class: %d\n",
+             ret);
     }
 #endif
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/src/lpc17_40_bringup.c
@@ -353,7 +353,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/lpc17xx_40xx/lx_cpu/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/src/lpc17_40_bringup.c
@@ -353,7 +353,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/lpc17xx_40xx/mcb1700/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/mcb1700/src/lpc17_40_bringup.c
@@ -291,7 +291,8 @@ static int nsh_usbhostinitialize(void)
   if (ret != OK)
     {
       syslog(LOG_ERR,
-             "ERROR: Failed to register the CDC/ACM serial class: %d\n", ret);
+             "ERROR: Failed to register the CDC/ACM serial class: %d\n",
+             ret);
     }
 #endif
 

--- a/boards/arm/lpc17xx_40xx/mcb1700/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/mcb1700/src/lpc17_40_bringup.c
@@ -308,7 +308,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_ERR, "ERROR: Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_MCB1700_USBHOST_PRIO,
-                           CONFIG_MCB1700_USBHOST_STACKSIZE,
+                           NULL, CONFIG_MCB1700_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/src/lpc17_40_bringup.c
@@ -288,7 +288,8 @@ static int nsh_usbhostinitialize(void)
   if (ret < 0)
     {
       syslog(LOG_ERR,
-             "ERROR: Failed to register the CDC/ACM serial class: %d\n", ret);
+             "ERROR: Failed to register the CDC/ACM serial class: %d\n",
+             ret);
     }
 #endif
 

--- a/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/src/lpc17_40_bringup.c
@@ -327,7 +327,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_ERR, "ERROR: Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_LPC1766STK_USBHOST_PRIO,
-                           CONFIG_LPC1766STK_USBHOST_STACKSIZE,
+                           NULL, CONFIG_LPC1766STK_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/lpc17xx_40xx/open1788/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/open1788/src/lpc17_40_bringup.c
@@ -337,7 +337,8 @@ static int nsh_usbhostinitialize(void)
   if (ret != OK)
     {
       syslog(LOG_ERR,
-             "ERROR: Failed to register the CDC/ACM serial class: %d\n", ret);
+             "ERROR: Failed to register the CDC/ACM serial class: %d\n",
+             ret);
     }
 #endif
 

--- a/boards/arm/lpc17xx_40xx/open1788/src/lpc17_40_bringup.c
+++ b/boards/arm/lpc17xx_40xx/open1788/src/lpc17_40_bringup.c
@@ -352,7 +352,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/lpc31xx/ea3131/src/lpc31_usbhost.c
+++ b/boards/arm/lpc31xx/ea3131/src/lpc31_usbhost.c
@@ -235,7 +235,7 @@ int lpc31_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("EHCI Monitor", CONFIG_USBHOST_DEFPRIO,
-                       CONFIG_USBHOST_STACKSIZE,
+                       NULL, CONFIG_USBHOST_STACKSIZE,
                        (main_t)ehci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {

--- a/boards/arm/lpc31xx/olimex-lpc-h3131/src/lpc31_usbhost.c
+++ b/boards/arm/lpc31xx/olimex-lpc-h3131/src/lpc31_usbhost.c
@@ -235,7 +235,7 @@ int lpc31_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("EHCI Monitor", CONFIG_USBHOST_DEFPRIO, i
-                       CONFIG_USBHOST_STACKSIZE,
+                       NULL, CONFIG_USBHOST_STACKSIZE,
                        (main_t)ehci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {

--- a/boards/arm/sam34/sam4s-xplained-pro/src/sam_wdt.c
+++ b/boards/arm/sam34/sam4s-xplained-pro/src/sam_wdt.c
@@ -202,7 +202,7 @@ int sam_watchdog_initialize(void)
 
   int taskid = kthread_create(CONFIG_WDT_THREAD_NAME,
                               CONFIG_WDT_THREAD_PRIORITY,
-                              CONFIG_WDT_THREAD_STACKSIZE,
+                              NULL, CONFIG_WDT_THREAD_STACKSIZE,
                               (main_t)wdog_daemon, (FAR char * const *)NULL);
 
   DEBUGASSERT(taskid > 0);

--- a/boards/arm/sama5/sama5d2-xult/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d2-xult/src/sam_usb.c
@@ -340,7 +340,7 @@ int sam_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("OHCI Monitor", CONFIG_SAMA5D2XULT_USBHOST_PRIO,
-                       CONFIG_SAMA5D2XULT_USBHOST_STACKSIZE,
+                       NULL, CONFIG_SAMA5D2XULT_USBHOST_STACKSIZE,
                        (main_t)ohci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {
@@ -362,7 +362,7 @@ int sam_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("EHCI Monitor", CONFIG_SAMA5D2XULT_USBHOST_PRIO,
-                       CONFIG_SAMA5D2XULT_USBHOST_STACKSIZE,
+                       NULL, CONFIG_SAMA5D2XULT_USBHOST_STACKSIZE,
                        (main_t)ehci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_usb.c
@@ -363,7 +363,7 @@ int sam_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("OHCI Monitor", CONFIG_SAMA5D3XPLAINED_USBHOST_PRIO,
-                       CONFIG_SAMA5D3XPLAINED_USBHOST_STACKSIZE,
+                       NULL, CONFIG_SAMA5D3XPLAINED_USBHOST_STACKSIZE,
                        (main_t)ohci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {
@@ -385,7 +385,7 @@ int sam_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("EHCI Monitor", CONFIG_SAMA5D3XPLAINED_USBHOST_PRIO,
-                       CONFIG_SAMA5D3XPLAINED_USBHOST_STACKSIZE,
+                       NULL, CONFIG_SAMA5D3XPLAINED_USBHOST_STACKSIZE,
                        (main_t)ehci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_usb.c
@@ -194,8 +194,8 @@ static int ehci_waiter(int argc, char *argv[])
  * USB Ports
  *   The SAMA5D3 series-MB features three USB communication ports:
  *
- *     1. Port A Host High Speed (EHCI) and Full Speed (OHCI) multiplexed with
- *        USB Device High Speed Micro AB connector, J20
+ *     1. Port A Host High Speed (EHCI) and Full Speed (OHCI) multiplexed
+ *        with USB Device High Speed Micro AB connector, J20
  *
  *     2. Port B Host High Speed (EHCI) and Full Speed (OHCI) standard type A
  *        connector, J19 upper port

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_usb.c
@@ -362,7 +362,7 @@ int sam_usbhost_initialize(void)
 
   pid = kthread_create("OHCI Monitor",
                       CONFIG_SAMA5D3xEK_USBHOST_PRIO,
-                      CONFIG_SAMA5D3xEK_USBHOST_STACKSIZE,
+                      NULL, CONFIG_SAMA5D3xEK_USBHOST_STACKSIZE,
                       (main_t)ohci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {
@@ -384,7 +384,7 @@ int sam_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("EHCI Monitor", CONFIG_SAMA5D3xEK_USBHOST_PRIO,
-                       CONFIG_SAMA5D3xEK_USBHOST_STACKSIZE,
+                       NULL, CONFIG_SAMA5D3xEK_USBHOST_STACKSIZE,
                        (main_t)ehci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_usb.c
@@ -361,9 +361,9 @@ int sam_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("OHCI Monitor",
-                      CONFIG_SAMA5D3xEK_USBHOST_PRIO,
-                      NULL, CONFIG_SAMA5D3xEK_USBHOST_STACKSIZE,
-                      (main_t)ohci_waiter, (FAR char * const *)NULL);
+                       CONFIG_SAMA5D3xEK_USBHOST_PRIO,
+                       NULL, CONFIG_SAMA5D3xEK_USBHOST_STACKSIZE,
+                       (main_t)ohci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {
       uerr("ERROR: Failed to create ohci_waiter task: %d\n", ret);
@@ -535,8 +535,8 @@ xcpt_t sam_setup_overcurrent(xcpt_t handler)
  * Name:  sam_usbsuspend
  *
  * Description:
- *   Board logic must provide the sam_usbsuspend logic if the USBDEV driver is
- *   used.
+ *   Board logic must provide the sam_usbsuspend logic if the USBDEV driver
+ *   is used.
  *   This function is called whenever the USB enters or leaves suspend mode.
  *   This is an opportunity for the board logic to shutdown clocks, power,
  *   etc. while the USB is suspended.

--- a/boards/arm/sama5/sama5d4-ek/src/sam_usb.c
+++ b/boards/arm/sama5/sama5d4-ek/src/sam_usb.c
@@ -361,7 +361,7 @@ int sam_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("OHCI Monitor", CONFIG_SAMA5D4EK_USBHOST_PRIO,
-                       CONFIG_SAMA5D4EK_USBHOST_STACKSIZE,
+                       NULL, CONFIG_SAMA5D4EK_USBHOST_STACKSIZE,
                        (main_t)ohci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {
@@ -383,7 +383,7 @@ int sam_usbhost_initialize(void)
   /* Start a thread to handle device connection. */
 
   pid = kthread_create("EHCI Monitor", CONFIG_SAMA5D4EK_USBHOST_PRIO,
-                       CONFIG_SAMA5D4EK_USBHOST_STACKSIZE,
+                       NULL, CONFIG_SAMA5D4EK_USBHOST_STACKSIZE,
                        (main_t)ehci_waiter, (FAR char * const *)NULL);
   if (pid < 0)
     {

--- a/boards/arm/stm32/axoloti/src/stm32_usbhost.c
+++ b/boards/arm/stm32/axoloti/src/stm32_usbhost.c
@@ -224,6 +224,7 @@ int stm32_usbhost_initialize(void)
   /* First, register all of the class drivers needed to support the drivers
    * that we care about:
    */
+
   uinfo("Register class drivers\n");
 
 #ifdef CONFIG_USBHOST_MSC

--- a/boards/arm/stm32/axoloti/src/stm32_usbhost.c
+++ b/boards/arm/stm32/axoloti/src/stm32_usbhost.c
@@ -267,7 +267,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
       pid =
         kthread_create("usbhost", CONFIG_AXOLOTI_USBHOST_PRIO,
-                       CONFIG_AXOLOTI_USBHOST_STACKSIZE,
+                       NULL, CONFIG_AXOLOTI_USBHOST_STACKSIZE,
                        (main_t) usbhost_waiter, (FAR char *const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/cloudctrl/src/stm32_usb.c
+++ b/boards/arm/stm32/cloudctrl/src/stm32_usb.c
@@ -211,7 +211,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/cloudctrl/src/stm32_usb.c
+++ b/boards/arm/stm32/cloudctrl/src/stm32_usb.c
@@ -109,7 +109,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -140,16 +140,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM3240G-EVAL board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM3240G-EVAL board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -162,7 +166,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -224,21 +229,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -270,16 +278,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -294,10 +302,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_usb.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_usb.c
@@ -108,7 +108,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -139,16 +139,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM32F4Discovery board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM32F4Discovery board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -161,7 +165,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -223,21 +228,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -269,16 +277,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -290,13 +298,13 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
 #endif
 
 /****************************************************************************
- * Name:  stm32_usbsuspend
+ * Name: stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_usb.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_usb.c
@@ -210,7 +210,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/nucleo-f207zg/src/stm32_usb.c
+++ b/boards/arm/stm32/nucleo-f207zg/src/stm32_usb.c
@@ -105,7 +105,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -136,16 +136,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the nucleo-144 board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the nucleo-144 board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -158,7 +162,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -253,21 +258,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -290,16 +298,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -311,13 +319,13 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
 #endif
 
 /****************************************************************************
- * Name:  stm32_usbsuspend
+ * Name: stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/nucleo-f207zg/src/stm32_usb.c
+++ b/boards/arm/stm32/nucleo-f207zg/src/stm32_usb.c
@@ -240,7 +240,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_NUCLEOF207ZG_USBHOST_PRIO,
-                           CONFIG_NUCLEOF207ZG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_NUCLEOF207ZG_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/nucleo-f412zg/src/stm32_usb.c
+++ b/boards/arm/stm32/nucleo-f412zg/src/stm32_usb.c
@@ -254,7 +254,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F411DISCO_USBHOST_PRIO,
-                           CONFIG_STM32F411DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32F411DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_usb.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_usb.c
@@ -229,7 +229,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F4DISCO_USBHOST_PRIO,
-                           CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/olimex-stm32-e407/src/stm32_usb.c
+++ b/boards/arm/stm32/olimex-stm32-e407/src/stm32_usb.c
@@ -104,7 +104,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -142,9 +142,13 @@ static int usbhost_waiter(int argc, char *argv[])
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -153,7 +157,7 @@ void stm32_usbinitialize(void)
 #endif
 }
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_initialize
  *
  * Description:
@@ -161,7 +165,7 @@ void stm32_usbinitialize(void)
  *   functionality.  This function will start a thread that will monitor
  *   for device connection/disconnection events.
  *
- ***************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 int stm32_usbhost_initialize(void)

--- a/boards/arm/stm32/olimex-stm32-e407/src/stm32_usb.c
+++ b/boards/arm/stm32/olimex-stm32-e407/src/stm32_usb.c
@@ -239,7 +239,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F4DISCO_USBHOST_PRIO,
-                           CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/olimex-stm32-h407/src/stm32_usb.c
+++ b/boards/arm/stm32/olimex-stm32-h407/src/stm32_usb.c
@@ -217,7 +217,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32H407_USBHOST_PRIO,
-                           CONFIG_STM32H407_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32H407_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/olimex-stm32-h407/src/stm32_usb.c
+++ b/boards/arm/stm32/olimex-stm32-h407/src/stm32_usb.c
@@ -105,7 +105,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -136,16 +136,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM32F4Discovery board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM32F4Discovery board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG HS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG HS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGHS
   stm32_configgpio(GPIO_OTGHS_VBUS);
@@ -158,7 +162,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -230,21 +235,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG HS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_HS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -276,16 +284,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -300,10 +308,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/olimex-stm32-p207/src/stm32_usb.c
+++ b/boards/arm/stm32/olimex-stm32-p207/src/stm32_usb.c
@@ -107,7 +107,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -138,16 +138,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM32F4Discovery board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM32F4Discovery board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, and Power On GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -160,7 +164,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -234,16 +239,16 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -258,21 +263,24 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -304,10 +312,10 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/olimex-stm32-p207/src/stm32_usb.c
+++ b/boards/arm/stm32/olimex-stm32-p207/src/stm32_usb.c
@@ -221,7 +221,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/olimex-stm32-p407/src/stm32_usb.c
+++ b/boards/arm/stm32/olimex-stm32-p407/src/stm32_usb.c
@@ -104,7 +104,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -135,17 +135,21 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usb_configure
  *
  * Description:
- *   Called from stm32_boardinitialize very early in inialization to setup USB-related
- *   GPIO pins for the Olimex STM32 P407 board.
+ *   Called from stm32_usb_configure very early in inialization to setup
+ *   USB-related GPIO pins for the Olimex STM32 P407 board.
  *
  ****************************************************************************/
 
 void stm32_usb_configure(void)
 {
 #ifdef CONFIG_STM32_OTGFS
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
   stm32_configgpio(GPIO_OTGFS_VBUS);
   stm32_configgpio(GPIO_OTGFS_PWRON);
@@ -157,7 +161,8 @@ void stm32_usb_configure(void)
  * Name: stm32_usbhost_setup
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -251,21 +256,24 @@ int stm32_usbhost_setup(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -297,16 +305,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -321,10 +329,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/olimex-stm32-p407/src/stm32_usb.c
+++ b/boards/arm/stm32/olimex-stm32-p407/src/stm32_usb.c
@@ -238,7 +238,7 @@ int stm32_usbhost_setup(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_OLIMEXP407_USBHOST_PRIO,
-                           CONFIG_OLIMEXP407_USBHOST_STACKSIZE,
+                           NULL, CONFIG_OLIMEXP407_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/omnibusf4/src/stm32_usb.c
+++ b/boards/arm/stm32/omnibusf4/src/stm32_usb.c
@@ -137,16 +137,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the Omnibusf4 board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the Omnibusf4 board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -157,7 +161,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -263,21 +268,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -309,16 +317,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -333,10 +341,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/omnibusf4/src/stm32_usb.c
+++ b/boards/arm/stm32/omnibusf4/src/stm32_usb.c
@@ -250,7 +250,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_OMNIBUSF4_USBHOST_PRIO,
-                        CONFIG_OMNIBUSF4_USBHOST_STACKSIZE,
+                        NULL, CONFIG_OMNIBUSF4_USBHOST_STACKSIZE,
                         (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/photon/src/stm32_wdt.c
+++ b/boards/arm/stm32/photon/src/stm32_wdt.c
@@ -82,8 +82,8 @@ static int wdog_daemon(int argc, char *argv[])
   ret = file_ioctl(&filestruct, WDIOC_START, 0);
   if (ret < 0)
     {
-        wderr("ERROR: ioctl(WDIOC_START) failed: %d\n", errno);
-        goto exit_close_dev;
+      wderr("ERROR: ioctl(WDIOC_START) failed: %d\n", errno);
+      goto exit_close_dev;
     }
 
   while (1)
@@ -101,6 +101,7 @@ static int wdog_daemon(int argc, char *argv[])
     }
 
 exit_close_dev:
+
   /* Close watchdog device and exit. */
 
   file_close(&filestruct);

--- a/boards/arm/stm32/photon/src/stm32_wdt.c
+++ b/boards/arm/stm32/photon/src/stm32_wdt.c
@@ -159,7 +159,7 @@ int photon_watchdog_initialize(void)
 
   int taskid = kthread_create(CONFIG_PHOTON_WDG_THREAD_NAME,
                               CONFIG_PHOTON_WDG_THREAD_PRIORITY,
-                              CONFIG_PHOTON_WDG_THREAD_STACKSIZE,
+                              NULL, CONFIG_PHOTON_WDG_THREAD_STACKSIZE,
                               (main_t)wdog_daemon, (FAR char * const *)NULL);
 
   if (taskid <= 0)

--- a/boards/arm/stm32/shenzhou/src/stm32_usb.c
+++ b/boards/arm/stm32/shenzhou/src/stm32_usb.c
@@ -108,7 +108,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -139,16 +139,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM3240G-EVAL board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM3240G-EVAL board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -161,7 +165,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -223,21 +228,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -269,16 +277,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -293,10 +301,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/shenzhou/src/stm32_usb.c
+++ b/boards/arm/stm32/shenzhou/src/stm32_usb.c
@@ -210,7 +210,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/stm3220g-eval/src/stm32_usb.c
+++ b/boards/arm/stm32/stm3220g-eval/src/stm32_usb.c
@@ -108,7 +108,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -139,17 +139,21 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM3220G-EVAL board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM3220G-EVAL board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
 #ifdef HAVE_USB
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
   stm32_configgpio(GPIO_OTGFS_VBUS);
   stm32_configgpio(GPIO_OTGFS_PWRON);
@@ -161,7 +165,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -223,21 +228,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -269,16 +277,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -293,10 +301,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/stm3220g-eval/src/stm32_usb.c
+++ b/boards/arm/stm32/stm3220g-eval/src/stm32_usb.c
@@ -210,7 +210,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/stm3240g-eval/src/stm32_usb.c
+++ b/boards/arm/stm32/stm3240g-eval/src/stm32_usb.c
@@ -108,7 +108,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -139,16 +139,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM3240G-EVAL board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM3240G-EVAL board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -161,7 +165,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -223,21 +228,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -269,16 +277,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -293,10 +301,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/stm3240g-eval/src/stm32_usb.c
+++ b/boards/arm/stm32/stm3240g-eval/src/stm32_usb.c
@@ -210,7 +210,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                        CONFIG_USBHOST_STACKSIZE,
+                        NULL, CONFIG_USBHOST_STACKSIZE,
                         (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/stm32f411-minimum/src/stm32_usb.c
+++ b/boards/arm/stm32/stm32f411-minimum/src/stm32_usb.c
@@ -236,7 +236,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F411MINIMUM_USBHOST_PRIO,
-                           CONFIG_STM32F411MINIMUM_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32F411MINIMUM_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/stm32f411e-disco/src/stm32_usb.c
+++ b/boards/arm/stm32/stm32f411e-disco/src/stm32_usb.c
@@ -104,7 +104,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -135,16 +135,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM32F411 Discovery board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM32F411 board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -157,7 +161,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -263,21 +268,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -309,16 +317,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -333,10 +341,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/stm32f411e-disco/src/stm32_usb.c
+++ b/boards/arm/stm32/stm32f411e-disco/src/stm32_usb.c
@@ -250,7 +250,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F411DISCO_USBHOST_PRIO,
-                           CONFIG_STM32F411DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32F411DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_usb.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_usb.c
@@ -216,7 +216,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F429IDISCO_USBHOST_PRIO,
-                           CONFIG_STM32F429IDISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32F429IDISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/stm32f429i-disco/src/stm32_usb.c
+++ b/boards/arm/stm32/stm32f429i-disco/src/stm32_usb.c
@@ -104,7 +104,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -135,16 +135,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM32F4Discovery board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM32F4Discovery board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG HS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG HS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGHS
   stm32_configgpio(GPIO_OTGHS_VBUS);
@@ -157,7 +161,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -229,21 +234,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG HS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_HS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -275,16 +283,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -299,10 +307,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_usb.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_usb.c
@@ -250,7 +250,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F4DISCO_USBHOST_PRIO,
-                        CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
+                        NULL, CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
                         (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_usb.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_usb.c
@@ -104,7 +104,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -135,16 +135,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM32F4Discovery board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM32F4Discovery board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -157,7 +161,8 @@ void stm32_usbinitialize(void)
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -263,21 +268,24 @@ int stm32_usbhost_initialize(void)
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
@@ -309,16 +317,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -333,10 +341,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32/viewtool-stm32f107/src/stm32_max3421e.c
+++ b/boards/arm/stm32/viewtool-stm32f107/src/stm32_max3421e.c
@@ -411,7 +411,7 @@ int stm32_max3421e_setup(void)
 
   monpid = kthread_create("MAX3421E ConnMon",
                           CONFIG_VIEWTOOL_MAX3421E_CONNMON_PRIORITY,
-                          CONFIG_VIEWTOOL_MAX3421E_CONNMON_STACKSIZE,
+                          NULL, CONFIG_VIEWTOOL_MAX3421E_CONNMON_STACKSIZE,
                           usbhost_detect, NULL);
   if (monpid < 0)
     {

--- a/boards/arm/stm32/viewtool-stm32f107/src/stm32_max3421e.c
+++ b/boards/arm/stm32/viewtool-stm32f107/src/stm32_max3421e.c
@@ -92,7 +92,8 @@ struct viewtool_max3421elower_s
  *
  * Interrupts should be configured on the falling edge of nINT.
  *
- *   attach      - Attach the ADS7843E interrupt handler to the GPIO interrupt
+ *   attach      - Attach the ADS7843E interrupt handler to the GPIO
+ *                 interrupt
  *   enable      - Enable or disable the GPIO interrupt
  *   acknowledge - Acknowledge/clear any pending GPIO interrupt as necessary.
  */
@@ -101,7 +102,8 @@ static int max3421e_attach(FAR const struct max3421e_lowerhalf_s *lower,
                            xcpt_t isr, FAR void *arg);
 static void max3421e_enable(FAR const struct max3421e_lowerhalf_s *lower,
                             bool enable);
-static void max3421e_acknowledge(FAR const struct max3421e_lowerhalf_s *lower);
+static void max3421e_acknowledge
+                           (FAR const struct max3421e_lowerhalf_s *lower);
 static void max3421e_power(FAR const struct max3421e_lowerhalf_s *lower,
                            bool enable);
 
@@ -149,7 +151,8 @@ static FAR struct usbhost_connection_s *g_usbconn;
  * interrupts should be configured on both rising and falling edges
  * so that contact and loss-of-contact events can be detected.
  *
- *   attach      - Attach the ADS7843E interrupt handler to the GPIO interrupt
+ *   attach      - Attach the ADS7843E interrupt handler to the GPIO
+ *                 interrupt
  *   enable      - Enable or disable the GPIO interrupt
  *   acknowledge - Acknowledge/clear any pending GPIO interrupt as necessary.
  *   power       - Enable or disable 5V VBUS power
@@ -223,7 +226,8 @@ static void max3421e_enable(FAR const struct max3421e_lowerhalf_s *lower,
   leave_critical_section(flags);
 }
 
-static void max3421e_acknowledge(FAR const struct max3421e_lowerhalf_s *lower)
+static void max3421e_acknowledge
+            (FAR const struct max3421e_lowerhalf_s *lower)
 {
   /* Does nothing */
 }
@@ -238,7 +242,7 @@ static void max3421e_power(FAR const struct max3421e_lowerhalf_s *lower,
 #endif
 }
 
-/*****************************************************************************
+/****************************************************************************
  * Name: usbhost_detect
  *
  * Description:
@@ -251,7 +255,7 @@ static int usbhost_detect(int argc, FAR char *argv[])
 
   uinfo("Starting USB detect thread\n");
 
-  for (;;)
+  for (; ; )
     {
       CONN_WAIT(g_usbconn, &hport);
 
@@ -365,22 +369,20 @@ int stm32_max3421e_setup(void)
 #endif
 
 #if defined(CONFIG_RNDIS)
-  {
-    uint8_t mac[6];
+  uint8_t mac[6];
 
-    mac[0] = 0xa0; /* TODO */
-    mac[1] = (CONFIG_NETINIT_MACADDR_2 >> (8 * 0)) & 0xff;
-    mac[2] = (CONFIG_NETINIT_MACADDR_1 >> (8 * 3)) & 0xff;
-    mac[3] = (CONFIG_NETINIT_MACADDR_1 >> (8 * 2)) & 0xff;
-    mac[4] = (CONFIG_NETINIT_MACADDR_1 >> (8 * 1)) & 0xff;
-    mac[5] = (CONFIG_NETINIT_MACADDR_1 >> (8 * 0)) & 0xff;
+  mac[0] = 0xa0; /* TODO */
+  mac[1] = (CONFIG_NETINIT_MACADDR_2 >> (8 * 0)) & 0xff;
+  mac[2] = (CONFIG_NETINIT_MACADDR_1 >> (8 * 3)) & 0xff;
+  mac[3] = (CONFIG_NETINIT_MACADDR_1 >> (8 * 2)) & 0xff;
+  mac[4] = (CONFIG_NETINIT_MACADDR_1 >> (8 * 1)) & 0xff;
+  mac[5] = (CONFIG_NETINIT_MACADDR_1 >> (8 * 0)) & 0xff;
 
-    ret = usbdev_rndis_initialize(mac);
-    if (ret < 0)
-      {
-        uerr("ERROR: Failed to register RNDIS class: %d\n", ret);
-      }
-  }
+  ret = usbdev_rndis_initialize(mac);
+  if (ret < 0)
+    {
+      uerr("ERROR: Failed to register RNDIS class: %d\n", ret);
+    }
 #endif
 
 #ifdef CONFIG_VIEWTOOL_MAX3421E_RST

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_usb.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_usb.c
@@ -241,7 +241,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F4DISCO_USBHOST_PRIO,
-                           CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_usb.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_usb.c
@@ -106,7 +106,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -137,16 +137,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the nucleo-144 board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the nucleo-144 board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32F7_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -155,15 +159,16 @@ void stm32_usbinitialize(void)
 #endif
 }
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 int stm32_usbhost_initialize(void)
@@ -250,31 +255,34 @@ int stm32_usbhost_initialize(void)
 }
 #endif
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
  *   None
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 void stm32_usbhost_vbusdrive(int iface, bool enable)
@@ -291,16 +299,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -315,10 +323,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used. This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32f7/stm32f746-ws/src/stm32_usb.c
+++ b/boards/arm/stm32f7/stm32f746-ws/src/stm32_usb.c
@@ -242,7 +242,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F7F4DISCO_USBHOST_PRIO,
-                        CONFIG_STM32F7F4DISCO_USBHOST_STACKSIZE,
+                        NULL, CONFIG_STM32F7F4DISCO_USBHOST_STACKSIZE,
                         (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32f7/stm32f746-ws/src/stm32_usb.c
+++ b/boards/arm/stm32f7/stm32f746-ws/src/stm32_usb.c
@@ -104,7 +104,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -135,16 +135,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the STM32F4Discovery board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the STM32F4Discovery board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32F7_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -156,15 +160,16 @@ void stm32_usbinitialize(void)
 #endif
 }
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 int stm32_usbhost_initialize(void)
@@ -251,31 +256,34 @@ int stm32_usbhost_initialize(void)
 }
 #endif
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
  *   None
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 void stm32_usbhost_vbusdrive(int iface, bool enable)
@@ -301,16 +309,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -325,10 +333,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_usb.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_usb.c
@@ -136,16 +136,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the nucleo-144 board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the nucleo-144 board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32H7_OTGFS
   stm32_configgpio(GPIO_OTGFS_VBUS);
@@ -154,15 +158,16 @@ void stm32_usbinitialize(void)
 #endif
 }
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 int stm32_usbhost_initialize(void)
@@ -249,31 +254,34 @@ int stm32_usbhost_initialize(void)
 }
 #endif
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output. This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and status
+ *    register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port, and
+ *    the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
  *   None
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 void stm32_usbhost_vbusdrive(int iface, bool enable)
@@ -290,16 +298,16 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success.  Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
@@ -314,10 +322,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used. This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_usb.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_usb.c
@@ -240,7 +240,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_NUCLEOH743ZI_USBHOST_PRIO,
-                           CONFIG_NUCLEOH743ZI_USBHOST_STACKSIZE,
+                           NULL, CONFIG_NUCLEOH743ZI_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32h7/stm32h747i-disco/src/stm32_usb.c
+++ b/boards/arm/stm32h7/stm32h747i-disco/src/stm32_usb.c
@@ -236,7 +236,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32H747XI_DISCO_USBHOST_PRIO,
-                           CONFIG_STM32H747XI_DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32H747XI_DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32l4/nucleo-l496zg/src/stm32_usb.c
+++ b/boards/arm/stm32l4/nucleo-l496zg/src/stm32_usb.c
@@ -106,7 +106,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uinfo("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -137,16 +137,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32_usbinitialize
  *
  * Description:
- *   Called from stm32_usbinitialize very early in inialization to setup USB-related
- *   GPIO pins for the nucleo-144 board.
+ *   Called from stm32_usbinitialize very early in inialization to setup
+ *   USB-related GPIO pins for the nucleo-144 board.
  *
  ****************************************************************************/
 
 void stm32_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Overcurrent GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Overcurrent GPIOs
+   */
 
 #ifdef CONFIG_STM32L4_OTGFS
   stm32l4_configgpio(GPIO_OTGFS_VBUS);
@@ -155,15 +159,16 @@ void stm32_usbinitialize(void)
 #endif
 }
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 int stm32_usbhost_initialize(void)
@@ -250,31 +255,34 @@ int stm32_usbhost_initialize(void)
 }
 #endif
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output. This function must be
+ *    provided be each platform that implements the STM32 OTG FS host
+ *    interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and status
+ *    register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
  *   None
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 void stm32_usbhost_vbusdrive(int iface, bool enable)
@@ -291,23 +299,24 @@ void stm32_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an overcurrent condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an overcurrent
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New overcurrent interrupt handler
  *   arg     - The argument provided for the interrupt handler
  *
  * Returned Value:
- *   Zero (OK) is returned on success.  Otherwise, a negated errno value is returned
- *   to indicate the nature of the failure.
+ *   Zero (OK) is returned on success. Otherwise, a negated errno value
+ *   is returned to indicate the nature of the failure.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 int stm32_setup_overcurrent(xcpt_t handler, void *arg)
 {
-  return stm32l4_gpiosetevent(GPIO_OTGFS_OVER, true, true, true, handler, arg);
+  return stm32l4_gpiosetevent(GPIO_OTGFS_OVER,
+                              true, true, true, handler, arg);
 }
 #endif
 
@@ -315,10 +324,10 @@ int stm32_setup_overcurrent(xcpt_t handler, void *arg)
  * Name:  stm32_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32_usbsuspend logic if the USBDEV
+ *   driver is used. This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32l4/nucleo-l496zg/src/stm32_usb.c
+++ b/boards/arm/stm32l4/nucleo-l496zg/src/stm32_usb.c
@@ -241,7 +241,7 @@ int stm32_usbhost_initialize(void)
       uinfo("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32F4DISCO_USBHOST_PRIO,
-                           CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_usb.c
+++ b/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_usb.c
@@ -104,7 +104,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uvdbg("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -135,16 +135,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32l4_usbinitialize
  *
  * Description:
- *   Called from stm32l4_usbinitialize very early in initialization to setup USB-related
- *   GPIO pins for the STM32L4Discovery board.
+ *   Called from stm32l4_usbinitialize very early in initialization to
+ *   setup USB-related GPIO pins for the STM32L4Discovery board.
  *
  ****************************************************************************/
 
 void stm32l4_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Over current GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Over current GPIOs
+   */
 
 #ifdef CONFIG_STM32L4_OTGFS
   stm32l4_configgpio(GPIO_OTGFS_VBUS);
@@ -158,7 +162,7 @@ void stm32l4_usbinitialize(void)
  *
  * Description:
  *   Called at application startup time to initialize the USB host
-*    functionality.
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
@@ -249,31 +253,33 @@ int stm32l4_usbhost_initialize(void)
 }
 #endif
 
-/*****************************************************************************
+/****************************************************************************
  * Name: stm32l4_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output. This function must be provided
+ *   be each platform that implements the STM32 OTG FS host interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge
+ *    pump or, if 5 V are available on the application board, a basic power
+ *    switch, must be added externally to drive the 5 V VBUS line. The
+ *    external charge pump can be driven by any GPIO output. When the
+ *    application decides to power on VBUS using the chosen GPIO, it must
+ *    also set the port power bit in the host port control and status
+ *    register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an over current condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an over current condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
  *   None
  *
- *****************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 void stm32l4_usbhost_vbusdrive(int iface, bool enable)
@@ -299,8 +305,8 @@ void stm32l4_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32l4_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an over current condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an over current
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New over current interrupt handler
@@ -322,10 +328,10 @@ xcpt_t stm32l4_setup_overcurrent(xcpt_t handler)
  * Name:  stm32l4_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32l4_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32l4_usbsuspend logic if the USBDEV
+ *   driver is used.  This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_usb.c
+++ b/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_usb.c
@@ -240,7 +240,7 @@ int stm32l4_usbhost_initialize(void)
       uvdbg("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32L4DISCO_USBHOST_PRIO,
-                           CONFIG_STM32L4DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32L4DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/src/stm32_usb.c
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/src/stm32_usb.c
@@ -239,7 +239,7 @@ int stm32l4_usbhost_initialize(void)
       uvdbg("Start usbhost_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_STM32L4DISCO_USBHOST_PRIO,
-                           CONFIG_STM32L4DISCO_USBHOST_STACKSIZE,
+                           NULL, CONFIG_STM32L4DISCO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/src/stm32_usb.c
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/src/stm32_usb.c
@@ -104,7 +104,7 @@ static int usbhost_waiter(int argc, char *argv[])
   struct usbhost_hubport_s *hport;
 
   uvdbg("Running\n");
-  for (;;)
+  for (; ; )
     {
       /* Wait for the device to change state */
 
@@ -135,16 +135,20 @@ static int usbhost_waiter(int argc, char *argv[])
  * Name: stm32l4_usbinitialize
  *
  * Description:
- *   Called from stm32l4_usbinitialize very early in initialization to setup USB-related
- *   GPIO pins for the STM32L4Discovery board.
+ *   Called from stm32l4_usbinitialize very early in initialization to setup
+ *   USB-related GPIO pins for the STM32L4Discovery board.
  *
  ****************************************************************************/
 
 void stm32l4_usbinitialize(void)
 {
-  /* The OTG FS has an internal soft pull-up.  No GPIO configuration is required */
+  /* The OTG FS has an internal soft pull-up.
+   * No GPIO configuration is required
+   */
 
-  /* Configure the OTG FS VBUS sensing GPIO, Power On, and Over current GPIOs */
+  /* Configure the OTG FS VBUS sensing GPIO,
+   * Power On, and Over current GPIOs
+   */
 
 #ifdef CONFIG_STM32L4_OTGFS
   stm32l4_configgpio(GPIO_OTGFS_VBUS);
@@ -153,15 +157,16 @@ void stm32l4_usbinitialize(void)
 #endif
 }
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32l4_usbhost_initialize
  *
  * Description:
- *   Called at application startup time to initialize the USB host functionality.
+ *   Called at application startup time to initialize the USB host
+ *   functionality.
  *   This function will start a thread that will monitor for device
  *   connection/disconnection events.
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 int stm32l4_usbhost_initialize(void)
@@ -248,31 +253,34 @@ int stm32l4_usbhost_initialize(void)
 }
 #endif
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32l4_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a
+ *    basic power switch, must be added externally to drive the 5 V VBUS
+ *    line. The external charge pump can be driven by any GPIO output.
+ *    When the application decides to power on VBUS using the chosen GPIO,
+ *    it must also set the port power bit in the host port control and
+ *    status register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an over current condition."
+ *   "The application uses this field to control power to this port,
+ *    and the core clears this bit on an over current condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
  *   None
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_USBHOST
 void stm32l4_usbhost_vbusdrive(int iface, bool enable)
@@ -298,8 +306,8 @@ void stm32l4_usbhost_vbusdrive(int iface, bool enable)
  * Name: stm32l4_setup_overcurrent
  *
  * Description:
- *   Setup to receive an interrupt-level callback if an over current condition is
- *   detected.
+ *   Setup to receive an interrupt-level callback if an over current
+ *   condition is detected.
  *
  * Input Parameters:
  *   handler - New over current interrupt handler
@@ -321,10 +329,10 @@ xcpt_t stm32l4_setup_overcurrent(xcpt_t handler)
  * Name:  stm32l4_usbsuspend
  *
  * Description:
- *   Board logic must provide the stm32l4_usbsuspend logic if the USBDEV driver is
- *   used.  This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   Board logic must provide the stm32l4_usbsuspend logic if the USBDEV
+ *   driver is used. This function is called whenever the USB enters or
+ *   leaves suspend mode. This is an opportunity for the board logic to
+ *   shutdown clocks, power, etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_appinit.c
+++ b/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_appinit.c
@@ -301,7 +301,8 @@ static int nsh_usbhostinitialize(void)
   if (ret != OK)
     {
       syslog(LOG_ERR,
-             "ERROR: Failed to register the CDC/ACM serial class: %d\n", ret);
+             "ERROR: Failed to register the CDC/ACM serial class: %d\n",
+             ret);
     }
 #endif
 

--- a/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_appinit.c
+++ b/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_appinit.c
@@ -316,7 +316,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_bringup.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_bringup.c
@@ -66,7 +66,9 @@
 #define NSH_HAVEMMCSD   1
 #define NSH_HAVEUSBHOST 1
 
-/* The Mikroelektronika PIC32MX7 MMB has one SD slot on board, connected to SPI 1. */
+/* The Mikroelektronika PIC32MX7 MMB has one SD slot on board,
+ * connected to SPI 1.
+ */
 
 #ifndef CONFIG_PIC32MX_MMCSDSPIPORTNO
 #  define CONFIG_PIC32MX_MMCSDSPIPORTNO 1
@@ -312,7 +314,8 @@ static int nsh_usbhostinitialize(void)
   if (ret != OK)
     {
       syslog(LOG_ERR,
-             "ERROR: Failed to register the CDC/ACM serial class: %d\n", ret);
+             "ERROR: Failed to register the CDC/ACM serial class: %d\n",
+             ret);
     }
 #endif
 
@@ -331,6 +334,7 @@ static int nsh_usbhostinitialize(void)
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }
+
   return -ENODEV;
 }
 #else

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_bringup.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_bringup.c
@@ -327,7 +327,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_appinit.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_appinit.c
@@ -307,7 +307,8 @@ static int nsh_usbhostinitialize(void)
   if (ret != OK)
     {
       syslog(LOG_ERR,
-             "ERROR: Failed to register the CDC/ACM serial class: %d\n", ret);
+             "ERROR: Failed to register the CDC/ACM serial class: %d\n",
+             ret);
     }
 #endif
 
@@ -327,6 +328,7 @@ static int nsh_usbhostinitialize(void)
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }
+
   return -ENODEV;
 }
 #else

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_appinit.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_appinit.c
@@ -323,7 +323,7 @@ static int nsh_usbhostinitialize(void)
       syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
-                           CONFIG_USBHOST_STACKSIZE,
+                           NULL, CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
       return pid < 0 ? -ENOEXEC : OK;
     }

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -530,7 +530,7 @@ static int net_rpmsg_drv_sockioctl_handler(FAR struct rpmsg_endpoint *ept,
   /* Move the action into a temp thread to avoid the deadlock */
 
   rpmsg_hold_rx_buffer(ept, data);
-  kthread_create("rpmsg-net", CONFIG_NET_RPMSG_PRIORITY,
+  kthread_create("rpmsg-net", CONFIG_NET_RPMSG_PRIORITY, NULL,
           CONFIG_NET_RPMSG_STACKSIZE, net_rpmsg_drv_sockioctl_task, argv);
 
   return 0;

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -1010,8 +1010,8 @@ int slip_initialize(int intf, FAR const char *devname)
   argv[1] = NULL;
 
   priv->rxpid = kthread_create("rxslip", CONFIG_NET_SLIP_DEFPRIO,
-                               CONFIG_NET_SLIP_STACKSIZE, slip_rxtask,
-                               (FAR char * const *)argv);
+                               NULL, CONFIG_NET_SLIP_STACKSIZE,
+                               slip_rxtask, (FAR char * const *)argv);
   if (priv->rxpid < 0)
     {
       nerr("ERROR: Failed to start receiver task\n");
@@ -1025,8 +1025,8 @@ int slip_initialize(int intf, FAR const char *devname)
   /* Start the SLIP transmitter kernel thread */
 
   priv->txpid = kthread_create("txslip", CONFIG_NET_SLIP_DEFPRIO,
-                               CONFIG_NET_SLIP_STACKSIZE, slip_txtask,
-                               (FAR char * const *)argv);
+                               NULL, CONFIG_NET_SLIP_STACKSIZE,
+                               slip_txtask, (FAR char * const *)argv);
   if (priv->txpid < 0)
     {
       nerr("ERROR: Failed to start receiver task\n");

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -1118,8 +1118,8 @@ static int telnet_session(FAR struct telnet_session_s *session)
 
       g_telnet_io_kthread =
         kthread_create("telnet_io", CONFIG_TELNET_IOTHREAD_PRIORITY,
-                       CONFIG_TELNET_IOTHREAD_STACKSIZE, telnet_io_main,
-                       NULL);
+                       NULL, CONFIG_TELNET_IOTHREAD_STACKSIZE,
+                       telnet_io_main, NULL);
     }
 
   /* Save ourself in the list of Telnet client threads */

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -822,6 +822,7 @@ int rptun_initialize(FAR struct rptun_dev_s *dev)
 
   ret = kthread_create("rptun",
                        CONFIG_RPTUN_PRIORITY,
+                       NULL,
                        CONFIG_RPTUN_STACKSIZE,
                        rptun_thread,
                        argv);

--- a/drivers/usbdev/usbmsc.c
+++ b/drivers/usbdev/usbmsc.c
@@ -1688,7 +1688,7 @@ int usbmsc_exportluns(FAR void *handle)
 
   uinfo("Starting SCSI worker thread\n");
   priv->thpid = kthread_create("scsid", CONFIG_USBMSC_SCSI_PRIO,
-                               CONFIG_USBMSC_SCSI_STACKSIZE,
+                               NULL, CONFIG_USBMSC_SCSI_STACKSIZE,
                                usbmsc_scsi_main, NULL);
   if (priv->thpid <= 0)
     {

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -1736,7 +1736,7 @@ static inline int usbhost_devinit(FAR struct usbhost_state_s *priv)
   g_priv = priv;
 
   priv->pollpid = kthread_create("kbdpoll", CONFIG_HIDKBD_DEFPRIO,
-                                 CONFIG_HIDKBD_STACKSIZE,
+                                 NULL, CONFIG_HIDKBD_STACKSIZE,
                                  (main_t)usbhost_kbdpoll,
                                  (FAR char * const *)NULL);
   if (priv->pollpid < 0)

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -1701,7 +1701,7 @@ static inline int usbhost_devinit(FAR struct usbhost_state_s *priv)
   g_priv = priv;
 
   priv->pollpid = kthread_create("mouse", CONFIG_HIDMOUSE_DEFPRIO,
-                                 CONFIG_HIDMOUSE_STACKSIZE,
+                                 NULL, CONFIG_HIDMOUSE_STACKSIZE,
                                  (main_t)usbhost_mouse_poll,
                                  (FAR char * const *)NULL);
   if (priv->pollpid < 0)

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -1418,7 +1418,7 @@ static inline int usbhost_devinit(FAR struct usbhost_state_s *priv)
 
   uinfo("Starting thread\n");
   priv->pollpid = kthread_create("xbox", CONFIG_XBOXCONTROLLER_DEFPRIO,
-                                 CONFIG_XBOXCONTROLLER_STACKSIZE,
+                                 NULL, CONFIG_XBOXCONTROLLER_STACKSIZE,
                                  (main_t)usbhost_xboxcontroller_poll,
                                  (FAR char * const *)NULL);
   if (priv->pollpid < 0)

--- a/drivers/usbmonitor/usbmonitor.c
+++ b/drivers/usbmonitor/usbmonitor.c
@@ -226,7 +226,7 @@ int usbmonitor_start(void)
       g_usbmonitor.stop    = false;
 
       ret = kthread_create("USB Monitor", CONFIG_USBMONITOR_PRIORITY,
-                           CONFIG_USBMONITOR_STACKSIZE,
+                           NULL, CONFIG_USBMONITOR_STACKSIZE,
                            (main_t)usbmonitor_daemon,
                            (FAR char * const *)NULL);
       if (ret < 0)

--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -477,7 +477,7 @@ FAR void *bt_uart_shim_getdevice(FAR char *path)
 
   s->serialmontask = kthread_create("BT HCI Rx",
                                     CONFIG_BLUETOOTH_TXCONN_PRIORITY,
-                                    1024, hcicollecttask, NULL);
+                                    NULL, 1024, hcicollecttask, NULL);
 
   return g_n;
 }

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -761,8 +761,8 @@ int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
   /* Spawn bcmf daemon thread */
 
   ret = kthread_create(BCMF_THREAD_NAME, SCHED_PRIORITY_MAX,
-                       BCMF_THREAD_STACK_SIZE, bcmf_sdio_thread,
-                       (FAR char * const *)NULL);
+                       NULL, BCMF_THREAD_STACK_SIZE,
+                       bcmf_sdio_thread, (FAR char * const *)NULL);
 
   if (ret <= 0)
     {

--- a/graphics/nxmu/nxmu_start.c
+++ b/graphics/nxmu/nxmu_start.c
@@ -196,13 +196,13 @@ int nxmu_start(int display, int plane)
     {
       FAR char display_str[8];
       FAR char plane_str[8];
+      pid_t server;
       FAR char * const argv[3] =
       {
         (FAR char * const)display_str,
         (FAR char * const)plane_str,
         NULL
       };
-      pid_t server;
 
       /* Start the server kernel thread */
 
@@ -225,7 +225,7 @@ int nxmu_start(int display, int plane)
        * this operation cannot be done from the IDLE thread!
        */
 
-      nxsig_usleep(50*1000);
+      nxsig_usleep(50 * 1000);
     }
 
   return OK;

--- a/graphics/nxmu/nxmu_start.c
+++ b/graphics/nxmu/nxmu_start.c
@@ -210,7 +210,7 @@ int nxmu_start(int display, int plane)
       snprintf(plane_str, 8, "%d", plane);
 
       ginfo("Starting server task\n");
-      server = kthread_create("NX Server", CONFIG_NXSTART_SERVERPRIO,
+      server = kthread_create("NX Server", CONFIG_NXSTART_SERVERPRIO, NULL,
                               CONFIG_NXSTART_SERVERSTACK, nx_server, argv);
       if (server < 0)
         {

--- a/graphics/vnc/server/vnc_fbdev.c
+++ b/graphics/vnc/server/vnc_fbdev.c
@@ -450,7 +450,7 @@ static int vnc_start_server(int display)
   argv[1] = NULL;
 
   pid = kthread_create("vnc_server", CONFIG_VNCSERVER_PRIO,
-                       CONFIG_VNCSERVER_STACKSIZE,
+                       NULL, CONFIG_VNCSERVER_STACKSIZE,
                        (main_t)vnc_server, argv);
   if (pid < 0)
     {

--- a/include/nuttx/kthread.h
+++ b/include/nuttx/kthread.h
@@ -116,6 +116,8 @@ int nxtask_create(FAR const char *name, int priority,
  * Input Parameters:
  *   name       - Name of the new task
  *   priority   - Priority of the new task
+ *   stack      - Start of the pre-allocated stack
+ *              - NULL will allocate the stack from internal
  *   stack_size - size (in bytes) of the stack needed
  *   entry      - Entry point of a new task
  *   arg        - A pointer to an array of input parameters.  The array
@@ -129,8 +131,8 @@ int nxtask_create(FAR const char *name, int priority,
  *
  ********************************************************************************/
 
-int kthread_create(FAR const char *name, int priority, int stack_size,
-                   main_t entry, FAR char * const argv[]);
+int kthread_create(FAR const char *name, int priority, FAR void *stack,
+                   int stack_size, main_t entry, FAR char * const argv[]);
 
 /****************************************************************************
  * Name: kthread_delete

--- a/include/nuttx/kthread.h
+++ b/include/nuttx/kthread.h
@@ -105,13 +105,13 @@ extern "C"
 int nxtask_create(FAR const char *name, int priority,
                   int stack_size, main_t entry, FAR char * const argv[]);
 
-/********************************************************************************
+/****************************************************************************
  * Name: kthread_create
  *
  * Description:
- *   This function creates and activates a kernel thread task with kernel-mode
- *   privileges.  It is identical to task_create() except that it configures the
- *   newly started thread to run in kernel model.
+ *   This function creates and activates a kernel thread task with
+ *   kernel-mode privileges. It is identical to task_create() except
+ *   that it configures the newly started thread to run in kernel model.
  *
  * Input Parameters:
  *   name       - Name of the new task
@@ -129,7 +129,7 @@ int nxtask_create(FAR const char *name, int priority,
  *   errno value to indicate the nature of any failure.  If memory is
  *   insufficient or the task cannot be created -ENOMEM will be returned.
  *
- ********************************************************************************/
+ ****************************************************************************/
 
 int kthread_create(FAR const char *name, int priority, FAR void *stack,
                    int stack_size, main_t entry, FAR char * const argv[]);

--- a/sched/init/nx_bringup.c
+++ b/sched/init/nx_bringup.c
@@ -142,7 +142,7 @@ static inline void nx_pgworker(void)
   sinfo("Starting paging thread\n");
 
   g_pgworker = kthread_create("pgfill", CONFIG_PAGING_DEFPRIO,
-                              CONFIG_PAGING_STACKSIZE,
+                              NULL, CONFIG_PAGING_STACKSIZE,
                               (main_t)pg_worker, (FAR char * const *)NULL);
   DEBUGASSERT(g_pgworker > 0);
 }
@@ -354,7 +354,7 @@ static inline void nx_create_initthread(void)
    */
 
   pid = kthread_create("AppBringUp", CONFIG_BOARD_INITTHREAD_PRIORITY,
-                      CONFIG_BOARD_INITTHREAD_STACKSIZE,
+                      NULL, CONFIG_BOARD_INITTHREAD_STACKSIZE,
                       (main_t)nx_start_task, (FAR char * const *)NULL);
   DEBUGASSERT(pid > 0);
   UNUSED(pid);

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -68,8 +68,8 @@
  *
  ****************************************************************************/
 
-static int nxthread_create(FAR const char *name, uint8_t ttype,
-                           int priority, int stack_size, main_t entry,
+static int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
+                           FAR void *stack, int stack_size, main_t entry,
                            FAR char * const argv[])
 {
   FAR struct task_tcb_s *tcb;
@@ -91,7 +91,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, name, priority, NULL, stack_size, entry, argv);
+  ret = nxtask_init(tcb, name, priority, stack, stack_size, entry, argv);
   if (ret < OK)
     {
       kmm_free(tcb);
@@ -154,8 +154,8 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 int nxtask_create(FAR const char *name, int priority,
                   int stack_size, main_t entry, FAR char * const argv[])
 {
-  return nxthread_create(name, TCB_FLAG_TTYPE_TASK, priority, stack_size,
-                         entry, argv);
+  return nxthread_create(name, TCB_FLAG_TTYPE_TASK, priority, NULL,
+                         stack_size, entry, argv);
 }
 
 /****************************************************************************
@@ -229,9 +229,9 @@ int task_create(FAR const char *name, int priority,
  *
  ****************************************************************************/
 
-int kthread_create(FAR const char *name, int priority,
+int kthread_create(FAR const char *name, int priority, FAR void *stack,
                    int stack_size, main_t entry, FAR char * const argv[])
 {
-  return nxthread_create(name, TCB_FLAG_TTYPE_KERNEL, priority, stack_size,
-                         entry, argv);
+  return nxthread_create(name, TCB_FLAG_TTYPE_KERNEL, priority, stack,
+                         stack_size, entry, argv);
 }

--- a/sched/task/task_posixspawn.c
+++ b/sched/task/task_posixspawn.c
@@ -397,7 +397,7 @@ int posix_spawn(FAR pid_t *pid, FAR const char *path,
    */
 
   proxy = kthread_create("nxposix_spawn_proxy", param.sched_priority,
-                         CONFIG_POSIX_SPAWN_PROXY_STACKSIZE,
+                         NULL, CONFIG_POSIX_SPAWN_PROXY_STACKSIZE,
                          (main_t)nxposix_spawn_proxy,
                          (FAR char * const *)NULL);
   if (proxy < 0)

--- a/sched/wqueue/kwork_hpthread.c
+++ b/sched/wqueue/kwork_hpthread.c
@@ -147,7 +147,7 @@ int work_start_highpri(void)
   for (wndx = 0; wndx < CONFIG_SCHED_HPNTHREADS; wndx++)
     {
       pid = kthread_create(HPWORKNAME, CONFIG_SCHED_HPWORKPRIORITY,
-                           CONFIG_SCHED_HPWORKSTACKSIZE,
+                           NULL, CONFIG_SCHED_HPWORKSTACKSIZE,
                            (main_t)work_hpthread,
                            (FAR char * const *)NULL);
 

--- a/sched/wqueue/kwork_lpthread.c
+++ b/sched/wqueue/kwork_lpthread.c
@@ -147,7 +147,7 @@ int work_start_lowpri(void)
   for (wndx = 0; wndx < CONFIG_SCHED_LPNTHREADS; wndx++)
     {
       pid = kthread_create(LPWORKNAME, CONFIG_SCHED_LPWORKPRIORITY,
-                           CONFIG_SCHED_LPWORKSTACKSIZE,
+                           NULL, CONFIG_SCHED_LPWORKSTACKSIZE,
                            (main_t)work_lpthread,
                            (FAR char * const *)NULL);
 

--- a/wireless/bluetooth/bt_conn.c
+++ b/wireless/bluetooth/bt_conn.c
@@ -586,6 +586,7 @@ void bt_conn_set_state(FAR struct bt_conn_s *conn,
               g_conn_handoff.conn = bt_conn_addref(conn);
               pid = kthread_create("BT Conn Tx",
                                    CONFIG_BLUETOOTH_TXCONN_PRIORITY,
+                                   NULL,
                                    CONFIG_BLUETOOTH_TXCONN_STACKSIZE,
                                    conn_tx_kthread, NULL);
               DEBUGASSERT(pid > 0);

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1428,7 +1428,7 @@ static void cmd_queue_init(void)
 
   g_btdev.ncmd = 1;
   pid = kthread_create("BT HCI Tx", CONFIG_BLUETOOTH_TXCMD_PRIORITY,
-                       CONFIG_BLUETOOTH_TXCMD_STACKSIZE,
+                       NULL, CONFIG_BLUETOOTH_TXCMD_STACKSIZE,
                        hci_tx_kthread, NULL);
   DEBUGASSERT(pid > 0);
   UNUSED(pid);


### PR DESCRIPTION
## Summary
sched/kthread: extend kthread_create() to support configurable stack

Extended parameter to support configurable stack
unify the semantics with nxthread_create()

## Impact
kthread_create()

## Testing

create the kernel thread use reserve stack

```
static uint8_t g_stack[8192];
kthread_create("thread test", 100, g_stack, sizeof(g_stack), (main_t)test_thread, NULL);

nsh> hello &
hello [3:100]
Hello, World!!
Hello, thread!!
nsh> ps
  PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK COMMAND
    0     0   0 FIFO     Kthread N-- Ready              00000000 000000 Idle Task
    2     1 100 FIFO     Task    --- Running            00000000 008192 /system/bin/nsh
    3     2 100 FIFO     Task    --- Waiting  Signal    00000000 008208 hello
    4     3 100 FIFO     Kthread --- Waiting  Signal    00000000 008160 thread test
nsh> 

```


