### PR TITLE
arch/xtensa/src/esp32/esp32_wlan.c: Fix an unused var warning

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -1259,7 +1259,6 @@ static int esp_ioctl(FAR struct net_driver_s *dev,
   int ret;
   struct iw_point *essid;
   struct iw_encode_ext *ext;
-  struct mii_ioctl_notify_s *req;
   struct iwreq *iwr = (struct iwreq *)arg;
 
   /* Decode and dispatch the driver-specific IOCTL command */
@@ -1270,7 +1269,7 @@ static int esp_ioctl(FAR struct net_driver_s *dev,
 #ifdef CONFIG_ARCH_PHY_INTERRUPT
       case SIOCMIINOTIFY: /* Set up for PHY event notifications */
         {
-          req = (struct mii_ioctl_notify_s *)arg;
+          struct mii_ioctl_notify_s *req = (struct mii_ioctl_notify_s *)arg;
           ret = esp_wifi_notify_subscribe(req->pid, &req->event);
           if (ret)
             {


### PR DESCRIPTION

## Summary
chip/esp32_wlan.c: In function 'esp_ioctl':
chip/esp32_wlan.c:1262:30: warning: unused variable 'req' [-Wunused-variable]
   struct mii_ioctl_notify_s *req;
                              ^~~

## Impact

## Testing

build tested locally