### PR TITLE
tiva: Fix nxstyle warnings

### DIFF
--- a/arch/arm/src/tiva/common/lm4xx_tm3c_sysctrl.c
+++ b/arch/arm/src/tiva/common/lm4xx_tm3c_sysctrl.c
@@ -86,9 +86,9 @@
  * Name: tiva_delay
  *
  * Description:
- *   Wait for the newly selected oscillator(s) to settle.  This is tricky because
- *   the time that we wait can be significant and is determined by the previous
- *   clock setting, not the one that we are configuring.
+ *   Wait for the newly selected oscillator(s) to settle.  This is tricky
+ *   because the time that we wait can be significant and is determined by
+ *   the previous clock setting, not the one that we are configuring.
  *
  ****************************************************************************/
 
@@ -104,9 +104,9 @@ static inline void tiva_delay(uint32_t delay)
  * Name: tiva_oscdelay
  *
  * Description:
- *   Wait for the newly selected oscillator(s) to settle.  This is tricky because
- *   the time that we wait can be significant and is determined by the previous
- *   clock setting, not the one that we are configuring.
+ *   Wait for the newly selected oscillator(s) to settle.  This is tricky
+ *   because the time that we wait can be significant and is determined by
+ *   the previous clock setting, not the one that we are configuring.
  *
  ****************************************************************************/
 
@@ -210,21 +210,21 @@ void tiva_clock_reconfigure(uint32_t newrcc, uint32_t newrcc2)
     {
       uint32_t dummy;
 
-      /* According to TM4C123GH6PM datasheet page 231 item 5.3 we must perform
-       * the following steps to initialize and configure TM4C123G chip to use
-       * a PLL based system clock.
+      /* According to TM4C123GH6PM datasheet page 231 item 5.3 we must
+       * perform the following steps to initialize and configure TM4C123G
+       * chip to use a PLL based system clock.
        *
-       * 1. Bypass the PLL and system clock divider by setting the BYPASS bit
-       *    and clearing the USESYS bit in the RCC register.
+       * 1. Bypass the PLL and system clock divider by setting the BYPASS
+       *    bit and clearing the USESYS bit in the RCC register.
        *
        * 2. Select the crystal value (XTAL) and oscillator source (OSCSRC),
        *    and clear the PWRDN bit in RCC/RCC2. Setting the XTAL field
-       *    automatically pulls valid PLL configuration data for the appropriate
-       *    crystal, and clearing the PWRDN bit powers and enables the PLL and
-       *    its output.
+       *    automatically pulls valid PLL configuration data for the
+       *    appropriate crystal, and clearing the PWRDN bit powers and
+       *    enables the PLL and its output.
        *
-       * 3. Select the desired system divider (SYSDIV) in RCC/RCC2 and set the
-       *    USESYS bit in RCC. The SYSDIV field determines the system
+       * 3. Select the desired system divider (SYSDIV) in RCC/RCC2 and set
+       *    the USESYS bit in RCC. The SYSDIV field determines the system
        *    frequency for the microcontroller.
        *
        * 4. Wait for the PLL to lock by polling the PLLLRIS bit in the Raw
@@ -262,9 +262,9 @@ void tiva_clock_reconfigure(uint32_t newrcc, uint32_t newrcc2)
       /* Write the new RCC/RCC2 values.
        *
        * LM4F120 Data Sheet:  "Write the RCC register prior to writing the
-       * RCC2 register. If a subsequent write to the RCC register is required,
-       * include another register access after writing the RCC register and
-       * before writing the RCC2 register."
+       * RCC2 register. If a subsequent write to the RCC register is
+       * required, include another register access after writing the RCC
+       * register and before writing the RCC2 register."
        */
 
       putreg32(rcc, TIVA_SYSCON_RCC);
@@ -272,7 +272,9 @@ void tiva_clock_reconfigure(uint32_t newrcc, uint32_t newrcc2)
       UNUSED(dummy);
       putreg32(rcc2, TIVA_SYSCON_RCC2);
 
-      /* Wait for the new crystal value and oscillator source to take effect */
+      /* Wait for the new crystal value and oscillator source to take
+       * effect
+       */
 
       tiva_delay(16);
 
@@ -311,8 +313,10 @@ void tiva_clock_reconfigure(uint32_t newrcc, uint32_t newrcc2)
         }
     }
 #else
