### PR TITLE
libs/libc/semaphore/sem_getvalue: correct get_value descriptions

### DIFF
--- a/libs/libc/semaphore/sem_getvalue.c
+++ b/libs/libc/semaphore/sem_getvalue.c
@@ -59,8 +59,8 @@
  *   but may not reflect the actual value of the semaphore when it is
  *   returned to the calling task.
  *
- *   If 'sem' is locked, the value return by nxsem_get_value() will either be
- *   zero or a negative number whose absolute value represents the number
+ *   If 'sem' is locked, then the object to which 'sval' points shall either
+ *   be zero or a negative number whose absolute value represents the number
  *   of tasks waiting for the semaphore.
  *
  * Input Parameters:
@@ -96,8 +96,8 @@ int nxsem_get_value(FAR sem_t *sem, FAR int *sval)
  *   but may not reflect the actual value of the semaphore when it is
  *   returned to the calling task.
  *
- *   If 'sem' is locked, the value return by sem_getvalue() will either be
- *   zero or a negative number whose absolute value represents the number
+ *   If 'sem' is locked, then the object to which 'sval' points shall either
+ *   be zero or a negative number whose absolute value represents the number
  *   of tasks waiting for the semaphore.
  *
  * Input Parameters:


### PR DESCRIPTION
avoid possible confusion and follow the description POSIX.1-2017
https://pubs.opengroup.org/onlinepubs/9699919799/functions/sem_getvalue.html

PR as we discuss in #1354
