### PR TITLE
Add a workflow_dispatch hook so that a App PR can be used

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ on:
       - master
       - 'releases/*'
     tags:
+  workflow_dispatch:
+    inputs:
+      app_pr:
+        description: 'APP PR (just the number)'
 
 jobs:
   Fetch-Source:
@@ -30,6 +34,9 @@ jobs:
     steps:
       - name: Determine Target Branches
         id: gittargets
+        env:
+          APP_PR: ${{ github.event.inputs.app_pr }}
+          OS_PR: ${{ github.event.inputs.os_pr }}
         shell: bash
         run: |
           TESTING_REF="master"  # Always use master for testing
@@ -76,6 +83,13 @@ jobs:
                 echo "Trigger by change on $GITHUB_REPOSITORY. This is unexpected."
                 ;;
             esac
+          fi
+
+          if [ -n "$APP_PR" ]; then
+            APPS_REF=refs/pull/$APP_PR/head
+          fi
+          if [ -n "$OS_PR" ]; then
+            OS_REF=refs/pull/$OS_PR/head
           fi
 
           echo ::set-output name=os_ref::$OS_REF


### PR DESCRIPTION
## Summary
With the addition of the dispatch_request we should be able to now supply a PR number for a PR in the apps repo and enable running a build against that.  This does not yet let us use some kind of comment to do it, there is at least a manual way to trigger.

This is a fairly new feature to GitHub Actions, but we have already enabled it on the website repo
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

This should be low risk, but it is hard to test until it is merged in.  If it works here I'll update the apps repo to allow supplying a os PR.
