### PR TITLE
arch/arm/src/stm32h7/stm32_spi.c: fixed build issue when SPI is confi…

### DIFF
--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -1022,9 +1022,10 @@ static int spi_interrupt(int irq, void *context, void *arg)
       spi_modifyreg(priv, STM32_SPI_IER_OFFSET, SPI_IER_EOTIE, 0);
 
       /* Set result and release wait semaphore */
-
+#ifdef CONFIG_STM32H7_SPI_DMA
       priv->txresult = 0x80;
       nxsem_post(&priv->txsem);
+#endif
     }
 
   return 0;


### PR DESCRIPTION
## Summary
In nuttx\arch\arm\src\stm32h7\stm32_spi.c, "txresult" is defined and used only if the CONFIG_STM32H7_SPI_DMA is defined.
But in the spi_interrupt function, the txresult is used regardless of whether CONFIG_STM32H7_SPI_DMA is defined or not.
## Impact
The build does not work if you configure SPI but you do not configure DMA
## Testing
I made the code build and the SPI seems to work as expected - I am communicating with an at45db flash over SPI and mounted smartFS on it and the communication seems to work. I am not sure if the changes that I did are enough or if the entire spi_interrupt function should be surrounded by the #ifdef CONFIG_STM32H7_SPI_DMA condition as well (and also where it is called from).
It would be good if someone with more experience that understands the impact of the change could look into it.
