### PR TITLE
arch/sim: Add support for ucontext API

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -485,4 +485,10 @@ config SIM_HCISOCKET
 		control of the device, but is abstracted from the
 		physical interface which is still handled by Linux.
 
+config SIM_UCONTEXT_PREEMPTION
+	bool "Preempt tasks using ucontext API"
+	default false
+	---help---
+		Save and restore the task context using ucontext API.
+
 endif # ARCH_SIM

--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -76,11 +76,15 @@ typedef int xcpt_reg_t;
 
 struct xcptcontext
 {
-  void *sigdeliver; /* Actual type is sig_deliver_t */
+  void *sigdeliver;
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+  void *ucontext_buffer; /* Actual type is ucontext_t  */
+  void *ucontext_sp;     /* The ucontext stack pointer */
+#else
   xcpt_reg_t regs[XCPTCONTEXT_REGS];
-};
 #endif
+};
 
 /****************************************************************************
  * Public Function Prototypes
@@ -108,9 +112,6 @@ extern "C"
 irqstate_t up_irq_save(void);
 void up_irq_restore(irqstate_t flags);
 
-#undef EXTERN
-#ifdef __cplusplus
-}
 #endif
 
 #endif /* !__ASSEMBLY__ */

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -97,6 +97,14 @@ ifeq ($(CONFIG_SPINLOCK),y)
   HOSTSRCS += up_testset.c
 endif
 
+ifeq ($(CONFIG_SIM_UCONTEXT_PREEMPTION),y)
+  HOSTSRCS += up_ucontext.c
+ifeq ($(CONFIG_HOST_MACOS), y)
+  HOSTCFLAGS += -Wno-deprecated-declarations
+  HOSTCFLAGS += -pthread
+endif
+endif
+
 ifeq ($(CONFIG_SMP),y)
   CSRCS += up_smpsignal.c up_cpuidlestack.c
   REQUIREDOBJS += up_smpsignal$(OBJEXT)

--- a/arch/sim/src/sim/up_blocktask.c
+++ b/arch/sim/src/sim/up_blocktask.c
@@ -118,7 +118,11 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
        * value, then this is really the previously running task restarting!
        */
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+      FAR struct tcb_s *prev_tcb = rtcb;
+#else
       if (!up_setjmp(rtcb->xcp.regs))
+#endif
         {
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -145,7 +149,12 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+          up_swap_context(prev_tcb->xcp.ucontext_buffer,
+                          rtcb->xcp.ucontext_buffer);
+#else
           up_longjmp(rtcb->xcp.regs, 1);
+#endif
         }
     }
 }

