### PR TITLE
arch/sim: Always preserve the heap memory dynamically

### DIFF
--- a/arch/sim/src/sim/up_allocateheap.c
+++ b/arch/sim/src/sim/up_allocateheap.c
@@ -73,20 +73,13 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
    * executable memory.
    */
 
-#if defined(CONFIG_LIBC_MODLIB) || defined(CONFIG_BINFMT_LOADABLE)
   /* We make the entire heap executable here to keep
    * the sim simpler. If it turns out to be a problem, the
    * ARCH_HAVE_MODULE_TEXT mechanism can be an alternative.
    */
 
   uint8_t *sim_heap = host_alloc_heap(SIM_HEAP_SIZE);
-#else
-  /* This sim_heap would be placed in BSS, which is often not
-   * executable on modern environments.
-   */
 
-  static uint8_t sim_heap[SIM_HEAP_SIZE];
-#endif
   *heap_start = sim_heap;
   *heap_size  = SIM_HEAP_SIZE;
 }


### PR DESCRIPTION
## Summary
so size with nuttx could report the correct bss value:
```
   text    data     bss     dec     hex filename
 155467    1464    1948  158879   26c9f nuttx
```
otherwise, the heap memmory classify to bss section.

## Impact

## Testing

