### PR TITLE
stm32: lowputc: Ensure USART is disabled before configuring

### DIFF
--- a/arch/arm/src/stm32/stm32_lowputc.c
+++ b/arch/arm/src/stm32/stm32_lowputc.c
@@ -614,6 +614,18 @@ void stm32_lowsetup(void)
   /* Enable and configure the selected console device */
 
 #if defined(HAVE_CONSOLE) && !defined(CONFIG_SUPPRESS_UART_CONFIG)
+  /* Ensure the USART is disabled because some bits of the following
+   * registers cannot be modified otherwise.
+   *
+   * Although the USART is expected to be disabled at power on reset, this
+   * might not be the case if we boot from a serial bootloader that does not
+   * clean up properly.
+   */
+
+  cr  = getreg32(STM32_CONSOLE_BASE + STM32_USART_CR1_OFFSET);
+  cr &= ~USART_CR1_UE;
+  putreg32(cr, STM32_CONSOLE_BASE + STM32_USART_CR1_OFFSET);
+
   /* Configure CR2 */
 
   cr  = getreg32(STM32_CONSOLE_BASE + STM32_USART_CR2_OFFSET);


### PR DESCRIPTION
## Summary

arch/arm/src/stm32/stm32_lowputc.c:

- stm32_lowsetup(): Ensure the USART is disabled before attempting to configure it because some register bits cannot be modified otherwise. See the mail thread "[stm32 uart init bug?](https://lists.apache.org/thread.html/rf09668db5ec0cf378afcce66cb6aaefec9f01fe99c3bfbedb33b12e4%40%3Cdev.nuttx.apache.org%3E)" beginning 2020/09/03.

## Impact

This solves an issue that was encountered when a serial bootloader did not perform a full teardown/cleanup before launching NuttX.

## Testing

Tested with STM32G474RE MCU in the ST Micro B-G474E-DPOW1 board (b-g474e-dpow1:nsh config).

Performed build testing on the following configurations:

- stm32ldiscovery:nsh
- nucleo-f302r8:nsh
- nucleo-f207zg:nsh
- nucleo-f334r8:nsh
- stm32f411e-disco:nsh

Tested nxstyle.