### PR TITLE
libc: Don't define localtime[_r] to macro when CONFIG_LIBC_LOCALTIME not define

### DIFF
--- a/Documentation/NuttxUserGuide.html
+++ b/Documentation/NuttxUserGuide.html
@@ -4204,11 +4204,7 @@ Otherwise, an -1 (<code>ERROR</code>) will be returned and the <code>errno</code
 <H3><a name="localtime">2.6.6 localtime</a></H3>
 <ul><pre>
 #include &lt;time.h&gt;
-#ifdef CONFIG_LIBC_LOCALTIME
-#  define localtime(c) gmtime(c)
-#else
 FAR struct tm *localtime(FAR const time_t *timep);
-#endif
 </pre></ul>
 <p>
   <b>Description:</b>
@@ -4317,11 +4313,7 @@ FAR char *ctime(FAR const time_t *timep);
 <H3><a name="localtimer">2.6.10 localtime_r</a></H3>
 <ul><pre>
 #include &lt;time.h&gt;
-#ifdef CONFIG_LIBC_LOCALTIME
-#  define localtime_r(c,r) gmtime_r(c,r)
-#else
 FAR struct tm *localtime_r(FAR const time_t *timep, FAR struct tm *result);
-#endif
 </pre></ul>
 <p>
   <b>Description:</b>

