### PR TITLE
Cc13xx nxstyle fix

### DIFF
--- a/arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.c
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.c
@@ -1,12 +1,12 @@
-/*****************************************************************************
+/****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.c
  * Driver for the AUX System Interface
  *
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
  *
- * Technical content derives from a TI aux_sysif.c file that has a compatible BSD
- * license:
+ * Technical content derives from a TI aux_sysif.c file that has a
+ * compatible BSD license:
  *
  *   Copyright (c) 2015-2017, Texas Instruments Incorporated
  *   All rights reserved.
@@ -38,11 +38,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- *****************************************************************************/
+ ****************************************************************************/
 
-/*****************************************************************************
+/****************************************************************************
  * Included Files
- *****************************************************************************/
+ ****************************************************************************/
 
 #include <stdint.h>
 #include "arm_arch.h"
@@ -50,11 +50,13 @@
 #include "hardware/tiva_aux_sysif.h"
 #include "cc13xx/cc13x2_aux_sysif.h"
 
-/*****************************************************************************
+/****************************************************************************
  * Private Data
- *****************************************************************************/
+ ****************************************************************************/
 
-/* Used in aux_sysif_opmode() to control the change of the operational mode. */
+/* Used in aux_sysif_opmode() to control the change of the operational
+ * mode.
+ */
 
 static const uint8_t g_opmode_to_order[4] =
 {
@@ -66,11 +68,11 @@ static const uint8_t g_order_to_opmode[4] =
   2, 0, 1, 3
 };
 
-/*****************************************************************************
+/****************************************************************************
  * Public Functions
- *****************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Name: aux_sysif_opmode
  *
  * Description:
@@ -81,17 +83,17 @@ static const uint8_t g_order_to_opmode[4] =
  *
  * Input Parameters:
  *   - opmode:  AUX operational mode.  One of
- *              AUX_SYSIF_OPMODE_TARGET_PDLP: Power down operational mode with wakeup
- *                                            to low power mode)
- *              AUX_SYSIF_OPMODE_TARGET_PDA:  Power down operational mode with wakeup
-                                              to active mode
+ *              AUX_SYSIF_OPMODE_TARGET_PDLP: Power down operational mode
+ *                                            with wakeup to low power mode)
+ *              AUX_SYSIF_OPMODE_TARGET_PDA:  Power down operational mode
+ *                                            with wakeup to active mode
  *              AUX_SYSIF_OPMODE_TARGET_LP:   Low power operational mode)
  *              AUX_SYSIF_OPMODE_TARGET_A:    Active operational mode
  *
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void aux_sysif_opmode(uint32_t opmode)
 {

--- a/arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.h
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.h
@@ -1,10 +1,11 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.h
  *
  *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * This is a port of TI's aux_sysif.h file which has a fully compatible BSD license:
+ * This is a port of TI's aux_sysif.h file which has a fully compatible BSD
+ * license:
  *
  *    Copyright (c) 2015-2017, Texas Instruments Incorporated
  *    All rights reserved.
@@ -36,32 +37,32 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_TIVA_CC13XX_CC13X2_AUX_SYSIF_H
 #define __ARCH_ARM_SRC_TIVA_CC13XX_CC13X2_AUX_SYSIF_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <stdint.h>
 #include "hardware/tiva_aux_sysif.h"
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
 #define AUX_SYSIF_OPMODE_TARGET_PDLP AUX_SYSIF_OPMODEREQ_REQ_PDLP
 #define AUX_SYSIF_OPMODE_TARGET_PDA  AUX_SYSIF_OPMODEREQ_REQ_PDA
 #define AUX_SYSIF_OPMODE_TARGET_LP   AUX_SYSIF_OPMODEREQ_REQ_LP
 #define AUX_SYSIF_OPMODE_TARGET_A    AUX_SYSIF_OPMODEREQ_REQ_A
 
-/************************************************************************************
+/****************************************************************************
  * Public Function Prototypes
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Name: aux_sysif_opmode
  *
  * Description:
@@ -72,17 +73,17 @@
  *
  * Input Parameters:
  *   - opmode:  AUX operational mode.  One of
- *              AUX_SYSIF_OPMODE_TARGET_PDLP: Power down operational mode with wakeup
- *                                            to low power mode)
- *              AUX_SYSIF_OPMODE_TARGET_PDA:  Power down operational mode with wakeup
-                                              to active mode
+ *              AUX_SYSIF_OPMODE_TARGET_PDLP: Power down operational mode
+ *                                            with wakeup to low power mode)
+ *              AUX_SYSIF_OPMODE_TARGET_PDA:  Power down operational mode
+ *                                            with wakeup to active mode
  *              AUX_SYSIF_OPMODE_TARGET_LP:   Low power operational mode)
  *              AUX_SYSIF_OPMODE_TARGET_A:    Active operational mode
  *
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void aux_sysif_opmode(uint32_t opmode);
 

--- a/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
@@ -58,13 +58,13 @@ static uint16_t g_domain_usage[2];
  * Public Functions
  ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Name:  cc13xx_periph_enablepwr
  *
  * Description:
  *   Enable the power domain associated with the peripheral.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void cc13xx_periph_enablepwr(uint32_t peripheral)
 {
@@ -87,8 +87,8 @@ void cc13xx_periph_enablepwr(uint32_t peripheral)
   prcm_powerdomain_on(domain);
   spin_unlock_irqrestore(flags);
 
-  /* Wait for the power domain to be ready.  REVISIT:  This really should be in the
-   * critical section but this could take too long.
+  /* Wait for the power domain to be ready.  REVISIT:  This really should be
+   * in the critical section but this could take too long.
    */
 
   while (!prcm_powerdomain_status(domain))
