### PR TITLE
net/usrsock: fix outputted function name in debug prints

### DIFF
--- a/net/usrsock/usrsock_bind.c
+++ b/net/usrsock/usrsock_bind.c
@@ -182,7 +182,7 @@ int usrsock_bind(FAR struct socket *psock,
     {
       /* Invalid state or closed by daemon. */
 
-      ninfo("usockid=%d; connect() with uninitialized usrsock.\n",
+      ninfo("usockid=%d; bind() with uninitialized usrsock.\n",
             conn->usockid);
 
       ret = (conn->state == USRSOCK_CONN_STATE_ABORTED) ? -EPIPE :

--- a/net/usrsock/usrsock_getpeername.c
+++ b/net/usrsock/usrsock_getpeername.c
@@ -172,7 +172,7 @@ int usrsock_getpeername(FAR struct socket *psock,
     {
       /* Invalid state or closed by daemon. */
 
-      ninfo("usockid=%d; usrsock_getpeername() with uninitialized usrsock\n",
+      ninfo("usockid=%d; getpeername() with uninitialized usrsock\n",
             conn->usockid);
 
       ret = (conn->state == USRSOCK_CONN_STATE_ABORTED) ? -EPIPE :

--- a/net/usrsock/usrsock_getsockname.c
+++ b/net/usrsock/usrsock_getsockname.c
@@ -187,7 +187,7 @@ int usrsock_getsockname(FAR struct socket *psock,
     {
       /* Invalid state or closed by daemon. */
 
-      ninfo("usockid=%d; connect() with uninitialized usrsock.\n",
+      ninfo("usockid=%d; getsockname() with uninitialized usrsock.\n",
             conn->usockid);
 
       ret = (conn->state == USRSOCK_CONN_STATE_ABORTED) ? -EPIPE :

--- a/net/usrsock/usrsock_getsockopt.c
+++ b/net/usrsock/usrsock_getsockopt.c
@@ -183,7 +183,8 @@ static int do_getsockopt_request(FAR struct usrsock_conn_s *conn, int level,
  *
  ****************************************************************************/
 
-int usrsock_getsockopt(FAR struct usrsock_conn_s *conn, int level, int option,
+int usrsock_getsockopt(FAR struct usrsock_conn_s *conn,
+                       int level, int option,
                        FAR void *value, FAR socklen_t *value_len)
 {
   struct usrsock_data_reqstate_s state =
@@ -200,7 +201,7 @@ int usrsock_getsockopt(FAR struct usrsock_conn_s *conn, int level, int option,
     {
       /* Invalid state or closed by daemon. */
 
-      ninfo("usockid=%d; connect() with uninitialized usrsock.\n",
+      ninfo("usockid=%d; getsockopt() with uninitialized usrsock.\n",
             conn->usockid);
 
       ret = (conn->state == USRSOCK_CONN_STATE_ABORTED) ? -EPIPE :

--- a/net/usrsock/usrsock_recvfrom.c
+++ b/net/usrsock/usrsock_recvfrom.c
@@ -248,7 +248,7 @@ ssize_t usrsock_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
     {
       /* Invalid state or closed by daemon. */
 
-      ninfo("usockid=%d; connect() with uninitialized usrsock.\n",
+      ninfo("usockid=%d; recvfrom() with uninitialized usrsock.\n",
             conn->usockid);
 
       ret = (conn->state == USRSOCK_CONN_STATE_ABORTED) ? -EPIPE :

--- a/net/usrsock/usrsock_sendto.c
+++ b/net/usrsock/usrsock_sendto.c
@@ -229,7 +229,7 @@ ssize_t usrsock_sendto(FAR struct socket *psock, FAR const void *buf,
     {
       /* Invalid state or closed by daemon. */
 
-      ninfo("usockid=%d; connect() with uninitialized usrsock.\n",
+      ninfo("usockid=%d; sendto() with uninitialized usrsock.\n",
             conn->usockid);
 
       ret = (conn->state == USRSOCK_CONN_STATE_ABORTED) ? -EPIPE :

--- a/net/usrsock/usrsock_setsockopt.c
+++ b/net/usrsock/usrsock_setsockopt.c
@@ -107,8 +107,8 @@ static uint16_t setsockopt_event(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 static int do_setsockopt_request(FAR struct usrsock_conn_s *conn,
-                                 int level, int option, FAR const void *value,
-                                 socklen_t value_len)
+                                 int level, int option,
+                                 FAR const void *value, socklen_t value_len)
 {
   struct usrsock_request_setsockopt_s req =
   {
@@ -174,7 +174,8 @@ static int do_setsockopt_request(FAR struct usrsock_conn_s *conn,
  *
  ****************************************************************************/
 
-int usrsock_setsockopt(FAR struct usrsock_conn_s *conn, int level, int option,
+int usrsock_setsockopt(FAR struct usrsock_conn_s *conn,
+                       int level, int option,
                        FAR const void *value, FAR socklen_t value_len)
 {
   struct usrsock_reqstate_s state =
@@ -192,7 +193,7 @@ int usrsock_setsockopt(FAR struct usrsock_conn_s *conn, int level, int option,
     {
       /* Invalid state or closed by daemon. */
 
-      ninfo("usockid=%d; connect() with uninitialized usrsock.\n",
+      ninfo("usockid=%d; setsockopt() with uninitialized usrsock.\n",
             conn->usockid);
 
       ret = (conn->state == USRSOCK_CONN_STATE_ABORTED) ? -EPIPE :


### PR DESCRIPTION
## Summary 

Patch fixes few misleading ninfo() debug prints in usrsock.

## Impact

No functional change other than debug output.

## Testing

