### PR TITLE
sim: Fix make export

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -287,9 +287,11 @@ board/libboard$(LIBEXT):
 # Step 3 cheat the host there is no object to construct
 # Note: the destructor can be fixed in the same way.
 
-nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(LINKOBJS) $(HOSTOBJS)
-	$(Q) echo "LD:  nuttx$(EXEEXT)"
+nuttx-names.dat: nuttx-names.in
 	$(call PREPROCESS, nuttx-names.in, nuttx-names.dat)
+
+nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(LINKOBJS) $(HOSTOBJS) nuttx-names.dat
+	$(Q) echo "LD:  nuttx$(EXEEXT)"
 	$(Q) $(LD) -r $(LDLINKFLAGS) $(RELPATHS) $(EXTRA_LIBPATHS) -o nuttx.rel $(REQUIREDOBJS) $(LDSTARTGROUP) $(RELLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 	$(Q) $(OBJCOPY) --redefine-syms=nuttx-names.dat nuttx.rel
 	$(Q) $(CC) $(CCLINKFLAGS) -Wl,-verbose 2>&1 | \
@@ -305,7 +307,7 @@ nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(LINKOBJS) $(HOSTOBJS)
 
 # This is part of the top-level export target
 
-export_startup: board/libboard$(LIBEXT) up_head.o $(HOSTOBJS)
+export_startup: board/libboard$(LIBEXT) up_head.o $(HOSTOBJS) nuttx-names.dat
 	cp up_head.o $(HOSTOBJS) ${EXPORT_DIR}/startup
 	cp nuttx-names.dat ${EXPORT_DIR}/libs
 	echo main NXmain >> ${EXPORT_DIR}/libs/nuttx-names.dat


### PR DESCRIPTION
Namely, don't forget to generate nuttx-names.dat.

## Summary
fix an error during "make export" for sim

## Impact
"make export" on clean tree can produce the zip now.

## Testing
tested on macOS
