### PR TITLE
mmcsd: Allow setting ID Mode SPI frequency vi Kconfig

### DIFF
--- a/drivers/mmcsd/Kconfig
+++ b/drivers/mmcsd/Kconfig
@@ -92,6 +92,14 @@ config MMCSD_SPIMODE
 	---help---
 		Should be mode 0.  However, sometimes this is useful for experimenting.
 
+config MMCSD_IDMODE_CLOCK
+	int "MMC/SD ID Mode SPI clock"
+	default 400000
+	depends on MMCSD_SPI
+	---help---
+		SPI clock identify MMC/SD card.
+		Should be 400KHz or less.
+
 endif
 
 config SDIO_DMA

--- a/drivers/mmcsd/mmcsd_spi.c
+++ b/drivers/mmcsd/mmcsd_spi.c
@@ -54,27 +54,10 @@
 
 /* Configuration ************************************************************/
 
-#ifndef CONFIG_MMCSD_NSLOTS
-#  ifdef CONFIG_CPP_HAVE_WARNING
-#    warning "CONFIG_MMCSD_NSLOTS not defined"
-#  endif
-#  define CONFIG_MMCSD_NSLOTS 1
-#endif
-
-#define MMCSD_IDMODE_CLOCK           (400000)
-
 #if !defined(CONFIG_MMCSD_READONLY)
 #  define MMCSD_MODE 0666
 #else
 #  define MMCSD_MODE 0444
-#endif
-
-#ifndef CONFIG_MMCSD_SPICLOCK
-#  define CONFIG_MMCSD_SPICLOCK 20000000
-#endif
-
-#ifndef CONFIG_MMCSD_SPIMODE
-#  define CONFIG_MMCSD_SPIMODE SPIDEV_MODE0
 #endif
 
 #ifndef CONFIG_MMCSD_SECTOR512
@@ -1656,8 +1639,8 @@ static int mmcsd_mediainitialize(FAR struct mmcsd_slot_s *slot)
 
   /* Clock Freq. Identification Mode < 400kHz */
 
-  slot->spispeed = MMCSD_IDMODE_CLOCK;
-  SPI_SETFREQUENCY(spi, MMCSD_IDMODE_CLOCK);
+  slot->spispeed = CONFIG_MMCSD_IDMODE_CLOCK;
+  SPI_SETFREQUENCY(spi, CONFIG_MMCSD_IDMODE_CLOCK);
 
   /* Set the maximum access time out */
 
@@ -2034,7 +2017,7 @@ int mmcsd_spislotinitialize(int minor, int slotno, FAR struct spi_dev_s *spi)
   /* Bind the SPI port to the slot */
 
   slot->spi      = spi;
-  slot->spispeed = MMCSD_IDMODE_CLOCK;
+  slot->spispeed = CONFIG_MMCSD_IDMODE_CLOCK;
 
   /* Get exclusive access to the SPI bus and make sure that SPI is properly
    * configured for the MMC/SD card


### PR DESCRIPTION
## Summary
The SPI frequency of `IDMODE_CLOCK` clock for SPI was hard coded.  This change keeps the default of 400KHz, but allows for it to be overwritten via Kconfig.

## Impact
Allow setting alternative clock rates.

## Testing
Verified on nRF52 platform at a rate of 250kHZ.
