### PR TITLE
tools/zipme.sh: Remove the option to exclude patterns based on the VCS' "ignore" file.

### DIFF
--- a/tools/zipme.sh
+++ b/tools/zipme.sh
@@ -129,7 +129,7 @@ for pat in ${EXCLPAT} ; do
   TAR+=" --exclude=${pat}"
 done
 
-TAR+=" --exclude-vcs-ignores --exclude-vcs"
+TAR+=" --exclude-vcs"
 
 if [ $verbose != 0 ] ; then
   TAR+=" -czvf"


### PR DESCRIPTION
## Summary
With too many gitignore files, TAR isn't picking all the patterns.  This is an issue with negated patterns when we try to include files that were excluded by the top-level .gitignore.

## Impact
N/A

## Testing
N/A
