### PR TITLE
sched: Support config the argument passed to init

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -329,6 +329,13 @@ config INIT_FILEPATH
 
 endchoice # Initialization task
 
+config INIT_ARGS
+	string "Application argument list"
+	depends on !INIT_NONE
+	---help---
+		The argument list for user applications. e.g.:
+		  "\"arg1\",\"arg2\",\"arg3\""
+
 if INIT_ENTRYPOINT
 config USER_ENTRYPOINT
 	string "Application entry point"
@@ -337,6 +344,13 @@ config USER_ENTRYPOINT
 		The name of the entry point for user applications.  For the example
 		applications this is of the form 'app_main' where 'app' is the application
 		name. If not defined, USER_ENTRYPOINT defaults to "main".
+
+config USERMAIN_STACKSIZE
+	int "Main thread stack size"
+	default DEFAULT_TASK_STACKSIZE
+	---help---
+		The size of the stack to allocate for the user initialization thread
+		that is started as soon as the OS completes its initialization.
 
 config USERMAIN_PRIORITY
 	int "init thread priority"
@@ -1740,13 +1754,6 @@ config IDLETHREAD_STACKSIZE
 		is the thread that (1) performs the initial boot of the system up to the
 		point where start-up application is spawned, and (2) there after is the
 		IDLE thread that executes only when there is no other thread ready to run.
-
-config USERMAIN_STACKSIZE
-	int "Main thread stack size"
-	default DEFAULT_TASK_STACKSIZE
-	---help---
-		The size of the stack to allocate for the user initialization thread
-		that is started as soon as the OS completes its initialization.
 
 config PTHREAD_STACK_MIN
 	int "Minimum pthread stack size"

--- a/tools/cfgdefine.c
+++ b/tools/cfgdefine.c
@@ -63,27 +63,28 @@ static const char *dequote_list[] =
 {
   /* NuttX */
 
-  "CONFIG_USER_ENTRYPOINT",               /* Name of entry point function */
-  "CONFIG_EXECFUNCS_SYMTAB_ARRAY",        /* Symbol table array used by exec[l|v] */
+  "CONFIG_DEBUG_OPTLEVEL",                /* Custom debug level */
   "CONFIG_EXECFUNCS_NSYMBOLS_VAR",        /* Variable holding number of symbols in the table */
+  "CONFIG_EXECFUNCS_SYMTAB_ARRAY",        /* Symbol table array used by exec[l|v] */
+  "CONFIG_INIT_ARGS",                     /* Argument list of entry point */
+  "CONFIG_INIT_SYMTAB",                   /* Global symbol table */
+  "CONFIG_INIT_NEXPORTS",                 /* Global symbol table size */
   "CONFIG_MODLIB_SYMTAB_ARRAY",           /* Symbol table array used by modlib functions */
   "CONFIG_MODLIB_NSYMBOLS_VAR",           /* Variable holding number of symbols in the table */
   "CONFIG_PASS1_BUILDIR",                 /* Pass1 build directory */
   "CONFIG_PASS1_TARGET",                  /* Pass1 build target */
   "CONFIG_PASS1_OBJECT",                  /* Pass1 build object */
-  "CONFIG_DEBUG_OPTLEVEL",                /* Custom debug level */
-  "CONFIG_INIT_SYMTAB",                   /* Global symbol table */
-  "CONFIG_INIT_NEXPORTS",                 /* Global symbol table size */
+  "CONFIG_USER_ENTRYPOINT",               /* Name of entry point function */
 
   /* NxWidgets/NxWM */
 
   "CONFIG_NXWM_BACKGROUND_IMAGE",         /* Name of bitmap image class */
-  "CONFIG_NXWM_STOP_BITMAP",              /* Name of bitmap image class */
-  "CONFIG_NXWM_MINIMIZE_BITMAP",          /* Name of bitmap image class */
-  "CONFIG_NXWM_STARTWINDOW_ICON",         /* Name of bitmap image class */
-  "CONFIG_NXWM_NXTERM_ICON",              /* Name of bitmap image class */
   "CONFIG_NXWM_CALIBRATION_ICON",         /* Name of bitmap image class */
   "CONFIG_NXWM_HEXCALCULATOR_ICON",       /* Name of bitmap image class */
+  "CONFIG_NXWM_MINIMIZE_BITMAP",          /* Name of bitmap image class */
+  "CONFIG_NXWM_NXTERM_ICON",              /* Name of bitmap image class */
+  "CONFIG_NXWM_STARTWINDOW_ICON",         /* Name of bitmap image class */
+  "CONFIG_NXWM_STOP_BITMAP",              /* Name of bitmap image class */
 
   /* apps/ definitions */
 


### PR DESCRIPTION
## Summary
it is useful to pass the nonempty argument to change the init task behaviour

## Impact

## Testing

