### PR TITLE
arch: Add custom arch chip build support

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -148,6 +148,44 @@ source arch/z16/Kconfig
 source arch/z80/Kconfig
 source arch/or1k/Kconfig
 
+config ARCH_CHIP_CUSTOM
+	bool
+	default n
+
+if ARCH_CHIP_CUSTOM
+menu "Custom Chip Configuration"
+
+config ARCH_CHIP_CUSTOM_NAME
+	string "Custom chip name"
+	default ""
+	---help---
+		This is a name for the chip.  It is not used except to return the
+		information via the NSH uname command.
+
+config ARCH_CHIP_CUSTOM_DIR
+	string "Custom chip directory"
+	default ""
+	---help---
+		If the custom chip configuration is selected, then it is necessary
+		to also tell the build system where it can find the chip directory
+		for the custom chip.
+
+		In this case, the chip directory is assumed to lie outside the
+		NuttX directory.  The provided path must then be a full, absolute
+		path to some location outside of the NuttX source tree (like
+		"~/projects/mychip").
+
+config ARCH_CHIP_CUSTOM_DIR_RELPATH
+	bool "Relative custom chip directory"
+	default y
+	---help---
+		Specifies that the chip directory is relative to the NuttX directory.
+
+endmenu # Custom Chip Configuration
+endif #ARCH_CHIP_CUSTOM
+
+source arch/dummy/Kconfig
+
 config ARCH_TOOLCHAIN_IAR
 	bool
 	default n

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -434,6 +434,12 @@ config ARCH_CHIP_CXD56XX
 	---help---
 		Sony CXD56XX (ARM Cortex-M4) architectures
 
+config ARCH_CHIP_ARM_CUSTOM
+	bool "Custom ARM chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/arm/src/.
+
 endchoice
 
 config ARCH_ARM7TDMI

--- a/arch/avr/Kconfig
+++ b/arch/avr/Kconfig
@@ -29,6 +29,12 @@ config ARCH_CHIP_AT32UC3
 	---help---
 		Atmel AT32UC3A/B/C family of 32-bit AVR32s.
 
+config ARCH_CHIP_AVR_CUSTOM
+	bool "Custom AVR chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/avr/src/.
+
 endchoice
 
 config ARCH_FAMILY_AVR

--- a/arch/dummy/.gitignore
+++ b/arch/dummy/.gitignore
@@ -1,0 +1,1 @@
+/Kconfig

--- a/arch/dummy/dummy_kconfig
+++ b/arch/dummy/dummy_kconfig
@@ -1,0 +1,4 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#

--- a/arch/hc/Kconfig
+++ b/arch/hc/Kconfig
@@ -16,6 +16,12 @@ config ARCH_CHIP_MCS92S12NEC64
 	---help---
 		Motorola/Freescale MCS92S12NEC64 (M9S12)
 
+config ARCH_CHIP_HC_CUSTOM
+	bool "Custom HC chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/hc/src/.
+
 endchoice
 
 config ARCH_HSC12

--- a/arch/mips/Kconfig
+++ b/arch/mips/Kconfig
@@ -30,6 +30,12 @@ config ARCH_CHIP_PIC32MZ
 	---help---
 		Microchip PIC32MZ (MIPS32)
 
+config ARCH_CHIP_MIPS_CUSTOM
+	bool "Custom MIPS chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/mips/src/.
+
 endchoice
 
 config ARCH_MIPS32

--- a/arch/misoc/Kconfig
+++ b/arch/misoc/Kconfig
@@ -21,6 +21,12 @@ config ARCH_CHIP_MINERVA
 	---help---
 		LambdaConcept MINERVAL Chip Selected
 
+config ARCH_CHIP_MISOC_CUSTOM
+	bool "Custom MISOC chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/misoc/src/.
+
 endchoice # Misoc Chip Selection
 
 config ARCH_CHIP

--- a/arch/or1k/Kconfig
+++ b/arch/or1k/Kconfig
@@ -13,6 +13,12 @@ choice
 config ARCH_CHIP_MOR1KX
 	bool "mor1kx"
 
+config ARCH_CHIP_OR1K_CUSTOM
+	bool "Custom OpenRISC chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/or1k/src/.
+
 endchoice
 
 config ARCH_CHIP

--- a/arch/renesas/Kconfig
+++ b/arch/renesas/Kconfig
@@ -45,6 +45,12 @@ config ARCH_CHIP_R5F565NEHDFP
 	---help---
 		Renesas RX65N on GR-ROSE
 
