### PR TITLE
tools/configure.sh: Add -L option to list all available configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,11 @@
 
 ifeq ($(wildcard .config),)
 .DEFAULT default:
-	@echo "Nuttx has not been configured:"
-	@echo "  tools/configure.sh <target>"
+	@echo "NuttX has not been configured!"
+	@echo "To configure the project:"
+	@echo "  tools/configure.sh <config>"
+	@echo "For a list of available configurations:"
+	@echo "  tools/configure.sh -L"
 else
 include .config
 

--- a/tools/configure.bat
+++ b/tools/configure.bat
@@ -65,6 +65,7 @@ if "%1"=="-l" goto :SetHostOption
 if "%1"=="-c" goto :SetHostOption
 if "%1"=="-u" goto :SetHostOption
 if "%1"=="-n" goto :SetHostOption
+if "%1"=="-L" goto :SetList
 if "%1"=="-a" goto :SetAppDir
 
 set config=%1
@@ -81,6 +82,10 @@ goto :NextArg
 :SetHostOption
 set hostopt=%1
 goto :NextArg
+
+:SetList
+set list=%1
+goto :EndOfLoop
 
 :SetAppDir
 shift
@@ -108,7 +113,7 @@ if errorlevel 1 (
 
 :HaveConfigureExe
 cd ..
-tools\configure.exe %debug% %fmt% %hostopt% %appdir% %config%
+tools\configure.exe %debug% %fmt% %hostopt% %appdir% %config% %list%
 if errorlevel 1 echo configure.exe failed
 goto End
 
@@ -133,6 +138,8 @@ echo    select one of the Windows environments.  Default:  Use host setup
 echo    in the defconfig file
 echo  [-c^|u^|n] selects the Windows host and a Windows environment:  Cygwin (c),
 echo    Ubuntu under Windows 10 (u), or Windows native (n).  Default Cygwin
+echo  -L:
+echo    List all available configurations.
 echo  -a ^<app-dir^>:
 echo    Informs the configuration tool where the application build
 echo    directory.  This is a relative path from the top-level NuttX

--- a/tools/configure.c
+++ b/tools/configure.c
@@ -78,6 +78,7 @@
  ****************************************************************************/
 
 static void show_usage(const char *progname, int exitcode);
+static void dumpcfgs(void);
 static void debug(const char *fmt, ...);
 static void parse_args(int argc, char **argv);
 static int run_make(const char *arg);
@@ -181,7 +182,7 @@ static const char *g_optfiles[] =
 
 static void show_usage(const char *progname, int exitcode)
 {
-  fprintf(stderr, "\nUSAGE: %s  [-d] [-E] [-e] [-b|f] [-l|m|c|u|g|n] "
+  fprintf(stderr, "\nUSAGE: %s  [-d] [-E] [-e] [-b|f] [-L] [-l|m|c|u|g|n] "
           "[-a <app-dir>] <board-name>:<config-name> [make-opts]\n",
           progname);
   fprintf(stderr, "\nUSAGE: %s  [-h]\n", progname);
@@ -224,6 +225,8 @@ static void show_usage(const char *progname, int exitcode)
   fprintf(stderr, "    -n Selects the Windows native (n) environment.\n");
   fprintf(stderr, "  Default: Use host setup in the defconfig file.\n");
   fprintf(stderr, "  Default Windows: Cygwin.\n");
+  fprintf(stderr, "  -L:\n");
+  fprintf(stderr, "    Lists all available configurations.\n");
   fprintf(stderr, "  -a <app-dir>:\n");
   fprintf(stderr, "    Informs the configuration tool where the\n");
   fprintf(stderr, "    application build directory.  This is a relative\n");
@@ -250,6 +253,17 @@ static void show_usage(const char *progname, int exitcode)
   exit(exitcode);
 }
 
+static void dumpcfgs(void)
+{
+  find_topdir();
+  snprintf(g_buffer, BUFFER_SIZE, "%s%cboards", g_topdir, g_delim);
+  verify_directory(g_buffer);
+  g_configtop = strdup(g_buffer);
+  enumerate_configs();
+  free(g_configtop);
+  exit(EXIT_SUCCESS);
+}
+
 static void debug(const char *fmt, ...)
 {
   va_list ap;
@@ -269,7 +283,7 @@ static void parse_args(int argc, char **argv)
 
   /* Parse command line options */
 
-  while ((ch = getopt(argc, argv, "a:bcdEefghlmnu")) > 0)
+  while ((ch = getopt(argc, argv, "a:bcdEefghLlmnu")) > 0)
     {
       switch (ch)
         {
@@ -311,6 +325,9 @@ static void parse_args(int argc, char **argv)
 
           case 'h' :
             show_usage(argv[0], EXIT_SUCCESS);
+
+          case 'L' :
+            dumpcfgs();
 
           case 'l' :
             g_host = HOST_LINUX;
@@ -811,7 +828,8 @@ static void check_configdir(void)
   if (!verify_optiondir(g_buffer))
     {
       fprintf(stderr, "ERROR: No configuration at %s\n", g_buffer);
-      enumerate_configs();
+      fprintf(stderr, "Run tools/configure -L"
+                      " to list available configurations.\n");
       exit(EXIT_FAILURE);
     }
 
@@ -1072,7 +1090,8 @@ static void check_configuration(void)
     {
       fprintf(stderr, "ERROR: No configuration in %s\n", g_configpath);
       fprintf(stderr, "       No defconfig file found.\n");
-      enumerate_configs();
+      fprintf(stderr, "Run tools/configure -L"
+                      " to list available configurations.\n");
       exit(EXIT_FAILURE);
     }
 
@@ -1097,14 +1116,16 @@ static void check_configuration(void)
                       g_configpath);
               fprintf(stderr, "       No Make.defs file in %s\n",
                       g_scriptspath);
-              enumerate_configs();
+              fprintf(stderr, "Run tools/configure -L"
+                              " to list available configurations.\n");
               exit(EXIT_FAILURE);
             }
         }
       else
         {
           fprintf(stderr, "ERROR: No Make.defs file in %s\n", g_configpath);
-          enumerate_configs();
+          fprintf(stderr, "Run tools/configure -L"
+                          " to list available configurations.\n");
           exit(EXIT_FAILURE);
         }
     }

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -37,7 +37,7 @@ WD=`test -d ${0%/*} && cd ${0%/*}; pwd`
 TOPDIR="${WD}/.."
 USAGE="
 
-USAGE: ${0} [-E] [-e] [-l|m|c|u|g|n] [-a <app-dir>] <board-name>:<config-name> [make-opts]
+USAGE: ${0} [-E] [-e] [-l|m|c|u|g|n] [L] [-a <app-dir>] <board-name>:<config-name> [make-opts]
 
 Where:
   -E enforces distclean if already configured.
@@ -50,6 +50,7 @@ Where:
   -n selects the Windows host and Windows native (n) environment.
   Default: Use host setup in the defconfig file
   Default Windows: Cygwin
+  -L  Lists all available configurations.
   -a <app-dir> is the path to the apps/ directory, relative to the nuttx
      directory
   <board-name> is the name of the board in the boards directory
@@ -75,6 +76,17 @@ unset host
 unset enforce_distclean
 unset distclean
 
+function dumpcfgs
+{
+  configlist=`find ${TOPDIR}/boards -name defconfig`
+  for defconfig in ${configlist}; do
+    config=`dirname ${defconfig} | sed -e "s,${TOPDIR}/boards/,,g"`
+    boardname=`echo ${config} | cut -d'/' -f3`
+    configname=`echo ${config} | cut -d'/' -f5`
+    echo "  ${boardname}:${configname}"
+  done
+}
+
 while [ ! -z "$1" ]; do
   case "$1" in
   -a )
