### PR TITLE
imxrt, s32k1xx, or1kx, risk-v: Bugfix: C++ static constructors not called

### DIFF
--- a/boards/arm/imxrt/imxrt1050-evk/scripts/kernel-space.ld
+++ b/boards/arm/imxrt/imxrt1050-evk/scripts/kernel-space.ld
@@ -63,7 +63,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > kflash
 

--- a/boards/arm/imxrt/imxrt1050-evk/scripts/user-space.ld
+++ b/boards/arm/imxrt/imxrt1050-evk/scripts/user-space.ld
@@ -79,7 +79,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > uflash
 

--- a/boards/arm/imxrt/imxrt1060-evk/scripts/kernel-space.ld
+++ b/boards/arm/imxrt/imxrt1060-evk/scripts/kernel-space.ld
@@ -64,7 +64,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > kflash
 

--- a/boards/arm/imxrt/imxrt1060-evk/scripts/user-space.ld
+++ b/boards/arm/imxrt/imxrt1060-evk/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > uflash
 

--- a/boards/arm/s32k1xx/rddrone-uavcan144/scripts/flash.ld
+++ b/boards/arm/s32k1xx/rddrone-uavcan144/scripts/flash.ld
@@ -88,7 +88,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/rddrone-uavcan144/scripts/sram.ld
+++ b/boards/arm/s32k1xx/rddrone-uavcan144/scripts/sram.ld
@@ -76,7 +76,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k1xx/rddrone-uavcan146/scripts/flash.ld
+++ b/boards/arm/s32k1xx/rddrone-uavcan146/scripts/flash.ld
@@ -88,7 +88,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/rddrone-uavcan146/scripts/sram.ld
+++ b/boards/arm/s32k1xx/rddrone-uavcan146/scripts/sram.ld
@@ -76,7 +76,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k1xx/s32k118evb/scripts/flash.ld
+++ b/boards/arm/s32k1xx/s32k118evb/scripts/flash.ld
@@ -88,7 +88,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/s32k144evb/scripts/flash.ld
+++ b/boards/arm/s32k1xx/s32k144evb/scripts/flash.ld
@@ -88,7 +88,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/s32k144evb/scripts/sram.ld
+++ b/boards/arm/s32k1xx/s32k144evb/scripts/sram.ld
@@ -76,7 +76,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k1xx/s32k146evb/scripts/flash.ld
+++ b/boards/arm/s32k1xx/s32k146evb/scripts/flash.ld
@@ -88,7 +88,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/s32k146evb/scripts/sram.ld
+++ b/boards/arm/s32k1xx/s32k146evb/scripts/sram.ld
@@ -76,7 +76,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/arm/s32k1xx/s32k148evb/scripts/flash.ld
+++ b/boards/arm/s32k1xx/s32k148evb/scripts/flash.ld
@@ -88,7 +88,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > dflash
 

--- a/boards/arm/s32k1xx/s32k148evb/scripts/sram.ld
+++ b/boards/arm/s32k1xx/s32k148evb/scripts/sram.ld
@@ -76,7 +76,7 @@ SECTIONS
   .init_section :
   {
     _sinit = ABSOLUTE(.);
-    *(.init_array .init_array.*)
+    KEEP(*(.init_array .init_array.*))
     _einit = ABSOLUTE(.);
   } > sram
 

--- a/boards/or1k/mor1kx/or1k/scripts/flash.ld
+++ b/boards/or1k/mor1kx/or1k/scripts/flash.ld
@@ -64,7 +64,7 @@ SECTIONS
     .init_section :
     {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(.init_array .init_array.*))
         _einit = ABSOLUTE(.);
     } > dram
 

--- a/boards/risc-v/k210/maix-bit/scripts/user-space.ld
+++ b/boards/risc-v/k210/maix-bit/scripts/user-space.ld
@@ -47,7 +47,7 @@ SECTIONS
 
     .init_section : {
         _sinit = ABSOLUTE(.);
-        *(.init_array .init_array.*)
+        KEEP(*(.init_array .init_array.*))
         _einit = ABSOLUTE(.);
     } > uflash
 


### PR DESCRIPTION
## Summary

The init_section was not being emitted to the image resulting in C++ static constructors not being called.

## Impact

Critical on CPP systems,

## Testing

Verified on nxp_rddrone-uavcan146
