### PR TITLE
libs/libc/time: add stub for futimes/ns(2) 

### DIFF
--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -387,6 +387,49 @@ int setitimer(int which, FAR const struct itimerval *value,
 int utimes(FAR const char *path, const struct timeval times[2]);
 
 /****************************************************************************
+ * Name: futimes
+ *
+ * Description:
+ *  futimens() update the timestamps of a file with nanosecond precision.
+ *  This contrasts with the historical utime(2) and utimes(2), which permit
+ *  only second and microsecond precision, respectively, when setting file
+ *  timestamps. With futimens() the file whose timestamps are to be updated
+ *  is specified via an open file descriptor, fd.
+ *
+ * Input Parameters:
+ *   fd  - Specifies the fd to be modified
+ *   times - Specifies the time value to set
+ *
+ * Returned Value:
+ *   On success, futimens() return 0.
+ *   On error, -1 is returned and errno is set to indicate the error.
+ *
+ ****************************************************************************/
+
+int futimes(int fd, const struct timeval tv[2]);
+
+/****************************************************************************
+ * Name: futimes
+ *
+ * Description:
+ *  futimens() update the timestamps of a file with nanosecond precision.
+ *  This contrasts with the historical utime(2) and utimes(2), which permit
+ *  only second and microsecond precision, respectively, when setting file
+ *  timestamps.
+ *
+ * Input Parameters:
+ *   fd  - Specifies the fd to be modified
+ *   times - Specifies the time value to set
+ *
+ * Returned Value:
+ *   On success, futimens() return 0.
+ *   On error, -1 is returned and errno is set to indicate the error.
+ *
+ ****************************************************************************/
+
+int futimens(int fd, const struct timespec times[2]);
+
+/****************************************************************************
  * Name: gethrtime
  *
  * Description:

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -43,6 +43,7 @@ CSRCS += lib_setreuid.c lib_setregid.c
 CSRCS += lib_getrusage.c lib_utimes.c
 CSRCS += lib_setrlimit.c lib_getrlimit.c
 CSRCS += lib_setpriority.c lib_getpriority.c
+CSRCS += lib_futimes.c lib_futimens.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c

--- a/libs/libc/unistd/lib_futimens.c
+++ b/libs/libc/unistd/lib_futimens.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_futimens.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/time.h>
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int futimens(int fd, const struct timespec times[2])
+{
+  set_errno(ENOTSUP);
+  return ERROR;
+}

--- a/libs/libc/unistd/lib_futimes.c
+++ b/libs/libc/unistd/lib_futimes.c
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_futimes.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/time.h>
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int futimes(int fd, const struct timeval tv[2])
+{
+  set_errno(ENOTSUP);
+  return ERROR;
+}


### PR DESCRIPTION
## Summary

libs/libc/time: add stub for futimes/ns(2) 

Change-Id: I231817d10b9e2071b1f642e8694839b2a64b1c4c
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

stub implement for futimes(2) futimens(2)

## Testing

API Testing
