### PR TITLE
drivers: wireless: Fix null pointer dereference in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -1425,14 +1425,14 @@ static enum pkt_type_e gs2200m_recv_pkt(FAR struct gs2200m_dev_s *dev,
   if (pkt_dat)
     {
       pkt_dat->type = t;
-    }
 
-  if (pkt_dat->type == TYPE_BULK_DATA_TCP ||
-      pkt_dat->type == TYPE_BULK_DATA_UDP)
-    {
-      /* Update total bulk data size */
+      if (t == TYPE_BULK_DATA_TCP ||
+          t == TYPE_BULK_DATA_UDP)
+        {
+          /* Update total bulk data size */
 
-      dev->total_bulk += pkt_dat->len;
+          dev->total_bulk += pkt_dat->len;
+        }
     }
 
 errout:


### PR DESCRIPTION
## Summary

- This PR fixes null pointer dereference in gs2200m.c

## Impact

- This PR affects gs2200m driver.

## Testing

- Use spresense:wifi and run gs2200m daemon in STA mode.
- Then execute 'renew eth0' to obtain DHCP address.


