### PR TITLE
Fix wrong use of nxsem_getvalue

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -1337,13 +1337,24 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 
           fifo->rx_tail = nexttail;
 
-          /* The increment the counting semaphore. The maximum value should
+          sval = 0;
+          if (nxsem_get_value(&fifo->rx_sem, &sval) < 0)
+            {
+              DEBUGASSERT(false);
+#ifdef CONFIG_CAN_ERRORS
+              /* Report unspecified error */
+
+              dev->cd_error |= CAN_ERROR5_UNSPEC;
+#endif
+              return -EINVAL;
+            }
+
+          /* Increment the counting semaphore. The maximum value should
            * be CONFIG_CAN_FIFOSIZE -- one possible count for each allocated
            * message buffer.
            */
 
-          sval = 0;
-          if (nxsem_get_value(&fifo->rx_sem, &sval) <= 0)
+          if (sval < 0)
             {
               can_givesem(&fifo->rx_sem);
             }


### PR DESCRIPTION
Bug caused increase of fifo->rx_sem with each received msg until finally after 32767 messages get into
DEBUGASSERT(sem->semcount<SEM_VALUE_MAX);
or stopping receiving anything at all without debug, while tx was working.

issue #1354 

Also perform can_poll inside critical_section. I'm not sure, maybe it not necessary, please advise.