### PR TITLE
tools/incdir: Assume GCC compatibility for unknown compilers

### DIFF
--- a/tools/incdir.c
+++ b/tools/incdir.c
@@ -179,7 +179,6 @@ static enum compiler_e get_compiler(char *ccname, enum os_e os)
 
   if (strstr(ccname, "gcc")     != NULL ||
       strstr(ccname, "g++")     != NULL ||
-      strcmp(ccname, "cc")      == 0    ||
       strncmp(ccname, "cc.", 3) == 0)
     {
       return COMPILER_GCC;
@@ -204,8 +203,9 @@ static enum compiler_e get_compiler(char *ccname, enum os_e os)
     }
   else
     {
-      fprintf(stderr, "ERROR:  Unknown compiler: %s\n", ccname);
-      return COMPILER_UNKNOWN;
+      /* Unknown compiler. Assume GCC-compatible */
+
+      return COMPILER_GCC;
     }
 }
 


### PR DESCRIPTION
## Summary
tools/incdir: Assume GCC compatibility for unknown compilers

A use case:
    intercept-build --override-compiler make CC=intercept-cc
    cf. https://github.com/rizsotto/scan-build

## Impact
i expect no critical problems as it was treated as a failure before this change

## Testing
locally tested with "intercept-build --override-compiler make CC=intercept-cc"
