### PR TITLE
arch: serial: fix all TCGETS retrieving zero baud rate

### DIFF
--- a/arch/arm/src/a1x/a1x_serial.c
+++ b/arch/arm/src/a1x/a1x_serial.c
@@ -1270,8 +1270,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
          * that only one speed is supported.
          */
 
-        /* Get the c_speed field in the termios struct */
-
         priv->baud = cfgetispeed(termiosp);
 
         /* TODO: Re-calculate the optimal CCLK divisor for the new baud and

--- a/arch/arm/src/am335x/am335x_serial.c
+++ b/arch/arm/src/am335x/am335x_serial.c
@@ -515,7 +515,8 @@ static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint32_t value)
 {
   putreg32(value, priv->uartbase + offset);
 }
@@ -565,13 +566,13 @@ static inline void up_enablebreaks(struct up_dev_s *priv, bool enable)
   up_serialout(priv, AM335X_UART_LCR_OFFSET, lcr);
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: am335x_uart0config, uart1config, uart2config, ..., uart5config
  *
  * Descrption:
  *   Configure the UART
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_AM335X_UART0
 static inline void am335x_uart0config(void)
@@ -699,7 +700,7 @@ static inline void am335x_uart5config(void)
 };
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Name: am335x_uartdl
  *
  * Description:
@@ -708,7 +709,7 @@ static inline void am335x_uart5config(void)
  *     BAUD = PCLK / (16 * DL), or
  *     DL   = PCLK / BAUD / 16
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static inline uint32_t am335x_uartdl(uint32_t baud)
 {
@@ -758,11 +759,13 @@ static int up_setup(struct uart_dev_s *dev)
 
   /* Clear FIFOs */
 
-  up_serialout(priv, AM335X_UART_FCR_OFFSET, (UART_FCR_RFIFO_CLEAR | UART_FCR_TFIFO_CLEAR));
+  up_serialout(priv, AM335X_UART_FCR_OFFSET,
+               (UART_FCR_RFIFO_CLEAR | UART_FCR_TFIFO_CLEAR));
 
   /* Configure the FIFOs */
 
-  up_serialout(priv, AM335X_UART_FCR_OFFSET, (UART_FCR_FIFO_EN | UART_FCR_RFT_60CHAR | UART_FCR_TFT_56CHAR));
+  up_serialout(priv, AM335X_UART_FCR_OFFSET,
+    (UART_FCR_FIFO_EN | UART_FCR_RFT_60CHAR | UART_FCR_TFT_56CHAR));
 
   /* Set up the IER */
 
@@ -846,14 +849,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -882,8 +886,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -990,7 +994,9 @@ static int uart_interrupt(int irq, void *context, void *arg)
               return OK;
             }
 
-            /* Otherwise we have received an interrupt that we cannot handle */
+            /* Otherwise we have received an interrupt that we cannot
+             * handle
+             */
 
           default:
             {
@@ -1096,8 +1102,10 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
          * and reset the divider in the CLKSEL0/1 register.
          */
 
-        /* DLAB open latch */
-        /* REVISIT:  Shouldn't we just call up_setup() to do all of the following? */
+        /* DLAB open latch
+         * REVISIT:  Shouldn't we just call up_setup() to do all of the
+         *           following?
+         */
 
         lcr = up_serialin(priv, AM335X_UART_LCR_OFFSET);
         up_serialout(priv, AM335X_UART_LCR_OFFSET, (lcr | UART_LCR_DLAB));
@@ -1105,7 +1113,8 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
         /* Set the BAUD divisor */
 
         dl = am335x_uartdl(priv->baud);
-        up_serialout(priv, AM335X_UART_DLH_OFFSET, (dl >> 8) & UART_DLH_MASK);
+        up_serialout(priv, AM335X_UART_DLH_OFFSET,
+                     (dl >> 8) & UART_DLH_MASK);
         up_serialout(priv, AM335X_UART_DLL_OFFSET, dl & UART_DLL_MASK);
 
         /* Clear DLAB */

--- a/arch/arm/src/am335x/am335x_serial.c
+++ b/arch/arm/src/am335x/am335x_serial.c
@@ -1090,8 +1090,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
          * that only one speed is supported.
          */
 
-        /* Get the c_speed field in the termios struct */
-
         priv->baud = cfgetispeed(termiosp);
 
         /* TODO: Re-calculate the optimal CCLK divisor for the new baud and

--- a/arch/arm/src/cxd56xx/cxd56_serial.c
+++ b/arch/arm/src/cxd56xx/cxd56_serial.c
@@ -778,8 +778,6 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           flags = spin_lock_irqsave();
 
-          cfsetispeed(termiosp, priv->baud);
-
           termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
                               ((priv->parity == 1) ? PARODD : 0) |
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
@@ -789,6 +787,8 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
                               ((priv->iflow) ? CRTS_IFLOW : 0) |
 #endif
                               ((priv->stopbits2) ? CSTOPB : 0);
+
+          cfsetispeed(termiosp, priv->baud);
 
           switch (priv->bits)
             {

--- a/arch/arm/src/efm32/efm32_serial.c
+++ b/arch/arm/src/efm32/efm32_serial.c
@@ -68,7 +68,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-/* Some sanity checks *******************************************************/
+
+/* Some sanity checks */
+
 /* Is there at least one UART enabled and configured as a RS-232 device? */
 
 #ifndef HAVE_UART_DEVICE
@@ -81,8 +83,9 @@
 
 #ifdef USE_SERIALDRIVER
 
-/* Which UART with be ttyS0/console and which tty1-4?  The console will always
- * be ttyS0.  If there is no console then will use the lowest numbered UART.
+/* Which UART with be ttyS0/console and which tty1-4?  The console will
+ * always be ttyS0.  If there is no console then will use the lowest
+ * numbered UART.
  */
 
 /* First pick the console and ttys0.  This could be any of USART0-2 or
@@ -240,7 +243,8 @@ struct efm32_usart_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static inline uint32_t efm32_serialin(struct efm32_usart_s *priv, int offset);
+static inline uint32_t efm32_serialin(struct efm32_usart_s *priv,
+                                      int offset);
 static inline void efm32_serialout(struct efm32_usart_s *priv, int offset,
                                    uint32_t value);
 static inline void efm32_setuartint(struct efm32_usart_s *priv);
@@ -331,18 +335,18 @@ static struct efm32_usart_s g_usart0priv =
 
 static struct uart_dev_s g_usart0port =
 {
-  .recv      =
-  {
-    .size    = CONFIG_USART0_RXBUFSIZE,
-    .buffer  = g_usart0rxbuffer,
-  },
-  .xmit      =
-  {
-    .size    = CONFIG_USART0_TXBUFSIZE,
-    .buffer  = g_usart0txbuffer,
-   },
-  .ops       = &g_uart_ops,
-  .priv      = &g_usart0priv,
+  .recv        =
+    {
+      .size    = CONFIG_USART0_RXBUFSIZE,
+      .buffer  = g_usart0rxbuffer,
+    },
+  .xmit        =
+    {
+      .size    = CONFIG_USART0_TXBUFSIZE,
+      .buffer  = g_usart0txbuffer,
+    },
+  .ops         = &g_uart_ops,
+  .priv        = &g_usart0priv,
 };
 #endif
 
@@ -367,18 +371,18 @@ static struct efm32_usart_s g_usart1priv =
 
 static struct uart_dev_s g_usart1port =
 {
-  .recv      =
-  {
-    .size    = CONFIG_USART1_RXBUFSIZE,
-    .buffer  = g_usart1rxbuffer,
-  },
-  .xmit      =
-  {
-    .size    = CONFIG_USART1_TXBUFSIZE,
-    .buffer  = g_usart1txbuffer,
-   },
-  .ops       = &g_uart_ops,
-  .priv      = &g_usart1priv,
+  .recv        =
+    {
+      .size    = CONFIG_USART1_RXBUFSIZE,
+      .buffer  = g_usart1rxbuffer,
+    },
+  .xmit        =
+    {
+      .size    = CONFIG_USART1_TXBUFSIZE,
+      .buffer  = g_usart1txbuffer,
+    },
+  .ops         = &g_uart_ops,
+  .priv        = &g_usart1priv,
 };
 #endif
 
@@ -403,18 +407,18 @@ static struct efm32_usart_s g_usart2priv =
 
 static struct uart_dev_s g_usart2port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_USART2_RXBUFSIZE,
-    .buffer = g_usart2rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_USART2_TXBUFSIZE,
-    .buffer = g_usart2txbuffer,
-   },
-  .ops      = &g_uart_ops,
-  .priv     = &g_usart2priv,
+  .recv       =
+    {
+      .size   = CONFIG_USART2_RXBUFSIZE,
+      .buffer = g_usart2rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_USART2_TXBUFSIZE,
+      .buffer = g_usart2txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_usart2priv,
 };
 #endif
 
@@ -439,18 +443,18 @@ static struct efm32_usart_s g_uart0priv =
 
 static struct uart_dev_s g_uart0port =
 {
-  .recv      =
-  {
-    .size    = CONFIG_UART0_RXBUFSIZE,
-    .buffer  = g_uart0rxbuffer,
-  },
-  .xmit      =
-  {
-    .size    = CONFIG_UART0_TXBUFSIZE,
-    .buffer  = g_uart0txbuffer,
-   },
-  .ops       = &g_uart_ops,
-  .priv      = &g_uart0priv,
+  .recv        =
+    {
+      .size    = CONFIG_UART0_RXBUFSIZE,
+      .buffer  = g_uart0rxbuffer,
+    },
+  .xmit        =
+    {
+      .size    = CONFIG_UART0_TXBUFSIZE,
+      .buffer  = g_uart0txbuffer,
+    },
+  .ops         = &g_uart_ops,
+  .priv        = &g_uart0priv,
 };
 #endif
 
@@ -475,18 +479,18 @@ static struct efm32_usart_s g_uart1priv =
 
 static struct uart_dev_s g_uart1port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART1_RXBUFSIZE,
-    .buffer = g_uart1rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART1_TXBUFSIZE,
-    .buffer = g_uart1txbuffer,
-   },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart1priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART1_RXBUFSIZE,
+      .buffer = g_uart1rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART1_TXBUFSIZE,
+      .buffer = g_uart1txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart1priv,
 };
 #endif
 
@@ -530,7 +534,9 @@ static void efm32_restoreuartint(struct efm32_usart_s *priv, uint32_t ien)
 {
   irqstate_t flags;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in ien */
+  /* Re-enable/re-disable interrupts corresponding to the state of bits in
+   * ien
+   */
 
   flags     = enter_critical_section();
   priv->ien = ien;
@@ -624,14 +630,15 @@ static void efm32_shutdown(struct uart_dev_s *dev)
  * Name: efm32_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -668,8 +675,8 @@ static int efm32_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -979,8 +986,8 @@ static void efm32_rxint(struct uart_dev_s *dev, bool enable)
   flags = enter_critical_section();
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when their is anything in the Rx data register
+       * (or an RX timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1011,7 +1018,8 @@ static bool efm32_rxavailable(struct uart_dev_s *dev)
 
   /* Return true if the receive data is available (RXDATAV). */
 
-  return (efm32_serialin(priv, EFM32_USART_STATUS_OFFSET) & USART_STATUS_RXDATAV) != 0;
+  return (efm32_serialin(priv, EFM32_USART_STATUS_OFFSET) & \
+          USART_STATUS_RXDATAV) != 0;
 }
 
 /****************************************************************************
@@ -1085,7 +1093,8 @@ static bool efm32_txready(struct uart_dev_s *dev)
    * buffer is half-full or empty.
    */
 
-  return (efm32_serialin(priv, EFM32_USART_STATUS_OFFSET) & USART_STATUS_TXBL) != 0;
+  return (efm32_serialin(priv, EFM32_USART_STATUS_OFFSET) & \
+          USART_STATUS_TXBL) != 0;
 }
 
 /****************************************************************************
@@ -1104,7 +1113,8 @@ static bool efm32_txempty(struct uart_dev_s *dev)
    * data is available in the transmit buffer.
    */
 
-  return (efm32_serialin(priv, EFM32_USART_STATUS_OFFSET) & USART_STATUS_TXC) != 0;
+  return (efm32_serialin(priv, EFM32_USART_STATUS_OFFSET) & \
+          USART_STATUS_TXC) != 0;
 }
 
 /****************************************************************************
@@ -1118,8 +1128,8 @@ static bool efm32_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before arm_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in efm32_consoleinit() and main clock iniialization
- *   performed in efm32_clkinitialize().
+ *   configuration performed in efm32_consoleinit() and main clock
+ *   iniialization performed in efm32_clkinitialize().
  *
  ****************************************************************************/
 

--- a/arch/arm/src/efm32/efm32_serial.c
+++ b/arch/arm/src/efm32/efm32_serial.c
@@ -839,8 +839,6 @@ static int efm32_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        cfsetispeed(termiosp, priv->config->baud);
-
         /* Note that since we only support 8/9 bit modes and
          * there is no way to report 9-bit mode, we always claim 8.
          */
@@ -848,6 +846,8 @@ static int efm32_ioctl(struct file *filep, int cmd, unsigned long arg)
         termiosp->c_cflag = CS8;
 
         /* TODO: PARENB, PARODD, CSTOPB, CCTS_IFLOW, CCTS_OFLOW */
