### PR TITLE
arch: cxd56xx: Introduce CONFIG_CXD56_SPI_DMATHRESHOLD

### DIFF
--- a/arch/arm/src/cxd56xx/Kconfig
+++ b/arch/arm/src/cxd56xx/Kconfig
@@ -356,6 +356,15 @@ config CXD56_SPI_DRIVER
 		used to perform SPI bus transfers from applications.  The intent of
 		this driver is to support SPI testing.
 
+config CXD56_SPI_DMATHRESHOLD
+       int "SPI DMA threshold"
+       default 64
+       depends on CXD56_DMAC
+	---help---
+		When SPI DMA is enabled, small DMA transfers will still be performed
+		by polling logic.  But we need a threshold value to determine what
+		is small.
+
 config CXD56_SPI0
 	bool "SPI0"
 

--- a/arch/arm/src/cxd56xx/cxd56_spi.c
+++ b/arch/arm/src/cxd56xx/cxd56_spi.c
@@ -855,7 +855,13 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
 #ifdef CONFIG_CXD56_DMAC
   FAR struct cxd56_spidev_s *priv = (FAR struct cxd56_spidev_s *)dev;
 
-  if (priv->dmaenable)
+#ifdef CONFIG_CXD56_SPI_DMATHRESHOLD
+  size_t dmath = CONFIG_CXD56_SPI_DMATHRESHOLD;
+#else
+  size_t dmath = 0;
+#endif
+
+  if (priv->dmaenable && dmath < nwords)
     {
       spi_dmaexchange(dev, txbuffer, rxbuffer, nwords);
     }


### PR DESCRIPTION
## Summary

- This commit improves SPI performance.
- For small data, it does not use DMA.

## Impact

- All use cases which use SPI with DMA

## Testing

- Tested with spresense:wifi and spresense:example_lcd

