### PR TITLE
Replace WINTOOL with CONFIG_CYGWIN_WINTOOL

### DIFF
--- a/boards/arm/stm32/nucleo-f412zg/scripts/Make.defs
+++ b/boards/arm/stm32/nucleo-f412zg/scripts/Make.defs
@@ -39,7 +39,7 @@ include ${TOPDIR}/arch/arm/src/armv7-m/Toolchain.defs
 
 LDSCRIPT = f412zg.ld
 
-ifeq ($(WINTOOL),y)
+ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   ARCHSCRIPT = -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)}"
 else
   ARCHSCRIPT = -T$(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)

--- a/tools/README.txt
+++ b/tools/README.txt
@@ -227,7 +227,7 @@ mkexport.sh and Makefile.export
   Makefile.export is used only by the mkexport.sh script to parse out
   options from the top-level Make.defs file.
 
-  USAGE: tools/mkexport.sh [-d] [-z] [-u] [-w|wy|wn] -t <top-dir> [-x <lib-ext>] -l "lib1 [lib2 [lib3 ...]]"
+  USAGE: tools/mkexport.sh [-d] [-z] [-u] -t <top-dir> [-x <lib-ext>] -l "lib1 [lib2 [lib3 ...]]"
 
   This script also depends on the environment variable MAKE which is set
   in the top-level Makefile before starting mkexport.sh.  If MAKE is not

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -34,7 +34,7 @@
 
 # Get the input parameter list
 
-USAGE="USAGE: $0 [-d] [-z] [-u] [-w|wy|wn] -t <top-dir> [-x <lib-ext>] [-a <apps-dir>] [-m <make-exe>] -l \"lib1 [lib2 [lib3 ...]]\""
+USAGE="USAGE: $0 [-d] [-z] [-u] [-t <top-dir> [-x <lib-ext>] [-a <apps-dir>] [-m <make-exe>] -l \"lib1 [lib2 [lib3 ...]]\""
 unset TOPDIR
 unset LIBLIST
 unset TGZ
@@ -42,7 +42,6 @@ unset APPDIR
 unset BOARDDIR
 
 USRONLY=n
-WINTOOL=n
 LIBEXT=.a
 
 while [ ! -z "$1" ]; do
@@ -65,12 +64,6 @@ while [ ! -z "$1" ]; do
   -m )
     shift
     MAKE="$1"
-    ;;
-  -wy )
-    WINTOOL=y
-    ;;
-  -w | -wn )
-    WINTOOL=n
     ;;
   -t )
     shift


### PR DESCRIPTION
## Summary
WINTOOL is removed by commit:
```
commit bd656888f26c92e8832f0e76b395a5ece7704530
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Mon May 18 22:18:15 2020 +0800

    build: Replace WINTOOL with CYGWIN_WINTOOL Kconfig
    
    so the correct value can be determinated by Kconfig system automatically
    
    Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
```
But some new code forget to follow the new usage.

## Impact

## Testing