+
+        cfsetispeed(termiosp, priv->config->baud);
       }
       break;
 

--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -321,29 +321,29 @@
 
 struct imxrt_uart_s
 {
-  uint32_t uartbase;    /* Base address of UART registers */
-  uint32_t baud;        /* Configured baud */
-  uint32_t ie;          /* Saved enabled interrupts */
-  uint8_t  irq;         /* IRQ associated with this UART */
-  uint8_t  parity;      /* 0=none, 1=odd, 2=even */
-  uint8_t  bits;        /* Number of bits (7 or 8) */
+  uint32_t uartbase;        /* Base address of UART registers */
+  uint32_t baud;            /* Configured baud */
+  uint32_t ie;              /* Saved enabled interrupts */
+  uint8_t  irq;             /* IRQ associated with this UART */
+  uint8_t  parity;          /* 0=none, 1=odd, 2=even */
+  uint8_t  bits;            /* Number of bits (7 or 8) */
 #if defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL)
-  uint8_t  inviflow:1;  /* Invert RTS sense */
+  uint8_t  inviflow:1;      /* Invert RTS sense */
   const uint32_t rts_gpio;  /* U[S]ART RTS GPIO pin configuration */
 #endif
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   const uint32_t cts_gpio;  /* U[S]ART CTS GPIO pin configuration */
 #endif
 
-  uint8_t  stopbits2:1; /* 1: Configure with 2 stop bits vs 1 */
+  uint8_t  stopbits2:1;     /* 1: Configure with 2 stop bits vs 1 */
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-  uint8_t  iflow:1;     /* input flow control (RTS) enabled */
+  uint8_t  iflow:1;         /* input flow control (RTS) enabled */
 #endif
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
-  uint8_t  oflow:1;     /* output flow control (CTS) enabled */
+  uint8_t  oflow:1;         /* output flow control (CTS) enabled */
 #endif
 #ifdef CONFIG_SERIAL_RS485CONTROL
-  uint8_t rs485mode:1;  /* We are in RS485 (RTS on TX) mode */
+  uint8_t rs485mode:1;      /* We are in RS485 (RTS on TX) mode */
 #endif
 };
 
@@ -855,8 +855,8 @@ static inline uint32_t imxrt_serialin(struct imxrt_uart_s *priv,
  * Name: imxrt_serialout
  ****************************************************************************/
 
-static inline void imxrt_serialout(struct imxrt_uart_s *priv, uint32_t offset,
-                                   uint32_t value)
+static inline void imxrt_serialout(struct imxrt_uart_s *priv,
+                                   uint32_t offset, uint32_t value)
 {
   putreg32(value, priv->uartbase + offset);
 }
@@ -949,11 +949,13 @@ static int imxrt_setup(struct uart_dev_s *dev)
 
   ret = imxrt_lpuart_configure(priv->uartbase, &config);
 
-  priv->ie = imxrt_serialin(priv, IMXRT_LPUART_CTRL_OFFSET) & LPUART_ALL_INTS;
+  priv->ie = imxrt_serialin(priv, IMXRT_LPUART_CTRL_OFFSET) & \
+             LPUART_ALL_INTS;
   return ret;
 
 #else
-  priv->ie = imxrt_serialin(priv, IMXRT_LPUART_CTRL_OFFSET) & LPUART_ALL_INTS;
+  priv->ie = imxrt_serialin(priv, IMXRT_LPUART_CTRL_OFFSET) & \
+             LPUART_ALL_INTS;
   return OK;
 #endif
 }
@@ -1327,7 +1329,9 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
         stat   = imxrt_serialin(priv, IMXRT_LPUART_STAT_OFFSET);
         regval = ctrl;
 
-        /* {R|T}XINV bit field can only be written when the receiver is disabled (RE=0). */
+        /* {R|T}XINV bit field can only be written when the receiver
+         * is disabled (RE=0).
+         */
 
         regval &= ~LPUART_CTRL_RE;
 

--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -1155,10 +1155,6 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Return baud */
-
-        cfsetispeed(termiosp, priv->baud);
-
         /* Return parity */
 
         termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
@@ -1176,6 +1172,10 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
         termiosp->c_cflag |= ((priv->iflow) ? CRTS_IFLOW : 0);
 #endif
+        /* Return baud */
+
+        cfsetispeed(termiosp, priv->baud);
+
         /* Return number of bits */
 
         switch (priv->bits)

--- a/arch/arm/src/kinetis/kinetis_serial.c
+++ b/arch/arm/src/kinetis/kinetis_serial.c
@@ -76,7 +76,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Some sanity checks *******************************************************/
+/* Some sanity checks */
+
 /* Is there at least one UART enabled and configured as a RS-232 device? */
 
 #ifndef HAVE_UART_DEVICE
@@ -502,27 +503,26 @@ static struct up_dev_s g_uart0priv =
   .rxdma_reqsrc   = KINETIS_DMA_REQUEST_SRC_UART0_RX,
   .rxfifo         = g_uart0rxfifo,
 #endif
-
 };
 
 static uart_dev_t g_uart0port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART0_RXBUFSIZE,
-    .buffer = g_uart0rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART0_TXBUFSIZE,
-    .buffer = g_uart0txbuffer,
-   },
+  .recv       =
+    {
+      .size   = CONFIG_UART0_RXBUFSIZE,
+      .buffer = g_uart0rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART0_TXBUFSIZE,
+      .buffer = g_uart0txbuffer,
+    },
 #ifdef CONFIG_KINETIS_UART0_RXDMA
-  .ops      = &g_uart_dma_ops,
+  .ops        = &g_uart_dma_ops,
 #else
-  .ops      = &g_uart_ops,
+  .ops        = &g_uart_ops,
 #endif
-  .priv     = &g_uart0priv,
+  .priv       = &g_uart0priv,
 };
 #endif
 
@@ -557,22 +557,22 @@ static struct up_dev_s g_uart1priv =
 
 static uart_dev_t g_uart1port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART1_RXBUFSIZE,
-    .buffer = g_uart1rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART1_TXBUFSIZE,
-    .buffer = g_uart1txbuffer,
-   },
+  .recv       =
+    {
+      .size   = CONFIG_UART1_RXBUFSIZE,
+      .buffer = g_uart1rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART1_TXBUFSIZE,
+      .buffer = g_uart1txbuffer,
+    },
 #ifdef CONFIG_KINETIS_UART1_RXDMA
-  .ops      = &g_uart_dma_ops,
+  .ops        = &g_uart_dma_ops,
 #else
-  .ops      = &g_uart_ops,
+  .ops        = &g_uart_ops,
 #endif
-  .priv     = &g_uart1priv,
+  .priv       = &g_uart1priv,
 };
 #endif
 
@@ -607,22 +607,22 @@ static struct up_dev_s g_uart2priv =
 
 static uart_dev_t g_uart2port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART2_RXBUFSIZE,
-    .buffer = g_uart2rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART2_TXBUFSIZE,
-    .buffer = g_uart2txbuffer,
-   },
+  .recv       =
+    {
+      .size   = CONFIG_UART2_RXBUFSIZE,
+      .buffer = g_uart2rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART2_TXBUFSIZE,
+      .buffer = g_uart2txbuffer,
+    },
 #ifdef CONFIG_KINETIS_UART2_RXDMA
-  .ops      = &g_uart_dma_ops,
+  .ops        = &g_uart_dma_ops,
 #else
-  .ops      = &g_uart_ops,
+  .ops        = &g_uart_ops,
 #endif
-  .priv     = &g_uart2priv,
+  .priv       = &g_uart2priv,
 };
 #endif
 
@@ -657,22 +657,22 @@ static struct up_dev_s g_uart3priv =
 
 static uart_dev_t g_uart3port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART3_RXBUFSIZE,
-    .buffer = g_uart3rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART3_TXBUFSIZE,
-    .buffer = g_uart3txbuffer,
-   },
+  .recv       =
+    {
+      .size   = CONFIG_UART3_RXBUFSIZE,
+      .buffer = g_uart3rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART3_TXBUFSIZE,
+      .buffer = g_uart3txbuffer,
+    },
 #ifdef CONFIG_KINETIS_UART3_RXDMA
-  .ops      = &g_uart_dma_ops,
+  .ops        = &g_uart_dma_ops,
 #else
-  .ops      = &g_uart_ops,
+  .ops        = &g_uart_ops,
 #endif
-  .priv     = &g_uart3priv,
+  .priv       = &g_uart3priv,
 };
 #endif
 
@@ -707,22 +707,22 @@ static struct up_dev_s g_uart4priv =
 
 static uart_dev_t g_uart4port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART4_RXBUFSIZE,
-    .buffer = g_uart4rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART4_TXBUFSIZE,
-    .buffer = g_uart4txbuffer,
-   },
+  .recv       =
+    {
+      .size   = CONFIG_UART4_RXBUFSIZE,
+      .buffer = g_uart4rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART4_TXBUFSIZE,
+      .buffer = g_uart4txbuffer,
+    },
 #ifdef CONFIG_KINETIS_UART4_RXDMA
-  .ops      = &g_uart_dma_ops,
+  .ops        = &g_uart_dma_ops,
 #else
-  .ops      = &g_uart_ops,
+  .ops        = &g_uart_ops,
 #endif
-  .priv     = &g_uart4priv,
+  .priv       = &g_uart4priv,
 };
 #endif
 
@@ -757,22 +757,22 @@ static struct up_dev_s g_uart5priv =
 
 static uart_dev_t g_uart5port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART5_RXBUFSIZE,
-    .buffer = g_uart5rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART5_TXBUFSIZE,
-    .buffer = g_uart5txbuffer,
-   },
+  .recv       =
+    {
+      .size   = CONFIG_UART5_RXBUFSIZE,
+      .buffer = g_uart5rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART5_TXBUFSIZE,
+      .buffer = g_uart5txbuffer,
+    },
 #ifdef CONFIG_KINETIS_UART5_RXDMA
-  .ops      = &g_uart_dma_ops,
+  .ops        = &g_uart_dma_ops,
 #else
-  .ops      = &g_uart_ops,
+  .ops        = &g_uart_ops,
 #endif
-  .priv     = &g_uart5priv,
+  .priv       = &g_uart5priv,
 };
 #endif
 
@@ -793,7 +793,8 @@ static inline uint8_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint8_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint8_t value)
 {
   putreg8(value, priv->uartbase + offset);
 }
@@ -807,7 +808,9 @@ static void up_setuartint(struct up_dev_s *priv)
   irqstate_t flags;
   uint8_t regval;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in ie */
+  /* Re-enable/re-disable interrupts corresponding to the state of bits in
+   * ie
+   */
 
   flags    = enter_critical_section();
   regval   = up_serialin(priv, KINETIS_UART_C2_OFFSET);
@@ -825,7 +828,9 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t ie)
 {
   irqstate_t flags;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in ie */
+  /* Re-enable/re-disable interrupts corresponding to the state of bits in
+   * ie
+   */
 
   flags    = enter_critical_section();
   priv->ie = ie & UART_C2_ALLINTS;
@@ -952,23 +957,25 @@ static int up_dma_setup(struct uart_dev_s *dev)
         }
     }
 
-  /* Acquire the DMA channel.*/
+  /* Acquire the DMA channel. */
 
   rxdma = kinetis_dmachannel(priv->rxdma_reqsrc,
                              priv->uartbase + KINETIS_UART_D_OFFSET,
                              KINETIS_DMA_DATA_SZ_8BIT,
                              KINETIS_DMA_DIRECTION_PERIPHERAL_TO_MEMORY);
   if (rxdma == NULL)
-  {
-    return -EBUSY;
-  }
+    {
+      return -EBUSY;
+    }
 
   /* Configure for circular DMA reception into the RX FIFO */
 
   kinetis_dmasetup(rxdma, (uint32_t)priv->rxfifo, RXDMA_BUFFER_SIZE,
                    SERIAL_DMA_CONTROL_WORD);
 
-  /* Reset our DMA shadow pointer to match the address just programmed above. */
+  /* Reset our DMA shadow pointer to match the address just programmed
+   * above.
+   */
 
   priv->rxdmanext = 0;
 
