### PR TITLE
net: For Bluetooth sockets use the Linux sockaddr types

### DIFF
--- a/include/netpacket/bluetooth.h
+++ b/include/netpacket/bluetooth.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * include/netpacket/bluetooth.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -75,7 +60,7 @@
  *   should be used.
  * BTPROTO_L2CAP
  *   L2CAP sockets give sequential packet access over channels to other
- *   Bluetooth devices and make use of the bt_psm field in the sockaddr_bt_s
+ *   Bluetooth devices and make use of the bt_psm field in the sockaddr_l2
  *   structure to select the Protocol/Service Multiplexer to specify when
  *   making connections.  If the special value of L2CAP_PSM_ANY is bound
  *   when the listen() call is made, the next available PSM from the
@@ -83,16 +68,12 @@
  *   using the getsockname() call.
  * BTPROTO_RFCOMM
  *   RFCOMM sockets provide streamed data over Bluetooth connection and
- *   make use of the bt_psm, and bt_channel fields in the sockaddr_bt_s
- *   structure.  The channel number must be between 1 and 30 inclusive
- *   except that if the special value RFCOMM_CHANNEL_ANY is bound, when
- *   the listen() call is made, the first unused channel for the relevant
- *   bdaddr will be allocated and may be discovered using the
- *   getsockname(2) call.  If no PSM is specified, a default value of
- *   L2CAP_PSM_RFCOMM (0x0003) will be used.
+ *   make use of the l2_cid field in the sockaddr_rc structure.
+ *   The channel number must be between 1 and 30 inclusive except that if
+ *   the special value RFCOMM_CHANNEL_ANY is bound, when the listen() call
+ *   is made, the first unused channel for the relevant bdaddr will be
+ *   allocated and may be discovered using the getsockname(2) call.
  *
- * NOTE:  All protocol values currently ignored.  Only BTPROTO_L2CAP is
- * supported by default.
  */
 
 #define BTPROTO_L2CAP   0
@@ -217,13 +198,13 @@
                                          * use */
 #define BT_LE_CID_ATT           0x0004  /* Attribute Protocol */
 #define BT_LE_CID_L2CAP         0x0005  /* Low Energy L2CAP Signaling channel */
-#define BT_LE_CID_SMP           0x0006  /* Security Manager Protocol
-                                        /* 0x0007-0x001f Reserved for future
-                                        /* 0x0020-0x003e Assigned Numbers
+#define BT_LE_CID_SMP           0x0006  /* Security Manager Protocol */
+                                        /* 0x0007-0x001f Reserved for future */
+                                        /* 0x0020-0x003e Assigned Numbers */
                                         /* 0x003f Reserved for future use */
                                         /* 0x0040-0x007f Dynamically allocated
                                          * using the L2CAP LE credit based
-                                         * connection mechanism
+                                         * connection mechanism */
                                         /* Others reserved for future use */
 
 /* Protocol and Service Multiplexers (PSMs) */
@@ -276,14 +257,29 @@
  *   sendto()  - Send to specified remote address
  *   recvfrom()- Receive from indicated remote address.
  *
- * REVISIT: Some protocols would require a bt_psm field as well.
  */
 
-struct sockaddr_bt_s
+struct sockaddr_l2
 {
-  sa_family_t  bt_family;  /* Must be AF_BLUETOOTH */
-  bt_addr_t    bt_bdaddr;  /* 6-byte Bluetooth address */
-  uint8_t      bt_channel; /* Channel identifier (CID) */
+  sa_family_t  l2_family;       /* Must be AF_BLUETOOTH */
+  uint16_t     l2_psm;          /* Protocol Service Multiplexer (PSM) */
+  bt_addr_t    l2_bdaddr;       /* 6-byte Bluetooth address */
+  uint16_t     l2_cid;          /* Channel identifier (CID) */
+  uint8_t      l2_bdaddr_type;  /* Bluetooth address type */
+};
+
+struct sockaddr_hci
+{
+  sa_family_t hci_family;   /* Must be AF_BLUETOOTH */
+  uint16_t    hci_dev;      /* Network Device ID */
+  uint16_t    hci_channel;  /* Channel: USER, MONITOR, CONTROL, etc... */
+};
+
+struct sockaddr_rc
+{
+  sa_family_t rc_family;    /* Must be AF_BLUETOOTH */
+  bt_addr_t   rc_bdaddr;    /* 6-byte Bluetooth address */
+  uint8_t     rc_channel;   /* Channel number */
 };
 
 /****************************************************************************

--- a/net/bluetooth/bluetooth_recvfrom.c
+++ b/net/bluetooth/bluetooth_recvfrom.c
@@ -110,7 +110,7 @@ static int bluetooth_count_frames(FAR struct bluetooth_conn_s *conn)
  * Returned Value:
  *
  * Assumptions:
- *   The network is lockec
+ *   The network is locked
  *
  ****************************************************************************/
 
