### PR TITLE
Fix in STM32F4 over-drive configuration.

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -1713,6 +1713,7 @@ config STM32_STM32F407
 config STM32_STM32F427
 	bool
 	default n
+	select STM32_HAVE_OVERDRIVE
 	select STM32_HAVE_FMC
 	select STM32_HAVE_CCM
 	select STM32_HAVE_USART3
@@ -1756,6 +1757,7 @@ config STM32_STM32F427
 config STM32_STM32F429
 	bool
 	default n
+	select STM32_HAVE_OVERDRIVE
 	select STM32_HAVE_FMC
 	select STM32_HAVE_LTDC
 	select STM32_HAVE_CCM
@@ -1798,6 +1800,7 @@ config STM32_STM32F429
 config STM32_STM32F446
 	bool
 	default n
+	select STM32_HAVE_OVERDRIVE
 	select STM32_HAVE_USART3
 	select STM32_HAVE_UART4
 	select STM32_HAVE_UART5
@@ -1834,6 +1837,7 @@ config STM32_STM32F446
 config STM32_STM32F469
 	bool
 	default n
+	select STM32_HAVE_OVERDRIVE
 	select STM32_HAVE_FMC
 	select STM32_HAVE_LTDC
 	select STM32_HAVE_CCM
@@ -1987,6 +1991,10 @@ menu "STM32 Peripheral Support"
 
 # These "hidden" settings determine whether a peripheral option is available
 # for the selected MCU
+
+config STM32_HAVE_OVERDRIVE
+	bool
+	default n
 
 config STM32_HAVE_AES
 	bool

--- a/arch/arm/src/stm32/stm32_pwr.c
+++ b/arch/arm/src/stm32/stm32_pwr.c
@@ -351,10 +351,10 @@ bool stm32_pwr_getwuf(void)
  * Description:
  *   Enables the Backup regulator, the Backup regulator (used to maintain backup
  *   SRAM content in Standby and VBAT modes) is enabled. If BRE is reset, the backup
- *   regulator is switched off. The backup SRAM can still be used but its content will
- *   be lost in the Standby and VBAT modes. Once set, the application must wait that
- *   the Backup Regulator Ready flag (BRR) is set to indicate that the data written
- *   into the RAM will be maintained in the Standby and VBAT modes.
+ *   regulator is switched off. The backup SRAM can still be used but its content
+ *   will be lost in the Standby and VBAT modes. Once set, the application must wait
+ *   that the Backup Regulator Ready flag (BRR) is set to indicate that the data
+ *   written into the RAM will be maintained in the Standby and VBAT modes.
  *
  * Input Parameters:
  *   region - state to set it to
@@ -498,11 +498,9 @@ void stm32_pwr_disablepvd(void)
  *
  ************************************************************************************/
 
-#if defined(CONFIG_STM32_STM32F427) || defined(CONFIG_STM32_STM32F429) || \
-    defined(CONFIG_STM32_STM32F446) || defined(CONFIG_STM32_STM32F469)
+#if defined(CONFIG_STM32_HAVE_OVERDRIVE)
 void stm32_pwr_enableoverdrive(bool state)
 {
-
   /* Switch overdrive state */
 
   if (state)
@@ -518,7 +516,7 @@ void stm32_pwr_enableoverdrive(bool state)
 
   while ((stm32_pwr_getreg32(STM32_PWR_CSR_OFFSET) & PWR_CSR_ODRDY) == 0);
 
-  /* Set ODSWEN to switch to this new state*/
+  /* Set ODSWEN to switch to this new state */
 
   stm32_pwr_modifyreg32(STM32_PWR_CR_OFFSET, 0, PWR_CR_ODSWEN);
 

--- a/arch/arm/src/stm32/stm32_pwr.h
+++ b/arch/arm/src/stm32/stm32_pwr.h
@@ -79,7 +79,7 @@ enum stm32_pwr_wupin_e
 };
 
 /************************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ************************************************************************************/
 
 /************************************************************************************
@@ -187,10 +187,10 @@ bool stm32_pwr_getwuf(void);
  * Description:
  *   Enables the Backup regulator, the Backup regulator (used to maintain backup
  *   SRAM content in Standby and VBAT modes) is enabled. If BRE is reset, the backup
- *   regulator is switched off. The backup SRAM can still be used but its content will
- *   be lost in the Standby and VBAT modes. Once set, the application must wait that
- *   the Backup Regulator Ready flag (BRR) is set to indicate that the data written
- *   into the RAM will be maintained in the Standby and VBAT modes.
+ *   regulator is switched off. The backup SRAM can still be used but its content
+ *   will be lost in the Standby and VBAT modes. Once set, the application must wait
+ *   that the Backup Regulator Ready flag (BRR) is set to indicate that the data
+ *   written into the RAM will be maintained in the Standby and VBAT modes.
  *
  * Input Parameters:
  *   region - state to set it to
@@ -278,8 +278,7 @@ void stm32_pwr_disablepvd(void);
  *
  ************************************************************************************/
 
-#if defined(CONFIG_STM32_STM32F427) || defined(CONFIG_STM32_STM32F429) || \
-    defined(CONFIG_STM32_STM32F446) || defined(CONFIG_STM32_STM32F469)
+#if defined(CONFIG_STM32_HAVE_OVERDRIVE)
 void stm32_pwr_enableoverdrive(bool state);
 #endif
 

--- a/arch/arm/src/stm32/stm32f40xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f40xxx_rcc.c
@@ -41,6 +41,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+
+#include <arch/board/board.h>
+
 #include "chip.h"
 #include "stm32_pwr.h"
 #include "itm_syslog.h"
@@ -755,8 +758,7 @@ static void stm32_stdclockconfig(void)
         {
         }
 
-#if defined(CONFIG_STM32_STM32F429) || defined(CONFIG_STM32_STM32F446) || \
-    defined(CONFIG_STM32_STM32F469)
+#if defined(CONFIG_STM32_HAVE_OVERDRIVE) && (STM32_SYSCLK_FREQUENCY > 168000000)
 
       /* Enable the Over-drive to extend the clock frequency to 180 MHz */
 


### PR DESCRIPTION
## Summary
Some MCUs of the STM32F4 family have the ability to operate up to 180MHz, but only if core over-drive is enabled.
The current code indeed enables the core over-drive, but not for all MCUs that need it.

The MCUs in need of over-drive to reach their maximum clock are:
STM32F427
STM32F429
STM32F437
STM32F439
STM32F446
STM32F469
STM32F479

## Impact
For some of the aforementioned MCUs, core over-drive was not enabled, resulting in invalid clocking configuration.
Unfortunately as tested, at least on my board, the MCU happily accepted 180MHz without over-drive enabled and worked OK.
Thus it is very possible that many users of this chip are not aware of this miss-configuration. The chip though may be unstable in certain conditions.

## Testing
Tested on a custom board, using an STM32F427VI.
After the change, the respective code is indeed enabled. After boot, the core over-drive is enabled as it should, checked by the respective register value.
