### PR TITLE
Fix cxd56 uart deadlock

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_serial.c
+++ b/arch/arm/src/cxd56xx/cxd56_serial.c
@@ -996,7 +996,7 @@ static void up_txint(FAR struct uart_dev_s *dev, bool enable)
   FAR struct up_dev_s *priv = (FAR struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = enter_critical_section();
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1016,7 +1016,7 @@ static void up_txint(FAR struct uart_dev_s *dev, bool enable)
       up_serialout(priv, CXD56_UART_IMSC, priv->ier);
     }
 
-  spin_unlock_irqrestore(flags);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
- This commit fixes a deadlock problem in up_txint() for cxd56xx.
- Because uart_xmitchars() called by up_txint() takes a lock by enter_critical_section(), taking a spinlock here can cause a deadlock.

## Impact
- This commit affects the cxd56_serial driver in SMP mode only.

## Testing
- Tested with spresense:smp
