### PR TITLE
nRF52: handle LFCLK/HFCLK in clockconfig

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -246,6 +246,44 @@ config NRF52_COMP
 
 endmenu # NRF52 Peripheral Selection
 
+menu "Clock Configuration"
+
+config NRF52_HFCLK_XTAL
+  bool "Enable HFCLK from external crystal"
+  default n
+  ---help---
+    If the board includes an external high-frequency crystal, enable this
+    option to supply the HFCLK. If this option is disabled, the internal
+    oscillator will be used.
+    Note that the RADIO peripheral requires the HFCLK to be used.
+
+config NRF52_USE_LFCLK
+  bool "Enable LFCLK"
+  default n
+  ---help---
+    Enable low-frequency clock.
+
+if NRF52_USE_LFCLK
+
+choice
+	prompt "LFCLK source"
+	default NRF52_LFCLK_XTAL
+
+config NRF52_LFCLK_XTAL
+	bool "External 32.768Khz crystal"
+
+config NRF52_LFCLK_RC
+	bool "Internal RC oscillator"
+
+config NRF52_LFCLK_SYNTH
+  bool "Synthesized from HFCLK"
+
+endchoice
+
+endif # NRF52_USE_LFCLK
+
+endmenu # Clock Configuration
+
 config NRF52_FLASH_PREFETCH
 	bool "Enable FLASH Pre-fetch"
 	default y

--- a/arch/arm/src/nrf52/nrf52_clockconfig.c
+++ b/arch/arm/src/nrf52/nrf52_clockconfig.c
@@ -49,6 +49,7 @@
 #include "arm_internal.h"
 
 #include "nrf52_clockconfig.h"
+#include "hardware/nrf52_clock.h"
 
 /****************************************************************************
  * Public Functions
@@ -65,6 +66,43 @@
  *
  ****************************************************************************/
 
-void nrf52_clockconfig()
+void nrf52_clockconfig(void)
 {
+#ifdef CONFIG_NRF52_HFCLK_XTAL
+  /* Initilize HFCLK crystal oscillator */
+
+  putreg32(0x0, NRF52_CLOCK_EVENTS_HFCLKSTARTED);
+  putreg32(0x1, NRF52_CLOCK_TASKS_HFCLKSTART);
+
+  while (!getreg32(NRF52_CLOCK_EVENTS_HFCLKSTARTED))
+    {
+      /* wait for external oscillator to start */
+    }
+#endif
+
+#ifdef CONFIG_NRF52_USE_LFCLK
+  /* Initialize LFCLK */
+
+#if defined(CONFIG_NRF52_LFCLK_XTAL)
+  putreg32(CLOCK_LFCLKSRC_SRC_XTAL, NRF52_CLOCK_LFCLKSRC);
+#elif defined(CONFIG_NRF52_LFCLK_SYNTH)
+  putreg32(CLOCK_LFCLKSRC_SRC_SYNTH, NRF52_CLOCK_LFCLKSRC);
+#else
+  putreg32(CLOCK_LFCLKSRC_SRC_RC, NRF52_CLOCK_LFCLKSRC);
+#endif
+
+  /* Trigger LFCLK start */
+
+  putreg32(0x0, NRF52_CLOCK_EVENTS_LFCLKSTARTED);
+  putreg32(0x1, NRF52_CLOCK_TASKS_LFCLKSTART);
+
+  while (!getreg32(NRF52_CLOCK_EVENTS_LFCLKSTARTED))
+    {
+      /* Wait for LFCLK to be running */
+    }
+
+#if defined(CONFIG_NRF52_LFCLK_RC)
+  /* TODO: calibrate LFCLK RC oscillator */
+#endif
+#endif
 }


### PR DESCRIPTION
## Summary

Adds support for enabling LFCLK and HFCLK and selecting oscillator sources. LFCLK calibration for RC case is not yet addressed.

## Impact

Does not change default behaviour prior to adding this change as it defaults to HFCLK from RC and LFCLK disabled.

## Testing

Tested enabling both clocks from external XTAL
