### PR TITLE
rwbuffer: Optimize the buffer algorithm

### DIFF
--- a/drivers/rwbuffer.c
+++ b/drivers/rwbuffer.c
@@ -492,7 +492,7 @@ int rwb_invalidate_writebuffer(FAR struct rwbuffer_s *rwb,
 
       else if (wrbend > startblock && wrbend <= invend)
         {
-          rwb->wrnblocks = wrbend - startblock;
+          rwb->wrnblocks -= wrbend - startblock;
           ret = OK;
         }
 
@@ -612,11 +612,11 @@ int rwb_invalidate_readahead(FAR struct rwbuffer_s *rwb,
 
       else if (rhbend > startblock && rhbend <= invend)
         {
-          rwb->rhnblocks = rhbend - startblock;
+          rwb->rhnblocks -= rhbend - startblock;
           ret = OK;
         }
 
-      /* 4. We invalidate a portion at the beginning of the write buffer */
+      /* 4. We invalidate a portion at the begin of the read-ahead buffer */
 
       else /* if (rwb->rhblockstart >= startblock && rhbend > invend) */
         {

--- a/include/nuttx/drivers/rwbuffer.h
+++ b/include/nuttx/drivers/rwbuffer.h
@@ -144,7 +144,6 @@ struct rwbuffer_s
   uint8_t      *wrbuffer;        /* Allocated write buffer */
   uint16_t      wrnblocks;       /* Number of blocks in write buffer */
   off_t         wrblockstart;    /* First block in write buffer */
-  off_t         wrexpectedblock; /* Next block expected */
 #endif
 
   /* This is the state of the read-ahead buffering */


### PR DESCRIPTION
## Summary
avoid the buffer flush as much as possible. The new algo try to avoid the buffer flush if the new buffer overlap with the cache.

## Impact
Improve the performance by 4 time in our test case.

## Testing
Perform the raw block write through:
bch->ftl(with rwbuffer)->mtd
