### PR TITLE
USB MSC state change notifier and USB MSC automount for Freedom K28

### DIFF
--- a/boards/arm/kinetis/freedom-k28f/Kconfig
+++ b/boards/arm/kinetis/freedom-k28f/Kconfig
@@ -33,4 +33,34 @@ config FRDMK28F_SDHC_AUTOMOUNT_UDELAY
 	default 2000
 
 endif # FRDMK28F_SDHC_AUTOMOUNT
+
+config FRDMK28F_USB_AUTOMOUNT
+	bool "USB Mass Storage automounter"
+	default n
+	depends on USBHOST_MSC && USBHOST_MSC_NOTIFIER
+
+if FRDMK28F_USB_AUTOMOUNT
+
+config FRDMK28F_USB_AUTOMOUNT_FSTYPE
+	string "USB file system type"
+	default "vfat"
+
+config FRDMK28F_USB_AUTOMOUNT_BLKDEV
+	string "USB block device prefix"
+	default "/dev/sd"
+
+config FRDMK28F_USB_AUTOMOUNT_MOUNTPOINT
+	string "USB mount point prefix"
+	default "/mnt/usb"
+
+config FRDMK28F_USB_AUTOMOUNT_NUM_BLKDEV
+	int "Number of block devices to monitor."
+	range 1 26
+	default 4
+
+config FRDMK28F_USB_AUTOMOUNT_UDELAY
+	int "USB unmount retry delay (milliseconds)"
+	default 2000
+	
+endif # FRDMK28F_USB_AUTOMOUNT
 endif # ARCH_BOARD_FREEDOM_K28F

--- a/boards/arm/kinetis/freedom-k28f/src/k28_bringup.c
+++ b/boards/arm/kinetis/freedom-k28f/src/k28_bringup.c
@@ -118,12 +118,6 @@ int k28_bringup(void)
 #endif /* CONFIG_FRDMK28F_SDHC_MOUNT */
 #endif /* HAVE_MMCSD */
 
-#ifdef HAVE_AUTOMOUNTER
-  /* Initialize the auto-mounter */
-
-  k28_automount_initialize();
-#endif
-
 #if defined(CONFIG_USBDEV) && defined(CONFIG_KINETIS_USBOTG)
   if (k28_usbdev_initialize)
     {
@@ -154,7 +148,15 @@ int k28_bringup(void)
 #endif
 
 #if defined(CONFIG_USBHOST) && defined(CONFIG_KINETIS_USBHS)
+  /* Initialize the USB highspeed host */
+
   k28_usbhost_initialize();
+#endif
+
+#ifdef HAVE_SDHC_AUTOMOUNTER
+  /* Initialize the auto-mounter */
+
+  k28_automount_initialize();
 #endif
 
   UNUSED(ret);

--- a/boards/arm/kinetis/freedom-k28f/src/k28_sdhc.c
+++ b/boards/arm/kinetis/freedom-k28f/src/k28_sdhc.c
@@ -109,15 +109,17 @@ static void k28_mediachange(void)
     {
       mcinfo("Media change: %d->%d\n",  g_sdhc.inserted, inserted);
 
-      /* Yes.. perform the appropriate action (this might need some debounce). */
+      /* Yes.. perform the appropriate action
+       * (this might need some debounce).
+       */
 
       g_sdhc.inserted = inserted;
       sdhc_mediachange(g_sdhc.sdhc, inserted);
 
-#ifdef CONFIG_FRDMK28F_SDHC_AUTOMOUNT
+#ifdef HAVE_SDHC_AUTOMOUNTER
       /* Let the automounter know about the insertion event */
 
-      k28_automount_event(k28_cardinserted());
+      k28_sdhc_automount_event(k28_cardinserted());
 #endif
     }
 }
