### PR TITLE
RX65N Pre-check Warning Resolved

### DIFF
--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_bringup.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_bringup.c
@@ -106,6 +106,7 @@ static int rtc_driver_initialize(void)
 
 int rx65n_bringup(void)
 {
+#if defined (HAVE_RTC_DRIVER) || defined (CONFIG_FS_PROCFS)
   int ret;
 #ifdef HAVE_RTC_DRIVER
   ret = rtc_driver_initialize();
@@ -127,6 +128,7 @@ int rx65n_bringup(void)
              ret, errno);
     }
 
+#endif
 #endif
 
 #ifdef CONFIG_RX65N_SBRAM


### PR DESCRIPTION
## Summary
Resolve warning produced in rx65n_bringup.c
## Impact
Warning resolved
## Testing
Tested in local setup
