### PR TITLE
tiva/cc13x0: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi4_aux.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi4_aux.h
@@ -1,10 +1,11 @@
-/********************************************************************************************************************
+/****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi4_aux.h
  *
  *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
  *
- * Technical content derives from a TI header file that has a compatible BSD license:
+ * Technical content derives from a TI header file that has a compatible
+ * BSD license:
  *
  *   Copyright (c) 2015-2017, Texas Instruments Incorporated
  *   All rights reserved.
@@ -36,24 +37,24 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ********************************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_TIVA_HARDWARE_CC13X0_CC13X0_ADI4_AUX_H
 #define __ARCH_ARM_SRC_TIVA_HARDWARE_CC13X0_CC13X0_ADI4_AUX_H
 
-/********************************************************************************************************************
+/****************************************************************************
  * Included Files
- ********************************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include "hardware/tiva_memorymap.h"
 #include "hardware/tiva_ddi.h"
 
-/********************************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ********************************************************************************************************************/
+ ****************************************************************************/
 
-/* ADI3 AUX Register Offsets ****************************************************************************************/
+/* ADI3 AUX Register Offsets ************************************************/
 
 #define TIVA_ADI4_AUX_MUX0_OFFSET                          0x0000
 #define TIVA_ADI4_AUX_MUX1_OFFSET                          0x0001
@@ -67,7 +68,7 @@
 #define TIVA_ADI4_AUX_ADCREF0_OFFSET                       0x000a  /* ADC Reference 0 */
 #define TIVA_ADI4_AUX_ADCREF1_OFFSET                       0x000b  /* ADC Reference 1 */
 
-/* ADI3 AUX Register Addresses **************************************************************************************/
+/* ADI3 AUX Register Addresses **********************************************/
 
 #define TIVA_ADI4_AUX_MUX0                                 (TIVA_AUX_ADI4_BASE + TIVA_ADI4_AUX_MUX0_OFFSET)
 #define TIVA_ADI4_AUX_MUX1                                 (TIVA_AUX_ADI4_BASE + TIVA_ADI4_AUX_MUX1_OFFSET)
@@ -81,7 +82,9 @@
 #define TIVA_ADI4_AUX_ADCREF0                              (TIVA_AUX_ADI4_BASE + TIVA_ADI4_AUX_ADCREF0_OFFSET)
 #define TIVA_ADI4_AUX_ADCREF1                              (TIVA_AUX_ADI4_BASE + TIVA_ADI4_AUX_ADCREF1_OFFSET)
 
-/* Offsets may also be used in conjunction with access as described in cc13x0_ddi.h */
+/* Offsets may also be used in conjunction with access as described in
+ * cc13x0_ddi.h
+ */
 
 #define TIVA_ADI4_AUX_DIR                                  (TIVA_AUX_ADI4_BASE + TIVA_DDI_DIR_OFFSET)
 #define TIVA_ADI4_AUX_SET                                  (TIVA_AUX_ADI4_BASE + TIVA_DDI_SET_OFFSET)
@@ -90,7 +93,7 @@
 #define TIVA_ADI4_AUX_MASK8B                               (TIVA_AUX_ADI4_BASE + TIVA_DDI_MASK8B_OFFSET)
 #define TIVA_ADI4_AUX_MASK16B                              (TIVA_AUX_ADI4_BASE + TIVA_DDI_MASK16B_OFFSET)
 
-/* ADI3 AUX Register Bitfield Definitions ***************************************************************************/
+/* ADI3 AUX Register Bitfield Definitions ***********************************/
 
 /* TIVA_ADI4_AUX_MUX0 */
 
@@ -168,17 +171,17 @@
 
 /* TIVA_ADI4_AUX_COMP */
 
