### PR TITLE
sched: Call up_[use|create]_stack after nxtask_setup_scheduler

### DIFF
--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -289,27 +289,6 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
       pjoin->detached = true;
     }
 
-  if (attr->stackaddr)
-    {
-      /* Use pre-allocated stack */
-
-      ret = up_use_stack((FAR struct tcb_s *)ptcb, attr->stackaddr,
-                         attr->stacksize);
-    }
-  else
-    {
-      /* Allocate the stack for the TCB */
-
-      ret = up_create_stack((FAR struct tcb_s *)ptcb, attr->stacksize,
-                            TCB_FLAG_TTYPE_PTHREAD);
-    }
-
-  if (ret != OK)
-    {
-      errcode = ENOMEM;
-      goto errout_with_join;
-    }
-
   /* Should we use the priority and scheduler specified in the pthread
    * attributes?  Or should we use the current thread's priority and
    * scheduler?
@@ -430,6 +409,27 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
       ptcb->cmn.affinity = attr->affinity;
     }
 #endif
+
+  if (attr->stackaddr)
+    {
+      /* Use pre-allocated stack */
+
+      ret = up_use_stack((FAR struct tcb_s *)ptcb, attr->stackaddr,
+                         attr->stacksize);
+    }
+  else
+    {
+      /* Allocate the stack for the TCB */
+
+      ret = up_create_stack((FAR struct tcb_s *)ptcb, attr->stacksize,
+                            TCB_FLAG_TTYPE_PTHREAD);
+    }
+
+  if (ret != OK)
+    {
+      errcode = ENOMEM;
+      goto errout_with_join;
+    }
 
   /* Configure the TCB for a pthread receiving on parameter
    * passed by value

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -108,6 +108,15 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
       goto errout_with_group;
     }
 
+  /* Initialize the task control block */
+
+  ret = nxtask_setup_scheduler(tcb, priority, nxtask_start,
+                               entry, ttype);
+  if (ret < OK)
+    {
+      goto errout_with_group;
+    }
+
   if (stack)
     {
       /* Use pre-allocated stack */
@@ -121,15 +130,6 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
       ret = up_create_stack(&tcb->cmn, stack_size, ttype);
     }
 
-  if (ret < OK)
-    {
-      goto errout_with_group;
-    }
-
-  /* Initialize the task control block */
-
-  ret = nxtask_setup_scheduler(tcb, priority, nxtask_start,
-                               entry, ttype);
   if (ret < OK)
     {
       goto errout_with_group;


### PR DESCRIPTION
## Summary
to ensure the basic info(e.g. pid) setup correctly before call arch API and then up_use_stack don't skip the colorize the stack:
https://github.com/apache/incubator-nuttx/blob/master/arch/arm/src/common/arm_usestack.c#L159

## Impact
pthread_create with caller provided stack get the color correctly.

## Testing

