### PR TITLE
make/clean: clean the OBJ directly if declare in subdirectory

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -458,7 +458,8 @@ define CLEAN
 endef
 else
 define CLEAN
-	$(Q) rm -f *$(OBJEXT) *$(LIBEXT) *~ .*.swp
+	$(call DELFILE, $(wildcard $(foreach obj, $(OBJS), $(addsuffix /$(obj), $(subst :, ,$(VPATH))))))
+	$(call DELFILE, *$(OBJEXT) *$(LIBEXT) *~ .*.swp)
 endef
 endif
 


### PR DESCRIPTION
## Summary

make/clean: clean the OBJ directly if declare in subdirectory

Discussion on https://github.com/apache/incubator-nuttx-apps/pull/395

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

make clean 

## Testing

build nuttx and make clean 
