### PR TITLE
support building external code into the OS, similar to how "external" apps work

### DIFF
--- a/.external-dummy/Kconfig
+++ b/.external-dummy/Kconfig
@@ -1,0 +1,1 @@
+# This is supposed to be empty

--- a/.external-dummy/README.md
+++ b/.external-dummy/README.md
@@ -1,0 +1,2 @@
+This directory exists to hold an empty Kconfig which is used
+when no nuttx/external is present.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@
 core
 Make*.dep
 uImage
+/external

--- a/Kconfig
+++ b/Kconfig
@@ -1826,3 +1826,15 @@ endmenu
 menu "Application Configuration"
 source "$APPSDIR/Kconfig"
 endmenu
+
+# Support optionally including external code
+# into the OS build. EXTERNALDIR will be used
+# to either point to 'nuttx/external' or
+# 'nuttx/.external-dummy', if 'nuttx/external'
+# does not contain a Kconfig file
+
+config EXTERNALDIR
+        string
+        option env="EXTERNALDIR"
+
+source "$EXTERNALDIR/Kconfig"

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -72,6 +72,11 @@ endif
 
 KERNDEPDIRS += sched drivers boards $(ARCH_SRC)
 KERNDEPDIRS += fs binfmt
+
+ifeq ($(EXTERNALDIR),external)
+  KERNDEPDIRS += external
+endif
+
 CONTEXTDIRS = boards fs $(APPDIR)
 CLEANDIRS += pass1
 

--- a/tools/FlatLibs.mk
+++ b/tools/FlatLibs.mk
@@ -48,6 +48,12 @@ USERLIBS =
 
 NUTTXLIBS += staging$(DELIM)libdrivers$(LIBEXT)
 
+# External code support
+
+ifeq ($(EXTERNALDIR),external)
+  NUTTXLIBS += staging$(DELIM)libexternal$(LIBEXT)
+endif
+
 # Add libraries for board support
 
 NUTTXLIBS += staging$(DELIM)libboards$(LIBEXT)

--- a/tools/KernelLibs.mk
+++ b/tools/KernelLibs.mk
@@ -47,6 +47,12 @@ USERLIBS =
 
 NUTTXLIBS += staging$(DELIM)libdrivers$(LIBEXT)
 
+# External code support
+
+ifeq ($(EXTERNALDIR),external)
+  NUTTXLIBS += staging$(DELIM)libexternal$(LIBEXT)
+endif
+
 # Add libraries for board support
 
 NUTTXLIBS += staging$(DELIM)libboards$(LIBEXT)

--- a/tools/LibTargets.mk
+++ b/tools/LibTargets.mk
@@ -106,6 +106,12 @@ drivers$(DELIM)libdrivers$(LIBEXT): pass2dep
 staging$(DELIM)libdrivers$(LIBEXT): drivers$(DELIM)libdrivers$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
+external$(DELIM)libexternal$(LIBEXT): pass2dep
+	$(Q) $(MAKE) -C external libexternal$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+
+staging$(DELIM)libexternal$(LIBEXT): external$(DELIM)libexternal$(LIBEXT)
+	$(Q) $(call INSTALL_LIB,$<,$@)
+
 binfmt$(DELIM)libbinfmt$(LIBEXT): pass2dep
 	$(Q) $(MAKE) -C binfmt TOPDIR="$(TOPDIR)" libbinfmt$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -63,6 +63,13 @@ CONFIG_APPS_DIR = ../apps
 endif
 APPDIR := $(realpath ${shell if [ -r $(CONFIG_APPS_DIR)/Makefile ]; then echo "$(CONFIG_APPS_DIR)"; fi})
 
+# External code support
+# If external/ contains a Kconfig, we define the EXTERNALDIR variable to 'external'
+# so that main Kconfig can find it. Otherwise, we redirect it to a dummy Kconfig
+# This is due to kconfig inability to do conditional inclusion.
+
+EXTERNALDIR := $(shell if [ -r $(TOPDIR)/external/Kconfig ]; then echo 'external'; else echo '.external-dummy'; fi)
+
 # CONTEXTDIRS include directories that have special, one-time pre-build
 #   requirements.  Normally this includes things like auto-generation of
 #   configuration specific files or creation of configurable symbolic links
