### PR TITLE
[BACKPORT #2013] arch: x86: Fix x86 linking

### DIFF
--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -74,7 +74,7 @@ OBJS = $(AOBJS) $(COBJS)
 
 LDSTARTGROUP ?= --start-group
 LDENDGROUP ?= --end-group
-LDFLAGS += $(ARCHSCRIPT)
+LDFLAGS += $(ARCHSCRIPT) -static
 
 BOARDMAKE = $(if $(wildcard board$(DELIM)Makefile),y,)
 


### PR DESCRIPTION
## Summary
Backport of #2013 
## Impact

## Testing

