### PR TITLE
sched: Fix nuttx typo

### DIFF
--- a/include/sched.h
+++ b/include/sched.h
@@ -122,7 +122,7 @@
 
 /* void CPU_FREE(cpu_set_t *set); */
 
-#  define CPU_ALLOC(s) free(s)
+#  define CPU_FREE(s) free(s)
 
 /* size_t CPU_ALLOC_SIZE(int num_cpus); */
 


### PR DESCRIPTION
## Summary
Rename one of CPU_ALLOC to CPU_FREE

## Impact
user can call CPU_FREE now

## Testing

