### PR TITLE
Update macro definition to avoid integer division side effect for RX65N

### DIFF
--- a/boards/renesas/rx65n/rx65n-grrose/include/board.h
+++ b/boards/renesas/rx65n/rx65n-grrose/include/board.h
@@ -36,13 +36,13 @@
 /* Clocking *****************************************************************/
 
 #define RX_CLK_1MHz                     (1000UL * 1000UL)
-#define RX_FCLK                         ( 60 * RX_CLK_1MHz)
-#define RX_ICLK                         (120 * RX_CLK_1MHz)
-#define RX_PCLKA                        (120 * RX_CLK_1MHz)
-#define RX_PCLKB                        ( 60 * RX_CLK_1MHz)
-#define RX_PCLKC                        ( 60 * RX_CLK_1MHz)
-#define RX_PCLKD                        ( 60 * RX_CLK_1MHz)
-#define RX_BCK                          (120 * RX_CLK_1MHz)
+#define RX_FCLK                         ( 60.0 * RX_CLK_1MHz)
+#define RX_ICLK                         (120.0 * RX_CLK_1MHz)
+#define RX_PCLKA                        (120.0 * RX_CLK_1MHz)
+#define RX_PCLKB                        ( 60.0 * RX_CLK_1MHz)
+#define RX_PCLKC                        ( 60.0 * RX_CLK_1MHz)
+#define RX_PCLKD                        ( 60.0 * RX_CLK_1MHz)
+#define RX_BCK                          (120.0 * RX_CLK_1MHz)
 
 #if defined(CONFIG_ARCH_BOARD_RX65N_RSK1MB) || defined(CONFIG_ARCH_BOARD_RX65N_RSK2MB)
 #define RX_RESONATOR            ( 24 * RX_CLK_1MHz)
@@ -69,41 +69,49 @@
 #if     defined(CONFIG_ARCH_BOARD_RX65N_RSK1MB)
 #define LED0                            (PORT0.PODR.BIT.B3)
 #define LED1                            (PORT0.PODR.BIT.B5)
-#define LED_PORTINIT(X)         { LED0 = LED1 = (X);            \
-        PORT0.ODR0.BIT.B6       =       PORT0.ODR1.BIT.B2       = 0;    \
-        PORT0.DSCR.BIT.B3       =       PORT0.DSCR.BIT.B5       = 1;    \
-        PORT0.PMR.BIT.B3        =       PORT0.PMR.BIT.B5        = 0;    \
-        PORT0.PDR.BIT.B3        =       PORT0.PDR.BIT.B5        = 1;    \
-}
+#define LED_PORTINIT(X) \
+  { \
+    LED0                 =    LED1                  = (X); \
+    PORT0.ODR0.BIT.B6    =    PORT0.ODR1.BIT.B2     = 0; \
+    PORT0.DSCR.BIT.B3    =    PORT0.DSCR.BIT.B5     = 1; \
+    PORT0.PMR.BIT.B3     =    PORT0.PMR.BIT.B5      = 0; \
+    PORT0.PDR.BIT.B3     =    PORT0.PDR.BIT.B5      = 1; \
+  }
 #elif   defined(CONFIG_ARCH_BOARD_RX65N_RSK2MB)
 #define LED0                            (PORT7.PODR.BIT.B3)
 #define LED1                            (PORTG.PODR.BIT.B7)
-#define LED_PORTINIT(X)         { LED0 = LED1 = (X);            \
-        PORT7.ODR0.BIT.B6       =       PORTG.ODR1.BIT.B6       = 0;    \
-        PORT7.DSCR.BIT.B3       =       PORTG.DSCR.BIT.B7       = 1;    \
-        PORT7.DSCR2.BIT.B3      =       PORTG.DSCR2.BIT.B7      = 0;    \
-        PORT7.PMR.BIT.B3        =       PORTG.PMR.BIT.B7        = 0;    \
-        PORT7.PDR.BIT.B3        =       PORTG.PDR.BIT.B7        = 1;    \
-}
+#define LED_PORTINIT(X) \
+  { \
+    LED0                 =    LED1                  = (X); \
+    PORT7.ODR0.BIT.B6    =    PORTG.ODR1.BIT.B6     = 0; \
+    PORT7.DSCR.BIT.B3    =    PORTG.DSCR.BIT.B7     = 1; \
+    PORT7.DSCR2.BIT.B3   =    PORTG.DSCR2.BIT.B7    = 0; \
+    PORT7.PMR.BIT.B3     =    PORTG.PMR.BIT.B7      = 0; \
+    PORT7.PDR.BIT.B3     =    PORTG.PDR.BIT.B7      = 1; \
+  }
 #elif   defined(CONFIG_ARCH_BOARD_RX65N)
 #define LED0                            (PORT0.PODR.BIT.B3)
 #define LED1                            (PORT0.PODR.BIT.B5)
