### PR TITLE
libc/time: Implement tm::tm_gmtoff field

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -131,15 +131,16 @@ struct timespec
 
 struct tm
 {
-  int tm_sec;     /* Seconds (0-61, allows for leap seconds) */
-  int tm_min;     /* Minutes (0-59) */
-  int tm_hour;    /* Hours (0-23) */
-  int tm_mday;    /* Day of the month (1-31) */
-  int tm_mon;     /* Month (0-11) */
-  int tm_year;    /* Years since 1900 */
-  int tm_wday;    /* Day of the week (0-6) */
-  int tm_yday;    /* Day of the year (0-365) */
-  int tm_isdst;   /* Non-0 if daylight savings time is in effect */
+  int  tm_sec;    /* Seconds (0-61, allows for leap seconds) */
+  int  tm_min;    /* Minutes (0-59) */
+  int  tm_hour;   /* Hours (0-23) */
+  int  tm_mday;   /* Day of the month (1-31) */
+  int  tm_mon;    /* Month (0-11) */
+  int  tm_year;   /* Years since 1900 */
+  int  tm_wday;   /* Day of the week (0-6) */
+  int  tm_yday;   /* Day of the year (0-365) */
+  int  tm_isdst;  /* Non-0 if daylight savings time is in effect */
+  long tm_gmtoff; /* Offset from UTC in seconds */
 };
 
 /* Struct itimerspec is used to define settings for an interval timer */

--- a/libs/libc/time/lib_gmtimer.c
+++ b/libs/libc/time/lib_gmtimer.c
@@ -342,18 +342,19 @@ FAR struct tm *gmtime_r(FAR const time_t *timep, FAR struct tm *result)
 
   /* Then return the struct tm contents */
 
-  result->tm_year  = (int)year - 1900; /* Relative to 1900 */
-  result->tm_mon   = (int)month - 1;   /* zero-based */
-  result->tm_mday  = (int)day;         /* one-based */
-  result->tm_hour  = (int)hour;
-  result->tm_min   = (int)min;
-  result->tm_sec   = (int)sec;
+  result->tm_year   = (int)year - 1900; /* Relative to 1900 */
+  result->tm_mon    = (int)month - 1;   /* zero-based */
+  result->tm_mday   = (int)day;         /* one-based */
+  result->tm_hour   = (int)hour;
+  result->tm_min    = (int)min;
+  result->tm_sec    = (int)sec;
 
-  result->tm_wday  = clock_dayoftheweek(day, month, year);
-  result->tm_yday  = day +
-                     clock_daysbeforemonth(result->tm_mon,
-                                           clock_isleapyear(year));
-  result->tm_isdst = 0;
+  result->tm_wday   = clock_dayoftheweek(day, month, year);
+  result->tm_yday   = day +
+                      clock_daysbeforemonth(result->tm_mon,
+                                            clock_isleapyear(year));
+  result->tm_isdst  = 0;
+  result->tm_gmtoff = 0;
 
   return result;
 }

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -1974,6 +1974,7 @@ static struct tm *timesub(FAR const time_t * const timep,
 
   tmp->tm_mday = (int)(idays + 1);
   tmp->tm_isdst = 0;
+  tmp->tm_gmtoff = offset;
 
   return tmp;
 }


### PR DESCRIPTION
## Summary
defined by BSD and GNU library extension:
https://www.gnu.org/software/libc/manual/html_node/Broken_002ddown-Time.html

## Impact
New field

## Testing

