### PR TITLE
STM32F7 and STM32F0/L0/G0 IO compensation fixes

### DIFF
--- a/arch/arm/src/stm32f0l0g0/stm32_rcc.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_rcc.c
@@ -50,7 +50,6 @@
 #include "arm_arch.h"
 
 #include "hardware/stm32_flash.h"
-#include "stm32_gpio.h"
 #include "stm32_rcc.h"
 #include "stm32_hsi48.h"
 
@@ -187,12 +186,6 @@ void stm32_clockconfig(void)
 
   stm32_stdclockconfig();
 
-#endif
-
-#ifdef CONFIG_STM32F0L0G0_SYSCFG_IOCOMPENSATION
-  /* Enable I/O Compensation */
-
-  stm32_iocompensation();
 #endif
 
   /* Enable peripheral clocking */

--- a/arch/arm/src/stm32f0l0g0/stm32_rcc.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_rcc.c
@@ -77,7 +77,7 @@
 #define HSERDY_TIMEOUT (100 * CONFIG_BOARD_LOOPSPERMSEC)
 
 /****************************************************************************
- * Private Functions
+ * Included Files
  ****************************************************************************/
 
 /* Include chip-specific clocking initialization logic */
@@ -101,9 +101,9 @@
  *
  * Description:
  *   The RTC needs to reset the Backup Domain to change RTCSEL and resetting
- *   the Backup Domain renders to disabling the LSE as consequence.   In order
- *   to avoid resetting the Backup Domain when we already configured LSE we
- *   will reset the Backup Domain early (here).
+ *   the Backup Domain renders to disabling the LSE as consequence.
+ *   In order to avoid resetting the Backup Domain when we already configured
+ *   LSE we will reset the Backup Domain early (here).
  *
  * Input Parameters:
  *   None
@@ -155,8 +155,8 @@ static inline void rcc_resetbkp(void)
  *   configuration file.
  *
  *   If CONFIG_ARCH_BOARD_STM32_CUSTOM_CLOCKCONFIG is defined, then clocking
- *   will be enabled by an externally provided, board-specific function called
- *   stm32_board_clockconfig().
+ *   will be enabled by an externally provided, board-specific function
+ *   called stm32_board_clockconfig().
  *
  * Input Parameters:
  *   None
@@ -182,7 +182,9 @@ void stm32_clockconfig(void)
   stm32_board_clockconfig();
 
 #else
-  /* Invoke standard, fixed clock configuration based on definitions in board.h */
+  /* Invoke standard, fixed clock configuration based on definitions
+   * in board.h
+   */
 
   stm32_stdclockconfig();
 
@@ -227,7 +229,9 @@ void stm32_clockenable(void)
   stm32_board_clockconfig();
 
 #else
-  /* Invoke standard, fixed clock configuration based on definitions in board.h */
+  /* Invoke standard, fixed clock configuration based on definitions
+   * in board.h
+   */
 
   stm32_stdclockconfig();
 

--- a/arch/arm/src/stm32f7/stm32_rcc.c
+++ b/arch/arm/src/stm32f7/stm32_rcc.c
@@ -138,15 +138,15 @@ void stm32_clockconfig(void)
 
 #endif
 
+  /* Enable peripheral clocking */
+
+  rcc_enableperipherals();
+
 #ifdef CONFIG_STM32F7_SYSCFG_IOCOMPENSATION
   /* Enable I/O Compensation */
 
   stm32_iocompensation();
 #endif
-
-  /* Enable peripheral clocking */
-
-  rcc_enableperipherals();
 }
 
 /************************************************************************************

--- a/arch/arm/src/stm32f7/stm32_rcc.c
+++ b/arch/arm/src/stm32f7/stm32_rcc.c
@@ -71,7 +71,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Private Functions
+ * Included Files
  ****************************************************************************/
 
 /* Include chip-specific clocking initialization logic */
@@ -100,8 +100,8 @@
  *   configurationfile.
  *
  *   If CONFIG_STM32F7_CUSTOM_CLOCKCONFIG is defined, then clocking
- *   will be enabled by an externally provided, board-specific function called
- *   stm32_board_clockconfig().
+ *   will be enabled by an externally provided, board-specific function
+ *   called stm32_board_clockconfig().
  *
  * Input Parameters:
  *   None
@@ -109,7 +109,7 @@
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_clockconfig(void)
 {
@@ -132,7 +132,9 @@ void stm32_clockconfig(void)
 
 #else
 
-  /* Invoke standard, fixed clock configuration based on definitions in board.h */
+  /* Invoke standard, fixed clock configuration based on definitions
+   * in board.h
+   */
 
   stm32_stdclockconfig();
 
@@ -149,22 +151,22 @@ void stm32_clockconfig(void)
 #endif
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_clockenable
  *
  * Description:
- *   Re-enable the clock and restore the clock settings based on settings in board.h.
- *   This function is only available to support low-power modes of operation:  When
- *   re-awakening from deep-sleep modes, it is necessary to re-enable/re-start the
- *   PLL
+ *   Re-enable the clock and restore the clock settings based on settings
+ *   in board.h. This function is only available to support low-power
+ *   modes of operation:  When re-awakening from deep-sleep modes, it is
+ *   necessary to re-enable/re-start the PLL
  *
  *   This functional performs a subset of the operations performed by
- *   stm32_clockconfig():  It does not reset any devices, and it does not reset the
- *   currently enabled peripheral clocks.
+ *   stm32_clockconfig():  It does not reset any devices, and it does not
+ *   reset the currently enabled peripheral clocks.
  *
- *   If CONFIG_STM32F7_CUSTOM_CLOCKCONFIG is defined, then clocking will be enabled
- *   by an externally provided, board-specific function called
- *   stm32_board_clockconfig().
+ *   If CONFIG_STM32F7_CUSTOM_CLOCKCONFIG is defined, then clocking
+ *   will be enabled by an externally provided, board-specific function
+ *   called stm32_board_clockconfig().
  *
  * Input Parameters:
  *   None
@@ -172,7 +174,7 @@ void stm32_clockconfig(void)
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_PM
 void stm32_clockenable(void)
@@ -185,7 +187,9 @@ void stm32_clockenable(void)
 
 #else
 
-  /* Invoke standard, fixed clock configuration based on definitions in board.h */
+  /* Invoke standard, fixed clock configuration based on definitions
+   * in board.h
+   */
 
   stm32_stdclockconfig();
 


### PR DESCRIPTION
## Summary
1. Apply fix from https://github.com/apache/incubator-nuttx/pull/1544 to STM32F7.
2. Remove reference to IO compensation from STM32F0/L0/G0

## Impact

## Testing

