### PR TITLE
pollnotify: we should send poll events before semaphore incrementes.

### DIFF
--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -254,19 +254,6 @@ static void sam_tsd_notify(struct sam_tsd_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the
-       * touchscreen is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for touchscreen data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
@@ -282,6 +269,19 @@ static void sam_tsd_notify(struct sam_tsd_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the
+       * touchscreen is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/arch/sim/src/sim/up_touchscreen.c
+++ b/arch/sim/src/sim/up_touchscreen.c
@@ -181,20 +181,6 @@ static void up_notify(FAR struct up_dev_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  iinfo("contact=%d nwaiters=%d\n", priv->sample.contact, priv->nwaiters);
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because
-       * the touchscreen is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for touchscreen data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know what they are going to do.  If they all try to
@@ -210,6 +196,20 @@ static void up_notify(FAR struct up_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  iinfo("contact=%d nwaiters=%d\n", priv->sample.contact, priv->nwaiters);
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because
+       * the touchscreen is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 
@@ -239,7 +239,9 @@ static int up_sample(FAR struct up_dev_s *priv,
 
       if (sample->contact == CONTACT_UP)
         {
-          /* Next.. no contract.  Increment the ID so that next contact ID will be unique */
+          /* Next.. no contract.  Increment the ID so that next contact ID
+           * will be unique
+           */
 
           priv->sample.contact = CONTACT_NONE;
           priv->id++;

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -605,19 +605,6 @@ static void tc_notify(FAR struct tc_dev_s *priv)
     }
 #endif
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the
-       * touchscreen is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for touchscreen data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
@@ -633,6 +620,19 @@ static void tc_notify(FAR struct tc_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the
+       * touchscreen is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -491,19 +491,6 @@ static void tc_notify(FAR struct tc_dev_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the
-       * touchscreen is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for touchscreen data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.
@@ -520,6 +507,19 @@ static void tc_notify(FAR struct tc_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the
+       * touchscreen is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -487,6 +487,12 @@ static void adc_notify(FAR struct adc_dev_s *dev)
 {
   FAR struct adc_fifo_s *fifo = &dev->ad_recv;
 
+  /* If there are threads waiting on poll() for data to become available,
+   * then wake them up now.
+   */
+
+  adc_pollnotify(dev, POLLIN);
+
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.
    */
@@ -495,12 +501,6 @@ static void adc_notify(FAR struct adc_dev_s *dev)
     {
       nxsem_post(&fifo->af_sem);
     }
-
-  /* If there are threads waiting on poll() for data to become available,
-   * then wake them up now.
-   */
-
-  adc_pollnotify(dev, POLLIN);
 }
 
 /****************************************************************************

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -1326,6 +1326,12 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
 
           fifo->rx_tail = nexttail;
 
+          /* Notify all poll/select waiters that they can read from the
+           * cd_recv buffer
+           */
+
+          can_pollnotify(dev, POLLIN);
+
           sval = 0;
           if (nxsem_get_value(&fifo->rx_sem, &sval) < 0)
             {
@@ -1349,12 +1355,6 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
             }
 
           errcode = OK;
-
-          /* Notify all poll/select waiters that they can read from the
-           * cd_recv buffer
-           */
-
-          can_pollnotify(dev, POLLIN);
         }
 #ifdef CONFIG_CAN_ERRORS
       else
@@ -1471,6 +1471,12 @@ int can_txdone(FAR struct can_dev_s *dev)
 
       can_xmit(dev);
 
+      /* Notify all poll/select waiters that they can write to the cd_xmit
+       * buffer
+       */
+
+      can_pollnotify(dev, POLLOUT);
+
       /* Are there any threads waiting for space in the TX FIFO? */
 
       if (dev->cd_ntxwaiters > 0)
@@ -1484,12 +1490,6 @@ int can_txdone(FAR struct can_dev_s *dev)
           ret = OK;
         }
     }
-
-  /* Notify all poll/select waiters that they can write to the cd_xmit
-   * buffer
-   */
-
-  can_pollnotify(dev, POLLOUT);
 
   return ret;
 }

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -294,19 +294,6 @@ static void ads7843e_notify(FAR struct ads7843e_dev_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the ADS7843E
-       * is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for ADS7843E data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
@@ -322,6 +309,19 @@ static void ads7843e_notify(FAR struct ads7843e_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the ADS7843E
+       * is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -224,19 +224,6 @@ static void ft5x06_notify(FAR struct ft5x06_dev_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the FT5x06
-       * is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for FT5x06 data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
@@ -252,6 +239,19 @@ static void ft5x06_notify(FAR struct ft5x06_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the FT5x06
+       * is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -253,19 +253,6 @@ static void max11802_notify(FAR struct max11802_dev_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the sample
-       * is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for MAX11802 data to become
    * available, then wake them up now.  NOTE: we wake up all waiting
    * threads because we do not know that they are going to do.  If they
@@ -281,6 +268,19 @@ static void max11802_notify(FAR struct max11802_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the sample
+       * is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -583,19 +583,6 @@ static void mxt_notify(FAR struct mxt_dev_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the maXTouch
-       * is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for maXTouch data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
@@ -611,6 +598,19 @@ static void mxt_notify(FAR struct mxt_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the maXTouch
+       * is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -158,19 +158,6 @@ static void stmpe811_notify(FAR struct stmpe811_dev_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the STMPE811
-       * is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for STMPE811 data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
@@ -186,6 +173,19 @@ static void stmpe811_notify(FAR struct stmpe811_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the STMPE811
+       * is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -236,19 +236,6 @@ static void tsc2007_notify(FAR struct tsc2007_dev_s *priv)
 {
   int i;
 
-  /* If there are threads waiting for read data, then signal one of them
-   * that the read data is available.
-   */
-
-  if (priv->nwaiters > 0)
-    {
-      /* After posting this semaphore, we need to exit because the TSC2007
-       * is no longer available.
-       */
-
-      nxsem_post(&priv->waitsem);
-    }
-
   /* If there are threads waiting on poll() for TSC2007 data to become
    * available, then wake them up now.  NOTE: we wake up all waiting
    * threads because we do not know that they are going to do.  If they
@@ -264,6 +251,19 @@ static void tsc2007_notify(FAR struct tsc2007_dev_s *priv)
           iinfo("Report events: %02x\n", fds->revents);
           nxsem_post(fds->sem);
         }
+    }
+
+  /* If there are threads waiting for read data, then signal one of them
+   * that the read data is available.
+   */
+
+  if (priv->nwaiters > 0)
+    {
+      /* After posting this semaphore, we need to exit because the TSC2007
+       * is no longer available.
+       */
+
+      nxsem_post(&priv->waitsem);
     }
 }
 

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -1284,16 +1284,6 @@ static int usbhost_kbdpoll(int argc, char *argv[])
           newstate = (priv->headndx == priv->tailndx);
           if (!newstate)
             {
-              /* Yes.. Is there a thread waiting for keyboard data now? */
-
-              if (priv->waiting)
-                {
-                  /* Yes.. wake it up */
-
-                  usbhost_givesem(&priv->waitsem);
-                  priv->waiting = false;
-                }
-
               /* Did we just transition from no data available to data
                * available?  If so, wake up any threads waiting for the
                * POLLIN event.
@@ -1302,6 +1292,16 @@ static int usbhost_kbdpoll(int argc, char *argv[])
               if (empty)
                 {
                   usbhost_pollnotify(priv);
+                }
+
+              /* Yes.. Is there a thread waiting for keyboard data now? */
+
+              if (priv->waiting)
+                {
+                  /* Yes.. wake it up */
+
+                  usbhost_givesem(&priv->waitsem);
+                  priv->waiting = false;
                 }
             }
 

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -381,6 +381,12 @@ static ssize_t eventfd_do_read(FAR struct file *filep, FAR char *buffer,
       dev->counter = 0;
     }
 
+#ifdef CONFIG_EVENT_FD_POLL
+  /* Notify all poll/select waiters */
+
+  eventfd_pollnotify(dev, POLLOUT);
+#endif
+
   /* Notify all waiting writers that counter have been decremented */
 
   eventfd_waiter_sem_t *cur_sem = dev->wrsems;
@@ -391,12 +397,6 @@ static ssize_t eventfd_do_read(FAR struct file *filep, FAR char *buffer,
     }
 
   dev->wrsems = NULL;
-
-#ifdef CONFIG_EVENT_FD_POLL
-  /* Notify all poll/select waiters */
-
-  eventfd_pollnotify(dev, POLLOUT);
-#endif
 
   nxsem_post(&dev->exclsem);
   return sizeof(eventfd_t);
@@ -458,6 +458,12 @@ static ssize_t eventfd_do_write(FAR struct file *filep,
 
   dev->counter = new_counter;
 
+#ifdef CONFIG_EVENT_FD_POLL
+  /* Notify all poll/select waiters */
+
+  eventfd_pollnotify(dev, POLLIN);
+#endif
+
   /* Notify all of the waiting readers */
 
   eventfd_waiter_sem_t *cur_sem = dev->rdsems;
@@ -468,12 +474,6 @@ static ssize_t eventfd_do_write(FAR struct file *filep,
     }
 
   dev->rdsems = NULL;
-
-#ifdef CONFIG_EVENT_FD_POLL
-  /* Notify all poll/select waiters */
-
-  eventfd_pollnotify(dev, POLLIN);
-#endif
 
   nxsem_post(&dev->exclsem);
   return sizeof(eventfd_t);

--- a/graphics/nxterm/nxterm_kbdin.c
+++ b/graphics/nxterm/nxterm_kbdin.c
@@ -136,8 +136,8 @@ ssize_t nxterm_read(FAR struct file *filep, FAR char *buffer, size_t len)
               break;
             }
 
-          /* If the driver was opened with O_NONBLOCK option, then don't wait.
-           * Just return EGAIN.
+          /* If the driver was opened with O_NONBLOCK option, then
+           * don't wait. Just return EGAIN.
            */
 
           if (filep->f_oflags & O_NONBLOCK)
@@ -147,8 +147,9 @@ ssize_t nxterm_read(FAR struct file *filep, FAR char *buffer, size_t len)
             }
 
           /* Otherwise, wait for something to be written to the circular
-           * buffer. Increment the number of waiters so that the nxterm_write()
-           * will not that it needs to post the semaphore to wake us up.
+           * buffer. Increment the number of waiters so that the
+           * nxterm_write() will not that it needs to post the semaphore
+           * to wake us up.
            */
 
           sched_lock();
@@ -162,8 +163,8 @@ ssize_t nxterm_read(FAR struct file *filep, FAR char *buffer, size_t len)
 
           ret = nxsem_wait(&priv->waitsem);
 
-          /* Pre-emption will be disabled when we return.  So the decrementing
-           * nwaiters here is safe.
+          /* Pre-emption will be disabled when we return.  So the
+           * decrementing nwaiters here is safe.
            */
 
           priv->nwaiters--;
@@ -313,15 +314,14 @@ int nxterm_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
       /* Check if the receive buffer is empty */
 
       if (priv->head != priv->tail)
-       {
-         eventset |= POLLIN;
-       }
+        {
+          eventset |= POLLIN;
+        }
 
       if (eventset)
         {
           nxterm_pollnotify(priv, eventset);
         }
-
     }
   else if (fds->priv)
     {
@@ -429,7 +429,9 @@ void nxterm_kbdin(NXTERM handle, FAR const uint8_t *buffer, uint8_t buflen)
 
       if (nexthead == priv->tail)
         {
-          /* Yes... Return an indication that nothing was saved in the buffer. */
+          /* Yes... Return an indication that nothing was saved in
+           * the buffer.
+           */
 
           gerr("ERROR: Keyboard data overrun\n");
           break;
@@ -450,16 +452,20 @@ void nxterm_kbdin(NXTERM handle, FAR const uint8_t *buffer, uint8_t buflen)
       /* Are there threads waiting for read data? */
 
       sched_lock();
-      for (i = 0; i < priv->nwaiters; i++)
-        {
-          /* Yes.. Notify all of the waiting readers that more data is available */
-
-          nxsem_post(&priv->waitsem);
-        }
 
       /* Notify all poll/select waiters that they can read from the FIFO */
 
       nxterm_pollnotify(priv, POLLIN);
+
+      for (i = 0; i < priv->nwaiters; i++)
+        {
+          /* Yes.. Notify all of the waiting readers that more data is
+           * available
+           */
+
+          nxsem_post(&priv->waitsem);
+        }
+
       sched_unlock();
     }
 


### PR DESCRIPTION
## Summary
we should send poll events before semaphore incrementes.

There is a good case on sim platform:
When we input some cmd and click enter key to start application in terminal,
this context will change to application from IDLE loop. Althrough entey key '\r'
has been received to recv buffer and complete post semaphore of reader, but
pollnotify may not be called because context change. So when application run
poll function, because no events happend and poll enter wait, context will
again change to IDLE loop, this pollnotify of IDLE loop will run to send poll
events, poll function of applicaton will wake up. It's wrong!
## Impact

## Testing
daily test
