### PR TITLE
net/usrsock: Fix recv() couldn't peek data

### DIFF
--- a/net/usrsock/usrsock_recvfrom.c
+++ b/net/usrsock/usrsock_recvfrom.c
@@ -424,6 +424,15 @@ ssize_t usrsock_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
                */
 
               outaddrlen = state.valuelen_nontrunc;
+
+              /* If the MSG_PEEK flag is enabled, it will only peek
+               * from the buffer, so remark the input as ready.
+               */
+
+              if (flags & MSG_PEEK)
+                {
+                  conn->flags |= USRSOCK_EVENT_RECVFROM_AVAIL;
+                }
             }
         }
 


### PR DESCRIPTION


## Summary
* Fix a bug that recv() couldn't peek receive data. recv() would be failed by previous recv() call with MSG_PEEK.
* Fix nxstyle issue

## Impact

recv() calls

## Testing

Tested by spresense:wifi
