### PR TITLE
nuttx:board.h add  extern C under cpp

### DIFF
--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -120,6 +120,14 @@
  *
  ****************************************************************************/
 
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 /****************************************************************************
  * Name: board_early_initialize
  *
@@ -713,6 +721,11 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
 
 #ifdef CONFIG_BOARD_INITRNGSEED
 void board_init_rngseed(void);
+#endif
+
+#undef EXTERN
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __INCLUDE_NUTTX_BOARD_H */


### PR DESCRIPTION
## Summary

maintain extern "C" linkage in cpp files

## Impact

None. But will now work with CPP files.

## Testing

Build and link and xxx_init.cpp that defines `board_app_initialize`. 