+config ARCH_CHIP_RENESAS_CUSTOM
+	bool "Custom Renesas chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/renesas/src/.
+
 endchoice
 
 config ARCH_SH1

--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -44,6 +44,12 @@ config ARCH_CHIP_GAP8
 		GreenwavesTechnologies GAP8 features a 1+8-core RI5CY DSP-like
 		processor, which originally comes from the ETH PULP platform.
 
+config ARCH_CHIP_RISCV_CUSTOM
+	bool "Custom RISC-V chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/risc-v/src/.
+
 endchoice
 
 config ARCH_RV32I

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -16,6 +16,12 @@ config ARCH_I486
 	---help---
 		Intel i486 architecture
 
+config ARCH_CHIP_X86_CUSTOM
+	bool "Custom x86 chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/x86/src/.
+
 endchoice
 
 config ARCH_CHIP_QEMU

--- a/arch/x86_64/Kconfig
+++ b/arch/x86_64/Kconfig
@@ -24,6 +24,12 @@ config ARCH_INTEL64
 	---help---
 		Intel x86_64 architecture
 
+config ARCH_CHIP_X86_64_CUSTOM
+	bool "Custom x86_64 chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/x86_64/src/.
+
 endchoice
 
 choice

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -36,6 +36,13 @@ config ARCH_CHIP_ESP32
 		"application"), however for most purposes the two CPUs are
 		interchangeable.
 
+config ARCH_CHIP_XTENSA_CUSTOM
+	bool "Custom XTENSA chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/xtensa/src/.
+
+
 endchoice # XTENSA chip selection
 
 config ARCH_FAMILY_LX6

--- a/arch/z16/Kconfig
+++ b/arch/z16/Kconfig
@@ -38,6 +38,12 @@ config ARCH_CHIP_Z16F6411
 	---help---
 		ZiLOG Z16F6411
 
+config ARCH_CHIP_Z16_CUSTOM
+	bool "Custom ZNEO chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/z16/src/.
+
 endchoice
 
 config ARCH_CHIP_Z16F

--- a/arch/z80/Kconfig
+++ b/arch/z80/Kconfig
@@ -40,6 +40,12 @@ config ARCH_CHIP_Z8
 	---help---
 		ZiLOG z8 architecture
 
+config ARCH_CHIP_Z80_CUSTOM
+	bool "Custom Z80 chip"
+	select ARCH_CHIP_CUSTOM
+	---help---
+		Select this option if there is no directory for the chip under arch/z80/src/.
+
 endchoice
 
 config ARCH_CHIP

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -135,6 +135,22 @@ else
   DELIM ?= $(strip /)
 endif
 
+# Process chip-specific directories
+
+ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
+  CUSTOM_CHIP_DIR = $(patsubst "%",%,$(CONFIG_ARCH_CHIP_CUSTOM_DIR))
+ifeq ($(CONFIG_ARCH_CHIP_CUSTOM_DIR_RELPATH),y)
+  CHIP_DIR ?= $(TOPDIR)$(DELIM)$(CUSTOM_CHIP_DIR)
+  CHIP_KCONFIG = $(TOPDIR)$(DELIM)$(CUSTOM_CHIP_DIR)$(DELIM)Kconfig
+else
+  CHIP_DIR ?= $(CUSTOM_CHIP_DIR)
+  CHIP_KCONFIG = $(CUSTOM_CHIP_DIR)$(DELIM)Kconfig
+endif
+else
+  CHIP_DIR ?= $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)$(CONFIG_ARCH_CHIP)
+  CHIP_KCONFIG = $(TOPDIR)$(DELIM)arch$(DELIM)dummy$(DELIM)dummy_kconfig
+endif
+
 # Process board-specific directories
 
 ifeq ($(CONFIG_ARCH_BOARD_CUSTOM),y)

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -304,20 +304,27 @@ drivers/platform: .clean_context
 # Link arch/<arch-name>/src/<chip-name> to arch/<arch-name>/src/chip
 
 $(ARCH_SRC)/chip: .clean_context
-ifneq ($(CONFIG_ARCH_CHIP),)
+ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
+	@echo "LN: $(ARCH_SRC)/chip to $(CHIP_DIR)"
+	$(Q) $(DIRLINK) $(CHIP_DIR) $(ARCH_SRC)/chip
+else ifneq ($(CONFIG_ARCH_CHIP),)
 	@echo "LN: $(ARCH_SRC)/chip to $(ARCH_SRC)/$(CONFIG_ARCH_CHIP)"
 	$(Q) $(DIRLINK) $(TOPDIR)/$(ARCH_SRC)/$(CONFIG_ARCH_CHIP) $(ARCH_SRC)/chip
