### PR TITLE
Add note_syscall args support

### DIFF
--- a/Documentation/guides/tasktraceuser.rst
+++ b/Documentation/guides/tasktraceuser.rst
@@ -41,6 +41,7 @@ The following configurations are configurable parameters for trace.
     - Bit 0 = Enable instrumentation
     - Bit 1 = Enable syscall instrumentation
     - Bit 2 = Enable IRQ instrumentation
+    - Bit 3 = Enable collecting syscall arguments
 
 - ``CONFIG_SCHED_INSTRUMENTATION_NOTERAM_BUFSIZE``
 
@@ -232,7 +233,7 @@ The default value is given by the kernel configuration ``CONFIG_SCHED_INSTRUMENT
 
 .. code-block::
 
-  trace mode [{+|-}{o|s|i}...]
+  trace mode [{+|-}{o|s|a|i}...]
 
 - ``+o`` : Enable overwrite mode.
   The trace buffer is a ring buffer and it can overwrite old data if no free space is available in the buffer.
@@ -247,6 +248,11 @@ The default value is given by the kernel configuration ``CONFIG_SCHED_INSTRUMENT
   All system calls are recorded by default. ``trace syscall`` command can filter the system calls to be recorded.
 
 - ``-s`` : Disable system call trace.
+
+- ``+a`` : Enable recording the system call arguments.
+  It records the arguments passed to the issued system call to the trace data.
+
+- ``-a`` : Disable recording the system call arguments.
 
 - ``+i`` : Enable interrupt trace.
   It records the event of enter/leave interrupt handler which is occured while the tracing.
@@ -266,6 +272,7 @@ If no command parameters are specified, display the current mode as the follows.
    Overwrite               : on  (+o)
    Syscall trace           : on  (+s)
     Filtered Syscalls      : 16
+   Syscall trace with args : on  (+a)
    IRQ trace               : on  (+i)
     Filtered IRQs          : 2
 

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -69,6 +69,9 @@
 #ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
 #define NOTE_FILTER_MODE_FLAG_IRQ          (1 << 2) /* Enable IRQ instrumentaiton */
 #endif
+#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
+#define NOTE_FILTER_MODE_FLAG_SYSCALL_ARGS (1 << 3) /* Enable collecting syscall arguments */
+#endif
 
 /* Helper macros for syscall instrumentation filter */
 
@@ -278,10 +281,17 @@ struct note_spinlock_s
 #ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
 /* This is the specific form of the NOTE_SYSCALL_ENTER/LEAVE notes */
 
+#define MAX_SYSCALL_ARGS  6
+#define SIZEOF_NOTE_SYSCALL_ENTER(n) (sizeof(struct note_common_s) + \
+                                      sizeof(uint8_t) + sizeof(uint8_t) + \
+                                      (sizeof(uintptr_t) * (n)))
+
 struct note_syscall_enter_s
 {
-  struct note_common_s nsc_cmn; /* Common note parameters */
-  uint8_t nsc_nr;               /* System call number */
+  struct note_common_s nsc_cmn;                           /* Common note parameters */
+  uint8_t nsc_nr;                                         /* System call number */
+  uint8_t nsc_argc;                                       /* Number of system call arguments */
+  uint8_t nsc_args[sizeof(uintptr_t) * MAX_SYSCALL_ARGS]; /* System call arguments */
 };
 
 struct note_syscall_leave_s

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1003,12 +1003,13 @@ config SCHED_INSTRUMENTATION_FILTER
 config SCHED_INSTRUMENTATION_FILTER_DEFAULT_MODE
 	hex "Default instrumentation filter mode"
 	depends on SCHED_INSTRUMENTATION_FILTER
-	default 0x7
+	default 0xf
 	---help---
 		Default mode of the instrumentation filter logic.
 			Bit 0 = Enable instrumentation
 			Bit 1 = Enable syscall instrumentation
 			Bit 2 = Enable IRQ instrumentation
+			Bit 3 = Enable collecting syscall arguments
 
 endif # SCHED_INSTRUMENTATION
 endmenu # Performance Monitoring


### PR DESCRIPTION
## Summary
Add the option for syscall instrumentation to save arguments passed to syscalls 

## Impact
- `struct note_syscall_enter_s` will be changed to keep argc and args.
- `trace mode +a` command will be added to enable the feature

## Testing
spesense:smp
When the feature is enabled, `trace dump` can show what arguments are passed to syscalls as follows:
```
   trace-7   [0]   8.060000000: sys_open(arg0: 0xd01aa54, arg1: 0x0, arg2: 0x1)
   trace-7   [0]   8.060000000: sys_open -> 0x3
   trace-7   [0]   8.060000000: sys_nxsched_get_streams()
   trace-7   [0]   8.060000000: sys_nxsched_get_streams -> 0xd02bfcc
   trace-7   [0]   8.060000000: sys_ioctl(arg0: 0x3, arg1: 0x2c01, arg2: 0xd02c888)
   trace-7   [0]   8.060000000: sys_ioctl -> 0x0
   trace-7   [0]   8.060000000: sys_ioctl(arg0: 0x3, arg1: 0x2c02, arg2: 0xd02c888)
```
