### PR TITLE
TCP-stack fix for stalled tcp sockets due to broken keepalive

### DIFF
--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -106,15 +106,15 @@
 #define NSEC_PER_MIN           (NSEC_PER_SEC * SEC_PER_MIN)
 #define USEC_PER_MIN           (USEC_PER_SEC * SEC_PER_MIN)
 #define MSEC_PER_MIN           (MSEC_PER_SEC * SEC_PER_MIN)
-#define DSEC_PER_MIN           (HSEC_PER_SEC * SEC_PER_MIN)
+#define DSEC_PER_MIN           (DSEC_PER_SEC * SEC_PER_MIN)
 #define HSEC_PER_MIN           (HSEC_PER_SEC * SEC_PER_MIN)
 
 #define MIN_PER_HOUR                  60L
 #define NSEC_PER_HOUR          (NSEC_PER_MIN * MIN_PER_HOUR)
 #define USEC_PER_HOUR          (USEC_PER_MIN * MIN_PER_HOUR)
 #define MSEC_PER_HOUR          (MSEC_PER_MIN * MIN_PER_HOUR)
-#define DSEC_PER_HOUR          (HSEC_PER_SEC * MIN_PER_HOUR)
-#define HSEC_PER_HOUR          (DSEC_PER_MIN * MIN_PER_HOUR)
+#define DSEC_PER_HOUR          (DSEC_PER_MIN * MIN_PER_HOUR)
+#define HSEC_PER_HOUR          (HSEC_PER_MIN * MIN_PER_HOUR)
 #define SEC_PER_HOUR           (SEC_PER_MIN  * MIN_PER_HOUR)
 
 #define HOURS_PER_DAY                 24L

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -255,8 +255,8 @@ struct tcp_conn_s
   clock_t    keeptime;    /* Last time that the TCP socket was known to be
                            * alive (ACK or data received) OR time that the
                            * last probe was sent. */
-  uint16_t   keepidle;    /* Elapsed idle time before first probe sent (dsec) */
-  uint16_t   keepintvl;   /* Interval between probes (dsec) */
+  uint32_t   keepidle;    /* Elapsed idle time before first probe sent (dsec) */
+  uint32_t   keepintvl;   /* Interval between probes (dsec) */
   bool       keepalive;   /* True: KeepAlive enabled; false: disabled */
   uint8_t    keepcnt;     /* Number of retries before the socket is closed */
   uint8_t    keepretries; /* Number of retries attempted */

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -311,6 +311,19 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
                            FAR struct tcp_conn_s *conn,
                            FAR struct tcp_hdr_s *tcp)
 {
+  /* If keepalive is outstanding, cancel it  */
+
+#ifdef CONFIG_NET_TCP_KEEPALIVE
+  if (conn->keepretries > 0)
+    {
+      uint32_t saveseq = tcp_getsequence(conn->sndseq);
+      saveseq += conn->tx_unacked;
+      tcp_setsequence(conn->sndseq, saveseq);
+      conn->tx_unacked--;
+      conn->keepretries = 0;
+    }
+#endif /* CONFIG_NET_TCP_KEEPALIVE */
+
   /* Copy the IP address into the IPv6 header */
 
 #ifdef CONFIG_NET_IPv6


### PR DESCRIPTION
## Summary  
Fixes an issue where tcp sockets with activated keepalives stalled and were not properly closed. Poll would not indicate a POLLHUP and therefore locks down the application.

## Impact
1. Keepalives will continue and not stop after one
2. Keepalives will eventually terminate the connection successfully and fire a POLLHUP to application

## Testing
Set-up a tcp connection, pull cable and monitor on device side packets (tcpdump/wireshark). Once keepalive count is reached a fin/close and later rst/close should be seen. Application shuold now also receive the POLLHUP.
