### PR TITLE
Removed broken overdrive function in STM32.

### DIFF
--- a/arch/arm/src/stm32/stm32_pwr.c
+++ b/arch/arm/src/stm32/stm32_pwr.c
@@ -489,41 +489,4 @@ void stm32_pwr_disablepvd(void)
 
 #endif /* CONFIG_STM32_ENERGYLITE */
 
-/************************************************************************************
- * Name: stm32_pwr_enableoverdrive
- *
- * Description:
- *   Enable or disable the overdrive mode, allowing clock rates up to 180 MHz.
- *   If not enabled, the max allowed frequency is 168 MHz.
- *
- ************************************************************************************/
-
-#if defined(CONFIG_STM32_HAVE_OVERDRIVE)
-void stm32_pwr_enableoverdrive(bool state)
-{
-  /* Switch overdrive state */
-
-  if (state)
-    {
-      stm32_pwr_modifyreg32(STM32_PWR_CR_OFFSET, 0, PWR_CR_ODEN);
-    }
-  else
-    {
-      stm32_pwr_modifyreg32(STM32_PWR_CR_OFFSET, PWR_CR_ODEN, 0);
-    }
-
-  /* Wait for overdrive ready */
-
-  while ((stm32_pwr_getreg32(STM32_PWR_CSR_OFFSET) & PWR_CSR_ODRDY) == 0);
-
-  /* Set ODSWEN to switch to this new state */
-
-  stm32_pwr_modifyreg32(STM32_PWR_CR_OFFSET, 0, PWR_CR_ODSWEN);
-
-  /* Wait for completion */
-
-  while ((stm32_pwr_getreg32(STM32_PWR_CSR_OFFSET) & PWR_CSR_ODSWRDY) == 0);
-}
-#endif
-
 #endif /* CONFIG_STM32_PWR */

--- a/arch/arm/src/stm32/stm32_pwr.h
+++ b/arch/arm/src/stm32/stm32_pwr.h
@@ -269,19 +269,6 @@ void stm32_pwr_disablepvd(void);
 
 #endif /* CONFIG_STM32_ENERGYLITE */
 
-/************************************************************************************
- * Name: stm32_pwr_enableoverdrive
- *
- * Description:
- *   Enable or disable the overdrive mode, allowing clock rates up to 180 MHz.
- *   If not enabled, the max allowed frequency is 168 MHz.
- *
- ************************************************************************************/
-
-#if defined(CONFIG_STM32_HAVE_OVERDRIVE)
-void stm32_pwr_enableoverdrive(bool state);
-#endif
-
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary
The function `void stm32_pwr_enableoverdrive(bool state)` is broken.  
It violates the sequence defined by ST, and generally it seems that it is not fixable due to very strange requirements defined by ST regarding its usage.  

Even if there was a way to fix it, its value would be minimal for the project. It is currently not used anywhere, and it would not actually provide any actual and useful functionality to the users.

This issue is discussed in #1568.

## Impact
This function is not used anywhere in NuttX code. Removing it shouldn't have any impact.  
If a user was using this function, their code will break, but this is for good. It will be a good indication that their code was buggy.

## Testing
Deleted code is debugged code.
