### PR TITLE
Move gettid() implementation to /libs/libc/unistd

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -27,7 +27,6 @@
 SYSCALL_LOOKUP1(_exit,                     1)
 SYSCALL_LOOKUP(exit,                       1)
 SYSCALL_LOOKUP(getpid,                     0)
-SYSCALL_LOOKUP(gettid,                     0)
 
 SYSCALL_LOOKUP(sched_getparam,             2)
 SYSCALL_LOOKUP(sched_getscheduler,         1)

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -44,6 +44,7 @@ CSRCS += lib_getrusage.c lib_utimes.c
 CSRCS += lib_setrlimit.c lib_getrlimit.c
 CSRCS += lib_setpriority.c lib_getpriority.c
 CSRCS += lib_futimes.c lib_futimens.c
+CSRCS += lib_gettid.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c

--- a/libs/libc/unistd/lib_gettid.c
+++ b/libs/libc/unistd/lib_gettid.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/task/task_gettid.c
+ * libs/libc/unistd/lib_gettid.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/sched/task/Make.defs
+++ b/sched/task/Make.defs
@@ -37,7 +37,7 @@ CSRCS += task_create.c task_init.c task_setup.c task_activate.c
 CSRCS += task_start.c task_delete.c task_exit.c task_exithook.c
 CSRCS += task_getgroup.c task_getpid.c task_prctl.c task_recover.c
 CSRCS += task_restart.c task_spawnparms.c task_setcancelstate.c
-CSRCS += task_cancelpt.c task_terminate.c task_gettid.c exit.c
+CSRCS += task_cancelpt.c task_terminate.c exit.c
 
 ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
 ifeq ($(CONFIG_SCHED_WAITPID),y)

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -35,7 +35,6 @@
 "getitimer","sys/time.h","!defined(CONFIG_DISABLE_POSIX_TIMERS)","int","int","FAR struct itimerval *"
 "getpeername","sys/socket.h","defined(CONFIG_NET)","int","int","FAR struct sockaddr *","FAR socklen_t *"
 "getpid","unistd.h","","pid_t"
-"gettid","unistd.h","","pid_t"
 "getrandom","sys/random.h","defined(CONFIG_CRYPTO_RANDOM_POOL)","void","FAR void *","size_t"
 "getsockname","sys/socket.h","defined(CONFIG_NET)","int","int","FAR struct sockaddr *","FAR socklen_t *"
 "getsockopt","sys/socket.h","defined(CONFIG_NET)","int","int","int","int","FAR void *","FAR socklen_t *"


### PR DESCRIPTION
## Summary

Move sched/task/task/task_gettid.c to libs/libc/unistd/lib_gettid.c.  gettid() is a dumb wrapper around getpid().  It is wasteful of resources to support TWO systme calls, one for getpid() and one for gettid().  Instead, move gettid() in the C library where it calls the single sysgtem call, getpid().  Much cleaner.

## Impact

Re-organization only.  There should be no functional change.

## Testing

The only verification is checking that moved code compiles without error


