### PR TITLE
Fix note driver initialization

### DIFF
--- a/arch/arm/src/common/arm_initialize.c
+++ b/arch/arm/src/common/arm_initialize.c
@@ -28,12 +28,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -159,8 +159,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/avr/src/common/up_initialize.c
+++ b/arch/avr/src/common/up_initialize.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * arch/avr/src/common/up_initialize.c
  *
- *   Copyright (C) 2010, 2012-2013, 2015-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2010, 2012-2013, 2015-2017 Gregory Nutt. All rights
+ *   reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -64,7 +65,8 @@
 
 /* Determine which (if any) console driver to use.  This will probably cause
  * up_serialinit to be incorrectly called if there is no USART configured to
- * be an RS-232 device (see as an example arch/avr/src/at32uc23/at32uc3_config.h)
+ * be an RS-232 device (see as an example
+ * arch/avr/src/at32uc23/at32uc3_config.h)
  * This will probably have to be revisited someday.
  *
  * If a console is enabled and no other console device is specified, then a
@@ -166,8 +168,8 @@ void up_initialize(void)
 #endif
 
 #ifdef CONFIG_ARCH_DMA
-  /* Initialize the DMA subsystem if the weak function up_dma_initialize has been
-   * brought into the build
+  /* Initialize the DMA subsystem if the weak function up_dma_initialize has
+   * been brought into the build
    */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS

--- a/arch/avr/src/common/up_initialize.c
+++ b/arch/avr/src/common/up_initialize.c
@@ -42,12 +42,12 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -200,8 +200,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/hc/src/common/up_initialize.c
+++ b/arch/hc/src/common/up_initialize.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * arch/hc/src/common/up_initialize.c
  *
- *   Copyright (C) 2009-2010, 2012-2013, 2015-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2009-2010, 2012-2013, 2015-2017 Gregory Nutt. All rights
+ *   reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -99,8 +100,8 @@ void up_initialize(void)
 #endif
 
 #ifdef CONFIG_ARCH_DMA
-  /* Initialize the DMA subsystem if the weak function up_dma_initialize has been
-   * brought into the build
+  /* Initialize the DMA subsystem if the weak function up_dma_initialize has
+   * been brought into the build
    */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS

--- a/arch/hc/src/common/up_initialize.c
+++ b/arch/hc/src/common/up_initialize.c
@@ -43,12 +43,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -133,8 +133,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/mips/src/common/mips_initialize.c
+++ b/arch/mips/src/common/mips_initialize.c
@@ -43,12 +43,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -135,8 +135,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/or1k/src/common/up_initialize.c
+++ b/arch/or1k/src/common/up_initialize.c
@@ -74,7 +74,8 @@ void up_enable_icache(void)
 
   mfspr(SPR_SYS_ICCFGR, iccfg);
 
