### PR TITLE
Sources and Docs: Fix typos and nxstyle issues

### DIFF
--- a/Documentation/contributing/coding_style.rst
+++ b/Documentation/contributing/coding_style.rst
@@ -6,7 +6,7 @@ C Coding Standard
 =================
 
 NuttX follows a specific coding style which needs to be followed at all times
-a contribution to be accepted. Please read this document before working on 
+a contribution to be accepted. Please read this document before working on
 new code so that you can follow the style from the start. To check your code
 for conformance to the coding style, you should use the `nxstyle <#nxstyle>`_
 tool included under ``tools/`` in the main NuttX repository.
@@ -18,7 +18,7 @@ General Conventions
 File Organization
 =================
 
-**File Extensions** Use the ``.h`` extension for C header files 
+**File Extensions** Use the ``.h`` extension for C header files
 and ``.c`` for C source files.
 
 **File header**. Every C, C++, make file, or script begins with a file header.
@@ -153,10 +153,10 @@ may be used in the file provided that it is used consistently.
 
 **Line Wrapping**.
 
-.. error:: This is incorrect  
-  
+.. error:: This is incorrect
+
   .. code-block:: c
-  
+
     struct some_long_struct_name_s
     {
       struct some_long_struct_name_s *flink;  /* The forward link to the next instance of struct some_long_struct_name_s in a singly linked list */
@@ -182,7 +182,7 @@ may be used in the file provided that it is used consistently.
 .. hint:: This is correct
 
   .. code-block:: c
-  
+
     struct some_long_struct_name_s
     {
       /* The forward link to the next instance of struct
@@ -212,7 +212,7 @@ may be used in the file provided that it is used consistently.
                                              long_parameter_name_5,
                                              long_parameter_name_6,
                                              long_parameter_name_7,
-                                             long_parameter_name_8);    
+                                             long_parameter_name_8);
 
 **NOTE**: See the discussion of `pointers <#farnear>`__ for
 information about the ``FAR`` qualifier used above.
@@ -229,19 +229,19 @@ exceeded.
 .. note:: This is acceptable
 
   .. code-block:: c
-  
+
     dog = cat;
     monkey = oxen;
-    aardvark = macaque;   
-    
+    aardvark = macaque;
+
 .. hint:: This is preferred
- 
+
   .. code-block:: c
-  
+
     dog      = cat;
     monkey   = oxen;
     aardvark = macaque;
-     
+
 **Block Comments** The final asterisk (``*``) should occur at
 column 78 (or the line width of files with longer lines). Note
 that the final comment delimiter of the block comment is an
@@ -281,10 +281,10 @@ that may be the final line preceding a closing right brace.
 With Labels. No blank line separates the line containing the label
 from a comment.
 
-.. error:: This is incorrect  
- 
+.. error:: This is incorrect
+
   .. code-block:: c
-  
+
       /* set a equal to b */
       a = b;
       /* set b equal to c */
@@ -306,11 +306,11 @@ from a comment.
       here:
 
       /* This is the place */
-      
+
 .. tip:: This is correct
 
   .. code-block:: c
-  
+
       /* Set a equal to b. */
 
       a = b;
@@ -344,7 +344,7 @@ single line. The comment delimiters must lie on the same line.
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     /*
      * This is a single line comment
      */
@@ -352,7 +352,7 @@ single line. The comment delimiters must lie on the same line.
 .. tip:: This is correct
 
   .. code-block:: c
-    
+
     /* This is a single line comment. */
 
 **Multi-line comments**. If the comment is too long to fit on a
@@ -368,7 +368,7 @@ preceding line.
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     /*
        This is the first line of a multi-line comment.
        This is the second line of a multi-line comment.
@@ -377,11 +377,11 @@ preceding line.
     /* This is the first line of another multi-line comment.  */
     /* This is the second line of another multi-line comment. */
     /* This is the third line of another multi-line comment.  */
-  
+
 .. tip:: This is correct
 
   .. code-block:: c
-  
+
     /* This is the first line of a multi-line comment.
      * This is the second line of a multi-line comment.
      * This is the third line of a multi-line comment.
@@ -396,23 +396,23 @@ comment begins in the same column on each line.
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     dog = cat; /* Make the dog be a cat */
     monkey = oxen; /* Make the monkey be an oxen */
     aardvark = macaque; /* Make the aardvark be a macaque */
-  
+
 .. note:: This is acceptable
 
   .. code-block:: c
-  
+
     dog      = cat;     /* Make the dog be a cat. */
     monkey   = oxen;    /* Make the monkey be an oxen. */
-    aardvark = macaque; /* Make the aardvark be a macaque. */  
+    aardvark = macaque; /* Make the aardvark be a macaque. */
 
 .. tip:: This is preferred
 
   .. code-block:: c
-  
+
     /* Make the dog be a cat. */
 
     dog      = cat;
@@ -424,7 +424,7 @@ comment begins in the same column on each line.
     /* Make the aardvark be a macaque. */
 
     aardvark = macaque;
-    
+
 **Comments to the Right of Data Definitions**. Comments to the
 right of a declaration with an enumeration or structure, on the
 other hand, are encouraged, provided that the comments are short
@@ -435,7 +435,7 @@ be achieved without violating the line width).
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     struct animals_s
     {
       int dog; /* This is a dog */
@@ -445,11 +445,11 @@ be achieved without violating the line width).
       bool aardvark; /* This is an aardvark */
       bool macaque; /* This is a macaque */
     };
-  
+
 .. note:: This is acceptable
 
   .. code-block:: c
-  
+
     struct animals_s
     {
       int dog;       /* This is a dog. */
@@ -463,7 +463,7 @@ be achieved without violating the line width).
 .. tip:: This is preferred
 
   .. code-block:: c
