### PR TITLE
sysconf: add _SC_PAGESIZE sysconf support

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -274,6 +274,7 @@
 #define link(p1, p2)                     symlink((p1), (p2))
 #define fdatasync(f)                     fsync(f)
 #define getdtablesize(f)                 ((int)sysconf(_SC_OPEN_MAX))
+#define getpagesize(f)                   ((int)sysconf(_SC_PAGESIZE))
 
 /****************************************************************************
  * Public Data

--- a/libs/libc/unistd/lib_sysconf.c
+++ b/libs/libc/unistd/lib_sysconf.c
@@ -241,6 +241,13 @@ long sysconf(int name)
         return 1;
 #endif
 
+      case _SC_PAGESIZE:
+#ifdef CONFIG_MM_PGSIZE
+        return CONFIG_MM_PGSIZE;
+#else
+        return 1;
+#endif
+
       default:
 #if 0 /* Assume valid but not implemented for the time being */
         errcode = EINVAL;


### PR DESCRIPTION
## Summary
Add sysconf(_SC_PAGESIZE) support, also implement getpagesize() based on it.

## Impact

## Testing
Make linux testing project LTP using them to pass build.
