### PR TITLE
fs/nxffs: Fix scan good block slowly and scan an invalid block

### DIFF
--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -495,7 +495,11 @@ int nxffs_limits(FAR struct nxffs_volume_s *volume)
         }
       else
         {
-          offset += nerased + 1;
+          volume->ioblock += 1;
+          volume->iooffset = SIZEOF_NXFFS_BLOCK_HDR;
+
+          offset = volume->ioblock * volume->geo.blocksize +
+                   volume->iooffset;
           nerased = 0;
         }
     }


### PR DESCRIPTION
## Summary

I am in charge of porting ESP32 SPI flash driver to NuttX, and I develop it as MTD. I mount the SPI Flash MTD to NxFFS, then test it with nuttx-app/fstest.

The first testing is success, but the second testing fail. I open the debug information and found that the scanning function find the invalid "block" as start block and write data fail.

I add the following scanning algorithm:

1. scan the block to find "block header"
2. at offset 5 of block, try to find continue 128 data of 0xff
3. if fail. then read and check next block
4. if OK, mark it as first good block

## Impact

1. scan faster
2. fix scanning an invalid block

## Testing

Test nuttx-app/fstest for multi time.