### PR TITLE
user-space memalign() must not be called from within the OS.

### DIFF
--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -55,6 +55,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/kmalloc.h>
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/net/arp.h>
@@ -96,7 +97,9 @@
 # define CONFIG_FTMAC100_NINTERFACES 1
 #endif
 
-/* TX poll delay = 1 seconds. CLK_TCK is the number of clock ticks per second */
+/* TX poll delay = 1 seconds. CLK_TCK is the number of clock ticks per
+ * second.
+ */
 
 #define FTMAC100_WDDELAY   (1*CLK_TCK)
 
@@ -104,7 +107,9 @@
 
 #define FTMAC100_TXTIMEOUT (60*CLK_TCK)
 
-/* This is a helper pointer for accessing the contents of the Ethernet header */
+/* This is a helper pointer for accessing the contents of the Ethernet
+ * header.
+ */
 
 #define BUF ((struct eth_hdr_s *)priv->ft_dev.d_buf)
 
@@ -401,8 +406,8 @@ static int ftmac100_txpoll(struct net_driver_s *dev)
         }
     }
 
-  /* If zero is returned, the polling will continue until all connections have
-   * been examined.
+  /* If zero is returned, the polling will continue until all connections
+   * have been examined.
    */
 
   return 0;
@@ -479,7 +484,7 @@ static void ftmac100_init(FAR struct ftmac100_driver_s *priv)
 
   rxdes[CONFIG_FTMAC100_RX_DESC - 1].rxdes1 = FTMAC100_RXDES1_EDORR;
 
-  kmem = memalign(RX_BUF_SIZE, CONFIG_FTMAC100_RX_DESC * RX_BUF_SIZE);
+  kmem = kmm_memalign(RX_BUF_SIZE, CONFIG_FTMAC100_RX_DESC * RX_BUF_SIZE);
 
   ninfo("KMEM=%08x\n", kmem);
 
@@ -689,7 +694,9 @@ static void ftmac100_receive(FAR struct ftmac100_driver_s *priv)
       priv->ft_dev.d_len = len;
 
 #ifdef CONFIG_NET_PKT
-      /* When packet sockets are enabled, feed the frame into the packet tap */
+      /* When packet sockets are enabled, feed the frame into the packet
+       * tap.
+       */
 
       pkt_input(&priv->ft_dev);
 #endif
