### PR TITLE
Risc v

### DIFF
--- a/arch/risc-v/src/common/riscv_arch.h
+++ b/arch/risc-v/src/common/riscv_arch.h
@@ -61,6 +61,7 @@
 # define putreg16(v,a)        (*(volatile uint16_t *)(a) = (v))
 # define getreg32(a)          (*(volatile uint32_t *)(a))
 # define putreg32(v,a)        (*(volatile uint32_t *)(a) = (v))
+# define putreg64(v,a)        (*(volatile uint64_t *)(a) = (v))
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/risc-v/src/rv32im/riscv_copystate.c
+++ b/arch/risc-v/src/rv32im/riscv_copystate.c
@@ -81,5 +81,9 @@ void up_copystate(uint32_t *dest, uint32_t *src)
         {
           *dest++ = *src++;
         }
+
+#ifdef CONFIG_ARCH_FPU
+      up_savefpu(dest);
+#endif
     }
 }


### PR DESCRIPTION
## Summary
1.Add macro 'putreg64' for writing 64bits registers (like mtimecmp),.
2.Add call of 'up_savefpu' in function 'up_copystate' when fpu is enabled to make sure the fpu registers are saved.
## Impact

## Testing

