### PR TITLE
Nrf52 improvements

### DIFF
--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -49,7 +49,7 @@ CMN_CSRCS += arm_memfault.c arm_mdelay.c arm_modifyreg8.c arm_modifyreg16.c
 CMN_CSRCS += arm_modifyreg32.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_stackframe.c arm_svcall.c arm_trigger_irq.c arm_udelay.c
-CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_vfork.c
+CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_vfork.c arm_systemreset.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -79,6 +79,7 @@ endif
 
 CHIP_CSRCS  = nrf52_start.c nrf52_clockconfig.c nrf52_irq.c nrf52_utils.c
 CHIP_CSRCS += nrf52_allocateheap.c nrf52_lowputc.c nrf52_gpio.c nrf52_nvmc.c
+CHIP_CSRCS += nrf52_uid.c
 
 ifeq ($(CONFIG_ARCH_CHIP_NRF52832),y)
 CHIP_CSRCS += nrf52832_errdata.c

--- a/arch/arm/src/nrf52/nrf52_i2c.c
+++ b/arch/arm/src/nrf52/nrf52_i2c.c
@@ -157,7 +157,7 @@ static struct nrf52_i2c_priv_s g_nrf52_i2c0_priv =
 static struct nrf52_i2c_priv_s g_nrf52_i2c1_priv =
 {
   .ops     = &g_nrf52_i2c_ops,
-  .base    = NRF52_TWIM0_BASE,
+  .base    = NRF52_TWIM1_BASE,
   .scl_pin = BOARD_I2C1_SCL_PIN,
   .sda_pin = BOARD_I2C1_SDA_PIN,
   .refs    = 0,

--- a/arch/arm/src/nrf52/nrf52_irq.c
+++ b/arch/arm/src/nrf52/nrf52_irq.c
@@ -312,7 +312,7 @@ static int nrf52_irqinfo(int irq, uintptr_t *regaddr, uint32_t *bit,
 void up_irqinitialize(void)
 {
   uint32_t regaddr;
-#ifdef CONFIG_DEBUG_FEATURES
+#if defined(CONFIG_DEBUG_FEATURES) && !defined(CONFIG_ARMV7M_USEBASEPRI)
   uint32_t regval;
 #endif
   int num_priority_registers;

--- a/arch/arm/src/nrf52/nrf52_uid.c
+++ b/arch/arm/src/nrf52/nrf52_uid.c
@@ -1,0 +1,50 @@
+/************************************************************************************
+ * arch/arm/src/nrf52/nrf52_uid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ************************************************************************************/
+
+/************************************************************************************
+ * Included Files
+ ************************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "arm_arch.h"
+
+#include "nrf52_uid.h"
+
+#include "hardware/nrf52_ficr.h"
+
+/************************************************************************************
+ * Public Functions
+ ************************************************************************************/
+
+void nrf52_get_uniqueid(uint8_t uniqueid[])
+{
+  uint32_t uid0 = getreg32(NRF52_FICR_BASE + NRF52_FICR_DEVICEID0_OFFSET);
+  uint32_t uid1 = getreg32(NRF52_FICR_BASE + NRF52_FICR_DEVICEID1_OFFSET);
+
+  uniqueid[0] = (uint8_t)((uid0 >> 0) & 0xff);
+  uniqueid[1] = (uint8_t)((uid0 >> 8) & 0xff);
+  uniqueid[2] = (uint8_t)((uid0 >> 16) & 0xff);
+  uniqueid[3] = (uint8_t)((uid0 >> 24) & 0xff);
+  uniqueid[4] = (uint8_t)((uid1 >> 0) & 0xff);
+  uniqueid[5] = (uint8_t)((uid1 >> 8) & 0xff);
+  uniqueid[6] = (uint8_t)((uid1 >> 16) & 0xff);
+  uniqueid[7] = (uint8_t)((uid1 >> 24) & 0xff);
+}

--- a/arch/arm/src/nrf52/nrf52_uid.h
+++ b/arch/arm/src/nrf52/nrf52_uid.h
@@ -1,0 +1,36 @@
+/************************************************************************************
+ * arch/arm/src/nrf52/nrf52_uid.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ************************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_NRF52_UID_H
+#define __ARCH_ARM_SRC_NRF52_UID_H
+
+/************************************************************************************
+ * Included Files
+ ************************************************************************************/
+
+#include <stdint.h>
+
+/************************************************************************************
+ * Public Function Prototypes
+ ************************************************************************************/
+
+void nrf52_get_uniqueid(uint8_t uniqueid[]);
+
+#endif /* __ARCH_ARM_SRC_NRF52_UID_H */


### PR DESCRIPTION
## Summary

- arch/nrf52: add ARM system reset support 
- arch/nrf52: add UID support
- arch/arm/src/nrf52/nrf52_i2c.c: fix typo
- arch/arm/src/nrf52/nrf52_irq.c: fix compilation warning

## Impact

## Testing
Custom NRF52 board
