### PR TITLE
arch/sim: Fix the linkage of up_irqinitialize mismatch

### DIFF
--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -47,6 +47,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* No interrupts */
 
 #define NR_IRQS 0
@@ -54,11 +55,11 @@
 /* Number of registers saved in context switch */
 
 #if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
-   /* Storage order: %rbx, %rsp, %rbp, %r12, %r13, %r14, %r15, %rip */
+  /* Storage order: %rbx, %rsp, %rbp, %r12, %r13, %r14, %r15, %rip */
 
 #  define XCPTCONTEXT_REGS    8
 #elif defined(CONFIG_HOST_X86) || defined(CONFIG_SIM_M32)
-   /* Storage order: %ebx, %esi, %edi, %ebp, sp, and return PC */
+  /* Storage order: %ebx, %esi, %edi, %ebp, sp, and return PC */
 
 #  define XCPTCONTEXT_REGS    6
 #elif defined(CONFIG_HOST_ARM)
@@ -81,9 +82,9 @@ typedef int xcpt_reg_t;
 
 struct xcptcontext
 {
-   void *sigdeliver; /* Actual type is sig_deliver_t */
+  void *sigdeliver; /* Actual type is sig_deliver_t */
 
-   xcpt_reg_t regs[XCPTCONTEXT_REGS];
+  xcpt_reg_t regs[XCPTCONTEXT_REGS];
 };
 #endif
 
@@ -92,6 +93,14 @@ struct xcptcontext
  ****************************************************************************/
 
 #ifndef __ASSEMBLY__
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
 
 /****************************************************************************
  * Name: up_irqinitialize
@@ -118,27 +127,11 @@ static inline irqstate_t up_irq_save(void)
 static inline void up_irq_restore(irqstate_t flags)
 {
 }
-#endif
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-/****************************************************************************
- * Public Function Prototypes
- ****************************************************************************/
-
-#ifdef __cplusplus
-#define EXTERN extern "C"
-extern "C"
-{
-#else
-#define EXTERN extern
-#endif
 
 #undef EXTERN
 #ifdef __cplusplus
 }
 #endif
 
+#endif /* !__ASSEMBLY__ */
 #endif /* __ARCH_SIM_INCLUDE_IRQ_H */


### PR DESCRIPTION
## Summary
```
include/arch/irq.h:100:20: note: previous declaration with ‘C++’ linkage
  100 | static inline void up_irqinitialize(void)
      |                    ^~~~~~~~~~~~~~~~
In file included from include/ctype.h:45,
                 from include/libcxx/ctype.h:38,
                 from include/libcxx/cctype:38,
                 from include/libcxx/cwctype:53,
                 from include/libcxx/cwchar:106,
                 from include/libcxx/string:510,
                 from libcxx/src/debug.cpp:13:
include/nuttx/arch.h:1343:6: error: conflicting declaration of ‘void up_irqinitialize()’ with ‘C’ linkage
 1343 | void up_irqinitialize(void);
      |      ^~~~~~~~~~~~~~~~
```

## Impact
No functionality change.

## Testing