-#define ADI4_AUX_COMP_COMPA_EN                              (1 << 1)  /* Bit 1:  COMPA enable */
-#define ADI4_AUX_COMP_COMPB_EN                              (1 << 2)  /* Bit 2:  COMPB enable */
-#define ADI4_AUX_COMP_COMPB_TRIM_SHIFT                      (3)       /* Bits 3-5 */
+#define ADI4_AUX_COMP_COMPA_EN                              (1 << 1)                              /* Bit 1:  COMPA enable */
+#define ADI4_AUX_COMP_COMPB_EN                              (1 << 2)                              /* Bit 2:  COMPB enable */
+#define ADI4_AUX_COMP_COMPB_TRIM_SHIFT                      (3)                                   /* Bits 3-5 */
 #define ADI4_AUX_COMP_COMPB_TRIM_MASK                       (7 << ADI4_AUX_COMP_COMPB_TRIM_SHIFT)
 #  define ADI4_AUX_COMP_COMPB_TRIM(n)                       ((uint32_t)(n) << ADI4_AUX_COMP_COMPB_TRIM_SHIFT)
 #  define ADI4_AUX_COMP_COMPB_TRIM_DIV1                     (0 << ADI4_AUX_COMP_COMPB_TRIM_SHIFT) /* No reference division */
 #  define ADI4_AUX_COMP_COMPB_TRIM_DIV2                     (1 << ADI4_AUX_COMP_COMPB_TRIM_SHIFT) /* Divide reference by 2 */
 #  define ADI4_AUX_COMP_COMPB_TRIM_DIV3                     (3 << ADI4_AUX_COMP_COMPB_TRIM_SHIFT) /* Divide reference by 3 */
 #  define ADI4_AUX_COMP_COMPB_TRIM_DIV4                     (7 << ADI4_AUX_COMP_COMPB_TRIM_SHIFT) /* Divide reference by 4 */
-#define ADI4_AUX_COMP_COMPA_REF_CURR_EN                     (1 << 6)  /* Bit 6:  Enables 2uA IPTAT current from ISRC to COMPA reference */
-#define ADI4_AUX_COMP_COMPA_REF_RES_EN                      (1 << 7)  /* Bit 7:  Enables 400kohm resistance from COMPA reference */
+#define ADI4_AUX_COMP_COMPA_REF_CURR_EN                     (1 << 6)                              /* Bit 6:  Enables 2uA IPTAT current from ISRC to COMPA reference */
+#define ADI4_AUX_COMP_COMPA_REF_RES_EN                      (1 << 7)                              /* Bit 7:  Enables 400kohm resistance from COMPA reference */
 
 /* TIVA_ADI4_AUX_MUX4 */
 
@@ -217,7 +220,7 @@
 #  define ADI4_AUX_ADC0_SMPL_CYCLE_EXP_2p73_MS              (13 << ADI4_AUX_ADC0_SMPL_CYCLE_EXP_SHIFT) /* 16384 clocks = 2.73ms */
 #  define ADI4_AUX_ADC0_SMPL_CYCLE_EXP_5p46_MS              (14 << ADI4_AUX_ADC0_SMPL_CYCLE_EXP_SHIFT) /* 32768 clocks = 5.46ms */
 #  define ADI4_AUX_ADC0_SMPL_CYCLE_EXP_10p9_MS              (15 << ADI4_AUX_ADC0_SMPL_CYCLE_EXP_SHIFT) /* 65536 clocks = 10.9ms */
-#define ADI4_AUX_ADC0_SMPL_MODE                             (1 << 7)  /* Bit 7:  ADC Sampling mode */
+#define ADI4_AUX_ADC0_SMPL_MODE                             (1 << 7)                                   /* Bit 7:  ADC Sampling mode */
 #  define ADI4_AUX_ADC0_SMPL_MODE_SYNCH                     (0)
 #  define ADI4_AUX_ADC0_SMPL_MODE_ASYNCH                    ADI4_AUX_ADC0_SMPL_MODE
 
@@ -234,7 +237,6 @@
 #define ADI4_AUX_ADCREF0_EXT                                (1 << 4)  /* Bit 4 */
 #define ADI4_AUX_ADCREF0_IOMUX                              (1 << 5)  /* Bit 5 */
 #define ADI4_AUX_ADCREF0_REF_ON_IDLE                        (1 << 6)  /* Bit 6:  Enable ADCREF in IDLE state */
-
 
 /* TIVA_ADI4_AUX_ADCREF1 */
 

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_smph.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_smph.h
@@ -4,7 +4,8 @@
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
  *
