### PR TITLE
Add POLLPRI for exception condition on the file descriptor

### DIFF
--- a/include/poll.h
+++ b/include/poll.h
@@ -80,15 +80,16 @@
 #define POLLIN       (0x01)  /* NuttX does not make priority distinctions */
 #define POLLRDNORM   (0x01)
 #define POLLRDBAND   (0x01)
-#define POLLPRI      (0x01)
 
-#define POLLOUT      (0x02)  /* NuttX does not make priority distinctions */
-#define POLLWRNORM   (0x02)
-#define POLLWRBAND   (0x02)
+#define POLLPRI      (0x02)
 
-#define POLLERR      (0x04)
-#define POLLHUP      (0x08)
-#define POLLNVAL     (0x10)
+#define POLLOUT      (0x04)  /* NuttX does not make priority distinctions */
+#define POLLWRNORM   (0x04)
+#define POLLWRBAND   (0x04)
+
+#define POLLERR      (0x08)
+#define POLLHUP      (0x10)
+#define POLLNVAL     (0x20)
 
 #define POLLFD       (0x00)
 #define POLLFILE     (0x40)


### PR DESCRIPTION
#Summary

POLLPRI
       There is some exceptional condition on the file descriptor.  Possibilities include:
       *  There is out-of-band data on a TCP socket (see tcp(7)).
       *  A pseudoterminal master in packet mode has seen a state change on the slave (see ioctl_tty(2)).
       *  A cgroup.events file has been modified (see cgroups(7)).

include/poll: add POLLPRI for exceptional event
Change-Id: I40d566e2c6f0d1fd7232148918635fa8d336ce28
Signed-off-by: dongjiuzhu <dongjiuzhu1@xiaomi.com>

## Impact

## Testing
build local.
