### PR TITLE
arch: esp32: Fix crash on startup

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -16,7 +16,6 @@ config ARCH_CHIP_ESP32
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_MODULE_TEXT
 	select ARCH_HAVE_SDRAM
-	select ARCH_HAVE_HEAP2
 	select ARCH_HAVE_RESET
 	select ARCH_TOOLCHAIN_GNU
 	---help---

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -138,6 +138,7 @@ config ESP32_SPI3
 config ESP32_SPIRAM
 	bool "SPI RAM Support"
 	default n
+	select ARCH_HAVE_HEAP2
 
 if ESP32_SPIRAM && SMP
 


### PR DESCRIPTION
## Summary

- This commit fixes crash on startup introduced by commit 232aa62f03

## Impact

- Affects all use cases for esp32

## Testing

- Tested with esp32-core:smp with QEMU

