### PR TITLE
fs/vfs/fs_ioctl.c: Add FIOCLEX/FIONCLEX support

### DIFF
--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -195,10 +195,10 @@ int nx_vioctl(int fd, int req, va_list ap)
               }
             break;
           case FIOCLEX:
-            ret = nx_fcntl(fd, F_SETFD, FD_CLOEXEC);
+            ret = nx_fcntl(fd, F_SETFD, nx_fcntl(fd, F_GETFD) | FD_CLOEXEC);
             break;
           case FIONCLEX:
-            ret = nx_fcntl(fd, F_SETFD, 0);
+            ret = nx_fcntl(fd, F_SETFD, nx_fcntl(fd, F_GETFD) & ~FD_CLOEXEC);
             break;
         }
     }

--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -194,6 +194,12 @@ int nx_vioctl(int fd, int req, va_list ap)
                                nx_fcntl(fd, F_GETFL) & ~O_NONBLOCK);
               }
             break;
+          case FIOCLEX:
+            ret = nx_fcntl(fd, F_SETFD, FD_CLOEXEC);
+            break;
+          case FIONCLEX:
+            ret = nx_fcntl(fd, F_SETFD, 0);
+            break;
         }
     }
 

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -184,6 +184,12 @@
                                            * OUT: Integer that contains device
                                            *      minor number
                                            */
+#define FIOCLEX         _FIOC(0x000d)     /* IN:  None
+                                           * OUT: None
+                                           */
+#define FIONCLEX        _FIOC(0x000e)     /* IN:  None
+                                           * OUT: None
+                                           */
 
 /* NuttX file system ioctl definitions **************************************/
 


### PR DESCRIPTION
## Summary

Add FIOCLEX/FIONCLEX support

## Impact

ioctl

## Testing

hifive1-revb:nsh
on QEMU

```
int main(int argc, FAR char *argv[])
{
  int fd = open("/dev/null", O_RDONLY);
  assert(fd != -1);

  int flags = fcntl(fd, F_GETFD);
  assert(flags != -1);
  assert(0 == flags & FD_CLOEXEC);

  int rc = ioctl(fd, FIOCLEX, NULL);
  assert(0 == rc);

  flags = fcntl(fd, F_GETFD);
  assert(flags != -1);
  assert(FD_CLOEXEC == flags & FD_CLOEXEC);

  rc = ioctl(fd, FIONCLEX, NULL);
  assert(0 == rc);

  flags = fcntl(fd, F_GETFD);
  assert(flags != -1);
  assert(0 == flags & FD_CLOEXEC);

  close(fd);

  printf("OK\n");
  return 0;
}
```

