### PR TITLE
configure.sh: update custom board config build support

### DIFF
--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -165,8 +165,12 @@ if [ ! -r ${src_makedefs} ]; then
   if [ ! -r ${src_makedefs} ]; then
     src_makedefs=${TOPDIR}/${boardconfig}/Make.defs
     if [ ! -r ${src_makedefs} ]; then
-      echo "File Make.defs could not be found"
-      exit 4
+      src_makedefs=${TOPDIR}/${boardconfig}/../../scripts/Make.defs
+
+      if [ ! -r ${src_makedefs} ]; then
+        echo "File Make.defs could not be found"
+        exit 4
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
##  Summary
If Make.defs not found under custom boardconfig dir, then try scripts/Make.defs.

## Impact

## Testing
Verified locally with custom boards in which scripts/Make.defs exists.