@@ -1045,14 +1052,15 @@ static void up_dma_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
- *   the setup() method is called, however, the serial console may operate in
- *   a non-interrupt driven mode during the boot phase.
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
+ *   the the setup() method is called, however, the serial console may
+ *   operate in a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -1089,8 +1097,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -1305,7 +1313,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
       {
         if ((arg & SER_SINGLEWIRE_PULLUP) != 0)
           {
-            ret = -EINVAL; // Not supported
+            ret = -EINVAL; /* Not supported */
             break;
           }
 
@@ -1341,9 +1349,9 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Note: CSIZE only supports 5-8 bits. The driver only support 8/9 bit
-         * modes and therefore is no way to report 9-bit mode, we always claim
-         * 8 bit mode.
+        /* Note: CSIZE only supports 5-8 bits. The driver only support
+         * 8/9 bit modes and therefore is no way to report 9-bit mode, we
+         * always claim 8 bit mode.
          */
 
         termiosp->c_cflag =
@@ -1666,8 +1674,8 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
   flags = enter_critical_section();
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when their is anything in the Rx data register
+       * (or an RX timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1935,7 +1943,8 @@ static bool up_txempty(struct uart_dev_s *dev)
 
   /* Return true if the transmit buffer/fifo is "empty." */
 
-  return (up_serialin(priv, KINETIS_UART_SFIFO_OFFSET) & UART_SFIFO_TXEMPT) != 0;
+  return (up_serialin(priv, KINETIS_UART_SFIFO_OFFSET) & \
+          UART_SFIFO_TXEMPT) != 0;
 }
 #endif
 
@@ -2042,26 +2051,26 @@ unsigned int kinetis_uart_serialinit(unsigned int first)
 
   /* Register all UARTs */
 
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0]))-2] = '0' + first++;
   uart_register(devname, &TTYS0_DEV);
 #ifdef TTYS1_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0]))-2] = '0' + first++;
   uart_register(devname, &TTYS1_DEV);
 #endif
 #ifdef TTYS2_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0]))-2] = '0' + first++;
   uart_register(devname, &TTYS2_DEV);
 #endif
 #ifdef TTYS3_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0]))-2] = '0' + first++;
   uart_register(devname, &TTYS3_DEV);
 #endif
 #ifdef TTYS4_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0]))-2] = '0' + first++;
   uart_register(devname, &TTYS4_DEV);
 #endif
 #ifdef TTYS5_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0]))-2] = '0' + first++;
   uart_register(devname, &TTYS5_DEV);
 #endif
   return first;

--- a/arch/arm/src/kinetis/kinetis_serial.c
+++ b/arch/arm/src/kinetis/kinetis_serial.c
@@ -1341,8 +1341,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        cfsetispeed(termiosp, priv->baud);
-
         /* Note: CSIZE only supports 5-8 bits. The driver only support 8/9 bit
          * modes and therefore is no way to report 9-bit mode, we always claim
          * 8 bit mode.
@@ -1359,6 +1357,8 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           ((priv->iflow) ? CRTS_IFLOW : 0) |
 #  endif
           CS8;
+
+        cfsetispeed(termiosp, priv->baud);
 
         /* TODO: CCTS_IFLOW, CCTS_OFLOW */
       }

--- a/arch/arm/src/lc823450/lc823450_serial.c
+++ b/arch/arm/src/lc823450/lc823450_serial.c
@@ -757,8 +757,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
-          cfsetispeed(termiosp, priv->baud);
-
           /* Note that since we only support 8/9 bit modes and
            * there is no way to report 9-bit mode, we always claim 8.
            */
@@ -773,6 +771,8 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
                               ((priv->iflow) ? CRTS_IFLOW : 0) |
 #endif
                               CS8;
+
+          cfsetispeed(termiosp, priv->baud);
         }
         break;
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_serial.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_serial.c
@@ -479,9 +479,10 @@ static uart_dev_t g_uart3port =
 #  endif
 #endif /* HAVE_CONSOLE */
 
-/************************************************************************************
+/****************************************************************************
+
  * Inline Functions
- ************************************************************************************/
+ ****************************************************************************/
 
 /****************************************************************************
  * Name: up_serialin
@@ -496,7 +497,8 @@ static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint32_t value)
 {
   putreg32(value, priv->uartbase + offset);
 }
@@ -671,7 +673,8 @@ void up_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
 
   /* Then save the fractional divider values */
 
-  putreg32((mul << UART_FDR_MULVAL_SHIFT) | (divadd << UART_FDR_DIVADDVAL_SHIFT),
+  putreg32((mul << UART_FDR_MULVAL_SHIFT) | \
+           (divadd << UART_FDR_DIVADDVAL_SHIFT),
            uartbase + LPC17_40_UART_FDR_OFFSET);
 }
 #  ifdef LPC176x
@@ -685,13 +688,14 @@ static inline uint32_t lpc17_40_uartcclkdiv(uint32_t baud)
 }
 #  endif
 #else
-/************************************************************************************
+
+/****************************************************************************
  * Name: lpc17_40_uartcclkdiv
  *
  * Description:
- *   Select a CCLK divider to produce the UART PCLK.  The strategy is to select the
- *   smallest divisor that results in an solution within range of the 16-bit
- *   DLM and DLL divisor:
+ *   Select a CCLK divider to produce the UART PCLK.  The strategy is to
+ *   select the smallest divisor that results in an solution within range of
+ *   the 16-bit DLM and DLL divisor:
  *
  *     PCLK = CCLK / divisor
  *     BAUD = PCLK / (16 * DL)
@@ -702,14 +706,15 @@ static inline uint32_t lpc17_40_uartcclkdiv(uint32_t baud)
  *
  *     PCLK = CCLK / divisor
  *
- *   For the LPC178x/40xx, the PCLK is determined by the global divisor setting in
- *   the PLKSEL register (and, in that case, this function is not needed).
+ *   For the LPC178x/40xx, the PCLK is determined by the global divisor
+ *   setting in the PLKSEL register (and, in that case, this function is not
+ *   needed).
  *
- *   NOTE:  This is an inline function.  If a typical optimization level is used and
- *   a constant is provided for the desired frequency, then most of the following
- *   logic will be optimized away.
+ *   NOTE:  This is an inline function.  If a typical optimization level is
+ *   used and a constant is provided for the desired frequency, then most of
+ *   the following logic will be optimized away.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #  ifdef LPC176x
 static inline uint32_t lpc17_40_uartcclkdiv(uint32_t baud)
@@ -719,13 +724,14 @@ static inline uint32_t lpc17_40_uartcclkdiv(uint32_t baud)
    *   BAUD = PCLK / (16 * DL), or
    *   DL   = PCLK / BAUD / 16
    *
-   * Where for the LPC176x the PCLK is determined by the UART-specific divisor in
-   * PCLKSEL0 or PCLKSEL1:
+   * Where for the LPC176x the PCLK is determined by the UART-specific
+   * divisor in PCLKSEL0 or PCLKSEL1:
    *
    *   PCLK = CCLK / divisor
    *
-   * And for the LPC178x/40xx, the PCLK is determined by the global divisor setting in
-   * the PLKSEL register (and, in that case, this function is not needed).
+   * And for the LPC178x/40xx, the PCLK is determined by the global divisor
+   * setting in the PLKSEL register (and, in that case, this function is not
+   * needed).
    */
 
   /* Calculate and optimal PCLKSEL0/1 divisor.
@@ -799,23 +805,25 @@ static inline uint32_t lpc17_40_uartcclkdiv(uint32_t baud)
 }
 #  endif /* LPC176x */
 #endif /* CONFIG_LPC17_40_UART_USE_FRACTIONAL_DIVIDER */
-/************************************************************************************
+
+/****************************************************************************
  * Name: lpc17_40_uart0config, uart1config, uart2config, and uart3config
  *
  * Description:
- *   Configure the UART.  UART0/1/2/3 peripherals are configured using the following
- *   registers:
+ *   Configure the UART.  UART0/1/2/3 peripherals are configured using the
+ *   following registers:
  *
  *   1. Power: In the PCONP register, set bits PCUART0/1/2/3.
  *      On reset, UART0 and UART 1 are enabled (PCUART0 = 1 and PCUART1 = 1)
  *      and UART2/3 are disabled (PCUART1 = 0 and PCUART3 = 0).
  *   2. Peripheral clock: In the PCLKSEL0 register, select PCLK_UART0 and
- *      PCLK_UART1; in the PCLKSEL1 register, select PCLK_UART2 and PCLK_UART3.
+ *      PCLK_UART1; in the PCLKSEL1 register, select PCLK_UART2 and
+ *      PCLK_UART3.
  *   3. Pins: Select UART pins through the PINSEL registers and pin modes
  *      through the PINMODE registers. UART receive pins should not have
  *      pull-down resistors enabled.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_LPC17_40_UART0
 static inline void lpc17_40_uart0config(void)
@@ -966,7 +974,7 @@ static inline void lpc17_40_uart3config(void)
 };
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Name: lpc17_40_uartdl
  *
  * Description:
@@ -975,7 +983,7 @@ static inline void lpc17_40_uart3config(void)
  *     BAUD = PCLK / (16 * DL), or
  *     DL   = PCLK / BAUD / 16
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef CONFIG_LPC17_40_UART_USE_FRACTIONAL_DIVIDER
 #  ifdef LPC176x
@@ -1082,7 +1090,8 @@ static int up_setup(struct uart_dev_s *dev)
    */
 
   up_serialout(priv, LPC17_40_UART_FDR_OFFSET,
-              (1 << UART_FDR_MULVAL_SHIFT) + (0 << UART_FDR_DIVADDVAL_SHIFT));
+               (1 << UART_FDR_MULVAL_SHIFT) + \
+               (0 << UART_FDR_DIVADDVAL_SHIFT));
 #endif
 
   /* Enter DLAB=1 */
@@ -1119,7 +1128,8 @@ static int up_setup(struct uart_dev_s *dev)
   if (priv->uartbase == LPC17_40_UART1_BASE)
     {
 #if defined(CONFIG_UART1_IFLOWCONTROL) && defined(CONFIG_UART1_OFLOWCONTROL)
-      up_serialout(priv, LPC17_40_UART_MCR_OFFSET, (UART_MCR_RTSEN | UART_MCR_CTSEN));
+      up_serialout(priv, LPC17_40_UART_MCR_OFFSET,
+                   (UART_MCR_RTSEN | UART_MCR_CTSEN));
 #elif defined(CONFIG_UART1_IFLOWCONTROL)
       up_serialout(priv, LPC17_40_UART_MCR_OFFSET, UART_MCR_RTSEN);
 #else
@@ -1150,14 +1160,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -1186,8 +1197,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -1398,14 +1409,16 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
          */
 
 #  ifdef CONFIG_LPC17_40_UART_USE_FRACTIONAL_DIVIDER
-        up_setbaud(priv->uartbase, LPC17_40_CCLK / priv->cclkdiv, priv->baud);
+        up_setbaud(priv->uartbase, LPC17_40_CCLK / \
+                   priv->cclkdiv, priv->baud);
 #  else
 #    if 0 /* ifdef LPC176x */
         priv->cclkdiv = lpc17_40_uartcclkdiv(priv->baud);
 #    endif
-        /* DLAB open latch */
-
-        /* REVISIT:  Shouldn't we just call up_setup() to do all of the following? */
+        /* DLAB open latch
+         * REVISIT: Shouldn't we just call up_setup() to do all of the
+         *          following?
+         */
 
         lcr = getreg32(priv->uartbase + LPC17_40_UART_LCR_OFFSET);
         up_serialout(priv, LPC17_40_UART_LCR_OFFSET, (lcr | UART_LCR_DLAB));
@@ -1556,7 +1569,8 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
 static bool up_txready(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  return ((up_serialin(priv, LPC17_40_UART_LSR_OFFSET) & UART_LSR_THRE) != 0);
+  return ((up_serialin(priv, LPC17_40_UART_LSR_OFFSET) & \
+          UART_LSR_THRE) != 0);
 }
 
 /****************************************************************************
@@ -1570,7 +1584,8 @@ static bool up_txready(struct uart_dev_s *dev)
 static bool up_txempty(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  return ((up_serialin(priv, LPC17_40_UART_LSR_OFFSET) & UART_LSR_THRE) != 0);
+  return ((up_serialin(priv, LPC17_40_UART_LSR_OFFSET) & \
+          UART_LSR_THRE) != 0);
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_serial.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_serial.c
@@ -1391,8 +1391,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
          * that only one speed is supported.
          */
 
-        /* Get the c_speed field in the termios struct */
-
         priv->baud = cfgetispeed(termiosp);
 
         /* TODO: Re-calculate the optimal CCLK divisor for the new baud and

--- a/arch/arm/src/nrf52/nrf52_serial.c
+++ b/arch/arm/src/nrf52/nrf52_serial.c
@@ -475,12 +475,6 @@ static int nrf52_ioctl(struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
-          /* Get baud */
-
-          cfsetispeed(termiosp, config->baud);
-
-          /* Get flags */
-
           termiosp->c_cflag = ((config->parity != 0) ? PARENB : 0)
                               | ((config->parity == 1) ? PARODD : 0)
                               | ((config->stopbits2) ? CSTOPB : 0) |
@@ -491,6 +485,8 @@ static int nrf52_ioctl(struct file *filep, int cmd, unsigned long arg)
                               ((config->iflow) ? CRTS_IFLOW : 0) |
 #endif
                               CS8;
+
+          cfsetispeed(termiosp, config->baud);
 
           break;
         }

--- a/arch/arm/src/nuc1xx/nuc_serial.c
+++ b/arch/arm/src/nuc1xx/nuc_serial.c
@@ -160,7 +160,7 @@ static struct nuc_dev_s g_uart0priv =
   .irq            = NUC_IRQ_UART0,
   .parity         = CONFIG_UART0_PARITY,
   .bits           = CONFIG_UART0_BITS,
-  .depth          = (UART0_FIFO_DEPTH-1),
+  .depth          = (UART0_FIFO_DEPTH - 1),
   .stopbits2      = CONFIG_UART0_2STOP,
 };
 
@@ -191,24 +191,24 @@ static struct nuc_dev_s g_uart1priv =
   .irq            = NUC_IRQ_UART1,
   .parity         = CONFIG_UART1_PARITY,
   .bits           = CONFIG_UART1_BITS,
