### PR TITLE
xtensa/tools: Updated makefile to download the IDF stable version

### DIFF
--- a/tools/esp32/Makefile
+++ b/tools/esp32/Makefile
@@ -41,7 +41,7 @@ ${IDF_PATH}:
 	mkdir -p ${ESP_PATH}
 	echo "WARNING:this directory can be automatically removed" > ${ESP_PATH}/README
 	cd ${ESP_PATH} && \
-		ls esp-idf || git clone -b master --recursive https://github.com/espressif/esp-idf.git && \
+		ls esp-idf || git clone -b v4.1 --recursive https://github.com/espressif/esp-idf.git && \
 	cd ${IDF_PATH} && \
 		./install.sh
 


### PR DESCRIPTION
## Summary

This commit only changes the version of IDF download at tools/esp32/Makefile. It changes from the latest to stable.

## Impact

Avoid issues regarding nonstable releases.

## Testing
N/A
