### PR TITLE
arch/sim: Add host timer and improve the oneshot timer logic

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -98,8 +98,16 @@ config SIM_X8664_MICROSOFT
 endchoice
 
 config SIM_WALLTIME
-	bool "Execution simulation in near real-time"
+	bool "Run the simulation at a fixed cadence in near real-time"
 	default n
+
+if SIM_WALLTIME
+choice
+	prompt "Simulation at a fixed cadence in near real-time"
+	default SIM_WALLTIME_SLEEP
+
+config SIM_WALLTIME_SLEEP
+	bool "Execution the simulation in near real-time using host sleep"
 	---help---
 		NOTE:  In order to facility fast testing, the sim target's IDLE loop, by default,
 		calls the system timer "interrupt handler" as fast as possible.  As a result, there
@@ -110,6 +118,18 @@ config SIM_WALLTIME
 		on each call so that the system "timer interrupt" is called at a rate approximately
 		correct for the system timer tick rate.  With this definition in the configuration,
 		sleep() behavior is more or less normal.
+
+config SIM_WALLTIME_SIGNAL
+	bool "Execute the simulation using a host timer"
+	---help---
+		Run the NuttX simulation using a host timer that delivers periodic SIGALRM
+		events at a tick rate specified by CONFIG_USEC_PER_TICK. Enabling this option
+		will generate the timer 'tick' events from the host timer at a fixed rate.
+		The simulated 'tick' events from Idle task are no longer sent.
+
+endchoice
+
+endif
 
 config SIM_NETDEV
 	bool "Simulated Network Device"

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -83,6 +83,7 @@ ifeq ($(CONFIG_HOST_MACOS),y)
   HOSTCFLAGS += -Wno-deprecated-declarations
 endif
 
+HOSTCFLAGS += -DCONFIG_USEC_PER_TICK=$(CONFIG_USEC_PER_TICK)
 HOSTSRCS = up_hostirq.c up_hostmemory.c up_hosttime.c up_simuart.c
 STDLIBS += -lpthread
 ifneq ($(CONFIG_HOST_MACOS),y)
@@ -101,7 +102,6 @@ ifeq ($(CONFIG_SMP),y)
   CSRCS += up_smpsignal.c up_cpuidlestack.c
   REQUIREDOBJS += up_smpsignal$(OBJEXT)
   HOSTCFLAGS += -DCONFIG_SMP=1 -DCONFIG_SMP_NCPUS=$(CONFIG_SMP_NCPUS)
-  HOSTCFLAGS += -DCONFIG_USEC_PER_TICK=$(CONFIG_USEC_PER_TICK)
 ifeq ($(CONFIG_SIM_WALLTIME),y)
   HOSTCFLAGS += -DCONFIG_SIM_WALLTIME=1
 endif

--- a/arch/sim/src/sim/up_hosttime.c
+++ b/arch/sim/src/sim/up_hosttime.c
@@ -37,8 +37,11 @@
  * Included Files
  ****************************************************************************/
 
+#include <errno.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -88,4 +91,38 @@ void host_sleepuntil(uint64_t nsec)
     {
       usleep((nsec - now) / 1000);
     }
+}
+
+/****************************************************************************
+ * Name: host_settimer
+ *
+ * Description:
+ *   Set up a timer to send periodic signals.
+ *
+ * Input Parameters:
+ *   irq - a pointer where we save the host signal number for SIGALRM
+ *
+ * Returned Value:
+ *   On success, (0) zero value is returned, otherwise a negative value.
+ *
+ ****************************************************************************/
+
+int host_settimer(int *irq)
+{
+  struct itimerval it;
+
+  if (irq == NULL)
+    {
+      return -EINVAL;
+    }
+
+  *irq = SIGALRM;
+
+  it.it_interval.tv_sec  = 0;
+  it.it_interval.tv_usec = CONFIG_USEC_PER_TICK;
+  it.it_value            = it.it_interval;
+
+  /* Start a host timer at a rate indicated by CONFIG_USEC_PER_TICK */
+
+  return setitimer(ITIMER_REAL, &it, NULL);
 }

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -232,6 +232,7 @@ void  host_free_shmem(void *mem);
 uint64_t host_gettime(bool rtc);
 void host_sleep(uint64_t nsec);
 void host_sleepuntil(uint64_t nsec);
+int host_settimer(int *irq);
 
 /* up_simsmp.c **************************************************************/
 

--- a/boards/sim/sim/sim/README.txt
+++ b/boards/sim/sim/sim/README.txt
@@ -57,8 +57,12 @@ behavior that is closer to normal timing, then you can define
 CONFIG_SIM_WALLTIME=y in your configuration file.  This configuration setting
 will cause the sim target's IDLE loop to delay on each call so that the system
 "timer interrupt" is called at a rate approximately correct for the system
-timer tick rate.  With this definition in the configuration, sleep() behavior
-is more or less normal.
+timer tick rate.  This option can be enabled with CONFIG_SIM_WALLTIME_SIGNAL
+which will drive the entire simulation by using a host timer that ticks at
+CONFIG_USEC_PER_TICK.  This option will no longer deliver 'tick' events
+from Idle task and it will generate them from the host signal handler.
+Another option is to use CONFIG_SIM_WALLTIME_SLEEP which will enable the
+tick events to be delayed from the Idle task by using a host sleep call.
 
 Debugging
 ^^^^^^^^^


### PR DESCRIPTION
 ## Summary of Changes

Add a host timer that generates periodic signals and sends SIGALRM to
the process that runs the NuttX simulation. This logic is integrated as
part of the existing NuttX oneshot timer. The host timer installs an
irq handler which is expected to run every CONFIG_USEC_PER_TICK .

## Impact

This should not impact the current implementation because it adds a new
Kconfig option which is not enabled by default. `CONFIG_SIM_WALLTIME_SIGNAL=n`

## Testing

I verified the implementation by running this config : `sim/ostest`.

Signed-off-by: Sebastian Ene <nuttx@fitbit.com>
