### PR TITLE
libc: Change ctype macro to normal function

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -49,8 +49,16 @@
 #include <nuttx/compiler.h>
 
 /****************************************************************************
- * Pre-processor Definitions
+ * Inline Functions
  ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
 
 /****************************************************************************
  * Name: isspace
@@ -69,9 +77,7 @@ static inline int isspace(int c)
          c == '\f' || c == '\v';
 }
 #else
-#  define isspace(c) \
-    ((c) == ' '  || (c) == '\t' || (c) == '\n' || (c) == '\r' || \
-     (c) == '\f' || (c) == '\v')
+int isspace(int c);
 #endif
 
 /****************************************************************************
@@ -89,7 +95,7 @@ static inline int isascii(int c)
   return c >= 0 && c <= 0x7f;
 }
 #else
-#  define isascii(c)   ((c) >= 0 && (c) <= 0x7f)
+int isascii(int c);
 #endif
 
 /****************************************************************************
@@ -106,7 +112,7 @@ static inline int isprint(int c)
   return c >= 0x20 && c < 0x7f;
 }
 #else
-#  define isprint(c)   ((c) >= 0x20 && (c) < 0x7f)
+int isprint(int c);
 #endif
 
 /****************************************************************************
@@ -123,7 +129,7 @@ static inline int isgraph(int c)
   return c > 0x20 && c < 0x7f;
 }
 #else
-#  define isgraph(c)   ((c) > 0x20 && (c) < 0x7f)
+int isgraph(int c);
 #endif
 
 /****************************************************************************
@@ -140,7 +146,7 @@ static inline int iscntrl(int c)
   return !isprint(c);
 }
 #else
-#  define iscntrl(c) (!isprint(c))
+int iscntrl(int c);
 #endif
 
 /****************************************************************************
@@ -157,7 +163,7 @@ static inline int islower(int c)
   return c >= 'a' && c <= 'z';
 }
 #else
-#  define islower(c)   ((c) >= 'a' && (c) <= 'z')
+int islower(int c);
 #endif
 
 /****************************************************************************
@@ -174,7 +180,7 @@ static inline int isupper(int c)
   return c >= 'A' && c <= 'Z';
 }
 #else
-#  define isupper(c)   ((c) >= 'A' && (c) <= 'Z')
+int isupper(int c);
 #endif
 
 /****************************************************************************
@@ -191,7 +197,7 @@ static inline int isalpha(int c)
   return islower(c) || isupper(c);
 }
 #else
-#  define isalpha(c)   (islower(c) || isupper(c))
+int isalpha(int c);
 #endif
 
 /****************************************************************************
@@ -208,7 +214,7 @@ static inline int isblank(int c)
   return c == ' ' || c == '\t';
 }
 #else
-#  define isblank(c)   ((c) == ' ' || (c) == '\t')
+int isblank(int c);
 #endif
 
 /****************************************************************************
@@ -225,7 +231,7 @@ static inline int isdigit(int c)
   return c >= '0' && c <= '9';
 }
 #else
-#  define isdigit(c)   ((c) >= '0' && (c) <= '9')
+int isdigit(int c);
 #endif
 
 /****************************************************************************
@@ -242,7 +248,7 @@ static inline int isalnum(int c)
   return isalpha(c) || isdigit(c);
 }
 #else
-#  define isalnum(c)   (isalpha(c) || isdigit(c))
+int isalnum(int c);
 #endif
 
 /****************************************************************************
@@ -260,7 +266,7 @@ static inline int ispunct(int c)
   return isgraph(c) && !isalnum(c);
 }
 #else
-#  define ispunct(c)   (isgraph(c) && !isalnum(c))
+int ispunct(int c);
 #endif
 
 /****************************************************************************
@@ -279,10 +285,7 @@ static inline int isxdigit(int c)
          (c >= 'A' && c <= 'F');
 }
 #else
-#  define isxdigit(c) \
-    (((c) >= '0' && (c) <= '9') || \
-     ((c) >= 'a' && (c) <= 'f') || \
-     ((c) >= 'A' && (c) <= 'F'))
+int isxdigit(int c);
 #endif
 
 /****************************************************************************
@@ -299,8 +302,7 @@ static inline int toupper(int c)
   return (c >= 'a' && c <= 'z') ? c - 'a' + 'A' : c;
 }
 #else
-#  define toupper(c) \
-    (((c) >= 'a' && (c) <= 'z') ? ((c) - 'a' + 'A') : (c))
+int toupper(int c);
 #endif
 
 /****************************************************************************
@@ -317,20 +319,7 @@ static inline int tolower(int c)
   return (c >= 'A' && c <= 'Z') ? (c - 'A' + 'a') : c;
 }
 #else
-#  define tolower(c) \
-    (((c) >= 'A' && (c) <= 'Z') ? ((c) - 'A' + 'a') : (c))
-#endif
-
-/****************************************************************************
- * Public Type Definitions
- ****************************************************************************/
-
-#ifdef __cplusplus
-#define EXTERN extern "C"
-extern "C"
-{
-#else
-#define EXTERN extern
+int tolower(int c);
 #endif
 
 #undef EXTERN

--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -24,6 +24,7 @@ include aio/Make.defs
 include assert/Make.defs
 include audio/Make.defs
 include builtin/Make.defs
+include ctype/Make.defs
 include dirent/Make.defs
 include dlfcn/Make.defs
 include endian/Make.defs

--- a/libs/libc/ctype/Make.defs
+++ b/libs/libc/ctype/Make.defs
@@ -1,0 +1,29 @@
+############################################################################
+# libs/libc/ctype/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Add the ctype C files to the build
+
+CSRCS += lib_isalnum.c lib_isalpha.c lib_isascii.c lib_isblank.c
+CSRCS += lib_iscntrl.c lib_isdigit.c lib_isgraph.c lib_islower.c
+CSRCS += lib_isprint.c lib_ispunct.c lib_isspace.c lib_isupper.c
+CSRCS += lib_isxdigit.c lib_tolower.c lib_toupper.c
+
+DEPPATH += --dep-path ctype
+VPATH += :ctype

--- a/libs/libc/ctype/lib_isalnum.c
+++ b/libs/libc/ctype/lib_isalnum.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isalnum.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isalnum(int c)
+{
+  return isalpha(c) || isdigit(c);
+}

--- a/libs/libc/ctype/lib_isalpha.c
+++ b/libs/libc/ctype/lib_isalpha.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isalpha.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isalpha(int c)
+{
+  return islower(c) || isupper(c);
+}

--- a/libs/libc/ctype/lib_isascii.c
+++ b/libs/libc/ctype/lib_isascii.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isascii.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isascii(int c)
+{
+  return c >= 0 && c <= 0x7f;
+}

--- a/libs/libc/ctype/lib_isblank.c
+++ b/libs/libc/ctype/lib_isblank.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isblank.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isblank(int c)
+{
+  return c == ' ' || c == '\t';
+}

--- a/libs/libc/ctype/lib_iscntrl.c
+++ b/libs/libc/ctype/lib_iscntrl.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_iscntrl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int iscntrl(int c)
+{
+  return !isprint(c);
+}

--- a/libs/libc/ctype/lib_isdigit.c
+++ b/libs/libc/ctype/lib_isdigit.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isdigit.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isdigit(int c)
+{
+  return c >= '0' && c <= '9';
+}

--- a/libs/libc/ctype/lib_isgraph.c
+++ b/libs/libc/ctype/lib_isgraph.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isgraph.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isgraph(int c)
+{
+  return c > 0x20 && c < 0x7f;
+}

--- a/libs/libc/ctype/lib_islower.c
+++ b/libs/libc/ctype/lib_islower.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_islower.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int islower(int c)
+{
+  return c >= 'a' && c <= 'z';
+}

--- a/libs/libc/ctype/lib_isprint.c
+++ b/libs/libc/ctype/lib_isprint.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isprint.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isprint(int c)
+{
+  return c >= 0x20 && c < 0x7f;
+}

--- a/libs/libc/ctype/lib_ispunct.c
+++ b/libs/libc/ctype/lib_ispunct.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_ispunct.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int ispunct(int c)
+{
+  return isgraph(c) && !isalnum(c);
+}

--- a/libs/libc/ctype/lib_isspace.c
+++ b/libs/libc/ctype/lib_isspace.c
@@ -1,0 +1,35 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isspace.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isspace(int c)
+{
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
+         c == '\f' || c == '\v';
+}

--- a/libs/libc/ctype/lib_isupper.c
+++ b/libs/libc/ctype/lib_isupper.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isupper.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isupper(int c)
+{
+  return c >= 'A' && c <= 'Z';
+}

--- a/libs/libc/ctype/lib_isxdigit.c
+++ b/libs/libc/ctype/lib_isxdigit.c
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_isxdigit.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int isxdigit(int c)
+{
+  return (c >= '0' && c <= '9') ||
+         (c >= 'a' && c <= 'f') ||
+         (c >= 'A' && c <= 'F');
+}

--- a/libs/libc/ctype/lib_tolower.c
+++ b/libs/libc/ctype/lib_tolower.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_tolower.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int tolower(int c)
+{
+  return (c >= 'A' && c <= 'Z') ? (c - 'A' + 'a') : c;
+}

--- a/libs/libc/ctype/lib_toupper.c
+++ b/libs/libc/ctype/lib_toupper.c
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * libs/libc/ctype/lib_toupper.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <ctype.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int toupper(int c)
+{
+  return (c >= 'a' && c <= 'z') ? c - 'a' + 'A' : c;
+}


### PR DESCRIPTION
## Summary
to avoid the argument evaluation more than once
https://lists.apache.org/thread.html/r0121646a9d5fbb27d43413b6e712d13e9fac9e17cc41f91bc4206134%40%3Cdev.nuttx.apache.org%3E

## Impact

## Testing

