### PR TITLE
libc: Replace all malloc/free to lib_malloc/lib_free

### DIFF
--- a/libs/libc/dlfcn/lib_dlopen.c
+++ b/libs/libc/dlfcn/lib_dlopen.c
@@ -290,10 +290,12 @@ static inline FAR void *dlinsert(FAR const char *filename)
       return NULL;
     }
 
-  /* Then install the file using the basename of the file as the module name. */
+  /* Then install the file using the basename of the file as the module
+   * name.
+   */
 
   handle = insmod(filename, basename(name));
-  free(name);
+  lib_free(name);
   return handle;
 }
 #else /* if defined(CONFIG_BUILD_KERNEL) */

--- a/libs/libc/grp/lib_getgrbuf.c
+++ b/libs/libc/grp/lib_getgrbuf.c
@@ -45,6 +45,7 @@
 #include <grp.h>
 
 #include "grp/lib_grp.h"
+#include "libc.h"
 
 /****************************************************************************
  * Private Data
@@ -85,7 +86,7 @@ FAR struct group *getgrbuf(gid_t gid, FAR const char *name,
 
   buflen = sizeof(FAR char **) + strlen(name) + 1 + strlen(passwd) + 1;
 
-  newbuf = (FAR char *)realloc(g_buf, buflen);
+  newbuf = (FAR char *)lib_realloc(g_buf, buflen);
 
   if (!newbuf)
     {
@@ -97,7 +98,7 @@ FAR struct group *getgrbuf(gid_t gid, FAR const char *name,
 
   if (!g_grp)
     {
-      g_grp = (FAR struct group *)malloc(sizeof(struct group));
+      g_grp = (FAR struct group *)lib_malloc(sizeof(struct group));
     }
 
   if (!g_grp)
@@ -116,8 +117,8 @@ FAR struct group *getgrbuf(gid_t gid, FAR const char *name,
   return result;
 
 error:
-  free(g_grp);
-  free(g_buf);
+  lib_free(g_grp);
+  lib_free(g_buf);
   g_grp = NULL;
   g_buf = NULL;
   set_errno(err);

--- a/libs/libc/hex2bin/lib_hex2bin.c
+++ b/libs/libc/hex2bin/lib_hex2bin.c
@@ -42,6 +42,8 @@
 
 #include <nuttx/streams.h>
 
+#include "libc.h"
+
 #ifdef CONFIG_LIB_HEX2BIN
 
 /****************************************************************************
@@ -422,7 +424,7 @@ int hex2bin(FAR struct lib_instream_s *instream,
 
   /* Allocate buffer memory */
 
-  alloc = (FAR uint8_t *)malloc(LINE_ALLOC + BIN_ALLOC);
+  alloc = (FAR uint8_t *)lib_malloc(LINE_ALLOC + BIN_ALLOC);
   if (alloc == NULL)
     {
       lerr("ERROR: Failed to allocate memory\n");
@@ -703,7 +705,7 @@ errout_with_einval:
 
 errout_with_buffers:
 exit_with_buffers:
-  free(alloc);
+  lib_free(alloc);
   return ret;
 }
 

--- a/libs/libc/pwd/lib_getpwbuf.c
+++ b/libs/libc/pwd/lib_getpwbuf.c
@@ -45,6 +45,7 @@
 #include <pwd.h>
 
 #include "pwd/lib_pwd.h"
