### PR TITLE
arm_createstack.c: Save tcb->adj_stack_size without tls overhead.

### DIFF
--- a/arch/arm/src/common/arm_createstack.c
+++ b/arch/arm/src/common/arm_createstack.c
@@ -218,7 +218,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       arm_stack_color((FAR void *)((uintptr_t)tcb->adj_stack_ptr -
           tcb->adj_stack_size), tcb->adj_stack_size);
-
 #endif /* CONFIG_STACK_COLORATION */
 
       board_autoled_on(LED_STACKCREATED);

--- a/arch/arm/src/common/arm_createstack.c
+++ b/arch/arm/src/common/arm_createstack.c
@@ -190,10 +190,11 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      /* The ARM uses a push-down stack:  the stack grows toward lower
-       * addresses in memory.  The stack pointer register, points to
-       * the lowest, valid work address (the "top" of the stack).  Items
-       * on the stack are referenced as positive word offsets from sp.
+      /* The ARM uses a "full descending" stack:
+       * the stack grows toward lower addresses in memory.
+       * The stack pointer register points to the last pushed item in
+       * the stack.
+       * Items on the stack are referenced as positive word offsets from sp.
        */
 
       /* Since both stack_alloc_ptr and alloc_size are in

--- a/arch/arm/src/common/arm_usestack.c
+++ b/arch/arm/src/common/arm_usestack.c
@@ -137,7 +137,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
       memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
-    #ifdef CONFIG_STACK_COLORATION
+#ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a
        * recognizable value that we can use later to test for high
        * water marks.
@@ -145,8 +145,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
       arm_stack_color((FAR void *)((uintptr_t)tcb->adj_stack_ptr -
           tcb->adj_stack_size), tcb->adj_stack_size);
-
-    #endif /* CONFIG_STACK_COLORATION */
+#endif /* CONFIG_STACK_COLORATION */
 
       return OK;
     }

--- a/arch/arm/src/common/arm_vfork.c
+++ b/arch/arm/src/common/arm_vfork.c
@@ -126,12 +126,9 @@ pid_t up_vfork(const struct vfork_s *context)
 
   sinfo("TCBs: Parent=%p Child=%p\n", parent, child);
 
-  /* Get the size of the parent task's stack.  Due to alignment operations,
-   * the adjusted stack size may be smaller than the stack size originally
-   * requested.
-   */
+  /* Get the size of the parent task's stack. */
 
-  stacksize = parent->adj_stack_size + CONFIG_STACK_ALIGNMENT - 1;
+  stacksize = parent->adj_stack_size;
 
   /* Allocate the stack for the TCB */
 


### PR DESCRIPTION
## Summary
The adjusted stack size should be without task local storage overhead.
## Impact
E.g. external tools for task aware debugging are using adjusted stack size for stack debugging (stack coloration).
They interpret tls as used stack.
## Testing
Tested with Kinetis Freedom-K28f and Lauterbach Trace32 NuttX awareness.
I searched the source code for possible side effects of the change but found none. According to documentation the variable adj_stack_size is only there for debugging purposes. (Please correct me if I'm wrong).
