### PR TITLE
Fix note structure members types

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -239,14 +239,14 @@ struct note_spinlock_s
 struct note_syscall_enter_s
 {
   struct note_common_s nsc_cmn; /* Common note parameters */
-  int nsc_nr;                   /* System call number */
+  uint8_t nsc_nr;               /* System call number */
 };
 
 struct note_syscall_leave_s
 {
   struct note_common_s nsc_cmn; /* Common note parameters */
   uintptr_t nsc_result;         /* Result of the system call */
-  int nsc_nr;                   /* System call number */
+  uint8_t nsc_nr;               /* System call number */
 };
 #endif /* CONFIG_SCHED_INSTRUMENTATION_SYSCALL */
 
@@ -256,7 +256,7 @@ struct note_syscall_leave_s
 struct note_irqhandler_s
 {
   struct note_common_s nih_cmn; /* Common note parameters */
-  int nih_irq;                  /* IRQ number */
+  uint8_t nih_irq;              /* IRQ number */
 };
 #endif /* CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER */
 #endif /* CONFIG_SCHED_INSTRUMENTATION_BUFFER */

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -585,6 +585,7 @@ void sched_note_syscall_enter(int nr, int argc, ...)
 
   note_common(tcb, &note.nsc_cmn, sizeof(struct note_syscall_enter_s),
               NOTE_SYSCALL_ENTER);
+  DEBUGASSERT(nr <= UCHAR_MAX);
   note.nsc_nr = nr;
 
   /* Add the note to circular buffer */
@@ -602,6 +603,7 @@ void sched_note_syscall_leave(int nr, uintptr_t result)
   note_common(tcb, &note.nsc_cmn, sizeof(struct note_syscall_leave_s),
               NOTE_SYSCALL_LEAVE);
   note.nsc_result = result;
+  DEBUGASSERT(nr <= UCHAR_MAX);
   note.nsc_nr     = nr;
 
   /* Add the note to circular buffer */
@@ -620,6 +622,7 @@ void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
 
   note_common(tcb, &note.nih_cmn, sizeof(struct note_irqhandler_s),
               enter ? NOTE_IRQ_ENTER : NOTE_IRQ_LEAVE);
+  DEBUGASSERT(irq <= UCHAR_MAX);
   note.nih_irq = irq;
 
   /* Add the note to circular buffer */


### PR DESCRIPTION
## Summary
Fix the member types of note_syscall_enter_s, note_syscall_leave_s and note_irqhandler_s.
Because the structure is not word aligned, int member should not be used.

## Impact
Only when CONFIG_SCHED_INSTRUMENTATION_SYSCALL or CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER is enabled.

## Testing

