### PR TITLE
serial: Shouldn't mangle pid when ISIG is changed

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1363,18 +1363,10 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           case TIOCSCTTY:
             {
-              /* Check if the ISIG flag is set in the termios c_lflag to enable
-               * this feature.  This flag is set automatically for a serial console
-               * device.
-               */
+              /* Save the PID of the recipient of the SIGINT signal. */
 
-             if ((dev->tc_lflag & ISIG) != 0)
-               {
-                  /* Save the PID of the recipient of the SIGINT signal. */
-
-                  dev->pid = (pid_t)arg;
-                  DEBUGASSERT((unsigned long)(dev->pid) == arg);
-               }
+              dev->pid = (pid_t)arg;
+              DEBUGASSERT((unsigned long)(dev->pid) == arg);
             }
             break;
 #endif
@@ -1421,17 +1413,6 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               dev->tc_iflag = termiosp->c_iflag;
               dev->tc_oflag = termiosp->c_oflag;
               dev->tc_lflag = termiosp->c_lflag;
-
-#if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGSTP)
-              /* If the ISIG flag has been cleared in c_lflag, then un-
-               * register the controlling terminal.
-               */
-
-              if ((dev->tc_lflag & ISIG) == 0)
-                {
-                  dev->pid = (pid_t)-1;
-                }
-#endif
             }
             break;
         }

--- a/drivers/serial/serial_dma.c
+++ b/drivers/serial/serial_dma.c
@@ -373,9 +373,11 @@ void uart_recvchars_done(FAR uart_dev_t *dev)
 #if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGSTP)
   int signo = 0;
 
-  /* Check if the SIGINT character is anywhere in the newly received DMA buffer. */
+  /* Check if the SIGINT character is anywhere in the newly received DMA
+   * buffer.
+   */
 
-  if (dev->pid >= 0)
+  if (dev->pid >= 0 && (dev->tc_lflag & ISIG))
     {
       signo = uart_recvchars_signo(dev);
     }

--- a/drivers/serial/serial_io.c
+++ b/drivers/serial/serial_io.c
@@ -184,8 +184,8 @@ void uart_recvchars(FAR uart_dev_t *dev)
 
       if (nbuffered >= watermark)
         {
-          /* Let the lower level driver know that the watermark level has been
-           * crossed.  It will probably activate RX flow control.
+          /* Let the lower level driver know that the watermark level has
+           * been crossed.  It will probably activate RX flow control.
            */
 
           if (uart_rxflowcontrol(dev, nbuffered, true))
@@ -196,8 +196,9 @@ void uart_recvchars(FAR uart_dev_t *dev)
             }
         }
 #else
-      /* Check if RX buffer is full and allow serial low-level driver to pause
-       * processing. This allows proper utilization of hardware flow control.
+      /* Check if RX buffer is full and allow serial low-level driver to
+       * pause processing. This allows proper utilization of hardware flow
+       * control.
        */
 
       if (is_full)
@@ -217,9 +218,12 @@ void uart_recvchars(FAR uart_dev_t *dev)
       ch = uart_receive(dev, &status);
 
 #ifdef CONFIG_TTY_SIGINT
-      /* Is this the special character that will generate the SIGINT signal? */
+      /* Is this the special character that will generate the SIGINT
+       * signal?
+       */
 
-      if (dev->pid >= 0 && ch == CONFIG_TTY_SIGINT_CHAR)
+      if (dev->pid >= 0 && (dev->tc_lflag & ISIG) &&
+          ch == CONFIG_TTY_SIGINT_CHAR)
         {
           /* Yes.. note that the kill is needed and do not put the character
            * into the Rx buffer.  It should not be read as normal data.
@@ -230,9 +234,12 @@ void uart_recvchars(FAR uart_dev_t *dev)
       else
 #endif
 #ifdef CONFIG_TTY_SIGSTP
-      /* Is this the special character that will generate the SIGSTP signal? */
+      /* Is this the special character that will generate the SIGSTP
+       * signal?
+       */
 
-      if (dev->pid >= 0 && ch == CONFIG_TTY_SIGSTP_CHAR)
+      if (dev->pid >= 0 && (dev->tc_lflag & ISIG) &&
+          ch == CONFIG_TTY_SIGSTP_CHAR)
         {
 #ifdef CONFIG_TTY_SIGINT
           /* Give precedence to SIGINT */


### PR DESCRIPTION
## Summary
Let's check ISIG flag directly instead since pid is sent by user and the modification will surprise user.

## Impact
The behaviour same as before if user don't care pid.