### PR TITLE
fs/vfs/fs_epoll: fix epoll_wait function

### DIFF
--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -245,7 +245,12 @@ int epoll_wait(int epfd, FAR struct epoll_event *evs, int maxevents,
 
   /* Iterate over non NULL event fds */
 
-  for (i = 0, counter = 0; i < rc && counter < eph->size; counter++)
+  if (rc > maxevents)
+    {
+      rc = maxevents;
+    }
+
+  for (i = 0, counter = 0; i < rc && counter < eph->occupied; counter++)
     {
       if (eph->evs[counter].revents != 0)
         {

--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -95,11 +95,11 @@ struct epoll_event
 {
   epoll_data_t data;
   pollevent_t  events;   /* The input event flags */
-  pollevent_t  revents;  /* The output event flags */
 
   /* Non-standard fields used internally by NuttX. */
 
-  void        *reserved; /* reserved feild sync with struct pollfd */
+  pollevent_t  revents;  /* The output event flags */
+  void        *reserved; /* reserved field sync with struct pollfd */
   FAR sem_t   *sem;      /* Pointer to semaphore used to post output event */
   FAR void    *priv;     /* For use by drivers */
 };


### PR DESCRIPTION
## Summary

epoll_wait() must loop until "maxevents" to fill output evs array

## Impact

## Testing