### PR TITLE
drivers/bch: delay the sector flush 

### DIFF
--- a/drivers/bch/bchlib_write.c
+++ b/drivers/bch/bchlib_write.c
@@ -141,6 +141,15 @@ ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset,
           nsectors = bch->nsectors - sector;
         }
 
+      /* Flush the dirty sector to keep the sector sequence */
+
+      ret = bchlib_flushsector(bch);
+      if (ret < 0)
+        {
+          ferr("ERROR: Flush failed: %d\n", ret);
+          return ret;
+        }
+
       /* Write the contiguous sectors */
 
       ret = bch->inode->u.i_bops->write(bch->inode, (FAR uint8_t *)buffer,

--- a/drivers/bch/bchlib_write.c
+++ b/drivers/bch/bchlib_write.c
@@ -184,14 +184,5 @@ ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset,
       byteswritten += len;
     }
 
-  /* Finally, flush any cached writes to the device as well */
-
-  ret = bchlib_flushsector(bch);
-  if (ret < 0)
-    {
-      ferr("ERROR: Flush failed: %d\n", ret);
-      return ret;
-    }
-
   return byteswritten;
 }


### PR DESCRIPTION
## Summary

1. drivers/bch: flush the dirty sector to keep the sector sequence

flush the dirty sector to keep the sector sequence before ftl write

2. drivers/bch: delay the sector flush

Delay the sector flush to avoid multiple earse/write operations in sequence write

## Impact

MTD write/read

## Testing

MTD write/read
