### PR TITLE
sched: The secondary idle threads should call nx_idle_trampoline

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_cpustart.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpustart.c
@@ -137,7 +137,7 @@ static void appdsp_boot(void)
 
   /* Then transfer control to the IDLE task */
 
-  nx_idle_task(0, NULL);
+  nx_idle_trampoline();
 }
 
 /****************************************************************************

--- a/arch/arm/src/lc823450/lc823450_cpustart.c
+++ b/arch/arm/src/lc823450/lc823450_cpustart.c
@@ -132,7 +132,7 @@ static void cpu1_boot(void)
 
   /* Then transfer control to the IDLE task */
 
-  nx_idle_task(0, NULL);
+  nx_idle_trampoline();
 }
 
 /****************************************************************************

--- a/arch/arm/src/sam34/sam4cm_cpustart.c
+++ b/arch/arm/src/sam34/sam4cm_cpustart.c
@@ -83,6 +83,10 @@ volatile static spinlock_t g_cpu1_boot;
 extern int arm_pause_handler(int irq, void *c, FAR void *arg);
 
 /****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
  * Name: cpu1_boot
  *
  * Description:
@@ -134,7 +138,7 @@ static void cpu1_boot(void)
 
   /* Then transfer control to the IDLE task */
 
-  nx_idle_task(0, NULL);
+  nx_idle_trampoline();
 }
 
 /****************************************************************************
@@ -168,7 +172,7 @@ int up_cpu_start(int cpu)
 {
   struct tcb_s *tcb = current_task(cpu);
 
-  DPRINTF("cpu=%d\n",cpu);
+  DPRINTF("cpu=%d\n", cpu);
 
   if (cpu != 1)
     {

--- a/arch/risc-v/src/k210/k210_cpustart.c
+++ b/arch/risc-v/src/k210/k210_cpustart.c
@@ -143,7 +143,7 @@ void k210_cpu_boot(int cpu)
 
   /* Then transfer control to the IDLE task */
 
-  nx_idle_task(0, NULL);
+  nx_idle_trampoline();
 }
 
 /****************************************************************************

--- a/sched/init/init.h
+++ b/sched/init/init.h
@@ -105,25 +105,6 @@ void nx_idle_trampoline(void);
 #endif
 
 /****************************************************************************
- * Name: nx_idle_task
- *
- * Description:
- *   This is the common IDLE task for CPUs 1 through (CONFIG_SMP_NCPUS-1).
- *   It is equivalent to the CPU 0 IDLE logic in nx_start.c
- *
- * Input Parameters:
- *   Standard task arguments.
- *
- * Returned Value:
- *   This function does not return.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_SMP
-int nx_idle_task(int argc, FAR char *argv[]);
-#endif
-
-/****************************************************************************
  * Name: nx_bringup
  *
  * Description:

--- a/sched/init/nx_smpstart.c
+++ b/sched/init/nx_smpstart.c
@@ -87,32 +87,6 @@ void nx_idle_trampoline(void)
   sched_note_start(tcb);
 #endif
 
-  /* Then transfer control to the IDLE task */
-
-  nx_idle_task(0, NULL);
-
-  /* The IDLE task should never return */
-
-  DEBUGPANIC();
-}
-
-/****************************************************************************
- * Name: nx_idle_task
- *
- * Description:
- *   This is the common IDLE task for CPUs 1 through (CONFIG_SMP_NCPUS-1).
- *   It is equivalent to the CPU 0 IDLE logic in nx_start.c
- *
- * Input Parameters:
- *   Standard task arguments.
- *
- * Returned Value:
- *   This function does not return.
- *
- ****************************************************************************/
-
-int nx_idle_task(int argc, FAR char *argv[])
-{
   /* Enter the IDLE loop */
 
   sinfo("CPU%d: Beginning Idle Loop\n", this_cpu());

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -450,12 +450,12 @@ void nx_start(void)
       if (cpu > 0)
         {
           g_idletcb[cpu].cmn.start      = nx_idle_trampoline;
-          g_idletcb[cpu].cmn.entry.main = nx_idle_task;
+          g_idletcb[cpu].cmn.entry.main = (main_t)nx_idle_trampoline;
         }
       else
 #endif
         {
-          g_idletcb[cpu].cmn.start      = (start_t)nx_start;
+          g_idletcb[cpu].cmn.start      = nx_start;
           g_idletcb[cpu].cmn.entry.main = (main_t)nx_start;
         }
 


### PR DESCRIPTION
## Summary
because nx_task_idle doesn't call sched_note_start. To avoid the
same error happen again in the furture, nx_task_idle is removed.

## Impact

## Testing

