### PR TITLE
Fixed AVR build issues

### DIFF
--- a/arch/avr/include/avr/types.h
+++ b/arch/avr/include/avr/types.h
@@ -74,6 +74,9 @@ typedef unsigned long      _uint32_t;
 
 typedef signed long long   _int64_t;   /* long long is 64-bits */
 typedef unsigned long long _uint64_t;
+
+typedef double double_t;
+
 #define __INT64_DEFINED
 
 /* A (near) size is 2 bytes */

--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -76,18 +76,25 @@ endif
 
 ifeq ($(CONFIG_ARCH_CHIP_ATMEGA128),y)
   ARCHCPUFLAGS += -mmcu=atmega128
+  LDFLAGS += -mavr51
 else ifeq ($(CONFIG_ARCH_CHIP_ATMEGA1284P),y)
   ARCHCPUFLAGS += -mmcu=atmega1284p
+  LDFLAGS += -mavr51
 else ifeq ($(CONFIG_ARCH_CHIP_AT90USB646),y)
   ARCHCPUFLAGS += -mmcu=at90usb646
+  LDFLAGS += -mavr5
 else ifeq ($(CONFIG_ARCH_CHIP_AT90USB647),y)
   ARCHCPUFLAGS += -mmcu=at90usb647
+  LDFLAGS += -mavr5
 else ifeq ($(CONFIG_ARCH_CHIP_AT90USB1286),y)
   ARCHCPUFLAGS += -mmcu=at90usb1286
+  LDFLAGS += -mavr51
 else ifeq ($(CONFIG_ARCH_CHIP_AT90USB1287),y)
   ARCHCPUFLAGS += -mmcu=at90usb1287
+  LDFLAGS += -mavr51
 else ifeq ($(CONFIG_ARCH_CHIP_ATMEGA2560),y)
   ARCHCPUFLAGS += -mmcu=atmega2560
+  LDFLAGS += -mavr6
 else
   $(error "No valid CONFIG_ARCH_CHIP_ set in the configuration")
 endif

--- a/arch/avr/src/avr/up_stackframe.c
+++ b/arch/avr/src/avr/up_stackframe.c
@@ -53,6 +53,16 @@
  * Pre-processor Macros
  ****************************************************************************/
 
+/* Stack can be aligned to 1 byte */
+
+#define CONFIG_STACK_ALIGNMENT 1
+
+/* Stack alignment macros */
+
+#define STACK_ALIGN_MASK    (CONFIG_STACK_ALIGNMENT-1)
+#define STACK_ALIGN_DOWN(a) ((a) & ~STACK_ALIGN_MASK)
+#define STACK_ALIGN_UP(a)   (((a) + STACK_ALIGN_MASK) & ~STACK_ALIGN_MASK)
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/


### PR DESCRIPTION
## Summary
* Missing double_t type (on the compiler side)
* Missing CONFIG_STACK_ALIGNMENT macro
* Missing linker emulation flags (avr-ld fails at last step)

## Impact
Build failed for the aforementioned platform

## Testing

