### PR TITLE
fs: add missing macro 'CONFIG_FS_HOSTFS' for 'NODFS_SUPPORT'.

### DIFF
--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -67,7 +67,8 @@
 #if defined(CONFIG_FS_NXFFS) || defined(CONFIG_FS_BINFS) || \
     defined(CONFIG_FS_PROCFS) || defined(CONFIG_NFS) || \
     defined(CONFIG_FS_TMPFS) || defined(CONFIG_FS_USERFS) || \
-    defined(CONFIG_FS_CROMFS) || defined(CONFIG_FS_UNIONFS)
+    defined(CONFIG_FS_CROMFS) || defined(CONFIG_FS_UNIONFS) || \
+    defined(CONFIG_FS_HOSTFS)
 #  define NODFS_SUPPORT
 #endif
 


### PR DESCRIPTION
When just enable 'CONFIG_FS_HOSTFS', NODFS_SUPPORT may not enable.

Change-Id: I8317f18bf3ceae873e29c027561948c17b4aab38
Signed-off-by: zhongan <zhongan@xiaomi.com>

## Summary

## Impact

## Testing

