### PR TITLE
arch/sim: Extend the heap size to 64MB

### DIFF
--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -126,11 +126,7 @@
 
 /* Size of the simulated heap */
 
-#ifdef CONFIG_MM_SMALL
-#  define SIM_HEAP_SIZE (64*1024)
-#else
-#  define SIM_HEAP_SIZE (4*1024*1024)
-#endif
+#define SIM_HEAP_SIZE (64*1024*1024)
 
 /* File System Definitions **************************************************/
 


### PR DESCRIPTION
## Summary
to support the more complex application and
remove the special definition for CONFIG_MM_SMALL

## Impact
extend the heap size from 4MB to 64MB and can launch more complex application

## Testing

