### PR TITLE
libs/libc/stdio: replace double_t to double

### DIFF
--- a/libs/libc/stdio/legacy_dtoa.c
+++ b/libs/libc/stdio/legacy_dtoa.c
@@ -144,14 +144,14 @@ static FAR bigint_t *g_freelist[KMAX + 1];
 static FAR bigint_t *g_p5s;
 
 #ifdef IEEE_ARITH
-static const double_t g_bigtens[] =
+static const double g_bigtens[] =
 {
   1e16, 1e32, 1e64, 1e128, 1e256
 };
 
 #  define n_bigtens 5
 #else
-static const double_t g_bigtens[] =
+static const double g_bigtens[] =
 {
   1e16, 1e32
 };
@@ -770,7 +770,7 @@ static FAR bigint_t *diff(FAR bigint_t *a, FAR bigint_t *b)
   return c;
 }
 
-static FAR bigint_t *d2b(double_t d, int *e, int *bits)
+static FAR bigint_t *d2b(double d, int *e, int *bits)
 {
   FAR bigint_t *b;
   FAR unsigned long *x;
@@ -906,7 +906,7 @@ static FAR bigint_t *d2b(double_t d, int *e, int *bits)
   return b;
 }
 
-static const double_t tens[] =
+static const double tens[] =
 {
   1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9,
   1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
@@ -1088,7 +1088,7 @@ static int quorem(FAR bigint_t *b, FAR bigint_t *s)
  *         calculation.
  */
 
-FAR char *__dtoa(double_t d, int mode, int ndigits, FAR int *decpt,
+FAR char *__dtoa(double d, int mode, int ndigits, FAR int *decpt,
                  FAR int *sign, FAR char **rve)
 {
   /* Arguments ndigits, decpt, sign are similar to those of ecvt and fcvt;
@@ -1126,9 +1126,9 @@ FAR char *__dtoa(double_t d, int mode, int ndigits, FAR int *decpt,
   FAR bigint_t *s;
   FAR char *st;
   FAR char *st0;
-  double_t d2;
-  double_t ds;
-  double_t eps;
+  double d2;
+  double ds;
+  double eps;
   long l;
   unsigned long x;
   int denorm;

--- a/libs/libc/stdio/legacy_libvsprintf.c
+++ b/libs/libc/stdio/legacy_libvsprintf.c
@@ -508,7 +508,7 @@ static int getusize(uint8_t fmt, uint16_t flags, unsigned int n)
  ****************************************************************************/
 
 #ifdef CONFIG_LIBC_FLOATINGPOINT
-static int getdblsize(uint8_t fmt, int trunc, uint16_t flags, double_t n)
+static int getdblsize(uint8_t fmt, int trunc, uint16_t flags, double n)
 {
   struct lib_outstream_s nulloutstream;
   lib_nulloutstream(&nulloutstream);
@@ -1565,7 +1565,7 @@ int lib_vsprintf(FAR struct lib_outstream_s *obj, FAR const IPTR char *src,
 #ifdef CONFIG_LIBC_FLOATINGPOINT
       else if (strchr("eEfgG", FMT_CHAR))
         {
-          double_t dblval = va_arg(ap, double_t);
+          double dblval = va_arg(ap, double);
           int dblsize;
 
           if (FMT_CHAR == 'g' || FMT_CHAR == 'G')

--- a/libs/libc/stdio/lib_dtoa_data.c
+++ b/libs/libc/stdio/lib_dtoa_data.c
@@ -68,7 +68,7 @@
  * Public Data
  ****************************************************************************/
 
-const double_t g_dtoa_scale_up[] =
+const double g_dtoa_scale_up[] =
 {
 #if DBL_MAX_10_EXP >= 1
   1e1,
@@ -123,7 +123,7 @@ const double_t g_dtoa_scale_up[] =
 #endif
 };
 
-const double_t g_dtoa_scale_down[] =
+const double g_dtoa_scale_down[] =
 {
 #if DBL_MIN_10_EXP <= -1
   1e-1,
@@ -178,7 +178,7 @@ const double_t g_dtoa_scale_down[] =
 #endif
 };
 
-const double_t g_dtoa_round[] =
+const double g_dtoa_round[] =
 {
 #if DBL_DIG >= 30
   5e30,

--- a/libs/libc/stdio/lib_dtoa_engine.c
+++ b/libs/libc/stdio/lib_dtoa_engine.c
@@ -61,7 +61,7 @@
  * Public Functions
  ****************************************************************************/
 
-int __dtoa_engine(double_t x, FAR struct dtoa_s *dtoa, int max_digits,
+int __dtoa_engine(double x, FAR struct dtoa_s *dtoa, int max_digits,
                   int max_decimals)
 {
   int32_t exp = 0;
@@ -90,7 +90,7 @@ int __dtoa_engine(double_t x, FAR struct dtoa_s *dtoa, int max_digits,
     }
   else
     {
-      double_t y;
+      double y;
 
       exp = MIN_MANT_EXP;
 

--- a/libs/libc/stdio/lib_dtoa_engine.h
+++ b/libs/libc/stdio/lib_dtoa_engine.h
@@ -176,15 +176,15 @@ struct dtoa_s
  * Public Data
  ****************************************************************************/
 
-extern const double_t g_dtoa_scale_up[];
-extern const double_t g_dtoa_scale_down[];
-extern const double_t g_dtoa_round[];
+extern const double g_dtoa_scale_up[];
+extern const double g_dtoa_scale_down[];
+extern const double g_dtoa_round[];
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-int __dtoa_engine(double_t x, FAR struct dtoa_s *dtoa, int max_digits,
+int __dtoa_engine(double x, FAR struct dtoa_s *dtoa, int max_digits,
                   int max_decimals);
 
 #endif /* __LIBS_LIBC_STDIO_LIB_DTOA_ENGINE_H */

--- a/libs/libc/stdio/lib_libdtoa.c
+++ b/libs/libc/stdio/lib_libdtoa.c
@@ -158,7 +158,7 @@ static void lib_dtoa_string(FAR struct lib_outstream_s *obj, const char *str)
  ****************************************************************************/
 
 static void lib_dtoa(FAR struct lib_outstream_s *obj, int fmt, int prec,
-                     uint16_t flags, double_t value)
+                     uint16_t flags, double value)
 {
   FAR char *digits;     /* String returned by __dtoa */
   FAR char *rve;        /* Points to the end of the return value */

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -918,7 +918,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
           else if (strchr("aAfFeEgG", fmt_char(fmt)) != NULL)
             {
 #ifdef CONFIG_HAVE_DOUBLE
-              FAR double_t *pd = NULL;
+              FAR double *pd = NULL;
 #endif
               FAR float *pf = NULL;
 
@@ -938,7 +938,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 #ifdef CONFIG_HAVE_DOUBLE
                   if (modifier >= L_MOD)
                     {
-                      pd = va_arg(ap, FAR double_t *);
+                      pd = va_arg(ap, FAR double *);
                       *pd = 0.0;
                     }
                   else
@@ -971,7 +971,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                   bool stopconv;
                   int errsave;
 #  ifdef CONFIG_HAVE_DOUBLE
-                  double_t dvalue;
+                  double dvalue;
 #  endif
                   float fvalue;
 
@@ -1057,7 +1057,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
 #  ifdef CONFIG_HAVE_DOUBLE
                   if (modifier >= L_MOD)
                     {
-                      /* Get the converted double_t value */
+                      /* Get the converted double value */
 
                       dvalue = strtod(tmp, &endptr);
                     }
@@ -1080,13 +1080,13 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                   if (!noassign)
                     {
                       /* We have to check whether we need to return a float
-                       * or a double_t.
+                       * or a double.
                        */
 
 #  ifdef CONFIG_HAVE_DOUBLE
                       if (modifier >= L_MOD)
                         {
-                          /* Return the double_t value */
+                          /* Return the double value */
 
                           linfo("Return %f to %p\n", dvalue, pd);
                           *pd = dvalue;
@@ -1096,7 +1096,7 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                         {
                           /* Return the float value */
 
-                          linfo("Return %f to %p\n", (double_t)fvalue, pf);
+                          linfo("Return %f to %p\n", (double)fvalue, pf);
                           *pf = fvalue;
                         }
 

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -131,7 +131,7 @@ struct arg
 #ifdef CONFIG_LIBC_LONG_LONG
     unsigned long long ull;
 #endif
-    double_t d;
+    double d;
     FAR char *cp;
   } value;
 };
@@ -540,7 +540,7 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
         }
       else if (c >= 'e' && c <= 'g')
         {
-          double_t value;
+          double value;
           int exp;              /* Exponent of master decimal digit */
           int n;
           uint8_t sign;         /* Sign character (or 0) */
@@ -589,10 +589,10 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
             }
           else
             {
-              value = va_arg(ap, double_t);
+              value = va_arg(ap, double);
             }
 #else
-          value = va_arg(ap, double_t);
+          value = va_arg(ap, double);
 #endif
 
           ndigs = __dtoa_engine(value, &_dtoa, ndigs,
@@ -858,7 +858,7 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
 #else /* !CONFIG_LIBC_FLOATINGPOINT */
       if ((c >= 'E' && c <= 'G') || (c >= 'e' && c <= 'g'))
         {
-          va_arg(ap, double_t);
+          va_arg(ap, double);
           pnt  = "*float*";
           size = sizeof("*float*") - 1;
           goto str_lpad;
@@ -1273,7 +1273,7 @@ int lib_vsprintf(FAR struct lib_outstream_s *stream,
           break;
 
         case TYPE_DOUBLE:
-          arglist[i].value.d = va_arg(ap, double_t);
+          arglist[i].value.d = va_arg(ap, double);
           break;
 
         case TYPE_CHAR_POINTER:


### PR DESCRIPTION
The CI check failed because, include *.c not in "Include field",   ignore it.
```
#ifdef CONFIG_LIBC_FLOATINGPOINT
#  include "stdio/lib_libdtoa.c"
#endif
```

Modify reason:

When build Nuttx SIM, in x86_64 system:

Compile with gcc option '-m64' (default):
sizeof(double_t) = 8
sizeof(double)   = 8

Compile with gcc option '-mx32':
sizeof(double_t) = 8
sizeof(double)   = 8

Compile with gcc option '-m32':
sizeof(double_t) = 12       // long double
sizeof(double)   = 8

When use '-m32', and print sth. like this:
printf("%f\n", (double)3.0);
SIM will print out: nan

This is because sizeof(double_t) is not equal with double.

Resolve:
replace all double_t to double in libs/libc/stdio.

As a user of '-m32', you should know double_t is one type
long double, and len is 12. And you use use '%lf' to print.
like:
printf("%lf\n", (double_t)3.0);

Currently we don't support '%lf'.

Change-Id: I9b9d11853140d5296dd80416c8ed6a260a9d2d9c
Signed-off-by: ligd <liguiding1@xiaomi.com>

## Summary

## Impact

## Testing