-  .depth          = (UART1_FIFO_DEPTH-1),
+  .depth          = (UART1_FIFO_DEPTH - 1),
   .stopbits2      = CONFIG_UART1_2STOP,
 };
 
 static uart_dev_t g_uart1port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART1_RXBUFSIZE,
-    .buffer = g_uart1rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART1_TXBUFSIZE,
-    .buffer = g_uart1txbuffer,
-  },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart1priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART1_RXBUFSIZE,
+      .buffer = g_uart1rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART1_TXBUFSIZE,
+      .buffer = g_uart1txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart1priv,
 };
 #endif /* CONFIG_NUC_UART1 */
 
@@ -222,24 +222,24 @@ static struct nuc_dev_s g_uart2priv =
   .irq            = NUC_IRQ_UART2,
   .parity         = CONFIG_UART2_PARITY,
   .bits           = CONFIG_UART2_BITS,
-  .depth          = (UART2_FIFO_DEPTH-1),
+  .depth          = (UART2_FIFO_DEPTH - 1),
   .stopbits2      = CONFIG_UART2_2STOP,
 };
 
 static uart_dev_t g_uart2port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART2_RXBUFSIZE,
-    .buffer = g_uart2rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART2_TXBUFSIZE,
-    .buffer = g_uart2txbuffer,
-  },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart2priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART2_RXBUFSIZE,
+      .buffer = g_uart2rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART2_TXBUFSIZE,
+      .buffer = g_uart2txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart2priv,
 };
 #endif /* CONFIG_NUC_UART2 */
 
@@ -276,7 +276,9 @@ static uart_dev_t g_uart2port =
 #  endif
 #endif
 
-/* Pick ttys1.  This could be any two of UART0-2 excluding the console UART. */
+/* Pick ttys1.  This could be any two of UART0-2 excluding the console
+ * UART.
+ */
 
 #if defined(CONFIG_NUC_UART0) && !defined(UART0_ASSIGNED)
 #  define TTYS1_DEV           g_uart0port /* UART0 is ttyS1 */
@@ -319,7 +321,8 @@ static inline uint32_t up_serialin(struct nuc_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct nuc_dev_s *priv, int offset, uint32_t value)
+static inline void up_serialout(struct nuc_dev_s *priv, int offset,
+                                uint32_t value)
 {
   putreg32(value, priv->uartbase + offset);
 }
@@ -525,6 +528,7 @@ static int up_setup(struct uart_dev_s *dev)
   priv->ier = up_serialin(priv, NUC_UART_IER_OFFSET);
 
   /* Enable Flow Control in the Modem Control Register */
+
   /* Not implemented */
 
 #endif /* CONFIG_SUPPRESS_UART_CONFIG */
@@ -549,14 +553,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
- *   the setup() method is called, however, the serial console may operate in
- *   a non-interrupt driven mode during the boot phase.
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
+ *   the setup() method is called, however, the serial console may operate
+ *   in a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -585,8 +590,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -632,11 +637,12 @@ static int up_interrupt(int irq, void *context,  void *arg)
 
        isr = up_serialin(priv, NUC_UART_ISR_OFFSET);
 
-      /* Check if the RX FIFO is empty.  Check if an RX timeout occur.  These affect
-       * some later decisions.
+      /* Check if the RX FIFO is empty.  Check if an RX timeout occur.
+       * These affect some later decisions.
        */
 
-      rxfe = ((up_serialin(priv, NUC_UART_FSR_OFFSET) & UART_FSR_RX_EMPTY) != 0);
+      rxfe = ((up_serialin(priv, NUC_UART_FSR_OFFSET) & \
+              UART_FSR_RX_EMPTY) != 0);
       rxto = ((isr & UART_ISR_TOUT_INT) != 0);
 
       /* Check if the RX FIFO is filled to the threshold value OR if the RX
@@ -676,7 +682,8 @@ static int up_interrupt(int irq, void *context,  void *arg)
        * data in the RX FIFO when we entered the interrupt handler?
        */
 
-      else if ((priv->ier & (UART_IER_RTO_IEN | UART_IER_RDA_IEN)) == UART_IER_RDA_IEN && !rxfe)
+      else if ((priv->ier & (UART_IER_RTO_IEN | UART_IER_RDA_IEN)) == \
+               UART_IER_RDA_IEN && !rxfe)
         {
           /* We are receiving data and the RX timeout is not enabled.
            * Set the RX FIFO threshold so that RX interrupts will only be
@@ -700,7 +707,9 @@ static int up_interrupt(int irq, void *context,  void *arg)
 
       if ((isr & UART_ISR_MODEM_INT) != 0)
         {
-          /* Cleared by setting the DCTSF bit in the modem control register (MCR) */
+          /* Cleared by setting the DCTSF bit in the modem control register
+           * (MCR)
+           */
 
          regval = up_serialin(priv, NUC_UART_MCR_OFFSET);
          up_serialout(priv, NUC_UART_MCR_OFFSET, regval | UART_MSR_DCTSF);

--- a/arch/arm/src/nuc1xx/nuc_serial.c
+++ b/arch/arm/src/nuc1xx/nuc_serial.c
@@ -797,8 +797,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
          * that only one speed is supported.
          */
 
-        /* Get the c_speed field in the termios struct */
-
         priv->baud = cfgetispeed(termiosp);
 
         /* Reset the baud */

--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -727,10 +727,6 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Return baud */
-
-        cfsetispeed(termiosp, priv->baud);
-
         /* Return parity */
 
         termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
@@ -748,6 +744,10 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
         termiosp->c_cflag |= ((priv->iflow) ? CRTS_IFLOW : 0);
 #endif
+        /* Return baud */
+
+        cfsetispeed(termiosp, priv->baud);
+
         /* Return number of bits */
 
         switch (priv->bits)

--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -154,29 +154,29 @@
 
 struct s32k1xx_uart_s
 {
-  uint32_t uartbase;    /* Base address of UART registers */
-  uint32_t baud;        /* Configured baud */
-  uint32_t ie;          /* Saved enabled interrupts */
-  uint8_t  irq;         /* IRQ associated with this UART */
-  uint8_t  parity;      /* 0=none, 1=odd, 2=even */
-  uint8_t  bits;        /* Number of bits (7 or 8) */
+  uint32_t uartbase;        /* Base address of UART registers */
+  uint32_t baud;            /* Configured baud */
+  uint32_t ie;              /* Saved enabled interrupts */
+  uint8_t  irq;             /* IRQ associated with this UART */
+  uint8_t  parity;          /* 0=none, 1=odd, 2=even */
+  uint8_t  bits;            /* Number of bits (7 or 8) */
 #if defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL)
-  uint8_t  inviflow:1;  /* Invert RTS sense */
+  uint8_t  inviflow:1;      /* Invert RTS sense */
   const uint32_t rts_gpio;  /* U[S]ART RTS GPIO pin configuration */
 #endif
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   const uint32_t cts_gpio;  /* U[S]ART CTS GPIO pin configuration */
 #endif
 
-  uint8_t  stopbits2:1; /* 1: Configure with 2 stop bits vs 1 */
+  uint8_t  stopbits2:1;     /* 1: Configure with 2 stop bits vs 1 */
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-  uint8_t  iflow:1;     /* input flow control (RTS) enabled */
+  uint8_t  iflow:1;         /* input flow control (RTS) enabled */
 #endif
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
-  uint8_t  oflow:1;     /* output flow control (CTS) enabled */
+  uint8_t  oflow:1;         /* output flow control (CTS) enabled */
 #endif
 #ifdef CONFIG_SERIAL_RS485CONTROL
-  uint8_t rs485mode:1;  /* We are in RS485 (RTS on TX) mode */
+  uint8_t rs485mode:1;      /* We are in RS485 (RTS on TX) mode */
 #endif
 };
 
@@ -340,18 +340,18 @@ static struct s32k1xx_uart_s g_uart1priv =
 
 static struct uart_dev_s g_uart1port =
 {
-  .recv         =
-  {
-    .size       = CONFIG_LPUART1_RXBUFSIZE,
-    .buffer     = g_uart1rxbuffer,
-  },
-  .xmit         =
-  {
-    .size       = CONFIG_LPUART1_TXBUFSIZE,
-    .buffer     = g_uart1txbuffer,
-   },
-  .ops          = &g_uart_ops,
-  .priv         = &g_uart1priv,
+  .recv           =
+    {
+      .size       = CONFIG_LPUART1_RXBUFSIZE,
+      .buffer     = g_uart1rxbuffer,
+    },
+  .xmit           =
+    {
+      .size       = CONFIG_LPUART1_TXBUFSIZE,
+      .buffer     = g_uart1txbuffer,
+    },
+  .ops            = &g_uart_ops,
+  .priv           = &g_uart1priv,
 };
 #endif
 
@@ -387,18 +387,18 @@ static struct s32k1xx_uart_s g_uart2priv =
 
 static struct uart_dev_s g_uart2port =
 {
-  .recv         =
-  {
-    .size       = CONFIG_LPUART2_RXBUFSIZE,
-    .buffer     = g_uart2rxbuffer,
-  },
-  .xmit         =
-  {
-    .size       = CONFIG_LPUART2_TXBUFSIZE,
-    .buffer     = g_uart2txbuffer,
-  },
-  .ops          = &g_uart_ops,
-  .priv         = &g_uart2priv,
+  .recv           =
+    {
+      .size       = CONFIG_LPUART2_RXBUFSIZE,
+      .buffer     = g_uart2rxbuffer,
+    },
+  .xmit           =
+    {
+      .size       = CONFIG_LPUART2_TXBUFSIZE,
+      .buffer     = g_uart2txbuffer,
+    },
+  .ops            = &g_uart_ops,
+  .priv           = &g_uart2priv,
 };
 #endif
 
@@ -428,8 +428,8 @@ static inline uint32_t s32k1xx_serialin(struct s32k1xx_uart_s *priv,
  * Name: s32k1xx_serialout
  ****************************************************************************/
 
-static inline void s32k1xx_serialout(struct s32k1xx_uart_s *priv, uint32_t offset,
-                                   uint32_t value)
+static inline void s32k1xx_serialout(struct s32k1xx_uart_s *priv,
+                                     uint32_t offset, uint32_t value)
 {
   putreg32(value, priv->uartbase + offset);
 }
@@ -439,7 +439,7 @@ static inline void s32k1xx_serialout(struct s32k1xx_uart_s *priv, uint32_t offse
  ****************************************************************************/
 
 static inline void s32k1xx_disableuartint(struct s32k1xx_uart_s *priv,
-                                        uint32_t *ie)
+                                          uint32_t *ie)
 {
   irqstate_t flags;
   uint32_t regval;
@@ -496,9 +496,10 @@ static int s32k1xx_setup(struct uart_dev_s *dev)
   struct s32k1xx_uart_s *priv = (struct s32k1xx_uart_s *)dev->priv;
 #ifndef CONFIG_SUPPRESS_LPUART_CONFIG
   struct uart_config_s config =
-  {
-    0
-  };
+    {
+      0
+    };
+
   int ret;
 
   /* Configure the UART */
@@ -522,11 +523,13 @@ static int s32k1xx_setup(struct uart_dev_s *dev)
 
   ret = s32k1xx_lpuart_configure(priv->uartbase, &config);
 
-  priv->ie = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET) & LPUART_ALL_INTS;
+  priv->ie = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET) & \
+             LPUART_ALL_INTS;
   return ret;
 
 #else
-  priv->ie = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET) & LPUART_ALL_INTS;
+  priv->ie = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET) & \
+             LPUART_ALL_INTS;
   return OK;
 #endif
 }
@@ -651,12 +654,14 @@ static int s32k1xx_interrupt(int irq, void *context, FAR void *arg)
 
       if ((usr & LPUART_STAT_OR) != 0)
         {
-          s32k1xx_serialout(priv, S32K1XX_LPUART_STAT_OFFSET, LPUART_STAT_OR);
+          s32k1xx_serialout(priv, S32K1XX_LPUART_STAT_OFFSET,
+                            LPUART_STAT_OR);
         }
 
       if ((usr & LPUART_STAT_FE) != 0)
         {
-          s32k1xx_serialout(priv, S32K1XX_LPUART_STAT_OFFSET, LPUART_STAT_FE);
+          s32k1xx_serialout(priv, S32K1XX_LPUART_STAT_OFFSET,
+                            LPUART_STAT_FE);
         }
 
       /* Handle incoming, receive bytes */
@@ -894,7 +899,9 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
         stat   = s32k1xx_serialin(priv, S32K1XX_LPUART_STAT_OFFSET);
         regval = ctrl;
 
-        /* {R|T}XINV bit field can only be written when the receiver is disabled (RE=0). */
+        /* {R|T}XINV bit field can only be written when the receiver is
+        * disabled (RE=0).
+        */
 
         regval &= ~LPUART_CTRL_RE;
 
@@ -1125,32 +1132,29 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
       case(PM_NORMAL):
         {
           /* Logic for PM_NORMAL goes here */
-
         }
         break;
 
       case(PM_IDLE):
         {
           /* Logic for PM_IDLE goes here */
-
         }
         break;
 
       case(PM_STANDBY):
         {
           /* Logic for PM_STANDBY goes here */
-
         }
         break;
 
       case(PM_SLEEP):
         {
           /* Logic for PM_SLEEP goes here */
-
         }
         break;
 
       default:
