### PR TITLE
Fix spresense smp

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_cpupause.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpupause.c
@@ -210,6 +210,13 @@ bool up_cpu_pausereq(int cpu)
 
 int up_cpu_paused(int cpu)
 {
+  /* Fistly, check if this IPI is to enable/disable IRQ */
+
+  if (handle_irqreq(cpu))
+    {
+      return OK;
+    }
+
   FAR struct tcb_s *tcb = this_task();
 
   /* Update scheduler parameters */
@@ -282,13 +289,6 @@ int arm_pause_handler(int irq, void *c, FAR void *arg)
   /* Clear SW_INT for APP_DSP(cpu) */
 
   putreg32(0, CXD56_CPU_P2_INT + (4 * cpu));
-
-  /* Check if this IPI is to enable/disable IRQ */
-
-  if (handle_irqreq(cpu))
-    {
-      return OK;
-    }
 
   /* Check for false alarms.  Such false could occur as a consequence of
    * some deadlock breaking logic that might have already serviced the SG2

--- a/boards/arm/cxd56xx/common/src/cxd56_gs2200m.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_gs2200m.c
@@ -112,35 +112,18 @@ static int gs2200m_irq_attach(xcpt_t handler, FAR void *arg)
 
 static void gs2200m_irq_enable(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = enter_critical_section();
 
   wlinfo("== ec:%d called=%d \n", _enable_count, _n_called++);
 
   if (0 == _enable_count)
     {
-#ifdef CONFIG_SMP
-      bool unlock = false;
-
-      if (0 != up_cpu_index())
-        {
-          unlock = true;
-          spin_unlock_irqrestore(flags);
-        }
-#endif
-
       cxd56_gpioint_enable(PIN_UART2_CTS);
-
-#ifdef CONFIG_SMP
-      if (unlock)
-        {
-          flags = spin_lock_irqsave();
-        }
-#endif
     }
 
   _enable_count++;
 
-  spin_unlock_irqrestore(flags);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************
@@ -149,7 +132,7 @@ static void gs2200m_irq_enable(void)
 
 static void gs2200m_irq_disable(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = enter_critical_section();
 
   wlinfo("== ec:%d called=%d \n", _enable_count, _n_called++);
 
@@ -157,27 +140,10 @@ static void gs2200m_irq_disable(void)
 
   if (0 == _enable_count)
     {
-#ifdef CONFIG_SMP
-      bool unlock = false;
-
-      if (0 != up_cpu_index())
-        {
-          unlock = true;
-          spin_unlock_irqrestore(flags);
-        }
-#endif
-
       cxd56_gpioint_disable(PIN_UART2_CTS);
-
-#ifdef CONFIG_SMP
-      if (unlock)
-        {
-          flags = spin_lock_irqsave();
-        }
-#endif
     }
 
-  spin_unlock_irqrestore(flags);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************
@@ -186,7 +152,7 @@ static void gs2200m_irq_disable(void)
 
 static uint32_t gs2200m_dready(int *ec)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = enter_critical_section();
 
   uint32_t r = cxd56_gpio_read(PIN_UART2_CTS);
 
@@ -197,7 +163,7 @@ static uint32_t gs2200m_dready(int *ec)
       *ec = _enable_count;
     }
 
-  spin_unlock_irqrestore(flags);
+  leave_critical_section(flags);
   return r;
 }
 


### PR DESCRIPTION
## Summary

- This PR consists of two commits.
- cxd56_cpupause.c
During Wi-Fi audio streaming test, I noticed data corruption in tcb
Finally, I found an issue in IRQ request handing with IPI
This commit fixes this issue
- cxd56_gs2200m.c
During streaming test, I noticed a dealock when controlling IRQ
Actually, it will send an IPI when the cpu index is not 0
However, up_cpu_pause() also sends IPI with critical section
So the IRQ control must follow the same rule

## Impact

- Affects SMP only

## Testing

-  Tested with spresense:wifi_smp