### PR TITLE
Warnings in NuttX Renesas common files Resolved

### DIFF
--- a/arch/renesas/src/common/up_blocktask.c
+++ b/arch/renesas/src/common/up_blocktask.c
@@ -104,7 +104,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the g_current_regs into the OLD rtcb.
            */
 
-          up_copystate(rtcb->xcp.regs, g_current_regs);
+          up_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/renesas/src/common/up_doirq.c
+++ b/arch/renesas/src/common/up_doirq.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/renesas/src/common/up_doirq.c
  *
- *   Copyright (C) 2008-2009, 2011, 2014-2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -71,7 +56,7 @@
  * Public Functions
  ****************************************************************************/
 
-uint32_t *up_doirq(int irq, uint32_t* regs)
+uint32_t *up_doirq(int irq, uint32_t * regs)
 {
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
@@ -95,10 +80,10 @@ uint32_t *up_doirq(int irq, uint32_t* regs)
 
 #if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
       /* Check for a context switch.  If a context switch occurred, then
-       * g_current_regs will have a different value than it did on entry.  If an
-       * interrupt level context switch has occurred, then restore the floating
-       * point state and the establish the correct address environment before
-       * returning from the interrupt.
+       * g_current_regs will have a different value than it did on entry.
+       * If an interrupt level context switch has occurred, then restore the
+       * floating point state and the establish the correct address
+       * environment before returning from the interrupt.
        */
 
       if (regs != g_current_regs)
@@ -106,7 +91,7 @@ uint32_t *up_doirq(int irq, uint32_t* regs)
 #ifdef CONFIG_ARCH_FPU
           /* Restore floating point registers */
 
-          up_restorefpu((uint32_t*)g_current_regs);
+          up_restorefpu((uint32_t *)g_current_regs);
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
@@ -119,12 +104,13 @@ uint32_t *up_doirq(int irq, uint32_t* regs)
           group_addrenv(NULL);
 #endif
         }
+
 #endif
       /* Get the current value of regs... it may have changed because
        * of a context switch performed during interrupt processing.
        */
 
-      regs = g_current_regs;
+      regs = (uint32_t *)g_current_regs;
 
       /* Set g_current_regs to NULL to indicate that we are no longer in an
        * interrupt handler.

--- a/arch/renesas/src/common/up_internal.h
+++ b/arch/renesas/src/common/up_internal.h
@@ -75,6 +75,8 @@
 #  define CONFIG_ARCH_INTERRUPTSTACK 0
 #endif
 
+#define up_savestate(regs)    up_copystate(regs, (uint32_t *)g_current_regs)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/arch/renesas/src/common/up_releasepending.c
+++ b/arch/renesas/src/common/up_releasepending.c
@@ -74,7 +74,7 @@ void up_release_pending(void)
            * Just copy the g_current_regs into the OLD rtcb.
            */
 
-           up_copystate(rtcb->xcp.regs, g_current_regs);
+           up_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/renesas/src/common/up_reprioritizertr.c
+++ b/arch/renesas/src/common/up_reprioritizertr.c
@@ -129,7 +129,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the g_current_regs into the OLD rtcb.
                */
 
-               up_copystate(rtcb->xcp.regs, g_current_regs);
+               up_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.

--- a/arch/renesas/src/common/up_unblocktask.c
+++ b/arch/renesas/src/common/up_unblocktask.c
@@ -89,7 +89,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the g_current_regs into the OLD rtcb.
            */
 
-          up_copystate(rtcb->xcp.regs, g_current_regs);
+          up_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.

--- a/arch/renesas/src/common/up_usestack.c
+++ b/arch/renesas/src/common/up_usestack.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/renesas/src/common/up_usestack.c
  *
- *   Copyright (C) 2008-2009, 2013 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -134,7 +119,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->adj_stack_ptr = top_of_stack;
+  tcb->adj_stack_ptr = (FAR void *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
 
   /* Initialize the TLS data structure */


### PR DESCRIPTION
## Summary
1. Warnings were generated due to up_copystate() call from functions in up_block_task(), up_release_pending(), up_reprioritize_rtr() and up_unblock_task() due to mismatch between formal and actual parameters passed.
Following the approach taken by other architectures, files are modified to handle the issue in the same way as them.

2. Warnings were generated in assignment operation in functions up_doirq() and up_use_stack() as the datatype of the operands are different. Used explicit type-casting to resolve the warning. 
## Impact
Renesas common file warnings were resolved
## Testing
Tested on RX65N reference board
