### PR TITLE
Renesas .gitignore files added

### DIFF
--- a/arch/renesas/include/.gitignore
+++ b/arch/renesas/include/.gitignore
@@ -1,0 +1,2 @@
+/board
+/chip

--- a/arch/renesas/src/.gitignore
+++ b/arch/renesas/src/.gitignore
@@ -1,0 +1,2 @@
+/board
+/chip


### PR DESCRIPTION
## Summary

Following the same approach taken by other architectures, the directory /board and /chip generated during the build are to be ignored from the below root directories:
arch/renesas/src
arch/renesas/include

## Impact

Renesas pre-check failure fixed

## Testing

