### PR TITLE
vfs: opendir shouldn't remove the trailing whitespace or '/'

### DIFF
--- a/fs/dirent/fs_opendir.c
+++ b/fs/dirent/fs_opendir.c
@@ -26,7 +26,6 @@
 
 #include <stdbool.h>
 #include <string.h>
-#include <ctype.h>
 #include <dirent.h>
 #include <assert.h>
 #include <errno.h>
@@ -217,51 +216,7 @@ FAR DIR *opendir(FAR const char *path)
 #ifndef CONFIG_DISABLE_MOUNTPOINT
   FAR const char *relpath = NULL;
 #endif
-  FAR char *alloc = NULL;
-  int len;
   int ret;
-
-  /* Strip off any trailing whitespace or '/' characters.  In this case we
-   * must make a copy of the user string so we can chop off bytes on the
-   * 'right' without modifying the user's const string.
-   */
-
-  if (path != NULL)
-    {
-      /* Length of the string excludes NUL terminator */
-
-      len = strlen(path);
-
-      /* Check for whitespace or a dangling '/' at the end of the string.
-       * But don't muck with the string any further if it has been reduced
-       * to "/"
-       */
-
-      while (len > 0 && strcmp(path, "/") != 0 &&
-             (isspace(path[len - 1]) || path[len - 1] == '/'))
-        {
-          /* Have we already allocated memory for the modified string? */
-
-          if (alloc == NULL)
-            {
-              alloc = strdup(path); /* Allocates one too many bytes */
-              if (alloc == NULL)
-                {
-                  ret = ENOMEM;
-                  goto errout;
-                }
-
-              /* Use the cloned, writable string instead of the user string */
-
-              path = alloc;
-            }
-
-          /* Chop off the final character */
-
-          len--;
-          alloc[len] = '\0';
-        }
-    }
 
   /* If we are given 'nothing' then we will interpret this as
    * request for the root inode.
@@ -273,7 +228,7 @@ FAR DIR *opendir(FAR const char *path)
   if (ret < 0)
     {
       ret = -ret;
-      goto errout_with_alloc;
+      goto errout;
     }
 
   /* We don't know what to do with relative paths */
@@ -375,14 +330,6 @@ FAR DIR *opendir(FAR const char *path)
 
   RELEASE_SEARCH(&desc);
   inode_semgive();
-
-  /* Free any allocated string memory */
-
-  if (alloc != NULL)
-    {
-      kmm_free(alloc);
-    }
-
   return ((FAR DIR *)dir);
 
   /* Nasty goto's make error handling simpler */
@@ -393,15 +340,6 @@ errout_with_direntry:
 errout_with_semaphore:
   RELEASE_SEARCH(&desc);
   inode_semgive();
-
-errout_with_alloc:
-
-  /* Free any allocated string memory */
-
-  if (alloc != NULL)
-    {
-      kmm_free(alloc);
-    }
 
 errout:
   set_errno(ret);

--- a/fs/fat/fs_fat32dirent.c
+++ b/fs/fat/fs_fat32dirent.c
@@ -2656,6 +2656,11 @@ int fat_finddirentry(FAR struct fat_mountpt_s *fs,
           return -ENOTDIR;
         }
 
+      if (*path == '\0')
+        {
+          return OK;
+        }
+
       /* Get the cluster number of this directory */
 
       cluster =


### PR DESCRIPTION
## Summary
because:
1.The name of directory may terminated by the whitespace
2.inode_search can handle the trailing '/' correctly

## Impact

## Testing

