### PR TITLE
xtensa/ESP32: Fixed the type of cpuint variables in esp32_emac.c esp32_i2c.c esp32_spi.c esp32_spi_slave.c

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpuint.c
+++ b/arch/xtensa/src/esp32/esp32_cpuint.c
@@ -233,7 +233,7 @@ static inline void xtensa_disable_all(void)
  *
  ****************************************************************************/
 
-int esp32_alloc_cpuint(uint32_t intmask)
+static int esp32_alloc_cpuint(uint32_t intmask)
 {
   irqstate_t flags;
   uint32_t *freeints;

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -208,7 +208,7 @@ struct esp32_emac_s
   struct work_s         timeoutwork; /* For TX timeout work to the work queue */
   struct work_s         pollwork;    /* For deferring poll work to the work queue */
 
-  uint32_t              cpuint;      /* SPI interrupt ID */
+  int                   cpuint;      /* SPI interrupt ID */
 
   sq_queue_t            freeb;       /* The free buffer list */
 

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -57,7 +57,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_GPIO_IRQ
-static uint8_t g_gpio_cpuint;
+static int g_gpio_cpuint;
 #endif
 
 static const uint8_t g_pin2func[40] =

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -152,7 +152,7 @@ struct esp32_i2c_priv_s
   uint8_t msgid;               /* Current message ID */
   ssize_t bytes;               /* Processed data bytes */
 
-  uint8_t  cpuint;             /* CPU interrupt assigned to this I2C */
+  int     cpuint;              /* CPU interrupt assigned to this I2C */
 
   uint32_t error;              /* I2C transform error */
 

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -168,7 +168,7 @@ struct esp32_dev_s
   const struct esp32_config_s *config; /* Constant configuration */
   uint32_t baud;                       /* Configured baud */
   uint32_t status;                     /* Saved status bits */
-  uint8_t  cpuint;                     /* CPU interrupt assigned to this UART */
+  int      cpuint;                     /* CPU interrupt assigned to this UART */
   uint8_t  parity;                     /* 0=none, 1=odd, 2=even */
   uint8_t  bits;                       /* Number of bits (5-9) */
   bool     stopbits2;                  /* true: Configure with 2 stop bits instead of 1 */
@@ -711,7 +711,7 @@ static void esp32_detach(struct uart_dev_s *dev)
   /* And release the CPU interrupt */
 
   esp32_free_cpuint(priv->cpuint);
-  priv->cpuint = 0xff;
+  priv->cpuint = -1;
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -134,7 +134,7 @@ struct esp32_spi_priv_s
 
   sem_t            sem_isr;
 
-  uint32_t         cpuint;      /* SPI interrupt ID */
+  int              cpuint;      /* SPI interrupt ID */
 
   uint32_t         frequency;   /* Requested clock frequency */
   uint32_t         actual;      /* Actual clock frequency */

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -134,7 +134,7 @@ struct esp32_spislv_priv_s
 
   const struct esp32_spislv_config_s *config; /* Port configuration */
 
-  uint32_t         cpuint;      /* SPI interrupt ID */
+  int              cpuint;      /* SPI interrupt ID */
 
   enum spi_mode_e  mode;        /* Actual SPI hardware mode */
   uint8_t          nbits;       /* Actual SPI send/receive bits once transmission */


### PR DESCRIPTION
Fixed the type of cpuint variables in esp32_emac.c esp32_i2c.c esp32_spi.c esp32_spi_slave.c

## Summary
The cpuint variable is used in the drivers' config struct to indicate to which CPU interrupt the peripheral interrupt will be allocated to. Since there's only 32 cpu interrupts and 69 peripheral interrupts, if there's no other CPU interrupt available to address a new peripheral interrupt, them the `esp32_alloc_cpuint` function will answer with an "Out of Memory" error. (-ENOMEM). This value is negative and will be forwarded to unsigned variables leading to 2 problems:

1. The program will never enter in the error catching routine. 
2. Since ENOMEM is number 12, the driver code may deallocate the peripheral interrupt previously attached to CPU interrupt 12 leading to unpredictable behavior. 

## Impact

The developer will now be able to catch the error.
If there's no CPU interrupts available, it will not detach a previous attached peripheral interrupt.  

## Testing

N/A