@@ -97,6 +109,10 @@ while [ ! -z "$1" ]; do
     ;;
   -h )
     echo "$USAGE"
+    exit 0
+    ;;
+  -L )
+    dumpcfgs
     exit 0
     ;;
   *)
@@ -131,17 +147,9 @@ if [ ! -d ${configpath} ]; then
 
   configpath=${TOPDIR}/${boardconfig}
   if [ ! -d ${configpath} ]; then
-    echo "Directory for ${boardconfig} does not exist.  Options are:"
+    echo "Directory for ${boardconfig} does not exist."
     echo ""
-    echo "Select one of the following options for <board-name>:"
-    configlist=`find ${TOPDIR}/boards -name defconfig`
-    for defconfig in ${configlist}; do
-      config=`dirname ${defconfig} | sed -e "s,${TOPDIR}/boards/,,g"`
-      boardname=`echo ${config} | cut -d'/' -f3`
-      configname=`echo ${config} | cut -d'/' -f5`
-      echo "  ${boardname}:${configname}"
-    done
-    echo ""
+    echo "Run tools/configure.sh -L to list available configurations."
     echo "$USAGE"
     exit 3
   fi


### PR DESCRIPTION
## Summary
Add -L option to list all available configurations.
Mention this option when Make is run on a not configured project.
## Impact

## Testing

