### PR TITLE
Allow dma capable to be permissive

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -2634,6 +2634,17 @@ config STM32F7_DMACAPABLE
 		Drivers then may use this information to determine if they should
 		attempt the DMA or fall back to a different transfer method.
 
+config STM32F7_DMACAPABLE_ASSUME_CACHE_ALIGNED
+	bool "Do not disqualify DMA capability based on cache alignment"
+	depends on STM32F7_DMACAPABLE && ARMV7M_DCACHE && !ARMV7M_DCACHE_WRITETHROUGH
+	default n
+	---help---
+		This option configures the stm32_dmacapable to not disqualify
+		DMA operations on memory that is not dcache aligned based solely
+		on the starting addresss and byte count.
+		Use this when ALL buffer extents are known to be aligned, but the
+		the count does not use the complete buffer.
+
 menu "Timer Configuration"
 
 if SCHED_TICKLESS

--- a/arch/arm/src/stm32f7/stm32_dma.c
+++ b/arch/arm/src/stm32f7/stm32_dma.c
@@ -933,10 +933,12 @@ bool stm32_dmacapable(uint32_t maddr, uint32_t count, uint32_t ccr)
   if ((maddr & (ARMV7M_DCACHE_LINESIZE - 1)) != 0 ||
       ((mend + 1) & (ARMV7M_DCACHE_LINESIZE - 1)) != 0)
     {
-      dmainfo("stm32_dmacapable:"
+      dmawarn("stm32_dmacapable:"
               " dcache unaligned maddr:0x%08x mend:0x%08x\n",
               maddr, mend);
+#if !defined(CONFIG_STM32F7_DMACAPABLE_ASSUME_CACHE_ALIGNED)
       return false;
+#endif
     }
 #  endif
 

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1684,6 +1684,16 @@ config STM32H7_DMACAPABLE
 		Drivers then may use this information to determine if they should
 		attempt the DMA or fall back to a different transfer method.
 
+config STM32H7_DMACAPABLE_ASSUME_CACHE_ALIGNED
+	bool "Do not disqualify DMA capability based on cache alignment"
+	depends on STM32H7_DMACAPABLE && ARMV7M_DCACHE && !ARMV7M_DCACHE_WRITETHROUGH
+	default n
+	---help---
+		This option configures the stm32_dmacapable to not disqualify
+		DMA operations on memory that is not dcache aligned based solely
+		on the starting addresss and byte count.
+		Use this when ALL buffer extents are known to be aligned, but the
+		the count does not use the complete buffer.
 
 menu "Timer Configuration"
 

--- a/arch/arm/src/stm32h7/stm32_dma.c
+++ b/arch/arm/src/stm32h7/stm32_dma.c
@@ -1536,7 +1536,9 @@ static bool stm32_sdma_capable(FAR stm32_dmacfg_t *cfg)
         {
           dmainfo("stm32_dmacapable: dcache unaligned "
                   "maddr:0x%08x mend:0x%08x\n", cfg->maddr, mend);
-          return false;
+#if !defined(CONFIG_STM32H7_DMACAPABLE_ASSUME_CACHE_ALIGNED)
+      return false;
+#endif
         }
     }
 #  endif
@@ -2059,7 +2061,9 @@ static bool stm32_bdma_capable(FAR stm32_dmacfg_t *cfg)
     {
       dmainfo("stm32_dmacapable: dcache unaligned maddr:0x%08x "
               "mend:0x%08x\n", cfg->maddr, mend);
+#if !defined(CONFIG_STM32H7_DMACAPABLE_ASSUME_CACHE_ALIGNED)
       return false;
+#endif
     }
 #  endif
 


### PR DESCRIPTION
## Summary
  A driver passing a buffer that is aligned and sized on d-cache bounders but does not used the full extent of the buffer will fail the dma_capable test and in a debug build DEBUGASSERT. 


This PR adds the option configures the stm32_dmacapable to not disqualify DMA operations on memory that is not dcache aligned based solely on the starting addresss and byte count.

One would use this when ALL buffer extents are known to be aligned, but the the count does not use the complete buffer.

## Impact
  None - if disabled and it is by default.

## Testing

Run a debug build and pass a buffer that is 64 bytes and aligned on 32, but a count of 16 bytes to DMA. It will no longer assert.
