### PR TITLE
tiva/cc13xx: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/tiva/cc13xx/cc13x0_rom.h
+++ b/arch/arm/src/tiva/cc13xx/cc13x0_rom.h
@@ -611,8 +611,8 @@
 
 /* ROM Hard-API function interface types */
 
-typedef uint32_t (*fptr_crc32_t)              (uint8_t *     /* data        */,\
-                                               uint32_t      /* bytecount   */,\
+typedef uint32_t (*fptr_crc32_t)              (uint8_t *     /* data        */,
+                                               uint32_t      /* bytecount   */,
                                                uint32_t      /* repeatcount */);
 
 typedef uint32_t (*fptr_getflsize_t)          (void);
@@ -623,26 +623,26 @@ typedef uint32_t (*fptr_reserved1_t)          (uint32_t);
 
 typedef uint32_t (*fptr_reserved2_t)          (void);
 
-typedef uint32_t (*fptr_reserved3_t)          (uint8_t *,\
-                                               uint32_t ,\
+typedef uint32_t (*fptr_reserved3_t)          (uint8_t *,
+                                               uint32_t ,
                                                uint32_t);
 
 typedef void     (*fptr_resetdev_t)           (void);
 
-typedef uint32_t (*fptr_fletcher32_t)         (uint16_t *    /* data        */,\
-                                               uint16_t      /* wordcount   */,\
+typedef uint32_t (*fptr_fletcher32_t)         (uint16_t *    /* data        */,
+                                               uint16_t      /* wordcount   */,
                                                uint16_t      /* repeatcount */);
 
-typedef uint32_t (*fptr_minval_t)             (uint32_t *    /* data   */,\
+typedef uint32_t (*fptr_minval_t)             (uint32_t *    /* data   */,
                                                uint32_t      /* count  */);
 
-typedef uint32_t (*fptr_maxval_t)             (uint32_t *    /* buffer */,\
+typedef uint32_t (*fptr_maxval_t)             (uint32_t *    /* buffer */,
                                                uint32_t      /* count  */);
 
-typedef uint32_t (*fptr_meanval_t)            (uint32_t *    /* buffer */,\
+typedef uint32_t (*fptr_meanval_t)            (uint32_t *    /* buffer */,
                                                uint32_t      /* count  */);
 
-typedef uint32_t (*fptr_stddval_t)            (uint32_t *    /* buffer */,\
+typedef uint32_t (*fptr_stddval_t)            (uint32_t *    /* buffer */,
                                                uint32_t      /* count  */);
 
 typedef void     (*fptr_hfsourcesafeswitch_t) (void);

--- a/arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v2_rom.h
+++ b/arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v2_rom.h
@@ -974,8 +974,8 @@
 
 /* ROM Hard-API function interface types */
 
-typedef uint32_t (*fptr_crc32_t)              (uint8_t *     /* data        */,\
-                                               uint32_t      /* bytecount   */,\
+typedef uint32_t (*fptr_crc32_t)              (uint8_t *     /* data        */,
+                                               uint32_t      /* bytecount   */,
                                                uint32_t      /* repeatcount */);
 
 typedef uint32_t (*fptr_getflsize_t)          (void);
@@ -986,26 +986,26 @@ typedef uint32_t (*fptr_reserved1_t)          (uint32_t);
 
 typedef uint32_t (*fptr_reserved2_t)          (void);
 
-typedef uint32_t (*fptr_reserved3_t)          (uint8_t *,\
-                                               uint32_t,\
+typedef uint32_t (*fptr_reserved3_t)          (uint8_t *,
+                                               uint32_t,
                                                uint32_t);
 
 typedef void     (*fptr_resetdev_t)           (void);
 
-typedef uint32_t (*fptr_fletcher32_t)         (uint16_t *    /* data        */,\
-                                               uint16_t      /* wordcount   */,\
+typedef uint32_t (*fptr_fletcher32_t)         (uint16_t *    /* data        */,
+                                               uint16_t      /* wordcount   */,
                                                uint16_t      /* repeatcount */);
 
-typedef uint32_t (*fptr_minval_t)             (uint32_t *    /* data   */,\
+typedef uint32_t (*fptr_minval_t)             (uint32_t *    /* data   */,
                                                uint32_t      /* count  */);
 
-typedef uint32_t (*fptr_maxval_t)             (uint32_t *    /* buffer */,\
+typedef uint32_t (*fptr_maxval_t)             (uint32_t *    /* buffer */,
                                                uint32_t      /* count  */);
 
-typedef uint32_t (*fptr_meanval_t)            (uint32_t *    /* buffer */,\
+typedef uint32_t (*fptr_meanval_t)            (uint32_t *    /* buffer */,
                                                uint32_t      /* count  */);
 
-typedef uint32_t (*fptr_stddval_t)            (uint32_t *    /* buffer */,\
+typedef uint32_t (*fptr_stddval_t)            (uint32_t *    /* buffer */,
                                                uint32_t      /* count  */);
 
 typedef void     (*fptr_hfsourcesafeswitch_t) (void);


### PR DESCRIPTION
## Summary

Fix nxstyle errors. In arch/arm/src/tiva/cc13xx/cc13x0_rom.h and arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v2_rom.h, nxstyle was complaining about lack of a space after comma because of the presence of line continuation backslashes immediately after the comma. Removed these backslashes as they are not necessary: these lines are typedefs, not preprocessor defines.

## Impact

Removes nxstyle errors.

## Testing

nxstyle