### PR TITLE
arch/sim: Should use HOSTCFLAGS for the HOSTSRCS dependence generation

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -323,7 +323,8 @@ export_startup: board/libboard$(LIBEXT) up_head.o $(HOSTOBJS)
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
 	fi
-	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(ASRCS) $(CSRCS) >Make.dep
+	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(HOSTCFLAGS) -- $(HOSTSRCS) >>Make.dep
 	$(Q) touch $@
 
 depend: .depend


### PR DESCRIPTION
## Summary
Correct HOSTSRCS dependence generation.

## Impact

## Testing

