### PR TITLE
Fix build breakage from PR #1565

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_rtc.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc.c
@@ -355,7 +355,7 @@ static void cxd56_rtc_initialize(wdparm_t arg)
 
 int up_rtc_initialize(void)
 {
-  cxd56_rtc_initialize(1, NULL);
+  cxd56_rtc_initialize(0);
   return OK;
 }
 

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -834,7 +834,7 @@ static void tun_poll_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void tun_poll_expiry(FAR void *arg)
+static void tun_poll_expiry(wdparm_t arg)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)arg;
 
@@ -878,7 +878,7 @@ static int tun_ifup(FAR struct net_driver_s *dev)
 
   /* Set and activate a timer process */
 
-  wd_start(&priv->txpoll, TUN_WDDELAY, tun_poll_expiry, priv);
+  wd_start(&priv->txpoll, TUN_WDDELAY, tun_poll_expiry, (wdparm_t)priv);
 
   priv->bifup = true;
   return OK;


### PR DESCRIPTION
## Summary

Fixes:

    ##[error]net/tun.c:837:13: error: conflicting types for 'tun_poll_expiry'
      837 | static void tun_poll_expiry(FAR void *arg)
          |             ^~~~~~~~~~~~~~~
    net/tun.c:196:13: note: previous declaration of 'tun_poll_expiry' was here
      196 | static void tun_poll_expiry(wdparm_t arg);
          |             ^~~~~~~~~~~~~~~

And

     ##[error]net/tun.c:881:57: error: passing argument 4 of 'wd_start' makes integer from pointer without a cast [-Werror=int-conversion]
      881 |   wd_start(&priv->txpoll, TUN_WDDELAY, tun_poll_expiry, priv);
          |                                                         ^~~~
          |                                                         |
          |                                                         struct tun_device_s *
    In file included from /github/workspace/sources/nuttx/include/nuttx/sched.h:41,
                     from /github/workspace/sources/nuttx/include/sched.h:34,
                     from /github/workspace/sources/nuttx/include/nuttx/arch.h:81,
                     from net/tun.c:60:
    /github/workspace/sources/nuttx/include/nuttx/wdog.h:134:42: note: expected 'wdparm_t' {aka 'long unsigned int'} but argument is of type 'struct tun_device_s *'
      134 |              wdentry_t wdentry, wdparm_t arg);
          |                                 ~~~~~~~~~^~~

And

    chip/cxd56_rtc.c: In function 'up_rtc_initialize':
    ##[error]chip/cxd56_rtc.c:358:3: error: too many arguments to function 'cxd56_rtc_initialize'
      358 |   cxd56_rtc_initialize(1, NULL);
          |   ^~~~~~~~~~~~~~~~~~~~
    chip/cxd56_rtc.c:253:13: note: declared here
      253 | static void cxd56_rtc_initialize(wdparm_t arg)

## Impact

Hopefully this fixes the PR checks broken by #1565 

## Testing

PR Checks.

