### PR TITLE
ESP32: Keep the 'waiti 0' instruction - noticed by Masayuki Ishikawa

### DIFF
--- a/arch/xtensa/src/common/xtensa_idle.c
+++ b/arch/xtensa/src/common/xtensa_idle.c
@@ -73,5 +73,8 @@ void up_idle(void)
    * sleep in a reduced power mode until an interrupt occurs to save power
    */
 
+#if XCHAL_HAVE_INTERRUPTS
+  __asm__ __volatile__ ("waiti 0");
+#endif
 #endif
 }


### PR DESCRIPTION
## Summary
This patch will revert part of the last modification I did to remove the 'kludge' code at xtensa_idle.
## Impact
This code was added to reduce power consumption and is the same as in the esp-idf.
## Testing
ESP32 Ethernet

