### PR TITLE
CI: Test enabling ccache for MacOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,4 +221,4 @@ jobs:
         run: |
           echo "::add-matcher::sources/nuttx/.github/gcc.json"
           cd sources/testing
-          ./cibuild.sh -i -x testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -i -c -x testlist/${{matrix.boards}}.dat


### PR DESCRIPTION
## Summary
The MacOS builds are significantly slower than Linux.  Let's see if we can improve the performance with ccache.

