### PR TITLE
arch/arm: Add ARCH_ARMV6M Kconfig to prepare the support of CortexM0+

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -704,7 +704,7 @@ config ARCH_CORTEXM35P
 
 config ARCH_FAMILY
 	string
-	default "arm"		if ARCH_ARM7TDMI || ARCH_ARM926EJS || ARCH_ARM920T
+	default "arm"		if ARCH_ARM7TDMI || ARCH_ARM920T || ARCH_ARM926EJS || ARCH_ARM1136J || ARCH_ARM1156T2 || ARCH_ARM1176JZ
 	default "armv6-m"	if ARCH_ARMV6M
 	default "armv7-a"	if ARCH_ARMV7A
 	default "armv7-m"	if ARCH_ARMV7M

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -520,9 +520,14 @@ config ARCH_ARM1176JZ
 		the Classic Arm family. It also introduced TrustZone technology to
 		enable secure execution outside of the reach of malicious code.
 
+config ARCH_ARMV6M
+	bool
+	default n
+
 config ARCH_CORTEXM0
 	bool
 	default n
+	select ARCH_ARMV6M
 	select ARCH_HAVE_IRQPRIO
 	select ARCH_HAVE_RESET
 	select ARCH_HAVE_HARDFAULT_DEBUG
@@ -700,7 +705,7 @@ config ARCH_CORTEXM35P
 config ARCH_FAMILY
 	string
 	default "arm"		if ARCH_ARM7TDMI || ARCH_ARM926EJS || ARCH_ARM920T
-	default "armv6-m"	if ARCH_CORTEXM0
+	default "armv6-m"	if ARCH_ARMV6M
 	default "armv7-a"	if ARCH_ARMV7A
 	default "armv7-m"	if ARCH_ARMV7M
 	default "armv7-r"	if ARCH_ARMV7R
@@ -884,7 +889,7 @@ config ARM_LWL_CONSOLE
 		added to other ARM architectures be add up_low_console.c to the
 		architecture Make.defs file.
 
-if ARCH_CORTEXM0
+if ARCH_ARMV6M
 source arch/arm/src/armv6-m/Kconfig
 endif
 if ARCH_ARMV7A

--- a/arch/arm/include/irq.h
+++ b/arch/arm/include/irq.h
@@ -49,7 +49,7 @@
 #  include <arch/armv7-m/irq.h>
 #elif defined(CONFIG_ARCH_ARMV8M)
 #  include <arch/armv8-m/irq.h>
-#elif defined(CONFIG_ARCH_CORTEXM0)
+#elif defined(CONFIG_ARCH_ARMV6M)
 #  include <arch/armv6-m/irq.h>
 #else
 #  include <arch/arm/irq.h>

--- a/arch/arm/include/s32k1xx/chip.h
+++ b/arch/arm/include/s32k1xx/chip.h
@@ -60,7 +60,7 @@
 #  define NVIC_SYSH_PRIORITY_MAX        0x00 /* Zero is maximum priority */
 #  define NVIC_SYSH_PRIORITY_STEP       0x10 /* Steps between priorities */
 
-#elif defined(CONFIG_ARCH_CORTEXM0)
+#elif defined(CONFIG_ARCH_ARMV6M)
 /* The Cortex-M0+ core supports 4 programmable interrupt priority levels. */
 
 #  define NVIC_SYSH_PRIORITY_MIN        0xc0 /* All bits[7:4] set is minimum priority */
@@ -79,7 +79,7 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ************************************************************************************/
 
 #endif /* __ARCH_ARM_INCLUDE_S32K1XX_CHIP_H */

--- a/arch/arm/include/spinlock.h
+++ b/arch/arm/include/spinlock.h
@@ -54,7 +54,7 @@
 #  include <arch/armv7-r/spinlock.h>
 #elif defined(CONFIG_ARCH_ARMV7M)
 #  include <arch/armv7-m/spinlock.h>
-#elif defined(CONFIG_ARCH_CORTEXM0)
+#elif defined(CONFIG_ARCH_ARMV6M)
 #  include <arch/armv6-m/spinlock.h>
 #else
 #  include <arch/arm/spinlock.h>
@@ -117,7 +117,7 @@
 typedef uint8_t spinlock_t;
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************

