### PR TITLE
binfmt: Fix warning: unused variable ‘exidx’

### DIFF
--- a/binfmt/libelf/libelf_load.c
+++ b/binfmt/libelf/libelf_load.c
@@ -248,7 +248,7 @@ static inline int elf_loadfile(FAR struct elf_loadinfo_s *loadinfo)
 int elf_load(FAR struct elf_loadinfo_s *loadinfo)
 {
   size_t heapsize;
-#ifdef CONFIG_CXX_EXCEPTION
+#ifdef CONFIG_ELF_EXIDX_SECTNAME
   int exidx;
 #endif
   int ret;


### PR DESCRIPTION
## Summary
Minor change.

## Impact
No

## Testing

