### PR TITLE
use "export" to expose TOPDIR to all child make instead of passing it around every time

### DIFF
--- a/Documentation/components/nxgraphics/appendix.rst
+++ b/Documentation/components/nxgraphics/appendix.rst
@@ -357,10 +357,10 @@ CONFIG_NXFONT_SANS23X27 for examaples:
        
     genfontsources:
       ifeq ($(CONFIG_NXFONT_SANS23X27),y)
-          @$(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=1 EXTRAFLAGS=$(EXTRAFLAGS)
+          @$(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=1 EXTRAFLAGS=$(EXTRAFLAGS)
       endif
       ifeq ($(CONFIG_NXFONT_MYFONT),y)
-          @$(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=2 EXTRAFLAGS=$(EXTRAFLAGS)
+          @$(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=2 EXTRAFLAGS=$(EXTRAFLAGS)
       endif   
 
 6. ``nuttx/graphics/nxfonts/Make.defs``. Set the make variable

--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -165,7 +165,7 @@ $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board$(DELIM)libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT)
 	$(Q) echo "LD: nuttx"
@@ -196,7 +196,7 @@ endif
 
 .depend: Makefile chip$(DELIM)Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) $(patsubst %,--dep-path %,$(subst :, ,$(VPATH))) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -206,7 +206,7 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, $(KBIN))
 	$(call DELFILE, $(BIN))
@@ -214,7 +214,7 @@ endif
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/avr/src/Makefile
+++ b/arch/avr/src/Makefile
@@ -115,7 +115,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	@echo "LD: nuttx"
@@ -142,7 +142,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile chip/Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -152,14 +152,14 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/hc/src/Makefile
+++ b/arch/hc/src/Makefile
@@ -130,7 +130,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	$(Q) echo "LD: nuttx"
@@ -157,7 +157,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile chip/Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -167,14 +167,14 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/mips/src/Makefile
+++ b/arch/mips/src/Makefile
@@ -113,7 +113,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	@echo "LD: nuttx"
@@ -140,7 +140,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile chip/Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -150,14 +150,14 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/misoc/src/Makefile
+++ b/arch/misoc/src/Makefile
@@ -117,7 +117,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
@@ -143,7 +143,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile chip/Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -153,14 +153,14 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/or1k/src/Makefile
+++ b/arch/or1k/src/Makefile
@@ -152,7 +152,7 @@ $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board$(DELIM)libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT)
 	$(Q) echo "LD: nuttx"
@@ -183,7 +183,7 @@ endif
 
 .depend: Makefile chip$(DELIM)Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) $(patsubst %,--dep-path %,$(subst :, ,$(VPATH))) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -193,7 +193,7 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, $(KBIN))
 	$(call DELFILE, $(BIN))
@@ -201,7 +201,7 @@ endif
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/renesas/src/Makefile
+++ b/arch/renesas/src/Makefile
@@ -124,7 +124,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	@echo "LD: nuttx"
@@ -151,7 +151,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile chip/Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
 	$(Q) touch $@
@@ -160,14 +160,14 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -155,7 +155,7 @@ $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	$(Q) echo "LD: nuttx"
@@ -186,7 +186,7 @@ endif
 
 .depend: Makefile $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) $(patsubst %,--dep-path %,$(subst :, ,$(VPATH))) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) > Make.dep
@@ -196,7 +196,7 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, $(KBIN))
 	$(call DELFILE, $(BIN))
@@ -205,7 +205,7 @@ endif
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -271,7 +271,7 @@ libarch$(LIBEXT): $(NUTTXOBJS)
 # that are not hardware-related.
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 # A partially linked object containing only NuttX code (no interface to host OS)
 # Change the names of most symbols that conflict with libc symbols.
@@ -318,7 +318,7 @@ export_startup: board/libboard$(LIBEXT) up_head.o $(HOSTOBJS)
 
 .depend: Makefile $(SRCS) $(TOPDIR)$(DELIM).config
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
+		$(MAKE) -C board depend ; \
 	fi
 	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $(ASRCS) $(CSRCS) >Make.dep
 	$(Q) $(MKDEP) $(DEPPATH) "$(CC)" -- $(HOSTCFLAGS) -- $(HOSTSRCS) >>Make.dep
@@ -328,7 +328,7 @@ depend: .depend
 
 clean:
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" clean ; \
+		$(MAKE) -C board clean ; \
 	fi
 	$(call DELFILE, nuttx.ld)
 	$(call DELFILE, nuttx.rel)
@@ -338,7 +338,7 @@ clean:
 
 distclean: clean
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" distclean ; \
+		$(MAKE) -C board distclean ; \
 	fi
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -128,7 +128,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT)
 	@echo "LD: nuttx$(EXEEXT)"
@@ -155,7 +155,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile chip/Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -165,14 +165,14 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -123,7 +123,7 @@ $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): board/libboard$(LIBEXT)
 	@echo "LD: nuttx$(EXEEXT)"
@@ -150,7 +150,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile chip/Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -160,14 +160,14 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -114,7 +114,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx$(EXEEXT): $(STARTUP_OBJS) board/libboard$(LIBEXT)
 	@echo "LD: nuttx"
@@ -141,7 +141,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile chip/Make.defs $(SRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" depend
+	$(Q) $(MAKE) -C board depend
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common --dep-path $(ARCH_SUBDIR) \
 	 "$(CC)" -- $(CFLAGS) -- $(SRCS) >Make.dep
@@ -151,14 +151,14 @@ depend: .depend
 
 clean:
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C board clean
 endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
 ifeq ($(BOARDMAKE),y)
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C board distclean
 endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/z16/src/Makefile
+++ b/arch/z16/src/Makefile
@@ -79,7 +79,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 ifeq ($(COMPILER),zneocc.exe)
 nuttx.linkcmd: $(LINKCMDTEMPLATE)
@@ -111,10 +111,10 @@ nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT) nuttx.linkcmd
 
 .depend: Makefile chip/Make.defs $(DEPSRCS) $(TOPDIR)$(DELIM).config
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" depend )
+	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board depend )
 else
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
+		$(MAKE) -C board depend ; \
 	fi
 endif
 	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