--- a/arch/arm/include/spinlock.h
+++ b/arch/arm/include/spinlock.h
@@ -54,6 +54,8 @@
 #  include <arch/armv7-r/spinlock.h>
 #elif defined(CONFIG_ARCH_ARMV7M)
 #  include <arch/armv7-m/spinlock.h>
+#elif defined(CONFIG_ARCH_ARMV8M)
+#  include <arch/armv8-m/spinlock.h>
 #elif defined(CONFIG_ARCH_ARMV6M)
 #  include <arch/armv6-m/spinlock.h>
 #else

--- a/arch/arm/include/syscall.h
+++ b/arch/arm/include/syscall.h
@@ -39,7 +39,7 @@
 #  include <arch/armv7-m/syscall.h>
 #elif defined(CONFIG_ARCH_ARMV8M)
 #  include <arch/armv8-m/syscall.h>
-#elif defined(CONFIG_ARCH_CORTEXM0)
+#elif defined(CONFIG_ARCH_ARMV6M)
 #  include <arch/armv6-m/syscall.h>
 #else
 #  include <arch/arm/syscall.h>

--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -45,7 +45,7 @@ else ifeq ($(CONFIG_ARCH_ARMV7M),y)     # ARMv7-M
 ARCH_SUBDIR = armv7-m
 else ifeq ($(CONFIG_ARCH_ARMV8M),y)     # ARMv8-M
 ARCH_SUBDIR = armv8-m
-else ifeq ($(CONFIG_ARCH_CORTEXM0),y)   # Cortex-M0 is ARMv6-M
+else ifeq ($(CONFIG_ARCH_ARMV6M),y)     # ARMv6-M
 ARCH_SUBDIR = armv6-m
 else                                    # ARM9, ARM7TDMI, etc.
 ARCH_SUBDIR = arm

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -82,7 +82,7 @@
  * some configurations.
  */
 
-#if defined(CONFIG_ARCH_CORTEXM0) || defined(CONFIG_ARCH_ARMV7M) || \
+#if defined(CONFIG_ARCH_ARMV6M) || defined(CONFIG_ARCH_ARMV7M) || \
     defined(CONFIG_ARCH_ARMV8M)
 
   /* If the floating point unit is present and enabled, then save the
@@ -319,7 +319,7 @@ void arm_pminitialize(void);
 
 /* Exception handling logic unique to the Cortex-M family */
 
-#if defined(CONFIG_ARCH_CORTEXM0) || defined(CONFIG_ARCH_ARMV7M) || \
+#if defined(CONFIG_ARCH_ARMV6M) || defined(CONFIG_ARCH_ARMV7M) || \
     defined(CONFIG_ARCH_ARMV8M)
 
 /* Interrupt acknowledge and dispatch */
@@ -390,7 +390,7 @@ void arm_prefetchabort(uint32_t *regs);
 void arm_syscall(uint32_t *regs);
 void arm_undefinedinsn(uint32_t *regs);
 
-#endif /* CONFIG_ARCH_CORTEXM0,3,4,7 */
+#endif /* CONFIG_ARCH_ARMV[6-8]M */
 
 void arm_vectorundefinsn(void);
 void arm_vectorswi(void);

--- a/arch/arm/src/common/arm_vfork.c
+++ b/arch/arm/src/common/arm_vfork.c
@@ -225,16 +225,15 @@ pid_t up_vfork(const struct vfork_s *context)
 
 #  endif
 
-#elif defined(CONFIG_ARCH_CORTEXR4) || defined(CONFIG_ARCH_CORTEXR5) || \
-      defined(CONFIG_ARCH_CORTEXR7)
+#elif defined(CONFIG_ARCH_ARMV7R)
 #  ifdef CONFIG_BUILD_PROTECTED
 
           child->cmn.xcp.syscall[index].cpsr =
             parent->xcp.syscall[index].cpsr;
 
 #  endif
-#elif defined(CONFIG_ARCH_CORTEXM3) || defined(CONFIG_ARCH_CORTEXM4) || \
-      defined(CONFIG_ARCH_CORTEXM0) || defined(CONFIG_ARCH_CORTEXM7)
+#elif defined(CONFIG_ARCH_ARMV6M) || defined(CONFIG_ARCH_ARMV7M) || \
+      defined(CONFIG_ARCH_ARMV8M)
 
           child->cmn.xcp.syscall[index].excreturn =
             parent->xcp.syscall[index].excreturn;


### PR DESCRIPTION
## Summary
also align with the armv7m implementation

## Impact
No function change.

## Testing

