### PR TITLE
arch: x86: Fix x86 linking

### DIFF
--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -74,7 +74,7 @@ OBJS = $(AOBJS) $(COBJS)
 
 LDSTARTGROUP ?= --start-group
 LDENDGROUP ?= --end-group
-LDFLAGS += $(ARCHSCRIPT)
+LDFLAGS += $(ARCHSCRIPT) -static
 
 BOARDMAKE = $(if $(wildcard board$(DELIM)Makefile),y,)
 


### PR DESCRIPTION
## Summary

- I noticed that qemu-i486:nsh can not start
- Finally, I found that the issue was introduced by 4910d43ab0
- Actually, nuttx_elf was linked dynamically
- This commit fixes this issue

## Impact

- Affects x86 (32bit) only

## Testing

- Tested with qemu-i486:nsh
