### PR TITLE
nRF: Allow configuration of non connected GPIO 

### DIFF
--- a/arch/arm/src/nrf52/nrf52_gpio.c
+++ b/arch/arm/src/nrf52/nrf52_gpio.c
@@ -177,6 +177,13 @@ int nrf52_gpio_config(nrf52_pinset_t cfgset)
   unsigned int port;
   unsigned int pin;
 
+  /* Check if the "pin" is disabled */
+
+  if ((cfgset & GPIO_FUNC_MASK) == GPIO_DISABLED)
+    {
+      return OK;
+    }
+
   /* Verify that this hardware supports the select GPIO port */
 
   port = (cfgset & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT;
@@ -232,6 +239,11 @@ int nrf52_gpio_unconfig(nrf52_pinset_t cfgset)
   unsigned int port;
   uint32_t offset;
 
+  if ((cfgset & GPIO_FUNC_MASK) == GPIO_DISABLED)
+    {
+      return OK;
+    }
+
   /* Get port and pin number */
 
   pin  = GPIO_PIN_DECODE(cfgset);
@@ -261,6 +273,11 @@ void nrf52_gpio_write(nrf52_pinset_t pinset, bool value)
   unsigned int pin;
   unsigned int port;
   uint32_t offset;
+
+  if ((pinset & GPIO_FUNC_MASK) == GPIO_DISABLED)
+    {
+      return;
+    }
 
   /* Get port and pin number */
 
@@ -297,6 +314,11 @@ bool nrf52_gpio_read(nrf52_pinset_t pinset)
   unsigned int pin;
   uint32_t regval;
   uint32_t offset;
+
+  if ((pinset & GPIO_FUNC_MASK) == GPIO_DISABLED)
+    {
+      return false;
+    }
 
   /* Get port and pin number */
 

--- a/arch/arm/src/nrf52/nrf52_gpio.h
+++ b/arch/arm/src/nrf52/nrf52_gpio.h
@@ -77,6 +77,7 @@
 #define GPIO_FUNC_MASK          (0x03 << GPIO_FUNC_SHIFT)
 #  define GPIO_INPUT            (0x00 << GPIO_FUNC_SHIFT)  /* 00000 GPIO input pin */
 #  define GPIO_OUTPUT           (0x01 << GPIO_FUNC_SHIFT)  /* 00001 GPIO output pin */
+#  define GPIO_DISABLED         (0x02 << GPIO_FUNC_SHIFT)  /* 00010 GPIO disabled pin */
 
 /* Pin Sense bits:
  *


### PR DESCRIPTION
## Summary
This adds a new GPIO functional mode GPIO_DISABLED where
pins for hardware like the SPI controller can be defined
but not connected to physical pin.

This also implements this feature in the nRF SPIM driver
and was tested leaving the MISO pin disconnected.

## Impact
Right now is it really hard to not bring out all pins for a hardware block even if they are not used.  In my use case I need to use the SPI driver to control and LED driver, but it is used only as a single IO pin.  I still have to bring out the CLK (SPIM docs clarify this) but I no longer have to waste a physical pin.

## Testing
Was able to drive the LED controller with out SCK and MOSI connected to pins.

```
#define BOARD_SPI1_SCK_PIN (GPIO_OUTPUT | GPIO_VALUE_ZERO | GPIO_PORT0 | GPIO_PIN(16))
#define BOARD_SPI1_MOSI_PIN (GPIO_OUTPUT | GPIO_VALUE_ZERO | GPIO_PORT0 | GPIO_PIN(7))
#define BOARD_SPI1_MISO_PIN (GPIO_DISABLED)
```