@@ -140,10 +140,10 @@ depend: .depend
 
 clean:
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" clean )
+	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board clean )
 else
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" clean ; \
+		$(MAKE) -C board clean ; \
 	fi
 endif
 ifeq ($(COMPILER),zneocc.exe)
@@ -157,10 +157,10 @@ endif
 
 distclean: clean
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean )
+	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board distclean )
 else
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" distclean ; \
+		$(MAKE) -C board distclean ; \
 	fi
 endif
 	$(call DELFILE, Make.dep)

--- a/arch/z80/src/Makefile.sdccl
+++ b/arch/z80/src/Makefile.sdccl
@@ -149,7 +149,7 @@ libarch$(LIBEXT): asm_mem.h $(OBJS)
 # This builds the libboard library in the board/ subdirectory
 
 board/libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 # This target builds the final executable
 
@@ -209,7 +209,7 @@ export_startup: board/libboard$(LIBEXT) $(STARTUP_OBJS)
 
 .depend: Makefile asm_mem.h chip/Make.defs $(DEPSRCS) $(TOPDIR)$(DELIM).config
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
+		$(MAKE) -C board depend ; \
 	fi
 	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
 	$(Q) touch $@
@@ -218,7 +218,7 @@ depend: .depend
 
 clean:
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" clean ; \
+		$(MAKE) -C board clean ; \
 	fi
 	$(call DELFILE, asm_mem.h)
 	$(call DELFILE, nuttx.*)
@@ -227,7 +227,7 @@ clean:
 
 distclean: clean
 	$(Q) if [ -e board/Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" distclean ; \
+		$(MAKE) -C board distclean ; \
 	fi
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/z80/src/Makefile.sdccw
+++ b/arch/z80/src/Makefile.sdccw
@@ -149,7 +149,7 @@ libarch$(LIBEXT): asm_mem.h $(OBJS)
 # This builds the libboard library in the board\ subdirectory
 
 board\libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 # This target builds the final executable
 
@@ -202,21 +202,21 @@ export_startup: board\libboard$(LIBEXT) $(STARTUP_OBJS)
 # Build dependencies
 
 .depend: Makefile asm_mem.h chip\Make.defs $(DEPSRCS) $(TOPDIR)$(DELIM).config
-	$(Q) if exist board\Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" depend )
+	$(Q) if exist board\Makefile ( $(MAKE) -C board depend )
 	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
 	$(Q) touch $@
 
 depend: .depend
 
 clean:
-	$(Q) if exist board\Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" clean )
+	$(Q) if exist board\Makefile ( $(MAKE) -C board clean )
 	$(call DELFILE, asm_mem.h)
 	$(call DELFILE, nuttx.*)
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
 distclean: clean
-	$(Q) if exist board\Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean )
+	$(Q) if exist board\Makefile ( $(MAKE) -C board distclean )
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/z80/src/Makefile.zdsiil
+++ b/arch/z80/src/Makefile.zdsiil
@@ -101,7 +101,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board$(DELIM)libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx.linkcmd: $(LINKCMDTEMPLATE)
 	$(Q) cp -f $(LINKCMDTEMPLATE) nuttx.linkcmd
@@ -139,7 +139,7 @@ nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) nuttx.linkcmd
 
 .depend: Makefile chip$(DELIM)Make.defs $(DEPSRCS) $(TOPDIR)$(DELIM).config
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" depend ; \
+		$(MAKE) -C board depend ; \
 	fi
 	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
 	$(Q) touch $@
@@ -160,7 +160,7 @@ depend: .depend
 
 clean:
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" clean ; \
+		$(MAKE) -C board clean ; \
 	fi
 	$(call DELFILE, nuttx.linkcmd)
 	$(call DELFILE, *.asm)
@@ -171,7 +171,7 @@ clean:
 
 distclean: clean
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
-		$(MAKE) -C board TOPDIR="$(TOPDIR)" distclean ; \
+		$(MAKE) -C board distclean ; \
 	fi
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/z80/src/Makefile.zdsiiw
+++ b/arch/z80/src/Makefile.zdsiiw
@@ -92,7 +92,7 @@ libarch$(LIBEXT): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
 board$(DELIM)libboard$(LIBEXT):
-	$(Q) $(MAKE) -C board TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 nuttx.linkcmd: $(LINKCMDTEMPLATE)
 	$(Q) cp -f $(LINKCMDTEMPLATE) nuttx.linkcmd
@@ -127,7 +127,7 @@ nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) nuttx.linkcmd
 	$(Q) "$(LD)" $(LDFLAGS)
 
 .depend: Makefile chip$(DELIM)Make.defs $(DEPSRCS) $(TOPDIR)$(DELIM).config
-	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" depend )
+	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board depend )
 	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
 	$(Q) touch $@
 
@@ -141,7 +141,7 @@ export_startup: board$(DELIM)libboard$(LIBEXT) $(STARTUP_OBJS)
 depend: .depend
 
 clean:
-	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" clean )
+	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board clean )
 	$(call DELFILE, nuttx.linkcmd)
 	$(call DELFILE, *.asm)
 	$(call DELFILE, *.tmp)
@@ -150,7 +150,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
-	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board TOPDIR="$(TOPDIR)" distclean )
+	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board distclean )
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/boards/Makefile
+++ b/boards/Makefile
@@ -118,7 +118,7 @@ dirlinks: $(DUMMY_KCONFIG)
 
 context: $(DUMMY_KCONFIG)
 ifeq ($(BOARD_INSTALLED),y)
-	$(Q) $(MAKE) -C $(BOARDDIR) TOPDIR="$(TOPDIR)" context
+	$(Q) $(MAKE) -C $(BOARDDIR) context
 endif
 
 clean_context:

--- a/boards/arm/lpc31xx/ea3131/locked/Makefile
+++ b/boards/arm/lpc31xx/ea3131/locked/Makefile
@@ -84,7 +84,7 @@ ld-locked.inc: mklocked.sh $(TOPDIR)$(DELIM).config
 # is available to link against.
 
 $(PASS1_LIBBOARD):
