### PR TITLE
Remove all fclose with stdin, stdout and stderr

### DIFF
--- a/libs/libc/unistd/lib_daemon.c
+++ b/libs/libc/unistd/lib_daemon.c
@@ -133,31 +133,17 @@ int daemon(int nochdir, int noclose)
         }
 
 #ifdef CONFIG_FILE_STREAM
-      /* Make sure the stdin, stdout, and stderr are closed */
+      /* Make sure the stdin, stdout, and stderr are flushed */
 
-      fclose(stdin);
-      fclose(stdout);
-      fclose(stderr);
+      fflush(stdin);
+      fflush(stdout);
+      fflush(stderr);
 #endif
       /* Dup the fd to create standard fd 0-2 */
 
       dup2(fd, 0);
       dup2(fd, 1);
       dup2(fd, 2);
-
-      /* fdopen to get the stdin, stdout and stderr streams. The
-       * following logic depends on the fact that the library layer
-       * will allocate FILEs in order.  And since we closed stdin,
-       * stdout, and stderr above, that is what we should get.
-       *
-       * fd = 0 is stdin  (read-only)
-       * fd = 1 is stdout (write-only, append)
-       * fd = 2 is stderr (write-only, append)
-       */
-
-      fdopen(0, "r");
-      fdopen(1, "a");
-      fdopen(2, "a");
 
       /* We can close the original file descriptor now (unless it was
        * one of* 0-2)


### PR DESCRIPTION
## Summary
since it is wrong to close the builtin stream and specially note
https://pubs.opengroup.org/onlinepubs/9699919799/functions/fclose.html:

Since after the call to fclose() any use of stream results in
undefined behavior, fclose() should not be used on stdin, stdout,
or stderr except immediately before process termination (see XBD
Process Termination), so as to avoid triggering undefined behavior
in other standard interfaces that rely on these streams. If there
are any atexit() handlers registered by the application, such a
call to fclose() should not occur until the last handler is
finishing. Once fclose() has been used to close stdin, stdout, or
stderr, there is no standard way to reopen any of these streams.

and it is also unnecessary because the stream always get flushed.

## Impact
Remove the undefined behaviour

## Testing
reported here:
apache/incubator-nuttx@b079726
