### PR TITLE
fs: Skip the enumeration of root directory in foreach_inode

### DIFF
--- a/fs/inode/fs_foreachinode.c
+++ b/fs/inode/fs_foreachinode.c
@@ -186,7 +186,7 @@ int foreach_inode(foreach_inode_t handler, FAR void *arg)
   ret = inode_semtake();
   if (ret >= 0)
     {
-      ret = foreach_inodelevel(g_root_inode, info);
+      ret = foreach_inodelevel(g_root_inode->i_child, info);
       inode_semgive();
     }
 
@@ -210,7 +210,7 @@ int foreach_inode(foreach_inode_t handler, FAR void *arg)
   ret = inode_semtake();
   if (ret >= 0)
     {
-      ret = foreach_inodelevel(g_root_inode, &info);
+      ret = foreach_inodelevel(g_root_inode->i_child, &info);
       inode_semgive();
     }
 


### PR DESCRIPTION
## Summary
ensure the behaviour same before:
```
commit b76c4672d64d226e6ea5c44fa7d3b95e2df8482c (origin/root)
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Tue Sep 15 17:42:42 2020 +0800

    vfs: Create a node as the root of pseudo file system

    to remove the special process for root
```

## Impact
Fix the problem reported here: https://github.com/apache/incubator-nuttx/pull/1805
```
nsh> mount
  //bin type binfs
  //etc type romfs
  //proc type procfs
  //tmp type vfat
```

## Testing

