### PR TITLE
[Backport-1376] tools/zipme.sh: Remove the option to exclude patterns based on the VCS' "ignore" file.

### DIFF
--- a/tools/zipme.sh
+++ b/tools/zipme.sh
@@ -129,7 +129,7 @@ for pat in ${EXCLPAT} ; do
   TAR+=" --exclude=${pat}"
 done
 
-TAR+=" --exclude-vcs-ignores --exclude-vcs"
+TAR+=" --exclude-vcs"
 
 if [ $verbose != 0 ] ; then
   TAR+=" -czvf"


### PR DESCRIPTION
## Summary
Backport #1376 

## Impact

## Testing

