### PR TITLE
kinetis: kinetis.h missing-semi

### DIFF
--- a/arch/arm/src/kinetis/kinetis.h
+++ b/arch/arm/src/kinetis/kinetis.h
@@ -778,7 +778,7 @@ int kinetis_netinitialize(int intf);
  *
  ************************************************************************************/
 #ifdef CONFIG_KINETIS_FLEXCAN
-int kinetis_caninitialize(int intf)
+int kinetis_caninitialize(int intf);
 #endif
 
 #endif /* __ASSEMBLY__ */

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -1718,9 +1718,6 @@ int kinetis_caninitialize(int intf)
   struct kinetis_driver_s *priv;
   int ret;
   uint32_t regval;
-#ifdef TX_TIMEOUT_WQ
-  uint32_t i;
-#endif
 
   switch (intf)
     {


### PR DESCRIPTION
## Summary

We must not have CONFIG_KINETIS_FLEXCAN lit.

## Impact

build fails, missing semi

## Testing

