### PR TITLE
FAT Filesystem: UTF8 support for long filenames, bugfixes.

### DIFF
--- a/fs/fat/Kconfig
+++ b/fs/fat/Kconfig
@@ -58,6 +58,13 @@ config FAT_LFN_ALIAS_HASH
 		filename. This method is similar to what is used by Windows 2000 and
 		later.
 
+config FAT_LFN_UTF8
+	bool "Allow UTF8 long filenames"
+	depends on FAT_LFN
+	default n
+	---help---
+		UTF8 long filenames are accepted and converted to UCS2.
+
 config FAT_LFN_ALIAS_TRAILCHARS
 	int "Number of trailing characters to use for 8.3 alias"
 	depends on FAT_LFN

--- a/fs/fat/fs_fat32.h
+++ b/fs/fat/fs_fat32.h
@@ -943,6 +943,14 @@ struct fat_dirseq_s
 #endif
 };
 
+#ifdef CONFIG_FAT_LFN
+#  ifdef CONFIG_FAT_LFN_UTF8
+typedef wchar_t lfnchar;
+#  else
+typedef uint8_t lfnchar;
+#  endif
+#endif
+
 /* This structure is used internally for describing directory entries */
 
 struct fat_dirinfo_s
@@ -950,7 +958,7 @@ struct fat_dirinfo_s
   /* The file/directory name */
 
 #ifdef CONFIG_FAT_LFN
-  uint8_t fd_lfname[LDIR_MAXFNAME + 1]; /* Long filename with terminator */
+  lfnchar fd_lfname[LDIR_MAXFNAME + 1]; /* Long filename with terminator */
 #endif
   uint8_t fd_name[DIR_MAXFNAME];   /* Short 8.3 alias filename (no terminator) */
 


### PR DESCRIPTION
Had been PR #1478, can't reopen, perhaps because of force push.

## Summary
New CONFIG_FAT_LFN_UTF8: UTF8 strings are converted to UCS2-LFN
Bugfix in fat_createalias: space is now also converted to underbar.
Change (bugfix) in fat_getlfname: init characters (0xff) and '\0' are rewound as well.

## Impact
When activating CONFIG_FAT_LFN_UTF8 the full 3byte UTF8 space is converted to UCS2 for long filenames, which allows e.g. for chinese characters in folder and file names.
The bug in createalias caused problems with names including space characters.

## Testing
Tested with mkdir on nsh and with apps/testing/fatutf8 (seperate commit on nuttx-apps).
