### PR TITLE
Added options for I-Cache & D-Cache, in STM32F2 & STM32F4.

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -1399,6 +1399,8 @@ config STM32_STM32F20XX
 	bool
 	default n
 	select ARCH_CORTEXM3
+	select STM32_HAVE_FLASH_ICACHE
+	select STM32_HAVE_FLASH_DCACHE
 	select STM32_HAVE_CRYP
 	select STM32_HAVE_OTGFS
 	select STM32_HAVE_OTGHS
@@ -1549,6 +1551,8 @@ config STM32_STM32F4XXX
 	default n
 	select ARCH_CORTEXM4
 	select ARCH_HAVE_FPU
+	select STM32_HAVE_FLASH_ICACHE
+	select STM32_HAVE_FLASH_DCACHE
 	select STM32_HAVE_CRYP
 	select STM32_HAVE_SPI2
 	select STM32_HAVE_I2C2
@@ -1991,6 +1995,14 @@ menu "STM32 Peripheral Support"
 
 # These "hidden" settings determine whether a peripheral option is available
 # for the selected MCU
+
+config STM32_HAVE_FLASH_ICACHE
+	bool
+	default n
+
+config STM32_HAVE_FLASH_DCACHE
+	bool
+	default n
 
 config STM32_HAVE_OVERDRIVE
 	bool
@@ -3344,24 +3356,38 @@ endchoice
 
 endmenu
 
+config STM32_FLASH_ICACHE
+	bool "Enable FLASH Instruction Cache"
+	default y
+	depends on STM32_HAVE_ICACHE
+	---help---
+		Enable the FLASH instruction cache.
+
+config STM32_FLASH_DCACHE
+	bool "Enable FLASH Data Cache"
+	default y
+	depends on STM32_HAVE_DCACHE
+	---help---
+		Enable the FLASH data cache.
+
+config STM32_FLASH_WORKAROUND_DATA_CACHE_CORRUPTION_ON_RWW
+	bool "Workaround for FLASH data cache corruption"
+	default n
+	depends on (STM32_STM32F20XX || STM32_STM32F4XXX) && STM32_FLASH_DCACHE
+	---help---
+		Enable the workaround to fix flash data cache corruption when reading
+		from one flash bank while writing on other flash bank.  See your STM32
+		errata to check if your STM32 is affected by this problem.
+
 config STM32_FLASH_PREFETCH
 	bool "Enable FLASH Pre-fetch"
 	default y if STM32_STM32F427 || STM32_STM32F429 || STM32_STM32F446
 	default n
 	depends on STM32_STM32F20XX || STM32_STM32F4XXX
 	---help---
-		Enable FLASH prefetch and F2 and F4 parts (FLASH pre-fetch is always enabled
+		Enable FLASH prefetch in F2 and F4 parts (FLASH pre-fetch is always enabled
 		on F1 parts).  Some early revisions of F4 parts do not support FLASH pre-fetch
 		properly and enabling this option may interfere with ADC accuracy.
-
-config STM32_FLASH_WORKAROUND_DATA_CACHE_CORRUPTION_ON_RWW
-	bool "Workaround for FLASH data cache corruption"
-	default n
-	depends on STM32_STM32F20XX || STM32_STM32F4XXX
-	---help---
-		Enable the workaround to fix flash data cache corruption when reading
-		from one flash bank while writing on other flash bank.  See your STM32
-		errata to check if your STM32 is affected by this problem.
 
 choice
 	prompt "JTAG Configuration"

--- a/arch/arm/src/stm32/stm32f20xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f20xxx_rcc.c
@@ -182,7 +182,8 @@ static inline void rcc_enableahb1(void)
 #ifdef CONFIG_STM32_ETHMAC
   /* Ethernet MAC clocking */
 
-  regval |= (RCC_AHB1ENR_ETHMACEN | RCC_AHB1ENR_ETHMACTXEN | RCC_AHB1ENR_ETHMACRXEN);
+  regval |= (RCC_AHB1ENR_ETHMACEN | RCC_AHB1ENR_ETHMACTXEN |
+                RCC_AHB1ENR_ETHMACRXEN);
 
 #ifdef CONFIG_STM32_ETH_PTP
   /* Precision Time Protocol (PTP) */
@@ -644,13 +645,21 @@ static void stm32_stdclockconfig(void)
 
       while ((getreg32(STM32_RCC_CR) & RCC_CR_PLLRDY) == 0);
 
-      /* Enable FLASH prefetch, instruction cache, data cache, and 5 wait states */
+      /* Enable FLASH prefetch, instruction cache, data cache,
+       * and 5 wait states.
+       */
 
-#ifdef CONFIG_STM32_FLASH_PREFETCH
-      regval = (FLASH_ACR_LATENCY_5 | FLASH_ACR_ICEN | FLASH_ACR_DCEN | FLASH_ACR_PRFTEN);
-#else
-      regval = (FLASH_ACR_LATENCY_5 | FLASH_ACR_ICEN | FLASH_ACR_DCEN);
+      regval = (FLASH_ACR_LATENCY_5
+#ifdef CONFIG_STM32_FLASH_ICACHE
+                | FLASH_ACR_ICEN
 #endif
+#ifdef CONFIG_STM32_FLASH_DCACHE
+                | FLASH_ACR_DCEN
+#endif
+#ifdef CONFIG_STM32_FLASH_PREFETCH
+                | FLASH_ACR_PRFTEN
+#endif
+                );
       putreg32(regval, STM32_FLASH_ACR);
 
       /* Select the main PLL as system clock source */
@@ -662,7 +671,8 @@ static void stm32_stdclockconfig(void)
 
       /* Wait until the PLL source is used as the system clock source */
 
-      while ((getreg32(STM32_RCC_CFGR) & RCC_CFGR_SWS_MASK) != RCC_CFGR_SWS_PLL);
+      while ((getreg32(STM32_RCC_CFGR) & RCC_CFGR_SWS_MASK)
+                != RCC_CFGR_SWS_PLL);
 
 #if defined(CONFIG_STM32_IWDG) || defined(CONFIG_STM32_RTC_LSICLOCK)
       /* Low speed internal clock source LSI */

--- a/arch/arm/src/stm32/stm32f40xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f40xxx_rcc.c
@@ -781,7 +781,13 @@ static void stm32_stdclockconfig(void)
        * and 5 wait states.
        */
 
-      regval = (FLASH_ACR_LATENCY_5 | FLASH_ACR_ICEN | FLASH_ACR_DCEN
+      regval = (FLASH_ACR_LATENCY_5
+#ifdef CONFIG_STM32_FLASH_ICACHE
+                | FLASH_ACR_ICEN
+#endif
+#ifdef CONFIG_STM32_FLASH_DCACHE
+                | FLASH_ACR_DCEN
+#endif
 #ifdef CONFIG_STM32_FLASH_PREFETCH
                 | FLASH_ACR_PRFTEN
 #endif


### PR DESCRIPTION
## Summary
STM32F2 & STM32F4 MCUs support instruction & data caches. Previously they were always enabled.  
Now both features can be enabled individually through Kconfig options.

## Impact
Existing system are not affect. New projects however have the option to disable these features.

## Testing
Tested on an STM32F427VI, and configuration works as expected.
Not tested for the STM32F2 family, as I don't have hardware available.