@@ -96,14 +96,14 @@ void cc13xx_periph_enablepwr(uint32_t peripheral)
     }
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name:  cc13xx_periph_disablepwr
  *
  * Description:
- *   Disable the power domain associated with the peripheral if and only if all
- *   peripherals using that power domain no longer need power.
+ *   Disable the power domain associated with the peripheral if and only if
+ *   all peripherals using that power domain no longer need power.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void cc13xx_periph_disablepwr(uint32_t peripheral)
 {
@@ -116,13 +116,14 @@ void cc13xx_periph_disablepwr(uint32_t peripheral)
   flags = spin_lock_irqsave();
   g_domain_usage[dndx] &= ~(1 << pndx);
 
-  /* If there are no peripherals needing power in this domain, then turn off the
-   * power domain.
+  /* If there are no peripherals needing power in this domain, then turn off
+   * the power domain.
    */
 
   if (g_domain_usage[dndx] == 0)
     {
-      prcm_powerdomain_off(pndx == 0 ? PRCM_DOMAIN_SERIAL : PRCM_DOMAIN_PERIPH);
+      prcm_powerdomain_off(pndx == 0 ?
+                           PRCM_DOMAIN_SERIAL : PRCM_DOMAIN_PERIPH);
     }
 
   spin_unlock_irqrestore(flags);

--- a/arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c
@@ -88,7 +88,7 @@ static struct gpio_handler_s g_gpio_inthandler[TIVA_NIRQ_PINS];
  *
  ****************************************************************************/
 
-static int cc13xx_gpio_interrupt)(int irq, FAR void *context, FAR void *arg)
+static int cc13xx_gpio_interrupt(int irq, FAR void *context, FAR void *arg)
 {
   uint32_t evflags;
   uint32_t regval;
@@ -118,7 +118,8 @@ static int cc13xx_gpio_interrupt)(int irq, FAR void *context, FAR void *arg)
 
           FAR struct gpio_handler_s *handler = &g_gpio_inthandler[dio];
 
-          gpioinfo("dio=%d isr=%p arg=%p\n", dio, handler->isr, handler->arg);
+          gpioinfo("dio=%d isr=%p arg=%p\n", dio, handler->isr,
+                   handler->arg);
           handler->isr(irq, context, handler->arg);
 
           evflags &= ~diomask;


### PR DESCRIPTION
## Summary

tiva/cc13xx: Fix syntax error and nxstyle errors

Fix syntax error (stray closing parenthesis in function cc13xx_gpio_interrupt()) and nxstyle error in:

- arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c

Fix nxstyle errors only in these files:

- arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.c
- arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.h
- arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c

## Impact

Removes nxstyle errors. Fixes 1 syntax error. Note that this architecture appears to be broken at this time. That will be addressed in a later PR.

## Testing

nxstyle
