### PR TITLE
sched/task: do not migrate the task state to INVALID 

### DIFF
--- a/sched/task/task_terminate.c
+++ b/sched/task/task_terminate.c
@@ -158,7 +158,6 @@ int nxtask_terminate(pid_t pid, bool nonblocking)
   /* Remove the task from the task list */
 
   dq_rem((FAR dq_entry_t *)dtcb, tasklist);
-  dtcb->task_state = TSTATE_TASK_INVALID;
 
   /* At this point, the TCB should no longer be accessible to the system */
 


### PR DESCRIPTION

## Summary

sched/task: do not migrate the task state to INVALID 

which still on used in task/nxmq_recover()

Change-Id: I31273aadd9e09c283cc3d0420dfc854ca8ae1899
Signed-off-by: chao.an <anchao@xiaomi.com>


assertion:
up_assert: Assertion failed at file:mqueue/mq_sndinternal.c line: 420 task: lpwork
up_registerdump: R0: 00000001 10008640 100126df 1000f524 00000000 9b8123d4 10012600 1000f81c
up_registerdump: R8: 10013358 0000002c 00000000 10013420 00004000 10013358 9b0070c7 9b007716
up_registerdump: xPSR: 61000000 BASEPRI: 000000a0 CONTROL: 00000000
up_registerdump: EXC_RETURN: fffffff9
up_dumpstate: sp:         10013358
up_dumpstate: stack base: 10013500


## Impact

## Testing

kill a thread which blocked in mq_receive(2) and restart the thread again.

