### PR TITLE
include/sys/types.h: Warn on unexpected __WCHAR_WIDTH__

### DIFF
--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -134,13 +134,13 @@ ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),CLANG)
   CROSSDEV ?= arm-none-eabi-
   MAXOPTIMIZATION ?= -Os
   ARCHCPUFLAGS = -target arm-none-eabi $(TOOLCHAIN_MCPU) $(TOOLCHAIN_MFLOAT)
-  CC = clang
-  CXX = clang++
-  CPP = clang -E -P -x c
+  CC = clang -fshort-wchar
+  CXX = clang++ -fshort-wchar
+  CPP = clang -E -P -x c -fshort-wchar
 else
-  CC = $(CROSSDEV)gcc
-  CXX = $(CROSSDEV)g++
-  CPP = $(CROSSDEV)gcc -E -P -x c
+  CC = $(CROSSDEV)gcc -fshort-wchar
+  CXX = $(CROSSDEV)g++ -fshort-wchar
+  CPP = $(CROSSDEV)gcc -E -P -x c -fshort-wchar
 endif
 
 LD = $(CROSSDEV)ld

--- a/arch/risc-v/src/rv64gc/Toolchain.defs
+++ b/arch/risc-v/src/rv64gc/Toolchain.defs
@@ -66,9 +66,9 @@ endif
 
 # Default toolchain
 
-CC = $(CROSSDEV)gcc
-CXX = $(CROSSDEV)g++
-CPP = $(CROSSDEV)gcc -E -P -x c
+CC = $(CROSSDEV)gcc -fshort-wchar
+CXX = $(CROSSDEV)g++ -fshort-wchar
+CPP = $(CROSSDEV)gcc -E -P -x c -fshort-wchar
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -163,7 +163,7 @@ typedef uint16_t     wchar_t;
 #endif
 
 #if defined(__WCHAR_WIDTH__) && __WCHAR_WIDTH__ != 16
-#warning __WCHAR_WIDTH__ should be 16 on NuttX. Your toolchain might need -fshort-wchar.
+#error __WCHAR_WIDTH__ should be 16 on NuttX. Your toolchain might need -fshort-wchar.
 #endif
 
 /* wint_t

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -162,6 +162,10 @@ typedef intptr_t     ptrdiff_t;
 typedef uint16_t     wchar_t;
 #endif
 
+#if defined(__WCHAR_WIDTH__) && __WCHAR_WIDTH__ != 16
+#warning __WCHAR_WIDTH__ should be 16 on NuttX. Your toolchain might need -fshort-wchar.
+#endif
+
 /* wint_t
  *   An integral type capable of storing any valid value of wchar_t, or WEOF.
  */


### PR DESCRIPTION
For NuttX, it should always be 16.

## Summary

## Impact

## Testing

