### PR TITLE
Refine the signal handling in sim

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -72,7 +72,6 @@ config ARCH_SIM
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_POWEROFF
 	select ARCH_HAVE_TESTSET
-	select ARCH_NOINTC
 	select ALARM_ARCH
 	select ONESHOT
 	select SERIAL_CONSOLE

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -41,10 +41,6 @@
 #define __ARCH_SIM_INCLUDE_IRQ_H
 
 /****************************************************************************
- * Included Files
- ****************************************************************************/
-
-/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -89,7 +85,7 @@ struct xcptcontext
 #endif
 
 /****************************************************************************
- * Inline functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 #ifndef __ASSEMBLY__
@@ -102,31 +98,17 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************
- * Name: up_irqinitialize
- ****************************************************************************/
-
-static inline void up_irqinitialize(void)
-{
-}
-
 /* Name: up_irq_save, up_irq_restore, and friends.
  *
- * NOTE: This function should never be called from application code and,
+ * NOTE: These functions should never be called from application code and,
  * as a general rule unless you really know what you are doing, this
  * function should not be called directly from operation system code either:
  * Typically, the wrapper functions, enter_critical_section() and
  * leave_critical section(), are probably what you really want.
  */
 
-static inline irqstate_t up_irq_save(void)
-{
-  return 0;
-}
-
-static inline void up_irq_restore(irqstate_t flags)
-{
-}
+irqstate_t up_irq_save(void);
+void up_irq_restore(irqstate_t flags);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -44,9 +44,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* No interrupts */
-
-#define NR_IRQS 0
+#define NR_IRQS 64
 
 /* Number of registers saved in context switch */
 

--- a/arch/sim/include/types.h
+++ b/arch/sim/include/types.h
@@ -121,7 +121,7 @@ typedef unsigned int       _size_t;
  * up_irq_save()
  */
 
-typedef unsigned int       irqstate_t;
+typedef _uint64_t          irqstate_t;
 
 #endif /* __ASSEMBLY__ */
 

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -83,7 +83,8 @@ ifeq ($(CONFIG_HOST_MACOS),y)
   HOSTCFLAGS += -Wno-deprecated-declarations
 endif
 
-HOSTSRCS = up_hostmemory.c up_hosttime.c
+HOSTSRCS = up_hostirq.c up_hostmemory.c up_hosttime.c
+STDLIBS += -lpthread
 ifneq ($(CONFIG_HOST_MACOS),y)
   STDLIBS += -lrt
 endif
@@ -108,7 +109,6 @@ ifeq ($(CONFIG_SCHED_INSTRUMENTATION),y)
   HOSTCFLAGS += -DCONFIG_SCHED_INSTRUMENTATION=1
 endif
   HOSTSRCS += up_simsmp.c
-  STDLIBS += -lpthread
 endif
 
 ifeq ($(CONFIG_SCHED_INSTRUMENTATION),y)

--- a/arch/sim/src/sim/up_hostirq.c
+++ b/arch/sim/src/sim/up_hostirq.c
@@ -1,0 +1,88 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_hostirq.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <signal.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+union sigset_u
+{
+  uint64_t flags;
+  sigset_t sigset;
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_irq_save
+ *
+ * Description:
+ *   Disable interrupts and returned the mask before disabling them.
+ *
+ ****************************************************************************/
+
+uint64_t up_irq_save(void)
+{
+  union sigset_u nmask;
+  union sigset_u omask;
+
+  sigfillset(&nmask.sigset);
+  pthread_sigmask(SIG_SETMASK, &nmask.sigset, &omask.sigset);
+
+  return omask.flags;
+}
+
+/****************************************************************************
+ * Name: up_irq_restore
+ *
+ * Input Parameters:
+ *   flags - the mask used to restore interrupts
+ *
+ * Description:
+ *   Re-enable interrupts using the specified mask in flags argument.
+ *
+ ****************************************************************************/
+
+void up_irq_restore(uint64_t flags)
+{
+  union sigset_u nmask;
+
+  sigemptyset(&nmask.sigset);
+  nmask.flags = flags;
+  pthread_sigmask(SIG_SETMASK, &nmask.sigset, NULL);
+}
+
+/****************************************************************************
+ * Name: up_irqinitialize
+ ****************************************************************************/
+
+void up_irqinitialize(void)
+{
+}

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -169,6 +169,28 @@ struct ioexpander_dev_s;
  * Public Data
  ****************************************************************************/
 
+/* g_current_regs[] holds a references to the current interrupt level
+ * register storage structure.  If is non-NULL only during interrupt
+ * processing.  Access to g_current_regs[] must be through the macro
+ * CURRENT_REGS for portability.
+ */
+
+#ifdef CONFIG_SMP
+/* For the case of architectures with multiple CPUs, then there must be one
+ * such value for each processor that can receive an interrupt.
+ */
+
+int up_cpu_index(void); /* See include/nuttx/arch.h */
+extern volatile void *g_current_regs[CONFIG_SMP_NCPUS];
+#  define CURRENT_REGS (g_current_regs[up_cpu_index()])
+
+#else
+
+extern volatile void *g_current_regs[1];
+#  define CURRENT_REGS (g_current_regs[0])
+
+#endif
+
 #ifdef CONFIG_SMP
 /* These spinlocks are used in the SMP configuration in order to implement
  * up_cpu_pause().  The protocol for CPUn to pause CPUm is as follows
@@ -191,6 +213,8 @@ extern volatile uint8_t g_cpu_paused[CONFIG_SMP_NCPUS];
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+void *up_doirq(int irq, void *regs);
 
 /* up_setjmp32.S ************************************************************/
 


### PR DESCRIPTION
## Summary
Model the host signal handling as NuttX's irq. The next step is:
1.Save/restore context with ucontext API
2.trigger the context switch by signal

## Impact

## Testing