-	$(Q) $(MAKE) -C $(TOPDIR)$(DELIM)boards$(DELIM)arm$(DELIM)lpc31xx$(DELIM)ea3131$(DELIM)src TOPDIR="$(TOPDIR)" libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C $(TOPDIR)$(DELIM)boards$(DELIM)arm$(DELIM)lpc31xx$(DELIM)ea3131$(DELIM)src libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 # Create the locked.r file containing all of the code (except the start-up code)
 # that needs to lie in the locked text region.

--- a/graphics/Makefile
+++ b/graphics/Makefile
@@ -58,57 +58,57 @@ all: mklibgraphics
 	 gen32bppsources
 
 gen1bppsources:
-	$(Q) $(MAKE) -C nxglib -f Makefile.devblit TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=1 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.devblit NXGLIB_BITSPERPIXEL=1 EXTRAFLAGS="$(EXTRAFLAGS)"
 ifeq ($(CONFIG_NX_RAMBACKED),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=1 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb NXGLIB_BITSPERPIXEL=1 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 gen2bppsource:
-	$(Q) $(MAKE) -C nxglib -f Makefile.devblit TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=2 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.devblit NXGLIB_BITSPERPIXEL=2 EXTRAFLAGS="$(EXTRAFLAGS)"
 ifeq ($(CONFIG_NX_RAMBACKED),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=2 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb NXGLIB_BITSPERPIXEL=2 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 gen4bppsource:
-	$(Q) $(MAKE) -C nxglib -f Makefile.devblit TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=4 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.devblit NXGLIB_BITSPERPIXEL=4 EXTRAFLAGS="$(EXTRAFLAGS)"
 ifeq ($(CONFIG_NX_RAMBACKED),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=4 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb NXGLIB_BITSPERPIXEL=4 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 gen8bppsource:
-	$(Q) $(MAKE) -C nxglib -f Makefile.devblit TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=8 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.devblit NXGLIB_BITSPERPIXEL=8 EXTRAFLAGS="$(EXTRAFLAGS)"
 ifeq ($(CONFIG_NX_RAMBACKED),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=8 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb NXGLIB_BITSPERPIXEL=8 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NX_SWCURSOR),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.cursor TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=8 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.cursor NXGLIB_BITSPERPIXEL=8 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 gen16bppsource:
-	$(Q) $(MAKE) -C nxglib -f Makefile.devblit TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=16 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.devblit NXGLIB_BITSPERPIXEL=16 EXTRAFLAGS="$(EXTRAFLAGS)"
 ifeq ($(CONFIG_NX_RAMBACKED),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=16 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb NXGLIB_BITSPERPIXEL=16 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NX_SWCURSOR),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.cursor TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=16 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.cursor NXGLIB_BITSPERPIXEL=16 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 gen24bppsource:
-	$(Q) $(MAKE) -C nxglib -f Makefile.devblit TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=24 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.devblit NXGLIB_BITSPERPIXEL=24 EXTRAFLAGS="$(EXTRAFLAGS)"
 ifeq ($(CONFIG_NX_RAMBACKED),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=24 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb NXGLIB_BITSPERPIXEL=24 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NX_SWCURSOR),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.cursor TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=24 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.cursor NXGLIB_BITSPERPIXEL=24 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 gen32bppsources:
-	$(Q) $(MAKE) -C nxglib -f Makefile.devblit TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=32 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.devblit NXGLIB_BITSPERPIXEL=32 EXTRAFLAGS="$(EXTRAFLAGS)"
 ifeq ($(CONFIG_NX_RAMBACKED),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=32 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb NXGLIB_BITSPERPIXEL=32 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NX_SWCURSOR),y)
-	$(Q) $(MAKE) -C nxglib -f Makefile.cursor TOPDIR=$(TOPDIR) NXGLIB_BITSPERPIXEL=32 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.cursor NXGLIB_BITSPERPIXEL=32 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 gensources: gen1bppsources gen2bppsource gen4bppsource gen8bppsource gen16bppsource gen24bppsource gen32bppsources
@@ -131,9 +131,9 @@ mklibgraphics: $(BIN)
 depend: .depend
 
 clean_context:
-	$(Q) $(MAKE) -C nxglib -f Makefile.devblit distclean TOPDIR=$(TOPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
-	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb distclean TOPDIR=$(TOPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
-	$(Q) $(MAKE) -C nxglib -f Makefile.cursor distclean TOPDIR=$(TOPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.devblit distclean EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.pwfb distclean EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxglib -f Makefile.cursor distclean EXTRAFLAGS="$(EXTRAFLAGS)"
 
 context: gensources
 

--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -137,21 +137,21 @@ $(COBJS): $(BINDIR)$(DELIM)%$(OBJEXT): %.c
 $(BIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 ifeq ($(CONFIG_LIB_ZONEINFO_ROMFS),y)
-	$(Q) $(MAKE) -C zoneinfo all TOPDIR=$(TOPDIR) BIN=$(BIN)
+	$(Q) $(MAKE) -C zoneinfo all BIN=$(BIN)
 endif
 
 # C library for the kernel phase of the two-pass kernel build
 
 ifneq ($(BIN),$(KBIN))
 $(KBIN):
-	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin TOPDIR=$(TOPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 # Context
 
 context:
 ifeq ($(CONFIG_LIB_ZONEINFO_ROMFS),y)
-	$(Q) $(MAKE) -C zoneinfo context TOPDIR=$(TOPDIR) BIN=$(BIN)
+	$(Q) $(MAKE) -C zoneinfo context BIN=$(BIN)
 endif
 
 # Dependencies
@@ -162,7 +162,7 @@ ifneq ($(CONFIG_BUILD_FLAT),y)
 	$(Q) $(MKDEP) --obj-path kbin --obj-suffix $(OBJEXT) $(DEPPATH) "$(CC)" -- $(CFLAGS) $(KDEFINE) -- $(SRCS) >kbin/Make.dep
 endif
 ifeq ($(CONFIG_LIB_ZONEINFO_ROMFS),y)
-	$(Q) $(MAKE) -C zoneinfo depend TOPDIR=$(TOPDIR) BIN=$(BIN)
+	$(Q) $(MAKE) -C zoneinfo depend BIN=$(BIN)
 endif
 	$(Q) touch $@
 
@@ -171,9 +171,9 @@ depend: .depend
 # Clean most derived files, retaining the configuration
 
 clean:
-	$(Q) $(MAKE) -C bin  clean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C kbin clean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C zoneinfo clean TOPDIR=$(TOPDIR) BIN=$(BIN)
+	$(Q) $(MAKE) -C bin  clean
+	$(Q) $(MAKE) -C kbin clean
+	$(Q) $(MAKE) -C zoneinfo clean BIN=$(BIN)
 	$(call DELFILE, $(BIN))
 	$(call DELFILE, $(KBIN))
 	$(call CLEAN)
@@ -181,9 +181,9 @@ clean:
 # Deep clean -- removes all traces of the configuration
 
 distclean: clean
-	$(Q) $(MAKE) -C bin  distclean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C kbin distclean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C zoneinfo distclean TOPDIR=$(TOPDIR) BIN=$(BIN)
+	$(Q) $(MAKE) -C bin  distclean
+	$(Q) $(MAKE) -C kbin distclean
+	$(Q) $(MAKE) -C zoneinfo distclean BIN=$(BIN)
 	$(call DELFILE, exec_symtab.c)
 	$(call DELFILE, bin/Make.dep)
 	$(call DELFILE, kbin/Make.dep)

--- a/libs/libnx/Makefile
+++ b/libs/libnx/Makefile
@@ -60,156 +60,156 @@ all: $(BIN)
 	 gen4bppsource gen8bppsource gen16bppsource gen24bppsource gen32bppsources genfontsources
 
 gen1bppsources:
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_BITSPERPIXEL=1 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_BITSPERPIXEL=1 EXTRAFLAGS="$(EXTRAFLAGS)"
 
 gen2bppsource:
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_BITSPERPIXEL=2 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_BITSPERPIXEL=2 EXTRAFLAGS="$(EXTRAFLAGS)"
 
 gen4bppsource:
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_BITSPERPIXEL=4 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_BITSPERPIXEL=4 EXTRAFLAGS="$(EXTRAFLAGS)"
 
 gen8bppsource:
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_BITSPERPIXEL=8 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_BITSPERPIXEL=8 EXTRAFLAGS="$(EXTRAFLAGS)"
 
 gen16bppsource:
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_BITSPERPIXEL=16 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_BITSPERPIXEL=16 EXTRAFLAGS="$(EXTRAFLAGS)"
 
 gen24bppsource:
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_BITSPERPIXEL=24 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_BITSPERPIXEL=24 EXTRAFLAGS="$(EXTRAFLAGS)"
 
 gen32bppsources:
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_BITSPERPIXEL=32 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_BITSPERPIXEL=32 EXTRAFLAGS="$(EXTRAFLAGS)"
 
 genfontsources:
 ifeq ($(CONFIG_NXFONT_MONO5X8),y)
-	@$(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=18 EXTRAFLAGS="$(EXTRAFLAGS)"
+	@$(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=18 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS23X27),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=1 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=1 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS22X29),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=2 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=2 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS28X37),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=3 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=3 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS39X48),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=4 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=4 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS17X23B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=16 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=16 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS20X27B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=17 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=17 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS22X29B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=5 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=5 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS28X37B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=6 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=6 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS40X49B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=7 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=7 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SERIF22X29),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=8 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=8 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SERIF29X37),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=9 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=9 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SERIF38X48),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=10 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=10 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SERIF22X28B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=11 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=11 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SERIF27X38B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=12 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=12 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SERIF38X49B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=13 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=13 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS17X22),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=14 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=14 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_SANS20X26),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=15 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=15 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_PIXEL_UNICODE),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=19 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=19 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_PIXEL_LCD_MACHINE),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=20 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=20 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_4X6),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=21 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=21 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_5X7),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=22 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=22 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_5X8),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=23 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=23 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_6X9),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=24 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=24 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_6X10),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=25 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=25 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_6X12),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=26 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=26 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_6X13),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=27 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=27 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_6X13B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=28 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=28 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_6X13O),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=29 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=29 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_7X13),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=30 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=30 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_7X13B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=31 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=31 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_7X13O),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=32 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=32 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_7X14),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=33 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=33 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_7X14B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=34 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=34 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_8X13),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=35 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=35 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_8X13B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=36 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=36 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_8X13O),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=37 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=37 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_9X15),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=38 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=38 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_9X15B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=39 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=39 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_9X18),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=40 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=40 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_9X18B),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=41 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=41 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 ifeq ($(CONFIG_NXFONT_X11_MISC_FIXED_10X20),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=42 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=42 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 ifeq ($(CONFIG_NXFONT_TOM_THUMB_4X6),y)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=43 EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=43 EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 gensources: gen1bppsources gen2bppsource gen4bppsource gen8bppsource gen16bppsource gen24bppsource gen32bppsources genfontsources
@@ -230,7 +230,7 @@ $(BIN): $(OBJS)
 
 ifneq ($(BIN),$(KBIN))
 $(KBIN):
-	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin TOPDIR=$(TOPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 # Dependencies
@@ -251,9 +251,9 @@ context: gensources
 # Clean most derived files, retaining the configuration
 
 clean:
-	$(Q) $(MAKE) -C bin  clean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C kbin clean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources clean TOPDIR=$(TOPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C bin  clean
+	$(Q) $(MAKE) -C kbin clean
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources clean EXTRAFLAGS="$(EXTRAFLAGS)"
 	$(call DELFILE, $(BIN))
 	$(call DELFILE, $(KBIN))
 	$(call CLEAN)
@@ -261,9 +261,9 @@ clean:
 # Deep clean -- removes all traces of the configuration
 
 distclean: clean
-	$(Q) $(MAKE) -C bin  distclean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C kbin distclean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C nxfonts -f Makefile.sources distclean TOPDIR=$(TOPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C bin  distclean
+	$(Q) $(MAKE) -C kbin distclean
+	$(Q) $(MAKE) -C nxfonts -f Makefile.sources distclean EXTRAFLAGS="$(EXTRAFLAGS)"
 	$(call DELFILE, bin/Make.dep)
 	$(call DELFILE, kbin/Make.dep)
 	$(call DELFILE, .depend)

--- a/libs/libnx/nxfonts/README.txt
+++ b/libs/libnx/nxfonts/README.txt
@@ -67,10 +67,10 @@ Installing New Fonts
 
        genfontsources:
          ifeq ($(CONFIG_NXFONT_SANS23X27),y)
-          @$(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=1 EXTRAFLAGS=$(EXTRAFLAGS)
+          @$(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=1 EXTRAFLAGS=$(EXTRAFLAGS)
         endif
          ifeq ($(CONFIG_NXFONT_MYFONT),y)
-          @$(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=2 EXTRAFLAGS=$(EXTRAFLAGS)
+          @$(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=2 EXTRAFLAGS=$(EXTRAFLAGS)
         endif
 
     6. nuttx/graphics/nxfonts/Make.defs.  Set the make variable NXFSET_CSRCS.

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -76,7 +76,7 @@ $(BIN):	$(OBJS)
 
 ifneq ($(BIN),$(KBIN))
 $(KBIN):
-	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin TOPDIR=$(TOPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 # Dependencies
@@ -93,8 +93,8 @@ depend: .depend
 # Clean most derived files, retaining the configuration
 
 clean:
-	$(Q) $(MAKE) -C bin  clean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C kbin clean TOPDIR=$(TOPDIR)
+	$(Q) $(MAKE) -C bin  clean
+	$(Q) $(MAKE) -C kbin clean
 	$(call DELFILE, $(BIN))
 	$(call DELFILE, $(KBIN))
 	$(call CLEAN)
@@ -102,8 +102,8 @@ clean:
 # Deep clean -- removes all traces of the configuration
 
 distclean: clean
-	$(Q) $(MAKE) -C bin  distclean TOPDIR=$(TOPDIR)
-	$(Q) $(MAKE) -C kbin distclean TOPDIR=$(TOPDIR)
+	$(Q) $(MAKE) -C bin  distclean
+	$(Q) $(MAKE) -C kbin distclean
 	$(call DELFILE, bin/Make.dep)
 	$(call DELFILE, kbin/Make.dep)
 	$(call DELFILE, .depend)

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -491,13 +491,13 @@ endif
 # Invoke make
 
 define MAKE_template
-	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"
+	+$(Q) $(MAKE) -C $(1) $(2) APPDIR="$(APPDIR)"
 
 endef
 
 define SDIR_template
 $(1)_$(2):
-	+$(Q) $(MAKE) -C $(1) $(2) TOPDIR="$(TOPDIR)" APPDIR="$(APPDIR)"
+	+$(Q) $(MAKE) -C $(1) $(2) APPDIR="$(APPDIR)"
 
 endef
 

--- a/tools/LibTargets.mk
+++ b/tools/LibTargets.mk
@@ -41,115 +41,115 @@
 # Possible kernel-mode builds
 
 libs$(DELIM)libc$(DELIM)libkc$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C libs$(DELIM)libc TOPDIR="$(TOPDIR)" libkc$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C libs$(DELIM)libc libkc$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libkc$(LIBEXT): libs$(DELIM)libc$(DELIM)libkc$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 libs$(DELIM)libnx$(DELIM)libknx$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C libs$(DELIM)libnx TOPDIR="$(TOPDIR)" libknx$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C libs$(DELIM)libnx libknx$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libknx$(LIBEXT): libs$(DELIM)libnx$(DELIM)libknx$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 mm$(DELIM)libkmm$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C mm TOPDIR="$(TOPDIR)" libkmm$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C mm libkmm$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libkmm$(LIBEXT): mm$(DELIM)libkmm$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 $(ARCH_SRC)$(DELIM)libkarch$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" libkarch$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C $(ARCH_SRC) libkarch$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libkarch$(LIBEXT): $(ARCH_SRC)$(DELIM)libkarch$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 pass1$(DELIM)libpass1$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C pass1 TOPDIR="$(TOPDIR)" libpass1$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C pass1 libpass1$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libpass1$(LIBEXT): pass1$(DELIM)libpass1$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 sched$(DELIM)libsched$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C sched TOPDIR="$(TOPDIR)" libsched$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C sched libsched$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libsched$(LIBEXT): sched$(DELIM)libsched$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 net$(DELIM)libnet$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C net TOPDIR="$(TOPDIR)" libnet$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C net libnet$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libnet$(LIBEXT): net$(DELIM)libnet$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 boards$(DELIM)libboards$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C boards TOPDIR="$(TOPDIR)" libboards$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C boards libboards$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libboards$(LIBEXT): boards$(DELIM)libboards$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 crypto$(DELIM)libcrypto$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C crypto TOPDIR="$(TOPDIR)" libcrypto$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C crypto libcrypto$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libcrypto$(LIBEXT): crypto$(DELIM)libcrypto$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 fs$(DELIM)libfs$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C fs TOPDIR="$(TOPDIR)" libfs$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C fs libfs$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libfs$(LIBEXT): fs$(DELIM)libfs$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 drivers$(DELIM)libdrivers$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C drivers TOPDIR="$(TOPDIR)" libdrivers$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C drivers libdrivers$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libdrivers$(LIBEXT): drivers$(DELIM)libdrivers$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 binfmt$(DELIM)libbinfmt$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C binfmt TOPDIR="$(TOPDIR)" libbinfmt$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C binfmt libbinfmt$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libbinfmt$(LIBEXT): binfmt$(DELIM)libbinfmt$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 graphics$(DELIM)libgraphics$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C graphics TOPDIR="$(TOPDIR)" libgraphics$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C graphics libgraphics$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libgraphics$(LIBEXT): graphics$(DELIM)libgraphics$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 audio$(DELIM)libaudio$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C audio TOPDIR="$(TOPDIR)" libaudio$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C audio libaudio$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libaudio$(LIBEXT): audio$(DELIM)libaudio$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 video$(DELIM)libvideo$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C video TOPDIR="$(TOPDIR)" libvideo$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C video libvideo$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libvideo$(LIBEXT): video$(DELIM)libvideo$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 wireless$(DELIM)libwireless$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C wireless TOPDIR="$(TOPDIR)" libwireless$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C wireless libwireless$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libwireless$(LIBEXT): wireless$(DELIM)libwireless$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 openamp$(DELIM)libopenamp$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C openamp TOPDIR="$(TOPDIR)" libopenamp$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C openamp libopenamp$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libopenamp$(LIBEXT): openamp$(DELIM)libopenamp$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 syscall$(DELIM)libstubs$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C syscall TOPDIR="$(TOPDIR)" libstubs$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C syscall libstubs$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libstubs$(LIBEXT): syscall$(DELIM)libstubs$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 syscall$(DELIM)libwraps$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C syscall TOPDIR="$(TOPDIR)" libwraps$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C syscall libwraps$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libwraps$(LIBEXT): syscall$(DELIM)libwraps$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
@@ -158,10 +158,10 @@ staging$(DELIM)libwraps$(LIBEXT): syscall$(DELIM)libwraps$(LIBEXT)
 
 ifeq ($(CONFIG_BUILD_FLAT),y)
 $(ARCH_SRC)$(DELIM)libarch$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" libarch$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C $(ARCH_SRC) libarch$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 else
 $(ARCH_SRC)$(DELIM)libarch$(LIBEXT): pass1dep
-	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" libarch$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C $(ARCH_SRC) libarch$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 staging$(DELIM)libarch$(LIBEXT): $(ARCH_SRC)$(DELIM)libarch$(LIBEXT)
@@ -174,7 +174,7 @@ libs$(DELIM)libc$(DELIM)libc$(LIBEXT): pass2dep
 else
 libs$(DELIM)libc$(DELIM)libc$(LIBEXT): pass1dep
 endif
-	$(Q) $(MAKE) -C libs$(DELIM)libc TOPDIR="$(TOPDIR)" libc$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C libs$(DELIM)libc libc$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 staging$(DELIM)libc$(LIBEXT): libs$(DELIM)libc$(DELIM)libc$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
@@ -184,7 +184,7 @@ libs$(DELIM)libnx$(DELIM)libnx$(LIBEXT): pass2dep
 else
 libs$(DELIM)libnx$(DELIM)libnx$(LIBEXT): pass1dep
 endif
-	$(Q) $(MAKE) -C libs$(DELIM)libnx TOPDIR="$(TOPDIR)" libnx$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C libs$(DELIM)libnx libnx$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 staging$(DELIM)libnx$(LIBEXT): libs$(DELIM)libnx$(DELIM)libnx$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
@@ -194,19 +194,19 @@ mm$(DELIM)libmm$(LIBEXT): pass2dep
 else
 mm$(DELIM)libmm$(LIBEXT): pass1dep
 endif
-	$(Q) $(MAKE) -C mm TOPDIR="$(TOPDIR)" libmm$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C mm libmm$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 staging$(DELIM)libmm$(LIBEXT): mm$(DELIM)libmm$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 libs$(DELIM)libxx$(DELIM)libxx$(LIBEXT): pass1dep
-	$(Q) $(MAKE) -C libs$(DELIM)libxx TOPDIR="$(TOPDIR)" libxx$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C libs$(DELIM)libxx libxx$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 staging$(DELIM)libxx$(LIBEXT): libs$(DELIM)libxx$(DELIM)libxx$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 libs$(DELIM)libdsp$(DELIM)libdsp$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C libs$(DELIM)libdsp TOPDIR="$(TOPDIR)" libdsp$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C libs$(DELIM)libdsp libdsp$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 staging$(DELIM)libdsp$(LIBEXT): libs$(DELIM)libdsp$(DELIM)libdsp$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
@@ -216,13 +216,13 @@ $(APPDIR)$(DELIM)libapps$(LIBEXT): pass2dep
 else
 $(APPDIR)$(DELIM)libapps$(LIBEXT): pass1dep
 endif
-	$(Q) $(MAKE) -C $(APPDIR) TOPDIR="$(TOPDIR)" EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C $(APPDIR) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 staging$(DELIM)libapps$(LIBEXT): $(APPDIR)$(DELIM)libapps$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 syscall$(DELIM)libproxies$(LIBEXT): pass1dep
-	$(Q) $(MAKE) -C syscall TOPDIR="$(TOPDIR)" libproxies$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C syscall libproxies$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
 staging$(DELIM)libproxies$(LIBEXT): syscall$(DELIM)libproxies$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)

--- a/tools/Makefile.host
+++ b/tools/Makefile.host
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-TOPDIR ?= $(CURDIR)/..
+export TOPDIR ?= $(CURDIR)/..
 -include $(TOPDIR)/Make.defs
 include ${TOPDIR}/tools/Config.mk
 
@@ -260,7 +260,7 @@ clean:
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) rm -rf *.dSYM
 endif
-	$(Q) $(MAKE) -C pic32 -f Makefile.host TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C pic32 -f Makefile.host clean
 	$(call DELFILE, incdir)
 	$(call DELFILE, incdir.exe)
 	$(call CLEAN)

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
+export TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
 include $(TOPDIR)/Make.defs
 
 # GIT directory present
@@ -215,7 +215,7 @@ endif
 # tools/mkversion tool is built and used to create include/nuttx/version.h
 
 tools/mkversion$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" mkversion$(HOSTEXEEXT)
+	$(Q) $(MAKE) -C tools -f Makefile.host mkversion$(HOSTEXEEXT)
 
 # [Re-]create .version if it doesn't already exist.
 
@@ -234,7 +234,7 @@ include/nuttx/version.h: $(TOPDIR)/.version tools/mkversion$(HOSTEXEEXT) .clean_
 # tools/mkconfig tool is built and used to create include/nuttx/config.h
 
 tools/mkconfig$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" mkconfig$(HOSTEXEEXT)
+	$(Q) $(MAKE) -C tools -f Makefile.host mkconfig$(HOSTEXEEXT)
 
 include/nuttx/config.h: $(TOPDIR)/.config tools/mkconfig$(HOSTEXEEXT) .clean_context
 	$(Q) tools/mkconfig $(TOPDIR) > $@.tmp
@@ -243,10 +243,10 @@ include/nuttx/config.h: $(TOPDIR)/.config tools/mkconfig$(HOSTEXEEXT) .clean_con
 # Targets used to create dependencies
 
 tools/mkdeps$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" mkdeps$(HOSTEXEEXT)
+	$(Q) $(MAKE) -C tools -f Makefile.host mkdeps$(HOSTEXEEXT)
 
 tools/cnvwindeps$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" cnvwindeps$(HOSTEXEEXT)
+	$(Q) $(MAKE) -C tools -f Makefile.host cnvwindeps$(HOSTEXEEXT)
 
 # dirlinks, and helpers
 #
@@ -313,10 +313,10 @@ ifneq ($(CONFIG_ARCH_CHIP),)
 endif
 
 dirlinks: include/arch include/arch/board include/arch/chip $(ARCH_SRC)/board $(ARCH_SRC)/chip drivers/platform
-	$(Q) $(MAKE) -C libs/libxx dirlinks TOPDIR="$(TOPDIR)"
-	$(Q) $(MAKE) -C boards dirlinks TOPDIR="$(TOPDIR)"
-	$(Q) $(MAKE) -C openamp dirlinks TOPDIR="$(TOPDIR)"
-	$(Q) $(MAKE) -C $(CONFIG_APPS_DIR) dirlinks TOPDIR="$(TOPDIR)"
+	$(Q) $(MAKE) -C libs/libxx dirlinks 
+	$(Q) $(MAKE) -C boards dirlinks 
+	$(Q) $(MAKE) -C openamp dirlinks
+	$(Q) $(MAKE) -C $(CONFIG_APPS_DIR) dirlinks 
 
 # context
 #
@@ -328,7 +328,7 @@ dirlinks: include/arch include/arch/board include/arch/chip $(ARCH_SRC)/board $(
 context: include/nuttx/config.h include/nuttx/version.h include/math.h include/float.h include/stdarg.h include/setjmp.h dirlinks
 	$(Q) mkdir -p staging
 	$(Q) for dir in $(CONTEXTDIRS) ; do \
-		$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" context || exit; \
+		$(MAKE) -C $$dir context || exit; \
 	done
 
 # clean_context
@@ -339,7 +339,7 @@ context: include/nuttx/config.h include/nuttx/version.h include/math.h include/f
 clean_context:
 	$(Q) for dir in $(CCLEANDIRS) ; do \
 		if [ -e $$dir/Makefile ]; then \
-			$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" clean_context ; \
+			$(MAKE) -C $$dir clean_context ; \
 		fi \
 	done
 	$(call DELFILE, include/nuttx/config.h)
@@ -396,9 +396,9 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 		echo "ERROR: No Makefile in CONFIG_PASS1_BUILDIR"; \
 		exit 1; \
 	fi
-	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
+	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
-	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
+	$(Q) $(MAKE) -C $(ARCH_SRC) EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f $(BIN) /tftpboot/$(BIN).${CONFIG_ARCH}; \
 	fi
@@ -439,12 +439,12 @@ download: $(BIN)
 
 pass1dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
 	$(Q) for dir in $(USERDEPDIRS) ; do \
-		$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" depend || exit; \
+		$(MAKE) -C $$dir depend || exit; \
 	done
 
 pass2dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
 	$(Q) for dir in $(KERNDEPDIRS) ; do \
-		$(MAKE) -C $$dir TOPDIR="$(TOPDIR)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend || exit; \
+		$(MAKE) -C $$dir EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend || exit; \
 	done
 
 # Configuration targets
@@ -524,7 +524,7 @@ $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
 
 subdir_clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
 ifeq ($(CONFIG_BUILD_2PASS),y)
-	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) clean
 endif
 
 clean: subdir_clean
@@ -545,7 +545,7 @@ subdir_distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
 
 distclean: clean subdir_distclean clean_context
 ifeq ($(CONFIG_BUILD_2PASS),y)
-	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) distclean
 endif
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
@@ -562,7 +562,7 @@ endif
 	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board
 	$(Q) $(DIRUNLINK) $(ARCH_SRC)/chip
 	$(Q) $(DIRUNLINK) $(TOPDIR)/drivers/platform
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C tools -f Makefile.host clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps/ directory is included with NuttX,
@@ -580,15 +580,15 @@ endif
 
 apps_preconfig: dirlinks
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C $(APPDIR) TOPDIR="$(TOPDIR)" preconfig
+	$(Q) $(MAKE) -C $(APPDIR) preconfig
 endif
 
 apps_clean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C $(APPDIR) TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C $(APPDIR) clean
 endif
 
 apps_distclean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C $(APPDIR) TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C $(APPDIR) distclean
 endif

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -20,7 +20,7 @@
 
 export SHELL=cmd
 
-TOPDIR := ${shell echo %CD%}
+export TOPDIR := ${shell echo %CD%}
 include $(TOPDIR)\Make.defs
 -include $(TOPDIR)\.version
 
@@ -200,7 +200,7 @@ endif
 # tools\mkversion tool is built and used to create include\nuttx\version.h
 
 tools\mkversion$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" mkversion$(HOSTEXEEXT)
+	$(Q) $(MAKE) -C tools -f Makefile.host mkversion$(HOSTEXEEXT)
 
 $(TOPDIR)\.version:
 	$(Q) echo CONFIG_VERSION_STRING="0" > .version
@@ -217,7 +217,7 @@ include\nuttx\version.h: $(TOPDIR)\.version tools\mkversion$(HOSTEXEEXT) .clean_
 # tools\mkconfig tool is built and used to create include\nuttx\config.h
 
 tools\mkconfig$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" mkconfig$(HOSTEXEEXT)
+	$(Q) $(MAKE) -C tools -f Makefile.host mkconfig$(HOSTEXEEXT)
 
 include\nuttx\config.h: $(TOPDIR)\.config tools\mkconfig$(HOSTEXEEXT) .clean_context
 	$(Q) tools\mkconfig$(HOSTEXEEXT) $(TOPDIR) > include\nuttx\config.h
@@ -225,7 +225,7 @@ include\nuttx\config.h: $(TOPDIR)\.config tools\mkconfig$(HOSTEXEEXT) .clean_con
 # Targets used to create dependencies
 
 tools\mkdeps$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" mkdeps$(HOSTEXEEXT)
+	$(Q) $(MAKE) -C tools -f Makefile.host mkdeps$(HOSTEXEEXT)
 
 # dirlinks, and helpers
 #
@@ -292,10 +292,10 @@ ifneq ($(CONFIG_ARCH_CHIP),)
 endif
 
 dirlinks: include\arch include\arch\board include\arch\chip $(ARCH_SRC)\board $(ARCH_SRC)\chip drivers\platform
-	$(Q) $(MAKE) -C libs/libxx dirlinks TOPDIR="$(TOPDIR)"
-	$(Q) $(MAKE) -C boards dirlinks TOPDIR="$(TOPDIR)"
-	$(Q) $(MAKE) -C openamp dirlinks TOPDIR="$(TOPDIR)"
-	$(Q) $(MAKE) -C $(CONFIG_APPS_DIR) dirlinks TOPDIR="$(TOPDIR)"
+	$(Q) $(MAKE) -C libs/libxx dirlinks 
+	$(Q) $(MAKE) -C boards dirlinks 
+	$(Q) $(MAKE) -C openamp dirlinks
+	$(Q) $(MAKE) -C $(CONFIG_APPS_DIR) dirlinks
 
 # context
 #
@@ -306,7 +306,7 @@ dirlinks: include\arch include\arch\board include\arch\chip $(ARCH_SRC)\board $(
 
 context: include\nuttx\config.h include\nuttx\version.h include\math.h include\float.h include\stdarg.h include\setjmp.h dirlinks
 	$(Q) mkdir -p staging
-	$(Q) for %%G in ($(CONTEXTDIRS)) do ( $(MAKE) -C %%G TOPDIR="$(TOPDIR)" context )
+	$(Q) for %%G in ($(CONTEXTDIRS)) do ( $(MAKE) -C %%G context )
 
 # clean_context
 #
@@ -314,7 +314,7 @@ context: include\nuttx\config.h include\nuttx\version.h include\math.h include\f
 # and symbolic links created by the context target.
 
 clean_context:
-	$(Q) for %%G in ($(CCLEANDIRS)) do ( if exist %%G\Makefile $(MAKE) -C %%G TOPDIR="$(TOPDIR)" clean_context )
+	$(Q) for %%G in ($(CCLEANDIRS)) do ( if exist %%G\Makefile $(MAKE) -C %%G clean_context )
 	$(call DELFILE, include\nuttx\config.h)
 	$(call DELFILE, include\nuttx\version.h)
 	$(call DELFILE, include\float.h)
@@ -367,9 +367,9 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 		echo "ERROR: No Makefile in CONFIG_PASS1_BUILDIR"; \
 		exit 1; \
 	fi
-	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
+	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
-	$(Q) $(MAKE) -C $(ARCH_SRC) TOPDIR="$(TOPDIR)" EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
+	$(Q) $(MAKE) -C $(ARCH_SRC) EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: $(NUTTXNAME).hex"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(NUTTXNAME).hex
@@ -398,10 +398,10 @@ download: $(BIN)
 # pass2dep: Create pass2 build dependencies
 
 pass1dep: context tools\mkdeps$(HOSTEXEEXT)
-	$(Q) for %%G in ($(USERDEPDIRS)) do ( $(MAKE) -C %%G TOPDIR="$(TOPDIR)" depend )
+	$(Q) for %%G in ($(USERDEPDIRS)) do ( $(MAKE) -C %%G depend )
 
 pass2dep: context tools\mkdeps$(HOSTEXEEXT)
-	$(Q) for %%G in ($(KERNDEPDIRS)) do ( $(MAKE) -C %%G TOPDIR="$(TOPDIR)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend )
+	$(Q) for %%G in ($(KERNDEPDIRS)) do ( $(MAKE) -C %%G EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend )
 
 # Configuration targets
 #
@@ -474,7 +474,7 @@ $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),clean)))
 
 subdir_clean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_clean)
 ifeq ($(CONFIG_BUILD_2PASS),y)
-	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) clean
 endif
 
 clean: subdir_clean
@@ -495,7 +495,7 @@ subdir_distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
 
 distclean: clean subdir_distclean clean_context
 ifeq ($(CONFIG_BUILD_2PASS),y)
-	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) distclean
 endif
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
@@ -511,7 +511,7 @@ endif
 	$(call DIRUNLINK, $(ARCH_SRC)\board)
 	$(call DIRUNLINK, $(ARCH_SRC)\chip)
 	$(call DIRUNLINK, $(TOPDIR)\drivers\platform)
-	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C tools -f Makefile.host clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps\ directory is included with NuttX,
@@ -529,15 +529,15 @@ endif
 
 apps_preconfig: dirlinks
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(APPDIR)" TOPDIR="$(TOPDIR)" preconfig
+	$(Q) $(MAKE) -C "$(APPDIR)" preconfig
 endif
 
 apps_clean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(APPDIR)" TOPDIR="$(TOPDIR)" clean
+	$(Q) $(MAKE) -C "$(APPDIR)" clean
 endif
 
 apps_distclean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(APPDIR)" TOPDIR="$(TOPDIR)" distclean
+	$(Q) $(MAKE) -C "$(APPDIR)" distclean
 endif

--- a/tools/README.txt
+++ b/tools/README.txt
@@ -414,10 +414,10 @@ bdf-convert.c
 
        genfontsources:
          ifeq ($(CONFIG_NXFONT_SANS23X27),y)
-          @$(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=1 EXTRAFLAGS=$(EXTRAFLAGS)
+          @$(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=1 EXTRAFLAGS=$(EXTRAFLAGS)
         endif
          ifeq ($(CONFIG_NXFONT_MYFONT),y)
-          @$(MAKE) -C nxfonts -f Makefile.sources TOPDIR=$(TOPDIR) NXFONTS_FONTID=2 EXTRAFLAGS=$(EXTRAFLAGS)
+          @$(MAKE) -C nxfonts -f Makefile.sources NXFONTS_FONTID=2 EXTRAFLAGS=$(EXTRAFLAGS)
         endif
 
     6. nuttx/libnx/nxfonts/Make.defs.  Set the make variable NXFSET_CSRCS.


### PR DESCRIPTION
## Summary

The "export" keyword can be used in make to have all child `$(MAKE)` calls have the variable defined without having to manually pass it via command line. Since `TOPDIR` is needed everywhere, this removes the need to pass it around all the time.

## Impact

Build

## Testing

Built locally