### PR TITLE
libs/libc/unistd: Implement pipe2(2) syscall

### DIFF
--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -186,7 +186,7 @@ static int pipe_close(FAR struct file *filep)
  *
  ****************************************************************************/
 
-int nx_pipe(int fd[2], size_t bufsize)
+int nx_pipe(int fd[2], size_t bufsize, int flags)
 {
   FAR struct pipe_dev_s *dev = NULL;
   char devname[16];
@@ -249,7 +249,7 @@ int nx_pipe(int fd[2], size_t bufsize)
 
   /* Get a write file descriptor */
 
-  fd[1] = nx_open(devname, O_WRONLY);
+  fd[1] = nx_open(devname, O_WRONLY | flags);
   if (fd[1] < 0)
     {
       ret = fd[1];
@@ -258,7 +258,7 @@ int nx_pipe(int fd[2], size_t bufsize)
 
   /* Get a read file descriptor */
 
-  fd[0] = nx_open(devname, O_RDONLY);
+  fd[0] = nx_open(devname, O_RDONLY | flags);
   if (fd[0] < 0)
     {
       ret = fd[0];

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -1119,13 +1119,13 @@ int pty_register(int minor)
    *   pipe_b:  Master sink, slave source (RX, master-to-slave)
    */
 
-  ret = nx_pipe(pipe_a, CONFIG_PSEUDOTERM_TXBUFSIZE);
+  ret = nx_pipe(pipe_a, CONFIG_PSEUDOTERM_TXBUFSIZE, 0);
   if (ret < 0)
     {
       goto errout_with_devpair;
     }
 
-  ret = nx_pipe(pipe_b, CONFIG_PSEUDOTERM_RXBUFSIZE);
+  ret = nx_pipe(pipe_b, CONFIG_PSEUDOTERM_RXBUFSIZE, 0);
   if (ret < 0)
     {
       goto errout_with_pipea;

--- a/include/nuttx/drivers/drivers.h
+++ b/include/nuttx/drivers/drivers.h
@@ -233,6 +233,7 @@ ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset,
  *   fd[2] - The user provided array in which to catch the pipe file
  *   descriptors
  *   bufsize - The size of the in-memory, circular buffer in bytes.
+ *   flags - The file status flags.
  *
  * Returned Value:
  *   0 is returned on success; otherwise, the negative error code return
@@ -241,7 +242,7 @@ ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset,
  ****************************************************************************/
 
 #if defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0
-int nx_pipe(int fd[2], size_t bufsize);
+int nx_pipe(int fd[2], size_t bufsize, int flags);
 #endif
 
 /****************************************************************************

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -343,6 +343,7 @@ FAR void *sbrk(intptr_t incr);
 /* Special devices */
 
 int     pipe(int fd[2]);
+int     pipe2(int pipefd[2], int flags);
 
 /* Schedule an alarm */
 

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -60,7 +60,7 @@ CSRCS += lib_truncate.c
 endif
 
 ifeq ($(CONFIG_PIPES),y)
-CSRCS += lib_pipe.c
+CSRCS += lib_pipe.c lib_pipe2.c
 endif
 
 CSRCS += lib_gethostname.c lib_sethostname.c

--- a/libs/libc/unistd/lib_pipe2.c
+++ b/libs/libc/unistd/lib_pipe2.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/unistd/lib_pipe.c
+ * libs/libc/unistd/lib_pipe2.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -36,16 +36,17 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: pipe
+ * Name: pipe2
  *
  * Description:
- *   pipe() creates a pair of file descriptors, pointing to a pipe inode,
+ *   pipe2() creates a pair of file descriptors, pointing to a pipe inode,
  *   and  places them in the array pointed to by 'fd'. fd[0] is for reading,
- *   fd[1] is for writing.
+ *   fd[1] is for writing. If flags is 0, then pipe2() is the same as pipe().
  *
  * Input Parameters:
  *   fd[2] - The user provided array in which to catch the pipe file
  *   descriptors
+ *   flags - The file status flags.
  *
  * Returned Value:
  *   0 is returned on success; otherwise, -1 is returned with errno set
@@ -53,11 +54,11 @@
  *
  ****************************************************************************/
 
-int pipe(int fd[2])
+int pipe2(int fd[2], int flags)
 {
   int ret;
 
-  ret = nx_pipe(fd, CONFIG_DEV_PIPE_SIZE, 0);
+  ret = nx_pipe(fd, CONFIG_DEV_PIPE_SIZE, flags);
   if (ret < 0)
     {
       set_errno(-ret);

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -64,7 +64,7 @@
 "mq_unlink","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","int","FAR const char *"
 "munmap","sys/mman.h","defined(CONFIG_FS_RAMMAP)","int","FAR void *","size_t"
 "nx_mkfifo","nuttx/drivers/drivers.h","defined(CONFIG_PIPES) && CONFIG_DEV_FIFO_SIZE > 0","int","FAR const char *","mode_t","size_t"
-"nx_pipe","nuttx/drivers/drivers.h","defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0","int","int [2]|FAR int *","size_t"
+"nx_pipe","nuttx/drivers/drivers.h","defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0","int","int [2]|FAR int *","size_t","int"
 "nx_task_spawn","nuttx/spawn.h","defined(CONFIG_LIB_SYSCALL) && !defined(CONFIG_BUILD_KERNEL)","int","FAR const struct spawn_syscall_parms_s *"
 "nx_vsyslog","nuttx/syslog/syslog.h","","int","int","FAR const IPTR char *","FAR va_list *"
 "on_exit","stdlib.h","defined(CONFIG_SCHED_ONEXIT)","int","CODE void (*)(int, FAR void *)","FAR void *"


### PR DESCRIPTION
## Summary

libs/libc/unistd: Implement pipe2(2) syscall

See the reference here:
https://www.man7.org/linux/man-pages/man2/pipe2.2.html

Change-Id: Ife19b9bdbde73c7421be381a094da67017819e63
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

extend nx_pipe to support pipe2(2)

## Testing

API Testing
