### PR TITLE
Fix sam_ili9488.c:1605:7: error: label 'errout_with_dmadog' used but not defined

### DIFF
--- a/boards/arm/samv7/samv71-xult/src/sam_ili9488.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_ili9488.c
@@ -1602,7 +1602,7 @@ int board_lcd_initialize(void)
   if (ret < 0)
     {
       lcderr("ERROR: sam_poweroff failed: %d\n", ret);
-      goto errout_with_dmadog;
+      goto errout_with_dmach;
     }
 
   return OK;

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.h
@@ -105,7 +105,7 @@ struct bcmf_sdio_dev_s
 
   int thread_id;                   /* Processing thread id */
   sem_t thread_signal;             /* Semaphore for processing thread event */
-  struct wdog_s *waitdog;          /* Processing thread waitdog */
+  struct wdog_s waitdog;           /* Processing thread waitdog */
 
   uint32_t backplane_current_addr; /* Current function 1 backplane base addr */
 


### PR DESCRIPTION
## Summary
sam_ili9488.c:1605:7: error: label 'errout_with_dmadog' used but not defined
bcmf_sdio.c:855:16: error: passing argument 1 of 'wd_start' from incompatible pointer type

## Impact

## Testing

