### PR TITLE
nRF52: Add hooks for missing SPI register callbacks

### DIFF
--- a/arch/arm/src/nrf52/nrf52_spi.c
+++ b/arch/arm/src/nrf52/nrf52_spi.c
@@ -175,6 +175,14 @@ static const struct spi_ops_s g_spi0ops =
   .sendlock          = nrf52_spi_sendblock,
   .recvblock         = nrf52_spi_recvblock
 #  endif
+#ifdef CONFIG_SPI_TRIGGER
+  .trigger           = nrf52_spi_trigger,
+#endif
+#ifdef CONFIG_SPI_CALLBACK
+  .registercallback  = nrf52_spi0register,  /* Provided externally */
+#else
+  .registercallback  = 0,                   /* Not implemented */
+#endif
 };
 
 static struct nrf52_spidev_s g_spi0dev =
@@ -220,6 +228,14 @@ static const struct spi_ops_s g_spi1ops =
   .sendlock          = nrf52_spi_sendblock,
   .recvblock         = nrf52_spi_recvblock
 #  endif
+#ifdef CONFIG_SPI_TRIGGER
+  .trigger           = nrf52_spi_trigger,
+#endif
+#ifdef CONFIG_SPI_CALLBACK
+  .registercallback  = nrf52_spi1register,  /* Provided externally */
+#else
+  .registercallback  = 0,                   /* Not implemented */
+#endif
 };
 
 static struct nrf52_spidev_s g_spi1dev =
@@ -265,6 +281,14 @@ static const struct spi_ops_s g_spi2ops =
   .sendlock          = nrf52_spi_sendblock,
   .recvblock         = nrf52_spi_recvblock
 #  endif
+#ifdef CONFIG_SPI_TRIGGER
+  .trigger           = nrf52_spi_trigger,
+#endif
+#ifdef CONFIG_SPI_CALLBACK
+  .registercallback  = nrf52_spi2register,  /* Provided externally */
+#else
+  .registercallback  = 0,                   /* Not implemented */
+#endif
 };
 
 static struct nrf52_spidev_s g_spi2dev =
@@ -310,6 +334,14 @@ static const struct spi_ops_s g_spi3ops =
   .sendlock          = nrf52_spi_sendblock,
   .recvblock         = nrf52_spi_recvblock
 #  endif
+#ifdef CONFIG_SPI_TRIGGER
+  .trigger           = nrf52_spi_trigger,
+#endif
+#ifdef CONFIG_SPI_CALLBACK
+  .registercallback  = nrf52_spi3register,  /* Provided externally */
+#else
+  .registercallback  = 0,                   /* Not implemented */
+#endif
 };
 
 static struct nrf52_spidev_s g_spi3dev =
@@ -1028,6 +1060,29 @@ static void nrf52_spi_recvblock(FAR struct spi_dev_s *dev,
   return nrf52_spi_exchange(dev, txbuffer, NULL, nwords);
 }
 #endif /* CONFIG_SPI_EXCHANGE */
+
+/****************************************************************************
+ * Name: nrf52_spi_trigger
+ *
+ * Description:
+ *   Trigger a previously configured DMA transfer.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *
+ * Returned Value:
+ *   OK       - Trigger was fired
+ *   -ENOSYS  - Trigger not fired due to lack of DMA or low level support
+ *   -EIO     - Trigger not fired because not previously primed
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_TRIGGER
+static int nrf52_spi_trigger(FAR struct spi_dev_s *dev)
+{
+  return -ENOSYS;
+}
+#endif
 
 /****************************************************************************
  * Public Functions

--- a/arch/arm/src/nrf52/nrf52_spi.h
+++ b/arch/arm/src/nrf52/nrf52_spi.h
@@ -123,4 +123,46 @@ uint8_t nrf52_spi3status(FAR struct spi_dev_s *dev, uint32_t devid);
 int nrf52_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 
+/****************************************************************************
+ * Name: nrf52_spi0/1/2/3register
+ *
+ * Description:
+ *   If the board supports a card detect callback to inform the SPI-based
+ *   MMC/SD driver when an SD card is inserted or removed, then
+ *   CONFIG_SPI_CALLBACK should be defined and the following function(s) must
+ *   be implemented.  These functions implements the registercallback method
+ *   of the SPI interface (see include/nuttx/spi/spi.h for details)
+ *
+ * Input Parameters:
+ *   dev -      Device-specific state data
+ *   callback - The function to call on the media change
+ *   arg -      A caller provided value to return with the callback
+ *
+ * Returned Value:
+ *   0 on success; negated errno on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_CALLBACK
+#ifdef CONFIG_NRF52_SPI0_MASTER
+int nrf52_spi0register(FAR struct spi_dev_s *dev, spi_mediachange_t callback,
+                       FAR void *arg);
+#endif
+
+#ifdef CONFIG_NRF52_SPI1_MASTER
+int nrf52_spi1register(FAR struct spi_dev_s *dev, spi_mediachange_t callback,
+                       FAR void *arg);
+#endif
+
+#ifdef CONFIG_NRF52_SPI2_MASTER
+int nrf52_spi2register(FAR struct spi_dev_s *dev, spi_mediachange_t callback,
+                       FAR void *arg);
+#endif
+
+#ifdef CONFIG_NRF52_SPI3_MASTER
+int nrf52_spi3register(FAR struct spi_dev_s *dev, spi_mediachange_t callback,
+                       FAR void *arg);
+#endif
+#endif
+
 #endif /* __ARCH_ARM_SRC_NRF52_NRF52_SPI_H */


