### PR TITLE
stm32f7:serial TXDMA ISR was looping on TX Empty

### DIFF
--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -3181,10 +3181,6 @@ static void up_dma_send(struct uart_dev_s *dev)
 
   stm32_dmastop(priv->txdma);
 
-  /* Wait until TX UART is ready for new transfer it should be */
-
-  while (!up_txready(dev));
-
   /* Flush the contents of the TX buffer into physical memory */
 
   up_clean_dcache((uintptr_t)dev->dmatx.buffer,


### PR DESCRIPTION
## Summary

   Interrupts were blocked 1*n/baud Seconds. The former comment indicates
   there was an assumption that the TXE would be set at DMA completion.
   In reality this is not true. There can be 1 char in the TX Shift
   register and one in the TX holding register, when DMA completes.
   Waiting on TXE is not needed at all. The DMA will resume on the
   DMA req when the TX holding register is written to the TX Shift
   register.

## Impact

When TX DMA was enabled l loss of data/real time performances. 
I.E. At 8,1,n,57600 interrupts were off for 173.61 uS.

## Testing

Run Linux serial test on PC and NuttX, Scoping the ISR.