### PR TITLE
vfs: Create a node as the root of pseudo file system

### DIFF
--- a/fs/inode/fs_inode.c
+++ b/fs/inode/fs_inode.c
@@ -87,6 +87,10 @@ void inode_initialize(void)
   g_inode_sem.holder = NO_HOLDER;
   g_inode_sem.count  = 0;
 
+  /* Reserve the root node */
+
+  inode_root_reserve();
+
   /* Initialize files array (if it is used) */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS

--- a/fs/inode/fs_inoderemove.c
+++ b/fs/inode/fs_inoderemove.c
@@ -100,20 +100,12 @@ FAR struct inode *inode_unlink(FAR const char *path)
           desc.peer->i_peer = node->i_peer;
         }
 
-      /* If parent is non-null, then remove the node from head of
-       * of the list of children.
-       */
-
-      else if (desc.parent)
-        {
-          desc.parent->i_child = node->i_peer;
-        }
-
-      /* Otherwise, we must be removing the root inode. */
+      /* Then remove the node from head of the list of children. */
 
       else
         {
-           g_root_inode = node->i_peer;
+          DEBUGASSERT(desc.parent != NULL);
+          desc.parent->i_child = node->i_peer;
         }
 
       node->i_peer = NULL;
@@ -162,7 +154,8 @@ int inode_remove(FAR const char *path)
       else
         {
           /* And delete it now -- recursively to delete all of its children.
-           * Since it has been unlinked, then the peer pointer should be NULL.
+           * Since it has been unlinked, then the peer pointer should be
+           * NULL.
            */
 
           DEBUGASSERT(node->i_peer == NULL);

--- a/fs/inode/fs_inodereserve.c
+++ b/fs/inode/fs_inodereserve.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * fs/inode/fs_registerreserve.c
+ * fs/inode/fs_inodereserve.c
  *
  *   Copyright (C) 2007-2009, 2011-2012, 2015, 2017 Gregory Nutt. All
  *     rights reserved.
@@ -118,28 +118,32 @@ static void inode_insert(FAR struct inode *node,
       peer->i_peer = node;
     }
 
-  /* If parent is non-null, then it must go at the head of its
-   * list of children.
-   */
-
-  else if (parent)
-    {
-      node->i_peer    = parent->i_child;
-      parent->i_child = node;
-    }
-
-  /* Otherwise, this must be the new root_inode */
+  /* Then it must go at the head of parent's list of children. */
 
   else
     {
-      node->i_peer = g_root_inode;
-      g_root_inode = node;
+      DEBUGASSERT(parent != NULL);
+      node->i_peer    = parent->i_child;
+      parent->i_child = node;
     }
 }
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: inode_root_reserve
+ *
+ * Description:
+ *   Reserve the root inode for the pseudo file system.
+ *
+ ****************************************************************************/
+
+void inode_root_reserve(void)
+{
+  g_root_inode = inode_alloc("");
+}
 
 /****************************************************************************
  * Name: inode_reserve

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * fs/inode/fs_inodesearch.c
  *
- *   Copyright (C) 2007-2009, 2011-2012, 2016-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2011-2012, 2016-2017 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -255,24 +256,6 @@ static int _inode_search(FAR struct inode_search_s *desc)
       return -EINVAL;
     }
 
-  /* Skip over the leading '/' */
-
-  while (*name == '/')
-    {
-      name++;
-    }
-
-  /* Special case the root directory.  There is no root inode and there is
-   * no name for the root.
-   */
-
-  if (*name == '\0')
-    {
-      /* This is a bug.  I don't know how to handle this case yet. */
-
-      return -ENOSYS;
-    }
-
   /* Traverse the pseudo file system node tree until either (1) all nodes
    * have been examined without finding the matching node, or (2) the
    * matching node is found.
@@ -347,7 +330,8 @@ static int _inode_search(FAR struct inode_search_s *desc)
                   /* If this intermediate inode in the is a soft link, then
                    * (1) get the name of the full path of the soft link, (2)
                    * recursively look-up the inode referenced by the soft
-                   * link, and (3) continue searching with that inode instead.
+                   * link, and (3) continue searching with that inode
+                   * instead.
                    */
 
                   status = _inode_linktarget(node, desc);

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -284,6 +284,16 @@ void inode_free(FAR struct inode *node);
 const char *inode_nextname(FAR const char *name);
 
 /****************************************************************************
+ * Name: inode_root_reserve
+ *
+ * Description:
+ *   Reserve the root node for the pseudo file system.
+ *
+ ****************************************************************************/
+
+void inode_root_reserve(void);
+
+/****************************************************************************
  * Name: inode_reserve
  *
  * Description:

--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -65,39 +65,7 @@ static int pseudorename(FAR const char *oldpath, FAR struct inode *oldinode,
   struct inode_search_s newdesc;
   FAR struct inode *newinode;
   FAR char *subdir = NULL;
-  FAR const char *name;
   int ret;
-
-  /* Special case the root directory.  There is no root inode and there is
-   * no name for the root.  inode_find() will fail to the find the root
-   * inode -- because there isn't one.
-   */
-
-  name = newpath;
-  while (*name == '/')
-    {
-      name++;
-    }
-
-  if (*name == '\0')
-    {
-      FAR char *subdirname;
-
-      /* In the newpath is the root directory, the target of the rename must
-       * be a directory entry under the root.
-       */
-
-      subdirname = basename((FAR char *)oldpath);
-
-      asprintf(&subdir, "/%s", subdirname);
-      if (subdir == NULL)
-        {
-          ret = -ENOMEM;
-          goto errout;
-        }
-
-      newpath = subdir;
-    }
 
   /* According to POSIX, any old inode at this path should be removed
    * first, provided that it is not a directory.

--- a/fs/vfs/fs_stat.c
+++ b/fs/vfs/fs_stat.c
@@ -57,26 +57,12 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static inline int statroot(FAR struct stat *buf);
 static int stat_recursive(FAR const char *path,
                           FAR struct stat *buf, int resolve);
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: statroot
- ****************************************************************************/
-
-static inline int statroot(FAR struct stat *buf)
-{
-  /* There is no inode associated with the fake root directory */
-
-  RESET_BUF(buf);
-  buf->st_mode = S_IFDIR | S_IROTH | S_IRGRP | S_IRUSR;
-  return OK;
-}
 
 /****************************************************************************
  * Name: stat_recursive
@@ -185,13 +171,6 @@ int nx_stat(FAR const char *path, FAR struct stat *buf, int resolve)
   if (*path == '\0')
     {
       return -ENOENT;
-    }
-
-  /* Check for the fake root directory (which has no inode) */
-
-  if (strcmp(path, "/") == 0)
-    {
-      return statroot(buf);
     }
 
   /* The perform the stat() operation on the path.  This is potentially

--- a/fs/vfs/fs_statfs.c
+++ b/fs/vfs/fs_statfs.c
@@ -104,13 +104,6 @@ int statfs(FAR const char *path, FAR struct statfs *buf)
       goto errout;
     }
 
-  /* Check for the fake root directory (which has no inode) */
-
-  if (strcmp(path, "/") == 0)
-    {
-      return statpseudofs(NULL, buf);
-    }
-
   /* Get an inode for this file */
 
   SETUP_SEARCH(&desc, path, false);


### PR DESCRIPTION
## Summary
to remove the special process for the root.
For example, if we have this root layout:
```
/
  bin/
  proc/
```
Before the modification, g_root_inode point to "bin" node, but it will point to "/" with this patch.

## Impact
No change, the behaviour is same as before, but the code get simplified.

## Testing

