### PR TITLE
CI: Fix check patch to handle renames / deletes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         echo "::add-matcher::nuttx/.github/nxstyle.json"
         cd nuttx
-        commits=`git log -1 --merges --pretty=format:%P | awk -F" " '{ print $1 ".." $2 }'`
+        commits="${{ github.event.pull_request.base.sha }}..HEAD"
         git log --oneline $commits
         echo "../nuttx/tools/checkpatch.sh -g $commits"
         ../nuttx/tools/checkpatch.sh -g $commits

--- a/tools/checkpatch.sh
+++ b/tools/checkpatch.sh
@@ -91,7 +91,7 @@ check_patch() {
 }
 
 check_commit() {
-  diffs=`git show $1`
+  diffs=`git diff $1`
   check_ranges <<< "$diffs"
 }
 


### PR DESCRIPTION
## Summary
Previously `checkpatch.sh` was using `git show` instead of `git diff`. The issue with this is we get a list of all the changes from all the commits, this breaks the CI check because it will look for those files in the final result of the patch (which might include a file that got renamed and then edited).  We only want to look a the final changes which is what we get from `diff`.

We also simplify the computing of the commit range.

## Impact
Style checks should be more robust now.

## Testing
Local testing and this should be validated by the CI run.

