### PR TITLE
kinetis:flexcan fixed compile error 

### DIFF
--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -642,7 +642,7 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
 
 #ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
   struct timespec ts;
-  clock_systimespec(&ts);
+  clock_systime_timespec(&ts);
 
   if (priv->dev.d_sndlen > priv->dev.d_len)
     {
@@ -1102,7 +1102,7 @@ static void kinetis_txtimeout_work(FAR void *arg)
 
   struct timespec ts;
   struct timeval *now = (struct timeval *)&ts;
-  clock_systimespec(&ts);
+  clock_systime_timespec(&ts);
   now->tv_usec = ts.tv_nsec / 1000; /* timespec to timeval conversion */
 
   /* The watchdog timed out, yet we still check mailboxes in case the


### PR DESCRIPTION
## Summary

clock_systimespec->clock_systime_spec

## Impact

master build was broken 

## Testing

Build nxp_fmuk66-e_socketcan
