### PR TITLE
sched: Fix undefined reference to 'sched_cpu_count'

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -60,8 +60,9 @@
  */
 
 #if __GNUC__ >= 4
-#  define CONFIG_HAVE_BUILTIN_CTZ 1
-#  define CONFIG_HAVE_BUILTIN_CLZ 1
+#  define CONFIG_HAVE_BUILTIN_CTZ      1
+#  define CONFIG_HAVE_BUILTIN_CLZ      1
+#  define CONFIG_HAVE_BUILTIN_POPCOUNT 1
 #endif
 
 /* C++ support */

--- a/include/sched.h
+++ b/include/sched.h
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <strings.h>
 
 #include <nuttx/sched.h>
 
@@ -90,7 +91,7 @@
 
 /* int CPU_COUNT(FAR const cpu_set_t *set); */
 
-#  define CPU_COUNT(s) sched_cpu_count(s)
+#  define CPU_COUNT(s) popcountl(*s)
 
 /* void CPU_AND(FAR cpu_set_t *destset, FAR const cpu_set_t *srcset1,
  *              FAR const cpu_set_t *srcset2);

--- a/include/strings.h
+++ b/include/strings.h
@@ -89,6 +89,10 @@ int flsl(long j);
 int flsll(long long j);
 #endif
 
+unsigned int popcount(unsigned int j);
+unsigned int popcountl(unsigned long j);
+unsigned int popcountll(unsigned long long j);
+
 FAR char *index(FAR const char *s, int c);
 FAR char *rindex(FAR const char *s, int c);
 

--- a/libs/libc/string/Make.defs
+++ b/libs/libc/string/Make.defs
@@ -39,6 +39,7 @@
 CSRCS += lib_ffs.c lib_ffsl.c lib_ffsll.c lib_fls.c lib_flsl.c
 CSRCS += lib_flsll.c lib_isbasedigit.c lib_memset.c lib_memchr.c
 CSRCS += lib_memccpy.c lib_memcmp.c lib_memmove.c lib_memrchr.c
+CSRCS += lib_popcount.c lib_popcountl.c lib_popcountll.c
 CSRCS += lib_skipspace.c lib_stpcpy.c lib_stpncpy.c lib_strcasecmp.c
 CSRCS += lib_strcat.c lib_strchr.c lib_strcpy.c lib_strcmp.c lib_strcspn.c
 CSRCS += lib_strdup.c lib_strerror.c lib_strlen.c lib_strnlen.c

--- a/libs/libc/string/lib_popcount.c
+++ b/libs/libc/string/lib_popcount.c
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * libs/libc/string/lib_popcount.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/compiler.h>
+#include <strings.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: popcount
+ ****************************************************************************/
+
+unsigned int popcount(unsigned int j)
+{
+#ifdef CONFIG_HAVE_BUILTIN_POPCOUNT
+  return __builtin_popcount(j);
+#else
+  unsigned int count = 0;
+
+  while (j > 0)
+    {
+      if ((j & 1) == 1)
+        {
+          count++;
+        }
+
+      j >>= 1;
+    }
+
+  return count;
+#endif
+}

--- a/libs/libc/string/lib_popcountl.c
+++ b/libs/libc/string/lib_popcountl.c
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * libs/libc/string/lib_popcountl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/compiler.h>
+#include <strings.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: popcount
+ ****************************************************************************/
+
+unsigned int popcountl(unsigned long j)
+{
+#ifdef CONFIG_HAVE_BUILTIN_POPCOUNT
+  return __builtin_popcountl(j);
+#else
+  unsigned int count = 0;
+
+  while (j > 0)
+    {
+      if ((j & 1) == 1)
+        {
+          count++;
+        }
+
+      j >>= 1;
+    }
+
+  return count;
+#endif
+}

--- a/libs/libc/string/lib_popcountll.c
+++ b/libs/libc/string/lib_popcountll.c
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * libs/libc/string/lib_popcountll.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/compiler.h>
+#include <strings.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: popcount
+ ****************************************************************************/
+
+unsigned int popcountll(unsigned long long j)
+{
+#ifdef CONFIG_HAVE_BUILTIN_POPCOUNT
+  return __builtin_popcountll(j);
+#else
+  unsigned int count = 0;
+
+  while (j > 0)
+    {
+      if ((j & 1) == 1)
+        {
+          count++;
+        }
+
+      j >>= 1;
+    }
+
+  return count;
+#endif
+}


### PR DESCRIPTION
## Summary
By:

1. Implement popcount/popcountl/popcountll
2. Redirect CPU_COUNT to popcountl

## Impact
Fix the linker failure

## Testing

