### PR TITLE
Improved Kconfig help entry for ARMV7M_STACKCHECK.

### DIFF
--- a/arch/arm/src/armv7-m/Kconfig
+++ b/arch/arm/src/armv7-m/Kconfig
@@ -205,9 +205,9 @@ config ARMV7M_STACKCHECK
 		other architectures will be accepted.
 
 		This option requires that you are using a GCC toolchain and that
-		you also include -finstrument-functions in your CFLAGS when you
-		compile.  This addition to your CFLAGS should probably be added
-		to the definition of the CFFLAGS in your board Make.defs file.
+		you also include -finstrument-functions and -ffixed-r10 in your
+		CFLAGS when you compile. This addition to your CFLAGS should probably
+		be added to the definition of the CFFLAGS in your board Make.defs file.
 
 config ARMV7M_ITMSYSLOG
 	bool "ITM SYSLOG support"


### PR DESCRIPTION
## Summary
`ARMV7M_STACKCHECK` option needs `-finstrument-functions` and `-ffixed-r10` to be added to  compiler flags.  
The Kconfig help entry of the above option mentions only `-finstrument-functions` but not `-ffixed-r10`, which is misleading.

## Impact
This commit only adds more information in the Kconfig help entry of the aforementioned entry, so users can be informed of the requirements of this option more precisely. 

## Testing
N/A

