### PR TITLE
net/usrsock: Add flags to sendto/recvfrom in usrsock

### DIFF
--- a/include/nuttx/net/usrsock.h
+++ b/include/nuttx/net/usrsock.h
@@ -168,6 +168,7 @@ begin_packed_struct struct usrsock_request_sendto_s
   struct usrsock_request_common_s head;
 
   int16_t usockid;
+  int32_t flags;
   uint16_t addrlen;
   uint16_t buflen;
 } end_packed_struct;
@@ -177,6 +178,7 @@ begin_packed_struct struct usrsock_request_recvfrom_s
   struct usrsock_request_common_s head;
 
   int16_t usockid;
+  int32_t flags;
   uint16_t max_buflen;
   uint16_t max_addrlen;
 } end_packed_struct;

--- a/net/usrsock/usrsock_recvfrom.c
+++ b/net/usrsock/usrsock_recvfrom.c
@@ -159,8 +159,9 @@ static uint16_t recvfrom_event(FAR struct net_driver_s *dev,
  * Name: do_recvfrom_request
  ****************************************************************************/
 
-static int do_recvfrom_request(FAR struct usrsock_conn_s *conn, size_t buflen,
-                               socklen_t addrlen)
+static int do_recvfrom_request(FAR struct usrsock_conn_s *conn,
+                               size_t buflen, socklen_t addrlen,
+                               int32_t flags)
 {
   struct usrsock_request_recvfrom_s req =
   {
@@ -182,6 +183,7 @@ static int do_recvfrom_request(FAR struct usrsock_conn_s *conn, size_t buflen,
 
   req.head.reqid = USRSOCK_REQUEST_RECVFROM;
   req.usockid = conn->usockid;
+  req.flags = flags;
   req.max_addrlen = addrlen;
   req.max_buflen = buflen;
 
@@ -397,9 +399,13 @@ ssize_t usrsock_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
       usrsock_setup_datain(conn, inbufs, ARRAY_SIZE(inbufs));
 
+      /* MSG_DONTWAIT is only use in usrsock. */
+
+      flags &= ~MSG_DONTWAIT;
+
       /* Request user-space daemon to close socket. */
 
-      ret = do_recvfrom_request(conn, len, addrlen);
+      ret = do_recvfrom_request(conn, len, addrlen, flags);
       if (ret >= 0)
         {
           /* Wait for completion of request. */

--- a/net/usrsock/usrsock_sendto.c
+++ b/net/usrsock/usrsock_sendto.c
@@ -150,7 +150,7 @@ static uint16_t sendto_event(FAR struct net_driver_s *dev, FAR void *pvconn,
 static int do_sendto_request(FAR struct usrsock_conn_s *conn,
                              FAR const void *buf, size_t buflen,
                              FAR const struct sockaddr *addr,
-                             socklen_t addrlen)
+                             socklen_t addrlen, int32_t flags)
 {
   struct usrsock_request_sendto_s req =
   {
@@ -172,6 +172,7 @@ static int do_sendto_request(FAR struct usrsock_conn_s *conn,
 
   req.head.reqid = USRSOCK_REQUEST_SENDTO;
   req.usockid = conn->usockid;
+  req.flags = flags;
   req.addrlen = addrlen;
   req.buflen = buflen;
 
@@ -376,9 +377,13 @@ ssize_t usrsock_sendto(FAR struct socket *psock, FAR const void *buf,
           goto errout_unlock;
         }
 
+      /* MSG_DONTWAIT is only use in usrsock. */
+
+       flags &= ~MSG_DONTWAIT;
+
       /* Request user-space daemon to close socket. */
 
-      ret = do_sendto_request(conn, buf, len, to, tolen);
+      ret = do_sendto_request(conn, buf, len, to, tolen, flags);
       if (ret >= 0)
         {
           /* Wait for completion of request. */


### PR DESCRIPTION
## Summary

Add flags argument to sendto/recvfrom interface in usrsock.

## Impact

## Testing

Tested by spresense:wifi