### PR TITLE
Kconfig: Fix syntax error in giant-board

### DIFF
--- a/boards/arm/sama5/giant-board/Kconfig
+++ b/boards/arm/sama5/giant-board/Kconfig
@@ -106,7 +106,8 @@ config SAMA5D27_SDMMC1_MOUNT_MOUNTPOINT
 	depends on SAMA5_SDMMC1
 
 config SAMA5D27_SDMMC1_MOUNT_FSTYPE
-	string "SDMMC1 file system type" default "vfat"
+	string "SDMMC1 file system type"
+	default "vfat"
 	depends on SAMA5_SDMMC1
 
 config MMCSD_HAVE_CARDDETECT


### PR DESCRIPTION
##  Summary
Fix syntax error in Kconfig introduced by #1728 

## Impact
Builds should work again.

## Testing
`configure.sh` now runs
