### PR TITLE
freedom-k64f: Include kinetis.h for resources macros

### DIFF
--- a/boards/arm/kinetis/freedom-k64f/src/k64_buttons.c
+++ b/boards/arm/kinetis/freedom-k64f/src/k64_buttons.c
@@ -46,6 +46,8 @@
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
+#include "kinetis.h"
+
 #include "freedom-k64f.h"
 
 #ifdef CONFIG_ARCH_BUTTONS


### PR DESCRIPTION
Change-Id: I37560525678b820668abcb6e4aae93b978797066
Forwarded: https://github.com/apache/incubator-nuttx/pulls/rzr
Signed-off-by: Philippe Coval rzr@users.sf.net

## Summary

## Impact

## Testing

