### PR TITLE
make/export: Fix mkexport silently failing on missing tools

### DIFF
--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -445,10 +445,10 @@ if [ -e "${APPDIR}/Makefile" ]; then
 fi
 
 if [ "X${TGZ}" = "Xy" ]; then
-  tar cvf "${EXPORTSUBDIR}.tar" "${EXPORTSUBDIR}" 1>/dev/null 2>&1
+  tar cvf "${EXPORTSUBDIR}.tar" "${EXPORTSUBDIR}" 1>/dev/null
   gzip -f "${EXPORTSUBDIR}.tar"
 else
-  zip -r "${EXPORTSUBDIR}.zip" "${EXPORTSUBDIR}" 1>/dev/null 2>&1
+  zip -r "${EXPORTSUBDIR}.zip" "${EXPORTSUBDIR}" 1>/dev/null
 fi
 
 # Clean up after ourselves


### PR DESCRIPTION
## Summary
On a fresh installed Ubuntu 20.04 LTS, mkexport may fail to generate the export package due to the missing **zip** tool.
The problem is that it is failing silently due to the redirection of the error output to /dev/null

## Impact
No impact when zip is already present on the Host PC.
For the users that don't have zip installed on the Host PC, a positive impact of avoid wasting an hour of debugging.

## Testing
Remove zip package and see that now mkexport properly throws the following error:
```
tools/mkexport.sh: line 451: zip: command not found
```
