### PR TITLE
libs: add libuv async i/o library

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1803,6 +1803,7 @@ menu "Library Routines"
 source libs/libc/Kconfig
 source libs/libxx/Kconfig
 source libs/libdsp/Kconfig
+source libs/libuv/Kconfig
 endmenu
 
 menu "Open Asymmetric Multi Processing"

--- a/libs/libuv/0001-initial-libuv-portage-to-nuttx.patch
+++ b/libs/libuv/0001-initial-libuv-portage-to-nuttx.patch
@@ -1,0 +1,1124 @@
+From 7a43f8806325eea5bfbf66c221e208a1d57880f5 Mon Sep 17 00:00:00 2001
+From: spiriou <spiriou31@gmail.com>
+Date: Sat, 1 Aug 2020 18:10:07 +0200
+Subject: [PATCH 1/8] initial libuv portage to nuttx
+
+---
+ include/uv/nuttx.h |  33 +++++
+ include/uv/unix.h  |  26 +++-
+ src/threadpool.c   |  19 ++-
+ src/unix/async.c   |  10 +-
+ src/unix/core.c    |  58 +++++----
+ src/unix/loop.c    |  19 ++-
+ src/unix/nuttx.c   | 301 +++++++++++++++++++++++++++++++++++++++++++++
+ src/unix/poll.c    |   2 +
+ src/unix/process.c |  15 +--
+ src/unix/signal.c  |   5 +-
+ src/unix/thread.c  |  15 ++-
+ src/uv-common.c    |  12 +-
+ 12 files changed, 461 insertions(+), 54 deletions(-)
+ create mode 100644 include/uv/nuttx.h
+ create mode 100644 src/unix/nuttx.c
+
+diff --git a/include/uv/nuttx.h b/include/uv/nuttx.h
+new file mode 100644
+index 0000000..29858f3
+--- /dev/null
++++ b/include/uv/nuttx.h
+@@ -0,0 +1,33 @@
++/****************************************************************************
++ * libs/libuv/include/uv/nuttx.h
++ *
++ * Licensed to the Apache Software Foundation (ASF) under one or more
++ * contributor license agreements.  See the NOTICE file distributed with
++ * this work for additional information regarding copyright ownership.  The
++ * ASF licenses this file to you under the Apache License, Version 2.0 (the
++ * "License"); you may not use this file except in compliance with the
++ * License.  You may obtain a copy of the License at
++ *
++ *   http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
++ * License for the specific language governing permissions and limitations
++ * under the License.
++ *
++ ****************************************************************************/
++
++#ifndef UV_NUTTX_H
++#define UV_NUTTX_H
++
++#include <nuttx/config.h>
++#include <poll.h>
++
++#define UV_PLATFORM_LOOP_FIELDS                                               \
++  struct pollfd poll_fds[CONFIG_LIBUV_NPOLLWAITERS];                          \
++  size_t poll_fds_used;
++
++#define UV_PLATFORM_FS_EVENT_FIELDS
++
++#endif /* UV_NUTTX_H */
+diff --git a/include/uv/unix.h b/include/uv/unix.h
+index 3a13163..d2d39da 100644
+--- a/include/uv/unix.h
++++ b/include/uv/unix.h
+@@ -45,7 +45,9 @@
+ 
+ #include "uv/threadpool.h"
+ 
+-#if defined(__linux__)
++#if defined(__NUTTX__)
++# include "uv/nuttx.h"
++#elif defined(__linux__)
+ # include "uv/linux.h"
+ #elif defined (__MVS__)
+ # include "uv/os390.h"
+@@ -218,6 +220,22 @@ typedef struct {
+   char* errmsg;
+ } uv_lib_t;
+ 
++#ifdef CONFIG_LIBUV_SIGNAL
++#define UV_LOOP_PRIVATE_SIGNAL_FIELDS                                         \
++  int signal_pipefd[2];                                                       \
++  uv__io_t signal_io_watcher;
++#else
++#define UV_LOOP_PRIVATE_SIGNAL_FIELDS
++#endif
++
++#ifdef CONFIG_LIBUV_PROCESS
++#define UV_LOOP_PRIVATE_PROCESS_FIELDS                                        \
++  void* process_handles[2];                                                   \
++  uv_signal_t child_watcher;
++#else
++#define UV_LOOP_PRIVATE_PROCESS_FIELDS
++#endif
++
+ #define UV_LOOP_PRIVATE_FIELDS                                                \
+   unsigned long flags;                                                        \
+   int backend_fd;                                                             \
+@@ -231,7 +249,6 @@ typedef struct {
+   uv_async_t wq_async;                                                        \
+   uv_rwlock_t cloexec_lock;                                                   \
+   uv_handle_t* closing_handles;                                               \
+-  void* process_handles[2];                                                   \
+   void* prepare_handles[2];                                                   \
+   void* check_handles[2];                                                     \
+   void* idle_handles[2];                                                      \
+@@ -245,9 +262,8 @@ typedef struct {
+   } timer_heap;                                                               \
+   uint64_t timer_counter;                                                     \
+   uint64_t time;                                                              \
+-  int signal_pipefd[2];                                                       \
+-  uv__io_t signal_io_watcher;                                                 \
+-  uv_signal_t child_watcher;                                                  \
++  UV_LOOP_PRIVATE_SIGNAL_FIELDS                                               \
++  UV_LOOP_PRIVATE_PROCESS_FIELDS                                              \
+   int emfile_fd;                                                              \
+   UV_PLATFORM_LOOP_FIELDS                                                     \
+ 
+diff --git a/src/threadpool.c b/src/threadpool.c
+index 0998938..b934595 100644
+--- a/src/threadpool.c
++++ b/src/threadpool.c
+@@ -187,9 +187,15 @@ void uv__threadpool_cleanup(void) {
+ 
+ static void init_threads(void) {
+   unsigned int i;
++#ifndef __NUTTX__
+   const char* val;
++#endif
+   uv_sem_t sem;
+ 
++#ifdef __NUTTX__
++  threads = default_threads;
++  nthreads = ARRAY_SIZE(default_threads);
++#else
+   nthreads = ARRAY_SIZE(default_threads);
+   val = getenv("UV_THREADPOOL_SIZE");
+   if (val != NULL)
+@@ -207,6 +213,7 @@ static void init_threads(void) {
+       threads = default_threads;
+     }
+   }
++#endif
+ 
+   if (uv_cond_init(&cond))
+     abort();
+@@ -232,7 +239,7 @@ static void init_threads(void) {
+ }
+ 
+ 
+-#ifndef _WIN32
++#if !defined(_WIN32) && !defined(__NUTTX__)
+ static void reset_once(void) {
+   uv_once_t child_once = UV_ONCE_INIT;
+   memcpy(&once, &child_once, sizeof(child_once));
+@@ -241,7 +248,7 @@ static void reset_once(void) {
+ 
+ 
+ static void init_once(void) {
+-#ifndef _WIN32
++#if !defined(_WIN32) && !defined(__NUTTX__)
+   /* Re-initialize the threadpool after fork.
+    * Note that this discards the global mutex and condition as well
+    * as the work queue.
+@@ -296,16 +303,16 @@ void uv__work_done(uv_async_t* handle) {
+   struct uv__work* w;
+   uv_loop_t* loop;
+   QUEUE* q;
+-  QUEUE wq;
++  QUEUE wql;
+   int err;
+ 
+   loop = container_of(handle, uv_loop_t, wq_async);
+   uv_mutex_lock(&loop->wq_mutex);
+-  QUEUE_MOVE(&loop->wq, &wq);
++  QUEUE_MOVE(&loop->wq, &wql);
+   uv_mutex_unlock(&loop->wq_mutex);
+ 
+-  while (!QUEUE_EMPTY(&wq)) {
+-    q = QUEUE_HEAD(&wq);
++  while (!QUEUE_EMPTY(&wql)) {
++    q = QUEUE_HEAD(&wql);
+     QUEUE_REMOVE(q);
+ 
+     w = container_of(q, struct uv__work, wq);
+diff --git a/src/unix/async.c b/src/unix/async.c
+index 5f58fb8..f7c0de1 100644
+--- a/src/unix/async.c
++++ b/src/unix/async.c
+@@ -120,7 +120,11 @@ void uv__async_close(uv_async_t* handle) {
+ 
+ 
+ static void uv__async_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
++#ifdef __NUTTX__
++  char buf[sizeof(eventfd_t)];
++#else
+   char buf[1024];
++#endif
+   ssize_t r;
+   QUEUE queue;
+   QUEUE* q;
+@@ -175,9 +179,9 @@ static void uv__async_send(uv_loop_t* loop) {
+   len = 1;
+   fd = loop->async_wfd;
+ 
+-#if defined(__linux__)
++#if defined(__linux__) || defined(__NUTTX__)
+   if (fd == -1) {
+-    static const uint64_t val = 1;
++    static const eventfd_t val = 1;
+     buf = &val;
+     len = sizeof(val);
+     fd = loop->async_io_watcher.fd;  /* eventfd */
+@@ -206,7 +210,7 @@ static int uv__async_start(uv_loop_t* loop) {
+   if (loop->async_io_watcher.fd != -1)
+     return 0;
+ 
+-#ifdef __linux__
++#if defined(__linux__) || defined(__NUTTX__)
+   err = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+   if (err < 0)
+     return UV__ERR(errno);
+diff --git a/src/unix/core.c b/src/unix/core.c
+index 5b0b64d..4d53ed7 100644
+--- a/src/unix/core.c
++++ b/src/unix/core.c
+@@ -58,6 +58,8 @@
+ # include <crt_externs.h>
+ # include <mach-o/dyld.h> /* _NSGetExecutablePath */
+ # define environ (*_NSGetEnviron())
++#elif defined(__NUTTX__)
++/* environ defined as function in stdlib in NuttX*/
+ #else /* defined(__APPLE__) && !TARGET_OS_IPHONE */
+ extern char** environ;
+ #endif /* !(defined(__APPLE__) && !TARGET_OS_IPHONE) */
+@@ -112,6 +114,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+   handle->close_cb = close_cb;
+ 
+   switch (handle->type) {
++#if 0
+   case UV_NAMED_PIPE:
+     uv__pipe_close((uv_pipe_t*)handle);
+     break;
+@@ -139,7 +142,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+   case UV_IDLE:
+     uv__idle_close((uv_idle_t*)handle);
+     break;
+-
++#endif
+   case UV_ASYNC:
+     uv__async_close((uv_async_t*)handle);
+     break;
+@@ -147,7 +150,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+   case UV_TIMER:
+     uv__timer_close((uv_timer_t*)handle);
+     break;
+-
++#if 0
+   case UV_PROCESS:
+     uv__process_close((uv_process_t*)handle);
+     break;
+@@ -155,11 +158,11 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+   case UV_FS_EVENT:
+     uv__fs_event_close((uv_fs_event_t*)handle);
+     break;
+-
++#endif
+   case UV_POLL:
+     uv__poll_close((uv_poll_t*)handle);
+     break;
+-
++#if 0
+   case UV_FS_POLL:
+     uv__fs_poll_close((uv_fs_poll_t*)handle);
+     /* Poll handles use file system requests, and one of them may still be
+@@ -169,7 +172,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+   case UV_SIGNAL:
+     uv__signal_close((uv_signal_t*) handle);
+     break;
+-
++#endif
+   default:
+     assert(0);
+   }
+@@ -241,7 +244,9 @@ int uv__getiovmax(void) {
+ 
+ 
+ static void uv__finish_close(uv_handle_t* handle) {
++#ifdef CONFIG_LIBUV_SIGNAL
+   uv_signal_t* sh;
++#endif
+ 
+   /* Note: while the handle is in the UV_HANDLE_CLOSING state now, it's still
+    * possible for it to be active in the sense that uv__is_active() returns
+@@ -256,17 +261,21 @@ static void uv__finish_close(uv_handle_t* handle) {
+   handle->flags |= UV_HANDLE_CLOSED;
+ 
+   switch (handle->type) {
++#if 0
+     case UV_PREPARE:
+     case UV_CHECK:
+     case UV_IDLE:
++#endif
+     case UV_ASYNC:
+     case UV_TIMER:
++#if 0
+     case UV_PROCESS:
+     case UV_FS_EVENT:
+     case UV_FS_POLL:
++#endif
+     case UV_POLL:
+       break;
+-
++#ifdef CONFIG_LIBUV_SIGNAL
+     case UV_SIGNAL:
+       /* If there are any caught signals "trapped" in the signal pipe,
+        * we can't call the close callback yet. Reinserting the handle
+@@ -280,7 +289,8 @@ static void uv__finish_close(uv_handle_t* handle) {
+         return;
+       }
+       break;
+-
++#endif
++#if 0
+     case UV_NAMED_PIPE:
+     case UV_TCP:
+     case UV_TTY:
+@@ -290,7 +300,7 @@ static void uv__finish_close(uv_handle_t* handle) {
+     case UV_UDP:
+       uv__udp_finish_close((uv_udp_t*)handle);
+       break;
+-
++#endif
+     default:
+       assert(0);
+       break;
+@@ -423,7 +433,7 @@ int uv_is_active(const uv_handle_t* handle) {
+   return uv__is_active(handle);
+ }
+ 
+-
++#if 0
+ /* Open a socket in non-blocking close-on-exec mode, atomically if possible. */
+ int uv__socket(int domain, int type, int protocol) {
+   int sockfd;
+@@ -460,6 +470,7 @@ int uv__socket(int domain, int type, int protocol) {
+ 
+   return sockfd;
+ }
++#endif
+ 
+ /* get a file pointer to a file in read-only and close-on-exec mode */
+ FILE* uv__open_file(const char* path) {
+@@ -477,7 +488,7 @@ FILE* uv__open_file(const char* path) {
+    return fp;
+ }
+ 
+-
++#if 0
+ int uv__accept(int sockfd) {
+   int peerfd;
+   int err;
+@@ -509,7 +520,7 @@ int uv__accept(int sockfd) {
+ 
+   return peerfd;
+ }
+-
++#endif
+ 
+ /* close() on macos has the "interesting" quirk that it fails with EINTR
+  * without closing the file descriptor when a thread is in the cancel state.
+@@ -531,6 +542,8 @@ int uv__close_nocancel(int fd) {
+   return close$NOCANCEL$UNIX2003(fd);
+ #endif
+ #pragma GCC diagnostic pop
++#elif defined(__NUTTX__)
++  return close(fd);
+ #elif defined(__linux__)
+   return syscall(SYS_close, fd);
+ #else
+@@ -581,7 +594,8 @@ int uv__nonblock_ioctl(int fd, int set) {
+ }
+ 
+ 
+-#if !defined(__CYGWIN__) && !defined(__MSYS__) && !defined(__HAIKU__)
++#if !defined(__CYGWIN__) && !defined(__MSYS__) && \
++    !defined(__HAIKU__)  && !defined(__NUTTX__)
+ int uv__cloexec_ioctl(int fd, int set) {
+   int r;
+ 
+@@ -658,7 +672,7 @@ int uv__cloexec_fcntl(int fd, int set) {
+   return 0;
+ }
+ 
+-
++#if 0
+ ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
+   struct cmsghdr* cmsg;
+   ssize_t rc;
+@@ -695,7 +709,7 @@ ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
+         uv__cloexec(*pfd, 1);
+   return rc;
+ }
+-
++#endif
+ 
+ int uv_cwd(char* buffer, size_t* size) {
+   char scratch[1 + UV__PATH_MAX];
+@@ -743,7 +757,7 @@ int uv_chdir(const char* dir) {
+   return 0;
+ }
+ 
+-
++#if 0
+ void uv_disable_stdio_inheritance(void) {
+   int fd;
+ 
+@@ -754,7 +768,7 @@ void uv_disable_stdio_inheritance(void) {
+     if (uv__cloexec(fd, 1) && fd > 15)
+       break;
+ }
+-
++#endif
+ 
+ int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd) {
+   int fd_out;
+@@ -958,7 +972,7 @@ int uv__fd_exists(uv_loop_t* loop, int fd) {
+   return (unsigned) fd < loop->nwatchers && loop->watchers[fd] != NULL;
+ }
+ 
+-
++#if 0
+ int uv_getrusage(uv_rusage_t* rusage) {
+   struct rusage usage;
+ 
+@@ -990,7 +1004,7 @@ int uv_getrusage(uv_rusage_t* rusage) {
+ 
+   return 0;
+ }
+-
++#endif
+ 
+ int uv__open_cloexec(const char* path, int flags) {
+ #if defined(O_CLOEXEC)
+@@ -1019,7 +1033,7 @@ int uv__open_cloexec(const char* path, int flags) {
+ #endif  /* O_CLOEXEC */
+ }
+ 
+-
++#if 0
+ int uv__dup2_cloexec(int oldfd, int newfd) {
+ #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__linux__)
+   int r;
+@@ -1046,7 +1060,7 @@ int uv__dup2_cloexec(int oldfd, int newfd) {
+   return r;
+ #endif
+ }
+-
++#endif
+ 
+ int uv_os_homedir(char* buffer, size_t* size) {
+   uv_passwd_t pwd;
+@@ -1390,11 +1404,11 @@ uv_pid_t uv_os_getpid(void) {
+   return getpid();
+ }
+ 
+-
++#if 0
+ uv_pid_t uv_os_getppid(void) {
+   return getppid();
+ }
+-
++#endif
+ 
+ int uv_os_getpriority(uv_pid_t pid, int* priority) {
+   int r;
+diff --git a/src/unix/loop.c b/src/unix/loop.c
+index e5b2889..1bdbe8d 100644
+--- a/src/unix/loop.c
++++ b/src/unix/loop.c
+@@ -56,8 +56,12 @@ int uv_loop_init(uv_loop_t* loop) {
+   uv__update_time(loop);
+   loop->async_io_watcher.fd = -1;
+   loop->async_wfd = -1;
++
++#ifdef CONFIG_LIBUV_SIGNAL
+   loop->signal_pipefd[0] = -1;
+   loop->signal_pipefd[1] = -1;
++#endif
++
+   loop->backend_fd = -1;
+   loop->emfile_fd = -1;
+ 
+@@ -68,7 +72,10 @@ int uv_loop_init(uv_loop_t* loop) {
+   if (err)
+     return err;
+ 
++#ifdef CONFIG_LIBUV_SIGNAL
+   uv__signal_global_once_init();
++
++#ifdef CONFIG_LIBUV_PROCESS
+   err = uv_signal_init(loop, &loop->child_watcher);
+   if (err)
+     goto fail_signal_init;
+@@ -76,6 +83,8 @@ int uv_loop_init(uv_loop_t* loop) {
+   uv__handle_unref(&loop->child_watcher);
+   loop->child_watcher.flags |= UV_HANDLE_INTERNAL;
+   QUEUE_INIT(&loop->process_handles);
++#endif
++#endif
+ 
+   err = uv_rwlock_init(&loop->cloexec_lock);
+   if (err)
+@@ -101,9 +110,11 @@ fail_mutex_init:
+   uv_rwlock_destroy(&loop->cloexec_lock);
+ 
+ fail_rwlock_init:
++#ifdef CONFIG_LIBUV_PROCESS
+   uv__signal_loop_cleanup(loop);
+ 
+ fail_signal_init:
++#endif
+   uv__platform_loop_delete(loop);
+ 
+   uv__free(loop->watchers);
+@@ -111,7 +122,7 @@ fail_signal_init:
+   return err;
+ }
+ 
+-
++#if 0
+ int uv_loop_fork(uv_loop_t* loop) {
+   int err;
+   unsigned int i;
+@@ -143,10 +154,12 @@ int uv_loop_fork(uv_loop_t* loop) {
+ 
+   return 0;
+ }
+-
++#endif
+ 
+ void uv__loop_close(uv_loop_t* loop) {
++#ifdef CONFIG_LIBUV_SIGNAL
+   uv__signal_loop_cleanup(loop);
++#endif
+   uv__platform_loop_delete(loop);
+   uv__async_stop(loop);
+ 
+@@ -185,6 +198,7 @@ void uv__loop_close(uv_loop_t* loop) {
+ 
+ 
+ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
++#ifndef __NUTTX__
+   if (option != UV_LOOP_BLOCK_SIGNAL)
+     return UV_ENOSYS;
+ 
+@@ -192,5 +206,6 @@ int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
+     return UV_EINVAL;
+ 
+   loop->flags |= UV_LOOP_BLOCK_SIGPROF;
++#endif
+   return 0;
+ }
+diff --git a/src/unix/nuttx.c b/src/unix/nuttx.c
+new file mode 100644
+index 0000000..d35a649
+--- /dev/null
++++ b/src/unix/nuttx.c
+@@ -0,0 +1,301 @@
++/****************************************************************************
++ * libs/libuv/src/unix/nuttx.c
++ *
++ * Licensed to the Apache Software Foundation (ASF) under one or more
++ * contributor license agreements.  See the NOTICE file distributed with
++ * this work for additional information regarding copyright ownership.  The
++ * ASF licenses this file to you under the Apache License, Version 2.0 (the
++ * "License"); you may not use this file except in compliance with the
++ * License.  You may obtain a copy of the License at
++ *
++ *   http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
++ * License for the specific language governing permissions and limitations
++ * under the License.
++ *
++ ****************************************************************************/
++
++/* Copyright libuv project contributors. All rights reserved.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in
++ * all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
++ * IN THE SOFTWARE.
++ */
++
++#include "uv.h"
++#include "unix/internal.h"
++
++#include <stdint.h>
++#include <time.h>
++#include <assert.h>
++
++#undef NANOSEC
++#define NANOSEC ((uint64_t) 1e9)
++
++int uv__platform_loop_init(uv_loop_t* loop) {
++  return 0;
++}
++
++void uv__platform_loop_delete(uv_loop_t* loop) {
++}
++
++/* From libuv/src/unix/posix-hrtime.c */
++
++uint64_t uv__hrtime(uv_clocktype_t type) {
++  struct timespec ts;
++  clock_gettime(CLOCK_MONOTONIC, &ts);
++  return (((uint64_t) ts.tv_sec) * NANOSEC + ts.tv_nsec);
++}
++
++/* From libuv/src/unix/posix-poll.c */
++
++/* Add a watcher's fd to our poll fds array with its pending events.  */
++static void uv__pollfds_add(uv_loop_t* loop, uv__io_t* w) {
++  size_t i;
++  struct pollfd* pe;
++  int available_slot = -1;
++
++  /* If the fd is already in the set just update its events.  */
++
++  for (i = 0; i < loop->poll_fds_used; ++i) {
++    if (loop->poll_fds[i].fd == w->fd) {
++      loop->poll_fds[i].events = w->pevents;
++      return;
++    }
++    /* Look for available slot to add pollfd */
++    if (available_slot < 0 && loop->poll_fds[i].fd < 0) {
++      available_slot = i;
++    }
++  }
++
++  /* Otherwise, allocate a new slot in the set for the fd.  */
++
++  if (available_slot >= 0) {
++    goto exit_setup_pollfd;
++  }
++
++  /* Try to extend array */
++
++  available_slot = loop->poll_fds_used++;
++  if (loop->poll_fds_used >= CONFIG_LIBUV_NPOLLWAITERS) {
++    /* Error no available pollfd for loop */
++    abort();
++  }
++
++exit_setup_pollfd:
++  pe = &loop->poll_fds[available_slot];
++  pe->fd = w->fd;
++  pe->events = w->pevents;
++}
++
++/* Remove a watcher's fd from our poll fds array.  */
++static void uv__pollfds_del(uv_loop_t* loop, int fd) {
++  size_t i;
++
++  for (i = 0; i < loop->poll_fds_used;) {
++    if (loop->poll_fds[i].fd == fd) {
++      /* swap to last position and remove */
++      --loop->poll_fds_used;
++
++      loop->poll_fds[i] = loop->poll_fds[loop->poll_fds_used];
++
++      if (-1 != fd)
++        return;
++    } else {
++      /* We must only increment the loop counter when the fds do not match.
++       * Otherwise, when we are purging an invalidated fd, the value just
++       * swapped here from the previous end of the array will be skipped.
++       */
++       ++i;
++    }
++  }
++}
++
++void uv__io_poll(uv_loop_t* loop, int timeout) {
++  uint64_t time_base;
++  uint64_t time_diff;
++  QUEUE* q;
++  uv__io_t* w;
++  size_t i;
++  unsigned int nevents;
++  int nfds;
++#ifdef CONFIG_LIBUV_SIGNAL
++  int have_signals;
++#endif
++  struct pollfd* pe;
++  int fd;
++
++  if (loop->nfds == 0) {
++    assert(QUEUE_EMPTY(&loop->watcher_queue));
++    if (timeout > 0) {
++      usleep(1000*timeout);
++    }
++    return;
++  }
++
++  /* Take queued watchers and add their fds to our poll fds array.  */
++  while (!QUEUE_EMPTY(&loop->watcher_queue)) {
++    q = QUEUE_HEAD(&loop->watcher_queue);
++    QUEUE_REMOVE(q);
++    QUEUE_INIT(q);
++
++    w = QUEUE_DATA(q, uv__io_t, watcher_queue);
++    assert(w->pevents != 0);
++    assert(w->fd >= 0);
++    assert(w->fd < (int) loop->nwatchers);
++
++    uv__pollfds_add(loop, w);
++
++    w->events = w->pevents;
++  }
++
++  assert(timeout >= -1);
++  time_base = loop->time;
++
++  /* Loop calls to poll() and processing of results.  If we get some
++   * results from poll() but they turn out not to be interesting to
++   * our caller then we need to loop around and poll() again.
++   */
++  for (;;) {
++    nfds = poll(loop->poll_fds, (nfds_t)loop->poll_fds_used, timeout);
++
++    /* Update loop->time unconditionally. It's tempting to skip the update when
++     * timeout == 0 (i.e. non-blocking poll) but there is no guarantee that the
++     * operating system didn't reschedule our process while in the syscall.
++     */
++    SAVE_ERRNO(uv__update_time(loop));
++
++    if (nfds == 0) {
++      assert(timeout != -1);
++      return;
++    }
++
++    if (nfds == -1) {
++      if (errno != EINTR)
++        abort();
++
++      if (timeout == -1)
++        continue;
++
++      if (timeout == 0)
++        return;
++
++      /* Interrupted by a signal. Update timeout and poll again. */
++      goto update_timeout;
++    }
++
++    /* Initialize a count of events that we care about.  */
++    nevents = 0;
++#ifdef CONFIG_LIBUV_SIGNAL
++    have_signals = 0;
++#endif
++
++    /* Loop over the entire poll fds array looking for returned events.  */
++    for (i = 0; i < loop->poll_fds_used; i++) {
++      pe = loop->poll_fds + i;
++      fd = pe->fd;
++
++      /* Skip invalidated events, see uv__platform_invalidate_fd.  */
++      if (fd == -1)
++        continue;
++
++      assert(fd >= 0);
++      assert((unsigned) fd < loop->nwatchers);
++
++      w = loop->watchers[fd];
++
++      if (w == NULL) {
++        /* File descriptor that we've stopped watching, ignore.  */
++        uv__platform_invalidate_fd(loop, fd);
++        continue;
++      }
++
++      /* Filter out events that user has not requested us to watch
++       * (e.g. POLLNVAL).
++       */
++      pe->revents &= w->pevents | POLLERR | POLLHUP;
++
++      if (pe->revents != 0) {
++#ifdef CONFIG_LIBUV_SIGNAL
++        /* Run signal watchers last.  */
++        if (w == &loop->signal_io_watcher) {
++          have_signals = 1;
++        } else
++#endif
++        {
++          w->cb(loop, w, pe->revents);
++        }
++
++        nevents++;
++      }
++    }
++
++#ifdef CONFIG_LIBUV_SIGNAL
++    if (have_signals != 0)
++      loop->signal_io_watcher.cb(loop, &loop->signal_io_watcher, POLLIN);
++#endif
++
++    /* Purge invalidated fds from our poll fds array.  */
++    uv__pollfds_del(loop, -1);
++
++#ifdef CONFIG_LIBUV_SIGNAL
++    if (have_signals != 0)
++      return;  /* Event loop should cycle now so don't poll again. */
++#endif
++
++    if (nevents != 0)
++      return;
++
++    if (timeout == 0)
++      return;
++
++    if (timeout == -1)
++      continue;
++
++update_timeout:
++    assert(timeout > 0);
++
++    time_diff = loop->time - time_base;
++    if (time_diff >= (uint64_t) timeout)
++      return;
++
++    timeout -= time_diff;
++  }
++}
++
++/* Remove the given fd from our poll fds array because no one
++ * is interested in its events anymore.
++ */
++void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
++  size_t i;
++
++  assert(fd >= 0);
++
++  /* Just invalidate fd as allocated in loop structure.  */
++  for (i = 0; i < loop->poll_fds_used; i++)
++    if (loop->poll_fds[i].fd == fd) {
++      loop->poll_fds[i].fd = -1;
++    }
++}
++
++/* Check whether the given fd is supported by poll().  */
++int uv__io_check_fd(uv_loop_t* loop, int fd) {
++  return 0;
++}
+diff --git a/src/unix/poll.c b/src/unix/poll.c
+index 3d5022b..130fbd6 100644
+--- a/src/unix/poll.c
++++ b/src/unix/poll.c
+@@ -75,6 +75,7 @@ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
+   if (err)
+     return err;
+ 
++#ifndef __NUTTX__
+   /* If ioctl(FIONBIO) reports ENOTTY, try fcntl(F_GETFL) + fcntl(F_SETFL).
+    * Workaround for e.g. kqueue fds not supporting ioctls.
+    */
+@@ -85,6 +86,7 @@ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
+ 
+   if (err)
+     return err;
++#endif
+ 
+   uv__handle_init(loop, (uv_handle_t*) handle, UV_POLL);
+   uv__io_init(&handle->io_watcher, uv__poll_io, fd);
+diff --git a/src/unix/process.c b/src/unix/process.c
+index b021aae..47b5828 100644
+--- a/src/unix/process.c
++++ b/src/unix/process.c
+@@ -111,7 +111,7 @@ static void uv__chld(uv_signal_t* handle, int signum) {
+   assert(QUEUE_EMPTY(&pending));
+ }
+ 
+-
++#if 0
+ static int uv__make_socketpair(int fds[2]) {
+ #if defined(__FreeBSD__) || defined(__linux__)
+   if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, fds))
+@@ -137,7 +137,7 @@ static int uv__make_socketpair(int fds[2]) {
+   return 0;
+ #endif
+ }
+-
++#endif
+ 
+ int uv__make_pipe(int fds[2], int flags) {
+ #if defined(__FreeBSD__) || defined(__linux__)
+@@ -172,7 +172,7 @@ fail:
+ #endif
+ }
+ 
+-
++#if 0
+ /*
+  * Used for initializing stdio streams like options.stdin_stream. Returns
+  * zero on success. See also the cleanup section in uv_spawn().
+@@ -243,7 +243,7 @@ static void uv__process_close_stream(uv_stdio_container_t* container) {
+   if (!(container->flags & UV_CREATE_PIPE)) return;
+   uv__stream_close(container->data.stream);
+ }
+-
++#endif
+ 
+ static void uv__write_int(int fd, int val) {
+   ssize_t n;
+@@ -259,7 +259,8 @@ static void uv__write_int(int fd, int val) {
+ }
+ 
+ 
+-#if !(defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH))
++#if !(defined(__APPLE__) && (TARGET_OS_TV || TARGET_OS_WATCH)) \
++ && !defined(__NUTTX__)
+ /* execvp is marked __WATCHOS_PROHIBITED __TVOS_PROHIBITED, so must be
+  * avoided. Since this isn't called on those targets, the function
+  * doesn't even need to be defined for them.
+@@ -404,7 +405,7 @@ static void uv__process_child_init(const uv_process_options_t* options,
+ }
+ #endif
+ 
+-
++#if 0
+ int uv_spawn(uv_loop_t* loop,
+              uv_process_t* process,
+              const uv_process_options_t* options) {
+@@ -572,7 +573,7 @@ error:
+   return err;
+ #endif
+ }
+-
++#endif
+ 
+ int uv_process_kill(uv_process_t* process, int signum) {
+   return uv_kill(process->pid, signum);
+diff --git a/src/unix/signal.c b/src/unix/signal.c
+index 1c83e09..2ba5089 100644
+--- a/src/unix/signal.c
++++ b/src/unix/signal.c
+@@ -63,6 +63,7 @@ RB_GENERATE_STATIC(uv__signal_tree_s,
+ static void uv__signal_global_reinit(void);
+ 
+ static void uv__signal_global_init(void) {
++#ifndef __NUTTX__
+   if (uv__signal_lock_pipefd[0] == -1)
+     /* pthread_atfork can register before and after handlers, one
+      * for each child. This only registers one for the child. That
+@@ -72,7 +73,7 @@ static void uv__signal_global_init(void) {
+      */
+     if (pthread_atfork(NULL, NULL, &uv__signal_global_reinit))
+       abort();
+-
++#endif
+   uv__signal_global_reinit();
+ }
+ 
+@@ -229,8 +230,10 @@ static int uv__signal_register_handler(int signum, int oneshot) {
+     abort();
+   sa.sa_handler = uv__signal_handler;
+   sa.sa_flags = SA_RESTART;
++#ifndef __NUTTX__
+   if (oneshot)
+     sa.sa_flags |= SA_RESETHAND;
++#endif
+ 
+   /* XXX save old action so we can restore it later on? */
+   if (sigaction(signum, &sa, NULL))
+diff --git a/src/unix/thread.c b/src/unix/thread.c
+index 1a85d1d..1b962c1 100644
+--- a/src/unix/thread.c
++++ b/src/unix/thread.c
+@@ -161,7 +161,7 @@ void uv_barrier_destroy(uv_barrier_t* barrier) {
+ 
+ #endif
+ 
+-
++#if 0
+ /* On MacOS, threads other than the main thread are created with a reduced
+  * stack size by default.  Adjust to RLIMIT_STACK aligned to the page size.
+  *
+@@ -205,14 +205,19 @@ static size_t thread_stack_size(void) {
+   return 2 << 20;  /* glibc default. */
+ #endif
+ }
+-
++#endif
+ 
+ int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
++#ifdef __NUTTX__
++  return pthread_create(tid, NULL, (pthread_startroutine_t)entry, arg);
++#else
+   uv_thread_options_t params;
+   params.flags = UV_THREAD_NO_FLAGS;
+   return uv_thread_create_ex(tid, &params, entry, arg);
++#endif
+ }
+ 
++#if 0
+ int uv_thread_create_ex(uv_thread_t* tid,
+                         const uv_thread_options_t* params,
+                         void (*entry)(void *arg),
+@@ -263,7 +268,7 @@ int uv_thread_create_ex(uv_thread_t* tid,
+ 
+   return UV__ERR(err);
+ }
+-
++#endif
+ 
+ uv_thread_t uv_thread_self(void) {
+   return pthread_self();
+@@ -280,7 +285,7 @@ int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2) {
+ 
+ 
+ int uv_mutex_init(uv_mutex_t* mutex) {
+-#if defined(NDEBUG) || !defined(PTHREAD_MUTEX_ERRORCHECK)
++#if defined(NDEBUG) || !defined(PTHREAD_MUTEX_ERRORCHECK) || defined(__NUTTX__)
+   return UV__ERR(pthread_mutex_init(mutex, NULL));
+ #else
+   pthread_mutexattr_t attr;
+@@ -709,9 +714,11 @@ int uv_cond_init(uv_cond_t* cond) {
+   if (err)
+     return UV__ERR(err);
+ 
++#ifndef __NUTTX__
+   err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+   if (err)
+     goto error2;
++#endif
+ 
+   err = pthread_cond_init(cond, &attr);
+   if (err)
+diff --git a/src/uv-common.c b/src/uv-common.c
+index 0cfb921..40034b9 100644
+--- a/src/uv-common.c
++++ b/src/uv-common.c
+@@ -217,7 +217,7 @@ const char* uv_strerror(int err) {
+ }
+ #undef UV_STRERROR_GEN
+ 
+-
++#if 0
+ int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr) {
+   memset(addr, 0, sizeof(*addr));
+   addr->sin_family = AF_INET;
+@@ -481,7 +481,7 @@ int uv_udp_recv_stop(uv_udp_t* handle) {
+   else
+     return uv__udp_recv_stop(handle);
+ }
+-
++#endif
+ 
+ void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
+   QUEUE queue;
+@@ -581,6 +581,7 @@ size_t uv__count_bufs(const uv_buf_t bufs[], unsigned int nbufs) {
+   return bytes;
+ }
+ 
++#if 0
+ int uv_recv_buffer_size(uv_handle_t* handle, int* value) {
+   return uv__socket_sockopt(handle, SO_RCVBUF, value);
+ }
+@@ -588,6 +589,7 @@ int uv_recv_buffer_size(uv_handle_t* handle, int* value) {
+ int uv_send_buffer_size(uv_handle_t* handle, int *value) {
+   return uv__socket_sockopt(handle, SO_SNDBUF, value);
+ }
++#endif
+ 
+ int uv_fs_event_getpath(uv_fs_event_t* handle, char* buffer, size_t* size) {
+   size_t required_len;
+@@ -742,7 +744,7 @@ void uv__fs_readdir_cleanup(uv_fs_t* req) {
+   }
+ }
+ 
+-
++#if 0
+ int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...) {
+   va_list ap;
+   int err;
+@@ -754,7 +756,7 @@ int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...) {
+ 
+   return err;
+ }
+-
++#endif
+ 
+ static uv_loop_t default_loop_struct;
+ static uv_loop_t* default_loop_ptr;
+@@ -863,7 +865,9 @@ void uv_library_shutdown(void) {
+     return;
+ 
+   uv__process_title_cleanup();
++#ifdef CONFIG_LIBUV_SIGNAL
+   uv__signal_cleanup();
++#endif
+   uv__threadpool_cleanup();
+   uv__store_relaxed(&was_shutdown, 1);
+ }
+-- 
+2.17.1
+

--- a/libs/libuv/0002-add-config-flag-for-libuv-async-support.patch
+++ b/libs/libuv/0002-add-config-flag-for-libuv-async-support.patch
@@ -1,0 +1,100 @@
+From c30c24a8a4af33f0f2bfef13910794665f26e237 Mon Sep 17 00:00:00 2001
+From: spiriou <spiriou31@gmail.com>
+Date: Sat, 1 Aug 2020 21:34:59 +0200
+Subject: [PATCH 2/8] add config flag for libuv async support
+
+---
+ include/uv/unix.h | 15 +++++++++++----
+ src/unix/core.c   |  3 +++
+ src/unix/loop.c   |  7 +++++++
+ 3 files changed, 21 insertions(+), 4 deletions(-)
+
+diff --git a/include/uv/unix.h b/include/uv/unix.h
+index d2d39da..e320ebb 100644
+--- a/include/uv/unix.h
++++ b/include/uv/unix.h
+@@ -236,6 +236,16 @@ typedef struct {
+ #define UV_LOOP_PRIVATE_PROCESS_FIELDS
+ #endif
+ 
++#ifdef CONFIG_LIBUV_ASYNC
++#define UV_LOOP_PRIVATE_ASYNC_FIELDS                                          \
++  void* async_handles[2];                                                     \
++  void (*async_unused)(void);  /* TODO(bnoordhuis) Remove in libuv v2. */     \
++  uv__io_t async_io_watcher;                                                  \
++  int async_wfd;
++#else
++#define UV_LOOP_PRIVATE_ASYNC_FIELDS
++#endif
++
+ #define UV_LOOP_PRIVATE_FIELDS                                                \
+   unsigned long flags;                                                        \
+   int backend_fd;                                                             \
+@@ -252,10 +262,7 @@ typedef struct {
+   void* prepare_handles[2];                                                   \
+   void* check_handles[2];                                                     \
+   void* idle_handles[2];                                                      \
+-  void* async_handles[2];                                                     \
+-  void (*async_unused)(void);  /* TODO(bnoordhuis) Remove in libuv v2. */     \
+-  uv__io_t async_io_watcher;                                                  \
+-  int async_wfd;                                                              \
++  UV_LOOP_PRIVATE_ASYNC_FIELDS                                                \
+   struct {                                                                    \
+     void* min;                                                                \
+     unsigned int nelts;                                                       \
+diff --git a/src/unix/core.c b/src/unix/core.c
+index 4d53ed7..6154f75 100644
+--- a/src/unix/core.c
++++ b/src/unix/core.c
+@@ -143,9 +143,12 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+     uv__idle_close((uv_idle_t*)handle);
+     break;
+ #endif
++
++#ifdef CONFIG_LIBUV_ASYNC
+   case UV_ASYNC:
+     uv__async_close((uv_async_t*)handle);
+     break;
++#endif
+ 
+   case UV_TIMER:
+     uv__timer_close((uv_timer_t*)handle);
+diff --git a/src/unix/loop.c b/src/unix/loop.c
+index 1bdbe8d..87420e4 100644
+--- a/src/unix/loop.c
++++ b/src/unix/loop.c
+@@ -39,7 +39,9 @@ int uv_loop_init(uv_loop_t* loop) {
+   heap_init((struct heap*) &loop->timer_heap);
+   QUEUE_INIT(&loop->wq);
+   QUEUE_INIT(&loop->idle_handles);
++#ifdef CONFIG_LIBUV_ASYNC
+   QUEUE_INIT(&loop->async_handles);
++#endif
+   QUEUE_INIT(&loop->check_handles);
+   QUEUE_INIT(&loop->prepare_handles);
+   QUEUE_INIT(&loop->handle_queue);
+@@ -54,8 +56,10 @@ int uv_loop_init(uv_loop_t* loop) {
+ 
+   loop->closing_handles = NULL;
+   uv__update_time(loop);
++#ifdef CONFIG_LIBUV_ASYNC
+   loop->async_io_watcher.fd = -1;
+   loop->async_wfd = -1;
++#endif
+ 
+ #ifdef CONFIG_LIBUV_SIGNAL
+   loop->signal_pipefd[0] = -1;
+@@ -161,7 +165,10 @@ void uv__loop_close(uv_loop_t* loop) {
+   uv__signal_loop_cleanup(loop);
+ #endif
+   uv__platform_loop_delete(loop);
++
++#ifdef CONFIG_LIBUV_ASYNC
+   uv__async_stop(loop);
++#endif
+ 
+   if (loop->emfile_fd != -1) {
+     uv__close(loop->emfile_fd);
+-- 
+2.17.1
+

--- a/libs/libuv/0003-add-config-flag-for-libuv-worker-threads-support.patch
+++ b/libs/libuv/0003-add-config-flag-for-libuv-worker-threads-support.patch
@@ -1,0 +1,128 @@
+From 7332f1d61024a0eecccd5e845927d2245a0c57c0 Mon Sep 17 00:00:00 2001
+From: spiriou <spiriou31@gmail.com>
+Date: Sat, 1 Aug 2020 21:45:11 +0200
+Subject: [PATCH 3/8] add config flag for libuv worker threads support
+
+---
+ include/uv/unix.h | 13 ++++++++++---
+ src/threadpool.c  |  2 +-
+ src/unix/loop.c   |  8 ++++++++
+ src/uv-common.c   |  4 ++++
+ 4 files changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/include/uv/unix.h b/include/uv/unix.h
+index e320ebb..df105bd 100644
+--- a/include/uv/unix.h
++++ b/include/uv/unix.h
+@@ -246,6 +246,15 @@ typedef struct {
+ #define UV_LOOP_PRIVATE_ASYNC_FIELDS
+ #endif
+ 
++#ifdef CONFIG_LIBUV_WQ
++#define UV_LOOP_PRIVATE_WQ_FIELDS                                             \
++  void* wq[2];                                                                \
++  uv_mutex_t wq_mutex;                                                        \
++  uv_async_t wq_async;
++#else
++#define UV_LOOP_PRIVATE_WQ_FIELDS
++#endif
++
+ #define UV_LOOP_PRIVATE_FIELDS                                                \
+   unsigned long flags;                                                        \
+   int backend_fd;                                                             \
+@@ -254,9 +263,7 @@ typedef struct {
+   uv__io_t** watchers;                                                        \
+   unsigned int nwatchers;                                                     \
+   unsigned int nfds;                                                          \
+-  void* wq[2];                                                                \
+-  uv_mutex_t wq_mutex;                                                        \
+-  uv_async_t wq_async;                                                        \
++  UV_LOOP_PRIVATE_WQ_FIELDS                                                   \
+   uv_rwlock_t cloexec_lock;                                                   \
+   uv_handle_t* closing_handles;                                               \
+   void* prepare_handles[2];                                                   \
+diff --git a/src/threadpool.c b/src/threadpool.c
+index b934595..5287b89 100644
+--- a/src/threadpool.c
++++ b/src/threadpool.c
+@@ -36,7 +36,7 @@ static unsigned int idle_threads;
+ static unsigned int slow_io_work_running;
+ static unsigned int nthreads;
+ static uv_thread_t* threads;
+-static uv_thread_t default_threads[4];
++static uv_thread_t default_threads[CONFIG_LIBUV_WQ_THREADS_COUNT];
+ static QUEUE exit_message;
+ static QUEUE wq;
+ static QUEUE run_slow_work_message;
+diff --git a/src/unix/loop.c b/src/unix/loop.c
+index 87420e4..cda3fc0 100644
+--- a/src/unix/loop.c
++++ b/src/unix/loop.c
+@@ -37,7 +37,9 @@ int uv_loop_init(uv_loop_t* loop) {
+   loop->data = saved_data;
+ 
+   heap_init((struct heap*) &loop->timer_heap);
++#ifdef CONFIG_LIBUV_WQ
+   QUEUE_INIT(&loop->wq);
++#endif
+   QUEUE_INIT(&loop->idle_handles);
+ #ifdef CONFIG_LIBUV_ASYNC
+   QUEUE_INIT(&loop->async_handles);
+@@ -94,6 +96,7 @@ int uv_loop_init(uv_loop_t* loop) {
+   if (err)
+     goto fail_rwlock_init;
+ 
++#ifdef CONFIG_LIBUV_WQ
+   err = uv_mutex_init(&loop->wq_mutex);
+   if (err)
+     goto fail_mutex_init;
+@@ -104,14 +107,17 @@ int uv_loop_init(uv_loop_t* loop) {
+ 
+   uv__handle_unref(&loop->wq_async);
+   loop->wq_async.flags |= UV_HANDLE_INTERNAL;
++#endif
+ 
+   return 0;
+ 
++#ifdef CONFIG_LIBUV_WQ
+ fail_async_init:
+   uv_mutex_destroy(&loop->wq_mutex);
+ 
+ fail_mutex_init:
+   uv_rwlock_destroy(&loop->cloexec_lock);
++#endif
+ 
+ fail_rwlock_init:
+ #ifdef CONFIG_LIBUV_PROCESS
+@@ -180,11 +186,13 @@ void uv__loop_close(uv_loop_t* loop) {
+     loop->backend_fd = -1;
+   }
+ 
++#ifdef CONFIG_LIBUV_WQ
+   uv_mutex_lock(&loop->wq_mutex);
+   assert(QUEUE_EMPTY(&loop->wq) && "thread pool work queue not empty!");
+   assert(!uv__has_active_reqs(loop));
+   uv_mutex_unlock(&loop->wq_mutex);
+   uv_mutex_destroy(&loop->wq_mutex);
++#endif
+ 
+   /*
+    * Note that all thread pool stuff is finished at this point and
+diff --git a/src/uv-common.c b/src/uv-common.c
+index 40034b9..47696ed 100644
+--- a/src/uv-common.c
++++ b/src/uv-common.c
+@@ -868,6 +868,10 @@ void uv_library_shutdown(void) {
+ #ifdef CONFIG_LIBUV_SIGNAL
+   uv__signal_cleanup();
+ #endif
++
++#ifdef CONFIG_LIBUV_WQ
+   uv__threadpool_cleanup();
++#endif
++
+   uv__store_relaxed(&was_shutdown, 1);
+ }
+-- 
+2.17.1
+

--- a/libs/libuv/0004-add-config-flag-for-libuv-software-timers-support.patch
+++ b/libs/libuv/0004-add-config-flag-for-libuv-software-timers-support.patch
@@ -1,0 +1,124 @@
+From eff891320deb2a7b013924836494ee3291d39baf Mon Sep 17 00:00:00 2001
+From: spiriou <spiriou31@gmail.com>
+Date: Sat, 1 Aug 2020 22:19:31 +0200
+Subject: [PATCH 4/8] add config flag for libuv software timers support
+
+---
+ include/uv/unix.h | 17 ++++++++++++-----
+ src/unix/core.c   | 13 +++++++++++++
+ src/unix/loop.c   |  4 ++++
+ 3 files changed, 29 insertions(+), 5 deletions(-)
+
+diff --git a/include/uv/unix.h b/include/uv/unix.h
+index df105bd..3292e2a 100644
+--- a/include/uv/unix.h
++++ b/include/uv/unix.h
+@@ -246,6 +246,17 @@ typedef struct {
+ #define UV_LOOP_PRIVATE_ASYNC_FIELDS
+ #endif
+ 
++#ifdef CONFIG_LIBUV_TIMER
++#define UV_LOOP_PRIVATE_TIMER_FIELDS                                          \
++  struct {                                                                    \
++    void* min;                                                                \
++    unsigned int nelts;                                                       \
++  } timer_heap;                                                               \
++  uint64_t timer_counter;
++#else
++#define UV_LOOP_PRIVATE_TIMER_FIELDS
++#endif
++
+ #ifdef CONFIG_LIBUV_WQ
+ #define UV_LOOP_PRIVATE_WQ_FIELDS                                             \
+   void* wq[2];                                                                \
+@@ -270,11 +281,7 @@ typedef struct {
+   void* check_handles[2];                                                     \
+   void* idle_handles[2];                                                      \
+   UV_LOOP_PRIVATE_ASYNC_FIELDS                                                \
+-  struct {                                                                    \
+-    void* min;                                                                \
+-    unsigned int nelts;                                                       \
+-  } timer_heap;                                                               \
+-  uint64_t timer_counter;                                                     \
++  UV_LOOP_PRIVATE_TIMER_FIELDS                                                \
+   uint64_t time;                                                              \
+   UV_LOOP_PRIVATE_SIGNAL_FIELDS                                               \
+   UV_LOOP_PRIVATE_PROCESS_FIELDS                                              \
+diff --git a/src/unix/core.c b/src/unix/core.c
+index 6154f75..a9d0a78 100644
+--- a/src/unix/core.c
++++ b/src/unix/core.c
+@@ -150,9 +150,11 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+     break;
+ #endif
+ 
++#ifdef CONFIG_LIBUV_TIMER
+   case UV_TIMER:
+     uv__timer_close((uv_timer_t*)handle);
+     break;
++#endif
+ #if 0
+   case UV_PROCESS:
+     uv__process_close((uv_process_t*)handle);
+@@ -359,7 +361,11 @@ int uv_backend_timeout(const uv_loop_t* loop) {
+   if (loop->closing_handles)
+     return 0;
+ 
++#ifdef CONFIG_LIBUV_TIMER
+   return uv__next_timeout(loop);
++#else
++  return -1;
++#endif
+ }
+ 
+ 
+@@ -386,7 +392,11 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
+ 
+   while (r != 0 && loop->stop_flag == 0) {
+     uv__update_time(loop);
++
++#ifdef CONFIG_LIBUV_TIMER
+     uv__run_timers(loop);
++#endif
++
+     ran_pending = uv__run_pending(loop);
+     uv__run_idle(loop);
+     uv__run_prepare(loop);
+@@ -409,7 +419,10 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
+        * the check.
+        */
+       uv__update_time(loop);
++
++#ifdef CONFIG_LIBUV_TIMER
+       uv__run_timers(loop);
++#endif
+     }
+ 
+     r = uv__loop_alive(loop);
+diff --git a/src/unix/loop.c b/src/unix/loop.c
+index cda3fc0..fc33892 100644
+--- a/src/unix/loop.c
++++ b/src/unix/loop.c
+@@ -36,7 +36,9 @@ int uv_loop_init(uv_loop_t* loop) {
+   memset(loop, 0, sizeof(*loop));
+   loop->data = saved_data;
+ 
++#ifdef CONFIG_LIBUV_TIMER
+   heap_init((struct heap*) &loop->timer_heap);
++#endif
+ #ifdef CONFIG_LIBUV_WQ
+   QUEUE_INIT(&loop->wq);
+ #endif
+@@ -71,7 +73,9 @@ int uv_loop_init(uv_loop_t* loop) {
+   loop->backend_fd = -1;
+   loop->emfile_fd = -1;
+ 
++#ifdef CONFIG_LIBUV_TIMER
+   loop->timer_counter = 0;
++#endif
+   loop->stop_flag = 0;
+ 
+   err = uv__platform_loop_init(loop);
+-- 
+2.17.1
+

--- a/libs/libuv/0005-add-flags-to-reduce-libuv-memory-usage.patch
+++ b/libs/libuv/0005-add-flags-to-reduce-libuv-memory-usage.patch
@@ -1,0 +1,430 @@
+From 863837502d2d8c1ecfba7eb0e5b8a493cd46988c Mon Sep 17 00:00:00 2001
+From: spiriou <spiriou31@gmail.com>
+Date: Sun, 2 Aug 2020 12:16:19 +0200
+Subject: [PATCH 5/8] add flags to reduce libuv memory usage
+
+---
+ include/uv/unix.h | 40 +++++++++++++++++++++++++++++++++-------
+ src/unix/async.c  | 24 ++++++++++++++++++++++++
+ src/unix/core.c   | 28 +++++++++++++++++++++++-----
+ src/unix/loop.c   | 20 ++++++++++++++++++++
+ src/unix/stream.c |  8 ++++++--
+ 5 files changed, 106 insertions(+), 14 deletions(-)
+
+diff --git a/include/uv/unix.h b/include/uv/unix.h
+index 3292e2a..201573c 100644
+--- a/include/uv/unix.h
++++ b/include/uv/unix.h
+@@ -237,12 +237,18 @@ typedef struct {
+ #endif
+ 
+ #ifdef CONFIG_LIBUV_ASYNC
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+ #define UV_LOOP_PRIVATE_ASYNC_FIELDS                                          \
+   void* async_handles[2];                                                     \
+   void (*async_unused)(void);  /* TODO(bnoordhuis) Remove in libuv v2. */     \
+   uv__io_t async_io_watcher;                                                  \
+   int async_wfd;
+ #else
++#define UV_LOOP_PRIVATE_ASYNC_FIELDS                                          \
++  void* async_handles[2];                                                     \
++  uv__io_t async_io_watcher;
++#endif /* CONFIG_LIBUV_LOW_FOOTPRINT */
++#else
+ #define UV_LOOP_PRIVATE_ASYNC_FIELDS
+ #endif
+ 
+@@ -266,26 +272,46 @@ typedef struct {
+ #define UV_LOOP_PRIVATE_WQ_FIELDS
+ #endif
+ 
+-#define UV_LOOP_PRIVATE_FIELDS                                                \
++#ifdef CONFIG_LIBUV_LOOP_WATCHERS
++#define UV_LOOP_PRIVATE_WATCHERS_FIELDS                                       \
++  void* prepare_handles[2];                                                   \
++  void* check_handles[2];                                                     \
++  void* idle_handles[2];
++#else
++#define UV_LOOP_PRIVATE_WATCHERS_FIELDS
++#endif
++
++#ifdef CONFIG_LIBUV_LOW_FOOTPRINT
++#define UV_LOOP_PRIVATE_PERFS_FIELDS
++#else
++#define UV_LOOP_PRIVATE_PERFS_FIELDS                                          \
+   unsigned long flags;                                                        \
+   int backend_fd;                                                             \
+-  void* pending_queue[2];                                                     \
++  uv_rwlock_t cloexec_lock;                                                   \
++  int emfile_fd;
++#endif
++
++#if 0
++#define UV_LOOP_PRIVATE_TODO_FIELDS                                           \
++  void* pending_queue[2];
++#else
++#define UV_LOOP_PRIVATE_TODO_FIELDS
++#endif
++
++#define UV_LOOP_PRIVATE_FIELDS                                                \
+   void* watcher_queue[2];                                                     \
+   uv__io_t** watchers;                                                        \
+   unsigned int nwatchers;                                                     \
+   unsigned int nfds;                                                          \
+   UV_LOOP_PRIVATE_WQ_FIELDS                                                   \
+-  uv_rwlock_t cloexec_lock;                                                   \
+   uv_handle_t* closing_handles;                                               \
+-  void* prepare_handles[2];                                                   \
+-  void* check_handles[2];                                                     \
+-  void* idle_handles[2];                                                      \
++  UV_LOOP_PRIVATE_WATCHERS_FIELDS                                             \
+   UV_LOOP_PRIVATE_ASYNC_FIELDS                                                \
+   UV_LOOP_PRIVATE_TIMER_FIELDS                                                \
+   uint64_t time;                                                              \
+   UV_LOOP_PRIVATE_SIGNAL_FIELDS                                               \
+   UV_LOOP_PRIVATE_PROCESS_FIELDS                                              \
+-  int emfile_fd;                                                              \
++  UV_LOOP_PRIVATE_PERFS_FIELDS                                                \
+   UV_PLATFORM_LOOP_FIELDS                                                     \
+ 
+ #define UV_REQ_TYPE_PRIVATE /* empty */
+diff --git a/src/unix/async.c b/src/unix/async.c
+index f7c0de1..336dcf9 100644
+--- a/src/unix/async.c
++++ b/src/unix/async.c
+@@ -177,7 +177,12 @@ static void uv__async_send(uv_loop_t* loop) {
+ 
+   buf = "";
+   len = 1;
++
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   fd = loop->async_wfd;
++#else
++  fd = -1;
++#endif
+ 
+ #if defined(__linux__) || defined(__NUTTX__)
+   if (fd == -1) {
+@@ -204,6 +209,8 @@ static void uv__async_send(uv_loop_t* loop) {
+ 
+ 
+ static int uv__async_start(uv_loop_t* loop) {
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
++
+   int pipefd[2];
+   int err;
+ 
+@@ -227,6 +234,21 @@ static int uv__async_start(uv_loop_t* loop) {
+   uv__io_start(loop, &loop->async_io_watcher, POLLIN);
+   loop->async_wfd = pipefd[1];
+ 
++#else /* CONFIG_LIBUV_LOW_FOOTPRINT */
++
++  int err;
++
++  if (loop->async_io_watcher.fd != -1)
++    return 0;
++
++  err = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
++  if (err < 0)
++    return UV__ERR(errno);
++  uv__io_init(&loop->async_io_watcher, uv__async_io, err);
++  uv__io_start(loop, &loop->async_io_watcher, POLLIN);
++
++#endif /* CONFIG_LIBUV_LOW_FOOTPRINT */
++
+   return 0;
+ }
+ 
+@@ -245,11 +267,13 @@ void uv__async_stop(uv_loop_t* loop) {
+   if (loop->async_io_watcher.fd == -1)
+     return;
+ 
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   if (loop->async_wfd != -1) {
+     if (loop->async_wfd != loop->async_io_watcher.fd)
+       uv__close(loop->async_wfd);
+     loop->async_wfd = -1;
+   }
++#endif
+ 
+   uv__io_stop(loop, &loop->async_io_watcher, POLLIN);
+   uv__close(loop->async_io_watcher.fd);
+diff --git a/src/unix/core.c b/src/unix/core.c
+index a9d0a78..7f11370 100644
+--- a/src/unix/core.c
++++ b/src/unix/core.c
+@@ -90,7 +90,9 @@ extern char** environ;
+ # define uv__accept4 accept4
+ #endif
+ 
++#if 0
+ static int uv__run_pending(uv_loop_t* loop);
++#endif
+ 
+ /* Verify that uv_buf_t is ABI-compatible with struct iovec. */
+ STATIC_ASSERT(sizeof(uv_buf_t) == sizeof(struct iovec));
+@@ -339,10 +341,11 @@ int uv_is_closing(const uv_handle_t* handle) {
+   return uv__is_closing(handle);
+ }
+ 
+-
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+ int uv_backend_fd(const uv_loop_t* loop) {
+   return loop->backend_fd;
+ }
++#endif
+ 
+ 
+ int uv_backend_timeout(const uv_loop_t* loop) {
+@@ -352,11 +355,15 @@ int uv_backend_timeout(const uv_loop_t* loop) {
+   if (!uv__has_active_handles(loop) && !uv__has_active_reqs(loop))
+     return 0;
+ 
++#ifdef CONFIG_LIBUV_LOOP_WATCHERS
+   if (!QUEUE_EMPTY(&loop->idle_handles))
+     return 0;
++#endif
+ 
++#if 0
+   if (!QUEUE_EMPTY(&loop->pending_queue))
+     return 0;
++#endif
+ 
+   if (loop->closing_handles)
+     return 0;
+@@ -397,16 +404,25 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
+     uv__run_timers(loop);
+ #endif
+ 
++#if 0
+     ran_pending = uv__run_pending(loop);
++#else
++    ran_pending = 0;
++#endif
++
++#ifdef CONFIG_LIBUV_LOOP_WATCHERS
+     uv__run_idle(loop);
+     uv__run_prepare(loop);
++#endif
+ 
+     timeout = 0;
+     if ((mode == UV_RUN_ONCE && !ran_pending) || mode == UV_RUN_DEFAULT)
+       timeout = uv_backend_timeout(loop);
+ 
+     uv__io_poll(loop, timeout);
++#ifdef CONFIG_LIBUV_LOOP_WATCHERS
+     uv__run_check(loop);
++#endif
+     uv__run_closing_handles(loop);
+ 
+     if (mode == UV_RUN_ONCE) {
+@@ -815,7 +831,7 @@ int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd) {
+   return 0;
+ }
+ 
+-
++#if 0
+ static int uv__run_pending(uv_loop_t* loop) {
+   QUEUE* q;
+   QUEUE pq;
+@@ -836,7 +852,7 @@ static int uv__run_pending(uv_loop_t* loop) {
+ 
+   return 1;
+ }
+-
++#endif
+ 
+ static unsigned int next_power_of_two(unsigned int val) {
+   val -= 1;
+@@ -887,7 +903,9 @@ static void maybe_resize(uv_loop_t* loop, unsigned int len) {
+ void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd) {
+   assert(cb != NULL);
+   assert(fd >= -1);
++#if 0
+   QUEUE_INIT(&w->pending_queue);
++#endif
+   QUEUE_INIT(&w->watcher_queue);
+   w->cb = cb;
+   w->fd = fd;
+@@ -960,7 +978,7 @@ void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
+     QUEUE_INSERT_TAIL(&loop->watcher_queue, &w->watcher_queue);
+ }
+ 
+-
++#if 0
+ void uv__io_close(uv_loop_t* loop, uv__io_t* w) {
+   uv__io_stop(loop, w, POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI);
+   QUEUE_REMOVE(&w->pending_queue);
+@@ -982,7 +1000,7 @@ int uv__io_active(const uv__io_t* w, unsigned int events) {
+   assert(0 != events);
+   return 0 != (w->pevents & events);
+ }
+-
++#endif
+ 
+ int uv__fd_exists(uv_loop_t* loop, int fd) {
+   return (unsigned) fd < loop->nwatchers && loop->watchers[fd] != NULL;
+diff --git a/src/unix/loop.c b/src/unix/loop.c
+index fc33892..1c60e31 100644
+--- a/src/unix/loop.c
++++ b/src/unix/loop.c
+@@ -42,12 +42,16 @@ int uv_loop_init(uv_loop_t* loop) {
+ #ifdef CONFIG_LIBUV_WQ
+   QUEUE_INIT(&loop->wq);
+ #endif
++#ifdef CONFIG_LIBUV_LOOP_WATCHERS
+   QUEUE_INIT(&loop->idle_handles);
++#endif
+ #ifdef CONFIG_LIBUV_ASYNC
+   QUEUE_INIT(&loop->async_handles);
+ #endif
++#ifdef CONFIG_LIBUV_LOOP_WATCHERS
+   QUEUE_INIT(&loop->check_handles);
+   QUEUE_INIT(&loop->prepare_handles);
++#endif
+   QUEUE_INIT(&loop->handle_queue);
+ 
+   loop->active_handles = 0;
+@@ -55,23 +59,29 @@ int uv_loop_init(uv_loop_t* loop) {
+   loop->nfds = 0;
+   loop->watchers = NULL;
+   loop->nwatchers = 0;
++#if 0
+   QUEUE_INIT(&loop->pending_queue);
++#endif
+   QUEUE_INIT(&loop->watcher_queue);
+ 
+   loop->closing_handles = NULL;
+   uv__update_time(loop);
+ #ifdef CONFIG_LIBUV_ASYNC
+   loop->async_io_watcher.fd = -1;
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   loop->async_wfd = -1;
+ #endif
++#endif
+ 
+ #ifdef CONFIG_LIBUV_SIGNAL
+   loop->signal_pipefd[0] = -1;
+   loop->signal_pipefd[1] = -1;
+ #endif
+ 
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   loop->backend_fd = -1;
+   loop->emfile_fd = -1;
++#endif
+ 
+ #ifdef CONFIG_LIBUV_TIMER
+   loop->timer_counter = 0;
+@@ -96,9 +106,11 @@ int uv_loop_init(uv_loop_t* loop) {
+ #endif
+ #endif
+ 
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   err = uv_rwlock_init(&loop->cloexec_lock);
+   if (err)
+     goto fail_rwlock_init;
++#endif
+ 
+ #ifdef CONFIG_LIBUV_WQ
+   err = uv_mutex_init(&loop->wq_mutex);
+@@ -120,10 +132,14 @@ fail_async_init:
+   uv_mutex_destroy(&loop->wq_mutex);
+ 
+ fail_mutex_init:
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   uv_rwlock_destroy(&loop->cloexec_lock);
+ #endif
++#endif
+ 
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+ fail_rwlock_init:
++#endif
+ #ifdef CONFIG_LIBUV_PROCESS
+   uv__signal_loop_cleanup(loop);
+ 
+@@ -180,6 +196,7 @@ void uv__loop_close(uv_loop_t* loop) {
+   uv__async_stop(loop);
+ #endif
+ 
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   if (loop->emfile_fd != -1) {
+     uv__close(loop->emfile_fd);
+     loop->emfile_fd = -1;
+@@ -189,6 +206,7 @@ void uv__loop_close(uv_loop_t* loop) {
+     uv__close(loop->backend_fd);
+     loop->backend_fd = -1;
+   }
++#endif
+ 
+ #ifdef CONFIG_LIBUV_WQ
+   uv_mutex_lock(&loop->wq_mutex);
+@@ -198,11 +216,13 @@ void uv__loop_close(uv_loop_t* loop) {
+   uv_mutex_destroy(&loop->wq_mutex);
+ #endif
+ 
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   /*
+    * Note that all thread pool stuff is finished at this point and
+    * it is safe to just destroy rw lock
+    */
+   uv_rwlock_destroy(&loop->cloexec_lock);
++#endif
+ 
+ #if 0
+   assert(QUEUE_EMPTY(&loop->pending_queue));
+diff --git a/src/unix/stream.c b/src/unix/stream.c
+index 8327f9c..943e644 100644
+--- a/src/unix/stream.c
++++ b/src/unix/stream.c
+@@ -101,6 +101,7 @@ void uv__stream_init(uv_loop_t* loop,
+   QUEUE_INIT(&stream->write_completed_queue);
+   stream->write_queue_size = 0;
+ 
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+   if (loop->emfile_fd == -1) {
+     err = uv__open_cloexec("/dev/null", O_RDONLY);
+     if (err < 0)
+@@ -111,6 +112,7 @@ void uv__stream_init(uv_loop_t* loop,
+     if (err >= 0)
+       loop->emfile_fd = err;
+   }
++#endif
+ 
+ #if defined(__APPLE__)
+   stream->select = NULL;
+@@ -482,7 +484,7 @@ void uv__stream_destroy(uv_stream_t* stream) {
+   assert(stream->write_queue_size == 0);
+ }
+ 
+-
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+ /* Implements a best effort approach to mitigating accept() EMFILE errors.
+  * We have a spare file descriptor stashed away that we close to get below
+  * the EMFILE limit. Next, we accept all pending connections and close them
+@@ -516,7 +518,7 @@ static int uv__emfile_trick(uv_loop_t* loop, int accept_fd) {
+ 
+   return err;
+ }
+-
++#endif
+ 
+ #if defined(UV_HAVE_KQUEUE)
+ # define UV_DEC_BACKLOG(w) w->rcount--;
+@@ -555,11 +557,13 @@ void uv__server_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
+       if (err == UV_ECONNABORTED)
+         continue;  /* Ignore. Nothing we can do about that. */
+ 
++#ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+       if (err == UV_EMFILE || err == UV_ENFILE) {
+         err = uv__emfile_trick(loop, uv__stream_fd(stream));
+         if (err == UV_EAGAIN || err == UV__ERR(EWOULDBLOCK))
+           break;
+       }
++#endif
+ 
+       stream->connection_cb(stream, err);
+       continue;
+-- 
+2.17.1
+

--- a/libs/libuv/0006-add-config-flag-for-uv_default_loop-API.patch
+++ b/libs/libuv/0006-add-config-flag-for-uv_default_loop-API.patch
@@ -1,0 +1,74 @@
+From 30873aee26addb013c732b139b425b5e5edc2f3f Mon Sep 17 00:00:00 2001
+From: spiriou <spiriou31@gmail.com>
+Date: Sun, 2 Aug 2020 13:51:15 +0200
+Subject: [PATCH 6/8] add config flag for uv_default_loop() API
+
+---
+ src/uv-common.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/uv-common.c b/src/uv-common.c
+index 47696ed..db62542 100644
+--- a/src/uv-common.c
++++ b/src/uv-common.c
+@@ -507,8 +507,10 @@ static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
+   QUEUE* q;
+   uv_handle_t* h;
+ 
++#ifdef CONFIG_LIBUV_DEFAULT_LOOP
+   if (loop == NULL)
+     loop = uv_default_loop();
++#endif
+ 
+   QUEUE_FOREACH(q, &loop->handle_queue) {
+     h = QUEUE_DATA(q, uv_handle_t, handle_queue);
+@@ -758,6 +760,7 @@ int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...) {
+ }
+ #endif
+ 
++#ifdef CONFIG_LIBUV_DEFAULT_LOOP
+ static uv_loop_t default_loop_struct;
+ static uv_loop_t* default_loop_ptr;
+ 
+@@ -772,7 +775,7 @@ uv_loop_t* uv_default_loop(void) {
+   default_loop_ptr = &default_loop_struct;
+   return default_loop_ptr;
+ }
+-
++#endif
+ 
+ uv_loop_t* uv_loop_new(void) {
+   uv_loop_t* loop;
+@@ -813,14 +816,16 @@ int uv_loop_close(uv_loop_t* loop) {
+   memset(loop, -1, sizeof(*loop));
+   loop->data = saved_data;
+ #endif
++#ifdef CONFIG_LIBUV_DEFAULT_LOOP
+   if (loop == default_loop_ptr)
+     default_loop_ptr = NULL;
+-
++#endif
+   return 0;
+ }
+ 
+ 
+ void uv_loop_delete(uv_loop_t* loop) {
++#ifdef CONFIG_LIBUV_DEFAULT_LOOP
+   uv_loop_t* default_loop;
+   int err;
+ 
+@@ -831,6 +836,11 @@ void uv_loop_delete(uv_loop_t* loop) {
+   assert(err == 0);
+   if (loop != default_loop)
+     uv__free(loop);
++#else
++  int err = uv_loop_close(loop);
++  (void) err;    /* Squelch compiler warnings. */
++  assert(err == 0);
++#endif
+ }
+ 
+ 
+-- 
+2.17.1
+

--- a/libs/libuv/0007-prefix-data-pointers-with-FAR-keyword.patch
+++ b/libs/libuv/0007-prefix-data-pointers-with-FAR-keyword.patch
@@ -1,0 +1,3965 @@
+From f2e1f73c92bd00837bfd02574fbf78867ac79cec Mon Sep 17 00:00:00 2001
+From: spiriou <spiriou31@gmail.com>
+Date: Mon, 3 Aug 2020 22:32:25 +0200
+Subject: [PATCH 7/8] prefix data pointers with FAR keyword
+
+---
+ include/uv.h            | 928 ++++++++++++++++++++--------------------
+ include/uv/threadpool.h |   8 +-
+ include/uv/unix.h       |  86 ++--
+ src/heap-inl.h          |  58 +--
+ src/queue.h             |   4 +-
+ src/strscpy.c           |   2 +-
+ src/strscpy.h           |   2 +-
+ src/threadpool.c        |  50 +--
+ src/timer.c             |  38 +-
+ src/unix/core.c         | 102 ++---
+ src/unix/internal.h     | 118 ++---
+ src/unix/loop-watcher.c |  14 +-
+ src/unix/loop.c         |   6 +-
+ src/unix/no-proctitle.c |   6 +-
+ src/unix/nuttx.c        |  22 +-
+ src/unix/poll.c         |  14 +-
+ src/unix/process.c      |  12 +-
+ src/unix/thread.c       | 122 +++---
+ src/uv-common.c         | 104 ++---
+ src/uv-common.h         |  90 ++--
+ 20 files changed, 893 insertions(+), 893 deletions(-)
+
+diff --git a/include/uv.h b/include/uv.h
+index fec6631..b4e9700 100644
+--- a/include/uv.h
++++ b/include/uv.h
+@@ -258,11 +258,11 @@ typedef enum {
+ 
+ 
+ UV_EXTERN unsigned int uv_version(void);
+-UV_EXTERN const char* uv_version_string(void);
++UV_EXTERN FAR const char* uv_version_string(void);
+ 
+-typedef void* (*uv_malloc_func)(size_t size);
+-typedef void* (*uv_realloc_func)(void* ptr, size_t size);
+-typedef void* (*uv_calloc_func)(size_t count, size_t size);
++typedef FAR void* (*uv_malloc_func)(size_t size);
++typedef FAR void* (*uv_realloc_func)(void* ptr, size_t size);
++typedef FAR void* (*uv_calloc_func)(size_t count, size_t size);
+ typedef void (*uv_free_func)(void* ptr);
+ 
+ UV_EXTERN void uv_library_shutdown(void);
+@@ -272,7 +272,7 @@ UV_EXTERN int uv_replace_allocator(uv_malloc_func malloc_func,
+                                    uv_calloc_func calloc_func,
+                                    uv_free_func free_func);
+ 
+-UV_EXTERN uv_loop_t* uv_default_loop(void);
++UV_EXTERN FAR uv_loop_t* uv_default_loop(void);
+ UV_EXTERN int uv_loop_init(uv_loop_t* loop);
+ UV_EXTERN int uv_loop_close(uv_loop_t* loop);
+ /*
+@@ -280,61 +280,61 @@ UV_EXTERN int uv_loop_close(uv_loop_t* loop);
+  *  This function is DEPRECATED (to be removed after 0.12), users should
+  *  allocate the loop manually and use uv_loop_init instead.
+  */
+-UV_EXTERN uv_loop_t* uv_loop_new(void);
++UV_EXTERN FAR uv_loop_t* uv_loop_new(void);
+ /*
+  * NOTE:
+  *  This function is DEPRECATED (to be removed after 0.12). Users should use
+  *  uv_loop_close and free the memory manually instead.
+  */
+-UV_EXTERN void uv_loop_delete(uv_loop_t*);
++UV_EXTERN void uv_loop_delete(FAR uv_loop_t*);
+ UV_EXTERN size_t uv_loop_size(void);
+-UV_EXTERN int uv_loop_alive(const uv_loop_t* loop);
+-UV_EXTERN int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...);
+-UV_EXTERN int uv_loop_fork(uv_loop_t* loop);
++UV_EXTERN int uv_loop_alive(FAR const uv_loop_t* loop);
++UV_EXTERN int uv_loop_configure(FAR uv_loop_t* loop, uv_loop_option option, ...);
++UV_EXTERN int uv_loop_fork(FAR uv_loop_t* loop);
+ 
+-UV_EXTERN int uv_run(uv_loop_t*, uv_run_mode mode);
+-UV_EXTERN void uv_stop(uv_loop_t*);
++UV_EXTERN int uv_run(FAR uv_loop_t*, uv_run_mode mode);
++UV_EXTERN void uv_stop(FAR uv_loop_t*);
+ 
+-UV_EXTERN void uv_ref(uv_handle_t*);
+-UV_EXTERN void uv_unref(uv_handle_t*);
+-UV_EXTERN int uv_has_ref(const uv_handle_t*);
++UV_EXTERN void uv_ref(FAR uv_handle_t*);
++UV_EXTERN void uv_unref(FAR uv_handle_t*);
++UV_EXTERN int uv_has_ref(FAR const uv_handle_t*);
+ 
+-UV_EXTERN void uv_update_time(uv_loop_t*);
+-UV_EXTERN uint64_t uv_now(const uv_loop_t*);
++UV_EXTERN void uv_update_time(FAR uv_loop_t*);
++UV_EXTERN uint64_t uv_now(FAR const uv_loop_t*);
+ 
+-UV_EXTERN int uv_backend_fd(const uv_loop_t*);
+-UV_EXTERN int uv_backend_timeout(const uv_loop_t*);
++UV_EXTERN int uv_backend_fd(FAR const uv_loop_t*);
++UV_EXTERN int uv_backend_timeout(FAR const uv_loop_t*);
+ 
+-typedef void (*uv_alloc_cb)(uv_handle_t* handle,
++typedef void (*uv_alloc_cb)(FAR uv_handle_t* handle,
+                             size_t suggested_size,
+-                            uv_buf_t* buf);
+-typedef void (*uv_read_cb)(uv_stream_t* stream,
++                            FAR uv_buf_t* buf);
++typedef void (*uv_read_cb)(FAR uv_stream_t* stream,
+                            ssize_t nread,
+-                           const uv_buf_t* buf);
+-typedef void (*uv_write_cb)(uv_write_t* req, int status);
+-typedef void (*uv_connect_cb)(uv_connect_t* req, int status);
+-typedef void (*uv_shutdown_cb)(uv_shutdown_t* req, int status);
+-typedef void (*uv_connection_cb)(uv_stream_t* server, int status);
+-typedef void (*uv_close_cb)(uv_handle_t* handle);
+-typedef void (*uv_poll_cb)(uv_poll_t* handle, int status, int events);
+-typedef void (*uv_timer_cb)(uv_timer_t* handle);
+-typedef void (*uv_async_cb)(uv_async_t* handle);
+-typedef void (*uv_prepare_cb)(uv_prepare_t* handle);
+-typedef void (*uv_check_cb)(uv_check_t* handle);
+-typedef void (*uv_idle_cb)(uv_idle_t* handle);
+-typedef void (*uv_exit_cb)(uv_process_t*, int64_t exit_status, int term_signal);
+-typedef void (*uv_walk_cb)(uv_handle_t* handle, void* arg);
+-typedef void (*uv_fs_cb)(uv_fs_t* req);
+-typedef void (*uv_work_cb)(uv_work_t* req);
+-typedef void (*uv_after_work_cb)(uv_work_t* req, int status);
+-typedef void (*uv_getaddrinfo_cb)(uv_getaddrinfo_t* req,
++                           FAR const uv_buf_t* buf);
++typedef void (*uv_write_cb)(FAR uv_write_t* req, int status);
++typedef void (*uv_connect_cb)(FAR uv_connect_t* req, int status);
++typedef void (*uv_shutdown_cb)(FAR uv_shutdown_t* req, int status);
++typedef void (*uv_connection_cb)(FAR uv_stream_t* server, int status);
++typedef void (*uv_close_cb)(FAR uv_handle_t* handle);
++typedef void (*uv_poll_cb)(FAR uv_poll_t* handle, int status, int events);
++typedef void (*uv_timer_cb)(FAR uv_timer_t* handle);
++typedef void (*uv_async_cb)(FAR uv_async_t* handle);
++typedef void (*uv_prepare_cb)(FAR uv_prepare_t* handle);
++typedef void (*uv_check_cb)(FAR uv_check_t* handle);
++typedef void (*uv_idle_cb)(FAR uv_idle_t* handle);
++typedef void (*uv_exit_cb)(FAR uv_process_t*, int64_t exit_status, int term_signal);
++typedef void (*uv_walk_cb)(FAR uv_handle_t* handle, void* arg);
++typedef void (*uv_fs_cb)(FAR uv_fs_t* req);
++typedef void (*uv_work_cb)(FAR uv_work_t* req);
++typedef void (*uv_after_work_cb)(FAR uv_work_t* req, int status);
++typedef void (*uv_getaddrinfo_cb)(FAR uv_getaddrinfo_t* req,
+                                   int status,
+-                                  struct addrinfo* res);
+-typedef void (*uv_getnameinfo_cb)(uv_getnameinfo_t* req,
++                                  FAR struct addrinfo* res);
++typedef void (*uv_getnameinfo_cb)(FAR uv_getnameinfo_t* req,
+                                   int status,
+-                                  const char* hostname,
+-                                  const char* service);
+-typedef void (*uv_random_cb)(uv_random_t* req,
++                                  FAR const char* hostname,
++                                  FAR const char* service);
++typedef void (*uv_random_cb)(FAR uv_random_t* req,
+                              int status,
+                              void* buf,
+                              size_t buflen);
+@@ -365,17 +365,17 @@ typedef struct {
+ } uv_stat_t;
+ 
+ 
+-typedef void (*uv_fs_event_cb)(uv_fs_event_t* handle,
+-                               const char* filename,
++typedef void (*uv_fs_event_cb)(FAR uv_fs_event_t* handle,
++                               FAR const char* filename,
+                                int events,
+                                int status);
+ 
+-typedef void (*uv_fs_poll_cb)(uv_fs_poll_t* handle,
++typedef void (*uv_fs_poll_cb)(FAR uv_fs_poll_t* handle,
+                               int status,
+-                              const uv_stat_t* prev,
+-                              const uv_stat_t* curr);
++                              FAR const uv_stat_t* prev,
++                              FAR const uv_stat_t* curr);
+ 
+-typedef void (*uv_signal_cb)(uv_signal_t* handle, int signum);
++typedef void (*uv_signal_cb)(FAR uv_signal_t* handle, int signum);
+ 
+ 
+ typedef enum {
+@@ -386,16 +386,16 @@ typedef enum {
+ 
+ UV_EXTERN int uv_translate_sys_error(int sys_errno);
+ 
+-UV_EXTERN const char* uv_strerror(int err);
+-UV_EXTERN char* uv_strerror_r(int err, char* buf, size_t buflen);
++UV_EXTERN FAR const char* uv_strerror(int err);
++UV_EXTERN FAR char* uv_strerror_r(int err, FAR char* buf, size_t buflen);
+ 
+-UV_EXTERN const char* uv_err_name(int err);
+-UV_EXTERN char* uv_err_name_r(int err, char* buf, size_t buflen);
++UV_EXTERN FAR const char* uv_err_name(int err);
++UV_EXTERN FAR char* uv_err_name_r(int err, FAR char* buf, size_t buflen);
+ 
+ 
+ #define UV_REQ_FIELDS                                                         \
+   /* public */                                                                \
+-  void* data;                                                                 \
++  FAR void* data;                                                             \
+   /* read-only */                                                             \
+   uv_req_type type;                                                           \
+   /* private */                                                               \
+@@ -412,8 +412,8 @@ struct uv_req_s {
+ UV_PRIVATE_REQ_TYPES
+ 
+ 
+-UV_EXTERN int uv_shutdown(uv_shutdown_t* req,
+-                          uv_stream_t* handle,
++UV_EXTERN int uv_shutdown(FAR uv_shutdown_t* req,
++                          FAR uv_stream_t* handle,
+                           uv_shutdown_cb cb);
+ 
+ struct uv_shutdown_s {
+@@ -426,13 +426,13 @@ struct uv_shutdown_s {
+ 
+ #define UV_HANDLE_FIELDS                                                      \
+   /* public */                                                                \
+-  void* data;                                                                 \
++  FAR void* data;                                                             \
+   /* read-only */                                                             \
+-  uv_loop_t* loop;                                                            \
++  FAR uv_loop_t* loop;                                                        \
+   uv_handle_type type;                                                        \
+   /* private */                                                               \
+-  uv_close_cb close_cb;                                                       \
+-  void* handle_queue[2];                                                      \
++  FAR uv_close_cb close_cb;                                                   \
++  FAR void* handle_queue[2];                                                  \
+   union {                                                                     \
+     int fd;                                                                   \
+     void* reserved[4];                                                        \
+@@ -445,34 +445,34 @@ struct uv_handle_s {
+ };
+ 
+ UV_EXTERN size_t uv_handle_size(uv_handle_type type);
+-UV_EXTERN uv_handle_type uv_handle_get_type(const uv_handle_t* handle);
+-UV_EXTERN const char* uv_handle_type_name(uv_handle_type type);
+-UV_EXTERN void* uv_handle_get_data(const uv_handle_t* handle);
+-UV_EXTERN uv_loop_t* uv_handle_get_loop(const uv_handle_t* handle);
+-UV_EXTERN void uv_handle_set_data(uv_handle_t* handle, void* data);
++UV_EXTERN uv_handle_type uv_handle_get_type(FAR const uv_handle_t* handle);
++UV_EXTERN FAR const char* uv_handle_type_name(uv_handle_type type);
++UV_EXTERN FAR void* uv_handle_get_data(FAR const uv_handle_t* handle);
++UV_EXTERN FAR uv_loop_t* uv_handle_get_loop(FAR const uv_handle_t* handle);
++UV_EXTERN void uv_handle_set_data(FAR uv_handle_t* handle, void* data);
+ 
+ UV_EXTERN size_t uv_req_size(uv_req_type type);
+-UV_EXTERN void* uv_req_get_data(const uv_req_t* req);
+-UV_EXTERN void uv_req_set_data(uv_req_t* req, void* data);
+-UV_EXTERN uv_req_type uv_req_get_type(const uv_req_t* req);
+-UV_EXTERN const char* uv_req_type_name(uv_req_type type);
++UV_EXTERN FAR void* uv_req_get_data(FAR const uv_req_t* req);
++UV_EXTERN void uv_req_set_data(FAR uv_req_t* req, FAR void* data);
++UV_EXTERN uv_req_type uv_req_get_type(FAR const uv_req_t* req);
++UV_EXTERN FAR const char* uv_req_type_name(uv_req_type type);
+ 
+-UV_EXTERN int uv_is_active(const uv_handle_t* handle);
++UV_EXTERN int uv_is_active(FAR const uv_handle_t* handle);
+ 
+-UV_EXTERN void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg);
++UV_EXTERN void uv_walk(FAR uv_loop_t* loop, uv_walk_cb walk_cb, FAR void* arg);
+ 
+ /* Helpers for ad hoc debugging, no API/ABI stability guaranteed. */
+-UV_EXTERN void uv_print_all_handles(uv_loop_t* loop, FILE* stream);
+-UV_EXTERN void uv_print_active_handles(uv_loop_t* loop, FILE* stream);
++UV_EXTERN void uv_print_all_handles(FAR uv_loop_t* loop, FAR FILE* stream);
++UV_EXTERN void uv_print_active_handles(FAR uv_loop_t* loop, FAR FILE* stream);
+ 
+-UV_EXTERN void uv_close(uv_handle_t* handle, uv_close_cb close_cb);
++UV_EXTERN void uv_close(FAR uv_handle_t* handle, uv_close_cb close_cb);
+ 
+-UV_EXTERN int uv_send_buffer_size(uv_handle_t* handle, int* value);
+-UV_EXTERN int uv_recv_buffer_size(uv_handle_t* handle, int* value);
++UV_EXTERN int uv_send_buffer_size(FAR uv_handle_t* handle, FAR int* value);
++UV_EXTERN int uv_recv_buffer_size(FAR uv_handle_t* handle, FAR int* value);
+ 
+-UV_EXTERN int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd);
++UV_EXTERN int uv_fileno(FAR const uv_handle_t* handle, FAR uv_os_fd_t* fd);
+ 
+-UV_EXTERN uv_buf_t uv_buf_init(char* base, unsigned int len);
++UV_EXTERN uv_buf_t uv_buf_init(FAR char* base, unsigned int len);
+ 
+ 
+ #define UV_STREAM_FIELDS                                                      \
+@@ -495,47 +495,47 @@ struct uv_stream_s {
+   UV_STREAM_FIELDS
+ };
+ 
+-UV_EXTERN size_t uv_stream_get_write_queue_size(const uv_stream_t* stream);
++UV_EXTERN size_t uv_stream_get_write_queue_size(FAR const uv_stream_t* stream);
+ 
+-UV_EXTERN int uv_listen(uv_stream_t* stream, int backlog, uv_connection_cb cb);
+-UV_EXTERN int uv_accept(uv_stream_t* server, uv_stream_t* client);
++UV_EXTERN int uv_listen(FAR uv_stream_t* stream, int backlog, uv_connection_cb cb);
++UV_EXTERN int uv_accept(FAR uv_stream_t* server, FAR uv_stream_t* client);
+ 
+-UV_EXTERN int uv_read_start(uv_stream_t*,
++UV_EXTERN int uv_read_start(FAR uv_stream_t*,
+                             uv_alloc_cb alloc_cb,
+                             uv_read_cb read_cb);
+-UV_EXTERN int uv_read_stop(uv_stream_t*);
++UV_EXTERN int uv_read_stop(FAR uv_stream_t*);
+ 
+-UV_EXTERN int uv_write(uv_write_t* req,
+-                       uv_stream_t* handle,
++UV_EXTERN int uv_write(FAR uv_write_t* req,
++                       FAR uv_stream_t* handle,
+                        const uv_buf_t bufs[],
+                        unsigned int nbufs,
+                        uv_write_cb cb);
+-UV_EXTERN int uv_write2(uv_write_t* req,
+-                        uv_stream_t* handle,
+-                        const uv_buf_t bufs[],
++UV_EXTERN int uv_write2(FAR uv_write_t* req,
++                        FAR uv_stream_t* handle,
++                        FAR const uv_buf_t bufs[],
+                         unsigned int nbufs,
+-                        uv_stream_t* send_handle,
++                        FAR uv_stream_t* send_handle,
+                         uv_write_cb cb);
+-UV_EXTERN int uv_try_write(uv_stream_t* handle,
+-                           const uv_buf_t bufs[],
++UV_EXTERN int uv_try_write(FAR uv_stream_t* handle,
++                           FAR const uv_buf_t bufs[],
+                            unsigned int nbufs);
+ 
+ /* uv_write_t is a subclass of uv_req_t. */
+ struct uv_write_s {
+   UV_REQ_FIELDS
+   uv_write_cb cb;
+-  uv_stream_t* send_handle; /* TODO: make private and unix-only in v2.x. */
+-  uv_stream_t* handle;
++  FAR uv_stream_t* send_handle; /* TODO: make private and unix-only in v2.x. */
++  FAR uv_stream_t* handle;
+   UV_WRITE_PRIVATE_FIELDS
+ };
+ 
+ 
+-UV_EXTERN int uv_is_readable(const uv_stream_t* handle);
+-UV_EXTERN int uv_is_writable(const uv_stream_t* handle);
++UV_EXTERN int uv_is_readable(FAR const uv_stream_t* handle);
++UV_EXTERN int uv_is_writable(FAR const uv_stream_t* handle);
+ 
+-UV_EXTERN int uv_stream_set_blocking(uv_stream_t* handle, int blocking);
++UV_EXTERN int uv_stream_set_blocking(FAR uv_stream_t* handle, int blocking);
+ 
+-UV_EXTERN int uv_is_closing(const uv_handle_t* handle);
++UV_EXTERN int uv_is_closing(FAR const uv_handle_t* handle);
+ 
+ 
+ /*
+@@ -549,40 +549,40 @@ struct uv_tcp_s {
+   UV_TCP_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_tcp_init(uv_loop_t*, uv_tcp_t* handle);
+-UV_EXTERN int uv_tcp_init_ex(uv_loop_t*, uv_tcp_t* handle, unsigned int flags);
+-UV_EXTERN int uv_tcp_open(uv_tcp_t* handle, uv_os_sock_t sock);
+-UV_EXTERN int uv_tcp_nodelay(uv_tcp_t* handle, int enable);
+-UV_EXTERN int uv_tcp_keepalive(uv_tcp_t* handle,
++UV_EXTERN int uv_tcp_init(FAR uv_loop_t*, FAR uv_tcp_t* handle);
++UV_EXTERN int uv_tcp_init_ex(FAR uv_loop_t*, FAR uv_tcp_t* handle, unsigned int flags);
++UV_EXTERN int uv_tcp_open(FAR uv_tcp_t* handle, uv_os_sock_t sock);
++UV_EXTERN int uv_tcp_nodelay(FAR uv_tcp_t* handle, int enable);
++UV_EXTERN int uv_tcp_keepalive(FAR uv_tcp_t* handle,
+                                int enable,
+                                unsigned int delay);
+-UV_EXTERN int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable);
++UV_EXTERN int uv_tcp_simultaneous_accepts(FAR uv_tcp_t* handle, int enable);
+ 
+ enum uv_tcp_flags {
+   /* Used with uv_tcp_bind, when an IPv6 address is used. */
+   UV_TCP_IPV6ONLY = 1
+ };
+ 
+-UV_EXTERN int uv_tcp_bind(uv_tcp_t* handle,
+-                          const struct sockaddr* addr,
++UV_EXTERN int uv_tcp_bind(FAR uv_tcp_t* handle,
++                          FAR const struct sockaddr* addr,
+                           unsigned int flags);
+-UV_EXTERN int uv_tcp_getsockname(const uv_tcp_t* handle,
+-                                 struct sockaddr* name,
+-                                 int* namelen);
+-UV_EXTERN int uv_tcp_getpeername(const uv_tcp_t* handle,
+-                                 struct sockaddr* name,
+-                                 int* namelen);
+-UV_EXTERN int uv_tcp_close_reset(uv_tcp_t* handle, uv_close_cb close_cb);
+-UV_EXTERN int uv_tcp_connect(uv_connect_t* req,
+-                             uv_tcp_t* handle,
+-                             const struct sockaddr* addr,
++UV_EXTERN int uv_tcp_getsockname(FAR const uv_tcp_t* handle,
++                                 FAR struct sockaddr* name,
++                                 FAR int* namelen);
++UV_EXTERN int uv_tcp_getpeername(FAR const uv_tcp_t* handle,
++                                 FAR struct sockaddr* name,
++                                 FAR int* namelen);
++UV_EXTERN int uv_tcp_close_reset(FAR uv_tcp_t* handle, uv_close_cb close_cb);
++UV_EXTERN int uv_tcp_connect(FAR uv_connect_t* req,
++                             FAR uv_tcp_t* handle,
++                             FAR const struct sockaddr* addr,
+                              uv_connect_cb cb);
+ 
+ /* uv_connect_t is a subclass of uv_req_t. */
+ struct uv_connect_s {
+   UV_REQ_FIELDS
+   uv_connect_cb cb;
+-  uv_stream_t* handle;
++  FAR uv_stream_t* handle;
+   UV_CONNECT_PRIVATE_FIELDS
+ };
+ 
+@@ -620,11 +620,11 @@ enum uv_udp_flags {
+   UV_UDP_RECVMMSG = 256
+ };
+ 
+-typedef void (*uv_udp_send_cb)(uv_udp_send_t* req, int status);
+-typedef void (*uv_udp_recv_cb)(uv_udp_t* handle,
++typedef void (*uv_udp_send_cb)(FAR uv_udp_send_t* req, int status);
++typedef void (*uv_udp_recv_cb)(FAR uv_udp_t* handle,
+                                ssize_t nread,
+-                               const uv_buf_t* buf,
+-                               const struct sockaddr* addr,
++                               FAR const uv_buf_t* buf,
++                               FAR const struct sockaddr* addr,
+                                unsigned flags);
+ 
+ /* uv_udp_t is a subclass of uv_handle_t. */
+@@ -646,56 +646,56 @@ struct uv_udp_s {
+ /* uv_udp_send_t is a subclass of uv_req_t. */
+ struct uv_udp_send_s {
+   UV_REQ_FIELDS
+-  uv_udp_t* handle;
++  FAR uv_udp_t* handle;
+   uv_udp_send_cb cb;
+   UV_UDP_SEND_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_udp_init(uv_loop_t*, uv_udp_t* handle);
+-UV_EXTERN int uv_udp_init_ex(uv_loop_t*, uv_udp_t* handle, unsigned int flags);
+-UV_EXTERN int uv_udp_open(uv_udp_t* handle, uv_os_sock_t sock);
+-UV_EXTERN int uv_udp_bind(uv_udp_t* handle,
+-                          const struct sockaddr* addr,
++UV_EXTERN int uv_udp_init(FAR uv_loop_t*, FAR uv_udp_t* handle);
++UV_EXTERN int uv_udp_init_ex(FAR uv_loop_t*, FAR uv_udp_t* handle, unsigned int flags);
++UV_EXTERN int uv_udp_open(FAR uv_udp_t* handle, uv_os_sock_t sock);
++UV_EXTERN int uv_udp_bind(FAR uv_udp_t* handle,
++                          FAR const struct sockaddr* addr,
+                           unsigned int flags);
+-UV_EXTERN int uv_udp_connect(uv_udp_t* handle, const struct sockaddr* addr);
+-
+-UV_EXTERN int uv_udp_getpeername(const uv_udp_t* handle,
+-                                 struct sockaddr* name,
+-                                 int* namelen);
+-UV_EXTERN int uv_udp_getsockname(const uv_udp_t* handle,
+-                                 struct sockaddr* name,
+-                                 int* namelen);
+-UV_EXTERN int uv_udp_set_membership(uv_udp_t* handle,
+-                                    const char* multicast_addr,
+-                                    const char* interface_addr,
++UV_EXTERN int uv_udp_connect(FAR uv_udp_t* handle, FAR const struct sockaddr* addr);
++
++UV_EXTERN int uv_udp_getpeername(FAR const uv_udp_t* handle,
++                                 FAR struct sockaddr* name,
++                                 FAR int* namelen);
++UV_EXTERN int uv_udp_getsockname(FAR const uv_udp_t* handle,
++                                 FAR struct sockaddr* name,
++                                 FAR int* namelen);
++UV_EXTERN int uv_udp_set_membership(FAR uv_udp_t* handle,
++                                    FAR const char* multicast_addr,
++                                    FAR const char* interface_addr,
+                                     uv_membership membership);
+-UV_EXTERN int uv_udp_set_source_membership(uv_udp_t* handle,
+-                                           const char* multicast_addr,
+-                                           const char* interface_addr,
+-                                           const char* source_addr,
++UV_EXTERN int uv_udp_set_source_membership(FAR uv_udp_t* handle,
++                                           FAR const char* multicast_addr,
++                                           FAR const char* interface_addr,
++                                           FAR const char* source_addr,
+                                            uv_membership membership);
+-UV_EXTERN int uv_udp_set_multicast_loop(uv_udp_t* handle, int on);
+-UV_EXTERN int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl);
+-UV_EXTERN int uv_udp_set_multicast_interface(uv_udp_t* handle,
+-                                             const char* interface_addr);
+-UV_EXTERN int uv_udp_set_broadcast(uv_udp_t* handle, int on);
+-UV_EXTERN int uv_udp_set_ttl(uv_udp_t* handle, int ttl);
+-UV_EXTERN int uv_udp_send(uv_udp_send_t* req,
+-                          uv_udp_t* handle,
+-                          const uv_buf_t bufs[],
++UV_EXTERN int uv_udp_set_multicast_loop(FAR uv_udp_t* handle, int on);
++UV_EXTERN int uv_udp_set_multicast_ttl(FAR uv_udp_t* handle, int ttl);
++UV_EXTERN int uv_udp_set_multicast_interface(FAR uv_udp_t* handle,
++                                             FAR const char* interface_addr);
++UV_EXTERN int uv_udp_set_broadcast(FAR uv_udp_t* handle, int on);
++UV_EXTERN int uv_udp_set_ttl(FAR uv_udp_t* handle, int ttl);
++UV_EXTERN int uv_udp_send(FAR uv_udp_send_t* req,
++                          FAR uv_udp_t* handle,
++                          FAR const uv_buf_t bufs[],
+                           unsigned int nbufs,
+-                          const struct sockaddr* addr,
++                          FAR const struct sockaddr* addr,
+                           uv_udp_send_cb send_cb);
+-UV_EXTERN int uv_udp_try_send(uv_udp_t* handle,
+-                              const uv_buf_t bufs[],
++UV_EXTERN int uv_udp_try_send(FAR uv_udp_t* handle,
++                              FAR const uv_buf_t bufs[],
+                               unsigned int nbufs,
+-                              const struct sockaddr* addr);
+-UV_EXTERN int uv_udp_recv_start(uv_udp_t* handle,
++                              FAR const struct sockaddr* addr);
++UV_EXTERN int uv_udp_recv_start(FAR uv_udp_t* handle,
+                                 uv_alloc_cb alloc_cb,
+                                 uv_udp_recv_cb recv_cb);
+-UV_EXTERN int uv_udp_recv_stop(uv_udp_t* handle);
+-UV_EXTERN size_t uv_udp_get_send_queue_size(const uv_udp_t* handle);
+-UV_EXTERN size_t uv_udp_get_send_queue_count(const uv_udp_t* handle);
++UV_EXTERN int uv_udp_recv_stop(FAR uv_udp_t* handle);
++UV_EXTERN size_t uv_udp_get_send_queue_size(FAR const uv_udp_t* handle);
++UV_EXTERN size_t uv_udp_get_send_queue_count(FAR const uv_udp_t* handle);
+ 
+ 
+ /*
+@@ -731,17 +731,17 @@ typedef enum {
+ } uv_tty_vtermstate_t;
+ 
+ 
+-UV_EXTERN int uv_tty_init(uv_loop_t*, uv_tty_t*, uv_file fd, int readable);
+-UV_EXTERN int uv_tty_set_mode(uv_tty_t*, uv_tty_mode_t mode);
++UV_EXTERN int uv_tty_init(FAR uv_loop_t*, FAR uv_tty_t*, uv_file fd, int readable);
++UV_EXTERN int uv_tty_set_mode(FAR uv_tty_t*, uv_tty_mode_t mode);
+ UV_EXTERN int uv_tty_reset_mode(void);
+-UV_EXTERN int uv_tty_get_winsize(uv_tty_t*, int* width, int* height);
++UV_EXTERN int uv_tty_get_winsize(FAR uv_tty_t*, FAR int* width, FAR int* height);
+ UV_EXTERN void uv_tty_set_vterm_state(uv_tty_vtermstate_t state);
+-UV_EXTERN int uv_tty_get_vterm_state(uv_tty_vtermstate_t* state);
++UV_EXTERN int uv_tty_get_vterm_state(FAR uv_tty_vtermstate_t* state);
+ 
+ #ifdef __cplusplus
+ extern "C++" {
+ 
+-inline int uv_tty_set_mode(uv_tty_t* handle, int mode) {
++inline int uv_tty_set_mode(FAR uv_tty_t* handle, int mode) {
+   return uv_tty_set_mode(handle, static_cast<uv_tty_mode_t>(mode));
+ }
+ 
+@@ -763,23 +763,23 @@ struct uv_pipe_s {
+   UV_PIPE_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_pipe_init(uv_loop_t*, uv_pipe_t* handle, int ipc);
+-UV_EXTERN int uv_pipe_open(uv_pipe_t*, uv_file file);
+-UV_EXTERN int uv_pipe_bind(uv_pipe_t* handle, const char* name);
+-UV_EXTERN void uv_pipe_connect(uv_connect_t* req,
+-                               uv_pipe_t* handle,
+-                               const char* name,
++UV_EXTERN int uv_pipe_init(FAR uv_loop_t*, FAR uv_pipe_t* handle, int ipc);
++UV_EXTERN int uv_pipe_open(FAR uv_pipe_t*, uv_file file);
++UV_EXTERN int uv_pipe_bind(FAR uv_pipe_t* handle, FAR const char* name);
++UV_EXTERN void uv_pipe_connect(FAR uv_connect_t* req,
++                               FAR uv_pipe_t* handle,
++                               FAR const char* name,
+                                uv_connect_cb cb);
+-UV_EXTERN int uv_pipe_getsockname(const uv_pipe_t* handle,
+-                                  char* buffer,
+-                                  size_t* size);
+-UV_EXTERN int uv_pipe_getpeername(const uv_pipe_t* handle,
+-                                  char* buffer,
+-                                  size_t* size);
+-UV_EXTERN void uv_pipe_pending_instances(uv_pipe_t* handle, int count);
+-UV_EXTERN int uv_pipe_pending_count(uv_pipe_t* handle);
+-UV_EXTERN uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle);
+-UV_EXTERN int uv_pipe_chmod(uv_pipe_t* handle, int flags);
++UV_EXTERN int uv_pipe_getsockname(FAR const uv_pipe_t* handle,
++                                  FAR char* buffer,
++                                  FAR size_t* size);
++UV_EXTERN int uv_pipe_getpeername(FAR const uv_pipe_t* handle,
++                                  FAR char* buffer,
++                                  FAR size_t* size);
++UV_EXTERN void uv_pipe_pending_instances(FAR uv_pipe_t* handle, int count);
++UV_EXTERN int uv_pipe_pending_count(FAR uv_pipe_t* handle);
++UV_EXTERN uv_handle_type uv_pipe_pending_type(FAR uv_pipe_t* handle);
++UV_EXTERN int uv_pipe_chmod(FAR uv_pipe_t* handle, int flags);
+ 
+ 
+ struct uv_poll_s {
+@@ -795,12 +795,12 @@ enum uv_poll_event {
+   UV_PRIORITIZED = 8
+ };
+ 
+-UV_EXTERN int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd);
+-UV_EXTERN int uv_poll_init_socket(uv_loop_t* loop,
+-                                  uv_poll_t* handle,
++UV_EXTERN int uv_poll_init(FAR uv_loop_t* loop, FAR uv_poll_t* handle, int fd);
++UV_EXTERN int uv_poll_init_socket(FAR uv_loop_t* loop,
++                                  FAR uv_poll_t* handle,
+                                   uv_os_sock_t socket);
+-UV_EXTERN int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb);
+-UV_EXTERN int uv_poll_stop(uv_poll_t* handle);
++UV_EXTERN int uv_poll_start(FAR uv_poll_t* handle, int events, uv_poll_cb cb);
++UV_EXTERN int uv_poll_stop(FAR uv_poll_t* handle);
+ 
+ 
+ struct uv_prepare_s {
+@@ -808,9 +808,9 @@ struct uv_prepare_s {
+   UV_PREPARE_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_prepare_init(uv_loop_t*, uv_prepare_t* prepare);
+-UV_EXTERN int uv_prepare_start(uv_prepare_t* prepare, uv_prepare_cb cb);
+-UV_EXTERN int uv_prepare_stop(uv_prepare_t* prepare);
++UV_EXTERN int uv_prepare_init(FAR uv_loop_t*, FAR uv_prepare_t* prepare);
++UV_EXTERN int uv_prepare_start(FAR uv_prepare_t* prepare, uv_prepare_cb cb);
++UV_EXTERN int uv_prepare_stop(FAR uv_prepare_t* prepare);
+ 
+ 
+ struct uv_check_s {
+@@ -818,9 +818,9 @@ struct uv_check_s {
+   UV_CHECK_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_check_init(uv_loop_t*, uv_check_t* check);
+-UV_EXTERN int uv_check_start(uv_check_t* check, uv_check_cb cb);
+-UV_EXTERN int uv_check_stop(uv_check_t* check);
++UV_EXTERN int uv_check_init(FAR uv_loop_t*, FAR uv_check_t* check);
++UV_EXTERN int uv_check_start(FAR uv_check_t* check, uv_check_cb cb);
++UV_EXTERN int uv_check_stop(FAR uv_check_t* check);
+ 
+ 
+ struct uv_idle_s {
+@@ -828,9 +828,9 @@ struct uv_idle_s {
+   UV_IDLE_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_idle_init(uv_loop_t*, uv_idle_t* idle);
+-UV_EXTERN int uv_idle_start(uv_idle_t* idle, uv_idle_cb cb);
+-UV_EXTERN int uv_idle_stop(uv_idle_t* idle);
++UV_EXTERN int uv_idle_init(FAR uv_loop_t*, FAR uv_idle_t* idle);
++UV_EXTERN int uv_idle_start(FAR uv_idle_t* idle, uv_idle_cb cb);
++UV_EXTERN int uv_idle_stop(FAR uv_idle_t* idle);
+ 
+ 
+ struct uv_async_s {
+@@ -838,10 +838,10 @@ struct uv_async_s {
+   UV_ASYNC_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_async_init(uv_loop_t*,
+-                            uv_async_t* async,
++UV_EXTERN int uv_async_init(FAR uv_loop_t*,
++                            FAR uv_async_t* async,
+                             uv_async_cb async_cb);
+-UV_EXTERN int uv_async_send(uv_async_t* async);
++UV_EXTERN int uv_async_send(FAR uv_async_t* async);
+ 
+ 
+ /*
+@@ -854,15 +854,15 @@ struct uv_timer_s {
+   UV_TIMER_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_timer_init(uv_loop_t*, uv_timer_t* handle);
+-UV_EXTERN int uv_timer_start(uv_timer_t* handle,
++UV_EXTERN int uv_timer_init(FAR uv_loop_t*, FAR uv_timer_t* handle);
++UV_EXTERN int uv_timer_start(FAR uv_timer_t* handle,
+                              uv_timer_cb cb,
+                              uint64_t timeout,
+                              uint64_t repeat);
+-UV_EXTERN int uv_timer_stop(uv_timer_t* handle);
+-UV_EXTERN int uv_timer_again(uv_timer_t* handle);
+-UV_EXTERN void uv_timer_set_repeat(uv_timer_t* handle, uint64_t repeat);
+-UV_EXTERN uint64_t uv_timer_get_repeat(const uv_timer_t* handle);
++UV_EXTERN int uv_timer_stop(FAR uv_timer_t* handle);
++UV_EXTERN int uv_timer_again(FAR uv_timer_t* handle);
++UV_EXTERN void uv_timer_set_repeat(FAR uv_timer_t* handle, uint64_t repeat);
++UV_EXTERN uint64_t uv_timer_get_repeat(FAR const uv_timer_t* handle);
+ 
+ 
+ /*
+@@ -879,13 +879,13 @@ struct uv_getaddrinfo_s {
+ };
+ 
+ 
+-UV_EXTERN int uv_getaddrinfo(uv_loop_t* loop,
+-                             uv_getaddrinfo_t* req,
++UV_EXTERN int uv_getaddrinfo(FAR uv_loop_t* loop,
++                             FAR uv_getaddrinfo_t* req,
+                              uv_getaddrinfo_cb getaddrinfo_cb,
+-                             const char* node,
+-                             const char* service,
+-                             const struct addrinfo* hints);
+-UV_EXTERN void uv_freeaddrinfo(struct addrinfo* ai);
++                             FAR const char* node,
++                             FAR const char* service,
++                             FAR const struct addrinfo* hints);
++UV_EXTERN void uv_freeaddrinfo(FAR struct addrinfo* ai);
+ 
+ 
+ /*
+@@ -896,15 +896,15 @@ UV_EXTERN void uv_freeaddrinfo(struct addrinfo* ai);
+ struct uv_getnameinfo_s {
+   UV_REQ_FIELDS
+   /* read-only */
+-  uv_loop_t* loop;
++  FAR uv_loop_t* loop;
+   /* host and service are marked as private, but they really aren't. */
+   UV_GETNAMEINFO_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_getnameinfo(uv_loop_t* loop,
+-                             uv_getnameinfo_t* req,
++UV_EXTERN int uv_getnameinfo(FAR uv_loop_t* loop,
++                             FAR uv_getnameinfo_t* req,
+                              uv_getnameinfo_cb getnameinfo_cb,
+-                             const struct sockaddr* addr,
++                             FAR const struct sockaddr* addr,
+                              int flags);
+ 
+ 
+@@ -934,31 +934,31 @@ typedef struct uv_stdio_container_s {
+   uv_stdio_flags flags;
+ 
+   union {
+-    uv_stream_t* stream;
++    FAR uv_stream_t* stream;
+     int fd;
+   } data;
+ } uv_stdio_container_t;
+ 
+ typedef struct uv_process_options_s {
+   uv_exit_cb exit_cb; /* Called after the process exits. */
+-  const char* file;   /* Path to program to execute. */
++  FAR const char* file;   /* Path to program to execute. */
+   /*
+    * Command line arguments. args[0] should be the path to the program. On
+    * Windows this uses CreateProcess which concatenates the arguments into a
+    * string this can cause some strange errors. See the note at
+    * windows_verbatim_arguments.
+    */
+-  char** args;
++  FAR char** args;
+   /*
+    * This will be set as the environ variable in the subprocess. If this is
+    * NULL then the parents environ will be used.
+    */
+-  char** env;
++  FAR char** env;
+   /*
+    * If non-null this represents a directory the subprocess should execute
+    * in. Stands for current working directory.
+    */
+-  const char* cwd;
++  FAR const char* cwd;
+   /*
+    * Various flags that control how uv_spawn() behaves. See the definition of
+    * `enum uv_process_flags` below.
+@@ -974,7 +974,7 @@ typedef struct uv_process_options_s {
+    * child process only if the child processes uses the MSVCRT runtime.
+    */
+   int stdio_count;
+-  uv_stdio_container_t* stdio;
++  FAR uv_stdio_container_t* stdio;
+   /*
+    * Libuv can change the child process' user/group id. This happens only when
+    * the appropriate bits are set in the flags fields. This is not supported on
+@@ -1043,12 +1043,12 @@ struct uv_process_s {
+   UV_PROCESS_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_spawn(uv_loop_t* loop,
+-                       uv_process_t* handle,
+-                       const uv_process_options_t* options);
+-UV_EXTERN int uv_process_kill(uv_process_t*, int signum);
++UV_EXTERN int uv_spawn(FAR uv_loop_t* loop,
++                       FAR uv_process_t* handle,
++                       FAR const uv_process_options_t* options);
++UV_EXTERN int uv_process_kill(FAR uv_process_t*, int signum);
+ UV_EXTERN int uv_kill(int pid, int signum);
+-UV_EXTERN uv_pid_t uv_process_get_pid(const uv_process_t*);
++UV_EXTERN uv_pid_t uv_process_get_pid(FAR const uv_process_t*);
+ 
+ 
+ /*
+@@ -1056,18 +1056,18 @@ UV_EXTERN uv_pid_t uv_process_get_pid(const uv_process_t*);
+  */
+ struct uv_work_s {
+   UV_REQ_FIELDS
+-  uv_loop_t* loop;
++  FAR uv_loop_t* loop;
+   uv_work_cb work_cb;
+   uv_after_work_cb after_work_cb;
+   UV_WORK_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_queue_work(uv_loop_t* loop,
+-                            uv_work_t* req,
++UV_EXTERN int uv_queue_work(FAR uv_loop_t* loop,
++                            FAR uv_work_t* req,
+                             uv_work_cb work_cb,
+                             uv_after_work_cb after_work_cb);
+ 
+-UV_EXTERN int uv_cancel(uv_req_t* req);
++UV_EXTERN int uv_cancel(FAR uv_req_t* req);
+ 
+ 
+ struct uv_cpu_times_s {
+@@ -1139,15 +1139,15 @@ typedef enum {
+ } uv_dirent_type_t;
+ 
+ struct uv_dirent_s {
+-  const char* name;
++  FAR const char* name;
+   uv_dirent_type_t type;
+ };
+ 
+-UV_EXTERN char** uv_setup_args(int argc, char** argv);
+-UV_EXTERN int uv_get_process_title(char* buffer, size_t size);
+-UV_EXTERN int uv_set_process_title(const char* title);
+-UV_EXTERN int uv_resident_set_memory(size_t* rss);
+-UV_EXTERN int uv_uptime(double* uptime);
++UV_EXTERN FAR char** uv_setup_args(int argc, FAR char** argv);
++UV_EXTERN int uv_get_process_title(FAR char* buffer, size_t size);
++UV_EXTERN int uv_set_process_title(FAR const char* title);
++UV_EXTERN int uv_resident_set_memory(FAR size_t* rss);
++UV_EXTERN int uv_uptime(FAR double* uptime);
+ UV_EXTERN uv_os_fd_t uv_get_osfhandle(int fd);
+ UV_EXTERN int uv_open_osfhandle(uv_os_fd_t os_fd);
+ 
+@@ -1180,12 +1180,12 @@ typedef struct {
+    uint64_t ru_nivcsw;    /* involuntary context switches */
+ } uv_rusage_t;
+ 
+-UV_EXTERN int uv_getrusage(uv_rusage_t* rusage);
++UV_EXTERN int uv_getrusage(FAR uv_rusage_t* rusage);
+ 
+-UV_EXTERN int uv_os_homedir(char* buffer, size_t* size);
+-UV_EXTERN int uv_os_tmpdir(char* buffer, size_t* size);
+-UV_EXTERN int uv_os_get_passwd(uv_passwd_t* pwd);
+-UV_EXTERN void uv_os_free_passwd(uv_passwd_t* pwd);
++UV_EXTERN int uv_os_homedir(FAR char* buffer, FAR size_t* size);
++UV_EXTERN int uv_os_tmpdir(FAR char* buffer, FAR size_t* size);
++UV_EXTERN int uv_os_get_passwd(FAR uv_passwd_t* pwd);
++UV_EXTERN void uv_os_free_passwd(FAR uv_passwd_t* pwd);
+ UV_EXTERN uv_pid_t uv_os_getpid(void);
+ UV_EXTERN uv_pid_t uv_os_getppid(void);
+ 
+@@ -1206,27 +1206,27 @@ UV_EXTERN uv_pid_t uv_os_getppid(void);
+ # define UV_PRIORITY_HIGHEST -20
+ #endif
+ 
+-UV_EXTERN int uv_os_getpriority(uv_pid_t pid, int* priority);
++UV_EXTERN int uv_os_getpriority(uv_pid_t pid, FAR int* priority);
+ UV_EXTERN int uv_os_setpriority(uv_pid_t pid, int priority);
+ 
+-UV_EXTERN int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count);
+-UV_EXTERN void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count);
++UV_EXTERN int uv_cpu_info(FAR uv_cpu_info_t** cpu_infos, FAR int* count);
++UV_EXTERN void uv_free_cpu_info(FAR uv_cpu_info_t* cpu_infos, int count);
+ 
+-UV_EXTERN int uv_interface_addresses(uv_interface_address_t** addresses,
+-                                     int* count);
+-UV_EXTERN void uv_free_interface_addresses(uv_interface_address_t* addresses,
++UV_EXTERN int uv_interface_addresses(FAR uv_interface_address_t** addresses,
++                                     FAR int* count);
++UV_EXTERN void uv_free_interface_addresses(FAR uv_interface_address_t* addresses,
+                                            int count);
+ 
+ struct uv_env_item_s {
+-  char* name;
+-  char* value;
++  FAR char* name;
++  FAR char* value;
+ };
+ 
+-UV_EXTERN int uv_os_environ(uv_env_item_t** envitems, int* count);
+-UV_EXTERN void uv_os_free_environ(uv_env_item_t* envitems, int count);
+-UV_EXTERN int uv_os_getenv(const char* name, char* buffer, size_t* size);
+-UV_EXTERN int uv_os_setenv(const char* name, const char* value);
+-UV_EXTERN int uv_os_unsetenv(const char* name);
++UV_EXTERN int uv_os_environ(FAR uv_env_item_t** envitems, FAR int* count);
++UV_EXTERN void uv_os_free_environ(FAR uv_env_item_t* envitems, int count);
++UV_EXTERN int uv_os_getenv(FAR const char* name, FAR char* buffer, FAR size_t* size);
++UV_EXTERN int uv_os_setenv(FAR const char* name, FAR const char* value);
++UV_EXTERN int uv_os_unsetenv(FAR const char* name);
+ 
+ #ifdef MAXHOSTNAMELEN
+ # define UV_MAXHOSTNAMESIZE (MAXHOSTNAMELEN + 1)
+@@ -1239,9 +1239,9 @@ UV_EXTERN int uv_os_unsetenv(const char* name);
+ # define UV_MAXHOSTNAMESIZE 256
+ #endif
+ 
+-UV_EXTERN int uv_os_gethostname(char* buffer, size_t* size);
++UV_EXTERN int uv_os_gethostname(FAR char* buffer, FAR size_t* size);
+ 
+-UV_EXTERN int uv_os_uname(uv_utsname_t* buffer);
++UV_EXTERN int uv_os_uname(FAR uv_utsname_t* buffer);
+ 
+ 
+ typedef enum {
+@@ -1286,7 +1286,7 @@ typedef enum {
+ } uv_fs_type;
+ 
+ struct uv_dir_s {
+-  uv_dirent_t* dirents;
++  FAR uv_dirent_t* dirents;
+   size_t nentries;
+   void* reserved[4];
+   UV_DIR_PRIVATE_FIELDS
+@@ -1296,48 +1296,48 @@ struct uv_dir_s {
+ struct uv_fs_s {
+   UV_REQ_FIELDS
+   uv_fs_type fs_type;
+-  uv_loop_t* loop;
++  FAR uv_loop_t* loop;
+   uv_fs_cb cb;
+   ssize_t result;
+-  void* ptr;
+-  const char* path;
++  FAR void* ptr;
++  FAR const char* path;
+   uv_stat_t statbuf;  /* Stores the result of uv_fs_stat() and uv_fs_fstat(). */
+   UV_FS_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN uv_fs_type uv_fs_get_type(const uv_fs_t*);
+-UV_EXTERN ssize_t uv_fs_get_result(const uv_fs_t*);
+-UV_EXTERN int uv_fs_get_system_error(const uv_fs_t*);
+-UV_EXTERN void* uv_fs_get_ptr(const uv_fs_t*);
+-UV_EXTERN const char* uv_fs_get_path(const uv_fs_t*);
+-UV_EXTERN uv_stat_t* uv_fs_get_statbuf(uv_fs_t*);
++UV_EXTERN uv_fs_type uv_fs_get_type(FAR const uv_fs_t*);
++UV_EXTERN ssize_t uv_fs_get_result(FAR const uv_fs_t*);
++UV_EXTERN int uv_fs_get_system_error(FAR const uv_fs_t*);
++UV_EXTERN FAR void* uv_fs_get_ptr(FAR const uv_fs_t*);
++UV_EXTERN FAR const char* uv_fs_get_path(FAR const uv_fs_t*);
++UV_EXTERN FAR uv_stat_t* uv_fs_get_statbuf(FAR uv_fs_t*);
+ 
+-UV_EXTERN void uv_fs_req_cleanup(uv_fs_t* req);
+-UV_EXTERN int uv_fs_close(uv_loop_t* loop,
+-                          uv_fs_t* req,
++UV_EXTERN void uv_fs_req_cleanup(FAR uv_fs_t* req);
++UV_EXTERN int uv_fs_close(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
+                           uv_file file,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_open(uv_loop_t* loop,
+-                         uv_fs_t* req,
+-                         const char* path,
++UV_EXTERN int uv_fs_open(FAR uv_loop_t* loop,
++                         FAR uv_fs_t* req,
++                         FAR const char* path,
+                          int flags,
+                          int mode,
+                          uv_fs_cb cb);
+-UV_EXTERN int uv_fs_read(uv_loop_t* loop,
+-                         uv_fs_t* req,
++UV_EXTERN int uv_fs_read(FAR uv_loop_t* loop,
++                         FAR uv_fs_t* req,
+                          uv_file file,
+-                         const uv_buf_t bufs[],
++                         FAR const uv_buf_t bufs[],
+                          unsigned int nbufs,
+                          int64_t offset,
+                          uv_fs_cb cb);
+-UV_EXTERN int uv_fs_unlink(uv_loop_t* loop,
+-                           uv_fs_t* req,
+-                           const char* path,
++UV_EXTERN int uv_fs_unlink(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
++                           FAR const char* path,
+                            uv_fs_cb cb);
+-UV_EXTERN int uv_fs_write(uv_loop_t* loop,
+-                          uv_fs_t* req,
++UV_EXTERN int uv_fs_write(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
+                           uv_file file,
+-                          const uv_buf_t bufs[],
++                          FAR const uv_buf_t bufs[],
+                           unsigned int nbufs,
+                           int64_t offset,
+                           uv_fs_cb cb);
+@@ -1359,117 +1359,117 @@ UV_EXTERN int uv_fs_write(uv_loop_t* loop,
+  */
+ #define UV_FS_COPYFILE_FICLONE_FORCE 0x0004
+ 
+-UV_EXTERN int uv_fs_copyfile(uv_loop_t* loop,
+-                             uv_fs_t* req,
+-                             const char* path,
+-                             const char* new_path,
++UV_EXTERN int uv_fs_copyfile(FAR uv_loop_t* loop,
++                             FAR uv_fs_t* req,
++                             FAR const char* path,
++                             FAR const char* new_path,
+                              int flags,
+                              uv_fs_cb cb);
+-UV_EXTERN int uv_fs_mkdir(uv_loop_t* loop,
+-                          uv_fs_t* req,
+-                          const char* path,
++UV_EXTERN int uv_fs_mkdir(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
++                          FAR const char* path,
+                           int mode,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_mkdtemp(uv_loop_t* loop,
+-                            uv_fs_t* req,
+-                            const char* tpl,
++UV_EXTERN int uv_fs_mkdtemp(FAR uv_loop_t* loop,
++                            FAR uv_fs_t* req,
++                            FAR const char* tpl,
+                             uv_fs_cb cb);
+-UV_EXTERN int uv_fs_mkstemp(uv_loop_t* loop,
+-                            uv_fs_t* req,
+-                            const char* tpl,
++UV_EXTERN int uv_fs_mkstemp(FAR uv_loop_t* loop,
++                            FAR uv_fs_t* req,
++                            FAR const char* tpl,
+                             uv_fs_cb cb);
+-UV_EXTERN int uv_fs_rmdir(uv_loop_t* loop,
+-                          uv_fs_t* req,
+-                          const char* path,
++UV_EXTERN int uv_fs_rmdir(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
++                          FAR const char* path,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_scandir(uv_loop_t* loop,
+-                            uv_fs_t* req,
+-                            const char* path,
++UV_EXTERN int uv_fs_scandir(FAR uv_loop_t* loop,
++                            FAR uv_fs_t* req,
++                            FAR const char* path,
+                             int flags,
+                             uv_fs_cb cb);
+-UV_EXTERN int uv_fs_scandir_next(uv_fs_t* req,
+-                                 uv_dirent_t* ent);
+-UV_EXTERN int uv_fs_opendir(uv_loop_t* loop,
+-                            uv_fs_t* req,
+-                            const char* path,
++UV_EXTERN int uv_fs_scandir_next(FAR uv_fs_t* req,
++                                 FAR uv_dirent_t* ent);
++UV_EXTERN int uv_fs_opendir(FAR uv_loop_t* loop,
++                            FAR uv_fs_t* req,
++                            FAR const char* path,
+                             uv_fs_cb cb);
+-UV_EXTERN int uv_fs_readdir(uv_loop_t* loop,
+-                            uv_fs_t* req,
+-                            uv_dir_t* dir,
++UV_EXTERN int uv_fs_readdir(FAR uv_loop_t* loop,
++                            FAR uv_fs_t* req,
++                            FAR uv_dir_t* dir,
+                             uv_fs_cb cb);
+-UV_EXTERN int uv_fs_closedir(uv_loop_t* loop,
+-                             uv_fs_t* req,
+-                             uv_dir_t* dir,
++UV_EXTERN int uv_fs_closedir(FAR uv_loop_t* loop,
++                             FAR uv_fs_t* req,
++                             FAR uv_dir_t* dir,
+                              uv_fs_cb cb);
+-UV_EXTERN int uv_fs_stat(uv_loop_t* loop,
+-                         uv_fs_t* req,
+-                         const char* path,
++UV_EXTERN int uv_fs_stat(FAR uv_loop_t* loop,
++                         FAR uv_fs_t* req,
++                         FAR const char* path,
+                          uv_fs_cb cb);
+-UV_EXTERN int uv_fs_fstat(uv_loop_t* loop,
+-                          uv_fs_t* req,
++UV_EXTERN int uv_fs_fstat(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
+                           uv_file file,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_rename(uv_loop_t* loop,
+-                           uv_fs_t* req,
+-                           const char* path,
+-                           const char* new_path,
++UV_EXTERN int uv_fs_rename(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
++                           FAR const char* path,
++                           FAR const char* new_path,
+                            uv_fs_cb cb);
+-UV_EXTERN int uv_fs_fsync(uv_loop_t* loop,
+-                          uv_fs_t* req,
++UV_EXTERN int uv_fs_fsync(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
+                           uv_file file,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_fdatasync(uv_loop_t* loop,
+-                              uv_fs_t* req,
++UV_EXTERN int uv_fs_fdatasync(FAR uv_loop_t* loop,
++                              FAR uv_fs_t* req,
+                               uv_file file,
+                               uv_fs_cb cb);
+-UV_EXTERN int uv_fs_ftruncate(uv_loop_t* loop,
+-                              uv_fs_t* req,
++UV_EXTERN int uv_fs_ftruncate(FAR uv_loop_t* loop,
++                              FAR uv_fs_t* req,
+                               uv_file file,
+                               int64_t offset,
+                               uv_fs_cb cb);
+-UV_EXTERN int uv_fs_sendfile(uv_loop_t* loop,
+-                             uv_fs_t* req,
++UV_EXTERN int uv_fs_sendfile(FAR uv_loop_t* loop,
++                             FAR uv_fs_t* req,
+                              uv_file out_fd,
+                              uv_file in_fd,
+                              int64_t in_offset,
+                              size_t length,
+                              uv_fs_cb cb);
+-UV_EXTERN int uv_fs_access(uv_loop_t* loop,
+-                           uv_fs_t* req,
+-                           const char* path,
++UV_EXTERN int uv_fs_access(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
++                           FAR const char* path,
+                            int mode,
+                            uv_fs_cb cb);
+-UV_EXTERN int uv_fs_chmod(uv_loop_t* loop,
+-                          uv_fs_t* req,
+-                          const char* path,
++UV_EXTERN int uv_fs_chmod(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
++                          FAR const char* path,
+                           int mode,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_utime(uv_loop_t* loop,
+-                          uv_fs_t* req,
+-                          const char* path,
++UV_EXTERN int uv_fs_utime(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
++                          FAR const char* path,
+                           double atime,
+                           double mtime,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_futime(uv_loop_t* loop,
+-                           uv_fs_t* req,
++UV_EXTERN int uv_fs_futime(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
+                            uv_file file,
+                            double atime,
+                            double mtime,
+                            uv_fs_cb cb);
+-UV_EXTERN int uv_fs_lutime(uv_loop_t* loop,
+-                           uv_fs_t* req,
+-                           const char* path,
++UV_EXTERN int uv_fs_lutime(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
++                           FAR const char* path,
+                            double atime,
+                            double mtime,
+                            uv_fs_cb cb);
+-UV_EXTERN int uv_fs_lstat(uv_loop_t* loop,
+-                          uv_fs_t* req,
+-                          const char* path,
++UV_EXTERN int uv_fs_lstat(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
++                          FAR const char* path,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_link(uv_loop_t* loop,
+-                         uv_fs_t* req,
+-                         const char* path,
+-                         const char* new_path,
++UV_EXTERN int uv_fs_link(FAR uv_loop_t* loop,
++                         FAR uv_fs_t* req,
++                         FAR const char* path,
++                         FAR const char* new_path,
+                          uv_fs_cb cb);
+ 
+ /*
+@@ -1484,46 +1484,46 @@ UV_EXTERN int uv_fs_link(uv_loop_t* loop,
+  */
+ #define UV_FS_SYMLINK_JUNCTION     0x0002
+ 
+-UV_EXTERN int uv_fs_symlink(uv_loop_t* loop,
+-                            uv_fs_t* req,
+-                            const char* path,
+-                            const char* new_path,
++UV_EXTERN int uv_fs_symlink(FAR uv_loop_t* loop,
++                            FAR uv_fs_t* req,
++                            FAR const char* path,
++                            FAR const char* new_path,
+                             int flags,
+                             uv_fs_cb cb);
+-UV_EXTERN int uv_fs_readlink(uv_loop_t* loop,
+-                             uv_fs_t* req,
+-                             const char* path,
++UV_EXTERN int uv_fs_readlink(FAR uv_loop_t* loop,
++                             FAR uv_fs_t* req,
++                             FAR const char* path,
+                              uv_fs_cb cb);
+-UV_EXTERN int uv_fs_realpath(uv_loop_t* loop,
+-                             uv_fs_t* req,
+-                             const char* path,
++UV_EXTERN int uv_fs_realpath(FAR uv_loop_t* loop,
++                             FAR uv_fs_t* req,
++                             FAR const char* path,
+                              uv_fs_cb cb);
+-UV_EXTERN int uv_fs_fchmod(uv_loop_t* loop,
+-                           uv_fs_t* req,
++UV_EXTERN int uv_fs_fchmod(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
+                            uv_file file,
+                            int mode,
+                            uv_fs_cb cb);
+-UV_EXTERN int uv_fs_chown(uv_loop_t* loop,
+-                          uv_fs_t* req,
+-                          const char* path,
++UV_EXTERN int uv_fs_chown(FAR uv_loop_t* loop,
++                          FAR uv_fs_t* req,
++                          FAR const char* path,
+                           uv_uid_t uid,
+                           uv_gid_t gid,
+                           uv_fs_cb cb);
+-UV_EXTERN int uv_fs_fchown(uv_loop_t* loop,
+-                           uv_fs_t* req,
++UV_EXTERN int uv_fs_fchown(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
+                            uv_file file,
+                            uv_uid_t uid,
+                            uv_gid_t gid,
+                            uv_fs_cb cb);
+-UV_EXTERN int uv_fs_lchown(uv_loop_t* loop,
+-                           uv_fs_t* req,
+-                           const char* path,
++UV_EXTERN int uv_fs_lchown(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
++                           FAR const char* path,
+                            uv_uid_t uid,
+                            uv_gid_t gid,
+                            uv_fs_cb cb);
+-UV_EXTERN int uv_fs_statfs(uv_loop_t* loop,
+-                           uv_fs_t* req,
+-                           const char* path,
++UV_EXTERN int uv_fs_statfs(FAR uv_loop_t* loop,
++                           FAR uv_fs_t* req,
++                           FAR const char* path,
+                            uv_fs_cb cb);
+ 
+ 
+@@ -1550,15 +1550,15 @@ struct uv_fs_poll_s {
+   void* poll_ctx;
+ };
+ 
+-UV_EXTERN int uv_fs_poll_init(uv_loop_t* loop, uv_fs_poll_t* handle);
+-UV_EXTERN int uv_fs_poll_start(uv_fs_poll_t* handle,
++UV_EXTERN int uv_fs_poll_init(FAR uv_loop_t* loop, FAR uv_fs_poll_t* handle);
++UV_EXTERN int uv_fs_poll_start(FAR uv_fs_poll_t* handle,
+                                uv_fs_poll_cb poll_cb,
+-                               const char* path,
++                               FAR const char* path,
+                                unsigned int interval);
+-UV_EXTERN int uv_fs_poll_stop(uv_fs_poll_t* handle);
+-UV_EXTERN int uv_fs_poll_getpath(uv_fs_poll_t* handle,
+-                                 char* buffer,
+-                                 size_t* size);
++UV_EXTERN int uv_fs_poll_stop(FAR uv_fs_poll_t* handle);
++UV_EXTERN int uv_fs_poll_getpath(FAR uv_fs_poll_t* handle,
++                                 FAR char* buffer,
++                                 FAR size_t* size);
+ 
+ 
+ struct uv_signal_s {
+@@ -1568,16 +1568,16 @@ struct uv_signal_s {
+   UV_SIGNAL_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN int uv_signal_init(uv_loop_t* loop, uv_signal_t* handle);
+-UV_EXTERN int uv_signal_start(uv_signal_t* handle,
++UV_EXTERN int uv_signal_init(FAR uv_loop_t* loop, FAR uv_signal_t* handle);
++UV_EXTERN int uv_signal_start(FAR uv_signal_t* handle,
+                               uv_signal_cb signal_cb,
+                               int signum);
+-UV_EXTERN int uv_signal_start_oneshot(uv_signal_t* handle,
++UV_EXTERN int uv_signal_start_oneshot(FAR uv_signal_t* handle,
+                                       uv_signal_cb signal_cb,
+                                       int signum);
+ UV_EXTERN int uv_signal_stop(uv_signal_t* handle);
+ 
+-UV_EXTERN void uv_loadavg(double avg[3]);
++UV_EXTERN void uv_loadavg(FAR double avg[3]);
+ 
+ 
+ /*
+@@ -1611,41 +1611,41 @@ enum uv_fs_event_flags {
+ };
+ 
+ 
+-UV_EXTERN int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle);
+-UV_EXTERN int uv_fs_event_start(uv_fs_event_t* handle,
++UV_EXTERN int uv_fs_event_init(FAR uv_loop_t* loop, FAR uv_fs_event_t* handle);
++UV_EXTERN int uv_fs_event_start(FAR uv_fs_event_t* handle,
+                                 uv_fs_event_cb cb,
+-                                const char* path,
++                                FAR const char* path,
+                                 unsigned int flags);
+-UV_EXTERN int uv_fs_event_stop(uv_fs_event_t* handle);
+-UV_EXTERN int uv_fs_event_getpath(uv_fs_event_t* handle,
+-                                  char* buffer,
+-                                  size_t* size);
++UV_EXTERN int uv_fs_event_stop(FAR uv_fs_event_t* handle);
++UV_EXTERN int uv_fs_event_getpath(FAR uv_fs_event_t* handle,
++                                  FAR char* buffer,
++                                  FAR size_t* size);
+ 
+-UV_EXTERN int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr);
+-UV_EXTERN int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr);
++UV_EXTERN int uv_ip4_addr(FAR const char* ip, int port, FAR struct sockaddr_in* addr);
++UV_EXTERN int uv_ip6_addr(FAR const char* ip, int port, FAR struct sockaddr_in6* addr);
+ 
+-UV_EXTERN int uv_ip4_name(const struct sockaddr_in* src, char* dst, size_t size);
+-UV_EXTERN int uv_ip6_name(const struct sockaddr_in6* src, char* dst, size_t size);
++UV_EXTERN int uv_ip4_name(FAR const struct sockaddr_in* src, FAR char* dst, size_t size);
++UV_EXTERN int uv_ip6_name(FAR const struct sockaddr_in6* src, FAR char* dst, size_t size);
+ 
+-UV_EXTERN int uv_inet_ntop(int af, const void* src, char* dst, size_t size);
+-UV_EXTERN int uv_inet_pton(int af, const char* src, void* dst);
++UV_EXTERN int uv_inet_ntop(int af, FAR const void* src, FAR char* dst, size_t size);
++UV_EXTERN int uv_inet_pton(int af, FAR const char* src, FAR void* dst);
+ 
+ 
+ struct uv_random_s {
+   UV_REQ_FIELDS
+   /* read-only */
+-  uv_loop_t* loop;
++  FAR uv_loop_t* loop;
+   /* private */
+   int status;
+-  void* buf;
++  FAR void* buf;
+   size_t buflen;
+   uv_random_cb cb;
+   struct uv__work work_req;
+ };
+ 
+-UV_EXTERN int uv_random(uv_loop_t* loop,
+-                        uv_random_t* req,
+-                        void *buf,
++UV_EXTERN int uv_random(FAR uv_loop_t* loop,
++                        FAR uv_random_t* req,
++                        FAR void *buf,
+                         size_t buflen,
+                         unsigned flags,  /* For future extension; must be 0. */
+                         uv_random_cb cb);
+@@ -1659,17 +1659,17 @@ UV_EXTERN int uv_random(uv_loop_t* loop,
+ #endif
+ 
+ UV_EXTERN int uv_if_indextoname(unsigned int ifindex,
+-                                char* buffer,
+-                                size_t* size);
++                                FAR char* buffer,
++                                FAR size_t* size);
+ UV_EXTERN int uv_if_indextoiid(unsigned int ifindex,
+-                               char* buffer,
+-                               size_t* size);
++                               FAR char* buffer,
++                               FAR size_t* size);
+ 
+-UV_EXTERN int uv_exepath(char* buffer, size_t* size);
++UV_EXTERN int uv_exepath(FAR char* buffer, FAR size_t* size);
+ 
+-UV_EXTERN int uv_cwd(char* buffer, size_t* size);
++UV_EXTERN int uv_cwd(FAR char* buffer, FAR size_t* size);
+ 
+-UV_EXTERN int uv_chdir(const char* dir);
++UV_EXTERN int uv_chdir(FAR const char* dir);
+ 
+ UV_EXTERN uint64_t uv_get_free_memory(void);
+ UV_EXTERN uint64_t uv_get_total_memory(void);
+@@ -1680,59 +1680,59 @@ UV_EXTERN void uv_sleep(unsigned int msec);
+ 
+ UV_EXTERN void uv_disable_stdio_inheritance(void);
+ 
+-UV_EXTERN int uv_dlopen(const char* filename, uv_lib_t* lib);
+-UV_EXTERN void uv_dlclose(uv_lib_t* lib);
+-UV_EXTERN int uv_dlsym(uv_lib_t* lib, const char* name, void** ptr);
+-UV_EXTERN const char* uv_dlerror(const uv_lib_t* lib);
+-
+-UV_EXTERN int uv_mutex_init(uv_mutex_t* handle);
+-UV_EXTERN int uv_mutex_init_recursive(uv_mutex_t* handle);
+-UV_EXTERN void uv_mutex_destroy(uv_mutex_t* handle);
+-UV_EXTERN void uv_mutex_lock(uv_mutex_t* handle);
+-UV_EXTERN int uv_mutex_trylock(uv_mutex_t* handle);
+-UV_EXTERN void uv_mutex_unlock(uv_mutex_t* handle);
+-
+-UV_EXTERN int uv_rwlock_init(uv_rwlock_t* rwlock);
+-UV_EXTERN void uv_rwlock_destroy(uv_rwlock_t* rwlock);
+-UV_EXTERN void uv_rwlock_rdlock(uv_rwlock_t* rwlock);
+-UV_EXTERN int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock);
+-UV_EXTERN void uv_rwlock_rdunlock(uv_rwlock_t* rwlock);
+-UV_EXTERN void uv_rwlock_wrlock(uv_rwlock_t* rwlock);
+-UV_EXTERN int uv_rwlock_trywrlock(uv_rwlock_t* rwlock);
+-UV_EXTERN void uv_rwlock_wrunlock(uv_rwlock_t* rwlock);
+-
+-UV_EXTERN int uv_sem_init(uv_sem_t* sem, unsigned int value);
+-UV_EXTERN void uv_sem_destroy(uv_sem_t* sem);
+-UV_EXTERN void uv_sem_post(uv_sem_t* sem);
+-UV_EXTERN void uv_sem_wait(uv_sem_t* sem);
+-UV_EXTERN int uv_sem_trywait(uv_sem_t* sem);
+-
+-UV_EXTERN int uv_cond_init(uv_cond_t* cond);
+-UV_EXTERN void uv_cond_destroy(uv_cond_t* cond);
+-UV_EXTERN void uv_cond_signal(uv_cond_t* cond);
+-UV_EXTERN void uv_cond_broadcast(uv_cond_t* cond);
+-
+-UV_EXTERN int uv_barrier_init(uv_barrier_t* barrier, unsigned int count);
+-UV_EXTERN void uv_barrier_destroy(uv_barrier_t* barrier);
+-UV_EXTERN int uv_barrier_wait(uv_barrier_t* barrier);
+-
+-UV_EXTERN void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex);
+-UV_EXTERN int uv_cond_timedwait(uv_cond_t* cond,
+-                                uv_mutex_t* mutex,
++UV_EXTERN int uv_dlopen(FAR const char* filename, FAR uv_lib_t* lib);
++UV_EXTERN void uv_dlclose(FAR uv_lib_t* lib);
++UV_EXTERN int uv_dlsym(FAR uv_lib_t* lib, FAR const char* name, FAR void** ptr);
++UV_EXTERN FAR const char* uv_dlerror(FAR const uv_lib_t* lib);
++
++UV_EXTERN int uv_mutex_init(FAR uv_mutex_t* handle);
++UV_EXTERN int uv_mutex_init_recursive(FAR uv_mutex_t* handle);
++UV_EXTERN void uv_mutex_destroy(FAR uv_mutex_t* handle);
++UV_EXTERN void uv_mutex_lock(FAR uv_mutex_t* handle);
++UV_EXTERN int uv_mutex_trylock(FAR uv_mutex_t* handle);
++UV_EXTERN void uv_mutex_unlock(FAR uv_mutex_t* handle);
++
++UV_EXTERN int uv_rwlock_init(FAR uv_rwlock_t* rwlock);
++UV_EXTERN void uv_rwlock_destroy(FAR uv_rwlock_t* rwlock);
++UV_EXTERN void uv_rwlock_rdlock(FAR uv_rwlock_t* rwlock);
++UV_EXTERN int uv_rwlock_tryrdlock(FAR uv_rwlock_t* rwlock);
++UV_EXTERN void uv_rwlock_rdunlock(FAR uv_rwlock_t* rwlock);
++UV_EXTERN void uv_rwlock_wrlock(FAR uv_rwlock_t* rwlock);
++UV_EXTERN int uv_rwlock_trywrlock(FAR uv_rwlock_t* rwlock);
++UV_EXTERN void uv_rwlock_wrunlock(FAR uv_rwlock_t* rwlock);
++
++UV_EXTERN int uv_sem_init(FAR uv_sem_t* sem, unsigned int value);
++UV_EXTERN void uv_sem_destroy(FAR uv_sem_t* sem);
++UV_EXTERN void uv_sem_post(FAR uv_sem_t* sem);
++UV_EXTERN void uv_sem_wait(FAR uv_sem_t* sem);
++UV_EXTERN int uv_sem_trywait(FAR uv_sem_t* sem);
++
++UV_EXTERN int uv_cond_init(FAR uv_cond_t* cond);
++UV_EXTERN void uv_cond_destroy(FAR uv_cond_t* cond);
++UV_EXTERN void uv_cond_signal(FAR uv_cond_t* cond);
++UV_EXTERN void uv_cond_broadcast(FAR uv_cond_t* cond);
++
++UV_EXTERN int uv_barrier_init(FAR uv_barrier_t* barrier, unsigned int count);
++UV_EXTERN void uv_barrier_destroy(FAR uv_barrier_t* barrier);
++UV_EXTERN int uv_barrier_wait(FAR uv_barrier_t* barrier);
++
++UV_EXTERN void uv_cond_wait(FAR uv_cond_t* cond, FAR uv_mutex_t* mutex);
++UV_EXTERN int uv_cond_timedwait(FAR uv_cond_t* cond,
++                                FAR uv_mutex_t* mutex,
+                                 uint64_t timeout);
+ 
+-UV_EXTERN void uv_once(uv_once_t* guard, void (*callback)(void));
++UV_EXTERN void uv_once(FAR uv_once_t* guard, void (*callback)(void));
+ 
+-UV_EXTERN int uv_key_create(uv_key_t* key);
+-UV_EXTERN void uv_key_delete(uv_key_t* key);
+-UV_EXTERN void* uv_key_get(uv_key_t* key);
+-UV_EXTERN void uv_key_set(uv_key_t* key, void* value);
++UV_EXTERN int uv_key_create(FAR uv_key_t* key);
++UV_EXTERN void uv_key_delete(FAR uv_key_t* key);
++UV_EXTERN void* uv_key_get(FAR uv_key_t* key);
++UV_EXTERN void uv_key_set(FAR uv_key_t* key, FAR void* value);
+ 
+-UV_EXTERN int uv_gettimeofday(uv_timeval64_t* tv);
++UV_EXTERN int uv_gettimeofday(FAR uv_timeval64_t* tv);
+ 
+-typedef void (*uv_thread_cb)(void* arg);
++typedef void (*uv_thread_cb)(FAR void* arg);
+ 
+-UV_EXTERN int uv_thread_create(uv_thread_t* tid, uv_thread_cb entry, void* arg);
++UV_EXTERN int uv_thread_create(FAR uv_thread_t* tid, uv_thread_cb entry, FAR void* arg);
+ 
+ typedef enum {
+   UV_THREAD_NO_FLAGS = 0x00,
+@@ -1747,13 +1747,13 @@ struct uv_thread_options_s {
+ 
+ typedef struct uv_thread_options_s uv_thread_options_t;
+ 
+-UV_EXTERN int uv_thread_create_ex(uv_thread_t* tid,
+-                                  const uv_thread_options_t* params,
++UV_EXTERN int uv_thread_create_ex(FAR uv_thread_t* tid,
++                                  FAR const uv_thread_options_t* params,
+                                   uv_thread_cb entry,
+-                                  void* arg);
++                                  FAR void* arg);
+ UV_EXTERN uv_thread_t uv_thread_self(void);
+-UV_EXTERN int uv_thread_join(uv_thread_t *tid);
+-UV_EXTERN int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2);
++UV_EXTERN int uv_thread_join(FAR uv_thread_t *tid);
++UV_EXTERN int uv_thread_equal(FAR const uv_thread_t* t1, FAR const uv_thread_t* t2);
+ 
+ /* The presence of these unions force similar struct layout. */
+ #define XX(_, name) uv_ ## name ## _t name;
+@@ -1769,12 +1769,12 @@ union uv_any_req {
+ 
+ struct uv_loop_s {
+   /* User data - use this for whatever. */
+-  void* data;
++  FAR void* data;
+   /* Loop reference counting. */
+   unsigned int active_handles;
+-  void* handle_queue[2];
++  FAR void* handle_queue[2];
+   union {
+-    void* unused[2];
++    FAR void* unused[2];
+     unsigned int count;
+   } active_reqs;
+   /* Internal flag to signal loop stop. */
+@@ -1782,8 +1782,8 @@ struct uv_loop_s {
+   UV_LOOP_PRIVATE_FIELDS
+ };
+ 
+-UV_EXTERN void* uv_loop_get_data(const uv_loop_t*);
+-UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);
++UV_EXTERN FAR void* uv_loop_get_data(FAR const uv_loop_t*);
++UV_EXTERN void uv_loop_set_data(FAR uv_loop_t*, FAR void* data);
+ 
+ /* Don't export the private CPP symbols. */
+ #undef UV_HANDLE_TYPE_PRIVATE
+diff --git a/include/uv/threadpool.h b/include/uv/threadpool.h
+index 9708ebd..9af220f 100644
+--- a/include/uv/threadpool.h
++++ b/include/uv/threadpool.h
+@@ -28,10 +28,10 @@
+ #define UV_THREADPOOL_H_
+ 
+ struct uv__work {
+-  void (*work)(struct uv__work *w);
+-  void (*done)(struct uv__work *w, int status);
+-  struct uv_loop_s* loop;
+-  void* wq[2];
++  void (*work)(FAR struct uv__work *w);
++  void (*done)(FAR struct uv__work *w, int status);
++  FAR struct uv_loop_s* loop;
++  FAR void* wq[2];
+ };
+ 
+ #endif /* UV_THREADPOOL_H_ */
+diff --git a/include/uv/unix.h b/include/uv/unix.h
+index 201573c..9de6ea8 100644
+--- a/include/uv/unix.h
++++ b/include/uv/unix.h
+@@ -88,15 +88,15 @@
+ struct uv__io_s;
+ struct uv_loop_s;
+ 
+-typedef void (*uv__io_cb)(struct uv_loop_s* loop,
+-                          struct uv__io_s* w,
++typedef void (*uv__io_cb)(FAR struct uv_loop_s* loop,
++                          FAR struct uv__io_s* w,
+                           unsigned int events);
+ typedef struct uv__io_s uv__io_t;
+ 
+ struct uv__io_s {
+   uv__io_cb cb;
+-  void* pending_queue[2];
+-  void* watcher_queue[2];
++  FAR void* pending_queue[2];
++  FAR void* watcher_queue[2];
+   unsigned int pevents; /* Pending event mask i.e. mask at next tick. */
+   unsigned int events;  /* Current event mask. */
+   int fd;
+@@ -154,7 +154,7 @@ struct _uv_barrier {
+ };
+ 
+ typedef struct {
+-  struct _uv_barrier* b;
++  FAR struct _uv_barrier* b;
+ # if defined(PTHREAD_BARRIER_SERIAL_THREAD)
+   /* TODO(bnoordhuis) Remove padding in v2. */
+   char pad[sizeof(pthread_barrier_t) - sizeof(struct _uv_barrier*)];
+@@ -230,7 +230,7 @@ typedef struct {
+ 
+ #ifdef CONFIG_LIBUV_PROCESS
+ #define UV_LOOP_PRIVATE_PROCESS_FIELDS                                        \
+-  void* process_handles[2];                                                   \
++  FAR void* process_handles[2];                                               \
+   uv_signal_t child_watcher;
+ #else
+ #define UV_LOOP_PRIVATE_PROCESS_FIELDS
+@@ -239,13 +239,13 @@ typedef struct {
+ #ifdef CONFIG_LIBUV_ASYNC
+ #ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+ #define UV_LOOP_PRIVATE_ASYNC_FIELDS                                          \
+-  void* async_handles[2];                                                     \
++  FAR void* async_handles[2];                                                 \
+   void (*async_unused)(void);  /* TODO(bnoordhuis) Remove in libuv v2. */     \
+   uv__io_t async_io_watcher;                                                  \
+   int async_wfd;
+ #else
+ #define UV_LOOP_PRIVATE_ASYNC_FIELDS                                          \
+-  void* async_handles[2];                                                     \
++  FAR void* async_handles[2];                                                 \
+   uv__io_t async_io_watcher;
+ #endif /* CONFIG_LIBUV_LOW_FOOTPRINT */
+ #else
+@@ -255,7 +255,7 @@ typedef struct {
+ #ifdef CONFIG_LIBUV_TIMER
+ #define UV_LOOP_PRIVATE_TIMER_FIELDS                                          \
+   struct {                                                                    \
+-    void* min;                                                                \
++    FAR void* min;                                                            \
+     unsigned int nelts;                                                       \
+   } timer_heap;                                                               \
+   uint64_t timer_counter;
+@@ -265,7 +265,7 @@ typedef struct {
+ 
+ #ifdef CONFIG_LIBUV_WQ
+ #define UV_LOOP_PRIVATE_WQ_FIELDS                                             \
+-  void* wq[2];                                                                \
++  FAR void* wq[2];                                                            \
+   uv_mutex_t wq_mutex;                                                        \
+   uv_async_t wq_async;
+ #else
+@@ -274,9 +274,9 @@ typedef struct {
+ 
+ #ifdef CONFIG_LIBUV_LOOP_WATCHERS
+ #define UV_LOOP_PRIVATE_WATCHERS_FIELDS                                       \
+-  void* prepare_handles[2];                                                   \
+-  void* check_handles[2];                                                     \
+-  void* idle_handles[2];
++  FAR void* prepare_handles[2];                                               \
++  FAR void* check_handles[2];                                                 \
++  FAR void* idle_handles[2];
+ #else
+ #define UV_LOOP_PRIVATE_WATCHERS_FIELDS
+ #endif
+@@ -299,12 +299,12 @@ typedef struct {
+ #endif
+ 
+ #define UV_LOOP_PRIVATE_FIELDS                                                \
+-  void* watcher_queue[2];                                                     \
+-  uv__io_t** watchers;                                                        \
++  FAR void* watcher_queue[2];                                                 \
++  FAR uv__io_t** watchers;                                                    \
+   unsigned int nwatchers;                                                     \
+   unsigned int nfds;                                                          \
+   UV_LOOP_PRIVATE_WQ_FIELDS                                                   \
+-  uv_handle_t* closing_handles;                                               \
++  FAR uv_handle_t* closing_handles;                                           \
+   UV_LOOP_PRIVATE_WATCHERS_FIELDS                                             \
+   UV_LOOP_PRIVATE_ASYNC_FIELDS                                                \
+   UV_LOOP_PRIVATE_TIMER_FIELDS                                                \
+@@ -321,41 +321,41 @@ typedef struct {
+ #define UV_PRIVATE_REQ_TYPES /* empty */
+ 
+ #define UV_WRITE_PRIVATE_FIELDS                                               \
+-  void* queue[2];                                                             \
++  FAR void* queue[2];                                                         \
+   unsigned int write_index;                                                   \
+-  uv_buf_t* bufs;                                                             \
++  FAR uv_buf_t* bufs;                                                         \
+   unsigned int nbufs;                                                         \
+   int error;                                                                  \
+   uv_buf_t bufsml[4];                                                         \
+ 
+ #define UV_CONNECT_PRIVATE_FIELDS                                             \
+-  void* queue[2];                                                             \
++  FAR void* queue[2];                                                         \
+ 
+ #define UV_SHUTDOWN_PRIVATE_FIELDS /* empty */
+ 
+ #define UV_UDP_SEND_PRIVATE_FIELDS                                            \
+-  void* queue[2];                                                             \
++  FAR void* queue[2];                                                         \
+   struct sockaddr_storage addr;                                               \
+   unsigned int nbufs;                                                         \
+-  uv_buf_t* bufs;                                                             \
++  FAR uv_buf_t* bufs;                                                         \
+   ssize_t status;                                                             \
+   uv_udp_send_cb send_cb;                                                     \
+   uv_buf_t bufsml[4];                                                         \
+ 
+ #define UV_HANDLE_PRIVATE_FIELDS                                              \
+-  uv_handle_t* next_closing;                                                  \
++  FAR uv_handle_t* next_closing;                                              \
+   unsigned int flags;                                                         \
+ 
+ #define UV_STREAM_PRIVATE_FIELDS                                              \
+-  uv_connect_t *connect_req;                                                  \
+-  uv_shutdown_t *shutdown_req;                                                \
++  FAR uv_connect_t *connect_req;                                              \
++  FAR uv_shutdown_t *shutdown_req;                                            \
+   uv__io_t io_watcher;                                                        \
+-  void* write_queue[2];                                                       \
+-  void* write_completed_queue[2];                                             \
++  FAR void* write_queue[2];                                                   \
++  FAR void* write_completed_queue[2];                                         \
+   uv_connection_cb connection_cb;                                             \
+   int delayed_error;                                                          \
+   int accepted_fd;                                                            \
+-  void* queued_fds;                                                           \
++  FAR void* queued_fds;                                                       \
+   UV_STREAM_PRIVATE_PLATFORM_FIELDS                                           \
+ 
+ #define UV_TCP_PRIVATE_FIELDS /* empty */
+@@ -364,35 +364,35 @@ typedef struct {
+   uv_alloc_cb alloc_cb;                                                       \
+   uv_udp_recv_cb recv_cb;                                                     \
+   uv__io_t io_watcher;                                                        \
+-  void* write_queue[2];                                                       \
+-  void* write_completed_queue[2];                                             \
++  FAR void* write_queue[2];                                                   \
++  FAR void* write_completed_queue[2];                                         \
+ 
+ #define UV_PIPE_PRIVATE_FIELDS                                                \
+-  const char* pipe_fname; /* strdup'ed */
++  FAR const char* pipe_fname; /* strdup'ed */
+ 
+ #define UV_POLL_PRIVATE_FIELDS                                                \
+   uv__io_t io_watcher;
+ 
+ #define UV_PREPARE_PRIVATE_FIELDS                                             \
+   uv_prepare_cb prepare_cb;                                                   \
+-  void* queue[2];                                                             \
++  FAR void* queue[2];                                                         \
+ 
+ #define UV_CHECK_PRIVATE_FIELDS                                               \
+   uv_check_cb check_cb;                                                       \
+-  void* queue[2];                                                             \
++  FAR void* queue[2];                                                         \
+ 
+ #define UV_IDLE_PRIVATE_FIELDS                                                \
+   uv_idle_cb idle_cb;                                                         \
+-  void* queue[2];                                                             \
++  FAR void* queue[2];                                                         \
+ 
+ #define UV_ASYNC_PRIVATE_FIELDS                                               \
+   uv_async_cb async_cb;                                                       \
+-  void* queue[2];                                                             \
++  FAR void* queue[2];                                                         \
+   int pending;                                                                \
+ 
+ #define UV_TIMER_PRIVATE_FIELDS                                               \
+   uv_timer_cb timer_cb;                                                       \
+-  void* heap_node[3];                                                         \
++  FAR void* heap_node[3];                                                     \
+   uint64_t timeout;                                                           \
+   uint64_t repeat;                                                            \
+   uint64_t start_id;
+@@ -400,10 +400,10 @@ typedef struct {
+ #define UV_GETADDRINFO_PRIVATE_FIELDS                                         \
+   struct uv__work work_req;                                                   \
+   uv_getaddrinfo_cb cb;                                                       \
+-  struct addrinfo* hints;                                                     \
++  FAR struct addrinfo* hints;                                                 \
+   char* hostname;                                                             \
+   char* service;                                                              \
+-  struct addrinfo* addrinfo;                                                  \
++  FAR struct addrinfo* addrinfo;                                              \
+   int retcode;
+ 
+ #define UV_GETNAMEINFO_PRIVATE_FIELDS                                         \
+@@ -416,16 +416,16 @@ typedef struct {
+   int retcode;
+ 
+ #define UV_PROCESS_PRIVATE_FIELDS                                             \
+-  void* queue[2];                                                             \
++  FAR void* queue[2];                                                         \
+   int status;                                                                 \
+ 
+ #define UV_FS_PRIVATE_FIELDS                                                  \
+-  const char *new_path;                                                       \
++  FAR const char *new_path;                                                   \
+   uv_file file;                                                               \
+   int flags;                                                                  \
+   mode_t mode;                                                                \
+   unsigned int nbufs;                                                         \
+-  uv_buf_t* bufs;                                                             \
++  FAR uv_buf_t* bufs;                                                         \
+   off_t off;                                                                  \
+   uv_uid_t uid;                                                               \
+   uv_gid_t gid;                                                               \
+@@ -444,9 +444,9 @@ typedef struct {
+ #define UV_SIGNAL_PRIVATE_FIELDS                                              \
+   /* RB_ENTRY(uv_signal_s) tree_entry; */                                     \
+   struct {                                                                    \
+-    struct uv_signal_s* rbe_left;                                             \
+-    struct uv_signal_s* rbe_right;                                            \
+-    struct uv_signal_s* rbe_parent;                                           \
++    FAR struct uv_signal_s* rbe_left;                                         \
++    FAR struct uv_signal_s* rbe_right;                                        \
++    FAR struct uv_signal_s* rbe_parent;                                       \
+     int rbe_color;                                                            \
+   } tree_entry;                                                               \
+   /* Use two counters here so we don have to fiddle with atomics. */          \
+diff --git a/src/heap-inl.h b/src/heap-inl.h
+index 1e2ed60..fad7f0b 100644
+--- a/src/heap-inl.h
++++ b/src/heap-inl.h
+@@ -25,9 +25,9 @@
+ #endif
+ 
+ struct heap_node {
+-  struct heap_node* left;
+-  struct heap_node* right;
+-  struct heap_node* parent;
++  FAR struct heap_node* left;
++  FAR struct heap_node* right;
++  FAR struct heap_node* parent;
+ };
+ 
+ /* A binary min heap.  The usual properties hold: the root is the lowest
+@@ -38,41 +38,41 @@ struct heap_node {
+  * of a minor reduction in performance.  Compile with -DNDEBUG to disable.
+  */
+ struct heap {
+-  struct heap_node* min;
++  FAR struct heap_node* min;
+   unsigned int nelts;
+ };
+ 
+ /* Return non-zero if a < b. */
+-typedef int (*heap_compare_fn)(const struct heap_node* a,
+-                               const struct heap_node* b);
++typedef int (*heap_compare_fn)(FAR const struct heap_node* a,
++                               FAR const struct heap_node* b);
+ 
+ /* Public functions. */
+-HEAP_EXPORT(void heap_init(struct heap* heap));
+-HEAP_EXPORT(struct heap_node* heap_min(const struct heap* heap));
+-HEAP_EXPORT(void heap_insert(struct heap* heap,
+-                             struct heap_node* newnode,
++HEAP_EXPORT(void heap_init(FAR struct heap* heap));
++HEAP_EXPORT(FAR struct heap_node* heap_min(FAR const struct heap* heap));
++HEAP_EXPORT(void heap_insert(FAR struct heap* heap,
++                             FAR struct heap_node* newnode,
+                              heap_compare_fn less_than));
+-HEAP_EXPORT(void heap_remove(struct heap* heap,
+-                             struct heap_node* node,
++HEAP_EXPORT(void heap_remove(FAR struct heap* heap,
++                             FAR struct heap_node* node,
+                              heap_compare_fn less_than));
+-HEAP_EXPORT(void heap_dequeue(struct heap* heap, heap_compare_fn less_than));
++HEAP_EXPORT(void heap_dequeue(FAR struct heap* heap, heap_compare_fn less_than));
+ 
+ /* Implementation follows. */
+ 
+-HEAP_EXPORT(void heap_init(struct heap* heap)) {
++HEAP_EXPORT(void heap_init(FAR struct heap* heap)) {
+   heap->min = NULL;
+   heap->nelts = 0;
+ }
+ 
+-HEAP_EXPORT(struct heap_node* heap_min(const struct heap* heap)) {
++HEAP_EXPORT(FAR struct heap_node* heap_min(FAR const struct heap* heap)) {
+   return heap->min;
+ }
+ 
+ /* Swap parent with child. Child moves closer to the root, parent moves away. */
+-static void heap_node_swap(struct heap* heap,
+-                           struct heap_node* parent,
+-                           struct heap_node* child) {
+-  struct heap_node* sibling;
++static void heap_node_swap(FAR struct heap* heap,
++                           FAR struct heap_node* parent,
++                           FAR struct heap_node* child) {
++  FAR struct heap_node* sibling;
+   struct heap_node t;
+ 
+   t = *parent;
+@@ -103,11 +103,11 @@ static void heap_node_swap(struct heap* heap,
+     child->parent->right = child;
+ }
+ 
+-HEAP_EXPORT(void heap_insert(struct heap* heap,
+-                             struct heap_node* newnode,
++HEAP_EXPORT(void heap_insert(FAR struct heap* heap,
++                             FAR struct heap_node* newnode,
+                              heap_compare_fn less_than)) {
+-  struct heap_node** parent;
+-  struct heap_node** child;
++  FAR struct heap_node** parent;
++  FAR struct heap_node** child;
+   unsigned int path;
+   unsigned int n;
+   unsigned int k;
+@@ -147,12 +147,12 @@ HEAP_EXPORT(void heap_insert(struct heap* heap,
+     heap_node_swap(heap, newnode->parent, newnode);
+ }
+ 
+-HEAP_EXPORT(void heap_remove(struct heap* heap,
+-                             struct heap_node* node,
++HEAP_EXPORT(void heap_remove(FAR struct heap* heap,
++                             FAR struct heap_node* node,
+                              heap_compare_fn less_than)) {
+-  struct heap_node* smallest;
+-  struct heap_node** max;
+-  struct heap_node* child;
++  FAR struct heap_node* smallest;
++  FAR struct heap_node** max;
++  FAR struct heap_node* child;
+   unsigned int path;
+   unsigned int k;
+   unsigned int n;
+@@ -236,7 +236,7 @@ HEAP_EXPORT(void heap_remove(struct heap* heap,
+     heap_node_swap(heap, child->parent, child);
+ }
+ 
+-HEAP_EXPORT(void heap_dequeue(struct heap* heap, heap_compare_fn less_than)) {
++HEAP_EXPORT(void heap_dequeue(FAR struct heap* heap, heap_compare_fn less_than)) {
+   heap_remove(heap, heap->min, less_than);
+ }
+ 
+diff --git a/src/queue.h b/src/queue.h
+index ff3540a..b805137 100644
+--- a/src/queue.h
++++ b/src/queue.h
+@@ -21,8 +21,8 @@
+ typedef void *QUEUE[2];
+ 
+ /* Private macros. */
+-#define QUEUE_NEXT(q)       (*(QUEUE **) &((*(q))[0]))
+-#define QUEUE_PREV(q)       (*(QUEUE **) &((*(q))[1]))
++#define QUEUE_NEXT(q)       (*(FAR QUEUE **) &((*(q))[0]) )
++#define QUEUE_PREV(q)       (*(FAR QUEUE **) &((*(q))[1]) )
+ #define QUEUE_PREV_NEXT(q)  (QUEUE_NEXT(QUEUE_PREV(q)))
+ #define QUEUE_NEXT_PREV(q)  (QUEUE_PREV(QUEUE_NEXT(q)))
+ 
+diff --git a/src/strscpy.c b/src/strscpy.c
+index 2a2bdce..646bc17 100644
+--- a/src/strscpy.c
++++ b/src/strscpy.c
+@@ -1,7 +1,7 @@
+ #include "strscpy.h"
+ #include <limits.h>  /* SSIZE_MAX */
+ 
+-ssize_t uv__strscpy(char* d, const char* s, size_t n) {
++ssize_t uv__strscpy(FAR char* d, FAR const char* s, size_t n) {
+   size_t i;
+ 
+   for (i = 0; i < n; i++)
+diff --git a/src/strscpy.h b/src/strscpy.h
+index fbe0a39..42773fa 100644
+--- a/src/strscpy.h
++++ b/src/strscpy.h
+@@ -13,6 +13,6 @@
+  *
+  * See https://www.kernel.org/doc/htmldocs/kernel-api/API-strscpy.html
+  */
+-ssize_t uv__strscpy(char* d, const char* s, size_t n);
++ssize_t uv__strscpy(FAR char* d, FAR const char* s, size_t n);
+ 
+ #endif  /* UV_STRSCPY_H_ */
+diff --git a/src/threadpool.c b/src/threadpool.c
+index 5287b89..46fb26c 100644
+--- a/src/threadpool.c
++++ b/src/threadpool.c
+@@ -35,7 +35,7 @@ static uv_mutex_t mutex;
+ static unsigned int idle_threads;
+ static unsigned int slow_io_work_running;
+ static unsigned int nthreads;
+-static uv_thread_t* threads;
++static FAR uv_thread_t* threads;
+ static uv_thread_t default_threads[CONFIG_LIBUV_WQ_THREADS_COUNT];
+ static QUEUE exit_message;
+ static QUEUE wq;
+@@ -46,7 +46,7 @@ static unsigned int slow_work_thread_threshold(void) {
+   return (nthreads + 1) / 2;
+ }
+ 
+-static void uv__cancelled(struct uv__work* w) {
++static void uv__cancelled(FAR struct uv__work* w) {
+   abort();
+ }
+ 
+@@ -54,12 +54,12 @@ static void uv__cancelled(struct uv__work* w) {
+ /* To avoid deadlock with uv_cancel() it's crucial that the worker
+  * never holds the global mutex and the loop-local mutex at the same time.
+  */
+-static void worker(void* arg) {
+-  struct uv__work* w;
+-  QUEUE* q;
++static void worker(FAR void* arg) {
++  FAR struct uv__work* w;
++  FAR QUEUE* q;
+   int is_slow_work;
+ 
+-  uv_sem_post((uv_sem_t*) arg);
++  uv_sem_post((FAR uv_sem_t*) arg);
+   arg = NULL;
+ 
+   uv_mutex_lock(&mutex);
+@@ -139,7 +139,7 @@ static void worker(void* arg) {
+ }
+ 
+ 
+-static void post(QUEUE* q, enum uv__work_kind kind) {
++static void post(FAR QUEUE* q, enum uv__work_kind kind) {
+   uv_mutex_lock(&mutex);
+   if (kind == UV__WORK_SLOW_IO) {
+     /* Insert into a separate queue. */
+@@ -260,11 +260,11 @@ static void init_once(void) {
+ }
+ 
+ 
+-void uv__work_submit(uv_loop_t* loop,
+-                     struct uv__work* w,
++void uv__work_submit(FAR uv_loop_t* loop,
++                     FAR struct uv__work* w,
+                      enum uv__work_kind kind,
+-                     void (*work)(struct uv__work* w),
+-                     void (*done)(struct uv__work* w, int status)) {
++                     void (*work)(FAR struct uv__work* w),
++                     void (*done)(FAR struct uv__work* w, int status)) {
+   uv_once(&once, init_once);
+   w->loop = loop;
+   w->work = work;
+@@ -273,7 +273,7 @@ void uv__work_submit(uv_loop_t* loop,
+ }
+ 
+ 
+-static int uv__work_cancel(uv_loop_t* loop, uv_req_t* req, struct uv__work* w) {
++static int uv__work_cancel(FAR uv_loop_t* loop, FAR uv_req_t* req, FAR struct uv__work* w) {
+   int cancelled;
+ 
+   uv_mutex_lock(&mutex);
+@@ -299,10 +299,10 @@ static int uv__work_cancel(uv_loop_t* loop, uv_req_t* req, struct uv__work* w) {
+ }
+ 
+ 
+-void uv__work_done(uv_async_t* handle) {
+-  struct uv__work* w;
+-  uv_loop_t* loop;
+-  QUEUE* q;
++void uv__work_done(FAR uv_async_t* handle) {
++  FAR struct uv__work* w;
++  FAR uv_loop_t* loop;
++  FAR QUEUE* q;
+   QUEUE wql;
+   int err;
+ 
+@@ -322,15 +322,15 @@ void uv__work_done(uv_async_t* handle) {
+ }
+ 
+ 
+-static void uv__queue_work(struct uv__work* w) {
+-  uv_work_t* req = container_of(w, uv_work_t, work_req);
++static void uv__queue_work(FAR struct uv__work* w) {
++  FAR uv_work_t* req = container_of(w, uv_work_t, work_req);
+ 
+   req->work_cb(req);
+ }
+ 
+ 
+-static void uv__queue_done(struct uv__work* w, int err) {
+-  uv_work_t* req;
++static void uv__queue_done(FAR struct uv__work* w, int err) {
++  FAR uv_work_t* req;
+ 
+   req = container_of(w, uv_work_t, work_req);
+   uv__req_unregister(req->loop, req);
+@@ -342,8 +342,8 @@ static void uv__queue_done(struct uv__work* w, int err) {
+ }
+ 
+ 
+-int uv_queue_work(uv_loop_t* loop,
+-                  uv_work_t* req,
++int uv_queue_work(FAR uv_loop_t* loop,
++                  FAR uv_work_t* req,
+                   uv_work_cb work_cb,
+                   uv_after_work_cb after_work_cb) {
+   if (work_cb == NULL)
+@@ -362,9 +362,9 @@ int uv_queue_work(uv_loop_t* loop,
+ }
+ 
+ 
+-int uv_cancel(uv_req_t* req) {
+-  struct uv__work* wreq;
+-  uv_loop_t* loop;
++int uv_cancel(FAR uv_req_t* req) {
++  FAR struct uv__work* wreq;
++  FAR uv_loop_t* loop;
+ 
+   switch (req->type) {
+   case UV_FS:
+diff --git a/src/timer.c b/src/timer.c
+index 4cf4ed4..b65063a 100644
+--- a/src/timer.c
++++ b/src/timer.c
+@@ -26,19 +26,19 @@
+ #include <limits.h>
+ 
+ 
+-static struct heap *timer_heap(const uv_loop_t* loop) {
++static struct heap *timer_heap(FAR const uv_loop_t* loop) {
+ #ifdef _WIN32
+   return (struct heap*) loop->timer_heap;
+ #else
+-  return (struct heap*) &loop->timer_heap;
++  return (FAR struct heap*) &loop->timer_heap;
+ #endif
+ }
+ 
+ 
+-static int timer_less_than(const struct heap_node* ha,
+-                           const struct heap_node* hb) {
+-  const uv_timer_t* a;
+-  const uv_timer_t* b;
++static int timer_less_than(FAR const struct heap_node* ha,
++                           FAR const struct heap_node* hb) {
++  FAR const uv_timer_t* a;
++  FAR const uv_timer_t* b;
+ 
+   a = container_of(ha, uv_timer_t, heap_node);
+   b = container_of(hb, uv_timer_t, heap_node);
+@@ -55,7 +55,7 @@ static int timer_less_than(const struct heap_node* ha,
+ }
+ 
+ 
+-int uv_timer_init(uv_loop_t* loop, uv_timer_t* handle) {
++int uv_timer_init(FAR uv_loop_t* loop, FAR uv_timer_t* handle) {
+   uv__handle_init(loop, (uv_handle_t*)handle, UV_TIMER);
+   handle->timer_cb = NULL;
+   handle->repeat = 0;
+@@ -63,7 +63,7 @@ int uv_timer_init(uv_loop_t* loop, uv_timer_t* handle) {
+ }
+ 
+ 
+-int uv_timer_start(uv_timer_t* handle,
++int uv_timer_start(FAR uv_timer_t* handle,
+                    uv_timer_cb cb,
+                    uint64_t timeout,
+                    uint64_t repeat) {
+@@ -94,7 +94,7 @@ int uv_timer_start(uv_timer_t* handle,
+ }
+ 
+ 
+-int uv_timer_stop(uv_timer_t* handle) {
++int uv_timer_stop(FAR uv_timer_t* handle) {
+   if (!uv__is_active(handle))
+     return 0;
+ 
+@@ -107,7 +107,7 @@ int uv_timer_stop(uv_timer_t* handle) {
+ }
+ 
+ 
+-int uv_timer_again(uv_timer_t* handle) {
++int uv_timer_again(FAR uv_timer_t* handle) {
+   if (handle->timer_cb == NULL)
+     return UV_EINVAL;
+ 
+@@ -120,19 +120,19 @@ int uv_timer_again(uv_timer_t* handle) {
+ }
+ 
+ 
+-void uv_timer_set_repeat(uv_timer_t* handle, uint64_t repeat) {
++void uv_timer_set_repeat(FAR uv_timer_t* handle, uint64_t repeat) {
+   handle->repeat = repeat;
+ }
+ 
+ 
+-uint64_t uv_timer_get_repeat(const uv_timer_t* handle) {
++uint64_t uv_timer_get_repeat(FAR const uv_timer_t* handle) {
+   return handle->repeat;
+ }
+ 
+ 
+-int uv__next_timeout(const uv_loop_t* loop) {
+-  const struct heap_node* heap_node;
+-  const uv_timer_t* handle;
++int uv__next_timeout(FAR const uv_loop_t* loop) {
++  FAR const struct heap_node* heap_node;
++  FAR const uv_timer_t* handle;
+   uint64_t diff;
+ 
+   heap_node = heap_min(timer_heap(loop));
+@@ -151,9 +151,9 @@ int uv__next_timeout(const uv_loop_t* loop) {
+ }
+ 
+ 
+-void uv__run_timers(uv_loop_t* loop) {
+-  struct heap_node* heap_node;
+-  uv_timer_t* handle;
++void uv__run_timers(FAR uv_loop_t* loop) {
++  FAR struct heap_node* heap_node;
++  FAR uv_timer_t* handle;
+ 
+   for (;;) {
+     heap_node = heap_min(timer_heap(loop));
+@@ -171,6 +171,6 @@ void uv__run_timers(uv_loop_t* loop) {
+ }
+ 
+ 
+-void uv__timer_close(uv_timer_t* handle) {
++void uv__timer_close(FAR uv_timer_t* handle) {
+   uv_timer_stop(handle);
+ }
+diff --git a/src/unix/core.c b/src/unix/core.c
+index 7f11370..2c38632 100644
+--- a/src/unix/core.c
++++ b/src/unix/core.c
+@@ -109,7 +109,7 @@ uint64_t uv_hrtime(void) {
+ }
+ 
+ 
+-void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
++void uv_close(FAR uv_handle_t* handle, uv_close_cb close_cb) {
+   assert(!uv__is_closing(handle));
+ 
+   handle->flags |= UV_HANDLE_CLOSING;
+@@ -187,7 +187,7 @@ void uv_close(uv_handle_t* handle, uv_close_cb close_cb) {
+   uv__make_close_pending(handle);
+ }
+ 
+-int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value) {
++int uv__socket_sockopt(FAR uv_handle_t* handle, int optname, FAR int* value) {
+   int r;
+   int fd;
+   socklen_t len;
+@@ -215,7 +215,7 @@ int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value) {
+   return 0;
+ }
+ 
+-void uv__make_close_pending(uv_handle_t* handle) {
++void uv__make_close_pending(FAR uv_handle_t* handle) {
+   assert(handle->flags & UV_HANDLE_CLOSING);
+   assert(!(handle->flags & UV_HANDLE_CLOSED));
+   handle->next_closing = handle->loop->closing_handles;
+@@ -250,9 +250,9 @@ int uv__getiovmax(void) {
+ }
+ 
+ 
+-static void uv__finish_close(uv_handle_t* handle) {
++static void uv__finish_close(FAR uv_handle_t* handle) {
+ #ifdef CONFIG_LIBUV_SIGNAL
+-  uv_signal_t* sh;
++  FAR uv_signal_t* sh;
+ #endif
+ 
+   /* Note: while the handle is in the UV_HANDLE_CLOSING state now, it's still
+@@ -289,7 +289,7 @@ static void uv__finish_close(uv_handle_t* handle) {
+        * into the closing queue makes the event loop spin but that's
+        * okay because we only need to deliver the pending events.
+        */
+-      sh = (uv_signal_t*) handle;
++      sh = (FAR uv_signal_t*) handle;
+       if (sh->caught_signals > sh->dispatched_signals) {
+         handle->flags ^= UV_HANDLE_CLOSED;
+         uv__make_close_pending(handle);  /* Back into the queue. */
+@@ -322,7 +322,7 @@ static void uv__finish_close(uv_handle_t* handle) {
+ }
+ 
+ 
+-static void uv__run_closing_handles(uv_loop_t* loop) {
++static void uv__run_closing_handles(FAR uv_loop_t* loop) {
+   uv_handle_t* p;
+   uv_handle_t* q;
+ 
+@@ -337,18 +337,18 @@ static void uv__run_closing_handles(uv_loop_t* loop) {
+ }
+ 
+ 
+-int uv_is_closing(const uv_handle_t* handle) {
++int uv_is_closing(FAR const uv_handle_t* handle) {
+   return uv__is_closing(handle);
+ }
+ 
+ #ifndef CONFIG_LIBUV_LOW_FOOTPRINT
+-int uv_backend_fd(const uv_loop_t* loop) {
++int uv_backend_fd(FAR const uv_loop_t* loop) {
+   return loop->backend_fd;
+ }
+ #endif
+ 
+ 
+-int uv_backend_timeout(const uv_loop_t* loop) {
++int uv_backend_timeout(FAR const uv_loop_t* loop) {
+   if (loop->stop_flag != 0)
+     return 0;
+ 
+@@ -376,19 +376,19 @@ int uv_backend_timeout(const uv_loop_t* loop) {
+ }
+ 
+ 
+-static int uv__loop_alive(const uv_loop_t* loop) {
++static int uv__loop_alive(FAR const uv_loop_t* loop) {
+   return uv__has_active_handles(loop) ||
+          uv__has_active_reqs(loop) ||
+          loop->closing_handles != NULL;
+ }
+ 
+ 
+-int uv_loop_alive(const uv_loop_t* loop) {
++int uv_loop_alive(FAR const uv_loop_t* loop) {
+     return uv__loop_alive(loop);
+ }
+ 
+ 
+-int uv_run(uv_loop_t* loop, uv_run_mode mode) {
++int uv_run(FAR uv_loop_t* loop, uv_run_mode mode) {
+   int timeout;
+   int r;
+   int ran_pending;
+@@ -456,12 +456,12 @@ int uv_run(uv_loop_t* loop, uv_run_mode mode) {
+ }
+ 
+ 
+-void uv_update_time(uv_loop_t* loop) {
++void uv_update_time(FAR uv_loop_t* loop) {
+   uv__update_time(loop);
+ }
+ 
+ 
+-int uv_is_active(const uv_handle_t* handle) {
++int uv_is_active(FAR const uv_handle_t* handle) {
+   return uv__is_active(handle);
+ }
+ 
+@@ -505,9 +505,9 @@ int uv__socket(int domain, int type, int protocol) {
+ #endif
+ 
+ /* get a file pointer to a file in read-only and close-on-exec mode */
+-FILE* uv__open_file(const char* path) {
++FAR FILE* uv__open_file(FAR const char* path) {
+   int fd;
+-  FILE* fp;
++  FAR FILE* fp;
+ 
+   fd = uv__open_cloexec(path, O_RDONLY);
+   if (fd < 0)
+@@ -743,7 +743,7 @@ ssize_t uv__recvmsg(int fd, struct msghdr* msg, int flags) {
+ }
+ #endif
+ 
+-int uv_cwd(char* buffer, size_t* size) {
++int uv_cwd(FAR char* buffer, FAR size_t* size) {
+   char scratch[1 + UV__PATH_MAX];
+ 
+   if (buffer == NULL || size == NULL)
+@@ -782,7 +782,7 @@ fixup:
+ }
+ 
+ 
+-int uv_chdir(const char* dir) {
++int uv_chdir(FAR const char* dir) {
+   if (chdir(dir))
+     return UV__ERR(errno);
+ 
+@@ -802,22 +802,22 @@ void uv_disable_stdio_inheritance(void) {
+ }
+ #endif
+ 
+-int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd) {
++int uv_fileno(FAR const uv_handle_t* handle, FAR uv_os_fd_t* fd) {
+   int fd_out;
+ 
+   switch (handle->type) {
+   case UV_TCP:
+   case UV_NAMED_PIPE:
+   case UV_TTY:
+-    fd_out = uv__stream_fd((uv_stream_t*) handle);
++    fd_out = uv__stream_fd((FAR uv_stream_t*) handle);
+     break;
+ 
+   case UV_UDP:
+-    fd_out = ((uv_udp_t *) handle)->io_watcher.fd;
++    fd_out = ((FAR uv_udp_t *) handle)->io_watcher.fd;
+     break;
+ 
+   case UV_POLL:
+-    fd_out = ((uv_poll_t *) handle)->io_watcher.fd;
++    fd_out = ((FAR uv_poll_t *) handle)->io_watcher.fd;
+     break;
+ 
+   default:
+@@ -865,10 +865,10 @@ static unsigned int next_power_of_two(unsigned int val) {
+   return val;
+ }
+ 
+-static void maybe_resize(uv_loop_t* loop, unsigned int len) {
++static void maybe_resize(FAR uv_loop_t* loop, unsigned int len) {
+   uv__io_t** watchers;
+-  void* fake_watcher_list;
+-  void* fake_watcher_count;
++  FAR void* fake_watcher_list;
++  FAR void* fake_watcher_count;
+   unsigned int nwatchers;
+   unsigned int i;
+ 
+@@ -900,7 +900,7 @@ static void maybe_resize(uv_loop_t* loop, unsigned int len) {
+ }
+ 
+ 
+-void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd) {
++void uv__io_init(FAR uv__io_t* w, uv__io_cb cb, int fd) {
+   assert(cb != NULL);
+   assert(fd >= -1);
+ #if 0
+@@ -919,7 +919,7 @@ void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd) {
+ }
+ 
+ 
+-void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
++void uv__io_start(FAR uv_loop_t* loop, FAR uv__io_t* w, unsigned int events) {
+   assert(0 == (events & ~(POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI)));
+   assert(0 != events);
+   assert(w->fd >= 0);
+@@ -947,7 +947,7 @@ void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
+ }
+ 
+ 
+-void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
++void uv__io_stop(FAR uv_loop_t* loop, FAR uv__io_t* w, unsigned int events) {
+   assert(0 == (events & ~(POLLIN | POLLOUT | UV__POLLRDHUP | UV__POLLPRI)));
+   assert(0 != events);
+ 
+@@ -1002,7 +1002,7 @@ int uv__io_active(const uv__io_t* w, unsigned int events) {
+ }
+ #endif
+ 
+-int uv__fd_exists(uv_loop_t* loop, int fd) {
++int uv__fd_exists(FAR uv_loop_t* loop, int fd) {
+   return (unsigned) fd < loop->nwatchers && loop->watchers[fd] != NULL;
+ }
+ 
+@@ -1040,7 +1040,7 @@ int uv_getrusage(uv_rusage_t* rusage) {
+ }
+ #endif
+ 
+-int uv__open_cloexec(const char* path, int flags) {
++int uv__open_cloexec(FAR const char* path, int flags) {
+ #if defined(O_CLOEXEC)
+   int fd;
+ 
+@@ -1096,7 +1096,7 @@ int uv__dup2_cloexec(int oldfd, int newfd) {
+ }
+ #endif
+ 
+-int uv_os_homedir(char* buffer, size_t* size) {
++int uv_os_homedir(FAR char* buffer, FAR size_t* size) {
+   uv_passwd_t pwd;
+   size_t len;
+   int r;
+@@ -1132,8 +1132,8 @@ int uv_os_homedir(char* buffer, size_t* size) {
+ }
+ 
+ 
+-int uv_os_tmpdir(char* buffer, size_t* size) {
+-  const char* buf;
++int uv_os_tmpdir(FAR char* buffer, FAR size_t* size) {
++  FAR const char* buf;
+   size_t len;
+ 
+   if (buffer == NULL || size == NULL || *size == 0)
+@@ -1183,10 +1183,10 @@ return_buffer:
+ }
+ 
+ 
+-int uv__getpwuid_r(uv_passwd_t* pwd) {
++int uv__getpwuid_r(FAR uv_passwd_t* pwd) {
+   struct passwd pw;
+-  struct passwd* result;
+-  char* buf;
++  FAR struct passwd* result;
++  FAR char* buf;
+   uid_t uid;
+   size_t bufsize;
+   size_t name_size;
+@@ -1265,7 +1265,7 @@ int uv__getpwuid_r(uv_passwd_t* pwd) {
+ }
+ 
+ 
+-void uv_os_free_passwd(uv_passwd_t* pwd) {
++void uv_os_free_passwd(FAR uv_passwd_t* pwd) {
+   if (pwd == NULL)
+     return;
+ 
+@@ -1281,7 +1281,7 @@ void uv_os_free_passwd(uv_passwd_t* pwd) {
+ }
+ 
+ 
+-int uv_os_get_passwd(uv_passwd_t* pwd) {
++int uv_os_get_passwd(FAR uv_passwd_t* pwd) {
+   return uv__getpwuid_r(pwd);
+ }
+ 
+@@ -1292,9 +1292,9 @@ int uv_translate_sys_error(int sys_errno) {
+ }
+ 
+ 
+-int uv_os_environ(uv_env_item_t** envitems, int* count) {
++int uv_os_environ(FAR uv_env_item_t** envitems, FAR int* count) {
+   int i, j, cnt;
+-  uv_env_item_t* envitem;
++  FAR uv_env_item_t* envitem;
+ 
+   *envitems = NULL;
+   *count = 0;
+@@ -1348,8 +1348,8 @@ fail:
+ }
+ 
+ 
+-int uv_os_getenv(const char* name, char* buffer, size_t* size) {
+-  char* var;
++int uv_os_getenv(FAR const char* name, FAR char* buffer, FAR size_t* size) {
++  FAR char* var;
+   size_t len;
+ 
+   if (name == NULL || buffer == NULL || size == NULL || *size == 0)
+@@ -1374,7 +1374,7 @@ int uv_os_getenv(const char* name, char* buffer, size_t* size) {
+ }
+ 
+ 
+-int uv_os_setenv(const char* name, const char* value) {
++int uv_os_setenv(FAR const char* name, FAR const char* value) {
+   if (name == NULL || value == NULL)
+     return UV_EINVAL;
+ 
+@@ -1385,7 +1385,7 @@ int uv_os_setenv(const char* name, const char* value) {
+ }
+ 
+ 
+-int uv_os_unsetenv(const char* name) {
++int uv_os_unsetenv(FAR const char* name) {
+   if (name == NULL)
+     return UV_EINVAL;
+ 
+@@ -1396,7 +1396,7 @@ int uv_os_unsetenv(const char* name) {
+ }
+ 
+ 
+-int uv_os_gethostname(char* buffer, size_t* size) {
++int uv_os_gethostname(FAR char* buffer, FAR size_t* size) {
+   /*
+     On some platforms, if the input buffer is not large enough, gethostname()
+     succeeds, but truncates the result. libuv can detect this and return ENOBUFS
+@@ -1444,7 +1444,7 @@ uv_pid_t uv_os_getppid(void) {
+ }
+ #endif
+ 
+-int uv_os_getpriority(uv_pid_t pid, int* priority) {
++int uv_os_getpriority(uv_pid_t pid, FAR int* priority) {
+   int r;
+ 
+   if (priority == NULL)
+@@ -1472,7 +1472,7 @@ int uv_os_setpriority(uv_pid_t pid, int priority) {
+ }
+ 
+ 
+-int uv_os_uname(uv_utsname_t* buffer) {
++int uv_os_uname(FAR uv_utsname_t* buffer) {
+   struct utsname buf;
+   int r;
+ 
+@@ -1527,9 +1527,9 @@ error:
+   return r;
+ }
+ 
+-int uv__getsockpeername(const uv_handle_t* handle,
++int uv__getsockpeername(FAR const uv_handle_t* handle,
+                         uv__peersockfunc func,
+-                        struct sockaddr* name,
++                        FAR struct sockaddr* name,
+                         int* namelen) {
+   socklen_t socklen;
+   uv_os_fd_t fd;
+@@ -1549,7 +1549,7 @@ int uv__getsockpeername(const uv_handle_t* handle,
+   return 0;
+ }
+ 
+-int uv_gettimeofday(uv_timeval64_t* tv) {
++int uv_gettimeofday(FAR uv_timeval64_t* tv) {
+   struct timeval time;
+ 
+   if (tv == NULL)
+diff --git a/src/unix/internal.h b/src/unix/internal.h
+index 402ee87..1fb8149 100644
+--- a/src/unix/internal.h
++++ b/src/unix/internal.h
+@@ -193,88 +193,88 @@ int uv__close(int fd); /* preserves errno */
+ int uv__close_nocheckstdio(int fd);
+ int uv__close_nocancel(int fd);
+ int uv__socket(int domain, int type, int protocol);
+-ssize_t uv__recvmsg(int fd, struct msghdr *msg, int flags);
+-void uv__make_close_pending(uv_handle_t* handle);
++ssize_t uv__recvmsg(int fd, FAR struct msghdr *msg, int flags);
++void uv__make_close_pending(FAR uv_handle_t* handle);
+ int uv__getiovmax(void);
+ 
+-void uv__io_init(uv__io_t* w, uv__io_cb cb, int fd);
+-void uv__io_start(uv_loop_t* loop, uv__io_t* w, unsigned int events);
+-void uv__io_stop(uv_loop_t* loop, uv__io_t* w, unsigned int events);
+-void uv__io_close(uv_loop_t* loop, uv__io_t* w);
+-void uv__io_feed(uv_loop_t* loop, uv__io_t* w);
+-int uv__io_active(const uv__io_t* w, unsigned int events);
+-int uv__io_check_fd(uv_loop_t* loop, int fd);
+-void uv__io_poll(uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
+-int uv__io_fork(uv_loop_t* loop);
+-int uv__fd_exists(uv_loop_t* loop, int fd);
++void uv__io_init(FAR uv__io_t* w, uv__io_cb cb, int fd);
++void uv__io_start(FAR uv_loop_t* loop, FAR uv__io_t* w, unsigned int events);
++void uv__io_stop(FAR uv_loop_t* loop, FAR uv__io_t* w, unsigned int events);
++void uv__io_close(FAR uv_loop_t* loop, FAR uv__io_t* w);
++void uv__io_feed(FAR uv_loop_t* loop, FAR uv__io_t* w);
++int uv__io_active(FAR const uv__io_t* w, unsigned int events);
++int uv__io_check_fd(FAR uv_loop_t* loop, int fd);
++void uv__io_poll(FAR uv_loop_t* loop, int timeout); /* in milliseconds or -1 */
++int uv__io_fork(FAR uv_loop_t* loop);
++int uv__fd_exists(FAR uv_loop_t* loop, int fd);
+ 
+ /* async */
+-void uv__async_stop(uv_loop_t* loop);
+-int uv__async_fork(uv_loop_t* loop);
++void uv__async_stop(FAR uv_loop_t* loop);
++int uv__async_fork(FAR uv_loop_t* loop);
+ 
+ 
+ /* loop */
+-void uv__run_idle(uv_loop_t* loop);
+-void uv__run_check(uv_loop_t* loop);
+-void uv__run_prepare(uv_loop_t* loop);
++void uv__run_idle(FAR uv_loop_t* loop);
++void uv__run_check(FAR uv_loop_t* loop);
++void uv__run_prepare(FAR uv_loop_t* loop);
+ 
+ /* stream */
+-void uv__stream_init(uv_loop_t* loop, uv_stream_t* stream,
++void uv__stream_init(FAR uv_loop_t* loop, FAR uv_stream_t* stream,
+     uv_handle_type type);
+-int uv__stream_open(uv_stream_t*, int fd, int flags);
+-void uv__stream_destroy(uv_stream_t* stream);
++int uv__stream_open(FAR uv_stream_t*, int fd, int flags);
++void uv__stream_destroy(FAR uv_stream_t* stream);
+ #if defined(__APPLE__)
+ int uv__stream_try_select(uv_stream_t* stream, int* fd);
+ #endif /* defined(__APPLE__) */
+-void uv__server_io(uv_loop_t* loop, uv__io_t* w, unsigned int events);
++void uv__server_io(FAR uv_loop_t* loop, FAR uv__io_t* w, unsigned int events);
+ int uv__accept(int sockfd);
+ int uv__dup2_cloexec(int oldfd, int newfd);
+-int uv__open_cloexec(const char* path, int flags);
++int uv__open_cloexec(FAR const char* path, int flags);
+ 
+ /* tcp */
+-int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb);
++int uv_tcp_listen(FAR uv_tcp_t* tcp, int backlog, uv_connection_cb cb);
+ int uv__tcp_nodelay(int fd, int on);
+ int uv__tcp_keepalive(int fd, int on, unsigned int delay);
+ 
+ /* pipe */
+-int uv_pipe_listen(uv_pipe_t* handle, int backlog, uv_connection_cb cb);
++int uv_pipe_listen(FAR uv_pipe_t* handle, int backlog, uv_connection_cb cb);
+ 
+ /* signal */
+-void uv__signal_close(uv_signal_t* handle);
++void uv__signal_close(FAR uv_signal_t* handle);
+ void uv__signal_global_once_init(void);
+-void uv__signal_loop_cleanup(uv_loop_t* loop);
+-int uv__signal_loop_fork(uv_loop_t* loop);
++void uv__signal_loop_cleanup(FAR uv_loop_t* loop);
++int uv__signal_loop_fork(FAR uv_loop_t* loop);
+ 
+ /* platform specific */
+ uint64_t uv__hrtime(uv_clocktype_t type);
+-int uv__kqueue_init(uv_loop_t* loop);
+-int uv__platform_loop_init(uv_loop_t* loop);
+-void uv__platform_loop_delete(uv_loop_t* loop);
+-void uv__platform_invalidate_fd(uv_loop_t* loop, int fd);
++int uv__kqueue_init(FAR uv_loop_t* loop);
++int uv__platform_loop_init(FAR uv_loop_t* loop);
++void uv__platform_loop_delete(FAR uv_loop_t* loop);
++void uv__platform_invalidate_fd(FAR uv_loop_t* loop, int fd);
+ 
+ /* various */
+-void uv__async_close(uv_async_t* handle);
+-void uv__check_close(uv_check_t* handle);
+-void uv__fs_event_close(uv_fs_event_t* handle);
+-void uv__idle_close(uv_idle_t* handle);
+-void uv__pipe_close(uv_pipe_t* handle);
+-void uv__poll_close(uv_poll_t* handle);
+-void uv__prepare_close(uv_prepare_t* handle);
+-void uv__process_close(uv_process_t* handle);
+-void uv__stream_close(uv_stream_t* handle);
+-void uv__tcp_close(uv_tcp_t* handle);
+-void uv__udp_close(uv_udp_t* handle);
+-void uv__udp_finish_close(uv_udp_t* handle);
++void uv__async_close(FAR uv_async_t* handle);
++void uv__check_close(FAR uv_check_t* handle);
++void uv__fs_event_close(FAR uv_fs_event_t* handle);
++void uv__idle_close(FAR uv_idle_t* handle);
++void uv__pipe_close(FAR uv_pipe_t* handle);
++void uv__poll_close(FAR uv_poll_t* handle);
++void uv__prepare_close(FAR uv_prepare_t* handle);
++void uv__process_close(FAR uv_process_t* handle);
++void uv__stream_close(FAR uv_stream_t* handle);
++void uv__tcp_close(FAR uv_tcp_t* handle);
++void uv__udp_close(FAR uv_udp_t* handle);
++void uv__udp_finish_close(FAR uv_udp_t* handle);
+ uv_handle_type uv__handle_type(int fd);
+-FILE* uv__open_file(const char* path);
+-int uv__getpwuid_r(uv_passwd_t* pwd);
++FAR FILE* uv__open_file(FAR const char* path);
++int uv__getpwuid_r(FAR uv_passwd_t* pwd);
+ 
+ /* random */
+-int uv__random_devurandom(void* buf, size_t buflen);
+-int uv__random_getrandom(void* buf, size_t buflen);
+-int uv__random_getentropy(void* buf, size_t buflen);
+-int uv__random_readpath(const char* path, void* buf, size_t buflen);
+-int uv__random_sysctl(void* buf, size_t buflen);
++int uv__random_devurandom(FAR void* buf, size_t buflen);
++int uv__random_getrandom(FAR void* buf, size_t buflen);
++int uv__random_getentropy(FAR void* buf, size_t buflen);
++int uv__random_readpath(FAR const char* path, FAR void* buf, size_t buflen);
++int uv__random_sysctl(FAR void* buf, size_t buflen);
+ 
+ #if defined(__APPLE__)
+ int uv___stream_fd(const uv_stream_t* handle);
+@@ -299,13 +299,13 @@ void uv__fsevents_loop_delete(uv_loop_t* loop);
+ 
+ #endif /* defined(__APPLE__) */
+ 
+-UV_UNUSED(static void uv__update_time(uv_loop_t* loop)) {
++UV_UNUSED(static void uv__update_time(FAR uv_loop_t* loop)) {
+   /* Use a fast time source if available.  We only need millisecond precision.
+    */
+   loop->time = uv__hrtime(UV_CLOCK_FAST) / 1000000;
+ }
+ 
+-UV_UNUSED(static char* uv__basename_r(const char* path)) {
++UV_UNUSED(static FAR char* uv__basename_r(FAR const char* path)) {
+   char* s;
+ 
+   s = strrchr(path, '/');
+@@ -316,14 +316,14 @@ UV_UNUSED(static char* uv__basename_r(const char* path)) {
+ }
+ 
+ #if defined(__linux__)
+-int uv__inotify_fork(uv_loop_t* loop, void* old_watchers);
++int uv__inotify_fork(FAR uv_loop_t* loop, FAR void* old_watchers);
+ #endif
+ 
+-typedef int (*uv__peersockfunc)(int, struct sockaddr*, socklen_t*);
++typedef int (*uv__peersockfunc)(int, FAR struct sockaddr*, FAR socklen_t*);
+ 
+-int uv__getsockpeername(const uv_handle_t* handle,
++int uv__getsockpeername(FAR const uv_handle_t* handle,
+                         uv__peersockfunc func,
+-                        struct sockaddr* name,
++                        FAR struct sockaddr* name,
+                         int* namelen);
+ 
+ #if defined(__linux__)            ||                                      \
+@@ -336,12 +336,12 @@ struct uv__mmsghdr {
+ };
+ 
+ int uv__recvmmsg(int fd,
+-                 struct uv__mmsghdr* mmsg,
++                 FAR struct uv__mmsghdr* mmsg,
+                  unsigned int vlen,
+                  unsigned int flags,
+-                 struct timespec* timeout);
++                 FAR struct timespec* timeout);
+ int uv__sendmmsg(int fd,
+-                 struct uv__mmsghdr* mmsg,
++                 FAR struct uv__mmsghdr* mmsg,
+                  unsigned int vlen,
+                  unsigned int flags);
+ #else
+diff --git a/src/unix/loop-watcher.c b/src/unix/loop-watcher.c
+index b8c1c2a..aa9d508 100644
+--- a/src/unix/loop-watcher.c
++++ b/src/unix/loop-watcher.c
+@@ -23,13 +23,13 @@
+ #include "internal.h"
+ 
+ #define UV_LOOP_WATCHER_DEFINE(name, type)                                    \
+-  int uv_##name##_init(uv_loop_t* loop, uv_##name##_t* handle) {              \
+-    uv__handle_init(loop, (uv_handle_t*)handle, UV_##type);                   \
++  int uv_##name##_init(FAR uv_loop_t* loop, FAR uv_##name##_t* handle) {      \
++    uv__handle_init(loop, (FAR uv_handle_t*)handle, UV_##type);               \
+     handle->name##_cb = NULL;                                                 \
+     return 0;                                                                 \
+   }                                                                           \
+                                                                               \
+-  int uv_##name##_start(uv_##name##_t* handle, uv_##name##_cb cb) {           \
++  int uv_##name##_start(FAR uv_##name##_t* handle, uv_##name##_cb cb) {       \
+     if (uv__is_active(handle)) return 0;                                      \
+     if (cb == NULL) return UV_EINVAL;                                         \
+     QUEUE_INSERT_HEAD(&handle->loop->name##_handles, &handle->queue);         \
+@@ -38,17 +38,17 @@
+     return 0;                                                                 \
+   }                                                                           \
+                                                                               \
+-  int uv_##name##_stop(uv_##name##_t* handle) {                               \
++  int uv_##name##_stop(FAR uv_##name##_t* handle) {                           \
+     if (!uv__is_active(handle)) return 0;                                     \
+     QUEUE_REMOVE(&handle->queue);                                             \
+     uv__handle_stop(handle);                                                  \
+     return 0;                                                                 \
+   }                                                                           \
+                                                                               \
+-  void uv__run_##name(uv_loop_t* loop) {                                      \
++  void uv__run_##name(FAR uv_loop_t* loop) {                                  \
+     uv_##name##_t* h;                                                         \
+     QUEUE queue;                                                              \
+-    QUEUE* q;                                                                 \
++    FAR QUEUE* q;                                                             \
+     QUEUE_MOVE(&loop->name##_handles, &queue);                                \
+     while (!QUEUE_EMPTY(&queue)) {                                            \
+       q = QUEUE_HEAD(&queue);                                                 \
+@@ -59,7 +59,7 @@
+     }                                                                         \
+   }                                                                           \
+                                                                               \
+-  void uv__##name##_close(uv_##name##_t* handle) {                            \
++  void uv__##name##_close(FAR uv_##name##_t* handle) {                        \
+     uv_##name##_stop(handle);                                                 \
+   }
+ 
+diff --git a/src/unix/loop.c b/src/unix/loop.c
+index 1c60e31..a05a79b 100644
+--- a/src/unix/loop.c
++++ b/src/unix/loop.c
+@@ -27,7 +27,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ 
+-int uv_loop_init(uv_loop_t* loop) {
++int uv_loop_init(FAR uv_loop_t* loop) {
+   void* saved_data;
+   int err;
+ 
+@@ -186,7 +186,7 @@ int uv_loop_fork(uv_loop_t* loop) {
+ }
+ #endif
+ 
+-void uv__loop_close(uv_loop_t* loop) {
++void uv__loop_close(FAR uv_loop_t* loop) {
+ #ifdef CONFIG_LIBUV_SIGNAL
+   uv__signal_loop_cleanup(loop);
+ #endif
+@@ -236,7 +236,7 @@ void uv__loop_close(uv_loop_t* loop) {
+ }
+ 
+ 
+-int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap) {
++int uv__loop_configure(FAR uv_loop_t* loop, uv_loop_option option, va_list ap) {
+ #ifndef __NUTTX__
+   if (option != UV_LOOP_BLOCK_SIGNAL)
+     return UV_ENOSYS;
+diff --git a/src/unix/no-proctitle.c b/src/unix/no-proctitle.c
+index 32aa0af..973d9e6 100644
+--- a/src/unix/no-proctitle.c
++++ b/src/unix/no-proctitle.c
+@@ -25,18 +25,18 @@
+ #include <errno.h>
+ #include <stddef.h>
+ 
+-char** uv_setup_args(int argc, char** argv) {
++FAR char** uv_setup_args(int argc, FAR char** argv) {
+   return argv;
+ }
+ 
+ void uv__process_title_cleanup(void) {
+ }
+ 
+-int uv_set_process_title(const char* title) {
++int uv_set_process_title(FAR const char* title) {
+   return 0;
+ }
+ 
+-int uv_get_process_title(char* buffer, size_t size) {
++int uv_get_process_title(FAR char* buffer, size_t size) {
+   if (buffer == NULL || size == 0)
+     return UV_EINVAL;
+ 
+diff --git a/src/unix/nuttx.c b/src/unix/nuttx.c
+index d35a649..2cda60e 100644
+--- a/src/unix/nuttx.c
++++ b/src/unix/nuttx.c
+@@ -49,11 +49,11 @@
+ #undef NANOSEC
+ #define NANOSEC ((uint64_t) 1e9)
+ 
+-int uv__platform_loop_init(uv_loop_t* loop) {
++int uv__platform_loop_init(FAR uv_loop_t* loop) {
+   return 0;
+ }
+ 
+-void uv__platform_loop_delete(uv_loop_t* loop) {
++void uv__platform_loop_delete(FAR uv_loop_t* loop) {
+ }
+ 
+ /* From libuv/src/unix/posix-hrtime.c */
+@@ -67,9 +67,9 @@ uint64_t uv__hrtime(uv_clocktype_t type) {
+ /* From libuv/src/unix/posix-poll.c */
+ 
+ /* Add a watcher's fd to our poll fds array with its pending events.  */
+-static void uv__pollfds_add(uv_loop_t* loop, uv__io_t* w) {
++static void uv__pollfds_add(FAR uv_loop_t* loop, FAR uv__io_t* w) {
+   size_t i;
+-  struct pollfd* pe;
++  FAR struct pollfd* pe;
+   int available_slot = -1;
+ 
+   /* If the fd is already in the set just update its events.  */
+@@ -106,7 +106,7 @@ exit_setup_pollfd:
+ }
+ 
+ /* Remove a watcher's fd from our poll fds array.  */
+-static void uv__pollfds_del(uv_loop_t* loop, int fd) {
++static void uv__pollfds_del(FAR uv_loop_t* loop, int fd) {
+   size_t i;
+ 
+   for (i = 0; i < loop->poll_fds_used;) {
+@@ -128,18 +128,18 @@ static void uv__pollfds_del(uv_loop_t* loop, int fd) {
+   }
+ }
+ 
+-void uv__io_poll(uv_loop_t* loop, int timeout) {
++void uv__io_poll(FAR uv_loop_t* loop, int timeout) {
+   uint64_t time_base;
+   uint64_t time_diff;
+-  QUEUE* q;
+-  uv__io_t* w;
++  FAR QUEUE* q;
++  FAR uv__io_t* w;
+   size_t i;
+   unsigned int nevents;
+   int nfds;
+ #ifdef CONFIG_LIBUV_SIGNAL
+   int have_signals;
+ #endif
+-  struct pollfd* pe;
++  FAR struct pollfd* pe;
+   int fd;
+ 
+   if (loop->nfds == 0) {
+@@ -283,7 +283,7 @@ update_timeout:
+ /* Remove the given fd from our poll fds array because no one
+  * is interested in its events anymore.
+  */
+-void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
++void uv__platform_invalidate_fd(FAR uv_loop_t* loop, int fd) {
+   size_t i;
+ 
+   assert(fd >= 0);
+@@ -296,6 +296,6 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
+ }
+ 
+ /* Check whether the given fd is supported by poll().  */
+-int uv__io_check_fd(uv_loop_t* loop, int fd) {
++int uv__io_check_fd(FAR uv_loop_t* loop, int fd) {
+   return 0;
+ }
+diff --git a/src/unix/poll.c b/src/unix/poll.c
+index 130fbd6..a80387d 100644
+--- a/src/unix/poll.c
++++ b/src/unix/poll.c
+@@ -27,8 +27,8 @@
+ #include <errno.h>
+ 
+ 
+-static void uv__poll_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
+-  uv_poll_t* handle;
++static void uv__poll_io(FAR uv_loop_t* loop, FAR uv__io_t* w, unsigned int events) {
++  FAR uv_poll_t* handle;
+   int pevents;
+ 
+   handle = container_of(w, uv_poll_t, io_watcher);
+@@ -65,7 +65,7 @@ static void uv__poll_io(uv_loop_t* loop, uv__io_t* w, unsigned int events) {
+ }
+ 
+ 
+-int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
++int uv_poll_init(FAR uv_loop_t* loop, FAR uv_poll_t* handle, int fd) {
+   int err;
+ 
+   if (uv__fd_exists(loop, fd))
+@@ -95,7 +95,7 @@ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
+ }
+ 
+ 
+-int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
++int uv_poll_init_socket(FAR uv_loop_t* loop, FAR uv_poll_t* handle,
+     uv_os_sock_t socket) {
+   return uv_poll_init(loop, handle, socket);
+ }
+@@ -110,14 +110,14 @@ static void uv__poll_stop(uv_poll_t* handle) {
+ }
+ 
+ 
+-int uv_poll_stop(uv_poll_t* handle) {
++int uv_poll_stop(FAR uv_poll_t* handle) {
+   assert(!uv__is_closing(handle));
+   uv__poll_stop(handle);
+   return 0;
+ }
+ 
+ 
+-int uv_poll_start(uv_poll_t* handle, int pevents, uv_poll_cb poll_cb) {
++int uv_poll_start(FAR uv_poll_t* handle, int pevents, uv_poll_cb poll_cb) {
+   int events;
+ 
+   assert((pevents & ~(UV_READABLE | UV_WRITABLE | UV_DISCONNECT |
+@@ -147,6 +147,6 @@ int uv_poll_start(uv_poll_t* handle, int pevents, uv_poll_cb poll_cb) {
+ }
+ 
+ 
+-void uv__poll_close(uv_poll_t* handle) {
++void uv__poll_close(FAR uv_poll_t* handle) {
+   uv__poll_stop(handle);
+ }
+diff --git a/src/unix/process.c b/src/unix/process.c
+index 47b5828..bf89c1f 100644
+--- a/src/unix/process.c
++++ b/src/unix/process.c
+@@ -45,9 +45,9 @@ extern char **environ;
+ #endif
+ 
+ 
+-static void uv__chld(uv_signal_t* handle, int signum) {
+-  uv_process_t* process;
+-  uv_loop_t* loop;
++static void uv__chld(FAR uv_signal_t* handle, int signum) {
++  FAR uv_process_t* process;
++  FAR uv_loop_t* loop;
+   int exit_status;
+   int term_signal;
+   int status;
+@@ -265,7 +265,7 @@ static void uv__write_int(int fd, int val) {
+  * avoided. Since this isn't called on those targets, the function
+  * doesn't even need to be defined for them.
+  */
+-static void uv__process_child_init(const uv_process_options_t* options,
++static void uv__process_child_init(FAR const uv_process_options_t* options,
+                                    int stdio_count,
+                                    int (*pipes)[2],
+                                    int error_fd) {
+@@ -575,7 +575,7 @@ error:
+ }
+ #endif
+ 
+-int uv_process_kill(uv_process_t* process, int signum) {
++int uv_process_kill(FAR uv_process_t* process, int signum) {
+   return uv_kill(process->pid, signum);
+ }
+ 
+@@ -588,7 +588,7 @@ int uv_kill(int pid, int signum) {
+ }
+ 
+ 
+-void uv__process_close(uv_process_t* handle) {
++void uv__process_close(FAR uv_process_t* handle) {
+   QUEUE_REMOVE(&handle->queue);
+   uv__handle_stop(handle);
+   if (QUEUE_EMPTY(&handle->loop->process_handles))
+diff --git a/src/unix/thread.c b/src/unix/thread.c
+index 1b962c1..e2ba851 100644
+--- a/src/unix/thread.c
++++ b/src/unix/thread.c
+@@ -52,8 +52,8 @@ STATIC_ASSERT(sizeof(uv_barrier_t) == sizeof(pthread_barrier_t));
+ #if defined(_AIX) || \
+     defined(__OpenBSD__) || \
+     !defined(PTHREAD_BARRIER_SERIAL_THREAD)
+-int uv_barrier_init(uv_barrier_t* barrier, unsigned int count) {
+-  struct _uv_barrier* b;
++int uv_barrier_init(FAR uv_barrier_t* barrier, unsigned int count) {
++  FAR struct _uv_barrier* b;
+   int rc;
+ 
+   if (barrier == NULL || count == 0)
+@@ -86,8 +86,8 @@ error2:
+ }
+ 
+ 
+-int uv_barrier_wait(uv_barrier_t* barrier) {
+-  struct _uv_barrier* b;
++int uv_barrier_wait(FAR uv_barrier_t* barrier) {
++  FAR struct _uv_barrier* b;
+   int last;
+ 
+   if (barrier == NULL || barrier->b == NULL)
+@@ -115,8 +115,8 @@ int uv_barrier_wait(uv_barrier_t* barrier) {
+ }
+ 
+ 
+-void uv_barrier_destroy(uv_barrier_t* barrier) {
+-  struct _uv_barrier* b;
++void uv_barrier_destroy(FAR uv_barrier_t* barrier) {
++  FAR struct _uv_barrier* b;
+ 
+   b = barrier->b;
+   uv_mutex_lock(&b->mutex);
+@@ -137,12 +137,12 @@ void uv_barrier_destroy(uv_barrier_t* barrier) {
+ 
+ #else
+ 
+-int uv_barrier_init(uv_barrier_t* barrier, unsigned int count) {
++int uv_barrier_init(FAR uv_barrier_t* barrier, unsigned int count) {
+   return UV__ERR(pthread_barrier_init(barrier, NULL, count));
+ }
+ 
+ 
+-int uv_barrier_wait(uv_barrier_t* barrier) {
++int uv_barrier_wait(FAR uv_barrier_t* barrier) {
+   int rc;
+ 
+   rc = pthread_barrier_wait(barrier);
+@@ -154,7 +154,7 @@ int uv_barrier_wait(uv_barrier_t* barrier) {
+ }
+ 
+ 
+-void uv_barrier_destroy(uv_barrier_t* barrier) {
++void uv_barrier_destroy(FAR uv_barrier_t* barrier) {
+   if (pthread_barrier_destroy(barrier))
+     abort();
+ }
+@@ -207,7 +207,7 @@ static size_t thread_stack_size(void) {
+ }
+ #endif
+ 
+-int uv_thread_create(uv_thread_t *tid, void (*entry)(void *arg), void *arg) {
++int uv_thread_create(FAR uv_thread_t *tid, void (*entry)(FAR void *arg), FAR void *arg) {
+ #ifdef __NUTTX__
+   return pthread_create(tid, NULL, (pthread_startroutine_t)entry, arg);
+ #else
+@@ -274,17 +274,17 @@ uv_thread_t uv_thread_self(void) {
+   return pthread_self();
+ }
+ 
+-int uv_thread_join(uv_thread_t *tid) {
++int uv_thread_join(FAR uv_thread_t *tid) {
+   return UV__ERR(pthread_join(*tid, NULL));
+ }
+ 
+ 
+-int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2) {
++int uv_thread_equal(FAR const uv_thread_t* t1, FAR const uv_thread_t* t2) {
+   return pthread_equal(*t1, *t2);
+ }
+ 
+ 
+-int uv_mutex_init(uv_mutex_t* mutex) {
++int uv_mutex_init(FAR uv_mutex_t* mutex) {
+ #if defined(NDEBUG) || !defined(PTHREAD_MUTEX_ERRORCHECK) || defined(__NUTTX__)
+   return UV__ERR(pthread_mutex_init(mutex, NULL));
+ #else
+@@ -307,7 +307,7 @@ int uv_mutex_init(uv_mutex_t* mutex) {
+ }
+ 
+ 
+-int uv_mutex_init_recursive(uv_mutex_t* mutex) {
++int uv_mutex_init_recursive(FAR uv_mutex_t* mutex) {
+   pthread_mutexattr_t attr;
+   int err;
+ 
+@@ -326,19 +326,19 @@ int uv_mutex_init_recursive(uv_mutex_t* mutex) {
+ }
+ 
+ 
+-void uv_mutex_destroy(uv_mutex_t* mutex) {
++void uv_mutex_destroy(FAR uv_mutex_t* mutex) {
+   if (pthread_mutex_destroy(mutex))
+     abort();
+ }
+ 
+ 
+-void uv_mutex_lock(uv_mutex_t* mutex) {
++void uv_mutex_lock(FAR uv_mutex_t* mutex) {
+   if (pthread_mutex_lock(mutex))
+     abort();
+ }
+ 
+ 
+-int uv_mutex_trylock(uv_mutex_t* mutex) {
++int uv_mutex_trylock(FAR uv_mutex_t* mutex) {
+   int err;
+ 
+   err = pthread_mutex_trylock(mutex);
+@@ -352,30 +352,30 @@ int uv_mutex_trylock(uv_mutex_t* mutex) {
+ }
+ 
+ 
+-void uv_mutex_unlock(uv_mutex_t* mutex) {
++void uv_mutex_unlock(FAR uv_mutex_t* mutex) {
+   if (pthread_mutex_unlock(mutex))
+     abort();
+ }
+ 
+ 
+-int uv_rwlock_init(uv_rwlock_t* rwlock) {
++int uv_rwlock_init(FAR uv_rwlock_t* rwlock) {
+   return UV__ERR(pthread_rwlock_init(rwlock, NULL));
+ }
+ 
+ 
+-void uv_rwlock_destroy(uv_rwlock_t* rwlock) {
++void uv_rwlock_destroy(FAR uv_rwlock_t* rwlock) {
+   if (pthread_rwlock_destroy(rwlock))
+     abort();
+ }
+ 
+ 
+-void uv_rwlock_rdlock(uv_rwlock_t* rwlock) {
++void uv_rwlock_rdlock(FAR uv_rwlock_t* rwlock) {
+   if (pthread_rwlock_rdlock(rwlock))
+     abort();
+ }
+ 
+ 
+-int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
++int uv_rwlock_tryrdlock(FAR uv_rwlock_t* rwlock) {
+   int err;
+ 
+   err = pthread_rwlock_tryrdlock(rwlock);
+@@ -389,19 +389,19 @@ int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock) {
+ }
+ 
+ 
+-void uv_rwlock_rdunlock(uv_rwlock_t* rwlock) {
++void uv_rwlock_rdunlock(FAR uv_rwlock_t* rwlock) {
+   if (pthread_rwlock_unlock(rwlock))
+     abort();
+ }
+ 
+ 
+-void uv_rwlock_wrlock(uv_rwlock_t* rwlock) {
++void uv_rwlock_wrlock(FAR uv_rwlock_t* rwlock) {
+   if (pthread_rwlock_wrlock(rwlock))
+     abort();
+ }
+ 
+ 
+-int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
++int uv_rwlock_trywrlock(FAR uv_rwlock_t* rwlock) {
+   int err;
+ 
+   err = pthread_rwlock_trywrlock(rwlock);
+@@ -415,13 +415,13 @@ int uv_rwlock_trywrlock(uv_rwlock_t* rwlock) {
+ }
+ 
+ 
+-void uv_rwlock_wrunlock(uv_rwlock_t* rwlock) {
++void uv_rwlock_wrunlock(FAR uv_rwlock_t* rwlock) {
+   if (pthread_rwlock_unlock(rwlock))
+     abort();
+ }
+ 
+ 
+-void uv_once(uv_once_t* guard, void (*callback)(void)) {
++void uv_once(FAR uv_once_t* guard, void (*callback)(void)) {
+   if (pthread_once(guard, callback))
+     abort();
+ }
+@@ -528,9 +528,9 @@ typedef struct uv_semaphore_s {
+ STATIC_ASSERT(sizeof(uv_sem_t) >= sizeof(uv_semaphore_t*));
+ #endif
+ 
+-static int uv__custom_sem_init(uv_sem_t* sem_, unsigned int value) {
++static int uv__custom_sem_init(FAR uv_sem_t* sem_, unsigned int value) {
+   int err;
+-  uv_semaphore_t* sem;
++  FAR uv_semaphore_t* sem;
+ 
+   sem = uv__malloc(sizeof(*sem));
+   if (sem == NULL)
+@@ -553,20 +553,20 @@ static int uv__custom_sem_init(uv_sem_t* sem_, unsigned int value) {
+ }
+ 
+ 
+-static void uv__custom_sem_destroy(uv_sem_t* sem_) {
+-  uv_semaphore_t* sem;
++static void uv__custom_sem_destroy(FAR uv_sem_t* sem_) {
++  FAR uv_semaphore_t* sem;
+ 
+-  sem = *(uv_semaphore_t**)sem_;
++  sem = *(FAR uv_semaphore_t**)sem_;
+   uv_cond_destroy(&sem->cond);
+   uv_mutex_destroy(&sem->mutex);
+   uv__free(sem);
+ }
+ 
+ 
+-static void uv__custom_sem_post(uv_sem_t* sem_) {
+-  uv_semaphore_t* sem;
++static void uv__custom_sem_post(FAR uv_sem_t* sem_) {
++  FAR uv_semaphore_t* sem;
+ 
+-  sem = *(uv_semaphore_t**)sem_;
++  sem = *(FAR uv_semaphore_t**)sem_;
+   uv_mutex_lock(&sem->mutex);
+   sem->value++;
+   if (sem->value == 1)
+@@ -575,10 +575,10 @@ static void uv__custom_sem_post(uv_sem_t* sem_) {
+ }
+ 
+ 
+-static void uv__custom_sem_wait(uv_sem_t* sem_) {
+-  uv_semaphore_t* sem;
++static void uv__custom_sem_wait(FAR uv_sem_t* sem_) {
++  FAR uv_semaphore_t* sem;
+ 
+-  sem = *(uv_semaphore_t**)sem_;
++  sem = *(FAR uv_semaphore_t**)sem_;
+   uv_mutex_lock(&sem->mutex);
+   while (sem->value == 0)
+     uv_cond_wait(&sem->cond, &sem->mutex);
+@@ -587,10 +587,10 @@ static void uv__custom_sem_wait(uv_sem_t* sem_) {
+ }
+ 
+ 
+-static int uv__custom_sem_trywait(uv_sem_t* sem_) {
+-  uv_semaphore_t* sem;
++static int uv__custom_sem_trywait(FAR uv_sem_t* sem_) {
++  FAR uv_semaphore_t* sem;
+ 
+-  sem = *(uv_semaphore_t**)sem_;
++  sem = *(FAR uv_semaphore_t**)sem_;
+   if (uv_mutex_trylock(&sem->mutex) != 0)
+     return UV_EAGAIN;
+ 
+@@ -605,26 +605,26 @@ static int uv__custom_sem_trywait(uv_sem_t* sem_) {
+   return 0;
+ }
+ 
+-static int uv__sem_init(uv_sem_t* sem, unsigned int value) {
++static int uv__sem_init(FAR uv_sem_t* sem, unsigned int value) {
+   if (sem_init(sem, 0, value))
+     return UV__ERR(errno);
+   return 0;
+ }
+ 
+ 
+-static void uv__sem_destroy(uv_sem_t* sem) {
++static void uv__sem_destroy(FAR uv_sem_t* sem) {
+   if (sem_destroy(sem))
+     abort();
+ }
+ 
+ 
+-static void uv__sem_post(uv_sem_t* sem) {
++static void uv__sem_post(FAR uv_sem_t* sem) {
+   if (sem_post(sem))
+     abort();
+ }
+ 
+ 
+-static void uv__sem_wait(uv_sem_t* sem) {
++static void uv__sem_wait(FAR uv_sem_t* sem) {
+   int r;
+ 
+   do
+@@ -636,7 +636,7 @@ static void uv__sem_wait(uv_sem_t* sem) {
+ }
+ 
+ 
+-static int uv__sem_trywait(uv_sem_t* sem) {
++static int uv__sem_trywait(FAR uv_sem_t* sem) {
+   int r;
+ 
+   do
+@@ -652,7 +652,7 @@ static int uv__sem_trywait(uv_sem_t* sem) {
+   return 0;
+ }
+ 
+-int uv_sem_init(uv_sem_t* sem, unsigned int value) {
++int uv_sem_init(FAR uv_sem_t* sem, unsigned int value) {
+ #if defined(__GLIBC__) && !defined(__UCLIBC__)
+   uv_once(&glibc_version_check_once, glibc_version_check);
+ #endif
+@@ -664,7 +664,7 @@ int uv_sem_init(uv_sem_t* sem, unsigned int value) {
+ }
+ 
+ 
+-void uv_sem_destroy(uv_sem_t* sem) {
++void uv_sem_destroy(FAR uv_sem_t* sem) {
+   if (platform_needs_custom_semaphore)
+     uv__custom_sem_destroy(sem);
+   else
+@@ -672,7 +672,7 @@ void uv_sem_destroy(uv_sem_t* sem) {
+ }
+ 
+ 
+-void uv_sem_post(uv_sem_t* sem) {
++void uv_sem_post(FAR uv_sem_t* sem) {
+   if (platform_needs_custom_semaphore)
+     uv__custom_sem_post(sem);
+   else
+@@ -680,7 +680,7 @@ void uv_sem_post(uv_sem_t* sem) {
+ }
+ 
+ 
+-void uv_sem_wait(uv_sem_t* sem) {
++void uv_sem_wait(FAR uv_sem_t* sem) {
+   if (platform_needs_custom_semaphore)
+     uv__custom_sem_wait(sem);
+   else
+@@ -688,7 +688,7 @@ void uv_sem_wait(uv_sem_t* sem) {
+ }
+ 
+ 
+-int uv_sem_trywait(uv_sem_t* sem) {
++int uv_sem_trywait(FAR uv_sem_t* sem) {
+   if (platform_needs_custom_semaphore)
+     return uv__custom_sem_trywait(sem);
+   else
+@@ -706,7 +706,7 @@ int uv_cond_init(uv_cond_t* cond) {
+ 
+ #else /* !(defined(__APPLE__) && defined(__MACH__)) */
+ 
+-int uv_cond_init(uv_cond_t* cond) {
++int uv_cond_init(FAR uv_cond_t* cond) {
+   pthread_condattr_t attr;
+   int err;
+ 
+@@ -739,7 +739,7 @@ error2:
+ 
+ #endif /* defined(__APPLE__) && defined(__MACH__) */
+ 
+-void uv_cond_destroy(uv_cond_t* cond) {
++void uv_cond_destroy(FAR uv_cond_t* cond) {
+ #if defined(__APPLE__) && defined(__MACH__)
+   /* It has been reported that destroying condition variables that have been
+    * signalled but not waited on can sometimes result in application crashes.
+@@ -773,23 +773,23 @@ void uv_cond_destroy(uv_cond_t* cond) {
+     abort();
+ }
+ 
+-void uv_cond_signal(uv_cond_t* cond) {
++void uv_cond_signal(FAR uv_cond_t* cond) {
+   if (pthread_cond_signal(cond))
+     abort();
+ }
+ 
+-void uv_cond_broadcast(uv_cond_t* cond) {
++void uv_cond_broadcast(FAR uv_cond_t* cond) {
+   if (pthread_cond_broadcast(cond))
+     abort();
+ }
+ 
+-void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex) {
++void uv_cond_wait(FAR uv_cond_t* cond, FAR uv_mutex_t* mutex) {
+   if (pthread_cond_wait(cond, mutex))
+     abort();
+ }
+ 
+ 
+-int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
++int uv_cond_timedwait(FAR uv_cond_t* cond, FAR uv_mutex_t* mutex, uint64_t timeout) {
+   int r;
+   struct timespec ts;
+ #if defined(__MVS__)
+@@ -827,23 +827,23 @@ int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout) {
+ }
+ 
+ 
+-int uv_key_create(uv_key_t* key) {
++int uv_key_create(FAR uv_key_t* key) {
+   return UV__ERR(pthread_key_create(key, NULL));
+ }
+ 
+ 
+-void uv_key_delete(uv_key_t* key) {
++void uv_key_delete(FAR uv_key_t* key) {
+   if (pthread_key_delete(*key))
+     abort();
+ }
+ 
+ 
+-void* uv_key_get(uv_key_t* key) {
++void* uv_key_get(FAR uv_key_t* key) {
+   return pthread_getspecific(*key);
+ }
+ 
+ 
+-void uv_key_set(uv_key_t* key, void* value) {
++void uv_key_set(FAR uv_key_t* key, FAR void* value) {
+   if (pthread_setspecific(*key, value))
+     abort();
+ }
+diff --git a/src/uv-common.c b/src/uv-common.c
+index db62542..8829ee1 100644
+--- a/src/uv-common.c
++++ b/src/uv-common.c
+@@ -52,16 +52,16 @@ static uv__allocator_t uv__allocator = {
+   free,
+ };
+ 
+-char* uv__strdup(const char* s) {
++char* uv__strdup(FAR const char* s) {
+   size_t len = strlen(s) + 1;
+-  char* m = uv__malloc(len);
++  FAR char* m = uv__malloc(len);
+   if (m == NULL)
+     return NULL;
+   return memcpy(m, s, len);
+ }
+ 
+-char* uv__strndup(const char* s, size_t n) {
+-  char* m;
++char* uv__strndup(FAR const char* s, size_t n) {
++  FAR char* m;
+   size_t len = strlen(s);
+   if (n < len)
+     len = n;
+@@ -72,13 +72,13 @@ char* uv__strndup(const char* s, size_t n) {
+   return memcpy(m, s, len);
+ }
+ 
+-void* uv__malloc(size_t size) {
++FAR void* uv__malloc(size_t size) {
+   if (size > 0)
+     return uv__allocator.local_malloc(size);
+   return NULL;
+ }
+ 
+-void uv__free(void* ptr) {
++void uv__free(FAR void* ptr) {
+   int saved_errno;
+ 
+   /* Libuv expects that free() does not clobber errno.  The system allocator
+@@ -89,18 +89,18 @@ void uv__free(void* ptr) {
+   errno = saved_errno;
+ }
+ 
+-void* uv__calloc(size_t count, size_t size) {
++FAR void* uv__calloc(size_t count, size_t size) {
+   return uv__allocator.local_calloc(count, size);
+ }
+ 
+-void* uv__realloc(void* ptr, size_t size) {
++FAR void* uv__realloc(FAR void* ptr, size_t size) {
+   if (size > 0)
+     return uv__allocator.local_realloc(ptr, size);
+   uv__free(ptr);
+   return NULL;
+ }
+ 
+-void* uv__reallocf(void* ptr, size_t size) {
++FAR void* uv__reallocf(FAR void* ptr, size_t size) {
+   void* newptr;
+ 
+   newptr = uv__realloc(ptr, size);
+@@ -154,7 +154,7 @@ size_t uv_loop_size(void) {
+ }
+ 
+ 
+-uv_buf_t uv_buf_init(char* base, unsigned int len) {
++uv_buf_t uv_buf_init(FAR char* base, unsigned int len) {
+   uv_buf_t buf;
+   buf.base = base;
+   buf.len = len;
+@@ -162,7 +162,7 @@ uv_buf_t uv_buf_init(char* base, unsigned int len) {
+ }
+ 
+ 
+-static const char* uv__unknown_err_code(int err) {
++static FAR const char* uv__unknown_err_code(int err) {
+   char buf[32];
+   char* copy;
+ 
+@@ -175,7 +175,7 @@ static const char* uv__unknown_err_code(int err) {
+ #define UV_ERR_NAME_GEN_R(name, _) \
+ case UV_## name: \
+   uv__strscpy(buf, #name, buflen); break;
+-char* uv_err_name_r(int err, char* buf, size_t buflen) {
++FAR char* uv_err_name_r(int err, FAR char* buf, size_t buflen) {
+   switch (err) {
+     UV_ERRNO_MAP(UV_ERR_NAME_GEN_R)
+     default: snprintf(buf, buflen, "Unknown system error %d", err);
+@@ -186,7 +186,7 @@ char* uv_err_name_r(int err, char* buf, size_t buflen) {
+ 
+ 
+ #define UV_ERR_NAME_GEN(name, _) case UV_ ## name: return #name;
+-const char* uv_err_name(int err) {
++const FAR char* uv_err_name(int err) {
+   switch (err) {
+     UV_ERRNO_MAP(UV_ERR_NAME_GEN)
+   }
+@@ -198,7 +198,7 @@ const char* uv_err_name(int err) {
+ #define UV_STRERROR_GEN_R(name, msg) \
+ case UV_ ## name: \
+   snprintf(buf, buflen, "%s", msg); break;
+-char* uv_strerror_r(int err, char* buf, size_t buflen) {
++FAR char* uv_strerror_r(int err, FAR char* buf, size_t buflen) {
+   switch (err) {
+     UV_ERRNO_MAP(UV_STRERROR_GEN_R)
+     default: snprintf(buf, buflen, "Unknown system error %d", err);
+@@ -209,7 +209,7 @@ char* uv_strerror_r(int err, char* buf, size_t buflen) {
+ 
+ 
+ #define UV_STRERROR_GEN(name, msg) case UV_ ## name: return msg;
+-const char* uv_strerror(int err) {
++FAR const char* uv_strerror(int err) {
+   switch (err) {
+     UV_ERRNO_MAP(UV_STRERROR_GEN)
+   }
+@@ -483,10 +483,10 @@ int uv_udp_recv_stop(uv_udp_t* handle) {
+ }
+ #endif
+ 
+-void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
++void uv_walk(FAR uv_loop_t* loop, uv_walk_cb walk_cb, FAR void* arg) {
+   QUEUE queue;
+-  QUEUE* q;
+-  uv_handle_t* h;
++  FAR QUEUE* q;
++  FAR uv_handle_t* h;
+ 
+   QUEUE_MOVE(&loop->handle_queue, &queue);
+   while (!QUEUE_EMPTY(&queue)) {
+@@ -502,10 +502,10 @@ void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg) {
+ }
+ 
+ 
+-static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
++static void uv__print_handles(FAR uv_loop_t* loop, int only_active, FAR FILE* stream) {
+   const char* type;
+-  QUEUE* q;
+-  uv_handle_t* h;
++  FAR QUEUE* q;
++  FAR uv_handle_t* h;
+ 
+ #ifdef CONFIG_LIBUV_DEFAULT_LOOP
+   if (loop == NULL)
+@@ -536,43 +536,43 @@ static void uv__print_handles(uv_loop_t* loop, int only_active, FILE* stream) {
+ }
+ 
+ 
+-void uv_print_all_handles(uv_loop_t* loop, FILE* stream) {
++void uv_print_all_handles(FAR uv_loop_t* loop, FAR FILE* stream) {
+   uv__print_handles(loop, 0, stream);
+ }
+ 
+ 
+-void uv_print_active_handles(uv_loop_t* loop, FILE* stream) {
++void uv_print_active_handles(FAR uv_loop_t* loop, FAR FILE* stream) {
+   uv__print_handles(loop, 1, stream);
+ }
+ 
+ 
+-void uv_ref(uv_handle_t* handle) {
++void uv_ref(FAR uv_handle_t* handle) {
+   uv__handle_ref(handle);
+ }
+ 
+ 
+-void uv_unref(uv_handle_t* handle) {
++void uv_unref(FAR uv_handle_t* handle) {
+   uv__handle_unref(handle);
+ }
+ 
+ 
+-int uv_has_ref(const uv_handle_t* handle) {
++int uv_has_ref(FAR const uv_handle_t* handle) {
+   return uv__has_ref(handle);
+ }
+ 
+ 
+-void uv_stop(uv_loop_t* loop) {
++void uv_stop(FAR uv_loop_t* loop) {
+   loop->stop_flag = 1;
+ }
+ 
+ 
+-uint64_t uv_now(const uv_loop_t* loop) {
++uint64_t uv_now(FAR const uv_loop_t* loop) {
+   return loop->time;
+ }
+ 
+ 
+ 
+-size_t uv__count_bufs(const uv_buf_t bufs[], unsigned int nbufs) {
++size_t uv__count_bufs(FAR const uv_buf_t bufs[], unsigned int nbufs) {
+   unsigned int i;
+   size_t bytes;
+ 
+@@ -593,7 +593,7 @@ int uv_send_buffer_size(uv_handle_t* handle, int *value) {
+ }
+ #endif
+ 
+-int uv_fs_event_getpath(uv_fs_event_t* handle, char* buffer, size_t* size) {
++int uv_fs_event_getpath(FAR uv_fs_event_t* handle, FAR char* buffer, FAR size_t* size) {
+   size_t required_len;
+ 
+   if (!uv__is_active(handle)) {
+@@ -618,7 +618,7 @@ int uv_fs_event_getpath(uv_fs_event_t* handle, char* buffer, size_t* size) {
+  * the unix implementation (nbufs is not directly inside req but is
+  * contained in a nested union/struct) so this function locates it.
+ */
+-static unsigned int* uv__get_nbufs(uv_fs_t* req) {
++static FAR unsigned int* uv__get_nbufs(FAR uv_fs_t* req) {
+ #ifdef _WIN32
+   return &req->fs.info.nbufs;
+ #else
+@@ -636,10 +636,10 @@ static unsigned int* uv__get_nbufs(uv_fs_t* req) {
+ # define uv__fs_scandir_free free
+ #endif
+ 
+-void uv__fs_scandir_cleanup(uv_fs_t* req) {
+-  uv__dirent_t** dents;
++void uv__fs_scandir_cleanup(FAR uv_fs_t* req) {
++  FAR uv__dirent_t** dents;
+ 
+-  unsigned int* nbufs = uv__get_nbufs(req);
++  FAR unsigned int* nbufs = uv__get_nbufs(req);
+ 
+   dents = req->ptr;
+   if (*nbufs > 0 && *nbufs != (unsigned int) req->result)
+@@ -652,10 +652,10 @@ void uv__fs_scandir_cleanup(uv_fs_t* req) {
+ }
+ 
+ 
+-int uv_fs_scandir_next(uv_fs_t* req, uv_dirent_t* ent) {
+-  uv__dirent_t** dents;
+-  uv__dirent_t* dent;
+-  unsigned int* nbufs;
++int uv_fs_scandir_next(FAR uv_fs_t* req, FAR uv_dirent_t* ent) {
++  FAR uv__dirent_t** dents;
++  FAR uv__dirent_t* dent;
++  FAR unsigned int* nbufs;
+ 
+   /* Check to see if req passed */
+   if (req->result < 0)
+@@ -689,7 +689,7 @@ int uv_fs_scandir_next(uv_fs_t* req, uv_dirent_t* ent) {
+   return 0;
+ }
+ 
+-uv_dirent_type_t uv__fs_get_dirent_type(uv__dirent_t* dent) {
++uv_dirent_type_t uv__fs_get_dirent_type(FAR uv__dirent_t* dent) {
+   uv_dirent_type_t type;
+ 
+ #ifdef HAVE_DIRENT_TYPES
+@@ -725,9 +725,9 @@ uv_dirent_type_t uv__fs_get_dirent_type(uv__dirent_t* dent) {
+   return type;
+ }
+ 
+-void uv__fs_readdir_cleanup(uv_fs_t* req) {
+-  uv_dir_t* dir;
+-  uv_dirent_t* dirents;
++void uv__fs_readdir_cleanup(FAR uv_fs_t* req) {
++  FAR uv_dir_t* dir;
++  FAR uv_dirent_t* dirents;
+   int i;
+ 
+   if (req->ptr == NULL)
+@@ -762,10 +762,10 @@ int uv_loop_configure(uv_loop_t* loop, uv_loop_option option, ...) {
+ 
+ #ifdef CONFIG_LIBUV_DEFAULT_LOOP
+ static uv_loop_t default_loop_struct;
+-static uv_loop_t* default_loop_ptr;
++static FAR uv_loop_t* default_loop_ptr;
+ 
+ 
+-uv_loop_t* uv_default_loop(void) {
++FAR uv_loop_t* uv_default_loop(void) {
+   if (default_loop_ptr != NULL)
+     return default_loop_ptr;
+ 
+@@ -777,7 +777,7 @@ uv_loop_t* uv_default_loop(void) {
+ }
+ #endif
+ 
+-uv_loop_t* uv_loop_new(void) {
++FAR uv_loop_t* uv_loop_new(void) {
+   uv_loop_t* loop;
+ 
+   loop = uv__malloc(sizeof(*loop));
+@@ -793,9 +793,9 @@ uv_loop_t* uv_loop_new(void) {
+ }
+ 
+ 
+-int uv_loop_close(uv_loop_t* loop) {
+-  QUEUE* q;
+-  uv_handle_t* h;
++int uv_loop_close(FAR uv_loop_t* loop) {
++  FAR QUEUE* q;
++  FAR uv_handle_t* h;
+ #ifndef NDEBUG
+   void* saved_data;
+ #endif
+@@ -824,9 +824,9 @@ int uv_loop_close(uv_loop_t* loop) {
+ }
+ 
+ 
+-void uv_loop_delete(uv_loop_t* loop) {
++void uv_loop_delete(FAR uv_loop_t* loop) {
+ #ifdef CONFIG_LIBUV_DEFAULT_LOOP
+-  uv_loop_t* default_loop;
++  FAR uv_loop_t* default_loop;
+   int err;
+ 
+   default_loop = default_loop_ptr;
+@@ -844,7 +844,7 @@ void uv_loop_delete(uv_loop_t* loop) {
+ }
+ 
+ 
+-void uv_os_free_environ(uv_env_item_t* envitems, int count) {
++void uv_os_free_environ(FAR uv_env_item_t* envitems, int count) {
+   int i;
+ 
+   for (i = 0; i < count; i++) {
+@@ -855,7 +855,7 @@ void uv_os_free_environ(uv_env_item_t* envitems, int count) {
+ }
+ 
+ 
+-void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
++void uv_free_cpu_info(FAR uv_cpu_info_t* cpu_infos, int count) {
+   int i;
+ 
+   for (i = 0; i < count; i++)
+diff --git a/src/uv-common.h b/src/uv-common.h
+index 063588e..222a20a 100644
+--- a/src/uv-common.h
++++ b/src/uv-common.h
+@@ -49,7 +49,7 @@
+ #endif
+ 
+ #if !defined(snprintf) && defined(_MSC_VER) && _MSC_VER < 1900
+-extern int snprintf(char*, size_t, const char*, ...);
++extern int snprintf(FAR char*, size_t, FAR const IPTR char*, ...);
+ #endif
+ 
+ #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+@@ -132,59 +132,59 @@ enum {
+   UV_HANDLE_POLL_SLOW                   = 0x01000000
+ };
+ 
+-int uv__loop_configure(uv_loop_t* loop, uv_loop_option option, va_list ap);
++int uv__loop_configure(FAR uv_loop_t* loop, uv_loop_option option, va_list ap);
+ 
+-void uv__loop_close(uv_loop_t* loop);
++void uv__loop_close(FAR uv_loop_t* loop);
+ 
+-int uv__tcp_bind(uv_tcp_t* tcp,
+-                 const struct sockaddr* addr,
++int uv__tcp_bind(FAR uv_tcp_t* tcp,
++                 FAR const struct sockaddr* addr,
+                  unsigned int addrlen,
+                  unsigned int flags);
+ 
+-int uv__tcp_connect(uv_connect_t* req,
+-                   uv_tcp_t* handle,
+-                   const struct sockaddr* addr,
++int uv__tcp_connect(FAR uv_connect_t* req,
++                   FAR uv_tcp_t* handle,
++                   FAR const struct sockaddr* addr,
+                    unsigned int addrlen,
+                    uv_connect_cb cb);
+ 
+-int uv__udp_init_ex(uv_loop_t* loop,
+-                    uv_udp_t* handle,
++int uv__udp_init_ex(FAR uv_loop_t* loop,
++                    FAR uv_udp_t* handle,
+                     unsigned flags,
+                     int domain);
+ 
+-int uv__udp_bind(uv_udp_t* handle,
+-                 const struct sockaddr* addr,
++int uv__udp_bind(FAR uv_udp_t* handle,
++                 FAR const struct sockaddr* addr,
+                  unsigned int  addrlen,
+                  unsigned int flags);
+ 
+-int uv__udp_connect(uv_udp_t* handle,
+-                    const struct sockaddr* addr,
++int uv__udp_connect(FAR uv_udp_t* handle,
++                    FAR const struct sockaddr* addr,
+                     unsigned int addrlen);
+ 
+-int uv__udp_disconnect(uv_udp_t* handle);
++int uv__udp_disconnect(FAR uv_udp_t* handle);
+ 
+-int uv__udp_is_connected(uv_udp_t* handle);
++int uv__udp_is_connected(FAR uv_udp_t* handle);
+ 
+-int uv__udp_send(uv_udp_send_t* req,
+-                 uv_udp_t* handle,
+-                 const uv_buf_t bufs[],
++int uv__udp_send(FAR uv_udp_send_t* req,
++                 FAR uv_udp_t* handle,
++                 FAR const uv_buf_t bufs[],
+                  unsigned int nbufs,
+-                 const struct sockaddr* addr,
++                 FAR const struct sockaddr* addr,
+                  unsigned int addrlen,
+                  uv_udp_send_cb send_cb);
+ 
+-int uv__udp_try_send(uv_udp_t* handle,
++int uv__udp_try_send(FAR uv_udp_t* handle,
+                      const uv_buf_t bufs[],
+                      unsigned int nbufs,
+-                     const struct sockaddr* addr,
++                     FAR const struct sockaddr* addr,
+                      unsigned int addrlen);
+ 
+-int uv__udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloccb,
++int uv__udp_recv_start(FAR uv_udp_t* handle, uv_alloc_cb alloccb,
+                        uv_udp_recv_cb recv_cb);
+ 
+-int uv__udp_recv_stop(uv_udp_t* handle);
++int uv__udp_recv_stop(FAR uv_udp_t* handle);
+ 
+-void uv__fs_poll_close(uv_fs_poll_t* handle);
++void uv__fs_poll_close(FAR uv_fs_poll_t* handle);
+ 
+ int uv__getaddrinfo_translate_error(int sys_err);    /* EAI_* error. */
+ 
+@@ -194,25 +194,25 @@ enum uv__work_kind {
+   UV__WORK_SLOW_IO
+ };
+ 
+-void uv__work_submit(uv_loop_t* loop,
+-                     struct uv__work *w,
++void uv__work_submit(FAR uv_loop_t* loop,
++                     FAR struct uv__work *w,
+                      enum uv__work_kind kind,
+-                     void (*work)(struct uv__work *w),
+-                     void (*done)(struct uv__work *w, int status));
++                     void (*work)(FAR struct uv__work *w),
++                     void (*done)(FAR struct uv__work *w, int status));
+ 
+-void uv__work_done(uv_async_t* handle);
++void uv__work_done(FAR uv_async_t* handle);
+ 
+-size_t uv__count_bufs(const uv_buf_t bufs[], unsigned int nbufs);
++size_t uv__count_bufs(FAR const uv_buf_t bufs[], unsigned int nbufs);
+ 
+-int uv__socket_sockopt(uv_handle_t* handle, int optname, int* value);
++int uv__socket_sockopt(FAR uv_handle_t* handle, int optname, FAR int* value);
+ 
+-void uv__fs_scandir_cleanup(uv_fs_t* req);
+-void uv__fs_readdir_cleanup(uv_fs_t* req);
+-uv_dirent_type_t uv__fs_get_dirent_type(uv__dirent_t* dent);
++void uv__fs_scandir_cleanup(FAR uv_fs_t* req);
++void uv__fs_readdir_cleanup(FAR uv_fs_t* req);
++uv_dirent_type_t uv__fs_get_dirent_type(FAR uv__dirent_t* dent);
+ 
+-int uv__next_timeout(const uv_loop_t* loop);
+-void uv__run_timers(uv_loop_t* loop);
+-void uv__timer_close(uv_timer_t* handle);
++int uv__next_timeout(FAR const uv_loop_t* loop);
++void uv__run_timers(FAR uv_loop_t* loop);
++void uv__timer_close(FAR uv_timer_t* handle);
+ 
+ void uv__process_title_cleanup(void);
+ void uv__signal_cleanup(void);
+@@ -334,12 +334,12 @@ void uv__threadpool_cleanup(void);
+   while (0)
+ 
+ /* Allocator prototypes */
+-void *uv__calloc(size_t count, size_t size);
+-char *uv__strdup(const char* s);
+-char *uv__strndup(const char* s, size_t n);
+-void* uv__malloc(size_t size);
+-void uv__free(void* ptr);
+-void* uv__realloc(void* ptr, size_t size);
+-void* uv__reallocf(void* ptr, size_t size);
++FAR void *uv__calloc(size_t count, size_t size);
++FAR char *uv__strdup(FAR const char* s);
++FAR char *uv__strndup(FAR const char* s, size_t n);
++FAR void* uv__malloc(size_t size);
++void uv__free(FAR void* ptr);
++FAR void* uv__realloc(FAR void* ptr, size_t size);
++FAR void* uv__reallocf(FAR void* ptr, size_t size);
+ 
+ #endif /* UV_COMMON_H_ */
+-- 
+2.17.1
+

--- a/libs/libuv/0008-FIXME-add-trick-to-enable-NuttX-version-for-libuv.patch
+++ b/libs/libuv/0008-FIXME-add-trick-to-enable-NuttX-version-for-libuv.patch
@@ -1,0 +1,29 @@
+From 20bf9ec2dbb40869c67a70232c2e604edfc0747f Mon Sep 17 00:00:00 2001
+From: spiriou <spiriou31@gmail.com>
+Date: Tue, 4 Aug 2020 09:22:28 +0200
+Subject: [PATCH 8/8] FIXME add trick to enable NuttX version for libuv
+
+---
+ include/uv.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/include/uv.h b/include/uv.h
+index b4e9700..d920c19 100644
+--- a/include/uv.h
++++ b/include/uv.h
+@@ -23,6 +23,12 @@
+ 
+ #ifndef UV_H
+ #define UV_H
++
++/* FIXME hack to enable NuttX build target */
++#ifndef __NUTTX__
++#define __NUTTX__ 1
++#endif
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+-- 
+2.17.1
+

--- a/libs/libuv/Kconfig
+++ b/libs/libuv/Kconfig
@@ -1,0 +1,67 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig LIBUV
+	bool "libuv asynchronous I/O Library"
+	default n
+	---help---
+		Enable build for libuv asynchronous I/O Library
+
+if LIBUV
+
+config LIBUV_NPOLLWAITERS
+	int "Number of uv loop poll waiters"
+	default 8
+	---help---
+		Maximum number of events a loop can wait on.
+
+config LIBUV_ASYNC
+	bool "libuv async support"
+	default n
+	select EVENT_FD
+	select EVENT_FD_POLL
+	---help---
+		Enable async support in libuv.
+		Eventfd is required for this feature.
+
+config LIBUV_TIMER
+	bool "libuv software timers support"
+	default n
+	---help---
+		Enable software timers support in libuv.
+
+config LIBUV_WQ
+	bool "libuv workqueue support"
+	default n
+	select LIBUV_ASYNC
+	---help---
+		Enable workqueue support in libuv
+
+config LIBUV_WQ_THREADS_COUNT
+	int "libuv workqueue thread count"
+	depends on LIBUV_WQ
+	default 1
+	---help---
+		Specify worker thread count shared between all uv loops
+
+config LIBUV_LOOP_WATCHERS
+	bool "libuv loop watchers support"
+	default n
+	---help---
+		Enable loop watchers support in libuv (idle,prepare and check)
+
+config LIBUV_DEFAULT_LOOP
+	bool "uv_default_loop() API"
+	default n
+	---help---
+		Enable support for uv_default_loop() function
+
+config LIBUV_LOW_FOOTPRINT
+	bool "Reduce libuv memory usage"
+	default y
+	---help---
+		Enable optimizations to reduce libuv memory usage
+
+endif # LIBUV

--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -1,0 +1,97 @@
+############################################################################
+# libs/libuv/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(TOPDIR)/Make.defs
+
+ifeq ($(CONFIG_LIBUV),y)
+CSRCS += libuv/src/unix/core.c
+CSRCS += libuv/src/unix/poll.c
+CSRCS += libuv/src/unix/loop.c
+CSRCS += libuv/src/unix/thread.c
+CSRCS += libuv/src/uv-common.c
+CSRCS += libuv/src/strscpy.c
+CSRCS += libuv/src/unix/nuttx.c
+CSRCS += libuv/src/unix/no-proctitle.c
+
+ifeq ($(CONFIG_LIBUV_LOOP_WATCHERS),y)
+CSRCS += libuv/src/unix/loop-watcher.c
+endif
+
+ifeq ($(CONFIG_LIBUV_TIMER),y)
+CSRCS += libuv/src/timer.c
+endif
+
+ifeq ($(CONFIG_LIBUV_WQ),y)
+CSRCS += libuv/src/threadpool.c
+endif
+
+ifeq ($(CONFIG_LIBUV_ASYNC),y)
+CSRCS += libuv/src/unix/async.c
+endif
+
+# FIXME signal does not work yet
+ifeq ($(CONFIG_LIBUV_SIGNAL),y)
+CSRCS += libuv/src/unix/signal.c
+endif
+
+# FIXME process does not work yet
+ifeq ($(CONFIG_LIBUV_PROCESS),y)
+CSRCS += libuv/src/unix/process.c
+endif
+
+endif
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS)
+OBJS = $(AOBJS) $(COBJS)
+
+CFLAGS += -Ilibuv/src -D__NUTTX__
+
+BIN ?= libuv$(LIBEXT)
+
+all: $(BIN)
+.PHONY: depend clean distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+$(BIN): $(OBJS)
+	$(call ARCHIVE, $@, $(OBJS))
+
+.depend: Makefile $(SRCS)
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) touch $@
+
+depend: .depend
+
+clean:
+	$(call DELFILE, $(BIN))
+	$(call CLEAN)
+
+distclean: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep

--- a/libs/libuv/README.txt
+++ b/libs/libuv/README.txt
@@ -1,0 +1,22 @@
+README
+=====
+
+This README discusses how to setup libuv for NuttX.
+Current port is based on libuv v1.38.1.
+
+Install
+=======
+
+From NuttX root folder:
+
+# Fetch libuv source code
+git clone https://github.com/libuv/libuv.git -b v1.38.1 --depth=1 libs/libuv/libuv
+
+# Apply patchs
+cd libs/libuv/libuv
+git am ../000*.patch
+
+# Import headers in NuttX
+cd ../../../
+cp -r libs/libuv/libuv/include/* include/
+

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -153,6 +153,12 @@ else
 CLEANDIRS += libs$(DELIM)libdsp
 endif
 
+ifeq ($(CONFIG_LIBUV),y)
+KERNDEPDIRS += libs$(DELIM)libuv
+else
+CLEANDIRS += libs$(DELIM)libuv
+endif
+
 # Add networking directories to KERNDEPDIRS and CLEANDIRS
 
 ifeq ($(CONFIG_NET),y)

--- a/tools/FlatLibs.mk
+++ b/tools/FlatLibs.mk
@@ -138,6 +138,10 @@ ifeq ($(CONFIG_LIBDSP),y)
 NUTTXLIBS += staging$(DELIM)libdsp$(LIBEXT)
 endif
 
+ifeq ($(CONFIG_LIBUV),y)
+NUTTXLIBS += staging$(DELIM)libuv$(LIBEXT)
+endif
+
 ifeq ($(CONFIG_OPENAMP),y)
 NUTTXLIBS += staging$(DELIM)libopenamp$(LIBEXT)
 endif

--- a/tools/KernelLibs.mk
+++ b/tools/KernelLibs.mk
@@ -127,6 +127,10 @@ ifeq ($(CONFIG_OPENAMP),y)
 NUTTXLIBS += staging$(DELIM)libopenamp$(LIBEXT)
 endif
 
+ifeq ($(CONFIG_LIBUV),y)
+NUTTXLIBS += staging$(DELIM)libuv$(LIBEXT)
+endif
+
 # Export only the user libraries
 
 EXPORTLIBS = $(USERLIBS)

--- a/tools/LibTargets.mk
+++ b/tools/LibTargets.mk
@@ -211,6 +211,12 @@ libs$(DELIM)libdsp$(DELIM)libdsp$(LIBEXT): pass2dep
 staging$(DELIM)libdsp$(LIBEXT): libs$(DELIM)libdsp$(DELIM)libdsp$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
+libs$(DELIM)libuv$(DELIM)libuv$(LIBEXT): pass2dep
+	$(Q) $(MAKE) -C libs$(DELIM)libuv TOPDIR="$(TOPDIR)" libuv$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+staging$(DELIM)libuv$(LIBEXT): libs$(DELIM)libuv$(DELIM)libuv$(LIBEXT)
+	$(Q) $(call INSTALL_LIB,$<,$@)
+
 ifeq ($(CONFIG_BUILD_FLAT),y)
 $(APPDIR)$(DELIM)libapps$(LIBEXT): pass2dep
 else

--- a/tools/ProtectedLibs.mk
+++ b/tools/ProtectedLibs.mk
@@ -142,6 +142,10 @@ ifeq ($(CONFIG_OPENAMP),y)
 NUTTXLIBS += staging$(DELIM)libopenamp$(LIBEXT)
 endif
 
+ifeq ($(CONFIG_LIBUV),y)
+NUTTXLIBS += staging$(DELIM)libuv$(LIBEXT)
+endif
+
 # Export only the user libraries
 
 EXPORTLIBS = $(USERLIBS)


### PR DESCRIPTION
## Summary

From http://docs.libuv.org/en/v1.x/
"libuv is a multi-platform support library with a focus on asynchronous I/O. It was primarily developed for use by Node.js, but it’s also used by Luvit, Julia, pyuv, and others."

Initial port to NuttX with only basic features enabled (uv_loop_t, uv_poll_t, uv_async_t, uv_timer_t, uv_work_t).

## Impact

None, disabled by default (CONFIG_LIBUV)

## Testing

Follow instructions in libs/libuv/README.txt to setup the library then run "make menuconfig" to enable libuv features.

### Fetch libuv source code
git clone https://github.com/libuv/libuv.git -b v1.38.1 --depth=1 libs/libuv/libuv

### Apply patchs
cd libs/libuv/libuv
git am ../000*.patch

### Import headers in NuttX
cd ../../../
cp -r libs/libuv/libuv/include/* include/