### PR TITLE
nRF: Add missing Kconfig entry for SPI2_MASTER

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -139,6 +139,11 @@ config NRF52_SPI1_MASTER
 	default n
 	select NRF52_SPI_MASTER
 
+config NRF52_SPI2_MASTER
+	bool "SPI2 Master"
+	default n
+	select NRF52_SPI_MASTER
+
 config NRF52_SPI3_MASTER
 	bool "SPI3 Master"
 	default n


### PR DESCRIPTION
## Summary
Kconfig was missing an entry for SPI2_MASTER so it could not be selected.

## Testing
Tested using SPIM2 on nRF52-feather board