### PR TITLE
Fix build errors when using DEBUGASSERT

### DIFF
--- a/drivers/analog/dac7554.c
+++ b/drivers/analog/dac7554.c
@@ -199,7 +199,7 @@ static int dac7554_send(FAR struct dac_dev_s *dev, FAR struct dac_msg_s *msg)
 
   /* Sanity check */
 
-  DEBUGASSERT(priv->SPI != NULL);
+  DEBUGASSERT(priv->spi != NULL);
 
   /* Set up message to send */
 
@@ -261,7 +261,7 @@ FAR struct dac_dev_s *dac7554_initialize(FAR struct spi_dev_s *spi,
 
   /* Sanity check */
 
-  DEBUGASSERT(i2c != NULL);
+  DEBUGASSERT(spi != NULL);
 
   /* Initialize the DAC7554 device structure */
 

--- a/drivers/rf/dat-31r5-sp.c
+++ b/drivers/rf/dat-31r5-sp.c
@@ -230,7 +230,7 @@ static int dat31r5sp_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         {
           FAR struct attenuator_control *att =
             (FAR struct attenuator_control *)((uintptr_t)arg);
-          DEBUGASSERT(ptr != NULL);
+          DEBUGASSERT(att != NULL);
           dat31r5sp_set_attenuation(priv, att->attenuation);
         }
         break;


### PR DESCRIPTION
## Summary
Wrong variable names used inside DEBUGASSERT macros causes build errors when building with debug assertions enabled.

## Impact
This PR should fix these build errors

