### PR TITLE
Remove some of redundant assignments reported by clang-check

### DIFF
--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -1078,8 +1078,6 @@ static int hostfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
 
   /* Check if there are sill any files opened on the filesystem. */
 
-  ret = OK; /* Assume success */
-
   ret = hostfs_semtake(fs);
   if (ret < 0)
     {

--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -284,7 +284,7 @@ int nx_mount(FAR const char *source, FAR const char *target,
 
 #ifdef BDFS_SUPPORT
   if (source != NULL &&
-      (ret = find_blockdriver(source, mountflags, &drvr_inode)) >= 0)
+      find_blockdriver(source, mountflags, &drvr_inode) >= 0)
     {
       /* Find the block based file system */
 

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -428,7 +428,6 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
       offset     = rf->rf_startoffset + filep->f_pos;
       sector     = SEC_NSECTORS(rm, offset);
       sectorndx  = offset & SEC_NDXMASK(rm);
-      bytesread  = 0;
 
       /* Check if the user has provided a buffer large enough to
        * hold one or more complete sectors -AND- the read is
@@ -452,7 +451,6 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
               goto errout_with_semaphore;
             }
 
-          sector    += nsectors;
           bytesread  = nsectors * rm->rm_hwsectorsize;
         }
       else
@@ -478,12 +476,6 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
               /* We will not read to the end of the buffer */
 
               bytesread = buflen;
-            }
-          else
-            {
-              /* We will read to the end of the buffer (or beyond) */
-
-             sector++;
             }
 
           finfo("Return %d bytes from sector offset %d\n",


### PR DESCRIPTION
## Summary
Fix a set of redundant assignments reported by clang-check
## Impact
* less code
* can introduce bugs
## Testing
compile-tested only