### PR TITLE
arm: cxd56xx: Fix nvic settings for SMP

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_cpustart.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpustart.c
@@ -114,6 +114,10 @@ static void appdsp_boot(void)
   cpu = up_cpu_index();
   DPRINTF("cpu = %d\n", cpu);
 
+  /* Setup NVIC */
+
+  up_irqinitialize();
+
   /* Setup FPU */
 
   fpuconfig();


### PR DESCRIPTION
## Summary

- I noticed that ostest sometimes stops with DEBUGASSERT
- Finally I found a bug that cpu1 can not disable interrupt
- This commit initializes nvic to fix this bug

## Impact

- Only affects cxd56 in SMP mode

## Testing

- spresense:smp and spresense:wifi_smp with DEBUG_ASSERTIONS=y
