### PR TITLE
fix nxstyle warning

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_usbdev.c
+++ b/arch/arm/src/cxd56xx/cxd56_usbdev.c
@@ -42,7 +42,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <sys/types.h>

--- a/arch/arm/src/lc823450/lc823450_procfs_dvfs.c
+++ b/arch/arm/src/lc823450/lc823450_procfs_dvfs.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -136,7 +135,6 @@ extern int8_t   g_dvfs_enabled;
 extern int8_t   g_dvfs_auto;
 extern uint16_t g_dvfs_cur_freq;
 extern uint32_t g_dvfs_freq_stat[3];
-
 
 /****************************************************************************
  * Private Functions
@@ -269,7 +267,8 @@ static ssize_t dvfs_read(FAR struct file *filep, FAR char *buffer,
                           "idle%d %lld \n",
                           i, idletime[i]);
 
-      copysize = procfs_memcpy(priv->line, linesize, buffer, remaining, &offset);
+      copysize = procfs_memcpy(priv->line, linesize, buffer,
+                               remaining, &offset);
       totalsize += copysize;
       buffer    += copysize;
       remaining -= copysize;

--- a/arch/arm/src/stm32/stm32_procfs_ccm.c
+++ b/arch/arm/src/stm32/stm32_procfs_ccm.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -89,6 +88,7 @@ struct ccm_file_s
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
+
 /* File system methods */
 
 static int     ccm_open(FAR struct file *filep, FAR const char *relpath,
@@ -221,15 +221,14 @@ static ssize_t ccm_read(FAR struct file *filep, FAR char *buffer,
   priv = (FAR struct ccm_file_s *)filep->f_priv;
   DEBUGASSERT(priv);
 
-
   mm_mallinfo(&g_ccm_heap, &mem);
 
   remaining = buflen;
   totalsize = 0;
 
   linesize = snprintf(priv->line,
-                      CCM_LINELEN,
-                      "             total       used       free    largest\n");
+                    CCM_LINELEN,
+                    "             total       used       free    largest\n");
   copysize = procfs_memcpy(priv->line, linesize, buffer, remaining, &offset);
   totalsize += copysize;
   buffer    += copysize;

--- a/arch/arm/src/stm32f7/stm32_procfs_dtcm.c
+++ b/arch/arm/src/stm32f7/stm32_procfs_dtcm.c
@@ -45,7 +45,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -81,6 +80,7 @@
 /****************************************************************************
  * Private Types
  ****************************************************************************/
+
 /* This enumeration identifies all of the thread attributes that can be
  * accessed via the procfs file system.
  */
@@ -97,6 +97,7 @@ struct dtcm_file_s
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
+
 /* File system methods */
 
 static int     dtcm_open(FAR struct file *filep, FAR const char *relpath,
@@ -233,15 +234,14 @@ static ssize_t dtcm_read(FAR struct file *filep, FAR char *buffer,
   priv = (FAR struct dtcm_file_s *)filep->f_priv;
   DEBUGASSERT(priv);
 
-
   mm_mallinfo(&g_dtcm_heap, &mem);
 
   remaining = buflen;
   totalsize = 0;
 
   linesize = snprintf(priv->line,
-                      DTCM_LINELEN,
-                      "             total       used       free    largest\n");
+                    DTCM_LINELEN,
+                    "             total       used       free    largest\n");
   copysize = procfs_memcpy(priv->line, linesize, buffer, remaining, &offset);
   totalsize += copysize;
   buffer    += copysize;

--- a/arch/arm/src/stm32h7/stm32_procfs_dtcm.c
+++ b/arch/arm/src/stm32h7/stm32_procfs_dtcm.c
@@ -46,7 +46,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -82,6 +81,7 @@
 /****************************************************************************
  * Private Types
  ****************************************************************************/
+
 /* This enumeration identifies all of the thread attributes that can be
  * accessed via the procfs file system.
  */
@@ -241,8 +241,8 @@ static ssize_t dtcm_read(FAR struct file *filep, FAR char *buffer,
   totalsize = 0;
 
   linesize = snprintf(priv->line,
-                      DTCM_LINELEN,
-                      "             total       used       free    largest\n");
+                    DTCM_LINELEN,
+                    "             total       used       free    largest\n");
   copysize = procfs_memcpy(priv->line, linesize, buffer, remaining, &offset);
   totalsize += copysize;
   buffer    += copysize;

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -67,11 +67,14 @@
 static int     binfs_open(FAR struct file *filep, const char *relpath,
                           int oflags, mode_t mode);
 static int     binfs_close(FAR struct file *filep);
-static ssize_t binfs_read(FAR struct file *filep, char *buffer, size_t buflen);
-static int     binfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+static ssize_t binfs_read(FAR struct file *filep,
+                          char *buffer, size_t buflen);
+static int     binfs_ioctl(FAR struct file *filep,
+                           int cmd, unsigned long arg);
 
 static int     binfs_dup(FAR const struct file *oldp, FAR struct file *newp);
-static int     binfs_fstat(FAR const struct file *filep, FAR struct stat *buf);
+static int     binfs_fstat(FAR const struct file *filep,
+                           FAR struct stat *buf);
 
 static int     binfs_opendir(struct inode *mountpt, const char *relpath,
                              struct fs_dirent_s *dir);
@@ -185,7 +188,8 @@ static int binfs_close(FAR struct file *filep)
  * Name: binfs_read
  ****************************************************************************/
 
-static ssize_t binfs_read(FAR struct file *filep, char *buffer, size_t buflen)
+static ssize_t binfs_read(FAR struct file *filep,
+                          char *buffer, size_t buflen)
 {
   /* Reading is not supported.  Just return end-of-file */
 
@@ -426,7 +430,8 @@ static int binfs_statfs(struct inode *mountpt, struct statfs *buf)
  *
  ****************************************************************************/
 
-static int binfs_stat(struct inode *mountpt, const char *relpath, struct stat *buf)
+static int binfs_stat(struct inode *mountpt,
+                      const char *relpath, struct stat *buf)
 {
   finfo("Entry\n");
 

--- a/fs/cromfs/cromfs.h
+++ b/fs/cromfs/cromfs.h
@@ -52,7 +52,7 @@
  * target machines but 64-bits on 64-host machines.  We restrict offsets to
  * 32-bits for commonality (limiting the size of the CROMFS image to 4Gb).
  *
- * REVISIT:  What about small memory systems where the size_t is only 16-bits?
+ * REVISIT: What about small memory systems where the size_t is only 16-bits?
  *
  * Similarly, the NuttX mode_t is only 16-bits so uint16_t is explicitly used
  * for NuttX file modes.
@@ -94,8 +94,8 @@ struct cromfs_volume_s
   uint32_t cv_bsize;     /* Optimal block size for transfers */
 };
 
-/* This describes one node in the CROMFS file system.  It holds node meta
- * data that provides the information that will be return by stat() or fstat()
+/* This describes one node in the CROMFS file system. It holds node meta data
+ * that provides the information that will be return by stat() or fstat()
  * and also provides the information needed by the CROMFS file system to
  * access the node data.
  *

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -974,8 +974,9 @@ static int littlefs_bind(FAR struct inode *driver, FAR const void *data,
   fs->cfg.block_count    = fs->geo.neraseblocks;
   fs->cfg.block_cycles   = 500;
   fs->cfg.cache_size     = fs->geo.blocksize;
-  fs->cfg.lookahead_size = lfs_min(lfs_alignup(fs->cfg.block_count / 8, 8),
-                                   fs->cfg.read_size);
+  fs->cfg.lookahead_size =
+    lfs_min(lfs_alignup((fs->cfg.block_count + 7) / 8, 8),
+            fs->cfg.read_size);
 
   /* Then get information about the littlefs filesystem on the devices
    * managed by this driver.

--- a/fs/mount/fs_foreachmountpoint.c
+++ b/fs/mount/fs_foreachmountpoint.c
@@ -90,7 +90,7 @@ static int mountpoint_filter(FAR struct inode *node,
   /* Check if the inode is a mountpoint.  Mountpoints must support statfs.
    * If this one does not for some reason, then it will be ignored.
    *
-   * The root node is a special case:  It has no operations (u.i_mops == NULL)
+   * The root node is a special case: It has no operations (u.i_mops == NULL)
    */
 
   if (INODE_IS_MOUNTPT(node) && node->u.i_mops && node->u.i_mops->statfs)

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -219,8 +219,8 @@ static void mount_sprintf(FAR struct mount_info_s *info,
  ****************************************************************************/
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MOUNT
-static int mount_entry(FAR const char *mountpoint, FAR struct statfs *statbuf,
-                       FAR void *arg)
+static int mount_entry(FAR const char *mountpoint,
+                       FAR struct statfs *statbuf, FAR void *arg)
 {
   FAR struct mount_info_s *info = (FAR struct mount_info_s *)arg;
   FAR const char *fstype;
@@ -250,8 +250,8 @@ static int mount_entry(FAR const char *mountpoint, FAR struct statfs *statbuf,
  ****************************************************************************/
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_BLOCKS
-static int blocks_entry(FAR const char *mountpoint, FAR struct statfs *statbuf,
-                        FAR void *arg)
+static int blocks_entry(FAR const char *mountpoint,
+                        FAR struct statfs *statbuf, FAR void *arg)
 {
   FAR struct mount_info_s *info = (FAR struct mount_info_s *)arg;
 
@@ -289,8 +289,8 @@ static int blocks_entry(FAR const char *mountpoint, FAR struct statfs *statbuf,
  ****************************************************************************/
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_USAGE
-static int usage_entry(FAR const char *mountpoint, FAR struct statfs *statbuf,
-                       FAR void *arg)
+static int usage_entry(FAR const char *mountpoint,
+                       FAR struct statfs *statbuf, FAR void *arg)
 {
   FAR struct mount_info_s *info = (FAR struct mount_info_s *)arg;
   FAR const char *fstype;
@@ -318,7 +318,8 @@ static int usage_entry(FAR const char *mountpoint, FAR struct statfs *statbuf,
 
   if (!info->header)
     {
-      mount_sprintf(info, "  Filesystem    Size      Used  Available Mounted on\n");
+      mount_sprintf(info,
+        "  Filesystem    Size      Used  Available Mounted on\n");
       info->header = true;
     }
 

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -733,7 +733,7 @@ static int nfs_close(FAR struct file *filep)
 
   else
     {
-      /* Assume file structure will not be found.  This should never happen. */
+      /* Assume file structure won't be found. This should never happen. */
 
       ret = -EINVAL;
 
@@ -829,7 +829,9 @@ static ssize_t nfs_read(FAR struct file *filep, FAR char *buffer,
 
   for (bytesread = 0; bytesread < buflen; )
     {
-      /* Make sure that the attempted read size does not exceed the RPC maximum */
+      /* Make sure that the attempted read size does not exceed the RPC
+       * maximum
+       */
 
       readsize = buflen - bytesread;
       if (readsize > nmp->nm_rsize)
@@ -837,7 +839,9 @@ static ssize_t nfs_read(FAR struct file *filep, FAR char *buffer,
           readsize = nmp->nm_rsize;
         }
 
-      /* Make sure that the attempted read size does not exceed the IO buffer size */
+      /* Make sure that the attempted read size does not exceed the IO buffer
+       * size
+       */
 
       tmp = SIZEOF_rpc_reply_read(readsize);
       if (tmp > nmp->nm_buflen)
@@ -1405,7 +1409,9 @@ read_dir:
   ptr    += uint32_increment(DIRENT_NFS_VERFLEN);
   reqlen += DIRENT_NFS_VERFLEN;
 
-  /* Number of directory entries (We currently only process one entry at a time) */
+  /* Number of directory entries (We currently only process one entry at a
+   * time)
+   */
 
   readsize = nmp->nm_readdirsize;
   tmp      = SIZEOF_rpc_reply_readdir(readsize);
@@ -1692,7 +1698,9 @@ static void nfs_decode_args(FAR struct nfs_mount_parameters *nprmt,
       maxio = MAXBSIZE;
     }
 
-  /* Get the maximum amount of data that can be transferred in one write transfer */
+  /* Get the maximum amount of data that can be transferred in one write
+   * transfer
+   */
 
   if ((argp->flags & NFSMNT_WSIZE) != 0 && argp->wsize > 0)
     {
@@ -1712,7 +1720,9 @@ static void nfs_decode_args(FAR struct nfs_mount_parameters *nprmt,
       nprmt->wsize = maxio;
     }
 
-  /* Get the maximum amount of data that can be transferred in one read transfer */
+  /* Get the maximum amount of data that can be transferred in one read
+   * transfer
+   */
 
   if ((argp->flags & NFSMNT_RSIZE) != 0 && argp->rsize > 0)
     {
@@ -1732,7 +1742,9 @@ static void nfs_decode_args(FAR struct nfs_mount_parameters *nprmt,
       nprmt->rsize = maxio;
     }
 
-  /* Get the maximum amount of data that can be transferred in directory transfer */
+  /* Get the maximum amount of data that can be transferred in directory
+   * transfer
+   */
 
   if ((argp->flags & NFSMNT_READDIRSIZE) != 0 && argp->readdirsize > 0)
     {
@@ -2299,7 +2311,9 @@ static int nfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
       return ret;
     }
 
-  /* Find the NFS node of the directory containing the directory to be created */
+  /* Find the NFS node of the directory containing the directory to be
+   * created
+   */
 
   ret = nfs_finddir(nmp, relpath, &fhandle, &fattr, dirname);
   if (ret != OK)
@@ -2422,7 +2436,9 @@ static int nfs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
       return ret;
     }
 
-  /* Find the NFS node of the directory containing the directory to be removed */
+  /* Find the NFS node of the directory containing the directory to be
+   * removed
+   */
 
   ret = nfs_finddir(nmp, relpath, &fhandle, &fattr, dirname);
   if (ret != OK)

--- a/fs/nxffs/nxffs.h
+++ b/fs/nxffs/nxffs.h
@@ -56,13 +56,15 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* NXFFS Definitions ********************************************************/
+
 /* General NXFFS organization.  The following example assumes 4 logical
  * blocks per FLASH erase block.  The actual relationship is determined by
  * the FLASH geometry reported by the MTD driver.
  *
- * ERASE LOGICAL                   Inodes begin with a inode header.  inode may
- * BLOCK BLOCK       CONTENTS      be marked as "deleted," pending re-packing.
+ * ERASE LOGICAL                   Inodes begin with a inode header which may
+ * BLOCK BLOCK       CONTENTS      be marked as deleted, pending re-packing.
  *   n   4*n     --+--------------+
  *                 |BBBBBBBBBBBBBB| Logic block header
  *                 |IIIIIIIIIIIIII| Inodes begin with a inode header
@@ -70,10 +72,10 @@
  *                 | (Inode Data) |
  *       4*n+1   --+--------------+
  *                 |BBBBBBBBBBBBBB| Logic block header
- *                 |DDDDDDDDDDDDDD| Inodes may consist of multiple data blocks
+ *                 |DDDDDDDDDDDDDD| Inodes may consist multiple data blocks
  *                 | (Inode Data) |
  *                 |IIIIIIIIIIIIII| Next inode header
- *                 |              | Possibly a few unused bytes at the end of a block
+ *                 |              | Possibly unused bytes at the end of block
  *       4*n+2   --+--------------+
  *                 |BBBBBBBBBBBBBB| Logic block header
  *                 |DDDDDDDDDDDDDD|
@@ -85,8 +87,8 @@
  *                 | (Inode Data) |
  *  n+1  4*(n+1) --+--------------+
  *                 |BBBBBBBBBBBBBB| Logic block header
- *                 |              | All FLASH is unused after the end of the final
- *                 |              | inode.
+ *                 |              | All FLASH is unused after the end of the
+ *                 |              | final inode.
  *               --+--------------+
  *
  * General operation:
@@ -106,9 +108,9 @@
  *   formatted and also indicates bad blocks which should never be used.
  *
  * INODE HEADER:
- *   Each inode begins with an inode header that contains, among other things,
- *   the name of the inode, the offset to the first data block, and the
- *   length of the inode data.
+ *   Each inode begins with an inode header that contains, among other
+ *   things, the name of the inode, the offset to the first data block,
+ *   and the length of the inode data.
  *
  *   At present, the only kind of inode support is a file.  So for now, the
  *   term file and inode are interchangeable.
@@ -129,8 +131,8 @@
  *    writing will not work.
  * 4. There are no directories, however, '/' may be used within a file name
  *    string providing some illusion of directories.
- * 5. Files may be opened for reading or for writing, but not both: The O_RDWR
- *    open flag is not supported.
+ * 5. Files may be opened for reading or for writing, but not both: The
+ *    O_RDWR open flag is not supported.
  * 6. The re-packing process occurs only during a write when the free FLASH
  *    memory at the end of the FLASH is exhausted.  Thus, occasionally, file
  *    writing may take a long time.
@@ -160,8 +162,8 @@
  * INODE_STATE_DELETED - The inode has been deleted.
  * Other values        - The inode is bad and has an invalid state.
  *
- * Care is taken so that the VALID to DELETED transition only involves burning
- * bits from the erased to non-erased state.
+ * Care is taken so that the VALID to DELETED transition only involves
+ * burning bits from the erased to non-erased state.
  */
 
 #define INODE_STATE_FILE          (CONFIG_NXFFS_ERASEDSTATE ^ 0x22)
@@ -179,6 +181,7 @@
 #define NXFFS_MINDATA             16
 
 /* Internal definitions *****************************************************/
+
 /* If we encounter this number of erased bytes, we assume that all of the
  * flash beyond this point is erased.
  */
@@ -554,7 +557,7 @@ off_t nxffs_iotell(FAR struct nxffs_volume_s *volume);
  *   over bad blocks and block headers as necessary.
  *
  * Input Parameters:
- *   volume - Describes the NXFFS volume.  The parameters ioblock and iooffset
+ *   volume - Describes the NXFFS volume. The parameters ioblock and iooffset
  *     in the volume structure determine the behavior of nxffs_getc().
  *   reserve - If less than this much space is available at the end of the
  *     block, then skip to the next block.
@@ -822,7 +825,8 @@ FAR struct nxffs_ofile_s *nxffs_findofile(FAR struct nxffs_volume_s *volume,
  *
  ****************************************************************************/
 
-FAR struct nxffs_wrfile_s *nxffs_findwriter(FAR struct nxffs_volume_s *volume);
+FAR struct nxffs_wrfile_s *
+nxffs_findwriter(FAR struct nxffs_volume_s *volume);
 
 /****************************************************************************
  * Name: nxffs_wrinode
@@ -841,8 +845,8 @@ FAR struct nxffs_wrfile_s *nxffs_findwriter(FAR struct nxffs_volume_s *volume);
  *   entry  - Describes the inode header to write
  *
  * Returned Value:
- *   Zero is returned on success; Otherwise, a negated errno value is returned
- *   indicating the nature of the failure.
+ *   Zero is returned on success; Otherwise, a negated errno value is
+ *   returned indicating the nature of the failure.
  *
  * Defined in nxffs_open.c
  *
@@ -863,8 +867,8 @@ int nxffs_wrinode(FAR struct nxffs_volume_s *volume,
  *   entry  - Describes the new inode entry
  *
  * Returned Value:
- *   Zero is returned on success; Otherwise, a negated errno value is returned
- *   indicating the nature of the failure.
+ *   Zero is returned on success; Otherwise, a negated errno value is
+ *   returned indicating the nature of the failure.
  *
  ****************************************************************************/
 
@@ -1030,8 +1034,8 @@ int nxffs_nextblock(FAR struct nxffs_volume_s *volume, off_t offset,
  *
  * Input Parameters:
  *   volume - Describes the current volume.
- *   offset - The byte offset from the beginning of FLASH where the data block
- *     header is expected.
+ *   offset - The byte offset from the beginning of FLASH where the data
+ *     block header is expected.
  *   datlen  - A memory location to return the data block length.
  *
  * Returned Value:

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -175,7 +175,7 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
 
   /* Allocate a NXFFS volume structure */
 
-  volume = (FAR struct nxffs_volume_s *)kmm_zalloc(sizeof(struct nxffs_volume_s));
+  volume = kmm_zalloc(sizeof(struct nxffs_volume_s));
   if (!volume)
     {
       return -ENOMEM;
@@ -194,7 +194,8 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
    * from the size of a pointer).
    */
 
-  ret = MTD_IOCTL(mtd, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&volume->geo));
+  ret = MTD_IOCTL(mtd, MTDIOC_GEOMETRY,
+                  (unsigned long)((uintptr_t)&volume->geo));
   if (ret < 0)
     {
       ferr("ERROR: MTD ioctl(MTDIOC_GEOMETRY) failed: %d\n", -ret);
@@ -211,9 +212,9 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
       goto errout_with_volume;
     }
 
-  /* Pre-allocate one, full, in-memory erase block.  This is needed for filesystem
-   * packing (but is useful in other places as well). This buffer is not needed
-   * often, but is best to have pre-allocated and in-place.
+  /* Pre-allocate one, full, in-memory erase block.  This is needed for
+   * filesystem packing (but is useful in other places as well). This buffer
+   * is not needed often, but is best to have pre-allocated and in-place.
    */
 
   volume->pack = (FAR uint8_t *)kmm_malloc(volume->geo.erasesize);
@@ -230,7 +231,8 @@ int nxffs_initialize(FAR struct mtd_dev_s *mtd)
 
   volume->blkper  = volume->geo.erasesize / volume->geo.blocksize;
   volume->nblocks = volume->geo.neraseblocks * volume->blkper;
-  DEBUGASSERT((off_t)volume->blkper * volume->geo.blocksize == volume->geo.erasesize);
+  DEBUGASSERT((off_t)volume->blkper * volume->geo.blocksize ==
+              volume->geo.erasesize);
 
 #ifdef CONFIG_NXFFS_SCAN_VOLUME
   /* Check if there is a valid NXFFS file system on the flash */
@@ -439,10 +441,13 @@ int nxffs_limits(FAR struct nxffs_volume_s *volume)
           if (volume->ioblock + 1 >= volume->nblocks &&
               volume->iooffset + 1 >= volume->geo.blocksize)
             {
-              /* Yes.. the FLASH is full.  Force the offsets to the end of FLASH */
+              /* Yes.. the FLASH is full.  Force the offsets to the end of
+               * FLASH
+               */
 
               volume->froffset = volume->nblocks * volume->geo.blocksize;
-              finfo("Assume no free FLASH, froffset: %d\n", volume->froffset);
+              finfo("Assume no free FLASH, froffset: %d\n",
+                    volume->froffset);
               if (noinodes)
                 {
                   volume->inoffset = volume->froffset;
@@ -452,7 +457,9 @@ int nxffs_limits(FAR struct nxffs_volume_s *volume)
               return OK;
             }
 
-          /* No?  Then it is some other failure that we do not know how to handle */
+          /* No?  Then it is some other failure that we do not know how to
+           * handle
+           */
 
           ferr("ERROR: nxffs_getc failed: %d\n", -ch);
           return ch;
@@ -475,7 +482,8 @@ int nxffs_limits(FAR struct nxffs_volume_s *volume)
                */
 
               volume->froffset = offset;
-              finfo("Free FLASH region begins at offset: %d\n", volume->froffset);
+              finfo("Free FLASH region begins at offset: %d\n",
+                    volume->froffset);
               if (noinodes)
                 {
                   volume->inoffset = offset;

--- a/fs/procfs/fs_procfscpuload.c
+++ b/fs/procfs/fs_procfscpuload.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -163,7 +162,7 @@ static int cpuload_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  attr = (FAR struct cpuload_file_s *)kmm_zalloc(sizeof(struct cpuload_file_s));
+  attr = kmm_zalloc(sizeof(struct cpuload_file_s));
   if (!attr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -235,8 +234,8 @@ static ssize_t cpuload_read(FAR struct file *filep, FAR char *buffer,
 
       DEBUGVERIFY(clock_cpuload(0, &cpuload));
 
-      /* On the simulator, you may hit cpuload.total == 0, but probably never on
-       * real hardware.
+      /* On the simulator, you may hit cpuload.total == 0, but probably never
+       * on real hardware.
        */
 
       if (cpuload.total > 0)
@@ -264,7 +263,7 @@ static ssize_t cpuload_read(FAR struct file *filep, FAR char *buffer,
   /* Transfer the system up time to user receive buffer */
 
   offset = filep->f_pos;
-  ret    = procfs_memcpy(attr->line, attr->linesize, buffer, buflen, &offset);
+  ret = procfs_memcpy(attr->line, attr->linesize, buffer, buflen, &offset);
 
   /* Update the file offset */
 
@@ -298,7 +297,7 @@ static int cpuload_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = (FAR struct cpuload_file_s *)kmm_malloc(sizeof(struct cpuload_file_s));
+  newattr = kmm_malloc(sizeof(struct cpuload_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -163,7 +162,7 @@ static int critmon_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the file attributes */
 
-  attr = (FAR struct critmon_file_s *)kmm_zalloc(sizeof(struct critmon_file_s));
+  attr = kmm_zalloc(sizeof(struct critmon_file_s));
   if (!attr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -349,7 +348,7 @@ static int critmon_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = (FAR struct critmon_file_s *)kmm_malloc(sizeof(struct critmon_file_s));
+  newattr = kmm_malloc(sizeof(struct critmon_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -25,7 +25,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>

--- a/fs/procfs/fs_procfsuptime.c
+++ b/fs/procfs/fs_procfsuptime.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>

--- a/fs/procfs/fs_procfsversion.c
+++ b/fs/procfs/fs_procfsversion.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -237,7 +236,7 @@ static ssize_t version_read(FAR struct file *filep, FAR char *buffer,
     }
 
   offset = filep->f_pos;
-  ret    = procfs_memcpy(attr->line, attr->linesize, buffer, buflen, &offset);
+  ret = procfs_memcpy(attr->line, attr->linesize, buffer, buflen, &offset);
 
   /* Update the file offset */
 

--- a/fs/procfs/fs_skeleton.c
+++ b/fs/procfs/fs_skeleton.c
@@ -41,7 +41,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -109,7 +108,8 @@ struct smartfs_procfs_entry_s
 {
   const char  *name;                 /* Name of the directory entry */
   size_t (*read)(FAR struct file *filep, FAR char *buffer, size_t buflen);
-  ssize_t (*write)(FAR struct file *filep, FAR const char *buffer, size_t buflen);
+  ssize_t (*write)(FAR struct file *filep,
+                   FAR const char *buffer, size_t buflen);
   uint8_t type;
 };
 
@@ -130,15 +130,16 @@ static ssize_t  smartfs_write(FAR struct file *filep, FAR const char *buffer,
 static int      smartfs_dup(FAR const struct file *oldp,
                  FAR struct file *newp);
 
-static int      smartfs_opendir(const char *relpath, FAR struct fs_dirent_s *dir);
+static int      smartfs_opendir(const char *relpath,
+                  FAR struct fs_dirent_s *dir);
 static int      smartfs_closedir(FAR struct fs_dirent_s *dir);
 static int      smartfs_readdir(FAR struct fs_dirent_s *dir);
 static int      smartfs_rewinddir(FAR struct fs_dirent_s *dir);
 
 static int      smartfs_stat(FAR const char *relpath, FAR struct stat *buf);
 
-static ssize_t  smartfs_debug_write(FAR struct file *filep, FAR const char *buffer,
-                  size_t buflen);
+static ssize_t  smartfs_debug_write(FAR struct file *filep,
+                  FAR const char *buffer, size_t buflen);
 static size_t   smartfs_status_read(FAR struct file *filep, FAR char *buffer,
                   size_t buflen);
 #ifdef CONFIG_MTD_SMART_ALLOC_DEBUG
@@ -146,8 +147,8 @@ static size_t   smartfs_mem_read(FAR struct file *filep, FAR char *buffer,
                   size_t buflen);
 #endif
 #ifdef CONFIG_MTD_SMART_SECTOR_ERASE_DEBUG
-static size_t   smartfs_erasemap_read(FAR struct file *filep, FAR char *buffer,
-                  size_t buflen);
+static size_t   smartfs_erasemap_read(FAR struct file *filep,
+                  FAR char *buffer, size_t buflen);
 #endif
 #ifdef CONFIG_SMARTFS_FILE_SECTOR_DEBUG
 static size_t   smartfs_files_read(FAR struct file *filep, FAR char *buffer,
@@ -299,7 +300,9 @@ static int smartfs_find_dirref(FAR const char *relpath,
 
           if (relpath[0] == '\0')
             {
-              /* Requesting directory listing of a specific SMARTFS mount or entry */
+              /* Requesting directory listing of a specific SMARTFS mount or
+               * entry
+               */
 
               level1->base.level    = 2;
               level1->base.nentries = g_direntrycount;
@@ -318,7 +321,7 @@ static int smartfs_find_dirref(FAR const char *relpath,
                 {
                   /* Test if this entry matches */
 
-                  if (strcmp(relpath, g_direntry[level1->direntry].name) == 0)
+                  if (!strcmp(relpath, g_direntry[level1->direntry].name))
                     {
                       break;
                     }
@@ -368,7 +371,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the task and attribute selection */
 
-  priv = (FAR struct smartfs_file_s *)kmm_malloc(sizeof(struct smartfs_file_s));
+  priv = kmm_malloc(sizeof(struct smartfs_file_s));
   if (!priv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -441,7 +444,8 @@ static ssize_t smartfs_read(FAR struct file *filep, FAR char *buffer,
         {
           if (g_direntry[priv->level1.direntry].read)
             {
-              ret = g_direntry[priv->level1.direntry].read(filep, buffer, buflen);
+              ret = g_direntry[priv->level1.direntry].read(filep,
+                                                           buffer, buflen);
             }
         }
     }
@@ -481,7 +485,8 @@ static ssize_t smartfs_write(FAR struct file *filep, FAR const char *buffer,
         {
           if (g_direntry[priv->level1.direntry].write)
             {
-              ret = g_direntry[priv->level1.direntry].write(filep, buffer, buflen);
+              ret = g_direntry[priv->level1.direntry].write(filep,
+                                                            buffer, buflen);
             }
         }
     }
@@ -518,7 +523,7 @@ static int smartfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newpriv = (FAR struct smartfs_file_s *)kmm_malloc(sizeof(struct smartfs_file_s));
+  newpriv = kmm_malloc(sizeof(struct smartfs_file_s));
   if (!newpriv)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -543,7 +548,8 @@ static int smartfs_dup(FAR const struct file *oldp, FAR struct file *newp)
  *
  ****************************************************************************/
 
-static int smartfs_opendir(FAR const char *relpath, FAR struct fs_dirent_s *dir)
+static int smartfs_opendir(FAR const char *relpath,
+                           FAR struct fs_dirent_s *dir)
 {
   FAR struct smartfs_level1_s *level1;
   int        ret;
@@ -766,8 +772,8 @@ static int smartfs_stat(const char *relpath, struct stat *buf)
  *
  ****************************************************************************/
 
-static ssize_t smartfs_debug_write(FAR struct file *filep, FAR const char *buffer,
-                                  size_t buflen)
+static ssize_t smartfs_debug_write(FAR struct file *filep,
+                                   FAR const char *buffer, size_t buflen)
 {
   struct mtd_smart_debug_data_s debug_data;
   FAR struct smartfs_file_s *priv;
@@ -836,14 +842,15 @@ static size_t smartfs_status_read(FAR struct file *filep, FAR char *buffer,
 
           /* Format and return data in the buffer */
 
-          len = snprintf(buffer, buflen, "Format version:    %d\nName Len:          %d\n"
-                                         "Total Sectors:     %d\nSector Size:       %d\n"
-                                         "Format Sector:     %d\nDir Sector:        %d\n"
-                                         "Free Sectors:      %d\nReleased Sectors:  %d\n"
-                                         "Unused Sectors:    %d\nBlock Erases:      %d\n"
-                                         "Sectors Per Block: %d\nSector Utilization:%d%%\n"
+          len = snprintf(buffer, buflen,
+                         "Format version:    %d\nName Len:          %d\n"
+                         "Total Sectors:     %d\nSector Size:       %d\n"
+                         "Format Sector:     %d\nDir Sector:        %d\n"
+                         "Free Sectors:      %d\nReleased Sectors:  %d\n"
+                         "Unused Sectors:    %d\nBlock Erases:      %d\n"
+                         "Sectors Per Block: %d\nSector Utilization:%d%%\n"
 #ifdef CONFIG_MTD_SMART_WEAR_LEVEL
-                                         "Uneven Wear Count: %d\n"
+                         "Uneven Wear Count: %d\n"
 #endif
                   ,
                   procfs_data.formatversion, procfs_data.namelen,
@@ -912,14 +919,15 @@ static size_t   smartfs_mem_read(FAR struct file *filep, FAR char *buffer,
               if (procfs_data.allocs[x].ptr != NULL)
                 {
                   len += snprintf(&buffer[len], buflen - len, "   %s: %d\n",
-                      procfs_data.allocs[x].name, procfs_data.allocs[x].size);
+                    procfs_data.allocs[x].name, procfs_data.allocs[x].size);
                   total += procfs_data.allocs[x].size;
                 }
             }
 
           /* Add the total allocation amount to the buffer */
 
-          len += snprintf(&buffer[len], buflen - len, "\nTotal: %d\n", total);
+          len += snprintf(&buffer[len], buflen - len,
+                          "\nTotal: %d\n", total);
         }
 
       /* Indicate we have done the read */
@@ -939,8 +947,8 @@ static size_t   smartfs_mem_read(FAR struct file *filep, FAR char *buffer,
  ****************************************************************************/
 
 #ifdef CONFIG_MTD_SMART_SECTOR_ERASE_DEBUG
-static size_t   smartfs_erasemap_read(FAR struct file *filep, FAR char *buffer,
-                  size_t buflen)
+static size_t   smartfs_erasemap_read(FAR struct file *filep,
+                                      FAR char *buffer, size_t buflen)
 {
   struct mtd_smart_procfs_data_s procfs_data;
   FAR struct smartfs_file_s *priv;
@@ -994,7 +1002,8 @@ static size_t   smartfs_erasemap_read(FAR struct file *filep, FAR char *buffer,
 
               if (copylen >= priv->offset)
                 {
-                  buffer[len++] = procfs_data.erasecounts[y * cols + x] + 'A';
+                  buffer[len++] =
+                    procfs_data.erasecounts[y * cols + x] + 'A';
                   priv->offset++;
 
                   if (len >= buflen)

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -993,7 +993,6 @@ static off_t smartfs_seek(FAR struct file *filep, off_t offset, int whence)
   /* Call our internal routine to perform the seek */
 
   ret = smartfs_seek_internal(fs, sf, offset, whence);
-
   if (ret >= 0)
     {
       filep->f_pos = ret;
@@ -1670,7 +1669,9 @@ static int smartfs_unlink(struct inode *mountpt, const char *relpath)
 
       /* TODO:  Need to check permissions?  */
 
-      /* Okay, we are clear to delete the file.  Use the deleteentry routine. */
+      /* Okay, we are clear to delete the file.  Use the deleteentry
+       * routine.
+       */
 
       smartfs_deleteentry(fs, &entry);
     }
@@ -1846,7 +1847,9 @@ int smartfs_rmdir(struct inode *mountpt, const char *relpath)
           goto errout_with_semaphore;
         }
 
-      /* Okay, we are clear to delete the directory.  Use the deleteentry routine. */
+      /* Okay, we are clear to delete the directory.  Use the deleteentry
+       * routine.
+       */
 
       ret = smartfs_deleteentry(fs, &entry);
       if (ret < 0)

--- a/fs/spiffs/src/spiffs_check.c
+++ b/fs/spiffs/src/spiffs_check.c
@@ -270,8 +270,8 @@ static int spiffs_check_rewrite_index(FAR struct spiffs_s *fs,
 
   objndx_phdr = (FAR struct spiffs_page_header_s *)fs->lu_work;
 
-  /* Be ultra safe, double check header against provided data.  Return -EFAULT
-   * to indicate this condition.
+  /* Be ultra safe, double check header against provided data.  Return
+   * -EFAULT to indicate this condition.
    */
 
   if (objndx_phdr->objid != objid)
@@ -306,8 +306,8 @@ static int spiffs_check_rewrite_index(FAR struct spiffs_s *fs,
   else
     {
       ((FAR int16_t *)((FAR uint8_t *)fs->lu_work +
-        sizeof(struct spiffs_page_objndx_s)))[SPIFFS_OBJNDX_ENTRY(fs, data_spndx)] =
-          new_data_pgndx;
+        sizeof(struct spiffs_page_objndx_s)))
+          [SPIFFS_OBJNDX_ENTRY(fs, data_spndx)] = new_data_pgndx;
     }
 
   ret = spiffs_cache_write(fs, SPIFFS_OP_T_OBJ_DA | SPIFFS_OP_C_UPDT, 0,
@@ -320,10 +320,9 @@ static int spiffs_check_rewrite_index(FAR struct spiffs_s *fs,
     }
 
   ret = spiffs_cache_write(fs, SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_UPDT, 0,
-                           SPIFFS_BLOCK_TO_PADDR(fs, SPIFFS_BLOCK_FOR_PAGE(fs, free_pgndx)) +
-                           SPIFFS_OBJ_LOOKUP_ENTRY_FOR_PAGE(fs, free_pgndx) *
-                           sizeof(int16_t), sizeof(int16_t),
-                           (FAR uint8_t *)&objid);
+          SPIFFS_BLOCK_TO_PADDR(fs, SPIFFS_BLOCK_FOR_PAGE(fs, free_pgndx)) +
+          SPIFFS_OBJ_LOOKUP_ENTRY_FOR_PAGE(fs, free_pgndx) * sizeof(int16_t),
+          sizeof(int16_t), (FAR uint8_t *)&objid);
   if (ret < 0)
     {
       ferr("ERROR: spiffs_cache_write() failed: %d\n", ret);
@@ -377,8 +376,8 @@ static int spiffs_check_delobj_lazy(FAR struct spiffs_s *fs, int16_t objid)
 
   ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ, 0,
                    SPIFFS_PAGE_TO_PADDR(fs, objhdr_pgndx) +
-                   offsetof(struct spiffs_page_header_s, flags), sizeof(flags),
-                   &flags);
+                   offsetof(struct spiffs_page_header_s, flags),
+                   sizeof(flags), &flags);
   if (ret < 0)
     {
       ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
@@ -422,13 +421,14 @@ static int spiffs_check_delobj_lazy(FAR struct spiffs_s *fs, int16_t objid)
  *
  ****************************************************************************/
 
-static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
-                                         int16_t lu_objid,
-                                         FAR struct spiffs_page_header_s *pghdr,
-                                         int16_t cur_pgndx,
-                                         int16_t cur_block,
-                                         int cur_entry,
-                                         FAR bool *reload_lu)
+static int
+spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
+                              int16_t lu_objid,
+                              FAR struct spiffs_page_header_s *pghdr,
+                              int16_t cur_pgndx,
+                              int16_t cur_block,
+                              int cur_entry,
+                              FAR bool *reload_lu)
 {
   int16_t objndx_pgndx;
   int16_t ref_pgndx;
@@ -478,15 +478,17 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                * page to new place and re-write the object index to new place
                */
 
-              ret = spiffs_check_rewrite_page(fs, cur_pgndx, pghdr, &new_pgndx);
+              ret = spiffs_check_rewrite_page(fs, cur_pgndx, pghdr,
+                                              &new_pgndx);
 
-              spiffs_checkinfo("Data page not found elsewhere, rewriting %04x "
-                               "to new page %04x\n",
+              spiffs_checkinfo("Data page not found elsewhere, rewriting "
+                               "%04x to new page %04x\n",
                                cur_pgndx, new_pgndx);
 
               if (ret < 0)
                 {
-                  ferr("ERROR: spiffs_check_rewrite_page() failed: %d\n", ret);
+                  ferr("ERROR: spiffs_check_rewrite_page() failed: %d\n",
+                       ret);
                   return ret;
                 }
 
@@ -496,7 +498,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                                "affected objndx_pgndx %04x\n",
                                cur_pgndx, new_pgndx, objndx_pgndx);
 
-              ret = spiffs_check_rewrite_index(fs, pghdr->objid, pghdr->spndx,
+              ret = spiffs_check_rewrite_index(fs,
+                                               pghdr->objid, pghdr->spndx,
                                                new_pgndx, objndx_pgndx);
               if (ret == -EFAULT)
                 {
@@ -516,14 +519,16 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                   ret2 = spiffs_check_delobj_lazy(fs, pghdr->objid);
                   if (ret2 < 0)
                     {
-                      ferr("ERROR: spiffs_check_delobj_lazy() failed: %d\n", ret2);
+                      ferr("ERROR: spiffs_check_delobj_lazy() failed: %d\n",
+                           ret2);
                       return ret2;
                     }
                 }
 
               if (ret < 0)
                 {
-                  ferr("ERROR: spiffs_check_rewrite_index() failed: %d\n", ret);
+                  ferr("ERROR: spiffs_check_rewrite_index() failed: %d\n",
+                       ret);
                   return ret;
                 }
             }
@@ -535,8 +540,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
            */
 
           ret = spiffs_objlu_find_id_and_span(fs,
-                                              pghdr->objid | SPIFFS_OBJID_NDXFLAG,
-                                              pghdr->spndx, cur_pgndx, 0);
+                                         pghdr->objid | SPIFFS_OBJID_NDXFLAG,
+                                         pghdr->spndx, cur_pgndx, 0);
           if (ret == -ENOENT)
             {
               /* No such index page found, check for a data page amongst page
@@ -556,15 +561,17 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                    * corruption only, rewrite to new page
                    */
 
-                  ret = spiffs_check_rewrite_page(fs, cur_pgndx, pghdr, &new_pgndx);
+                  ret = spiffs_check_rewrite_page(fs, cur_pgndx, pghdr,
+                                                  &new_pgndx);
 
-                  spiffs_checkinfo("Index page with data not found elsewhere, "
+                  spiffs_checkinfo("Index page with data not found, "
                                    "rewriting %04x to new page %04x\n",
                                    cur_pgndx, new_pgndx);
 
                   if (ret < 0)
                     {
-                      ferr("ERROR: spiffs_check_rewrite_page() failed: %d\n", ret);
+                      ferr("ERROR: spiffs_check_rewrite_page() failed: %d\n",
+                           ret);
                       return ret;
                     }
 
@@ -573,7 +580,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
             }
           else if (ret < 0)
             {
-              ferr("ERROR: spiffs_objlu_find_id_and_span_byphdr() failed: %d\n", ret);
+              ferr("ERROR: spiffs_objlu_find_id_and_span_byphdr(): %d\n",
+                   ret);
               return ret;
             }
         }
@@ -592,7 +600,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
           delete_page = true;
           if ((pghdr->flags & SPIFFS_PH_FLAG_DELET) == 0 ||
               (pghdr->flags & SPIFFS_PH_FLAG_FINAL) ||
-              (pghdr->flags & (SPIFFS_PH_FLAG_INDEX | SPIFFS_PH_FLAG_NDXDELE)) == 0)
+              (pghdr->flags & (SPIFFS_PH_FLAG_INDEX |
+                               SPIFFS_PH_FLAG_NDXDELE)) == 0)
             {
               /* Page deleted or not finalized, just remove it */
             }
@@ -613,7 +622,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                 }
               else if (ret < 0)
                 {
-                  ferr("ERROR: spiffs_check_get_data_pgndx() failed: %d\n", ret);
+                  ferr("ERROR: spiffs_check_get_data_pgndx() failed: %d\n",
+                       ret);
                   return ret;
                 }
 
@@ -629,7 +639,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                                                   &new_pgndx);
                   if (ret < 0)
                     {
-                      ferr("ERROR: spiffs_check_rewrite_page() failed: %d\n", ret);
+                      ferr("ERROR: spiffs_check_rewrite_page() failed: %d\n",
+                           ret);
                       return ret;
                     }
 
@@ -647,14 +658,15 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                       ret2 = spiffs_page_delete(fs, new_pgndx);
                       if (ret2 < 0)
                         {
-                          ferr("ERROR: spiffs_page_delete() failed: %d\n", ret2);
+                          ferr("ERROR: spiffs_page_delete() failed: %d\n",
+                               ret2);
                           return ret2;
                         }
 
                       ret2 = spiffs_check_delobj_lazy(fs, pghdr->objid);
                       if (ret2 < 0)
                         {
-                          ferr("ERROR: spiffs_check_delobj_lazy() failed: %d\n",
+                          ferr("ERROR: spiffs_check_delobj_lazy(): %d\n",
                                ret2);
                           return ret2;
                         }
@@ -664,7 +676,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
 
                   if (ret < 0)
                     {
-                      ferr("ERROR: spiffs_check_rewrite_index() failed: %d\n", ret);
+                      ferr("ERROR: spiffs_check_rewrite_index(): %d\n",
+                           ret);
                       return ret;
                     }
                 }
@@ -682,9 +695,9 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                */
 
               ret = spiffs_objlu_find_id_and_span(fs,
-                                                  lu_objid | SPIFFS_OBJID_NDXFLAG,
-                                                  pghdr->spndx, 0,
-                                                  &objndx_pgndx_lu);
+                                             lu_objid | SPIFFS_OBJID_NDXFLAG,
+                                             pghdr->spndx, 0,
+                                             &objndx_pgndx_lu);
               if (ret == -ENOENT)
                 {
                   ret = OK;
@@ -692,7 +705,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                 }
               else if (ret < 0)
                 {
-                  ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n", ret);
+                  ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                       ret);
                   return ret;
                 }
 
@@ -701,9 +715,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                */
 
               ret = spiffs_objlu_find_id_and_span(fs,
-                                                  pghdr->objid | SPIFFS_OBJID_NDXFLAG,
-                                                  pghdr->spndx, 0,
-                                                  &objndx_pgndx_ph);
+                                         pghdr->objid | SPIFFS_OBJID_NDXFLAG,
+                                         pghdr->spndx, 0, &objndx_pgndx_ph);
               if (ret == -ENOENT)
                 {
                   ret = OK;
@@ -711,7 +724,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                 }
               else if (ret < 0)
                 {
-                  ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n", ret);
+                  ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                       ret);
                   return ret;
                 }
 
@@ -732,8 +746,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
 
                   ret =
                     spiffs_objlu_find_id_and_span(fs,
-                                                  lu_objid & ~SPIFFS_OBJID_NDXFLAG,
-                                                  0, 0, &data_pgndx_lu);
+                                            lu_objid & ~SPIFFS_OBJID_NDXFLAG,
+                                            0, 0, &data_pgndx_lu);
                   if (ret == -ENOENT)
                     {
                       ret = OK;
@@ -741,7 +755,7 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                     }
                   else if (ret < 0)
                     {
-                      ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                      ferr("ERROR: spiffs_objlu_find_id_and_span(): %d\n",
                            ret);
                       return ret;
                     }
@@ -762,12 +776,13 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                     }
                   else if (ret < 0)
                     {
-                      ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                      ferr("ERROR: spiffs_objlu_find_id_and_span(): %d\n",
                            ret);
                       return ret;
                     }
 
-                  new_ph.flags = 0xff & ~(SPIFFS_PH_FLAG_USED | SPIFFS_PH_FLAG_INDEX |
+                  new_ph.flags = 0xff & ~(SPIFFS_PH_FLAG_USED |
+                                          SPIFFS_PH_FLAG_INDEX |
                                           SPIFFS_PH_FLAG_FINAL);
                   new_ph.spndx = pghdr->spndx;
 
@@ -776,18 +791,21 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                       (objndx_pgndx_lu == 0 && data_pgndx_ph &&
                        objndx_pgndx_ph == 0))
                     {
-                      /* Got a data page for page header objid rewrite as objid_ph */
+                      /* Got a data page for page header objid rewrite as
+                       * objid_ph
+                       */
 
                       new_ph.objid = pghdr->objid | SPIFFS_OBJID_NDXFLAG;
                       ret = spiffs_check_rewrite_page(fs, cur_pgndx, &new_ph,
                                                       &new_pgndx);
 
-                      spiffs_checkinfo("Rewrite page %04x as %04x to pgndx %04x\n",
-                                       cur_pgndx, new_ph.objid, new_pgndx);
+                      spiffs_checkinfo(
+                        "Rewrite page %04x as %04x to pgndx %04x\n",
+                        cur_pgndx, new_ph.objid, new_pgndx);
 
                       if (ret < 0)
                         {
-                          ferr("ERROR: spiffs_check_rewrite_page() failed: %d\n",
+                          ferr("ERROR: spiffs_check_rewrite_page(): %d\n",
                                ret);
                           return ret;
                         }
@@ -799,7 +817,9 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                            (objndx_pgndx_ph == 0 && data_pgndx_lu &&
                             objndx_pgndx_lu == 0))
                     {
-                      /* Got a data page for look up objid rewrite as objid_lu */
+                      /* Got a data page for look up objid rewrite as
+                       * objid_lu
+                       */
 
                       new_ph.objid = lu_objid | SPIFFS_OBJID_NDXFLAG;
 
@@ -810,7 +830,7 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                                                       &new_pgndx);
                       if (ret < 0)
                         {
-                          ferr("ERROR: spiffs_check_rewrite_page() failed: %d\n",
+                          ferr("ERROR: spiffs_check_rewrite_page(): %d\n",
                                ret);
                           return ret;
                         }
@@ -839,8 +859,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
           /* see if other data page exists for given objid and span index */
 
           ret = spiffs_objlu_find_id_and_span(fs,
-                                              lu_objid & ~SPIFFS_OBJID_NDXFLAG,
-                                              pghdr->spndx, cur_pgndx, &data_pgndx);
+                                       lu_objid & ~SPIFFS_OBJID_NDXFLAG,
+                                       pghdr->spndx, cur_pgndx, &data_pgndx);
           if (ret == -ENOENT)
             {
               ret = OK;
@@ -848,16 +868,19 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
             }
           else if (ret < 0)
             {
-              ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n", ret);
+              ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                   ret);
               return ret;
             }
 
-          /* See if other object index exists for given objid and span index */
+          /* See if other object index exists for given objid and span
+           * index
+           */
 
           ret = spiffs_objlu_find_id_and_span(fs,
-                                              lu_objid | SPIFFS_OBJID_NDXFLAG,
-                                              pghdr->spndx, cur_pgndx,
-                                              &objndx_pgndx_d);
+                                             lu_objid | SPIFFS_OBJID_NDXFLAG,
+                                             pghdr->spndx, cur_pgndx,
+                                             &objndx_pgndx_d);
           if (ret == -ENOENT)
             {
               ret = OK;
@@ -865,7 +888,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
             }
           else if (ret < 0)
             {
-              ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n", ret);
+              ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                   ret);
               return ret;
             }
 
@@ -877,7 +901,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
 
           if (data_pgndx != 0 && objndx_pgndx_d != 0)
             {
-              spiffs_checkinfo("Other index and data page exists, simply remove\n");
+              spiffs_checkinfo(
+                "Other index and data page exists, simply remove\n");
             }
 
           /* If only data page exists, make this page index */
@@ -889,7 +914,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
 
               spiffs_checkinfo("Other data page exists, make this index\n");
 
-              new_ph.flags = 0xff & ~(SPIFFS_PH_FLAG_USED | SPIFFS_PH_FLAG_FINAL |
+              new_ph.flags = 0xff & ~(SPIFFS_PH_FLAG_USED |
+                                      SPIFFS_PH_FLAG_FINAL |
                                       SPIFFS_PH_FLAG_INDEX);
               new_ph.objid = lu_objid | SPIFFS_OBJID_NDXFLAG;
               new_ph.spndx = pghdr->spndx;
@@ -898,11 +924,13 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                                               0, 0, 0, 1, &new_pgndx);
               if (ret < 0)
                 {
-                  ferr("ERROR: spiffs_page_allocate_data() failed: %d\n", ret);
+                  ferr("ERROR: spiffs_page_allocate_data() failed: %d\n",
+                       ret);
                   return ret;
                 }
 
-              ret = spiffs_phys_cpy(fs, 0, SPIFFS_PAGE_TO_PADDR(fs, new_pgndx) +
+              ret = spiffs_phys_cpy(fs, 0,
+                                    SPIFFS_PAGE_TO_PADDR(fs, new_pgndx) +
                                     sizeof(struct spiffs_page_header_s),
                                     SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx) +
                                     sizeof(struct spiffs_page_header_s),
@@ -924,7 +952,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
 
               spiffs_checkinfo("Other index page exists, make this data\n");
 
-              new_ph.flags = 0xff & ~(SPIFFS_PH_FLAG_USED | SPIFFS_PH_FLAG_FINAL);
+              new_ph.flags = 0xff & ~(SPIFFS_PH_FLAG_USED |
+                                      SPIFFS_PH_FLAG_FINAL);
               new_ph.objid = lu_objid & ~SPIFFS_OBJID_NDXFLAG;
               new_ph.spndx = pghdr->spndx;
 
@@ -932,11 +961,13 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
                                               0, 0, 0, 1, &new_pgndx);
               if (ret < 0)
                 {
-                  ferr("ERROR: spiffs_page_allocate_data() failed: %d\n", ret);
+                  ferr("ERROR: spiffs_page_allocate_data() failed: %d\n",
+                       ret);
                   return ret;
                 }
 
-              ret = spiffs_phys_cpy(fs, 0, SPIFFS_PAGE_TO_PADDR(fs, new_pgndx) +
+              ret = spiffs_phys_cpy(fs, 0,
+                                    SPIFFS_PAGE_TO_PADDR(fs, new_pgndx) +
                                     sizeof(struct spiffs_page_header_s),
                                     SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx) +
                                     sizeof(struct spiffs_page_header_s),
@@ -950,7 +981,9 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
             }
           else
             {
-              /* If nothing exists, we cannot safely make a decision - delete */
+              /* If nothing exists, we cannot safely make a decision -
+               * delete
+               */
             }
         }
       else if ((pghdr->flags & SPIFFS_PH_FLAG_DELET) == 0)
@@ -983,7 +1016,8 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
             }
           else if (ref_pgndx != cur_pgndx)
             {
-              spiffs_checkinfo("Other finalized page is referred, just delete\n");
+              spiffs_checkinfo(
+                "Other finalized page is referred, just delete\n");
               delete_page = true;
             }
           else
@@ -997,10 +1031,11 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
               spiffs_checkinfo("Unfinalized page is referred, finalizing\n");
 
 #ifdef CONFIG_SPIFFS_NO_BLIND_WRITES
-              ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_DA | SPIFFS_OP_C_READ,
-                                      0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx) +
-                                      offsetof(struct spiffs_page_header_s, flags),
-                                      sizeof(flags), &flags);
+              ret = spiffs_cache_read(fs,
+                                SPIFFS_OP_T_OBJ_DA | SPIFFS_OP_C_READ,
+                                0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx) +
+                                offsetof(struct spiffs_page_header_s, flags),
+                                sizeof(flags), &flags);
               if (ret < 0)
                 {
                   ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
@@ -1009,10 +1044,11 @@ static int spiffs_check_luentry_validate(FAR struct spiffs_s *fs,
 #endif
 
               flags &= ~SPIFFS_PH_FLAG_FINAL;
-              ret = spiffs_cache_write(fs, SPIFFS_OP_T_OBJ_DA | SPIFFS_OP_C_UPDT,
-                                       0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx) +
-                                       offsetof(struct spiffs_page_header_s, flags),
-                                       sizeof(flags), &flags);
+              ret = spiffs_cache_write(fs,
+                                SPIFFS_OP_T_OBJ_DA | SPIFFS_OP_C_UPDT,
+                                0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx) +
+                                offsetof(struct spiffs_page_header_s, flags),
+                                sizeof(flags), &flags);
               if (ret < 0)
                 {
                   ferr("ERROR: spiffs_cache_write() failed: %d\n", ret);
@@ -1082,8 +1118,8 @@ static int spiffs_lucheck_callback(FAR struct spiffs_s *fs, int16_t objid,
       return ret;
     }
 
-  ret = spiffs_check_luentry_validate(fs, objid, &pghdr, cur_pgndx, cur_block,
-                                      cur_entry, &reload_lu);
+  ret = spiffs_check_luentry_validate(fs, objid, &pghdr, cur_pgndx,
+                                      cur_block, cur_entry, &reload_lu);
   if (ret < 0)
     {
       ferr("ERROR: spiffs_check_luentry_validate() failed: %d\n", ret);
@@ -1171,8 +1207,8 @@ static int spiffs_check_objidconsistency_callback(FAR struct spiffs_s *fs,
       /* Load header */
 
       ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
-                       0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
-                       sizeof(struct spiffs_page_header_s), (uint8_t *) & pghdr);
+                     0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
+                     sizeof(struct spiffs_page_header_s), (uint8_t *)&pghdr);
       if (ret < 0)
         {
           ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
@@ -1240,8 +1276,9 @@ static int spiffs_check_objidconsistency_callback(FAR struct spiffs_s *fs,
 
               /* Not in temporary index, try finding it */
 
-              ret = spiffs_objlu_find_id_and_span(fs, objid | SPIFFS_OBJID_NDXFLAG,
-                                                  0, 0, &objhdr_pgndx);
+              ret = spiffs_objlu_find_id_and_span(fs,
+                                                objid | SPIFFS_OBJID_NDXFLAG,
+                                                0, 0, &objhdr_pgndx);
               retc = SPIFFS_VIS_COUNTINUE_RELOAD;
 
               if (ret >= 0)
@@ -1259,7 +1296,8 @@ static int spiffs_check_objidconsistency_callback(FAR struct spiffs_s *fs,
                 }
               else if (ret < 0)
                 {
-                  ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n", ret);
+                  ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                       ret);
                   return ret;
                 }
 
@@ -1354,7 +1392,8 @@ int spiffs_check_luconsistency(FAR struct spiffs_s *fs)
  *      - x011 used, referenced only once, not index
  *      - x101 used, unreferenced, index
  *
- *   The working memory might not fit all pages so several scans might be needed
+ *   The working memory might not fit all pages so several scans might be
+ *   needed
  *
  * Input Parameters:
  *   fs - A reference to the SPIFFS volume object instance
@@ -1374,7 +1413,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
 
   /* For each range of pages fitting into work memory */
 
-  while (pgndx_offset < SPIFFS_GEO_PAGES_PER_BLOCK(fs) * SPIFFS_GEO_BLOCK_COUNT(fs))
+  while (pgndx_offset < SPIFFS_GEO_PAGES_PER_BLOCK(fs) *
+                        SPIFFS_GEO_BLOCK_COUNT(fs))
     {
       int16_t cur_block = 0;
       bool restart = false;
@@ -1390,8 +1430,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
           int16_t cur_pgndx = SPIFFS_OBJ_LOOKUP_PAGES(fs) +
                               SPIFFS_GEO_PAGES_PER_BLOCK(fs) * cur_block;
 
-          while (!restart &&
-                 cur_pgndx < SPIFFS_GEO_PAGES_PER_BLOCK(fs) * (cur_block + 1))
+          while (!restart && cur_pgndx <
+                 SPIFFS_GEO_PAGES_PER_BLOCK(fs) * (cur_block + 1))
             {
               struct spiffs_page_header_s pghdr;
               uint32_t pgndx_bytendx;
@@ -1427,7 +1467,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
 
               if ((pghdr.flags & SPIFFS_PH_FLAG_DELET) &&
                   (pghdr.flags & SPIFFS_PH_FLAG_NDXDELE) &&
-                  (pghdr.flags & (SPIFFS_PH_FLAG_INDEX | SPIFFS_PH_FLAG_USED)) == 0)
+                  (pghdr.flags & (SPIFFS_PH_FLAG_INDEX |
+                                  SPIFFS_PH_FLAG_USED)) == 0)
                 {
                   FAR struct spiffs_page_header_s *objndx_phdr;
                   FAR int16_t *object_page_index;
@@ -1444,9 +1485,10 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
 
                   /* Load non-deleted index */
 
-                  ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
-                                          0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
-                                          SPIFFS_GEO_PAGE_SIZE(fs), fs->lu_work);
+                  ret = spiffs_cache_read(fs,
+                                      SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
+                                      0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
+                                      SPIFFS_GEO_PAGE_SIZE(fs), fs->lu_work);
                   if (ret < 0)
                     {
                       ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
@@ -1455,7 +1497,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
 
                   /* traverse index for referenced pages */
 
-                  objndx_phdr = (FAR struct spiffs_page_header_s *)fs->lu_work;
+                  objndx_phdr =
+                    (FAR struct spiffs_page_header_s *)fs->lu_work;
 
                   if (pghdr.spndx == 0)
                     {
@@ -1473,7 +1516,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
 
                       entries           = SPIFFS_OBJNDX_LEN(fs);
                       data_spndx_offset = SPIFFS_OBJHDR_NDXLEN(fs) +
-                                          SPIFFS_OBJNDX_LEN(fs) * (pghdr.spndx - 1);
+                                          SPIFFS_OBJNDX_LEN(fs) *
+                                          (pghdr.spndx - 1);
                       object_page_index =
                         (FAR int16_t *)((FAR uint8_t *) fs->lu_work +
                           sizeof(struct spiffs_page_objndx_s));
@@ -1487,27 +1531,29 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                       bool rpgndx_within_range;
 
                       rpgndx_within_range = (rpgndx >= pgndx_offset &&
-                                             rpgndx < pgndx_offset + pages_per_scan);
+                                             rpgndx < pgndx_offset +
+                                             pages_per_scan);
 
                       if ((rpgndx != (int16_t) - 1 &&
                            rpgndx > SPIFFS_GEO_PAGE_COUNT(fs)) ||
-                           (rpgndx_within_range && SPIFFS_IS_LOOKUP_PAGE(fs, rpgndx)))
+                           (rpgndx_within_range &&
+                            SPIFFS_IS_LOOKUP_PAGE(fs, rpgndx)))
                         {
                           int16_t data_pgndx;
 
                           /* Bad reference */
 
-                          spiffs_checkinfo("pgndx=%04x bad pgndx / LU referenced "
-                                           "from page %04x\n",
+                          spiffs_checkinfo("pgndx=%04x bad pgndx / LU "
+                                           "referenced from page %04x\n",
                                            rpgndx, cur_pgndx);
 
                           /* Check for data page elsewhere */
 
                           ret = spiffs_objlu_find_id_and_span(fs,
-                                                              objndx_phdr->objid &
-                                                              ~SPIFFS_OBJID_NDXFLAG,
-                                                              data_spndx_offset + i,
-                                                              0, &data_pgndx);
+                                                       objndx_phdr->objid &
+                                                       ~SPIFFS_OBJID_NDXFLAG,
+                                                       data_spndx_offset + i,
+                                                       0, &data_pgndx);
                           if (ret == -ENOENT)
                             {
                               ret = OK;
@@ -1515,7 +1561,7 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                             }
                           else if (ret < 0)
                             {
-                              ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                              ferr("ERR: spiffs_objlu_find_id_and_span %d\n",
                                     ret);
                               return ret;
                             }
@@ -1532,31 +1578,33 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                                              ~SPIFFS_OBJID_NDXFLAG;
                               new_ph.spndx = data_spndx_offset + i;
 
-                              ret = spiffs_page_allocate_data(fs, new_ph.objid,
-                                                              &new_ph, 0, 0, 0, 1,
-                                                              &data_pgndx);
+                              ret = spiffs_page_allocate_data(fs,
+                                                         new_ph.objid,
+                                                         &new_ph, 0, 0, 0, 1,
+                                                         &data_pgndx);
                               if (ret < 0)
                                 {
-                                  ferr("ERROR: spiffs_page_allocate_data() failed: %d\n",
+                                  ferr("ERR: spiffs_page_allocate_data %d\n",
                                        ret);
                                   return ret;
                                 }
 
-                              spiffs_checkinfo("Found no existing data page, "
-                                               "created new @ %04x\n",
+                              spiffs_checkinfo("Found no existing data page,"
+                                               " created new @ %04x\n",
                                                data_pgndx);
                             }
 
                           /* Remap index */
 
-                          spiffs_checkinfo("Rewriting index pgndx=%04x\n", cur_pgndx);
+                          spiffs_checkinfo("Rewriting index pgndx=%04x\n",
+                                           cur_pgndx);
 
                           ret =
                             spiffs_check_rewrite_index(fs,
-                                                       objndx_phdr->objid |
-                                                       SPIFFS_OBJID_NDXFLAG,
-                                                       data_spndx_offset + i,
-                                                       data_pgndx, cur_pgndx);
+                                                      objndx_phdr->objid |
+                                                      SPIFFS_OBJID_NDXFLAG,
+                                                      data_spndx_offset + i,
+                                                      data_pgndx, cur_pgndx);
                           if (ret == -EFAULT)
                             {
                               /* Index bad also, cannot mend this file */
@@ -1570,14 +1618,14 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                               ret = spiffs_page_delete(fs, cur_pgndx);
                               if (ret < 0)
                                 {
-                                  ferr("ERROR: spiffs_page_delete() failed: %d\n",
+                                  ferr("ERROR: spiffs_page_delete(): %d\n",
                                        ret);
                                   return ret;
                                 }
                             }
                           else if (ret < 0)
                             {
-                              ferr("ERROR: spiffs_check_rewrite_index() failed: %d\n",
+                              ferr("ERR: spiffs_check_rewrite_index(): %d\n",
                                    ret);
                               return ret;
                             }
@@ -1591,19 +1639,21 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                           struct spiffs_page_header_s rphdr;
                           ret =
                             spiffs_cache_read(fs,
-                                              SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
-                                              0, SPIFFS_PAGE_TO_PADDR(fs, rpgndx),
-                                              sizeof(struct spiffs_page_header_s),
-                                              (FAR uint8_t *)&rphdr);
+                                      SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
+                                      0, SPIFFS_PAGE_TO_PADDR(fs, rpgndx),
+                                      sizeof(struct spiffs_page_header_s),
+                                      (FAR uint8_t *)&rphdr);
                           if (ret < 0)
                             {
-                              ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
+                              ferr("ERROR: spiffs_cache_read() failed: %d\n",
+                                   ret);
                               return ret;
                             }
 
                           /* Cross reference page header check */
 
-                          if (rphdr.objid != (pghdr.objid & ~SPIFFS_OBJID_NDXFLAG) ||
+                          if (rphdr.objid != (pghdr.objid &
+                                              ~SPIFFS_OBJID_NDXFLAG) ||
                               rphdr.spndx != data_spndx_offset + i ||
                               (rphdr.flags & (SPIFFS_PH_FLAG_DELET |
                                               SPIFFS_PH_FLAG_INDEX |
@@ -1612,24 +1662,22 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                             {
                               int16_t data_pgndx;
 
-                              spiffs_checkinfo("pgndx=%04x has inconsistent page "
-                                               "header index objid/span:"
-                                               "%04x/%04x, ref objid/span:%04x/%04x "
-                                               "flags=%02x\n",
-                                               rpgndx,
-                                               pghdr.objid & ~SPIFFS_OBJID_NDXFLAG,
-                                               data_spndx_offset + i,
-                                               rphdr.objid, rphdr.spndx,
-                                               rphdr.flags);
+                              spiffs_checkinfo(
+                                "pgndx=%04x has inconsistent page header "
+                                "index objid/span:%04x/%04x, "
+                                "ref objid/span:%04x/%04x flags=%02x\n",
+                                rpgndx, pghdr.objid & ~SPIFFS_OBJID_NDXFLAG,
+                                data_spndx_offset + i, rphdr.objid,
+                                rphdr.spndx, rphdr.flags);
 
                               /* Try finding correct page */
 
                               ret =
                                 spiffs_objlu_find_id_and_span(fs,
-                                                              pghdr.objid &
-                                                              ~SPIFFS_OBJID_NDXFLAG,
-                                                              data_spndx_offset + i,
-                                                              rpgndx, &data_pgndx);
+                                                       pghdr.objid &
+                                                       ~SPIFFS_OBJID_NDXFLAG,
+                                                       data_spndx_offset + i,
+                                                       rpgndx, &data_pgndx);
                               if (ret == -ENOENT)
                                 {
                                   ret = OK;
@@ -1637,7 +1685,7 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                                 }
                               else if (ret < 0)
                                 {
-                                  ferr("ERROR: spiffs_objlu_find_id_and_span() failed: %d\n",
+                                  ferr("spiffs_objlu_find_id_and_span: %d\n",
                                        ret);
                                   return ret;
                                 }
@@ -1646,13 +1694,15 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                                 {
                                   /* Not found, this index is badly borked */
 
-                                  spiffs_checkinfo("Index bad, delete object objid %04x\n",
-                                                   pghdr.objid);
+                                  spiffs_checkinfo(
+                                    "Index bad, delete object objid %04x\n",
+                                    pghdr.objid);
 
-                                  ret = spiffs_check_delobj_lazy(fs, pghdr.objid);
+                                  ret = spiffs_check_delobj_lazy(fs,
+                                                                pghdr.objid);
                                   if (ret < 0)
                                     {
-                                      ferr("ERROR: spiffs_check_delobj_lazy() failed: %d\n",
+                                      ferr("spiffs_check_delobj_lazy: %d\n",
                                            ret);
                                       return ret;
                                     }
@@ -1663,28 +1713,28 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                                 {
                                   /* Found it, so rewrite index */
 
-                                  spiffs_checkinfo("Found correct data pgndx=%04x, "
-                                                   "rewrite index pgndx=%04x "
-                                                   "objid=%04x\n",
-                                                   data_pgndx, cur_pgndx,
-                                                   pghdr.objid);
+                                  spiffs_checkinfo(
+                                    "Found correct data pgndx=%04x, "
+                                    "rewrite index pgndx=%04x objid=%04x\n",
+                                    data_pgndx, cur_pgndx, pghdr.objid);
 
                                   ret =
-                                    spiffs_check_rewrite_index(fs, pghdr.objid,
-                                                               data_spndx_offset + i,
-                                                               data_pgndx, cur_pgndx);
+                                    spiffs_check_rewrite_index(
+                                      fs, pghdr.objid, data_spndx_offset + i,
+                                      data_pgndx, cur_pgndx);
                                   if (ret == -EFAULT)
                                     {
-                                      /* Index bad also, cannot mend this file */
+                                      /* Index bad, cannot mend this file */
 
-                                      spiffs_checkinfo("Index bad %d, cannot mend!\n",
-                                                       ret);
+                                      spiffs_checkinfo(
+                                        "Index bad %d, cannot mend!\n", ret);
 
-                                      ret = spiffs_check_delobj_lazy(fs, pghdr.objid);
+                                      ret = spiffs_check_delobj_lazy(
+                                              fs, pghdr.objid);
                                     }
                                   else if (ret < 0)
                                     {
-                                      ferr("ERROR: spiffs_check_rewrite_index() failed: %d\n",
+                                      ferr("spiffs_check_rewrite_index %d\n",
                                            ret);
                                       return ret;
                                     }
@@ -1701,11 +1751,13 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                               const uint8_t rpgndx_bit_ix =
                                 (rpgndx & ((8 / bits) - 1)) * bits;
 
-                              if ((fs->work[rpgndx_byte_ix] & (1 << (rpgndx_bit_ix + 1))) != 0)
+                              if ((fs->work[rpgndx_byte_ix] &
+                                   (1 << (rpgndx_bit_ix + 1))) != 0)
                                 {
-                                  spiffs_checkinfo("pgndx=%04x multiple referenced "
-                                                   "from page %04x\n",
-                                                   rpgndx, cur_pgndx);
+                                  spiffs_checkinfo(
+                                    "pgndx=%04x multiple referenced "
+                                    "from page %04x\n",
+                                    rpgndx, cur_pgndx);
 
                                   /* Here, we should have fixed all broken
                                    * references - getting this means there
@@ -1719,20 +1771,21 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                                                    "page=%04x\n",
                                                    pghdr.objid, cur_pgndx);
 
-                                  ret = spiffs_check_delobj_lazy(fs, pghdr.objid);
+                                  ret = spiffs_check_delobj_lazy(
+                                          fs, pghdr.objid);
                                   if (ret < 0)
                                     {
-                                      ferr("ERROR: spiffs_check_delobj_lazy() failed: %d\n",
+                                      ferr("spiffs_check_delobj_lazy: %d\n",
                                            ret);
                                       return ret;
                                     }
 
-                                  /* Dxtra precaution, delete this page also */
+                                  /* Precaution, delete this page also */
 
                                   ret = spiffs_page_delete(fs, cur_pgndx);
                                   if (ret < 0)
                                     {
-                                      ferr("ERROR: spiffs_page_delete() failed: %d\n",
+                                      ferr("ERR: spiffs_page_delete(): %d\n",
                                            ret);
                                       return ret;
                                     }
@@ -1740,7 +1793,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                                   restart = true;
                                 }
 
-                              fs->work[rpgndx_byte_ix] |= (1 << (rpgndx_bit_ix + 1));
+                              fs->work[rpgndx_byte_ix] |=
+                                (1 << (rpgndx_bit_ix + 1));
                             }
                         }
                     }
@@ -1775,7 +1829,7 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                   int16_t cur_pgndx;
 
                   bitmask   = (fs->work[byte_ndx] >> (bit_ndx * bits)) & 0x7;
-                  cur_pgndx =  pgndx_offset + byte_ndx * (8 / bits) + bit_ndx;
+                  cur_pgndx = pgndx_offset + byte_ndx * (8 / bits) + bit_ndx;
 
                   /* 000 ok - free, unreferenced, not index */
 
@@ -1787,20 +1841,22 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
 
                       /* 001 */
 
-                      spiffs_checkinfo("pgndx=%04x USED, UNREFERENCED, not index\n",
-                                       cur_pgndx);
+                      spiffs_checkinfo(
+                        "pgndx=%04x USED, UNREFERENCED, not index\n",
+                        cur_pgndx);
 
                       /* Check corresponding object index entry */
 
                       ret = spiffs_cache_read(fs,
-                                              SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
-                                              0,
-                                              SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
-                                              sizeof(struct spiffs_page_header_s),
-                                              (FAR uint8_t *)&pghdr);
+                                      SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
+                                      0,
+                                      SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
+                                      sizeof(struct spiffs_page_header_s),
+                                      (FAR uint8_t *)&pghdr);
                       if (ret < 0)
                         {
-                          ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
+                          ferr("ERROR: spiffs_cache_read() failed: %d\n",
+                               ret);
                           return ret;
                         }
 
@@ -1819,9 +1875,10 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
 
                               rewrite_ndx_to_this = true;
 
-                              spiffs_checkinfo("Corresponding ref is bad: "
-                                               "%04x, rewrite to this %04x\n",
-                                               rpgndx, cur_pgndx);
+                              spiffs_checkinfo(
+                                "Corresponding ref is bad: "
+                                "%04x, rewrite to this %04x\n",
+                                rpgndx, cur_pgndx);
                             }
                           else
                             {
@@ -1831,15 +1888,15 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
 
                               ret =
                                 spiffs_cache_read(fs,
-                                                  SPIFFS_OP_T_OBJ_LU2 |
-                                                  SPIFFS_OP_C_READ,
-                                                  0,
-                                                  SPIFFS_PAGE_TO_PADDR(fs, rpgndx),
-                                                  sizeof(struct spiffs_page_header_s),
-                                                  (FAR uint8_t *)&rphdr);
+                                         SPIFFS_OP_T_OBJ_LU2 |
+                                         SPIFFS_OP_C_READ,
+                                         0,
+                                         SPIFFS_PAGE_TO_PADDR(fs, rpgndx),
+                                         sizeof(struct spiffs_page_header_s),
+                                         (FAR uint8_t *)&rphdr);
                               if (ret < 0)
                                 {
-                                  ferr("ERROR: spiffs_cache_read() failed: %d\n",
+                                  ferr("ERROR: spiffs_cache_read(): %d\n",
                                        ret);
                                   return ret;
                                 }
@@ -1850,16 +1907,17 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                                                     SPIFFS_PH_FLAG_DELET |
                                                     SPIFFS_PH_FLAG_USED |
                                                     SPIFFS_PH_FLAG_FINAL)) ==
-                                   (SPIFFS_PH_FLAG_INDEX | SPIFFS_PH_FLAG_DELET)))
+                                                  (SPIFFS_PH_FLAG_INDEX |
+                                                    SPIFFS_PH_FLAG_DELET)))
                                 {
                                   /* Pointing to something else valid, just
                                    * delete this page then
                                    */
 
-                                  spiffs_checkinfo("Corresponding ref is good but "
-                                                   "different: "
-                                                   "%04x, delete this %04x\n",
-                                                   rpgndx, cur_pgndx);
+                                  spiffs_checkinfo(
+                                    "Corresponding ref is good but "
+                                    "different: %04x, delete this %04x\n",
+                                    rpgndx, cur_pgndx);
 
                                   delete_page = true;
                                 }
@@ -1873,15 +1931,15 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                                   spiffs_checkinfo
                                     ("PA: corresponding ref is weird: "
                                      "%04x %s%s%s%s, rewrite this "
-                                         "%04x\n", rpgndx,
-                                         (rphdr.flags & SPIFFS_PH_FLAG_INDEX) ? "" :
-                                         "INDEX ",
-                                         (rphdr.flags & SPIFFS_PH_FLAG_DELET) ? "" :
-                                         "DELETED ",
-                                         (rphdr.flags & SPIFFS_PH_FLAG_USED) ?
-                                         "NOTUSED " : "",
-                                         (rphdr.flags & SPIFFS_PH_FLAG_FINAL) ?
-                                         "NOTFINAL " : "", cur_pgndx);
+                                      "%04x\n", rpgndx,
+                                      (rphdr.flags & SPIFFS_PH_FLAG_INDEX) ?
+                                       "" : "INDEX ",
+                                      (rphdr.flags & SPIFFS_PH_FLAG_DELET) ?
+                                       "" : "DELETED ",
+                                      (rphdr.flags & SPIFFS_PH_FLAG_USED) ?
+                                       "NOTUSED " : "",
+                                      (rphdr.flags & SPIFFS_PH_FLAG_FINAL) ?
+                                       "NOTFINAL " : "", cur_pgndx);
 
                                   rewrite_ndx_to_this = true;
                                 }
@@ -1907,13 +1965,13 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                            * this page
                            */
 
-                          spiffs_checkinfo("Rewrite index objid=%04x data spndx=%04x"
-                                           " to point to this pgndx: %04x\n",
-                                           pghdr.objid, pghdr.spndx, cur_pgndx);
+                          spiffs_checkinfo(
+                            "Rewrite index objid=%04x data spndx=%04x"
+                            " to point to this pgndx: %04x\n",
+                            pghdr.objid, pghdr.spndx, cur_pgndx);
 
-                          ret =  spiffs_check_rewrite_index(fs, pghdr.objid,
-                                                            pghdr.spndx, cur_pgndx,
-                                                           objndx_pgndx);
+                          ret = spiffs_check_rewrite_index(fs, pghdr.objid,
+                                  pghdr.spndx, cur_pgndx, objndx_pgndx);
                           if (ret == -EFAULT)
                             {
                               int ret2;
@@ -1926,22 +1984,24 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                               ret2 = spiffs_page_delete(fs, cur_pgndx);
                               if (ret2 < 0)
                                 {
-                                  ferr("ERROR: spiffs_page_delete() failed: %d\n",
+                                  ferr("ERROR: spiffs_page_delete(): %d\n",
                                        ret2);
                                   return ret2;
                                 }
 
-                              ret2 = spiffs_check_delobj_lazy(fs, pghdr.objid);
+                              ret2 = spiffs_check_delobj_lazy(fs,
+                                                              pghdr.objid);
                               if (ret2 < 0)
                                 {
-                                  ferr("ERROR: spiffs_check_delobj_lazy() failed: %d\n",
-                                       ret2);
+                                  ferr(
+                                    "ERR: spiffs_check_delobj_lazy(): %d\n",
+                                    ret2);
                                   return ret2;
                                 }
                             }
                           else if (ret < 0)
                             {
-                              ferr("ERROR: spiffs_check_rewrite_index() failed: %d\n",
+                              ferr("ERR: spiffs_check_rewrite_index(): %d\n",
                                    ret);
                               return ret;
                             }
@@ -1957,7 +2017,7 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                           ret = spiffs_page_delete(fs, cur_pgndx);
                           if (ret < 0)
                             {
-                              ferr("ERROR: spiffs_page_delete() failed: %d\n", ret);
+                              ferr("ERROR: spiffs_page_delete(): %d\n", ret);
                               return ret;
                             }
                         }
@@ -1967,8 +2027,9 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                     {
                       /* 010 */
 
-                      spiffs_checkinfo("pgndx=%04x  FREE, REFERENCED, not index\n",
-                                       cur_pgndx);
+                      spiffs_checkinfo(
+                        "pgndx=%04x  FREE, REFERENCED, not index\n",
+                        cur_pgndx);
 
                       /* No op, this should be taken care of when checking
                        * valid references
@@ -1981,8 +2042,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                     {
                       /* 100 */
 
-                      spiffs_checkinfo("pgndx=%04x FREE, unreferenced, INDEX\n",
-                                       cur_pgndx);
+                      spiffs_checkinfo(
+                        "pgndx=%04x FREE, unreferenced, INDEX\n", cur_pgndx);
 
                       /* This should never happen, major fubar */
                     }
@@ -1993,8 +2054,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                     {
                       /* 110 */
 
-                      spiffs_checkinfo("pgndx=%04x FREE, REFERENCED, INDEX\n",
-                                       cur_pgndx);
+                      spiffs_checkinfo(
+                        "pgndx=%04x FREE, REFERENCED, INDEX\n", cur_pgndx);
 
                       /* No op, this should be taken care of when checking
                        * valid references
@@ -2005,8 +2066,8 @@ int spiffs_check_pgconsistency(FAR struct spiffs_s *fs)
                     {
                       /* 111 */
 
-                      spiffs_checkinfo("pgndx=%04x USED, REFERENCED, INDEX\n",
-                                       cur_pgndx);
+                      spiffs_checkinfo(
+                        "pgndx=%04x USED, REFERENCED, INDEX\n", cur_pgndx);
 
                       /* No op, this should be taken care of when checking
                        * valid references
@@ -2182,7 +2243,8 @@ int spiffs_dump(FAR struct spiffs_s *fs)
 
       if (erase_count != (int16_t)-1)
         {
-          len += snprintf(&buffer[len], 80 - len, "  era_cnt=%d\n", erase_count);
+          len += snprintf(&buffer[len], 80 - len,
+                          "  era_cnt=%d\n", erase_count);
         }
       else
         {

--- a/fs/spiffs/src/spiffs_gc.c
+++ b/fs/spiffs/src/spiffs_gc.c
@@ -112,7 +112,8 @@ static int spiffs_gc_erase_block(FAR struct spiffs_s *fs, int16_t blkndx)
   ret = spiffs_erase_block(fs, blkndx);
   if (ret < 0)
     {
-      ferr("ERROR: spiffs_erase_block() blkndx=%d failed: %d\n", blkndx, ret);
+      ferr("ERROR: spiffs_erase_block() blkndx=%d failed: %d\n",
+           blkndx, ret);
     }
 
   /* Then remove the pages from the cache. */
@@ -141,8 +142,8 @@ static int spiffs_gc_erase_block(FAR struct spiffs_s *fs, int16_t blkndx)
  *   this method in order to determine what amount of bytes to give.
  *
  *   NB: the garbage collector is automatically called when spiffs needs free
- *   pages. The reason for this function is to give possibility to do background
- *   tidying when user knows the system is idle.
+ *   pages. The reason for this function is to give possibility to do
+ *   background tidying when user knows the system is idle.
  *
  * Input Parameters:
  *   fs            the file system struct
@@ -181,7 +182,8 @@ static int spiffs_gc_epage_stats(FAR struct spiffs_s *fs, int16_t blkndx)
       while (ret >= 0 &&
              cur_entry - entry_offset < entries_per_page &&
              cur_entry <
-             (int)(SPIFFS_GEO_PAGES_PER_BLOCK(fs) - SPIFFS_OBJ_LOOKUP_PAGES(fs)))
+             (int)(SPIFFS_GEO_PAGES_PER_BLOCK(fs) -
+                   SPIFFS_OBJ_LOOKUP_PAGES(fs)))
         {
           int16_t id = objlu_buf[cur_entry - entry_offset];
 
@@ -230,7 +232,8 @@ static int spiffs_gc_epage_stats(FAR struct spiffs_s *fs, int16_t blkndx)
 
 static int spiffs_gc_find_candidate(FAR struct spiffs_s *fs,
                                     FAR int16_t **block_candidates,
-                                    FAR int *candidate_count, bool fs_crammed)
+                                    FAR int *candidate_count,
+                                    bool fs_crammed)
 {
   FAR int32_t *cand_scores;
   FAR int16_t *objlu_buf  = (FAR int16_t *)fs->lu_work;
@@ -284,8 +287,8 @@ static int spiffs_gc_find_candidate(FAR struct spiffs_s *fs,
              obj_lookup_page < (int)SPIFFS_OBJ_LOOKUP_PAGES(fs))
         {
           int entry_offset = obj_lookup_page * entries_per_page;
-          ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ, 0,
-                                  cur_block_addr +
+          ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ,
+                                  0, cur_block_addr +
                                   SPIFFS_PAGE_TO_PADDR(fs, obj_lookup_page),
                                   SPIFFS_GEO_PAGE_SIZE(fs), fs->lu_work);
 
@@ -301,8 +304,8 @@ static int spiffs_gc_find_candidate(FAR struct spiffs_s *fs,
 
               if (id == SPIFFS_OBJID_FREE)
                 {
-                  /* When a free entry is encountered, scan logic ensures that
-                   * all following entries are free also
+                  /* When a free entry is encountered, scan logic ensures
+                   * that all following entries are free also
                    */
 
                   ret = 1;      /* Kill object lu loop */
@@ -341,9 +344,9 @@ static int spiffs_gc_find_candidate(FAR struct spiffs_s *fs,
 
           /* Read erase count */
 
-          ret = spiffs_cache_read(fs, SPIFFS_OP_C_READ | SPIFFS_OP_T_OBJ_LU2, 0,
-                                  SPIFFS_ERASE_COUNT_PADDR(fs, cur_block),
-                                  sizeof(int16_t), (uint8_t *) & erase_count);
+          ret = spiffs_cache_read(fs, SPIFFS_OP_C_READ | SPIFFS_OP_T_OBJ_LU2,
+                                  0, SPIFFS_ERASE_COUNT_PADDR(fs, cur_block),
+                                  sizeof(int16_t), (uint8_t *)&erase_count);
           if (ret < 0)
             {
               ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
@@ -497,8 +500,8 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
         {
           int entry_offset = obj_lookup_page * entries_per_page;
 
-          ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ, 0,
-                                  blkndx * SPIFFS_GEO_BLOCK_SIZE(fs) +
+          ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ,
+                                  0, blkndx * SPIFFS_GEO_BLOCK_SIZE(fs) +
                                   SPIFFS_PAGE_TO_PADDR(fs, obj_lookup_page),
                                   SPIFFS_GEO_PAGE_SIZE(fs), fs->lu_work);
 
@@ -512,7 +515,8 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
             {
               int16_t id = objlu_buf[cur_entry - entry_offset];
 
-              cur_pgndx = SPIFFS_OBJ_LOOKUP_ENTRY_TO_PGNDX(fs, blkndx, cur_entry);
+              cur_pgndx =
+                SPIFFS_OBJ_LOOKUP_ENTRY_TO_PGNDX(fs, blkndx, cur_entry);
 
               /* Act upon object id depending on gc state */
 
@@ -526,12 +530,13 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                       id != SPIFFS_OBJID_FREE &&
                       ((id & SPIFFS_OBJID_NDXFLAG) == 0))
                     {
-                      /* Found a data page, stop scanning and handle in switch
-                       * case below
+                      /* Found a data page, stop scanning and handle in
+                       * switch case below
                        */
 
-                      spiffs_gcinfo("Found data page, state=%d, objid=%04x\n",
-                                     gc.state, id);
+                      spiffs_gcinfo(
+                        "Found data page, state=%d, objid=%04x\n",
+                        gc.state, id);
 
                       gc.objid_found    = true;
                       gc.cur_objid      = id;
@@ -551,13 +556,14 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                       struct spiffs_page_header_s phdr;
 
                       ret = spiffs_cache_read(fs,
-                                              SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
-                                              0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
-                                              sizeof(struct spiffs_page_header_s),
-                                              (FAR uint8_t *)&phdr);
+                                      SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
+                                      0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
+                                      sizeof(struct spiffs_page_header_s),
+                                      (FAR uint8_t *)&phdr);
                       if (ret < 0)
                         {
-                          ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
+                          ferr("ERROR: spiffs_cache_read() failed: %d\n",
+                               ret);
                           return ret;
                         }
 
@@ -567,7 +573,8 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                       if (SPIFFS_OBJNDX_ENTRY_SPNDX(fs, phdr.spndx) !=
                           gc.cur_objndx_spndx)
                         {
-                          spiffs_gcinfo("No objndx spndx match, take in another run\n");
+                          spiffs_gcinfo(
+                            "No objndx spndx match, take in another run\n");
                         }
                       else
                         {
@@ -577,15 +584,17 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                               /* Move page */
 
                               ret = spiffs_page_move(fs, 0, 0, id, &phdr,
-                                                    cur_pgndx, &new_data_pgndx);
+                                                 cur_pgndx, &new_data_pgndx);
 
-                              spiffs_gcinfo("Move objndx=%04x:%04x page=%04x to %04x\n",
-                                            gc.cur_objid, phdr.spndx,
-                                            cur_pgndx, new_data_pgndx);
+                              spiffs_gcinfo(
+                                "Move objndx=%04x:%04x page=%04x to %04x\n",
+                                gc.cur_objid, phdr.spndx,
+                                cur_pgndx, new_data_pgndx);
 
                               if (ret < 0)
                                 {
-                                  ferr("ERROR: spiffs_page_move() failed: %d\n", ret);
+                                  ferr("ERROR: spiffs_page_move(): %d\n",
+                                       ret);
                                   return ret;
                                 }
 
@@ -593,15 +602,15 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
 
                               ret =
                                 spiffs_cache_read(fs,
-                                                  SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ,
-                                                  0,
-                                                  blkndx * SPIFFS_GEO_BLOCK_SIZE(fs) +
-                                                  SPIFFS_PAGE_TO_PADDR(fs, obj_lookup_page),
-                                                  SPIFFS_GEO_PAGE_SIZE(fs),
-                                                  fs->lu_work);
+                                   SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ,
+                                   0,
+                                   blkndx * SPIFFS_GEO_BLOCK_SIZE(fs) +
+                                   SPIFFS_PAGE_TO_PADDR(fs, obj_lookup_page),
+                                   SPIFFS_GEO_PAGE_SIZE(fs),
+                                   fs->lu_work);
                               if (ret < 0)
                                 {
-                                  ferr("ERROR: spiffs_cache_read() failed: %d\n",
+                                  ferr("ERROR: spiffs_cache_read(): %d\n",
                                        ret);
                                   return ret;
                                 }
@@ -613,13 +622,14 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                                * erase this block, but we might get aborted
                                */
 
-                              spiffs_gcinfo("Wipe objndx=%04x:%04x page=%04x\n",
-                                            id, phdr.spndx, cur_pgndx);
+                              spiffs_gcinfo(
+                                "Wipe objndx=%04x:%04x page=%04x\n",
+                                id, phdr.spndx, cur_pgndx);
 
                               ret = spiffs_page_delete(fs, cur_pgndx);
                               if (ret < 0)
                                 {
-                                  ferr("ERROR: spiffs_page_delete() failed: %d\n",
+                                  ferr("ERROR: spiffs_page_delete(): %d\n",
                                        ret);
                                   return ret;
                                 }
@@ -627,8 +637,8 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                               new_data_pgndx = SPIFFS_OBJID_FREE;
                             }
 
-                          /* Update memory representation of object index page
-                           * with new data page
+                          /* Update memory representation of object index
+                           * page with new data page
                            */
 
                           if (gc.cur_objndx_spndx == 0)
@@ -636,12 +646,13 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                               /* Update object index header page */
 
                               ((FAR int16_t *)((FAR uint8_t *)objhdr +
-                                 sizeof(struct spiffs_pgobj_ndxheader_s)))[phdr.spndx] =
-                                   new_data_pgndx;
+                                 sizeof(struct spiffs_pgobj_ndxheader_s)))
+                                 [phdr.spndx] = new_data_pgndx;
 
-                              spiffs_gcinfo("Wrote page=%04x to objhdr entry=%04x in mem\n",
-                                            new_data_pgndx,
-                                            (int16_t)SPIFFS_OBJNDX_ENTRY(fs, phdr.spndx));
+                              spiffs_gcinfo(
+                                "Wrote page=%04x to objhdr entry=%04x\n",
+                                new_data_pgndx,
+                                SPIFFS_OBJNDX_ENTRY(fs, phdr.spndx));
                             }
                           else
                             {
@@ -652,9 +663,10 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                                   [SPIFFS_OBJNDX_ENTRY(fs, phdr.spndx)] =
                                     new_data_pgndx;
 
-                              spiffs_gcinfo("Wrote page=%04x to objndx entry=%04x in mem\n",
-                                            new_data_pgndx,
-                                            (int16_t)SPIFFS_OBJNDX_ENTRY(fs, phdr.spndx));
+                              spiffs_gcinfo(
+                                "Wrote page=%04x to objndx entry=%04x\n",
+                                new_data_pgndx,
+                                SPIFFS_OBJNDX_ENTRY(fs, phdr.spndx));
                             }
                         }
                     }
@@ -676,14 +688,15 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                       /* Load header */
 
                       ret = spiffs_cache_read(fs,
-                                              SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
-                                              0,
-                                              SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
-                                              sizeof(struct spiffs_page_header_s),
-                                              (FAR uint8_t *)&phdr);
+                                      SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
+                                      0,
+                                      SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
+                                      sizeof(struct spiffs_page_header_s),
+                                      (FAR uint8_t *)&phdr);
                       if (ret < 0)
                         {
-                          ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
+                          ferr("ERROR: spiffs_cache_read() failed: %d\n",
+                               ret);
                           return ret;
                         }
 
@@ -694,41 +707,43 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                           ret = spiffs_page_move(fs, 0, 0, id, &phdr,
                                                  cur_pgndx, &new_pgndx);
 
-                          spiffs_gcinfo("Move objndx=%04x:%04x page=%04x to %04x\n",
-                                        id, phdr.spndx, cur_pgndx,
-                                        new_pgndx);
+                          spiffs_gcinfo(
+                            "Move objndx=%04x:%04x page=%04x to %04x\n",
+                            id, phdr.spndx, cur_pgndx, new_pgndx);
 
                           if (ret < 0)
                             {
-                              ferr("ERROR: spiffs_page_move() failed: %d\n", ret);
+                              ferr("ERROR: spiffs_page_move() failed: %d\n",
+                                   ret);
                               return ret;
                             }
 
                           spiffs_fobj_event(fs,
-                                            (FAR struct spiffs_page_objndx_s *)&phdr,
-                                            SPIFFS_EV_NDXMOV, id,
-                                            phdr.spndx, new_pgndx, 0);
+                                    (FAR struct spiffs_page_objndx_s *)&phdr,
+                                    SPIFFS_EV_NDXMOV, id,
+                                    phdr.spndx, new_pgndx, 0);
 
                           /* Move wipes obj_lu, reload it */
 
                           ret =
                             spiffs_cache_read(fs,
-                                              SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ,
-                                              0,
-                                              blkndx * SPIFFS_GEO_BLOCK_SIZE(fs) +
-                                              SPIFFS_PAGE_TO_PADDR(fs, obj_lookup_page),
-                                              SPIFFS_GEO_PAGE_SIZE(fs), fs->lu_work);
+                                   SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ,
+                                   0,
+                                   blkndx * SPIFFS_GEO_BLOCK_SIZE(fs) +
+                                   SPIFFS_PAGE_TO_PADDR(fs, obj_lookup_page),
+                                   SPIFFS_GEO_PAGE_SIZE(fs), fs->lu_work);
                           if (ret < 0)
                             {
-                              ferr("ERROR: spiffs_cache_read() failed: %d\n", ret);
+                              ferr("ERROR: spiffs_cache_read() failed: %d\n",
+                                   ret);
                               return ret;
                             }
                         }
                       else
                         {
                           /* Page is deleted but not deleted in lookup, scrap
-                           * it - might seem unnecessary as we will erase this
-                           * block, but we might get aborted
+                           * it - might seem unnecessary as we will erase
+                           * this block, but we might get aborted
                            */
 
                           spiffs_gcinfo("Wipe objndx=%04x:%04x page=%04x\n",
@@ -737,7 +752,8 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                           ret = spiffs_page_delete(fs, cur_pgndx);
                           if (ret < 0)
                             {
-                              ferr("ERROR: spiffs_fobj_event() failed: %d\n", ret);
+                              ferr("ERROR: spiffs_fobj_event() failed: %d\n",
+                                   ret);
                               return ret;
                             }
 
@@ -784,7 +800,8 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
               cur_entry                  = 0;         /* Sestart scan from start */
               gc.state                   = MOVE_OBJ_DATA;
 
-              ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
+              ret = spiffs_cache_read(fs,
+                                      SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
                                       0, SPIFFS_PAGE_TO_PADDR(fs, cur_pgndx),
                                       sizeof(struct spiffs_page_header_s),
                                       (FAR uint8_t *)&phdr);
@@ -800,9 +817,9 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
               spiffs_gcinfo("Find objndx spndx=%04x\n", gc.cur_objndx_spndx);
 
               ret = spiffs_objlu_find_id_and_span(fs,
-                                                  gc.cur_objid | SPIFFS_OBJID_NDXFLAG,
-                                                  gc.cur_objndx_spndx, 0,
-                                                  &objndx_pgndx);
+                                         gc.cur_objid | SPIFFS_OBJID_NDXFLAG,
+                                         gc.cur_objndx_spndx, 0,
+                                         &objndx_pgndx);
               if (ret == -ENOENT)
                 {
                   /* On borked systems we might get an ERR_NOT_FOUND here -
@@ -834,7 +851,8 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                   return ret;
                 }
 
-              spiffs_gcinfo("Found object index at page=%04x\n", objndx_pgndx);
+              spiffs_gcinfo("Found object index at page=%04x\n",
+                            objndx_pgndx);
 
               ret = spiffs_cache_read(fs,
                                       SPIFFS_OP_T_OBJ_LU2 | SPIFFS_OP_C_READ,
@@ -852,8 +870,8 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                */
 
               ret = spiffs_validate_objndx(&objndx->phdr,
-                                           gc.cur_objid | SPIFFS_OBJID_NDXFLAG,
-                                           gc.cur_objndx_spndx);
+                                         gc.cur_objid | SPIFFS_OBJID_NDXFLAG,
+                                         gc.cur_objndx_spndx);
               if (ret < 0)
                 {
                   ferr("ERROR: spiffs_validate_objndx() failed: %d\n", ret);
@@ -877,9 +895,9 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
           {
             int16_t new_objndx_pgndx;
 
-            /* Store modified objndx (hdr) page residing in memory now that all
-             * data pages belonging to this object index and residing in the
-             * block we want to evacuate
+            /* Store modified objndx (hdr) page residing in memory now that
+             * all data pages belonging to this object index and residing in
+             * the block we want to evacuate
              */
 
             gc.state  = FIND_OBJ_DATA;
@@ -890,16 +908,17 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                 /* Store object index header page */
 
                 ret = spiffs_fobj_update_ndxhdr(fs, 0,
-                                                gc.cur_objid | SPIFFS_OBJID_NDXFLAG,
-                                                gc.cur_objndx_pgndx, fs->work, 0,
-                                                0, &new_objndx_pgndx);
+                                         gc.cur_objid | SPIFFS_OBJID_NDXFLAG,
+                                         gc.cur_objndx_pgndx, fs->work, 0,
+                                         0, &new_objndx_pgndx);
 
                 spiffs_gcinfo("Store modified objhdr page=%04x:%04x\n",
                               new_objndx_pgndx, 0);
 
                 if (ret < 0)
                   {
-                    ferr("ERROR: spiffs_fobj_update_ndxhdr() failed: %d\n", ret);
+                    ferr("ERROR: spiffs_fobj_update_ndxhdr() failed: %d\n",
+                         ret);
                     return ret;
                   }
               }
@@ -922,10 +941,10 @@ static int spiffs_gc_clean(FAR struct spiffs_s *fs, int16_t blkndx)
                   }
 
                 spiffs_fobj_event(fs,
-                                  (FAR struct spiffs_page_objndx_s *)fs->work,
-                                  SPIFFS_EV_NDXUPD, gc.cur_objid,
-                                  objndx->phdr.spndx,
-                                  new_objndx_pgndx, 0);
+                                 (FAR struct spiffs_page_objndx_s *)fs->work,
+                                 SPIFFS_EV_NDXUPD, gc.cur_objid,
+                                 objndx->phdr.spndx,
+                                 new_objndx_pgndx, 0);
               }
           }
           break;
@@ -1001,8 +1020,8 @@ int spiffs_gc_quick(FAR struct spiffs_s *fs, uint16_t max_free_pages)
         {
           int entry_offset = obj_lookup_page * entries_per_page;
 
-          ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ, 0,
-                                  cur_block_addr +
+          ret = spiffs_cache_read(fs, SPIFFS_OP_T_OBJ_LU | SPIFFS_OP_C_READ,
+                                  0, cur_block_addr +
                                   SPIFFS_PAGE_TO_PADDR(fs, obj_lookup_page),
                                   SPIFFS_GEO_PAGE_SIZE(fs), fs->lu_work);
 
@@ -1095,8 +1114,8 @@ int spiffs_gc_quick(FAR struct spiffs_s *fs, uint16_t max_free_pages)
  *   this method in order to determine what amount of bytes to give.
  *
  *   NB: the garbage collector is automatically called when spiffs needs free
- *   pages. The reason for this function is to give possibility to do background
- *   tidying when user knows the system is idle.
+ *   pages. The reason for this function is to give possibility to do
+ *   background tidying when user knows the system is idle.
  *
  * Input Parameters:
  *   fs            the file system struct
@@ -1118,7 +1137,8 @@ int spiffs_gc_check(FAR struct spiffs_s *fs, off_t len)
   /* Get the number of free pages */
 
   free_pages = (SPIFFS_GEO_PAGES_PER_BLOCK(fs) -
-                SPIFFS_OBJ_LOOKUP_PAGES(fs)) * (SPIFFS_GEO_BLOCK_COUNT(fs) - 2) -
+                SPIFFS_OBJ_LOOKUP_PAGES(fs)) *
+                (SPIFFS_GEO_BLOCK_COUNT(fs) - 2) -
                 fs->alloc_pages - fs->deleted_pages;
 
   spiffs_gcinfo("len=%ld free_blocks=%lu free_pages=%ld\n",
@@ -1162,15 +1182,15 @@ int spiffs_gc_check(FAR struct spiffs_s *fs, off_t len)
       int16_t cand;
       int32_t prev_free_pages = free_pages;
 
-      spiffs_gcinfo("#%d: run gc free_blocks=%d pfree=%d pallo=%d pdele=%d [%d] "
-                    "len=%d of %d\n",
+      spiffs_gcinfo("#%d: run gc free_blocks=%d pfree=%d pallo=%d pdele=%d "
+                    "[%d] len=%d of %d\n",
                     tries, fs->free_blocks, free_pages,
                     fs->alloc_pages, fs->deleted_pages,
                     (free_pages + fs->alloc_pages + fs->deleted_pages),
                     len, (uint32_t)(free_pages * SPIFFS_DATA_PAGE_SIZE(fs)));
 
-      /* If the fs is crammed, ignore block age when selecting candidate - kind
-       * of a bad state
+      /* If the fs is crammed, ignore block age when selecting candidate -
+       * kind of a bad state
        */
 
       ret = spiffs_gc_find_candidate(fs, &cands, &count, free_pages <= 0);
@@ -1216,7 +1236,8 @@ int spiffs_gc_check(FAR struct spiffs_s *fs, off_t len)
         }
 
       free_pages = (SPIFFS_GEO_PAGES_PER_BLOCK(fs) -
-                    SPIFFS_OBJ_LOOKUP_PAGES(fs)) * (SPIFFS_GEO_BLOCK_COUNT(fs) - 2) -
+                    SPIFFS_OBJ_LOOKUP_PAGES(fs)) *
+                    (SPIFFS_GEO_BLOCK_COUNT(fs) - 2) -
                     fs->alloc_pages - fs->deleted_pages;
 
       if (prev_free_pages <= 0 && prev_free_pages == free_pages)
@@ -1234,7 +1255,8 @@ int spiffs_gc_check(FAR struct spiffs_s *fs, off_t len)
   /* Re-calculate the number of free pages */
 
   free_pages = (SPIFFS_GEO_PAGES_PER_BLOCK(fs) -
-                SPIFFS_OBJ_LOOKUP_PAGES(fs)) * (SPIFFS_GEO_BLOCK_COUNT(fs) - 2) -
+                SPIFFS_OBJ_LOOKUP_PAGES(fs)) *
+                (SPIFFS_GEO_BLOCK_COUNT(fs) - 2) -
                 fs->alloc_pages - fs->deleted_pages;
 
   if ((int32_t) len > free_pages * (int32_t)SPIFFS_DATA_PAGE_SIZE(fs))

--- a/fs/tmpfs/fs_tmpfs.h
+++ b/fs/tmpfs/fs_tmpfs.h
@@ -50,6 +50,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Indicates that there is no holder of the re-entrant semaphore */
 
 #define TMPFS_NO_HOLDER   -1
@@ -169,7 +170,9 @@ struct tmpfs_s
   struct tmpfs_sem_s tfs_exclsem;
 };
 
-/* This is the type used the tmpfs_statfs_callout to accumulate memory usage */
+/* This is the type used the tmpfs_statfs_callout to accumulate memory
+ * usage
+ */
 
 struct tmpfs_statfs_s
 {

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -1533,7 +1533,9 @@ static int unionfs_opendir(FAR struct inode *mountpt,
 
       if (unionfs_ispartprefix(relpath, ui->ui_fs[0].um_prefix))
         {
-          /* File system 1 offset includes this relpath.  Make sure that only one */
+          /* File system 1 offset includes this relpath.  Make sure that only
+           * one
+           */
 
           fu->fu_ndx = 0;
           fu->fu_prefix[0] = true;
@@ -1816,7 +1818,9 @@ static int unionfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
                     {
                       int tmp;
 
-                      /* Check if anything exists at this path on file system 1 */
+                      /* Check if anything exists at this path on file
+                       * system 1
+                       */
 
                       um0 = &ui->ui_fs[0];
                       tmp = unionfs_trystat(um0->um_node, relpath,

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -114,7 +114,8 @@ static int     userfs_ioctl(FAR struct file *filep, int cmd,
                  unsigned long arg);
 
 static int     userfs_sync(FAR struct file *filep);
-static int     userfs_dup(FAR const struct file *oldp, FAR struct file *newp);
+static int     userfs_dup(FAR const struct file *oldp,
+                          FAR struct file *newp);
 static int     userfs_fstat(FAR const struct file *filep,
                  FAR struct stat *buf);
 static int     userfs_truncate(FAR struct file *filep, off_t length);
@@ -143,8 +144,8 @@ static int     userfs_rmdir(FAR struct inode *mountpt,
                  FAR const char *relpath);
 static int     userfs_rename(FAR struct inode *mountpt,
                  FAR const char *oldrelpath, FAR const char *newrelpath);
-static int     userfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
-                 FAR struct stat *buf);
+static int     userfs_stat(FAR struct inode *mountpt,
+                 FAR const char *relpath, FAR struct stat *buf);
 
 /****************************************************************************
  * Public Data
@@ -1334,7 +1335,7 @@ static int userfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   /* Allocate an instance of the UserFS state structure */
 
   iolen = USERFS_REQ_MAXSIZE + config->mxwrite;
-  priv  = (FAR struct userfs_state_s *)kmm_malloc(SIZEOF_USERFS_STATE_S(iolen));
+  priv  = kmm_malloc(SIZEOF_USERFS_STATE_S(iolen));
   if (priv == NULL)
     {
       ferr("ERROR: Failed to allocate state structure\n");
@@ -1870,9 +1871,9 @@ static int userfs_rename(FAR struct inode *mountpt,
   strncpy(&req->oldrelpath[oldpathlen], newrelpath, newpathlen);
 
   nsent = psock_sendto(&priv->psock, priv->iobuffer,
-                       SIZEOF_USERFS_RENAME_REQUEST_S(oldpathlen, newpathlen), 0,
-                       (FAR struct sockaddr *)&priv->server,
-                       sizeof(struct sockaddr_in));
+                      SIZEOF_USERFS_RENAME_REQUEST_S(oldpathlen, newpathlen),
+                      0, (FAR struct sockaddr *)&priv->server,
+                      sizeof(struct sockaddr_in));
   if (nsent < 0)
     {
       ferr("ERROR: psock_sendto failed: %d\n", (int)nsent);

--- a/include/nuttx/fs/userfs.h
+++ b/include/nuttx/fs/userfs.h
@@ -60,7 +60,7 @@
  *    value that was provided when file system was created.
  * 3. The UserFs will receive system file system requests and forward them
  *    on the the MqUfsReqN to the user-space file system server
- *    (userfs_run()).  These requests may be accompanied by additional data in
+ *    (userfs_run()). These requests may be accompanied by additional data in
  *    an provided request buffer that was provided when the UserFS was
  *    created.  This buffer would hold, for example, the data to be
  *    written that would accompany a write request.
@@ -95,7 +95,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* UserFS IOCTLs are defined in included/nuttx/fs/ioctl.h.  There is only one:
+/* UserFS IOCTLs are defined in included/nuttx/fs/ioctl.h. There is only one:
  *
  * FIONUSERFS.  The is the IOCTL that is used with the dev/userfs factory to
  *   create a UserFS instance.
@@ -103,7 +103,7 @@
  *   Input:  This function receives an pointer to a read-only instance of
  *           struct userfs_config_s that contains information needed to
  *           configure the UserFS instance.
- *   Output: On success the UserFS nn instance is created.  nn is non-negative
+ *   Output: On success the UserFS nn instance is created. nn is non-negative
  *           and will be provided as the IOCTL return value on success.  On
  *           failure, ioctl() will return -1 with the errno variable set to
  *           indicate the cause of the failure.
@@ -524,7 +524,7 @@ struct userfs_destroy_request_s
 
 struct userfs_destroy_response_s
 {
-  uint8_t resp;              /* Must be USERFS_RESP_DESTROY */
+  uint8_t resp;             /* Must be USERFS_RESP_DESTROY */
   int ret;                  /* Result of the operation */
 };
 
@@ -569,7 +569,7 @@ int userfs_register(void);
  *   the UserFS file system and will not return until that file system has
  *   been unmounted.
  *
- *   userfs_run() implements the UserFS server.  It performs there operations:
+ *   userfs_run() implements the UserFS server. It performs there operations:
  *
  *   1. It configures and creates the UserFS file system and
  *   2. Mounts the user file system at the provide mount point path.

--- a/libs/libc/userfs/lib_userfs.c
+++ b/libs/libc/userfs/lib_userfs.c
@@ -62,7 +62,7 @@
 
 struct userfs_info_s
 {
-  FAR const struct userfs_operations_s *userops; /* File system callbacks */
+  FAR const struct userfs_operations_s *userops;
   FAR void *volinfo;          /* Data that accompanies the user callbacks */
   struct sockaddr_in client;  /* Client to send response back to */
   int16_t sockfd;             /* Server socket */
@@ -388,7 +388,8 @@ static inline int userfs_dup_dispatch(FAR struct userfs_info_s *info,
   /* Dispatch the request */
 
   DEBUGASSERT(info->userops != NULL && info->userops->dup != NULL);
-  resp.ret  = info->userops->dup(info->volinfo, req->openinfo, &resp.openinfo);
+  resp.ret  = info->userops->dup(info->volinfo,
+                                 req->openinfo, &resp.openinfo);
 
   /* Send the response */
 
@@ -444,7 +445,8 @@ static inline int userfs_truncate_dispatch(FAR struct userfs_info_s *info,
   /* Dispatch the request */
 
   DEBUGASSERT(info->userops != NULL && info->userops->truncate != NULL);
-  resp.ret  = info->userops->truncate(info->volinfo, req->openinfo, req->length);
+  resp.ret  = info->userops->truncate(info->volinfo,
+                                      req->openinfo, req->length);
 
   /* Send the response */
 
@@ -749,7 +751,7 @@ static inline int userfs_rename_dispatch(FAR struct userfs_info_s *info,
 
   /* Verify the request size */
 
-  if (reqlen < SIZEOF_USERFS_RENAME_REQUEST_S(0,0))
+  if (reqlen < SIZEOF_USERFS_RENAME_REQUEST_S(0, 0))
     {
       return -EINVAL;
     }
@@ -886,7 +888,7 @@ static inline int userfs_destroy_dispatch(FAR struct userfs_info_s *info,
  *   the UserFS file system and will not return until that file system has
  *   been unmounted.
  *
- *   userfs_run() implements the UserFS server.  It performs there operations:
+ *   userfs_run() implements the UserFS server. It performs there operations:
  *
  *   1. It configures and creates the UserFS file system and
  *   2. Mounts the user file system at the provide mount point path.
@@ -932,7 +934,9 @@ int userfs_run(FAR const char *mountpt,
   DEBUGASSERT(mountpt != NULL && userops != NULL && mxwrite <= UINT16_MAX);
   DEBUGASSERT(mxwrite > 0 && mxwrite <= (UINT16_MAX - USERFS_REQ_MAXSIZE));
 
-  /* Allocate a state structure with an I/O buffer to receive UserFS requests */
+  /* Allocate a state structure with an I/O buffer to receive UserFS
+   * requests
+   */
 
   iolen = USERFS_REQ_MAXSIZE + mxwrite;
   info  = (FAR struct userfs_info_s *)zalloc(SIZEOF_USERFS_INFO_S(iolen));
@@ -1020,111 +1024,133 @@ int userfs_run(FAR const char *mountpt,
         {
           case USERFS_REQ_OPEN:
             ret = userfs_open_dispatch(info,
-                   (FAR struct userfs_open_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_open_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_CLOSE:
             ret = userfs_close_dispatch(info,
-                   (FAR struct userfs_close_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_close_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_READ:
             ret = userfs_read_dispatch(info,
-                   (FAR struct userfs_read_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_read_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_WRITE:
             ret = userfs_write_dispatch(info,
-                   (FAR struct userfs_write_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_write_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_SEEK:
             ret = userfs_seek_dispatch(info,
-                   (FAR struct userfs_seek_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_seek_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_IOCTL:
             ret = userfs_ioctl_dispatch(info,
-                   (FAR struct userfs_ioctl_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_ioctl_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_SYNC:
             ret = userfs_sync_dispatch(info,
-                   (FAR struct userfs_sync_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_sync_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_DUP:
             ret = userfs_dup_dispatch(info,
-                   (FAR struct userfs_dup_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_dup_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_FSTAT:
             ret = userfs_fstat_dispatch(info,
-                   (FAR struct userfs_fstat_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_fstat_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_TRUNCATE:
             ret = userfs_truncate_dispatch(info,
-                   (FAR struct userfs_truncate_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_truncate_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_OPENDIR:
             ret = userfs_opendir_dispatch(info,
-                   (FAR struct userfs_opendir_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_opendir_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_CLOSEDIR:
             ret = userfs_closedir_dispatch(info,
-                   (FAR struct userfs_closedir_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_closedir_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_READDIR:
             ret = userfs_readdir_dispatch(info,
-                   (FAR struct userfs_readdir_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_readdir_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_REWINDDIR:
             ret = userfs_rewinddir_dispatch(info,
-                   (FAR struct userfs_rewinddir_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_rewinddir_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_STATFS:
             ret = userfs_statfs_dispatch(info,
-                   (FAR struct userfs_statfs_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_statfs_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_UNLINK:
             ret = userfs_unlink_dispatch(info,
-                   (FAR struct userfs_unlink_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_unlink_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_MKDIR:
             ret = userfs_mkdir_dispatch(info,
-                   (FAR struct userfs_mkdir_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_mkdir_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_RMDIR:
             ret = userfs_rmdir_dispatch(info,
-                   (FAR struct userfs_rmdir_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_rmdir_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_RENAME:
             ret = userfs_rename_dispatch(info,
-                   (FAR struct userfs_rename_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_rename_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_STAT:
             ret = userfs_stat_dispatch(info,
-                   (FAR struct userfs_stat_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_stat_request_s *)info->iobuffer,
+                   nread);
             break;
 
           case USERFS_REQ_DESTROY:
             ret = userfs_destroy_dispatch(info,
-                   (FAR struct userfs_destroy_request_s *)info->iobuffer, nread);
+                   (FAR struct userfs_destroy_request_s *)info->iobuffer,
+                   nread);
             break;
 
           default:
-            ferr("ERROR: Unrecognized request received: %u\n", *info->iobuffer);
+            ferr("ERROR: Unrecognized request received: %u\n",
+                 *info->iobuffer);
             ret = -EINVAL;
             break;
         }

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -96,8 +95,9 @@
 
 /* File system methods */
 
-static int     netprocfs_open(FAR struct file *filep, FAR const char *relpath,
-                 int oflags, mode_t mode);
+static int     netprocfs_open(FAR struct file *filep,
+                              FAR const char *relpath,
+                              int oflags, mode_t mode);
 static int     netprocfs_close(FAR struct file *filep);
 static ssize_t netprocfs_read(FAR struct file *filep, FAR char *buffer,
                  size_t buflen);
@@ -182,7 +182,9 @@ static int netprocfs_open(FAR struct file *filep, FAR const char *relpath,
     }
   else
 #ifdef CONFIG_NET_MLD
-  /* "net/mld" is an acceptable value for the relpath only if MLD is enabled. */
+  /* "net/mld" is an acceptable value for the relpath only if MLD is
+   * enabled.
+   */
 
   if (strcmp(relpath, "net/mld") == 0)
     {

--- a/net/procfs/net_procfs_route.c
+++ b/net/procfs/net_procfs_route.c
@@ -40,7 +40,6 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
-#include <sys/statfs.h>
 #include <sys/stat.h>
 
 #include <stdint.h>
@@ -108,10 +107,10 @@ enum route_node_e
 
 struct route_file_s
 {
-  struct procfs_file_s base;           /* Base open file structure */
+  struct procfs_file_s base;          /* Base open file structure */
   FAR const char *name;               /* Terminal node segment name */
   uint8_t node;                       /* Type of node (see enum route_node_e) */
-  char line[STATUS_LINELEN];           /* Pre-allocated buffer for formatted lines */
+  char line[STATUS_LINELEN];          /* Pre-allocated buffer for formatted lines */
 };
 
 /* This structure describes one open "directory" */
@@ -288,7 +287,8 @@ static void route_sprintf(FAR struct route_info_s *info,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_IPv4
-static int route_ipv4_entry(FAR struct net_route_ipv4_s *route, FAR void *arg)
+static int route_ipv4_entry(FAR struct net_route_ipv4_s *route,
+                            FAR void *arg)
 {
   FAR struct route_info_s *info = (FAR struct route_info_s *)arg;
   char target[INET_ADDRSTRLEN];
@@ -345,7 +345,8 @@ static int route_ipv4_entry(FAR struct net_route_ipv4_s *route, FAR void *arg)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_IPv6
-static int route_ipv6_entry(FAR struct net_route_ipv6_s *route, FAR void *arg)
+static int route_ipv6_entry(FAR struct net_route_ipv6_s *route,
+                            FAR void *arg)
 {
   FAR struct route_info_s *info = (FAR struct route_info_s *)arg;
   char addr[INET6_ADDRSTRLEN];
@@ -391,7 +392,8 @@ static int route_ipv6_entry(FAR struct net_route_ipv6_s *route, FAR void *arg)
 
 #ifdef CONFIG_NET_IPv4
 static ssize_t route_ipv4_table(FAR struct route_file_s *procfile,
-                                FAR char *buffer, size_t buflen, off_t offset)
+                                FAR char *buffer, size_t buflen,
+                                off_t offset)
 {
   struct route_info_s info;
 
@@ -416,7 +418,8 @@ static ssize_t route_ipv4_table(FAR struct route_file_s *procfile,
 
 #ifdef CONFIG_NET_IPv6
 static ssize_t route_ipv6_table(FAR struct route_file_s *procfile,
-                                FAR char *buffer, size_t buflen, off_t offset)
+                                FAR char *buffer, size_t buflen,
+                                off_t offset)
 {
   struct route_info_s info;
 


### PR DESCRIPTION
## Summary

## Impact
No, only style change.

## Testing

Please ignore the following nxstyle false alarm:
```
nuttx/fs/nfs/nfs_vfsops.c:846:12: error: Mixed case identifier found
nuttx/nuttx/fs/nfs/nfs_vfsops.c:1017:16: error: Mixed case identifier found
```