### PR TITLE
drivers/timer: auto select the related option in Kconfig

### DIFF
--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -67,6 +67,7 @@ config TIMER_ARCH
 	bool "Timer Arch Implementation"
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_TIMEKEEPING
+	select SCHED_TICKLESS_LIMIT_MAX_SLEEP if SCHED_TICKLESS
 	---help---
 		Implement timer arch API on top of timer driver interface.
 
@@ -86,6 +87,8 @@ config ALARM_ARCH
 	bool "Alarm Arch Implementation"
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_TIMEKEEPING
+	select SCHED_TICKLESS_ALARM if SCHED_TICKLESS
+	select SCHED_TICKLESS_LIMIT_MAX_SLEEP if SCHED_TICKLESS
 	---help---
 		Implement alarm arch API on top of oneshot driver interface.
 

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -32,18 +32,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_TICKLESS
-
-#  ifndef CONFIG_SCHED_TICKLESS_ALARM
-#    error CONFIG_SCHED_TICKLESS_ALARM must be set to use CONFIG_SCHED_TICKLESS
-#  endif
-
-#  ifndef CONFIG_SCHED_TICKLESS_LIMIT_MAX_SLEEP
-#    error CONFIG_SCHED_TICKLESS_LIMIT_MAX_SLEEP must be set to use CONFIG_SCHED_TICKLESS
-#  endif
-
-#endif
-
 #define CONFIG_BOARD_LOOPSPER100USEC ((CONFIG_BOARD_LOOPSPERMSEC+5)/10)
 #define CONFIG_BOARD_LOOPSPER10USEC  ((CONFIG_BOARD_LOOPSPERMSEC+50)/100)
 #define CONFIG_BOARD_LOOPSPERUSEC    ((CONFIG_BOARD_LOOPSPERMSEC+500)/1000)

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -32,16 +32,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_TICKLESS
-
-#  ifdef CONFIG_SCHED_TICKLESS_ALARM
-#    error CONFIG_SCHED_TICKLESS_ALARM must be unset to use CONFIG_SCHED_TICKLESS
-#  endif
-
-#  ifndef CONFIG_SCHED_TICKLESS_LIMIT_MAX_SLEEP
-#    error CONFIG_SCHED_TICKLESS_LIMIT_MAX_SLEEP must be set to use CONFIG_SCHED_TICKLESS
-#  endif
-
+#if defined(CONFIG_SCHED_TICKLESS) && defined(CONFIG_SCHED_TICKLESS_ALARM)
+#  error CONFIG_SCHED_TICKLESS_ALARM must be unset to use the arch timer
 #endif
 
 #define CONFIG_BOARD_LOOPSPER100USEC ((CONFIG_BOARD_LOOPSPERMSEC+5)/10)


### PR DESCRIPTION
## Summary
to avoid the user make the wrong combination in defconfig

## Impact

## Testing

