### PR TITLE
Allows network monitoring (apps repo) using polling and allows the board to provide the IP config at runtime.

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1144,6 +1144,10 @@ config STM32F7_HAVE_ETHRNET
 	bool
 	default n
 
+config STM32F7_HAVE_PHY_POLLED
+	bool
+	default n
+
 config STM32F7_HAVE_RNG
 	bool
 	default n
@@ -1402,6 +1406,7 @@ config STM32F7_ETHMAC
 	depends on STM32F7_HAVE_ETHRNET
 	select NETDEVICES
 	select ARCH_HAVE_PHY
+	select STM32F7_HAVE_PHY_POLLED
 
 config STM32F7_FMC
 	bool "FMC"
@@ -5267,6 +5272,16 @@ config STM32F7_PHYINIT
 		STM32F7_PHYINIT is defined in the configuration then the board specific logic must
 		provide stm32_phyinitialize();  The STM32 Ethernet driver will call this function
 		one time before it first uses the PHY.
+
+config STM32F7_PHY_POLLING
+	bool "Support network monitoring by poling the PHY"
+	default n
+	depends on STM32F7_HAVE_PHY_POLLED
+	select ARCH_PHY_POLLED
+	---help---
+		Some boards may not have an interrupt connected to the PHY.
+		This option allows the network monitor to be used by polling the
+		the PHY for status.
 
 config STM32F7_MII
 	bool "Use MII interface"

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3118,6 +3118,14 @@ config BOARDCTL_UNIQUEID_SIZE
 		Provides the size of the memory buffer that must be provided by the
 		caller of board_uniqueid() in which to receive the board unique ID.
 
+config BOARDCTL_NETCONF
+	bool "Return board network configuration"
+	default n
+	---help---
+		Enables support for the BOARDIOC_NETCONF boardctl() command.
+		Architecture specific logic must provide the board_get_netconf()
+		interface.
+
 config BOARDCTL_MKRD
 	bool "Enable application space creation of RAM disks"
 	default n

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -410,6 +410,23 @@ int boardctl(unsigned int cmd, uintptr_t arg)
         break;
 #endif
 
