### PR TITLE
arch: cxd56xx: Use spinlock API in cxd56_serial.c

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_serial.c
+++ b/arch/arm/src/cxd56xx/cxd56_serial.c
@@ -305,7 +305,7 @@ static inline void up_disableuartint(FAR struct up_dev_s *priv,
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave();
   if (ier)
     {
       *ier = priv->ier & UART_INTR_ALL;
@@ -313,7 +313,7 @@ static inline void up_disableuartint(FAR struct up_dev_s *priv,
 
   priv->ier &= ~UART_INTR_ALL;
   up_serialout(priv, CXD56_UART_IMSC, priv->ier);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(flags);
 }
 
 /****************************************************************************
@@ -324,10 +324,10 @@ static inline void up_restoreuartint(FAR struct up_dev_s *priv, uint32_t ier)
 {
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave();
   priv->ier |= ier & UART_INTR_ALL;
   up_serialout(priv, CXD56_UART_IMSC, priv->ier);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(flags);
 }
 
 /****************************************************************************
@@ -389,7 +389,7 @@ static void up_set_format(struct uart_dev_s *dev)
   uint32_t cr_en;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave();
 
   /* Get the original state of control register */
 
@@ -455,7 +455,7 @@ static void up_set_format(struct uart_dev_s *dev)
 #endif
   up_serialout(priv, CXD56_UART_CR, cr | cr_en);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(flags);
 }
 #endif /* CONFIG_SUPPRESS_UART_CONFIG */
 
@@ -776,7 +776,7 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
-          flags = enter_critical_section();
+          flags = spin_lock_irqsave();
 
           cfsetispeed(termiosp, priv->baud);
 
@@ -810,7 +810,7 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
                 break;
             }
 
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(flags);
         }
         break;
 
@@ -825,7 +825,7 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
-          flags = enter_critical_section();
+          flags = spin_lock_irqsave();
 
           switch (termiosp->c_cflag & CSIZE)
             {
@@ -870,25 +870,25 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           up_set_format(dev);
 
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(flags);
         }
         break;
 #endif
 
       case TIOCSBRK: /* BSD compatibility: Turn break on, unconditionally */
         {
-          irqstate_t flags = enter_critical_section();
+          irqstate_t flags = spin_lock_irqsave();
           up_enablebreaks(priv, true);
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(flags);
         }
         break;
 
       case TIOCCBRK: /* BSD compatibility: Turn break off, unconditionally */
         {
           irqstate_t flags;
-          flags = enter_critical_section();
+          flags = spin_lock_irqsave();
           up_enablebreaks(priv, false);
-          leave_critical_section(flags);
+          spin_unlock_irqrestore(flags);
         }
         break;
 
@@ -939,7 +939,7 @@ static void up_rxint(FAR struct uart_dev_s *dev, bool enable)
   FAR struct up_dev_s *priv = (FAR struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave();
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -952,7 +952,7 @@ static void up_rxint(FAR struct uart_dev_s *dev, bool enable)
     }
 
   up_serialout(priv, CXD56_UART_IMSC, priv->ier);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(flags);
 }
 
 /****************************************************************************
@@ -996,7 +996,7 @@ static void up_txint(FAR struct uart_dev_s *dev, bool enable)
   FAR struct up_dev_s *priv = (FAR struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave();
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1016,7 +1016,7 @@ static void up_txint(FAR struct uart_dev_s *dev, bool enable)
       up_serialout(priv, CXD56_UART_IMSC, priv->ier);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- This commit improves cxd56_serial performance in SMP mode.

## Impact

- This commit affects SMP mode only.

## Testing

- Tested with spresense:smp
