### PR TITLE
arch/x86_64: Fix Warning: ignoring changed section attributes

### DIFF
--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -278,7 +278,7 @@ start64:
  *
  ****************************************************************************/
 
-    .section .text, "a"
+    .section .text, "ax"
     .type   __nxstart, @function
 
 __nxstart:
@@ -482,7 +482,7 @@ pt_low:
  * do in the system (see up_idle()).
  */
 
-    .section    .bss, "a"
+    .section    .bss
 
     .type    idle_stack, @object
     .comm    idle_stack, CONFIG_IDLETHREAD_STACKSIZE, 32


### PR DESCRIPTION
## Summary
chip/intel64_head.S: Assembler messages:
chip/intel64_head.S:281: Warning: ignoring changed section attributes for .text
chip/intel64_head.S:485: Warning: ignoring changed section attributes for .bss

## Impact
Only impact x86_64/intel64 platform.

## Testing

