### PR TITLE
Update the boards matrix to add AVR builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, mips-riscv-x86-xtensa, sim]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, avr-mips-riscv-x86-xtensa, sim]
 
     steps:
       - name: Fetch Cached Source
@@ -188,7 +188,7 @@ jobs:
     needs: Fetch-Source
     strategy:
       matrix:
-        boards: [arm-12, mips-riscv-x86-xtensa, sim]
+        boards: [arm-12, avr-mips-riscv-x86-xtensa, sim]
     steps:
       - name: Fetch Cached Source
         id: cache-source


### PR DESCRIPTION
## Summary
The checks are failing because the change is only in testing/.  This updates nuttx/.
## Impact

## Testing

