### PR TITLE
Fix sched_lock() and sched_unlock() for SMP

### DIFF
--- a/sched/sched/sched_unlock.c
+++ b/sched/sched/sched_unlock.c
@@ -54,14 +54,12 @@
 int sched_unlock(void)
 {
   FAR struct tcb_s *rtcb;
-  int cpu;
 
   /* This operation is safe because the scheduler is locked and no context
    * switch may occur.
    */
 
-  cpu  = this_cpu();
-  rtcb = current_task(cpu);
+  rtcb = this_task();
 
   /* Check for some special cases:  (1) rtcb may be NULL only during
    * early boot-up phases, and (2) sched_unlock() should have no
@@ -73,6 +71,7 @@ int sched_unlock(void)
       /* Prevent context switches throughout the following. */
 
       irqstate_t flags = enter_critical_section();
+      int cpu = this_cpu();
 
       /* Decrement the preemption lock counter */
 


### PR DESCRIPTION
## Summary

- This PR contains following two commits
- sched: Fix DEBUGASSERT() in sched_unlock() for SMP
    - I noticed DEBUGASSERT() happens in sched_unlock()
    - The test was Wi-Fi audio streaming stress test with spresense 3cores
    - Actually, g_cpu_schedlock was locked but g_cpu_lockset was incorrect
    - Finally, I found that cpu was obtained before enter_critical_section()
    - And the task was moved from one cpu to another cpu
    - However, that call should be done within the critical section
    - This commit fixes this issue
- sched: Fix sched_lock() logic for SMP
    - I noticed sched_lock() logic is different from sched_unlock()
    - I think sched_lock() should use critical section
    - Also, the code should be simple like sched_unlock()
    - This commit fixes these issues and consistent with sched_unlock()

## Impact

- Affects SMP only

## Testing

- Tested with spresense:wifi_smp (both NCPUS=2 and 3)
- Tested with lc823450-xgevk:rndis
- Tested with maix-bit:smp (QEMU)
- Tested with esp32-core:smp (QEMU)
- Tested with sabre-6quad:smp (QEMU)
