### PR TITLE
mmcsd_sdio: Arm the write complete detection

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -2077,6 +2077,12 @@ static ssize_t mmcsd_writemultiple(FAR struct mmcsd_state_s *priv,
 
   priv->wrbusy = true;
 
+#if defined(CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE)
+  /* Arm the write complete detection with timeout */
+
+  SDIO_WAITENABLE(priv->dev, SDIOWAIT_WRCOMPLETE | SDIOWAIT_TIMEOUT);
+#endif
+
   /* On success, return the number of blocks written */
 
   return nblocks;


### PR DESCRIPTION
## Summary

   The Multiblock write path was missing the
   the SDIO_WAITENABLE with SDIOWAIT_WRCOMPLETE.

   This could be seen with debugging turned on as

  ```
 mmcsd_eventwait: ERROR: Awakened with 10
 mmcsd_transferready: ERROR: mmcsd_eventwait for transfer ready failed: -5
```

## Impact
 Performance, and error messages under debug.

## Testing
master:
```
Insh> sd_bench
INFO  [sd_bench] Using block size = 4096 bytes, sync=0
INFO  [sd_bench]
INFO  [sd_bench] Testing Sequential Write Speed...
INFO  [sd_bench]   Run  0:  1860.04 KB/s, max write time: 66 ms (=  60.61 KB/s), fsync: 15 ms
INFO  [sd_bench]   Run  1:  2544.74 KB/s, max write time: 20 ms (= 200.00 KB/s), fsync: 4 ms
INFO  [sd_bench]   Run  2:  1402.85 KB/s, max write time: 22 ms (= 181.82 KB/s), fsync: 4 ms
INFO  [sd_bench]   Run  3:  2719.82 KB/s, max write time: 35 ms (= 114.29 KB/s), fsync: 4 ms
INFO  [sd_bench]   Run  4:  2581.84 KB/s, max write time: 24 ms (= 166.67 KB/s), fsync: 3 ms
INFO  [sd_bench]   Avg   :  2221.40 KB/s

```
With this PR:

```
 nsh> sd_bench
INFO  [sd_bench] Using block size = 4096 bytes, sync=0
INFO  [sd_bench]
INFO  [sd_bench] Testing Sequential Write Speed...
INFO  [sd_bench]   Run  0:  2788.61 KB/s, max write time: 9 ms (= 444.44 KB/s), fsync: 4 ms
INFO  [sd_bench]   Run  1:  2813.93 KB/s, max write time: 6 ms (= 666.67 KB/s), fsync: 6 ms
INFO  [sd_bench]   Run  2:  2795.05 KB/s, max write time: 6 ms (= 666.67 KB/s), fsync: 4 ms
INFO  [sd_bench]   Run  3:  1719.35 KB/s, max write time: 23 ms (= 173.91 KB/s), fsync: 3 ms
INFO  [sd_bench]   Run  4:  2508.10 KB/s, max write time: 142 ms (=  28.17 KB/s), fsync: 4 ms
INFO  [sd_bench]   Avg   :  2525.04 KB/s

```

