### PR TITLE
drivers: wireless: Fix warnings in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -280,6 +280,7 @@ static enum pkt_type_e _spi_err_to_pkt_type(enum spi_status_e s)
         break;
 
       default:
+        r = TYPE_UNMATCH;
         ASSERT(false);
     }
 
@@ -304,6 +305,7 @@ static uint8_t _cid_to_uint8(char c)
     }
   else
     {
+      ret = 0xff;
       ASSERT(false);
     }
 


### PR DESCRIPTION
## Summary

- This commit fixes warnings when we remove noreturn from _assert()

## Impact

- Should have no impact

## Testing

- Tested with spresense:wifi

