### PR TITLE
baords/arm/stm32/olimex-stm32-p407: Add hooks to configure UEXT USART3

### DIFF
--- a/boards/arm/stm32/olimex-stm32-p407/Kconfig
+++ b/boards/arm/stm32/olimex-stm32-p407/Kconfig
@@ -5,14 +5,18 @@
 
 if ARCH_BOARD_OLIMEX_STM32P407
 
-config STM32F4DISCO_OLIMEXP407_STACKSIZE
+config STM32_OLIMEXP407_STACKSIZE
 	int "USB host waiter stack size"
 	default 1024
 	depends on USBHOST
 
-config STM32F4DISCO_OLIMEXP407_PRIO
+config STM32_OLIMEXP407_PRIO
 	int "USB host waiter task priority"
 	default 100
 	depends on USBHOST
+
+config STM32_OLIMEXP407_UEXT_USART3
+  bool "Enable UEXT USART3"
+  default n
 
 endif

--- a/boards/arm/stm32/olimex-stm32-p407/README.txt
+++ b/boards/arm/stm32/olimex-stm32-p407/README.txt
@@ -192,9 +192,9 @@ OTGFS Host
 
    Olimex STM32 P407 Configuration:
 
-     CONFIG_STM32F4DISCO_OLIMEXP407_PRIO - Priority of the USB host watier
+     CONFIG_STM32F_OLIMEXP407_PRIO - Priority of the USB host watier
        thread (default 100).
-     CONFIG_STM32F4DISCO_OLIMEXP407_STACKSIZE - Stacksize of the USB host
+     CONFIG_STM32_OLIMEXP407_STACKSIZE - Stacksize of the USB host
        waiter thread (default 1024)
 
   Class Driver Configuration

--- a/boards/arm/stm32/olimex-stm32-p407/include/board.h
+++ b/boards/arm/stm32/olimex-stm32-p407/include/board.h
@@ -244,6 +244,18 @@
 #define GPIO_USART3_CTS   GPIO_USART3_CTS_2 /* PD11 */
 #define GPIO_USART3_RTS   GPIO_USART3_RTS_2 /* PD12 */
 
+/* UEXT USART3: This will redefine the above macros if enabled. */
+
+#ifdef CONFIG_STM32_OLIMEXP407_UEXT_USART3
+#  undef  GPIO_USART3_RX    GPIO_USART3_RX_3
+#  undef  GPIO_USART3_TX    GPIO_USART3_TX_3
+#  undef  GPIO_USART3_CTS   GPIO_USART3_CTS_2
+#  undef  GPIO_USART3_RTS   GPIO_USART3_RTS_2
+
+#  define GPIO_USART3_RX    GPIO_USART3_RX_2 /* PC11 */
+#  define GPIO_USART3_TX    GPIO_USART3_TX_2 /* PC10 */
+#endif
+
 /* USART6: */
 
 #define GPIO_USART6_RX    GPIO_USART6_RX_2  /* PG9  */


### PR DESCRIPTION
## Summary
Make it possible to select USART3 from the UEXT header.

## Impact
None on existing code.

## Testing
Use the header with external serial modules.
