### PR TITLE
CI: Enable ccache for Linux and MacOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Cache Source
         id: cache-source
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: sources
           key: build-sources-${{ github.run_id }}
@@ -136,7 +136,7 @@ jobs:
     steps:
       - name: Fetch Cached Source
         id: cache-source
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: sources-cache
           key: build-sources-${{ github.run_id }}
@@ -170,6 +170,13 @@ jobs:
 
       - name: Export NuttX Repo SHA
         run:  echo "::set-env name=nuttx_sha::`git -C sources/nuttx rev-parse HEAD`"
+      - name: Restore ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: ccache
+          key: ccache-${{ runner.os }}-${{matrix.boards}}-${{ github.run_id }}
+          restore-keys: ccache-${{ runner.os }}-${{matrix.boards}}-
       - name: Run builds
         uses: ./sources/testing/.github/actions/ci-container
         env:
@@ -177,8 +184,12 @@ jobs:
         with:
           run: |
             echo "::add-matcher::sources/nuttx/.github/gcc.json"
+            export CCACHE_DIR=`pwd`/ccache
             cd sources/testing
-            ./cibuild.sh -x testlist/${{matrix.boards}}.dat
+            ./cibuild.sh -c -x testlist/${{matrix.boards}}.dat
+            ccache -s
+            ccache -M 400M
+            ccache -c
 
   macOS:
     runs-on: macos-10.15
@@ -189,7 +200,7 @@ jobs:
     steps:
       - name: Fetch Cached Source
         id: cache-source
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: sources-cache
           key: build-sources-${{ github.run_id }}
@@ -208,7 +219,7 @@ jobs:
 
       - name: Restore Tools Cache
         id: cache-tools
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           cache-name: ${{ runner.os }}-cache-tools
         with:
@@ -217,8 +228,19 @@ jobs:
 
       - name: Export NuttX Repo SHA
         run:  echo "::set-env name=nuttx_sha::`git -C sources/nuttx rev-parse HEAD`"
+      - name: Restore ccache
+        id: ccache
+        uses: actions/cache@v2
+        with:
+          path: ccache
+          key: ccache-${{ runner.os }}-${{matrix.boards}}-${{ github.run_id }}
+          restore-keys: ccache-${{ runner.os }}-${{matrix.boards}}-
       - name: Run Builds
         run: |
           echo "::add-matcher::sources/nuttx/.github/gcc.json"
+          export CCACHE_DIR=`pwd`/ccache
           cd sources/testing
-          ./cibuild.sh -i -x testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -i -c -x testlist/${{matrix.boards}}.dat
+          ccache -s
+          ccache -M 400M
+          ccache -c


### PR DESCRIPTION
## Summary
Enables ccache using infrastructure from https://github.com/apache/incubator-nuttx-testing/pull/61
Also update the GitHub Actions Cache action to v2 for improved performance.

## Impact
Faster builds for both MacOS and Linux

## Testing
Validated by CI system
