### PR TITLE
ws2812: moved SPI_LOCK and forgot to change spi drv var name

### DIFF
--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -134,7 +134,7 @@ static inline void ws2812_configspi(FAR struct spi_dev_s *spi)
    * There is no CS on this device we just use MOSI and it is exclusive
    */
 
-  SPI_LOCK(priv->spi, true);  /* Exclusive use of the bus */
+  SPI_LOCK(spi, true);  /* Exclusive use of the bus */
   SPI_SETMODE(spi, SPIDEV_MODE3);
   SPI_SETBITS(spi, 8);
   SPI_HWFEATURES(spi, 0);


### PR DESCRIPTION
## Summary
The SPI_LOCK was moved as part of a minor PR comment when the driver was merged in and the name of the SPI variable was not updated so the driver would not build.

## Impact
Driver now builds correctly.

## Testing
nRF52 Feather with Keyboard FeatherWing.
