### PR TITLE
freedom-k64f: Add I2C initial support

### DIFF
--- a/boards/arm/kinetis/freedom-k64f/include/board.h
+++ b/boards/arm/kinetis/freedom-k64f/include/board.h
@@ -269,4 +269,15 @@
 #define PIN_UART3_RX      PIN_UART3_RX_2
 #define PIN_UART3_TX      PIN_UART3_TX_2
 
+/* I2C Bus 0
+ *
+ *  Pin Name   K64   Name
+ *  ---- ----- ------ ---------
+ *   11  SCL    PTE24  2C0_SCL
+ *   12  SDA    PTE25  2C0_SDA
+ */
+
+#define PIN_I2C0_SCL      PIN_I2C0_SCL_4
+#define PIN_I2C0_SDA      PIN_I2C0_SDA_4
+
 #endif /* __BOARDS_ARM_FREEDOM_K64F_INCLUDE_BOARD_H */

--- a/boards/arm/kinetis/freedom-k64f/src/Makefile
+++ b/boards/arm/kinetis/freedom-k64f/src/Makefile
@@ -53,6 +53,10 @@ else ifeq ($(CONFIG_BOARD_LATE_INITIALIZE),y)
 CSRCS += k64_bringup.c
 endif
 
+ifeq ($(CONFIG_I2C),y)
+CSRCS += k64_i2c.c
+endif
+
 ifeq ($(CONFIG_KINETIS_SDHC),y)
 CSRCS += k64_sdhc.c
 ifeq ($(CONFIG_FS_AUTOMOUNTER),y)

--- a/boards/arm/kinetis/freedom-k64f/src/k64_bringup.c
+++ b/boards/arm/kinetis/freedom-k64f/src/k64_bringup.c
@@ -88,6 +88,12 @@ int k64_bringup(void)
     }
 #endif
 
+#if defined(CONFIG_KINETIS_I2C0)
+  /* Initialize I2C buses */
+
+  k64_i2cdev_initialize();
+#endif
+
 #ifdef HAVE_MMCSD
   /* Initialize the SDHC driver */
 
@@ -109,7 +115,7 @@ int k64_bringup(void)
 
       if (ret < 0)
         {
-          syslog(LOG_ERR,"ERROR: Failed to mount %s: %d\n",
+          syslog(LOG_ERR, "ERROR: Failed to mount %s: %d\n",
                  CONFIG_FRDMK64F_SDHC_MOUNT_MOUNTPOINT, errno);
         }
     }

--- a/boards/arm/kinetis/freedom-k64f/src/k64_i2c.c
+++ b/boards/arm/kinetis/freedom-k64f/src/k64_i2c.c
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * boards/arm/kinetis/freedom-k64f/src/k64_i2c.c
+ *
+ *   Copyright (C) 2020 Philippe Coval. All rights reserved.
+ *   Author:  Philippe Coval <rzr@users.sf.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/i2c/i2c_master.h>
+
+#include "kinetis_i2c.h"
+
+#if defined(CONFIG_KINETIS_I2C0)
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef CONFIG_KINETIS_I2C0
+FAR struct i2c_master_s * g_i2c0_dev;
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: k64_i2cdev_initialize
+ *
+ * Description:
+ *   Called to configure I2C
+ *
+ ****************************************************************************/
+
+int k64_i2cdev_initialize(void)
+{
+  int ret = OK;
+
+#ifdef CONFIG_KINETIS_I2C0
+  g_i2c0_dev = kinetis_i2cbus_initialize(0);
+  if (g_i2c0_dev == NULL)
+    {
+      syslog(LOG_ERR, "ERROR: kinetis_i2cbus_initialize(0) failed: %d\n",
+             ret);
+      ret = -ENODEV;
+    }
+  else
+    {
+#ifdef CONFIG_I2C_DRIVER
+      ret = i2c_register(g_i2c0_dev, 0);
+#endif
+    }
+#endif
+
+  return ret;
+}
+
+#endif /* CONFIG_KINETIS_I2C0 */


### PR DESCRIPTION
It was checked using i2c tool and onboard sensor:

    nsh> i2c bus
    Bus 0: YES

    nsh> i2c dev 1 0x7F
    10: -- -- -- -- -- -- -- -- -- -- -- -- -- 1d -- --

    nsh> i2c get -a 1d -r 0d
    #| READ Bus: 0 Addr: 1d Subaddr: 0d Value: c7

Sensor driver to come next.

Feature should be enabled using:

    CONFIG_SYSTEM_I2CTOOL=y
    CONFIG_KINETIS_I2C0=y

Change-Id: I4f3ff16fae994250f62537cd0c3021465db1189c
Forwarded: https://github.com/apache/incubator-nuttx/pulls/rzr
Signed-off-by: Philippe Coval <rzr@users.sf.net>

## Summary

## Impact

## Testing

