### PR TITLE
libc: Add quick_exit/at_quick_exit declaration to make libcxx happy

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -133,8 +133,10 @@ int       unsetenv(FAR const char *name);
 /* Process exit functions */
 
 void      exit(int status) noreturn_function;
+void      quick_exit(int status) noreturn_function;
 void      abort(void) noreturn_function;
 int       atexit(CODE void (*func)(void));
+int       at_quick_exit(CODE void (*func)(void));
 int       on_exit(CODE void (*func)(int, FAR void *), FAR void *arg);
 
 /* _Exit() is a stdlib.h equivalent to the unistd.h _exit() function */


### PR DESCRIPTION
## Summary
will provide the real implementation later

## Impact

## Testing