-#define LED_PORTINIT(X)         { LED0 = LED1 = (X);            \
-        PORT0.ODR0.BIT.B6       =       PORT0.ODR1.BIT.B2       = 0;    \
-        PORT0.DSCR.BIT.B3       =       PORT0.DSCR.BIT.B5       = 1;    \
-        PORT0.PMR.BIT.B3        =       PORT0.PMR.BIT.B5        = 0;    \
-        PORT0.PDR.BIT.B3        =       PORT0.PDR.BIT.B5        = 1;    \
-}
+#define LED_PORTINIT(X) \
+  { \
+    LED0                 =    LED1                  = (X); \
+    PORT0.ODR0.BIT.B6    =    PORT0.ODR1.BIT.B2     = 0; \
+    PORT0.DSCR.BIT.B3    =    PORT0.DSCR.BIT.B5     = 1; \
+    PORT0.PMR.BIT.B3     =    PORT0.PMR.BIT.B5      = 0; \
+    PORT0.PDR.BIT.B3     =    PORT0.PDR.BIT.B5      = 1; \
+  }
 #elif   defined(CONFIG_ARCH_BOARD_RX65N_GRROSE)
 #define LED0                            (PORTA.PODR.BIT.BT0)
 #define LED1                            (PORTA.PODR.BIT.B1)
-#define LED_PORTINIT(X)         { LED0 = LED1 = (X);            \
-        PORTA.ODR0.BIT.BT0      =       PORTA.ODR0.BIT.B2       = 0;    \
-        PORTA.DSCR.BIT.BT0      =       PORTA.DSCR.BIT.B1       = 1;    \
-        PORTA.DSCR2.BIT.BT0     =       PORTA.DSCR2.BIT.B1      = 0;    \
-        PORTA.PMR.BIT.BT0       =       PORTA.PMR.BIT.B1        = 0;    \
-        PORTA.PDR.BIT.BT0       =       PORTA.PDR.BIT.B1        = 1;    \
-}
+#define LED_PORTINIT(X) \
+  { \
+    LED0                 =    LED1                  = (X); \
+    PORTA.ODR0.BIT.BT0   =    PORTA.ODR0.BIT.B2     = 0; \
+    PORTA.DSCR.BIT.BT0   =    PORTA.DSCR.BIT.B1     = 1; \
+    PORTA.DSCR2.BIT.BT0  =    PORTA.DSCR2.BIT.B1    = 0; \
+    PORTA.PMR.BIT.BT0    =    PORTA.PMR.BIT.B1      = 0; \
+    PORTA.PDR.BIT.BT0    =    PORTA.PDR.BIT.B1      = 1; \
+  }
 #else
 #error "LEDs are not defined."
 #endif

--- a/boards/renesas/rx65n/rx65n-rsk2mb/include/board.h
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/include/board.h
@@ -36,13 +36,13 @@
 /* Clocking *****************************************************************/
 
 #define RX_CLK_1MHz                     (1000UL * 1000UL)
-#define RX_FCLK                         ( 60 * RX_CLK_1MHz)
-#define RX_ICLK                         (120 * RX_CLK_1MHz)
-#define RX_PCLKA                        (120 * RX_CLK_1MHz)
-#define RX_PCLKB                        ( 60 * RX_CLK_1MHz)
-#define RX_PCLKC                        ( 60 * RX_CLK_1MHz)
-#define RX_PCLKD                        ( 60 * RX_CLK_1MHz)
-#define RX_BCK                          (120 * RX_CLK_1MHz)
+#define RX_FCLK                         ( 60.0 * RX_CLK_1MHz)
+#define RX_ICLK                         (120.0 * RX_CLK_1MHz)
+#define RX_PCLKA                        (120.0 * RX_CLK_1MHz)
+#define RX_PCLKB                        ( 60.0 * RX_CLK_1MHz)
+#define RX_PCLKC                        ( 60.0 * RX_CLK_1MHz)
+#define RX_PCLKD                        ( 60.0 * RX_CLK_1MHz)
+#define RX_BCK                          (120.0 * RX_CLK_1MHz)
 
 #if defined(CONFIG_ARCH_BOARD_RX65N_RSK1MB) || defined(CONFIG_ARCH_BOARD_RX65N_RSK2MB)
 #define RX_RESONATOR            ( 24 * RX_CLK_1MHz)
@@ -69,41 +69,49 @@
 #if     defined(CONFIG_ARCH_BOARD_RX65N_RSK1MB)
 #define LED0                            (PORT0.PODR.BIT.B3)
 #define LED1                            (PORT0.PODR.BIT.B5)
