### PR TITLE
Revert "sched: Call up_[use|create]_stack after nxtask_setup_scheduler"

### DIFF
--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -108,15 +108,6 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
       goto errout_with_group;
     }
 
-  /* Initialize the task control block */
-
-  ret = nxtask_setup_scheduler(tcb, priority, nxtask_start,
-                               entry, ttype);
-  if (ret < OK)
-    {
-      goto errout_with_group;
-    }
-
   if (stack)
     {
       /* Use pre-allocated stack */
@@ -130,6 +121,15 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
       ret = up_create_stack(&tcb->cmn, stack_size, ttype);
     }
 
+  if (ret < OK)
+    {
+      goto errout_with_group;
+    }
+
+  /* Initialize the task control block */
+
+  ret = nxtask_setup_scheduler(tcb, priority, nxtask_start,
+                               entry, ttype);
   if (ret < OK)
     {
       goto errout_with_group;


### PR DESCRIPTION
Reverts apache/incubator-nuttx#2000

## Summary
- I found that auto test for spresense:elf, spresense:smp failed 
- So let me revert 
