### PR TITLE
sim/Make.defs: add -fvisibility=hidden to CFLAGS

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -41,6 +41,12 @@ ARCHPICFLAGS = -fpic
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 
+# Add -fvisibility=hidden
+# Because we don't want export nuttx's symbols to share libraries
+
+ARCHCPUFLAGS += -fvisibility=hidden
+ARCHCPUFLAGSXX += -fvisibility=hidden
+
 # Add -fno-common because macOS "ld -r" doesn't seem to pick objects
 # for common symbols.
 ARCHCPUFLAGS += -fno-common


### PR DESCRIPTION
## Summary
This can hidden all nuttx's symbols,
and DO NOT export nuttx's symbols to share libraries.
```
wrong:
NUTTX       PC       NUTTX
ffmpeg -> asound -> sysconf

right:
NUTTX       PC       PC
ffmpeg -> asound -> sysconf
```

## Impact

## Testing

