### PR TITLE
Allow single wire mode to use push pull to support inverted protocols (S.Port etc) 

### DIFF
--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -1980,7 +1980,9 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 #else
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
-            uint32_t gpio_val = GPIO_OPENDRAIN;
+            uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
+                                 SER_SINGLEWIRE_PUSHPULL ?
+                                 GPIO_PUSHPULL : GPIO_OPENDRAIN;
             gpio_val |= ((arg & SER_SINGLEWIRE_PULL_MASK) ==
                          SER_SINGLEWIRE_PULLUP) ? GPIO_PULLUP
                                                 : GPIO_FLOAT;

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
@@ -1,4 +1,4 @@
-/****************************************************************************
+/**************************************************************************************************
  * arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
  *
  *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
@@ -32,11 +32,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
-/****************************************************************************
+/**************************************************************************************************
  * Included Files
- ****************************************************************************/
+ **************************************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -73,11 +73,12 @@
 
 #include <arch/board/board.h>
 
-/****************************************************************************
+/**************************************************************************************************
  * Pre-processor Definitions
- ****************************************************************************/
+ **************************************************************************************************/
 
-/* Some sanity checks *******************************************************/
+/* Some sanity checks *****************************************************************************/
+
 /* DMA configuration */
 
 /* If DMA is enabled on any USART, then very that other pre-requisites
@@ -198,9 +199,9 @@
 #ifdef USE_SERIALDRIVER
 #ifdef HAVE_USART
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Types
- ****************************************************************************/
+ **************************************************************************************************/
 
 struct stm32_serial_s
 {
@@ -262,14 +263,14 @@ struct stm32_serial_s
 #endif
 
 #ifdef HAVE_RS485
-  const uint32_t    rs485_dir_gpio; /* U[S]ART RS-485 DIR GPIO pin configuration */
+  const uint32_t    rs485_dir_gpio;     /* U[S]ART RS-485 DIR GPIO pin configuration */
   const bool        rs485_dir_polarity; /* U[S]ART RS-485 DIR pin state for TX enabled */
 #endif
 };
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Function Prototypes
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef CONFIG_SUPPRESS_UART_CONFIG
 static void stm32serial_setformat(FAR struct uart_dev_s *dev);
@@ -314,9 +315,9 @@ static int  stm32serial_pmprepare(FAR struct pm_callback_s *cb, int domain,
                                   enum pm_state_e pmstate);
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Variables
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef SERIAL_HAVE_ONLY_DMA
 static const struct uart_ops_s g_uart_ops =
@@ -744,13 +745,13 @@ static  struct pm_callback_s g_serialcb =
 };
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Functions
- ****************************************************************************/
+ **************************************************************************************************/
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_getreg
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline uint32_t stm32serial_getreg(FAR struct stm32_serial_s *priv,
                                           int offset)