-  syslog(LOG_INFO, "ICACHE NCW: %d NCS: %d CBS: %d CCRI: %d CBIRI: %d CBPRI: %d\n",
+  syslog(LOG_INFO,
+         "ICACHE NCW: %d NCS: %d CBS: %d CCRI: %d CBIRI: %d CBPRI: %d\n",
          (iccfg & SPR_ICCFGR_NCW_MASK) >> SPR_ICCFGR_NCW_SHIFT,
          (iccfg & SPR_ICCFGR_NCS_MASK) >> SPR_ICCFGR_NCS_SHIFT,
          (iccfg & SPR_ICCFGR_CBS) ? 1 : 0,
@@ -91,7 +92,6 @@ void up_enable_icache(void)
   mfspr(SPR_SYS_SR, sr);
   sr |= SPR_SR_ICE;
   mtspr(SPR_SYS_SR, sr);
-
 }
 #endif
 
@@ -104,7 +104,8 @@ void up_enable_dcache(void)
 
   mfspr(SPR_SYS_DCCFGR, dccfg);
 
-  syslog(LOG_INFO, "DCACHE NCW: %d NCS: %d CBS: %d CCRI: %d CBIRI: %d CBPRI: %d\n",
+  syslog(LOG_INFO,
+         "DCACHE NCW: %d NCS: %d CBS: %d CCRI: %d CBIRI: %d CBPRI: %d\n",
          (dccfg & SPR_DCCFGR_NCW_MASK) >> SPR_DCCFGR_NCW_SHIFT,
          (dccfg & SPR_DCCFGR_NCS_MASK) >> SPR_DCCFGR_NCS_SHIFT,
          (dccfg & SPR_DCCFGR_CBS) ? 1 : 0,
@@ -194,8 +195,8 @@ void up_initialize(void)
 #endif
 
 #ifdef CONFIG_ARCH_DMA
-  /* Initialize the DMA subsystem if the weak function up_dma_initialize has been
-   * brought into the build
+  /* Initialize the DMA subsystem if the weak function up_dma_initialize has
+   * been brought into the build
    */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS

--- a/arch/or1k/src/common/up_initialize.c
+++ b/arch/or1k/src/common/up_initialize.c
@@ -43,12 +43,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -228,8 +228,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/renesas/src/common/up_initialize.c
+++ b/arch/renesas/src/common/up_initialize.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * arch/renesas/src/common/up_initialize.c
  *
- *   Copyright (C) 2008-2010, 2012-2013, 2015-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2008-2010, 2012-2013, 2015-2017 Gregory Nutt. All rights
+ *   reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -131,9 +132,10 @@ void up_initialize(void)
 #endif
 
   /* Initialize the console device driver (if it is other than the standard
-   * serial driver). NOTE that the naming implies that the console is a serial
-   * driver.  That is usually the case, however, if no UARTs are enabled, the
-   * console could also be provided through some other device, such as an LCD.
+   * serial driver). NOTE that the naming implies that the console is a
+   * serial driver.  That is usually the case, however, if no UARTs are
+   * enabled, the console could also be provided through some other device,
+   * such as an LCD.
    * Architecture-specific logic will have to detect that case.
    */
 

--- a/arch/renesas/src/common/up_initialize.c
+++ b/arch/renesas/src/common/up_initialize.c
@@ -43,12 +43,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -116,8 +116,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/risc-v/src/common/riscv_initialize.c
+++ b/arch/risc-v/src/common/riscv_initialize.c
@@ -45,6 +45,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/serial/pty.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/drivers/drivers.h>
 
@@ -142,6 +143,10 @@ void up_initialize(void)
 
 #if defined(CONFIG_DEV_ZERO)
   devzero_register();   /* Standard /dev/zero */
+#endif
+
+#if defined(CONFIG_DRIVER_NOTE)
+  note_register();      /* Non-standard /dev/note */
 #endif
 
   /* Initialize the serial device driver */

--- a/arch/sim/src/sim/up_initialize.c
+++ b/arch/sim/src/sim/up_initialize.c
@@ -42,7 +42,6 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/fs/ioctl.h>
@@ -50,6 +49,7 @@
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
 #include <nuttx/mtd/mtd.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -212,8 +212,7 @@ void up_initialize(void)
   loop_register();          /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();          /* Non-standard /dev/note */
 #endif
 

--- a/arch/sim/src/sim/up_initialize.c
+++ b/arch/sim/src/sim/up_initialize.c
@@ -91,7 +91,9 @@ static void up_init_smartfs(void)
     {
       mtd = m25p_initialize(spi);
 
-      /* Now initialize a SMART Flash block device and bind it to the MTD device */
+      /* Now initialize a SMART Flash block device and bind it to the MTD
+       * device
+       */
 
       if (mtd != NULL)
         {
@@ -108,7 +110,9 @@ static void up_init_smartfs(void)
     {
       mtd = sst26_initialize_spi(spi);
 
-      /* Now initialize a SMART Flash block device and bind it to the MTD device */
+      /* Now initialize a SMART Flash block device and bind it to the MTD
+       * device
+       */
 
       if (mtd != NULL)
         {
@@ -125,7 +129,9 @@ static void up_init_smartfs(void)
     {
       mtd = w25_initialize(spi);
 
-      /* Now initialize a SMART Flash block device and bind it to the MTD device */
+      /* Now initialize a SMART Flash block device and bind it to the MTD
+       * device
+       */
 
       if (mtd != NULL)
         {
@@ -143,7 +149,9 @@ static void up_init_smartfs(void)
     {
       mtd = n25qxxx_initialize(qspi, 0);
 
-      /* Now initialize a SMART Flash block device and bind it to the MTD device */
+      /* Now initialize a SMART Flash block device and bind it to the MTD
+       * device
+       */
 
       if (mtd != NULL)
         {

--- a/arch/x86/src/common/up_initialize.c
+++ b/arch/x86/src/common/up_initialize.c
@@ -43,12 +43,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -135,8 +135,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/x86/src/common/up_initialize.c
+++ b/arch/x86/src/common/up_initialize.c
@@ -101,8 +101,8 @@ void up_initialize(void)
 #endif
 
 #ifdef CONFIG_ARCH_DMA
-  /* Initialize the DMA subsystem if the weak function up_dma_initialize has been
-   * brought into the build
+  /* Initialize the DMA subsystem if the weak function up_dma_initialize has
+   * been brought into the build
    */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS

--- a/arch/x86_64/src/common/up_initialize.c
+++ b/arch/x86_64/src/common/up_initialize.c
@@ -28,7 +28,6 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/mm/iob.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
@@ -36,6 +35,7 @@
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
 #include <nuttx/syslog/syslog.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -160,8 +160,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -43,12 +43,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -143,8 +143,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/z16/src/common/z16_initialize.c
+++ b/arch/z16/src/common/z16_initialize.c
@@ -28,12 +28,12 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/tun.h>
 #include <nuttx/net/telnet.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -120,8 +120,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/arch/z80/src/common/z80_initialize.c
+++ b/arch/z80/src/common/z80_initialize.c
@@ -28,13 +28,13 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
-#include <nuttx/sched_note.h>
 #include <nuttx/mm/mm.h>
 #include <nuttx/drivers/drivers.h>
 #include <nuttx/fs/loop.h>
 #include <nuttx/net/loopback.h>
 #include <nuttx/net/telnet.h>
 #include <nuttx/net/tun.h>
+#include <nuttx/syslog/note_driver.h>
 #include <nuttx/syslog/syslog_console.h>
 #include <nuttx/serial/pty.h>
 #include <nuttx/crypto/crypto.h>
@@ -119,8 +119,7 @@ void up_initialize(void)
   loop_register();      /* Standard /dev/loop */
 #endif
 
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
+#if defined(CONFIG_DRIVER_NOTE)
   note_register();      /* Non-standard /dev/note */
 #endif
 

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -391,27 +391,6 @@ ssize_t sched_note_get(FAR uint8_t *buffer, size_t buflen);
 ssize_t sched_note_size(void);
 #endif
 
-/****************************************************************************
- * Name: note_register
- *
- * Description:
- *   Register a serial driver at /dev/note that can be used by an
- *   application to read data from the circular not buffer.
- *
- * Input Parameters:
- *   None.
- *
- * Returned Value:
- *   Zero is returned if the circular buffer is empty.  Otherwise, a negated
- *   errno value is returned.
- *
- ****************************************************************************/
-
-#if defined(CONFIG_SCHED_INSTRUMENTATION_BUFFER) && \
-    defined(CONFIG_DRIVER_NOTE)
-int note_register(void);
-#endif
-
 #else /* CONFIG_SCHED_INSTRUMENTATION */
 
 #  define sched_note_start(t)

--- a/include/nuttx/syslog/note_driver.h
+++ b/include/nuttx/syslog/note_driver.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * include/nuttx/syslog/note_driver.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_SYSLOG_NOTE_DRIVER_H
+#define __INCLUDE_NUTTX_SYSLOG_NOTE_DRIVER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#if defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT)
+
+/****************************************************************************
+ * Name: note_register
+ *
+ * Description:
+ *   Register a serial driver at /dev/note that can be used by an
+ *   application to read data from the circular note buffer.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   Zero on succress. A negated errno value is returned on a failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DRIVER_NOTE
+int note_register(void);
+#endif
+
+#endif /* defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT) */
+
+#endif /* CONFIG_SCHED_INSTRUMENTATION */
+
+#endif /* __INCLUDE_NUTTX_SYSLOG_NOTE_DRIVER_H */


### PR DESCRIPTION
## Summary
Fix header file location and kernel configuration dependency for /dev/note driver initialization.

## Impact
Affected only when CONFIG_DRIVER_NOTE is enabled.

## Testing
