### PR TITLE
sethost.sh: always print logs to ease identify problem in configure phase

### DIFF
--- a/tools/sethost.sh
+++ b/tools/sethost.sh
@@ -182,8 +182,4 @@ fi
 
 echo "  Refreshing..."
 
-if grep -q "V=1" <<< "$*" ; then
-  make olddefconfig $* || { echo "ERROR: failed to refresh"; exit 1; }
-else
-  make olddefconfig $* 1>/dev/null || { echo "ERROR: failed to refresh"; exit 1; }
-fi
+make olddefconfig $* || { echo "ERROR: failed to refresh"; exit 1; }

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -199,7 +199,7 @@ function distclean {
 
 function configure {
   echo "  Configuring..."
-  if ! ./tools/configure.sh ${HOPTION} $config ${JOPTION}; then
+  if ! ./tools/configure.sh ${HOPTION} $config ${JOPTION} 1>/dev/null; then
     fail=1
   fi
 


### PR DESCRIPTION
## Summary
Always print logs in configure phase  to ease identify problem. It also fixes some corner case in issue https://github.com/apache/incubator-nuttx/issues/1407

## Impact

## Testing

