### PR TITLE
sched_note:Allow for external endpoints

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -916,6 +916,12 @@ config SCHED_INSTRUMENTATION
 
 if SCHED_INSTRUMENTATION
 
+config SCHED_INSTRUMENTATION_EXTENAL
+	bool "System performance monitor endpoints are external"
+	default n
+	---help---
+		Monitor only CPUs in the bitset.  Bit 0=CPU0, Bit1=CPU1, etc.
+
 config SCHED_INSTRUMENTATION_CPUSET
 	hex "CPU bit set"
 	default 0xffff

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -36,6 +36,7 @@
 
 #include "sched/sched.h"
 
+#if !defined(CONFIG_SCHED_INSTRUMENTATION_EXTENAL)
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -610,3 +611,4 @@ void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
   note_add((FAR const uint8_t *)&note, sizeof(struct note_irqhandler_s));
 }
 #endif
+#endif /* CONFIG_SCHED_INSTRUMENTATION_EXTENAL */


### PR DESCRIPTION
## Summary

Fixes breakage introduced by https://github.com/apache/incubator-nuttx/pull/1520

Breaks build that used the board supported interfaces.

This PR restore the ability to not use ONLY the transport and keeps the contract that is stated in Kconfig, 

## Impact
None on current development, 
Fixes Legacy usage.


## Testing

Build with and without option.