### PR TITLE
Kinetis USBHSHOST improvement.

### DIFF
--- a/arch/arm/src/kinetis/Kconfig
+++ b/arch/arm/src/kinetis/Kconfig
@@ -1114,6 +1114,41 @@ config KINETIS_SD4BIT_FREQ
 endif
 endmenu # Kinetis SDHC Configuration
 
+if KINETIS_USBHS && USBHOST
+
+menu "USB host controller driver (HCD) options"
+
+config KINETIS_EHCI_NQHS
+	int "Number of Queue Head (QH) structures"
+	default 4
+	---help---
+		Configurable number of Queue Head (QH) structures.
+
+config KINETIS_EHCI_NQTDS
+	int "Number of Queue Element Transfer Descriptor (qTDs)"
+	default 6
+	---help---
+		Configurable number of Queue Element Transfer Descriptor (qTDs).
+
+config KINETIS_EHCI_BUFSIZE
+	int "Size of one request/descriptor buffer"
+	default 128
+	---help---
+		The size of one request/descriptor buffer in bytes.  The TD buffe
+		size must be an even number of 32-bit words and must be large enough
+		to hangle the largest transfer via a SETUP request.
+
+config KINETIS_EHCI_PREALLOCATE
+	bool "Preallocate descriptor pool"
+	default y
+	---help---
+		Select this option to pre-allocate EHCI queue and descriptor
+		structure pools in .bss.  Otherwise, these pools will be
+		dynamically allocated using kmm_memalign().
+
+endmenu # USB host controller driver (HCD) options
+endif # KINETIS_USBHS && USBHOST
+
 #
 # MCU serial peripheral driver?
 #


### PR DESCRIPTION
Avoid race conditions during freeing of queue head structures by using Async Advance Doorbell.

## Summary
During rework of FTDI FT232 driver (which will be a seperate PR), I realized that the EHCI host controller sometimes suddenly stops (RUN/STOP 0 HALTED 1).
I tracked that down to interleaved in and out transfers which were causing race conditions between the host controller and the driver during QH unlink/reuse.
EHCI Spec (4.8.2 Removing Queue Heads from Asynchronous Schedule) proposes the use of the Async Advance Doorbell mechanism to overcome that issue.
## Impact
The unlinked QH are added to an intermediate linked list and the Async Advance Doorbell mechanism is started. When the corresponding interrupt occurs the QH are put on the free list. Because we are not allowed to modify the contents of the hardware representation of the QH before AA interrupt we can't use the generic list structure any more . The links are now maintained in the former pad area of the QH itself.
## Testing
Freedom K28 board, with modified FT232R driver with a small stresstest application.

Please ignore "error: Mixed case identifier found" complaints, they are related to a header file.