--- a/arch/arm/src/kinetis/kinetis_rtc_lowerhalf.c
+++ b/arch/arm/src/kinetis/kinetis_rtc_lowerhalf.c
@@ -107,7 +107,7 @@ static int kinetis_settime(FAR struct rtc_lowerhalf_s *lower,
 static int kinetis_setalarm(FAR struct rtc_lowerhalf_s *lower,
                             FAR const struct lower_setalarm_s *alarminfo);
 static int kinetis_setrelative(FAR struct rtc_lowerhalf_s *lower,
-                               FAR const struct lower_setrelative_s *alarminfo);
+                            FAR const struct lower_setrelative_s *alarminfo);
 static int kinetis_cancelalarm(FAR struct rtc_lowerhalf_s *lower,
                                int alarmid);
 static int kinetis_rdalarm(FAR struct rtc_lowerhalf_s *lower,
@@ -168,7 +168,7 @@ static struct kinetis_lowerhalf_s g_rtc_lowerhalf =
 #ifdef CONFIG_RTC_ALARM
 static void kinetis_alarm_callback(void)
 {
-  FAR struct kinetis_cbinfo_s *cbinfo = &g_rtc_lowerhalf.cbinfo;/*[0];*/
+  FAR struct kinetis_cbinfo_s *cbinfo = &g_rtc_lowerhalf.cbinfo;
 
   /* Sample and clear the callback information to minimize the window in
    * time in which race conditions can occur.
@@ -330,7 +330,7 @@ static int kinetis_setalarm(FAR struct rtc_lowerhalf_s *lower,
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   priv = (FAR struct kinetis_lowerhalf_s *)lower;
 
-  if (alarminfo->id == RTC_ALARMA )
+  if (alarminfo->id == RTC_ALARMA)
     {
       /* Remember the callback information */
 
@@ -374,8 +374,9 @@ static int kinetis_setalarm(FAR struct rtc_lowerhalf_s *lower,
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_ALARM
-static int kinetis_setrelative(FAR struct rtc_lowerhalf_s *lower,
-                               FAR const struct lower_setrelative_s *alarminfo)
+static int
+kinetis_setrelative(FAR struct rtc_lowerhalf_s *lower,
+                    FAR const struct lower_setrelative_s *alarminfo)
 {
   struct lower_setalarm_s setalarm;
 #if defined(CONFIG_RTC_DATETIME)
@@ -388,7 +389,7 @@ static int kinetis_setrelative(FAR struct rtc_lowerhalf_s *lower,
   DEBUGASSERT(lower != NULL && alarminfo != NULL);
   DEBUGASSERT(alarminfo->id == RTC_ALARMA);
 
-  if ((alarminfo->id == RTC_ALARMA ) &&
+  if (alarminfo->id == RTC_ALARMA &&
       alarminfo->reltime > 0)
     {
       /* Disable pre-emption while we do this so that we don't have to worry
@@ -419,6 +420,7 @@ static int kinetis_setrelative(FAR struct rtc_lowerhalf_s *lower,
           return ret;
         }
 #endif
+
       /* Convert to seconds since the epoch */
 
       seconds = ts.tv_sec;
@@ -466,7 +468,8 @@ static int kinetis_setrelative(FAR struct rtc_lowerhalf_s *lower,
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_ALARM
-static int kinetis_cancelalarm(FAR struct rtc_lowerhalf_s *lower, int alarmid)
+static int
+kinetis_cancelalarm(FAR struct rtc_lowerhalf_s *lower, int alarmid)
 {
   FAR struct kinetis_lowerhalf_s *priv;
   FAR struct kinetis_cbinfo_s *cbinfo;
@@ -489,7 +492,6 @@ static int kinetis_cancelalarm(FAR struct rtc_lowerhalf_s *lower, int alarmid)
       /* Then cancel the alarm */
 
       ret = kinetis_rtc_cancelalarm();
-
     }
 
   return ret;

--- a/arch/arm/src/kinetis/kinetis_rtc_lowerhalf.c
+++ b/arch/arm/src/kinetis/kinetis_rtc_lowerhalf.c
@@ -531,13 +531,8 @@ static int kinetis_rdalarm(FAR struct rtc_lowerhalf_s *lower,
       sched_lock();
       ret = kinetis_rtc_rdalarm(&ts);
 
-#ifdef CONFIG_LIBC_LOCALTIME
       localtime_r((FAR const time_t *)&ts.tv_sec,
                   (FAR struct tm *)alarminfo->time);
-#else
-      gmtime_r((FAR const time_t *)&ts.tv_sec,
-               (FAR struct tm *)alarminfo->time);
-#endif
       sched_unlock();
     }
 

--- a/arch/arm/src/max326xx/common/max326_rtc_lowerhalf.c
+++ b/arch/arm/src/max326xx/common/max326_rtc_lowerhalf.c
@@ -119,7 +119,7 @@ static bool max326_havesettime(FAR struct rtc_lowerhalf_s *lower);
 static int max326_setalarm(FAR struct rtc_lowerhalf_s *lower,
                            FAR const struct lower_setalarm_s *alarminfo);
 static int max326_setrelative(FAR struct rtc_lowerhalf_s *lower,
-                             FAR const struct lower_setrelative_s *alarminfo);
+                           FAR const struct lower_setrelative_s *alarminfo);
 static int max326_cancelalarm(FAR struct rtc_lowerhalf_s *lower,
                              int alarmid);
 static int max326_rdalarm(FAR struct rtc_lowerhalf_s *lower,
@@ -128,7 +128,7 @@ static int max326_rdalarm(FAR struct rtc_lowerhalf_s *lower,
 
 #ifdef CONFIG_RTC_PERIODIC
 static int max326_setperiodic(FAR struct rtc_lowerhalf_s *lower,
-                             FAR const struct lower_setperiodic_s *alarminfo);
+                           FAR const struct lower_setperiodic_s *alarminfo);
 static int max326_cancelperiodic(FAR struct rtc_lowerhalf_s *lower, int id);
 #endif
 
@@ -598,9 +598,9 @@ static int max326_rdalarm(FAR struct rtc_lowerhalf_s *lower,
         {
           /* Extract integer seconds from the b32_t value */
 
-           time_t sec = (time_t)(b32toi(ftime));
+          time_t sec = (time_t)(b32toi(ftime));
 
-           /* Convert to struct rtc_time (aka struct tm) */
+          /* Convert to struct rtc_time (aka struct tm) */
 
           localtime_r(&sec, (FAR struct tm *)alarminfo->time);
           ret = OK;
@@ -615,8 +615,9 @@ static int max326_rdalarm(FAR struct rtc_lowerhalf_s *lower,
  * Name: max326_periodic_callback
  *
  * Description:
- *   This is the function that is called from the RTC driver when the periodic
- *   wakeup goes off.  It just invokes the upper half drivers callback.
+ *   This is the function that is called from the RTC driver when the
+ *   periodic wakeup goes off. It just invokes the upper half drivers
+ *   callback.
  *
  * Input Parameters:
  *   None

--- a/arch/arm/src/max326xx/common/max326_rtc_lowerhalf.c
+++ b/arch/arm/src/max326xx/common/max326_rtc_lowerhalf.c
@@ -602,11 +602,7 @@ static int max326_rdalarm(FAR struct rtc_lowerhalf_s *lower,
 
            /* Convert to struct rtc_time (aka struct tm) */
 
-#ifdef CONFIG_LIBC_LOCALTIME
           localtime_r(&sec, (FAR struct tm *)alarminfo->time);
-#else
-          gmtime_r(&sec, (FAR struct tm *)alarminfo->time);
-#endif
           ret = OK;
         }
     }

--- a/arch/renesas/src/rx65n/rx65n_rtc.c
+++ b/arch/renesas/src/rx65n/rx65n_rtc.c
@@ -774,7 +774,6 @@ int up_rtc_settime(FAR const struct timespec *tp)
 
   /* Day of the week (0-6, 0=Sunday) */
 
-#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
   RTC.RWKCNT.BYTE = rtc_dec2bcd((uint8_t) newtime.tm_wday);
 
   /* WAIT_LOOP */
@@ -783,7 +782,6 @@ int up_rtc_settime(FAR const struct timespec *tp)
     {
       dummy_byte = RTC.RWKCNT.BYTE;
     }
-#endif
 
   /* Day of the month (1-31) */
 
@@ -1355,9 +1353,7 @@ int up_rtc_getdatetime(FAR struct tm *tp)
 
       /* Days since Sunday (0-6) */
 
-#if defined(CONFIG_LIBC_LOCALTIME) || defined(CONFIG_TIME_EXTENDED)
-    tp->tm_wday = (int) (RTC.RWKCNT.BYTE & 0x07u);
-#endif
+      tp->tm_wday = (int) (RTC.RWKCNT.BYTE & 0x07u);
       rtc_dumptime(tp, "Returning");
     }
 

--- a/drivers/timers/ds3231.c
+++ b/drivers/timers/ds3231.c
@@ -425,20 +425,11 @@ int up_rtc_settime(FAR const struct timespec *tp)
       newtime++;
     }
 
-#ifdef CONFIG_LIBC_LOCALTIME
   if (localtime_r(&newtime, &newtm) == NULL)
     {
       rtcerr("ERROR: localtime_r failed\n");
       return -EINVAL;
     }
-
-#else
-  if (gmtime_r(&newtime, &newtm) == NULL)
-    {
-      rtcerr("ERROR: gmtime_r failed\n");
-      return -EINVAL;
-    }
-#endif
 
   rtc_dumptime(&newtm, "New time");
 

--- a/drivers/timers/mcp794xx.c
+++ b/drivers/timers/mcp794xx.c
@@ -426,20 +426,11 @@ int up_rtc_settime(FAR const struct timespec *tp)
       newtime++;
     }
 
-#ifdef CONFIG_LIBC_LOCALTIME
   if (localtime_r(&newtime, &newtm) == NULL)
     {
       rtcerr("ERROR: localtime_r failed\n");
       return -EINVAL;
     }
-
-#else
-  if (gmtime_r(&newtime, &newtm) == NULL)
-    {
-      rtcerr("ERROR: gmtime_r failed\n");
-      return -EINVAL;
-    }
-#endif
 
   rtc_dumptime(&newtm, "New time");
 

--- a/drivers/timers/pcf85263.c
+++ b/drivers/timers/pcf85263.c
@@ -408,20 +408,11 @@ int up_rtc_settime(FAR const struct timespec *tp)
       newtime++;
     }
 
-#ifdef CONFIG_LIBC_LOCALTIME
   if (localtime_r(&newtime, &newtm) == NULL)
     {
       rtcerr("ERROR: localtime_r failed\n")
       return -EINVAL;
     }
-
-#else
-  if (gmtime_r(&newtime, &newtm) == NULL)
-    {
-      rtcerr("ERROR: gmtime_r failed\n")
-      return -EINVAL;
-    }
-#endif
 
   rtc_dumptime(&tm, "New time");
 

--- a/include/time.h
+++ b/include/time.h
@@ -100,13 +100,6 @@
 
 #define TIME_UTC           1
 
-#ifndef CONFIG_LIBC_LOCALTIME
-/* Local time is the same as gmtime in this implementation */
-
-#  define localtime(c)     gmtime(c)
-#  define localtime_r(c,r) gmtime_r(c,r)
-#endif
-
 /********************************************************************************
  * Public Types
  ********************************************************************************/
@@ -206,10 +199,8 @@ time_t mktime(FAR struct tm *tp);
 FAR struct tm *gmtime(FAR const time_t *timep);
 FAR struct tm *gmtime_r(FAR const time_t *timep, FAR struct tm *result);
 
-#ifdef CONFIG_LIBC_LOCALTIME
 FAR struct tm *localtime(FAR const time_t *timep);
 FAR struct tm *localtime_r(FAR const time_t *timep, FAR struct tm *result);
-#endif
 
 size_t strftime(FAR char *s, size_t max, FAR const char *format,
                 FAR const struct tm *tm);

--- a/libs/libc/time/lib_ctime.c
+++ b/libs/libc/time/lib_ctime.c
@@ -64,7 +64,6 @@
 
 FAR char *ctime(FAR const time_t *timep)
 {
-#ifdef CONFIG_LIBC_LOCALTIME
   /* Section 4.12.3.2 of X3.159-1989 requires that
    *    The ctime function converts the calendar time pointed to by timer
    *    to local time in the form of a string. It is equivalent to
@@ -72,7 +71,4 @@ FAR char *ctime(FAR const time_t *timep)
    */
 
   return asctime(localtime(timep));
-#else
-  return asctime(gmtime(timep));
-#endif
 }

--- a/libs/libc/time/lib_ctimer.c
+++ b/libs/libc/time/lib_ctimer.c
@@ -71,9 +71,5 @@ FAR char *ctime_r(FAR const time_t *timep, FAR char *buf)
 {
   struct tm tm;
 
-#ifdef CONFIG_LIBC_LOCALTIME
   return asctime_r(localtime_r(timep, &tm), buf);
-#else
-  return asctime_r(gmtime_r(timep, &tm), buf);
-#endif
 }

--- a/libs/libc/time/lib_gmtime.c
+++ b/libs/libc/time/lib_gmtime.c
@@ -57,8 +57,15 @@
  *
  ****************************************************************************/
 
-struct tm *gmtime(const time_t *timer)
+FAR struct tm *gmtime(FAR const time_t *timep)
 {
   static struct tm tm;
-  return gmtime_r(timer, &tm);
+  return gmtime_r(timep, &tm);
 }
+
+#ifndef CONFIG_LIBC_LOCALTIME
+FAR struct tm *localtime(FAR const time_t *timep)
+{
+  return gmtime(timep);
+}
+#endif

--- a/libs/libc/time/lib_gmtimer.c
+++ b/libs/libc/time/lib_gmtimer.c
@@ -301,7 +301,7 @@ static void clock_utc2calendar(time_t days, FAR int *year, FAR int *month,
  *
  ****************************************************************************/
 
-FAR struct tm *gmtime_r(FAR const time_t *timer, FAR struct tm *result)
+FAR struct tm *gmtime_r(FAR const time_t *timep, FAR struct tm *result)
 {
   time_t epoch;
   time_t jdn;
@@ -314,7 +314,7 @@ FAR struct tm *gmtime_r(FAR const time_t *timer, FAR struct tm *result)
 
   /* Get the seconds since the EPOCH */
 
-  epoch = *timer;
+  epoch = *timep;
   linfo("timer=%d\n", (int)epoch);
 
   /* Convert to days, hours, minutes, and seconds since the EPOCH */
@@ -357,3 +357,10 @@ FAR struct tm *gmtime_r(FAR const time_t *timer, FAR struct tm *result)
 
   return result;
 }
+
+#ifndef CONFIG_LIBC_LOCALTIME
+FAR struct tm *localtime_r(FAR const time_t *timep, FAR struct tm *result)
+{
+  return gmtime_r(timep, result);
+}
+#endif

--- a/libs/libc/time/lib_gmtimer.c
+++ b/libs/libc/time/lib_gmtimer.c
@@ -273,14 +273,14 @@ static void clock_utc2calendar(time_t days, FAR int *year, FAR int *month,
     }
   while (min < max);
 
-  /* The selected month number is in value. Subtract the number of days in the
-   * selected month
+  /* The selected month number is in value. Subtract the number of days in
+   * the selected month
    */
 
   days -= clock_daysbeforemonth(value, leapyear);
 
-  /* At this point, value has the month into this year (zero based) and days has
-   * number of days into this month (zero based)
+  /* At this point, value has the month into this year (zero based) and days
+   * has number of days into this month (zero based)
    */
 
   *month = value + 1; /* 1-based */


### PR DESCRIPTION
## Summary
since libc++ declare these function in ctime by:
```
using ::localtime[_r];
```

## Impact

## Testing

