### PR TITLE
init: Move file system initialization before clock/irq

### DIFF
--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -613,6 +613,10 @@ void nx_start(void)
     }
 #endif
 
+  /* Initialize the file system (needed to support device drivers) */
+
+  fs_initialize();
+
   /* Initialize the interrupt handling subsystem (if included) */
 
 #ifdef CONFIG_HAVE_WEAKFUNCTIONS
@@ -679,10 +683,6 @@ void nx_start(void)
       pthread_initialize();
     }
 #endif
-
-  /* Initialize the file system (needed to support device drivers) */
-
-  fs_initialize();
 
 #ifdef CONFIG_NET
   /* Initialize the networking system */


### PR DESCRIPTION
## Summary
since these subsystem may register the driver under /dev, report here https://github.com/apache/incubator-nuttx/pull/1805

## Impact
No assert like this:
```
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
* frame #0: 0x00000001000009ef nuttx`up_assert(filename="inode/fs_inodereserve.c", line=125) at up_head.c:120:11
    frame #1: 0x000000010001967b nuttx`_assert(filename="inode/fs_inodereserve.c", linenum=125) at lib_assert.c:36:3
    frame #2: 0x0000000100116d0c nuttx`inode_insert(node=0x0000000100400070, peer=0x0000000000000000, parent=0x0000000000000000) at fs_inodereserve.c:125:7
    frame #3: 0x0000000100116bf1 nuttx`inode_reserve(path="/dev/rtc0", inode=0x00007ffeefbff0a0) at fs_inodereserve.c:230:15
    frame #4: 0x000000010011ce6f nuttx`register_driver(path="/dev/rtc0", fops=0x00000001001445b8, mode=438, priv=0x0000000100400050) at fs_registerdriver.c:78:9
    frame #5: 0x0000000100017fbd nuttx`rtc_initialize(minor=0, lower=0x000000010014a6f0) at rtc.c:867:9
    frame #6: 0x0000000100034870 nuttx`up_rtc_initialize at up_rtc.c:126:10
    frame #7: 0x0000000100000b10 nuttx`clock_initialize at clock_initialize.c:226:3 
    frame #8: 0x0000000100002ffc nuttx`nx_start at nx_start.c:640:7
    frame #9: 0x00000001000009a2 nuttx`main(argc=1, argv=0x00007ffeefbff218, envp=0x00007ffeefbff228) at up_head.c:96:7
    frame #10: 0x00007fff7831b3d5 libdyld.dylib`start + 1
    frame #11: 0x00007fff7831b3d5 libdyld.dylib`start + 1
```
## Testing

