### PR TITLE
arch/arm: stm32l4: Fix typo in TIM15 PWM config

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_pwm.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwm.c
@@ -1126,7 +1126,7 @@ static struct stm32l4_pwmchan_s g_pwm15channels[] =
   {
     .channel = 2,
     .mode    = CONFIG_STM32L4_TIM15_CH2MODE,
-#ifdef CONFIG_STM32L4_TIM12_CH2OUT
+#ifdef CONFIG_STM32L4_TIM15_CH2OUT
     .out1    =
     {
       .in_use  = 1,


### PR DESCRIPTION
## Summary

When configuring TIM15_CH2 as output, we mistakenly referred to TIM**12** instead. This fixes that typo.

## Impact

A PWM signal can now be generated on TIM15_CH2 for stm32l4 devices.

## Testing

Tested successfully on a custom board used to drive a motor.