### PR TITLE
tools/Config.mk: Don't set HOSTEXEEXT to .exe for Ubuntu on Windows

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -114,7 +114,9 @@ ifeq ($(HOSTOS),Cygwin)
 endif
 
 ifeq ($(CONFIG_HOST_WINDOWS),y)
+ifneq ($(CONFIG_WINDOWS_UBUNTU),y)
   HOSTEXEEXT ?= .exe
+endif
 endif
 
 # This define is passed as EXTRAFLAGS for kernel-mode builds.  It is also passed


### PR DESCRIPTION
## Summary
Fix issue report here: #1985

## Impact

## Testing
The follow command should work without error:
```
 ./tools/configure.sh -u nucleo-h743zi:nsh
make
```