### PR TITLE
nRF52: add support for PPI peripheral

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -212,6 +212,10 @@ config NRF52_TIMER4
 	select NRF52_TIMER
 	default n
 
+config NRF52_PPI
+  bool "PPI"
+  default n
+
 config NRF52_RTC0
 	bool "RTC0"
 	select NRF52_RTC

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -126,6 +126,10 @@ ifeq ($(CONFIG_NRF52_I2C_MASTER),y)
 CHIP_CSRCS += nrf52_i2c.c
 endif
 
+ifeq ($(CONFIG_NRF52_PPI),y)
+CHIP_CSRCS += nrf52_ppi.c
+endif
+
 ifeq ($(CONFIG_NRF52_RADIO),y)
 CHIP_CSRCS += nrf52_radio.c
 endif

--- a/arch/arm/src/nrf52/nrf52_ppi.c
+++ b/arch/arm/src/nrf52/nrf52_ppi.c
@@ -79,33 +79,33 @@ void nrf52_ppi_channel_enable(uint8_t ch, bool enable)
  * Name: nrf52_ppi_set_event_ep
  ****************************************************************************/
 
-void nrf52_ppi_set_event_ep(uint8_t ch, volatile uint32_t *event_reg)
+void nrf52_ppi_set_event_ep(uint8_t ch, uint32_t event_reg)
 {
   DEBUGASSERT(ch < NRF52_PPI_NUM_CONFIGURABLE_CHANNELS);
 
-  putreg32((uint32_t)event_reg, NRF52_PPI_CHEEP(ch));
+  putreg32(event_reg, NRF52_PPI_CHEEP(ch));
 }
 
 /****************************************************************************
  * Name: nrf52_ppi_set_task_ep
  ****************************************************************************/
 
-void nrf52_ppi_set_task_ep(uint8_t ch, volatile uint32_t *task_reg)
+void nrf52_ppi_set_task_ep(uint8_t ch, uint32_t task_reg)
 {
   DEBUGASSERT(ch < NRF52_PPI_NUM_CONFIGURABLE_CHANNELS);
 
-  putreg32((uint32_t)task_reg, NRF52_PPI_CHTEP(ch));
+  putreg32(task_reg, NRF52_PPI_CHTEP(ch));
 }
 
 /****************************************************************************
  * Name: nrf52_ppi_set_task2_ep
  ****************************************************************************/
 
