### PR TITLE
arch/risc-v/src/fe310: Branch to up_sigdeliver() with interrupts disabled

### DIFF
--- a/arch/risc-v/src/fe310/fe310_schedulesigaction.c
+++ b/arch/risc-v/src/fe310/fe310_schedulesigaction.c
@@ -155,7 +155,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               g_current_regs[REG_EPC]     = (uint32_t)up_sigdeliver;
 
               int_ctx                     = g_current_regs[REG_INT_CTX];
-              int_ctx                    &= ~MSTATUS_MIE;
+              int_ctx                    &= ~MSTATUS_MPIE;
 
               g_current_regs[REG_INT_CTX] = int_ctx;
 
@@ -195,7 +195,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_EPC]      = (uint32_t)up_sigdeliver;
 
           int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
-          int_ctx                    &= ~MSTATUS_MIE;
+          int_ctx                    &= ~MSTATUS_MPIE;
 
           tcb->xcp.regs[REG_INT_CTX]  = int_ctx;
 

--- a/arch/risc-v/src/k210/k210_schedulesigaction.c
+++ b/arch/risc-v/src/k210/k210_schedulesigaction.c
@@ -159,7 +159,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               CURRENT_REGS[REG_EPC]     = (uintptr_t)up_sigdeliver;
 
               int_ctx                     = CURRENT_REGS[REG_INT_CTX];
-              int_ctx                    &= ~MSTATUS_MIE;
+              int_ctx                    &= ~MSTATUS_MPIE;
 #ifdef CONFIG_BUILD_PROTECTED
               int_ctx                    |= MSTATUS_MPPM;
 #endif
@@ -203,7 +203,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_EPC]      = (uintptr_t)up_sigdeliver;
 
           int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
-          int_ctx                    &= ~MSTATUS_MIE;
+          int_ctx                    &= ~MSTATUS_MPIE;
 
           tcb->xcp.regs[REG_INT_CTX]  = int_ctx;
 
@@ -304,7 +304,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                   tcb->xcp.regs[REG_EPC]      = (uintptr_t)up_sigdeliver;
 
                   int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
-                  int_ctx                    &= ~MSTATUS_MIE;
+                  int_ctx                    &= ~MSTATUS_MPIE;
 
                   tcb->xcp.regs[REG_INT_CTX] = int_ctx;
                 }
@@ -329,7 +329,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                   CURRENT_REGS[REG_EPC]     = (uintptr_t)up_sigdeliver;
 
                   int_ctx                   = CURRENT_REGS[REG_INT_CTX];
-                  int_ctx                   &= ~MSTATUS_MIE;
+                  int_ctx                   &= ~MSTATUS_MPIE;
 #ifdef CONFIG_BUILD_PROTECTED
                   int_ctx                   |= MSTATUS_MPPM;
 #endif
@@ -400,7 +400,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_EPC]      = (uintptr_t)up_sigdeliver;
 
           int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
-          int_ctx                    &= ~MSTATUS_MIE;
+          int_ctx                    &= ~MSTATUS_MPIE;
 
           tcb->xcp.regs[REG_INT_CTX]  = int_ctx;
         }

--- a/arch/risc-v/src/litex/litex_schedulesigaction.c
+++ b/arch/risc-v/src/litex/litex_schedulesigaction.c
@@ -138,7 +138,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               g_current_regs[REG_EPC]     = (uint32_t)up_sigdeliver;
 
               int_ctx                     = g_current_regs[REG_INT_CTX];
-              int_ctx                    &= ~MSTATUS_MIE;
+              int_ctx                    &= ~MSTATUS_MPIE;
 
               g_current_regs[REG_INT_CTX] = int_ctx;
 
@@ -178,7 +178,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_EPC]      = (uint32_t)up_sigdeliver;
 
           int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
-          int_ctx                    &= ~MSTATUS_MIE;
+          int_ctx                    &= ~MSTATUS_MPIE;
 
           tcb->xcp.regs[REG_INT_CTX]  = int_ctx;
 

--- a/arch/risc-v/src/rv32im/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/rv32im/riscv_schedulesigaction.c
@@ -139,7 +139,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               g_current_regs[REG_EPC]     = (uint32_t)up_sigdeliver;
 
               int_ctx                     = g_current_regs[REG_INT_CTX];
-              int_ctx                    &= ~MSTATUS_MIE;
+              int_ctx                    &= ~MSTATUS_MPIE;
 
               g_current_regs[REG_INT_CTX] = int_ctx;
 
@@ -179,7 +179,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_EPC]     = (uint32_t)up_sigdeliver;
 
           int_ctx                    = tcb->xcp.regs[REG_INT_CTX];
-          int_ctx                   &= ~MSTATUS_MIE;
+          int_ctx                   &= ~MSTATUS_MPIE;
 
           tcb->xcp.regs[REG_INT_CTX] = int_ctx;
 


### PR DESCRIPTION
##  Summary

When executing an MRET instruction, MIE is set to MPIE.
In order to branch to up_sigdeliver() with interrupts disabled,
we need to change MPIE, not MIE.

## Impact

signal on fe310

## Testing

hifive1-revb:nsh
on QEMU

In the beginning of up_sigdeliver(), I confirmed that the MIE of mstatus is zero.
