### PR TITLE
Fix up_interrupt_context() for SMP

### DIFF
--- a/arch/arm/src/common/arm_interruptcontext.c
+++ b/arch/arm/src/common/arm_interruptcontext.c
@@ -59,5 +59,15 @@
 
 bool up_interrupt_context(void)
 {
-  return CURRENT_REGS != NULL;
+#ifdef CONFIG_SMP
+  irqstate_t flags = up_irq_save();
+#endif
+
+  bool ret = CURRENT_REGS != NULL;
+
+#ifdef CONFIG_SMP
+  up_irq_restore(flags);
+#endif
+
+  return ret;
 }

--- a/arch/arm/src/common/arm_interruptcontext.c
+++ b/arch/arm/src/common/arm_interruptcontext.c
@@ -60,6 +60,12 @@
 bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
+  /* REVISIT:  Currently up_irq_save() will not disable the Software
+   * Generated Interrupts (SGIs) for the case of ARMv7-A architecture using
+   * the GIC.  So this will not be sufficient in that case, at least not
+   * until we add support for the ICCMPR.
+   */
+
   irqstate_t flags = up_irq_save();
 #endif
 

--- a/arch/risc-v/src/common/riscv_interruptcontext.c
+++ b/arch/risc-v/src/common/riscv_interruptcontext.c
@@ -67,7 +67,17 @@
 bool up_interrupt_context(void)
 {
 #ifdef CONFIG_ARCH_RV64GC
-  return CURRENT_REGS != NULL;
+#ifdef CONFIG_SMP
+  irqstate_t flags = up_irq_save();
+#endif
+
+  bool ret = CURRENT_REGS != NULL;
+
+#ifdef CONFIG_SMP
+  up_irq_restore(flags);
+#endif
+
+  return ret;
 #else
   return g_current_regs != NULL;
 #endif

--- a/arch/xtensa/src/common/xtensa_interruptcontext.c
+++ b/arch/xtensa/src/common/xtensa_interruptcontext.c
@@ -59,5 +59,15 @@
 
 bool up_interrupt_context(void)
 {
-  return CURRENT_REGS != NULL;
+#ifdef CONFIG_SMP
+  irqstate_t flags = up_irq_save();
+#endif
+
+  bool ret = CURRENT_REGS != NULL;
+
+#ifdef CONFIG_SMP
+  up_irq_restore(flags);
+#endif
+
+  return ret;
 }


### PR DESCRIPTION
## Summary

- I found an issue with up_interrupt_context() when testing.
- And finally found that up_interrupt_context() is not atomic.
- This commit fixes the issue

## Impact

- Affects SMP only

## Testing

- Tested with spresense:wifi_smp and sabre-6quad:smp (qemu)
- Tested with maix-bit:smp (qemu)
- Tested with esp32-core:smp (qemu)

