### PR TITLE
net: Fix dupulicated NET_USRSOCK in Kconfig

### DIFF
--- a/net/Kconfig
+++ b/net/Kconfig
@@ -231,23 +231,6 @@ config NET_TUN_PKTSIZE
 
 endif # NET_TUN
 
-config NET_USRSOCK
-	bool "User-space networking stack API"
-	default n
-	---help---
-		Enable or disable user-space networking stack support.
-
-		User-space networking stack API allows user-space daemon to
-		provide TCP/IP stack implementation for NuttX network.
-
-		Main use for this is to allow use and integration of
-		HW-provided TCP/IP stacks for NuttX.
-
-		For example, user-space daemon can translate /dev/usrsock API
-		requests to HW TCP/IP API requests while rest of the user-space
-		can access standard socket API, with socket descriptors that
-		can be used with NuttX system calls.
-
 config NETDEV_LATEINIT
 	bool "Late driver initialization"
 	default n

--- a/net/usrsock/Kconfig
+++ b/net/usrsock/Kconfig
@@ -12,6 +12,17 @@ config NET_USRSOCK
 	---help---
 		Enable or disable user-space networking stack support.
 
+		User-space networking stack API allows user-space daemon to
+		provide TCP/IP stack implementation for NuttX network.
+
+		Main use for this is to allow use and integration of
+		HW-provided TCP/IP stacks for NuttX.
+
+		For example, user-space daemon can translate /dev/usrsock API
+		requests to HW TCP/IP API requests while rest of the user-space
+		can access standard socket API, with socket descriptors that
+		can be used with NuttX system calls.
+
 if NET_USRSOCK
 
 config NET_USRSOCK_CONNS


### PR DESCRIPTION
## Summary

- We found that NET_USRSOCK is duplicated in Kconfig
- This PR fixes this issue

## Impact

- I think we have no impacts 

## Testing

- I checked spresense:wifi
