### PR TITLE
drivers: note: Fix compile errors in noteram_driver.c

### DIFF
--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -310,7 +310,7 @@ static ssize_t noteram_get(FAR uint8_t *buffer, size_t buflen)
   /* Get the read index of the circular buffer */
 
   read    = g_noteram_info.ni_read;
-  DEBUGASSERT(tail < CONFIG_DRIVER_NOTERAM_BUFSIZE);
+  DEBUGASSERT(read < CONFIG_DRIVER_NOTERAM_BUFSIZE);
 
   /* Get the length of the note at the read index */
 
@@ -392,7 +392,7 @@ static ssize_t noteram_size(void)
   /* Get the read index of the circular buffer */
 
   read = g_noteram_info.ni_read;
-  DEBUGASSERT(read < CONFIG_SCHED_NOTE_BUFSIZE);
+  DEBUGASSERT(read < CONFIG_DRIVER_NOTERAM_BUFSIZE);
 
   /* Get the length of the note at the read index */
 


### PR DESCRIPTION
## Summary

- This commit fixes compile errors if CONFIG_DEBUG_ASSERTIONS=y

## Impact

- Affects noteram_driver only

## Testing

- Tested with spresense:wifi_smp with CONFIG_DEBUG_ASSERTIONS=y
