### PR TITLE
vfs/epoll: add epoll_create1(2) implement 

### DIFF
--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -30,6 +30,12 @@ config FS_AUTOMOUNTER_DEBUG
 		system debug is not enable.  This is useful primarily for in vivo
 		unit testing of the auto-mount feature.
 
+config FS_NEPOLL_DESCRIPTORS
+	int "Maximum number of default epoll descriptors for epoll_create1(2)"
+	default 8
+	---help---
+		The maximum number of default epoll descriptors for epoll_create1(2)
+
 config DISABLE_PSEUDOFS_OPERATIONS
 	bool "Disable pseudo-filesystem operations"
 	default y if DEFAULT_SMALL

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -81,6 +81,31 @@ int epoll_create(int size)
 }
 
 /****************************************************************************
+ * Name: epoll_create1
+ *
+ * Description:
+ *
+ * Input Parameters:
+ *
+ * Returned Value:
+ *
+ ****************************************************************************/
+
+int epoll_create1(int flags)
+{
+  /* For current implementation, Close-on-exec is a default behavior,
+   * the handle of epoll(2) is not a real file handle.
+   */
+
+  if (flags != EPOLL_CLOEXEC)
+    {
+      return EINVAL;
+    }
+
+  return epoll_create(CONFIG_FS_NEPOLL_DESCRIPTORS);
+}
+
+/****************************************************************************
  * Name: epoll_close
  *
  * Description:

--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -76,6 +76,14 @@ enum EPOLL_EVENTS
 #define EPOLLHUP EPOLLHUP
   };
 
+/* Flags to be passed to epoll_create1.  */
+
+enum
+{
+    EPOLL_CLOEXEC = 02000000
+#define EPOLL_CLOEXEC EPOLL_CLOEXEC
+};
+
 typedef union poll_data
 {
   void        *ptr;
@@ -108,8 +116,10 @@ struct epoll_head
  ****************************************************************************/
 
 int epoll_create(int size);
+int epoll_create1(int flags);
 int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev);
-int epoll_wait(int epfd, struct epoll_event *evs, int maxevents, int timeout);
+int epoll_wait(int epfd, struct epoll_event *evs,
+               int maxevents, int timeout);
 
 void epoll_close(int epfd);
 

--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -78,16 +78,22 @@ enum EPOLL_EVENTS
 
 typedef union poll_data
 {
-  FAR void    *ptr;      /* For use by drivers */
-  int          fd;       /* The descriptor being polled */
+  void        *ptr;
+  int          fd;
+  uint32_t     u32;
 } epoll_data_t;
 
 struct epoll_event
 {
   epoll_data_t data;
-  FAR sem_t   *sem;      /* Pointer to semaphore used to post output event */
   pollevent_t  events;   /* The input event flags */
   pollevent_t  revents;  /* The output event flags */
+
+  /* Non-standard fields used internally by NuttX. */
+
+  void        *reserved; /* reserved feild sync with struct pollfd */
+  FAR sem_t   *sem;      /* Pointer to semaphore used to post output event */
+  FAR void    *priv;     /* For use by drivers */
 };
 
 struct epoll_head

--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -78,6 +78,7 @@ enum EPOLL_EVENTS
 
 typedef union poll_data
 {
+  FAR void    *ptr;      /* For use by drivers */
   int          fd;       /* The descriptor being polled */
 } epoll_data_t;
 
@@ -87,7 +88,6 @@ struct epoll_event
   FAR sem_t   *sem;      /* Pointer to semaphore used to post output event */
   pollevent_t  events;   /* The input event flags */
   pollevent_t  revents;  /* The output event flags */
-  FAR void    *priv;     /* For use by drivers */
 };
 
 struct epoll_head


### PR DESCRIPTION
## Summary

1. vfs/epoll: add epoll_create1(2) implement 

Linux Programmer's Manual

NAME
       epoll_create, epoll_create1 - open an epoll file descriptor

...
SYNOPSIS
       #include <sys/epoll.h>

       int epoll_create1(int flags);
...

   epoll_create1()
       If flags is 0, then, other than the fact that the obsolete
       size argument is dropped, epoll_create1() is the same as
       epoll_create(). The following value can be included in flags
       to obtain different behavior:

       EPOLL_CLOEXEC
              Set the close-on-exec (FD_CLOEXEC) flag on the new file
              descriptor. See the description of the O_CLOEXEC flag in
              open(2) for reasons why this may be useful.

https://man7.org/linux/man-pages/man7/epoll.7.html

2. sys/poll/epoll: sync the epoll_event struct layout with pollfd

epoll(2) call broken caused by 94fe5c834904c1c2c1dfbe9e29cd5efbc7f5b284

Change-Id: I0811bb7a756797651819d46236e26869559b1767
Signed-off-by: chao.an <anchao@xiaomi.com>


3. sys/epoll: move the private handle to epoll_data_t

sync the struct epoll_event define with linux:

Linux Programmer's Manual:

DESCRIPTION

  EPOLL_CTL_DEL
    ...
       The event argument describes the object linked to the file descriptor
       fd.  The struct epoll_event is defined as:

           typedef union epoll_data {
               void        *ptr;
               int          fd;
               uint32_t     u32;
               uint64_t     u64;
           } epoll_data_t;

           struct epoll_event {
               uint32_t     events;      /* Epoll events */
               epoll_data_t data;        /* User data variable */
           };

https: //man7.org/linux/man-pages/man2/epoll_ctl.2.html

Change-Id: Ida4fed27454fedd356d29c6fdae3cecdf3114ca2
Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

## Testing

api test
