### PR TITLE
boards/Board.mk: Allow boards context to be extended just by providing a double colon target

### DIFF
--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -128,9 +128,7 @@ endif
 
 depend: .depend
 
-ifneq ($(BOARD_CONTEXT),y)
-context:
-endif
+context::
 
 clean:
 	$(call DELFILE, libboard$(LIBEXT))

--- a/boards/xtensa/esp32/esp32-core/src/Makefile
+++ b/boards/xtensa/esp32/esp32-core/src/Makefile
@@ -60,7 +60,6 @@ endif
 SCRIPTIN = $(SCRIPTDIR)$(DELIM)esp32.template
 SCRIPTOUT = $(SCRIPTDIR)$(DELIM)esp32_out.ld
 
-BOARD_CONTEXT = y
 EXTRA_DISTCLEAN = $(call DELFILE, $(SCRIPTOUT))
 
 .PHONY = context
@@ -70,4 +69,4 @@ include $(TOPDIR)/boards/Board.mk
 $(SCRIPTOUT): $(SCRIPTIN) $(CONFIGFILE)
 	$(Q) $(CC) -isystem $(TOPDIR)/include -C -P -x c -E $(SCRIPTIN) -o $@
 
-context: $(SCRIPTOUT)
+context:: $(SCRIPTOUT)


### PR DESCRIPTION
## Summary
This allows boards to extend the context target just by providing a context:: instead of conditionally relaying on a definition of a variable.

## Impact

## Testing

