### PR TITLE
fs: rename the mountpoint should go through pseudorename branch

### DIFF
--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -513,7 +513,7 @@ int rename(FAR const char *oldpath, FAR const char *newpath)
 #ifndef CONFIG_DISABLE_MOUNTPOINT
   /* Verify that the old inode is a valid mountpoint. */
 
-  if (INODE_IS_MOUNTPT(oldinode))
+  if (INODE_IS_MOUNTPT(oldinode) && *olddesc.relpath != '\0')
     {
       ret = mountptrename(oldpath, oldinode, olddesc.relpath, newpath);
     }


### PR DESCRIPTION
## Summary
to avoid this type of error:
mount -t procfs /a/b
mv /a/b /
mv: rename failed: 88

## Impact

## Testing

