### PR TITLE
Fix: ensure archive files do not carry object files from prior builds

### DIFF
--- a/Documentation/quickstart/install.rst
+++ b/Documentation/quickstart/install.rst
@@ -39,8 +39,6 @@ Prerequisites
 
     .. code-block:: console
 
-      $ brew tap discoteq/discoteq
-      $ brew install flock
       $ brew install x86_64-elf-gcc  # Used by simulator
       $ brew install u-boot-tools  # Some platform integrate with u-boot
 

--- a/README.md
+++ b/README.md
@@ -525,16 +525,8 @@ framework like GTK or Qt.  So this might be a trip down the rabbit hole.
 
 ### Using macOS
 
-You need to install at least the following tools specific to macOS.
-
-  * flock (used by APPDIR build logic)
-
-A macOS port is available at: <https://github.com/discoteq/flock>
-
-    brew tap discoteq/discoteq
-    brew install flock
-
-  If you want to build the sim:
+You need to install at least the following tools specific to macOS
+if you want to build the sim:
 
   * Xcode (the native compiler and the rest of the toolchain)
 

--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -105,12 +105,7 @@ $(CXXOBJS) $(LINKOBJS): %$(OBJEXT): %.cxx
 	$(call COMPILEXX, $<, $@)
 
 libboard$(LIBEXT): $(OBJS) $(CXXOBJS)
-ifneq ($(OBJS),)
-	$(call ARCHIVE, $@, $(OBJS))
-endif
-ifneq ($(CXXOBJS),)
-	$(call ARCHIVE, $@, $(CXXOBJS))
-endif
+	$(call ARCHIVE, $@, $(OBJS) $(CXXOBJS))
 
 .depend: Makefile $(SRCS) $(CXXSRCS) $(RCSRCS) $(TOPDIR)$(DELIM).config
 ifneq ($(ZDSVERSION),)

--- a/libs/libc/zoneinfo/Makefile
+++ b/libs/libc/zoneinfo/Makefile
@@ -61,7 +61,7 @@ $(COBJS): %$(OBJEXT): %.c
 	$(call COMPILE, $<, $@)
 
 .built: .tzbuilt romfs $(OBJS)
-	$(call ARCHIVE, ..$(DELIM)$(BIN), $(OBJS))
+	$(call ARCHIVE_ADD, ..$(DELIM)$(BIN), $(OBJS))
 	$(Q) touch .built
 
 # ROMFS file system containing the TZ database

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -300,8 +300,8 @@ define INSTALL_LIB
 	$(Q) install -m 0644 $1 $2
 endef
 
-# ARCHIVE - Add a list of files to an archive
-# Example: $(call ARCHIVE, archive-file, "file1 file2 file3 ...")
+# ARCHIVE_ADD - Add a list of files to an archive
+# Example: $(call ARCHIVE_ADD, archive-file, "file1 file2 file3 ...")
 #
 # Note: The fileN strings may not contain spaces or  characters that may be
 # interpreted strangely by the shell
@@ -316,8 +316,18 @@ endef
 #
 #   CONFIG_WINDOWS_NATIVE - Defined for a Windows native build
 
+define ARCHIVE_ADD
+	@echo "AR (add): $(notdir $1) $(2)"
+	$(Q) $(AR) $1 $(2)
+endef
+
+# ARCHIVE - Same as above, but ensure the archive is
+# created from scratch
+
 define ARCHIVE
-	$(AR) $1 $(2)
+	@echo "AR (create): $(notdir $1) $(2)"
+	$(Q) $(RM) $1
+	$(Q) $(AR) $1 $(2)
 endef
 
 # PRELINK - Prelink a list of files


### PR DESCRIPTION
## Summary

In some cases, when NuttX configuration changes and this makes the
object list used to build one of the .a libraries change as well,
since the command used to build it is "ar crs" and this simply appends
the list of object files, the library could still include object
files from prior builds. This commit modifies the ARCHIVE macro to
erase the .a file if it already exists.

Since in some cases this behavior was actually expected (object
files from a subdirectory were appended to a library created one
level above) I added a ARCHIVE_ADD which works as ARCHIVE did.

This change should greatly improve behavior of building after
configuration changes.

NOTE: this will not build to yet another interdependent PR, since we
need a similar change in `apps` repo.

## Impact

Build system

## Testing

Build problem was fixed, the archive was recreated and linker errors due to "multiple references" disappeared.
