### PR TITLE
Refactor gs2200m board specific driver

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_gs2200m.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_gs2200m.c
@@ -116,19 +116,12 @@ static void gs2200m_irq_enable(void)
 
   wlinfo("== ec:%d called=%d \n", _enable_count, _n_called++);
 
-  if (1 == _enable_count)
-    {
-      /* NOTE: This would happen if we received an event */
-
-      return;
-    }
-
-  _enable_count++;
-
-  if (1 == _enable_count)
+  if (0 == _enable_count)
     {
       cxd56_gpioint_enable(PIN_UART2_CTS);
     }
+
+  _enable_count++;
 
   spin_unlock_irqrestore(flags);
 }

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_gs2200m.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_gs2200m.c
@@ -123,16 +123,7 @@ static void gs2200m_irq_enable(void)
 
   wlinfo("== ec:%d called=%d \n", _enable_count, _n_called++);
 
-  if (1 == _enable_count)
-    {
-      /* NOTE: This would happen if we received an event */
-
-      return;
-    }
-
-  _enable_count++;
-
-  if (1 == _enable_count)
+  if (0 == _enable_count)
     {
       /* Check if irq has been asserted */
 
@@ -143,6 +134,8 @@ static void gs2200m_irq_enable(void)
       stm32_gpiosetevent(GPIO_GS2200M_INT, true, false,
                          true, g_irq_handler, g_irq_arg);
     }
+
+  _enable_count++;
 
   spin_unlock_irqrestore(flags);
 


### PR DESCRIPTION
## Summary

- This PR refactors cxd56_gs2200m.c and stm32_gs2200m.c
- gs2200m_irq_enable() and gs2200m_irq_disable() are now symmetric.

## Impact

- All use cases which use the gs2200m driver.

## Testing

- Tested with spresense:wifi and stm32f4discovery