+#include "libc.h"
 
 /****************************************************************************
  * Private Data
@@ -87,7 +88,7 @@ FAR struct passwd *getpwbuf(uid_t uid, gid_t gid, FAR const char *name,
 
   buflen = strlen(name) + 1 + strlen(dir) + 1 + strlen(shell) + 1;
 
-  newbuf = (FAR char *)realloc(g_buf, buflen);
+  newbuf = (FAR char *)lib_realloc(g_buf, buflen);
 
   if (!newbuf)
     {
@@ -99,7 +100,7 @@ FAR struct passwd *getpwbuf(uid_t uid, gid_t gid, FAR const char *name,
 
   if (!g_pwd)
     {
-      g_pwd = (FAR struct passwd *)malloc(sizeof(struct passwd));
+      g_pwd = (FAR struct passwd *)lib_malloc(sizeof(struct passwd));
     }
 
   if (!g_pwd)
@@ -108,7 +109,8 @@ FAR struct passwd *getpwbuf(uid_t uid, gid_t gid, FAR const char *name,
       goto error;
     }
 
-  err = getpwbuf_r(uid, gid, name, dir, shell, g_pwd, g_buf, buflen, &result);
+  err = getpwbuf_r(uid, gid, name, dir, shell,
+                   g_pwd, g_buf, buflen, &result);
 
   if (err)
     {
@@ -118,8 +120,8 @@ FAR struct passwd *getpwbuf(uid_t uid, gid_t gid, FAR const char *name,
   return result;
 
 error:
-  free(g_pwd);
-  free(g_buf);
+  lib_free(g_pwd);
+  lib_free(g_buf);
   g_pwd = NULL;
   g_buf = NULL;
   set_errno(err);

--- a/libs/libc/stdio/lib_tempnam.c
+++ b/libs/libc/stdio/lib_tempnam.c
@@ -43,6 +43,8 @@
 #include <stdlib.h>
 #include <errno.h>
 
+#include "libc.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -97,7 +99,7 @@ FAR char *tempnam(FAR const char *dir, FAR const char *pfx)
           return path;
         }
 
-      free(path);
+      lib_free(path);
     }
 
   set_errno(ENOMEM);

--- a/libs/libc/stdio/lib_vasprintf.c
+++ b/libs/libc/stdio/lib_vasprintf.c
@@ -105,7 +105,7 @@ int vasprintf(FAR char **ptr, FAR const IPTR char *fmt, va_list ap)
    * for the null terminator.
    */
 
-  buf = (FAR char *)malloc(nulloutstream.nput + 1);
+  buf = (FAR char *)lib_malloc(nulloutstream.nput + 1);
   if (!buf)
     {
       va_end(ap);
@@ -125,16 +125,15 @@ int vasprintf(FAR char **ptr, FAR const IPTR char *fmt, va_list ap)
 
   /* Then let lib_vsprintf do it's real thing */
 
-  nbytes = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.public,
 #ifdef va_copy
+  nbytes = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.public,
                         fmt, ap2);
+  va_end(ap2);
 #else
+  nbytes = lib_vsprintf((FAR struct lib_outstream_s *)&memoutstream.public,
                         fmt, ap);
 #endif
 
-#ifdef va_copy
-  va_end(ap2);
-#endif
   va_end(ap);
 
   /* Return a pointer to the string to the caller.  NOTE: the memstream put()

--- a/libs/libc/stdlib/lib_realpath.c
+++ b/libs/libc/stdlib/lib_realpath.c
@@ -30,6 +30,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "libc.h"
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -62,7 +64,7 @@ FAR char *realpath(FAR const char *path, FAR char *resolved)
 
   if (resolved == NULL)
     {
-      fres = resolved = malloc(PATH_MAX);
+      fres = resolved = lib_malloc(PATH_MAX);
       if (resolved == NULL)
         {
           return NULL;
@@ -230,6 +232,6 @@ loop:
   goto loop;
 
 out:
-  free(fres);
+  lib_free(fres);
   return NULL;
 }

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -60,6 +60,8 @@
 
 #include <nuttx/fs/fs.h>
 
+#include "libc.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -544,7 +546,7 @@ static int tzload(FAR const char *name,
   int doaccess;
   union local_storage *lsp;
 
-  lsp = malloc(sizeof *lsp);
+  lsp = lib_malloc(sizeof *lsp);
   if (!lsp)
     {
       return -1;
@@ -897,11 +899,11 @@ static int tzload(FAR const char *name,
     }
 
   sp->defaulttype = i;
-  free(up);
+  lib_free(up);
   return 0;
 
 oops:
-  free(up);
+  lib_free(up);
   return -1;
 }
 
@@ -1646,7 +1648,7 @@ static void tzsetwall(void)
 
   if (lclptr == NULL)
     {
-      lclptr = malloc(sizeof *lclptr);
+      lclptr = lib_malloc(sizeof *lclptr);
       if (lclptr == NULL)
         {
           settzname();          /* all we can do */
