### PR TITLE
nrf52_ppi: fix group disable and add group clear operation

### DIFF
--- a/arch/arm/src/nrf52/nrf52_ppi.c
+++ b/arch/arm/src/nrf52/nrf52_ppi.c
@@ -67,10 +67,12 @@ void nrf52_ppi_channel_enable(uint8_t ch, bool enable)
 
   if (enable)
     {
+      DEBUGASSERT(!(getreg32(NRF52_PPI_CHENSET) & PPI_CHEN_CH(ch)));
       putreg32(PPI_CHEN_CH(ch), NRF52_PPI_CHENSET);
     }
   else
     {
+      DEBUGASSERT(getreg32(NRF52_PPI_CHENSET) & PPI_CHEN_CH(ch));
       putreg32(PPI_CHEN_CH(ch), NRF52_PPI_CHENCLR);
     }
 }
@@ -122,6 +124,17 @@ void nrf52_ppi_grp_channel_enable(uint8_t group, uint8_t ch, bool enable)
 }
 
 /****************************************************************************
+ * Name: nrf52_ppi_grp_clear
+ ****************************************************************************/
+
+void nrf52_ppi_grp_clear(uint8_t group)
+{
+  DEBUGASSERT(group < NRF52_PPI_NUM_GROUPS);
+
+  putreg32(0, NRF52_PPI_CHG(group));
+}
+
+/****************************************************************************
  * Name: nrf52_ppi_grp_enable
  ****************************************************************************/
 
@@ -130,5 +143,5 @@ void nrf52_ppi_grp_enable(uint8_t group, bool enable)
   DEBUGASSERT(group < NRF52_PPI_NUM_GROUPS);
 
   putreg32(1, (enable ? NRF52_PPI_TASK_CHGEN(group) :
-                        NRF52_PPI_TASK_CHGDIS_OFFSET(group)));
+                        NRF52_PPI_TASK_CHGDIS(group)));
 }

--- a/arch/arm/src/nrf52/nrf52_ppi.h
+++ b/arch/arm/src/nrf52/nrf52_ppi.h
@@ -132,6 +132,19 @@ void nrf52_ppi_set_task2_ep(uint8_t ch, uint32_t task_reg);
 void nrf52_ppi_grp_channel_enable(uint8_t group, uint8_t ch, bool enable);
 
 /****************************************************************************
+ * Name: nrf52_ppi_grp_clear
+ *
+ * Description:
+ *   Clear group (disable all its channels)
+ *
+ * Input Parameters:
+ *   - group: group number
+ *
+ ****************************************************************************/
+
+void nrf52_ppi_grp_clear(uint8_t group);
+
+/****************************************************************************
  * Name: nrf52_ppi_grp_enable
  *
  * Description:


### PR DESCRIPTION
## Summary

This change fixes wrong implementation of PPI channel group disable operation. Also, this adds the possibility of clearing all channels from a group in one operation (useful for ensuring a clean slate). Finally, this adds various DEBUGASSERTS() that ensure that when enabling a channel, it wasn't already enabled and viceversa. This helps detecting when using a PPI channel already in use.

## Impact

Bug fix, extra operation and extra checks for nRF52's PPI peripheral.

## Testing

Normal use of PPI