### PR TITLE
tools: Remove the special handle for Ubuntu under Windows 10

### DIFF
--- a/Documentation/quickstart/configuring.rst
+++ b/Documentation/quickstart/configuring.rst
@@ -32,7 +32,6 @@ has your configuration options selected.
        -l selects the Linux (l) host environment.
        -m selects the macOS (m) host environment.
        -c selects the Windows host and Cygwin (c) environment.
-       -u selects the Windows host and Ubuntu under Windows 10 (u) environment.
        -g selects the Windows host and MinGW/MSYS environment.
        -n selects the Windows host and Windows native (n) environment.
 

--- a/Kconfig
+++ b/Kconfig
@@ -93,12 +93,6 @@ config WINDOWS_CYGWIN
 		Build natively in a Cygwin environment with POSIX style paths (like
 		/cygdrive/c/Program Files)
 
-config WINDOWS_UBUNTU
-	bool "Ubuntu under Windows 10"
-	---help---
-		Build natively in an Ubuntu shell under Windows 10 environment with
-		POSIX style paths (like /mnt/c/Program Files)
-
 config WINDOWS_MSYS
 	bool "MSYS or MSYS2"
 	select TOOLCHAIN_WINDOWS

--- a/arch/mips/src/mips32/Kconfig
+++ b/arch/mips/src/mips32/Kconfig
@@ -58,7 +58,7 @@ config MIPS32_TOOLCHAIN_MICROCHIPOPENL
 
 config MIPS32_TOOLCHAIN_PINGUINOW
 	bool "Pinguino mips-elf toolchain under Windows"
-	depends on TOOLCHAIN_WINDOWS || WINDOWS_UBUNTU
+	depends on TOOLCHAIN_WINDOWS
 	select CYGWIN_WINTOOL if WINDOWS_CYGWIN
 	select ARCH_TOOLCHAIN_GNU
 

--- a/boards/arm/stm32l4/b-l475e-iot01a/README.txt
+++ b/boards/arm/stm32l4/b-l475e-iot01a/README.txt
@@ -190,14 +190,14 @@ Configurations
   Each  B-L475E-IOT01A configuration is maintained in a sub-directory and
   can be selected as follow:
 
-    tools/configure.sh [-l|c|u|n] /b-l475e-iot01a:<subdir>
+    tools/configure.sh [-l|c|n] /b-l475e-iot01a:<subdir>
 
   Where:
    -l selects the Linux (l) host environment.  The [-c|u|n] options
        select one of the Windows environments.  Default:  Use host setup
        in the defconfig file
-   [-c|u|n] selects the Windows host and a Windows environment:  Cygwin (c),
-       Ubuntu under Windows 10 (u), or Windows native (n).  Default Cygwin
+   [-c|n] selects the Windows host and a Windows environment:
+      Cygwin (c), or Windows native (n). Default Cygwin
 
   Before building, make sure that:
 

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -114,9 +114,7 @@ ifeq ($(HOSTOS),Cygwin)
 endif
 
 ifeq ($(CONFIG_HOST_WINDOWS),y)
-ifneq ($(CONFIG_WINDOWS_UBUNTU),y)
   HOSTEXEEXT ?= .exe
-endif
 endif
 
 # This define is passed as EXTRAFLAGS for kernel-mode builds.  It is also passed

--- a/tools/README.txt
+++ b/tools/README.txt
@@ -935,13 +935,12 @@ sethost.sh
 
     $ ./sethost.sh -h
 
-    USAGE: ./sethost.sh [-l|m|c|u|g|n] [make-opts]
+    USAGE: ./sethost.sh [-l|m|c|g|n] [make-opts]
            ./sethost.sh -h
 
     Where:
-      -l|m|c|u|g|n selects Linux (l), macOS (m), Cygwin (c),
-         Ubuntu under Windows 10 (u), MSYS/MSYS2 (g)
-         or Windows native (n).  Default Linux
+      -l|m|c|g|n selects Linux (l), macOS (m), Cygwin (c),
+         MSYS/MSYS2 (g) or Windows native (n). Default Linux
       make-opts directly pass to make
       -h will show this help test and terminate
 
