### PR TITLE
freedom-k64f: Init PWM only if enabled

### DIFF
--- a/boards/arm/kinetis/freedom-k64f/src/k64_pwm.c
+++ b/boards/arm/kinetis/freedom-k64f/src/k64_pwm.c
@@ -77,6 +77,7 @@ int k64_pwm_setup(void)
 
   if (!initialized)
     {
+#ifdef CONFIG_KINETIS_FTM0_PWM
       /* Call k64_pwminitialize() to get an instance of the PWM interface */
 
       pwm = kinetis_pwminitialize(0);
@@ -86,6 +87,7 @@ int k64_pwm_setup(void)
           return -ENODEV;
         }
 
+#endif
       /* Register the PWM driver at "/dev/pwm0" */
 
       ret = pwm_register("/dev/pwm0", pwm);


### PR DESCRIPTION
Aligned to k28f.

Change-Id: I1b384ee69dd1b87268545ef6343acc63f29b2ae6
Forwarded: https://github.com/apache/incubator-nuttx/pulls/rzr
Signed-off-by: Philippe Coval <rzr@users.sf.net>

## Summary

## Impact

## Testing

