### PR TITLE
CI: Move fetch of tags back to source stage now that cache is faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,8 @@ jobs:
           ref: ${{ steps.gittargets.outputs.os_ref }}
           path: sources/nuttx
           fetch-depth: 1
+      - name: Checkout nuttx repo tags
+        run: git -C sources/nuttx fetch --tags
 
       - name: Checkout apps repo
         uses: actions/checkout@v2
@@ -168,15 +170,6 @@ jobs:
 
       - name: Export NuttX Repo SHA
         run:  echo "::set-env name=nuttx_sha::`git -C sources/nuttx rev-parse HEAD`"
-      - name: Refresh Git Credentials
-        uses: actions/checkout@v2
-        with:
-          repository: apache/incubator-nuttx
-          ref: ${{ env.nuttx_sha }}
-          path: sources/nuttx
-          fetch-depth: 1
-      - name: Get Tags for NuttX Repo
-        run: git -C sources/nuttx fetch --tags
       - name: Run builds
         uses: ./sources/testing/.github/actions/ci-container
         env:
@@ -224,15 +217,6 @@ jobs:
 
       - name: Export NuttX Repo SHA
         run:  echo "::set-env name=nuttx_sha::`git -C sources/nuttx rev-parse HEAD`"
-      - name: Refresh Git Credentials
-        uses: actions/checkout@v2
-        with:
-          repository: apache/incubator-nuttx
-          ref: ${{ env.nuttx_sha }}
-          path: sources/nuttx
-          fetch-depth: 1
-      - name: Get Tags for NuttX Repo
-        run: git -C sources/nuttx fetch --tags
       - name: Run Builds
         run: |
           echo "::add-matcher::sources/nuttx/.github/gcc.json"


### PR DESCRIPTION
# Summary
Previously we would fetch the tags for the NuttX repo after the cache stage because the upload/download of the cache was slow.
Unfortunately there is no good way to sync the auth of the repo and this costs us about 90sec of build time.

If cache has improved enough we can drop all this extra logic and improve the build time for the actual build stages.

## Impact
This change increases the checkout source stage by about 90sec, but cuts down the build time by 90sec in each of the fanned out runners. So while the total build time in unchanged we improve the time the runners are busy.  I suspect we can improve this further later.

## Testing
See CI Result.
