### PR TITLE
nRF52: Add basic error handling for i2c in polling mode

### DIFF
--- a/arch/arm/src/nrf52/nrf52_i2c.c
+++ b/arch/arm/src/nrf52/nrf52_i2c.c
@@ -325,6 +325,25 @@ static int nrf52_i2c_transfer(FAR struct i2c_master_s *dev,
 #ifdef CONFIG_I2C_POLLED
           while (nrf52_i2c_getreg(priv,
                                   NRF52_TWIM_EVENTS_LASTTX_OFFSET) != 1);
+          while (1)
+            {
+              regval = nrf52_i2c_getreg(priv,
+                                        NRF52_TWIM_ERRORSRC_OFFSET) & 0x7;
+              if (regval != 0)
+                {
+                  i2cerr("Error SRC: %x\n", regval);
+                  ret = -1;
+                  nrf52_i2c_putreg(priv,
+                                  NRF52_TWIM_ERRORSRC_OFFSET, 0x7);
+                  goto errout;
+                }
+
+              if (nrf52_i2c_getreg(priv,
+                                  NRF52_TWIM_EVENTS_LASTTX_OFFSET) == 1)
+                {
+                  break;
+                }
+            }
 
           /* Clear event */
 
@@ -357,8 +376,25 @@ static int nrf52_i2c_transfer(FAR struct i2c_master_s *dev,
           /* Wait for last RX done */
 
 #ifdef CONFIG_I2C_POLLED
-          while (nrf52_i2c_getreg(priv,
-                                  NRF52_TWIM_EVENTS_LASTRX_OFFSET) != 1);
+        while (1)
+          {
+            regval = nrf52_i2c_getreg(priv,
+                                      NRF52_TWIM_ERRORSRC_OFFSET) & 0x7;
+            if (regval != 0)
+              {
+                i2cerr("Error SRC: %x\n", regval);
+                ret = -1;
+                nrf52_i2c_putreg(priv,
+                                 NRF52_TWIM_ERRORSRC_OFFSET, 0x7);
+                goto errout;
+              }
+
+            if (nrf52_i2c_getreg(priv,
+                                 NRF52_TWIM_EVENTS_LASTRX_OFFSET) == 1)
+              {
+                break;
+              }
+          }
 
           /* Clear event */
 
@@ -387,8 +423,25 @@ static int nrf52_i2c_transfer(FAR struct i2c_master_s *dev,
   /* Wait for stop event */
 
 #ifdef CONFIG_I2C_POLLED
-  while (nrf52_i2c_getreg(priv,
-                          NRF52_TWIM_EVENTS_STOPPED_OFFSET) != 1);
+  while (1)
+    {
+      regval = nrf52_i2c_getreg(priv,
+                                NRF52_TWIM_ERRORSRC_OFFSET) & 0x7;
+      if (regval != 0)
+        {
+          i2cerr("Error SRC: %x\n", regval);
+          ret = -1;
+          nrf52_i2c_putreg(priv,
+                           NRF52_TWIM_ERRORSRC_OFFSET, 0x7);
+          goto errout;
+        }
+
+      if (nrf52_i2c_getreg(priv,
+                           NRF52_TWIM_EVENTS_STOPPED_OFFSET) == 1)
+        {
+          break;
+        }
+    }
 
   /* Clear event */
 


### PR DESCRIPTION
## Summary
Add basic error handling for i2c in polling mode.

There was no error handling before and it would block on common cases like NACK which meant that you could not use the i2ctool to perform a scan of the bus.

This does not handle the interrupt flow which also has incomplete error handling.

## Impact
If `CONFIG_I2C_POLLED` is used unexpected NACKs no longer block the I2C bus forever.  This means that you can use the i2ctool to scan for a range of devices that do no exist and not lock the bus.

## Testing
This was tested by scanning the full i2c address space for devices with only 4 devices 
```
NuttShell (NSH) NuttX-9.1.0
nsh> i2c dev -b 1 0x00  0x7f
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- 1e 1f
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- 3c -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: 60 -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
```
