### PR TITLE
sim: Fix 32-bit module build

### DIFF
--- a/boards/sim/sim/sim/configs/cxxtest/Make.defs
+++ b/boards/sim/sim/sim/configs/cxxtest/Make.defs
@@ -82,12 +82,15 @@ AFLAGS = $(CFLAGS) -D__ASSEMBLY__
 CMODULEFLAGS = $(CFLAGS)
 # -fno-pic to avoid GOT relocations
 CMODULEFLAGS += -fno-pic
-# It seems macOS/x86_64 loads the program text around 00000001_xxxxxxxx.
-# The gcc default (-mcmodel=small) would produce out-of-range 32-bit
-# relocations.
-# Even on Linux, NuttX modules are loaded into the NuttX heap, which
-# can be out of range with -mcmodel=small.
-CMODULEFLAGS += -mcmodel=large
+ifeq ($(CONFIG_LIBC_ARCH_ELF_64BIT),y)
+  # For amd64:
+  # It seems macOS/x86_64 loads the program text around 00000001_xxxxxxxx.
+  # The gcc default (-mcmodel=small) would produce out-of-range 32-bit
+  # relocations.
+  # Even on Linux, NuttX modules are loaded into the NuttX heap, which
+  # can be out of range with -mcmodel=small.
+  CMODULEFLAGS += -mcmodel=large
+endif
 # On Linux, we (ab)use the host compiler to compile binaries for NuttX.
 # Explicitly disable features which might be default on the host while
 # not available on NuttX.

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -77,12 +77,15 @@ AFLAGS = $(CFLAGS) -D__ASSEMBLY__
 CMODULEFLAGS = $(CFLAGS)
 # -fno-pic to avoid GOT relocations
 CMODULEFLAGS += -fno-pic
-# It seems macOS/x86_64 loads the program text around 00000001_xxxxxxxx.
-# The gcc default (-mcmodel=small) would produce out-of-range 32-bit
-# relocations.
-# Even on Linux, NuttX modules are loaded into the NuttX heap, which
-# can be out of range with -mcmodel=small.
-CMODULEFLAGS += -mcmodel=large
+ifeq ($(CONFIG_LIBC_ARCH_ELF_64BIT),y)
+  # For amd64:
+  # It seems macOS/x86_64 loads the program text around 00000001_xxxxxxxx.
+  # The gcc default (-mcmodel=small) would produce out-of-range 32-bit
+  # relocations.
+  # Even on Linux, NuttX modules are loaded into the NuttX heap, which
+  # can be out of range with -mcmodel=small.
+  CMODULEFLAGS += -mcmodel=large
+endif
 # On Linux, we (ab)use the host compiler to compile binaries for NuttX.
 # Explicitly disable features which might be default on the host while
 # not available on NuttX.


### PR DESCRIPTION
## Summary
Specify -mcmodel=large only on 64-bit case. (x86-64)
The code model is not available for 32-bit.

This fixes the following error:

    MODULECC: chardev.c
    cc1: error: code model 'large' not supported in the 32 bit mode
    Makefile:79: recipe for target 'chardev.o' failed


## Impact

## Testing
manually build-tested sim:module32