@@ -897,7 +904,8 @@ static void ftmac100_interrupt_work(FAR void *arg)
   status = priv->status;
 
   ninfo("status=%08x(%08x) BASE=%p ISR=%p PHYCR=%p\n",
-        status, getreg32(&iobase->isr), iobase, &iobase->isr, &iobase->phycr);
+        status, getreg32(&iobase->isr), iobase, &iobase->isr,
+        &iobase->phycr);
 
   if (!status)
     {
@@ -906,7 +914,9 @@ static void ftmac100_interrupt_work(FAR void *arg)
 
   /* Handle interrupts according to status bit settings */
 
-  /* Check if we received an incoming packet, if so, call ftmac100_receive() */
+  /* Check if we received an incoming packet, if so, call
+   * ftmac100_receive().
+   */
 
   if (status & FTMAC100_INT_RPKT_SAV)
     {
@@ -1206,7 +1216,9 @@ static int ftmac100_ifup(struct net_driver_s *dev)
 
   ftmac100_init(priv);
 
-  /* Instantiate the MAC address from priv->ft_dev.d_mac.ether.ether_addr_octet */
+  /* Instantiate the MAC address from
+   * priv->ft_dev.d_mac.ether.ether_addr_octet
+   */
 
   ftmac100_set_mac(priv, priv->ft_dev.d_mac.ether.ether_addr_octet);
 
@@ -1305,7 +1317,9 @@ static void ftmac100_txavail_work(FAR void *arg)
 
   if (priv->ft_bifup)
     {
-      /* Check if there is room in the hardware to hold another outgoing packet. */
+      /* Check if there is room in the hardware to hold another outgoing
+       * packet.
+       */
 
       /* If so, then poll the network for new XMIT data */
 
@@ -1600,7 +1614,9 @@ int ftmac100_initialize(int intf)
 
   ftmac100_reset(priv);
 
-  /* Read the MAC address from the hardware into priv->ft_dev.d_mac.ether.ether_addr_octet */
+  /* Read the MAC address from the hardware into
+   * priv->ft_dev.d_mac.ether.ether_addr_octet
+   */
 
   memcpy(priv->ft_dev.d_mac.ether.ether_addr_octet,
          (FAR void *)(CONFIG_FTMAC100_MAC0_ENV_ADDR), 6);

--- a/libs/libc/libc.h
+++ b/libs/libc/libc.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * libs/libc/libc.h
  *
- *   Copyright (C) 2007-2014, 2016-2017 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -87,34 +72,37 @@
 
   /* Domain-specific allocations */
 
-#  define lib_malloc(s)     kmm_malloc(s)
-#  define lib_zalloc(s)     kmm_zalloc(s)
-#  define lib_realloc(p,s)  kmm_realloc(p,s)
-#  define lib_memalign(p,s) kmm_memalign(p,s)
-#  define lib_free(p)       kmm_free(p)
+#  define lib_malloc(s)      kmm_malloc(s)
+#  define lib_zalloc(s)      kmm_zalloc(s)
+#  define lib_realloc(p,s)   kmm_realloc(p,s)
+#  define lib_memalign(p,s)  kmm_memalign(p,s)
+#  define lib_free(p)        kmm_free(p)
 
   /* User-accessible allocations */
 
-#  define lib_umalloc(s)    kumm_malloc(s)
-#  define lib_uzalloc(s)    kumm_zalloc(s)
-#  define lib_urealloc(p,s) kumm_realloc(p,s)
-#  define lib_ufree(p)      kumm_free(p)
+#  define lib_umalloc(s)     kumm_malloc(s)
+#  define lib_uzalloc(s)     kumm_zalloc(s)
+#  define lib_urealloc(p,s)  kumm_realloc(p,s)
+#  define lib_umemalign(p,s) kumm_memalign(p,s)
+#  define lib_ufree(p)       kumm_free(p)
 
 #else
 
   /* Domain-specific allocations */
 
-#  define lib_malloc(s)     malloc(s)
-#  define lib_zalloc(s)     zalloc(s)
-#  define lib_realloc(p,s)  realloc(p,s)
-#  define lib_free(p)       free(p)
+#  define lib_malloc(s)      malloc(s)
+#  define lib_zalloc(s)      zalloc(s)
+#  define lib_realloc(p,s)   realloc(p,s)
+#  define lib_memalign(p,s)  memalign(p,s)
+#  define lib_free(p)        free(p)
 
   /* User-accessible allocations */
 
-#  define lib_umalloc(s)    malloc(s)
-#  define lib_uzalloc(s)    zalloc(s)
-#  define lib_urealloc(p,s) realloc(p,s)
-#  define lib_ufree(p)      free(p)
+#  define lib_umalloc(s)     malloc(s)
+#  define lib_uzalloc(s)     zalloc(s)
+#  define lib_urealloc(p,s)  realloc(p,s)
+#  define lib_umemalign(p,s) memalign(p,s)
+#  define lib_ufree(p)       free(p)
 
 #endif
 
@@ -151,8 +139,8 @@ void  stream_semgive(FAR struct streamlist *list);
 /* Defined in lib_dtoa.c */
 
 #ifdef CONFIG_LIBC_FLOATINGPOINT
-char *__dtoa(double d, int mode, int ndigits, int *decpt, int *sign,
-             char **rve);
+FAR char *__dtoa(double d, int mode, int ndigits, FAR int *decpt,
+                 FAR int *sign, FAR char **rve);
 #endif
 
 /* Defined in lib_fopen.c */
@@ -194,19 +182,19 @@ void lib_give_semaphore(FAR struct file_struct *stream);
 
 /* Defined in lib_libgetbase.c */
 
-int lib_getbase(const char *nptr, const char **endptr);
+int lib_getbase(FAR const char *nptr, FAR const char **endptr);
 
 /* Defined in lib_skipspace.c */
 
-void lib_skipspace(const char **pptr);
+void lib_skipspace(FAR const char **pptr);
 
 /* Defined in lib_isbasedigit.c */
 
-bool lib_isbasedigit(int ch, int base, int *value);
+bool lib_isbasedigit(int ch, int base, FAR int *value);
 
 /* Defined in lib_checkbase.c */
 
-int lib_checkbase(int base, const char **pptr);
+int lib_checkbase(int base, FAR const char **pptr);
 
 /* Defined in lib_expi.c */
 

--- a/libs/libc/stdlib/lib_aligned_alloc.c
+++ b/libs/libc/stdlib/lib_aligned_alloc.c
@@ -22,7 +22,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <stdlib.h>
+#include <libc.h>
 
 /****************************************************************************
  * Public Functions
@@ -30,5 +30,5 @@
 
 FAR void *aligned_alloc(size_t align, size_t size)
 {
-  return memalign(align, size);
+  return lib_memalign(align, size);
 }


### PR DESCRIPTION
## Summary

drivers/net/ftmac100.c, libs/libc/stdlib/lib_aligned_alloc.c

A continuation of PRs #1507, #1510, and #1512.  See Issue #1481 for additional information.

## Impact

Will use correct memory allocator in PROTECTED and KERNEL build modes.
## Testing

