### PR TITLE
freedom-k64f: Register on board sensor driver

### DIFF
--- a/boards/arm/kinetis/freedom-k64f/src/k64_i2c.c
+++ b/boards/arm/kinetis/freedom-k64f/src/k64_i2c.c
@@ -48,6 +48,10 @@
 
 #if defined(CONFIG_KINETIS_I2C0)
 
+# if defined(CONFIG_SENSORS_FXOS8700CQ)
+#  include "nuttx/sensors/fxos8700cq.h"
+# endif
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -84,6 +88,9 @@ int k64_i2cdev_initialize(void)
     {
 #ifdef CONFIG_I2C_DRIVER
       ret = i2c_register(g_i2c0_dev, 0);
+#if defined(CONFIG_SENSORS_FXOS8700CQ)
+      fxos8700cq_register("/dev/accel0", g_i2c0_dev);
+#endif
 #endif
     }
 #endif


### PR DESCRIPTION
Change-Id: I4f3ff16fae994250f62537cd0c3021465db1189c
Forwarded: https://github.com/apache/incubator-nuttx/pulls/rzr
Bug: https://github.com/apache/incubator-nuttx/issues/1988
Signed-off-by: Philippe Coval <rzr@users.sf.net>

## Summary

## Impact

## Testing

