### PR TITLE
do DIRUNLINK in clean_context instead of in disctclean

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -355,6 +355,13 @@ clean_context:
 	$(call DELFILE, include/math.h)
 	$(call DELFILE, include/stdarg.h)
 	$(call DELFILE, include/setjmp.h)
+	$(Q) $(DIRUNLINK) include/arch/board
+	$(Q) $(DIRUNLINK) include/arch/chip
+	$(Q) $(DIRUNLINK) include/arch
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board/board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/chip
+	$(Q) $(DIRUNLINK) $(TOPDIR)/drivers/platform
 
 .clean_context: .config
 	+$(Q) $(MAKE) clean_context
@@ -562,13 +569,6 @@ endif
 	$(call DELFILE, .config-e)
 	$(call DELFILE, .gdbinit)
 	$(call DELFILE, .clean_context)
-	$(Q) $(DIRUNLINK) include/arch/board
-	$(Q) $(DIRUNLINK) include/arch/chip
-	$(Q) $(DIRUNLINK) include/arch
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board/board
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/chip
-	$(Q) $(DIRUNLINK) $(TOPDIR)/drivers/platform
 	$(Q) $(MAKE) -C tools -f Makefile.host clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -328,6 +328,13 @@ clean_context:
 	$(call DELFILE, include\math.h)
 	$(call DELFILE, include\stdarg.h)
 	$(call DELFILE, include\setjmp.h)
+	$(call DIRUNLINK, include\arch\board)
+	$(call DIRUNLINK, include\arch\chip)
+	$(call DIRUNLINK, include\arch)
+	$(call DIRUNLINK, $(ARCH_SRC)\board\board)
+	$(call DIRUNLINK, $(ARCH_SRC)\board)
+	$(call DIRUNLINK, $(ARCH_SRC)\chip)
+	$(call DIRUNLINK, $(TOPDIR)\drivers\platform)
 
 .clean_context: .config
 	+$(Q) $(MAKE) clean_context
@@ -511,13 +518,6 @@ endif
 	$(call DELFILE, .config.old)
 	$(call DELFILE, .config-e)
 	$(call DELFILE, .clean_context)
-	$(call DIRUNLINK, include\arch\board)
-	$(call DIRUNLINK, include\arch\chip)
-	$(call DIRUNLINK, include\arch)
-	$(call DIRUNLINK, $(ARCH_SRC)\board\board)
-	$(call DIRUNLINK, $(ARCH_SRC)\board)
-	$(call DIRUNLINK, $(ARCH_SRC)\chip)
-	$(call DIRUNLINK, $(TOPDIR)\drivers\platform)
 	$(Q) $(MAKE) -C tools -f Makefile.host clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user


### PR DESCRIPTION
## Summary
do DIRUNLINK in clean_context instead of in disctclean to be symmetric with context. And fix cygwin build break of dirlinks issue.

## Impact
To see whether this PR may cause parallel build breaks.

## Testing
Wait for testing.