+#ifdef CONFIG_BOARDCTL_NETCONF
+      /*  CMD:           BOARDIOC_NETCONF
+       *  DESCRIPTION:   Provide network configuration settings
+       *  ARG:           A pointer to writable netconf structure which to
+       *                 receive the netconf.
+       *  CONFIGURATION: CONFIG_BOARDIOC_NETCONF
+       *  DEPENDENCIES:  Board logic must provide the board_get_netconf()
+       *                 interface.
+       */
+
+      case BOARDIOC_NETCONF:
+        {
+          ret = board_get_netconf((struct boardioc_netconf_s *) arg);
+        }
+        break;
+#endif
+
 #ifdef CONFIG_BOARDCTL_MKRD
       /* CMD:           BOARDIOC_MKRD
        * DESCRIPTION:   Create a RAM disk

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -275,6 +275,28 @@ int board_reset(int status);
 #endif
 
 /****************************************************************************
+ * Name: board_get_netconf
+ *
+ * Description:
+ *   Populates the values if the boardioc_netconf_s to configure the
+ *   network.
+ *
+ *
+ * Input Parameters:
+ *   netconf - A reference to a writable memory location provided by the
+ *     caller to receive the board boardioc_netconf_s.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise a negated errno value is
+ *   returned indicating the nature of the failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARDCTL_NETCONF
+int board_get_netconf(struct boardioc_netconf_s *netconf);
+#endif
+
+/****************************************************************************
  * Name: board_uniqueid
  *
  * Description:

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -81,6 +81,13 @@
  * CONFIGURATION: CONFIG_LIB_BOARDCTL
  * DEPENDENCIES:  Board logic must provide board_app_initialize()
  *
+ * CMD:           BOARDIOC_NETCONF
+ * DESCRIPTION:   Provide network configuration settings
+ * ARG:           A pointer to a writable netconf structure which to receive
+ *                the netconf.
+ * CONFIGURATION: CONFIG_BOARDIOC_NETCONF
+ * DEPENDENCIES:  Board logic must provide the board_get_netconf() interface.
+ *
  * CMD:           BOARDIOC_POWEROFF
  * DESCRIPTION:   Power off the board
  * ARG:           Integer value providing power off status information
@@ -215,6 +222,7 @@
 #define BOARDIOC_NXTERM            _BOARDIOC(0x000f)
 #define BOARDIOC_NXTERM_IOCTL      _BOARDIOC(0x0010)
 #define BOARDIOC_TESTSET           _BOARDIOC(0x0011)
+#define BOARDIOC_NETCONF           _BOARDIOC(0x0012)
 
 /* If CONFIG_BOARDCTL_IOCTL=y, then board-specific commands will be support.
  * In this case, all commands not recognized by boardctl() will be forwarded
@@ -250,6 +258,26 @@ struct boardioc_pm_ctrl_s
   uint32_t state;
   uint32_t count;
   uint32_t priority;
+};
+#endif
+
+#ifdef CONFIG_BOARDCTL_NETCONF
+/* Describes the network configuration */
+
+enum boardioc_netconf_e
+{
+  BOARDIOC_NETCONF_DHCP     = 0x1, /* Use DHCP */
+  BOARDIOC_NETCONF_STATIC   = 0x2, /* Use static IP */
+  BOARDIOC_NETCONF_FALLBACK = 0x3, /* Use DHCP with fall back static IP */
+};
+
+struct boardioc_netconf_s
+{
+  enum boardioc_netconf_e flags; /* Configure for static and/or DHCP */
+  uint32_t ipaddr;
+  uint32_t netmask;
+  uint32_t dnsaddr;
+  uint32_t default_router;
 };
 #endif
 
@@ -432,10 +460,10 @@ extern "C"
  *   to "correct" but awkward implementations.
  *
  *   boardctl() is non-standard OS interface to alleviate the problem.  It
- *   basically circumvents the normal device driver ioctl interlace and allows
- *   the application to perform direct IOCTL-like calls to the board-specific
- *   logic.  It is especially useful for setting up board operational and
- *   test configurations.
+ *   basically circumvents the normal device driver ioctl interlace and
+ *   allows the application to perform direct IOCTL-like calls to the
+ *   board-specific logic.  It is especially useful for setting up board
+ *   operational and test configurations.
  *
  * Input Parameters:
  *   cmd - Identifies the board command to be executed

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -15,6 +15,10 @@ config ARCH_PHY_INTERRUPT
 	bool
 	default n
 
+config ARCH_PHY_POLLED
+	bool
+	default n
+
 config ARCH_HAVE_NETDEV_STATISTICS
 	bool
 	default n


### PR DESCRIPTION
## Summary
   This PR brings in two features and is a [sister to apps PR](https://github.com/apache/incubator-nuttx-apps/pull/402)

### Low level Net Monitor Polling 
  Not all boards have an interrupt line from the phy to the Soc. This commit allows the phy to be polled for
   link status.

   This may not work on all MAC/PHY combination that have mutually exclusive link management and operating
   modes. The STM32F7 and LAN8742AI do not have such a  limitation.

###  Support setting the network configuration from the board through BOARDIOC_NETCONF.

   This adds the interfaces for the Net Monitor (apps repo)  to load the IP addresses and weather or not to use  DHCP from the board. This allows the board to save setting on the media of it's choosing and provide the setting to the system in a uniform way.

The modes of support for `proto` can now be DHCP or static chosen at **run time**. There is all so support for FALLBACK to use DHCP with fall back static IP after a configurable number of attempts (seconds) [see sister apps PR](https://github.com/apache/incubator-nuttx-apps/pull/402)


## Impact

None all  configurations have Kconfig knobs. 

## Testing

PX4 FMUV5X 

All Kconfig options build and run tested. 