--- a/arch/sim/src/sim/up_exit.c
+++ b/arch/sim/src/sim/up_exit.c
@@ -65,9 +65,12 @@
 
 void up_exit(int status)
 {
-  FAR struct tcb_s *tcb;
+  FAR struct tcb_s *tcb = this_task();
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+  FAR struct tcb_s *prev_tcb = tcb;
+#endif
 
-  sinfo("TCB=%p exiting\n", this_task());
+  sinfo("TCB=%p exiting\n", tcb);
 
   /* Destroy the task at the head of the ready to run list. */
 
@@ -94,7 +97,14 @@ void up_exit(int status)
 
   /* Then switch contexts */
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+  up_destroy_context(prev_tcb->xcp.ucontext_buffer,
+                     prev_tcb->xcp.ucontext_sp,
+                     tcb->xcp.ucontext_buffer,
+                     this_cpu());
+#else
   up_longjmp(tcb->xcp.regs, 1);
+#endif
 
   /* The function does not return */
 

--- a/arch/sim/src/sim/up_initialstate.c
+++ b/arch/sim/src/sim/up_initialstate.c
@@ -44,6 +44,7 @@
 
 #include <nuttx/arch.h>
 
+#include "sched/sched.h"
 #include "up_internal.h"
 
 /****************************************************************************
@@ -66,7 +67,13 @@
 
 void up_initial_state(struct tcb_s *tcb)
 {
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+  FAR struct tcb_s *rtcb = this_task();
+  tcb->xcp.ucontext_buffer = up_create_context(&tcb->xcp.ucontext_sp,
+      rtcb->xcp.ucontext_buffer, tcb->start);
+#else
   memset(&tcb->xcp, 0, sizeof(struct xcptcontext));
   tcb->xcp.regs[JB_SP] = (xcpt_reg_t)tcb->adj_stack_ptr - sizeof(xcpt_reg_t);
   tcb->xcp.regs[JB_PC] = (xcpt_reg_t)tcb->start;
+#endif
 }

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -216,6 +216,15 @@ extern volatile uint8_t g_cpu_paused[CONFIG_SMP_NCPUS];
 
 void *up_doirq(int irq, void *regs);
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+void *up_create_context(void **ucontext_sp, void *prev_ucontext,
+    void (*entry_point)(void));
+void up_destroy_context(void *current_ucontext, void *ucontext_sp,
+    void *next_ucontext, int cpu_id);
+void up_swap_context(void *old_ucontext, void *activate_ucontext);
+void up_set_context(void *current_context);
+#endif
+
 /* up_setjmp32.S ************************************************************/
 
 int  up_setjmp(void *jb);

--- a/arch/sim/src/sim/up_releasepending.c
+++ b/arch/sim/src/sim/up_releasepending.c
@@ -87,7 +87,11 @@ void up_release_pending(void)
        * this is really the previously running task restarting!
        */
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+      FAR struct tcb_s *prev_tcb = rtcb;
+#else
       if (!up_setjmp(rtcb->xcp.regs))
+#endif
         {
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -114,7 +118,12 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+          up_swap_context(prev_tcb->xcp.ucontext_buffer,
+                          rtcb->xcp.ucontext_buffer);
+#else
           up_longjmp(rtcb->xcp.regs, 1);
+#endif
         }
     }
 }

--- a/arch/sim/src/sim/up_reprioritizertr.c
+++ b/arch/sim/src/sim/up_reprioritizertr.c
@@ -142,7 +142,11 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
            * restarting!
            */
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+          FAR struct tcb_s *prev_tcb = rtcb;
+#else
           if (!up_setjmp(rtcb->xcp.regs))
+#endif
             {
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -169,7 +173,12 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
+#ifdef CONFIG_SIM_UCONTEXT_PREEMPTION
+              up_swap_context(prev_tcb->xcp.ucontext_buffer,
+                              rtcb->xcp.ucontext_buffer);
+#else
               up_longjmp(rtcb->xcp.regs, 1);
+#endif
             }
         }
     }

--- a/arch/sim/src/sim/up_stackframe.c
+++ b/arch/sim/src/sim/up_stackframe.c
@@ -119,9 +119,12 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
   tcb->adj_stack_ptr   = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size -= frame_size;
 
+#ifndef CONFIG_SIM_UCONTEXT_PREEMPTION
+
   /* Reset the initial state */
 
   tcb->xcp.regs[JB_SP] = (xcpt_reg_t)tcb->adj_stack_ptr - sizeof(xcpt_reg_t);
+#endif
 
   /* And return a pointer to the allocated memory */
 