-	$(Q) touch $@
 endif
+	$(Q) cp -f $(CHIP_KCONFIG) $(TOPDIR)/arch/dummy/Kconfig
+	$(Q) touch $@
 
 # Link arch/<arch-name>/include/<chip-name> to include/arch/chip
 
 include/arch/chip: include/arch
-ifneq ($(CONFIG_ARCH_CHIP),)
+ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
+	@echo "LN: include/arch/chip to $(CHIP_DIR)/include"
+	$(Q) $(DIRLINK) $(CHIP_DIR)/include include/arch/chip
+else ifneq ($(CONFIG_ARCH_CHIP),)
 	@echo "LN: include/arch/chip to $(ARCH_INC)/$(CONFIG_ARCH_CHIP)"
 	$(Q) $(DIRLINK) $(TOPDIR)/$(ARCH_INC)/$(CONFIG_ARCH_CHIP) include/arch/chip
-	$(Q) touch $@
 endif
+	$(Q) touch $@
 
 dirlinks: include/arch include/arch/board include/arch/chip $(ARCH_SRC)/board $(ARCH_SRC)/chip drivers/platform
 	$(Q) $(MAKE) -C libs/libxx dirlinks 
@@ -355,6 +362,7 @@ clean_context:
 	$(call DELFILE, include/math.h)
 	$(call DELFILE, include/stdarg.h)
 	$(call DELFILE, include/setjmp.h)
+	$(call DELFILE, arch/dummy/Kconfig)
 	$(Q) $(DIRUNLINK) include/arch/board
 	$(Q) $(DIRUNLINK) include/arch/chip
 	$(Q) $(DIRUNLINK) include/arch

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -283,20 +283,27 @@ drivers\platform: .clean_context
 # Link arch\<arch-name>\src\<chip-name> to arch\<arch-name>\src\chip
 
 $(ARCH_SRC)\chip: .clean_context
-ifneq ($(CONFIG_ARCH_CHIP),)
+ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
+	@echo LN: $(ARCH_SRC)\chip to $(CHIP_DIR)
+	$(Q) $(DIRLINK) $(CHIP_DIR) $(ARCH_SRC)\chip
+else ifneq ($(CONFIG_ARCH_CHIP),)
 	@echo LN: $(ARCH_SRC)\chip to $(ARCH_SRC)\$(CONFIG_ARCH_CHIP)
 	$(Q) $(DIRLINK) $(TOPDIR)\$(ARCH_SRC)\$(CONFIG_ARCH_CHIP) $(ARCH_SRC)\chip
-	$(Q) touch $@
 endif
+	$(Q) cp -f $(CHIP_KCONFIG) $(TOPDIR)\arch\dummy\Kconfig
+	$(Q) touch $@
 
 # Link arch\<arch-name>\include\<chip-name> to arch\<arch-name>\include\chip
 
 include\arch\chip: include\arch
-ifneq ($(CONFIG_ARCH_CHIP),)
+ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
+	@echo LN: include\arch\chip to $(CHIP_DIR)\include
+	$(Q) $(DIRLINK) $(CHIP_DIR)\include include\arch\chip
+else ifneq ($(CONFIG_ARCH_CHIP),)
 	@echo LN: include\arch\chip to $(ARCH_INC)\$(CONFIG_ARCH_CHIP)
 	$(Q) $(DIRLINK) $(TOPDIR)\$(ARCH_INC)\$(CONFIG_ARCH_CHIP) include\arch\chip
-	$(Q) touch $@
 endif
+	$(Q) touch $@
 
 dirlinks: include\arch include\arch\board include\arch\chip $(ARCH_SRC)\board $(ARCH_SRC)\chip drivers\platform
 	$(Q) $(MAKE) -C libs/libxx dirlinks 
@@ -328,6 +335,7 @@ clean_context:
 	$(call DELFILE, include\math.h)
 	$(call DELFILE, include\stdarg.h)
 	$(call DELFILE, include\setjmp.h)
+	$(call DELFILE, arch\dummy\Kconfig)
 	$(call DIRUNLINK, include\arch\board)
 	$(call DIRUNLINK, include\arch\chip)
 	$(call DIRUNLINK, include\arch)


### PR DESCRIPTION
## Summary
Just like custom board build support, add custom arch chip build support.

## Impact

## Testing
Local test with custom chip build well. 