@@ -180,7 +182,8 @@ int k28_sdhc_initialize(void)
   ret = mmcsd_slotinitialize(MMSCD_MINOR, g_sdhc.sdhc);
   if (ret != OK)
     {
-      syslog(LOG_ERR, "ERROR: Failed to bind SDHC to the MMC/SD driver: %d\n",
+      syslog(LOG_ERR,
+          "ERROR: Failed to bind SDHC to the MMC/SD driver: %d\n",
              ret);
       return ret;
     }
@@ -205,7 +208,7 @@ int k28_sdhc_initialize(void)
  *
  ****************************************************************************/
 
-#ifdef HAVE_AUTOMOUNTER
+#ifdef HAVE_SDHC_AUTOMOUNTER
 bool k28_cardinserted(void)
 {
   bool inserted;
@@ -228,7 +231,7 @@ bool k28_cardinserted(void)
  *
  ****************************************************************************/
 
-#ifdef HAVE_AUTOMOUNTER
+#ifdef HAVE_SDHC_AUTOMOUNTER
 bool k28_writeprotected(void)
 {
   /* There are no write protect pins */

--- a/drivers/usbhost/Kconfig
+++ b/drivers/usbhost/Kconfig
@@ -108,7 +108,17 @@ config USBHOST_MSC
 	---help---
 		Enable support for the mass storage class driver.  This also depends on
 		NFILE_DESCRIPTORS > 0 && SCHED_WORKQUEUE=y
-
+		
+config USBHOST_MSC_NOTIFIER
+	bool "Support USB Mass Storage notifications"
+	default n
+	depends on USBHOST_MSC
+	select WQUEUE_NOTIFIER
+	---help---
+		Enable building of USB MSC notifier logic that will execute a worker
+		function on the low priority work queue when a mass storage device is
+		connected or disconnected. 
+		
 config USBHOST_CDCACM
 	bool "CDC/ACM support"
 	default n

--- a/drivers/usbhost/usbhost_storage.c
+++ b/drivers/usbhost/usbhost_storage.c
@@ -482,7 +482,7 @@ static int usbhost_allocdevno(FAR struct usbhost_state_s *priv)
 
 static void usbhost_freedevno(FAR struct usbhost_state_s *priv)
 {
-  int devno = 'a' - priv->sdchar;
+  int devno = priv->sdchar - 'a';
 
   if (devno >= 0 && devno < 26)
     {

--- a/drivers/usbhost/usbhost_storage.c
+++ b/drivers/usbhost/usbhost_storage.c
@@ -1400,6 +1400,14 @@ static inline int usbhost_initvolume(FAR struct usbhost_state_s *priv)
 
       ret = -ENODEV;
     }
+#  ifdef CONFIG_USBHOST_MSC_NOTIFIER
+  else
+    {
+      /* Signal the connect */
+
+      usbhost_msc_notifier_signal(WORK_USB_MSC_CONNECT, priv->sdchar);
+    }
+#  endif
 
   /* Release the semaphore... there is a race condition here.
    * Decrementing the reference count and releasing the semaphore
@@ -1409,6 +1417,7 @@ static inline int usbhost_initvolume(FAR struct usbhost_state_s *priv)
    */
 
   usbhost_givesem(&priv->exclsem);
+
   return ret;
 }
 
@@ -1847,6 +1856,12 @@ static int usbhost_disconnected(struct usbhost_class_s *usbclass)
   irqstate_t flags;
 
   DEBUGASSERT(priv != NULL);
+
+#  ifdef CONFIG_USBHOST_MSC_NOTIFIER
+  /* Signal the disconnect */
+
+  usbhost_msc_notifier_signal(WORK_USB_MSC_DISCONNECT, priv->sdchar);
+#  endif
 
   /* Set an indication to any users of the mass storage device that the
    * device is no longer available.
@@ -2359,5 +2374,99 @@ int usbhost_msc_initialize(void)
 
   return usbhost_registerclass(&g_storage);
 }
+
+#  ifdef CONFIG_USBHOST_MSC_NOTIFIER
+
+/****************************************************************************
+ * Name: usbhost_msc_notifier_setup
+ *
+ * Description:
+ *   Set up to perform a callback to the worker function when a mass storage
+ *   device is attached.
+ *
+ * Input Parameters:
+ *   worker - The worker function to execute on the low priority work queue
+ *            when the event occurs.
+ *   event  - Currently only USBHOST_MSC_DISCONNECT and USBHOST_MSC_CONNECT
+ *   sdchar - sdchar of the connected or disconnected block device
+ *   arg    - A user-defined argument that will be available to the worker
+ *            function when it runs.
+ *
+ * Returned Value:
+ *   > 0   - The notification is in place. The returned value is a key that
+ *           may be used later in a call to
+ *           usbmsc_attach_notifier_teardown().
+ *   == 0  - Not used.
+ *   < 0   - An unexpected error occurred and no notification will occur. The
+ *           returned value is a negated errno value that indicates the
+ *           nature of the failure.
+ *
+ ****************************************************************************/
+
+int usbhost_msc_notifier_setup(worker_t worker, uint8_t event, char sdchar,
+    FAR void *arg)
+{
+  struct work_notifier_s info;
+
+  DEBUGASSERT(worker != NULL);
+
+  info.evtype    = event;
+  info.qid       = LPWORK;
+  info.qualifier = (FAR void *)(uintptr_t)sdchar;
+  info.arg       = arg;
+  info.worker    = worker;
+
+  return work_notifier_setup(&info);
+}
+
+/****************************************************************************
+ * Name: usbhost_msc_notifier_teardown
+ *
+ * Description:
+ *   Eliminate an USB MSC notification previously setup by
+ *   usbhost_msc_notifier_setup().
+ *   This function should only be called if the notification should be
+ *   aborted prior to the notification.  The notification will automatically
+ *   be torn down after the notification.
+ *
+ * Input Parameters:
+ *   key - The key value returned from a previous call to
+ *         usbhost_msc_notifier_setup().
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   any failure.
+ *
+ ****************************************************************************/
+
+int usbhost_msc_notifier_teardown(int key)
+{
+  /* This is just a simple wrapper around work_notifier_teardown(). */
+
+  return work_notifier_teardown(key);
+}
+
+/****************************************************************************
+ * Name: usbhost_msc_notifier_signal
+ *
+ * Description:
+ *   An USB mass storage device has been connected or disconnected.
+ *   Signal all threads.
+ *
+ * Input Parameters:
+ *   event  - Currently only USBHOST_MSC_DISCONNECT and USBHOST_MSC_CONNECT
+ *   sdchar - sdchar of the connected or disconnected block device
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void usbhost_msc_notifier_signal(uint8_t event, char sdchar)
+{
+  work_notifier_signal(event, (FAR void *)(uintptr_t)sdchar);
+}
+
+#  endif /* CONFIG_USBHOST_MSC_NOTIFIER */
 
 #endif /* CONFIG_USBHOST && !CONFIG_USBHOST_BULK_DISABLE && !CONFIG_DISABLE_MOUNTPOINT */

--- a/include/nuttx/usb/usbhost.h
+++ b/include/nuttx/usb/usbhost.h
@@ -39,6 +39,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef CONFIG_USBHOST_MSC_NOTIFIER
+#  include <nuttx/wqueue.h>
+#endif
+
 #include <nuttx/usb/usbhost_devaddr.h>
 
 /************************************************************************************
@@ -1014,6 +1018,78 @@ int usbhost_hub_initialize(void);
  ************************************************************************************/
 
 int usbhost_msc_initialize(void);
+
+#  ifdef CONFIG_USBHOST_MSC_NOTIFIER
+/************************************************************************************
+ * Name: usbhost_msc_notifier_setup
+ *
+ * Description:
+ *   Set up to perform a callback to the worker function when a mass storage
+ *   device is attached.
+ *
+ * Input Parameters:
+ *   worker - The worker function to execute on the low priority work queue
+ *            when the event occurs.
+ *   event  - Only WORK_USB_MSC_CONNECT and WORK_USB_MSC_DISCONNECT
+ *   sdchar - sdchar of the connected or disconnected block device
+ *   arg    - A user-defined argument that will be available to the worker
+ *            function when it runs.
+ *
+ * Returned Value:
+ *   > 0   - The notification is in place. The returned value is a key that
+ *           may be used later in a call to
+ *           usbmsc_attach_notifier_teardown().
+ *   == 0  - Not used.
+ *   < 0   - An unexpected error occurred and no notification will occur. The
+ *           returned value is a negated errno value that indicates the
+ *           nature of the failure.
+ *
+ ************************************************************************************/
+
+int usbhost_msc_notifier_setup(worker_t worker, uint8_t event, char sdchar,
+    FAR void *arg);
+
+/************************************************************************************
+ * Name: usbhost_msc_notifier_teardown
+ *
+ * Description:
+ *   Eliminate an USB MSC notification previously setup by
+ *   usbhost_msc_notifier_setup().
+ *   This function should only be called if the notification should be
+ *   aborted prior to the notification.  The notification will automatically
+ *   be torn down after the notification.
+ *
+ * Input Parameters:
+ *   key - The key value returned from a previous call to
+ *         usbhost_msc_notifier_setup().
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   any failure.
+ *
+ ************************************************************************************/
+
+int usbhost_msc_notifier_teardown(int key);
+
+/************************************************************************************
+ * Name: usbhost_msc_notifier_signal
+ *
+ * Description:
+ *   An USB mass storage device has been connected or disconnected.
+ *   Signal all threads.
+ *
+ * Input Parameters:
+ *   event  - Currently only USBHOST_MSC_DISCONNECT and USBHOST_MSC_CONNECT
+ *   sdchar - sdchar of the connected or disconnected block device
+ *
+ * Returned Value:
+ *   None.
+ *
+ ************************************************************************************/
+
+void usbhost_msc_notifier_signal(uint8_t event, char sdchar);
+
+#  endif
 #endif
 
 #ifdef CONFIG_USBHOST_CDCACM

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -273,15 +273,17 @@ struct work_s
 
 enum work_evtype_e
 {
-  WORK_IOB_AVAIL  = 1,   /* Notify availability of an IOB */
-  WORK_NET_DOWN,         /* Notify that the network is down */
-  WORK_TCP_READAHEAD,    /* Notify that TCP read-ahead data is available */
-  WORK_TCP_WRITEBUFFER,  /* Notify that TCP write buffer is empty */
-  WORK_TCP_DISCONNECT,   /* Notify loss of TCP connection */
-  WORK_UDP_READAHEAD,    /* Notify that UDP read-ahead data is available */
-  WORK_UDP_WRITEBUFFER,  /* Notify that UDP write buffer is empty */
-  WORK_NETLINK_RESPONSE, /* Notify that Netlink response is available */
-  WORK_CAN_READAHEAD     /* Notify that CAN read-ahead data is available */
+  WORK_IOB_AVAIL  = 1,     /* Notify availability of an IOB */
+  WORK_NET_DOWN,           /* Notify that the network is down */
+  WORK_TCP_READAHEAD,      /* Notify that TCP read-ahead data is available */
+  WORK_TCP_WRITEBUFFER,    /* Notify that TCP write buffer is empty */
+  WORK_TCP_DISCONNECT,     /* Notify loss of TCP connection */
+  WORK_UDP_READAHEAD,      /* Notify that UDP read-ahead data is available */
+  WORK_UDP_WRITEBUFFER,    /* Notify that UDP write buffer is empty */
+  WORK_NETLINK_RESPONSE,   /* Notify that Netlink response is available */
+  WORK_CAN_READAHEAD,      /* Notify that CAN read-ahead data is available */
+  WORK_USB_MSC_CONNECT,    /* Notify that an USB MSC connect occured */
+  WORK_USB_MSC_DISCONNECT  /* Notify that an USB MSC connect occured */
 };
 
 /* This structure describes one notification and is provided as input to


### PR DESCRIPTION
## Summary
Added USB MSC state change notifiers in notifier work queue.
Added USB MSC automount for Freedom K28 using the above.

## Impact
A state change sends a connect or a disconnect notifier.
The registered blockdriver is signalled as sdchar in the qualifier. 'a' is for dev/sda 'b' is for dev/sdb (...).

The corresponding Kconfig option is USBHOST_MSC_NOTIFIER.

## Testing
Introduced USB automount for a configurable number of devices for Kinetis Freedom K28 board.