@@ -989,12 +988,12 @@ testbuild.sh
 
     $ ./testbuild.sh -h
 
-    USAGE: ./testbuild.sh [-l|m|c|u|g|n] [-d] [-x] [-j <ncpus>] [-a <appsdir>] [-t <topdir>] [-p] [-G] <testlist-file>
+    USAGE: ./testbuild.sh [-l|m|c|g|n] [-d] [-x] [-j <ncpus>] [-a <appsdir>] [-t <topdir>] [-p] [-G] <testlist-file>
            ./testbuild.sh -h
 
     Where:
-      -l|m|c|u|g|n selects Linux (l), macOS (m), Cygwin (c),
-         Ubuntu under Windows 10 (u), MSYS/MSYS2 (g) or Windows native (n).  Default Linux
+      -l|m|c|g|n selects Linux (l), macOS (m), Cygwin (c),
+         MSYS/MSYS2 (g) or Windows native (n).  Default Linux
       -d enables script debug output
       -x exit on build failures
       -j <ncpus> passed on to make.  Default:  No -j make option.
@@ -1018,7 +1017,7 @@ testbuild.sh
   These script needs two pieces of information.
 
     a. A description of the platform that you are testing on.  This description
-       is provided by the optional -l, -m, -c, -u, -g and -n options.
+       is provided by the optional -l, -m, -c, -g and -n options.
     b. A list of configurations to build.  That list is provided by a test
        list file.  The final, non-optional parameter, <testlist-file>,
        provides the path to that file.

--- a/tools/configure.bat
+++ b/tools/configure.bat
@@ -63,7 +63,6 @@ if "%1"=="-f" goto :SetFormat
 if "%1"=="-b" goto :SetFormat
 if "%1"=="-l" goto :SetHostOption
 if "%1"=="-c" goto :SetHostOption
-if "%1"=="-u" goto :SetHostOption
 if "%1"=="-n" goto :SetHostOption
 if "%1"=="-L" goto :SetList
 if "%1"=="-a" goto :SetAppDir
@@ -133,11 +132,11 @@ echo    style paths are used by default.
 echo  -f:
 echo    Informs the tool that it should use POSIX style paths like /usr/local/bin.
 echo    By default, Windows style paths like C:\\Program Files are used.
-echo  -l selects the Linux (l) host environment.  The [-c^|u^|n] options
+echo  -l selects the Linux (l) host environment.  The [-c^|n] options
 echo    select one of the Windows environments.  Default:  Use host setup
 echo    in the defconfig file
-echo  [-c^|u^|n] selects the Windows host and a Windows environment:  Cygwin (c),
-echo    Ubuntu under Windows 10 (u), or Windows native (n).  Default Cygwin
+echo  [-c^|n] selects the Windows host and a Windows environment:
+echo    Cygwin (c), or Windows native (n). Default Cygwin
 echo  -L:
 echo    List all available configurations.
 echo  -a ^<app-dir^>:

--- a/tools/configure.c
+++ b/tools/configure.c
@@ -70,8 +70,7 @@
 
 #define WINDOWS_NATIVE 1
 #define WINDOWS_CYGWIN 2
