### PR TITLE
nRF52: add support for RTC event handling

### DIFF
--- a/arch/arm/src/nrf52/nrf52_rtc.c
+++ b/arch/arm/src/nrf52/nrf52_rtc.c
@@ -207,37 +207,37 @@ static uint32_t nrf52_rtc_irq2reg(FAR struct nrf52_rtc_dev_s *dev, uint8_t s)
 
   switch (s)
     {
-      case NRF52_RTC_INT_TICK:
+      case NRF52_RTC_EVT_TICK:
         {
           regval = RTC_INT_TICK;
           break;
         }
 
-      case NRF52_RTC_INT_OVRFLW:
+      case NRF52_RTC_EVT_OVRFLW:
         {
           regval = RTC_INT_OVRFLW;
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE0:
+      case NRF52_RTC_EVT_COMPARE0:
         {
           regval = RTC_INT_COMPARE(0);
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE1:
+      case NRF52_RTC_EVT_COMPARE1:
         {
           regval = RTC_INT_COMPARE(1);
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE2:
+      case NRF52_RTC_EVT_COMPARE2:
         {
           regval = RTC_INT_COMPARE(2);
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE3:
+      case NRF52_RTC_EVT_COMPARE3:
         {
           regval = RTC_INT_COMPARE(3);
           break;
@@ -550,37 +550,37 @@ static int nrf52_rtc_checkint(FAR struct nrf52_rtc_dev_s *dev, uint8_t s)
 
   switch (s)
     {
-      case NRF52_RTC_INT_TICK:
+      case NRF52_RTC_EVT_TICK:
         {
           ret = nrf52_rtc_getreg(dev, NRF52_RTC_EVENTS_TICK_OFFSET);
           break;
         }
 
-      case NRF52_RTC_INT_OVRFLW:
+      case NRF52_RTC_EVT_OVRFLW:
         {
           ret = nrf52_rtc_getreg(dev, NRF52_RTC_EVENTS_OVRFLW_OFFSET);
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE0:
+      case NRF52_RTC_EVT_COMPARE0:
         {
           ret = nrf52_rtc_getreg(dev, NRF52_RTC_EVENTS_COMPARE_OFFSET(0));
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE1:
+      case NRF52_RTC_EVT_COMPARE1:
         {
           ret = nrf52_rtc_getreg(dev, NRF52_RTC_EVENTS_COMPARE_OFFSET(0));
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE2:
+      case NRF52_RTC_EVT_COMPARE2:
         {
           ret = nrf52_rtc_getreg(dev, NRF52_RTC_EVENTS_COMPARE_OFFSET(2));
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE3:
+      case NRF52_RTC_EVT_COMPARE3:
         {
           ret = nrf52_rtc_getreg(dev, NRF52_RTC_EVENTS_COMPARE_OFFSET(3));
           break;
@@ -610,37 +610,37 @@ static int nrf52_rtc_ackint(FAR struct nrf52_rtc_dev_s *dev, uint8_t s)
 
   switch (s)
     {
-      case NRF52_RTC_INT_TICK:
+      case NRF52_RTC_EVT_TICK:
         {
           nrf52_rtc_putreg(dev, NRF52_RTC_EVENTS_TICK_OFFSET, 0);
           break;
         }
 
-      case NRF52_RTC_INT_OVRFLW:
+      case NRF52_RTC_EVT_OVRFLW:
         {
           nrf52_rtc_putreg(dev, NRF52_RTC_EVENTS_OVRFLW_OFFSET, 0);
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE0:
+      case NRF52_RTC_EVT_COMPARE0:
         {
           nrf52_rtc_putreg(dev, NRF52_RTC_EVENTS_COMPARE_OFFSET(0), 0);
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE1:
+      case NRF52_RTC_EVT_COMPARE1:
         {
           nrf52_rtc_putreg(dev, NRF52_RTC_EVENTS_COMPARE_OFFSET(1), 0);
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE2:
+      case NRF52_RTC_EVT_COMPARE2:
         {
           nrf52_rtc_putreg(dev, NRF52_RTC_EVENTS_COMPARE_OFFSET(2), 0);
           break;
         }
 
-      case NRF52_RTC_INT_COMPARE3:
+      case NRF52_RTC_EVT_COMPARE3:
         {
           nrf52_rtc_putreg(dev, NRF52_RTC_EVENTS_COMPARE_OFFSET(3), 0);
           break;

--- a/arch/arm/src/nrf52/nrf52_rtc.c
+++ b/arch/arm/src/nrf52/nrf52_rtc.c
@@ -89,7 +89,8 @@ static int nrf52_rtc_disableint(FAR struct nrf52_rtc_dev_s *dev, uint8_t s);
 static int nrf52_rtc_checkint(FAR struct nrf52_rtc_dev_s *dev, uint8_t s);
 static int nrf52_rtc_ackint(FAR struct nrf52_rtc_dev_s *dev, uint8_t s);
 static int nrf52_rtc_enableevt(FAR struct nrf52_rtc_dev_s *dev, uint8_t evt);
-static int nrf52_rtc_disableevt(FAR struct nrf52_rtc_dev_s *dev, uint8_t evt);
+static int nrf52_rtc_disableevt(FAR struct nrf52_rtc_dev_s *dev,
+                                uint8_t evt);
 
 /****************************************************************************
  * Private Data

--- a/arch/arm/src/nrf52/nrf52_rtc.h
+++ b/arch/arm/src/nrf52/nrf52_rtc.h
@@ -64,19 +64,7 @@ enum nrf52_rtc_cc_e
   NRF52_RTC_CC3 = 3,
 };
 
-/* RTC IRQ source */
-
-enum nrf52_rtc_irq_e
-{
-  NRF52_RTC_INT_TICK     = 0,
-  NRF52_RTC_INT_OVRFLW   = 1,
-  NRF52_RTC_INT_COMPARE0 = 2,
-  NRF52_RTC_INT_COMPARE1 = 3,
-  NRF52_RTC_INT_COMPARE2 = 4,
-  NRF52_RTC_INT_COMPARE3 = 5,
-};
-
-/* RTC Events */
+/* RTC Interrupts/Events */
 
 enum nrf52_rtc_evt_e
 {

--- a/arch/arm/src/nrf52/nrf52_rtc.h
+++ b/arch/arm/src/nrf52/nrf52_rtc.h
@@ -42,11 +42,13 @@
 #define NRF52_RTC_SETCC(d, i, cc)         ((d)->ops->setcc(d, i, cc))
 #define NRF52_RTC_GETCC(d, i, cc)         ((d)->ops->setcc(d, i, cc))
 #define NRF52_RTC_SETPRE(d, pre)          ((d)->ops->setpre(d, pre))
-#define NRF52_RTC_SETISR(d, hnd, arg, s)  ((d)->ops->setisr(d, hnd, arg, s))
+#define NRF52_RTC_SETISR(d, hnd, arg)     ((d)->ops->setisr(d, hnd, arg))
 #define NRF52_RTC_ENABLEINT(d, s)         ((d)->ops->enableint(d, s))
 #define NRF52_RTC_DISABLEINT(d, s)        ((d)->ops->disableint(d, s))
 #define NRF52_RTC_CHECKINT(d, s)          ((d)->ops->checkint(d, s))
 #define NRF52_RTC_ACKINT(d, s)            ((d)->ops->ackint(d, s))
+#define NRF52_RTC_ENABLEEVT(d, s)         ((d)->ops->enableevt(d, s))
+#define NRF52_RTC_DISABLEEVT(d, s)        ((d)->ops->disableevt(d, s))
 
 /****************************************************************************
  * Public Types
@@ -72,6 +74,18 @@ enum nrf52_rtc_irq_e
   NRF52_RTC_INT_COMPARE1 = 3,
   NRF52_RTC_INT_COMPARE2 = 4,
   NRF52_RTC_INT_COMPARE3 = 5,
+};
+
+/* RTC Events */
+
+enum nrf52_rtc_evt_e
+{
+  NRF52_RTC_EVT_TICK     = 0,
+  NRF52_RTC_EVT_OVRFLW   = 1,
+  NRF52_RTC_EVT_COMPARE0 = 2,
+  NRF52_RTC_EVT_COMPARE1 = 3,
+  NRF52_RTC_EVT_COMPARE2 = 4,
+  NRF52_RTC_EVT_COMPARE3 = 5,
 };
 
 /* NRF52 RTC device */
@@ -107,6 +121,11 @@ struct nrf52_rtc_ops_s
   CODE int (*disableint)(FAR struct nrf52_rtc_dev_s *dev, uint8_t source);
   CODE int (*checkint)(FAR struct nrf52_rtc_dev_s *dev, uint8_t source);
   CODE int (*ackint)(FAR struct nrf52_rtc_dev_s *dev, uint8_t source);
+
+  /* RTC events */
+
+  CODE int (*enableevt)(FAR struct nrf52_rtc_dev_s *dev, uint8_t evt);
+  CODE int (*disableevt)(FAR struct nrf52_rtc_dev_s *dev, uint8_t evt);
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Adds support for setting up events on RTC peripheral

## Impact

Add support for new feature.

## Testing

Used events and work correctly.
