### PR TITLE
arch: cxd56xx: Fix handle_irqreq() in cxd56_cpupause.c

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_cpupause.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpupause.c
@@ -149,6 +149,8 @@ static bool handle_irqreq(int cpu)
 
           spin_unlock(&g_cpu_wait[cpu]);
           handled = true;
+
+          break;
         }
     }
 


### PR DESCRIPTION
## Summary

- The handle_irqreq() is used for remote IRQ control.
- The logic is called via IPI (Inter-Processor Interrupt)
- And the handler should handle only one request
- However, I noticed that the handler handles up to two requests
- This commit fixes this issue

## Impact

- Affects SMP cases only

## Testing

- Tested with spresense:wifi_smp
