### PR TITLE
[BACKPORT-1941]esp32_intdecode.c: Don't clear A2, the mask argument is passed in that register

### DIFF
--- a/arch/xtensa/src/esp32/esp32_intdecode.c
+++ b/arch/xtensa/src/esp32/esp32_intdecode.c
@@ -60,7 +60,6 @@ static inline void xtensa_intclear(uint32_t mask)
 {
   __asm__ __volatile__
   (
-    "movi a2, 0\n"
     "wsr %0, INTCLEAR\n"
     : "=r"(mask) : :
   );


### PR DESCRIPTION
## Summary
This PR backports #1941
## Impact
N/A
## Testing
N/A