@@ -119,7 +119,7 @@ static ssize_t
                              FAR struct bluetooth_recvfrom_s *pstate)
 {
   FAR struct bluetooth_container_s *container;
-  FAR struct sockaddr_bt_s *iaddr;
+  FAR struct sockaddr_l2 *iaddr;
   FAR struct bluetooth_conn_s *conn;
   FAR struct iob_s *iob;
   size_t copylen;
@@ -175,10 +175,10 @@ static ssize_t
 
       if (pstate->ir_from != NULL)
         {
-          iaddr             = (FAR struct sockaddr_bt_s *)pstate->ir_from;
-          iaddr->bt_family  = AF_BLUETOOTH;
-          BLUETOOTH_ADDRCOPY(&iaddr->bt_bdaddr, &container->bn_raddr);
-          iaddr->bt_channel = container->bn_channel;
+          iaddr             = (FAR struct sockaddr_l2 *)pstate->ir_from;
+          iaddr->l2_family  = AF_BLUETOOTH;
+          BLUETOOTH_ADDRCOPY(&iaddr->l2_bdaddr, &container->bn_raddr);
+          iaddr->l2_cid = container->bn_channel;
         }
 
       /* Free both the IOB and the container */
@@ -319,7 +319,7 @@ ssize_t bluetooth_recvfrom(FAR struct socket *psock, FAR void *buf,
    * enough to hold this address family.
    */
 
-  if (from != NULL && *fromlen < sizeof(struct sockaddr_bt_s))
+  if (from != NULL && *fromlen < sizeof(struct sockaddr_l2))
     {
       return -EINVAL;
     }

--- a/net/bluetooth/bluetooth_sendto.c
+++ b/net/bluetooth/bluetooth_sendto.c
@@ -235,7 +235,7 @@ ssize_t psock_bluetooth_sendto(FAR struct socket *psock, FAR const void *buf,
                                FAR const struct sockaddr *to,
                                socklen_t tolen)
 {
-  FAR struct sockaddr_bt_s *destaddr;
+  FAR struct sockaddr_l2 *destaddr;
   FAR struct radio_driver_s *radio;
   FAR struct bluetooth_conn_s *conn;
   struct bluetooth_sendto_s state;
@@ -290,8 +290,8 @@ ssize_t psock_bluetooth_sendto(FAR struct socket *psock, FAR const void *buf,
 
   /* Copy the destination address */
 
-  destaddr = (FAR struct sockaddr_bt_s *)to;
-  memcpy(&state.is_destaddr, &destaddr->bt_bdaddr,
+  destaddr = (FAR struct sockaddr_l2 *)to;
+  memcpy(&state.is_destaddr, &destaddr->l2_bdaddr,
          sizeof(bt_addr_t));
 
   if (len > 0)


### PR DESCRIPTION
## Summary
For Bluetooth sockets use the Linux sockaddr types:

```
struct sockaddr_l2
{
  sa_family_t  l2_family;       /* Must be AF_BLUETOOTH */
  uint16_t     l2_psm;          /* Protocol Service Multiplexer (PSM) */
  bt_addr_t    l2_bdaddr;       /* 6-byte Bluetooth address */
  uint16_t     l2_cid;          /* Channel identifier (CID) */
  uint8_t      l2_bdaddr_type;  /* Bluetooth address type */
};

struct sockaddr_hci
{
  sa_family_t hci_family;   /* Must be AF_BLUETOOTH */
  uint16_t    hci_dev;      /* Network Device ID */
  uint16_t    hci_channel;  /* Channel: USER, MONITOR, CONTROL, etc... */
};

struct sockaddr_rc
{
  sa_family_t rc_family;    /* Must be AF_BLUETOOTH */
  bt_addr_t   rc_bdaddr;    /* 6-byte Bluetooth address */
  uint8_t     rc_channel;   /* Channel number */
};
```

## Impact
Before everything was using L2CAP protocol sockets with a NuttX specific sockaddr struct `sockaddr_bt_s`  This struct is removed and application code should use the correct addr type for the socket needed.  This change does not add support for HCI or RFCOMM protocols so existing code should just switch to `sockaddr_l2` and make the minor change to `br_channel` -> `l2_cid` br_bdaddr` -> `l2_bdaddr` `br_family` -> `l2_family`

## Testing
This was validated with `btsak` application with changes in PR https://github.com/apache/incubator-nuttx-apps/pull/374
