### PR TITLE
libc: Avoid ctype function to evaluate the argument more than once

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -24,6 +24,7 @@ include aio/Make.defs
 include assert/Make.defs
 include audio/Make.defs
 include builtin/Make.defs
+include ctype/Make.defs
 include dirent/Make.defs
 include dlfcn/Make.defs
 include endian/Make.defs

--- a/libs/libc/ctype/Make.defs
+++ b/libs/libc/ctype/Make.defs
@@ -1,0 +1,26 @@
+############################################################################
+# libs/libc/ctype/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+CSRCS += lib_ctype.c lib_isblank.c lib_tolower.c lib_toupper.c
+
+# Add the ctype directory to the build
+
+DEPPATH += --dep-path ctype
+VPATH += :ctype

--- a/libs/libc/ctype/lib_ctype.c
+++ b/libs/libc/ctype/lib_ctype.c
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * libs/libc/assert/lib_ctype.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const IOBJ char _ctype_[1 + 256 + 1] =
+{
+  0,
+  _C,      _C,      _C,      _C,      _C,      _C,      _C,      _C,
+  _C,      _C | _S, _C | _S, _C | _S, _C | _S, _C | _S, _C,      _C,
+  _C,      _C,      _C,      _C,      _C,      _C,      _C,      _C,
+  _C,      _C,      _C,      _C,      _C,      _C,      _C,      _C,
+  _S | _B, _P,      _P,      _P,      _P,      _P,      _P,      _P,
+  _P,      _P,      _P,      _P,      _P,      _P,      _P,      _P,
+  _N,      _N,      _N,      _N,      _N,      _N,      _N,      _N,
+  _N,      _N,      _P,      _P,      _P,      _P,      _P,      _P,
+  _P,      _U | _X, _U | _X, _U | _X, _U | _X, _U | _X, _U | _X, _U,
+  _U,      _U,      _U,      _U,      _U,      _U,      _U,      _U,
+  _U,      _U,      _U,      _U,      _U,      _U,      _U,      _U,
+  _U,      _U,      _U,      _P,      _P,      _P,      _P,      _P,
+  _P,      _L | _X, _L | _X, _L | _X, _L | _X, _L | _X, _L | _X, _L,
+  _L,      _L,      _L,      _L,      _L,      _L,      _L,      _L,
+  _L,      _L,      _L,      _L,      _L,      _L,      _L,      _L,
+  _L,      _L,      _L,      _P,      _P,      _P,      _P,      _C,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0,       0,       0,       0,       0,       0,       0,       0,
+  0
+};
+
+/* +1 because we want for mapping EOF to _ctype_[0] */
+
+const IPTR char *const __ctype_ = _ctype_ + 1;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/libs/libc/ctype/lib_isblank.c
+++ b/libs/libc/ctype/lib_isblank.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isblank.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isblank(int c)
+{
+  return (__ctype_lookup(c) & _B) || c == '\t';
+}

--- a/libs/libc/ctype/lib_tolower.c
+++ b/libs/libc/ctype/lib_tolower.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_tolower.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int tolower(int c)
+{
+  return isupper(c) ? (c - 'A' + 'a') : c;
+}

--- a/libs/libc/ctype/lib_toupper.c
+++ b/libs/libc/ctype/lib_toupper.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_toupper.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int toupper(int c)
+{
+  return islower(c) ? (c - 'a' + 'A') : c;
+}


### PR DESCRIPTION
## Summary
1.Utilize the lookup table for classification
2.Change the remaining macro to normal functions
Here is the related email thread:
https://lists.apache.org/thread.html/ra2f3416909dd64c22e9a194f293a7d1450d04904f7e3f64a400829b0%40%3Cdev.nuttx.apache.org%3E

## Impact
More confirm to the standard and other libc implementation

## Testing

