### PR TITLE
drivers/rwbuffer: Avoid ftl driver allocate the temporary erase buffer

### DIFF
--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -519,7 +519,7 @@ static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
         }
 #endif
 
-      /* Just change the BIOC_XIPBASE command to the MTDIOC_XIPBASE command. */
+      /* Change the BIOC_XIPBASE command to the MTDIOC_XIPBASE command. */
 
       cmd = MTDIOC_XIPBASE;
     }
@@ -638,18 +638,19 @@ int ftl_initialize_by_path(FAR const char *path, FAR struct mtd_dev_s *mtd)
       /* Configure read-ahead/write buffering */
 
 #ifdef FTL_HAVE_RWBUFFER
-      dev->rwb.blocksize   = dev->geo.blocksize;
-      dev->rwb.nblocks     = dev->geo.neraseblocks * dev->blkper;
-      dev->rwb.dev         = (FAR void *)dev;
-      dev->rwb.wrflush     = ftl_flush;
-      dev->rwb.rhreload    = ftl_reload;
+      dev->rwb.blocksize     = dev->geo.blocksize;
+      dev->rwb.nblocks       = dev->geo.neraseblocks * dev->blkper;
+      dev->rwb.dev           = (FAR void *)dev;
+      dev->rwb.wrflush       = ftl_flush;
+      dev->rwb.rhreload      = ftl_reload;
 
 #if defined(CONFIG_FTL_WRITEBUFFER)
-      dev->rwb.wrmaxblocks = dev->blkper;
+      dev->rwb.wrmaxblocks   = dev->blkper;
+      dev->rwb.wralignblocks = dev->blkper;
 #endif
 
 #ifdef CONFIG_FTL_READAHEAD
-      dev->rwb.rhmaxblocks = dev->blkper;
+      dev->rwb.rhmaxblocks   = dev->blkper;
 #endif
 
       ret = rwb_initialize(&dev->rwb);

--- a/drivers/rwbuffer.c
+++ b/drivers/rwbuffer.c
@@ -828,16 +828,12 @@ int rwb_initialize(FAR struct rwbuffer_s *rwb)
 
       /* Allocate the write buffer */
 
-      rwb->wrbuffer = NULL;
-      if (rwb->wrmaxblocks > 0)
+      allocsize     = rwb->wrmaxblocks * rwb->blocksize;
+      rwb->wrbuffer = kmm_malloc(allocsize);
+      if (!rwb->wrbuffer)
         {
-          allocsize     = rwb->wrmaxblocks * rwb->blocksize;
-          rwb->wrbuffer = kmm_malloc(allocsize);
-          if (!rwb->wrbuffer)
-            {
-              ferr("Write buffer kmm_malloc(%d) failed\n", allocsize);
-              return -ENOMEM;
-            }
+          ferr("Write buffer kmm_malloc(%d) failed\n", allocsize);
+          return -ENOMEM;
         }
 
       finfo("Write buffer size: %d bytes\n", allocsize);
@@ -859,16 +855,12 @@ int rwb_initialize(FAR struct rwbuffer_s *rwb)
 
       /* Allocate the read-ahead buffer */
 
-      rwb->rhbuffer = NULL;
-      if (rwb->rhmaxblocks > 0)
+      allocsize     = rwb->rhmaxblocks * rwb->blocksize;
+      rwb->rhbuffer = kmm_malloc(allocsize);
+      if (!rwb->rhbuffer)
         {
-          allocsize     = rwb->rhmaxblocks * rwb->blocksize;
-          rwb->rhbuffer = kmm_malloc(allocsize);
-          if (!rwb->rhbuffer)
-            {
-              ferr("Read-ahead buffer kmm_malloc(%d) failed\n", allocsize);
-              return -ENOMEM;
-            }
+          ferr("Read-ahead buffer kmm_malloc(%d) failed\n", allocsize);
+          return -ENOMEM;
         }
 
       finfo("Read-ahead buffer size: %d bytes\n", allocsize);

--- a/drivers/rwbuffer.c
+++ b/drivers/rwbuffer.c
@@ -880,6 +880,7 @@ void rwb_uninitialize(FAR struct rwbuffer_s *rwb)
   if (rwb->wrmaxblocks > 0)
     {
       rwb_wrcanceltimeout(rwb);
+      rwb_wrflush(rwb);
       nxsem_destroy(&rwb->wrsem);
       if (rwb->wrbuffer)
         {

--- a/include/nuttx/drivers/rwbuffer.h
+++ b/include/nuttx/drivers/rwbuffer.h
@@ -113,6 +113,9 @@ struct rwbuffer_s
 
 #ifdef CONFIG_DRVR_WRITEBUFFER
   uint16_t      wrmaxblocks;     /* The number of blocks to buffer in memory */
+  uint16_t      wralignblocks;   /* The buffer to be flash is always multiplied by this
+                                  * number. It must be 0 or divisible by wrmaxblocks.
+                                  */
 #endif
 #ifdef CONFIG_DRVR_READAHEAD
   uint16_t      rhmaxblocks;     /* The number of blocks to buffer in memory */


### PR DESCRIPTION
## Summary
If the buffer to be flushed isn't multipled by the erase size,
let's pad the buffer proactively to avoid the allocation in ftl.

## Impact

## Testing

