### PR TITLE
sched/task: Implement gettid(2) syscall

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -27,6 +27,7 @@
 SYSCALL_LOOKUP1(_exit,                     1)
 SYSCALL_LOOKUP(exit,                       1)
 SYSCALL_LOOKUP(getpid,                     0)
+SYSCALL_LOOKUP(gettid,                     0)
 
 SYSCALL_LOOKUP(sched_getparam,             2)
 SYSCALL_LOOKUP(sched_getscheduler,         1)

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -308,6 +308,7 @@ EXTERN int       optopt; /* Unrecognized option character */
 
 pid_t   vfork(void);
 pid_t   getpid(void);
+pid_t   gettid(void);
 void    _exit(int status) noreturn_function;
 unsigned int sleep(unsigned int seconds);
 int     usleep(useconds_t usec);

--- a/sched/task/Make.defs
+++ b/sched/task/Make.defs
@@ -37,7 +37,7 @@ CSRCS += task_create.c task_init.c task_setup.c task_activate.c
 CSRCS += task_start.c task_delete.c task_exit.c task_exithook.c
 CSRCS += task_getgroup.c task_getpid.c task_prctl.c task_recover.c
 CSRCS += task_restart.c task_spawnparms.c task_setcancelstate.c
-CSRCS += task_cancelpt.c task_terminate.c exit.c
+CSRCS += task_cancelpt.c task_terminate.c task_gettid.c exit.c
 
 ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
 ifeq ($(CONFIG_SCHED_WAITPID),y)

--- a/sched/task/task_gettid.c
+++ b/sched/task/task_gettid.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * sched/task/task_gettid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/types.h>
+#include <unistd.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: gettid
+ *
+ * Description:
+ *   Get the thread ID of the currently executing thread.
+ *
+ * Input parameters:
+ *   None
+ *
+ * Returned Value:
+ *   On success, returns the thread ID of the calling process.
+ *
+ ****************************************************************************/
+
+pid_t gettid(void)
+{
+  return getpid();
+}

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -35,6 +35,7 @@
 "getitimer","sys/time.h","!defined(CONFIG_DISABLE_POSIX_TIMERS)","int","int","FAR struct itimerval *"
 "getpeername","sys/socket.h","defined(CONFIG_NET)","int","int","FAR struct sockaddr *","FAR socklen_t *"
 "getpid","unistd.h","","pid_t"
+"gettid","unistd.h","","pid_t"
 "getrandom","sys/random.h","defined(CONFIG_CRYPTO_RANDOM_POOL)","void","FAR void *","size_t"
 "getsockname","sys/socket.h","defined(CONFIG_NET)","int","int","FAR struct sockaddr *","FAR socklen_t *"
 "getsockopt","sys/socket.h","defined(CONFIG_NET)","int","int","int","int","FAR void *","FAR socklen_t *"


### PR DESCRIPTION
## Summary

sched/task: Implement gettid(2) syscall

See the reference here:
https://man7.org/linux/man-pages/man2/gettid.2.html

Change-Id: Ia814d0ccc3b20d8dfc36c809682ddf6e21811d20
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

add get thread id support, which is no different as process id on NuttX os

## Testing

API Testing
