### PR TITLE
cygwin build - path issue fix for Renesas arch

### DIFF
--- a/arch/renesas/src/Makefile
+++ b/arch/renesas/src/Makefile
@@ -96,16 +96,16 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
+EXTRA_LIBPATHS += -L"${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}"
+  EXTRA_LIBPATHS += -L"${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
 endif
 
 ifeq ($(CONFIG_CXX_LIBSUPCXX),y)
   EXTRA_LIBS += -lsupc++
-  EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a}}"
+  EXTRA_LIBPATHS += -L"${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}"
 endif
 
 VPATH = chip:common


### PR DESCRIPTION
## Summary
The Makefile is updated for the cygwin library path. The build on cygwin was failing since the path to libc, libm, etc were incorrect.
EXTRA_LIBPATHS is updated to match the cygwin style.
## Impact
cygwin build issue fixed
## Testing
Build tested for RX65N