-#define WINDOWS_UBUNTU 3
-#define WINDOWS_MSYS   4
+#define WINDOWS_MSYS   3
 
 /****************************************************************************
  * Private Function Prototypes
@@ -182,7 +181,7 @@ static const char *g_optfiles[] =
 
 static void show_usage(const char *progname, int exitcode)
 {
-  fprintf(stderr, "\nUSAGE: %s  [-d] [-E] [-e] [-b|f] [-L] [-l|m|c|u|g|n] "
+  fprintf(stderr, "\nUSAGE: %s  [-d] [-E] [-e] [-b|f] [-L] [-l|m|c|g|n] "
           "[-a <app-dir>] <board-name>:<config-name> [make-opts]\n",
           progname);
   fprintf(stderr, "\nUSAGE: %s  [-h]\n", progname);
@@ -215,12 +214,11 @@ static void show_usage(const char *progname, int exitcode)
   fprintf(stderr, "    style paths like C:\\Program Files are used.\n");
   fprintf(stderr, "    POSIX style paths are used by default.\n");
 #endif
-  fprintf(stderr, "  [-l|m|c|u|g|n]\n");
+  fprintf(stderr, "  [-l|m|c|g|n]\n");
   fprintf(stderr, "    Selects the host environment.\n");
   fprintf(stderr, "    -l Selects the Linux (l) host environment.\n");
   fprintf(stderr, "    -m Selects the macOS (m) host environment.\n");
   fprintf(stderr, "    -c Selects the Windows Cygwin (c) environment.\n");
-  fprintf(stderr, "    -u Selects the Windows Ubuntu (u) environment.\n");
   fprintf(stderr, "    -g Selects the Windows MinGW/MSYS environment.\n");
   fprintf(stderr, "    -n Selects the Windows native (n) environment.\n");
   fprintf(stderr, "  Default: Use host setup in the defconfig file.\n");
@@ -340,11 +338,6 @@ static void parse_args(int argc, char **argv)
           case 'n' :
             g_host    = HOST_WINDOWS;
             g_windows = WINDOWS_NATIVE;
-            break;
-
-          case 'u' :
-            g_host    = HOST_WINDOWS;
-            g_windows = WINDOWS_UBUNTU;
             break;
 
           case '?' :
@@ -1353,7 +1346,6 @@ static void set_host(const char *destconfig)
 
           disable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
           disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
-          disable_feature(destconfig, "CONFIG_WINDOWS_UBUNTU");
           disable_feature(destconfig, "CONFIG_WINDOWS_MSYS");
           disable_feature(destconfig, "CONFIG_WINDOWS_OTHER");
 
@@ -1372,7 +1364,6 @@ static void set_host(const char *destconfig)
 
           disable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
           disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
-          disable_feature(destconfig, "CONFIG_WINDOWS_UBUNTU");
           disable_feature(destconfig, "CONFIG_WINDOWS_MSYS");
           disable_feature(destconfig, "CONFIG_WINDOWS_OTHER");
 
@@ -1398,7 +1389,6 @@ static void set_host(const char *destconfig)
                 printf("  Select Windows/Cygwin host\n");
                 enable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
                 disable_feature(destconfig, "CONFIG_WINDOWS_MSYS");
-                disable_feature(destconfig, "CONFIG_WINDOWS_UBUNTU");
                 disable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
                 break;
 
@@ -1406,15 +1396,6 @@ static void set_host(const char *destconfig)
                 printf("  Select Windows/MSYS host\n");
                 disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
                 enable_feature(destconfig, "CONFIG_WINDOWS_MSYS");
-                disable_feature(destconfig, "CONFIG_WINDOWS_UBUNTU");
-                disable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
-                break;
-
-              case WINDOWS_UBUNTU:
-                printf("  Select Ubuntu for Windows 10 host\n");
-                disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
-                disable_feature(destconfig, "CONFIG_WINDOWS_MSYS");
-                enable_feature(destconfig, "CONFIG_WINDOWS_UBUNTU");
                 disable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
                 break;
 
@@ -1422,7 +1403,6 @@ static void set_host(const char *destconfig)
                 printf("  Select Windows native host\n");
                 disable_feature(destconfig, "CONFIG_WINDOWS_CYGWIN");
                 disable_feature(destconfig, "CONFIG_WINDOWS_MSYS");
-                disable_feature(destconfig, "CONFIG_WINDOWS_UBUNTU");
                 enable_feature(destconfig, "CONFIG_WINDOWS_NATIVE");
                 break;
 

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -39,7 +39,7 @@ WD=`test -d ${0%/*} && cd ${0%/*}; pwd`
 TOPDIR="${WD}/.."
 USAGE="
 
-USAGE: ${0} [-E] [-e] [-l|m|c|u|g|n] [L] [-a <app-dir>] <board-name>:<config-name> [make-opts]
+USAGE: ${0} [-E] [-e] [-l|m|c|g|n] [L] [-a <app-dir>] <board-name>:<config-name> [make-opts]
 
 Where:
   -E enforces distclean if already configured.
@@ -47,7 +47,6 @@ Where:
   -l selects the Linux (l) host environment.
   -m selects the macOS (m) host environment.
   -c selects the Windows host and Cygwin (c) environment.
-  -u selects the Windows host and Ubuntu under Windows 10 (u) environment.
   -g selects the Windows host and MinGW/MSYS environment.
   -n selects the Windows host and Windows native (n) environment.
   Default: Use host setup in the defconfig file
@@ -95,7 +94,7 @@ while [ ! -z "$1" ]; do
     shift
     appdir=$1
     ;;
-  -c | -g | -l | -m | -u )
+  -c | -g | -l | -m )
     winnative=n
     host+=" $1"
     ;;

--- a/tools/sethost.sh
+++ b/tools/sethost.sh
@@ -25,13 +25,12 @@ wenv=
 
 function showusage {
   echo ""
-  echo "USAGE: $progname [-l|m|c|u|g|n] [make-opts]"
+  echo "USAGE: $progname [-l|m|c|g|n] [make-opts]"
   echo "       $progname -h"
   echo ""
   echo "Where:"
-  echo "  -l|m|c|u|g|n selects Linux (l), macOS (m), Cygwin (c),"
-  echo "     Ubuntu under Windows 10 (u), MSYS/MSYS2 (g)"
-  echo "     or Windows native (n). Default Linux"
+  echo "  -l|m|c|g|n selects Linux (l), macOS (m), Cygwin (c),"
+  echo "     MSYS/MSYS2 (g) or Windows native (n). Default Linux"
   echo "  make-opts directly pass to make"
   echo "  -h will show this help test and terminate"
   exit 1
@@ -51,10 +50,6 @@ while [ ! -z "$1" ]; do
   -g )
     host=windows
     wenv=msys
-    ;;
-  -u )
-    host=windows
-    wenv=ubuntu
     ;;
   -m )
     host=macos
@@ -171,13 +166,8 @@ else
       echo "  Select CONFIG_WINDOWS_MSYS=y"
       kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_MSYS
     else
-      if [ "X$wenv" == "Xubuntu" ]; then
-        echo "  Select CONFIG_WINDOWS_UBUNTU=y"
-        kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_UBUNTU
-      else
-        echo "  Select CONFIG_WINDOWS_NATIVE=y"
-        kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_NATIVE
-      fi
+      echo "  Select CONFIG_WINDOWS_NATIVE=y"
+      kconfig-tweak --file $nuttx/.config --enable CONFIG_WINDOWS_NATIVE
     fi
   fi
 fi

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -49,12 +49,12 @@ GITCLEAN=0
 
 function showusage {
   echo ""
-  echo "USAGE: $progname [-l|m|c|u|g|n] [-d] [-e <extraflags>] [-x] [-j <ncpus>] [-a <appsdir>] [-t <topdir>] [-p] [-G] <testlist-file>"
+  echo "USAGE: $progname [-l|m|c|g|n] [-d] [-e <extraflags>] [-x] [-j <ncpus>] [-a <appsdir>] [-t <topdir>] [-p] [-G] <testlist-file>"
   echo "       $progname -h"
   echo ""
   echo "Where:"
-  echo "  -l|m|c|u|g|n selects Linux (l), macOS (m), Cygwin (c),"
-  echo "     Ubuntu under Windows 10 (u), MSYS/MSYS2 (g) or Windows native (n).  Default Linux"
+  echo "  -l|m|c|g|n selects Linux (l), macOS (m), Cygwin (c),"
+  echo "     MSYS/MSYS2 (g) or Windows native (n). Default Linux"
   echo "  -d enables script debug output"
   echo "  -e pass extra c/c++ flags such as -Wno-cpp via make command line"
   echo "  -x exit on build failures"
@@ -81,7 +81,7 @@ function showusage {
 
 while [ ! -z "$1" ]; do
   case $1 in
-  -l | -m | -c | -u | -g | -n )
+  -l | -m | -c | -g | -n )
     HOPTION+=" $1"
     ;;
   -d )


### PR DESCRIPTION
## Summary
since the Native Linux support could be reused for this case:
https://lists.apache.org/thread.html/r315682ed20bbeb2f1403cf592f892ef009274423189ffc5b3841a6a9%40%3Cdev.nuttx.apache.org%3E

## Impact
User should use -l instead -u for WSL.

## Testing

