### PR TITLE
Ensure the filesystem handle the tail '/' correctly

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -406,7 +406,12 @@ static FAR const struct proc_node_s *proc_findnode(FAR const char *relpath)
 
   for (i = 0; i < PROC_NNODES; i++)
     {
-      if (strcmp(g_nodeinfo[i]->relpath, relpath) == 0)
+      size_t len = strlen(g_nodeinfo[i]->relpath);
+
+      if (strncmp(g_nodeinfo[i]->relpath, relpath, len) == 0 &&
+          (relpath[len] == '\0' || (relpath[len] == '/' &&
+           relpath[len + 1] == '\0' &&
+           g_nodeinfo[i]->dtype == DTYPE_DIRECTORY)))
         {
           return g_nodeinfo[i];
         }

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -751,6 +751,11 @@ int romfs_finddirentry(struct romfs_mountpt_s *rm,
           entrylen = terminator - entryname;
         }
 
+      if (entrylen == 0)
+        {
+          return OK;
+        }
+
       /* Long path segment names will be truncated to NAME_MAX */
 
       if (entrylen > NAME_MAX)

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -660,7 +660,7 @@ static int netprocfs_stat(FAR const char *relpath, FAR struct stat *buf)
 {
   /* Check for the directory "net" */
 
-  if (strcmp(relpath, "net") == 0)
+  if (strcmp(relpath, "net") == 0 || strcmp(relpath, "net/") == 0)
     {
       buf->st_mode = S_IFDIR | S_IROTH | S_IRGRP | S_IRUSR;
     }


### PR DESCRIPTION
## Summary
During the ftw/nftw development(https://github.com/apache/incubator-nuttx/pull/1486), I found that procfs and romfs can't work handle the path with tail '/', e.g.:
/proc/net/
/proc/0/group/
Let's fix them.

## Impact

## Testing