-void nrf52_ppi_set_task2_ep(uint8_t ch, volatile uint32_t *task_reg)
+void nrf52_ppi_set_task2_ep(uint8_t ch, uint32_t task_reg)
 {
   DEBUGASSERT(ch < NRF52_PPI_NUM_CHANNELS);
 
-  putreg32((uint32_t)task_reg, NRF52_PPI_FORKTEP(ch));
+  putreg32(task_reg, NRF52_PPI_FORKTEP(ch));
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf52/nrf52_ppi.c
+++ b/arch/arm/src/nrf52/nrf52_ppi.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * /home/v01d/coding/nuttx_nrf_ble/nuttx/arch/arm/src/chip/nrf52_ppi.c
+ * arch/arm/src/chip/nrf52_ppi.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/nrf52/nrf52_ppi.c
+++ b/arch/arm/src/nrf52/nrf52_ppi.c
@@ -1,0 +1,134 @@
+/****************************************************************************
+ * /home/v01d/coding/nuttx_nrf_ble/nuttx/arch/arm/src/chip/nrf52_ppi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "arm_arch.h"
+#include "chip.h"
+#include "nrf52_ppi.h"
+#include "hardware/nrf52_ppi.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nrf52_ppi_channel_enable
+ ****************************************************************************/
+
+void nrf52_ppi_channel_enable(uint8_t ch, bool enable)
+{
+  DEBUGASSERT(ch < NRF52_PPI_NUM_CHANNELS);
+
+  if (enable)
+    {
+      putreg32(PPI_CHEN_CH(ch), NRF52_PPI_CHENSET);
+    }
+  else
+    {
+      putreg32(PPI_CHEN_CH(ch), NRF52_PPI_CHENCLR);
+    }
+}
+
+/****************************************************************************
+ * Name: nrf52_ppi_set_event_ep
+ ****************************************************************************/
+
+void nrf52_ppi_set_event_ep(uint8_t ch, volatile uint32_t *event_reg)
+{
+  DEBUGASSERT(ch < NRF52_PPI_NUM_CONFIGURABLE_CHANNELS);
+
+  putreg32((uint32_t)event_reg, NRF52_PPI_CHEEP(ch));
+}
+
+/****************************************************************************
+ * Name: nrf52_ppi_set_task_ep
+ ****************************************************************************/
+
+void nrf52_ppi_set_task_ep(uint8_t ch, volatile uint32_t *task_reg)
+{
+  DEBUGASSERT(ch < NRF52_PPI_NUM_CONFIGURABLE_CHANNELS);
+
+  putreg32((uint32_t)task_reg, NRF52_PPI_CHTEP(ch));
+}
+
+/****************************************************************************
+ * Name: nrf52_ppi_set_task2_ep
+ ****************************************************************************/
+
+void nrf52_ppi_set_task2_ep(uint8_t ch, volatile uint32_t *task_reg)
+{
+  DEBUGASSERT(ch < NRF52_PPI_NUM_CHANNELS);
+
+  putreg32((uint32_t)task_reg, NRF52_PPI_FORKTEP(ch));
+}
+
+/****************************************************************************
+ * Name: nrf52_ppi_grp_channel_enable
+ ****************************************************************************/
+
+void nrf52_ppi_grp_channel_enable(uint8_t group, uint8_t ch, bool enable)
+{
+  DEBUGASSERT(group < NRF52_PPI_NUM_GROUPS);
+  DEBUGASSERT(ch < NRF52_PPI_NUM_CHANNELS);
+
+  modifyreg32(NRF52_PPI_CHG(group), (enable ? PPI_CHEN_CH(ch) : 0),
+                                    (enable ? 0 : PPI_CHEN_CH(ch)));
+}
+
+/****************************************************************************
+ * Name: nrf52_ppi_grp_enable
+ ****************************************************************************/
+
+void nrf52_ppi_grp_enable(uint8_t group, bool enable)
+{
+  DEBUGASSERT(group < NRF52_PPI_NUM_GROUPS);
+
+  putreg32(1, (enable ? NRF52_PPI_TASK_CHGEN(group) :
+                        NRF52_PPI_TASK_CHGDIS_OFFSET(group)));
+}

--- a/arch/arm/src/nrf52/nrf52_ppi.c
+++ b/arch/arm/src/nrf52/nrf52_ppi.c
@@ -117,8 +117,8 @@ void nrf52_ppi_grp_channel_enable(uint8_t group, uint8_t ch, bool enable)
   DEBUGASSERT(group < NRF52_PPI_NUM_GROUPS);
   DEBUGASSERT(ch < NRF52_PPI_NUM_CHANNELS);
 
-  modifyreg32(NRF52_PPI_CHG(group), (enable ? PPI_CHEN_CH(ch) : 0),
-                                    (enable ? 0 : PPI_CHEN_CH(ch)));
+  modifyreg32(NRF52_PPI_CHG(group), (enable ? 0 : PPI_CHEN_CH(ch)),
+                                    (enable ? PPI_CHEN_CH(ch) : 0));
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf52/nrf52_ppi.c
+++ b/arch/arm/src/nrf52/nrf52_ppi.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/chip/nrf52_ppi.c
+ * arch/arm/src/nrf52/nrf52_ppi.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/arm/src/nrf52/nrf52_ppi.h
+++ b/arch/arm/src/nrf52/nrf52_ppi.h
@@ -86,7 +86,7 @@ void nrf52_ppi_channel_enable(uint8_t ch, bool enable);
  *
  ****************************************************************************/
 
-void nrf52_ppi_set_event_ep(uint8_t ch, volatile uint32_t *event_reg);
+void nrf52_ppi_set_event_ep(uint8_t ch, uint32_t event_reg);
 
 /****************************************************************************
  * Name: nrf52_ppi_set_task_ep
@@ -100,7 +100,7 @@ void nrf52_ppi_set_event_ep(uint8_t ch, volatile uint32_t *event_reg);
  *
  ****************************************************************************/
 
-void nrf52_ppi_set_task_ep(uint8_t ch, volatile uint32_t *task_reg);
+void nrf52_ppi_set_task_ep(uint8_t ch, uint32_t task_reg);
 
 /****************************************************************************
  * Name: nrf52_ppi_set_task2_ep
@@ -114,7 +114,7 @@ void nrf52_ppi_set_task_ep(uint8_t ch, volatile uint32_t *task_reg);
  *
  ****************************************************************************/
 
-void nrf52_ppi_set_task2_ep(uint8_t ch, volatile uint32_t *task_reg);
+void nrf52_ppi_set_task2_ep(uint8_t ch, uint32_t task_reg);
 
 /****************************************************************************
  * Name: nrf52_ppi_grp_channel_enable

--- a/arch/arm/src/nrf52/nrf52_ppi.h
+++ b/arch/arm/src/nrf52/nrf52_ppi.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/chip/nrf52_ppi.h
+ * arch/arm/src/nrf52/nrf52_ppi.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_ARM_SRC_CHIP_NRF52_PPI_H
-#define __ARCH_ARM_SRC_CHIP_NRF52_PPI_H
+#ifndef __ARCH_ARM_SRC_NRF52_NRF52_PPI_H
+#define __ARCH_ARM_SRC_NRF52_NRF52_PPI_H
 
 /****************************************************************************
  * Included Files
@@ -150,4 +150,4 @@ void nrf52_ppi_grp_enable(uint8_t group, bool enable);
 }
 #endif
 
-#endif // __ARCH_ARM_SRC_CHIP_NRF52_PPI_H
+#endif // __ARCH_ARM_SRC_NRF52_NRF52_PPI_H

--- a/arch/arm/src/nrf52/nrf52_ppi.h
+++ b/arch/arm/src/nrf52/nrf52_ppi.h
@@ -1,0 +1,153 @@
+/****************************************************************************
+ * arch/arm/src/chip/nrf52_ppi.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_CHIP_NRF52_PPI_H
+#define __ARCH_ARM_SRC_CHIP_NRF52_PPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define NRF52_PPI_NUM_CHANNELS              32    /* Total number of PPI channels */
+#define NRF52_PPI_NUM_CONFIGURABLE_CHANNELS 20    /* Number of configurable PPI channels */
+#define NRF52_PPI_NUM_GROUPS                6     /* Number of PPI channel groups */
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nrf52_ppi_channel_enable
+ *
+ * Description:
+ *   Enable/disable a given PPI channel
+ *
+ * Input Parameters:
+ *   - ch: channel number
+ *   - enable: enable (true) or disable (false)
+ *
+ ****************************************************************************/
+
+void nrf52_ppi_channel_enable(uint8_t ch, bool enable);
+
+/****************************************************************************
+ * Name: nrf52_ppi_set_event_ep
+ *
+ * Description:
+ *   Associate a channel with an event
+ *
+ * Input Parameters:
+ *   - ch: channel number
+ *   - event_reg: address of event register
+ *
+ ****************************************************************************/
+
+void nrf52_ppi_set_event_ep(uint8_t ch, volatile uint32_t *event_reg);
+
+/****************************************************************************
+ * Name: nrf52_ppi_set_task_ep
+ *
+ * Description:
+ *   Associate a channel with a task
+ *
+ * Input Parameters:
+ *   - ch: channel number
+ *   - event_reg: address of task register
+ *
+ ****************************************************************************/
+
+void nrf52_ppi_set_task_ep(uint8_t ch, volatile uint32_t *task_reg);
+
+/****************************************************************************
+ * Name: nrf52_ppi_set_task2_ep
+ *
+ * Description:
+ *   Associate a second channel with a task ("fork" task)
+ *
+ * Input Parameters:
+ *   - ch: channel number
+ *   - event_reg: address of task register
+ *
+ ****************************************************************************/
+
+void nrf52_ppi_set_task2_ep(uint8_t ch, volatile uint32_t *task_reg);
+
+/****************************************************************************
+ * Name: nrf52_ppi_grp_channel_enable
+ *
+ * Description:
+ *   Add/remove a channel to/from a group
+ *
+ * Input Parameters:
+ *   - group: group number
+ *   - ch: channel number
+ *   - enable: add (true) or remove (false)
+ *
+ ****************************************************************************/
+
+void nrf52_ppi_grp_channel_enable(uint8_t group, uint8_t ch, bool enable);
+
+/****************************************************************************
+ * Name: nrf52_ppi_grp_enable
+ *
+ * Description:
+ *   Enable/disable a given PPI channel group
+ *
+ * Input Parameters:
+ *   - group: group number
+ *   - enable: enable (true) or disable (false)
+ *
+ ****************************************************************************/
+
+void nrf52_ppi_grp_enable(uint8_t group, bool enable);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __ARCH_ARM_SRC_CHIP_NRF52_PPI_H


### PR DESCRIPTION
## Summary

Add support for PPI peripheral in nRF52

## Impact

Add new feature

## Testing

Used PPI and works as expected.

