### PR TITLE
libc: Always declare getenv, link/symlink and atexit/on_exit

### DIFF
--- a/include/cxx/cstdlib
+++ b/include/cxx/cstdlib
@@ -40,7 +40,6 @@ namespace std
   using ::rand;
   using ::random;
 
-#ifndef CONFIG_DISABLE_ENVIRON
   // Environment variable support
 
   using ::get_environ_ptr;
@@ -49,18 +48,13 @@ namespace std
   using ::clearenv;
   using ::setenv;
   using ::unsetenv;
-#endif
 
   // Process exit functions
 
   using ::exit;
   using ::abort;
-#ifdef CONFIG_SCHED_ATEXIT
   using ::atexit;
-#endif
-#ifdef CONFIG_SCHED_ONEXIT
   using ::on_exit;
-#endif
 
 #ifndef __KERNEL__
   // System command

--- a/include/cxx/cunistd
+++ b/include/cxx/cunistd
@@ -94,10 +94,8 @@ namespace std
   using ::access;
   using ::rmdir;
   using ::unlink;
-#ifdef CONFIG_PSEUDOFS_SOFTLINKS
-  using ::link;
+  using ::symlink;
   using ::readlink;
-#endif
 
   // Execution of program files
 

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -121,7 +121,6 @@ int       rand(void);
 #define   srandom(s) srand(s)
 long      random(void);
 
-#ifndef CONFIG_DISABLE_ENVIRON
 /* Environment variable support */
 
 FAR char **get_environ_ptr(void);
@@ -130,18 +129,13 @@ int       putenv(FAR const char *string);
 int       clearenv(void);
 int       setenv(FAR const char *name, FAR const char *value, int overwrite);
 int       unsetenv(FAR const char *name);
-#endif
 
 /* Process exit functions */
 
 void      exit(int status) noreturn_function;
 void      abort(void) noreturn_function;
-#ifdef CONFIG_SCHED_ATEXIT
 int       atexit(CODE void (*func)(void));
-#endif
-#ifdef CONFIG_SCHED_ONEXIT
 int       on_exit(CODE void (*func)(int, FAR void *), FAR void *arg);
-#endif
 
 /* _Exit() is a stdlib.h equivalent to the unistd.h _exit() function */
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -357,11 +357,8 @@ int     access(FAR const char *path, int amode);
 int     rmdir(FAR const char *pathname);
 int     unlink(FAR const char *pathname);
 int     truncate(FAR const char *path, off_t length);
-
-#ifdef CONFIG_PSEUDOFS_SOFTLINKS
 int     symlink(FAR const char *path1, FAR const char *path2);
 ssize_t readlink(FAR const char *path, FAR char *buf, size_t bufsize);
-#endif
 
 /* Execution of programs from files */
 


### PR DESCRIPTION
## Summary
since many c++ library implementation reference these symbols by using ::xxx but never
really use them, the declaration avoid the unused code is pulled into the final binary

## Impact
No, only the conditional guard is removed.

## Testing

