### PR TITLE
fs/smartfs: Fix file size corruption when opening with overwriting mode

### DIFF
--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -331,10 +331,11 @@ static int smartfs_open(FAR struct file *filep, const char *relpath,
 
   /* When using sector buffering, current sector with its header should
    * always be present in sf->buffer. Otherwise data corruption may arise
-   * when writing.
+   * when writing. However, this does not apply when overwriting without
+   * append mode.
    */
 
-  if (sf->currsector != SMARTFS_ERASEDSTATE_16BIT)
+  if ((sf->currsector != SMARTFS_ERASEDSTATE_16BIT) && (oflags & O_APPEND))
     {
       readwrite.logsector = sf->currsector;
       readwrite.offset    = 0;


### PR DESCRIPTION

## Summary

If a existing file is opened with overwriting mode e.g. fopen(file, "w+"),
the file size will be incorrect after writing any data to the file.
This bug is caused by previous commit 10903b5, and its changes should be
limited to only O_APPEND mode.

## Impact

All of the systems using SmartFS.
 
## Testing

Call fopen and check it's file size on Spresense board.

