### PR TITLE
unistd/priority: Implement [s/g]etpriority(2) syscall

### DIFF
--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -42,6 +42,7 @@ CSRCS += lib_seteuid.c lib_setegid.c lib_geteuid.c lib_getegid.c
 CSRCS += lib_setreuid.c lib_setregid.c
 CSRCS += lib_getrusage.c lib_utimes.c
 CSRCS += lib_setrlimit.c lib_getrlimit.c
+CSRCS += lib_setpriority.c lib_getpriority.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c

--- a/libs/libc/unistd/lib_getpriority.c
+++ b/libs/libc/unistd/lib_getpriority.c
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_getpriority.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sched.h>
+
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: getpriority
+ *
+ * Description:
+ *   The getpriority() function shall obtain the nice value of a process,
+ *   process group, or user.
+ *
+ * Input Parameters:
+ *   which  - PRIO_PROCESS, PRIO_PGRP, or PRIO_USER, ignored in current
+ *            implementation.
+ *   who    - Process id is interpreted relative to "which"
+ *
+ * Returned Value:
+ *   Upon successful completion, getpriority() shall return an integer in
+ *   the range -{NZERO} to {NZERO}-1. Otherwise, -1 shall be returned and
+ *   errno set to indicate the error.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int getpriority(int which, id_t who)
+{
+  struct sched_param param;
+  int ret;
+
+  if (who == 0)
+    {
+      who = getpid();
+    }
+
+  ret = sched_getparam(who, &param);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return param.sched_priority;
+}

--- a/libs/libc/unistd/lib_setpriority.c
+++ b/libs/libc/unistd/lib_setpriority.c
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_setpriority.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sched.h>
+
+#include <errno.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: setpriority
+ *
+ * Description:
+ *   The setpriority() function shall set the nice value of a process,
+ *   process group, or user to value+ {NZERO}.
+ *
+ * Input Parameters:
+ *   which  - PRIO_PROCESS, PRIO_PGRP, or PRIO_USER, ignored in current
+ *            implementation.
+ *   who    - Process id is interpreted relative to "which"
+ *   value  - Value in the range SCHED_PRIORITY_MIN to SCHED_PRIORITY_MAX
+ *
+ * Returned Value:
+ *   Upon successful completion, setpriority() shall return 0; otherwise,
+ *   -1 shall be returned and errno set to indicate the error.
+ *
+ * Assumptions:
+ *
+ ****************************************************************************/
+
+int setpriority(int which, id_t who, int value)
+{
+  struct sched_param param;
+  int ret;
+
+  if (who == 0)
+    {
+      who = getpid();
+    }
+
+  ret = sched_getparam(who, &param);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  param.sched_priority = value;
+
+  return sched_setparam(who, &param);
+}


### PR DESCRIPTION
## Summary

unistd/priority: Implement [s/g]etpriority(2) syscall

See the reference here:
https://pubs.opengroup.org/onlinepubs/009695399/functions/getpriority.html

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

Implement [s/g]etpriority(2) syscall for dummy definitions.

## Testing

API Testing( setpriority(2)  getpriority(2))