-  
+
     struct animals_s
     {
       int    dog;      /* This is a dog. */
@@ -492,20 +492,20 @@ comment delimiter must lie on the *same* line with the asterisk.
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     dog = cat; /* This assignment will convert what was at one time a lowly dog into a ferocious feline. */
 
 .. note:: This is acceptable
 
   .. code-block:: c
-  
+
     dog = cat;       /* This assignment will convert what was at one time a
                       * lowly dog into a ferocious feline. */
 
 .. tip:: This is preferred
 
   .. code-block:: c
-  
+
     /* This assignment will convert what was at one time a lowly dog into a
      * ferocious feline.
      */
@@ -533,7 +533,7 @@ compatible with C89.
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     // This is a structure of animals
     struct animals_s
     {
@@ -548,7 +548,7 @@ compatible with C89.
 .. tip:: This is correct
 
   .. code-block:: c
-  
+
     /* This is a structure of animals. */
 
     struct animals_s
@@ -569,7 +569,7 @@ why the code is not compiled.
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     void some_function(void)
     {
       ... compiled code ...
@@ -595,7 +595,7 @@ why the code is not compiled.
 .. tip:: This is correct
 
   .. code-block:: c
-  
+
     void some_function(void)
     {
       ... compiled code ...
@@ -646,7 +646,7 @@ few subtle differences.
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     while (true)
       {
         if (valid)
@@ -671,11 +671,11 @@ few subtle differences.
           c = b;
       }
     }
-    
+
 .. tip:: This is correct
 
   .. code-block:: c
-      
+
     while (true)
       {
         if (valid)
@@ -709,7 +709,7 @@ few subtle differences.
           {
             c = b;
           }
-      }  
+      }
 
 **Exception to Indentation Rule for Braces**. The exception is braces
 that following structure, enumeration, union, and function declarations.
@@ -719,7 +719,7 @@ with the beginning of the definition
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     enum kinds_of_dogs_e
       {
       ...
@@ -747,11 +747,11 @@ with the beginning of the definition
       {
       ...
       }
-    
+
 .. tip:: This is correct
 
   .. code-block:: c
-      
+
     enum kinds_of_dogs_e
     {
       ...
@@ -797,11 +797,11 @@ indentation levels. TAB characters may not be used for indentation.
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     if (x == y) {
 	    dosomething(x);
     }
-    
+
       if (x == y) {
           dosomething(x);
       }
@@ -809,7 +809,7 @@ indentation levels. TAB characters may not be used for indentation.
 .. tip:: This is correct
 
   .. code-block:: c
-  
+
     if (x == y)
       {
         dosomething(x);
@@ -861,7 +861,7 @@ statements should be omitted in those sections (only).
 .. error:: This is incorrect
 
   .. code-block:: c
-  
+
     #ifdef CONFIG_ABC
     #define ABC_THING1 1
     #define ABC_THING2 2
@@ -877,7 +877,7 @@ statements should be omitted in those sections (only).
 .. tip:: This is correct
 
   .. code-block:: c
-  
+
     #ifdef CONFIG_ABC
     #  define ABC_THING1 1
     #  define ABC_THING2 2
@@ -895,9 +895,9 @@ definitions <#idempotence>`__ at the beginning of the header file. This
 conditional compilation does *not* cause any change to the indentation.
 
 .. error:: This is incorrect
- 
+
   .. code-block:: c
-  
+
     #ifndef __INCLUDE_SOMEHEADER_H
     #  define __INCLUDE_SOMEHEADER_H
     ...
@@ -908,9 +908,9 @@ conditional compilation does *not* cause any change to the indentation.
     #endif /* __INCLUDE_SOMEHEADER_H */
 
 .. tip:: This is correct
- 
+
   .. code-block:: c
-  
+
     #ifndef __INCLUDE_SOMEHEADER_H
     #define __INCLUDE_SOMEHEADER_H
     ...
@@ -941,9 +941,9 @@ Parentheses
    to force the correct order of operations in a computed return value.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     int do_foobar ( void )
     {
       int ret = 0;
@@ -958,9 +958,9 @@ Parentheses
     }
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     int do_foobar(void)
     {
       int ret = 0;
@@ -992,24 +992,24 @@ One Definition/Declaration Per Line
 ===================================
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     extern long time, money;
     char **ach, *bch;
     int i, j, k;
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     extern long time;
     extern long money;
     FAR char **ach;
     FAR char *bch;
     int i;
     int j;
-    int k;  
+    int k;
 
 **NOTE**: See the discussion of `pointers <#farnear>`__ for information
 about the ``FAR`` qualifier used above.
@@ -1052,27 +1052,27 @@ any variable that has more than local scope.
    general, is discourage unless there is no other reasonable solution.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     extern int someint;
     static int anotherint;
     uint32_t dwA32BitInt;
     uint32_t gAGlobalVariable;
 
 .. note:: This is acceptable
-  
+
   .. code-block:: c
-  
+
     extern int g_someint;
     static int g_anotherint;
     uint32_t g_a32bitint;
     uint32_t g_aglobal;
 
 .. tip:: This is preferred
-  
+
   .. code-block:: c
-  
+
     struct my_variables_s
     {
       uint32_t a32bitint;
@@ -1113,9 +1113,9 @@ Parameters and Local Variables
    discouraged.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     uint32_t somefunction(int a, uint32_t dwBValue)
     {
       uint32_t this_is_a_long_variable_name = 1;
@@ -1128,11 +1128,11 @@ Parameters and Local Variables
 
       return this_is_a_long_variable_name;
     }
-    
+
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     uint32_t somefunction(int limit, uint32_t value)
     {
       uint32_t ret = 1;
@@ -1145,7 +1145,7 @@ Parameters and Local Variables
 
       return ret;
     }
-  
+
 
 **NOTE:** You will see the local variable named ``ret`` is frequently
 used in the code base for the name of a local variable whose value will
@@ -1173,16 +1173,16 @@ Type Definitions
    discouraged.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     typedef void *myhandle;
     typedef int myInteger;
-    
+
 .. tip:: This is correct
-  
+
   .. code-block:: c
-   
+
     typedef FAR void *myhandle_t;
     typedef int myinteger_t;
 
@@ -1209,8 +1209,8 @@ Structures
    structure may be another structure that is defined only with the
    scope of the containing structure. This practice is acceptable, but
    discouraged.
--  **No un-named structure fields**. Structure may contain other
-   structures as fields. This this case, the structure field must be
+-  **No un-named structure fields**. Structures may contain other
+   structures as fields. In this case, the structure field must be
    named. C11 permits such un-named structure fields within a structure.
    NuttX generally follows C89 and all code outside of architecture
    specific directories must be compatible with C89.
@@ -1272,9 +1272,9 @@ well known like ``uint8_t`` and ``uint32_t`` should also be place in
 either ascending or descending size order.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     typedef struct       /* Un-named structure */
     {
       ...
@@ -1304,9 +1304,9 @@ either ascending or descending size order.
     };
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     struct xyz_info_s
     {
       ...
@@ -1317,17 +1317,17 @@ either ascending or descending size order.
     };
 
 .. warning:: This is discouraged
-  
+
   .. code-block:: c
-  
+
     typedef struct xyz_info_s xzy_info_t;
 
 The use of typedef'ed structures is acceptable but discouraged.
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     struct xyz_info_s
     {
       ...
@@ -1336,11 +1336,11 @@ The use of typedef'ed structures is acceptable but discouraged.
       uint8_t bitc : 1,  /* Bit C */
       ...
     };
-    
+
 .. warning:: This is discouraged
-  
+
   .. code-block:: c
-  
+
     struct abc_s
     {
       ...
@@ -1358,9 +1358,9 @@ The general practice of defining a structure within the scope of another structu
 The following is preferred:
 
 .. tip:: This is preferred
-  
+
   .. code-block:: c
-  
+
     struct abc_s
     {
       ...
@@ -1385,7 +1385,7 @@ formatting <#lines>`__, `use of braces <#braces>`__,
 .. note:: This is acceptable
 
   .. code-block:: c
-     
+
     union xyz_union_u  /* All unions must be named */
     {
       uint8_t  b[4];   /* Byte values. */
@@ -1398,9 +1398,9 @@ formatting <#lines>`__, `use of braces <#braces>`__,
 The use of typedef'ed unions is acceptable but discouraged.
 
 .. tip:: This is preferred
-  
+
   .. code-block:: c
-  
+
     struct xyz_info_s
     {
       ...
@@ -1447,9 +1447,9 @@ formatting <#lines>`__, `use of braces <#braces>`__,
 `indentation <#indentation>`__, and `comments <#comments>`__.
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     enum xyz_state_e
     {
       XYZ_STATE_UNINITIALIZED = 0, /* Uninitialized state. */
@@ -1509,9 +1509,9 @@ formatting <#lines>`__, `indentation <#indentation>`__, and
 `comments <#comments>`__.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     #define max(a,b) a > b ? a : b
 
     #define ADD(x,y) x + y
@@ -1531,12 +1531,12 @@ formatting <#lines>`__, `indentation <#indentation>`__, and
         a = b*value;                                         \
       }
 
-    #define DO_ASSIGN(a,b) a = b  
+    #define DO_ASSIGN(a,b) a = b
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     #define MAX(a,b) (((a) > (b)) ? (a) : (b))
 
     #define ADD(x,y) ((x) + (y))
@@ -1577,17 +1577,17 @@ immediately before the variable name with no intervening spaces. A space
 should precede the asterisk in a cast to a pointer type.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     int somefunction(struct somestruct_s* psomething);
 
     ptr = (struct somestruct_s*)value;
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     int somefunction(FAR struct somestruct_s *something);
 
     ptr = (FAR struct somestruct_s *)value;
@@ -1766,9 +1766,9 @@ Conventions <#general>`__, `Parameters and Local
 Variables <#localvariable>`__, and `Statements <#statements>`__.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     int myfunction(int a, int b)
       {
         int c, d;
@@ -1787,11 +1787,11 @@ Variables <#localvariable>`__, and `Statements <#statements>`__.
 
         return (e / a);
       }
-    
+
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     int myfunction(int a, int b)
     {
       int c;
@@ -1815,7 +1815,7 @@ Variables <#localvariable>`__, and `Statements <#statements>`__.
 
       return e / a;
     }
-  
+
 Returned Values
 ===============
 
@@ -1839,7 +1839,7 @@ particular, must be checked for failures to allocate memory to avoid use
 of NULL pointers.
 
 **********
-Statements                                            
+Statements
 **********
 
 One Statement Per Line
@@ -1859,9 +1859,9 @@ One Statement Per Line
 use of `braces <#braces>`__.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     if (var1 &lt; var2) var1 = var2;
 
     case 5: var1 = var2; break;
@@ -1869,11 +1869,11 @@ use of `braces <#braces>`__.
     var1 = 5; var2 = 6; var3 = 7;
 
     var1 = var2 = var3 = 0;
-  
+
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     if (var1 &lt; var2)
       {
         var1 = var2;
@@ -1902,15 +1902,15 @@ Casts
    value being cast.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     struct something_s *x = (struct something_s*) y;
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     struct something_s *x = (struct something_s *)y;
 
 Operators
@@ -1922,17 +1922,17 @@ Operators
 operator, for readability. As examples:
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     for=bar;
     if(a==b)
     for(i=0;i<5;i++)
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     for = bar;
     if (a == b)
     for (i = 0; i < 5; i++)
@@ -1942,15 +1942,15 @@ operate on only one value), such as ``++``, should *not* have a space
 between the operator and the variable or number they are operating on.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     x ++;
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-      
+
     x++;
 
 **Forbidden Multicharacter Forms**. Many operators are expressed as a
@@ -2001,9 +2001,9 @@ different.
 braces <#braces>`__ and `indentation <#indentation>`__.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     if(var1 < var2) var1 = var2;
 
     if(var > 0)
@@ -2017,11 +2017,11 @@ braces <#braces>`__ and `indentation <#indentation>`__.
       var1 = 0;
     }
     var2 = var1;
-  
+
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     if (var1 < var2)
       {
         var1 = var2;
@@ -2047,7 +2047,7 @@ braces <#braces>`__ and `indentation <#indentation>`__.
 
     var2 = var1;
 
-**Ternary operator** (``<condition> ? <then> : <else>``):  
+**Ternary operator** (``<condition> ? <then> : <else>``):
 
 -  **Only if the expression is short**. Use of this form is only
    appropriate if the entire sequence is short and fits neatly on the
@@ -2062,9 +2062,9 @@ braces <#braces>`__ and `indentation <#indentation>`__.
 `parentheses <#parentheses>`__.
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     int arg1 = arg2 > arg3 ? arg2 : arg3;
     int arg1 = ((arg2 > arg3) ? arg2 : arg3);
 
@@ -2113,9 +2113,9 @@ braces <#braces>`__, `indentation <#indentation>`__, and
 `comments <#comments>`__.
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     switch (...)
       {
         case 1:  /* Example of a comment following a case selector. */
@@ -2170,9 +2170,9 @@ braces <#braces>`__, `indentation <#indentation>`__, and
 `comments <#comments>`__.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     while( notready() )
       {
       }
@@ -2181,9 +2181,9 @@ braces <#braces>`__, `indentation <#indentation>`__, and
     while (*ptr != '\0') ptr++;
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
     while (notready());
 
     ready = true;
@@ -2218,9 +2218,9 @@ braces <#braces>`__, `indentation <#indentation>`__, and
 `comments <#comments>`__.
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-  
+
     do {
       ready = !notready();
     } while (!ready);
@@ -2229,9 +2229,9 @@ braces <#braces>`__, `indentation <#indentation>`__, and
     do ptr++; while (*ptr != '\0');
 
 .. error:: This is incorrect
-  
+
   .. code-block:: c
-   
+
     do
       {
         ready = !notready();
@@ -2267,9 +2267,9 @@ Use of ``goto``
    begin in column 1.
 
 .. tip:: This is correct
-  
+
   .. code-block:: c
-  
+
        FAR struct some_struct_s *ptr;
        int fd;
        int ret;
@@ -2310,7 +2310,7 @@ Use of ``goto``
 
     error:
       return ret;
-    
+
 **NOTE**: See the discussion of `pointers <#farnear>`__ for information
 about the ``FAR`` qualifier used above.
 
@@ -2353,31 +2353,31 @@ method;
 Namespaces, global variable, class, structure, template, and enumeration
 names begin with a capital letter identifying what is being named:
 
- *Namespace Names* 
+ *Namespace Names*
    Namespaces begin with an upper case character but no particular
    character is specified. As an example, ``MyNamespace`` is fully
    compliant.
- *Global Variable Names* 
+ *Global Variable Names*
    Global variables and singletons begin with an upper case '**G**'. For
    example, ``GMyGlobalVariable``. The prefix ``g_`` is never used.
- *Implementation Class Names* 
+ *Implementation Class Names*
    Classes that implement methods begin with an upper case '**C**'. For
    example, ``CMyClass``. A fully qualified method of ``CMyClass`` could
    be ``MyNamespace::CMyClass::myMethod``
- *Pure Virtual Base Class Names* 
+ *Pure Virtual Base Class Names*
    Such base classes begin with an upper case '**I**'. For example,
    ``IMyInterface``.
- *Template Class Names* 
+ *Template Class Names*
    Template classes begin with an upper case '**T**'. For example,
    ``TMyTemplate``.
- *``typedef``'d Type Names* 
+ *``typedef``'d Type Names*
    Currently all such types also begin with an upper case '**T**'. That
    probably needs some resolution to distinguish for template names. The
    suffix ``_t`` is never used.
- *Structure Names* 
+ *Structure Names*
    Structures begin with an upper case '**S**'. For example,
    ``SMyStructure``. The suffix ``_s`` is never used.
- *Enumerations Names* 
+ *Enumerations Names*
    Enumerations begin with an upper case '**E**'. For example,
    ``EMyEnumeration``. The suffix ``_e`` is never used.
 
@@ -2393,7 +2393,7 @@ C Source File Structure
 =======================
 
 
-.. code-block:: c  
+.. code-block:: c
 
    /****************************************************************************
     * <Relative path to the file>
@@ -2422,7 +2422,7 @@ C Source File Structure
 
 *All header files are included here.*
 
-.. code-block:: c  
+.. code-block:: c
 
    /****************************************************************************
     * Pre-processor Definitions
@@ -2432,7 +2432,7 @@ C Source File Structure
 
 
 .. code-block:: c
-  
+
    /****************************************************************************
     * Private Types
     ****************************************************************************/
@@ -2552,7 +2552,7 @@ C Header File Structure
   /****************************************************************************
   * Included Files
   ****************************************************************************/
-  
+
 *All header files are included here.*
 
 .. code-block:: c
@@ -2560,7 +2560,7 @@ C Header File Structure
   /****************************************************************************
   * Pre-processor Definitions
   ****************************************************************************/
-  
+
 *All C pre-processor macros are defined here.*
 
 .. code-block:: c
@@ -2568,17 +2568,17 @@ C Header File Structure
   /****************************************************************************
   * Public Types
   ****************************************************************************/
-  
+
   #ifndef __ASSEMBLY__
 
 *Any types, enumerations, structures or unions are defined here.*
 
 .. code-block:: c
-  
+
   /****************************************************************************
   * Public Data
   ****************************************************************************/
-  
+
   #ifdef __cplusplus
   #define EXTERN extern "C"
   extern "C"

--- a/arch/arm/src/armv7-a/arm_assert.c
+++ b/arch/arm/src/armv7-a/arm_assert.c
@@ -247,7 +247,7 @@ static void up_dumpstate(void)
 #endif
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
-  /* This this thread have a kernel stack allocated? */
+  /* Does this thread have a kernel stack allocated? */
 
   if (rtcb->xcp.kstack)
     {

--- a/arch/arm/src/armv7-r/arm_assert.c
+++ b/arch/arm/src/armv7-r/arm_assert.c
@@ -240,7 +240,7 @@ static void up_dumpstate(void)
 #endif
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
-  /* This this thread have a kernel stack allocated? */
+  /* Does this thread have a kernel stack allocated? */
 
   if (rtcb->xcp.kstack)
     {

--- a/arch/arm/src/cxd56xx/cxd56_usbdev.c
+++ b/arch/arm/src/cxd56xx/cxd56_usbdev.c
@@ -2203,9 +2203,9 @@ static void cxd56_usbdevreset(FAR struct cxd56_usbdev_s *priv)
  * Input Parameters:
  *   ep   - the struct usbdev_ep_s instance obtained from allocep()
  *   desc - A struct usb_epdesc_s instance describing the endpoint
- *   last - true if this this last endpoint to be configured.  Some hardware
- *          needs to take special action when all of the endpoints have been
- *          configured.
+ *   last - true if this is the last endpoint to be configured.  Some
+ *          hardware needs to take special action when all of the endpoints
+ *          have been configured.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -1090,7 +1090,7 @@ static void imxrt_enet_interrupt_work(FAR void *arg)
  * Function: imxrt_enet_interrupt
  *
  * Description:
- *   Three interrupt sources will vector this this function:
+ *   Three interrupt sources will vector to this function:
  *   1. Ethernet MAC transmit interrupt handler
  *   2. Ethernet MAC receive interrupt handler
  *   3.

--- a/arch/arm/src/imxrt/imxrt_usbdev.c
+++ b/arch/arm/src/imxrt/imxrt_usbdev.c
@@ -257,7 +257,9 @@ struct imxrt_dtd_s
 #define DTD_CONFIG_BUFFER_ERROR      (1 << 5)    /* Bit 6      : Status Buffer Error */
 #define DTD_CONFIG_TRANSACTION_ERROR (1 << 3)    /* Bit 3      : Status Transaction Error */
 
-/* This represents a queue head  - not these must be aligned to a 2048 byte boundary */
+/* This represents a queue head  - not these must be aligned to a 2048 byte
+ * boundary
+ */
 
 struct imxrt_dqh_s
 {
@@ -313,7 +315,9 @@ struct imxrt_dqh_s
 #define IMXRT_INTRMAXPACKET          (1024)       /* Interrupt endpoint max packet (1 to 1024) */
 #define IMXRT_ISOCMAXPACKET          (512)        /* Acutally 1..1023 */
 
-/* Endpoint bit position in SETUPSTAT, PRIME, FLUSH, STAT, COMPLETE registers */
+/* Endpoint bit position in SETUPSTAT, PRIME, FLUSH, STAT, COMPLETE
+ * registers
+ */
 
 #define IMXRT_ENDPTSHIFT(epphy)      (IMXRT_EPPHYIN(epphy) ? (16 + ((epphy) >> 1)) : ((epphy) >> 1))
 #define IMXRT_ENDPTMASK(epphy)       (1 << IMXRT_ENDPTSHIFT(epphy))
@@ -1180,7 +1184,9 @@ static void imxrt_usbreset(struct imxrt_usbdev_s *priv)
   imxrt_putreg (imxrt_getreg(IMXRT_USBDEV_ENDPTCOMPLETE),
                 IMXRT_USBDEV_ENDPTCOMPLETE);
 
-  /* Wait for all prime operations to have completed and then flush all DTDs */
+  /* Wait for all prime operations to have completed and then flush all
+   * DTDs
+   */
 
   while (imxrt_getreg (IMXRT_USBDEV_ENDPTPRIME) != 0)
     ;
@@ -1857,13 +1863,17 @@ bool imxrt_epcomplete(struct imxrt_usbdev_s *priv, uint8_t epphy)
   bool complete = true;
   if (IMXRT_EPPHYOUT(privep->epphy))
     {
-      /* read(OUT) completes when request filled, or a short transfer is received */
+      /* read(OUT) completes when request filled, or a short transfer is
+       * received
+       */
 
       usbtrace(TRACE_INTDECODE(IMXRT_TRACEINTID_EPIN), complete);
     }
   else
     {
-      /* write(IN) completes when request finished, unless we need to terminate with a ZLP */
+      /* write(IN) completes when request finished, unless we need to
+       * terminate with a ZLP
+       */
 
       bool need_zlp = (xfrd == privep->ep.maxpacket) &&
           ((privreq->req.flags & USBDEV_REQFLAGS_NULLPKT) != 0);
@@ -1873,7 +1883,9 @@ bool imxrt_epcomplete(struct imxrt_usbdev_s *priv, uint8_t epphy)
       usbtrace(TRACE_INTDECODE(IMXRT_TRACEINTID_EPOUT), complete);
     }
 
-  /* If the transfer is complete, then dequeue and progress any further queued requests */
+  /* If the transfer is complete, then dequeue and progress any further
+   * queued requests
+   */
 
   if (complete)
     {
@@ -1885,7 +1897,9 @@ bool imxrt_epcomplete(struct imxrt_usbdev_s *priv, uint8_t epphy)
       imxrt_progressep(privep);
     }
 
-  /* Now it's safe to call the completion callback as it may well submit a new request */
+  /* Now it's safe to call the completion callback as it may well submit a
+   * new request
+   */
 
   if (complete)
     {
@@ -2049,7 +2063,9 @@ static int imxrt_usbinterrupt(int irq, FAR void *context, FAR void *arg)
       uint32_t setupstat = imxrt_getreg(IMXRT_USBDEV_ENDPTSETUPSTAT);
       if (setupstat)
         {
-          /* Clear the endpoint complete CTRL OUT and IN when a Setup is received */
+          /* Clear the endpoint complete CTRL OUT and IN when a Setup is
+           * received
+           */
 
           imxrt_putreg(IMXRT_ENDPTMASK(IMXRT_EP0_IN) |
                        IMXRT_ENDPTMASK(IMXRT_EP0_OUT),
@@ -2105,9 +2121,9 @@ static int imxrt_usbinterrupt(int irq, FAR void *context, FAR void *arg)
  * Input Parameters:
  *   ep   - the struct usbdev_ep_s instance obtained from allocep()
  *   desc - A struct usb_epdesc_s instance describing the endpoint
- *   last - true if this this last endpoint to be configured.  Some hardware
- *          needs to take special action when all of the endpoints have been
- *          configured.
+ *   last - true if this is the last endpoint to be configured.  Some
+ *          hardware needs to take special action when all of the endpoints
+ *          have been configured.
  *
  ****************************************************************************/
 
@@ -2623,7 +2639,9 @@ static FAR struct usbdev_ep_s *imxrt_allocep(FAR struct usbdev_s *dev,
       epset &= priv->epavail;
       if (epset)
         {
-          /* Select the lowest bit in the set of matching, available endpoints */
+          /* Select the lowest bit in the set of matching, available
+           * endpoints
+           */
 
           for (epndx = 2; epndx < IMXRT_NPHYSENDPOINTS; epndx++)
             {
@@ -2635,7 +2653,9 @@ static FAR struct usbdev_ep_s *imxrt_allocep(FAR struct usbdev_s *dev,
                   priv->epavail &= ~bit;
                   leave_critical_section(flags);
 
-                  /* And return the pointer to the standard endpoint structure */
+                  /* And return the pointer to the standard endpoint
+                   * structure
+                   */
 
                   return &priv->eplist[epndx].ep;
                 }

--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -940,7 +940,7 @@ static void kinetis_interrupt_work(FAR void *arg)
  * Function: kinetis_interrupt
  *
  * Description:
- *   Three interrupt sources will vector this this function:
+ *   Three interrupt sources will vector to this function:
  *   1. Ethernet MAC transmit interrupt handler
  *   2. Ethernet MAC receive interrupt handler
  *   3.

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -1023,7 +1023,7 @@ static void kinetis_txdone(FAR void *arg)
  * Function: kinetis_flexcan_interrupt
  *
  * Description:
- *   Three interrupt sources will vector this this function:
+ *   Three interrupt sources will vector to this function:
  *   1. CAN MB transmit interrupt handler
  *   2. CAN MB receive interrupt handler
  *   3.

--- a/arch/arm/src/lc823450/lc823450_usbdev.c
+++ b/arch/arm/src/lc823450/lc823450_usbdev.c
@@ -385,9 +385,9 @@ static void epcmd_write(int epnum, uint32_t val)
  * Input Parameters:
  *   ep   - the struct usbdev_ep_s instance obtained from allocep()
  *   desc - A struct usb_epdesc_s instance describing the endpoint
- *   last - true if this this last endpoint to be configured.  Some hardware
- *          needs to take special action when all of the endpoints have been
- *          configured.
+ *   last - true if this is the last endpoint to be configured.  Some
+ *          hardware needs to take special action when all of the endpoints
+ *          have been configured.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -1099,7 +1099,7 @@ static void s32k1xx_enet_interrupt_work(FAR void *arg)
  * Function: s32k1xx_enet_interrupt
  *
  * Description:
- *   Three interrupt sources will vector this this function:
+ *   Three interrupt sources will vector to this function:
  *   1. Ethernet MAC transmit interrupt handler
  *   2. Ethernet MAC receive interrupt handler
  *   3.

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1024,7 +1024,7 @@ static void s32k1xx_txdone(FAR void *arg)
  * Function: s32k1xx_flexcan_interrupt
  *
  * Description:
- *   Three interrupt sources will vector this this function:
+ *   Three interrupt sources will vector to this function:
  *   1. CAN MB transmit interrupt handler
  *   2. CAN MB receive interrupt handler
  *   3.

--- a/arch/arm/src/stm32/stm32_dac.c
+++ b/arch/arm/src/stm32/stm32_dac.c
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32/stm32_dac.c
  *
  *   Copyright (C) 2011, 2013, 2016 Gregory Nutt. All rights reserved.
@@ -32,7 +32,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 /****************************************************************************
  * Included Files
@@ -68,13 +68,16 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* Up to 2 DAC interfaces for up to 3 channels are supported
  *
  * NOTE: STM32_NDAC tells how many channels chip supports.
- *       ST is not consistent in the naming of DAC interfaces, so we introduce
- *       our own naming convention. We distinguish DAC1 and DAC2 only if the chip
- *       has two separate areas in memory map to support DAC channels.
+ *       ST is not consistent in the naming of DAC interfaces, so we
+ *       introduce our own naming convention. We distinguish DAC1 and DAC2
+ *       only if the chip has two separate areas in memory map to support DAC
+ *       channels.
  */
 
 #if STM32_NDAC < 3
@@ -205,7 +208,8 @@
 #  endif
 #endif
 
-/* DMA *********************************************************************/
+/* DMA **********************************************************************/
+
 /* DMA channels and interface values differ for the F1 and F4 families */
 
 #undef HAVE_DMA
@@ -485,8 +489,7 @@
 #  define DAC2CH1_TSEL_VALUE DAC_CR_TSEL_SW
 #endif
 
-/*
- * We need index which describes when HRTIM is selected as trigger.
+/* We need index which describes when HRTIM is selected as trigger.
  * It will be used to skip timer configuration where needed.
  */
 
@@ -534,7 +537,9 @@
  * Private Types
  ****************************************************************************/
 
-/* This structure represents the internal state of the single STM32 DAC block */
+/* This structure represents the internal state of the single STM32 DAC
+ * block
+ */
 
 struct stm32_dac_s
 {
@@ -571,6 +576,7 @@ struct stm32_chan_s
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
+
 /* DAC Register access */
 
 #ifdef HAVE_TIMER
@@ -603,7 +609,7 @@ static int  dac_ioctl(FAR struct dac_dev_s *dev, int cmd, unsigned long arg);
 static int  dac_timinit(FAR struct stm32_chan_s *chan);
 #  endif
 static int  dma_remap(FAR struct stm32_chan_s *chan);
-static void dma_bufferinit(FAR struct stm32_chan_s *chan, uint16_t* buffer,
+static void dma_bufferinit(FAR struct stm32_chan_s *chan, uint16_t *buffer,
                            uint16_t len);
 #endif
 static int  dac_chaninit(FAR struct stm32_chan_s *chan);
@@ -917,8 +923,8 @@ static void dac_reset(FAR struct dac_dev_s *dev)
  * Description:
  *   Configure the DAC. This method is called the first time that the DAC
  *   device is opened.  This will occur when the port is first opened.
- *   This setup includes configuring and attaching DAC interrupts.  Interrupts
- *   are all disabled upon return.
+ *   This setup includes configuring and attaching DAC interrupts.
+ *   Interrupts are all disabled upon return.
  *
  * Input Parameters:
  *
@@ -1015,7 +1021,7 @@ static int dac_send(FAR struct dac_dev_s *dev, FAR struct dac_msg_s *msg)
 
   if (chan->intf > 0)
     {
-      stm32_dac_modify_cr(chan, 0, DAC_CR_EN|DAC_CR_BOFF);
+      stm32_dac_modify_cr(chan, 0, DAC_CR_EN | DAC_CR_BOFF);
     }
   else
 #endif
@@ -1070,6 +1076,7 @@ static int dac_send(FAR struct dac_dev_s *dev, FAR struct dac_msg_s *msg)
       tim_modifyreg(chan, STM32_BTIM_EGR_OFFSET, 0, ATIM_EGR_UG);
     }
 #endif
+
   return OK;
 }
 
@@ -1125,7 +1132,7 @@ static int dac_ioctl(FAR struct dac_dev_s *dev, int cmd, unsigned long arg)
  * Name: dma_bufferinit
  ****************************************************************************/
 
-static void dma_bufferinit(FAR struct stm32_chan_s *chan, uint16_t* buffer,
+static void dma_bufferinit(FAR struct stm32_chan_s *chan, uint16_t *buffer,
                            uint16_t len)
 {
   memcpy(chan->dmabuffer, buffer, len);
@@ -1289,8 +1296,8 @@ static int dac_timinit(FAR struct stm32_chan_s *chan)
 
   modifyreg32(regaddr, 0, setbits);
 
-  /* Calculate optimal values for the timer prescaler and for the timer reload
-   * register.  If 'frequency' is the desired frequency, then
+  /* Calculate optimal values for the timer prescaler and for the timer
+   * reload register.  If 'frequency' is the desired frequency, then
    *
    *   reload = timclk / frequency
    *   timclk = pclk / presc
@@ -1299,8 +1306,8 @@ static int dac_timinit(FAR struct stm32_chan_s *chan)
    *
    *   reload = pclk / presc / frequency
    *
-   * There are many solutions to this this, but the best solution will be the
-   * one that has the largest reload value and the smallest prescaler value.
+   * There are many solutions to this, but the best solution will be the one
+   * that has the largest reload value and the smallest prescaler value.
    * That is the solution that should give us the most accuracy in the timer
    * control.  Subject to:
    *
@@ -1439,7 +1446,7 @@ static int dac_chaninit(FAR struct stm32_chan_s *chan)
 
   if (chan->hasdma)
     {
-      /* Remap DMA request if necessary*/
+      /* Remap DMA request if necessary */
 
       dma_remap(chan);
 

--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -2369,8 +2369,8 @@ static int pwm_frequency_update(FAR struct pwm_lowerhalf_s *dev,
    *
    *   reload = pclk / presc / frequency
    *
-   * There are many solutions to this this, but the best solution will be the
-   * one that has the largest reload value and the smallest prescaler value.
+   * There are many solutions to this, but the best solution will be the one
+   * that has the largest reload value and the smallest prescaler value.
    * That is the solution that should give us the most accuracy in the timer
    * control.  Subject to:
    *

--- a/arch/arm/src/stm32f0l0g0/stm32_pwm.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_pwm.c
@@ -198,12 +198,14 @@ struct stm32_pwmtimer_s
 
 static uint32_t stm32pwm_getreg(struct stm32_pwmtimer_s *priv, int offset);
 static void stm32pwm_putreg(struct stm32_pwmtimer_s *priv, int offset,
-                       uint32_t value);
-static void stm32pwm_modifyreg(struct stm32_pwmtimer_s *priv, uint32_t offset,
-                          uint32_t clearbits, uint32_t setbits);
+                            uint32_t value);
+static void stm32pwm_modifyreg(struct stm32_pwmtimer_s *priv,
+                               uint32_t offset, uint32_t clearbits,
+                               uint32_t setbits);
 
 #ifdef CONFIG_DEBUG_PWM_INFO
-static void stm32pwm_dumpregs(struct stm32_pwmtimer_s *priv, const char *msg);
+static void stm32pwm_dumpregs(struct stm32_pwmtimer_s *priv,
+                              const char *msg);
 #else
 #  define stm32pwm_dumpregs(priv,msg)
 #endif
@@ -680,8 +682,9 @@ static void stm32pwm_putreg(struct stm32_pwmtimer_s *priv, int offset,
  *
  ****************************************************************************/
 
-static void stm32pwm_modifyreg(struct stm32_pwmtimer_s *priv, uint32_t offset,
-                               uint32_t clearbits, uint32_t setbits)
+static void stm32pwm_modifyreg(struct stm32_pwmtimer_s *priv,
+                               uint32_t offset, uint32_t clearbits,
+                               uint32_t setbits)
 {
   if (stm32pwm_reg_is_32bit(priv->timtype, offset) == true)
     {
@@ -790,7 +793,9 @@ static int stm32pwm_output_configure(FAR struct stm32_pwmtimer_s *priv,
   cr2  = stm32pwm_getreg(priv, STM32_GTIM_CR2_OFFSET);
   ccer = stm32pwm_getreg(priv, STM32_GTIM_CCER_OFFSET);
 
-  /* Reset the output polarity level of all channels (selects high polarity) */
+  /* Reset the output polarity level of all channels (selects high
+   * polarity)
+   */
 
   ccer &= ~(GTIM_CCER_CC1P << ((channel - 1) * 4));
 
@@ -799,13 +804,14 @@ static int stm32pwm_output_configure(FAR struct stm32_pwmtimer_s *priv,
   ccer |= (GTIM_CCER_CC1E << ((channel - 1) * 4));
 
 #ifdef HAVE_ADVTIM
-  if (priv->timtype == TIMTYPE_ADVANCED || priv->timtype == TIMTYPE_COUNTUP16_N)
+  if (priv->timtype == TIMTYPE_ADVANCED ||
+      priv->timtype == TIMTYPE_COUNTUP16_N)
     {
       cr2 &= ~(ATIM_CR2_OIS1 << ((channel - 1) * 2));
     }
 #ifdef HAVE_PWM_COMPLEMENTARY
 
-  /* Verify if the current complementary channel is defined*/
+  /* Verify if the current complementary channel is defined */
 
   if (priv->channels[channel - 1].npincfg != 0)
     {
@@ -889,7 +895,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
           info->duty, info->count);
 #else
   pwminfo("TIM%u channel: %u frequency: %u duty: %08x\n",
-          priv->timid, priv->channels[0].channel, info->frequency, info->duty);
+          priv->timid, priv->channels[0].channel, info->frequency,
+          info->duty);
 #endif
 
   DEBUGASSERT(info->frequency > 0);
@@ -904,8 +911,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
   stm32pwm_putreg(priv, STM32_GTIM_SR_OFFSET, 0);
 #endif
 
-  /* Calculate optimal values for the timer prescaler and for the timer reload
-   * register.  If 'frequency' is the desired frequency, then
+  /* Calculate optimal values for the timer prescaler and for the timer
+   * reload register.  If 'frequency' is the desired frequency, then
    *
    *   reload = timclk / frequency
    *   timclk = pclk / presc
@@ -914,7 +921,7 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
    *
    *   reload = pclk / presc / frequency
    *
-   * There are many solutions to this this, but the best solution will be the
+   * There are many solutions to this, but the best solution will be the
    * one that has the largest reload value and the smallest prescaler value.
    * That is the solution that should give us the most accuracy in the timer
    * control.  Subject to:
@@ -951,13 +958,14 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
 
   reload = timclk / info->frequency;
 
-  /* In center-aligned mode, the timer performs upcounting from zero to ARR value
-   * and then performs downcounting from ARR to zero and repeat. In other words,
-   * in one cycle the timer counts 2*ARR. For that reason, the reload (ARR) value
-   * is divided by 2.
+  /* In center-aligned mode, the timer performs upcounting from zero to ARR
+   * value and then performs downcounting from ARR to zero and repeat. In
+   * other words, in one cycle the timer counts 2*ARR. For that reason, the
+   * reload (ARR) value is divided by 2.
    */
 
-  if (priv->mode == STM32_TIMMODE_CENTER1 || priv->mode == STM32_TIMMODE_CENTER2 ||
+  if (priv->mode == STM32_TIMMODE_CENTER1 ||
+      priv->mode == STM32_TIMMODE_CENTER2 ||
       priv->mode == STM32_TIMMODE_CENTER3)
     {
       reload /= 2;
@@ -976,8 +984,10 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
       reload--;
     }
 
-  pwminfo("TIM%u PCLK: %u frequency: %u TIMCLK: %u prescaler: %u reload: %u\n",
-          priv->timid, priv->pclk, info->frequency, timclk, prescaler, reload);
+  pwminfo("TIM%u PCLK: %u frequency: %u "
+          "TIMCLK: %u prescaler: %u reload: %u\n",
+          priv->timid, priv->pclk, info->frequency, timclk,
+          prescaler, reload);
 
   /* Set up the timer CR1 register:
    *
@@ -1040,7 +1050,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             break;
 
           default:
-            pwmerr("ERROR: No such timer mode: %u\n", (unsigned int)priv->mode);
+            pwmerr("ERROR: No such timer mode: %u\n",
+                   (unsigned int)priv->mode);
             return -EINVAL;
         }
     }
@@ -1224,7 +1235,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
               /* Set the CCMR1 mode values (leave CCMR2 zero) */
 
               ocmode1  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC1S_SHIFT) |
-                          (chanmode << ATIM_CCMR1_OC1M_SHIFT) | ATIM_CCMR1_OC1PE;
+                          (chanmode << ATIM_CCMR1_OC1M_SHIFT) |
+                          ATIM_CCMR1_OC1PE;
 
               if (ocmbit)
                 {
@@ -1252,7 +1264,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
               /* Set the CCMR1 mode values (leave CCMR2 zero) */
 
               ocmode1  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC2S_SHIFT) |
-                          (chanmode << ATIM_CCMR1_OC2M_SHIFT) | ATIM_CCMR1_OC2PE;
+                          (chanmode << ATIM_CCMR1_OC2M_SHIFT) |
+                          ATIM_CCMR1_OC2PE;
 
               if (ocmbit)
                 {
@@ -1348,7 +1361,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
   /* Special configuration for HAVE_ADVTIM */
 
 #ifdef HAVE_ADVTIM
-  if (priv->timtype == TIMTYPE_ADVANCED || priv->timtype == TIMTYPE_COUNTUP16_N)
+  if (priv->timtype == TIMTYPE_ADVANCED ||
+      priv->timtype == TIMTYPE_COUNTUP16_N)
     {
       uint32_t bdtr;
 
@@ -1577,7 +1591,9 @@ static int stm32pwm_interrupt(struct stm32_pwmtimer_s *priv)
       stm32pwm_putreg(priv, STM32_ATIM_RCR_OFFSET, priv->curr - 1);
     }
 
-  /* Now all of the time critical stuff is done so we can do some debug output */
+  /* Now all of the time critical stuff is done so we can do some debug
+   * output
+   */
 
   pwminfo("Update interrupt SR: %04x prev: %u curr: %u count: %u\n",
           regval, priv->prev, priv->curr, priv->count);
@@ -1936,7 +1952,8 @@ static int stm32pwm_start(FAR struct pwm_lowerhalf_s *dev,
             }
         }
 #else
-      ret = stm32pwm_update_duty(priv, priv->channels[0].channel, info->duty);
+      ret = stm32pwm_update_duty(priv, priv->channels[0].channel,
+                                 info->duty);
 #endif
     }
   else

--- a/arch/arm/src/stm32f7/stm32_pwm.c
+++ b/arch/arm/src/stm32f7/stm32_pwm.c
@@ -231,10 +231,12 @@ struct stm32_pwmtimer_s
 /****************************************************************************
  * Static Function Prototypes
  ****************************************************************************/
+
 /* Register access */
 
 static uint16_t pwm_getreg(struct stm32_pwmtimer_s *priv, int offset);
-static void pwm_putreg(struct stm32_pwmtimer_s *priv, int offset, uint16_t value);
+static void pwm_putreg(struct stm32_pwmtimer_s *priv, int offset,
+                       uint16_t value);
 
 #ifdef CONFIG_DEBUG_PWM_INFO
 static void pwm_dumpregs(struct stm32_pwmtimer_s *priv, FAR const char *msg);
@@ -1032,7 +1034,7 @@ static void pwm_dumpregs(struct stm32_pwmtimer_s *priv, FAR const char *msg)
               pwm_getreg(priv, STM32_GTIM_EGR_OFFSET),
               pwm_getreg(priv, STM32_GTIM_CCMR1_OFFSET));
     }
-   else
+  else
     {
       pwminfo("   SR: %04x EGR:  %04x CCMR1: %04x CCMR2: %04x\n",
               pwm_getreg(priv, STM32_GTIM_SR_OFFSET),
@@ -1148,8 +1150,8 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
   pwm_putreg(priv, STM32_GTIM_SR_OFFSET, 0);
 #endif
 
-  /* Calculate optimal values for the timer prescaler and for the timer reload
-   * register.  If 'frequency' is the desired frequency, then
+  /* Calculate optimal values for the timer prescaler and for the timer
+   * reload register.  If 'frequency' is the desired frequency, then
    *
    *   reload = timclk / frequency
    *   timclk = pclk / presc
@@ -1158,8 +1160,8 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
    *
    *   reload = pclk / presc / frequency
    *
-   * There are many solutions to this this, but the best solution will be the
-   * one that has the largest reload value and the smallest prescaler value.
+   * There are many solutions to this, but the best solution will be the one
+   * that has the largest reload value and the smallest prescaler value.
    * That is the solution that should give us the most accuracy in the timer
    * control.  Subject to:
    *
@@ -1207,8 +1209,10 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
       reload--;
     }
 
-  pwminfo("TIM%u PCLK: %u frequency: %u TIMCLK: %u prescaler: %u reload: %u\n",
-          priv->timid, priv->pclk, info->frequency, timclk, prescaler, reload);
+  pwminfo("TIM%u PCLK: %u frequency: %u "
+          "TIMCLK: %u prescaler: %u reload: %u\n",
+          priv->timid, priv->pclk, info->frequency,
+          timclk, prescaler, reload);
 
   /* Set up the timer CR1 register:
    *
@@ -1440,7 +1444,9 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
                           (chanmode << ATIM_CCMR1_OC1M_SHIFT) |
                           ATIM_CCMR1_OC1PE;
 
-              /* Set the duty cycle by writing to the CCR register for this channel */
+              /* Set the duty cycle by writing to the CCR register for this
+               * channel
+               */
 
               pwm_putreg(priv, STM32_GTIM_CCR1_OFFSET, (uint16_t)ccr);
             }
@@ -1458,7 +1464,9 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
                           (chanmode << ATIM_CCMR1_OC2M_SHIFT) |
                           ATIM_CCMR1_OC2PE;
 
-              /* Set the duty cycle by writing to the CCR register for this channel */
+              /* Set the duty cycle by writing to the CCR register for this
+               * channel
+               */
 
               pwm_putreg(priv, STM32_GTIM_CCR2_OFFSET, (uint16_t)ccr);
             }
@@ -1476,7 +1484,9 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
                           (chanmode << ATIM_CCMR2_OC3M_SHIFT) |
                           ATIM_CCMR2_OC3PE;
 
-              /* Set the duty cycle by writing to the CCR register for this channel */
+              /* Set the duty cycle by writing to the CCR register for this
+               * channel
+               */
 
               pwm_putreg(priv, STM32_GTIM_CCR3_OFFSET, (uint16_t)ccr);
             }
@@ -1494,7 +1504,9 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
                           (chanmode << ATIM_CCMR2_OC4M_SHIFT) |
                           ATIM_CCMR2_OC4PE;
 
-              /* Set the duty cycle by writing to the CCR register for this channel */
+              /* Set the duty cycle by writing to the CCR register for this
+               * channel
+               */
 
               pwm_putreg(priv, STM32_GTIM_CCR4_OFFSET, (uint16_t)ccr);
             }
@@ -1518,7 +1530,9 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
   ccmr1 = pwm_getreg(priv, STM32_GTIM_CCMR1_OFFSET);
   ccmr2 = pwm_getreg(priv, STM32_GTIM_CCMR2_OFFSET);
 
-  /* Reset the Output Compare Mode Bits and set the select output compare mode */
+  /* Reset the Output Compare Mode Bits and set the select output compare
+   * mode
+   */
 
   ccmr1 &= ~(ATIM_CCMR1_CC1S_MASK | ATIM_CCMR1_OC1M_MASK | ATIM_CCMR1_OC1PE |
              ATIM_CCMR1_CC2S_MASK | ATIM_CCMR1_OC2M_MASK | ATIM_CCMR1_OC2PE);
@@ -1527,7 +1541,9 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
   ccmr1 |= ocmode1;
   ccmr2 |= ocmode2;
 
-  /* Reset the output polarity level of all channels (selects high polarity) */
+  /* Reset the output polarity level of all channels (selects high
+   * polarity)
+   */
 
   ccer &= ~(ATIM_CCER_CC1P | ATIM_CCER_CC2P | ATIM_CCER_CC3P |
             ATIM_CCER_CC4P);
@@ -1543,7 +1559,8 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
 #if defined(CONFIG_STM32F7_TIM1_PWM) || defined(CONFIG_STM32F7_TIM8_PWM) || \
     defined(CONFIG_STM32F7_TIM15_PWM) || defined(CONFIG_STM32F7_TIM16_PWM) || \
     defined(CONFIG_STM32F7_TIM17_PWM)
-  if (priv->timtype == TIMTYPE_ADVANCED || priv->timtype == TIMTYPE_COUNTUP16)
+  if (priv->timtype == TIMTYPE_ADVANCED ||
+      priv->timtype == TIMTYPE_COUNTUP16)
     {
       uint16_t bdtr;
 
@@ -1784,7 +1801,9 @@ static int pwm_interrupt(struct stm32_pwmtimer_s *priv)
       pwm_putreg(priv, STM32_ATIM_RCR_OFFSET, (uint16_t)priv->curr - 1);
     }
 
-  /* Now all of the time critical stuff is done so we can do some debug output */
+  /* Now all of the time critical stuff is done so we can do some debug
+   * output
+   */
 
   pwminfo("Update interrupt SR: %04x prev: %u curr: %u count: %u\n",
           regval, priv->prev, priv->curr, priv->count);

--- a/arch/arm/src/stm32h7/stm32_pwm.c
+++ b/arch/arm/src/stm32h7/stm32_pwm.c
@@ -2087,8 +2087,8 @@ static int pwm_frequency_update(FAR struct pwm_lowerhalf_s *dev,
    *
    *   reload = pclk / presc / frequency
    *
-   * There are many solutions to this this, but the best solution will be the
-   * one that has the largest reload value and the smallest prescaler value.
+   * There are many solutions to this, but the best solution will be the one
+   * that has the largest reload value and the smallest prescaler value.
    * That is the solution that should give us the most accuracy in the timer
    * control.  Subject to:
    *

--- a/arch/arm/src/stm32l4/stm32l4_pwm.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwm.c
@@ -1919,8 +1919,8 @@ static int pwm_frequency_update(FAR struct pwm_lowerhalf_s *dev,
    *
    *   reload = pclk / presc / frequency
    *
-   * There are many solutions to this this, but the best solution will be the
-   * one that has the largest reload value and the smallest prescaler value.
+   * There are many solutions to this, but the best solution will be the one
+   * that has the largest reload value and the smallest prescaler value.
    * That is the solution that should give us the most accuracy in the timer
    * control.  Subject to:
    *

--- a/arch/arm/src/tiva/lm/lm4f_gpio.h
+++ b/arch/arm/src/tiva/lm/lm4f_gpio.h
@@ -129,8 +129,8 @@
  *
  *    FFFS SPPP III. AAAA .... ...V PPPP PBBB
  *
- * TODO: The LM4F alsso support configuration of pins to trigger ADC and/or uDMA.
- * That configuration is not addressed in this this encoding.
+ * TODO: The LM4F also supports configuration of pins to trigger ADC and/or
+ * uDMA. That configuration is not addressed in this encoding.
  */
 
 /* These bits set the primary function of the pin:
@@ -214,7 +214,9 @@
 #  define GPIO_ALT_14                 (14 << GPIO_ALT_SHIFT)
 #  define GPIO_ALT_15                 (15 << GPIO_ALT_SHIFT)
 
-/* If the pin is an GPIO digital output, then this identifies the initial output value:
+/* If the pin is an GPIO digital output, then this identifies the initial
+ * output value:
+ *
  *    .... .... .... .... .... ...V .... ....
  */
 

--- a/arch/renesas/src/rx65n/rx65n_usbdev.c
+++ b/arch/renesas/src/rx65n/rx65n_usbdev.c
@@ -116,7 +116,7 @@
 #define RX65N_TRACEERR_INVALIDCTRLREQ    0x001c
 #define RX65N_TRACEERR_BADEPTYPE         0x001d
 #define RX65N_TRACEERR_BADEPNO           0x001e
-#define RX65N_TRACEERR_EPRESERVE         0x001f   
+#define RX65N_TRACEERR_EPRESERVE         0x001f
 #define RX65N_TRACEERR_BADSETCONFIG      0x0020
 
 /* Trace interrupt codes */
@@ -2867,9 +2867,9 @@ void usb_pstd_set_pipe_reg (uint16_t pipe_no, uint16_t pipe_cfgint,
  * Input Parameters:
  *   ep   - the struct usbdev_ep_s instance obtained from allocep()
  *   desc - A struct usb_epdesc_s instance describing the endpoint
- *   last - true if this this last endpoint to be configured.  Some hardware
- *          needs to take special action when all of the endpoints have been
- *          configured.
+ *   last - true if this is the last endpoint to be configured.  Some
+ *          hardware needs to take special action when all of the endpoints
+ *          have been configured.
  *
  ****************************************************************************/
 

--- a/binfmt/libnxflat/libnxflat_bind.c
+++ b/binfmt/libnxflat/libnxflat_bind.c
@@ -454,7 +454,7 @@ static inline int nxflat_bindimports(FAR struct nxflat_loadinfo_s *loadinfo,
           symname = (FAR char *)
             (offset + loadinfo->ispace + sizeof(struct nxflat_hdr_s));
 
-          /* Find the exported symbol value for this this symbol name. */
+          /* Find the exported symbol value for this symbol name. */
 
 #ifdef CONFIG_SYMTAB_ORDEREDBYNAME
           symbol = symtab_findorderedbyname(exports, symname, nexports);

--- a/boards/z80/z80/z80sim/README.txt
+++ b/boards/z80/z80/z80sim/README.txt
@@ -116,11 +116,11 @@ tool.  To change this configuration using that tool, you should:
 Reconfiguring for Windows Native, Cygwin, or macOS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All of the z80 configurations in this this directory are set up to build
-under Linux.  That configuration can be converted to run natively in a
-Windows CMD.exe shell.  That configuration requires the MinGW host compiler
-and several GNUWin32 tools (see discussion in the top-level NuttX/README.txt
-file) and the following changes to the configuration file:
+All of the z80 configurations in this directory are set up to build under
+Linux.  That configuration can be converted to run natively in a Windows
+CMD.exe shell.  That configuration requires the MinGW host compiler and
+several GNUWin32 tools (see discussion in the top-level NuttX/README.txt file)
+and the following changes to the configuration file:
 
   -CONFIG_HOST_LINUX=y
   +CONFIG_HOST_WINDOWS=y

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -213,9 +213,8 @@ int pipecommon_open(FAR struct file *filep)
     {
       dev->d_nwriters++;
 
-      /* If this this is the first writer, then the read semaphore indicates
-       * the number of readers waiting for the first writer.  Wake them all
-       * up.
+      /* If this is the first writer, then the read semaphore indicates the
+       * number of readers waiting for the first writer.  Wake them all up.
        */
 
       if (dev->d_nwriters == 1)

--- a/fs/nxffs/nxffs_write.c
+++ b/fs/nxffs/nxffs_write.c
@@ -227,7 +227,9 @@ static inline int nxffs_wralloc(FAR struct nxffs_volume_s *volume,
           ret = nxffs_hdrerased(volume, wrfile, mindata);
           if (ret == OK)
             {
-              /* Valid memory for the data block was found.  Return success. */
+              /* Valid memory for the data block was found.  Return
+               * success.
+               */
 
               return OK;
             }
@@ -519,7 +521,8 @@ static inline ssize_t nxffs_zappend(FAR struct nxffs_volume_s *volume,
  *
  ****************************************************************************/
 
-ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer, size_t buflen)
+ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer,
+                    size_t buflen)
 {
   FAR struct nxffs_volume_s *volume;
   FAR struct nxffs_wrfile_s *wrfile;
@@ -590,7 +593,9 @@ ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer, size_t bufle
 
       nxffs_ioseek(volume, wrfile->doffset);
 
-      /* Verify that the FLASH data that was previously written is still intact */
+      /* Verify that the FLASH data that was previously written is still
+       * intact
+       */
 
       ret = nxffs_reverify(volume, wrfile);
       if (ret < 0)
@@ -606,7 +611,8 @@ ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer, size_t bufle
       nwritten = nxffs_wrappend(volume, wrfile, &buffer[total], remaining);
       if (nwritten < 0)
         {
-          ferr("ERROR: Failed to append to FLASH to a data block: %d\n", -ret);
+          ferr("ERROR: Failed to append to FLASH to a data block: %d\n",
+               -ret);
           goto errout_with_semaphore;
         }
 
@@ -684,7 +690,9 @@ int nxffs_wrextend(FAR struct nxffs_volume_s *volume,
 
       nxffs_ioseek(volume, wrfile->doffset);
 
-      /* Verify that the FLASH data that was previously written is still intact */
+      /* Verify that the FLASH data that was previously written is still
+       * intact
+       */
 
       ret = nxffs_reverify(volume, wrfile);
       if (ret < 0)
@@ -898,7 +906,7 @@ int nxffs_wrverify(FAR struct nxffs_volume_s *volume, size_t size)
 
                   if (nerased >= size)
                     {
-                      /* Yes.. this this is where we will put the object */
+                      /* Yes.. this is where we will put the object */
 
                       off_t offset =
                         volume->ioblock * volume->geo.blocksize + iooffset;
@@ -1005,7 +1013,8 @@ int nxffs_wrblkhdr(FAR struct nxffs_volume_s *volume,
    *     begin the search for the next inode header or data block.
    */
 
-  volume->froffset = (wrfile->doffset + wrfile->datlen + SIZEOF_NXFFS_DATA_HDR);
+  volume->froffset = (wrfile->doffset + wrfile->datlen +
+                      SIZEOF_NXFFS_DATA_HDR);
 
   /* wrfile->file.entry:
    *   datlen:  Total file length accumulated so far.  When the file is

--- a/graphics/Kconfig
+++ b/graphics/Kconfig
@@ -20,7 +20,7 @@ config NX_LCDDRIVER
 	---help---
 		By default, the NX graphics system uses the frame buffer driver interface
 		defined in include/nuttx/video/fb.h.  However, if LCD is support is enabled,
-		this this option is provide to select, instead, the LCD driver interface
+		this option is provided to select, instead, the LCD driver interface
 		defined in include/nuttx/lcd/lcd.h.
 
 config NX_NDISPLAYS
@@ -495,11 +495,11 @@ config NXSTART_EXTERNINIT
 	select LCD_EXTERNINIT if LCD && LCD_FRAMEBUFFER && NX_LCDDRIVER
 	---help---
 		Define to support external display initialization by platform-
-		specific code.  This this option is defined, then nxmu_start()
-		will call board_graphics_setup(CONFIG_NXSTART_DEVNO) to initialize
-		the graphics device.  This option is necessary if display is used
-		that cannot be initialized using the standard LCD or framebuffer
-		interfaces.
+		specific code.  If this option is defined, then nxmu_start()
+		will call board_graphics_setup(CONFIG_NXSTART_DEVNO) to
+		initialize the graphics device.  This option is necessary if
+		display is used that cannot be initialized using the standard
+		LCD or framebuffer interfaces.
 
 config NXSTART_SERVERPRIO
 	int "NX Server priority"

--- a/include/nuttx/analog/pga11x.h
+++ b/include/nuttx/analog/pga11x.h
@@ -53,7 +53,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* Prerequisites:
  *  CONFIG_ADC=y is needed to enable support for analog input devices
  *
@@ -86,11 +88,12 @@
 #endif
 
 /* PGA11x Commands **********************************************************/
+
 /* Write command Gain Selection Bits (PGA112/PGA113)
  *
  * the PGA112 and PGA116 provide binary gain selections (1, 2, 4, 8, 16, 32,
- * 64, 128); the PGA113 and PGA117 provide scope gain selections (1, 2, 5, 10,
- * 20, 50, 100, 200).
+ * 64, 128); the PGA113 and PGA117 provide scope gain selections (1, 2, 5,
+ * 10, 20, 50, 100, 200).
  */
 
 #define PGA11X_GAIN_1          (0) /* Gain=1:   Scope Gain=1 */
@@ -114,17 +117,17 @@
  * 10-channel input MUX.
  */
 
-#define PGA11X_CHAN_VCAL       (0) /* VCAL/CH0 */
-#define PGA11X_CHAN_CH0        (0) /* VCAL/CH0 */
-#define PGA11X_CHAN_CH1        (1) /* CH1 */
-#define PGA11X_CHAN_CH2        (2) /* CH2 (PGA116/PGA117 only) */
-#define PGA11X_CHAN_CH3        (3) /* CH3 (PGA116/PGA117 only) */
-#define PGA11X_CHAN_CH4        (4) /* CH4 (PGA116/PGA117 only) */
-#define PGA11X_CHAN_CH5        (5) /* CH5 (PGA116/PGA117 only) */
-#define PGA11X_CHAN_CH6        (6) /* CH6 (PGA116/PGA117 only) */
-#define PGA11X_CHAN_CH7        (7) /* CH7 (PGA116/PGA117 only) */
-#define PGA11X_CHAN_CH8        (8) /* CH8 (PGA116/PGA117 only) */
-#define PGA11X_CHAN_CH9        (9) /* CH9 (PGA116/PGA117 only) */
+#define PGA11X_CHAN_VCAL       (0)  /* VCAL/CH0 */
+#define PGA11X_CHAN_CH0        (0)  /* VCAL/CH0 */
+#define PGA11X_CHAN_CH1        (1)  /* CH1 */
+#define PGA11X_CHAN_CH2        (2)  /* CH2 (PGA116/PGA117 only) */
+#define PGA11X_CHAN_CH3        (3)  /* CH3 (PGA116/PGA117 only) */
+#define PGA11X_CHAN_CH4        (4)  /* CH4 (PGA116/PGA117 only) */
+#define PGA11X_CHAN_CH5        (5)  /* CH5 (PGA116/PGA117 only) */
+#define PGA11X_CHAN_CH6        (6)  /* CH6 (PGA116/PGA117 only) */
+#define PGA11X_CHAN_CH7        (7)  /* CH7 (PGA116/PGA117 only) */
+#define PGA11X_CHAN_CH8        (8)  /* CH8 (PGA116/PGA117 only) */
+#define PGA11X_CHAN_CH9        (9)  /* CH9 (PGA116/PGA117 only) */
 #define PGA11X_CHAN_CAL1       (12) /* CAL1: connects to GND */
 #define PGA11X_CHAN_CAL2       (13) /* CAL2: connects to 0.9VCAL */
 #define PGA11X_CHAN_CAL3       (14) /* CAL3: connects to 0.1VCAL */
@@ -150,8 +153,8 @@ struct pga11x_usettings_s
 
 /* These structures are used to encode gain and channel settings.  This
  * includes both devices in the case of a daisy-chained configuration.
- * NOTE: This this logic is currently limited to only 2 devices in the
- * daisy-chain.
+ * NOTE: This logic is currently limited to only 2 devices in the daisy-
+ * chain.
  */
 
 struct pga11x_settings_s
@@ -269,7 +272,8 @@ int pga11x_uselect(PGA11X_HANDLE handle, int pos,
  *
  ****************************************************************************/
 
-int pga11x_read(PGA11X_HANDLE handle, FAR struct pga11x_settings_s *settings);
+int pga11x_read(PGA11X_HANDLE handle,
+                FAR struct pga11x_settings_s *settings);
 
 /****************************************************************************
  * Name: pga11x_uread

--- a/include/nuttx/usb/usbdev.h
+++ b/include/nuttx/usb/usbdev.h
@@ -68,7 +68,7 @@
  *
  * ep   - the struct usbdev_ep_s instance obtained from allocep()
  * desc - A struct usb_epdesc_s instance describing the endpoint
- * last - true if this this last endpoint to be configured.  Some hardware needs
+ * last - true if this is the last endpoint to be configured.  Some hardware needs
  *        to take special action when all of the endpoints have been configured.
  */
 
@@ -152,6 +152,7 @@
 #define DEV_DISCONNECT(dev)        (dev)->ops->pullup ? (dev)->ops->pullup(dev,false) : -EOPNOTSUPP
 
 /* USB Class Driver Helpers *********************************************************/
+
 /* All may be called from interrupt handling logic except bind() and unbind() */
 
 /* Invoked when the driver is bound to a USB device driver. */
@@ -328,8 +329,8 @@ struct usbdev_ops_s
 
   /* Device-specific I/O command support */
 
- CODE int (*ioctl)(FAR struct usbdev_s *dev, unsigned code,
-          unsigned long param);
+  CODE int (*ioctl)(FAR struct usbdev_s *dev, unsigned code,
+                    unsigned long param);
 };
 
 struct usbdev_s
@@ -380,7 +381,7 @@ extern "C"
 #endif
 
 /************************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ************************************************************************************/
 
 /************************************************************************************
@@ -406,7 +407,7 @@ int usbdev_register(FAR struct usbdevclass_driver_s *driver);
 
 int usbdev_unregister(FAR struct usbdevclass_driver_s *driver);
 
-/****************************************************************************
+/************************************************************************************
  * Name: usbdev_dma_alloc and usbdev_dma_free
  *
  * Description:
@@ -430,7 +431,7 @@ int usbdev_unregister(FAR struct usbdevclass_driver_s *driver);
  *   does require the size of the allocation to be freed; that would need
  *   to be managed in the board-specific logic.
  *
- ****************************************************************************/
+ ************************************************************************************/
 
 #if defined(CONFIG_USBDEV_DMA) && defined(CONFIG_USBDEV_DMAMEMORY)
 FAR void *usbdev_dma_alloc(size_t size);

--- a/libs/libc/math/Kconfig
+++ b/libs/libc/math/Kconfig
@@ -11,7 +11,7 @@ config LIBM
 	depends on !ARCH_MATH_H
 	select ARCH_FLOAT_H
 	---help---
-		By default, no math library will be provided by NuttX.  In this this
+		By default, no math library will be provided by NuttX.  In this
 		case, it is assumed that (1) no math library is required, or (2) you
 		will be using the math.h and float.h headers file and the libm
 		library provided by your toolchain.

--- a/net/igmp/igmp_input.c
+++ b/net/igmp/igmp_input.c
@@ -178,7 +178,7 @@ void igmp_input(struct net_driver_s *dev)
 
         if (net_ipv4addr_cmp(destipaddr, g_ipv4_allsystems))
           {
-            /* Yes... Now check the if this this is a general or a group
+            /* Yes... Now check the if this is a general or a group
              * specific query.
              *
              * RFC 2236, 2.1.  Type

--- a/net/mld/mld_join.c
+++ b/net/mld/mld_join.c
@@ -13,21 +13,21 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. Neither the name of CITEL Technologies Ltd nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ * 3. Neither the name of CITEL Technologies Ltd nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY CITEL TECHNOLOGIES AND CONTRIBUTORS ``AS IS''
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL CITEL TECHNOLOGIES OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
+ * ARE DISCLAIMED.  IN NO EVENT SHALL CITEL TECHNOLOGIES OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
 
@@ -184,7 +184,7 @@ int mld_joingroup(FAR const struct ipv6_mreq *mrec)
           return -ENOMEM;
         }
 
-      /* Indicate one request to join the group from this this host */
+      /* Indicate one request to join the group from this host */
 
       group->njoins = 1;
 
@@ -241,7 +241,7 @@ int mld_joingroup(FAR const struct ipv6_mreq *mrec)
       DEBUGASSERT(group->njoins > 0);
 #endif
 
-      /* Indicate one more request to join the group from this this host */
+      /* Indicate one more request to join the group from this host */
 
       DEBUGASSERT(group->njoins < UINT8_MAX);
       group->njoins++;

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -99,7 +99,7 @@ static dq_queue_t g_active_tcp_connections;
  *
  * Description:
  *   Given a local port number (in network byte order), find the TCP
- *   connection that listens on this this port.
+ *   connection that listens on this port.
  *
  *   Primary uses: (1) to determine if a port number is available, (2) to
  *   To identify the socket that will accept new connections on a local port.
@@ -150,7 +150,7 @@ static inline FAR struct tcp_conn_s *tcp_ipv4_listener(in_addr_t ipaddr,
  *
  * Description:
  *   Given a local port number (in network byte order), find the TCP
- *   connection that listens on this this port.
+ *   connection that listens on this port.
  *
  *   Primary uses: (1) to determine if a port number is available, (2) to
  *   To identify the socket that will accept new connections on a local port.
@@ -201,7 +201,7 @@ tcp_ipv6_listener(const net_ipv6addr_t ipaddr, uint16_t portno)
  *
  * Description:
  *   Given a local port number (in network byte order), find the TCP
- *   connection that listens on this this port.
+ *   connection that listens on this port.
  *
  *   Primary uses: (1) to determine if a port number is available, (2) to
  *   To identify the socket that will accept new connections on a local port.

--- a/sched/sched/sched_roundrobin.c
+++ b/sched/sched/sched_roundrobin.c
@@ -141,7 +141,7 @@ uint32_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, uint32_t ticks,
               tcb->flink->sched_priority >= tcb->sched_priority)
             {
               /* Just resetting the task priority to its current value.
-               * This this will cause the task to be rescheduled behind any
+               * This will cause the task to be rescheduled behind any
                * other tasks at the same priority.
                */
 


### PR DESCRIPTION
## Summary

Fix numerous instances of repeated words ("this this"). In some cases, substitute another word that seems sensible based on the context. Rewrap text lines when necessary and fix nxstyle issues in all affected source files.

## Impact

Fixes many nxstyle issues. Otherwise, no functional changes.

## Testing

nxstyle