### PR TITLE
nrf52: SPI cmddata function mapping wrong for SPI(0,2,3)

### DIFF
--- a/arch/arm/src/nrf52/nrf52_spi.c
+++ b/arch/arm/src/nrf52/nrf52_spi.c
@@ -166,7 +166,7 @@ static const struct spi_ops_s g_spi0ops =
 #  endif
   .status            = nrf52_spi0status,
 #  ifdef CONFIG_SPI_CMDDATA
-  .cmddata           = nrf52_spi1cmddata,
+  .cmddata           = nrf52_spi0cmddata,
 #  endif
   .send              = nrf52_spi_send,
 #  ifdef CONFIG_SPI_EXCHANGE
@@ -256,7 +256,7 @@ static const struct spi_ops_s g_spi2ops =
 #  endif
   .status            = nrf52_spi2status,
 #  ifdef CONFIG_SPI_CMDDATA
-  .cmddata           = nrf52_spi1cmddata,
+  .cmddata           = nrf52_spi2cmddata,
 #  endif
   .send              = nrf52_spi_send,
 #  ifdef CONFIG_SPI_EXCHANGE
@@ -301,7 +301,7 @@ static const struct spi_ops_s g_spi3ops =
 #  endif
   .status            = nrf52_spi3status,
 #  ifdef CONFIG_SPI_CMDDATA
-  .cmddata           = nrf52_spi1cmddata,
+  .cmddata           = nrf52_spi3cmddata,
 #  endif
   .send              = nrf52_spi_send,
 #  ifdef CONFIG_SPI_EXCHANGE


### PR DESCRIPTION
## Summary
The cmddata function for the SPI Master drivers was mapped to nrf52_spi1cmddata for all drivers not just 1.

## Impact
And build that used SPI masters 0,2,3 would not work correctly with cmddata.

## Testing
Build testing, error is clear.
