### PR TITLE
s32k1xx:flexcan Remove unused variable

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1718,9 +1718,6 @@ int s32k1xx_caninitialize(int intf)
 {
   struct s32k1xx_driver_s *priv;
   int ret;
-#ifdef TX_TIMEOUT_WQ
-  uint32_t i;
-#endif
 
   switch (intf)
     {


### PR DESCRIPTION
## Summary
Same problem as ee60a26c7fd241778f5117faf3923a05df2177a4, same fix too,
## Impact

Build will build....
## Testing

