### PR TITLE
stack check: Support Stack Smashing Protector(SSP)

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1686,6 +1686,20 @@ config STACK_COLORATION
 
 		Only supported by a few architectures.
 
+config STACK_CANARIES
+	bool "Compiler stack canaries"
+	depends on ARCH_HAVE_STACKCHECK
+	default n
+	---help---
+		This option enables compiler stack canaries.
+		If stack canaries are supported by the compiler, it will emit
+		extra code that inserts a canary value into the stack frame when
+		a function is entered and validates this value upon exit.
+		Stack corruption (such as that caused by buffer overflow) results
+		in a fatal error condition for the running entity.
+		Enabling this option can result in a significant increase
+		in footprint and an associated decrease in performance.
+
 config ARCH_HAVE_HEAPCHECK
 	bool
 	default n

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -31,6 +31,10 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += -O2 -fno-strict-aliasing
 endif
 
+ifeq ($(CONFIG_STACK_CANARIES),y)
+  ARCHOPTIMIZATION += -fstack-protector-all
+endif
+
 ARCHCPUFLAGS = -fno-builtin
 ARCHCPUFLAGSXX = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHPICFLAGS = -fpic

--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -36,6 +36,10 @@ ifeq ($(CONFIG_PSEUDOTERM_SUSV1),y)
 CSRCS += lib_ptsname.c lib_ptsnamer.c
 endif
 
+ifeq ($(CONFIG_STACK_CANARIES),y)
+CSRCS += lib_stackchk.c
+endif
+
 ifeq ($(CONFIG_PSEUDOTERM),y)
 CSRCS += lib_unlockpt.c
 endif

--- a/libs/libc/stdlib/lib_stackchk.c
+++ b/libs/libc/stdlib/lib_stackchk.c
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * libs/libc/stdlib/lib_stackchk.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+
+#ifdef CONFIG_STACK_CANARIES
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+FAR const void *const __stack_chk_guard = &__stack_chk_guard;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: __stack_chk_fail
+ *
+ * Description:
+ *   The interface __stack_chk_fail() shall abort the function that called
+ *   it with a message that a stack overflow has been detected. The program
+ *   that called the function shall then exit.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void __stack_chk_fail(void)
+{
+  PANIC();
+}
+
+#endif /* CONFIG_STACK_CANARIES */


### PR DESCRIPTION
and enable on sim as a demo. Here is the paper:
ftp://gcc.gnu.org/pub/gcc/summit/2003/Stackguard.pdf

## Summary

## Impact
New feature, don't have effect if CONFIG_STACK_CANARIES=n(default).

## Testing

