### PR TITLE
Rename note_add to sched_note_add in sched_note_irqhandler()

### DIFF
--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -607,6 +607,7 @@ void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
 
   /* Add the note to circular buffer */
 
-  note_add((FAR const uint8_t *)&note, sizeof(struct note_irqhandler_s));
+  sched_note_add((FAR const uint8_t *)&note,
+                 sizeof(struct note_irqhandler_s));
 }
 #endif


### PR DESCRIPTION
## Summary
- #1747 forgot to rename in sched_note_irqhandler(). This commit fixes it.

## Impact

## Testing

