### PR TITLE
libc: Replace all [nx]sem_xxx with _SEM_XXX

### DIFF
--- a/libs/libc/misc/lib_filesem.c
+++ b/libs/libc/misc/lib_filesem.c
@@ -69,7 +69,7 @@ void lib_sem_initialize(FAR struct file_struct *stream)
    * to private data sets.
    */
 
-  nxsem_init(&stream->fs_sem, 0, 1);
+  _SEM_INIT(&stream->fs_sem, 0, 1);
 
   stream->fs_holder = -1;
   stream->fs_counts = 0;
@@ -106,7 +106,8 @@ void lib_take_semaphore(FAR struct file_struct *stream)
            * was awakened by a signal.
            */
 
-          DEBUGASSERT(_SEM_ERRNO(ret) == EINTR || _SEM_ERRNO(ret) == ECANCELED);
+          DEBUGASSERT(_SEM_ERRNO(ret) == EINTR ||
+                      _SEM_ERRNO(ret) == ECANCELED);
           UNUSED(ret);
         }
 

--- a/libs/libc/misc/lib_stream.c
+++ b/libs/libc/misc/lib_stream.c
@@ -83,7 +83,7 @@ void lib_stream_initialize(FAR struct task_group_s *group)
 
   /* Initialize the list access mutex */
 
-  nxsem_init(&list->sl_sem, 0, 1);
+  _SEM_INIT(&list->sl_sem, 0, 1);
 
   /* Initialize each FILE structure */
 

--- a/libs/libc/stdio/lib_fclose.c
+++ b/libs/libc/stdio/lib_fclose.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * libs/libc/stdio/lib_fclose.c
  *
- *   Copyright (C) 2007-2009, 2011, 2013, 2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2011, 2013, 2017 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -92,7 +93,7 @@ int fclose(FAR FILE *stream)
               errcode = get_errno();
             }
 
-          /* Close the underlying file descriptor and save the return status */
+          /* Close the file descriptor and save the return status */
 
           status = close(stream->fs_fd);
 
@@ -110,7 +111,7 @@ int fclose(FAR FILE *stream)
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
       /* Destroy the semaphore */
 
-      sem_destroy(&stream->fs_sem);
+      _SEM_DESTROY(&stream->fs_sem);
 
       /* Release the buffer */
 
@@ -135,7 +136,7 @@ int fclose(FAR FILE *stream)
       stream->fs_oflags = 0;
 #endif
 
-      /* Setting the file descriptor to -1 makes the stream available for reuse */
+      /* Set file descriptor to -1 makes the stream available for reuse */
 
       stream->fs_fd = -1;
     }

--- a/libs/libc/wqueue/work_lock.c
+++ b/libs/libc/wqueue/work_lock.c
@@ -73,19 +73,20 @@ int work_lock(void)
   int ret;
 
 #ifdef CONFIG_BUILD_PROTECTED
-  ret = sem_wait(&g_usrsem);
+  ret = _SEM_WAIT(&g_usrsem);
   if (ret < 0)
     {
-      DEBUGASSERT(errno == EINTR || errno == ECANCELED);
+      DEBUGASSERT(_SEM_ERRNO(ret) == EINTR ||
+                  _SEM_ERRNO(ret) == ECANCELED);
       return -EINTR;
     }
 #else
-   ret = pthread_mutex_lock(&g_usrmutex);
-   if (ret != 0)
-     {
-       DEBUGASSERT(ret == EINTR);
-       return -EINTR;
-     }
+  ret = pthread_mutex_lock(&g_usrmutex);
+  if (ret != 0)
+    {
+      DEBUGASSERT(ret == EINTR);
+      return -EINTR;
+    }
 #endif
 
   return ret;
@@ -108,7 +109,7 @@ int work_lock(void)
 void work_unlock(void)
 {
 #ifdef CONFIG_BUILD_PROTECTED
-  sem_post(&g_usrsem);
+  _SEM_POST(&g_usrsem);
 #else
   pthread_mutex_unlock(&g_usrmutex);
 #endif


### PR DESCRIPTION
## Summary
Most internal nxsem_* interfaces are not available in the user space in
PROTECTED and KERNEL builds.  In that context, the application semaphore
interfaces must be used.  The differences between the two sets of
interfaces are:  (1) the nxsem_* interfaces do not cause cancellation
points and (2) they do not modify the errno variable.

This is only important when compiling libraries (libc or libnx) that are
used both by the OS (libkc.a and libknx.a) or by the applications
(libc.a and libnx.a).  In that case, the correct interface must be
used for the build context.

## Impact

## Testing

