### PR TITLE
ESP32: Fixes the GPIO's function mask test

### DIFF
--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -213,12 +213,12 @@ int esp32_configgpio(int pin, gpio_pinattr_t attr)
   func |= FUN_IE;
 
   /* Select the pad's function.  If no function was given, consider it a
-   * normal input or output (i.e. function2).
+   * normal input or output (i.e. function3).
    */
 
-  if ((attr & FUNCTION) != 0)
+  if ((attr & FUNCTION_MASK) != 0)
     {
-      func |= (uint32_t)((attr >> FUNCTION_SHIFT) << MCU_SEL_S);
+      func |= (uint32_t)(((attr >> FUNCTION_SHIFT) - 1) << MCU_SEL_S);
     }
   else
     {

--- a/arch/xtensa/src/esp32/esp32_gpio.h
+++ b/arch/xtensa/src/esp32/esp32_gpio.h
@@ -60,12 +60,12 @@
 #define OPEN_DRAIN          (1 << 5)
 #define FUNCTION_SHIFT      6
 #define FUNCTION_MASK       (7 << FUNCTION_SHIFT)
-#  define FUNCTION_1        (0 << FUNCTION_SHIFT)
-#  define FUNCTION_2        (1 << FUNCTION_SHIFT)
-#  define FUNCTION_3        (2 << FUNCTION_SHIFT)
-#  define FUNCTION_4        (3 << FUNCTION_SHIFT)
-#  define FUNCTION_5        (4 << FUNCTION_SHIFT)
-#  define FUNCTION_6        (5 << FUNCTION_SHIFT)
+#  define FUNCTION_1        (1 << FUNCTION_SHIFT)
+#  define FUNCTION_2        (2 << FUNCTION_SHIFT)
+#  define FUNCTION_3        (3 << FUNCTION_SHIFT)
+#  define FUNCTION_4        (4 << FUNCTION_SHIFT)
+#  define FUNCTION_5        (5 << FUNCTION_SHIFT)
+#  define FUNCTION_6        (6 << FUNCTION_SHIFT)
 
 #define INPUT_PULLUP        (INPUT | PULLUP)
 #define INPUT_PULLDOWN      (INPUT | PULLDOWN)

--- a/arch/xtensa/src/esp32/esp32_psram.c
+++ b/arch/xtensa/src/esp32/esp32_psram.c
@@ -1205,10 +1205,10 @@ static void IRAM_ATTR psram_gpio_config(psram_io_t *psram_io,
   esp32_configgpio(psram_io->psram_clk_io, OUTPUT | FUNCTION_3);
   esp32_configgpio(psram_io->psram_spiq_sd0_io, OUTPUT | INPUT | FUNCTION_3);
   esp32_configgpio(psram_io->psram_spid_sd1_io, OUTPUT | INPUT | FUNCTION_3);
-  esp32_configgpio(psram_io->psram_spihd_sd2_io, OUTPUT | INPUT | \
-                   FUNCTION_3);
-  esp32_configgpio(psram_io->psram_spiwp_sd3_io, OUTPUT | INPUT | \
-                   FUNCTION_3);
+  esp32_configgpio(psram_io->psram_spihd_sd2_io,
+                   OUTPUT | INPUT | FUNCTION_3);
+  esp32_configgpio(psram_io->psram_spiwp_sd3_io,
+                   OUTPUT | INPUT | FUNCTION_3);
 
 #if 0
   uint32_t flash_id = g_rom_flashchip.device_id;

--- a/arch/xtensa/src/esp32/esp32_psram.c
+++ b/arch/xtensa/src/esp32/esp32_psram.c
@@ -1191,24 +1191,24 @@ static void IRAM_ATTR psram_gpio_config(psram_io_t *psram_io,
     {
       /* flash clock signal should come from IO MUX. */
 
-      esp32_configgpio(psram_io->flash_clk_io, OUTPUT_FUNCTION_1);
+      esp32_configgpio(psram_io->flash_clk_io, OUTPUT_FUNCTION_2);
     }
   else
     {
       /* flash clock signal should come from GPIO matrix. */
 
-      esp32_configgpio(psram_io->flash_clk_io, OUTPUT_FUNCTION_2);
+      esp32_configgpio(psram_io->flash_clk_io, OUTPUT_FUNCTION_3);
     }
 
-  esp32_configgpio(psram_io->flash_cs_io, OUTPUT | FUNCTION_2);
-  esp32_configgpio(psram_io->psram_cs_io, OUTPUT | FUNCTION_2);
-  esp32_configgpio(psram_io->psram_clk_io, OUTPUT | FUNCTION_2);
-  esp32_configgpio(psram_io->psram_spiq_sd0_io, OUTPUT | INPUT | FUNCTION_2);
-  esp32_configgpio(psram_io->psram_spid_sd1_io, OUTPUT | INPUT | FUNCTION_2);
+  esp32_configgpio(psram_io->flash_cs_io, OUTPUT | FUNCTION_3);
+  esp32_configgpio(psram_io->psram_cs_io, OUTPUT | FUNCTION_3);
+  esp32_configgpio(psram_io->psram_clk_io, OUTPUT | FUNCTION_3);
+  esp32_configgpio(psram_io->psram_spiq_sd0_io, OUTPUT | INPUT | FUNCTION_3);
+  esp32_configgpio(psram_io->psram_spid_sd1_io, OUTPUT | INPUT | FUNCTION_3);
   esp32_configgpio(psram_io->psram_spihd_sd2_io, OUTPUT | INPUT | \
-                   FUNCTION_2);
+                   FUNCTION_3);
   esp32_configgpio(psram_io->psram_spiwp_sd3_io, OUTPUT | INPUT | \
-                   FUNCTION_2);
+                   FUNCTION_3);
 
 #if 0
   uint32_t flash_id = g_rom_flashchip.device_id;


### PR DESCRIPTION
## Summary

This PR fixes the test for function mask and also adapts the newest PSRAM to the configgpio change.

## Impact
Fixes a bug in GPIO function mask.

## Testing
esp32-core:nsh
