### PR TITLE
Fix -x of testbuild.sh; Do not use -x on CI to have all build errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
             export CCACHE_DIR=`pwd`/ccache
             mkdir $CCACHE_DIR
             cd sources/testing
-            ./cibuild.sh -c -x testlist/${{matrix.boards}}.dat
+            ./cibuild.sh -c testlist/${{matrix.boards}}.dat
             ccache -s
 
   macOS:
@@ -195,5 +195,5 @@ jobs:
           export CCACHE_DIR=`pwd`/ccache
           mkdir $CCACHE_DIR
           cd sources/testing
-          ./cibuild.sh -i -c -x testlist/${{matrix.boards}}.dat
+          ./cibuild.sh -i -c testlist/${{matrix.boards}}.dat
           ccache -s

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -161,6 +161,8 @@ function makefunc {
   if ! ${MAKE} ${MAKE_FLAGS} "${EXTRA_FLAGS}" ${JOPTION} $@ 1>/dev/null; then
     fail=1
   fi
+
+  return $fail
 }
 
 # Clean up after the last build
@@ -193,6 +195,8 @@ function distclean {
       fi
     fi
   fi
+
+  return $fail
 }
 
 # Configure for the next build
@@ -225,6 +229,8 @@ function configure {
 
     makefunc olddefconfig
   fi
+
+  return $fail
 }
 
 # Perform the next build
@@ -251,6 +257,8 @@ function build {
       fail=1
     fi
   fi
+
+  return $fail
 }
 
 # Coordinate the steps for the next build test


### PR DESCRIPTION
## Summary

This makes intermediate functions in testbuild.sh do `return $fail` which will make the script abort when run with `-x`. As we want the CI build to not abort on first error, we also remove `-x` on the GH workflow.

## Impact

CI

## Testing

CI from this PR