### PR TITLE
Fix Cygwin build broken by commit 34b34e2d451

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -317,7 +317,7 @@ endef
 #   CONFIG_WINDOWS_NATIVE - Defined for a Windows native build
 
 define ARCHIVE_ADD
-	@echo "AR (add): $(notdir $1) $(2)"
+	@echo "AR (add): ${shell basename $(1)} $(2)"
 	$(Q) $(AR) $1 $(2)
 endef
 
@@ -325,7 +325,7 @@ endef
 # created from scratch
 
 define ARCHIVE
-	@echo "AR (create): $(notdir $1) $(2)"
+	@echo "AR (create): ${shell basename $(1)} $(2)"
 	$(Q) $(RM) $1
 	$(Q) $(AR) $1 $(2)
 endef


### PR DESCRIPTION
## Summary

Commit 34b34e2d451 uses the full path to libapps.a and introduced the use of the Make notdir command.  That command breaks the Cygwin build because when a native Windows toolchain is used, the full path to libapps.a is a Windows-sytle path and the Make notdir command (like most other GNU Make commands) fails if it is passed a Windows-style path.  This commit replaces the Make notdir command with the Bash basename command which can handle Windows paths.

See issue #1870

## Impact

There should be no impacts to other build environments.

## Testing

On Cygwin:

    $ make distclean
    $ tools/configure.sh -c stm32f4discovery:nsh
    $make

and PR checks for the other platforms.

