### PR TITLE
STM32 IO compensation cell initialization fix.

### DIFF
--- a/arch/arm/src/stm32/stm32_rcc.c
+++ b/arch/arm/src/stm32/stm32_rcc.c
@@ -207,15 +207,15 @@ void stm32_clockconfig(void)
 
 #endif
 
+  /* Enable peripheral clocking */
+
+  rcc_enableperipherals();
+
 #ifdef CONFIG_STM32_SYSCFG_IOCOMPENSATION
   /* Enable I/O Compensation */
 
   stm32_iocompensation();
 #endif
-
-  /* Enable peripheral clocking */
-
-  rcc_enableperipherals();
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
STM32 IO compensation cell is enabled after clocking to SYSCFG is enabled.
Currently the IO compensation cell is enabled before the call to rcc_enableperipherals(). Thus the peripheral SYSCFG is accessed before clocking is enabled.

## Impact
If CONFIG_STM32_SYSCFG_IOCOMPENSATION is enabled, code hangs while it waits for the IO cell to be ready.

## Testing
Tested on custom board (based on an STM32F427VI), and after the fix boot proceeds normally, with IO compensation cell enabled.
