### PR TITLE
ESP32: Implement BASIC reset logic

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -15,6 +15,7 @@ config ARCH_CHIP_ESP32
 	select XTENSA_HAVE_INTERRUPTS
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_MODULE_TEXT
+	select ARCH_HAVE_RESET
 	select ARCH_TOOLCHAIN_GNU
 	---help---
 		The ESP32 is a dual-core system from Espressif with two Harvard

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -53,7 +53,7 @@ CMN_CSRCS += xtensa_puts.c xtensa_releasepending.c xtensa_releasestack.c
 CMN_CSRCS += xtensa_reprioritizertr.c xtensa_schedsigaction.c
 CMN_CSRCS += xtensa_sigdeliver.c xtensa_stackframe.c xtensa_udelay.c
 CMN_CSRCS += xtensa_unblocktask.c xtensa_usestack.c
-CMN_CSRCS += esp32_systemreset.c
+CMN_CSRCS += esp32_systemreset.c esp32_resetcause.c
 
 # Configuration-dependent common XTENSA files
 

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -53,6 +53,7 @@ CMN_CSRCS += xtensa_puts.c xtensa_releasepending.c xtensa_releasestack.c
 CMN_CSRCS += xtensa_reprioritizertr.c xtensa_schedsigaction.c
 CMN_CSRCS += xtensa_sigdeliver.c xtensa_stackframe.c xtensa_udelay.c
 CMN_CSRCS += xtensa_unblocktask.c xtensa_usestack.c
+CMN_CSRCS += esp32_systemreset.c
 
 # Configuration-dependent common XTENSA files
 

--- a/arch/xtensa/src/esp32/esp32_resetcause.h
+++ b/arch/xtensa/src/esp32/esp32_resetcause.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/xtensa/esp32/esp32-core/src/esp32_reset.c
+ * arch/xtensa/src/esp32/esp32_resetcause.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,45 +19,36 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Included Files
+ * Public Types
  ****************************************************************************/
 
-#include <nuttx/config.h>
-
-#include <nuttx/arch.h>
-#include <nuttx/board.h>
-
-#ifdef CONFIG_BOARDCTL_RESET
+enum esp32_resetcause_e
+{
+  ESP32_RESETCAUSE_SYS_CHIPPOR = 0x01,
+  ESP32_RESETCAUSE_SYS_RWDTSR  = 0x10,
+  ESP32_RESETCAUSE_SYS_BOR     = 0x0f,
+  ESP32_RESETCAUSE_CORE_SOFT   = 0x03,
+  ESP32_RESETCAUSE_CORE_DPSP   = 0x05,
+  ESP32_RESETCAUSE_CORE_MWDT0  = 0x07,
+  ESP32_RESETCAUSE_CORE_MWDT1  = 0x08,
+  ESP32_RESETCAUSE_CORE_RWDT   = 0x09,
+  ESP32_RESETCAUSE_CPU_MWDT0   = 0x0b,
+  ESP32_RESETCAUSE_CPU_SOFT    = 0x0c,
+  ESP32_RESETCAUSE_CPU_RWDT    = 0x0d,
+  ESP32_RESETCAUSE_CPU_PROCPU  = 0x0e
+};
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
- * Name: board_reset
+ * Name: esp32_resetcause
  *
  * Description:
- *   Reset board.  Support for this function is required by board-level
- *   logic if CONFIG_BOARDCTL_RESET is selected.
- *
- * Input Parameters:
- *   status - Status information provided with the reset event.  This
- *            meaning of this status information is board-specific.  If not
- *            used by a board, the value zero may be provided in calls to
- *            board_reset().
- *
- * Returned Value:
- *   If this function returns, then it was not possible to power-off the
- *   board due to some constraints.  The return value in this case is a
- *   board-specific reason for the failure to shutdown.
+ *   Get the cause of the last reset of the given CPU
  *
  ****************************************************************************/
 
-int board_reset(int status)
-{
-  up_systemreset();
+enum esp32_resetcause_e esp32_resetcause(int cpu);
 
-  return 0;
-}
-
-#endif /* CONFIG_BOARDCTL_RESET */

--- a/arch/xtensa/src/esp32/esp32_systemreset.c
+++ b/arch/xtensa/src/esp32/esp32_systemreset.c
@@ -1,0 +1,54 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_systemreset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#include "xtensa.h"
+#include "hardware/esp32_rtccntl.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_systemreset
+ *
+ * Description:
+ *   Internal reset logic.
+ *
+ ****************************************************************************/
+
+void up_systemreset(void)
+{
+  putreg32(RTC_CNTL_SW_SYS_RST, RTC_CNTL_OPTIONS0_REG);
+
+  /* Wait for the reset */
+
+  for (; ; );
+}

--- a/boards/xtensa/esp32/esp32-core/src/Makefile
+++ b/boards/xtensa/esp32/esp32-core/src/Makefile
@@ -43,6 +43,9 @@ CSRCS = esp32_boot.c esp32_bringup.c
 
 ifeq ($(CONFIG_LIB_BOARDCTL),y)
 CSRCS += esp32_appinit.c
+ifeq ($(CONFIG_BOARDCTL_RESET),y)
+CSRCS += esp32_reset.c
+endif
 endif
 
 ifeq ($(CONFIG_ESP32_SPI),y)

--- a/boards/xtensa/esp32/esp32-core/src/esp32_reset.c
+++ b/boards/xtensa/esp32/esp32-core/src/esp32_reset.c
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * boards/xtensa/esp32/esp32-core/src/esp32_reset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#ifdef CONFIG_BOARDCTL_RESET
+
+/****************************************************************************
+ * Public functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_reset
+ *
+ * Description:
+ *   Reset board.  Support for this function is required by board-level
+ *   logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ * Input Parameters:
+ *   status - Status information provided with the reset event.  This
+ *            meaning of this status information is board-specific.  If not
+ *            used by a board, the value zero may be provided in calls to
+ *            board_reset().
+ *
+ * Returned Value:
+ *   If this function returns, then it was not possible to power-off the
+ *   board due to some constraints.  The return value in this case is a
+ *   board-specific reason for the failure to shutdown.
+ *
+ ****************************************************************************/
+
+int board_reset(int status)
+{
+  up_systemreset();
+
+  return 0;
+}
+
+#endif /* CONFIG_BOARDCTL_RESET */


### PR DESCRIPTION
## Summary
Implement basic reset logic and how to retrieve the cause of the reset.

## Impact
Add reset to ESP32
## Testing

Testing with reboot command from NSH and also by enabling reboot on assertions.
