### PR TITLE
arch/armv7-a: Fix the wrong idle stack setup for SMP case

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpuhead.S
+++ b/arch/arm/src/armv7-a/arm_cpuhead.S
@@ -420,12 +420,13 @@ __cpu3_start:
 	 */
 
 	adr		r3, .Lstkinit
-	ldmia	r3, {r0, r1, r2}	/* R0 = start of IDLE stack; R1 = Size of stack; R2 = coloration */
+	mov		r0, sp		/* R0 = end of IDLE stack */
+	ldmia		r3, {r1, r2}	/* R1 = Size of stack; R2 = coloration */
 
 1:								/* Top of the loop */
 	sub		r1, r1, #1			/* R1 = Number of words remaining */
 	cmp		r1, #0				/* Check (nwords == 0) */
-	str		r2, [r0], #4		/* Save stack color word, increment stack address */
+	str		r2, [r0, #-4]!		/* Save stack color word, increment stack address */
 	bne		1b					/* Bottom of the loop */
 #endif
 
@@ -494,14 +495,5 @@ g_cpu3_idlestack:
 #endif /* CONFIG_SMP_NCPUS > 3 */
 #endif /* CONFIG_SMP_NCPUS > 2 */
 #endif /* CONFIG_SMP_NCPUS > 1 */
-
-	.align	8
-	.globl	g_idle_topstack
-	.type	g_idle_topstack, object
-
-g_idle_topstack:
-	.long	_enoinit
-	.size	g_idle_topstack, .-g_idle_topstack
-
 #endif /* CONFIG_SMP */
 	.end

--- a/arch/arm/src/armv7-a/arm_head.S
+++ b/arch/arm/src/armv7-a/arm_head.S
@@ -754,6 +754,8 @@ arm_data_initialize:
 .Lstackpointer:
 #ifdef CONFIG_BOOT_SDRAM_DATA
 	.long	IDLE_STACK_VBASE+CONFIG_IDLETHREAD_STACKSIZE-4
+#elif defined(CONFIG_SMP)
+	.long	_enoinit+CONFIG_IDLETHREAD_STACKSIZE-4
 #else
 	.long	_ebss+CONFIG_IDLETHREAD_STACKSIZE-4
 #endif
@@ -773,6 +775,8 @@ arm_data_initialize:
 .Lstkinit:
 #ifdef CONFIG_BOOT_SDRAM_DATA
 	.long	IDLE_STACK_VBASE		/* Beginning of the IDLE stack, then words of IDLE stack */
+#elif defined(CONFIG_SMP)
+	.long	_enoinit
 #else
 	.long	_ebss					/* Beginning of the IDLE stack, then words of IDLE stack */
 #endif
@@ -785,7 +789,6 @@ arm_data_initialize:
  * Data section variables
  ***************************************************************************/
 
-#ifndef CONFIG_SMP
 	/* This global variable is unsigned long g_idle_topstack and is
 	 * exported from here only because of its coupling to .Linitparms
 	 * above.
@@ -800,10 +803,11 @@ g_idle_topstack:
 
 #ifdef CONFIG_BOOT_SDRAM_DATA
 	.long	IDLE_STACK_VBASE+CONFIG_IDLETHREAD_STACKSIZE
+#elif defined(CONFIG_SMP)
+	.long	_enoinit+CONFIG_IDLETHREAD_STACKSIZE
 #else
 	.long	_ebss+CONFIG_IDLETHREAD_STACKSIZE
 #endif
 	.size	g_idle_topstack, .-g_idle_topstack
-#endif
 	.end
 #endif


### PR DESCRIPTION
## Summary
1.Add the idle stack base as The first field of .Lstkinit
2.Make g_idle_topstack point to the end of the idle stack

## Impact
Fix the error in ARMV7-A SMP

## Testing

