### PR TITLE
fs/munmap: export the symbols to avoid build break on C++ syntax

### DIFF
--- a/fs/mmap/Make.defs
+++ b/fs/mmap/Make.defs
@@ -33,10 +33,10 @@
 #
 ############################################################################
 
-CSRCS += fs_mmap.c
+CSRCS += fs_mmap.c fs_munmap.c
 
 ifeq ($(CONFIG_FS_RAMMAP),y)
-CSRCS += fs_munmap.c fs_rammap.c
+CSRCS += fs_rammap.c
 endif
 
 # Include MMAP build support

--- a/fs/mmap/fs_munmap.c
+++ b/fs/mmap/fs_munmap.c
@@ -52,8 +52,6 @@
 #include "inode/inode.h"
 #include "fs_rammap.h"
 
-#ifdef CONFIG_FS_RAMMAP
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -110,6 +108,7 @@
 
 int munmap(FAR void *start, size_t length)
 {
+#ifdef CONFIG_FS_RAMMAP
   FAR struct fs_rammap_s *prev;
   FAR struct fs_rammap_s *curr;
   FAR void *newaddr;
@@ -129,7 +128,8 @@ int munmap(FAR void *start, size_t length)
 
   /* Search the list of regions */
 
-  for (prev = NULL, curr = g_rammaps.head; curr; prev = curr, curr = curr->flink)
+  for (prev = NULL, curr = g_rammaps.head; curr;
+       prev = curr, curr = curr->flink)
     {
       /* Does this region include any part of the specified range? */
 
@@ -196,7 +196,8 @@ int munmap(FAR void *start, size_t length)
 
   else
     {
-      newaddr = kumm_realloc(curr->addr, sizeof(struct fs_rammap_s) + length);
+      newaddr = kumm_realloc(curr->addr,
+                             sizeof(struct fs_rammap_s) + length);
       DEBUGASSERT(newaddr == (FAR void *)(curr->addr));
       UNUSED(newaddr); /* May not be used */
       curr->length = length;
@@ -211,6 +212,7 @@ errout_with_semaphore:
 errout:
   set_errno(errcode);
   return ERROR;
-}
-
+#else
+  return OK;
 #endif /* CONFIG_FS_RAMMAP */
+}

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -174,16 +174,13 @@ int msync(FAR void *addr, size_t len, int flags);
 int munlock(FAR const void *addr, size_t len);
 int munlockall(void);
 
-#ifdef CONFIG_FS_RAMMAP
 int munmap(FAR void *start, size_t length);
-#else
-#  define munmap(start, length)
-#endif
 
 int posix_madvise(FAR void *addr, size_t len, int advice);
 int posix_mem_offset(FAR const void *addr, size_t len, FAR off_t *off,
                      FAR size_t *contig_len, FAR int *fildes);
-int posix_typed_mem_get_info(int fildes, FAR struct posix_typed_mem_info *info);
+int posix_typed_mem_get_info(int fildes,
+                             FAR struct posix_typed_mem_info *info);
 int posix_typed_mem_open(FAR const char *name, int oflag, int tflag);
 int shm_open(FAR const char *name, int oflag, mode_t mode);
 int shm_unlink(FAR const char *name);


### PR DESCRIPTION

## Summary

fs/munmap: export the symbols to avoid build break on C++ syntax

base/metrics/persistent_memory_allocator.cc:1009:18: error: expected id-expression before ‘-’ token
 1009 |   int result = ::munmap(memory, size);
      |                  ^~~~~~

Change-Id: I24e55c18d09553d3acc341a27063d01489d905ec
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

The dummy definitions can not satisfy scenarios that require the return value

## Testing

API Testing