### PR TITLE
documentation CI: add step to check valid external links using "linkcheck" sphinx builder

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "Documentation/"
+        build-command: "make html linkcheck"
     - uses: actions/upload-artifact@v2
       with:
         name: sphinx-docs

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -23,7 +23,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
## Summary

Add an extra step to the documentation workflow which goes through every external link and tries to access it to check if it is still valid and fail if so.

## Impact

CI

## Testing

Tested locally, will be tested on CI for this PR