### PR TITLE
Fix cases where memory is allocated using malloc()

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -910,7 +910,7 @@ static int cxd56_gnss_save_backup_data(FAR struct file *filep,
   int       n = 0;
   int32_t   offset = 0;
 
-  buf = (char *)malloc(CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
+  buf = (char *)kmm_malloc(CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
   if (buf == NULL)
     {
       return -ENOMEM;
@@ -919,7 +919,7 @@ static int cxd56_gnss_save_backup_data(FAR struct file *filep,
   fp = fopen(CONFIG_CXD56_GNSS_BACKUP_FILENAME, "wb");
   if (fp == NULL)
     {
-      free(buf);
+      kmm_free(buf);
       return -ENOENT;
     }
 
@@ -937,7 +937,7 @@ static int cxd56_gnss_save_backup_data(FAR struct file *filep,
     }
   while (n == CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
 
-  free(buf);
+  kmm_free(buf);
   fclose(fp);
 
   return n < 0 ? n : 0;
@@ -2168,7 +2168,7 @@ static FAR char *cxd56_gnss_read_cep_file(FAR FILE *fp, int32_t offset,
       goto _err0;
     }
 
-  buf = (char *)malloc(len);
+  buf = (char *)kmm_malloc(len);
   if (buf == NULL)
     {
       ret = -ENOMEM;
@@ -2199,7 +2199,7 @@ static FAR char *cxd56_gnss_read_cep_file(FAR FILE *fp, int32_t offset,
    */
 
   _err1:
-  free(buf);
+  kmm_free(buf);
   _err0:
   *retval = ret;
   cxd56_cpu1sigsend(CXD56_CPU1_DATA_TYPE_CEP, 0);
@@ -2229,7 +2229,7 @@ static void cxd56_gnss_read_backup_file(FAR int *retval)
   size_t      n;
   int         ret = 0;
 
-  buf = (char *)malloc(CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
+  buf = (char *)kmm_malloc(CONFIG_CXD56_GNSS_BACKUP_BUFFER_SIZE);
   if (buf == NULL)
     {
       ret = -ENOMEM;
@@ -2239,7 +2239,7 @@ static void cxd56_gnss_read_backup_file(FAR int *retval)
   fp = fopen(CONFIG_CXD56_GNSS_BACKUP_FILENAME, "rb");
   if (fp == NULL)
     {
-      free(buf);
+      kmm_free(buf);
       ret = -ENOENT;
       goto _err;
     }
@@ -2264,7 +2264,7 @@ static void cxd56_gnss_read_backup_file(FAR int *retval)
   while (n > 0);
 
   fclose(fp);
-  free(buf);
+  kmm_free(buf);
 
   /* Notify the termination of backup sequence by write zero length data */
 
@@ -2372,7 +2372,7 @@ static void cxd56_gnss_default_sighandler(uint32_t data, FAR void *userdata)
     case CXD56_GNSS_NOTIFY_TYPE_REQCEPBUFFREE:
       if (priv->cepbuf)
         {
-          free(priv->cepbuf);
+          kmm_free(priv->cepbuf);
         }
 
       return;

--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -54,6 +54,7 @@
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/wdog.h>
+#include <nuttx/kmalloc.h>
 #include <nuttx/clock.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/spi/spi.h>
@@ -1806,7 +1807,7 @@ struct spi_dev_s *xmc4_spibus_initialize(int channel)
    * chip select structures.
    */
 
-  spics = (struct xmc4_spics_s *)zalloc(sizeof(struct xmc4_spics_s));
+  spics = (struct xmc4_spics_s *)kmm_zalloc(sizeof(struct xmc4_spics_s));
   if (!spics)
     {
       spierr("ERROR: Failed to allocate a chip select structure\n");
@@ -2104,7 +2105,7 @@ struct spi_dev_s *xmc4_spibus_initialize(int channel)
   return &spics->spidev;
 
 errchannel:
-  free(spics);
+  kmm_free(spics);
   return NULL;
 }
 #endif /* CONFIG_XMC4_SPI0 || CONFIG_XMC4_SPI1 */

--- a/crypto/blake2s.c
+++ b/crypto/blake2s.c
@@ -52,6 +52,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <nuttx/kmalloc.h>
 #include <nuttx/crypto/blake2s.h>
 
 /****************************************************************************
@@ -330,7 +331,7 @@ static int blake2s_selftest(void)
   blake2s_state ctx;
   int ret = -1;
 
-  in = malloc(1024);
+  in = kmm_malloc(1024);
   if (!in)
     {
       goto out;
@@ -372,7 +373,7 @@ static int blake2s_selftest(void)
   ret = 0;
 
 out:
-  free(in);
+  kmm_free(in);
   return ret;
 }
 #endif

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -699,7 +699,7 @@ static void lcd_scroll_up(FAR struct pcf8574_lcd_dev_s *priv)
   int nrow;
   int ncol;
 
-  data = (FAR uint8_t *)malloc(priv->cfg.cols);
+  data = (FAR uint8_t *)kmm_malloc(priv->cfg.cols);
   if (NULL == data)
     {
       lcdinfo("Failed to allocate buffer in lcd_scroll_up()\n");
@@ -729,7 +729,7 @@ static void lcd_scroll_up(FAR struct pcf8574_lcd_dev_s *priv)
 
   lcd_set_curpos(priv, priv->cfg.rows - 1, 0);
 
-  free(data);
+  kmm_free(data);
   return;
 }
 


### PR DESCRIPTION
 ## Summary

Fix cases where memory is allocated using malloc()

arch/arm/src/cxd56xx/cxd56_gnss.c, arch/arm/src/xmc4/xmc4_spi.c,  crypto/blake2s.c, drivers/lcd/pcf8574_lcd_backpack.c, drivers/lcd/st7032.c

User space memory should not be used within the OS and, when it is absolutely necessary to use user-space memory, it should be allocated using kumm_malloc().

This resolves part of issue #1481

## Impact

Kernel memory, vs. user-space memory, will by used by drivers in PROTECTED and KERNEL builds.

## Testing


