### PR TITLE
lib_libvscanf.c: Implement "j" modifier for scanf

### DIFF
--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -332,6 +332,15 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                       fmt++;
                     }
                 }
+              else if (fmt_char(fmt) == 'j')
+                {
+                  /* Same as long long if available. Otherwise, long. */
+#ifdef CONFIG_LIBC_LONG_LONG
+                  modifier = LL_MOD;
+#else
+                  modifier = L_MOD;
+#endif
+                }
               else if (fmt_char(fmt) == 'h' || fmt_char(fmt) == 'H')
                 {
                   modifier = H_MOD;


### PR DESCRIPTION
It's a part of C99 and commonly used these days.

## Summary
Implement "j" modifier for scanf

## Impact

## Testing
tested with a local app which uses %ju. only with CONFIG_LIBC_LONG_LONG=y.
