### PR TITLE
SIM in MacOS: make MacOS link process same with Linux

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -225,9 +225,7 @@ OBJS = $(AOBJS) $(COBJS) $(HOSTOBJS)
 
 # Override in Make.defs if linker is not 'ld'
 
-ifeq ($(HOSTOS),Darwin)
-  LDUNEXPORTSYMBOLS ?= -unexported_symbols_list nuttx-names.dat
-else
+ifneq ($(HOSTOS),Darwin)
   ARCHSCRIPT += -T nuttx.ld
   LDSTARTGROUP ?= --start-group
   LDENDGROUP ?= --end-group
@@ -292,14 +290,12 @@ board/libboard$(LIBEXT):
 nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(LINKOBJS) $(HOSTOBJS)
 	$(Q) echo "LD:  nuttx$(EXEEXT)"
 	$(call PREPROCESS, nuttx-names.in, nuttx-names.dat)
-	$(Q) $(LD) -r $(LDLINKFLAGS) $(RELPATHS) $(EXTRA_LIBPATHS) -o nuttx.rel $(REQUIREDOBJS) $(LDSTARTGROUP) $(RELLIBS) $(EXTRA_LIBS) $(LDENDGROUP) $(LDUNEXPORTSYMBOLS)
-ifneq ($(HOSTOS),Darwin)
+	$(Q) $(LD) -r $(LDLINKFLAGS) $(RELPATHS) $(EXTRA_LIBPATHS) -o nuttx.rel $(REQUIREDOBJS) $(LDSTARTGROUP) $(RELLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 	$(Q) $(OBJCOPY) --redefine-syms=nuttx-names.dat nuttx.rel
 	$(Q) $(CC) $(CCLINKFLAGS) -Wl,-verbose 2>&1 | \
 	     sed -e '/====/,/====/!d;//d' -e 's/__executable_start/_stext/g' -e 's/__init_array_start/_sinit/g' \
 	         -e 's/__init_array_end/_einit/g' -e 's/__fini_array_start/_sfini/g' -e 's/__fini_array_end/_efini/g' >nuttx.ld
 	$(Q) echo "__init_array_start = .; __init_array_end = .; __fini_array_start = .; __fini_array_end = .;" >>nuttx.ld
-endif
 	$(if $(CONFIG_HAVE_CXX),\
 	$(Q) "$(CXX)" $(CCLINKFLAGS) $(LIBPATHS) $(ARCHSCRIPT) -o $(TOPDIR)/$@ nuttx.rel $(HOSTOBJS) $(DRVLIB) $(STDLIBS),\
 	$(Q) "$(CC)" $(CCLINKFLAGS) $(LIBPATHS) $(ARCHSCRIPT) -o $(TOPDIR)/$@ nuttx.rel $(HOSTOBJS) $(DRVLIB) $(STDLIBS))

--- a/arch/sim/src/nuttx-names.in
+++ b/arch/sim/src/nuttx-names.in
@@ -23,9 +23,8 @@
 #define CONCAT_(x, y) x##y
 #define CONCAT(x, y)  CONCAT_(x, y)
 
-#if defined(CONFIG_HOST_MACOS)
-  #define NXSYMBOLS(s) _##s
-#elif defined(CONFIG_HOST_WINDOWS) && defined(CONFIG_SIM_CYGWIN_DECORATED)
+#if defined(CONFIG_HOST_MACOS) || \
+    (defined(CONFIG_HOST_WINDOWS) && defined(CONFIG_SIM_CYGWIN_DECORATED))
   #define NXSYMBOLS(s) _##s NX##s
 #else
   #define NXSYMBOLS(s) s NX##s

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -47,10 +47,6 @@ ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 ARCHCPUFLAGS += -fvisibility=hidden
 ARCHCPUFLAGSXX += -fvisibility=hidden
 
-ifeq ($(CONFIG_HOST_MACOS),y)
-  LDLINKFLAGS += -keep_private_externs
-endif
-
 # Add -fno-common because macOS "ld -r" doesn't seem to pick objects
 # for common symbols.
 ARCHCPUFLAGS += -fno-common


### PR DESCRIPTION


## Summary

SIM in MacOS: make MacOS link process same with Linux

## Impact

1. There is difference about symbol replace on nuttx-names.in
   between MacOS & Linux
2. For MacOS, if open '-fvisibility=hidden' and adjust nuttx-names.in,
   it will meet symbol link-back-to-nuttx error.
3. Make the MacOS replace behaviour, same with Linux

Note:
MacOS should install objcopy with command:
$ brew install binutils
$ export PATH=$PATH:/usr/local/opt/binutils/bin

already check in to cibuild.sh

## Testing