--- a/arch/sim/src/sim/up_ucontext.c
+++ b/arch/sim/src/sim/up_ucontext.c
@@ -1,0 +1,283 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_ucontext.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/* This define is required to compile on OSX */
+
+#ifndef _XOPEN_SOURCE
+#  define _XOPEN_SOURCE           (500)
+#endif
+
+#include <assert.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <ucontext.h>
+
+/****************************************************************************
+ * Preprocessor Definition
+ ****************************************************************************/
+
+/* The minimum ucontext stack size */
+
+#define MIN_UCONTEXT_STACK_LENGTH (128 * 1024)
+#define STACK_ALIGNMENT_BYTES     (8)
+#define ASSERT(x)                 assert((x))
+#define ARRAY_LENGTH(array)       (sizeof((array))/sizeof((array)[0]))
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* This container stores the exit information for a NuttX task */
+
+typedef struct exit_data_context_s
+{
+  ucontext_t *parent_ucontext;    /* We jump to this context after we release
+                                   * the resources for the task that wants to
+                                   * exit.
+                                   */
+  ucontext_t *current_ucontext;
+  void *ucontext_sp;
+  int cpu_index;
+} exit_data_context_t;
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* This context is used on the exit path for the initial task */
+
+static ucontext_t g_uctx_main;
+
+/* We use an alternate ucontext for the task exit point to tear down
+ * allocated resources. On the task exit we jump to this exit context
+ * and we free the stack memory used by ucontext.
+ */
+
+#ifdef CONFIG_SMP
+static exit_data_context_t g_task_exit_details[CONFIG_SMP_NCPUS];
+static ucontext_t g_task_exit_context[CONFIG_SMP_NCPUS];
+static uint8_t
+  g_task_exit_context_stack[CONFIG_SMP_NCPUS][MIN_UCONTEXT_STACK_LENGTH];
+#else
+static exit_data_context_t g_task_exit_details[1];
+static ucontext_t g_task_exit_context[1];
+static uint8_t g_task_exit_context_stack[1][MIN_UCONTEXT_STACK_LENGTH];
+#endif
+
+/****************************************************************************
+ * Public Prototype
+ ****************************************************************************/
+
+#ifdef CONFIG_SMP
+int up_cpu_index(void);
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: task_exit_point
+ *
+ * Description:
+ *   This function is used to release the allocated stack memory for a task
+ *   on it's exit path.
+ *
+ * Assumptions:
+ *   This function does not return.
+ *
+ ****************************************************************************/
+
+static void task_exit_point(void)
+{
+  for (; ; )
+    {
+      int cpu_id = 0;
+
+#ifdef CONFIG_SMP
+      cpu_id = up_cpu_index();
+#endif
+      if (g_task_exit_details[cpu_id].ucontext_sp)
+        {
+          /* Free stack memory used by the ucontext structure */
+
+          free(g_task_exit_details[cpu_id].current_ucontext);
+          free(g_task_exit_details[cpu_id].ucontext_sp);
+
+          /* Activate the parent ucontext */
+
+          setcontext(g_task_exit_details[cpu_id].parent_ucontext);
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: up_setup_exit_context
+ *
+ * Description:
+ *   Creates new exit context for tasks. In a SMP configuration every CPU
+ *   has a different exit context.
+ *
+ ****************************************************************************/
+
+static void up_setup_exit_context(int cpu)
+{
+  ucontext_t *exit_context = &g_task_exit_context[cpu];
+  int ret = getcontext(exit_context);
+  ASSERT(ret >= 0);
+
+  uint8_t *sp = &g_task_exit_context_stack[cpu][0];
+
+  uint64_t align_offset = STACK_ALIGNMENT_BYTES - ((uint64_t)sp %
+      STACK_ALIGNMENT_BYTES);
+
+  uint8_t *aligned_stack = sp + align_offset;
+  exit_context->uc_stack.ss_sp   = aligned_stack;
+  exit_context->uc_stack.ss_size = MIN_UCONTEXT_STACK_LENGTH -
+    align_offset;
+  exit_context->uc_link          = &g_uctx_main;
+
+  makecontext(exit_context, task_exit_point, 0);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_create_context
+ *
+ * Description:
+ *   Creates a new ucontext structure and initialize it.
+ *
+ * Input Parameters:
+ *   ucontext_sp   - buffer where we store the ucontext stack pointer
+ *   prev_ucontext - the parent ucontext used%i to return to when the
+ *    execution of the current context ends.
+ *   entry_point   - the entry point of the new context
+ *
+ * Return Value:
+ *   A pointer to the ucontext structure or NULL in case something went
+ *   wrong.
+ *
+ ****************************************************************************/
+
+void *up_create_context(void **ucontext_sp, void *prev_ucontext,
+    void (*entry_point)(void))
+{
+  ucontext_t *new_context = calloc(1, sizeof(ucontext_t));
+  ASSERT(new_context != NULL);
+
+  int ret = getcontext(new_context);
+  ASSERT(ret >= 0);
+
+  uint8_t *sp = calloc(1, MIN_UCONTEXT_STACK_LENGTH);
+  ASSERT(sp != NULL);
+
+  *((uintptr_t *)ucontext_sp) = (uintptr_t)sp;
+
+  uint64_t align_offset = STACK_ALIGNMENT_BYTES - ((uint64_t)sp %
+      STACK_ALIGNMENT_BYTES);
+
+  uint8_t *aligned_stack = sp + align_offset;
+  new_context->uc_stack.ss_sp   = aligned_stack;
+  new_context->uc_stack.ss_size = MIN_UCONTEXT_STACK_LENGTH - align_offset;
+  new_context->uc_link          = prev_ucontext == NULL ? &g_uctx_main :
+    prev_ucontext;
+
+  makecontext(new_context, entry_point, 0);
+
+  return new_context;
+}
+
+/****************************************************************************
+ * Name: up_destroy_context
+ *
+ * Description:
+ *   This function saves the ucontext for the current task and the parent
+ *   task in a container and then activates the exit context. This mechanism
+ *   is used to free the stack memory that we are currently executing on.
+ *
+ * Input Parameters:
+ *   current_ucontext - pointer to the current active ucontext structure
+ *   ucontext_sp      - pointer to the ucontext stack
+ *   parent_ucontext  - the next context that we want to jump to
+ *   cpu_id           - the CPU identificator
+ *
+ * Assumptions:
+ *   This function does not return.
+ *
+ ****************************************************************************/
+
+void up_destroy_context(void *current_ucontext, void *ucontext_sp,
+    void *parent_ucontext, int cpu_id)
+{
+  g_task_exit_details[cpu_id].parent_ucontext  = parent_ucontext;
+  g_task_exit_details[cpu_id].current_ucontext = current_ucontext;
+  g_task_exit_details[cpu_id].cpu_index        = cpu_id;
+  g_task_exit_details[cpu_id].ucontext_sp      = ucontext_sp;
+
+  up_setup_exit_context(cpu_id);
+
+  setcontext(&g_task_exit_context[cpu_id]);
+}
+
+/****************************************************************************
+ * Name: up_swap_context
+ *
+ * Description:
+ *   Save the current context in the old_ucontext and activate the
+ *   context from activate_ucontext.
+ *
+ * Input Parameters:
+ *   old_ucontext       - place where we store the current context
+ *   activate_ucontext  - context that we will activate after function
+ *     invocation
+ *
+ ****************************************************************************/
+
+void up_swap_context(void *old_ucontext, void *activate_ucontext)
+{
+  swapcontext(old_ucontext, activate_ucontext);
+}
+
+/****************************************************************************
+ * Name: up_set_context
+ *
+ * Description:
+ *   Set the current context to the specified ucontext
+ *
+ * Input Parameters:
+ *   current_context - the current context
+ *
+ ****************************************************************************/
+
+void up_set_context(void *current_context)
+{
+  setcontext(current_context);
+}


### PR DESCRIPTION
 ## Summary of Changes

The `ucontext` API allows us to jump from the signal handler without altering the
handler's execution flow. A new host API is introduced:
getcontext()/setcontext()/swapcontext()/makecontext().
This feature can be enabled by setting CONFIG_SIM_UCONTEXT_PREEMPTION=y.

This is a continuation of the work done here: https://github.com/apache/incubator-nuttx/pull/1663

## Impact

When the option `CONFIG_SIM_UCONTEXT_PREEMPTION` is not enabled the patch is using the previous mechanism :
`setjmp/longjmp` and is not altering the original functionality.

Signed-off-by: Sebastian Ene <nuttx@fitbit.com>
