### PR TITLE
sys/epoll: sync the epoll_event struct layout with pollfd

### DIFF
--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -78,16 +78,22 @@ enum EPOLL_EVENTS
 
 typedef union poll_data
 {
-  FAR void    *ptr;      /* For use by drivers */
-  int          fd;       /* The descriptor being polled */
+  void        *ptr;
+  int          fd;
+  uint32_t     u32;
 } epoll_data_t;
 
 struct epoll_event
 {
   epoll_data_t data;
-  FAR sem_t   *sem;      /* Pointer to semaphore used to post output event */
   pollevent_t  events;   /* The input event flags */
   pollevent_t  revents;  /* The output event flags */
+
+  /* Non-standard fields used internally by NuttX. */
+
+  void        *reserved; /* reserved feild sync with struct pollfd */
+  FAR sem_t   *sem;      /* Pointer to semaphore used to post output event */
+  FAR void    *priv;     /* For use by drivers */
 };
 
 struct epoll_head

--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -78,6 +78,7 @@ enum EPOLL_EVENTS
 
 typedef union poll_data
 {
+  FAR void    *ptr;      /* For use by drivers */
   int          fd;       /* The descriptor being polled */
 } epoll_data_t;
 
@@ -87,7 +88,6 @@ struct epoll_event
   FAR sem_t   *sem;      /* Pointer to semaphore used to post output event */
   pollevent_t  events;   /* The input event flags */
   pollevent_t  revents;  /* The output event flags */
-  FAR void    *priv;     /* For use by drivers */
 };
 
 struct epoll_head


### PR DESCRIPTION
## Summary

1. sys/poll/epoll: sync the epoll_event struct layout with pollfd

epoll(2) call broken caused by 94fe5c834904c1c2c1dfbe9e29cd5efbc7f5b284

Change-Id: I0811bb7a756797651819d46236e26869559b1767
Signed-off-by: chao.an <anchao@xiaomi.com>


2. sys/epoll: move the private handle to epoll_data_t

sync the struct epoll_event define with linux:

Linux Programmer's Manual:

DESCRIPTION

  EPOLL_CTL_DEL
    ...
       The event argument describes the object linked to the file descriptor
       fd.  The struct epoll_event is defined as:

           typedef union epoll_data {
               void        *ptr;
               int          fd;
               uint32_t     u32;
               uint64_t     u64;
           } epoll_data_t;

           struct epoll_event {
               uint32_t     events;      /* Epoll events */
               epoll_data_t data;        /* User data variable */
           };

https: //man7.org/linux/man-pages/man2/epoll_ctl.2.html

## Impact

## Testing

API test