### PR TITLE
Fix note_syscall_leave_s to avoid unaligned access

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -269,9 +269,9 @@ struct note_csection_s
 
 struct note_spinlock_s
 {
-  struct note_common_s nsp_cmn; /* Common note parameters */
-  FAR void *nsp_spinlock;       /* Address of spinlock */
-  uint8_t nsp_value;            /* Value of spinlock */
+  struct note_common_s nsp_cmn;             /* Common note parameters */
+  uint8_t nsp_spinlock[sizeof(uintptr_t)];  /* Address of spinlock */
+  uint8_t nsp_value;                        /* Value of spinlock */
 };
 #endif /* CONFIG_SCHED_INSTRUMENTATION_SPINLOCKS */
 
@@ -286,9 +286,9 @@ struct note_syscall_enter_s
 
 struct note_syscall_leave_s
 {
-  struct note_common_s nsc_cmn; /* Common note parameters */
-  uintptr_t nsc_result;         /* Result of the system call */
-  uint8_t nsc_nr;               /* System call number */
+  struct note_common_s nsc_cmn;          /* Common note parameters */
+  uint8_t nsc_nr;                        /* System call number */
+  uint8_t nsc_result[sizeof(uintptr_t)]; /* Result of the system call */
 };
 #endif /* CONFIG_SCHED_INSTRUMENTATION_SYSCALL */
 

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -319,7 +319,20 @@ static void note_spincommon(FAR struct tcb_s *tcb,
   /* Format the note */
 
   note_common(tcb, &note.nsp_cmn, sizeof(struct note_spinlock_s), type);
-  note.nsp_spinlock = (FAR void *)spinlock;
+
+  note.nsp_spinlock[0] = (uint8_t)((uintptr_t)spinlock & 0xff);
+  note.nsp_spinlock[1] = (uint8_t)(((uintptr_t)spinlock >> 8)  & 0xff);
+#if UINTPTR_MAX > UINT16_MAX
+  note.nsp_spinlock[2] = (uint8_t)(((uintptr_t)spinlock >> 16) & 0xff);
+  note.nsp_spinlock[3] = (uint8_t)(((uintptr_t)spinlock >> 24) & 0xff);
+#if UINTPTR_MAX > UINT32_MAX
+  note.nsp_spinlock[4] = (uint8_t)(((uintptr_t)spinlock >> 32) & 0xff);
+  note.nsp_spinlock[5] = (uint8_t)(((uintptr_t)spinlock >> 40) & 0xff);
+  note.nsp_spinlock[6] = (uint8_t)(((uintptr_t)spinlock >> 48) & 0xff);
+  note.nsp_spinlock[7] = (uint8_t)(((uintptr_t)spinlock >> 56) & 0xff);
+#endif
+#endif
+
   note.nsp_value    = (uint8_t)*spinlock;
 
   /* Add the note to circular buffer */
@@ -670,9 +683,21 @@ void sched_note_syscall_leave(int nr, uintptr_t result)
 
   note_common(tcb, &note.nsc_cmn, sizeof(struct note_syscall_leave_s),
               NOTE_SYSCALL_LEAVE);
-  note.nsc_result = result;
   DEBUGASSERT(nr <= UCHAR_MAX);
   note.nsc_nr     = nr;
+
+  note.nsc_result[0] = (uint8_t)(result & 0xff);
+  note.nsc_result[1] = (uint8_t)((result >> 8)  & 0xff);
+#if UINTPTR_MAX > UINT16_MAX
+  note.nsc_result[2] = (uint8_t)((result >> 16) & 0xff);
+  note.nsc_result[3] = (uint8_t)((result >> 24) & 0xff);
+#if UINTPTR_MAX > UINT32_MAX
+  note.nsc_result[4] = (uint8_t)((result >> 32) & 0xff);
+  note.nsc_result[5] = (uint8_t)((result >> 40) & 0xff);
+  note.nsc_result[6] = (uint8_t)((result >> 48) & 0xff);
+  note.nsc_result[7] = (uint8_t)((result >> 56) & 0xff);
+#endif
+#endif
 
   /* Add the note to circular buffer */
 


### PR DESCRIPTION
## Summary
Currently `struct note_syscall_leave_s` contains a member of uintptr_t (nsc_result).
Because note struct is stored with packed in the buffer, nsc_result may placed on unaligned address.
If the processor architecture doesn't support unaligned word access (ex. Cortex-M0), accessing nsc_result may crash.
This PR fixes the member nsc_result to uint8_t array like nc_pid and nc_systime.

Additionally this PR fixes similar problem in `struct note_spinlock_s`.

## Impact
`struct note_syscall_leave_s` and `struct note_spinlock_s` are changed. All app codes using them must be fixed.
(Another PR for apps (https://github.com/apache/incubator-nuttx-apps/pull/429) fixes them)

## Testing
Tested with spresense:nsh
Because Cortex-M4 supports unaligned access by default, I have intentionally modified CPU control register to disable unaligned access for test.
```
nsh> mw 0xe000ed14=0x208
```
This crashes "trace dump" command. The PR fixes it.



