### PR TITLE
board_crashdump:use consistent type from outer function for file name

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -114,7 +114,7 @@ static void copy_reverse(stack_word_t *dest, stack_word_t *src, int size)
  ****************************************************************************/
 
 void board_crashdump(uintptr_t currentsp, FAR void *tcb,
-                     FAR const uint8_t *filename, int lineno)
+                     FAR const char *filename, int lineno)
 {
   FAR struct tcb_s *rtcb;
   fullcontext_t *pdump;

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -379,7 +379,7 @@ int stm32_bbsram_int(void)
 
 #if defined(CONFIG_STM32F4_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t currentsp, FAR void *tcb,
-                     FAR const uint8_t *filename, int lineno)
+                     FAR const char *filename, int lineno)
 {
   fullcontext_t *pdump = (fullcontext_t *)&g_sdata;
   FAR struct tcb_s *rtcb;

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
@@ -393,7 +393,7 @@ int stm32_bbsram_int(void)
 
 #if defined(CONFIG_STM32F7_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t currentsp, FAR void *tcb,
-                     FAR const uint8_t *filename, int lineno)
+                     FAR const char *filename, int lineno)
 {
   fullcontext_t *pdump = (fullcontext_t *)&g_sdata;
   FAR struct tcb_s *rtcb;

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
@@ -31,7 +31,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- *****************************************************************************/
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
@@ -118,7 +118,7 @@
 
 #define ARRAYSIZE(a) (sizeof((a))/sizeof(a[0]))
 
-/* For Assert keep this much of the file name*/
+/* For Assert keep this much of the file name */
 
 #define MAX_FILE_PATH_LENGTH 40
 
@@ -142,7 +142,6 @@ typedef struct
   uint32_t sp;
   uint32_t top;
   uint32_t size;
-
 } _stack_t;
 
 typedef struct
@@ -264,12 +263,13 @@ typedef struct
 typedef struct
 {
   info_t    info;                  /* The info */
-#if CONFIG_ARCH_INTERRUPTSTACK > 3 /* The amount of stack data is compile time
-                                    * sized backed on what is left after the
-                                    * other BBSRAM files are defined
-                                    * The order is such that only the
-                                    * ustack should be truncated
-                                    */
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+  /* The amount of stack data is compile time
+   * sized backed on what is left after the
+   * other BBSRAM files are defined
+   * The order is such that only the
+   * ustack should be truncated
+   */
   stack_word_t istack[CONFIG_USTACK_SIZE];
 #endif
   stack_word_t ustack[CONFIG_ISTACK_SIZE];
@@ -308,8 +308,8 @@ static int hardfault_get_desc(struct bbsramd_s *desc)
 
       if (ret < 0)
         {
-          syslog(LOG_INFO, "stm32 bbsram: Failed to get Fault Log descriptor "
-              "(%d)\n", ret);
+          syslog(LOG_INFO, "stm32 bbsram: Failed to get Fault Log "
+              "descriptor (%d)\n", ret);
         }
     }
 
@@ -354,6 +354,7 @@ int stm32_bbsram_int(void)
 
 #if defined(CONFIG_STM32F7_SAVE_CRASHDUMP)
   /* Panic Logging in Battery Backed Up Files */
+
   /* Do we have an hard fault in BBSRAM? */
 
   rv = hardfault_get_desc(&desc);
@@ -363,7 +364,7 @@ int stm32_bbsram_int(void)
       state = (desc.lastwrite.tv_sec || desc.lastwrite.tv_nsec) ?  OK : 1;
 
       syslog(LOG_INFO, "Fault Log info File No %d Length %d flags:0x%02x "
-          "state:%d\n",(unsigned int)desc.fileno, (unsigned int) desc.len,
+          "state:%d\n", (unsigned int)desc.fileno, (unsigned int) desc.len,
           (unsigned int)desc.flags, state);
 
       if (state == OK)
@@ -378,8 +379,8 @@ int stm32_bbsram_int(void)
       rv = unlink(HARDFAULT_PATH);
       if (rv < 0)
         {
-          syslog(LOG_INFO, "stm32 bbsram: Failed to unlink Fault Log file [%s"
-                 "] (%d)\n", HARDFAULT_PATH, rv);
+          syslog(LOG_INFO, "stm32 bbsram: Failed to unlink Fault Log file "
+                 "[%s] (%d)\n", HARDFAULT_PATH, rv);
         }
     }
 #endif /* CONFIG_STM32F7_SAVE_CRASHDUMP */
@@ -493,7 +494,8 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
 
   /* Is it Invalid? */
 
-  if (!(pdump->info.stacks.interrupt.sp <= pdump->info.stacks.interrupt.top &&
+  if (!(pdump->info.stacks.interrupt.sp <=
+        pdump->info.stacks.interrupt.top &&
         pdump->info.stacks.interrupt.sp > pdump->info.stacks.interrupt.top -
           pdump->info.stacks.interrupt.size))
     {

--- a/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
@@ -332,7 +332,7 @@ int rx65n_sbram_int(void)
 
 #if defined(CONFIG_RX65N_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t currentsp, FAR void *tcb,
-                     FAR const uint8_t *filename, int lineno)
+                     FAR const char *filename, int lineno)
 {
   struct fullcontext *pdump ;
   pdump = (struct fullcontext *)&g_sdata;

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
@@ -330,7 +330,7 @@ int rx65n_sbram_int(void)
 
 #if defined(CONFIG_RX65N_SAVE_CRASHDUMP)
 void board_crashdump(uintptr_t currentsp, FAR void *tcb,
-                     FAR const uint8_t *filename, int lineno)
+                     FAR const char *filename, int lineno)
 {
   struct fullcontext *pdump ;
   pdump = (struct fullcontext *)&g_sdata;

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -695,7 +695,7 @@ int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg);
 
 #ifdef CONFIG_BOARD_CRASHDUMP
 void board_crashdump(uintptr_t currentsp, FAR void *tcb,
-                     FAR const uint8_t *filename,
+                     FAR const char *filename,
                      int lineno);
 #endif
 


### PR DESCRIPTION
## Summary

Fixes compile warning  on type mis match.

## Impact

None

## Testing

compiled the change. 
