### PR TITLE
arch: cxd56xx: Use spinlock API in cxd56_uart.c

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_uart.c
+++ b/arch/arm/src/cxd56xx/cxd56_uart.c
@@ -471,7 +471,7 @@ void cxd56_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
   uint32_t div;
   uint32_t lcr_h;
 
-  irqstate_t flags = enter_critical_section();
+  irqstate_t flags = spin_lock_irqsave();
 
   if (uartbase == CXD56_UART2_BASE)
     {
@@ -483,7 +483,7 @@ void cxd56_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
     }
   else
     {
-      leave_critical_section(flags);
+      spin_unlock_irqrestore(flags);
       return;
     }
 
@@ -510,7 +510,7 @@ void cxd56_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
   putreg32(lcr_h, uartbase + CXD56_UART_LCR_H);
 
 finish:
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- This commit improves cxd56_uart performance in SMP mode.

## Impact

- This commit affects SMP mode only.

## Testing

- Tested with spresense:smp

