### PR TITLE
arch/Toolchain.defs: Change all ARCROSSDEV to CROSSDEV

### DIFF
--- a/arch/arm/src/arm/Toolchain.defs
+++ b/arch/arm/src/arm/Toolchain.defs
@@ -55,8 +55,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -72,10 +70,8 @@ endif
 ifeq ($(CONFIG_ARM_TOOLCHAIN),BUILDROOT)
 ifeq ($(CONFIG_ARM_OABI_TOOLCHAIN),y)
   CROSSDEV ?= arm-nuttx-elf-
-  ARCROSSDEV ?= arm-nuttx-elf-
 else
   CROSSDEV ?= arm-nuttx-eabi-
-  ARCROSSDEV ?= arm-nuttx-eabi-
 endif
   MAXOPTIMIZATION ?= -Os
 endif
@@ -84,7 +80,6 @@ endif
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= arm-none-eabi-
-  ARCROSSDEV ?= arm-none-eabi-
   MAXOPTIMIZATION ?= -Os
 endif
 
@@ -95,8 +90,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -49,8 +49,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -65,7 +63,6 @@ endif
 
 ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),BUILDROOT)
   CROSSDEV ?= arm-nuttx-eabi-
-  ARCROSSDEV ?= arm-nuttx-eabi-
   ARCHCPUFLAGS = -mcpu=cortex-m0 -mthumb -mfloat-abi=soft
 endif
 
@@ -73,7 +70,6 @@ endif
 
 ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= arm-none-eabi-
-  ARCROSSDEV ?= arm-none-eabi-
   ARCHCPUFLAGS = -mcpu=cortex-m0 -mthumb -mfloat-abi=soft
 endif
 
@@ -89,8 +85,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -49,8 +49,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -90,10 +88,8 @@ endif
 ifeq ($(CONFIG_ARMV7A_TOOLCHAIN),BUILDROOT)
 ifeq ($(CONFIG_ARMV7A_OABI_TOOLCHAIN),y)
   CROSSDEV ?= $(TARGET_ARCH)-nuttx-elf-
-  ARCROSSDEV ?= $(TARGET_ARCH)-nuttx-elf-
 else
   CROSSDEV ?= $(TARGET_ARCH)-nuttx-eabi-
-  ARCROSSDEV ?= $(TARGET_ARCH)-nuttx-eabi-
 endif
   MAXOPTIMIZATION ?= -Os
 endif
@@ -102,7 +98,6 @@ endif
 
 ifeq ($(CONFIG_ARMV7A_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= $(TARGET_ARCH)-none-eabi-
-  ARCROSSDEV ?= $(TARGET_ARCH)-none-eabi-
   MAXOPTIMIZATION ?= -Os
 endif
 
@@ -113,8 +108,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -63,8 +63,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -114,11 +112,9 @@ endif
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),BUILDROOT)
 ifeq ($(CONFIG_ARMV7M_OABI_TOOLCHAIN),y)
   CROSSDEV ?= arm-nuttx-elf-
-  ARCROSSDEV ?= arm-nuttx-elf-
   ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) $(TOOLCHAIN_MFLOAT)
 else
   CROSSDEV ?= arm-nuttx-eabi-
-  ARCROSSDEV ?= arm-nuttx-eabi-
   ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
   MAXOPTIMIZATION ?= -Os
@@ -128,7 +124,6 @@ endif
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= arm-none-eabi-
-  ARCROSSDEV ?= arm-none-eabi-
   MAXOPTIMIZATION ?= -Os
   ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
@@ -137,7 +132,6 @@ endif
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),CLANG)
   CROSSDEV ?= arm-none-eabi-
-  ARCROSSDEV ?= arm-none-eabi-
   MAXOPTIMIZATION ?= -Os
   ARCHCPUFLAGS = -target arm-none-eabi $(TOOLCHAIN_MCPU) $(TOOLCHAIN_MFLOAT)
   CC = clang
@@ -151,8 +145,8 @@ endif
 
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/arm/src/armv7-r/Toolchain.defs
+++ b/arch/arm/src/armv7-r/Toolchain.defs
@@ -49,8 +49,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -72,10 +70,8 @@ endif
 ifeq ($(CONFIG_ARMV7R_TOOLCHAIN),BUILDROOT)
 ifeq ($(CONFIG_ARMV7R_OABI_TOOLCHAIN),y)
   CROSSDEV ?= $(TARGET_ARCH)-nuttx-elf-
-  ARCROSSDEV ?= $(TARGET_ARCH)-nuttx-elf-
 else
   CROSSDEV ?= $(TARGET_ARCH)-nuttx-eabi-
-  ARCROSSDEV ?= $(TARGET_ARCH)-nuttx-eabi-
 endif
   MAXOPTIMIZATION ?= -Os
 endif
@@ -84,7 +80,6 @@ endif
 
 ifeq ($(CONFIG_ARMV7R_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= $(TARGET_ARCH)-none-eabi-
-  ARCROSSDEV ?= $(TARGET_ARCH)-none-eabi-
   MAXOPTIMIZATION ?= -Os
 endif
 
@@ -95,8 +90,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -63,8 +63,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -104,11 +102,9 @@ endif
 ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),BUILDROOT)
 ifeq ($(CONFIG_ARMV8M_OABI_TOOLCHAIN),y)
   CROSSDEV ?= arm-nuttx-elf-
