### PR TITLE
arch/xtensa/src/esp32/esp32_intdecode.c: Don't clear A2 beforing INTCLEAR

### DIFF
--- a/arch/xtensa/src/esp32/esp32_intdecode.c
+++ b/arch/xtensa/src/esp32/esp32_intdecode.c
@@ -60,7 +60,6 @@ static inline void xtensa_intclear(uint32_t mask)
 {
   __asm__ __volatile__
   (
-    "movi a2, 0\n"
     "wsr %0, INTCLEAR\n"
     : "=r"(mask) : :
   );


### PR DESCRIPTION
## Summary

The mask arguments was going through A2, clearing A2 was also clearing the mask and preventing the interrupt state to be reset.

## Impact
Fix interrupt clearing in case of edge interrupts.

## Testing
esp32-core:nsh with GPIO IRQs.

