### PR TITLE
libc/pthread: Implement pthread_condattr_[g|s]etclock 

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -270,14 +270,20 @@ typedef pid_t pthread_t;
 #define __PTHREAD_T_DEFINED 1
 #endif
 
+struct pthread_condattr_s
+{
+  clockid_t clockid;
+};
+
 #ifndef __PTHREAD_CONDATTR_T_DEFINED
-typedef int pthread_condattr_t;
+typedef struct pthread_condattr_s pthread_condattr_t;
 #define __PTHREAD_CONDATTR_T_DEFINED 1
 #endif
 
 struct pthread_cond_s
 {
   sem_t sem;
+  clockid_t clockid;
 };
 
 #ifndef __PTHREAD_COND_T_DEFINED
@@ -285,7 +291,7 @@ typedef struct pthread_cond_s pthread_cond_t;
 #define __PTHREAD_COND_T_DEFINED 1
 #endif
 
-#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0)}
+#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME }
 
 struct pthread_mutexattr_s
 {
@@ -607,6 +613,10 @@ int pthread_mutex_consistent(FAR pthread_mutex_t *mutex);
 
 int pthread_condattr_init(FAR pthread_condattr_t *attr);
 int pthread_condattr_destroy(FAR pthread_condattr_t *attr);
+int pthread_condattr_getclock(FAR const pthread_condattr_t *attr,
+                              clockid_t *clock_id);
+int pthread_condattr_setclock(FAR pthread_condattr_t *attr,
+                              clockid_t clock_id);
 
 /* A thread can create and delete condition variables. */
 
@@ -739,7 +749,7 @@ typedef pid_t pthread_t;
 #endif
 
 #ifndef __PTHREAD_CONDATTR_T_DEFINED
-typedef int pthread_condattr_t;
+typedef struct pthread_condattr_s pthread_condattr_t;
 #  define __PTHREAD_CONDATTR_T_DEFINED 1
 #endif
 

--- a/libs/libc/pthread/Make.defs
+++ b/libs/libc/pthread/Make.defs
@@ -49,6 +49,7 @@ CSRCS += pthread_testcancel.c
 CSRCS += pthread_rwlock.c pthread_rwlock_rdlock.c pthread_rwlock_wrlock.c
 CSRCS += pthread_once.c pthread_yield.c
 CSRCS += pthread_get_stackaddr_np.c pthread_get_stacksize_np.c
+CSRCS += pthread_condattr_setclock.c pthread_condattr_getclock.c
 
 ifeq ($(CONFIG_SMP),y)
 CSRCS += pthread_attr_getaffinity.c pthread_attr_setaffinity.c

--- a/libs/libc/pthread/pthread_condattr_getclock.c
+++ b/libs/libc/pthread/pthread_condattr_getclock.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/pthread/pthread_condtimedwait.c
+ * libs/libc/pthread/pthread_condattr_getclock.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,33 +25,38 @@
 #include <nuttx/config.h>
 
 #include <pthread.h>
+#include <errno.h>
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pthread_cond_timedwait
+ * Name:  pthread_condattr_getclock
  *
  * Description:
- *   A thread can perform a timed wait on a condition variable.
+ *   set the clock selection condition variable attribute
  *
  * Input Parameters:
- *   cond    - the condition variable to wait on
- *   mutex   - the mutex that protects the condition variable
- *   abstime - wait until this absolute time
+ *   None
  *
  * Returned Value:
- *   OK (0) on success; A non-zero errno value is returned on failure.
- *
- * Assumptions:
- *   Timing is of resolution 1 msec, with +/-1 millisecond accuracy.
+ *   If successful, the pthread_condattr_getclock() function shall return
+ *   zero and store the value of the clock attribute of attr into the object
+ *   referenced by the clock_id argument. Otherwise, an error number shall
+ *   be returned to indicate the error.
  *
  ****************************************************************************/
 
-int pthread_cond_timedwait(FAR pthread_cond_t *cond,
-                           FAR pthread_mutex_t *mutex,
-                           FAR const struct timespec *abstime)
+int pthread_condattr_getclock(FAR const pthread_condattr_t *attr,
+                              FAR clockid_t *clock_id)
 {
-  return pthread_cond_clockwait(cond, mutex, cond->clockid, abstime);
+  if (!attr)
+    {
+      return EINVAL;
+    }
+
+  *clock_id = attr->clockid;
+
+  return OK;
 }

--- a/libs/libc/pthread/pthread_condattr_init.c
+++ b/libs/libc/pthread/pthread_condattr_init.c
@@ -75,7 +75,7 @@ int pthread_condattr_init(FAR pthread_condattr_t *attr)
     }
   else
     {
-      *attr = 0;
+      attr->clockid = CLOCK_REALTIME;
     }
 
   linfo("Returning %d\n", ret);

