### PR TITLE
freedom-k64f: Fix k64_buttons.c

### DIFF
--- a/boards/arm/kinetis/freedom-k64f/src/k64_buttons.c
+++ b/boards/arm/kinetis/freedom-k64f/src/k64_buttons.c
@@ -163,7 +163,7 @@ int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
    * Attach the new button handler.
    */
 
-  ret = kinetis_pinirqattach(pinset, irqhandler);
+  ret = kinetis_pinirqattach(pinset, irqhandler, NULL);
   if (ret >= 0)
     {
       /* Then make sure that interrupts are enabled on the pin */


### PR DESCRIPTION
Change-Id: I0c9f8903513fdbce05e9dc03a3b6c772f6920002
Bug: https://github.com/apache/incubator-nuttx/pull/1999
Signed-off-by: Philippe Coval <rzr@users.sf.net>

## Summary

## Impact

## Testing

