### PR TITLE
arch/xtensa/src/common/xtensa.h: Include sys/types.h needed if STACK_COLORATON is enabled

### DIFF
--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -44,6 +44,7 @@
 
 #ifndef __ASSEMBLY__
 #  include <stdint.h>
+#  include <sys/types.h>
 #  include <stdbool.h>
 #endif
 


### PR DESCRIPTION
## Summary
If STACK_COLORATION is enabled the build would fail as it can't find a definition for size_t.

## Impact
Fix build if STACK_COLORATION is enabled.
## Testing
esp32-core:nsh with CONFIG_STACK_COLORATION 1

