### PR TITLE
nuttx/audio/audio.h: add ac_chmap support for both input & output

### DIFF
--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -356,7 +356,10 @@ struct audio_caps_s
   uint8_t ac_len;           /* Length of the structure */
   uint8_t ac_type;          /* Capabilities (device) type */
   uint8_t ac_subtype;       /* Capabilities sub-type, if needed */
-  uint8_t ac_channels;      /* Number of channels (1, 2, 5, 7) */
+  uint8_t ac_channels;      /* Number of channels (1, 2, 3, ... 8) */
+  uint8_t ac_chmap;         /* Channel map, each ch for each bit,
+                             * zero means don't care */
+  uint8_t reserved;         /* Reserved for future use */
 
   /* Audio data format(s) for this device */
 


### PR DESCRIPTION
##  Summary
nuttx/audio/audio.h: add ac_chmap support for both input & output

## Impact
Increase the struct audio_caps_s,
add :
uint8_t ac_chmap;  /* Channel map, each ch for each bit, max 8,  zero means don't care */
uint8_t reserved;

## Testing

