### PR TITLE
sched/wdog: Remove MAX_WDOGPARMS and related stuff

### DIFF
--- a/Documentation/NuttxPortingGuide.html
+++ b/Documentation/NuttxPortingGuide.html
@@ -2838,7 +2838,7 @@ int up_timer_start(FAR const struct timespec *ts);
 <pre>
     #include &lt;nuttx/wdog.h&gt;
     int wd_start(FAR struct wdog_s *wdog, int delay,
-                 wdentry_t wdentry, int argc, ....);
+                 wdentry_t wdentry, wdparm_t arg);
 </pre>
 
 <p>
@@ -2860,11 +2860,10 @@ wd_start() on a given watchdog ID has any effect.
 <li><code>wdog</code>. Watchdog ID
 <li><code>delay</code>. Delay count in clock ticks
 <li><code>wdentry</code>. Function to call on timeout
-<li><code>argc</code>.  The number of uint32_t parameters to pass to wdentry.
-<li><code>...</code>. uint32_t size parameters to pass to wdentry
+<li><code>arg</code>. The parameter to pass to wdentry.
 
 <p>
-<b>NOTE</b>:  All parameters must be of type <code>wdparm_t</code>.
+<b>NOTE</b>:  The parameter must be of type <code>wdparm_t</code>.
 </p>
 </ul>
 
@@ -2955,24 +2954,14 @@ VxWorks provides the following comparable interface:
   When a watchdog expires, the callback function with this type is called:
 </p>
 <pre>
-    typedef void (*wdentry_t)(int argc, wdparm_t arg1, ...);
+    typedef void (*wdentry_t)(wdparm_t arg);
 </pre>
 <p>
-  Where <code>argc</code> is the number of <code>wdparm_t</code> type arguments that follow.
-</p>
-<p>
-  The arguments are passed as scalar <code>wdparm_t</code> values.  For systems where the <code>sizeof(pointer) &lt; sizeof(uint32_t)</code>, the following union defines the alignment of the pointer within the <code>uint32_t</code>.  For example, the SDCC MCS51 general pointer is 24-bits, but <code>uint32_t</code> is 32-bits (of course).
+  The argument is passed as scalar <code>wdparm_t</code> values.  For systems where the <code>sizeof(pointer) &lt; sizeof(uint32_t)</code>, the following union defines the alignment of the pointer within the <code>uint32_t</code>.  For example, the SDCC MCS51 general pointer is 24-bits, but <code>uint32_t</code> is 32-bits (of course).
 </p>
    We always have <code>sizeof(pointer) <= sizeof(uintptr_t)</code> by definition.
 </p>
 <ul><pre>
-union wdparm_u
-{
-  FAR void     *pvarg; /* The size one generic point */
-  uint32_t      dwarg; /* Big enough for a 32-bit value in any case */
-  uintptr_t     uiarg; /* sizeof(uintptr_t) >= sizeof(pointer) */
-};
-
 #if UINTPTR_MAX >= UINT32_MAX
 typedef uintptr_t wdparm_t;
 #else

--- a/arch/arm/src/c5471/c5471_ethernet.c
+++ b/arch/arm/src/c5471/c5471_ethernet.c
@@ -416,10 +416,10 @@ static int  c5471_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void c5471_txtimeout_work(FAR void *arg);
-static void c5471_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void c5471_txtimeout_expiry(wdparm_t arg);
 
 static void c5471_poll_work(FAR void *arg);
