### PR TITLE
sched: nxtask_start should call entry point directly for kernel thread

### DIFF
--- a/sched/task/task_start.c
+++ b/sched/task/task_start.c
@@ -134,18 +134,18 @@ void nxtask_start(void)
    * we have to switch to user-mode before calling the task.
    */
 
-#ifndef CONFIG_BUILD_FLAT
-  if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
-    {
-      up_task_start(tcb->cmn.entry.main, argc, tcb->argv);
-    }
-  else
+  if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
     {
       exitcode = tcb->cmn.entry.main(argc, tcb->argv);
     }
+  else
+    {
+#ifdef CONFIG_BUILD_FLAT
+      nxtask_startup(tcb->cmn.entry.main, argc, tcb->argv);
 #else
-  nxtask_startup(tcb->cmn.entry.main, argc, tcb->argv);
+      up_task_start(tcb->cmn.entry.main, argc, tcb->argv);
 #endif
+    }
 
   /* Call exit() if/when the task returns */
 


### PR DESCRIPTION
## Summary
since nxtask_startup will initialize c++ global variables which shouldn't be done inside the kernel thread.

## Impact
C++ global variables may initialize twice when SMP is enabled because cxx_initialize don't have any sync code. But we don't need add mutex/spinlock code to cxx_initialize, because we should avoid the kernel thread call cxx_initialize in the first place. Once we ensure that cxx_initialize get called only inside the user task entry point, the sync isn't a problem anymore because NuttX kernel always create one and only one user task(init).

## Testing