-  if (((rcc & SYSCON_RCC_MOSCDIS) != 0 && (newrcc & SYSCON_RCC_MOSCDIS) == 0) ||
-      ((rcc & SYSCON_RCC_IOSCDIS) != 0 && (newrcc & SYSCON_RCC_IOSCDIS) == 0))
+  if (((rcc & SYSCON_RCC_MOSCDIS) != 0 &&
+       (newrcc & SYSCON_RCC_MOSCDIS) == 0) ||
+      ((rcc & SYSCON_RCC_IOSCDIS) != 0 &&
+       (newrcc & SYSCON_RCC_IOSCDIS) == 0))
     {
       /* Temporarily bypass the PLL and system clock dividers */
 
@@ -328,9 +332,10 @@ void tiva_clock_reconfigure(uint32_t newrcc, uint32_t newrcc2)
       rcc &= (~RCC_OSCMASK | (newrcc & RCC_OSCMASK));
       putreg32(rcc, TIVA_SYSCON_RCC);
 
-      /* Wait for the newly selected oscillator(s) to settle.  This is tricky because
-       * the time that we wait can be significant and is determined by the previous
-       * clock setting, not the one that we are configuring.
+      /* Wait for the newly selected oscillator(s) to settle.  This is
+       * tricky because the time that we wait can be significant and is
+       * determined by the previous clock setting, not the one that we are
+       * configuring.
        */
 
       tiva_oscdelay(rcc, rcc2);
@@ -356,11 +361,15 @@ void tiva_clock_reconfigure(uint32_t newrcc, uint32_t newrcc2)
       putreg32(rcc, TIVA_SYSCON_RCC);
       putreg32(rcc2, TIVA_SYSCON_RCC2);
 
-      /* Wait for the new crystal value and oscillator source to take effect */
+      /* Wait for the new crystal value and oscillator source to take
+       * effect
+       */
 
       tiva_delay(16);
 
-      /* Set the requested system divider and disable the non-selected osciallators */
+      /* Set the requested system divider and disable the non-selected
+       * osciallators
+       */
 
       rcc  &= ~RCC_DIVMASK;
       rcc  |= (newrcc & RCC_DIVMASK);
@@ -413,8 +422,8 @@ void tiva_clock_configure(void)
   putreg32(SYSCON_LPDOPCTL_2750MV, TIVA_SYSCON_LDOPCTL);
 #endif
 
-  /* Set the clocking to run with the default settings provided in the board.h
-   * header file
+  /* Set the clocking to run with the default settings provided in the
+   * board.h header file
    */
 
   tiva_clock_reconfigure(TIVA_RCC_VALUE, TIVA_RCC2_VALUE);

--- a/arch/arm/src/tiva/common/lmxx_tm4c_enableclks.h
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_enableclks.h
@@ -49,6 +49,7 @@
 /************************************************************************************
  * Pre-processor Definitions
  ************************************************************************************/
+
 /* Clocks are enabled or disabled by setting or clearing a bit (b) in a system
  * control register (a))
  */

--- a/arch/arm/src/tiva/common/lmxx_tm4c_enablepwr.h
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_enablepwr.h
@@ -50,6 +50,7 @@
 /************************************************************************************
  * Pre-processor Definitions
  ************************************************************************************/
+
 /* Power control is enabled or disabled by setting or clearing a bit (b) in a system
  * control register (a))
  */

--- a/arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
@@ -284,7 +284,8 @@ static int tiva_gpioporthandler(uint8_t port, void *context)
           if (((mis >> pin) & 1) != 0)
             {
               int index = TIVA_GPIO_IRQ_IDX(port, pin);
-              FAR struct gpio_handler_s *handler = &g_gpioportirqvector[index];
+              FAR struct gpio_handler_s *handler =
+                &g_gpioportirqvector[index];
 
               gpioinfo("port=%d pin=%d isr=%p arg=%p index=%d\n",
                        port, pin, handler->isr, handler->arg, index);
@@ -752,9 +753,9 @@ void tiva_gpioirqclear(pinconfig_t pinconfig)
   uint8_t pin    = 1 << ((pinconfig & GPIO_PIN_MASK) >> GPIO_PIN_SHIFT);
   uintptr_t base = tiva_gpiobaseaddress(port);
 
-  /* "The GPIOICR register is the interrupt clear register. Writing a 1 to a bit
-   * in this register clears the corresponding interrupt edge detection logic
-   * register. Writing a 0 has no effect."
+  /* "The GPIOICR register is the interrupt clear register. Writing a 1 to a
+   * bit in this register clears the corresponding interrupt edge detection
+   * logic register. Writing a 0 has no effect."
    */
 
   putreg32((1 << pin), base + TIVA_GPIO_ICR_OFFSET);

--- a/arch/arm/src/tiva/common/lmxx_tm4c_start.c
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_start.c
@@ -122,7 +122,8 @@ const uintptr_t g_idle_topstack = HEAP_BASE;
  *       done, the processor reserves space on the stack for the FP state,
  *       but does not save that state information to the stack.
  *
- *  Software must not change the value of the ASPEN bit or LSPEN bit while either:
+ *  Software must not change the value of the ASPEN bit or LSPEN bit while
+ *  either:
  *   - the CPACR permits access to CP10 and CP11, that give access to the FP
  *     extension, or
  *   - the CONTROL.FPCA bit is set to 1
@@ -156,7 +157,7 @@ static inline void tiva_fpuconfig(void)
   /* Enable full access to CP10 and CP11 */
 
   regval = getreg32(NVIC_CPACR);
-  regval |= ((3 << (2*10)) | (3 << (2*11)));
+  regval |= ((3 << (2 * 10)) | (3 << (2 * 11)));
   putreg32(regval, NVIC_CPACR);
 }
 
@@ -186,7 +187,7 @@ static inline void tiva_fpuconfig(void)
   /* Enable full access to CP10 and CP11 */
 
   regval = getreg32(NVIC_CPACR);
-  regval |= ((3 << (2*10)) | (3 << (2*11)));
+  regval |= ((3 << (2 * 10)) | (3 << (2 * 11)));
   putreg32(regval, NVIC_CPACR);
 }
 
@@ -272,7 +273,7 @@ void __start(void)
   showprogress('F');
 
 #ifdef CONFIG_TIVA_EEPROM
-  /*Initialize the EEPROM */
+  /* Initialize the EEPROM */
 
   tiva_eeprom_initialize();
 #endif


### PR DESCRIPTION
## Summary

arch/arm/src/tiva/common/lm4xx_tm3c_sysctrl.c:

    * Fix nxstyle warnings. No functional changes.

arch/arm/src/tiva/common/lmxx_tm4c_enableclks.h:

    * Fix nxstyle warnings. No functional changes.

arch/arm/src/tiva/common/lmxx_tm4c_enablepwr.h:

    * Fix nxstyle warnings. No functional changes.

arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c:

    * Fix nxstyle warnings. No functional changes.

arch/arm/src/tiva/common/lmxx_tm4c_start.c:

    * Fix nxstyle warnings. No functional changes.

## Impact

Removes nxstyle errors

## Testing

nxstyle