@@ -758,9 +759,9 @@ static inline uint32_t stm32serial_getreg(FAR struct stm32_serial_s *priv,
   return getreg32(priv->usartbase + offset);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_putreg
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void stm32serial_putreg(FAR struct stm32_serial_s *priv,
                                       int offset, uint32_t value)
@@ -768,9 +769,9 @@ static inline void stm32serial_putreg(FAR struct stm32_serial_s *priv,
   putreg32(value, priv->usartbase + offset);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_setusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void stm32serial_setusartint(FAR struct stm32_serial_s *priv,
                                     uint16_t ie)
@@ -794,9 +795,9 @@ static void stm32serial_setusartint(FAR struct stm32_serial_s *priv,
   stm32serial_putreg(priv, STM32_USART_CR3_OFFSET, cr);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_restoreusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void stm32serial_restoreusartint(FAR struct stm32_serial_s *priv,
                                         uint16_t ie)
@@ -810,9 +811,9 @@ static void stm32serial_restoreusartint(FAR struct stm32_serial_s *priv,
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_disableusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void stm32serial_disableusartint(FAR struct stm32_serial_s *priv,
                                         FAR uint16_t *ie)
@@ -862,14 +863,14 @@ static void stm32serial_disableusartint(FAR struct stm32_serial_s *priv,
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmanextrx
  *
  * Description:
  *   Returns the index into the RX FIFO where the DMA will place the next
  *   byte that it receives.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static int stm32serial_dmanextrx(FAR struct stm32_serial_s *priv)
@@ -882,13 +883,13 @@ static int stm32serial_dmanextrx(FAR struct stm32_serial_s *priv)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_setformat
  *
  * Description:
  *   Set the serial line format and speed.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef CONFIG_SUPPRESS_UART_CONFIG
 static void stm32serial_setformat(FAR struct uart_dev_s *dev)
@@ -910,7 +911,7 @@ static void stm32serial_setformat(FAR struct uart_dev_s *dev)
    *   usartdiv8 = 2 * fCK / baud
    */
 
-   usartdiv8 = ((priv->apbclock << 1) + (priv->baud >> 1)) / priv->baud;
+  usartdiv8 = ((priv->apbclock << 1) + (priv->baud >> 1)) / priv->baud;
 
   /* Baud rate for standard USART (SPI mode included):
    *
@@ -946,8 +947,8 @@ static void stm32serial_setformat(FAR struct uart_dev_s *dev)
       cr1 |= USART_CR1_OVER8;
     }
 
-   stm32serial_putreg(priv, STM32_USART_CR1_OFFSET, cr1);
-   stm32serial_putreg(priv, STM32_USART_BRR_OFFSET, brr);
+  stm32serial_putreg(priv, STM32_USART_CR1_OFFSET, cr1);
+  stm32serial_putreg(priv, STM32_USART_BRR_OFFSET, brr);
 
   /* Configure parity mode */
 
@@ -984,6 +985,7 @@ static void stm32serial_setformat(FAR struct uart_dev_s *dev)
 
       regval |= USART_CR1_M1;
     }
+
   /* Else Select: 1 start, 7 data + parity, n stop, OR
    *              1 start, 8 data (no parity), n stop.
    */
@@ -1025,7 +1027,7 @@ static void stm32serial_setformat(FAR struct uart_dev_s *dev)
 }
 #endif /* CONFIG_SUPPRESS_UART_CONFIG */
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_setapbclock
  *
  * Description:
@@ -1035,7 +1037,7 @@ static void stm32serial_setformat(FAR struct uart_dev_s *dev)
  *   dev - A reference to the USART driver state structure
  *   on  - Enable clock if 'on' is 'true' and disable if 'false'
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void stm32serial_setapbclock(FAR struct uart_dev_s *dev, bool on)
 {
@@ -1093,14 +1095,14 @@ static void stm32serial_setapbclock(FAR struct uart_dev_s *dev, bool on)
     }
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_setup
  *
  * Description:
  *   Configure the USART baud, bits, parity, etc. This method is called the
  *   first time that the serial port is opened.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int stm32serial_setup(FAR struct uart_dev_s *dev)
 {
@@ -1151,8 +1153,10 @@ static int stm32serial_setup(FAR struct uart_dev_s *dev)
     }
 #endif
 
-  /* Configure CR2 */
-  /* Clear STOP, CLKEN, CPOL, CPHA, LBCL, and interrupt enable bits */
+  /* Configure CR2
+   *
+   * Clear STOP, CLKEN, CPOL, CPHA, LBCL, and interrupt enable bits
+   */
 
   regval  = stm32serial_getreg(priv, STM32_USART_CR2_OFFSET);
   regval &= ~(USART_CR2_STOP_MASK | USART_CR2_CLKEN | USART_CR2_CPOL |
@@ -1167,16 +1171,20 @@ static int stm32serial_setup(FAR struct uart_dev_s *dev)
 
   stm32serial_putreg(priv, STM32_USART_CR2_OFFSET, regval);
 
-  /* Configure CR1 */
-  /* Clear TE, REm and all interrupt enable bits */
+  /* Configure CR1
+   *
+   * Clear TE, REm and all interrupt enable bits
+   */
 
   regval  = stm32serial_getreg(priv, STM32_USART_CR1_OFFSET);
   regval &= ~(USART_CR1_TE | USART_CR1_RE | USART_CR1_ALLINTS);
 
   stm32serial_putreg(priv, STM32_USART_CR1_OFFSET, regval);
 
-  /* Configure CR3 */
-  /* Clear CTSE, RTSE, and all interrupt enable bits */
+  /* Configure CR3
+   *
+   * Clear CTSE, RTSE, and all interrupt enable bits
+   */
 
   regval  = stm32serial_getreg(priv, STM32_USART_CR3_OFFSET);
   regval &= ~(USART_CR3_CTSIE | USART_CR3_CTSE | USART_CR3_RTSE |
@@ -1202,14 +1210,14 @@ static int stm32serial_setup(FAR struct uart_dev_s *dev)
   return OK;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmasetup
  *
  * Description:
  *   Configure the USART baud, bits, parity, etc. This method is called the
  *   first time that the serial port is opened.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static int stm32serial_dmasetup(FAR struct uart_dev_s *dev)
@@ -1295,14 +1303,14 @@ static int stm32serial_dmasetup(FAR struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_shutdown
  *
  * Description:
  *   Disable the USART.  This method is called when the serial
  *   port is closed
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void stm32serial_shutdown(FAR struct uart_dev_s *dev)
 {
@@ -1356,14 +1364,14 @@ static void stm32serial_shutdown(FAR struct uart_dev_s *dev)
 #endif
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmashutdown
  *
  * Description:
  *   Disable the USART.  This method is called when the serial
  *   port is closed
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static void stm32serial_dmashutdown(FAR struct uart_dev_s *dev)
@@ -1385,7 +1393,7 @@ static void stm32serial_dmashutdown(FAR struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_attach
  *
  * Description:
@@ -1398,7 +1406,7 @@ static void stm32serial_dmashutdown(FAR struct uart_dev_s *dev)
  *   hardware supports multiple levels of interrupt enabling).  The RX and TX
  *   interrupts are not enabled until the txint() and rxint() methods are called.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int stm32serial_attach(FAR struct uart_dev_s *dev)
 {
@@ -1420,7 +1428,7 @@ static int stm32serial_attach(FAR struct uart_dev_s *dev)
   return ret;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_detach
  *
  * Description:
@@ -1428,7 +1436,7 @@ static int stm32serial_attach(FAR struct uart_dev_s *dev)
  *   closed normally just before the shutdown method is called.  The exception
  *   is the serial console which is never shutdown.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void stm32serial_detach(FAR struct uart_dev_s *dev)
 {
@@ -1437,7 +1445,7 @@ static void stm32serial_detach(FAR struct uart_dev_s *dev)
   irq_detach(priv->irq);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_interrupt
  *
  * Description:
@@ -1447,7 +1455,7 @@ static void stm32serial_detach(FAR struct uart_dev_s *dev)
  *   interrupt handling logic must be able to map the 'irq' number into the
  *   appropriate uart_dev_s structure in order to call these functions.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_interrupt(int irq, FAR void *context, FAR void *arg)
 {
@@ -1553,13 +1561,13 @@ static int up_interrupt(int irq, FAR void *context, FAR void *arg)
   return OK;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_ioctl
  *
  * Description:
  *   All ioctl calls will be routed through this method
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int stm32serial_ioctl(FAR struct file *filep, int cmd,
                                unsigned long arg)
@@ -1606,8 +1614,10 @@ static int stm32serial_ioctl(FAR struct file *filep, int cmd,
             uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
                                  SER_SINGLEWIRE_PUSHPULL ?
                                  GPIO_PUSHPULL : GPIO_OPENDRAIN;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ?
+                                                            GPIO_PULLUP : GPIO_FLOAT;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ?
+                                                            GPIO_PULLDOWN : GPIO_FLOAT;
             stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
             cr |= USART_CR3_HDSEL;
           }
@@ -1732,9 +1742,9 @@ static int stm32serial_ioctl(FAR struct file *filep, int cmd,
 
         stm32serial_txint(dev, false);
 
-        /* Configure TX as a GPIO output pin and Send a break signal*/
+        /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT | (~(GPIO_MODE_MASK|GPIO_OUTPUT_SET) & priv->tx_gpio);
+        tx_break = GPIO_OUTPUT | (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
         stm32_configgpio(tx_break);
 
         leave_critical_section(flags);
@@ -1795,7 +1805,7 @@ static int stm32serial_ioctl(FAR struct file *filep, int cmd,
   return ret;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_receive
  *
  * Description:
@@ -1803,7 +1813,7 @@ static int stm32serial_ioctl(FAR struct file *filep, int cmd,
  *   character from the USART.  Error bits associated with the
  *   receipt are provided in the return 'status'.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef SERIAL_HAVE_ONLY_DMA
 static int stm32serial_receive(FAR struct uart_dev_s *dev,
@@ -1827,13 +1837,13 @@ static int stm32serial_receive(FAR struct uart_dev_s *dev,
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_rxint
  *
  * Description:
  *   Call to enable or disable RX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef SERIAL_HAVE_ONLY_DMA
 static void stm32serial_rxint(FAR struct uart_dev_s *dev, bool enable)
@@ -1885,13 +1895,13 @@ static void stm32serial_rxint(FAR struct uart_dev_s *dev, bool enable)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_rxavailable
  *
  * Description:
  *   Return true if the receive register is not empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef SERIAL_HAVE_ONLY_DMA
 static bool stm32serial_rxavailable(FAR struct uart_dev_s *dev)
@@ -1901,7 +1911,7 @@ static bool stm32serial_rxavailable(FAR struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_rxflowcontrol
  *
  * Description:
@@ -1922,7 +1932,7 @@ static bool stm32serial_rxavailable(FAR struct uart_dev_s *dev)
  * Returned Value:
  *   true if RX flow control activated.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
 static bool stm32serial_rxflowcontrol(FAR struct uart_dev_s *dev,
@@ -1981,7 +1991,7 @@ static bool stm32serial_rxflowcontrol(FAR struct uart_dev_s *dev,
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmareceive
  *
  * Description:
@@ -1989,7 +1999,7 @@ static bool stm32serial_rxflowcontrol(FAR struct uart_dev_s *dev,
  *   character from the USART.  Error bits associated with the
  *   receipt are provided in the return 'status'.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static int stm32serial_dmareceive(FAR struct uart_dev_s *dev,
@@ -2024,13 +2034,13 @@ static int stm32serial_dmareceive(FAR struct uart_dev_s *dev,
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmareenable
  *
  * Description:
  *   Call to re-enable RX DMA.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #if defined(SERIAL_HAVE_RXDMA) && defined(CONFIG_SERIAL_IFLOWCONTROL)
 static void stm32serial_dmareenable(FAR struct stm32_serial_s *priv)
@@ -2059,13 +2069,13 @@ static void stm32serial_dmareenable(FAR struct stm32_serial_s *priv)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmarxint
  *
  * Description:
  *   Call to enable or disable RX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static void stm32serial_dmarxint(FAR struct uart_dev_s *dev, bool enable)
@@ -2093,13 +2103,13 @@ static void stm32serial_dmarxint(FAR struct uart_dev_s *dev, bool enable)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmarxavailable
  *
  * Description:
  *   Return true if the receive register is not empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static bool stm32serial_dmarxavailable(FAR struct uart_dev_s *dev)
@@ -2114,13 +2124,13 @@ static bool stm32serial_dmarxavailable(FAR struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_send
  *
  * Description:
  *   This method will send one byte on the USART
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void stm32serial_send(FAR struct uart_dev_s *dev, int ch)
 {
@@ -2136,13 +2146,13 @@ static void stm32serial_send(FAR struct uart_dev_s *dev, int ch)
   stm32serial_putreg(priv, STM32_USART_TDR_OFFSET, (uint32_t)ch);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_txint
  *
  * Description:
  *   Call to enable or disable TX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void stm32serial_txint(FAR struct uart_dev_s *dev, bool enable)
 {
@@ -2203,13 +2213,13 @@ static void stm32serial_txint(FAR struct uart_dev_s *dev, bool enable)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_txready
  *
  * Description:
  *   Return true if the transmit data register is empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static bool stm32serial_txready(FAR struct uart_dev_s *dev)
 {
@@ -2217,14 +2227,14 @@ static bool stm32serial_txready(FAR struct uart_dev_s *dev)
   return ((stm32serial_getreg(priv, STM32_USART_ISR_OFFSET) & USART_ISR_TXE) != 0);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmarxcallback
  *
  * Description:
  *   This function checks the current DMA state and calls the generic
  *   serial stack when bytes appear to be available.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static void stm32serial_dmarxcallback(DMA_HANDLE handle, uint8_t status,
@@ -2249,7 +2259,7 @@ static void stm32serial_dmarxcallback(DMA_HANDLE handle, uint8_t status,
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_pmnotify
  *
  * Description:
@@ -2269,7 +2279,7 @@ static void stm32serial_dmarxcallback(DMA_HANDLE handle, uint8_t status,
  *   consumption state when when it returned OK to the prepare() call.
  *
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static void stm32serial_pmnotify(FAR struct pm_callback_s *cb, int domain,
@@ -2280,39 +2290,37 @@ static void stm32serial_pmnotify(FAR struct pm_callback_s *cb, int domain,
       case(PM_NORMAL):
         {
           /* Logic for PM_NORMAL goes here */
-
         }
         break;
 
       case(PM_IDLE):
         {
           /* Logic for PM_IDLE goes here */
-
         }
         break;
 
       case(PM_STANDBY):
         {
           /* Logic for PM_STANDBY goes here */
-
         }
         break;
 
       case(PM_SLEEP):
         {
           /* Logic for PM_SLEEP goes here */
-
         }
         break;
 
       default:
+
         /* Should not get here */
+
         break;
     }
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_pmprepare
  *
  * Description:
@@ -2343,7 +2351,7 @@ static void stm32serial_pmnotify(FAR struct pm_callback_s *cb, int domain,
  *              return non-zero values when reverting back to higher power
  *              consumption modes!
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static int stm32serial_pmprepare(FAR struct pm_callback_s *cb, int domain,
@@ -2357,13 +2365,13 @@ static int stm32serial_pmprepare(FAR struct pm_callback_s *cb, int domain,
 #endif /* HAVE_USART */
 #endif /* USE_SERIALDRIVER */
 
-/****************************************************************************
+/**************************************************************************************************
  * Public Functions
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef USE_SERIALDRIVER
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: arm_earlyserialinit
  *
  * Description:
@@ -2371,7 +2379,7 @@ static int stm32serial_pmprepare(FAR struct pm_callback_s *cb, int domain,
  *   serial console will be available during bootup.  This must be called
  *   before stm32serial_getregit.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef USE_EARLYSERIALINIT
 void arm_earlyserialinit(void)
@@ -2398,14 +2406,14 @@ void arm_earlyserialinit(void)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_getregit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
  *   that arm_earlyserialinit was called previously.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 void arm_serialinit(void)
 {
@@ -2476,7 +2484,7 @@ void arm_serialinit(void)
 #endif /* HAVE USART */
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32serial_dmapoll
  *
  * Description:
@@ -2485,7 +2493,7 @@ void arm_serialinit(void)
  *
  *   This function should be called from a timer or other periodic context.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 void stm32serial_dmapoll(void)
@@ -2533,13 +2541,13 @@ void stm32serial_dmapoll(void)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_putc
  *
  * Description:
  *   Provide priority, low-level access to support OS debug  writes
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 int up_putc(int ch)
 {
@@ -2566,13 +2574,13 @@ int up_putc(int ch)
 
 #else /* USE_SERIALDRIVER */
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_putc
  *
  * Description:
  *   Provide priority, low-level access to support OS debug writes
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 int up_putc(int ch)
 {

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
@@ -1603,7 +1603,9 @@ static int stm32serial_ioctl(FAR struct file *filep, int cmd,
 
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
-            uint32_t gpio_val = GPIO_OPENDRAIN;
+            uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
+                                 SER_SINGLEWIRE_PUSHPULL ?
+                                 GPIO_PUSHPULL : GPIO_OPENDRAIN;
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
             stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
@@ -1162,7 +1162,9 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
-            uint32_t gpio_val = GPIO_OPENDRAIN;
+            uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
+                                 SER_SINGLEWIRE_PUSHPULL ?
+                                 GPIO_PUSHPULL : GPIO_OPENDRAIN;
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
             stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
@@ -1,4 +1,4 @@
-/****************************************************************************
+/**************************************************************************************************
  * arch/arm/src/stm32f0l0g0/stm32_serial.c
  *
  *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
@@ -32,11 +32,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
-/****************************************************************************
+/**************************************************************************************************
  * Included Files
- ****************************************************************************/
+ **************************************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -76,10 +76,12 @@
 #  error not supported yet
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Pre-processor Definitions
- ****************************************************************************/
-/* Some sanity checks *******************************************************/
+ **************************************************************************************************/
+
+/* Some sanity checks *****************************************************************************/
+
 /* Total number of possible serial devices */
 
 #define STM32_NSERIAL (STM32_NUSART)
@@ -121,9 +123,9 @@
           CONFIG_SERIAL_IFLOWCONTROL_WATERMARKS to be enabled."
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Types
- ****************************************************************************/
+ **************************************************************************************************/
 
 struct up_dev_s
 {
@@ -177,14 +179,14 @@ struct up_dev_s
 #endif
 
 #ifdef HAVE_RS485
-  const uint32_t    rs485_dir_gpio; /* U[S]ART RS-485 DIR GPIO pin configuration */
+  const uint32_t    rs485_dir_gpio;     /* U[S]ART RS-485 DIR GPIO pin configuration */
   const bool        rs485_dir_polarity; /* U[S]ART RS-485 DIR pin state for TX enabled */
 #endif
 };
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Function Prototypes
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_set_format(struct uart_dev_s *dev);
 static int  up_setup(struct uart_dev_s *dev);
@@ -211,9 +213,9 @@ static int  up_pm_prepare(struct pm_callback_s *cb, int domain,
                           enum pm_state_e pmstate);
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Data
- ****************************************************************************/
+ **************************************************************************************************/
 
 static const struct uart_ops_s g_uart_ops =
 {
@@ -394,31 +396,31 @@ static  struct pm_callback_s g_serialcb =
 };
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Functions
- ****************************************************************************/
+ **************************************************************************************************/
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_serialin
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
 {
   return getreg32(priv->usartbase + offset);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_serialout
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 {
   putreg32(value, priv->usartbase + offset);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_serialmod
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void up_serialmod(struct up_dev_s *priv, int offset,
                                 uint32_t clrbits, uint32_t setbits)
@@ -428,9 +430,9 @@ static inline void up_serialmod(struct up_dev_s *priv, int offset,
   putreg32(regval, addr);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_setusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void up_setusartint(struct up_dev_s *priv, uint16_t ie)
 {
@@ -453,9 +455,9 @@ static inline void up_setusartint(struct up_dev_s *priv, uint16_t ie)
   up_serialout(priv, STM32_USART_CR3_OFFSET, cr);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_restoreusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
 {
@@ -468,9 +470,9 @@ static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_disableusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 {
@@ -519,13 +521,13 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_set_format
  *
  * Description:
  *   Set the serial line format and speed.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef CONFIG_SUPPRESS_UART_CONFIG
 static void up_set_format(struct uart_dev_s *dev)
@@ -547,7 +549,8 @@ static void up_set_format(struct uart_dev_s *dev)
   cr1 &= ~USART_CR1_UE;
 
   /* Disable UE as the format bits and baud rate registers can not be
-   * updated while UE = 1 */
+   * updated while UE = 1
+   */
 
   up_serialout(priv, STM32_USART_CR1_OFFSET, cr1);
 
@@ -674,7 +677,7 @@ static void up_set_format(struct uart_dev_s *dev)
 }
 #endif /* CONFIG_SUPPRESS_UART_CONFIG */
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_set_apb_clock
  *
  * Description:
@@ -684,7 +687,7 @@ static void up_set_format(struct uart_dev_s *dev)
  *   dev - A reference to the UART driver state structure
  *   on  - Enable clock if 'on' is 'true' and disable if 'false'
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_set_apb_clock(struct uart_dev_s *dev, bool on)
 {
@@ -736,14 +739,14 @@ static void up_set_apb_clock(struct uart_dev_s *dev, bool on)
     }
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_setup
  *
  * Description:
  *   Configure the USART baud, bits, parity, etc. This method is called the
  *   first time that the serial port is opened.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_setup(struct uart_dev_s *dev)
 {
@@ -798,8 +801,10 @@ static int up_setup(struct uart_dev_s *dev)
     }
 #endif
 
-  /* Configure CR2 */
-  /* Clear STOP, CLKEN, CPOL, CPHA, LBCL, and interrupt enable bits */
+  /* Configure CR2
+   *
+   * Clear STOP, CLKEN, CPOL, CPHA, LBCL, and interrupt enable bits
+   */
 
   regval  = up_serialin(priv, STM32_USART_CR2_OFFSET);
   regval &= ~(USART_CR2_STOP_MASK | USART_CR2_CLKEN | USART_CR2_CPOL |
@@ -814,16 +819,20 @@ static int up_setup(struct uart_dev_s *dev)
 
   up_serialout(priv, STM32_USART_CR2_OFFSET, regval);
 
-  /* Configure CR1 */
-  /* Clear TE, REm and all interrupt enable bits */
+  /* Configure CR1
+   *
+   * Clear TE, REm and all interrupt enable bits
+   */
 
   regval  = up_serialin(priv, STM32_USART_CR1_OFFSET);
   regval &= ~(USART_CR1_TE | USART_CR1_RE | USART_CR1_ALLINTS);
 
   up_serialout(priv, STM32_USART_CR1_OFFSET, regval);
 
-  /* Configure CR3 */
-  /* Clear CTSE, RTSE, and all interrupt enable bits */
+  /* Configure CR3
+   *
+   * Clear CTSE, RTSE, and all interrupt enable bits
+   */
 
   regval  = up_serialin(priv, STM32_USART_CR3_OFFSET);
   regval &= ~(USART_CR3_CTSIE | USART_CR3_CTSE | USART_CR3_RTSE | USART_CR3_EIE);
@@ -839,6 +848,7 @@ static int up_setup(struct uart_dev_s *dev)
   up_set_format(dev);
 
   /* Enable Rx, Tx, and the USART */
+
   /* Enable FIFO */
 
   regval  = up_serialin(priv, STM32_USART_CR1_OFFSET);
@@ -860,15 +870,14 @@ static int up_setup(struct uart_dev_s *dev)
   return OK;
 }
 
-
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_shutdown
  *
  * Description:
  *   Disable the USART.  This method is called when the serial
  *   port is closed
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_shutdown(struct uart_dev_s *dev)
 {
@@ -926,8 +935,7 @@ static void up_shutdown(struct uart_dev_s *dev)
 #endif
 }
 
-
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_attach
  *
  * Description:
@@ -940,7 +948,7 @@ static void up_shutdown(struct uart_dev_s *dev)
  *   hardware supports multiple levels of interrupt enabling).  The RX and TX
  *   interrupts are not enabled until the txint() and rxint() methods are called.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_attach(struct uart_dev_s *dev)
 {
@@ -958,10 +966,11 @@ static int up_attach(struct uart_dev_s *dev)
 
        up_enable_irq(priv->irq);
     }
+
   return ret;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_detach
  *
  * Description:
@@ -969,7 +978,7 @@ static int up_attach(struct uart_dev_s *dev)
  *   closed normally just before the shutdown method is called.  The exception
  *   is the serial console which is never shutdown.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_detach(struct uart_dev_s *dev)
 {
@@ -978,7 +987,7 @@ static void up_detach(struct uart_dev_s *dev)
   irq_detach(priv->irq);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_interrupt
  *
  * Description:
@@ -988,7 +997,7 @@ static void up_detach(struct uart_dev_s *dev)
  *   interrupt handling logic must be able to map the 'irq' number into the
  *   appropriate uart_dev_s structure in order to call these functions.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_interrupt(int irq, void *context, FAR void *arg)
 {
@@ -1094,13 +1103,13 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
   return OK;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_ioctl
  *
  * Description:
  *   All ioctl calls will be routed through this method
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
@@ -1165,8 +1174,10 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
                                  SER_SINGLEWIRE_PUSHPULL ?
                                  GPIO_PUSHPULL : GPIO_OPENDRAIN;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ?
+                                                            GPIO_PULLUP : GPIO_FLOAT;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ?
+                                                            GPIO_PULLDOWN : GPIO_FLOAT;
             stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
             cr |= USART_CR3_HDSEL;
           }
@@ -1296,9 +1307,9 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         up_txint(dev, false);
 
-        /* Configure TX as a GPIO output pin and Send a break signal*/
+        /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT | (~(GPIO_MODE_MASK|GPIO_OUTPUT_SET) & priv->tx_gpio);
+        tx_break = GPIO_OUTPUT | (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
         stm32_configgpio(tx_break);
 
         leave_critical_section(flags);
@@ -1350,7 +1361,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   return ret;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_receive
  *
  * Description:
@@ -1358,7 +1369,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
  *   character from the USART.  Error bits associated with the
  *   receipt are provided in the return 'status'.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_receive(struct uart_dev_s *dev, unsigned int *status)
 {
@@ -1379,13 +1390,13 @@ static int up_receive(struct uart_dev_s *dev, unsigned int *status)
   return rdr & 0xff;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxint
  *
  * Description:
  *   Call to enable or disable RX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_rxint(struct uart_dev_s *dev, bool enable)
 {
@@ -1435,13 +1446,13 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxavailable
  *
  * Description:
  *   Return true if the receive register is not empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static bool up_rxavailable(struct uart_dev_s *dev)
 {
@@ -1449,7 +1460,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
   return ((up_serialin(priv, STM32_USART_ISR_OFFSET) & USART_ISR_RXNE) != 0);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxflowcontrol
  *
  * Description:
@@ -1470,7 +1481,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
  * Returned Value:
  *   true if RX flow control activated.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
 static bool up_rxflowcontrol(struct uart_dev_s *dev,
@@ -1545,13 +1556,13 @@ static bool up_rxflowcontrol(struct uart_dev_s *dev,
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_send
  *
  * Description:
  *   This method will send one byte on the USART
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_send(struct uart_dev_s *dev, int ch)
 {
@@ -1567,13 +1578,13 @@ static void up_send(struct uart_dev_s *dev, int ch)
   up_serialout(priv, STM32_USART_TDR_OFFSET, (uint32_t)ch);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_txint
  *
  * Description:
  *   Call to enable or disable TX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_txint(struct uart_dev_s *dev, bool enable)
 {
@@ -1634,13 +1645,13 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_txready
  *
  * Description:
  *   Return true if the transmit data register is empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static bool up_txready(struct uart_dev_s *dev)
 {
@@ -1648,7 +1659,7 @@ static bool up_txready(struct uart_dev_s *dev)
   return ((up_serialin(priv, STM32_USART_ISR_OFFSET) & USART_ISR_TXE) != 0);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_pm_notify
  *
  * Description:
@@ -1668,7 +1679,7 @@ static bool up_txready(struct uart_dev_s *dev)
  *   consumption state when when it returned OK to the prepare() call.
  *
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static void up_pm_notify(struct pm_callback_s *cb, int domain,
@@ -1679,39 +1690,37 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
       case(PM_NORMAL):
         {
           /* Logic for PM_NORMAL goes here */
-
         }
         break;
 
       case(PM_IDLE):
         {
           /* Logic for PM_IDLE goes here */
-
         }
         break;
 
       case(PM_STANDBY):
         {
           /* Logic for PM_STANDBY goes here */
-
         }
         break;
 
       case(PM_SLEEP):
         {
           /* Logic for PM_SLEEP goes here */
-
         }
         break;
 
       default:
+
         /* Should not get here */
+
         break;
     }
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_pm_prepare
  *
  * Description:
@@ -1742,7 +1751,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
  *              return non-zero values when reverting back to higher power
  *              consumption modes!
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static int up_pm_prepare(struct pm_callback_s *cb, int domain,
@@ -1756,19 +1765,19 @@ static int up_pm_prepare(struct pm_callback_s *cb, int domain,
 #endif /* HAVE_UART */
 #endif /* USE_SERIALDRIVER */
 
-/****************************************************************************
+/**************************************************************************************************
  * Public Functions
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef USE_SERIALDRIVER
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32_serial_get_uart
  *
  * Description:
  *   Get serial driver structure for STM32 USART
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 FAR uart_dev_t *stm32_serial_get_uart(int uart_num)
 {
@@ -1787,7 +1796,7 @@ FAR uart_dev_t *stm32_serial_get_uart(int uart_num)
   return &g_uart_devs[uart_idx]->dev;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: arm_earlyserialinit
  *
  * Description:
@@ -1795,7 +1804,7 @@ FAR uart_dev_t *stm32_serial_get_uart(int uart_num)
  *   serial console will be available during bootup.  This must be called
  *   before arm_serialinit.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef USE_EARLYSERIALINIT
 void arm_earlyserialinit(void)
@@ -1822,14 +1831,14 @@ void arm_earlyserialinit(void)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: arm_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
  *   that arm_earlyserialinit was called previously.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 void arm_serialinit(void)
 {
@@ -1895,13 +1904,13 @@ void arm_serialinit(void)
 #endif /* HAVE UART */
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_putc
  *
  * Description:
  *   Provide priority, low-level access to support OS debug  writes
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 int up_putc(int ch)
 {
@@ -1929,13 +1938,13 @@ int up_putc(int ch)
 
 #else /* USE_SERIALDRIVER */
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_putc
  *
  * Description:
  *   Provide priority, low-level access to support OS debug writes
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 int up_putc(int ch)
 {

--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -1,4 +1,4 @@
-/****************************************************************************
+/**************************************************************************************************
  * arch/arm/src/stm32f7/stm32_serial.c
  *
  *   Copyright (C) 2015-2019 Gregory Nutt. All rights reserved.
@@ -32,11 +32,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
-/****************************************************************************
+/**************************************************************************************************
  * Included Files
- ****************************************************************************/
+ **************************************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -70,11 +70,11 @@
 
 #include <arch/board/board.h>
 
-/****************************************************************************
+/**************************************************************************************************
  * Pre-processor Definitions
- ****************************************************************************/
+ **************************************************************************************************/
 
-/* Some sanity checks *******************************************************/
+/* Some sanity checks *****************************************************************************/
 
 /* Total number of possible serial devices */
 
@@ -431,9 +431,9 @@
 #  endif
 #endif /* CONFIG_STM32F7_FLOWCONTROL_BROKEN */
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Types
- ****************************************************************************/
+ **************************************************************************************************/
 
 struct up_dev_s
 {
@@ -497,24 +497,24 @@ struct up_dev_s
 
 #ifdef SERIAL_HAVE_TXDMA
   const unsigned int txdma_channel; /* DMA channel assigned */
-  DMA_HANDLE        txdma;      /* currently-open trasnmit DMA stream */
+  DMA_HANDLE        txdma;          /* currently-open trasnmit DMA stream */
 #endif
 
   /* RX DMA state */
 
 #ifdef SERIAL_HAVE_RXDMA
   const unsigned int rxdma_channel; /* DMA channel assigned */
-  DMA_HANDLE        rxdma;      /* currently-open receive DMA stream */
-  bool              rxenable;   /* DMA-based reception en/disable */
+  DMA_HANDLE        rxdma;          /* currently-open receive DMA stream */
+  bool              rxenable;       /* DMA-based reception en/disable */
 #ifdef CONFIG_PM
-  bool              rxdmasusp;  /* Rx DMA suspended */
+  bool              rxdmasusp;      /* Rx DMA suspended */
 #endif
-  uint32_t          rxdmanext;  /* Next byte in the DMA buffer to be read */
+  uint32_t          rxdmanext;      /* Next byte in the DMA buffer to be read */
 #ifdef CONFIG_ARMV7M_DCACHE
-  uint32_t          rxdmaavail; /* Number of bytes available without need to
-                                 * to invalidate the data cache */
+  uint32_t          rxdmaavail;     /* Number of bytes available without need to
+                                     * to invalidate the data cache */
 #endif
-  char      *const  rxfifo;     /* Receive DMA buffer */
+  char      *const  rxfifo;         /* Receive DMA buffer */
 #endif
 
 #ifdef HAVE_RS485
@@ -533,9 +533,9 @@ struct pm_config_s
 };
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Function Prototypes
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef CONFIG_SUPPRESS_UART_CONFIG
 static void up_set_format(struct uart_dev_s *dev);
@@ -591,9 +591,9 @@ static int  up_pm_prepare(struct pm_callback_s *cb, int domain,
                           enum pm_state_e pmstate);
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Data
- ****************************************************************************/
+ **************************************************************************************************/
 
 #if !defined(SERIAL_HAVE_ONLY_DMA)
 static const struct uart_ops_s g_uart_ops =
@@ -1366,22 +1366,22 @@ static struct pm_config_s g_serialpm =
 };
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Functions
- ****************************************************************************/
+ **************************************************************************************************/
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_serialin
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
 {
   return getreg32(priv->usartbase + offset);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_serialout
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void up_serialout(struct up_dev_s *priv, int offset,
                                 uint32_t value)
@@ -1389,9 +1389,9 @@ static inline void up_serialout(struct up_dev_s *priv, int offset,
   putreg32(value, priv->usartbase + offset);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_setusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void up_setusartint(struct up_dev_s *priv, uint16_t ie)
 {
@@ -1414,9 +1414,9 @@ static inline void up_setusartint(struct up_dev_s *priv, uint16_t ie)
   up_serialout(priv, STM32_USART_CR3_OFFSET, cr);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_restoreusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
 {
@@ -1429,9 +1429,9 @@ static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_disableusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 {
@@ -1481,14 +1481,14 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_nextrx
  *
  * Description:
  *   Returns the index into the RX FIFO where the DMA will place the next
  *   byte that it receives.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static int up_dma_nextrx(struct up_dev_s *priv)
@@ -1501,13 +1501,13 @@ static int up_dma_nextrx(struct up_dev_s *priv)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_set_format
  *
  * Description:
  *   Set the serial line format and speed.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef CONFIG_SUPPRESS_UART_CONFIG
 static void up_set_format(struct uart_dev_s *dev)
@@ -1657,13 +1657,13 @@ static void up_set_format(struct uart_dev_s *dev)
 }
 #endif /* CONFIG_SUPPRESS_UART_CONFIG */
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_setsuspend
  *
  * Description:
  *   Suspend or resume serial peripheral.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static void up_setsuspend(struct uart_dev_s *dev, bool suspend)
@@ -1769,13 +1769,13 @@ static void up_setsuspend(struct uart_dev_s *dev, bool suspend)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_pm_setsuspend
  *
  * Description:
  *   Suspend or resume serial peripherals for/from deep-sleep/stop modes.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static void up_pm_setsuspend(bool suspend)
@@ -1805,7 +1805,7 @@ static void up_pm_setsuspend(bool suspend)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_set_apb_clock
  *
  * Description:
@@ -1815,7 +1815,7 @@ static void up_pm_setsuspend(bool suspend)
  *   dev - A reference to the UART driver state structure
  *   on  - Enable clock if 'on' is 'true' and disable if 'false'
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_set_apb_clock(struct uart_dev_s *dev, bool on)
 {
@@ -1891,14 +1891,14 @@ static void up_set_apb_clock(struct uart_dev_s *dev, bool on)
     }
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_setup
  *
  * Description:
  *   Configure the USART baud, bits, parity, etc. This method is called the
  *   first time that the serial port is opened.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_setup(struct uart_dev_s *dev)
 {
@@ -2008,14 +2008,14 @@ static int up_setup(struct uart_dev_s *dev)
   return OK;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_setup
  *
  * Description:
  *   Configure the USART baud, bits, parity, etc. This method is called the
  *   first time that the serial port is opened.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #if defined(SERIAL_HAVE_RXDMA) || defined(SERIAL_HAVE_TXDMA)
 static int up_dma_setup(struct uart_dev_s *dev)
@@ -2088,14 +2088,14 @@ static int up_dma_setup(struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_shutdown
  *
  * Description:
  *   Disable the USART.  This method is called when the serial
  *   port is closed
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_shutdown(struct uart_dev_s *dev)
 {
@@ -2153,14 +2153,14 @@ static void up_shutdown(struct uart_dev_s *dev)
 #endif
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_shutdown
  *
  * Description:
  *   Disable the USART.  This method is called when the serial
  *   port is closed
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #if defined(SERIAL_HAVE_RXDMA) || defined(SERIAL_HAVE_TXDMA)
 static void up_dma_shutdown(struct uart_dev_s *dev)
@@ -2201,7 +2201,7 @@ static void up_dma_shutdown(struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_attach
  *
  * Description:
@@ -2215,7 +2215,7 @@ static void up_dma_shutdown(struct uart_dev_s *dev)
  *   interrupts are not enabled until the txint() and rxint() methods are
  *   called.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_attach(struct uart_dev_s *dev)
 {
@@ -2237,7 +2237,7 @@ static int up_attach(struct uart_dev_s *dev)
   return ret;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_detach
  *
  * Description:
@@ -2245,7 +2245,7 @@ static int up_attach(struct uart_dev_s *dev)
  *   closed normally just before the shutdown method is called.  The exception
  *   is the serial console which is never shutdown.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_detach(struct uart_dev_s *dev)
 {
@@ -2254,7 +2254,7 @@ static void up_detach(struct uart_dev_s *dev)
   irq_detach(priv->irq);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_interrupt
  *
  * Description:
@@ -2264,7 +2264,7 @@ static void up_detach(struct uart_dev_s *dev)
  *   interrupt handling logic must be able to map the 'irq' number into the
  *   appropriate uart_dev_s structure in order to call these functions.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_interrupt(int irq, void *context, FAR void *arg)
 {
@@ -2372,13 +2372,13 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
   return OK;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_ioctl
  *
  * Description:
  *   All ioctl calls will be routed through this method
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
@@ -2437,15 +2437,13 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
-            uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
-                                 SER_SINGLEWIRE_PUSHPULL ?
-                                 GPIO_PUSHPULL : GPIO_OPENDRAIN;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) ==
-                         SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) ==
-                         SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
-            stm32_configgpio((priv->tx_gpio &
-                             ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
+            uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) == SER_SINGLEWIRE_PUSHPULL ?
+                                                                   GPIO_PUSHPULL : GPIO_OPENDRAIN;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ?
+                                                            GPIO_PULLUP : GPIO_FLOAT;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ?
+                                                            GPIO_PULLDOWN : GPIO_FLOAT;
+            stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
             cr |= USART_CR3_HDSEL;
           }
         else
@@ -2733,7 +2731,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   return ret;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_receive
  *
  * Description:
@@ -2741,7 +2739,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
  *   character from the USART.  Error bits associated with the
  *   receipt are provided in the return 'status'.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef SERIAL_HAVE_ONLY_RXDMA
 static int up_receive(struct uart_dev_s *dev, unsigned int *status)
@@ -2764,13 +2762,13 @@ static int up_receive(struct uart_dev_s *dev, unsigned int *status)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxint
  *
  * Description:
  *   Call to enable or disable RX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef SERIAL_HAVE_ONLY_RXDMA
 static void up_rxint(struct uart_dev_s *dev, bool enable)
@@ -2822,13 +2820,13 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxavailable
  *
  * Description:
  *   Return true if the receive register is not empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef SERIAL_HAVE_ONLY_RXDMA
 static bool up_rxavailable(struct uart_dev_s *dev)
@@ -2838,7 +2836,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxflowcontrol
  *
  * Description:
@@ -2859,7 +2857,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
  * Returned Value:
  *   true if RX flow control activated.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
 static bool up_rxflowcontrol(struct uart_dev_s *dev,
@@ -2934,7 +2932,7 @@ static bool up_rxflowcontrol(struct uart_dev_s *dev,
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_receive
  *
  * Description:
@@ -2942,7 +2940,7 @@ static bool up_rxflowcontrol(struct uart_dev_s *dev,
  *   character from the USART.  Error bits associated with the
  *   receipt are provided in the return 'status'.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static int up_dma_receive(struct uart_dev_s *dev, unsigned int *status)
@@ -3019,13 +3017,13 @@ static int up_dma_receive(struct uart_dev_s *dev, unsigned int *status)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_reenable
  *
  * Description:
  *   Call to re-enable RX DMA.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #if defined(SERIAL_HAVE_RXDMA) && defined(CONFIG_PM)
 static void up_dma_reenable(struct up_dev_s *priv)
@@ -3060,13 +3058,13 @@ static void up_dma_reenable(struct up_dev_s *priv)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_rxint
  *
  * Description:
  *   Call to enable or disable RX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static void up_dma_rxint(struct uart_dev_s *dev, bool enable)
@@ -3085,13 +3083,13 @@ static void up_dma_rxint(struct uart_dev_s *dev, bool enable)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_rxavailable
  *
  * Description:
  *   Return true if the receive register is not empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static bool up_dma_rxavailable(struct uart_dev_s *dev)
@@ -3106,14 +3104,14 @@ static bool up_dma_rxavailable(struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_txcallback
  *
  * Description:
  *   This function clears dma buffer at complete of DMA transfer and wakes up
  *   threads waiting for space in buffer.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_TXDMA
 static void up_dma_txcallback(DMA_HANDLE handle, uint8_t status, void *arg)
@@ -3143,13 +3141,13 @@ static void up_dma_txcallback(DMA_HANDLE handle, uint8_t status, void *arg)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_txavailable
  *
  * Description:
  *        Informs DMA that Tx data is available and is ready for transfer.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_TXDMA
 static void up_dma_txavailable(struct uart_dev_s *dev)
@@ -3165,14 +3163,14 @@ static void up_dma_txavailable(struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_send
  *
  * Description:
  *   Called (usually) from the interrupt level to start DMA transfer.
  *   (Re-)Configures DMA Stream updating buffer and buffer length.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_TXDMA
 static void up_dma_send(struct uart_dev_s *dev)
@@ -3206,13 +3204,13 @@ static void up_dma_send(struct uart_dev_s *dev)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_send
  *
  * Description:
  *   This method will send one byte on the USART
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_send(struct uart_dev_s *dev, int ch)
 {
@@ -3228,13 +3226,13 @@ static void up_send(struct uart_dev_s *dev, int ch)
   up_serialout(priv, STM32_USART_TDR_OFFSET, (uint32_t)ch);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_txint
  *
  * Description:
  *   Call to enable or disable TX interrupts from the UART.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_TXDMA
 static void up_dma_txint(struct uart_dev_s *dev, bool enable)
@@ -3250,13 +3248,13 @@ static void up_dma_txint(struct uart_dev_s *dev, bool enable)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_txint
  *
  * Description:
  *   Call to enable or disable TX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_txint(struct uart_dev_s *dev, bool enable)
 {
@@ -3317,13 +3315,13 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_txready
  *
  * Description:
  *   Return true if the transmit data register is empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static bool up_txready(struct uart_dev_s *dev)
 {
@@ -3331,14 +3329,14 @@ static bool up_txready(struct uart_dev_s *dev)
   return ((up_serialin(priv, STM32_USART_ISR_OFFSET) & USART_ISR_TXE) != 0);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_dma_rxcallback
  *
  * Description:
  *   This function checks the current DMA state and calls the generic
  *   serial stack when bytes appear to be available.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 static void up_dma_rxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
@@ -3370,7 +3368,7 @@ static void up_dma_rxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_pm_notify
  *
  * Description:
@@ -3390,7 +3388,7 @@ static void up_dma_rxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
  *   consumption state when when it returned OK to the prepare() call.
  *
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static void up_pm_notify(struct pm_callback_s *cb, int domain,
@@ -3431,7 +3429,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_pm_prepare
  *
  * Description:
@@ -3462,7 +3460,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
  *              return non-zero values when reverting back to higher power
  *              consumption modes!
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static int up_pm_prepare(struct pm_callback_s *cb, int domain,
@@ -3545,13 +3543,13 @@ static int up_pm_prepare(struct pm_callback_s *cb, int domain,
 #endif /* HAVE_UART */
 #endif /* USE_SERIALDRIVER */
 
-/****************************************************************************
+/**************************************************************************************************
  * Public Functions
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef USE_SERIALDRIVER
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: arm_earlyserialinit
  *
  * Description:
@@ -3559,7 +3557,7 @@ static int up_pm_prepare(struct pm_callback_s *cb, int domain,
  *   serial console will be available during bootup.  This must be called
  *   before arm_serialinit.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef USE_EARLYSERIALINIT
 void arm_earlyserialinit(void)
@@ -3586,14 +3584,14 @@ void arm_earlyserialinit(void)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: arm_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
  *   that arm_earlyserialinit was called previously.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 void arm_serialinit(void)
 {
@@ -3673,7 +3671,7 @@ void arm_serialinit(void)
 #endif /* HAVE UART */
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32_serial_dma_poll
  *
  * Description:
@@ -3682,7 +3680,7 @@ void arm_serialinit(void)
  *
  *   This function should be called from a timer or other periodic context.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef SERIAL_HAVE_RXDMA
 void stm32_serial_dma_poll(void)
@@ -3751,13 +3749,13 @@ void stm32_serial_dma_poll(void)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_putc
  *
  * Description:
  *   Provide priority, low-level access to support OS debug writes
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 int up_putc(int ch)
 {
@@ -3784,13 +3782,13 @@ int up_putc(int ch)
 
 #else /* USE_SERIALDRIVER */
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_putc
  *
  * Description:
  *   Provide priority, low-level access to support OS debug writes
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 int up_putc(int ch)
 {

--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -2437,7 +2437,9 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
-            uint32_t gpio_val = GPIO_OPENDRAIN;
+            uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
+                                 SER_SINGLEWIRE_PUSHPULL ?
+                                 GPIO_PUSHPULL : GPIO_OPENDRAIN;
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) ==
                          SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) ==

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -1531,7 +1531,9 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
-            uint32_t gpio_val = GPIO_OPENDRAIN;
+            uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
+                                 SER_SINGLEWIRE_PUSHPULL ?
+                                 GPIO_PUSHPULL : GPIO_OPENDRAIN;
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
             stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -1,4 +1,4 @@
-/****************************************************************************
+/**************************************************************************************************
  * arch/arm/src/stm32h7/stm32_serial.c
  *
  *   Copyright (C) 2015-2019 Gregory Nutt. All rights reserved.
@@ -32,11 +32,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
-/****************************************************************************
+/**************************************************************************************************
  * Included Files
- ****************************************************************************/
+ **************************************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -69,10 +69,12 @@
 
 #include <arch/board/board.h>
 
-/****************************************************************************
+/**************************************************************************************************
  * Pre-processor Definitions
- ****************************************************************************/
-/* Some sanity checks *******************************************************/
+ **************************************************************************************************/
+
+/* Some sanity checks *****************************************************************************/
+
 /* Total number of possible serial devices */
 
 #define STM32_NSERIAL (STM32H7_NUSART + STM32H7_NUART)
@@ -113,9 +115,9 @@
           CONFIG_SERIAL_IFLOWCONTROL_WATERMARKS to be enabled."
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Types
- ****************************************************************************/
+ **************************************************************************************************/
 
 struct up_dev_s
 {
@@ -170,14 +172,14 @@ struct up_dev_s
 #endif
 
 #ifdef HAVE_RS485
-  const uint32_t    rs485_dir_gpio; /* U[S]ART RS-485 DIR GPIO pin configuration */
+  const uint32_t    rs485_dir_gpio;     /* U[S]ART RS-485 DIR GPIO pin configuration */
   const bool        rs485_dir_polarity; /* U[S]ART RS-485 DIR pin state for TX enabled */
 #endif
 };
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Function Prototypes
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_set_format(struct uart_dev_s *dev);
 static int  up_setup(struct uart_dev_s *dev);
@@ -204,9 +206,9 @@ static int  up_pm_prepare(struct pm_callback_s *cb, int domain,
                           enum pm_state_e pmstate);
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Data
- ****************************************************************************/
+ **************************************************************************************************/
 
 static const struct uart_ops_s g_uart_ops =
 {
@@ -739,31 +741,31 @@ static  struct pm_callback_s g_serialcb =
 };
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Private Functions
- ****************************************************************************/
+ **************************************************************************************************/
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_serialin
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
 {
   return getreg32(priv->usartbase + offset);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_serialout
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
 {
   putreg32(value, priv->usartbase + offset);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_serialmod
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void up_serialmod(struct up_dev_s *priv, int offset,
                                 uint32_t clrbits, uint32_t setbits)
@@ -773,9 +775,9 @@ static inline void up_serialmod(struct up_dev_s *priv, int offset,
   putreg32(regval, addr);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_setusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static inline void up_setusartint(struct up_dev_s *priv, uint16_t ie)
 {
@@ -798,9 +800,9 @@ static inline void up_setusartint(struct up_dev_s *priv, uint16_t ie)
   up_serialout(priv, STM32_USART_CR3_OFFSET, cr);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_restoreusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
 {
@@ -813,9 +815,9 @@ static void up_restoreusartint(struct up_dev_s *priv, uint16_t ie)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_disableusartint
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
 {
@@ -864,13 +866,13 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_set_format
  *
  * Description:
  *   Set the serial line format and speed.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifndef CONFIG_SUPPRESS_UART_CONFIG
 static void up_set_format(struct uart_dev_s *dev)
@@ -892,7 +894,8 @@ static void up_set_format(struct uart_dev_s *dev)
   cr1 &= ~USART_CR1_UE;
 
   /* Disable UE as the format bits and baud rate registers can not be
-   * updated while UE = 1 */
+   * updated while UE = 1
+   */
 
   up_serialout(priv, STM32_USART_CR1_OFFSET, cr1);
 
@@ -1019,7 +1022,7 @@ static void up_set_format(struct uart_dev_s *dev)
 }
 #endif /* CONFIG_SUPPRESS_UART_CONFIG */
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_set_apb_clock
  *
  * Description:
@@ -1029,7 +1032,7 @@ static void up_set_format(struct uart_dev_s *dev)
  *   dev - A reference to the UART driver state structure
  *   on  - Enable clock if 'on' is 'true' and disable if 'false'
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_set_apb_clock(struct uart_dev_s *dev, bool on)
 {
@@ -1105,14 +1108,14 @@ static void up_set_apb_clock(struct uart_dev_s *dev, bool on)
     }
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_setup
  *
  * Description:
  *   Configure the USART baud, bits, parity, etc. This method is called the
  *   first time that the serial port is opened.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_setup(struct uart_dev_s *dev)
 {
@@ -1167,8 +1170,10 @@ static int up_setup(struct uart_dev_s *dev)
     }
 #endif
 
-  /* Configure CR2 */
-  /* Clear STOP, CLKEN, CPOL, CPHA, LBCL, and interrupt enable bits */
+  /* Configure CR2
+   *
+   * Clear STOP, CLKEN, CPOL, CPHA, LBCL, and interrupt enable bits
+   */
 
   regval  = up_serialin(priv, STM32_USART_CR2_OFFSET);
   regval &= ~(USART_CR2_STOP_MASK | USART_CR2_CLKEN | USART_CR2_CPOL |
@@ -1183,16 +1188,20 @@ static int up_setup(struct uart_dev_s *dev)
 
   up_serialout(priv, STM32_USART_CR2_OFFSET, regval);
 
-  /* Configure CR1 */
-  /* Clear TE, REm and all interrupt enable bits */
+  /* Configure CR1
+   *
+   * Clear TE, REm and all interrupt enable bits
+   */
 
   regval  = up_serialin(priv, STM32_USART_CR1_OFFSET);
   regval &= ~(USART_CR1_TE | USART_CR1_RE | USART_CR1_ALLINTS);
 
   up_serialout(priv, STM32_USART_CR1_OFFSET, regval);
 
-  /* Configure CR3 */
-  /* Clear CTSE, RTSE, and all interrupt enable bits */
+  /* Configure CR3
+   *
+   * Clear CTSE, RTSE, and all interrupt enable bits
+   */
 
   regval  = up_serialin(priv, STM32_USART_CR3_OFFSET);
   regval &= ~(USART_CR3_CTSIE | USART_CR3_CTSE | USART_CR3_RTSE | USART_CR3_EIE);
@@ -1208,6 +1217,7 @@ static int up_setup(struct uart_dev_s *dev)
   up_set_format(dev);
 
   /* Enable Rx, Tx, and the USART */
+
   /* Enable FIFO */
 
   regval  = up_serialin(priv, STM32_USART_CR1_OFFSET);
@@ -1229,15 +1239,14 @@ static int up_setup(struct uart_dev_s *dev)
   return OK;
 }
 
-
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_shutdown
  *
  * Description:
  *   Disable the USART.  This method is called when the serial
  *   port is closed
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_shutdown(struct uart_dev_s *dev)
 {
@@ -1295,8 +1304,7 @@ static void up_shutdown(struct uart_dev_s *dev)
 #endif
 }
 
-
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_attach
  *
  * Description:
@@ -1309,7 +1317,7 @@ static void up_shutdown(struct uart_dev_s *dev)
  *   hardware supports multiple levels of interrupt enabling).  The RX and TX
  *   interrupts are not enabled until the txint() and rxint() methods are called.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_attach(struct uart_dev_s *dev)
 {
@@ -1327,10 +1335,11 @@ static int up_attach(struct uart_dev_s *dev)
 
        up_enable_irq(priv->irq);
     }
+
   return ret;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_detach
  *
  * Description:
@@ -1338,7 +1347,7 @@ static int up_attach(struct uart_dev_s *dev)
  *   closed normally just before the shutdown method is called.  The exception
  *   is the serial console which is never shutdown.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_detach(struct uart_dev_s *dev)
 {
@@ -1347,7 +1356,7 @@ static void up_detach(struct uart_dev_s *dev)
   irq_detach(priv->irq);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_interrupt
  *
  * Description:
@@ -1357,7 +1366,7 @@ static void up_detach(struct uart_dev_s *dev)
  *   interrupt handling logic must be able to map the 'irq' number into the
  *   appropriate uart_dev_s structure in order to call these functions.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_interrupt(int irq, void *context, FAR void *arg)
 {
@@ -1463,13 +1472,13 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
   return OK;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_ioctl
  *
  * Description:
  *   All ioctl calls will be routed through this method
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
@@ -1534,8 +1543,10 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
                                  SER_SINGLEWIRE_PUSHPULL ?
                                  GPIO_PUSHPULL : GPIO_OPENDRAIN;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ?
+                                                            GPIO_PULLUP : GPIO_FLOAT;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ?
+                                                            GPIO_PULLDOWN : GPIO_FLOAT;
             stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
             cr |= USART_CR3_HDSEL;
           }
@@ -1758,9 +1769,9 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         up_txint(dev, false);
 
-        /* Configure TX as a GPIO output pin and Send a break signal*/
+        /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT | (~(GPIO_MODE_MASK|GPIO_OUTPUT_SET) & priv->tx_gpio);
+        tx_break = GPIO_OUTPUT | (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
         stm32_configgpio(tx_break);
 
         leave_critical_section(flags);
@@ -1812,7 +1823,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
   return ret;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_receive
  *
  * Description:
@@ -1820,7 +1831,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
  *   character from the USART.  Error bits associated with the
  *   receipt are provided in the return 'status'.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static int up_receive(struct uart_dev_s *dev, unsigned int *status)
 {
@@ -1841,13 +1852,13 @@ static int up_receive(struct uart_dev_s *dev, unsigned int *status)
   return rdr & 0xff;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxint
  *
  * Description:
  *   Call to enable or disable RX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_rxint(struct uart_dev_s *dev, bool enable)
 {
@@ -1897,13 +1908,13 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxavailable
  *
  * Description:
  *   Return true if the receive register is not empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static bool up_rxavailable(struct uart_dev_s *dev)
 {
@@ -1911,7 +1922,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
   return ((up_serialin(priv, STM32_USART_ISR_OFFSET) & USART_ISR_RXNE) != 0);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_rxflowcontrol
  *
  * Description:
@@ -1932,7 +1943,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
  * Returned Value:
  *   true if RX flow control activated.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
 static bool up_rxflowcontrol(struct uart_dev_s *dev,
@@ -2007,13 +2018,13 @@ static bool up_rxflowcontrol(struct uart_dev_s *dev,
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_send
  *
  * Description:
  *   This method will send one byte on the USART
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_send(struct uart_dev_s *dev, int ch)
 {
@@ -2029,13 +2040,13 @@ static void up_send(struct uart_dev_s *dev, int ch)
   up_serialout(priv, STM32_USART_TDR_OFFSET, (uint32_t)ch);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_txint
  *
  * Description:
  *   Call to enable or disable TX interrupts
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static void up_txint(struct uart_dev_s *dev, bool enable)
 {
@@ -2096,13 +2107,13 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
   leave_critical_section(flags);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_txready
  *
  * Description:
  *   Return true if the transmit data register is empty
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 static bool up_txready(struct uart_dev_s *dev)
 {
@@ -2110,7 +2121,7 @@ static bool up_txready(struct uart_dev_s *dev)
   return ((up_serialin(priv, STM32_USART_ISR_OFFSET) & USART_ISR_TXE) != 0);
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_pm_notify
  *
  * Description:
@@ -2130,7 +2141,7 @@ static bool up_txready(struct uart_dev_s *dev)
  *   consumption state when when it returned OK to the prepare() call.
  *
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static void up_pm_notify(struct pm_callback_s *cb, int domain,
@@ -2141,39 +2152,37 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
       case(PM_NORMAL):
         {
           /* Logic for PM_NORMAL goes here */
-
         }
         break;
 
       case(PM_IDLE):
         {
           /* Logic for PM_IDLE goes here */
-
         }
         break;
 
       case(PM_STANDBY):
         {
           /* Logic for PM_STANDBY goes here */
-
         }
         break;
 
       case(PM_SLEEP):
         {
           /* Logic for PM_SLEEP goes here */
-
         }
         break;
 
       default:
+
         /* Should not get here */
+
         break;
     }
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_pm_prepare
  *
  * Description:
@@ -2204,7 +2213,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
  *              return non-zero values when reverting back to higher power
  *              consumption modes!
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef CONFIG_PM
 static int up_pm_prepare(struct pm_callback_s *cb, int domain,
@@ -2218,19 +2227,19 @@ static int up_pm_prepare(struct pm_callback_s *cb, int domain,
 #endif /* HAVE_UART */
 #endif /* USE_SERIALDRIVER */
 
-/****************************************************************************
+/**************************************************************************************************
  * Public Functions
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef USE_SERIALDRIVER
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: stm32_serial_get_uart
  *
  * Description:
  *   Get serial driver structure for STM32 USART
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 FAR uart_dev_t *stm32_serial_get_uart(int uart_num)
 {
@@ -2249,7 +2258,7 @@ FAR uart_dev_t *stm32_serial_get_uart(int uart_num)
   return &g_uart_devs[uart_idx]->dev;
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: arm_earlyserialinit
  *
  * Description:
@@ -2257,7 +2266,7 @@ FAR uart_dev_t *stm32_serial_get_uart(int uart_num)
  *   serial console will be available during bootup.  This must be called
  *   before arm_serialinit.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 #ifdef USE_EARLYSERIALINIT
 void arm_earlyserialinit(void)
@@ -2284,14 +2293,14 @@ void arm_earlyserialinit(void)
 }
 #endif
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: arm_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
  *   that arm_earlyserialinit was called previously.
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 void arm_serialinit(void)
 {
@@ -2357,13 +2366,13 @@ void arm_serialinit(void)
 #endif /* HAVE UART */
 }
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_putc
  *
  * Description:
  *   Provide priority, low-level access to support OS debug  writes
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 int up_putc(int ch)
 {
@@ -2391,13 +2400,13 @@ int up_putc(int ch)
 
 #else /* USE_SERIALDRIVER */
 
-/****************************************************************************
+/**************************************************************************************************
  * Name: up_putc
  *
  * Description:
  *   Provide priority, low-level access to support OS debug writes
  *
- ****************************************************************************/
+ **************************************************************************************************/
 
 int up_putc(int ch)
 {

--- a/arch/arm/src/stm32l4/stm32l4_serial.c
+++ b/arch/arm/src/stm32l4/stm32l4_serial.c
@@ -1877,12 +1877,12 @@ static int stm32l4serial_ioctl(FAR struct file *filep, int cmd,
                                  SER_SINGLEWIRE_PUSHPULL ?
                                  GPIO_PUSHPULL : GPIO_OPENDRAIN;
             gpio_val |=
-                (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ?
-                  GPIO_PULLUP : GPIO_FLOAT;
+              (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ?
+                                                  GPIO_PULLUP : GPIO_FLOAT;
 
             gpio_val |=
-                (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ?
-                  GPIO_PULLDOWN : GPIO_FLOAT;
+              (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ?
+                                                  GPIO_PULLDOWN : GPIO_FLOAT;
 
             stm32l4_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
                                                   GPIO_OPENDRAIN)) |

--- a/arch/arm/src/stm32l4/stm32l4_serial.c
+++ b/arch/arm/src/stm32l4/stm32l4_serial.c
@@ -1873,7 +1873,9 @@ static int stm32l4serial_ioctl(FAR struct file *filep, int cmd,
 
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
-            uint32_t gpio_val = GPIO_OPENDRAIN;
+            uint32_t gpio_val = (arg & SER_SINGLEWIRE_PUSHPULL) ==
+                                 SER_SINGLEWIRE_PUSHPULL ?
+                                 GPIO_PUSHPULL : GPIO_OPENDRAIN;
             gpio_val |=
                 (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ?
                   GPIO_PULLUP : GPIO_FLOAT;

--- a/include/nuttx/serial/tioctl.h
+++ b/include/nuttx/serial/tioctl.h
@@ -32,6 +32,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ********************************************************************************************/
+
 /* This function should not be included directly.  Rather, it should be included indirectly
  * via include/nuttx/fs/ioctl.h.
  */
@@ -190,6 +191,7 @@
 #  define SER_SINGLEWIRE_PULL_DISABLE (0 << SER_SINGLEWIRE_PULL_SHIFT) /* Float RX/TX Line */
 #  define SER_SINGLEWIRE_PULLUP       (1 << SER_SINGLEWIRE_PULL_SHIFT) /* Enable Pull up the RX/TX Line */
 #  define SER_SINGLEWIRE_PULLDOWN     (2 << SER_SINGLEWIRE_PULL_SHIFT) /* Enable Pull down the RX/TX Line */
+#  define SER_SINGLEWIRE_PUSHPULL     (1 << 3)                         /* Use PUSH/PULL not Open Drain with Single wire */
 
 /* Debugging */
 
@@ -220,8 +222,10 @@ struct winsize
 {
   uint16_t ws_row;
   uint16_t ws_col;
-/* uint16_t ws_xpixel;    unused */
-/* uint16_t ws_ypixel;    unused */
+
+  /* uint16_t ws_xpixel;    unused */
+
+  /* uint16_t ws_ypixel;    unused */
 };
 
 /* Structure used with TIOCSRS485 and TIOCGRS485 (Linux compatible) */


### PR DESCRIPTION
## Summary

The ubiquitous S.Port protocol, uses inverted single wire line protocol. The typical HW driver structure is:

![image](https://user-images.githubusercontent.com/1945821/89310258-4d78ff80-d629-11ea-8685-5810dcba307e.png)

While the TX (P1-3) is idle (1) Q2 is on and S.PORT (P2-3) sees 1K to ~GND.  Therefor it is  impossible to meet proper signaling level thresholds by following the reference manual, and configuring the TX for Open drain with a pull up. 

![OD-PU](https://user-images.githubusercontent.com/1945821/89310891-27a02a80-d62a-11ea-8040-096618c9f829.PNG)

The only configuration that will work is Push-Pull. Adding the pull down increases margins.

![PP-PD](https://user-images.githubusercontent.com/1945821/89311524-f83ded80-d62a-11ea-9de6-c042da3d39d5.PNG)

## Impact

None:
This will not break on existing code. The Push-pull setting is a 1 and if it is not or-ed to that IOCTL argument the code behaves as before.

## Testing

PX4 FMUV5 mini - See scope shots.

