### PR TITLE
arch/tms570: Remove the unused frac variable

### DIFF
--- a/arch/arm/src/tms570/tms570_lowputc.c
+++ b/arch/arm/src/tms570/tms570_lowputc.c
@@ -284,9 +284,8 @@ void tms570_lowsetup(void)
 int tms570_sci_configure(uint32_t base,
                          FAR const struct sci_config_s *config)
 {
-  float_t divb7;
+  float    divb7;
   uint32_t intpart;
-  float_t frac;
   uint32_t p;
   uint32_t m;
   uint32_t u;


### PR DESCRIPTION
and change the type of divb7 from float32_t to float.

## Summary
Suggested by @yamt here:
https://github.com/apache/incubator-nuttx/pull/1340

## Impact
No function change.

## Testing

