### PR TITLE
Documentation: build documentation using sphinx -j option which parallelizes jobs

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -23,7 +23,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
##  Summary

Make sphinx build docs considerably faster using -j option

## Impact

Documentation build

## Testing

Tested locally

