### PR TITLE
bt_ioctl.c: fix copy paste error

### DIFF
--- a/wireless/bluetooth/bt_ioctl.c
+++ b/wireless/bluetooth/bt_ioctl.c
@@ -600,7 +600,7 @@ int btnet_ioctl(FAR struct net_driver_s *netdev, int cmd, unsigned long arg)
         {
           ret = bt_start_advertising(btreq->btr_advtype,
                                      btreq->btr_advad,
-                                     btreq->btr_advad);
+                                     btreq->btr_advsd);
           wlinfo("Start advertising: %d\n", ret);
         }
         break;


### PR DESCRIPTION
# Summary

`bt_start_advertising` should receive both advertising and scan response data as parameters. Probably due to a copy paste error it receiving advertising data for both parameters.

## Impact

Fix

## Testing

Tested correct reception of scan response data on the BLE stack.