### PR TITLE
gpio: extend gpio_pintype_e for pulldown/up and opendrain

### DIFF
--- a/arch/sim/src/sim/up_ioexpander.c
+++ b/arch/sim/src/sim/up_ioexpander.c
@@ -199,9 +199,13 @@ static int sim_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
 {
   FAR struct sim_dev_s *priv = (FAR struct sim_dev_s *)dev;
 
-  DEBUGASSERT(priv != NULL && pin < CONFIG_IOEXPANDER_NPINS &&
-              (direction == IOEXPANDER_DIRECTION_IN ||
-               direction == IOEXPANDER_DIRECTION_OUT));
+  if (direction != IOEXPANDER_DIRECTION_IN &&
+      direction != IOEXPANDER_DIRECTION_OUT)
+    {
+      return -EINVAL;
+    }
+
+  DEBUGASSERT(priv != NULL && pin < CONFIG_IOEXPANDER_NPINS);
 
   gpioinfo("pin=%u direction=%s\n",
            pin, (direction == IOEXPANDER_DIRECTION_IN) ? "IN" : "OUT");

--- a/drivers/analog/lmp92001.c
+++ b/drivers/analog/lmp92001.c
@@ -1214,9 +1214,13 @@ static int lmp92001_gpio_direction(FAR struct ioexpander_dev_s *dev,
 
   int ret;
 
-  DEBUGASSERT(priv != NULL && pin < LMP92001_GPIO_MAX_PINS &&
-              (direction == IOEXPANDER_DIRECTION_IN ||
-               direction == IOEXPANDER_DIRECTION_OUT));
+  if (direction != IOEXPANDER_DIRECTION_IN &&
+      direction != IOEXPANDER_DIRECTION_OUT)
+    {
+      return -EINVAL;
+    }
+
+  DEBUGASSERT(priv != NULL && pin < LMP92001_GPIO_MAX_PINS);
 
   gpioinfo("I2C addr=%02x pin=%u direction=%s\n",
            priv->addr, pin,

--- a/drivers/ioexpander/pca9538.c
+++ b/drivers/ioexpander/pca9538.c
@@ -309,6 +309,12 @@ static int pca9538_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
   FAR struct pca9538_dev_s *pca = (FAR struct pca9538_dev_s *)dev;
   int ret;
 
+  if (direction != IOEXPANDER_DIRECTION_IN &&
+      direction != IOEXPANDER_DIRECTION_OUT)
+    {
+      return -EINVAL;
+    }
+
   /* Get exclusive access to the PCA555 */
 
   ret = pca9538_lock(pca);

--- a/drivers/ioexpander/pca9555.c
+++ b/drivers/ioexpander/pca9555.c
@@ -337,6 +337,12 @@ static int pca9555_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
   FAR struct pca9555_dev_s *pca = (FAR struct pca9555_dev_s *)dev;
   int ret;
 
+  if (direction != IOEXPANDER_DIRECTION_IN &&
+      direction != IOEXPANDER_DIRECTION_OUT)
+    {
+      return -EINVAL;
+    }
+
   /* Get exclusive access to the PCA555 */
 
   ret = pca9555_lock(pca);

--- a/drivers/ioexpander/pcf8574.c
+++ b/drivers/ioexpander/pcf8574.c
@@ -256,9 +256,13 @@ static int pcf8574_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
   FAR struct pcf8574_dev_s *priv = (FAR struct pcf8574_dev_s *)dev;
   int ret;
 
-  DEBUGASSERT(priv != NULL && priv->config != NULL && pin < 8 &&
-              (direction == IOEXPANDER_DIRECTION_IN ||
-               direction == IOEXPANDER_DIRECTION_OUT));
+  if (direction != IOEXPANDER_DIRECTION_IN &&
+      direction != IOEXPANDER_DIRECTION_OUT)
+    {
+      return -EINVAL;
+    }
+
+  DEBUGASSERT(priv != NULL && priv->config != NULL && pin < 8);
 
   gpioinfo("I2C addr=%02x pin=%u direction=%s\n",
            priv->config->address, pin,

--- a/drivers/ioexpander/skeleton.c
+++ b/drivers/ioexpander/skeleton.c
@@ -193,12 +193,16 @@ static int skel_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
   FAR struct skel_dev_s *priv = (FAR struct skel_dev_s *)dev;
   int ret;
 
+  if (direction != IOEXPANDER_DIRECTION_IN &&
+      direction != IOEXPANDER_DIRECTION_OUT)
+    {
+      return -EINVAL;
+    }
+
   gpioinfo("pin=%u direction=%s\n",
            pin, (direction == IOEXPANDER_DIRECTION_IN) ? "IN" : "OUT");
 
-  DEBUGASSERT(priv != NULL && pin < CONFIG_IOEXPANDER_NPINS &&
-              (direction == IOEXPANDER_DIRECTION_IN ||
-               direction == IOEXPANDER_DIRECTION_IN));
+  DEBUGASSERT(priv != NULL && pin < CONFIG_IOEXPANDER_NPINS);
 
   /* Get exclusive access to the I/O Expander */
 
@@ -730,7 +734,9 @@ static void skel_interrupt(FAR void *arg)
       /* Disable interrupts */
 #warning Missing logic
 
-      /* Schedule interrupt related work on the high priority worker thread. */
+      /* Schedule interrupt related work on the high priority worker
+       * thread.
+       */
 
       work_queue(HPWORK, &priv->work, skel_irqworker,
                  (FAR void *)priv, 0);

--- a/drivers/ioexpander/tca64xx.c
+++ b/drivers/ioexpander/tca64xx.c
@@ -419,10 +419,14 @@ static int tca64_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
   uint8_t regval;
   int ret;
 
+  if (direction != IOEXPANDER_DIRECTION_IN &&
+      direction != IOEXPANDER_DIRECTION_OUT)
+    {
+      return -EINVAL;
+    }
+
   DEBUGASSERT(priv != NULL && priv->config != NULL &&
-              pin < CONFIG_IOEXPANDER_NPINS &&
-              (direction == IOEXPANDER_DIRECTION_IN ||
-               direction == IOEXPANDER_DIRECTION_OUT));
+              pin < CONFIG_IOEXPANDER_NPINS);
 
   gpioinfo("I2C addr=%02x pin=%u direction=%s\n",
            priv->config->address, pin,

--- a/include/nuttx/ioexpander/gpio.h
+++ b/include/nuttx/ioexpander/gpio.h
@@ -100,8 +100,11 @@
 
 enum gpio_pintype_e
 {
-  GPIO_INPUT_PIN = 0,
-  GPIO_OUTPUT_PIN,
+  GPIO_INPUT_PIN = 0, /* float */
+  GPIO_INPUT_PIN_PULLUP,
+  GPIO_INPUT_PIN_PULLDOWN,
+  GPIO_OUTPUT_PIN, /* push-pull */
+  GPIO_OUTPUT_PIN_OPENDRAIN,
   GPIO_INTERRUPT_PIN,
   GPIO_INTERRUPT_HIGH_PIN,
   GPIO_INTERRUPT_LOW_PIN,
@@ -141,7 +144,7 @@ struct gpio_operations_s
                             enum gpio_pintype_e pintype);
 };
 
- /* Signal information */
+/* Signal information */
 
 struct gpio_signal_s
 {

--- a/include/nuttx/ioexpander/ioexpander.h
+++ b/include/nuttx/ioexpander/ioexpander.h
@@ -58,8 +58,11 @@
 
 /* Pin definitions **********************************************************/
 
-#define IOEXPANDER_DIRECTION_IN    0
-#define IOEXPANDER_DIRECTION_OUT   1
+#define IOEXPANDER_DIRECTION_IN            0  /* float */
+#define IOEXPANDER_DIRECTION_IN_PULLUP     1
+#define IOEXPANDER_DIRECTION_IN_PULLDOWN   2
+#define IOEXPANDER_DIRECTION_OUT           3  /* push-pull */
+#define IOEXPANDER_DIRECTION_OUT_OPENDRAIN 4
 
 #define IOEXPANDER_PINMASK         (((ioe_pinset_t)1 << CONFIG_IOEXPANDER_NPINS) - 1)
 #define PINSET_ALL                 (~((ioe_pinset_t)0))
@@ -144,14 +147,15 @@
  * Name: IOEXP_READPIN
  *
  * Description:
- *   Read the actual PIN level. This can be different from the last value written
- *      to this pin. Required.
+ *   Read the actual PIN level. This can be different from the last value
+ *   written to this pin. Required.
  *
  * Input Parameters:
  *   dev    - Device-specific state data
  *   pin    - The index of the pin
  *   valptr - Pointer to a buffer where the pin level is stored. Usually TRUE
- *            if the pin is high, except if OPTION_INVERT has been set on this pin.
+ *            if the pin is high, except if OPTION_INVERT has been set on
+ *            this pin.
  *
  * Returned Value:
  *   0 on success, else a negative error code
@@ -225,8 +229,8 @@
  * Name: IOEXP_MULTIREADBUF
  *
  * Description:
- *   Read the buffered level of multiple pins. This routine may be faster than
- *   individual pin accesses. Optional.
+ *   Read the buffered level of multiple pins. This routine may be faster
+ *   than individual pin accesses. Optional.
  *
  * Input Parameters:
  *   dev    - Device-specific state data


### PR DESCRIPTION
## Summary

Extends the GPIO types to specify pullup/down and opendrain (the lower half drivers are not extended to support that).

@davids5 
