### PR TITLE
drivers: wireless: Fix compile error with DEBUG_WIRELESS_INFO in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -543,13 +543,11 @@ static bool _control_pkt_q(FAR struct gs2200m_dev_s *dev)
 {
   bool over = BULK_THRESHOLD < dev->total_bulk ? true : false;
 
-  /* TODO: should enable again if disabled for long time
-   * Or, should use flow control commands for gs2200m
-   */
+  /* TODO: should enable again if disabled for long time */
 
   if (dev->int_enabled && over)
     {
-      wlinfo("--- pkt_q[%d] exceeds, disable irq \n", c);
+      wlinfo("--- disable irq \n");
       dev->int_enabled = false;
       dev->lower->disable();
     }


### PR DESCRIPTION
## Summary

- This PR fixes a compile error with DEBUG_WIRELESS_INFO in gs2200m.c
- Also, remove an inappropriate comment.

## Impact

- This PR affects gs2200m.c

## Testing

- I tested this PR with spresense:wifi

