### PR TITLE
Minor improvement in STM32 Kconfig menus.

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -3177,6 +3177,7 @@ config STM32_SYSCFG_IOCOMPENSATION
 		from 2.4 to 3.6 V.
 
 menu "Alternate Pin Mapping"
+	depends on STM32_STM32F10XX || STM32_CONNECTIVITYLINE
 
 choice
 	prompt "CAN1 Alternate Pin Mappings"


### PR DESCRIPTION
## Summary
The menu "Alternate Pin Mapping" is only relevant to the STM32F1series.
I just added the correct `depends on` to show this menu only when it is actually needed.

## Impact
If you don't use an STM32F1, then Kconfig gets uncluttered a bit.

## Testing
N/A.