@@ -1791,7 +1793,7 @@ static struct tm *gmtsub(FAR const time_t * const timep,
 {
   if (!g_gmt_isset)
     {
-      gmtptr = malloc(sizeof *gmtptr);
+      gmtptr = lib_malloc(sizeof *gmtptr);
       g_gmt_isset = gmtptr != NULL;
       if (g_gmt_isset)
         {
@@ -2510,7 +2512,7 @@ void tzset(void)
 
   if (lclptr == NULL)
     {
-      lclptr = malloc(sizeof *lclptr);
+      lclptr = lib_malloc(sizeof *lclptr);
       if (lclptr == NULL)
         {
           settzname(); /* all we can do */

--- a/libs/libc/unistd/lib_execl.c
+++ b/libs/libc/unistd/lib_execl.c
@@ -44,11 +44,14 @@
 #include <unistd.h>
 #include <errno.h>
 
+#include "libc.h"
+
 #ifdef CONFIG_LIBC_EXECFUNCS
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* This is an artificial limit to detect error conditions where an argv[]
  * list is not properly terminated.
  */
@@ -96,11 +99,12 @@
  *   The non-standard binfmt function 'exec()' needs to have (1) a symbol
  *   table that provides the list of symbols exported by the base code, and
  *   (2) the number of symbols in that table.  This information is currently
- *   provided to 'exec()' from 'exec[l|v]()' via NuttX configuration settings:
+ *   provided to 'exec()' from 'exec[l|v]()' via NuttX configuration setting:
  *
  *     CONFIG_LIBC_EXECFUNCS         : Enable exec[l|v] support
  *     CONFIG_EXECFUNCS_SYMTAB_ARRAY : Symbol table name used by exec[l|v]
- *     CONFIG_EXECFUNCS_NSYMBOLS_VAR : Variable holding number of symbols in the table
+ *     CONFIG_EXECFUNCS_NSYMBOLS_VAR : Variable holding number of symbols in
+ *                                     the table
  *
  *   As a result of the above, the current implementations of 'execl()' and
  *   'execv()' suffer from some incompatibilities that may or may not be
@@ -166,7 +170,7 @@ int execl(FAR const char *path, ...)
 
   if (nargs > 0)
     {
-      argv = (FAR char **)malloc((nargs + 1) * sizeof(FAR char *));
+      argv = (FAR char **)lib_malloc((nargs + 1) * sizeof(FAR char *));
       if (argv == (FAR char **)NULL)
         {
           set_errno(ENOMEM);
@@ -193,7 +197,7 @@ int execl(FAR const char *path, ...)
 
   if (argv)
     {
-      free(argv);
+      lib_free(argv);
     }
 
   return ret;

--- a/libs/libc/userfs/lib_userfs.c
+++ b/libs/libc/userfs/lib_userfs.c
@@ -56,6 +56,8 @@
 #include <nuttx/fs/userfs.h>
 #include <nuttx/semaphore.h>
 
+#include "libc.h"
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -939,7 +941,7 @@ int userfs_run(FAR const char *mountpt,
    */
 
   iolen = USERFS_REQ_MAXSIZE + mxwrite;
-  info  = (FAR struct userfs_info_s *)zalloc(SIZEOF_USERFS_INFO_S(iolen));
+  info  = lib_zalloc(SIZEOF_USERFS_INFO_S(iolen));
   if (info == NULL)
     {
       ferr("ERROR: Failed to allocate state structure\n");
@@ -1165,6 +1167,6 @@ errout_with_sockfd:
   /* Free the IO Buffer */
 
 errout_with_info:
-  free(info);
+  lib_free(info);
   return ret;
 }


### PR DESCRIPTION
## Summary
Since code inside libc shouldn't call malloc/free directly.

## Impact

## Testing

