### PR TITLE
include/nuttx/lib/math.h: Add signbit

### DIFF
--- a/include/nuttx/lib/math.h
+++ b/include/nuttx/lib/math.h
@@ -443,6 +443,8 @@ long double truncl (long double x);
 #define nanl(x) ((long double)(NAN))
 #endif
 
+#define	signbit(x)	__builtin_signbit(x)
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
## Summary
Add signbit, which is C99.

## Impact

## Testing
build-tested apps/interpreters/wamr for sim on macOS
(it fails without this patch)