+
         /* Should not get here */
 
         break;

--- a/arch/arm/src/sam34/sam_serial.c
+++ b/arch/arm/src/sam34/sam_serial.c
@@ -1013,10 +1013,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Return baud */
-
-        cfsetispeed(termiosp, priv->baud);
-
         /* Return parity */
 
         termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
@@ -1031,6 +1027,10 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) || defined(CONFIG_SERIAL_OFLOWCONTROL)
         termiosp->c_cflag |= (priv->flowc) ? (CCTS_OFLOW | CRTS_IFLOW): 0;
 #endif
+        /* Return baud */
+
+        cfsetispeed(termiosp, priv->baud);
+
         /* Return number of bits */
 
         switch (priv->bits)

--- a/arch/arm/src/sam34/sam_serial.c
+++ b/arch/arm/src/sam34/sam_serial.c
@@ -109,7 +109,9 @@
 #  define HAVE_USART
 #endif
 
-/* Hardware flow control requires using the PDC or DMAC channel for reception */
+/* Hardware flow control requires using the PDC or DMAC channel for
+ * reception
+ */
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
 #  warning PDC or DMAC support is required for RTS hardware flow control
@@ -180,9 +182,13 @@
 
 #ifdef USE_SERIALDRIVER
 
-/* Which UART/USART with be tty0/console and which tty1? tty2? tty3? tty4? tty5? */
+/* Which UART/USART with be tty0/console and which tty1? tty2? tty3?
+ * tty4? tty5?
+ */
 
-/* First pick the console and ttys0.  This could be any of UART0-1, USART0-3 */
+/* First pick the console and ttys0.  This could be any of UART0-1,
+ * USART0-3
+ */
 
 #if defined(CONFIG_UART0_SERIAL_CONSOLE)
 #    define CONSOLE_DEV         g_uart0port  /* UART0 is console */
@@ -230,7 +236,9 @@
 #  endif
 #endif
 
-/* Pick ttys1.  This could be any of UART0-1, USART0-3 excluding the console UART. */
+/* Pick ttys1.  This could be any of UART0-1, USART0-3 excluding the
+ * console UART.
+ */
 
 #if defined(CONFIG_SAM34_UART0) && !defined(UART0_ASSIGNED)
 #  define TTYS1_DEV           g_uart0port  /* UART0 is ttyS1 */
@@ -573,18 +581,18 @@ static struct up_dev_s g_usart2priv =
 
 static uart_dev_t g_usart2port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_USART2_RXBUFSIZE,
-    .buffer = g_usart2rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_USART2_TXBUFSIZE,
-    .buffer = g_usart2txbuffer,
-   },
-  .ops      = &g_uart_ops,
-  .priv     = &g_usart2priv,
+  .recv       =
+    {
+      .size   = CONFIG_USART2_RXBUFSIZE,
+      .buffer = g_usart2rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_USART2_TXBUFSIZE,
+      .buffer = g_usart2txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_usart2priv,
 };
 #endif
 
@@ -606,18 +614,18 @@ static struct up_dev_s g_usart3priv =
 
 static uart_dev_t g_usart3port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_USART3_RXBUFSIZE,
-    .buffer = g_usart3rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_USART3_TXBUFSIZE,
-    .buffer = g_usart3txbuffer,
-   },
-  .ops      = &g_uart_ops,
-  .priv     = &g_usart3priv,
+  .recv       =
+    {
+      .size   = CONFIG_USART3_RXBUFSIZE,
+      .buffer = g_usart3rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_USART3_TXBUFSIZE,
+      .buffer = g_usart3txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_usart3priv,
 };
 #endif
 
@@ -638,7 +646,8 @@ static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint32_t value)
 {
   putreg32(value, priv->usartbase + offset);
 }
@@ -713,7 +722,8 @@ static int up_setup(struct uart_dev_s *dev)
   /* "Setting the USART to operate with hardware handshaking is performed by
    *  writing the USART_MODE field in the Mode Register (US_MR) to the value
    *  0x2. ... Using this mode requires using the PDC or DMAC channel for
-   *  reception. The transmitter can handle hardware handshaking in any case."
+   *  reception. The transmitter can handle hardware handshaking in any
+   *  case."
    */
 
   if (priv->flowc)
@@ -812,7 +822,7 @@ static int up_setup(struct uart_dev_s *dev)
    * for lower USART clocks.
    */
 
-  regval  = (SAM_USART_CLOCK + (priv->baud << 3))/(priv->baud << 4);
+  regval  = (SAM_USART_CLOCK + (priv->baud << 3)) / (priv->baud << 4);
   up_serialout(priv, SAM_UART_BRGR_OFFSET, regval);
 
   /* Enable receiver & transmitter */
@@ -853,14 +863,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the USART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the USART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -880,6 +891,7 @@ static int up_attach(struct uart_dev_s *dev)
 
       up_enable_irq(priv->irq);
     }
+
   return ret;
 }
 
@@ -888,8 +900,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach USART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -933,14 +945,16 @@ static int up_interrupt(int irq, void *context, void *arg)
     {
       handled = false;
 
-      /* Get the UART/USART status (we are only interested in the unmasked interrupts). */
+      /* Get the UART/USART status (we are only interested in the unmasked
+       * interrupts).
+       */
 
       priv->sr = up_serialin(priv, SAM_UART_SR_OFFSET);  /* Save for error reporting */
       imr      = up_serialin(priv, SAM_UART_IMR_OFFSET); /* Interrupt mask */
-      pending  = priv->sr & imr;                        /* Mask out disabled interrupt sources */
+      pending  = priv->sr & imr;                         /* Mask out disabled interrupt sources */
 
-      /* Handle an incoming, receive byte.  RXRDY: At least one complete character
-       * has been received and US_RHR has not yet been read.
+      /* Handle an incoming, receive byte.  RXRDY: At least one complete
+       * character has been received and US_RHR has not yet been read.
        */
 
       if ((pending & UART_INT_RXRDY) != 0)
@@ -1206,8 +1220,8 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
 
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when their is anything in the Rx data register
+       * (or an RX timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS

--- a/arch/arm/src/sama5/sam_flexcom_serial.c
+++ b/arch/arm/src/sama5/sam_flexcom_serial.c
@@ -486,7 +486,9 @@ static inline void flexus_serialout(struct flexus_dev_s *priv, int offset,
 static inline void flexus_restoreusartint(struct flexus_dev_s *priv,
                                           uint32_t imr)
 {
-  /* Restore the previous interrupt state (assuming all interrupts disabled) */
+  /* Restore the previous interrupt state (assuming all interrupts
+   * disabled)
+   */
 
   flexus_serialout(priv, SAM_FLEXUS_IER_OFFSET, imr);
 }
@@ -547,7 +549,9 @@ static int flexus_interrupt(int irq, void *context, FAR void *arg)
     {
       handled = false;
 
-      /* Get the UART/USART status (we are only interested in the unmasked interrupts). */
+      /* Get the UART/USART status (we are only interested in the unmasked
+       * interrupts).
+       */
 
       priv->sr = flexus_serialin(priv, SAM_FLEXUS_CSR_OFFSET); /* Save for error reporting */
       imr      = flexus_serialin(priv, SAM_FLEXUS_IMR_OFFSET); /* Interrupt mask */

--- a/arch/arm/src/sama5/sam_flexcom_serial.c
+++ b/arch/arm/src/sama5/sam_flexcom_serial.c
@@ -820,10 +820,6 @@ static int flexus_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Return baud */
-
-        cfsetispeed(termiosp, priv->baud);
-
         /* Return parity */
 
         termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
@@ -838,6 +834,10 @@ static int flexus_ioctl(struct file *filep, int cmd, unsigned long arg)
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) || defined(CONFIG_SERIAL_OFLOWCONTROL)
         termiosp->c_cflag |= (priv->flowc) ? (CCTS_OFLOW | CRTS_IFLOW): 0;
 #endif
+        /* Return baud */
+
+        cfsetispeed(termiosp, priv->baud);
+
         /* Return number of bits */
 
         switch (priv->bits)

--- a/arch/arm/src/sama5/sam_serial.c
+++ b/arch/arm/src/sama5/sam_serial.c
@@ -185,7 +185,9 @@
 #  endif
 #endif
 
-/* Pick ttyS1.  This could be any of UART0-4, USART0-4 excluding the console UART. */
+/* Pick ttyS1.  This could be any of UART0-4, USART0-4 excluding the
+ * console UART.
+ */
 
 #if defined(CONFIG_SAMA5_UART0) && !defined(UART0_ASSIGNED)
 #  define TTYS1_DEV           g_uart0port  /* UART0 is ttyS1 */
@@ -908,7 +910,9 @@ static inline void up_serialout(struct up_dev_s *priv, int offset,
 
 static inline void up_restoreusartint(struct up_dev_s *priv, uint32_t imr)
 {
-  /* Restore the previous interrupt state (assuming all interrupts disabled) */
+  /* Restore the previous interrupt state (assuming all interrupts
+   * disabled)
+   */
 
   up_serialout(priv, SAM_UART_IER_OFFSET, imr);
 }
@@ -969,7 +973,9 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
     {
       handled = false;
 
-      /* Get the UART/USART status (we are only interested in the unmasked interrupts). */
+      /* Get the UART/USART status (we are only interested in the unmasked
+       * interrupts).
+       */
 
       priv->sr = up_serialin(priv, SAM_UART_SR_OFFSET);  /* Save for error reporting */
       imr      = up_serialin(priv, SAM_UART_IMR_OFFSET); /* Interrupt mask */

--- a/arch/arm/src/sama5/sam_serial.c
+++ b/arch/arm/src/sama5/sam_serial.c
@@ -1270,10 +1270,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Return baud */
-
-        cfsetispeed(termiosp, priv->baud);
-
         /* Return parity */
 
         termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
@@ -1288,6 +1284,10 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) || defined(CONFIG_SERIAL_OFLOWCONTROL)
         termiosp->c_cflag |= (priv->flowc) ? (CCTS_OFLOW | CRTS_IFLOW): 0;
 #endif
+        /* Return baud */
+
+        cfsetispeed(termiosp, priv->baud);
+
         /* Return number of bits */
 
         switch (priv->bits)

--- a/arch/arm/src/samv7/sam_serial.c
+++ b/arch/arm/src/samv7/sam_serial.c
@@ -1081,10 +1081,6 @@ static int sam_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Return baud */
-
-        cfsetispeed(termiosp, priv->baud);
-
         /* Return parity */
 
         termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
@@ -1099,6 +1095,10 @@ static int sam_ioctl(struct file *filep, int cmd, unsigned long arg)
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) || defined(CONFIG_SERIAL_OFLOWCONTROL)
         termiosp->c_cflag |= (priv->flowc) ? (CCTS_OFLOW | CRTS_IFLOW): 0;
 #endif
+        /* Return baud */
+
+        cfsetispeed(termiosp, priv->baud);
+
         /* Return number of bits */
 
         switch (priv->bits)

--- a/arch/arm/src/samv7/sam_serial.c
+++ b/arch/arm/src/samv7/sam_serial.c
@@ -71,7 +71,9 @@
 
 /* Which UART/USART with be tty0/console and which tty1-7? */
 
-/* First pick the console and ttys0.  This could be any of UART0-4, USART0-2 */
+/* First pick the console and ttys0.  This could be any of UART0-4,
+ * USART0-2
+ */
 
 #if defined(CONFIG_UART0_SERIAL_CONSOLE)
 #    define CONSOLE_DEV         g_uart0port  /* UART0 is console */
@@ -653,18 +655,18 @@ static struct sam_dev_s g_usart2priv =
 
 static uart_dev_t g_usart2port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_USART2_RXBUFSIZE,
-    .buffer = g_usart2rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_USART2_TXBUFSIZE,
-    .buffer = g_usart2txbuffer,
-   },
-  .ops      = &g_uart_ops,
-  .priv     = &g_usart2priv,
+  .recv       =
+    {
+      .size   = CONFIG_USART2_RXBUFSIZE,
+      .buffer = g_usart2rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_USART2_TXBUFSIZE,
+      .buffer = g_usart2txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_usart2priv,
 };
 #endif
 
@@ -685,7 +687,8 @@ static inline uint32_t sam_serialin(struct sam_dev_s *priv, int offset)
  * Name: sam_serialout
  ****************************************************************************/
 
-static inline void sam_serialout(struct sam_dev_s *priv, int offset, uint32_t value)
+static inline void sam_serialout(struct sam_dev_s *priv, int offset,
+                                 uint32_t value)
 {
   putreg32(value, priv->usartbase + offset);
 }
@@ -696,7 +699,9 @@ static inline void sam_serialout(struct sam_dev_s *priv, int offset, uint32_t va
 
 static inline void sam_restoreusartint(struct sam_dev_s *priv, uint32_t imr)
 {
-  /* Restore the previous interrupt state (assuming all interrupts disabled) */
+  /* Restore the previous interrupt state (assuming all interrupts
+   * disabled)
+   */
 
   sam_serialout(priv, SAM_UART_IER_OFFSET, imr);
 }
@@ -759,7 +764,8 @@ static int sam_setup(struct uart_dev_s *dev)
   /* "Setting the USART to operate with hardware handshaking is performed by
    *  writing the USART_MODE field in the Mode Register (US_MR) to the value
    *  0x2. ... Using this mode requires using the PDC or DMAC channel for
-   *  reception. The transmitter can handle hardware handshaking in any case."
+   *  reception. The transmitter can handle hardware handshaking in any
+   *  case."
    */
 
   if (priv->flowc)
@@ -921,14 +927,15 @@ static void sam_shutdown(struct uart_dev_s *dev)
  * Name: sam_attach
  *
  * Description:
- *   Configure the USART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the USART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -957,8 +964,8 @@ static int sam_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach USART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -1001,14 +1008,16 @@ static int sam_interrupt(int irq, void *context, FAR void *arg)
     {
       handled = false;
 
-      /* Get the UART/USART status (we are only interested in the unmasked interrupts). */
+      /* Get the UART/USART status (we are only interested in the unmasked
+       * interrupts).
+       */
 
       priv->sr = sam_serialin(priv, SAM_UART_SR_OFFSET);
       imr      = sam_serialin(priv, SAM_UART_IMR_OFFSET);
       pending  = priv->sr & imr;
 
-      /* Handle an incoming, receive byte.  RXRDY: At least one complete character
-       * has been received and US_RHR has not yet been read.
+      /* Handle an incoming, receive byte.  RXRDY: At least one complete
+       * character has been received and US_RHR has not yet been read.
        */
 
       if ((pending & UART_INT_RXRDY) != 0)
@@ -1274,8 +1283,8 @@ static void sam_rxint(struct uart_dev_s *dev, bool enable)
 
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when their is anything in the Rx data register
+       * (or an RX timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS

--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -2019,8 +2019,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        cfsetispeed(termiosp, priv->baud);
-
         /* Note that since we only support 8/9 bit modes and
          * there is no way to report 9-bit mode, we always claim 8.
          */
@@ -2036,6 +2034,8 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           ((priv->iflow) ? CRTS_IFLOW : 0) |
 #endif
           CS8;
+
+        cfsetispeed(termiosp, priv->baud);
 
         /* TODO: CCTS_IFLOW, CCTS_OFLOW */
       }

--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -2568,8 +2568,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        cfsetispeed(termiosp, priv->baud);
-
         /* Note that since we only support 8/9 bit modes and
          * there is no way to report 9-bit mode, we always claim 8.
          */
@@ -2585,6 +2583,8 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           ((priv->iflow) ? CRTS_IFLOW : 0) |
 #endif
           CS8;
+
+        cfsetispeed(termiosp, priv->baud);
 
         /* TODO: CCTS_IFLOW, CCTS_OFLOW */
       }

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -1670,8 +1670,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        cfsetispeed(termiosp, priv->baud);
-
         /* Note that since we only support 8/9 bit modes and
          * there is no way to report 9-bit mode, we always claim 8.
          */
@@ -1687,6 +1685,8 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           ((priv->iflow) ? CRTS_IFLOW : 0) |
 #endif
           CS8;
+
+        cfsetispeed(termiosp, priv->baud);
 
         /* TODO: CCTS_IFLOW, CCTS_OFLOW */
       }

--- a/arch/arm/src/stm32l4/stm32l4_serial.c
+++ b/arch/arm/src/stm32l4/stm32l4_serial.c
@@ -2013,8 +2013,6 @@ static int stm32l4serial_ioctl(FAR struct file *filep, int cmd,
             break;
           }
 
-        cfsetispeed(termiosp, priv->baud);
-
         /* Note that since we only support 8/9 bit modes and
          * there is no way to report 9-bit mode, we always claim 8.
          */
@@ -2030,6 +2028,8 @@ static int stm32l4serial_ioctl(FAR struct file *filep, int cmd,
           ((priv->iflow) ? CRTS_IFLOW : 0) |
 #endif
           CS8;
+
+        cfsetispeed(termiosp, priv->baud);
 
         /* TODO: CCTS_IFLOW, CCTS_OFLOW */
       }

--- a/arch/arm/src/tiva/common/tiva_hciuart.c
+++ b/arch/arm/src/tiva/common/tiva_hciuart.c
@@ -1040,7 +1040,7 @@ static int hciuart_configure(const struct hciuart_config_s *config)
   config->state->im = hciuart_getreg32(config, TIVA_UART_IM_OFFSET);
 
   hciuart_putreg32(config, TIVA_UART_IFLS_OFFSET,
-                   UART_IFLS_TXIFLSEL_18th | UART_IFLS_RXIFLSEL_78th);
+                   UART_IFLS_TXIFLSEL_18TH | UART_IFLS_RXIFLSEL_78TH);
 
   hciuart_putreg32(config, TIVA_UART_IM_OFFSET, UART_IM_RXIM | UART_IM_RTIM);
 
@@ -1585,7 +1585,9 @@ static ssize_t hciuart_write(const struct btuart_lowerhalf_s *lower,
         }
     }
 
