### PR TITLE
Fix for arch/arm/src/stm32/stm32_adc.c

### DIFF
--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -2886,8 +2886,6 @@ static int adc_setup(FAR struct adc_dev_s *dev)
       return OK;
     }
 
-  priv->initialized += 1;
-
   /* Attach the ADC interrupt */
 
 #ifndef CONFIG_STM32_ADC_NOIRQ
@@ -2959,6 +2957,10 @@ static int adc_setup(FAR struct adc_dev_s *dev)
   priv->cmn->initialized += 1;
   adccmn_lock(priv, false);
 #endif
+
+  /* The ADC device is ready */
+
+  priv->initialized += 1;
 
   return ret;
 }


### PR DESCRIPTION
## Summary
Increase the initialization counter after initialization is complete, otherwise the logic in adc_reset() will not execute correctly

## Impact
Re-launching examples/adc now works fine for arch/stm32.
I think this problem only affects arch/stm32 where we try to support different versions of ADC IP cores.

## Testing
Tested on stm32f429i-disco and nucleo-f303re.
