### PR TITLE
spi_xx25xx: in write operation return the number of bytes written

### DIFF
--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -730,17 +730,17 @@ static ssize_t ee25xx_write(FAR struct file *filep, FAR const char *buffer,
       len = eedev->size - filep->f_pos;
     }
 
-  /* From this point no failure cannot be detected anymore.
-   * The user should verify the write by rereading memory.
-   */
-
-  ret = len; /* save number of bytes written */
-
   ret = ee25xx_semtake(eedev);
   if (ret < 0)
     {
       return ret;
     }
+
+  /* From this point no failure cannot be detected anymore.
+   * The user should verify the write by rereading memory.
+   */
+
+  ret = len; /* save number of bytes written */
 
   /* Writes can't happen in a row like the read does.
    * The EEPROM is made of pages, and write sequences


### PR DESCRIPTION
spi_xx25xx:  in write operation return the number of bytes written not the result of ee25xx_semtake

## Summary

In the spi_xx25xx driver the ee25xx_write function never returns the number of bytes written, but errors or the result of ee25xx_semtake.

## Impact

Spi eerpom driver returns wrong result on write.

