### PR TITLE
tiva: tiva_adclow.c, tiva_allocateheap: Fix nxstyle warnings

### DIFF
--- a/arch/arm/src/tiva/common/tiva_adclow.c
+++ b/arch/arm/src/tiva/common/tiva_adclow.c
@@ -589,7 +589,9 @@ static int tiva_adc_ioctl(struct adc_dev_s *dev, int cmd, unsigned long arg)
 
           fifo_count = tiva_adc_sse_data(priv->devno, sse, buf);
 
-          /* Verify that the upper-half driver has bound its callback functions */
+          /* Verify that the upper-half driver has bound its callback
+           * functions
+           */
 
           if (priv->cb != NULL)
             {

--- a/arch/arm/src/tiva/common/tiva_allocateheap.c
+++ b/arch/arm/src/tiva/common/tiva_allocateheap.c
@@ -95,7 +95,8 @@
  *
  *     Kernel .data region.  Size determined at link time.
  *     Kernel .bss  region  Size determined at link time.
- *     Kernel IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
+ *     Kernel IDLE thread stack.  Size determined by
+ *                                CONFIG_IDLETHREAD_STACKSIZE.
  *     Padding for alignment
  *     User .data region.  Size determined at link time.
  *     User .bss region  Size determined at link time.
@@ -112,7 +113,8 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+                    CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = CONFIG_RAM_END - ubase;
   int       log2;
 
@@ -137,7 +139,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 
   /* Allow user-mode access to the user heap memory */
 
-   tiva_mpu_uheap((uintptr_t)ubase, usize);
+  tiva_mpu_uheap((uintptr_t)ubase, usize);
 #else
 
   /* Return the heap settings */
@@ -166,7 +168,8 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+                    CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = CONFIG_RAM_END - ubase;
   int       log2;
 


### PR DESCRIPTION
## Summary

tiva: tiva_adclow.c, tiva_allocateheap: Fix nxstyle warnings

arch/arm/src/tiva/common/tiva_adclow.c:

    * Fix nxstyle warnings. No functional changes.

arch/arm/src/tiva/common/tiva_allocateheap.c

    * Fix nxstyle warnings. No functional changes.

## Impact

No functional changes but will avoid old nxstyle errors when these files receive new maintenance.

## Testing

nxstyle