### PR TITLE
tools/mkdeps: Fix EOVERFLOW returned by stat when CONFIG_SIM_M32=y

### DIFF
--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -37,6 +37,8 @@
  * Included Files
  ****************************************************************************/
 
+#define _FILE_OFFSET_BITS 64
+
 #include <sys/stat.h>
 
 #include <stdbool.h>


### PR DESCRIPTION
## Summary
by define _FILE_OFFSET_BITS to 64 described here:
https://man7.org/linux/man-pages/man2/stat.2.html

## Impact

## Testing