-  ARCROSSDEV ?= arm-nuttx-elf-
   ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) $(TOOLCHAIN_MFLOAT)
 else
   CROSSDEV ?= arm-nuttx-eabi-
-  ARCROSSDEV ?= arm-nuttx-eabi-
   ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
   MAXOPTIMIZATION ?= -Os
@@ -118,7 +114,6 @@ endif
 
 ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= arm-none-eabi-
-  ARCROSSDEV ?= arm-none-eabi-
   MAXOPTIMIZATION ?= -Os
   ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
@@ -127,7 +122,6 @@ endif
 
 ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),CLANG)
   CROSSDEV ?= arm-none-eabi-
-  ARCROSSDEV ?= arm-none-eabi-
   MAXOPTIMIZATION ?= -Os
   ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
@@ -139,8 +133,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -140,8 +140,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/avr/src/avr32/Toolchain.defs
+++ b/arch/avr/src/avr32/Toolchain.defs
@@ -58,8 +58,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/mips/src/mips32/Toolchain.defs
+++ b/arch/mips/src/mips32/Toolchain.defs
@@ -108,8 +108,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -266,8 +264,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/misoc/src/lm32/Toolchain.defs
+++ b/arch/misoc/src/lm32/Toolchain.defs
@@ -64,8 +64,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -80,7 +78,6 @@ endif
 
 ifeq ($(CONFIG_LM32_TOOLCHAIN),BUILDROOT)
   CROSSDEV ?= lm32-nuttx-elf-
-  ARCROSSDEV ?= lm32-nuttx-elf-
   MAXOPTIMIZATION ?= -Os
 endif
 
@@ -88,7 +85,6 @@ endif
 
 ifeq ($(CONFIG_LM32_TOOLCHAIN),GNUL)
   CROSSDEV ?= lm32-elf-
-  ARCROSSDEV ?= lm32-elf-
   MAXOPTIMIZATION ?= -Os
 endif
 
@@ -99,8 +95,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/misoc/src/minerva/Toolchain.defs
+++ b/arch/misoc/src/minerva/Toolchain.defs
@@ -36,7 +36,6 @@
 ############################################################################
 
 CROSSDEV = riscv32-unknown-elf-
-ARCROSSDEV = riscv32-unknown-elf-
 ARCHCPUFLAGS = -march=rv32i
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),)
@@ -50,8 +49,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/or1k/src/mor1kx/Toolchain.defs
+++ b/arch/or1k/src/mor1kx/Toolchain.defs
@@ -41,8 +41,6 @@
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -77,8 +75,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/risc-v/src/rv32im/Toolchain.defs
+++ b/arch/risc-v/src/rv32im/Toolchain.defs
@@ -62,8 +62,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -78,7 +76,6 @@ endif
 
 ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
   CROSSDEV ?= riscv64-unknown-elf-
-  ARCROSSDEV ?= riscv64-unknown-elf-
   ifeq ($(CONFIG_ARCH_FPU),y)
       ARCHCPUFLAGS = -march=rv32imf -mabi=ilp32f
   else
@@ -93,7 +90,6 @@ endif
 
 ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RISCY)
   CROSSDEV ?= riscv32-unknown-elf-
-  ARCROSSDEV ?= riscv32-unknown-elf-
   ARCHCPUFLAGS = -march=rv32imcxgap8 -mPE=8 -mFC=1 -D__riscv__ -D__pulp__ -D__GAP8__
 endif
 
@@ -111,8 +107,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/risc-v/src/rv64gc/Toolchain.defs
+++ b/arch/risc-v/src/rv64gc/Toolchain.defs
@@ -58,8 +58,6 @@ endif
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -74,7 +72,6 @@ endif
 
 ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
   CROSSDEV ?= riscv64-unknown-elf-
-  ARCROSSDEV ?= riscv64-unknown-elf-
 endif
 
 # Individual tools may limit the optimization level but, by default, the
@@ -91,8 +88,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -39,8 +39,6 @@
 # Each toolchain definition should set:
 #
 #  CROSSDEV         The GNU toolchain triple (command prefix)
-#  ARCROSSDEV       If required, an alternative prefix used when
-#                   invoking ar and nm.
 #  ARCHCPUFLAGS     CPU-specific flags selecting the instruction set
 #                   FPU options, etc.
 #  MAXOPTIMIZATION  The maximum optimization level that results in
@@ -48,7 +46,6 @@
 #
 
 CROSSDEV = xtensa-esp32-elf-
-ARCROSSDEV = xtensa-esp32-elf-
 
 ARCHCPUFLAGS =
 
@@ -65,8 +62,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 


### PR DESCRIPTION
## Summary
ARCROSSDEV always equals to CROSSDEV, so it is no reason to keep ARCROSSDEV.

## Impact
No visible change.

## Testing

