### PR TITLE
tiva/cc13xx: Fix nxstyle warnings

### DIFF
--- a/arch/arm/src/tiva/cc13xx/cc13xx_start.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_start.c
@@ -131,7 +131,8 @@ void cc13xx_trim_device(void);
  *       done, the processor reserves space on the stack for the FP state,
  *       but does not save that state information to the stack.
  *
- *  Software must not change the value of the ASPEN bit or LSPEN bit while either:
+ *  Software must not change the value of the ASPEN bit or LSPEN bit while
+ *  either:
  *   - the CPACR permits access to CP10 and CP11, that give access to the FP
  *     extension, or
  *   - the CONTROL.FPCA bit is set to 1
@@ -224,7 +225,9 @@ void __start(void)
 #endif
   uint32_t *dest;
 
-  /* Perform the necessary trim of the device which is not done in boot code. */
+  /* Perform the necessary trim of the device which is not done in boot
+   * code.
+   */
 
   cc13xx_trim_device();
 
@@ -242,7 +245,9 @@ void __start(void)
   tiva_gpio_enablepwr();
   tiva_gpio_enableclk();
 
-  /* Configure the UART so that we can get debug output as soon as possible */
+  /* Configure the UART so that we can get debug output as soon as
+   * possible
+   */
 
   tiva_lowsetup();
   tiva_fpuconfig();
@@ -296,7 +301,7 @@ void __start(void)
   showprogress('F');
 
 #ifdef CONFIG_TIVA_EEPROM
-  /*Initialize the EEPROM */
+  /* Initialize the EEPROM */
 
   tiva_eeprom_initialize();
   showprogress('G');


### PR DESCRIPTION
## Summary

arch/arm/src/tiva/cc13xx/cc13xx_start.c:

    * Fix nxstyle warnings. No functional changes.

## Impact

Removes nxstyle warnings when the file receives maintainance.

## Testing

nxstyle