- * Technical content derives from a TI header file that has a compatible BSD license:
+ * Technical content derives from a TI header file that has a compatible
+ * BSD license:
  *
  *   Copyright (c) 2015-2017, Texas Instruments Incorporated
  *   All rights reserved.

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ccfg.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ccfg.h
@@ -4,7 +4,8 @@
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
  *
- * Technical content derives from a TI header file that has a compatible BSD license:
+ * Technical content derives from a TI header file that has a compatible
+ * BSD license:
  *
  *   Copyright (c) 2015-2017, Texas Instruments Incorporated
  *   All rights reserved.
@@ -221,8 +222,11 @@
 #define CCFG_FREQ_OFFSET_HF_COMP_P0_MASK        (0xffff << CCFG_FREQ_OFFSET_HF_COMP_P0_SHIFT)
 
 /* TIVA_CCFG_IEEE_MAC_0 (32-bit value) */
+
 /* TIVA_CCFG_IEEE_MAC_1 (32-bit value) */
+
 /* TIVA_CCFG_IEEE_BLE_0 (32-bit value) */
+
 /* TIVA_CCFG_IEEE_BLE_1 (32-bit value) */
 
 /* TIVA_CCFG_BL_CONFIG */

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi.h
@@ -4,7 +4,8 @@
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
  *
- * Technical content derives from a TI header file that has a compatible BSD license:
+ * Technical content derives from a TI header file that has a compatible
+ * BSD license:
  *
  *   Copyright (c) 2015-2017, Texas Instruments Incorporated
  *   All rights reserved.
@@ -234,6 +235,7 @@
 #define TIVA_DDI_MASK16B_OFFSET   0x0200  /* Offset for 16-bit masked access */
 
 /* DDI Register Addresses ***************************************************/
+
 /* Register base addresses depend on that base address of the master, e.g.
  * TIVA_AUX_DDI0_OSC_BASE.
  */

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_memorymap.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_memorymap.h
@@ -1,55 +1,57 @@
-/******************************************************************************
+/****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x0/cc13x0_memorymap.h
  *
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
- * Technical content derives from a TI header file that has a compatible BSD license:
+ * Technical content derives from a TI header file that has a compatible
+ * BSD license:
  *
  *   Copyright (c) 2015-2017, Texas Instruments Incorporated
  *   All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
  * 1) Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
- * 2) Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * 2) Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  *
  * 3) Neither the name NuttX nor the names of its contributors may be used
- *    to endorse or promote products derived from this software without specific
- *    prior written permission.
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- ******************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_TIVA_HARDWARE_C13X0_C13X0_MEMORYMAP_H
 #define __ARCH_ARM_SRC_TIVA_HARDWARE_C13X0_C13X0_MEMORYMAP_H
 
-/******************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ******************************************************************************/
+ ****************************************************************************/
 
-/******************************************************************************
+/****************************************************************************
  *
  * The following are defines for the base address of the memories and
  * peripherals on the CPU_MMAP interface
  *
- ******************************************************************************/
+ ****************************************************************************/
 
 #define TIVA_FLASHMEM_BASE            0x00000000 /* FLASHMEM */
 #define TIVA_BROM_BASE                0x10000000 /* BROM */

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_smph.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_smph.h
@@ -4,7 +4,8 @@
  *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
  *
- * Technical content derives from a TI header file that has a compatible BSD license:
+ * Technical content derives from a TI header file that has a compatible
+ * BSD license:
  *
  *   Copyright (c) 2015-2017, Texas Instruments Incorporated
  *   All rights reserved.


### PR DESCRIPTION
## Summary

arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi4_aux.h,
arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_smph.h,
arch/arm/src/tiva/hardware/cc13x0/cc13x0_ccfg.h,
arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi.h,
arch/arm/src/tiva/hardware/cc13x0/cc13x0_memorymap.h,
arch/arm/src/tiva/hardware/cc13x0/cc13x0_smph.h:

    * Fix nxstyle errors.

## Impact

Removes nxstyle errors.

## Testing

nxstyle