### PR TITLE
Correct compilation of arch/sim/src/sim/up_wpcap.c

### DIFF
--- a/arch/sim/src/sim/up_wpcap.c
+++ b/arch/sim/src/sim/up_wpcap.c
@@ -54,10 +54,6 @@
 #include <syslog.h>
 #include <malloc.h>
 
-#include <netinet/in.h>
-
-#include "up_internal.h"
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -67,6 +63,17 @@
 #else
 #  define WCAP_IPADDR (0)
 #endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* This is normally prototyped in up_internal.h.  However, up_internal.h
+ * cannot be included by this file do to collisions between BSD networking
+ * definitions and Windows network definitions.
+ */
+
+void netdriver_setmacaddr(unsigned char *macaddr);
 
 /****************************************************************************
  * Private Types
@@ -150,7 +157,7 @@ static void init_pcap(struct in_addr addr)
           struct in_addr interface_addr;
           interface_addr =
             ((struct sockaddr_in *)interfaces->addresses->addr)->sin_addr;
-          syslog(LOG_INFO, ("init_pcap: with address: %s\n",
+          syslog(LOG_INFO, "init_pcap: with address: %s\n",
                  inet_ntoa(interface_addr));
 
           if (interface_addr.s_addr == addr.s_addr)
@@ -228,7 +235,7 @@ static void set_ethaddr(struct in_addr addr)
                  adapters->PhysicalAddress[2], adapters->PhysicalAddress[3],
                  adapters->PhysicalAddress[4], adapters->PhysicalAddress[5]);
 
-                 netdriver_setmacaddr(adapters->PhysicalAddress);
+              netdriver_setmacaddr(adapters->PhysicalAddress);
               break;
             }
         }


### PR DESCRIPTION
## Summary

This PR corrects this build error:

    /usr/include/cygwin/socket.h:27:8: error: redefinition of 'struct sockaddr'
       27 | struct sockaddr {
          |        ^~~~~~~~
    In file included from /usr/include/w32api/winsock2.h:57,
                     from sim/up_wpcap.c:48:
    /usr/include/w32api/psdk_inc/_ip_types.h:70:8: note: originally defined here
       70 | struct sockaddr {
          |        ^~~~~~~~
    In file included from /usr/include/sys/socket.h:13,
                     from /usr/include/cygwin/in.h:21,
                     from /usr/include/netinet/in.h:12,
                     from sim/up_wpcap.c:57:
    /usr/include/cygwin/socket.h:39:8: error: redefinition of 'struct sockaddr_storage'
       39 | struct sockaddr_storage {
          |        ^~~~~~~~~~~~~~~~
    In file included from sim/up_wpcap.c:48:
    /usr/include/w32api/winsock2.h:269:10: note: originally defined here
      269 |   struct sockaddr_storage {
          |          ^~~~~~~~~~~~~

The compilation was broken by a couple of recent blind, unverified changes to up_wpcap.c.  Most were introduced with commit: 8ce0ff5ce44416511be343c842c8d714687182cf with this change:

    diff --git a/arch/sim/src/sim/up_wpcap.c b/arch/sim/src/sim/up_wpcap.c
    index ef7b4b3a0c..a15421e80c 100644
    --- a/arch/sim/src/sim/up_wpcap.c
    +++ b/arch/sim/src/sim/up_wpcap.c
    @@ -55,6 +55,8 @@

     #include <netinet/in.h>

    +#include "up_internal.h"
    +
     /****************************************************************************
      * Pre-processor Definitions
      ****************************************************************************/

up_internal.h includes:

     47 #  include <sys/types.h>
     48 #  include <stdbool.h>
     49 #  include <netinet/in.h>

And netinet/in.h includes:

     46 #include <sys/types.h>
     47 #include <sys/socket.h>
     48 #include <stdint.h>

Which is where the collision error is introduced since up_wpcap.c includes winsock2.h already.  There were additional problems introduced to the file by other changes:

- A malformed syslog() call was added
- Some issues with netdriver_setmacaddr()

## Impact

This corrects the compilation of up_wpcap.c.  It should affect only simulator builds for simulator

## Testing

I verified only that the sim:nettest configuration still builds.  The WPCAP configuration has not been verified in many years.  It would not surprise if there are not additional issues.
