### PR TITLE
Remove .asm from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.a
 *.adb
-*.asm
 *.bin
 *.d
 *.dSYM


### PR DESCRIPTION
## Summary
since zipme.sh(with --exclude-vcs-ignores) fail to copy z80's assembler files(.asm).

## Impact

## Testing

