### PR TITLE
Add task trace support

### DIFF
--- a/drivers/note/Kconfig
+++ b/drivers/note/Kconfig
@@ -55,4 +55,12 @@ config DRIVER_NOTERAM_BUFSIZE
 	---help---
 		The size of the in-memory, circular instrumentation buffer (in bytes).
 
+config DRIVER_NOTECTL
+	bool "Scheduler instrumentation filter control driver"
+	default n
+	depends on SCHED_INSTRUMENTATION_FILTER
+	---help---
+		If this option is selected, the instrumentation filter control device
+		/dev/notectl is provided.
+
 endif

--- a/drivers/note/Kconfig
+++ b/drivers/note/Kconfig
@@ -55,6 +55,15 @@ config DRIVER_NOTERAM_BUFSIZE
 	---help---
 		The size of the in-memory, circular instrumentation buffer (in bytes).
 
+config DRIVER_NOTERAM_DEFAULT_NOOVERWRITE
+	bool "Disable overwrite by default"
+	depends on DRIVER_NOTERAM
+	default n
+	---help---
+		Disables overwriting old notes in the circular buffer when the buffer
+		is full by default. This is useful to keep instrumentation data of the
+		beginning of a system boot.
+
 config DRIVER_NOTECTL
 	bool "Scheduler instrumentation filter control driver"
 	default n

--- a/drivers/note/Make.defs
+++ b/drivers/note/Make.defs
@@ -26,5 +26,9 @@ ifeq ($(CONFIG_DRIVER_NOTERAM),y)
   CSRCS += noteram_driver.c
 endif
 
+ifeq ($(CONFIG_DRIVER_NOTECTL),y)
+  CSRCS += notectl_driver.c
+endif
+
 DEPPATH += --dep-path note
 VPATH += :note

--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/note/note_driver.h>
 #include <nuttx/note/noteram_driver.h>
