### PR TITLE
drivers/can: correct checking sem is locked

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -1360,7 +1360,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
            * message buffer.
            */
 
-          if (sval < 0)
+          if (sval <= 0)
             {
               can_givesem(&fifo->rx_sem);
             }


### PR DESCRIPTION
Object filled by nxsem_get_value can be zero or a negative number
fix for 190782c2959de2b28867022941e52f429d5d07fb

issue #1354