-#define LED_PORTINIT(X)         { LED0 = LED1 = (X);            \
-        PORT0.ODR0.BIT.B6       =       PORT0.ODR1.BIT.B2       = 0;    \
-        PORT0.DSCR.BIT.B3       =       PORT0.DSCR.BIT.B5       = 1;    \
-        PORT0.PMR.BIT.B3        =       PORT0.PMR.BIT.B5        = 0;    \
-        PORT0.PDR.BIT.B3        =       PORT0.PDR.BIT.B5        = 1;    \
-}
+#define LED_PORTINIT(X) \
+  { \
+    LED0                 =    LED1                   = (X); \
+    PORT0.ODR0.BIT.B6    =    PORT0.ODR1.BIT.B2      = 0; \
+    PORT0.DSCR.BIT.B3    =    PORT0.DSCR.BIT.B5      = 1; \
+    PORT0.PMR.BIT.B3     =    PORT0.PMR.BIT.B5       = 0; \
+    PORT0.PDR.BIT.B3     =    PORT0.PDR.BIT.B5       = 1; \
+  }
 #elif   defined(CONFIG_ARCH_BOARD_RX65N_RSK2MB)
 #define LED0                            (PORT7.PODR.BIT.B3)
 #define LED1                            (PORTG.PODR.BIT.B7)
-#define LED_PORTINIT(X)         { LED0 = LED1 = (X);            \
-        PORT7.ODR0.BIT.B6       =       PORTG.ODR1.BIT.B6       = 0;    \
-        PORT7.DSCR.BIT.B3       =       PORTG.DSCR.BIT.B7       = 1;    \
-        PORT7.DSCR2.BIT.B3      =       PORTG.DSCR2.BIT.B7      = 0;    \
-        PORT7.PMR.BIT.B3        =       PORTG.PMR.BIT.B7        = 0;    \
-        PORT7.PDR.BIT.B3        =       PORTG.PDR.BIT.B7        = 1;    \
-}
+#define LED_PORTINIT(X) \
+  { \
+    LED0                 =    LED1                   = (X); \
+    PORT7.ODR0.BIT.B6    =    PORTG.ODR1.BIT.B6      = 0; \
+    PORT7.DSCR.BIT.B3    =    PORTG.DSCR.BIT.B7      = 1; \
+    PORT7.DSCR2.BIT.B3   =    PORTG.DSCR2.BIT.B7     = 0; \
+    PORT7.PMR.BIT.B3     =    PORTG.PMR.BIT.B7       = 0; \
+    PORT7.PDR.BIT.B3     =    PORTG.PDR.BIT.B7       = 1; \
+  }
 #elif   defined(CONFIG_ARCH_BOARD_RX65N)
 #define LED0                            (PORT0.PODR.BIT.B3)
 #define LED1                            (PORT0.PODR.BIT.B5)
-#define LED_PORTINIT(X)         { LED0 = LED1 = (X);            \
-        PORT0.ODR0.BIT.B6       =       PORT0.ODR1.BIT.B2       = 0;    \
-        PORT0.DSCR.BIT.B3       =       PORT0.DSCR.BIT.B5       = 1;    \
-        PORT0.PMR.BIT.B3        =       PORT0.PMR.BIT.B5        = 0;    \
-        PORT0.PDR.BIT.B3        =       PORT0.PDR.BIT.B5        = 1;    \
-}
+#define LED_PORTINIT(X) \
+  { \
+    LED0                 =    LED1                   = (X); \
+    PORT0.ODR0.BIT.B6    =    PORT0.ODR1.BIT.B2      = 0; \
+    PORT0.DSCR.BIT.B3    =    PORT0.DSCR.BIT.B5      = 1; \
+    PORT0.PMR.BIT.B3     =    PORT0.PMR.BIT.B5       = 0; \
+    PORT0.PDR.BIT.B3     =    PORT0.PDR.BIT.B5       = 1; \
+  }
 #elif   defined(CONFIG_ARCH_BOARD_RX65N_GRROSE)
 #define LED0                            (PORTA.PODR.BIT.BT0)
 #define LED1                            (PORTA.PODR.BIT.B1)
-#define LED_PORTINIT(X)         { LED0 = LED1 = (X);            \
-        PORTA.ODR0.BIT.BT0      =       PORTA.ODR0.BIT.B2       = 0;    \
-        PORTA.DSCR.BIT.BT0      =       PORTA.DSCR.BIT.B1       = 1;    \
-        PORTA.DSCR2.BIT.BT0     =       PORTA.DSCR2.BIT.B1      = 0;    \
-        PORTA.PMR.BIT.BT0       =       PORTA.PMR.BIT.B1        = 0;    \
-        PORTA.PDR.BIT.BT0       =       PORTA.PDR.BIT.B1        = 1;    \
-}
+#define LED_PORTINIT(X) \
+  { \
+    LED0                 =    LED1                   = (X); \
+    PORTA.ODR0.BIT.BT0   =    PORTA.ODR0.BIT.B2      = 0; \
+    PORTA.DSCR.BIT.BT0   =    PORTA.DSCR.BIT.B1      = 1; \
+    PORTA.DSCR2.BIT.BT0  =    PORTA.DSCR2.BIT.B1     = 0; \
+    PORTA.PMR.BIT.BT0    =    PORTA.PMR.BIT.B1       = 0; \
+    PORTA.PDR.BIT.BT0    =    PORTA.PDR.BIT.B1       = 1; \
+  }
 #else
 #error "LEDs are not defined."
 #endif


### PR DESCRIPTION
## Summary

Macro definitions for peripheral clocks updated to avoid integer division side effect

## Impact

## Testing

Tested on RX65N reference board
