### PR TITLE
Documentation/conf.py: add timezone to sphinx timestamp

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -109,7 +109,7 @@ html_show_license = True
 html_logo = '_static/NuttX.png'
 html_favicon = '_static/favicon.ico'
 
-today_fmt = '%d %B %y at %H:%M'
+today_fmt = '%d %B %Y at %H:%M %z'
 
 c_id_attributes = [
   'FAR',


### PR DESCRIPTION
- Show timezone: hour and minutes is useless without a timezone reference.
- 4 digits for year: less opportunity for misunderstanding.

It can be seen on the main doc page: https://nuttx.apache.org/docs/latest/

Thanks!