-  /* If the Tx buffer is not empty, then exit with the Tx interrupts enabled. */
+  /* If the Tx buffer is not empty, then exit with the Tx interrupts
+   * enabled.
+   */
 
   if (state->txhead != state->txtail)
     {

--- a/arch/arm/src/tiva/common/tiva_serial.c
+++ b/arch/arm/src/tiva/common/tiva_serial.c
@@ -435,18 +435,18 @@ static struct up_dev_s g_uart1priv =
 
 static uart_dev_t g_uart1port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART1_RXBUFSIZE,
-    .buffer = g_uart1rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART1_TXBUFSIZE,
-    .buffer = g_uart1txbuffer,
-   },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart1priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART1_RXBUFSIZE,
+      .buffer = g_uart1rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART1_TXBUFSIZE,
+      .buffer = g_uart1txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart1priv,
 };
 #endif
 
@@ -465,18 +465,18 @@ static struct up_dev_s g_uart2priv =
 
 static uart_dev_t g_uart2port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART2_RXBUFSIZE,
-    .buffer = g_uart2rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART2_TXBUFSIZE,
-    .buffer = g_uart2txbuffer,
-   },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart2priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART2_RXBUFSIZE,
+      .buffer = g_uart2rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART2_TXBUFSIZE,
+      .buffer = g_uart2txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart2priv,
 };
 #endif
 
@@ -495,18 +495,18 @@ static struct up_dev_s g_uart3priv =
 
 static uart_dev_t g_uart3port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART3_RXBUFSIZE,
-    .buffer = g_uart3rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART3_TXBUFSIZE,
-    .buffer = g_uart3txbuffer,
-  },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart3priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART3_RXBUFSIZE,
+      .buffer = g_uart3rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART3_TXBUFSIZE,
+      .buffer = g_uart3txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart3priv,
 };
 #endif
 
@@ -555,18 +555,18 @@ static struct up_dev_s g_uart5priv =
 
 static uart_dev_t g_uart5port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART5_RXBUFSIZE,
-    .buffer = g_uart5rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART5_TXBUFSIZE,
-    .buffer = g_uart5txbuffer,
-  },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart5priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART5_RXBUFSIZE,
+      .buffer = g_uart5rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART5_TXBUFSIZE,
+      .buffer = g_uart5txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart5priv,
 };
 #endif
 
@@ -585,18 +585,18 @@ static struct up_dev_s g_uart6priv =
 
 static uart_dev_t g_uart6port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART6_RXBUFSIZE,
-    .buffer = g_uart6rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART6_TXBUFSIZE,
-    .buffer = g_uart6txbuffer,
-  },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart6priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART6_RXBUFSIZE,
+      .buffer = g_uart6rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART6_TXBUFSIZE,
+      .buffer = g_uart6txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart6priv,
 };
 #endif
 
@@ -615,18 +615,18 @@ static struct up_dev_s g_uart7priv =
 
 static uart_dev_t g_uart7port =
 {
-  .recv     =
-  {
-    .size   = CONFIG_UART7_RXBUFSIZE,
-    .buffer = g_uart7rxbuffer,
-  },
-  .xmit     =
-  {
-    .size   = CONFIG_UART7_TXBUFSIZE,
-    .buffer = g_uart7txbuffer,
-  },
-  .ops      = &g_uart_ops,
-  .priv     = &g_uart7priv,
+  .recv       =
+    {
+      .size   = CONFIG_UART7_RXBUFSIZE,
+      .buffer = g_uart7rxbuffer,
+    },
+  .xmit       =
+    {
+      .size   = CONFIG_UART7_TXBUFSIZE,
+      .buffer = g_uart7txbuffer,
+    },
+  .ops        = &g_uart_ops,
+  .priv       = &g_uart7priv,
 };
 #endif
 
@@ -647,7 +647,8 @@ static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint32_t value)
 {
   putreg32(value, priv->uartbase + offset);
 }
@@ -749,36 +750,37 @@ static void up_set_format(struct uart_dev_s *dev)
    * "The baud-rate divisor is a 22-bit number consisting of a 16-bit integer
    *  and a 6-bit fractional part. The number formed by these two values is
    *  used by the baud-rate generator to determine the bit period. Having a
-   *  fractional baud-rate divider allows the UART to generate all the standard
-   *  baud rates.
+   *  fractional baud-rate divider allows the UART to generate all the
+   *  standard baud rates.
    *
    * "The 16-bit integer is loaded through the UART Integer Baud-Rate Divisor
-   *  (UARTIBRD) register ... and the 6-bit fractional part is loaded with the
-   *  UART Fractional Baud-Rate Divisor (UARTFBRD) register... The baud-rate
-   *  divisor (BRD) has the following relationship to the system clock (where
-   *  BRDI is the integer part of the BRD and BRDF is the fractional part,
-   *  separated by a decimal place.):
+   *  (UARTIBRD) register ... and the 6-bit fractional part is loaded with
+   *  the UART Fractional Baud-Rate Divisor (UARTFBRD) register... The
+   *  baud-rate divisor (BRD) has the following relationship to the system
+   *  clock (where BRDI is the integer part of the BRD and BRDF is the
+   *  fractional part, separated by a decimal place.):
    *
    *    "BRD = BRDI + BRDF = UARTSysClk / (16 * Baud Rate)
    *
    * "where UARTSysClk is the system clock connected to the UART. The 6-bit
-   *  fractional number (that is to be loaded into the DIVFRAC bit field in the
-   *  UARTFBRD register) can be calculated by taking the fractional part of the
-   *  baud-rate divisor, multiplying it by 64, and adding 0.5 to account for
-   *  rounding errors:
+   *  fractional number (that is to be loaded into the DIVFRAC bit field in
+   *  the UARTFBRD register) can be calculated by taking the fractional part
+   *  of the baud-rate divisor, multiplying it by 64, and adding 0.5 to
+   *  account for rounding errors:
    *
    *    "UARTFBRD[DIVFRAC] = integer(BRDF * 64 + 0.5)
    *
-   * "The UART generates an internal baud-rate reference clock at 16x the baud-
-   *  rate (referred to as Baud16). This reference clock is divided by 16 to
-   *  generate the transmit clock, and is used for error detection during receive
-   *  operations.
+   * "The UART generates an internal baud-rate reference clock at 16x the
+   *  baud-rate (referred to as Baud16). This reference clock is divided by
+   *  16 to generate the transmit clock, and is used for error detection
+   *  during receive operations.
    *
-   * "Along with the UART Line Control, High Byte (UARTLCRH) register ..., the
-   *  UARTIBRD and UARTFBRD registers form an internal 30-bit register. This
-   *  internal register is only updated when a write operation to UARTLCRH is
-   *  performed, so any changes to the baud-rate divisor must be followed by a
-   *  write to the UARTLCRH register for the changes to take effect. ..."
+   * "Along with the UART Line Control, High Byte (UARTLCRH) register ...,
+   *  the UARTIBRD and UARTFBRD registers form an internal 30-bit register.
+   *  This internal register is only updated when a write operation to
+   *  UARTLCRH is performed, so any changes to the baud-rate divisor must be
+   *  followed by a write to the UARTLCRH register for the changes to take
+   *  effect. ..."
    */
 
   den       = priv->baud << 4;
@@ -865,14 +867,15 @@ static int up_setup(struct uart_dev_s *dev)
    */
 
   up_serialout(priv, TIVA_UART_IFLS_OFFSET,
-               UART_IFLS_TXIFLSEL_18th | UART_IFLS_RXIFLSEL_18th);
+               UART_IFLS_TXIFLSEL_18TH | UART_IFLS_RXIFLSEL_18TH);
 
   /* Flush the Rx and Tx FIFOs -- How do you do that? */
 
-  /* Enable Rx interrupts from the UART except for Tx interrupts.  We don't want
-   * Tx interrupts until we have something to send.  We will check for serial
-   * errors as part of Rx interrupt processing (no interrupts will be received
-   * yet because the interrupt is still disabled at the interrupt controller.
+  /* Enable Rx interrupts from the UART except for Tx interrupts.  We don't
+   * want TX interrupts until we have something to send.  We will check for
+   * serial errors as part of Rx interrupt processing (no interrupts will be
+   * received yet because the interrupt is still disabled at the interrupt
+   * controller.
    */
 
   up_serialout(priv, TIVA_UART_IM_OFFSET, UART_IM_RXIM | UART_IM_RTIM);