--- a/libs/libc/pthread/pthread_condattr_setclock.c
+++ b/libs/libc/pthread/pthread_condattr_setclock.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/pthread/pthread_condtimedwait.c
+ * libs/libc/pthread/pthread_condattr_setclock.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,33 +25,42 @@
 #include <nuttx/config.h>
 
 #include <pthread.h>
+#include <errno.h>
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pthread_cond_timedwait
+ * Name:  pthread_condattr_setclock
  *
  * Description:
- *   A thread can perform a timed wait on a condition variable.
+ *   set the clock selection condition variable attribute
  *
  * Input Parameters:
- *   cond    - the condition variable to wait on
- *   mutex   - the mutex that protects the condition variable
- *   abstime - wait until this absolute time
+ *   None
  *
  * Returned Value:
- *   OK (0) on success; A non-zero errno value is returned on failure.
- *
- * Assumptions:
- *   Timing is of resolution 1 msec, with +/-1 millisecond accuracy.
+ *   If successful, the pthread_condattr_setclock() function shall
+ *   return zero; otherwise, an error number shall be returned to
+ *   indicate the error.
  *
  ****************************************************************************/
 
-int pthread_cond_timedwait(FAR pthread_cond_t *cond,
-                           FAR pthread_mutex_t *mutex,
-                           FAR const struct timespec *abstime)
+int pthread_condattr_setclock(FAR pthread_condattr_t *attr,
+                              clockid_t clock_id)
 {
-  return pthread_cond_clockwait(cond, mutex, cond->clockid, abstime);
+  if (!attr ||
+      (
+#ifdef CONFIG_CLOCK_MONOTONIC
+      clock_id != CLOCK_MONOTONIC &&
+#endif
+      clock_id != CLOCK_REALTIME))
+    {
+      return EINVAL;
+    }
+
+  attr->clockid = clock_id;
+
+  return OK;
 }

--- a/libs/libc/pthread/pthread_condinit.c
+++ b/libs/libc/pthread/pthread_condinit.c
@@ -64,7 +64,8 @@
  *
  ****************************************************************************/
 
-int pthread_cond_init(FAR pthread_cond_t *cond, FAR const pthread_condattr_t *attr)
+int pthread_cond_init(FAR pthread_cond_t *cond,
+                      FAR const pthread_condattr_t *attr)
 {
   int ret = OK;
 
@@ -90,6 +91,8 @@ int pthread_cond_init(FAR pthread_cond_t *cond, FAR const pthread_condattr_t *at
        */
 
       sem_setprotocol(&cond->sem, SEM_PRIO_NONE);
+
+      cond->clockid = attr ? attr->clockid : CLOCK_REALTIME;
     }
 
   sinfo("Returning %d\n", ret);


### PR DESCRIPTION
## Summary

libc/pthread: Implement pthread_condattr_[g|s]etclock 

Reference:
https: //pubs.opengroup.org/onlinepubs/009695399/functions/pthread_condattr_setclock.html

Change-Id: I19c15d5f219fcf28dbfeb2e5a1e3fc7b38ba2259
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact
pthread_condattr_setclock
pthread_cond_init
pthread_cond_timedwait
pthread_condattr_getclock
pthread_condattr_init

## Testing

API test