@@ -455,28 +462,28 @@ pass2dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
 # file in the NuttX tools GIT repository for additional information.
 
 config: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} kconfig-conf Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf Kconfig
 
 oldconfig: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} kconfig-conf --oldconfig Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --oldconfig Kconfig
 
 olddefconfig: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} kconfig-conf --olddefconfig Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --olddefconfig Kconfig
 
 menuconfig: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} kconfig-mconf Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-mconf Kconfig
 
 nconfig: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} kconfig-nconf Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-nconf Kconfig
 
 qconfig: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} kconfig-qconf Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-qconf Kconfig
 
 gconfig: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} kconfig-gconf Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-gconf Kconfig
 
 savedefconfig: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} kconfig-conf --savedefconfig defconfig.tmp Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --savedefconfig defconfig.tmp Kconfig
 	$(Q) sed -i -e "/CONFIG_APPS_DIR=/d" defconfig.tmp
 	$(Q) grep "CONFIG_ARCH=" .config >> defconfig.tmp
 	$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp; true

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -48,6 +48,13 @@ CONFIG_APPS_DIR = ..\apps
 endif
 APPDIR := $(realpath ${shell if exist "$(CONFIG_APPS_DIR)\Makefile" echo $(CONFIG_APPS_DIR)})
 
+# External code support
+# If external/ contains a Kconfig, we define the EXTERNALDIR variable to 'external'
+# so that main Kconfig can find it. Otherwise, we redirect it to a dummy Kconfig
+# This is due to kconfig inability to do conditional inclusion.
+
+EXTERNALDIR := $(shell if [ -r $(TOPDIR)\external\Kconfig ]; then echo 'external'; else echo '.external-dummy'; fi)
+
 # CONTEXTDIRS include directories that have special, one-time pre-build
 #   requirements.  Normally this includes things like auto-generation of
 #   configuration specific files or creation of configurable symbolic links
@@ -411,22 +418,22 @@ pass2dep: context tools\mkdeps$(HOSTEXEEXT)
 # misc\tools\README.txt for additional information.
 
 config: apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& kconfig-conf Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf Kconfig
 
 oldconfig: apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& kconfig-conf --oldconfig Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --oldconfig Kconfig
 
 olddefconfig: apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& kconfig-conf --olddefconfig Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --olddefconfig Kconfig
 
 menuconfig: configenv apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& kconfig-mconf Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-mconf Kconfig
 
 nconfig: apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& kconfig-nconf Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-nconf Kconfig
 
 savedefconfig: apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& kconfig-conf --savedefconfig defconfig.tmp Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --savedefconfig defconfig.tmp Kconfig
 	$(Q) sed -i -e "/CONFIG_APPS_DIR=/d" defconfig.tmp
 	$(Q) grep "CONFIG_ARCH=" .config >> defconfig.tmp
 	-$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp

--- a/tools/ProtectedLibs.mk
+++ b/tools/ProtectedLibs.mk
@@ -48,6 +48,12 @@ USERLIBS =
 
 NUTTXLIBS += staging$(DELIM)libdrivers$(LIBEXT)
 
+# External code support
+
+ifeq ($(EXTERNALDIR),external)
+  NUTTXLIBS += staging$(DELIM)libexternal$(LIBEXT)
+endif
+
 # Add libraries for board support
 
 NUTTXLIBS += staging$(DELIM)libboards$(LIBEXT)


### PR DESCRIPTION
## Summary

This works by having the build system look for nuttx/external/Kconfig
to determine whether this directory is present or not. nuttx/external
is gitignored in order to be added by the final user but not to be
commited into the repo. Tipically this will by a symbolic link, just like
apps/external.

Inside external/ a Makefile should be placed with the same structure
than any nuttx/ subdirectory (eg: nuttx/drivers/). The
nuttx/external/Kconfig will be sourced and any options defined there will
appear at the bottom of menuconfig (unless options are conditioned on
menus, in which case they will appear accordingly).

The purpose is to allow arch/board independent code, which for any
reason is not to be upstreamed (propietary, not relevant for mainline,
testing, etc), to be built into the OS during OS building stage. This
way the user does not need to fork the NuttX repo to do so. This feature
complements well with external apps and custom board support.

## Impact

This is implemented by extending the build to consider one extra subdirectory
`external` depending on if `external/Kconfig` is present. The build process for
this directory will be the same as for any of the nuttx top-level subdirectories.

There's one tricky part which is that as Kconfig cannot conditionally include a
file, in order to include include external/Kconfig when it exists, a similar strategy
that is used for including ../apps/Kconfig is used. This works by defining an environment
variable `EXTERNALDIR` which is set to `external` (when external/Kconfig exists)
or to `.external-dummy` (if not). Inside this directory there's an empty Kconfig which
will then be included when `external` is not present.
This strategy avoids the need for autogenerated Kconfig file, as it is done for `apps/Kconfig`
and thus I think it is a bit cleaner.

## Testing

I tested building either with external and without it and it works correctly. Also,
Kconfig options are exposed as expected.