@@ -919,9 +922,10 @@ static void up_shutdown(struct uart_dev_s *dev)
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -950,8 +954,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -1204,6 +1208,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
     {
       priv->im &= ~(UART_IM_RXIM | UART_IM_RTIM);
     }
+
   up_serialout(priv, TIVA_UART_IM_OFFSET, priv->im);
 }
 
@@ -1277,6 +1282,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
       priv->im &= ~UART_IM_TXIM;
       up_serialout(priv, TIVA_UART_IM_OFFSET, priv->im);
     }
+
   leave_critical_section(flags);
 }
 

--- a/arch/arm/src/tiva/common/tiva_serial.c
+++ b/arch/arm/src/tiva/common/tiva_serial.c
@@ -1073,8 +1073,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        cfsetispeed(termiosp, priv->baud);
-
         if (priv->bits >= 5 && priv->bits <= 8)
           {
             ccflag |= (CS5 + (priv->bits - 5));
@@ -1099,6 +1097,8 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
          */
 
         termiosp->c_cflag = ccflag;
+
+        cfsetispeed(termiosp, priv->baud);
       }
       break;
 

--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_uart.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_uart.h
@@ -67,7 +67,7 @@
 #define TIVA_UART_RIS_OFFSET       0x003c /* UART Raw Interrupt Status */
 #define TIVA_UART_MIS_OFFSET       0x0040 /* UART Masked Interrupt Status */
 #define TIVA_UART_ICR_OFFSET       0x0044 /* UART Interrupt Clear */
-#define TIVA_UART_DMACTL_OFFSET    0x0048  /* UART DMA Control */
+#define TIVA_UART_DMACTL_OFFSET    0x0048 /* UART DMA Control */
 
 #define TIVA_UART_PERIPHID4_OFFSET 0x0fd0 /* UART Peripheral Identification 4 */
 #define TIVA_UART_PERIPHID5_OFFSET 0x0fd4 /* UART Peripheral Identification 5 */
@@ -168,11 +168,13 @@
 #define UART_LCRH_STP2             (1 << 3)  /* Bit 3:  UART Two Stop Bits Select */
 #define UART_LCRH_FEN              (1 << 4)  /* Bit 4:  UART Enable FIFOs */
 #define UART_LCRH_WLEN_SHIFT       5         /* Bits 6-5: UART Word Length */
+
 #define UART_LCRH_WLEN_MASK        (3 << UART_LCRH_WLEN_SHIFT)
 #  define UART_LCRH_WLEN_5BITS     (0 << UART_LCRH_WLEN_SHIFT) /* 5-bits (reset) */
 #  define UART_LCRH_WLEN_6BITS     (1 << UART_LCRH_WLEN_SHIFT) /* 6-bits */
 #  define UART_LCRH_WLEN_7BITS     (2 << UART_LCRH_WLEN_SHIFT) /* 7-bits */
 #  define UART_LCRH_WLEN_8BITS     (3 << UART_LCRH_WLEN_SHIFT) /* 8-bits */
+
 #define UART_LCRH_SPS              (1 << 7)  /* Bit 7:  UART Stick Parity Select */
 
 /* UART Control (CTL) */
@@ -189,18 +191,19 @@
 
 #define UART_IFLS_TXIFLSEL_SHIFT   0         /* Bits 0-2: UART Transmit Interrupt FIFO Level Select */
 #define UART_IFLS_TXIFLSEL_MASK    (7 << UART_IFLS_TXIFLSEL_SHIFT)
-#  define UART_IFLS_TXIFLSEL_18th  (0 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/8th full */
-#  define UART_IFLS_TXIFLSEL_14th  (1 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/4th full */
-#  define UART_IFLS_TXIFLSEL_half  (2 << UART_IFLS_TXIFLSEL_SHIFT) /* half full */
-#  define UART_IFLS_TXIFLSEL_34th  (3 << UART_IFLS_TXIFLSEL_SHIFT) /* 3/4th full */
-#  define UART_IFLS_TXIFLSEL_78th  (4 << UART_IFLS_TXIFLSEL_SHIFT) /* 7/8th full */
+#  define UART_IFLS_TXIFLSEL_18TH  (0 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/8th full */
+#  define UART_IFLS_TXIFLSEL_14TH  (1 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/4th full */
+#  define UART_IFLS_TXIFLSEL_HALF  (2 << UART_IFLS_TXIFLSEL_SHIFT) /* half full */
+#  define UART_IFLS_TXIFLSEL_34TH  (3 << UART_IFLS_TXIFLSEL_SHIFT) /* 3/4th full */
+#  define UART_IFLS_TXIFLSEL_78TH  (4 << UART_IFLS_TXIFLSEL_SHIFT) /* 7/8th full */
+
 #define UART_IFLS_RXIFLSEL_SHIFT   3         /* Bits 3-5: UART Receive Interrupt FIFO Level Select */
 #define UART_IFLS_RXIFLSEL_MASK    (7 << UART_IFLS_RXIFLSEL_SHIFT)
-#  define UART_IFLS_RXIFLSEL_18th  (0 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/8th full */
-#  define UART_IFLS_RXIFLSEL_14th  (1 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/4th full */
-#  define UART_IFLS_RXIFLSEL_half  (2 << UART_IFLS_RXIFLSEL_SHIFT) /* half full */
-#  define UART_IFLS_RXIFLSEL_34th  (3 << UART_IFLS_RXIFLSEL_SHIFT) /* 3/4th full */
-#  define UART_IFLS_RXIFLSEL_78th  (4 << UART_IFLS_RXIFLSEL_SHIFT) /* 7/8th full */
+#  define UART_IFLS_RXIFLSEL_18TH  (0 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/8th full */
+#  define UART_IFLS_RXIFLSEL_14TH  (1 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/4th full */
+#  define UART_IFLS_RXIFLSEL_HALF  (2 << UART_IFLS_RXIFLSEL_SHIFT) /* half full */
+#  define UART_IFLS_RXIFLSEL_34TH  (3 << UART_IFLS_RXIFLSEL_SHIFT) /* 3/4th full */
+#  define UART_IFLS_RXIFLSEL_78TH  (4 << UART_IFLS_RXIFLSEL_SHIFT) /* 7/8th full */
 
 /* UART Interrupt Mask (IM) */
 
@@ -258,10 +261,6 @@
 
 /************************************************************************************
  * Public Data
- ************************************************************************************/
-
-/************************************************************************************
- * Public Functions
  ************************************************************************************/
 
 #endif /* __ARCH_ARM_SRC_TIVA_HARDWARE_CC13X0_CC13X0_UART_H */

--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_uart.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_uart.h
@@ -172,11 +172,13 @@
 #define UART_LCRH_STP2             (1 << 3)  /* Bit 3:  UART Two Stop Bits Select */
 #define UART_LCRH_FEN              (1 << 4)  /* Bit 4:  UART Enable FIFOs */
 #define UART_LCRH_WLEN_SHIFT       5         /* Bits 6-5: UART Word Length */
+
 #define UART_LCRH_WLEN_MASK        (3 << UART_LCRH_WLEN_SHIFT)
 #  define UART_LCRH_WLEN_5BITS     (0 << UART_LCRH_WLEN_SHIFT) /* 5-bits (reset) */
 #  define UART_LCRH_WLEN_6BITS     (1 << UART_LCRH_WLEN_SHIFT) /* 6-bits */
 #  define UART_LCRH_WLEN_7BITS     (2 << UART_LCRH_WLEN_SHIFT) /* 7-bits */
 #  define UART_LCRH_WLEN_8BITS     (3 << UART_LCRH_WLEN_SHIFT) /* 8-bits */
+
 #define UART_LCRH_SPS              (1 << 7)  /* Bit 7:  UART Stick Parity Select */
 
 /* UART Control (CTL) */
@@ -194,18 +196,19 @@
 
 #define UART_IFLS_TXIFLSEL_SHIFT   0         /* Bits 0-2: UART Transmit Interrupt FIFO Level Select */
 #define UART_IFLS_TXIFLSEL_MASK    (7 << UART_IFLS_TXIFLSEL_SHIFT)
-#  define UART_IFLS_TXIFLSEL_18th  (0 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/8th full */
-#  define UART_IFLS_TXIFLSEL_14th  (1 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/4th full */
-#  define UART_IFLS_TXIFLSEL_half  (2 << UART_IFLS_TXIFLSEL_SHIFT) /* half full */
-#  define UART_IFLS_TXIFLSEL_34th  (3 << UART_IFLS_TXIFLSEL_SHIFT) /* 3/4th full */
-#  define UART_IFLS_TXIFLSEL_78th  (4 << UART_IFLS_TXIFLSEL_SHIFT) /* 7/8th full */
+#  define UART_IFLS_TXIFLSEL_18TH  (0 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/8th full */
+#  define UART_IFLS_TXIFLSEL_14TH  (1 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/4th full */
+#  define UART_IFLS_TXIFLSEL_HALF  (2 << UART_IFLS_TXIFLSEL_SHIFT) /* half full */
+#  define UART_IFLS_TXIFLSEL_34TH  (3 << UART_IFLS_TXIFLSEL_SHIFT) /* 3/4th full */
+#  define UART_IFLS_TXIFLSEL_78TH  (4 << UART_IFLS_TXIFLSEL_SHIFT) /* 7/8th full */
+
 #define UART_IFLS_RXIFLSEL_SHIFT   3         /* Bits 3-5: UART Receive Interrupt FIFO Level Select */
 #define UART_IFLS_RXIFLSEL_MASK    (7 << UART_IFLS_RXIFLSEL_SHIFT)
-#  define UART_IFLS_RXIFLSEL_18th  (0 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/8th full */
-#  define UART_IFLS_RXIFLSEL_14th  (1 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/4th full */
-#  define UART_IFLS_RXIFLSEL_half  (2 << UART_IFLS_RXIFLSEL_SHIFT) /* half full */
-#  define UART_IFLS_RXIFLSEL_34th  (3 << UART_IFLS_RXIFLSEL_SHIFT) /* 3/4th full */
-#  define UART_IFLS_RXIFLSEL_78th  (4 << UART_IFLS_RXIFLSEL_SHIFT) /* 7/8th full */
+#  define UART_IFLS_RXIFLSEL_18TH  (0 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/8th full */
+#  define UART_IFLS_RXIFLSEL_14TH  (1 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/4th full */
+#  define UART_IFLS_RXIFLSEL_HALF  (2 << UART_IFLS_RXIFLSEL_SHIFT) /* half full */
+#  define UART_IFLS_RXIFLSEL_34TH  (3 << UART_IFLS_RXIFLSEL_SHIFT) /* 3/4th full */
+#  define UART_IFLS_RXIFLSEL_78TH  (4 << UART_IFLS_RXIFLSEL_SHIFT) /* 7/8th full */
 
 /* UART Interrupt Mask (IM) */
 
@@ -267,10 +270,6 @@
 
 /************************************************************************************
  * Public Data
- ************************************************************************************/
-
-/************************************************************************************
- * Public Functions
  ************************************************************************************/
 
 #endif /* __ARCH_ARM_SRC_TIVA_HARDWARE_CC13X20_CC26X2_CC13X20_CC26X2_UART_H */

--- a/arch/arm/src/tiva/hardware/lm/lm_uart.h
+++ b/arch/arm/src/tiva/hardware/lm/lm_uart.h
@@ -402,11 +402,13 @@
 #define UART_LCRH_STP2             (1 << 3)  /* Bit 3:  UART Two Stop Bits Select */
 #define UART_LCRH_FEN              (1 << 4)  /* Bit 4:  UART Enable FIFOs */
 #define UART_LCRH_WLEN_SHIFT       5         /* Bits 6-5: UART Word Length */
+
 #define UART_LCRH_WLEN_MASK        (3 << UART_LCRH_WLEN_SHIFT)
 #  define UART_LCRH_WLEN_5BITS     (0 << UART_LCRH_WLEN_SHIFT) /* 5-bits (reset) */
 #  define UART_LCRH_WLEN_6BITS     (1 << UART_LCRH_WLEN_SHIFT) /* 6-bits */
 #  define UART_LCRH_WLEN_7BITS     (2 << UART_LCRH_WLEN_SHIFT) /* 7-bits */
 #  define UART_LCRH_WLEN_8BITS     (3 << UART_LCRH_WLEN_SHIFT) /* 8-bits */
+
 #define UART_LCRH_SPS              (1 << 7)  /* Bit 7:  UART Stick Parity Select */
 
 /* UART Control (CTL) */
@@ -422,18 +424,19 @@
 
 #define UART_IFLS_TXIFLSEL_SHIFT   0         /* Bits 2-0: UART Transmit Interrupt FIFO Level Select */
 #define UART_IFLS_TXIFLSEL_MASK    (7 << UART_IFLS_TXIFLSEL_SHIFT)
