### PR TITLE
arch: imxrt: Fix ethernet configuration in Kconfig

### DIFF
--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -948,7 +948,7 @@ endif # IMXRT_GPIO_IRQ
 menu "Ethernet Configuration"
 	depends on IMXRT_ENET
 
-config MXRT_ENET_NRXBUFFERS
+config IMXRT_ENET_NRXBUFFERS
 	int "Number Rx buffers"
 	default 6
 


### PR DESCRIPTION
## Summary

- Fix typo in Kconfig so that we can configure IMXRT_ENET_NRXBUFFERS.

## Impact

- imxrt family with ethernet configuration

## Testing

- imxrt1060-evk:netnsh