+#include <nuttx/note/notectl_driver.h>
 
 /****************************************************************************
  * Public Functions
@@ -50,6 +51,14 @@ int note_register(void)
 
 #ifdef CONFIG_DRIVER_NOTERAM
   ret = noteram_register();
+  if (ret < 0)
+    {
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_DRIVER_NOTECTL
+  ret = notectl_register();
   if (ret < 0)
     {
       return ret;

--- a/drivers/note/notectl_driver.c
+++ b/drivers/note/notectl_driver.c
@@ -1,0 +1,241 @@
+/****************************************************************************
+ * drivers/note/notectl_driver.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <errno.h>
+
+#include <nuttx/fs/fs.h>
+#include <nuttx/note/notectl_driver.h>
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int notectl_ioctl(struct file *filep, int cmd, unsigned long arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations notectl_fops =
+{
+  NULL,          /* open */
+  NULL,          /* close */
+  NULL,          /* read */
+  NULL,          /* write */
+  NULL,          /* seek */
+  notectl_ioctl, /* ioctl */
+  NULL           /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , 0            /* unlink */
+#endif
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: notectl_ioctl
+ ****************************************************************************/
+
+static int notectl_ioctl(struct file *filep, int cmd, unsigned long arg)
+{
+  int ret = -ENOSYS;
+
+  /* Handle the ioctl commands */
+
+  switch (cmd)
+    {
+      /* NOTECTL_GETMODE
+       *      - Get note filter mode
+       *        Argument: A writable pointer to struct note_filter_mode_s
+       */
+
+      case NOTECTL_GETMODE:
+        {
+          struct note_filter_mode_s *mode = (struct note_filter_mode_s *)arg;
+
+          if (mode == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              sched_note_filter_mode(mode, NULL);
+              ret = OK;
+            }
+        }
+        break;
+
+      /* NOTECTL_SETMODE
+       *      - Set note filter mode
+       *        Argument: A read-only pointer to struct note_filter_mode_s
+       */
+
+      case NOTECTL_SETMODE:
+        {
+          struct note_filter_mode_s *mode = (struct note_filter_mode_s *)arg;
+
+          if (mode == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              sched_note_filter_mode(NULL, mode);
+              ret = OK;
+            }
+        }
+        break;
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+      /* NOTECTL_GETSYSCALLFILTER
+       *      - Get syscall filter setting
+       *        Argument: A writable pointer to struct note_filter_syscall_s
+       */
+
+      case NOTECTL_GETSYSCALLFILTER:
+        {
+          struct note_filter_syscall_s *filter;
+          filter = (struct note_filter_syscall_s *)arg;
+
+          if (filter == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              sched_note_filter_syscall(filter, NULL);
+              ret = OK;
+            }
+        }
+        break;
+
+      /* NOTECTL_SETSYSCALLFILTER
+       *      - Set syscall filter setting
+       *        Argument: A read-only pointer to struct note_filter_syscall_s
+       */
+
+      case NOTECTL_SETSYSCALLFILTER:
+        {
+          struct note_filter_syscall_s *filter;
+          filter = (struct note_filter_syscall_s *)arg;
+
+          if (filter == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              sched_note_filter_syscall(NULL, filter);
+              ret = OK;
+            }
+        }
+        break;
+#endif
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+      /* NOTECTL_GETIRQFILTER
+       *      - Get IRQ filter setting
+       *        Argument: A writable pointer to struct note_filter_irq_s
+       */
+
+      case NOTECTL_GETIRQFILTER:
+        {
+          struct note_filter_irq_s *filter;
+          filter = (struct note_filter_irq_s *)arg;
+
+          if (filter == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              sched_note_filter_irq(filter, NULL);
+              ret = OK;
+            }
+        }
+        break;
+
+      /* NOTECTL_SETIRQFILTER
+       *      - Set IRQ filter setting
+       *        Argument: A read-only pointer to struct
+       *                  note_filter_irq_s
+       */
+
+      case NOTECTL_SETIRQFILTER:
+        {
+          struct note_filter_irq_s *filter;
+          filter = (struct note_filter_irq_s *)arg;
+
+          if (filter == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              sched_note_filter_irq(NULL, filter);
+              ret = OK;
+            }
+        }
+        break;
+#endif
+
+      default:
+          break;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: notectl_register
+ *
+ * Description:
+ *   Register a driver at /dev/notectl that can be used by an application to
+ *   control the note filter.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   Zero on succress. A negated errno value is returned on a failure.
+ *
+ ****************************************************************************/
+
+int notectl_register(void)
+{
+  return register_driver("/dev/notectl", &notectl_fops, 0666, NULL);
+}

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -92,7 +92,11 @@ static const struct file_operations g_noteram_fops =
 
 static struct noteram_info_s g_noteram_info =
 {
+#ifdef CONFIG_DRIVER_NOTERAM_DEFAULT_NOOVERWRITE
+  .ni_overwrite = NOTERAM_MODE_OVERWRITE_DISABLE
+#else
   .ni_overwrite = NOTERAM_MODE_OVERWRITE_ENABLE
+#endif
 };
 
 #ifdef CONFIG_SMP

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -41,6 +41,7 @@
 
 #include <sys/types.h>
 #include <sched.h>
+#include <fcntl.h>
 #include <assert.h>
 #include <errno.h>
 
@@ -57,6 +58,8 @@ struct noteram_info_s
 {
   volatile unsigned int ni_head;
   volatile unsigned int ni_tail;
+  volatile unsigned int ni_read;
+  unsigned int ni_overwrite;
   uint8_t ni_buffer[CONFIG_DRIVER_NOTERAM_BUFSIZE];
 };
 
@@ -64,8 +67,10 @@ struct noteram_info_s
  * Private Function Prototypes
  ****************************************************************************/
 
+static int noteram_open(FAR struct file *filep);
 static ssize_t noteram_read(FAR struct file *filep,
                             FAR char *buffer, size_t buflen);
+static int noteram_ioctl(struct file *filep, int cmd, unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -73,19 +78,22 @@ static ssize_t noteram_read(FAR struct file *filep,
 
 static const struct file_operations g_noteram_fops =
 {
-  NULL,          /* open */
+  noteram_open,  /* open */
   NULL,          /* close */
   noteram_read,  /* read */
   NULL,          /* write */
   NULL,          /* seek */
-  NULL,          /* ioctl */
+  noteram_ioctl, /* ioctl */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , 0            /* unlink */
 #endif
 };
 
-static struct noteram_info_s g_noteram_info;
+static struct noteram_info_s g_noteram_info =
+{
+  .ni_overwrite = NOTERAM_MODE_OVERWRITE_ENABLE
+};
 
 #ifdef CONFIG_SMP
 static volatile spinlock_t g_noteram_lock;
@@ -94,6 +102,37 @@ static volatile spinlock_t g_noteram_lock;
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: noteram_buffer_clear
+ *
+ * Description:
+ *   Clear all contents of the circular buffer.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+static void noteram_buffer_clear(void)
+{
+  irqstate_t flags;
+
+  flags = enter_critical_section();
+
+  g_noteram_info.ni_tail = g_noteram_info.ni_head;
+  g_noteram_info.ni_read = g_noteram_info.ni_head;
+
+  if (g_noteram_info.ni_overwrite == NOTERAM_MODE_OVERWRITE_OVERFLOW)
+    {
+      g_noteram_info.ni_overwrite = NOTERAM_MODE_OVERWRITE_DISABLE;
+    }
+
+  leave_critical_section(flags);
+}
 
 /****************************************************************************
  * Name: noteram_next
@@ -136,6 +175,7 @@ static inline unsigned int noteram_next(unsigned int ndx,
  *
  ****************************************************************************/
 
+#ifdef CONFIG_DEBUG_ASSERTIONS
 static unsigned int noteram_length(void)
 {
   unsigned int head = g_noteram_info.ni_head;
@@ -147,6 +187,34 @@ static unsigned int noteram_length(void)
     }
 
   return head - tail;
+}
+#endif
+
+/****************************************************************************
+ * Name: noteram_unread_length
+ *
+ * Description:
+ *   Length of unread data currently in circular buffer.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Length of unread data currently in circular buffer.
+ *
+ ****************************************************************************/
+
+static unsigned int noteram_unread_length(void)
+{
+  unsigned int head = g_noteram_info.ni_head;
+  unsigned int read = g_noteram_info.ni_read;
+
+  if (read > head)
+    {
+      head += CONFIG_DRIVER_NOTERAM_BUFSIZE;
+    }
+
+  return head - read;
 }
 
 /****************************************************************************
@@ -187,6 +255,13 @@ static void noteram_remove(void)
    * buffer.
    */
 
+  if (g_noteram_info.ni_read == g_noteram_info.ni_tail)
+    {
+      /* The read index also needs increment. */
+
+      g_noteram_info.ni_read = noteram_next(tail, length);
+    }
+
   g_noteram_info.ni_tail = noteram_next(tail, length);
 }
 
@@ -194,8 +269,7 @@ static void noteram_remove(void)
  * Name: noteram_get
  *
  * Description:
- *   Remove the next note from the tail of the circular buffer.  The note
- *   is also removed from the circular buffer to make room for further notes.
+ *   Get the next note from the read index of the circular buffer.
  *
  * Input Parameters:
  *   buffer - Location to return the next note
@@ -213,7 +287,7 @@ static ssize_t noteram_get(FAR uint8_t *buffer, size_t buflen)
   FAR struct note_common_s *note;
   irqstate_t flags;
   unsigned int remaining;
-  unsigned int tail;
+  unsigned int read;
   ssize_t notelen;
   size_t circlen;
 
@@ -222,21 +296,21 @@ static ssize_t noteram_get(FAR uint8_t *buffer, size_t buflen)
 
   /* Verify that the circular buffer is not empty */
 
-  circlen = noteram_length();
+  circlen = noteram_unread_length();
   if (circlen <= 0)
     {
       notelen = 0;
       goto errout_with_csection;
     }
 
-  /* Get the index to the tail of the circular buffer */
+  /* Get the read index of the circular buffer */
 
-  tail    = g_noteram_info.ni_tail;
+  read    = g_noteram_info.ni_read;
   DEBUGASSERT(tail < CONFIG_DRIVER_NOTERAM_BUFSIZE);
 
-  /* Get the length of the note at the tail index */
+  /* Get the length of the note at the read index */
 
-  note    = (FAR struct note_common_s *)&g_noteram_info.ni_buffer[tail];
+  note    = (FAR struct note_common_s *)&g_noteram_info.ni_buffer[read];
   notelen = note->nc_length;
   DEBUGASSERT(notelen <= circlen);
 
@@ -244,9 +318,9 @@ static ssize_t noteram_get(FAR uint8_t *buffer, size_t buflen)
 
   if (buflen < notelen)
     {
-      /* Remove the large note so that we do not get constipated. */
+      /* Skip the large note so that we do not get constipated. */
 
-      noteram_remove();
+      g_noteram_info.ni_read = noteram_next(read, notelen);
 
       /* and return an error */
 
@@ -259,17 +333,17 @@ static ssize_t noteram_get(FAR uint8_t *buffer, size_t buflen)
   remaining = (unsigned int)notelen;
   while (remaining > 0)
     {
-      /* Copy the next byte at the tail index */
+      /* Copy the next byte at the read index */
 
-      *buffer++ = g_noteram_info.ni_buffer[tail];
+      *buffer++ = g_noteram_info.ni_buffer[read];
 
       /* Adjust indices and counts */
 
-      tail = noteram_next(tail, 1);
+      read = noteram_next(read, 1);
       remaining--;
     }
 
-  g_noteram_info.ni_tail = tail;
+  g_noteram_info.ni_read = read;
 
 errout_with_csection:
   leave_critical_section(flags);
@@ -280,7 +354,8 @@ errout_with_csection:
  * Name: noteram_size
  *
  * Description:
- *   Return the size of the next note at the tail of the circular buffer.
+ *   Return the size of the next note at the read index of the circular
+ *   buffer.
  *
  * Input Parameters:
  *   None.
@@ -295,7 +370,7 @@ static ssize_t noteram_size(void)
 {
   FAR struct note_common_s *note;
   irqstate_t flags;
-  unsigned int tail;
+  unsigned int read;
   ssize_t notelen;
   size_t circlen;
 
@@ -303,27 +378,40 @@ static ssize_t noteram_size(void)
 
   /* Verify that the circular buffer is not empty */
 
-  circlen = noteram_length();
+  circlen = noteram_unread_length();
   if (circlen <= 0)
     {
       notelen = 0;
       goto errout_with_csection;
     }
 
-  /* Get the index to the tail of the circular buffer */
+  /* Get the read index of the circular buffer */
 
-  tail = g_noteram_info.ni_tail;
-  DEBUGASSERT(tail < CONFIG_DRIVER_NOTERAM_BUFSIZE);
+  read = g_noteram_info.ni_read;
+  DEBUGASSERT(read < CONFIG_SCHED_NOTE_BUFSIZE);
 
-  /* Get the length of the note at the tail index */
+  /* Get the length of the note at the read index */
 
-  note    = (FAR struct note_common_s *)&g_noteram_info.ni_buffer[tail];
+  note    = (FAR struct note_common_s *)&g_noteram_info.ni_buffer[read];
   notelen = note->nc_length;
   DEBUGASSERT(notelen <= circlen);
 
 errout_with_csection:
   leave_critical_section(flags);
   return notelen;
+}
+
+/****************************************************************************
+ * Name: noteram_open
+ ****************************************************************************/
+
+static int noteram_open(FAR struct file *filep)
+{
+  /* Reset the read index of the circular buffer */
+
+  g_noteram_info.ni_read = g_noteram_info.ni_tail;
+
+  return OK;
 }
 
 /****************************************************************************
@@ -387,6 +475,69 @@ static ssize_t noteram_read(FAR struct file *filep,
 }
 
 /****************************************************************************
+ * Name: noteram_ioctl
+ ****************************************************************************/
+
+static int noteram_ioctl(struct file *filep, int cmd, unsigned long arg)
+{
+  int ret = -ENOSYS;
+
+  /* Handle the ioctl commands */
+
+  switch (cmd)
+    {
+      /* NOTERAM_CLEAR
+       *      - Clear all contents of the circular buffer
+       *        Argument: Ignored
+       */
+
+      case NOTERAM_CLEAR:
+        noteram_buffer_clear();
+        ret = OK;
+        break;
+
+      /* NOTERAM_GETMODE
+       *      - Get overwrite mode
+       *        Argument: A writable pointer to unsigned int
+       */
+
+      case NOTERAM_GETMODE:
+        if (arg == 0)
+          {
+            ret = -EINVAL;
+          }
+        else
+          {
+            *(unsigned int *)arg = g_noteram_info.ni_overwrite;
+            ret = OK;
+          }
+        break;
+
+      /* NOTERAM_SETMODE
+       *      - Set overwrite mode
+       *        Argument: A read-only pointer to unsigned int
+       */
+
+      case NOTERAM_SETMODE:
+        if (arg == 0)
+          {
+            ret = -EINVAL;
+          }
+        else
+          {
+            g_noteram_info.ni_overwrite = *(unsigned int *)arg;
+            ret = OK;
+          }
+        break;
+
+      default:
+          break;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -413,11 +564,21 @@ void sched_note_add(FAR const void *note, size_t notelen)
   FAR const char *buf = note;
   unsigned int head;
   unsigned int next;
+  irqstate_t flags;
 
+  flags = up_irq_save();
 #ifdef CONFIG_SMP
-  irqstate_t flags = up_irq_save();
   spin_lock_wo_note(&g_noteram_lock);
 #endif
+
+  if (g_noteram_info.ni_overwrite == NOTERAM_MODE_OVERWRITE_OVERFLOW)
+    {
+#ifdef CONFIG_SMP
+      spin_unlock_wo_note(&g_noteram_lock);
+#endif
+      up_irq_restore(flags);
+      return;
+    }
 
   /* Get the index to the head of the circular buffer */
 
@@ -435,6 +596,19 @@ void sched_note_add(FAR const void *note, size_t notelen)
       next = noteram_next(head, 1);
       if (next == g_noteram_info.ni_tail)
         {
+          if (g_noteram_info.ni_overwrite == NOTERAM_MODE_OVERWRITE_DISABLE)
+            {
+              /* Stop recording if not in overwrite mode */
+
+              g_noteram_info.ni_overwrite = NOTERAM_MODE_OVERWRITE_OVERFLOW;
+
+#ifdef CONFIG_SMP
+              spin_unlock_wo_note(&g_noteram_lock);
+#endif
+              up_irq_restore(flags);
+              return;
+            }
+
           /* Yes, then remove the note at the tail index */
 
           noteram_remove();
@@ -452,8 +626,8 @@ void sched_note_add(FAR const void *note, size_t notelen)
 
 #ifdef CONFIG_SMP
   spin_unlock_wo_note(&g_noteram_lock);
-  up_irq_restore(flags);
 #endif
+  up_irq_restore(flags);
 }
 
 /****************************************************************************

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -98,6 +98,7 @@
 #define _RFIOCBASE      (0x2a00) /* RF devices ioctl commands */
 #define _RPTUNBASE      (0x2b00) /* Remote processor tunnel ioctl commands */
 #define _NOTECTLBASE    (0x2c00) /* Note filter control ioctl commands*/
+#define _NOTERAMBASE    (0x2d00) /* Noteram device ioctl commands*/
 #define _WLIOCBASE      (0x8b00) /* Wireless modules ioctl network commands */
 
 /* boardctl() commands share the same number space */
@@ -532,6 +533,11 @@
 
 #define _NOTECTLIOCVALID(c) (_IOC_TYPE(c) == _NOTECTLBASE)
 #define _NOTECTLIOC(nr)     _IOC(_NOTECTLBASE, nr)
+
+/* Noteram drivers **********************************************************/
+
+#define _NOTERAMIOCVALID(c) (_IOC_TYPE(c) == _NOTERAMBASE)
+#define _NOTERAMIOC(nr)     _IOC(_NOTERAMBASE, nr)
 
 /* Wireless driver network ioctl definitions ********************************/
 

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -97,6 +97,7 @@
 #define _NXTERMBASE     (0x2900) /* NxTerm character driver ioctl commands */
 #define _RFIOCBASE      (0x2a00) /* RF devices ioctl commands */
 #define _RPTUNBASE      (0x2b00) /* Remote processor tunnel ioctl commands */
+#define _NOTECTLBASE    (0x2c00) /* Note filter control ioctl commands*/
 #define _WLIOCBASE      (0x8b00) /* Wireless modules ioctl network commands */
 
 /* boardctl() commands share the same number space */
@@ -526,6 +527,11 @@
 
 #define _RPTUNIOCVALID(c)   (_IOC_TYPE(c)==_RPTUNBASE)
 #define _RPTUNIOC(nr)       _IOC(_RPTUNBASE,nr)
+
+/* Notectl drivers **********************************************************/
+
+#define _NOTECTLIOCVALID(c) (_IOC_TYPE(c) == _NOTECTLBASE)
+#define _NOTECTLIOC(nr)     _IOC(_NOTECTLBASE, nr)
 
 /* Wireless driver network ioctl definitions ********************************/
 

--- a/include/nuttx/note/notectl_driver.h
+++ b/include/nuttx/note/notectl_driver.h
@@ -1,0 +1,116 @@
+/****************************************************************************
+ * include/nuttx/note/notectl_driver.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_NOTE_NOTECTL_DRIVER_H
+#define __INCLUDE_NUTTX_NOTE_NOTECTL_DRIVER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include <nuttx/sched_note.h>
+#include <nuttx/fs/ioctl.h>
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* IOCTL Commands ***********************************************************/
+
+/* NOTECTL_GETMODE
+ *              - Get note filter mode
+ *                Argument: A writable pointer to struct note_filter_mode_s
+ * NOTECTL_SETMODE
+ *              - Set note filter mode
+ *                Argument: A read-only pointer to struct note_filter_mode_s
+ * NOTECTL_GETSYSCALLFILTER
+ *              - Get syscall filter setting
+ *                Argument: A writable pointer to struct
+ *                          note_filter_syscall_s
+ * NOTECTL_SETSYSCALLFILTER
+ *              - Set syscall filter setting
+ *                Argument: A read-only pointer to struct
+ *                          note_filter_syscall_s
+ * NOTECTL_GETIRQFILTER
+ *              - Get IRQ filter setting
+ *                Argument: A writable pointer to struct
+ *                          note_filter_irq_s
+ * NOTECTL_SETIRQFILTER
+ *              - Set IRQ filter setting
+ *                Argument: A read-only pointer to struct
+ *                          note_filter_irq_s
+ */
+
+#ifdef CONFIG_DRIVER_NOTECTL
+
+#define NOTECTL_GETMODE             _NOTECTLIOC(0x01)
+#define NOTECTL_SETMODE             _NOTECTLIOC(0x02)
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+#define NOTECTL_GETSYSCALLFILTER    _NOTECTLIOC(0x03)
+#define NOTECTL_SETSYSCALLFILTER    _NOTECTLIOC(0x04)
+#endif
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
+#define NOTECTL_GETIRQFILTER        _NOTECTLIOC(0x05)
+#define NOTECTL_SETIRQFILTER        _NOTECTLIOC(0x06)
+#endif
+
+#endif
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#if defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT)
+
+/****************************************************************************
+ * Name: notectl_register
+ *
+ * Description:
+ *   Register a driver at /dev/notectl that can be used by an application to
+ *   control the note filter.
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   Zero on succress. A negated errno value is returned on a failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DRIVER_NOTECTL
+int notectl_register(void);
+#endif
+
+#endif /* defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT) */
+
+#endif /* CONFIG_SCHED_INSTRUMENTATION */
+
+#endif /* __INCLUDE_NUTTX_NOTE_NOTECTL_DRIVER_H */

--- a/include/nuttx/note/noteram_driver.h
+++ b/include/nuttx/note/noteram_driver.h
@@ -26,14 +26,38 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/fs/ioctl.h>
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-/****************************************************************************
- * Public Types
- ****************************************************************************/
+/* IOCTL Commands ***********************************************************/
+
+/* NOTERAM_CLEAR
+ *              - Clear all contents of the circular buffer
+ *                Argument: Ignored
+ * NOTERAM_GETMODE
+ *              - Get overwrite mode
+ *                Argument: A writable pointer to unsigned int
+ * NOTERAM_SETMODE
+ *              - Set overwrite mode
+ *                Argument: A read-only pointer to unsigned int
+ */
+
+#ifdef CONFIG_DRIVER_NOTERAM
+#define NOTERAM_CLEAR           _NOTERAMIOC(0x01)
+#define NOTERAM_GETMODE         _NOTERAMIOC(0x02)
+#define NOTERAM_SETMODE         _NOTERAMIOC(0x03)
+#endif
+
+/* Overwrite mode definitions */
+
+#ifdef CONFIG_DRIVER_NOTERAM
+#define NOTERAM_MODE_OVERWRITE_DISABLE      0
+#define NOTERAM_MODE_OVERWRITE_ENABLE       1
+#define NOTERAM_MODE_OVERWRITE_OVERFLOW     2
+#endif
 
 /****************************************************************************
  * Public Function Prototypes

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -934,7 +934,7 @@ config SCHED_INSTRUMENTATION_EXTERNAL
 config SCHED_INSTRUMENTATION_CPUSET
 	hex "CPU bit set"
 	default 0xffff
-	depends on SMP
+	depends on SMP && SCHED_INSTRUMENTATION_FILTER
 	---help---
 		Monitor only CPUs in the bitset.  Bit 0=CPU0, Bit1=CPU1, etc.
 
@@ -989,6 +989,16 @@ config SCHED_INSTRUMENTATION_IRQHANDLER
 		must provide this additional logic.
 
 			void sched_note_irqhandler(int irq, FAR void *handler, bool enter);
+
+config SCHED_INSTRUMENTATION_FILTER
+	bool "Instrumenation filter"
+	default n
+	---help---
+		Enables the filter logic for the instrumentation. If this option
+		is enabled, the instrumentation data passed to sched_note_add()
+		can be filtered by syscall and IRQ number.
+		The filter logic can be configured by sched_note_filter APIs defined in
+		include/nuttx/sched_note.h.
 
 endif # SCHED_INSTRUMENTATION
 endmenu # Performance Monitoring

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1000,6 +1000,16 @@ config SCHED_INSTRUMENTATION_FILTER
 		The filter logic can be configured by sched_note_filter APIs defined in
 		include/nuttx/sched_note.h.
 
+config SCHED_INSTRUMENTATION_FILTER_DEFAULT_MODE
+	hex "Default instrumentation filter mode"
+	depends on SCHED_INSTRUMENTATION_FILTER
+	default 0x7
+	---help---
+		Default mode of the instrumentation filter logic.
+			Bit 0 = Enable instrumentation
+			Bit 1 = Enable syscall instrumentation
+			Bit 2 = Enable IRQ instrumentation
+
 endif # SCHED_INSTRUMENTATION
 endmenu # Performance Monitoring
 

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -75,9 +75,13 @@ struct note_startalloc_s
 #ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER
 static struct note_filter_s g_note_filter =
 {
+  .mode =
+    {
+      .flag = CONFIG_SCHED_INSTRUMENTATION_FILTER_DEFAULT_MODE,
 #ifdef CONFIG_SMP
-  .mode.cpuset = CONFIG_SCHED_INSTRUMENTATION_CPUSET
+      .cpuset = CONFIG_SCHED_INSTRUMENTATION_CPUSET,
 #endif
+    }
 };
 
 #ifdef CONFIG_SMP


### PR DESCRIPTION
## Summary
This PR adds the features used for task trace.
The task trace is available by using `feature/task-tracer` branch in the following repository.
  https://github.com/YuuichiNakamura/incubator-nuttx-apps.git
(I'll send PR for apps after merging this PR)

- This is created to merge #1377 into the master branch.
- The document for this feature will be created later (issue #1882)

## Impact
- New kernel configurations are added
   CONFIG_SCHED_INSTRUMENTATION_FILTER,
   CONFIG_SCHED_INSTRUMENTATION_FILTER_DEFAULT_MODE,
   CONFIG_DRIVER_NOTECTL,
   CONFIG_DRIVER_NOTERAM_NOOVERWRITE
- The following features are added when the corresponding configuration is enabled.
  - note filter support
  - /dev/notectl device to control note filters
  - /dev/note ioctls to clear buffer and change buffering mode for task trace

## Testing
Tested by using `feature/task-tracer` branch in the following repository.
  https://github.com/YuuichiNakamura/incubator-nuttx-apps.git

Tested by spresense:nsh by changing the following configurations.
```
CONFIG_DRIVER_NOTE=y
CONFIG_DRIVER_NOTERAM=y
CONFIG_DRIVER_NOTECTL=y
CONFIG_SCHED_INSTRUMENTATION=y
CONFIG_SCHED_INSTRUMENTATION_FILTER=y
CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER=y
CONFIG_SCHED_INSTRUMENTATION_SYSCALL=y
```
`trace` command is added to nsh by this configuration.
```
nsh> trace cmd "usleep 1000"
nsh> trace dump
```
This can get the following results:
```
<noname>-1   [0]   7.640000000: sys_ioctl -> 0
<noname>-1   [0]   7.640000000: sys_close()
<noname>-1   [0]   7.640000000: sys_close -> 0
<noname>-1   [0]   7.640000000: sys_sched_lock()
<noname>-1   [0]   7.640000000: sys_sched_lock -> 0
<noname>-1   [0]   7.640000000: sys_nxsched_get_stackinfo()
<noname>-1   [0]   7.640000000: sys_nxsched_get_stackinfo -> 0
<noname>-1   [0]   7.640000000: sys_sched_unlock()
<noname>-1   [0]   7.640000000: sys_sched_unlock -> 0
<noname>-1   [0]   7.640000000: sys_clock_nanosleep()
<noname>-1   [0]   7.640000000: sched_switch: prev_comm=<noname> prev_pid=1 prev_state=S ==> next_comm=<noname> next_pid=0
<noname>-0   [0]   7.640000000: irq_handler_entry: irq=11
<noname>-0   [0]   7.640000000: irq_handler_exit: irq=11
<noname>-0   [0]   7.640000000: irq_handler_entry: irq=15
<noname>-0   [0]   7.650000000: irq_handler_exit: irq=15
<noname>-0   [0]   7.650000000: irq_handler_entry: irq=15
<noname>-0   [0]   7.660000000: sched_waking: comm=<noname> pid=1 target_cpu=0
<noname>-1   [0]   7.660000000: irq_handler_exit: irq=15
<noname>-1   [0]   7.660000000: sched_switch: prev_comm=<noname> prev_pid=1 prev_state=R ==> next_comm=<noname> next_pid=1
<noname>-1   [0]   7.660000000: sys_clock_nanosleep -> 0
```