### PR DESCRIPTION
## Summary
This implements the missing callback hooks nrf52_spi0/1/2/3register that are usually used with mmcsd for card detection.

This also stubs out the missing spi trigger function which is not used on this platform.

## Impact
SD Card detection with SPI can now be used on the nRF52 platform.

## Testing
The card detect was tested with the nRF52-feather board and a modified KeyBoard FeatherWing.

Here is an example of it running where I started with the SD Card in (not shown) and then removed it and inserted it back in.
```
NuttShell (NSH) NuttX-9.1.0
nsh> kb_card_state: Detected Card Change: Removed.
mmcsd_mediachanged: WARNING: No card present
kb_card_state: Detected Card Change: Inserted.
mmcsd_mediainitialize: Send CMD0
mmcsd_sendcmd: CMD0[00000000] R1=01
mmcsd_mediainitialize: Card is in IDLE state
mmcsd_mediainitialize: Send CMD8
mmcsd_sendcmd: CMD8[000001aa] R1=01 R7=000001aa
mmcsd_mediainitialize: 0. Send CMD55/ACMD41
mmcsd_sendcmd: CMD55[00000000] R1=01
mmcsd_sendcmd: CMD41[40000000] R1=01
mmcsd_mediainitialize: 1. Send CMD55/ACMD41
mmcsd_sendcmd: CMD55[00000000] R1=01
mmcsd_sendcmd: CMD41[40000000] R1=00
mmcsd_mediainitialize: Send CMD58
mmcsd_sendcmd: CMD58[00000000] R1=00 OCR=c0ff8000
mmcsd_mediainitialize: OCR: c0ff8000
mmcsd_mediainitialize: Identified SD ver2 card/with block access
mmcsd_mediainitialize: Get CSD
mmcsd_sendcmd: CMD9[00000000] R1=00
mmcsd_getcardinfo: 0. SPI send returned fe
mmcsd_dmpcsd: CSD
mmcsd_dmpcsd:   CSD_STRUCTURE:           1.1
mmcsd_dmpcsd:   TAAC:
mmcsd_dmpcsd:     TIME_VALUE:            0x01
mmcsd_dmpcsd:     TIME_UNIT:             0x06
mmcsd_dmpcsd:   NSAC:                    0x00
mmcsd_dmpcsd:   TRAN_SPEED:
mmcsd_dmpcsd:     TIME_VALUE:            0x06
mmcsd_dmpcsd:     RATE_UNIT:             0x02
mmcsd_dmpcsd:   CCC:                     0x5b5
mmcsd_dmpcsd:   READ_BL_LEN:             9
mmcsd_dmpcsd:   READ_BL_PARTIAL:         0
mmcsd_dmpcsd:   WRITE_BLK_MISALIGN:      0
mmcsd_dmpcsd:   READ_BLK_MISALIGN:       0
mmcsd_dmpcsd:   DSR_IMP:                 0
mmcsd_dmpcsd:   C_SIZE:                  30559
mmcsd_dmpcsd:   VDD_R_CURR_MIN:          7
mmcsd_dmpcsd:   VDD_R_CURR_MAX:          6
mmcsd_dmpcsd:   VDD_W_CURR_MIN:          7
mmcsd_dmpcsd:   VDD_W_CURR_MAX:          6
mmcsd_dmpcsd:   C_SIZE_MULT:             8
mmcsd_dmpcsd:   SD ER_BLK_EN:            1
mmcsd_dmpcsd:   SD SECTOR_SIZE:          127
mmcsd_dmpcsd:   SD WP_GRP_SIZE:          0
mmcsd_dmpcsd:   WP_GRP_EN:               0
mmcsd_dmpcsd:   R2W_FACTOR:              2
mmcsd_dmpcsd:   WRITE_BL_LEN:            9
mmcsd_dmpcsd:   WRITE_BL_PARTIAL:        0
mmcsd_dmpcsd:   FILE_FORMAT_GROUP:       0
mmcsd_dmpcsd:   COPY:                    0
mmcsd_dmpcsd:   PERM_WRITE_PROTECT:      0
mmcsd_dmpcsd:   TMP_WRITE_PROTECT:       0
mmcsd_dmpcsd:   FILE_FORMAT:             0
mmcsd_dmpcsd:   CRC:                     25
mmcsd_decodecsd: SPI Frequency
mmcsd_decodecsd:   Maximum:         25000000 Hz
mmcsd_decodecsd:   Actual:          8000000 Hz
mmcsd_decodecsd: Read access time:  11 ticks
mmcsd_decodecsd: Write access time: 26 ticks
mmcsd_decodecsd: Sector size:       512
mmcsd_decodecsd: Number of sectors: 31293440
mmcsd_mediachanged: mmcsd_mediainitialize returned OK
```