### PR TITLE
mm/mm_heap/mm_initialize.c: add sem lock to mm_addregion()

### DIFF
--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -82,6 +82,8 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   DEBUGASSERT(heapsize <= MMSIZE_MAX + 1);
 #endif
 
+  mm_takesemaphore(heap);
+
   /* Adjust the provide heap start and size so that they are both aligned
    * with the MM_MIN_CHUNK size.
    */
@@ -127,6 +129,8 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   /* Add the single, large free node to the nodelist */
 
   mm_addfreechunk(heap, node);
+
+  mm_givesemaphore(heap);
 }
 
 /****************************************************************************


### PR DESCRIPTION

# Summary
 mm/mm_heap/mm_initialize.c: add sem lock to mm_addregion()

## Impact
add sem lock to mm_addregion()， in case someone called mm_addregion() after thread scheduling 

## Testing

