### PR TITLE
Fix Added options for I-Cache & D-Cache broken on c101076704

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -3359,14 +3359,14 @@ endmenu
 config STM32_FLASH_ICACHE
 	bool "Enable FLASH Instruction Cache"
 	default y
-	depends on STM32_HAVE_ICACHE
+	depends on STM32_HAVE_FLASH_ICACHE
 	---help---
 		Enable the FLASH instruction cache.
 
 config STM32_FLASH_DCACHE
 	bool "Enable FLASH Data Cache"
 	default y
-	depends on STM32_HAVE_DCACHE
+	depends on STM32_HAVE_FLASH_DCACHE
 	---help---
 		Enable the FLASH data cache.
 


### PR DESCRIPTION
## Summary

   There was a suggestion in the PR review to disambiguate the I/D cache name applied only to the FLASH (ART) from that of the the m7 I/D cache. Not all the Kconfig names were not updated to reflect FLASH. This  killed performance on F4 and F2.

## Impact
Master is ruining 20% slower on F4.

## Testing

Before this PR:
![image](https://user-images.githubusercontent.com/1945821/90434925-140dae80-e083-11ea-9a30-b760e9da82da.png)

With this PR.

![image](https://user-images.githubusercontent.com/1945821/90434995-2f78b980-e083-11ea-8096-6eeb786cac8f.png)

FYI @fotis400 