### PR TITLE
Revert "arch/xtensa/src/esp32/esp32_gpio.c: Enable input mode only when"

### DIFF
--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -172,10 +172,6 @@ int esp32_configgpio(int pin, gpio_pinattr_t attr)
 
   if ((attr & INPUT) != 0)
     {
-      /* Enable input mode in the IO_MUX. */
-
-      func |= FUN_IE;
-
       if (pin < 32)
         {
           putreg32((1ul << pin), GPIO_ENABLE_W1TC_REG);
@@ -212,6 +208,10 @@ int esp32_configgpio(int pin, gpio_pinattr_t attr)
   /* Add drivers */
 
   func |= (uint32_t)(2ul << FUN_DRV_S);
+
+  /* Input enable... Required for output as well? */
+
+  func |= FUN_IE;
 
   pinmode = (attr & PINMODE_MASK);
   if (pinmode == INPUT || pinmode == OUTPUT)


### PR DESCRIPTION
## Summary
This reverts commit b5d3ba64e01aace8a64006b3393a69eaabffcb00.  Having the input config enabled is required for certain drivers, such as I2C.  Actually that change broke I2C.
## Impact
Fix a bug in GPIO that was causing a timeout in I2C driver.
## Testing

