### PR TITLE
arch: Change --print-file-name=libgcc.a to --print-libgcc-file-name

### DIFF
--- a/arch/arm/src/arm/Toolchain.defs
+++ b/arch/arm/src/arm/Toolchain.defs
@@ -91,7 +91,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L ${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}
+EXTRA_LIBPATHS += -L ${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -85,7 +85,7 @@ MAXOPTIMIZATION ?= -Os
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -109,7 +109,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -145,7 +145,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/arm/src/armv7-r/Toolchain.defs
+++ b/arch/arm/src/armv7-r/Toolchain.defs
@@ -91,7 +91,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -135,7 +135,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -136,7 +136,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/avr/src/avr32/Toolchain.defs
+++ b/arch/avr/src/avr32/Toolchain.defs
@@ -54,7 +54,7 @@ ARCHCPUFLAGS = -mpart=uc3b0256
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/hc/src/Makefile
+++ b/arch/hc/src/Makefile
@@ -103,7 +103,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/mips/src/mips32/Toolchain.defs
+++ b/arch/mips/src/mips32/Toolchain.defs
@@ -261,10 +261,15 @@ endif
 
 # Add the builtin library
 
-EXTRA_LIBS += ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS += -lgcc
+EXTRA_LIBPATHS += -L ${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}
+
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}
+  EXTRA_LIBS += -lm
+  EXTRA_LIBPATHS += -L ${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}
 endif
+
 ifeq ($(CONFIG_CXX_LIBSUPCXX),y)
-  EXTRA_LIBS += ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a}
+  EXTRA_LIBS += lsupc++
+  EXTRA_LIBPATHS += -L ${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a}}
 endif

--- a/arch/misoc/src/lm32/Toolchain.defs
+++ b/arch/misoc/src/lm32/Toolchain.defs
@@ -95,7 +95,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/misoc/src/minerva/Toolchain.defs
+++ b/arch/misoc/src/minerva/Toolchain.defs
@@ -46,7 +46,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/or1k/src/mor1kx/Toolchain.defs
+++ b/arch/or1k/src/mor1kx/Toolchain.defs
@@ -73,7 +73,7 @@ LDSCRIPT = or1k-elf-debug.ld
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/renesas/src/Makefile
+++ b/arch/renesas/src/Makefile
@@ -96,7 +96,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/risc-v/src/rv32im/Toolchain.defs
+++ b/arch/risc-v/src/rv32im/Toolchain.defs
@@ -107,7 +107,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/risc-v/src/rv64gc/Toolchain.defs
+++ b/arch/risc-v/src/rv64gc/Toolchain.defs
@@ -87,7 +87,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -100,7 +100,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -87,7 +87,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -61,7 +61,7 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}}"
+EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm


### PR DESCRIPTION
Since the new option is more compatible with clang

## Summary

## Impact

## Testing

