### PR TITLE
drivers: Change the location of the board specific driver's configuration option.

### DIFF
--- a/boards/arm/cxd56xx/drivers/Kconfig
+++ b/boards/arm/cxd56xx/drivers/Kconfig
@@ -3,12 +3,6 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config SPECIFIC_DRIVERS
-       bool "Board specific drivers"
-       default n
-       ---help---
-               Board specific drivers located in each board/driver folder.
-
 if SPECIFIC_DRIVERS
 source "drivers/platform/audio/Kconfig"
 source "drivers/platform/sensors/Kconfig"

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -72,6 +72,10 @@ endif # DRVR_WRITEBUFFER || DRVR_READAHEAD
 
 endmenu # Buffering
 
+config SPECIFIC_DRIVERS
+	bool "Board Specific drivers"
+	default n
+
 source drivers/crypto/Kconfig
 source drivers/loop/Kconfig
 source drivers/can/Kconfig


### PR DESCRIPTION
## Summary
Move the configuration to select a board specific drive folder to the common driver/Kconfig file.
## Impact
We don't need to add that config for every boards/drivers we (will) have.
## Testing
Spresense configs and some custom board configs.