-#  define UART_IFLS_TXIFLSEL_18th  (0 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/8th full */
-#  define UART_IFLS_TXIFLSEL_14th  (1 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/4th full */
-#  define UART_IFLS_TXIFLSEL_half  (2 << UART_IFLS_TXIFLSEL_SHIFT) /* half full */
-#  define UART_IFLS_TXIFLSEL_34th  (3 << UART_IFLS_TXIFLSEL_SHIFT) /* 3/4th full */
-#  define UART_IFLS_TXIFLSEL_78th  (4 << UART_IFLS_TXIFLSEL_SHIFT) /* 7/8th full */
+#  define UART_IFLS_TXIFLSEL_18TH  (0 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/8th full */
+#  define UART_IFLS_TXIFLSEL_14TH  (1 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/4th full */
+#  define UART_IFLS_TXIFLSEL_HALF  (2 << UART_IFLS_TXIFLSEL_SHIFT) /* half full */
+#  define UART_IFLS_TXIFLSEL_34TH  (3 << UART_IFLS_TXIFLSEL_SHIFT) /* 3/4th full */
+#  define UART_IFLS_TXIFLSEL_78TH  (4 << UART_IFLS_TXIFLSEL_SHIFT) /* 7/8th full */
+
 #define UART_IFLS_RXIFLSEL_SHIFT   3         /* Bits 5-3: UART Receive Interrupt FIFO Level Select */
 #define UART_IFLS_RXIFLSEL_MASK    (7 << UART_IFLS_RXIFLSEL_SHIFT)
-#  define UART_IFLS_RXIFLSEL_18th  (0 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/8th full */
-#  define UART_IFLS_RXIFLSEL_14th  (1 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/4th full */
-#  define UART_IFLS_RXIFLSEL_half  (2 << UART_IFLS_RXIFLSEL_SHIFT) /* half full */
-#  define UART_IFLS_RXIFLSEL_34th  (3 << UART_IFLS_RXIFLSEL_SHIFT) /* 3/4th full */
-#  define UART_IFLS_RXIFLSEL_78th  (4 << UART_IFLS_RXIFLSEL_SHIFT) /* 7/8th full */
+#  define UART_IFLS_RXIFLSEL_18TH  (0 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/8th full */
+#  define UART_IFLS_RXIFLSEL_14TH  (1 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/4th full */
+#  define UART_IFLS_RXIFLSEL_HALF  (2 << UART_IFLS_RXIFLSEL_SHIFT) /* half full */
+#  define UART_IFLS_RXIFLSEL_34TH  (3 << UART_IFLS_RXIFLSEL_SHIFT) /* 3/4th full */
+#  define UART_IFLS_RXIFLSEL_78TH  (4 << UART_IFLS_RXIFLSEL_SHIFT) /* 7/8th full */
 
 /* UART Interrupt Mask (IM) */
 
@@ -529,10 +532,6 @@
 
 /************************************************************************************
  * Public Data
- ************************************************************************************/
-
-/************************************************************************************
- * Public Functions
  ************************************************************************************/
 
 #endif /* __ARCH_ARM_SRC_TIVA_HARDWARE_LM_LM_UART_H */

--- a/arch/arm/src/tiva/hardware/tm4c/tm4c_uart.h
+++ b/arch/arm/src/tiva/hardware/tm4c/tm4c_uart.h
@@ -492,11 +492,13 @@
 #define UART_LCRH_STP2             (1 << 3)  /* Bit 3:  UART Two Stop Bits Select */
 #define UART_LCRH_FEN              (1 << 4)  /* Bit 4:  UART Enable FIFOs */
 #define UART_LCRH_WLEN_SHIFT       5         /* Bits 6-5: UART Word Length */
+
 #define UART_LCRH_WLEN_MASK        (3 << UART_LCRH_WLEN_SHIFT)
 #  define UART_LCRH_WLEN_5BITS     (0 << UART_LCRH_WLEN_SHIFT) /* 5-bits (reset) */
 #  define UART_LCRH_WLEN_6BITS     (1 << UART_LCRH_WLEN_SHIFT) /* 6-bits */
 #  define UART_LCRH_WLEN_7BITS     (2 << UART_LCRH_WLEN_SHIFT) /* 7-bits */
 #  define UART_LCRH_WLEN_8BITS     (3 << UART_LCRH_WLEN_SHIFT) /* 8-bits */
+
 #define UART_LCRH_SPS              (1 << 7)  /* Bit 7:  UART Stick Parity Select */
 
 /* UART Control (CTL) */
@@ -526,18 +528,19 @@
 
 #define UART_IFLS_TXIFLSEL_SHIFT   0         /* Bits 2-0: UART Transmit Interrupt FIFO Level Select */
 #define UART_IFLS_TXIFLSEL_MASK    (7 << UART_IFLS_TXIFLSEL_SHIFT)
-#  define UART_IFLS_TXIFLSEL_18th  (0 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/8th full */
-#  define UART_IFLS_TXIFLSEL_14th  (1 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/4th full */
-#  define UART_IFLS_TXIFLSEL_half  (2 << UART_IFLS_TXIFLSEL_SHIFT) /* half full */
-#  define UART_IFLS_TXIFLSEL_34th  (3 << UART_IFLS_TXIFLSEL_SHIFT) /* 3/4th full */
-#  define UART_IFLS_TXIFLSEL_78th  (4 << UART_IFLS_TXIFLSEL_SHIFT) /* 7/8th full */
+#  define UART_IFLS_TXIFLSEL_18TH  (0 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/8th full */
+#  define UART_IFLS_TXIFLSEL_14TH  (1 << UART_IFLS_TXIFLSEL_SHIFT) /* 1/4th full */
+#  define UART_IFLS_TXIFLSEL_HALF  (2 << UART_IFLS_TXIFLSEL_SHIFT) /* half full */
+#  define UART_IFLS_TXIFLSEL_34TH  (3 << UART_IFLS_TXIFLSEL_SHIFT) /* 3/4th full */
+#  define UART_IFLS_TXIFLSEL_78TH  (4 << UART_IFLS_TXIFLSEL_SHIFT) /* 7/8th full */
+
 #define UART_IFLS_RXIFLSEL_SHIFT   3         /* Bits 5-3: UART Receive Interrupt FIFO Level Select */
 #define UART_IFLS_RXIFLSEL_MASK    (7 << UART_IFLS_RXIFLSEL_SHIFT)
-#  define UART_IFLS_RXIFLSEL_18th  (0 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/8th full */
-#  define UART_IFLS_RXIFLSEL_14th  (1 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/4th full */
-#  define UART_IFLS_RXIFLSEL_half  (2 << UART_IFLS_RXIFLSEL_SHIFT) /* half full */
-#  define UART_IFLS_RXIFLSEL_34th  (3 << UART_IFLS_RXIFLSEL_SHIFT) /* 3/4th full */
-#  define UART_IFLS_RXIFLSEL_78th  (4 << UART_IFLS_RXIFLSEL_SHIFT) /* 7/8th full */
+#  define UART_IFLS_RXIFLSEL_18TH  (0 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/8th full */
+#  define UART_IFLS_RXIFLSEL_14TH  (1 << UART_IFLS_RXIFLSEL_SHIFT) /* 1/4th full */
+#  define UART_IFLS_RXIFLSEL_HALF  (2 << UART_IFLS_RXIFLSEL_SHIFT) /* half full */
+#  define UART_IFLS_RXIFLSEL_34TH  (3 << UART_IFLS_RXIFLSEL_SHIFT) /* 3/4th full */
+#  define UART_IFLS_RXIFLSEL_78TH  (4 << UART_IFLS_RXIFLSEL_SHIFT) /* 7/8th full */
 
 /* UART Interrupt Mask (IM) */
 
@@ -729,10 +732,6 @@
 
 /************************************************************************************
  * Public Data
- ************************************************************************************/
-
-/************************************************************************************
- * Public Functions
  ************************************************************************************/
 
 #endif /* __ARCH_ARM_SRC_TIVA_HARDWARE_TM4C_TM4C_UART_H */

--- a/arch/arm/src/tms570/tms570_serial.c
+++ b/arch/arm/src/tms570/tms570_serial.c
@@ -282,7 +282,9 @@ static inline void tms570_serialout(struct tms570_dev_s *priv, int offset,
 static inline void tms570_restoresciint(struct tms570_dev_s *priv,
                                         uint32_t ints)
 {
-  /* Restore the previous interrupt state (assuming all interrupts disabled) */
+  /* Restore the previous interrupt state (assuming all interrupts
+   * disabled)
+   */
 
   tms570_serialout(priv, TMS570_SCI_SETINT_OFFSET, ints);
 }
@@ -364,9 +366,10 @@ static void tms570_shutdown(struct uart_dev_s *dev)
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -395,8 +398,8 @@ static int tms570_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach SCI interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -435,7 +438,8 @@ static int tms570_interrupt(int irq, void *context, FAR void *arg)
        * INVECT0 register clears the corresponding INTFLAG.
        */
 
-      intvec = tms570_serialin(priv, TMS570_SCI_INTVECT0_OFFSET) & SCI_INTVECT_MASK;
+      intvec = tms570_serialin(priv, TMS570_SCI_INTVECT0_OFFSET) & \
+               SCI_INTVECT_MASK;
 
       /* Handle the pending interrupt */
 
@@ -445,6 +449,7 @@ static int tms570_interrupt(int irq, void *context, FAR void *arg)
             return OK;
 
           case SCI_INTVECT_WAKEUP:  /* Wake-up interrupt */
+
             /* SCI sets the WAKEUP flag if bus activity on the RX line
              * either prevents power-down mode from being entered, or RX
              * line activity causes an exit from power-down mode. If
@@ -480,7 +485,9 @@ static int tms570_interrupt(int irq, void *context, FAR void *arg)
 
           case SCI_INTVECT_TX:      /* Tranmit interrupt */
             {
-              /* Transmit data register available ... process outgoing bytes */
+              /* Transmit data register available ...
+               * process outgoing bytes
+               */
 
               uart_xmitchars(dev);
             }
@@ -728,8 +735,8 @@ static void tms570_rxint(struct uart_dev_s *dev, bool enable)
 
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when their is anything in the Rx data register
+       * (or an RX timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -753,7 +760,8 @@ static void tms570_rxint(struct uart_dev_s *dev, bool enable)
 static bool tms570_rxavailable(struct uart_dev_s *dev)
 {
   struct tms570_dev_s *priv = (struct tms570_dev_s *)dev->priv;
-  return ((tms570_serialin(priv, TMS570_SCI_FLR_OFFSET) & SCI_FLR_RXRDY) != 0);
+  return ((tms570_serialin(priv, TMS570_SCI_FLR_OFFSET) & \
+          SCI_FLR_RXRDY) != 0);
 }
 
 /****************************************************************************
@@ -821,7 +829,8 @@ static void tms570_txint(struct uart_dev_s *dev, bool enable)
 static bool tms570_txready(struct uart_dev_s *dev)
 {
   struct tms570_dev_s *priv = (struct tms570_dev_s *)dev->priv;
-  return ((tms570_serialin(priv, TMS570_SCI_FLR_OFFSET) & SCI_FLR_TXRDY) != 0);
+  return ((tms570_serialin(priv, TMS570_SCI_FLR_OFFSET) & \
+          SCI_FLR_TXRDY) != 0);
 }
 
 /****************************************************************************
@@ -835,7 +844,8 @@ static bool tms570_txready(struct uart_dev_s *dev)
 static bool tms570_txempty(struct uart_dev_s *dev)
 {
   struct tms570_dev_s *priv = (struct tms570_dev_s *)dev->priv;
-  return ((tms570_serialin(priv, TMS570_SCI_FLR_OFFSET) & SCI_FLR_TXEMPTY) != 0);
+  return ((tms570_serialin(priv, TMS570_SCI_FLR_OFFSET) & \
+          SCI_FLR_TXEMPTY) != 0);
 }
 
 /****************************************************************************

--- a/arch/arm/src/tms570/tms570_serial.c
+++ b/arch/arm/src/tms570/tms570_serial.c
@@ -551,10 +551,6 @@ static int tms570_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Return baud */
-
-        cfsetispeed(termiosp, priv->config.baud);
-
         /* Return parity */
 
         termiosp->c_cflag = ((priv->config.parity != 0) ? PARENB : 0) |
@@ -563,6 +559,10 @@ static int tms570_ioctl(struct file *filep, int cmd, unsigned long arg)
         /* Return stop bits */
 
         termiosp->c_cflag |= (priv->config.stopbits2) ? CSTOPB : 0;
+
+        /* Return baud */
+
+        cfsetispeed(termiosp, priv->config.baud);
 
         /* Return number of bits */
 

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -845,10 +845,6 @@ static int esp32_ioctl(struct file *filep, int cmd, unsigned long arg)
             break;
           }
 
-        /* Return baud */
-
-        cfsetispeed(termiosp, priv->baud);
-
         /* Return parity */
 
         termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
@@ -863,6 +859,10 @@ static int esp32_ioctl(struct file *filep, int cmd, unsigned long arg)
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) || defined(CONFIG_SERIAL_OFLOWCONTROL)
         termiosp->c_cflag |= (priv->flowc) ? (CCTS_OFLOW | CRTS_IFLOW): 0;
 #endif
+        /* Return baud */
+
+        cfsetispeed(termiosp, priv->baud);
+
         /* Return number of bits */
 
         switch (priv->bits)


### PR DESCRIPTION
cfsetispeed() now stores baud rate to c_cflag member of
struct termios, so it must not be overridden later on.

## Summary

## Impact

## Testing