-static void c5471_poll_expiry(int argc, wdparm_t arg, ...);
+static void c5471_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1012,7 +1012,7 @@ static int c5471_transmit(struct c5471_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->c_txtimeout, C5471_TXTIMEOUT,
-           c5471_txtimeout_expiry, 1, (wdparm_t)priv);
+           c5471_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -1762,8 +1762,7 @@ static void c5471_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1773,7 +1772,7 @@ static void c5471_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void c5471_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void c5471_txtimeout_expiry(wdparm_t arg)
 {
   struct c5471_driver_s *priv = (struct c5471_driver_s *)arg;
 
@@ -1828,8 +1827,8 @@ static void c5471_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->c_txpoll, C5471_WDDELAY, c5471_poll_expiry, 1,
-           (wdparm_t)priv);
+  wd_start(&priv->c_txpoll, C5471_WDDELAY,
+           c5471_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1840,8 +1839,7 @@ static void c5471_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1851,7 +1849,7 @@ static void c5471_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void c5471_poll_expiry(int argc, wdparm_t arg, ...)
+static void c5471_poll_expiry(wdparm_t arg)
 {
   struct c5471_driver_s *priv = (struct c5471_driver_s *)arg;
 
@@ -1915,8 +1913,8 @@ static int c5471_ifup(struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->c_txpoll, C5471_WDDELAY, c5471_poll_expiry,
-           1, (wdparm_t)priv);
+  wd_start(&priv->c_txpoll, C5471_WDDELAY,
+           c5471_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/arch/arm/src/cxd56xx/cxd56_i2c.c
+++ b/arch/arm/src/cxd56xx/cxd56_i2c.c
@@ -162,13 +162,13 @@ static int cxd56_i2c_disable(struct cxd56_i2cdev_s *priv);
 static void cxd56_i2c_enable(struct cxd56_i2cdev_s *priv);
 
 static int  cxd56_i2c_interrupt(int irq, FAR void *context, FAR void *arg);
-static void cxd56_i2c_timeout(int argc, wdparm_t arg, ...);
+static void cxd56_i2c_timeout(wdparm_t arg);
 static void cxd56_i2c_setfrequency(struct cxd56_i2cdev_s *priv,
                                    uint32_t frequency);
 static int  cxd56_i2c_transfer(FAR struct i2c_master_s *dev,
                                FAR struct i2c_msg_s *msgs, int count);
 #ifdef CONFIG_I2C_RESET
-static int cxd56_i2c_reset(FAR struct i2c_master_s * dev);
+static int cxd56_i2c_reset(FAR struct i2c_master_s *dev);
 #endif
 #if defined(CONFIG_CXD56_I2C0_SCUSEQ) || defined(CONFIG_CXD56_I2C1_SCUSEQ)
 static int  cxd56_i2c_transfer_scu(FAR struct i2c_master_s *dev,
@@ -383,7 +383,7 @@ static void cxd56_i2c_setfrequency(struct cxd56_i2cdev_s *priv,
  *
  ****************************************************************************/
 
-static void cxd56_i2c_timeout(int argc, wdparm_t arg, ...)
+static void cxd56_i2c_timeout(wdparm_t arg)
 {
   struct cxd56_i2cdev_s *priv = (struct cxd56_i2cdev_s *)arg;
   irqstate_t flags            = enter_critical_section();
@@ -551,7 +551,7 @@ static int cxd56_i2c_receive(struct cxd56_i2cdev_s *priv, int last)
 
       flags = enter_critical_section();
       wd_start(&priv->timeout, I2C_TIMEOUT,
-              cxd56_i2c_timeout, 1, (wdparm_t)priv);
+               cxd56_i2c_timeout, (wdparm_t)priv);
 
       /* Set stop flag for indicate the last data */
 
@@ -597,7 +597,7 @@ static int cxd56_i2c_send(struct cxd56_i2cdev_s *priv, int last)
 
   flags = enter_critical_section();
   wd_start(&priv->timeout, I2C_TIMEOUT,
-           cxd56_i2c_timeout, 1, (wdparm_t)priv);
+           cxd56_i2c_timeout, (wdparm_t)priv);
   i2c_reg_write(priv, CXD56_IC_DATA_CMD,
                 (uint32_t)msg->buffer[i] | (last ? CMD_STOP : 0));
 

--- a/arch/arm/src/cxd56xx/cxd56_icc.c
+++ b/arch/arm/src/cxd56xx/cxd56_icc.c
@@ -307,7 +307,7 @@ static int icc_msghandler(int cpuid, int protoid, uint32_t pdata,
   return -1;
 }
 
-static void icc_rxtimeout(int argc, wdparm_t arg, ...)
+static void icc_rxtimeout(wdparm_t arg)
 {
   FAR struct iccdev_s *priv = (FAR struct iccdev_s *)arg;
   icc_semgive(&priv->rxwait);
@@ -338,7 +338,7 @@ static int icc_recv(FAR struct iccdev_s *priv, FAR iccmsg_t *msg, int32_t ms)
     {
       int32_t timo;
       timo = ms * 1000 / CONFIG_USEC_PER_TICK;
-      wd_start(&priv->rxtimeout, timo, icc_rxtimeout, 1, (wdparm_t)priv);
+      wd_start(&priv->rxtimeout, timo, icc_rxtimeout, (wdparm_t)priv);
 
       icc_semtake(&priv->rxwait);
 

--- a/arch/arm/src/cxd56xx/cxd56_rtc.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc.c
@@ -250,7 +250,7 @@ static int cxd56_rtc_interrupt(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void cxd56_rtc_initialize(int argc, ...)
+static void cxd56_rtc_initialize(wdparm_t arg)
 {
   struct timespec ts;
 #ifdef CONFIG_CXD56_RTC_LATEINIT
@@ -274,7 +274,7 @@ static void cxd56_rtc_initialize(int argc, ...)
           rtcinfo("retry count: %d\n", s_retry);
 
           if (OK == wd_start(&s_wdog, MSEC2TICK(RTC_CLOCK_CHECK_INTERVAL),
-                             (wdentry_t)cxd56_rtc_initialize, 0))
+                             cxd56_rtc_initialize, 0))
             {
               /* Again, this function is called recursively */
 
@@ -355,7 +355,7 @@ static void cxd56_rtc_initialize(int argc, ...)
 
 int up_rtc_initialize(void)
 {
-  cxd56_rtc_initialize(1, (wdparm_t)NULL);
+  cxd56_rtc_initialize(1, NULL);
   return OK;
 }
 

--- a/arch/arm/src/cxd56xx/cxd56_sdhci.c
+++ b/arch/arm/src/cxd56xx/cxd56_sdhci.c
@@ -359,7 +359,7 @@ static void cxd56_datadisable(void);
 static void cxd56_transmit(struct cxd56_sdiodev_s *priv);
 static void cxd56_receive(struct cxd56_sdiodev_s *priv);
 #endif
-static void cxd56_eventtimeout(int argc, wdparm_t arg, ...);
+static void cxd56_eventtimeout(wdparm_t arg);
 static void cxd56_endwait(struct cxd56_sdiodev_s *priv,
               sdio_eventset_t wkupevent);
 static void cxd56_endtransfer(struct cxd56_sdiodev_s *priv,
@@ -960,8 +960,7 @@ static void cxd56_receive(struct cxd56_sdiodev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -971,11 +970,11 @@ static void cxd56_receive(struct cxd56_sdiodev_s *priv)
  *
  ****************************************************************************/
 
-static void cxd56_eventtimeout(int argc, wdparm_t arg, ...)
+static void cxd56_eventtimeout(wdparm_t arg)
 {
   struct cxd56_sdiodev_s *priv = (struct cxd56_sdiodev_s *)arg;
 
-  DEBUGASSERT(argc == 1 && priv != NULL);
+  DEBUGASSERT(priv != NULL);
   DEBUGASSERT((priv->waitevents & SDIOWAIT_TIMEOUT) != 0);
 
   /* Is a data transfer complete event expected? */
@@ -2590,7 +2589,7 @@ static sdio_eventset_t cxd56_sdio_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       cxd56_eventtimeout, 1, (wdparm_t)priv);
+                       cxd56_eventtimeout, (wdparm_t)priv);
       if (ret != OK)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/efm32/efm32_spi.c
+++ b/arch/arm/src/efm32/efm32_spi.c
@@ -161,7 +161,7 @@ static void      spi_wait_status(const struct efm32_spiconfig_s *config,
 /* DMA support */
 
 #ifdef CONFIG_EFM32_SPI_DMA
-static void      spi_dma_timeout(int argc, wdparm_t arg1, ...);
+static void      spi_dma_timeout(wdparm_t arg);
 static void      spi_dmarxwait(struct efm32_spidev_s *priv);
 static void      spi_dmatxwait(struct efm32_spidev_s *priv);
 static inline void spi_dmarxwakeup(struct efm32_spidev_s *priv);
@@ -407,9 +407,9 @@ static void spi_wait_status(const struct efm32_spiconfig_s *config,
  ****************************************************************************/
 
 #ifdef CONFIG_EFM32_SPI_DMA
-static void spi_dma_timeout(int argc, wdparm_t arg1, ...)
+static void spi_dma_timeout(wdparm_t arg)
 {
-  struct efm32_spidev_s *priv = (struct efm32_spidev_s *)((uintptr_t)arg1);
+  struct efm32_spidev_s *priv = (struct efm32_spidev_s *)arg;
 
   /* Mark DMA timeout error and wakeup form RX and TX waiters */
 
@@ -1465,8 +1465,8 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
        * when both RX and TX transfers complete.
        */
 
-      ret = wd_start(&priv->wdog, (int)ticks,
-                     spi_dma_timeout, 1, (wdparm_t)priv);
+      ret = wd_start(&priv->wdog, ticks,
+                     spi_dma_timeout, (wdparm_t)priv);
       if (ret < 0)
         {
           spierr("ERROR: Failed to start timeout: %d\n", ret);

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -336,10 +336,10 @@ static int  imxrt_enet_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void imxrt_txtimeout_work(FAR void *arg);
-static void imxrt_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void imxrt_txtimeout_expiry(wdparm_t arg);
 
 static void imxrt_poll_work(FAR void *arg);
-static void imxrt_polltimer_expiry(int argc, wdparm_t arg, ...);
+static void imxrt_polltimer_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -566,7 +566,7 @@ static int imxrt_transmit(FAR struct imxrt_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, IMXRT_TXTIMEOUT,
-           imxrt_txtimeout_expiry, 1, (wdparm_t)priv);
+           imxrt_txtimeout_expiry, (wdparm_t)priv);
 
   /* Start the TX transfer (if it was not already waiting for buffers) */
 
@@ -1171,8 +1171,7 @@ static void imxrt_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1182,7 +1181,7 @@ static void imxrt_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void imxrt_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void imxrt_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct imxrt_driver_s *priv = (FAR struct imxrt_driver_s *)arg;
 
@@ -1240,7 +1239,7 @@ static void imxrt_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again in any case */
 
   wd_start(&priv->txpoll, IMXRT_WDDELAY,
-           imxrt_polltimer_expiry, 1, (wdparm_t)priv);
+           imxrt_polltimer_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1251,8 +1250,7 @@ static void imxrt_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1262,7 +1260,7 @@ static void imxrt_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void imxrt_polltimer_expiry(int argc, wdparm_t arg, ...)
+static void imxrt_polltimer_expiry(wdparm_t arg)
 {
   FAR struct imxrt_driver_s *priv = (FAR struct imxrt_driver_s *)arg;
 
@@ -1372,7 +1370,7 @@ static int imxrt_ifup_action(struct net_driver_s *dev, bool resetphy)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, IMXRT_WDDELAY,
-           imxrt_polltimer_expiry, 1, (wdparm_t)priv);
+           imxrt_polltimer_expiry, (wdparm_t)priv);
 
   /* Clear all pending ENET interrupt */
 

--- a/arch/arm/src/imxrt/imxrt_usdhc.c
+++ b/arch/arm/src/imxrt/imxrt_usdhc.c
@@ -288,7 +288,7 @@ static void imxrt_transmit(struct imxrt_dev_s *priv);
 static void imxrt_receive(struct imxrt_dev_s *priv);
 #endif
 
-static void imxrt_eventtimeout(int argc, wdparm_t arg, ...);
+static void imxrt_eventtimeout(wdparm_t arg);
 static void imxrt_endwait(struct imxrt_dev_s *priv,
               sdio_eventset_t wkupevent);
 static void imxrt_endtransfer(struct imxrt_dev_s *priv,
@@ -1006,8 +1006,7 @@ static void imxrt_receive(struct imxrt_dev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1017,11 +1016,11 @@ static void imxrt_receive(struct imxrt_dev_s *priv)
  *
  ****************************************************************************/
 
-static void imxrt_eventtimeout(int argc, wdparm_t arg, ...)
+static void imxrt_eventtimeout(wdparm_t arg)
 {
   struct imxrt_dev_s *priv = (struct imxrt_dev_s *)arg;
 
-  DEBUGASSERT(argc == 1 && priv != NULL);
+  DEBUGASSERT(priv != NULL);
   DEBUGASSERT((priv->waitevents & SDIOWAIT_TIMEOUT) != 0);
 
   /* Is a data transfer complete event expected? */
@@ -2709,7 +2708,7 @@ static sdio_eventset_t imxrt_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret = wd_start(&priv->waitwdog, delay,
-                     imxrt_eventtimeout, 1, (wdparm_t)priv);
+                     imxrt_eventtimeout, (wdparm_t)priv);
 
       if (ret < 0)
         {

--- a/arch/arm/src/kinetis/hardware/kinetis_usbhs.h
+++ b/arch/arm/src/kinetis/hardware/kinetis_usbhs.h
@@ -770,8 +770,8 @@
 
 /* USB PHY General Control Register */
 
-#define USBPHY_CTRLn_SFTRST                               (1 << 31) /* Bit 31: Soft-reset the USBPHY_PWD, USBPHY_TX, USBPHY_RX, and USBPHY_CTRL */
-#define USBPHY_CTRLn_CLKGATE                              (1 << 30) /* Bit 30: Gate UTMI Clocks */
+#define USBPHY_CTRLN_SFTRST                               (1 << 31) /* Bit 31: Soft-reset the USBPHY_PWD, USBPHY_TX, USBPHY_RX, and USBPHY_CTRL */
+#define USBPHY_CTRLN_CLKGATE                              (1 << 30) /* Bit 30: Gate UTMI Clocks */
 #define USBPHY_CTRLn_UTMI_SUSPENDM                        (1 << 29) /* Bit 29: Indicats powered-down state */
 #define USBPHY_CTRLn_HOST_FORCE_LS_SE0                    (1 << 28) /* Bit 28: Forces next FS packet tohave a EOP with low-speed timing */
 #define USBPHY_CTRLn_OTG_ID_VALUE                         (1 << 27) /* Bit 27: Indicates the results of USB_ID pin  */
@@ -782,8 +782,8 @@
 #define USBPHY_CTRLn_ENAUTOCLR_CLKGATE                    (1 << 19) /* Bit 19: Auto-clear the CLKGATE bit if wakeup event while suspended */
 #define USBPHY_CTRLn_AUTORESUME_EN                        (1 << 18) /* Bit 18: Auto resume, HW will send Resume to respond to the device remote wakeup */
                                                                     /* Bit 16-17: Reserved */
-#define USBPHY_CTRLn_ENUTMILEVEL3                         (1 << 15) /* Bit 15: Enables UTMI+ Level 3 operation for the USB HS PHY */
-#define USBPHY_CTRLn_ENUTMILEVEL2                         (1 << 14) /* Bit 14: Enables UTMI+ Level 2 operation for the USB HS PHY */
+#define USBPHY_CTRLN_ENUTMILEVEL3                         (1 << 15) /* Bit 15: Enables UTMI+ Level 3 operation for the USB HS PHY */
+#define USBPHY_CTRLN_ENUTMILEVEL2                         (1 << 14) /* Bit 14: Enables UTMI+ Level 2 operation for the USB HS PHY */
                                                                     /* Bit 13: Reserved */
 #define USBPHY_CTRLn_DEVPLUGIN_IRQ                        (1 << 12) /* Bit 12: Indicates device is connected */
                                                                     /* Bits 5-11: Reserved */
@@ -855,21 +855,21 @@
 
 /* USB PHY PLL Control/Status Register */
 
-#define USBPHY_PLL_SICn_PLL_LOCK                          (1 << 31) /* Bit 31: USB PLL lock status indicator */
+#define USBPHY_PLL_SICN_PLL_LOCK                          (1 << 31) /* Bit 31: USB PLL lock status indicator */
                                                                     /* Bits 17-30: Reserved */
-#define USBPHY_PLL_SICn_PLL_BYPASS                        (1 << 16) /* Bit 16: Bypass the USB PLL */
+#define USBPHY_PLL_SICN_PLL_BYPASS                        (1 << 16) /* Bit 16: Bypass the USB PLL */
                                                                     /* Bits 14-15: Reserved */
 #define USBPHY_PLL_SICn_PLL_ENABLE                        (1 << 13) /* Bit 13: Enable the clock output from the USB PLL */
-#define USBPHY_PLL_SICn_PLL_POWER                         (1 << 12) /* Bit 12: Power up the USB PLL */
+#define USBPHY_PLL_SICN_PLL_POWER                         (1 << 12) /* Bit 12: Power up the USB PLL */
 #define USBPHY_PLL_SICn_PLL_HOLD_RING_OFF                 (1 << 11) /* Bit 11: Analog debug bit */
                                                                     /* Bits 7-10: Reserved */
-#define USBPHY_PLL_SICn_PLL_EN_USB_CLKS                   (1 << 6)  /* Bit 6:  Enable the USB clock output from the USB PHY PLL */
+#define USBPHY_PLL_SICN_PLL_EN_USB_CLKS                   (1 << 6)  /* Bit 6:  Enable the USB clock output from the USB PHY PLL */
                                                                     /* Bits 2-5: Reserved */
 #define USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT                 (0)       /* Bits 0-4: Controls the USB PLL feedback loop divider */
-#define USBPHY_PLL_SICn_PLL_DIV_SEL_MASK                  (0x1f << USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT)
-#  define USBPHY_PLL_SICn_PLL_DIV_SEL_24MHZ               (0 << USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT) /* 24Mhz XTAL */
-#  define USBPHY_PLL_SICn_PLL_DIV_SEL_16MHZ               (1 << USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT) /* 16Mhz XTAL */
-#  define USBPHY_PLL_SICn_PLL_DIV_SEL_12MHZ               (2 << USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT) /* 12Mhz XTAL */
+#define USBPHY_PLL_SICN_PLL_DIV_SEL_MASK                  (0x1f << USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT)
+#  define USBPHY_PLL_SICN_PLL_DIV_SEL_24MHZ               (0 << USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT) /* 24Mhz XTAL */
+#  define USBPHY_PLL_SICN_PLL_DIV_SEL_16MHZ               (1 << USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT) /* 16Mhz XTAL */
+#  define USBPHY_PLL_SICN_PLL_DIV_SEL_12MHZ               (2 << USBPHY_PLL_SICn_PLL_DIV_SEL_SHIFT) /* 12Mhz XTAL */
 
 /* USB PHY VBUS Detect Control Register */
 
@@ -968,6 +968,6 @@
 #define USBPHY_TRIM_OVERRIDE_ENn_TRIM_TX_CAL45DP_OVERRIDE           (1 << 3)  /* Bit 3:  Override enable for TX_CAL45DP */
 #define USBPHY_TRIM_OVERRIDE_ENn_TRIM_TX_D_CAL_OVERRIDE             (1 << 2)  /* Bit 2:  Override enable for TX_D_CAL */
 #define USBPHY_TRIM_OVERRIDE_ENn_TRIM_ENV_TAIL_ADJ_VD_OVERRIDE      (1 << 1)  /* Bit 1:  Override enable for ENV_TAIL_ADJ */
-#define USBPHY_TRIM_OVERRIDE_ENn_TRIM_DIV_SEL_OVERRIDE              (1 << 0)  /* Bit 0:  Override enable for PLL_DIV_SEL */
+#define USBPHY_TRIM_OVERRIDE_ENN_TRIM_DIV_SEL_OVERRIDE              (1 << 0)  /* Bit 0:  Override enable for PLL_DIV_SEL */
 
 #endif /* __ARCH_ARM_SRC_KINETIS_HARDWARE_KINETIS_USBHS_H */

--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -306,10 +306,10 @@ static int  kinetis_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void kinetis_txtimeout_work(FAR void *arg);
-static void kinetis_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void kinetis_txtimeout_expiry(wdparm_t arg);
 
 static void kinetis_poll_work(FAR void *arg);
-static void kinetis_polltimer_expiry(int argc, wdparm_t arg, ...);
+static void kinetis_polltimer_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -521,7 +521,7 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, KINETIS_TXTIMEOUT,
-           kinetis_txtimeout_expiry, 1, (wdparm_t)priv);
+           kinetis_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -1031,8 +1031,7 @@ static void kinetis_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1042,7 +1041,7 @@ static void kinetis_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void kinetis_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void kinetis_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct kinetis_driver_s *priv = (FAR struct kinetis_driver_s *)arg;
 
@@ -1101,7 +1100,7 @@ static void kinetis_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again in any case */
 
   wd_start(&priv->txpoll, KINETIS_WDDELAY,
-           kinetis_polltimer_expiry, 1, (wdparm_t)priv);
+           kinetis_polltimer_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1112,8 +1111,7 @@ static void kinetis_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1123,7 +1121,7 @@ static void kinetis_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void kinetis_polltimer_expiry(int argc, wdparm_t arg, ...)
+static void kinetis_polltimer_expiry(wdparm_t arg)
 {
   FAR struct kinetis_driver_s *priv = (FAR struct kinetis_driver_s *)arg;
 
@@ -1244,7 +1242,7 @@ static int kinetis_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, KINETIS_WDDELAY,
-           kinetis_polltimer_expiry, 1, (wdparm_t)priv);
+           kinetis_polltimer_expiry, (wdparm_t)priv);
 
   putreg32(0, KINETIS_ENET_EIMR);
 

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -519,7 +519,7 @@ static int  kinetis_flexcan_interrupt(int irq, FAR void *context,
 /* Watchdog timer expirations */
 #ifdef TX_TIMEOUT_WQ
 static void kinetis_txtimeout_work(FAR void *arg);
-static void kinetis_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void kinetis_txtimeout_expiry(wdparm_t arg);
 #endif
 
 /* NuttX callback functions */
@@ -752,7 +752,7 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
   if (timeout > 0)
     {
       wd_start(&priv->txtimeout[mbi], timeout + 1,
-               kinetis_txtimeout_expiry, 1, (wdparm_t)priv);
+               kinetis_txtimeout_expiry, (wdparm_t)priv);
     }
 #endif
 
@@ -1131,8 +1131,7 @@ static void kinetis_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1142,12 +1141,11 @@ static void kinetis_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void kinetis_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void kinetis_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct kinetis_driver_s *priv = (FAR struct kinetis_driver_s *)arg;
 
-  /* Schedule to perform the TX timeout processing on the worker thread
-   */
+  /* Schedule to perform the TX timeout processing on the worker thread */
 
   work_queue(CANWORK, &priv->irqwork, kinetis_txtimeout_work, priv, 0);
 }

--- a/arch/arm/src/kinetis/kinetis_i2c.c
+++ b/arch/arm/src/kinetis/kinetis_i2c.c
@@ -171,7 +171,7 @@ static void kinetis_i2c_setfrequency(struct kinetis_i2cdev_s *priv,
 static int  kinetis_i2c_start(struct kinetis_i2cdev_s *priv);
 static void kinetis_i2c_stop(struct kinetis_i2cdev_s *priv);
 static int kinetis_i2c_interrupt(int irq, void *context, void *arg);
-static void kinetis_i2c_timeout(int argc, wdparm_t arg, ...);
+static void kinetis_i2c_timeout(wdparm_t arg);
 static void kinetis_i2c_setfrequency(struct kinetis_i2cdev_s *priv,
                                      uint32_t frequency);
 
@@ -901,7 +901,7 @@ static void kinetis_i2c_stop(struct kinetis_i2cdev_s *priv)
  *
  ****************************************************************************/
 
-static void kinetis_i2c_timeout(int argc, wdparm_t arg, ...)
+static void kinetis_i2c_timeout(wdparm_t arg)
 {
   struct kinetis_i2cdev_s *priv = (struct kinetis_i2cdev_s *)arg;
 
@@ -1223,7 +1223,7 @@ static int kinetis_i2c_transfer(struct i2c_master_s *dev,
       /* Wait for transfer complete */
 
       wd_start(&priv->timeout, I2C_TIMEOUT,
-               kinetis_i2c_timeout, 1, (wdparm_t)priv);
+               kinetis_i2c_timeout, (wdparm_t)priv);
       kinetis_i2c_wait(priv);
 
       wd_cancel(&priv->timeout);

--- a/arch/arm/src/kinetis/kinetis_sdhc.c
+++ b/arch/arm/src/kinetis/kinetis_sdhc.c
@@ -264,7 +264,7 @@ static void kinetis_datadisable(void);
 static void kinetis_transmit(struct kinetis_dev_s *priv);
 static void kinetis_receive(struct kinetis_dev_s *priv);
 #endif
-static void kinetis_eventtimeout(int argc, wdparm_t arg, ...);
+static void kinetis_eventtimeout(wdparm_t arg);
 static void kinetis_endwait(struct kinetis_dev_s *priv,
               sdio_eventset_t wkupevent);
 static void kinetis_endtransfer(struct kinetis_dev_s *priv,
@@ -923,8 +923,7 @@ static void kinetis_receive(struct kinetis_dev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -934,11 +933,11 @@ static void kinetis_receive(struct kinetis_dev_s *priv)
  *
  ****************************************************************************/
 
-static void kinetis_eventtimeout(int argc, wdparm_t arg, ...)
+static void kinetis_eventtimeout(wdparm_t arg)
 {
   struct kinetis_dev_s *priv = (struct kinetis_dev_s *)arg;
 
-  DEBUGASSERT(argc == 1 && priv != NULL);
+  DEBUGASSERT(priv != NULL);
   DEBUGASSERT((priv->waitevents & SDIOWAIT_TIMEOUT) != 0);
 
   /* Is a data transfer complete event expected? */
@@ -2507,7 +2506,7 @@ static sdio_eventset_t kinetis_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       kinetis_eventtimeout, 1, (wdparm_t)priv);
+                       kinetis_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/kinetis/kinetis_usbdev.c
+++ b/arch/arm/src/kinetis/kinetis_usbdev.c
@@ -547,7 +547,7 @@ static void   khci_epwrite(struct khci_ep_s *privep,
                 const uint8_t *src, uint32_t nbytes);
 static void   khci_wrcomplete(struct khci_usbdev_s *priv,
                 struct khci_ep_s *privep);
-static void   khci_rqrestart(int argc, wdparm_t arg1, ...);
+static void   khci_rqrestart(wdparm_t arg);
 static void   khci_delayedrestart(struct khci_usbdev_s *priv,
                 uint8_t epno);
 static void   khci_rqstop(struct khci_ep_s *privep);
@@ -1050,7 +1050,7 @@ static void khci_wrcomplete(struct khci_usbdev_s *priv,
  * Name: khci_rqrestart
  ******************************************************************************************/
 
-static void khci_rqrestart(int argc, wdparm_t arg1, ...)
+static void khci_rqrestart(wdparm_t arg)
 {
   struct khci_usbdev_s *priv;
   struct khci_ep_s *privep;
@@ -1061,7 +1061,7 @@ static void khci_rqrestart(int argc, wdparm_t arg1, ...)
 
   /* Recover the pointer to the driver structure */
 
-  priv = (struct khci_usbdev_s *)((uintptr_t)arg1);
+  priv = (struct khci_usbdev_s *)arg;
   DEBUGASSERT(priv != NULL);
 
   /* Sample and clear the set of endpoints that have recovered from a stall */
@@ -1119,7 +1119,7 @@ static void khci_delayedrestart(struct khci_usbdev_s *priv, uint8_t epno)
   /* And start (or re-start) the watchdog timer */
 
   wd_start(&priv->wdog, RESTART_DELAY,
-           khci_rqrestart, 1, (wdparm_t)priv);
+           khci_rqrestart, (wdparm_t)priv);
 }
 
 /******************************************************************************************

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -382,10 +382,10 @@ static int  lpc17_40_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void lpc17_40_txtimeout_work(FAR void *arg);
-static void lpc17_40_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void lpc17_40_txtimeout_expiry(wdparm_t arg);
 
 static void lpc17_40_poll_work(FAR void *arg);
-static void lpc17_40_poll_expiry(int argc, wdparm_t arg, ...);
+static void lpc17_40_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -702,7 +702,7 @@ static int lpc17_40_transmit(struct lpc17_40_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->lp_txtimeout, LPC17_40_TXTIMEOUT,
-           lpc17_40_txtimeout_expiry, 1, (wdparm_t)priv);
+           lpc17_40_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -1419,8 +1419,7 @@ static void lpc17_40_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1430,7 +1429,7 @@ static void lpc17_40_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void lpc17_40_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void lpc17_40_txtimeout_expiry(wdparm_t arg)
 {
   struct lpc17_40_driver_s *priv = (struct lpc17_40_driver_s *)arg;
 
@@ -1510,7 +1509,7 @@ static void lpc17_40_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->lp_txpoll, LPC17_40_WDDELAY,
-           lpc17_40_poll_expiry, 1, (wdparm_t)priv);
+           lpc17_40_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1521,8 +1520,7 @@ static void lpc17_40_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1532,7 +1530,7 @@ static void lpc17_40_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void lpc17_40_poll_expiry(int argc, wdparm_t arg, ...)
+static void lpc17_40_poll_expiry(wdparm_t arg)
 {
   FAR struct lpc17_40_driver_s *priv = (FAR struct lpc17_40_driver_s *)arg;
 
@@ -1765,7 +1763,7 @@ static int lpc17_40_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->lp_txpoll, LPC17_40_WDDELAY,
-           lpc17_40_poll_expiry, 1, (wdparm_t)priv);
+           lpc17_40_poll_expiry, (wdparm_t)priv);
 
   /* Finally, make the interface up and enable the Ethernet interrupt at
    * the interrupt controller

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
@@ -129,7 +129,7 @@ struct lpc17_40_i2cdev_s
 static int  lpc17_40_i2c_start(struct lpc17_40_i2cdev_s *priv);
 static void lpc17_40_i2c_stop(struct lpc17_40_i2cdev_s *priv);
 static int  lpc17_40_i2c_interrupt(int irq, FAR void *context, void *arg);
-static void lpc17_40_i2c_timeout(int argc, wdparm_t arg, ...);
+static void lpc17_40_i2c_timeout(wdparm_t arg);
 static void lpc17_40_i2c_setfrequency(struct lpc17_40_i2cdev_s *priv,
               uint32_t frequency);
 static void lpc17_40_stopnext(struct lpc17_40_i2cdev_s *priv);
@@ -239,7 +239,7 @@ static int lpc17_40_i2c_start(struct lpc17_40_i2cdev_s *priv)
   priv->state = 0x00;
 
   wd_start(&priv->timeout, timeout,
-           lpc17_40_i2c_timeout, 1, (wdparm_t)priv);
+           lpc17_40_i2c_timeout, (wdparm_t)priv);
   nxsem_wait(&priv->wait);
 
   return priv->nmsg;
@@ -273,7 +273,7 @@ static void lpc17_40_i2c_stop(struct lpc17_40_i2cdev_s *priv)
  *
  ****************************************************************************/
 
-static void lpc17_40_i2c_timeout(int argc, wdparm_t arg, ...)
+static void lpc17_40_i2c_timeout(wdparm_t arg)
 {
   struct lpc17_40_i2cdev_s *priv = (struct lpc17_40_i2cdev_s *)arg;
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_sdcard.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_sdcard.c
@@ -347,7 +347,7 @@ static void lpc17_40_dataconfig(uint32_t timeout, uint32_t dlen,
 static void lpc17_40_datadisable(void);
 static void lpc17_40_sendfifo(struct lpc17_40_dev_s *priv);
 static void lpc17_40_recvfifo(struct lpc17_40_dev_s *priv);
-static void lpc17_40_eventtimeout(int argc, wdparm_t arg, ...);
+static void lpc17_40_eventtimeout(wdparm_t arg);
 static void lpc17_40_endwait(struct lpc17_40_dev_s *priv,
               sdio_eventset_t wkupevent);
 static void lpc17_40_endtransfer(struct lpc17_40_dev_s *priv,
@@ -1077,8 +1077,7 @@ static void lpc17_40_recvfifo(struct lpc17_40_dev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1088,7 +1087,7 @@ static void lpc17_40_recvfifo(struct lpc17_40_dev_s *priv)
  *
  ****************************************************************************/
 
-static void lpc17_40_eventtimeout(int argc, wdparm_t arg, ...)
+static void lpc17_40_eventtimeout(wdparm_t arg)
 {
   struct lpc17_40_dev_s *priv = (struct lpc17_40_dev_s *)arg;
 
@@ -2345,7 +2344,7 @@ static sdio_eventset_t lpc17_40_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       lpc17_40_eventtimeout, 1, (wdparm_t)priv);
+                       lpc17_40_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/lpc2378/lpc23xx_i2c.c
+++ b/arch/arm/src/lpc2378/lpc23xx_i2c.c
@@ -135,7 +135,7 @@ struct lpc2378_i2cdev_s
 static int  lpc2378_i2c_start(struct lpc2378_i2cdev_s *priv);
 static void lpc2378_i2c_stop(struct lpc2378_i2cdev_s *priv);
 static int  lpc2378_i2c_interrupt(int irq, FAR void *context, FAR void *arg);
-static void lpc2378_i2c_timeout(int argc, wdparm_t arg, ...);
+static void lpc2378_i2c_timeout(wdparm_t arg);
 static void lpc2378_i2c_setfrequency(struct lpc2378_i2cdev_s *priv,
               uint32_t frequency);
 static void lpc2378_stopnext(struct lpc2378_i2cdev_s *priv);
@@ -221,7 +221,7 @@ static int lpc2378_i2c_start(struct lpc2378_i2cdev_s *priv)
   putreg32(I2C_CONSET_STA, priv->base + I2C_CONSET_OFFSET);
 
   wd_start(&priv->timeout, I2C_TIMEOUT,
-           lpc2378_i2c_timeout, 1, (wdparm_t)priv);
+           lpc2378_i2c_timeout, (wdparm_t)priv);
   nxsem_wait(&priv->wait);
 
   wd_cancel(&priv->timeout);
@@ -256,7 +256,7 @@ static void lpc2378_i2c_stop(struct lpc2378_i2cdev_s *priv)
  *
  ****************************************************************************/
 
-static void lpc2378_i2c_timeout(int argc, wdparm_t arg, ...)
+static void lpc2378_i2c_timeout(wdparm_t arg)
 {
   struct lpc2378_i2cdev_s *priv = (struct lpc2378_i2cdev_s *)arg;
 

--- a/arch/arm/src/lpc31xx/lpc31_i2c.c
+++ b/arch/arm/src/lpc31xx/lpc31_i2c.c
@@ -116,7 +116,7 @@ static struct lpc31_i2cdev_s i2cdevices[2];
 
 static int  i2c_interrupt(int irq, FAR void *context, FAR void *arg);
 static void i2c_progress(struct lpc31_i2cdev_s *priv);
-static void i2c_timeout(int argc, wdparm_t arg, ...);
+static void i2c_timeout(wdparm_t arg);
 static void i2c_hwreset(struct lpc31_i2cdev_s *priv);
 static void i2c_setfrequency(struct lpc31_i2cdev_s *priv,
                              uint32_t frequency);
@@ -424,7 +424,7 @@ out:
  *
  ****************************************************************************/
 
-static void i2c_timeout(int argc, wdparm_t arg, ...)
+static void i2c_timeout(wdparm_t arg)
 {
   struct lpc31_i2cdev_s *priv = (struct lpc31_i2cdev_s *) arg;
 
@@ -515,7 +515,7 @@ static int i2c_transfer(FAR struct i2c_master_s *dev,
 
   /* Start a watchdog to timeout the transfer if the bus is locked up... */
 
-  wd_start(&priv->timeout, I2C_TIMEOUT, i2c_timeout, 1, (wdparm_t)priv);
+  wd_start(&priv->timeout, I2C_TIMEOUT, i2c_timeout, (wdparm_t)priv);
 
   /* Wait for the transfer to complete */
 

--- a/arch/arm/src/lpc43xx/lpc43_ethernet.c
+++ b/arch/arm/src/lpc43xx/lpc43_ethernet.c
@@ -613,10 +613,10 @@ static int  lpc43_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void lpc43_txtimeout_work(FAR void *arg);
-static void lpc43_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void lpc43_txtimeout_expiry(wdparm_t arg);
 
 static void lpc43_poll_work(FAR void *arg);
-static void lpc43_poll_expiry(int argc, wdparm_t arg, ...);
+static void lpc43_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1118,7 +1118,7 @@ static int lpc43_transmit(FAR struct lpc43_ethmac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, LPC43_TXTIMEOUT,
-           lpc43_txtimeout_expiry, 1, (wdparm_t)priv);
+           lpc43_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -2109,8 +2109,7 @@ static void lpc43_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2120,7 +2119,7 @@ static void lpc43_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void lpc43_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void lpc43_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct lpc43_ethmac_s *priv = (FAR struct lpc43_ethmac_s *)arg;
 
@@ -2210,7 +2209,7 @@ static void lpc43_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, LPC43_WDDELAY,
-           lpc43_poll_expiry, 1, (wdparm_t)priv);
+           lpc43_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2221,8 +2220,7 @@ static void lpc43_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2232,7 +2230,7 @@ static void lpc43_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void lpc43_poll_expiry(int argc, wdparm_t arg, ...)
+static void lpc43_poll_expiry(wdparm_t arg)
 {
   FAR struct lpc43_ethmac_s *priv = (FAR struct lpc43_ethmac_s *)arg;
 
@@ -2287,7 +2285,7 @@ static int lpc43_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, LPC43_WDDELAY,
-           lpc43_poll_expiry, 1, (wdparm_t)priv);
+           lpc43_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/arch/arm/src/lpc43xx/lpc43_i2c.c
+++ b/arch/arm/src/lpc43xx/lpc43_i2c.c
@@ -131,7 +131,7 @@ static struct lpc43_i2cdev_s g_i2c1dev;
 static int  lpc43_i2c_start(struct lpc43_i2cdev_s *priv);
 static void lpc43_i2c_stop(struct lpc43_i2cdev_s *priv);
 static int  lpc43_i2c_interrupt(int irq, FAR void *context, FAR void *arg);
-static void lpc43_i2c_timeout(int argc, wdparm_t arg, ...);
+static void lpc43_i2c_timeout(wdparm_t arg);
 static void lpc43_i2c_setfrequency(struct lpc43_i2cdev_s *priv,
               uint32_t frequency);
 static int  lpc43_i2c_transfer(FAR struct i2c_master_s *dev,
@@ -203,7 +203,7 @@ static int lpc43_i2c_start(struct lpc43_i2cdev_s *priv)
   putreg32(I2C_CONSET_STA, priv->base + LPC43_I2C_CONSET_OFFSET);
 
   wd_start(&priv->timeout, I2C_TIMEOUT,
-           lpc43_i2c_timeout, 1, (wdparm_t)priv);
+           lpc43_i2c_timeout, (wdparm_t)priv);
   nxsem_wait(&priv->wait);
 
   wd_cancel(&priv->timeout);
@@ -237,7 +237,7 @@ static void lpc43_i2c_stop(struct lpc43_i2cdev_s *priv)
  *
  ****************************************************************************/
 
-static void lpc43_i2c_timeout(int argc, wdparm_t arg, ...)
+static void lpc43_i2c_timeout(wdparm_t arg)
 {
   struct lpc43_i2cdev_s *priv = (struct lpc43_i2cdev_s *)arg;
 

--- a/arch/arm/src/lpc43xx/lpc43_sdmmc.c
+++ b/arch/arm/src/lpc43xx/lpc43_sdmmc.c
@@ -291,7 +291,7 @@ static void lpc43_config_dmaints(struct lpc43_dev_s *priv, uint32_t xfrmask,
 
 /* Data Transfer Helpers ****************************************************/
 
-static void lpc43_eventtimeout(int argc, wdparm_t arg, ...);
+static void lpc43_eventtimeout(wdparm_t arg);
 static void lpc43_endwait(struct lpc43_dev_s *priv,
               sdio_eventset_t wkupevent);
 static void lpc43_endtransfer(struct lpc43_dev_s *priv,
@@ -827,8 +827,7 @@ static void lpc43_config_dmaints(struct lpc43_dev_s *priv, uint32_t xfrmask,
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -838,7 +837,7 @@ static void lpc43_config_dmaints(struct lpc43_dev_s *priv, uint32_t xfrmask,
  *
  ****************************************************************************/
 
-static void lpc43_eventtimeout(int argc, wdparm_t arg, ...)
+static void lpc43_eventtimeout(wdparm_t arg)
 {
   struct lpc43_dev_s *priv = (struct lpc43_dev_s *)arg;
 
@@ -2314,7 +2313,7 @@ static sdio_eventset_t lpc43_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       lpc43_eventtimeout, 1, (wdparm_t)priv);
+                       lpc43_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -408,10 +408,10 @@ static void lpc54_eth_dotimer(struct lpc54_ethdriver_s *priv);
 static void lpc54_eth_dopoll(struct lpc54_ethdriver_s *priv);
 
 static void lpc54_eth_txtimeout_work(void *arg);
-static void lpc54_eth_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void lpc54_eth_txtimeout_expiry(wdparm_t arg);
 
 static void lpc54_eth_poll_work(void *arg);
-static void lpc54_eth_poll_expiry(int argc, wdparm_t arg, ...);
+static void lpc54_eth_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -687,7 +687,7 @@ static int lpc54_eth_transmit(struct lpc54_ethdriver_s *priv,
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->eth_txtimeout, LPC54_TXTIMEOUT,
-           lpc54_eth_txtimeout_expiry, 1, (wdparm_t)priv);
+           lpc54_eth_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -1660,8 +1660,7 @@ static void lpc54_eth_txtimeout_work(void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1672,7 +1671,7 @@ static void lpc54_eth_txtimeout_work(void *arg)
  *
  ****************************************************************************/
 
-static void lpc54_eth_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void lpc54_eth_txtimeout_expiry(wdparm_t arg)
 {
   struct lpc54_ethdriver_s *priv = (struct lpc54_ethdriver_s *)arg;
 
@@ -1859,7 +1858,7 @@ static void lpc54_eth_poll_work(void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->eth_txpoll, LPC54_WDDELAY,
-           lpc54_eth_poll_expiry, 1, (wdparm_t)priv);
+           lpc54_eth_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1870,8 +1869,7 @@ static void lpc54_eth_poll_work(void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1882,7 +1880,7 @@ static void lpc54_eth_poll_work(void *arg)
  *
  ****************************************************************************/
 
-static void lpc54_eth_poll_expiry(int argc, wdparm_t arg, ...)
+static void lpc54_eth_poll_expiry(wdparm_t arg)
 {
   struct lpc54_ethdriver_s *priv = (struct lpc54_ethdriver_s *)arg;
 
@@ -2170,7 +2168,7 @@ static int lpc54_eth_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->eth_txpoll, LPC54_WDDELAY,
-           lpc54_eth_poll_expiry, 1, (wdparm_t)priv);
+           lpc54_eth_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/arch/arm/src/lpc54xx/lpc54_i2c_master.c
+++ b/arch/arm/src/lpc54xx/lpc54_i2c_master.c
@@ -156,7 +156,7 @@ static inline uint32_t lpc54_i2c_getreg(struct lpc54_i2cdev_s *priv,
 
 static void lpc54_i2c_setfrequency(struct lpc54_i2cdev_s *priv,
               uint32_t frequency);
-static void lpc54_i2c_timeout(int argc, wdparm_t arg, ...);
+static void lpc54_i2c_timeout(wdparm_t arg);
 static void lpc54_i2c_xfrsetup(struct lpc54_i2cdev_s *priv);
 static bool lpc54_i2c_nextmsg(struct lpc54_i2cdev_s *priv);
 static bool lpc54_i2c_statemachine(struct lpc54_i2cdev_s *priv);
@@ -336,7 +336,7 @@ static void lpc54_i2c_setfrequency(struct lpc54_i2cdev_s *priv,
  *
  ****************************************************************************/
 
-static void lpc54_i2c_timeout(int argc, wdparm_t arg, ...)
+static void lpc54_i2c_timeout(wdparm_t arg)
 {
   struct lpc54_i2cdev_s *priv = (struct lpc54_i2cdev_s *)arg;
 
@@ -768,7 +768,7 @@ static int lpc54_i2c_transfer(FAR struct i2c_master_s *dev,
   /* Set up the transfer timeout */
 
   wd_start(&priv->timeout, priv->nmsgs * I2C_WDOG_TIMEOUT,
-           lpc54_i2c_timeout, 1, (wdparm_t)priv);
+           lpc54_i2c_timeout, (wdparm_t)priv);
 
   /* Initiate the transfer */
 

--- a/arch/arm/src/lpc54xx/lpc54_sdmmc.c
+++ b/arch/arm/src/lpc54xx/lpc54_sdmmc.c
@@ -295,7 +295,7 @@ static void lpc54_config_dmaints(struct lpc54_dev_s *priv, uint32_t xfrmask,
 
 /* Data Transfer Helpers ****************************************************/
 
-static void lpc54_eventtimeout(int argc, wdparm_t arg, ...);
+static void lpc54_eventtimeout(wdparm_t arg);
 static void lpc54_endwait(struct lpc54_dev_s *priv,
               sdio_eventset_t wkupevent);
 static void lpc54_endtransfer(struct lpc54_dev_s *priv,
@@ -827,8 +827,7 @@ static void lpc54_config_dmaints(struct lpc54_dev_s *priv, uint32_t xfrmask,
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -838,7 +837,7 @@ static void lpc54_config_dmaints(struct lpc54_dev_s *priv, uint32_t xfrmask,
  *
  ****************************************************************************/
 
-static void lpc54_eventtimeout(int argc, wdparm_t arg, ...)
+static void lpc54_eventtimeout(wdparm_t arg)
 {
   struct lpc54_dev_s *priv = (struct lpc54_dev_s *)arg;
 
@@ -2314,7 +2313,7 @@ static sdio_eventset_t lpc54_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       lpc54_eventtimeout, 1, (wdparm_t)priv);
+                       lpc54_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -343,10 +343,10 @@ static int  s32k1xx_enet_interrupt(int irq, FAR void *context,
 /* Watchdog timer expirations */
 
 static void s32k1xx_txtimeout_work(FAR void *arg);
-static void s32k1xx_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void s32k1xx_txtimeout_expiry(wdparm_t arg);
 
 static void s32k1xx_poll_work(FAR void *arg);
-static void s32k1xx_polltimer_expiry(int argc, wdparm_t arg, ...);
+static void s32k1xx_polltimer_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -573,7 +573,7 @@ static int s32k1xx_transmit(FAR struct s32k1xx_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, S32K1XX_TXTIMEOUT,
-           s32k1xx_txtimeout_expiry, 1, (wdparm_t)priv);
+           s32k1xx_txtimeout_expiry, (wdparm_t)priv);
 
   /* Start the TX transfer (if it was not already waiting for buffers) */
 
@@ -1181,8 +1181,7 @@ static void s32k1xx_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1192,7 +1191,7 @@ static void s32k1xx_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void s32k1xx_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void s32k1xx_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct s32k1xx_driver_s *priv = (FAR struct s32k1xx_driver_s *)arg;
 
@@ -1251,7 +1250,7 @@ static void s32k1xx_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again in any case */
 
   wd_start(&priv->txpoll, S32K1XX_WDDELAY,
-           s32k1xx_polltimer_expiry, 1, (wdparm_t)priv);
+           s32k1xx_polltimer_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1262,8 +1261,7 @@ static void s32k1xx_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1273,7 +1271,7 @@ static void s32k1xx_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void s32k1xx_polltimer_expiry(int argc, wdparm_t arg, ...)
+static void s32k1xx_polltimer_expiry(wdparm_t arg)
 {
   FAR struct s32k1xx_driver_s *priv = (FAR struct s32k1xx_driver_s *)arg;
 
@@ -1383,7 +1381,7 @@ static int s32k1xx_ifup_action(struct net_driver_s *dev, bool resetphy)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, S32K1XX_WDDELAY,
-           s32k1xx_polltimer_expiry, 1, (wdparm_t)priv);
+           s32k1xx_polltimer_expiry, (wdparm_t)priv);
 
   /* Clear all pending ENET interrupt */
 

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -520,7 +520,7 @@ static int  s32k1xx_flexcan_interrupt(int irq, FAR void *context,
 /* Watchdog timer expirations */
 #ifdef TX_TIMEOUT_WQ
 static void s32k1xx_txtimeout_work(FAR void *arg);
-static void s32k1xx_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void s32k1xx_txtimeout_expiry(wdparm_t arg);
 #endif
 
 /* NuttX callback functions */
@@ -753,7 +753,7 @@ static int s32k1xx_transmit(FAR struct s32k1xx_driver_s *priv)
   if (timeout >= 0)
     {
       wd_start(&priv->txtimeout[mbi], timeout + 1,
-               s32k1xx_txtimeout_expiry, 1, (wdparm_t)priv);
+               s32k1xx_txtimeout_expiry, (wdparm_t)priv);
     }
 #endif
 
@@ -1132,8 +1132,7 @@ static void s32k1xx_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1143,7 +1142,7 @@ static void s32k1xx_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void s32k1xx_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void s32k1xx_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct s32k1xx_driver_s *priv = (FAR struct s32k1xx_driver_s *)arg;
 

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -393,10 +393,10 @@ static int  sam_emac_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void sam_txtimeout_work(FAR void *arg);
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void sam_txtimeout_expiry(wdparm_t arg);
 
 static void sam_poll_work(FAR void *arg);
-static void sam_poll_expiry(int argc, wdparm_t arg, ...);
+static void sam_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -815,7 +815,7 @@ static int sam_transmit(struct sam_emac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, SAM_TXTIMEOUT,
-           sam_txtimeout_expiry, 1, (wdparm_t)priv);
+           sam_txtimeout_expiry, (wdparm_t)priv);
 
   /* Set d_len to zero meaning that the d_buf[] packet buffer is again
    * available.
@@ -1729,8 +1729,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1740,7 +1739,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void sam_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct sam_emac_s *priv = (FAR struct sam_emac_s *)arg;
 
@@ -1792,7 +1791,7 @@ static void sam_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1803,8 +1802,7 @@ static void sam_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1814,7 +1812,7 @@ static void sam_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_poll_expiry(int argc, wdparm_t arg, ...)
+static void sam_poll_expiry(wdparm_t arg)
 {
   FAR struct sam_emac_s *priv = (FAR struct sam_emac_s *)arg;
 
@@ -1891,7 +1889,7 @@ static int sam_ifup(struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
 
   /* Enable the EMAC interrupt */
 

--- a/arch/arm/src/sam34/sam_hsmci.c
+++ b/arch/arm/src/sam34/sam_hsmci.c
@@ -448,7 +448,7 @@ static void sam_dmacallback(DMA_HANDLE handle, void *arg, int result);
 
 /* Data Transfer Helpers ****************************************************/
 
-static void sam_eventtimeout(int argc, wdparm_t arg, ...);
+static void sam_eventtimeout(wdparm_t arg);
 static void sam_endwait(struct sam_dev_s *priv, sdio_eventset_t wkupevent);
 static void sam_endtransfer(struct sam_dev_s *priv,
               sdio_eventset_t wkupevent);
@@ -1077,8 +1077,7 @@ static void sam_dmacallback(DMA_HANDLE handle, void *arg, int result)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1088,11 +1087,11 @@ static void sam_dmacallback(DMA_HANDLE handle, void *arg, int result)
  *
  ****************************************************************************/
 
-static void sam_eventtimeout(int argc, wdparm_t arg, ...)
+static void sam_eventtimeout(wdparm_t arg)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)arg;
 
-  DEBUGASSERT(argc == 1 && priv != NULL);
+  DEBUGASSERT(priv != NULL);
   DEBUGASSERT((priv->waitevents & SDIOWAIT_TIMEOUT) != 0);
 
   /* Is a data transfer complete event expected? */
@@ -2329,7 +2328,7 @@ static sdio_eventset_t sam_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       sam_eventtimeout, 1, (wdparm_t)priv);
+                       sam_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/sam34/sam_spi.c
+++ b/arch/arm/src/sam34/sam_spi.c
@@ -724,8 +724,7 @@ static void spi_dma_sampledone(struct sam_spics_s *spics)
  *   DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -736,7 +735,7 @@ static void spi_dma_sampledone(struct sam_spics_s *spics)
  ****************************************************************************/
 
 #ifdef CONFIG_SAM34_SPI_DMA
-static void spi_dmatimeout(int argc, wdparm_t arg, ...)
+static void spi_dmatimeout(wdparm_t arg)
 {
   struct sam_spics_s *spics = (struct sam_spics_s *)arg;
   DEBUGASSERT(spics != NULL);
@@ -1590,7 +1589,7 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&spics->dmadog, DMA_TIMEOUT_TICKS,
-                     spi_dmatimeout, 1, (wdparm_t)spics);
+                     spi_dmatimeout, (wdparm_t)spics);
       if (ret < 0)
         {
            spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/sam34/sam_twi.c
+++ b/arch/arm/src/sam34/sam_twi.c
@@ -166,7 +166,7 @@ static inline void twi_putrel(struct twi_dev_s *priv, unsigned int offset,
 static int  twi_wait(struct twi_dev_s *priv);
 static void twi_wakeup(struct twi_dev_s *priv, int result);
 static int  twi_interrupt(int irq, FAR void *context, FAR void *arg);
-static void twi_timeout(int argc, wdparm_t arg, ...);
+static void twi_timeout(wdparm_t arg);
 
 static void twi_startread(struct twi_dev_s *priv, struct i2c_msg_s *msg);
 static void twi_startwrite(struct twi_dev_s *priv, struct i2c_msg_s *msg);
@@ -376,7 +376,7 @@ static int twi_wait(struct twi_dev_s *priv)
 
   /* Start a timeout to avoid hangs */
 
-  wd_start(&priv->timeout, TWI_TIMEOUT, twi_timeout, 1, (wdparm_t)priv);
+  wd_start(&priv->timeout, TWI_TIMEOUT, twi_timeout, (wdparm_t)priv);
 
   /* Wait for either the TWI transfer or the timeout to complete */
 
@@ -565,7 +565,7 @@ static int twi_interrupt(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void twi_timeout(int argc, wdparm_t arg, ...)
+static void twi_timeout(wdparm_t arg)
 {
   struct twi_dev_s *priv = (struct twi_dev_s *)arg;
 

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -397,10 +397,10 @@ static int  sam_emac_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void sam_txtimeout_work(FAR void *arg);
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void sam_txtimeout_expiry(wdparm_t arg);
 
 static void sam_poll_work(FAR void *arg);
-static void sam_poll_expiry(int argc, wdparm_t arg, ...);
+static void sam_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -823,7 +823,7 @@ static int sam_transmit(struct sam_emac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, SAM_TXTIMEOUT,
-           sam_txtimeout_expiry, 1, (wdparm_t)priv);
+           sam_txtimeout_expiry, (wdparm_t)priv);
 
   /* Set d_len to zero meaning that the d_buf[] packet buffer is again
    * available.
@@ -1763,8 +1763,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1774,7 +1773,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void sam_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct sam_emac_s *priv = (FAR struct sam_emac_s *)arg;
 
@@ -1826,7 +1825,7 @@ static void sam_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1837,8 +1836,7 @@ static void sam_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1848,7 +1846,7 @@ static void sam_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_poll_expiry(int argc, wdparm_t arg, ...)
+static void sam_poll_expiry(wdparm_t arg)
 {
   FAR struct sam_emac_s *priv = (FAR struct sam_emac_s *)arg;
 
@@ -1925,7 +1923,7 @@ static int sam_ifup(struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
 
   /* Enable the EMAC interrupt */
 

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -491,10 +491,10 @@ static int  sam_emac_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void sam_txtimeout_work(FAR void *arg);
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void sam_txtimeout_expiry(wdparm_t arg);
 
 static void sam_poll_work(FAR void *arg);
-static void sam_poll_expiry(int argc, wdparm_t arg, ...);
+static void sam_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1164,7 +1164,7 @@ static int sam_transmit(struct sam_emac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, SAM_TXTIMEOUT,
-           sam_txtimeout_expiry, 1, (wdparm_t)priv);
+           sam_txtimeout_expiry, (wdparm_t)priv);
 
   /* Set d_len to zero meaning that the d_buf[] packet buffer is again
    * available.
@@ -2128,8 +2128,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2139,7 +2138,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void sam_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct sam_emac_s *priv = (FAR struct sam_emac_s *)arg;
 
@@ -2191,7 +2190,7 @@ static void sam_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2202,8 +2201,7 @@ static void sam_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2213,7 +2211,7 @@ static void sam_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_poll_expiry(int argc, wdparm_t arg, ...)
+static void sam_poll_expiry(wdparm_t arg)
 {
   FAR struct sam_emac_s *priv = (FAR struct sam_emac_s *)arg;
 
@@ -2298,7 +2296,7 @@ static int sam_ifup(struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
 
   /* Enable the EMAC interrupt */
 

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -322,10 +322,10 @@ static int  sam_gmac_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void sam_txtimeout_work(FAR void *arg);
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void sam_txtimeout_expiry(wdparm_t arg);
 
 static void sam_poll_work(FAR void *arg);
-static void sam_poll_expiry(int argc, wdparm_t arg, ...);
+static void sam_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -765,7 +765,7 @@ static int sam_transmit(struct sam_gmac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, SAM_TXTIMEOUT,
-           sam_txtimeout_expiry, 1, (wdparm_t)priv);
+           sam_txtimeout_expiry, (wdparm_t)priv);
 
   /* Set d_len to zero meaning that the d_buf[] packet buffer is again
    * available.
@@ -1747,8 +1747,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1758,7 +1757,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void sam_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct sam_gmac_s *priv = (FAR struct sam_gmac_s *)arg;
 
@@ -1810,7 +1809,7 @@ static void sam_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1821,8 +1820,7 @@ static void sam_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1832,7 +1830,7 @@ static void sam_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_poll_expiry(int argc, wdparm_t arg, ...)
+static void sam_poll_expiry(wdparm_t arg)
 {
   FAR struct sam_gmac_s *priv = (FAR struct sam_gmac_s *)arg;
 
@@ -1912,7 +1910,7 @@ static int sam_ifup(struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
 
   /* Enable the GMAC interrupt */
 

--- a/arch/arm/src/sama5/sam_hsmci.c
+++ b/arch/arm/src/sama5/sam_hsmci.c
@@ -527,7 +527,7 @@ static inline uintptr_t hsmci_physregaddr(struct sam_dev_s *priv,
 
 /* Data Transfer Helpers ****************************************************/
 
-static void sam_eventtimeout(int argc, wdparm_t arg, ...);
+static void sam_eventtimeout(wdparm_t arg);
 static void sam_endwait(struct sam_dev_s *priv, sdio_eventset_t wkupevent);
 static void sam_endtransfer(struct sam_dev_s *priv,
               sdio_eventset_t wkupevent);
@@ -1299,8 +1299,7 @@ static inline uintptr_t hsmci_physregaddr(struct sam_dev_s *priv,
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1310,11 +1309,11 @@ static inline uintptr_t hsmci_physregaddr(struct sam_dev_s *priv,
  *
  ****************************************************************************/
 
-static void sam_eventtimeout(int argc, wdparm_t arg, ...)
+static void sam_eventtimeout(wdparm_t arg)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)arg;
 
-  DEBUGASSERT(argc == 1 && priv != NULL);
+  DEBUGASSERT(priv != NULL);
   sam_xfrsample((struct sam_dev_s *)arg, SAMPLENDX_TIMEOUT);
 
   /* Make sure that any hung DMA is stopped.  dmabusy == false is the cue
@@ -2756,7 +2755,7 @@ static sdio_eventset_t sam_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       sam_eventtimeout, 1, (wdparm_t)priv);
+                       sam_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
            lcderr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/sama5/sam_sdmmc.c
+++ b/arch/arm/src/sama5/sam_sdmmc.c
@@ -281,7 +281,7 @@ static void sam_transmit(struct sam_dev_s *priv);
 static void sam_receive(struct sam_dev_s *priv);
 #endif
 
-static void sam_eventtimeout(int argc, wdparm_t arg, ...);
+static void sam_eventtimeout(wdparm_t arg);
 static void sam_endwait(struct sam_dev_s *priv,
               sdio_eventset_t wkupevent);
 static void sam_endtransfer(struct sam_dev_s *priv,
@@ -1160,8 +1160,7 @@ static void sam_receive(struct sam_dev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1171,11 +1170,11 @@ static void sam_receive(struct sam_dev_s *priv)
  *
  ****************************************************************************/
 
-static void sam_eventtimeout(int argc, wdparm_t arg, ...)
+static void sam_eventtimeout(wdparm_t arg)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)arg;
 
-  DEBUGASSERT(argc == 1 && priv != NULL);
+  DEBUGASSERT(priv != NULL);
   DEBUGASSERT((priv->waitevents & SDIOWAIT_TIMEOUT) != 0);
 
   /* Is a data transfer complete event expected? */
@@ -2913,7 +2912,7 @@ static sdio_eventset_t sam_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret = wd_start(&priv->waitwdog, delay,
-                     sam_eventtimeout, 1, (wdparm_t)priv);
+                     sam_eventtimeout, (wdparm_t)priv);
 
       if (ret < 0)
         {

--- a/arch/arm/src/sama5/sam_spi.c
+++ b/arch/arm/src/sama5/sam_spi.c
@@ -712,8 +712,7 @@ static void spi_dma_sampledone(struct sam_spics_s *spics)
  *   DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -724,7 +723,7 @@ static void spi_dma_sampledone(struct sam_spics_s *spics)
  ****************************************************************************/
 
 #ifdef CONFIG_SAMA5_SPI_DMA
-static void spi_dmatimeout(int argc, wdparm_t arg, ...)
+static void spi_dmatimeout(wdparm_t arg)
 {
   struct sam_spics_s *spics = (struct sam_spics_s *)arg;
   DEBUGASSERT(spics != NULL);
@@ -1518,7 +1517,7 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&spics->dmadog, DMA_TIMEOUT_TICKS,
-                     spi_dmatimeout, 1, (wdparm_t)spics);
+                     spi_dmatimeout, (wdparm_t)spics);
       if (ret < 0)
         {
            spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/sama5/sam_ssc.c
+++ b/arch/arm/src/sama5/sam_ssc.c
@@ -580,14 +580,14 @@ static void     ssc_txdma_sampledone(struct sam_ssc_s *priv, int result);
 #endif
 
 #ifdef SSC_HAVE_RX
-static void     ssc_rxdma_timeout(int argc, wdparm_t arg, ...);
+static void     ssc_rxdma_timeout(wdparm_t arg);
 static int      ssc_rxdma_setup(struct sam_ssc_s *priv);
 static void     ssc_rx_worker(void *arg);
 static void     ssc_rx_schedule(struct sam_ssc_s *priv, int result);
 static void     ssc_rxdma_callback(DMA_HANDLE handle, void *arg, int result);
 #endif
 #ifdef SSC_HAVE_TX
-static void     ssc_txdma_timeout(int argc, wdparm_t arg, ...);
+static void     ssc_txdma_timeout(wdparm_t arg);
 static int      ssc_txdma_setup(struct sam_ssc_s *priv);
 static void     ssc_tx_worker(void *arg);
 static void     ssc_tx_schedule(struct sam_ssc_s *priv, int result);
@@ -1183,8 +1183,7 @@ static void ssc_txdma_sampledone(struct sam_ssc_s *priv, int result)
  *   The RX watchdog timeout without completion of the RX DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1195,7 +1194,7 @@ static void ssc_txdma_sampledone(struct sam_ssc_s *priv, int result)
  ****************************************************************************/
 
 #ifdef SSC_HAVE_RX
-static void ssc_rxdma_timeout(int argc, wdparm_t arg, ...)
+static void ssc_rxdma_timeout(wdparm_t arg)
 {
   struct sam_ssc_s *priv = (struct sam_ssc_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1345,7 +1344,7 @@ static int ssc_rxdma_setup(struct sam_ssc_s *priv)
   if (!notimeout)
     {
       ret = wd_start(&priv->rx.dog, timeout,
-                     ssc_rxdma_timeout, 1, (wdparm_t)priv);
+                     ssc_rxdma_timeout, (wdparm_t)priv);
 
       /* Check if we have successfully started the watchdog timer.  Note
        * that we do nothing in the case of failure to start the timer.  We
@@ -1599,8 +1598,7 @@ static void ssc_rxdma_callback(DMA_HANDLE handle, void *arg, int result)
  *   The RX watchdog timeout without completion of the RX DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1611,7 +1609,7 @@ static void ssc_rxdma_callback(DMA_HANDLE handle, void *arg, int result)
  ****************************************************************************/
 
 #ifdef SSC_HAVE_TX
-static void ssc_txdma_timeout(int argc, wdparm_t arg, ...)
+static void ssc_txdma_timeout(wdparm_t arg)
 {
   struct sam_ssc_s *priv = (struct sam_ssc_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1762,7 +1760,7 @@ static int ssc_txdma_setup(struct sam_ssc_s *priv)
   if (!notimeout)
     {
       ret = wd_start(&priv->tx.dog, timeout,
-                     ssc_txdma_timeout, 1, (wdparm_t)priv);
+                     ssc_txdma_timeout, (wdparm_t)priv);
 
       /* Check if we have successfully started the watchdog timer.  Note
        * that we do nothing in the case of failure to start the timer.  We

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -202,7 +202,7 @@ static int  sam_tsd_waitsample(struct sam_tsd_s *priv,
               struct sam_sample_s *sample);
 static void sam_tsd_bottomhalf(void *arg);
 static int  sam_tsd_schedule(struct sam_tsd_s *priv);
-static void sam_tsd_expiry(int argc, wdparm_t arg1, ...);
+static void sam_tsd_expiry(wdparm_t arg);
 
 /* Character driver methods */
 
@@ -587,7 +587,7 @@ static void sam_tsd_bottomhalf(void *arg)
        */
 
       wd_start(&priv->wdog, TSD_WDOG_DELAY,
-               sam_tsd_expiry, 1, (wdparm_t)priv);
+               sam_tsd_expiry, (wdparm_t)priv);
       ier = 0;
       goto ignored;
     }
@@ -666,7 +666,7 @@ static void sam_tsd_bottomhalf(void *arg)
       /* Continue to sample the position while the pen is down */
 
       wd_start(&priv->wdog, TSD_WDOG_DELAY,
-               sam_tsd_expiry, 1, (wdparm_t)priv);
+               sam_tsd_expiry, (wdparm_t)priv);
 
       /* Check the thresholds.  Bail if (1) this is not the first
        * measurement and (2) there is no significant difference from
@@ -806,9 +806,9 @@ static int sam_tsd_schedule(struct sam_tsd_s *priv)
  *
  ****************************************************************************/
 
-static void sam_tsd_expiry(int argc, wdparm_t arg1, ...)
+static void sam_tsd_expiry(wdparm_t arg)
 {
-  struct sam_tsd_s *priv = (struct sam_tsd_s *)((uintptr_t)arg1);
+  struct sam_tsd_s *priv = (struct sam_tsd_s *)arg;
 
   /* Schedule touchscreen work */
 

--- a/arch/arm/src/sama5/sam_twi.c
+++ b/arch/arm/src/sama5/sam_twi.c
@@ -206,7 +206,7 @@ static inline void twi_putrel(struct twi_dev_s *priv, unsigned int offset,
 static int  twi_wait(struct twi_dev_s *priv, unsigned int size);
 static void twi_wakeup(struct twi_dev_s *priv, int result);
 static int  twi_interrupt(int irq, FAR void *context, FAR void *arg);
-static void twi_timeout(int argc, wdparm_t arg, ...);
+static void twi_timeout(wdparm_t arg);
 
 static void twi_startread(struct twi_dev_s *priv, struct i2c_msg_s *msg);
 static void twi_startwrite(struct twi_dev_s *priv, struct i2c_msg_s *msg);
@@ -480,7 +480,7 @@ static int twi_wait(struct twi_dev_s *priv, unsigned int size)
    * a TWI transfer stalls.
    */
 
-  wd_start(&priv->timeout, timeout, twi_timeout, 1, (wdparm_t)priv);
+  wd_start(&priv->timeout, timeout, twi_timeout, (wdparm_t)priv);
 
   /* Wait for either the TWI transfer or the timeout to complete */
 
@@ -669,7 +669,7 @@ static int twi_interrupt(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void twi_timeout(int argc, wdparm_t arg, ...)
+static void twi_timeout(wdparm_t arg)
 {
   struct twi_dev_s *priv = (struct twi_dev_s *)arg;
 

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -320,10 +320,10 @@ static int  sam_gmac_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void sam_txtimeout_work(FAR void *arg);
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void sam_txtimeout_expiry(wdparm_t arg);
 
 static void sam_poll_work(FAR void *arg);
-static void sam_poll_expiry(int argc, wdparm_t arg, ...);
+static void sam_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -754,7 +754,7 @@ static int sam_transmit(struct sam_gmac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, SAM_TXTIMEOUT,
-          sam_txtimeout_expiry, 1, (wdparm_t)priv);
+          sam_txtimeout_expiry, (wdparm_t)priv);
 
   /* Set d_len to zero meaning that the d_buf[] packet buffer is again
    * available.
@@ -1715,8 +1715,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1726,7 +1725,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void sam_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct sam_gmac_s *priv = (FAR struct sam_gmac_s *)arg;
 
@@ -1778,7 +1777,7 @@ static void sam_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1789,8 +1788,7 @@ static void sam_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1800,7 +1798,7 @@ static void sam_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_poll_expiry(int argc, wdparm_t arg, ...)
+static void sam_poll_expiry(wdparm_t arg)
 {
   FAR struct sam_gmac_s *priv = (FAR struct sam_gmac_s *)arg;
 
@@ -1880,7 +1878,7 @@ static int sam_ifup(struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
 
   /* Enable the GMAC interrupt */
 

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -604,10 +604,10 @@ static int  sam_emac_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void sam_txtimeout_work(FAR void *arg);
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void sam_txtimeout_expiry(wdparm_t arg);
 
 static void sam_poll_work(FAR void *arg);
-static void sam_poll_expiry(int argc, wdparm_t arg, ...);
+static void sam_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1469,7 +1469,7 @@ static int sam_transmit(struct sam_emac_s *priv, int qid)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, SAM_TXTIMEOUT,
-           sam_txtimeout_expiry, 1, (wdparm_t)priv);
+           sam_txtimeout_expiry, (wdparm_t)priv);
 
   /* Set d_len to zero meaning that the d_buf[] packet buffer is again
    * available.
@@ -2590,8 +2590,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2601,7 +2600,7 @@ static void sam_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void sam_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct sam_emac_s *priv = (FAR struct sam_emac_s *)arg;
 
@@ -2653,7 +2652,7 @@ static void sam_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2664,8 +2663,7 @@ static void sam_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2675,7 +2673,7 @@ static void sam_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void sam_poll_expiry(int argc, wdparm_t arg, ...)
+static void sam_poll_expiry(wdparm_t arg)
 {
   FAR struct sam_emac_s *priv = (FAR struct sam_emac_s *)arg;
 
@@ -2771,7 +2769,7 @@ static int sam_ifup(struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, SAM_WDDELAY, sam_poll_expiry, (wdparm_t)priv);
 
   /* Enable the EMAC interrupt */
 

--- a/arch/arm/src/samv7/sam_hsmci.c
+++ b/arch/arm/src/samv7/sam_hsmci.c
@@ -462,7 +462,7 @@ static inline uintptr_t hsmci_regaddr(struct sam_dev_s *priv,
 
 /* Data Transfer Helpers ****************************************************/
 
-static void sam_eventtimeout(int argc, wdparm_t arg, ...);
+static void sam_eventtimeout(wdparm_t arg);
 static void sam_endwait(struct sam_dev_s *priv, sdio_eventset_t wkupevent);
 static void sam_endtransfer(struct sam_dev_s *priv,
               sdio_eventset_t wkupevent);
@@ -1235,8 +1235,7 @@ static inline uintptr_t hsmci_regaddr(struct sam_dev_s *priv,
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1246,12 +1245,12 @@ static inline uintptr_t hsmci_regaddr(struct sam_dev_s *priv,
  *
  ****************************************************************************/
 
-static void sam_eventtimeout(int argc, wdparm_t arg, ...)
+static void sam_eventtimeout(wdparm_t arg)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)arg;
 
-  DEBUGASSERT(argc == 1 && priv != NULL);
-  sam_xfrsample((struct sam_dev_s *)arg, SAMPLENDX_TIMEOUT);
+  DEBUGASSERT(priv != NULL);
+  sam_xfrsample(priv, SAMPLENDX_TIMEOUT);
 
   /* Make sure that any hung DMA is stopped.  dmabusy == false is the cue
    * so the DMA callback is ignored.
@@ -2804,7 +2803,7 @@ static sdio_eventset_t sam_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       sam_eventtimeout, 1, (wdparm_t)priv);
+                       sam_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
            mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/samv7/sam_qspi.c
+++ b/arch/arm/src/samv7/sam_qspi.c
@@ -578,8 +578,7 @@ static void qspi_dma_sampledone(struct sam_qspidev_s *priv)
  *   DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -590,7 +589,7 @@ static void qspi_dma_sampledone(struct sam_qspidev_s *priv)
  ****************************************************************************/
 
 #ifdef CONFIG_SAMV7_QSPI_DMA
-static void qspi_dma_timeout(int argc, wdparm_t arg, ...)
+static void qspi_dma_timeout(wdparm_t arg)
 {
   struct sam_qspidev_s *priv = (struct sam_qspidev_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -891,7 +890,7 @@ static int qspi_memory_dma(struct sam_qspidev_s *priv,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&priv->dmadog, DMA_TIMEOUT_TICKS,
-                     qspi_dma_timeout, 1, (wdparm_t)priv);
+                     qspi_dma_timeout, (wdparm_t)priv);
       if (ret < 0)
         {
            spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/samv7/sam_spi.c
+++ b/arch/arm/src/samv7/sam_spi.c
@@ -753,8 +753,7 @@ static void spi_dma_sampledone(struct sam_spics_s *spics)
  *   DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -765,7 +764,7 @@ static void spi_dma_sampledone(struct sam_spics_s *spics)
  ****************************************************************************/
 
 #ifdef CONFIG_SAMV7_SPI_DMA
-static void spi_dmatimeout(int argc, wdparm_t arg, ...)
+static void spi_dmatimeout(wdparm_t arg)
 {
   struct sam_spics_s *spics = (struct sam_spics_s *)arg;
   DEBUGASSERT(spics != NULL);
@@ -1865,7 +1864,7 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&spics->dmadog, DMA_TIMEOUT_TICKS,
-                     spi_dmatimeout, 1, (wdparm_t)spics);
+                     spi_dmatimeout, (wdparm_t)spics);
       if (ret < 0)
         {
            spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/samv7/sam_ssc.c
+++ b/arch/arm/src/samv7/sam_ssc.c
@@ -555,14 +555,14 @@ static void     ssc_txdma_sampledone(struct sam_ssc_s *priv, int result);
 #endif
 
 #ifdef SSC_HAVE_RX
-static void     ssc_rxdma_timeout(int argc, wdparm_t arg, ...);
+static void     ssc_rxdma_timeout(wdparm_t arg);
 static int      ssc_rxdma_setup(struct sam_ssc_s *priv);
 static void     ssc_rx_worker(void *arg);
 static void     ssc_rx_schedule(struct sam_ssc_s *priv, int result);
 static void     ssc_rxdma_callback(DMA_HANDLE handle, void *arg, int result);
 #endif
 #ifdef SSC_HAVE_TX
-static void     ssc_txdma_timeout(int argc, wdparm_t arg, ...);
+static void     ssc_txdma_timeout(wdparm_t arg);
 static int      ssc_txdma_setup(struct sam_ssc_s *priv);
 static void     ssc_tx_worker(void *arg);
 static void     ssc_tx_schedule(struct sam_ssc_s *priv, int result);
@@ -1158,8 +1158,7 @@ static void ssc_txdma_sampledone(struct sam_ssc_s *priv, int result)
  *   The RX watchdog timeout without completion of the RX DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1170,7 +1169,7 @@ static void ssc_txdma_sampledone(struct sam_ssc_s *priv, int result)
  ****************************************************************************/
 
 #ifdef SSC_HAVE_RX
-static void ssc_rxdma_timeout(int argc, wdparm_t arg, ...)
+static void ssc_rxdma_timeout(wdparm_t arg)
 {
   struct sam_ssc_s *priv = (struct sam_ssc_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1322,7 +1321,7 @@ static int ssc_rxdma_setup(struct sam_ssc_s *priv)
   if (!notimeout)
     {
       ret = wd_start(&priv->rx.dog, timeout,
-                     ssc_rxdma_timeout, 1, (wdparm_t)priv);
+                     ssc_rxdma_timeout, (wdparm_t)priv);
 
       /* Check if we have successfully started the watchdog timer.  Note
        * that we do nothing in the case of failure to start the timer.  We
@@ -1576,8 +1575,7 @@ static void ssc_rxdma_callback(DMA_HANDLE handle, void *arg, int result)
  *   The RX watchdog timeout without completion of the RX DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1588,7 +1586,7 @@ static void ssc_rxdma_callback(DMA_HANDLE handle, void *arg, int result)
  ****************************************************************************/
 
 #ifdef SSC_HAVE_TX
-static void ssc_txdma_timeout(int argc, wdparm_t arg, ...)
+static void ssc_txdma_timeout(wdparm_t arg)
 {
   struct sam_ssc_s *priv = (struct sam_ssc_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1743,7 +1741,7 @@ static int ssc_txdma_setup(struct sam_ssc_s *priv)
   if (!notimeout)
     {
       ret = wd_start(&priv->tx.dog, timeout,
-                     ssc_txdma_timeout, 1, (wdparm_t)priv);
+                     ssc_txdma_timeout, (wdparm_t)priv);
 
       /* Check if we have successfully started the watchdog timer.  Note
        * that we do nothing in the case of failure to start the timer.  We

--- a/arch/arm/src/samv7/sam_twihs.c
+++ b/arch/arm/src/samv7/sam_twihs.c
@@ -205,7 +205,7 @@ static inline void twi_putrel(struct twi_dev_s *priv, unsigned int offset,
 static int  twi_wait(struct twi_dev_s *priv, unsigned int size);
 static void twi_wakeup(struct twi_dev_s *priv, int result);
 static int  twi_interrupt(int irq, FAR void *context, FAR void *arg);
-static void twi_timeout(int argc, wdparm_t arg, ...);
+static void twi_timeout(wdparm_t arg);
 
 static void twi_startread(struct twi_dev_s *priv, struct i2c_msg_s *msg);
 static void twi_startwrite(struct twi_dev_s *priv, struct i2c_msg_s *msg);
@@ -485,7 +485,7 @@ static int twi_wait(struct twi_dev_s *priv, unsigned int size)
    */
 
   wd_start(&priv->timeout, (timeout * size),
-           twi_timeout, 1, (wdparm_t)priv);
+           twi_timeout, (wdparm_t)priv);
 
   /* Wait for either the TWIHS transfer or the timeout to complete */
 
@@ -769,7 +769,7 @@ static int twi_interrupt(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void twi_timeout(int argc, wdparm_t arg, ...)
+static void twi_timeout(wdparm_t arg)
 {
   struct twi_dev_s *priv = (struct twi_dev_s *)arg;
 

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -719,10 +719,10 @@ static int  stm32_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void stm32_txtimeout_work(FAR void *arg);
-static void stm32_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void stm32_txtimeout_expiry(wdparm_t arg);
 
 static void stm32_poll_work(FAR void *arg);
-static void stm32_poll_expiry(int argc, wdparm_t arg, ...);
+static void stm32_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1229,7 +1229,7 @@ static int stm32_transmit(FAR struct stm32_ethmac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, STM32_TXTIMEOUT,
-           stm32_txtimeout_expiry, 1, (wdparm_t)priv);
+           stm32_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -2217,8 +2217,7 @@ static void stm32_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2228,7 +2227,7 @@ static void stm32_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void stm32_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void stm32_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct stm32_ethmac_s *priv = (FAR struct stm32_ethmac_s *)arg;
 
@@ -2318,7 +2317,7 @@ static void stm32_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, STM32_WDDELAY,
-           stm32_poll_expiry, 1, (wdparm_t)priv);
+           stm32_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2329,8 +2328,7 @@ static void stm32_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2340,7 +2338,7 @@ static void stm32_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void stm32_poll_expiry(int argc, wdparm_t arg, ...)
+static void stm32_poll_expiry(wdparm_t arg)
 {
   FAR struct stm32_ethmac_s *priv = (FAR struct stm32_ethmac_s *)arg;
 
@@ -2396,7 +2394,7 @@ static int stm32_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, STM32_WDDELAY,
-           stm32_poll_expiry, 1, (wdparm_t)priv);
+           stm32_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/arch/arm/src/stm32/stm32_i2s.c
+++ b/arch/arm/src/stm32/stm32_i2s.c
@@ -409,7 +409,7 @@ static void     i2s_txdma_sampledone(struct stm32_i2s_s *priv, int result);
 #endif
 
 #ifdef I2S_HAVE_RX
-static void     i2s_rxdma_timeout(int argc, wdparm_t arg, ...);
+static void     i2s_rxdma_timeout(wdparm_t arg);
 static int      i2s_rxdma_setup(struct stm32_i2s_s *priv);
 static void     i2s_rx_worker(void *arg);
 static void     i2s_rx_schedule(struct stm32_i2s_s *priv, int result);
@@ -417,7 +417,7 @@ static void     i2s_rxdma_callback(DMA_HANDLE handle, uint8_t result,
                                    void *arg);
 #endif
 #ifdef I2S_HAVE_TX
-static void     i2s_txdma_timeout(int argc, wdparm_t arg, ...);
+static void     i2s_txdma_timeout(wdparm_t arg);
 static int      i2s_txdma_setup(struct stm32_i2s_s *priv);
 static void     i2s_tx_worker(void *arg);
 static void     i2s_tx_schedule(struct stm32_i2s_s *priv, int result);
@@ -945,8 +945,7 @@ static void i2s_txdma_sampledone(struct stm32_i2s_s *priv, int result)
  *   The RX watchdog timeout without completion of the RX DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -957,7 +956,7 @@ static void i2s_txdma_sampledone(struct stm32_i2s_s *priv, int result)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static void i2s_rxdma_timeout(int argc, wdparm_t arg, ...)
+static void i2s_rxdma_timeout(wdparm_t arg)
 {
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1096,7 +1095,7 @@ static int i2s_rxdma_setup(struct stm32_i2s_s *priv)
   if (!notimeout)
     {
       ret = wd_start(&priv->rx.dog, timeout,
-                     i2s_rxdma_timeout, 1, (wdparm_t)priv);
+                     i2s_rxdma_timeout, (wdparm_t)priv);
 
       /* Check if we have successfully started the watchdog timer.  Note
        * that we do nothing in the case of failure to start the timer.  We
@@ -1345,8 +1344,7 @@ static void i2s_rxdma_callback(DMA_HANDLE handle, uint8_t result, void *arg)
  *   The RX watchdog timeout without completion of the RX DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1357,7 +1355,7 @@ static void i2s_rxdma_callback(DMA_HANDLE handle, uint8_t result, void *arg)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static void i2s_txdma_timeout(int argc, wdparm_t arg, ...)
+static void i2s_txdma_timeout(wdparm_t arg)
 {
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1496,7 +1494,7 @@ static int i2s_txdma_setup(struct stm32_i2s_s *priv)
   if (!notimeout)
     {
       ret = wd_start(&priv->tx.dog, timeout,
-                     i2s_txdma_timeout, 1, (wdparm_t)priv);
+                     i2s_txdma_timeout, (wdparm_t)priv);
 
       /* Check if we have successfully started the watchdog timer.  Note
        * that we do nothing in the case of failure to start the timer.  We

--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -416,7 +416,7 @@ static void stm32_dataconfig(uint32_t timeout, uint32_t dlen,
 static void stm32_datadisable(void);
 static void stm32_sendfifo(struct stm32_dev_s *priv);
 static void stm32_recvfifo(struct stm32_dev_s *priv);
-static void stm32_eventtimeout(int argc, wdparm_t arg, ...);
+static void stm32_eventtimeout(wdparm_t arg);
 static void stm32_endwait(struct stm32_dev_s *priv,
                           sdio_eventset_t wkupevent);
 static void stm32_endtransfer(struct stm32_dev_s *priv,
@@ -1190,8 +1190,7 @@ static void stm32_recvfifo(struct stm32_dev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1201,7 +1200,7 @@ static void stm32_recvfifo(struct stm32_dev_s *priv)
  *
  ****************************************************************************/
 
-static void stm32_eventtimeout(int argc, wdparm_t arg, ...)
+static void stm32_eventtimeout(wdparm_t arg)
 {
   struct stm32_dev_s *priv = (struct stm32_dev_s *)arg;
 
@@ -2546,7 +2545,7 @@ static sdio_eventset_t stm32_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       stm32_eventtimeout, 1, (wdparm_t)priv);
+                       stm32_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -736,10 +736,10 @@ static int  stm32_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void stm32_txtimeout_work(void *arg);
-static void stm32_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void stm32_txtimeout_expiry(wdparm_t arg);
 
 static void stm32_poll_work(void *arg);
-static void stm32_poll_expiry(int argc, wdparm_t arg, ...);
+static void stm32_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1269,7 +1269,7 @@ static int stm32_transmit(struct stm32_ethmac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, STM32_TXTIMEOUT,
-           stm32_txtimeout_expiry, 1, (wdparm_t)priv);
+           stm32_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -2312,8 +2312,7 @@ static void stm32_txtimeout_work(void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2323,7 +2322,7 @@ static void stm32_txtimeout_work(void *arg)
  *
  ****************************************************************************/
 
-static void stm32_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void stm32_txtimeout_expiry(wdparm_t arg)
 {
   struct stm32_ethmac_s *priv = (struct stm32_ethmac_s *)arg;
 
@@ -2413,7 +2412,7 @@ static void stm32_poll_work(void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, STM32_WDDELAY,
-           stm32_poll_expiry, 1, (wdparm_t)priv);
+           stm32_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2424,8 +2423,7 @@ static void stm32_poll_work(void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2435,7 +2433,7 @@ static void stm32_poll_work(void *arg)
  *
  ****************************************************************************/
 
-static void stm32_poll_expiry(int argc, wdparm_t arg, ...)
+static void stm32_poll_expiry(wdparm_t arg)
 {
   struct stm32_ethmac_s *priv = (struct stm32_ethmac_s *)arg;
 
@@ -2448,7 +2446,7 @@ static void stm32_poll_expiry(int argc, wdparm_t arg, ...)
   else
     {
       wd_start(&priv->txpoll, STM32_WDDELAY,
-               stm32_poll_expiry, 1, (wdparm_t)priv);
+               stm32_poll_expiry, (wdparm_t)priv);
     }
 }
 
@@ -2497,7 +2495,7 @@ static int stm32_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, STM32_WDDELAY,
-           stm32_poll_expiry, 1, (wdparm_t)priv);
+           stm32_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/arch/arm/src/stm32f7/stm32_qspi.c
+++ b/arch/arm/src/stm32f7/stm32_qspi.c
@@ -1338,8 +1338,7 @@ static int qspi0_interrupt(int irq, void *context, FAR void *arg)
  *   DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1349,7 +1348,7 @@ static int qspi0_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void qspi_dma_timeout(int argc, wdparm_t arg, ...)
+static void qspi_dma_timeout(wdparm_t arg)
 {
   struct stm32f7_qspidev_s *priv = (struct stm32f7_qspidev_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1525,7 +1524,7 @@ static int qspi_memory_dma(struct stm32f7_qspidev_s *priv,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&priv->dmadog, DMA_TIMEOUT_TICKS,
-                     qspi_dma_timeout, 1, (wdparm_t)priv);
+                     qspi_dma_timeout, (wdparm_t)priv);
       if (ret < 0)
         {
            spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/stm32f7/stm32_sai.c
+++ b/arch/arm/src/stm32f7/stm32_sai.c
@@ -832,8 +832,7 @@ static void sai_mckdivider(struct stm32f7_sai_s *priv)
  *   The watchdog timeout without completion of the transfer.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -843,7 +842,7 @@ static void sai_mckdivider(struct stm32f7_sai_s *priv)
  *
  ****************************************************************************/
 
-static void sai_timeout(int argc, wdparm_t arg, ...)
+static void sai_timeout(wdparm_t arg)
 {
   struct stm32f7_sai_s *priv = (struct stm32f7_sai_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -989,7 +988,7 @@ static int sai_dma_setup(struct stm32f7_sai_s *priv)
   if (bfcontainer->timeout > 0)
     {
       ret = wd_start(&priv->dog, bfcontainer->timeout,
-                     sai_timeout, 1, (wdparm_t)priv);
+                     sai_timeout, (wdparm_t)priv);
 
       /* Check if we have successfully started the watchdog timer.  Note
        * that we do nothing in the case of failure to start the timer.  We

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -509,7 +509,7 @@ static void stm32_dataconfig(struct stm32_dev_s *priv, uint32_t timeout,
 static void stm32_datadisable(struct stm32_dev_s *priv);
 static void stm32_sendfifo(struct stm32_dev_s *priv);
 static void stm32_recvfifo(struct stm32_dev_s *priv);
-static void stm32_eventtimeout(int argc, wdparm_t arg, ...);
+static void stm32_eventtimeout(wdparm_t arg);
 static void stm32_endwait(struct stm32_dev_s *priv,
               sdio_eventset_t wkupevent);
 static void stm32_endtransfer(struct stm32_dev_s *priv,
@@ -1440,9 +1440,7 @@ static void stm32_recvfifo(struct stm32_dev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (the SDMMC private state structure reference cast
- *            to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1452,7 +1450,7 @@ static void stm32_recvfifo(struct stm32_dev_s *priv)
  *
  ****************************************************************************/
 
-static void stm32_eventtimeout(int argc, wdparm_t arg, ...)
+static void stm32_eventtimeout(wdparm_t arg)
 {
   struct stm32_dev_s *priv = (struct stm32_dev_s *)arg;
 
@@ -2828,7 +2826,7 @@ static sdio_eventset_t stm32_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       stm32_eventtimeout, 1, (wdparm_t)priv);
+                       stm32_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -717,10 +717,10 @@ static int  stm32_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void stm32_txtimeout_work(void *arg);
-static void stm32_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void stm32_txtimeout_expiry(wdparm_t arg);
 
 static void stm32_poll_work(void *arg);
-static void stm32_poll_expiry(int argc, wdparm_t arg, ...);
+static void stm32_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1278,7 +1278,7 @@ static int stm32_transmit(struct stm32_ethmac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, STM32_TXTIMEOUT,
-           stm32_txtimeout_expiry, 1, (wdparm_t)priv);
+           stm32_txtimeout_expiry, (wdparm_t)priv);
 
   /* Update the tx descriptor tail pointer register to start the DMA */
 
@@ -2399,8 +2399,7 @@ static void stm32_txtimeout_work(void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2410,7 +2409,7 @@ static void stm32_txtimeout_work(void *arg)
  *
  ****************************************************************************/
 
-static void stm32_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void stm32_txtimeout_expiry(wdparm_t arg)
 {
   struct stm32_ethmac_s *priv = (struct stm32_ethmac_s *)arg;
 
@@ -2503,7 +2502,7 @@ static void stm32_poll_work(void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, STM32_WDDELAY,
-           stm32_poll_expiry, 1, (wdparm_t)priv);
+           stm32_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2514,8 +2513,7 @@ static void stm32_poll_work(void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2525,7 +2523,7 @@ static void stm32_poll_work(void *arg)
  *
  ****************************************************************************/
 
-static void stm32_poll_expiry(int argc, wdparm_t arg, ...)
+static void stm32_poll_expiry(wdparm_t arg)
 {
   struct stm32_ethmac_s *priv = (struct stm32_ethmac_s *)arg;
 
@@ -2538,7 +2536,7 @@ static void stm32_poll_expiry(int argc, wdparm_t arg, ...)
   else
     {
       wd_start(&priv->txpoll, STM32_WDDELAY,
-               stm32_poll_expiry, 1, (wdparm_t)priv);
+               stm32_poll_expiry, (wdparm_t)priv);
     }
 }
 
@@ -2587,7 +2585,7 @@ static int stm32_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, STM32_WDDELAY,
-           stm32_poll_expiry, 1, (wdparm_t)priv);
+           stm32_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/arch/arm/src/stm32h7/stm32_qspi.c
+++ b/arch/arm/src/stm32h7/stm32_qspi.c
@@ -1382,8 +1382,7 @@ static int qspi0_interrupt(int irq, void *context, FAR void *arg)
  *   DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1393,7 +1392,7 @@ static int qspi0_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void qspi_dma_timeout(int argc, wdparm_t arg, ...)
+static void qspi_dma_timeout(wdparm_t arg)
 {
   struct stm32h7_qspidev_s *priv = (struct stm32h7_qspidev_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1569,7 +1568,7 @@ static int qspi_memory_dma(struct stm32h7_qspidev_s *priv,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&priv->dmadog, DMA_TIMEOUT_TICKS,
-                     qspi_dma_timeout, 1, (wdparm_t)priv);
+                     qspi_dma_timeout, (wdparm_t)priv);
       if (ret < 0)
         {
            spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -452,7 +452,7 @@ static void stm32_recvfifo(struct stm32_dev_s *priv);
       !defined(CONFIG_ARCH_HAVE_SDIO_DELAYED_INVLDT)
 static void stm32_recvdma(struct stm32_dev_s *priv);
 #endif
-static void stm32_eventtimeout(int argc, wdparm_t arg, ...);
+static void stm32_eventtimeout(wdparm_t arg);
 static void stm32_endwait(struct stm32_dev_s *priv,
                           sdio_eventset_t wkupevent);
 static void stm32_endtransfer(struct stm32_dev_s *priv,
@@ -1417,9 +1417,7 @@ static void stm32_recvdma(struct stm32_dev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (the SDMMC private state structure reference cast
- *            to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1429,7 +1427,7 @@ static void stm32_recvdma(struct stm32_dev_s *priv)
  *
  ****************************************************************************/
 
-static void stm32_eventtimeout(int argc, wdparm_t arg, ...)
+static void stm32_eventtimeout(wdparm_t arg)
 {
   struct stm32_dev_s *priv = (struct stm32_dev_s *)arg;
 
@@ -2892,7 +2890,7 @@ static sdio_eventset_t stm32_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       stm32_eventtimeout, 1, (wdparm_t)priv);
+                       stm32_eventtimeout, (wdparm_t)priv);
       if (ret < OK)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/stm32l4/stm32l4_qspi.c
+++ b/arch/arm/src/stm32l4/stm32l4_qspi.c
@@ -1293,8 +1293,7 @@ static int qspi0_interrupt(int irq, void *context, FAR void *arg)
  *   DMA.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1304,7 +1303,7 @@ static int qspi0_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void qspi_dma_timeout(int argc, wdparm_t arg, ...)
+static void qspi_dma_timeout(wdparm_t arg)
 {
   struct stm32l4_qspidev_s *priv = (struct stm32l4_qspidev_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1478,7 +1477,7 @@ static int qspi_memory_dma(struct stm32l4_qspidev_s *priv,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&priv->dmadog, DMA_TIMEOUT_TICKS,
-                     qspi_dma_timeout, 1, (wdparm_t)priv);
+                     qspi_dma_timeout, (wdparm_t)priv);
       if (ret < 0)
         {
            spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/stm32l4/stm32l4_sai.c
+++ b/arch/arm/src/stm32l4/stm32l4_sai.c
@@ -501,8 +501,7 @@ static void sai_mckdivider(struct stm32l4_sai_s *priv)
  *   The watchdog timeout without completion of the transfer.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -512,7 +511,7 @@ static void sai_mckdivider(struct stm32l4_sai_s *priv)
  *
  ****************************************************************************/
 
-static void sai_timeout(int argc, wdparm_t arg, ...)
+static void sai_timeout(wdparm_t arg)
 {
   struct stm32l4_sai_s *priv = (struct stm32l4_sai_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -658,7 +657,7 @@ static int sai_dma_setup(struct stm32l4_sai_s *priv)
   if (bfcontainer->timeout > 0)
     {
       ret = wd_start(&priv->dog, bfcontainer->timeout,
-                     sai_timeout, 1, (wdparm_t)priv);
+                     sai_timeout, (wdparm_t)priv);
 
       /* Check if we have successfully started the watchdog timer.  Note
        * that we do nothing in the case of failure to start the timer.  We

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -446,7 +446,7 @@ static void stm32_dataconfig(struct stm32_dev_s *priv, uint32_t timeout,
 static void stm32_datadisable(struct stm32_dev_s *priv);
 static void stm32_sendfifo(struct stm32_dev_s *priv);
 static void stm32_recvfifo(struct stm32_dev_s *priv);
-static void stm32_eventtimeout(int argc, wdparm_t arg, ...);
+static void stm32_eventtimeout(wdparm_t arg);
 static void stm32_endwait(struct stm32_dev_s *priv,
               sdio_eventset_t wkupevent);
 static void stm32_endtransfer(struct stm32_dev_s *priv,
@@ -1320,9 +1320,7 @@ static void stm32_recvfifo(struct stm32_dev_s *priv)
  *   any other waited-for event occurring.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (the SDMMC private state structure reference cast
- *            to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -1332,7 +1330,7 @@ static void stm32_recvfifo(struct stm32_dev_s *priv)
  *
  ****************************************************************************/
 
-static void stm32_eventtimeout(int argc, wdparm_t arg, ...)
+static void stm32_eventtimeout(wdparm_t arg)
 {
   struct stm32_dev_s *priv = (struct stm32_dev_s *)arg;
 
@@ -2632,7 +2630,7 @@ static sdio_eventset_t stm32_eventwait(FAR struct sdio_dev_s *dev,
 
       delay = MSEC2TICK(timeout);
       ret   = wd_start(&priv->waitwdog, delay,
-                       stm32_eventtimeout, 1, (wdparm_t)priv);
+                       stm32_eventtimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           mcerr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -267,10 +267,10 @@ static int  tiva_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void tiva_txtimeout_work(void *arg);
-static void tiva_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void tiva_txtimeout_expiry(wdparm_t arg);
 
 static void tiva_poll_work(void *arg);
-static void tiva_poll_expiry(int argc, wdparm_t arg, ...);
+static void tiva_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -598,7 +598,7 @@ static int tiva_transmit(struct tiva_driver_s *priv)
       /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
       wd_start(&priv->ld_txtimeout, TIVA_TXTIMEOUT,
-               tiva_txtimeout_expiry, 1, (wdparm_t)priv);
+               tiva_txtimeout_expiry, (wdparm_t)priv);
       ret = OK;
     }
 
@@ -1172,8 +1172,7 @@ static void tiva_txtimeout_work(void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1183,7 +1182,7 @@ static void tiva_txtimeout_work(void *arg)
  *
  ****************************************************************************/
 
-static void tiva_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void tiva_txtimeout_expiry(wdparm_t arg)
 {
   struct tiva_driver_s *priv = (struct tiva_driver_s *)arg;
 
@@ -1244,7 +1243,7 @@ static void tiva_poll_work(void *arg)
       /* Setup the watchdog poll timer again */
 
       wd_start(&priv->ld_txpoll, TIVA_WDDELAY,
-               tiva_poll_expiry, 1, (wdparm_t)priv);
+               tiva_poll_expiry, (wdparm_t)priv);
     }
 
   net_unlock();
@@ -1257,8 +1256,7 @@ static void tiva_poll_work(void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1268,7 +1266,7 @@ static void tiva_poll_work(void *arg)
  *
  ****************************************************************************/
 
-static void tiva_poll_expiry(int argc, wdparm_t arg, ...)
+static void tiva_poll_expiry(wdparm_t arg)
 {
   struct tiva_driver_s *priv = (struct tiva_driver_s *)arg;
 
@@ -1431,7 +1429,7 @@ static int tiva_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->ld_txpoll, TIVA_WDDELAY,
-           tiva_poll_expiry, 1, (wdparm_t)priv);
+           tiva_poll_expiry, (wdparm_t)priv);
 
   priv->ld_bifup = true;
   leave_critical_section(flags);

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -719,10 +719,10 @@ static int  tiva_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void tiva_txtimeout_work(FAR void *arg);
-static void tiva_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void tiva_txtimeout_expiry(wdparm_t arg);
 
 static void tiva_poll_work(FAR void *arg);
-static void tiva_poll_expiry(int argc, wdparm_t arg, ...);
+static void tiva_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1219,7 +1219,7 @@ static int tiva_transmit(FAR struct tiva_ethmac_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, TIVA_TXTIMEOUT,
-           tiva_txtimeout_expiry, 1, (wdparm_t)priv);
+           tiva_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -2215,8 +2215,7 @@ static void tiva_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2226,7 +2225,7 @@ static void tiva_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void tiva_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void tiva_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct tiva_ethmac_s *priv = (FAR struct tiva_ethmac_s *)arg;
 
@@ -2314,7 +2313,7 @@ static void tiva_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, TIVA_WDDELAY,
-           tiva_poll_expiry, 1, (wdparm_t)priv);
+           tiva_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2325,8 +2324,7 @@ static void tiva_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2336,7 +2334,7 @@ static void tiva_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void tiva_poll_expiry(int argc, wdparm_t arg, ...)
+static void tiva_poll_expiry(wdparm_t arg)
 {
   FAR struct tiva_ethmac_s *priv = (FAR struct tiva_ethmac_s *)arg;
 
@@ -2391,7 +2389,7 @@ static int tiva_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, TIVA_WDDELAY,
-           tiva_poll_expiry, 1, (wdparm_t)priv);
+           tiva_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -900,8 +900,7 @@ static void spi_dma_sampledone(struct xmc4_spics_s *spics)
  *   DMA.
  *
  * Input Parameters:
- *   argc - The number of arguments (should be 1)
- *   arg  - The argument (state structure reference cast to uint32_t)
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -912,7 +911,7 @@ static void spi_dma_sampledone(struct xmc4_spics_s *spics)
  ****************************************************************************/
 
 #ifdef CONFIG_XMC4_SPI_DMA
-static void spi_dmatimeout(int argc, wdparm_t arg, ...)
+static void spi_dmatimeout(wdparm_t arg)
 {
   struct xmc4_spics_s *spics = (struct xmc4_spics_s *)arg;
 
@@ -1662,7 +1661,7 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&spics->dmadog, DMA_TIMEOUT_TICKS,
-                     spi_dmatimeout, 1, (wdparm_t)spics);
+                     spi_dmatimeout, (wdparm_t)spics);
       if (ret != OK)
         {
            spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -133,8 +133,8 @@ static int  emac_interrupt(int irq, FAR void *context, FAR void *arg);
 
 /* Watchdog timer expirations */
 
-static void emac_polltimer(int argc, wdparm_t arg, ...);
-static void emac_txtimeout(int argc, wdparm_t arg, ...);
+static void emac_polltimer(wdparm_t arg);
+static void emac_txtimeout(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -186,7 +186,7 @@ static int emac_transmit(FAR struct emac_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->d_txtimeout, HCS12_TXTIMEOUT,
-           emac_txtimeout, 1, (wdparm_t)priv);
+           emac_txtimeout, (wdparm_t)priv);
   return OK;
 }
 
@@ -481,8 +481,7 @@ static int emac_interrupt(int irq, FAR void *context, FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -492,7 +491,7 @@ static int emac_interrupt(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void emac_txtimeout(int argc, wdparm_t arg, ...)
+static void emac_txtimeout(wdparm_t arg)
 {
   FAR struct emac_driver_s *priv = (FAR struct emac_driver_s *)arg;
 
@@ -512,8 +511,7 @@ static void emac_txtimeout(int argc, wdparm_t arg, ...)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -523,7 +521,7 @@ static void emac_txtimeout(int argc, wdparm_t arg, ...)
  *
  ****************************************************************************/
 
-static void emac_polltimer(int argc, wdparm_t arg, ...)
+static void emac_polltimer(wdparm_t arg)
 {
   FAR struct emac_driver_s *priv = (FAR struct emac_driver_s *)arg;
 
@@ -540,7 +538,7 @@ static void emac_polltimer(int argc, wdparm_t arg, ...)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->d_txpoll, HCS12_WDDELAY, emac_polltimer, 1, (wdparm_t)arg);
+  wd_start(&priv->d_txpoll, HCS12_WDDELAY, emac_polltimer, (wdparm_t)arg);
 }
 
 /****************************************************************************
@@ -574,7 +572,7 @@ static int emac_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->d_txpoll, HCS12_WDDELAY,
-           emac_polltimer, 1, (wdparm_t)priv);
+           emac_polltimer, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -412,15 +412,15 @@ static void pic32mx_rxdone(struct pic32mx_driver_s *priv);
 static void pic32mx_txdone(struct pic32mx_driver_s *priv);
 
 static void pic32mx_interrupt_work(void *arg);
-static int  pic32mx_interrupt(int irq, void *context, FAR void *arg);
+static int  pic32mx_interrupt(int irq, void *context, void *arg);
 
 /* Watchdog timer expirations */
 
 static void pic32mx_txtimeout_work(void *arg);
-static void pic32mx_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void pic32mx_txtimeout_expiry(wdparm_t arg);
 
 static void pic32mx_poll_work(void *arg);
-static void pic32mx_poll_expiry(int argc, wdparm_t arg, ...);
+static void pic32mx_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1113,7 +1113,7 @@ static int pic32mx_transmit(struct pic32mx_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->pd_txtimeout, PIC32MX_TXTIMEOUT,
-           pic32mx_txtimeout_expiry, 1, (wdparm_t)priv);
+           pic32mx_txtimeout_expiry, (wdparm_t)priv);
 
   return OK;
 }
@@ -1999,8 +1999,7 @@ static void pic32mx_txtimeout_work(void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2010,7 +2009,7 @@ static void pic32mx_txtimeout_work(void *arg)
  *
  ****************************************************************************/
 
-static void pic32mx_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void pic32mx_txtimeout_expiry(wdparm_t arg)
 {
   struct pic32mx_driver_s *priv = (struct pic32mx_driver_s *)arg;
 
@@ -2070,7 +2069,7 @@ static void pic32mx_poll_work(void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->pd_txpoll, PIC32MX_WDDELAY,
-           pic32mx_poll_expiry, 1, (wdparm_t)priv);
+           pic32mx_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2081,8 +2080,7 @@ static void pic32mx_poll_work(void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2092,7 +2090,7 @@ static void pic32mx_poll_work(void *arg)
  *
  ****************************************************************************/
 
-static void pic32mx_poll_expiry(int argc, wdparm_t arg, ...)
+static void pic32mx_poll_expiry(wdparm_t arg)
 {
   struct pic32mx_driver_s *priv = (struct pic32mx_driver_s *)arg;
 
@@ -2402,7 +2400,7 @@ static int pic32mx_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->pd_txpoll, PIC32MX_WDDELAY,
-           pic32mx_poll_expiry, 1, (wdparm_t)priv);
+           pic32mx_poll_expiry, (wdparm_t)priv);
 
   /* Finally, enable the Ethernet interrupt at the interrupt controller */
 

--- a/arch/mips/src/pic32mx/pic32mx_usbdev.c
+++ b/arch/mips/src/pic32mx/pic32mx_usbdev.c
@@ -465,7 +465,7 @@ static void pic32mx_epwrite(struct pic32mx_ep_s *privep,
                 const uint8_t *src, uint32_t nbytes);
 static void pic32mx_wrcomplete(struct pic32mx_usbdev_s *priv,
                 struct pic32mx_ep_s *privep);
-static void pic32mx_rqrestart(int argc, wdparm_t arg1, ...);
+static void pic32mx_rqrestart(wdparm_t arg);
 static void pic32mx_delayedrestart(struct pic32mx_usbdev_s *priv,
                 uint8_t epno);
 static void pic32mx_rqstop(struct pic32mx_ep_s *privep);
@@ -971,7 +971,7 @@ static void pic32mx_wrcomplete(struct pic32mx_usbdev_s *priv,
  * Name: pic32mx_rqrestart
  ****************************************************************************/
 
-static void pic32mx_rqrestart(int argc, wdparm_t arg1, ...)
+static void pic32mx_rqrestart(wdparm_t arg)
 {
   struct pic32mx_usbdev_s *priv;
   struct pic32mx_ep_s *privep;
@@ -982,7 +982,7 @@ static void pic32mx_rqrestart(int argc, wdparm_t arg1, ...)
 
   /* Recover the pointer to the driver structure */
 
-  priv = (struct pic32mx_usbdev_s *)((uintptr_t)arg1);
+  priv = (struct pic32mx_usbdev_s *)arg;
   DEBUGASSERT(priv != NULL);
 
   /* Sample and clear the set of endpoints that have recovered from a stall */
@@ -1043,7 +1043,7 @@ static void pic32mx_delayedrestart(struct pic32mx_usbdev_s *priv,
   /* And start (or re-start) the watchdog timer */
 
   wd_start(&priv->wdog, RESTART_DELAY,
-           pic32mx_rqrestart, 1, (wdparm_t)priv);
+           pic32mx_rqrestart, (wdparm_t)priv);
 }
 
 /****************************************************************************

--- a/arch/mips/src/pic32mz/pic32mz_ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz_ethernet.c
@@ -478,10 +478,10 @@ static int  pic32mz_interrupt(int irq, void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void pic32mz_txtimeout_work(void *arg);
-static void pic32mz_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void pic32mz_txtimeout_expiry(wdparm_t arg);
 
 static void pic32mz_poll_work(void *arg);
-static void pic32mz_poll_expiry(int argc, wdparm_t arg, ...);
+static void pic32mz_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1218,7 +1218,7 @@ static int pic32mz_transmit(struct pic32mz_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->pd_txtimeout, PIC32MZ_TXTIMEOUT,
-           pic32mz_txtimeout_expiry, 1, (wdparm_t)priv);
+           pic32mz_txtimeout_expiry, (wdparm_t)priv);
 
   return OK;
 }
@@ -2133,8 +2133,7 @@ static void pic32mz_txtimeout_work(void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2144,7 +2143,7 @@ static void pic32mz_txtimeout_work(void *arg)
  *
  ****************************************************************************/
 
-static void pic32mz_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void pic32mz_txtimeout_expiry(wdparm_t arg)
 {
   struct pic32mz_driver_s *priv = (struct pic32mz_driver_s *)arg;
 
@@ -2203,7 +2202,7 @@ static void pic32mz_poll_work(void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->pd_txpoll, PIC32MZ_WDDELAY,
-           pic32mz_poll_expiry, 1, (wdparm_t)priv);
+           pic32mz_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2214,8 +2213,7 @@ static void pic32mz_poll_work(void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2225,7 +2223,7 @@ static void pic32mz_poll_work(void *arg)
  *
  ****************************************************************************/
 
-static void pic32mz_poll_expiry(int argc, wdparm_t arg, ...)
+static void pic32mz_poll_expiry(wdparm_t arg)
 {
   struct pic32mz_driver_s *priv = (struct pic32mz_driver_s *)arg;
 
@@ -2546,7 +2544,7 @@ static int pic32mz_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->pd_txpoll, PIC32MZ_WDDELAY,
-           pic32mz_poll_expiry, 1, (wdparm_t)priv);
+           pic32mz_poll_expiry, (wdparm_t)priv);
 
   /* Finally, enable the Ethernet interrupt at the interrupt controller */
 

--- a/arch/mips/src/pic32mz/pic32mz_spi.c
+++ b/arch/mips/src/pic32mz/pic32mz_spi.c
@@ -218,7 +218,7 @@ static void spi_dma_sampledone(FAR struct pic32mz_dev_s *priv);
 #  endif
 static void spi_dmarxcallback(DMA_HANDLE handle, uint8_t status, void *arg);
 static void spi_dmatxcallback(DMA_HANDLE handle, uint8_t status, void *arg);
-static void spi_dmatimeout(int argc, wdparm_t arg, ...);
+static void spi_dmatimeout(wdparm_t arg);
 #endif
 
 /* SPI methods */
@@ -983,8 +983,7 @@ static void spi_dmatxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
  *   transfer.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -995,7 +994,7 @@ static void spi_dmatxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_SPI_DMA
-static void spi_dmatimeout(int argc, wdparm_t arg, ...)
+static void spi_dmatimeout(wdparm_t arg)
 {
   struct pic32mz_dev_s *priv = (struct pic32mz_dev_s *)arg;
   DEBUGASSERT(priv != NULL);
@@ -1775,7 +1774,7 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
       /* Start (or re-start) the watchdog timeout */
 
       ret = wd_start(&priv->dmadog, DMA_TIMEOUT_TICKS,
-                     spi_dmatimeout, 1, (wdparm_t)priv);
+                     spi_dmatimeout, (wdparm_t)priv);
       if (ret < 0)
         {
           spierr("ERROR: wd_start failed: %d\n", ret);

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -165,10 +165,10 @@ static int  misoc_net_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void misoc_net_txtimeout_work(FAR void *arg);
-static void misoc_net_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void misoc_net_txtimeout_expiry(wdparm_t arg);
 
 static void misoc_net_poll_work(FAR void *arg);
-static void misoc_net_poll_expiry(int argc, wdparm_t arg, ...);
+static void misoc_net_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -274,7 +274,7 @@ static int misoc_net_transmit(FAR struct misoc_net_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->misoc_net_txtimeout, MISOC_NET_TXTIMEOUT,
-           misoc_net_txtimeout_expiry, 1, (wdparm_t)priv);
+           misoc_net_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -713,8 +713,7 @@ static void misoc_net_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -724,7 +723,7 @@ static void misoc_net_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void misoc_net_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void misoc_net_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct misoc_net_driver_s *priv = (FAR struct misoc_net_driver_s *)arg;
 
@@ -782,7 +781,7 @@ static void misoc_net_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->misoc_net_txpoll, MISOC_NET_WDDELAY,
-           misoc_net_poll_expiry, 1, (wdparm_t)priv);
+           misoc_net_poll_expiry, (wdparm_t)priv);
 
   net_unlock();
 }
@@ -794,8 +793,7 @@ static void misoc_net_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -805,7 +803,7 @@ static void misoc_net_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void misoc_net_poll_expiry(int argc, wdparm_t arg, ...)
+static void misoc_net_poll_expiry(wdparm_t arg)
 {
   FAR struct misoc_net_driver_s *priv = (FAR struct misoc_net_driver_s *)arg;
 
@@ -867,7 +865,7 @@ static int misoc_net_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->misoc_net_txpoll, MISOC_NET_WDDELAY,
-           misoc_net_poll_expiry, 1, (wdparm_t)priv);
+           misoc_net_poll_expiry, (wdparm_t)priv);
 
   priv->misoc_net_bifup = true;
   up_enable_irq(ETHMAC_INTERRUPT);

--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -2058,8 +2058,7 @@ static void rx65n_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2069,7 +2068,7 @@ static void rx65n_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-void rx65n_txtimeout_expiry(int argc, wdparm_t arg, ...)
+void rx65n_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct rx65n_ethmac_s *priv = (FAR struct rx65n_ethmac_s *)arg;
   nerr("ERROR: Timeout!\n");
@@ -2169,8 +2168,7 @@ static void rx65n_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2180,7 +2178,7 @@ static void rx65n_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-void rx65n_poll_expiry(int argc, wdparm_t arg, ...)
+void rx65n_poll_expiry(wdparm_t arg)
 {
   FAR struct rx65n_ethmac_s *priv = (FAR struct rx65n_ethmac_s *)arg;
   rx65n_cmtw0_stop(rx65n_cmtw0_txpoll);

--- a/arch/renesas/src/rx65n/rx65n_eth.h
+++ b/arch/renesas/src/rx65n/rx65n_eth.h
@@ -79,7 +79,6 @@ int rx65n_ethinitialize(int intf);
  *   Poll Expiry timer
  *
  * Input Parameters:
- *   argc - Input argument
  *   arg  - Input argument
  *
  * Returned Value:
@@ -87,7 +86,7 @@ int rx65n_ethinitialize(int intf);
  *
  ****************************************************************************/
 
-void rx65n_poll_expiry(int argc, wdparm_t arg, ...);
+void rx65n_poll_expiry(wdparm_t arg);
 
 /****************************************************************************
  * Function: rx65n_txtimeout_expiry
@@ -96,7 +95,6 @@ void rx65n_poll_expiry(int argc, wdparm_t arg, ...);
  *   txtimeout timer
  *
  * Input Parameters:
- *   argc - Input argument
  *   arg  - Input argument
  *
  * Returned Value:
@@ -104,7 +102,7 @@ void rx65n_poll_expiry(int argc, wdparm_t arg, ...);
  *
  ****************************************************************************/
 
-void rx65n_txtimeout_expiry(int argc, wdparm_t arg, ...);
+void rx65n_txtimeout_expiry(wdparm_t arg);
 #endif
 
 #undef EXTERN

--- a/arch/sim/src/sim/up_ioexpander.c
+++ b/arch/sim/src/sim/up_ioexpander.c
@@ -144,7 +144,7 @@ static int sim_detach(FAR struct ioexpander_dev_s *dev, FAR void *handle);
 
 static ioe_pinset_t sim_int_update(FAR struct sim_dev_s *priv);
 static void sim_interrupt_work(void *arg);
-static void sim_interrupt(int argc, wdparm_t arg1, ...);
+static void sim_interrupt(wdparm_t arg);
 
 /****************************************************************************
  * Private Data
@@ -775,7 +775,7 @@ static void sim_interrupt_work(void *arg)
   /* Re-start the poll timer */
 
   ret = wd_start(&priv->wdog, SIM_POLLDELAY,
-                 sim_interrupt, 1, (wdparm_t)priv);
+                 sim_interrupt, (wdparm_t)priv);
   if (ret < 0)
     {
       gpioerr("ERROR: Failed to start poll timer\n");
@@ -793,12 +793,11 @@ static void sim_interrupt_work(void *arg)
  *
  ****************************************************************************/
 
-static void sim_interrupt(int argc, wdparm_t arg1, ...)
+static void sim_interrupt(wdparm_t arg)
 {
   FAR struct sim_dev_s *priv;
 
-  DEBUGASSERT(argc == 1);
-  priv = (FAR struct sim_dev_s *)arg1;
+  priv = (FAR struct sim_dev_s *)arg;
   DEBUGASSERT(priv != NULL);
 
   /* Defer interrupt processing to the worker thread.  This is not only
@@ -859,7 +858,7 @@ FAR struct ioexpander_dev_s *sim_ioexpander_initialize(void)
   priv->level[1] = PINSET_ALL;  /* All falling edge */
 
   ret = wd_start(&priv->wdog, SIM_POLLDELAY,
-                 sim_interrupt, 1, (wdparm_t)priv);
+                 sim_interrupt, (wdparm_t)priv);
   if (ret < 0)
     {
       gpioerr("ERROR: Failed to start poll timer\n");

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -415,10 +415,10 @@ static int  ez80emac_sysinterrupt(int irq, FAR void *context,
 /* Watchdog timer expirations */
 
 static void ez80emac_txtimeout_work(FAR void *arg);
-static void ez80emac_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void ez80emac_txtimeout_expiry(wdparm_t arg);
 
 static void ez80emac_poll_work(FAR void *arg);
-static void ez80emac_poll_expiry(int argc, wdparm_t arg, ...);
+static void ez80emac_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1135,7 +1135,7 @@ static int ez80emac_transmit(struct ez80emac_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->txtimeout, EMAC_TXTIMEOUT,
-           ez80emac_txtimeout_expiry, 1, (wdparm_t)priv);
+           ez80emac_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -1940,8 +1940,7 @@ static void ez80emac_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1951,7 +1950,7 @@ static void ez80emac_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void ez80emac_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void ez80emac_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct ez80emac_driver_s *priv = (FAR struct ez80emac_driver_s *)arg;
 
@@ -1996,7 +1995,7 @@ static void ez80emac_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, EMAC_WDDELAY,
-           ez80emac_poll_expiry, 1, (wdparm_t)priv);
+           ez80emac_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2007,8 +2006,7 @@ static void ez80emac_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2018,7 +2016,7 @@ static void ez80emac_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void ez80emac_poll_expiry(int argc, wdparm_t arg, ...)
+static void ez80emac_poll_expiry(wdparm_t arg)
 {
   FAR struct ez80emac_driver_s *priv = (FAR struct ez80emac_driver_s *)arg;
 
@@ -2039,7 +2037,7 @@ static void ez80emac_poll_expiry(int argc, wdparm_t arg, ...)
        */
 
       wd_start(&priv->txpoll, EMAC_WDDELAY,
-               ez80emac_poll_expiry, 1, (wdparm_t)arg);
+               ez80emac_poll_expiry, (wdparm_t)arg);
     }
 }
 
@@ -2131,7 +2129,7 @@ static int ez80emac_ifup(FAR struct net_driver_s *dev)
       /* Set and activate a timer process */
 
       wd_start(&priv->txpoll, EMAC_WDDELAY,
-               ez80emac_poll_expiry, 1, (wdparm_t)priv);
+               ez80emac_poll_expiry, (wdparm_t)priv);
 
       /* Enable the Ethernet interrupts */
 

--- a/boards/arm/samv7/samv71-xult/src/sam_ili9488.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_ili9488.c
@@ -382,7 +382,7 @@ static void sam_lcd_dump(struct sam_dev_s *priv);
 #endif
 
 static void sam_lcd_endwait(struct sam_dev_s *priv, int result);
-static void sam_lcd_dmatimeout(int argc, wdparm_t arg, ...);
+static void sam_lcd_dmatimeout(wdparm_t arg);
 static int  sam_lcd_dmawait(FAR struct sam_dev_s *priv, uint32_t timeout);
 static void sam_lcd_dmacallback(DMA_HANDLE handle, void *arg, int result);
 static int  sam_lcd_txtransfer(FAR struct sam_dev_s *priv,
@@ -930,8 +930,7 @@ static void sam_lcd_endwait(struct sam_dev_s *priv, int result)
  *   timeout failure.
  *
  * Input Parameters:
- *   argc   - The number of arguments (should be 1)
- *   arg    - The argument (state structure reference cast to uint32_t)
+ *   arg    - The argument
  *
  * Returned Value:
  *   None
@@ -941,12 +940,12 @@ static void sam_lcd_endwait(struct sam_dev_s *priv, int result)
  *
  ****************************************************************************/
 
-static void sam_lcd_dmatimeout(int argc, wdparm_t arg, ...)
+static void sam_lcd_dmatimeout(wdparm_t arg)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)arg;
 
-  DEBUGASSERT(argc == 1 && priv != NULL);
-  sam_lcd_sample((struct sam_dev_s *)arg, SAMPLENDX_TIMEOUT);
+  DEBUGASSERT(priv != NULL);
+  sam_lcd_sample(priv, SAMPLENDX_TIMEOUT);
 
   /* Make sure that any hung DMA is stopped.  dmabusy == false is the cue
    * so the DMA callback is ignored.
@@ -984,7 +983,7 @@ static int sam_lcd_dmawait(FAR struct sam_dev_s *priv, uint32_t timeout)
   /* Started ... setup the timeout */
 
   ret = wd_start(&priv->dmadog, timeout,
-                 sam_lcd_dmatimeout, 1, (wdparm_t)priv);
+                 sam_lcd_dmatimeout, (wdparm_t)priv);
   if (ret < 0)
     {
       lcderr("ERROR: wd_start failed: %d\n", errno);

--- a/boards/sim/sim/sim/src/sim_gpio.c
+++ b/boards/sim/sim/sim/src/sim_gpio.c
@@ -144,9 +144,9 @@ static struct simgpint_dev_s g_gpint =
  * Private Functions
  ****************************************************************************/
 
-static int sim_interrupt(int argc, wdparm_t arg1, ...)
+static int sim_interrupt(wdparm_t arg)
 {
-  FAR struct simgpint_dev_s *simgpint = (FAR struct simgpint_dev_s *)arg1;
+  FAR struct simgpint_dev_s *simgpint = (FAR struct simgpint_dev_s *)arg;
 
   DEBUGASSERT(simgpint != NULL && simgpint->callback != NULL);
   gpioinfo("Interrupt! callback=%p\n", simgpint->callback);
@@ -202,7 +202,7 @@ static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
         {
           gpioinfo("Start 1 second timer\n");
           wd_start(&simgpint->wdog, SEC2TICK(1),
-                   sim_interrupt, 1, (wdparm_t)dev);
+                   sim_interrupt, (wdparm_t)dev);
         }
     }
   else

--- a/boards/z16/z16f/z16f2800100zcog/tools/zneo-zdsii-5_0_1-variadic-func-fix.patch
+++ b/boards/z16/z16f/z16f2800100zcog/tools/zneo-zdsii-5_0_1-variadic-func-fix.patch
@@ -133,31 +133,3 @@ index c78362f..207f9b9 100644
 +int nsh_output(FAR struct nsh_vtbl_s *vtbl, FAR const char *fmt, ...);
  
  #endif /* __APPS_NSHLIB_NSH_CONSOLE_H */
-diff --git a/nuttx/include/wdog.h b/nuttx/include/nuttx/wdog.h
-index 0aa3584..ac4a36a 100644
---- a/nuttx/include/nuttx/wdog.h
-+++ b/nuttx/include/nuttx/wdog.h
-@@ -74,7 +74,23 @@ typedef union wdparm_u wdparm_t;
-  * watchdog function expires.  Up to four parameters may be passed.
-  */
- 
-+#if 0
- typedef CODE void (*wdentry_t)(int argc, uint32_t arg1, ...);
-+#elif CONFIG_MAX_WDOGPARMS < 1
-+typedef CODE void (*wdentry_t)(int argc);
-+#elif CONFIG_MAX_WDOGPARMS < 2
-+typedef CODE void (*wdentry_t)(int argc, uint32_t arg1);
-+#elif CONFIG_MAX_WDOGPARMS < 3
-+typedef CODE void (*wdentry_t)(int argc, uint32_t arg1, uint32_t arg2);
-+#elif CONFIG_MAX_WDOGPARMS < 4
-+typedef CODE void (*wdentry_t)(int argc, uint32_t arg1, uint32_t arg2,
-+                               uint32_t arg3);
-+#elif CONFIG_MAX_WDOGPARMS < 5
-+typedef CODE void (*wdentry_t)(int argc, uint32_t arg1, uint32_t arg2,
-+                               uint32_t arg3, uint32_t arg4);
-+#else
-+#  error Ooops.  CONFIG_MAX_WDOGPARMS > 4
-+#endif
- 
- /* Watchdog 'handle' */
- 

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -501,10 +501,10 @@ static int ads7843e_schedule(FAR struct ads7843e_dev_s *priv)
  * Name: ads7843e_wdog
  ****************************************************************************/
 
-static void ads7843e_wdog(int argc, wdparm_t arg1, ...)
+static void ads7843e_wdog(wdparm_t arg)
 {
   FAR struct ads7843e_dev_s *priv =
-    (FAR struct ads7843e_dev_s *)((uintptr_t)arg1);
+    (FAR struct ads7843e_dev_s *)arg;
 
   ads7843e_schedule(priv);
 }
@@ -603,7 +603,7 @@ static void ads7843e_worker(FAR void *arg)
        */
 
       wd_start(&priv->wdog, ADS7843E_WDOG_DELAY,
-               ads7843e_wdog, 1, (wdparm_t)priv);
+               ads7843e_wdog, (wdparm_t)priv);
       goto ignored;
     }
   else
@@ -638,7 +638,7 @@ static void ads7843e_worker(FAR void *arg)
       /* Continue to sample the position while the pen is down */
 
       wd_start(&priv->wdog, ADS7843E_WDOG_DELAY,
-               ads7843e_wdog, 1, (wdparm_t)priv);
+               ads7843e_wdog, (wdparm_t)priv);
 
       /* Check the thresholds.  Bail if there is no significant difference */
 

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -160,7 +160,7 @@ struct ft5x06_dev_s
 static void ft5x06_notify(FAR struct ft5x06_dev_s *priv);
 static void ft5x06_data_worker(FAR void *arg);
 #ifdef CONFIG_FT5X06_POLLMODE
-static void ft5x06_poll_timeout(int argc, wdparm_t arg1, ...);
+static void ft5x06_poll_timeout(wdparm_t arg);
 #else
 static int  ft5x06_data_interrupt(int irq, FAR void *context, FAR void *arg);
 #endif
@@ -364,7 +364,7 @@ static void ft5x06_data_worker(FAR void *arg)
   /* Exit, re-starting the poll. */
 
   wd_start(&priv->polltimer, priv->delay,
-           ft5x06_poll_timeout, 1, (wdparm_t)priv);
+           ft5x06_poll_timeout, (wdparm_t)priv);
 
 #else
   /* Exit, re-enabling FT5x06 interrupts */
@@ -380,9 +380,9 @@ static void ft5x06_data_worker(FAR void *arg)
  ****************************************************************************/
 
 #ifdef CONFIG_FT5X06_POLLMODE
-static void ft5x06_poll_timeout(int argc, wdparm_t arg1, ...)
+static void ft5x06_poll_timeout(wdparm_t arg)
 {
-  FAR struct ft5x06_dev_s *priv = (FAR struct ft5x06_dev_s *)arg1;
+  FAR struct ft5x06_dev_s *priv = (FAR struct ft5x06_dev_s *)arg;
   int ret;
 
   /* Transfer processing to the worker thread.  Since FT5x06 poll timer is

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -460,10 +460,10 @@ static int max11802_schedule(FAR struct max11802_dev_s *priv)
  * Name: max11802_wdog
  ****************************************************************************/
 
-static void max11802_wdog(int argc, wdparm_t arg1, ...)
+static void max11802_wdog(wdparm_t arg)
 {
   FAR struct max11802_dev_s *priv =
-    (FAR struct max11802_dev_s *)((uintptr_t)arg1);
+    (FAR struct max11802_dev_s *)arg;
 
   max11802_schedule(priv);
 }
@@ -581,7 +581,7 @@ static void max11802_worker(FAR void *arg)
       iinfo("Previous pen up event still in buffer\n");
       max11802_notify(priv);
       wd_start(&priv->wdog, MAX11802_WDOG_DELAY,
-               max11802_wdog, 1, (wdparm_t)priv);
+               max11802_wdog, (wdparm_t)priv);
       goto ignored;
     }
   else
@@ -621,7 +621,7 @@ static void max11802_worker(FAR void *arg)
       /* Continue to sample the position while the pen is down */
 
       wd_start(&priv->wdog, MAX11802_WDOG_DELAY,
-               max11802_wdog, 1, (wdparm_t)priv);
+               max11802_wdog, (wdparm_t)priv);
 
       /* Check if data is valid */
 

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -729,9 +729,9 @@ static void stmpe811_timeoutworker(FAR void *arg)
  *
  ****************************************************************************/
 
-static void stmpe811_timeout(int argc, wdparm_t arg1, ...)
+static void stmpe811_timeout(wdparm_t arg)
 {
-  FAR struct stmpe811_dev_s *priv = (FAR struct stmpe811_dev_s *)arg1;
+  FAR struct stmpe811_dev_s *priv = (FAR struct stmpe811_dev_s *)arg;
   int ret;
 
   /* Are we still stuck in the pen down state? */
@@ -1083,7 +1083,7 @@ ignored:
       priv->sample.contact == CONTACT_MOVE)
     {
       wd_start(&priv->wdog, STMPE811_PENUP_TICKS,
-               stmpe811_timeout, 1, (wdparm_t)priv);
+               stmpe811_timeout, (wdparm_t)priv);
     }
 
   /*  Reset and clear all data in the FIFO */

--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -398,10 +398,10 @@ static int  dm9x_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void dm9x_txtimeout_work(FAR void *arg);
-static void dm9x_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void dm9x_txtimeout_expiry(wdparm_t arg);
 
 static void dm9x_poll_work(FAR void *arg);
-static void dm9x_poll_expiry(int argc, wdparm_t arg, ...);
+static void dm9x_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -769,7 +769,7 @@ static int dm9x_transmit(FAR struct dm9x_driver_s *priv)
       /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
       wd_start(&priv->dm_txtimeout, DM6X_TXTIMEOUT,
-               dm9x_txtimeout_expiry, 1, (wdparm_t)priv);
+               dm9x_txtimeout_expiry, (wdparm_t)priv);
       return OK;
     }
 
@@ -1352,8 +1352,7 @@ static void dm9x_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1363,7 +1362,7 @@ static void dm9x_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void dm9x_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void dm9x_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct dm9x_driver_s *priv = (FAR struct dm9x_driver_s *)arg;
 
@@ -1428,7 +1427,7 @@ static void dm9x_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->dm_txpoll, DM9X_WDDELAY,
-           dm9x_poll_expiry, 1, (wdparm_t)priv);
+           dm9x_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1439,8 +1438,7 @@ static void dm9x_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1450,7 +1448,7 @@ static void dm9x_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void dm9x_poll_expiry(int argc, wdparm_t arg, ...)
+static void dm9x_poll_expiry(wdparm_t arg)
 {
   FAR struct dm9x_driver_s *priv = (FAR struct dm9x_driver_s *)arg;
 
@@ -1564,7 +1562,7 @@ static int dm9x_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->dm_txpoll, DM9X_WDDELAY,
-           dm9x_poll_expiry, 1, (wdparm_t)priv);
+           dm9x_poll_expiry, (wdparm_t)priv);
 
   /* Enable the DM9X interrupt */
 

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -335,9 +335,9 @@ static int  enc_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void enc_toworker(FAR void *arg);
-static void enc_txtimeout(int argc, wdparm_t arg, ...);
+static void enc_txtimeout(wdparm_t arg);
 static void enc_pollworker(FAR void *arg);
-static void enc_polltimer(int argc, wdparm_t arg, ...);
+static void enc_polltimer(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1159,7 +1159,7 @@ static int enc_transmit(FAR struct enc_driver_s *priv)
    */
 
   wd_start(&priv->txtimeout, ENC_TXTIMEOUT,
-           enc_txtimeout, 1, (wdparm_t)priv);
+           enc_txtimeout, (wdparm_t)priv);
   return OK;
 }
 
@@ -1932,8 +1932,7 @@ static void enc_toworker(FAR void *arg)
  *   The last TX never completed.  Perform work on the worker thread.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1942,7 +1941,7 @@ static void enc_toworker(FAR void *arg)
  *
  ****************************************************************************/
 
-static void enc_txtimeout(int argc, wdparm_t arg, ...)
+static void enc_txtimeout(wdparm_t arg)
 {
   FAR struct enc_driver_s *priv = (FAR struct enc_driver_s *)arg;
   int ret;
@@ -1972,8 +1971,7 @@ static void enc_txtimeout(int argc, wdparm_t arg, ...)
  *   Periodic timer handler continuation.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2017,7 +2015,7 @@ static void enc_pollworker(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, ENC_WDDELAY,
-           enc_polltimer, 1, (wdparm_t)arg);
+           enc_polltimer, (wdparm_t)arg);
 }
 
 /****************************************************************************
@@ -2027,8 +2025,7 @@ static void enc_pollworker(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2037,7 +2034,7 @@ static void enc_pollworker(FAR void *arg)
  *
  ****************************************************************************/
 
-static void enc_polltimer(int argc, wdparm_t arg, ...)
+static void enc_polltimer(wdparm_t arg)
 {
   FAR struct enc_driver_s *priv = (FAR struct enc_driver_s *)arg;
   int ret;
@@ -2117,7 +2114,7 @@ static int enc_ifup(struct net_driver_s *dev)
       /* Set and activate a timer process */
 
       wd_start(&priv->txpoll, ENC_WDDELAY,
-               enc_polltimer, 1, (wdparm_t)priv);
+               enc_polltimer, (wdparm_t)priv);
 
       /* Mark the interface up and enable the Ethernet interrupt at the
        * controller

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -353,9 +353,9 @@ static int  enc_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void enc_toworker(FAR void *arg);
-static void enc_txtimeout(int argc, wdparm_t arg, ...);
+static void enc_txtimeout(wdparm_t arg);
 static void enc_pollworker(FAR void *arg);
-static void enc_polltimer(int argc, wdparm_t arg, ...);
+static void enc_polltimer(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1065,7 +1065,7 @@ static int enc_transmit(FAR struct enc_driver_s *priv)
    */
 
   wd_start(&priv->txtimeout, ENC_TXTIMEOUT,
-           enc_txtimeout, 1, (wdparm_t)priv);
+           enc_txtimeout, (wdparm_t)priv);
 
   /* free the descriptor */
 
@@ -2086,8 +2086,7 @@ static void enc_toworker(FAR void *arg)
  *   The last TX never completed.  Perform work on the worker thread.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2096,7 +2095,7 @@ static void enc_toworker(FAR void *arg)
  *
  ****************************************************************************/
 
-static void enc_txtimeout(int argc, wdparm_t arg, ...)
+static void enc_txtimeout(wdparm_t arg)
 {
   FAR struct enc_driver_s *priv = (FAR struct enc_driver_s *)arg;
   int ret;
@@ -2126,8 +2125,7 @@ static void enc_txtimeout(int argc, wdparm_t arg, ...)
  *   Periodic timer handler continuation.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2170,7 +2168,7 @@ static void enc_pollworker(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->txpoll, ENC_WDDELAY, enc_polltimer, 1, (wdparm_t)arg);
+  wd_start(&priv->txpoll, ENC_WDDELAY, enc_polltimer, (wdparm_t)arg);
 }
 
 /****************************************************************************
@@ -2180,8 +2178,7 @@ static void enc_pollworker(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -2190,7 +2187,7 @@ static void enc_pollworker(FAR void *arg)
  *
  ****************************************************************************/
 
-static void enc_polltimer(int argc, wdparm_t arg, ...)
+static void enc_polltimer(wdparm_t arg)
 {
   FAR struct enc_driver_s *priv = (FAR struct enc_driver_s *)arg;
   int ret;
@@ -2273,7 +2270,7 @@ static int enc_ifup(struct net_driver_s *dev)
       /* Set and activate a timer process */
 
       wd_start(&priv->txpoll, ENC_WDDELAY,
-               enc_polltimer, 1, (wdparm_t)priv);
+               enc_polltimer, (wdparm_t)priv);
 
       /* Mark the interface up and enable the Ethernet interrupt at the
        * controller

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -222,10 +222,10 @@ static int  ftmac100_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void ftmac100_txtimeout_work(FAR void *arg);
-static void ftmac100_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void ftmac100_txtimeout_expiry(wdparm_t arg);
 
 static void ftmac100_poll_work(FAR void *arg);
-static void ftmac100_poll_expiry(int argc, wdparm_t arg, ...);
+static void ftmac100_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -330,7 +330,7 @@ static int ftmac100_transmit(FAR struct ftmac100_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->ft_txtimeout, FTMAC100_TXTIMEOUT,
-           ftmac100_txtimeout_expiry, 1, (wdparm_t)priv);
+           ftmac100_txtimeout_expiry, (wdparm_t)priv);
 
   return OK;
 }
@@ -1079,8 +1079,7 @@ static void ftmac100_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1090,7 +1089,7 @@ static void ftmac100_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void ftmac100_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void ftmac100_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct ftmac100_driver_s *priv = (FAR struct ftmac100_driver_s *)arg;
 
@@ -1145,7 +1144,7 @@ static void ftmac100_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->ft_txpoll, FTMAC100_WDDELAY,
-           ftmac100_poll_expiry, 1, (wdparm_t)priv);
+           ftmac100_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -1156,8 +1155,7 @@ static void ftmac100_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1167,7 +1165,7 @@ static void ftmac100_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void ftmac100_poll_expiry(int argc, wdparm_t arg, ...)
+static void ftmac100_poll_expiry(wdparm_t arg)
 {
   FAR struct ftmac100_driver_s *priv = (FAR struct ftmac100_driver_s *)arg;
 
@@ -1231,7 +1229,7 @@ static int ftmac100_ifup(struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->ft_txpoll, FTMAC100_WDDELAY,
-           ftmac100_poll_expiry, 1, (wdparm_t)priv);
+           ftmac100_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/drivers/net/lan91c111.c
+++ b/drivers/net/lan91c111.c
@@ -137,7 +137,7 @@ static int  lan91c111_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void lan91c111_poll_work(FAR void *arg);
-static void lan91c111_poll_expiry(int argc, wdparm_t arg, ...);
+static void lan91c111_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -1042,7 +1042,7 @@ static void lan91c111_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, LAN91C111_WDDELAY,
-           lan91c111_poll_expiry, 1, (wdparm_t)dev);
+           lan91c111_poll_expiry, (wdparm_t)dev);
   net_unlock();
 }
 
@@ -1053,8 +1053,7 @@ static void lan91c111_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1065,7 +1064,7 @@ static void lan91c111_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void lan91c111_poll_expiry(int argc, wdparm_t arg, ...)
+static void lan91c111_poll_expiry(wdparm_t arg)
 {
   FAR struct net_driver_s *dev = (FAR struct net_driver_s *)arg;
   FAR struct lan91c111_driver_s *priv = dev->d_private;
@@ -1143,7 +1142,7 @@ static int lan91c111_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, LAN91C111_WDDELAY,
-           lan91c111_poll_expiry, 1, (wdparm_t)dev);
+           lan91c111_poll_expiry, (wdparm_t)dev);
   net_unlock();
 
   /* Enable the Ethernet interrupt */

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -121,7 +121,7 @@ static uint8_t g_iobuffer[NET_LO_PKTSIZE + CONFIG_NET_GUARDSIZE];
 
 static int  lo_txpoll(FAR struct net_driver_s *dev);
 static void lo_poll_work(FAR void *arg);
-static void lo_poll_expiry(int argc, wdparm_t arg, ...);
+static void lo_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -251,7 +251,7 @@ static void lo_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->lo_polldog, LO_WDDELAY, lo_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->lo_polldog, LO_WDDELAY, lo_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -262,8 +262,7 @@ static void lo_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -273,7 +272,7 @@ static void lo_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void lo_poll_expiry(int argc, wdparm_t arg, ...)
+static void lo_poll_expiry(wdparm_t arg)
 {
   FAR struct lo_driver_s *priv = (FAR struct lo_driver_s *)arg;
 
@@ -319,7 +318,7 @@ static int lo_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->lo_polldog, LO_WDDELAY,
-           lo_poll_expiry, 1, (wdparm_t)priv);
+           lo_poll_expiry, (wdparm_t)priv);
 
   priv->lo_bifup = true;
   return OK;

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -210,7 +210,7 @@ static int  net_rpmsg_drv_send_recv(struct net_driver_s *dev,
 /* Watchdog timer expirations */
 
 static void net_rpmsg_drv_poll_work(FAR void *arg);
-static void net_rpmsg_drv_poll_expiry(int argc, wdparm_t arg, ...);
+static void net_rpmsg_drv_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -844,7 +844,7 @@ static void net_rpmsg_drv_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, NET_RPMSG_DRV_WDDELAY,
-           net_rpmsg_drv_poll_expiry, 1, (wdparm_t)dev);
+           net_rpmsg_drv_poll_expiry, (wdparm_t)dev);
   net_unlock();
 }
 
@@ -855,8 +855,7 @@ static void net_rpmsg_drv_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -867,7 +866,7 @@ static void net_rpmsg_drv_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void net_rpmsg_drv_poll_expiry(int argc, wdparm_t arg, ...)
+static void net_rpmsg_drv_poll_expiry(wdparm_t arg)
 {
   FAR struct net_driver_s *dev = (FAR struct net_driver_s *)arg;
   FAR struct net_rpmsg_drv_s *priv = dev->d_private;
@@ -969,7 +968,7 @@ static int net_rpmsg_drv_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, NET_RPMSG_DRV_WDDELAY,
-           net_rpmsg_drv_poll_expiry, 1, (wdparm_t)dev);
+           net_rpmsg_drv_poll_expiry, (wdparm_t)dev);
 
   net_unlock();
 

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -173,10 +173,10 @@ static int  skel_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void skel_txtimeout_work(FAR void *arg);
-static void skel_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void skel_txtimeout_expiry(wdparm_t arg);
 
 static void skel_poll_work(FAR void *arg);
-static void skel_poll_expiry(int argc, wdparm_t arg, ...);
+static void skel_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -242,7 +242,7 @@ static int skel_transmit(FAR struct skel_driver_s *priv)
   /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
   wd_start(&priv->sk_txtimeout, SKELETON_TXTIMEOUT,
-           skel_txtimeout_expiry, 1, (wdparm_t)priv);
+           skel_txtimeout_expiry, (wdparm_t)priv);
   return OK;
 }
 
@@ -675,8 +675,7 @@ static void skel_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -687,7 +686,7 @@ static void skel_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void skel_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void skel_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct skel_driver_s *priv = (FAR struct skel_driver_s *)arg;
 
@@ -748,7 +747,7 @@ static void skel_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->sk_txpoll, SKELETON_WDDELAY,
-           skel_poll_expiry, 1, (wdparm_t)priv);
+           skel_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -759,8 +758,7 @@ static void skel_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -771,7 +769,7 @@ static void skel_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void skel_poll_expiry(int argc, wdparm_t arg, ...)
+static void skel_poll_expiry(wdparm_t arg)
 {
   FAR struct skel_driver_s *priv = (FAR struct skel_driver_s *)arg;
 
@@ -828,7 +826,7 @@ static int skel_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->sk_txpoll, SKELETON_WDDELAY,
-           skel_poll_expiry, 1, (wdparm_t)priv);
+           skel_poll_expiry, (wdparm_t)priv);
 
   /* Enable the Ethernet interrupt */
 

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -193,7 +193,7 @@ static void tun_txdone(FAR struct tun_device_s *priv);
 /* Watchdog timer expirations */
 
 static void tun_poll_work(FAR void *arg);
-static void tun_poll_expiry(int argc, wdparm_t arg, ...);
+static void tun_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -811,7 +811,7 @@ static void tun_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->txpoll, TUN_WDDELAY, tun_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, TUN_WDDELAY, tun_poll_expiry, (wdparm_t)priv);
 
   net_unlock();
   tun_unlock(priv);
@@ -824,8 +824,7 @@ static void tun_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -835,7 +834,7 @@ static void tun_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void tun_poll_expiry(int argc, wdparm_t arg, ...)
+static void tun_poll_expiry(FAR void *arg)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)arg;
 
@@ -879,8 +878,7 @@ static int tun_ifup(FAR struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->txpoll, TUN_WDDELAY,
-           tun_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->txpoll, TUN_WDDELAY, tun_poll_expiry, priv);
 
   priv->bifup = true;
   return OK;

--- a/drivers/power/activity_governor.c
+++ b/drivers/power/activity_governor.c
@@ -548,13 +548,13 @@ static void governor_statechanged(int domain, enum pm_state_e newstate)
     }
 }
 
-static void governor_timer_cb(int argc, ...)
+static void governor_timer_cb(wdparm_t arg)
 {
   /* Do nothing here, cause we only need TIMER ISR to wake up PM,
    * for deceasing PM state.
    */
 
-  UNUSED(argc);
+  UNUSED(arg);
 }
 
 /****************************************************************************
@@ -602,7 +602,7 @@ static void governor_timer(int domain)
       if (!WDOG_ISACTIVE(&pdomstate->wdog) ||
           abs(delay - left) > PM_TIMER_GAP)
         {
-          wd_start(&pdomstate->wdog, delay, (wdentry_t)governor_timer_cb, 0);
+          wd_start(&pdomstate->wdog, delay, governor_timer_cb, 0);
         }
     }
   else

--- a/drivers/sensors/ak09912.c
+++ b/drivers/sensors/ak09912.c
@@ -398,7 +398,7 @@ static int ak09912_set_noise_suppr_flt(FAR struct ak09912_dev_s *priv,
  *
  ****************************************************************************/
 
-static void ak09912_wd_timeout(int argc, wdparm_t arg, ...)
+static void ak09912_wd_timeout(wdparm_t arg)
 {
   struct ak09912_dev_s *priv = (struct ak09912_dev_s *)arg;
   irqstate_t flags = enter_critical_section();
@@ -422,7 +422,7 @@ static int ak09912_read_mag_uncomp_data(FAR struct ak09912_dev_s *priv,
   uint8_t buffer[8];  /* TMPS and ST2 is read, but the value is omitted. */
 
   wd_start(&priv->wd, AK09912_POLLING_TIMEOUT,
-           ak09912_wd_timeout, 1, (wdparm_t)priv);
+           ak09912_wd_timeout, (wdparm_t)priv);
   state = ak09912_getreg8(priv, AK09912_ST1);
   while (! (state & 0x1))
     {

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -143,16 +143,16 @@ static int watchdog_automonitor_capture(int irq, FAR void *context,
   return 0;
 }
 #elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_TIMER)
-static void watchdog_automonitor_timer(int argc, wdparm_t arg1, ...)
+static void watchdog_automonitor_timer(wdparm_t arg)
 {
-  FAR struct watchdog_upperhalf_s *upper = (FAR void *)arg1;
+  FAR struct watchdog_upperhalf_s *upper = (FAR void *)arg;
   FAR struct watchdog_lowerhalf_s *lower = upper->lower;
 
   if (upper->monitor)
     {
       lower->ops->keepalive(lower);
       wd_start(&upper->wdog, WATCHDOG_AUTOMONITOR_TIMEOUT_TICK / 2,
-               watchdog_automonitor_timer, 1, (wdparm_t)upper);
+               watchdog_automonitor_timer, (wdparm_t)upper);
     }
 }
 #elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_WORKER)
@@ -195,7 +195,7 @@ static void watchdog_automonitor_start(FAR struct watchdog_upperhalf_s
       lower->ops->capture(lower, watchdog_automonitor_capture);
 #elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_TIMER)
       wd_start(&upper->wdog, WATCHDOG_AUTOMONITOR_TIMEOUT_TICK / 2,
-               watchdog_automonitor_timer, 1, (wdparm_t)upper);
+               watchdog_automonitor_timer, (wdparm_t)upper);
 #elif defined(CONFIG_WATCHDOG_AUTOMONITOR_BY_WORKER)
       work_queue(LPWORK, &upper->work, watchdog_automonitor_worker,
                  upper, WATCHDOG_AUTOMONITOR_TIMEOUT_TICK / 2);

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -175,7 +175,7 @@ static int     cdcacm_recvpacket(FAR struct cdcacm_dev_s *priv,
 static int     cdcacm_requeue_rdrequest(FAR struct cdcacm_dev_s *priv,
                  FAR struct cdcacm_rdreq_s *rdcontainer);
 static int     cdcacm_release_rxpending(FAR struct cdcacm_dev_s *priv);
-static void    cdcacm_rxtimeout(int argc, wdparm_t arg1, ...);
+static void    cdcacm_rxtimeout(wdparm_t arg);
 
 /* Request helpers **********************************************************/
 
@@ -747,7 +747,7 @@ static int cdcacm_release_rxpending(FAR struct cdcacm_dev_s *priv)
   if (!sq_empty(&priv->rxpending))
     {
       wd_start(&priv->rxfailsafe, CDCACM_RXDELAY,
-               cdcacm_rxtimeout, 1, (wdparm_t)priv);
+               cdcacm_rxtimeout, (wdparm_t)priv);
     }
 
   leave_critical_section(flags);
@@ -766,9 +766,9 @@ static int cdcacm_release_rxpending(FAR struct cdcacm_dev_s *priv)
  *
  ****************************************************************************/
 
-static void cdcacm_rxtimeout(int argc, wdparm_t arg1, ...)
+static void cdcacm_rxtimeout(wdparm_t arg)
 {
-  FAR struct cdcacm_dev_s *priv = (FAR struct cdcacm_dev_s *)arg1;
+  FAR struct cdcacm_dev_s *priv = (FAR struct cdcacm_dev_s *)arg;
 
   DEBUGASSERT(priv != NULL);
   cdcacm_release_rxpending(priv);

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -193,7 +193,7 @@ static void cdcecm_interrupt_work(FAR void *arg);
 /* Watchdog timer expirations */
 
 static void cdcecm_poll_work(FAR void *arg);
-static void cdcecm_poll_expiry(int argc, wdparm_t arg, ...);
+static void cdcecm_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -708,7 +708,7 @@ static void cdcecm_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&self->txpoll, CDCECM_WDDELAY,
-           cdcecm_poll_expiry, 1, (wdparm_t)self);
+           cdcecm_poll_expiry, (wdparm_t)self);
 
   net_unlock();
 }
@@ -720,8 +720,7 @@ static void cdcecm_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -732,7 +731,7 @@ static void cdcecm_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void cdcecm_poll_expiry(int argc, wdparm_t arg, ...)
+static void cdcecm_poll_expiry(wdparm_t arg)
 {
   FAR struct cdcecm_driver_s *priv = (FAR struct cdcecm_driver_s *)arg;
 
@@ -789,7 +788,7 @@ static int cdcecm_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->txpoll, CDCECM_WDDELAY,
-           cdcecm_poll_expiry, 1, (wdparm_t)priv);
+           cdcecm_poll_expiry, (wdparm_t)priv);
 
   priv->bifup = true;
   return OK;

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -226,7 +226,7 @@ static int rndis_ifdown(FAR struct net_driver_s *dev);
 static int rndis_txavail(FAR struct net_driver_s *dev);
 static int rndis_transmit(FAR struct rndis_dev_s *priv);
 static int rndis_txpoll(FAR struct net_driver_s *dev);
-static void rndis_polltimer(int argc, wdparm_t arg, ...);
+static void rndis_polltimer(wdparm_t arg);
 
 /* usbclass callbacks */
 
@@ -1108,7 +1108,7 @@ static void rndis_pollworker(FAR void *arg)
  *
  ****************************************************************************/
 
-static void rndis_polltimer(int argc, wdparm_t arg, ...)
+static void rndis_polltimer(wdparm_t arg)
 {
   FAR struct rndis_dev_s *priv = (FAR struct rndis_dev_s *)arg;
   int ret;
@@ -1124,7 +1124,7 @@ static void rndis_polltimer(int argc, wdparm_t arg, ...)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, RNDIS_WDDELAY,
-           rndis_polltimer, 1, (wdparm_t)arg);
+           rndis_polltimer, (wdparm_t)arg);
 }
 
 /****************************************************************************
@@ -1140,7 +1140,7 @@ static int rndis_ifup(FAR struct net_driver_s *dev)
   FAR struct rndis_dev_s *priv = (FAR struct rndis_dev_s *)dev->d_private;
 
   wd_start(&priv->txpoll, RNDIS_WDDELAY,
-           rndis_polltimer, 1, (wdparm_t)priv);
+           rndis_polltimer, (wdparm_t)priv);
   return OK;
 }
 

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -2302,7 +2302,7 @@ static void cdcmbim_receive(struct usbhost_cdcmbim_s *priv,
   net_unlock();
 }
 
-static void cdcmbim_txpoll_expiry(int argc, wdparm_t arg, ...)
+static void cdcmbim_txpoll_expiry(wdparm_t arg)
 {
   struct usbhost_cdcmbim_s *priv = (struct usbhost_cdcmbim_s *)arg;
 
@@ -2321,7 +2321,7 @@ static void cdcmbim_txpoll_work(void *arg)
   /* setup the watchdog poll timer again */
 
   wd_start(&priv->txpoll, (1 * CLK_TCK),
-           cdcmbim_txpoll_expiry, 1, (wdparm_t)priv);
+           cdcmbim_txpoll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -2428,7 +2428,7 @@ static int cdcmbim_ifup(struct net_driver_s *dev)
   /* Start network TX poll */
 
   wd_start(&priv->txpoll, (1 * CLK_TCK),
-           cdcmbim_txpoll_expiry, 1, (wdparm_t)priv);
+           cdcmbim_txpoll_expiry, (wdparm_t)priv);
   priv->bifup = true;
   return OK;
 }

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -947,9 +947,9 @@ exit_invalid_frame:
   bcmf_hexdump((uint8_t *)event, event_len, (unsigned long)event);
 }
 
-void bcmf_wl_scan_timeout(int argc, wdparm_t arg1, ...)
+void bcmf_wl_scan_timeout(wdparm_t arg)
 {
-  FAR struct bcmf_dev_s *priv = (FAR struct bcmf_dev_s *)arg1;
+  FAR struct bcmf_dev_s *priv = (FAR struct bcmf_dev_s *)arg;
 
   if (priv->scan_status < BCMF_SCAN_RUN)
     {
@@ -1142,7 +1142,7 @@ int bcmf_wl_start_scan(FAR struct bcmf_dev_s *priv, struct iwreq *iwr)
   /*  Start scan_timeout timer */
 
   wd_start(&priv->scan_timeout, BCMF_SCAN_TIMEOUT_TICK,
-           bcmf_wl_scan_timeout, 1, (wdparm_t)priv);
+           bcmf_wl_scan_timeout, (wdparm_t)priv);
 
   return OK;
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -127,7 +127,7 @@ static void bcmf_rxpoll(FAR void *arg);
 /* Watchdog timer expirations */
 
 static void bcmf_poll_work(FAR void *arg);
-static void bcmf_poll_expiry(int argc, wdparm_t arg, ...);
+static void bcmf_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -626,7 +626,7 @@ static void bcmf_poll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->bc_txpoll, BCMF_WDDELAY,
-           bcmf_poll_expiry, 1, (wdparm_t)priv);
+           bcmf_poll_expiry, (wdparm_t)priv);
 exit_unlock:
   net_unlock();
 }
@@ -638,8 +638,7 @@ exit_unlock:
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -649,7 +648,7 @@ exit_unlock:
  *
  ****************************************************************************/
 
-static void bcmf_poll_expiry(int argc, wdparm_t arg, ...)
+static void bcmf_poll_expiry(wdparm_t arg)
 {
   FAR struct bcmf_dev_s *priv = (FAR struct bcmf_dev_s *)arg;
 
@@ -702,7 +701,7 @@ static int bcmf_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->bc_txpoll, BCMF_WDDELAY,
-           bcmf_poll_expiry, 1, (wdparm_t)priv);
+           bcmf_poll_expiry, (wdparm_t)priv);
 
   /* Enable the hardware interrupt */
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -111,7 +111,7 @@ static int  bcmf_oob_irq(FAR void *arg);
 static int  bcmf_sdio_bus_sleep(FAR struct bcmf_sdio_dev_s *sbus,
                                 bool sleep);
 
-static void bcmf_sdio_waitdog_timeout(int argc, wdparm_t arg1, ...);
+static void bcmf_sdio_waitdog_timeout(wdparm_t arg);
 static int  bcmf_sdio_thread(int argc, char **argv);
 
 static int  bcmf_sdio_find_block_size(unsigned int size);
@@ -747,7 +747,7 @@ int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
   /* Start the waitdog timer */
 
   wd_start(&sbus->waitdog, BCMF_WAITDOG_TIMEOUT_TICK,
-           bcmf_sdio_waitdog_timeout, 1, (wdparm_t)priv);
+           bcmf_sdio_waitdog_timeout, (wdparm_t)priv);
 
   /* Spawn bcmf daemon thread */
 
@@ -816,9 +816,9 @@ int bcmf_chipinitialize(FAR struct bcmf_sdio_dev_s *sbus)
   return OK;
 }
 
-void bcmf_sdio_waitdog_timeout(int argc, wdparm_t arg1, ...)
+void bcmf_sdio_waitdog_timeout(wdparm_t arg)
 {
-  FAR struct bcmf_dev_s *priv = (FAR struct bcmf_dev_s *)arg1;
+  FAR struct bcmf_dev_s *priv = (FAR struct bcmf_dev_s *)arg;
   FAR struct bcmf_sdio_dev_s *sbus = (FAR struct bcmf_sdio_dev_s *)priv->bus;
 
   /* Notify bcmf thread */
@@ -853,7 +853,7 @@ int bcmf_sdio_thread(int argc, char **argv)
       /* Restart the waitdog timer */
 
       wd_start(&sbus->waitdog, BCMF_WAITDOG_TIMEOUT_TICK,
-               bcmf_sdio_waitdog_timeout, 1, (wdparm_t)priv);
+               bcmf_sdio_waitdog_timeout, (wdparm_t)priv);
 
       /* Wake up device */
 

--- a/drivers/wireless/ieee802154/xbee/xbee.c
+++ b/drivers/wireless/ieee802154/xbee/xbee.c
@@ -86,10 +86,10 @@ static void xbee_process_rxframe(FAR struct xbee_priv_s *priv,
 static void xbee_notify(FAR struct xbee_priv_s *priv,
                 FAR struct ieee802154_primitive_s *primitive);
 static void xbee_notify_worker(FAR void *arg);
-static void xbee_atquery_timeout(int argc, wdparm_t arg, ...);
+static void xbee_atquery_timeout(wdparm_t arg);
 
 #ifdef CONFIG_XBEE_LOCKUP_WORKAROUND
-static void xbee_lockupcheck_timeout(int argc, wdparm_t arg, ...);
+static void xbee_lockupcheck_timeout(wdparm_t arg);
 static void xbee_lockupcheck_worker(FAR void *arg);
 static void xbee_backup_worker(FAR void *arg);
 static void xbee_lockupcheck_reschedule(FAR struct xbee_priv_s *priv);
@@ -1098,8 +1098,7 @@ static void xbee_notify_worker(FAR void *arg)
  *   handle it gracefully by retrying the query.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1108,7 +1107,7 @@ static void xbee_notify_worker(FAR void *arg)
  *
  ****************************************************************************/
 
-static void xbee_atquery_timeout(int argc, wdparm_t arg, ...)
+static void xbee_atquery_timeout(wdparm_t arg)
 {
   FAR struct xbee_priv_s *priv = (FAR struct xbee_priv_s *)arg;
 
@@ -1131,8 +1130,7 @@ static void xbee_atquery_timeout(int argc, wdparm_t arg, ...)
  *   locked up.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1141,7 +1139,7 @@ static void xbee_atquery_timeout(int argc, wdparm_t arg, ...)
  *
  ****************************************************************************/
 
-static void xbee_lockupcheck_timeout(int argc, wdparm_t arg, ...)
+static void xbee_lockupcheck_timeout(wdparm_t arg)
 {
   FAR struct xbee_priv_s *priv = (FAR struct xbee_priv_s *)arg;
 
@@ -1212,7 +1210,7 @@ static void xbee_lockupcheck_reschedule(FAR struct xbee_priv_s *priv)
    */
 
   wd_start(&priv->lockup_wd, XBEE_LOCKUP_QUERYTIME,
-           xbee_lockupcheck_timeout, 1, (wdparm_t)priv);
+           xbee_lockupcheck_timeout, (wdparm_t)priv);
 }
 
 #endif
@@ -1578,7 +1576,7 @@ int xbee_atquery(FAR struct xbee_priv_s *priv, FAR const char *atcommand)
           /* Setup a timeout */
 
           wd_start(&priv->atquery_wd, XBEE_ATQUERY_TIMEOUT,
-                   xbee_atquery_timeout, 1, (wdparm_t)priv);
+                   xbee_atquery_timeout, (wdparm_t)priv);
         }
 
       /* Send the query */

--- a/drivers/wireless/ieee802154/xbee/xbee_mac.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_mac.c
@@ -70,7 +70,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static void xbee_assoctimer(int argc, wdparm_t arg, ...);
+static void xbee_assoctimer(wdparm_t arg);
 static void xbee_assocworker(FAR void *arg);
 
 /****************************************************************************
@@ -95,8 +95,7 @@ static void xbee_assocworker(FAR void *arg);
  *   again until the association is either successful or fails.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -105,7 +104,7 @@ static void xbee_assocworker(FAR void *arg);
  *
  ****************************************************************************/
 
-static void xbee_assoctimer(int argc, wdparm_t arg, ...)
+static void xbee_assoctimer(wdparm_t arg)
 {
   FAR struct xbee_priv_s *priv = (FAR struct xbee_priv_s *)arg;
   int ret;
@@ -156,7 +155,7 @@ static void xbee_assocworker(FAR void *arg)
       xbee_send_atquery(priv, "AI");
 
       wd_start(&priv->assocwd, XBEE_ASSOC_POLLDELAY,
-               xbee_assoctimer, 1, (wdparm_t)arg);
+               xbee_assoctimer, (wdparm_t)arg);
     }
 }
 
@@ -171,8 +170,7 @@ static void xbee_assocworker(FAR void *arg)
  *   randomly drops the request and never sends a response.
  *
  * Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -181,7 +179,7 @@ static void xbee_assocworker(FAR void *arg)
  *
  ****************************************************************************/
 
-static void xbee_reqdata_timeout(int argc, wdparm_t arg, ...)
+static void xbee_reqdata_timeout(wdparm_t arg)
 {
   FAR struct xbee_priv_s *priv = (FAR struct xbee_priv_s *)arg;
 
@@ -383,7 +381,7 @@ int xbee_req_data(XBEEHANDLE xbee,
       /* Setup a timeout in case the XBee never responds with a tx status */
 
       wd_start(&priv->reqdata_wd, XBEE_RESPONSE_TIMEOUT,
-               xbee_reqdata_timeout, 1, (wdparm_t)priv);
+               xbee_reqdata_timeout, (wdparm_t)priv);
 
       /* Send the frame */
 
@@ -706,7 +704,7 @@ int xbee_req_associate(XBEEHANDLE xbee,
    */
 
   return wd_start(&priv->assocwd, XBEE_ASSOC_POLLDELAY,
-                  xbee_assoctimer, 1, (wdparm_t)priv);
+                  xbee_assoctimer, (wdparm_t)priv);
 }
 
 /****************************************************************************

--- a/drivers/wireless/ieee802154/xbee/xbee_netdev.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_netdev.c
@@ -192,7 +192,7 @@ static int  xbeenet_rxframe(FAR struct xbeenet_driver_s *maccb,
 
 static int  xbeenet_txpoll_callback(FAR struct net_driver_s *dev);
 static void xbeenet_txpoll_work(FAR void *arg);
-static void xbeenet_txpoll_expiry(int argc, wdparm_t arg, ...);
+static void xbeenet_txpoll_expiry(wdparm_t arg);
 
 /* IOCTL support */
 
@@ -630,7 +630,7 @@ static void xbeenet_txpoll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->xd_txpoll, TXPOLL_WDDELAY,
-           xbeenet_txpoll_expiry, 1, (wdparm_t)priv);
+           xbeenet_txpoll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -641,8 +641,7 @@ static void xbeenet_txpoll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -652,7 +651,7 @@ static void xbeenet_txpoll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void xbeenet_txpoll_expiry(int argc, wdparm_t arg, ...)
+static void xbeenet_txpoll_expiry(wdparm_t arg)
 {
   FAR struct xbeenet_driver_s *priv = (FAR struct xbeenet_driver_s *)arg;
 
@@ -781,7 +780,7 @@ static int xbeenet_ifup(FAR struct net_driver_s *dev)
       /* Set and activate a timer process */
 
       wd_start(&priv->xd_txpoll, TXPOLL_WDDELAY,
-               xbeenet_txpoll_expiry, 1, (wdparm_t)priv);
+               xbeenet_txpoll_expiry, (wdparm_t)priv);
 
       /* The interface is now up */
 

--- a/drivers/wireless/spirit/drivers/spirit_netdev.c
+++ b/drivers/wireless/spirit/drivers/spirit_netdev.c
@@ -313,10 +313,10 @@ static int  spirit_interrupt(int irq, FAR void *context, FAR void *arg);
 /* Watchdog timer expirations */
 
 static void spirit_txtimeout_work(FAR void *arg);
-static void spirit_txtimeout_expiry(int argc, wdparm_t arg, ...);
+static void spirit_txtimeout_expiry(wdparm_t arg);
 
 static void spirit_txpoll_work(FAR void *arg);
-static void spirit_txpoll_expiry(int argc, wdparm_t arg, ...);
+static void spirit_txpoll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -927,7 +927,7 @@ static void spirit_transmit_work(FAR void *arg)
       /* Setup the TX timeout watchdog (perhaps restarting the timer) */
 
       wd_start(&priv->txtimeout, SPIRIT_TXTIMEOUT,
-               spirit_txtimeout_expiry, 1, (wdparm_t)priv);
+               spirit_txtimeout_expiry, (wdparm_t)priv);
     }
 
   spirit_txunlock(priv);
@@ -1720,8 +1720,7 @@ static void spirit_txtimeout_work(FAR void *arg)
  *   The last TX never completed.  Reset the hardware and start again.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1731,7 +1730,7 @@ static void spirit_txtimeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void spirit_txtimeout_expiry(int argc, wdparm_t arg, ...)
+static void spirit_txtimeout_expiry(wdparm_t arg)
 {
   FAR struct spirit_driver_s *priv = (FAR struct spirit_driver_s *)arg;
 
@@ -1807,7 +1806,7 @@ static void spirit_txpoll_work(FAR void *arg)
       /* Setup the watchdog poll timer again */
 
       wd_start(&priv->txpoll, SPIRIT_WDDELAY,
-               spirit_txpoll_expiry, 1, (wdparm_t)priv);
+               spirit_txpoll_expiry, (wdparm_t)priv);
     }
   else
     {
@@ -1826,8 +1825,7 @@ static void spirit_txpoll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -1837,7 +1835,7 @@ static void spirit_txpoll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void spirit_txpoll_expiry(int argc, wdparm_t arg, ...)
+static void spirit_txpoll_expiry(wdparm_t arg)
 {
   FAR struct spirit_driver_s *priv = (FAR struct spirit_driver_s *)arg;
 
@@ -1946,7 +1944,7 @@ static int spirit_ifup(FAR struct net_driver_s *dev)
       /* Set and activate a timer process */
 
       wd_start(&priv->txpoll, SPIRIT_WDDELAY,
-               spirit_txpoll_expiry, 1, (wdparm_t)priv);
+               spirit_txpoll_expiry, (wdparm_t)priv);
 
       /* Enables the interrupts from the SPIRIT1 */
 

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -84,7 +84,7 @@ struct automounter_state_s
 static int  automount_findinode(FAR const char *path);
 static void automount_mount(FAR struct automounter_state_s *priv);
 static int  automount_unmount(FAR struct automounter_state_s *priv);
-static void automount_timeout(int argc, wdparm_t arg1, ...);
+static void automount_timeout(wdparm_t arg);
 static void automount_worker(FAR void *arg);
 static int  automount_interrupt(FAR const struct automount_lower_s *lower,
               FAR void *arg, bool inserted);
@@ -294,7 +294,7 @@ static int automount_unmount(FAR struct automounter_state_s *priv)
               /* Start a timer to retry the umount2 after a delay */
 
               ret = wd_start(&priv->wdog, lower->udelay,
-                             automount_timeout, 1, (wdparm_t)priv);
+                             automount_timeout, (wdparm_t)priv);
               if (ret < 0)
                 {
                   ferr("ERROR: wd_start failed: %d\n", ret);
@@ -349,14 +349,14 @@ static int automount_unmount(FAR struct automounter_state_s *priv)
  *
  ****************************************************************************/
 
-static void automount_timeout(int argc, wdparm_t arg1, ...)
+static void automount_timeout(wdparm_t arg)
 {
   FAR struct automounter_state_s *priv =
-    (FAR struct automounter_state_s *)arg1;
+    (FAR struct automounter_state_s *)arg;
   int ret;
 
   finfo("Timeout!\n");
-  DEBUGASSERT(argc == 1 && priv);
+  DEBUGASSERT(priv);
 
   /* Check the state of things.  This timeout at the interrupt level and
    * will cancel the timeout if there is any change in the insertion

--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -56,13 +56,6 @@
  * We always have sizeof(pointer) <= sizeof(uintptr_t) by definition.
  */
 
-union wdparm_u
-{
-  FAR void     *pvarg; /* The size one generic point */
-  uint32_t      dwarg; /* Big enough for a 32-bit value in any case */
-  uintptr_t     uiarg; /* sizeof(uintptr_t) >= sizeof(pointer) */
-};
-
 #if UINTPTR_MAX >= UINT32_MAX
 typedef uintptr_t wdparm_t;
 #else
@@ -70,10 +63,10 @@ typedef uint32_t  wdparm_t;
 #endif
 
 /* This is the form of the function that is called when the
- * watchdog function expires.  Up to four parameters may be passed.
+ * watchdog function expires.
  */
 
-typedef CODE void (*wdentry_t)(int argc, wdparm_t arg1, ...);
+typedef CODE void (*wdentry_t)(wdparm_t arg);
 
 /* This is the internal representation of the watchdog timer structure. */
 
@@ -86,8 +79,7 @@ struct wdog_s
 #endif
   int                lag;        /* Timer associated with the delay */
   uint8_t            flags;      /* See WDOGF_* definitions above */
-  uint8_t            argc;       /* The number of parameters to pass */
-  wdparm_t           parm[CONFIG_MAX_WDOGPARMS];
+  wdparm_t           arg;        /* Callback argument */
 };
 
 /****************************************************************************
@@ -124,9 +116,9 @@ extern "C"
  *   wdog     - Watchdog ID
  *   delay    - Delay count in clock ticks
  *   wdentry  - Function to call on timeout
- *   parm1..4 - Parameters to pass to wdentry.
+ *   arg      - Parameter to pass to wdentry.
  *
- *   NOTE:  All parameters must be of type wdparm_t.
+ *   NOTE:  The parameter must be of type wdparm_t.
  *
  * Returned Value:
  *   Zero (OK) is returned on success; a negated errno value is return to
@@ -139,7 +131,7 @@ extern "C"
  ****************************************************************************/
 
 int wd_start(FAR struct wdog_s *wdog, int32_t delay,
-             wdentry_t wdentry, int argc, ...);
+             wdentry_t wdentry, wdparm_t arg);
 
 /****************************************************************************
  * Name: wd_cancel

--- a/net/igmp/igmp_timer.c
+++ b/net/igmp/igmp_timer.c
@@ -151,7 +151,7 @@ static void igmp_timeout_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void igmp_timeout(int argc, wdparm_t arg, ...)
+static void igmp_timeout(wdparm_t arg)
 {
   FAR struct igmp_group_s *group;
   int ret;
@@ -161,7 +161,7 @@ static void igmp_timeout(int argc, wdparm_t arg, ...)
   /* Recover the reference to the group */
 
   group = (FAR struct igmp_group_s *)arg;
-  DEBUGASSERT(argc == 1 && group != NULL);
+  DEBUGASSERT(group != NULL);
 
   /* Perform the timeout-related operations on (preferably) the low priority
    * work queue.
@@ -197,7 +197,7 @@ void igmp_startticks(FAR struct igmp_group_s *group, unsigned int ticks)
 
   gtmrinfo("ticks: %d\n", ticks);
 
-  ret = wd_start(&group->wdog, ticks, igmp_timeout, 1, (wdparm_t)group);
+  ret = wd_start(&group->wdog, ticks, igmp_timeout, (wdparm_t)group);
 
   DEBUGASSERT(ret == OK);
   UNUSED(ret);

--- a/net/mld/mld_timer.c
+++ b/net/mld/mld_timer.c
@@ -196,7 +196,7 @@ static void mld_gendog_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void mld_gendog_timout(int argc, wdparm_t arg, ...)
+static void mld_gendog_timout(wdparm_t arg)
 {
   FAR struct work_s *work;
   int ret;
@@ -285,7 +285,7 @@ static void mld_v1dog_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void mld_v1dog_timout(int argc, wdparm_t arg, ...)
+static void mld_v1dog_timout(wdparm_t arg)
 {
   FAR struct work_s *work;
   int ret;
@@ -400,7 +400,7 @@ static void mld_polldog_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void mld_polldog_timout(int argc, wdparm_t arg, ...)
+static void mld_polldog_timout(wdparm_t arg)
 {
   FAR struct mld_group_s *group;
   int ret;
@@ -410,7 +410,7 @@ static void mld_polldog_timout(int argc, wdparm_t arg, ...)
   /* Recover the reference to the group */
 
   group = (FAR struct mld_group_s *)arg;
-  DEBUGASSERT(argc == 1 && group != NULL);
+  DEBUGASSERT(group != NULL);
 
   /* Perform the timeout-related operations on (preferably) the low priority
    * work queue.
@@ -444,7 +444,7 @@ void mld_start_gentimer(FAR struct net_driver_s *dev, clock_t ticks)
   mldinfo("ticks: %lu\n", (unsigned long)ticks);
 
   ret = wd_start(&dev->d_mld.gendog, ticks,
-                 mld_gendog_timout, 1, (wdparm_t)dev->d_ifindex);
+                 mld_gendog_timout, dev->d_ifindex);
 
   DEBUGASSERT(ret == OK);
   UNUSED(ret);
@@ -469,7 +469,7 @@ void mld_start_v1timer(FAR struct net_driver_s *dev, clock_t ticks)
   mldinfo("ticks: %lu\n", (unsigned long)ticks);
 
   ret = wd_start(&dev->d_mld.v1dog, ticks,
-                 mld_v1dog_timout, 1, (wdparm_t)dev->d_ifindex);
+                 mld_v1dog_timout, dev->d_ifindex);
 
   DEBUGASSERT(ret == OK);
   UNUSED(ret);
@@ -492,7 +492,7 @@ void mld_start_polltimer(FAR struct mld_group_s *group, clock_t ticks)
   mldinfo("ticks: %lu\n", (unsigned long)ticks);
 
   ret = wd_start(&group->polldog, ticks,
-                 mld_polldog_timout, 1, (wdparm_t)group);
+                 mld_polldog_timout, (wdparm_t)group);
 
   DEBUGASSERT(ret == OK);
   UNUSED(ret);

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -217,12 +217,6 @@ config START_DAY
 	default 1
 	range 1 31
 
-config MAX_WDOGPARMS
-	int "Maximum number of watchdog parameters"
-	default 2
-	---help---
-		Maximum number of parameters that can be passed to a watchdog handler
-
 config PREALLOC_TIMERS
 	int "Number of pre-allocated POSIX timers"
 	default 8

--- a/sched/mqueue/mq_timedreceive.c
+++ b/sched/mqueue/mq_timedreceive.c
@@ -54,7 +54,6 @@
  *   becomes non-empty.
  *
  * Input Parameters:
- *   argc  - the number of arguments (should be 1)
  *   pid   - the task ID of the task to wakeup
  *
  * Returned Value:
@@ -64,7 +63,7 @@
  *
  ****************************************************************************/
 
-static void nxmq_rcvtimeout(int argc, wdparm_t pid, ...)
+static void nxmq_rcvtimeout(wdparm_t pid)
 {
   FAR struct tcb_s *wtcb;
   irqstate_t flags;
@@ -79,7 +78,7 @@ static void nxmq_rcvtimeout(int argc, wdparm_t pid, ...)
    * longer be active when this watchdog goes off.
    */
 
-  wtcb = nxsched_get_tcb((pid_t)pid);
+  wtcb = nxsched_get_tcb(pid);
 
   /* It is also possible that an interrupt/context switch beat us to the
    * punch and already changed the task's state.
@@ -209,8 +208,7 @@ ssize_t nxmq_timedreceive(mqd_t mqdes, FAR char *msg, size_t msglen,
 
       /* Start the watchdog */
 
-      wd_start(&rtcb->waitdog, ticks,
-               nxmq_rcvtimeout, 1, (wdparm_t)getpid());
+      wd_start(&rtcb->waitdog, ticks, nxmq_rcvtimeout, getpid());
     }
 
   /* Get the message from the message queue */

--- a/sched/mqueue/mq_timedsend.c
+++ b/sched/mqueue/mq_timedsend.c
@@ -53,7 +53,6 @@
  *   becomes non-full.
  *
  * Input Parameters:
- *   argc  - the number of arguments (should be 1)
  *   pid   - the task ID of the task to wakeup
  *
  * Returned Value:
@@ -63,7 +62,7 @@
  *
  ****************************************************************************/
 
-static void nxmq_sndtimeout(int argc, wdparm_t pid, ...)
+static void nxmq_sndtimeout(wdparm_t pid)
 {
   FAR struct tcb_s *wtcb;
   irqstate_t flags;
@@ -78,7 +77,7 @@ static void nxmq_sndtimeout(int argc, wdparm_t pid, ...)
    * longer be active when this watchdog goes off.
    */
 
-  wtcb = nxsched_get_tcb((pid_t)pid);
+  wtcb = nxsched_get_tcb(pid);
 
   /* It is also possible that an interrupt/context switch beat us to the
    * punch and already changed the task's state.
@@ -244,7 +243,7 @@ int nxmq_timedsend(mqd_t mqdes, FAR const char *msg, size_t msglen,
 
   /* Start the watchdog and begin the wait for MQ not full */
 
-  wd_start(&rtcb->waitdog, ticks, nxmq_sndtimeout, 1, (wdparm_t)getpid());
+  wd_start(&rtcb->waitdog, ticks, nxmq_sndtimeout, getpid());
 
   /* And wait for the message queue to be non-empty */
 

--- a/sched/sched/sched_sporadic.c
+++ b/sched/sched/sched_sporadic.c
@@ -84,10 +84,10 @@ static int sporadic_replenish_delay(FAR struct replenishment_s *repl,
 
 /* Timer expiration handlers */
 
-static void sporadic_budget_expire(int argc, wdparm_t arg1, ...);
-static void sporadic_interval_expire(int argc, wdparm_t arg1, ...);
-static void sporadic_replenish_expire(int argc, wdparm_t arg1, ...);
-static void sporadic_delay_expire(int argc, wdparm_t arg1, ...);
+static void sporadic_budget_expire(wdparm_t arg);
+static void sporadic_interval_expire(wdparm_t arg);
+static void sporadic_replenish_expire(wdparm_t arg);
+static void sporadic_delay_expire(wdparm_t arg);
 
 /* Misc. helpers */
 
@@ -290,7 +290,7 @@ static int sporadic_budget_start(FAR struct replenishment_s *mrepl)
   /* And start the timer for the budget interval */
 
   DEBUGVERIFY(wd_start(&mrepl->timer, sporadic->budget,
-                       sporadic_budget_expire, 1, (wdparm_t)mrepl));
+                       sporadic_budget_expire, (wdparm_t)mrepl));
 
   /* Then reprioritize to the higher priority */
 
@@ -349,7 +349,7 @@ static int sporadic_interval_start(FAR struct replenishment_s *mrepl)
    */
 
   DEBUGVERIFY(wd_start(&mrepl->timer, remainder,
-              sporadic_interval_expire, 1, (wdparm_t)mrepl));
+              sporadic_interval_expire, (wdparm_t)mrepl));
 
   /* Drop the priority of thread, possible causing a context switch. */
 
@@ -391,7 +391,7 @@ static int sporadic_replenish_start(FAR struct replenishment_s *repl)
   /* And start the timer for the budget interval */
 
   DEBUGVERIFY(wd_start(&repl->timer, repl->budget,
-                       sporadic_replenish_expire, 1, (wdparm_t)repl));
+                       sporadic_replenish_expire, (wdparm_t)repl));
 
   /* Then reprioritize to the higher priority */
 
@@ -427,7 +427,7 @@ static int sporadic_replenish_delay(FAR struct replenishment_s *repl,
   /* And start the timer for the delay prior to replenishing. */
 
   DEBUGVERIFY(wd_start(&repl->timer, period,
-                       sporadic_delay_expire, 1, (wdparm_t)repl));
+                       sporadic_delay_expire, (wdparm_t)repl));
   return OK;
 }
 
@@ -455,14 +455,14 @@ static int sporadic_replenish_delay(FAR struct replenishment_s *repl,
  *
  ****************************************************************************/
 
-static void sporadic_budget_expire(int argc, wdparm_t arg1, ...)
+static void sporadic_budget_expire(wdparm_t arg)
 {
-  FAR struct replenishment_s *mrepl = (FAR struct replenishment_s *)arg1;
+  FAR struct replenishment_s *mrepl = (FAR struct replenishment_s *)arg;
   FAR struct replenishment_s *repl;
   FAR struct sporadic_s *sporadic;
   FAR struct tcb_s *tcb;
 
-  DEBUGASSERT(argc == 1 && mrepl != NULL && mrepl->tcb != NULL);
+  DEBUGASSERT(mrepl != NULL && mrepl->tcb != NULL);
   tcb = mrepl->tcb;
 
   /* As a special case, we can do nothing here if scheduler has been locked.
@@ -562,11 +562,11 @@ static void sporadic_budget_expire(int argc, wdparm_t arg1, ...)
  *
  ****************************************************************************/
 
-static void sporadic_interval_expire(int argc, wdparm_t arg1, ...)
+static void sporadic_interval_expire(wdparm_t arg)
 {
-  FAR struct replenishment_s *mrepl = (FAR struct replenishment_s *)arg1;
+  FAR struct replenishment_s *mrepl = (FAR struct replenishment_s *)arg;
 
-  DEBUGASSERT(argc == 1 && mrepl != NULL);
+  DEBUGASSERT(mrepl != NULL);
 
   /* If we get here, then (1) this should be the main thread, and (2) there
    * should be no active replenishment thread.
@@ -597,13 +597,13 @@ static void sporadic_interval_expire(int argc, wdparm_t arg1, ...)
  *
  ****************************************************************************/
 
-static void sporadic_replenish_expire(int argc, wdparm_t arg1, ...)
+static void sporadic_replenish_expire(wdparm_t arg)
 {
-  FAR struct replenishment_s *repl = (FAR struct replenishment_s *)arg1;
+  FAR struct replenishment_s *repl = (FAR struct replenishment_s *)arg;
   FAR struct sporadic_s *sporadic;
   FAR struct tcb_s *tcb;
 
-  DEBUGASSERT(argc == 1 && repl != NULL && repl->tcb != NULL);
+  DEBUGASSERT(repl != NULL && repl->tcb != NULL);
   tcb      = repl->tcb;
 
   sporadic = tcb->sporadic;
@@ -664,11 +664,11 @@ static void sporadic_replenish_expire(int argc, wdparm_t arg1, ...)
  *
  ****************************************************************************/
 
-static void sporadic_delay_expire(int argc, wdparm_t arg1, ...)
+static void sporadic_delay_expire(wdparm_t arg)
 {
-  FAR struct replenishment_s *repl = (FAR struct replenishment_s *)arg1;
+  FAR struct replenishment_s *repl = (FAR struct replenishment_s *)arg;
 
-  DEBUGASSERT(argc == 1 && repl != NULL);
+  DEBUGASSERT(repl != NULL);
 
   /* Start the replenishment */
 

--- a/sched/semaphore/sem_clockwait.c
+++ b/sched/semaphore/sem_clockwait.c
@@ -166,7 +166,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
 
   /* Start the watchdog */
 
-  wd_start(&rtcb->waitdog, ticks, nxsem_timeout, 1, (wdparm_t)getpid());
+  wd_start(&rtcb->waitdog, ticks, nxsem_timeout, getpid());
 
   /* Now perform the blocking wait.  If nxsem_wait() fails, the
    * negated errno value will be returned below.

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -120,7 +120,7 @@ int nxsem_tickwait(FAR sem_t *sem, clock_t start, uint32_t delay)
 
   /* Start the watchdog with interrupts still disabled */
 
-  wd_start(&rtcb->waitdog, delay, nxsem_timeout, 1, (wdparm_t)getpid());
+  wd_start(&rtcb->waitdog, delay, nxsem_timeout, getpid());
 
   /* Now perform the blocking wait */
 

--- a/sched/semaphore/sem_timeout.c
+++ b/sched/semaphore/sem_timeout.c
@@ -60,7 +60,6 @@
  *   semaphore is acquired.
  *
  * Input Parameters:
- *   argc - The number of arguments (should be 1)
  *   pid  - The task ID of the task to wakeup
  *
  * Returned Value:
@@ -71,7 +70,7 @@
  *
  ****************************************************************************/
 
-void nxsem_timeout(int argc, wdparm_t pid, ...)
+void nxsem_timeout(wdparm_t pid)
 {
   FAR struct tcb_s *wtcb;
   irqstate_t flags;
@@ -84,7 +83,7 @@ void nxsem_timeout(int argc, wdparm_t pid, ...)
    * task may no longer be active when this watchdog goes off.
    */
 
-  wtcb = nxsched_get_tcb((pid_t)pid);
+  wtcb = nxsched_get_tcb(pid);
 
   /* It is also possible that an interrupt/context switch beat us to the
    * punch and already changed the task's state.

--- a/sched/semaphore/semaphore.h
+++ b/sched/semaphore/semaphore.h
@@ -60,7 +60,7 @@ void nxsem_wait_irq(FAR struct tcb_s *wtcb, int errcode);
 
 /* Handle semaphore timer expiration */
 
-void nxsem_timeout(int argc, wdparm_t pid, ...);
+void nxsem_timeout(wdparm_t pid);
 
 /* Recover semaphore resources with a task or thread is destroyed  */
 

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -87,28 +87,12 @@
  *
  ****************************************************************************/
 
-static void nxsig_timeout(int argc, wdparm_t itcb, ...)
+static void nxsig_timeout(wdparm_t arg)
 {
+  FAR struct tcb_s *wtcb = (FAR struct tcb_s *)(uintptr_t)arg;
 #ifdef CONFIG_SMP
   irqstate_t flags;
-#endif
 
-  /* On many small machines, pointers are encoded and cannot be simply cast
-   * from uint32_t to struct tcb_s *.  The following union works around this
-   * (see wdogparm_t).  This odd logic could be conditioned on
-   * CONFIG_CAN_CAST_POINTERS, but it is not too bad in any case.
-   */
-
-  union
-  {
-    FAR struct tcb_s *wtcb;
-    wdparm_t itcb;
-  } u;
-
-  u.itcb = itcb;
-  DEBUGASSERT(u.wtcb);
-
-#ifdef CONFIG_SMP
   /* We must be in a critical section in order to call up_unblock_task()
    * below.  If we are running on a single CPU architecture, then we know
    * interrupts a disabled an there is no need to explicitly call
@@ -125,17 +109,17 @@ static void nxsig_timeout(int argc, wdparm_t itcb, ...)
    * still waiting for a signal
    */
 
-  if (u.wtcb->task_state == TSTATE_WAIT_SIG)
+  if (wtcb->task_state == TSTATE_WAIT_SIG)
     {
-      u.wtcb->sigunbinfo.si_signo           = SIG_WAIT_TIMEOUT;
-      u.wtcb->sigunbinfo.si_code            = SI_TIMER;
-      u.wtcb->sigunbinfo.si_errno           = ETIMEDOUT;
-      u.wtcb->sigunbinfo.si_value.sival_int = 0;
+      wtcb->sigunbinfo.si_signo           = SIG_WAIT_TIMEOUT;
+      wtcb->sigunbinfo.si_code            = SI_TIMER;
+      wtcb->sigunbinfo.si_errno           = ETIMEDOUT;
+      wtcb->sigunbinfo.si_value.sival_int = 0;
 #ifdef CONFIG_SCHED_HAVE_PARENT
-      u.wtcb->sigunbinfo.si_pid             = 0;  /* Not applicable */
-      u.wtcb->sigunbinfo.si_status          = OK;
+      wtcb->sigunbinfo.si_pid             = 0;  /* Not applicable */
+      wtcb->sigunbinfo.si_status          = OK;
 #endif
-      up_unblock_task(u.wtcb);
+      up_unblock_task(wtcb);
     }
 
 #ifdef CONFIG_SMP
@@ -340,18 +324,10 @@ int nxsig_timedwait(FAR const sigset_t *set, FAR struct siginfo *info,
           waitticks = MSEC2TICK(waitmsec);
 #endif
 
-          /* This little bit of nonsense is necessary for some
-           * processors where sizeof(pointer) < sizeof(uint32_t).
-           * see wdog.h.
-           */
-
-          union wdparm_u wdparm;
-          wdparm.pvarg = (FAR void *)rtcb;
-
           /* Start the watchdog */
 
           wd_start(&rtcb->waitdog, waitticks,
-                   nxsig_timeout, 1, wdparm.pvarg);
+                   nxsig_timeout, (uintptr_t)rtcb);
 
           /* Now wait for either the signal or the watchdog, but
            * first, make sure this is not the idle task,

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -43,7 +43,7 @@
 static inline void timer_signotify(FAR struct posix_timer_s *timer);
 static inline void timer_restart(FAR struct posix_timer_s *timer,
                                  wdparm_t itimer);
-static void timer_timeout(int argc, wdparm_t itimer, ...);
+static void timer_timeout(wdparm_t itimer);
 
 /****************************************************************************
  * Private Functions
@@ -98,8 +98,7 @@ static inline void timer_restart(FAR struct posix_timer_s *timer,
   if (timer->pt_delay)
     {
       timer->pt_last = timer->pt_delay;
-      wd_start(&timer->pt_wdog, timer->pt_delay,
-               timer_timeout, 1, (wdparm_t)itimer);
+      wd_start(&timer->pt_wdog, timer->pt_delay, timer_timeout, itimer);
     }
 }
 
@@ -111,9 +110,7 @@ static inline void timer_restart(FAR struct posix_timer_s *timer,
  *   signaled.
  *
  * Input Parameters:
- *   argc   - the number of arguments (should be 1)
  *   itimer - A reference to the POSIX timer that just timed out
- *   signo  - The signal to use to wake up the task
  *
  * Returned Value:
  *   None
@@ -123,7 +120,7 @@ static inline void timer_restart(FAR struct posix_timer_s *timer,
  *
  ****************************************************************************/
 
-static void timer_timeout(int argc, wdparm_t itimer, ...)
+static void timer_timeout(wdparm_t itimer)
 {
   FAR struct posix_timer_s *timer = (FAR struct posix_timer_s *)itimer;
 
@@ -324,7 +321,7 @@ int timer_settime(timer_t timerid, int flags,
 
       timer->pt_last = delay;
       ret = wd_start(&timer->pt_wdog, delay,
-                     timer_timeout, 1, (wdparm_t)timer);
+                     timer_timeout, (wdparm_t)timer);
       if (ret < 0)
         {
           set_errno(-ret);

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -164,7 +164,7 @@ static void btnet_hci_disconnected(FAR struct bt_conn_s *conn,
 
 static int  btnet_txpoll_callback(FAR struct net_driver_s *netdev);
 static void btnet_txpoll_work(FAR void *arg);
-static void btnet_txpoll_expiry(int argc, wdparm_t arg, ...);
+static void btnet_txpoll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -550,7 +550,7 @@ static void btnet_txpoll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->bd_txpoll, TXPOLL_WDDELAY,
-           btnet_txpoll_expiry, 1, (wdparm_t)priv);
+           btnet_txpoll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -561,8 +561,7 @@ static void btnet_txpoll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -572,7 +571,7 @@ static void btnet_txpoll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void btnet_txpoll_expiry(int argc, wdparm_t arg, ...)
+static void btnet_txpoll_expiry(wdparm_t arg)
 {
   FAR struct btnet_driver_s *priv = (FAR struct btnet_driver_s *)arg;
 
@@ -630,7 +629,7 @@ static int btnet_ifup(FAR struct net_driver_s *netdev)
       /* Set and activate a timer process */
 
       wd_start(&priv->bd_txpoll, TXPOLL_WDDELAY,
-               btnet_txpoll_expiry, 1, (wdparm_t)priv);
+               btnet_txpoll_expiry, (wdparm_t)priv);
 
       /* The interface is now up */
 

--- a/wireless/ieee802154/mac802154_loopback.c
+++ b/wireless/ieee802154/mac802154_loopback.c
@@ -171,7 +171,7 @@ static inline void lo_netmask(FAR struct net_driver_s *dev);
 static int  lo_loopback(FAR struct net_driver_s *dev);
 static void lo_loopback_work(FAR void *arg);
 static void lo_poll_work(FAR void *arg);
-static void lo_poll_expiry(int argc, wdparm_t arg, ...);
+static void lo_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -491,7 +491,7 @@ static void lo_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->lo_polldog, LO_WDDELAY, lo_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->lo_polldog, LO_WDDELAY, lo_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -502,8 +502,7 @@ static void lo_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -513,7 +512,7 @@ static void lo_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void lo_poll_expiry(int argc, wdparm_t arg, ...)
+static void lo_poll_expiry(wdparm_t arg)
 {
   FAR struct lo_driver_s *priv = (FAR struct lo_driver_s *)arg;
 
@@ -595,7 +594,7 @@ static int lo_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->lo_polldog, LO_WDDELAY,
-           lo_poll_expiry, 1, (wdparm_t)priv);
+           lo_poll_expiry, (wdparm_t)priv);
 
   priv->lo_bifup = true;
   return OK;

--- a/wireless/ieee802154/mac802154_netdev.c
+++ b/wireless/ieee802154/mac802154_netdev.c
@@ -200,7 +200,7 @@ static int  macnet_rxframe(FAR struct macnet_driver_s *maccb,
 
 static int  macnet_txpoll_callback(FAR struct net_driver_s *dev);
 static void macnet_txpoll_work(FAR void *arg);
-static void macnet_txpoll_expiry(int argc, wdparm_t arg, ...);
+static void macnet_txpoll_expiry(wdparm_t arg);
 
 /* IOCTL support */
 
@@ -591,7 +591,7 @@ static void macnet_txpoll_work(FAR void *arg)
   /* Setup the watchdog poll timer again */
 
   wd_start(&priv->md_txpoll, TXPOLL_WDDELAY,
-           macnet_txpoll_expiry, 1, (wdparm_t)priv);
+           macnet_txpoll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -602,8 +602,7 @@ static void macnet_txpoll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -613,7 +612,7 @@ static void macnet_txpoll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void macnet_txpoll_expiry(int argc, wdparm_t arg, ...)
+static void macnet_txpoll_expiry(wdparm_t arg)
 {
   FAR struct macnet_driver_s *priv = (FAR struct macnet_driver_s *)arg;
 
@@ -779,7 +778,7 @@ static int macnet_ifup(FAR struct net_driver_s *dev)
       /* Set and activate a timer process */
 
       wd_start(&priv->md_txpoll, TXPOLL_WDDELAY,
-               macnet_txpoll_expiry, 1, (wdparm_t)priv);
+               macnet_txpoll_expiry, (wdparm_t)priv);
 
       ret = OK;
     }

--- a/wireless/pktradio/pktradio_loopback.c
+++ b/wireless/pktradio/pktradio_loopback.c
@@ -162,7 +162,7 @@ static inline void lo_netmask(FAR struct net_driver_s *dev);
 static int  lo_loopback(FAR struct net_driver_s *dev);
 static void lo_loopback_work(FAR void *arg);
 static void lo_poll_work(FAR void *arg);
-static void lo_poll_expiry(int argc, wdparm_t arg, ...);
+static void lo_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
@@ -449,7 +449,7 @@ static void lo_poll_work(FAR void *arg)
 
   /* Setup the watchdog poll timer again */
 
-  wd_start(&priv->lo_polldog, LO_WDDELAY, lo_poll_expiry, 1, (wdparm_t)priv);
+  wd_start(&priv->lo_polldog, LO_WDDELAY, lo_poll_expiry, (wdparm_t)priv);
   net_unlock();
 }
 
@@ -460,8 +460,7 @@ static void lo_poll_work(FAR void *arg)
  *   Periodic timer handler.  Called from the timer interrupt handler.
  *
  * Input Parameters:
- *   argc - The number of available arguments
- *   arg  - The first argument
+ *   arg  - The argument
  *
  * Returned Value:
  *   None
@@ -471,7 +470,7 @@ static void lo_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void lo_poll_expiry(int argc, wdparm_t arg, ...)
+static void lo_poll_expiry(wdparm_t arg)
 {
   FAR struct lo_driver_s *priv = (FAR struct lo_driver_s *)arg;
 
@@ -534,7 +533,7 @@ static int lo_ifup(FAR struct net_driver_s *dev)
   /* Set and activate a timer process */
 
   wd_start(&priv->lo_polldog, LO_WDDELAY,
-           lo_poll_expiry, 1, (wdparm_t)priv);
+           lo_poll_expiry, (wdparm_t)priv);
 
   priv->lo_bifup = true;
   return OK;


### PR DESCRIPTION
## Summary
since the variable arguments are error prone and seldom used. See the dissussion here: https://github.com/apache/incubator-nuttx/issues/740

## Impact
All wdog user, the code need update.

## Testing
Please ignore:
```
drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c:1081:34: error: Mixed case identifier found
drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c:1441:7: error: Mixed case identifier found
```