### PR TITLE
Fix the stack color failure when the thread stack setup through up_use_stack

### DIFF
--- a/arch/arm/src/arm/arm_initialstate.c
+++ b/arch/arm/src/arm/arm_initialstate.c
@@ -75,8 +75,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/arm/src/armv6-m/arm_initialstate.c
+++ b/arch/arm/src/armv6-m/arm_initialstate.c
@@ -77,8 +77,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/arm/src/armv7-a/arm_initialstate.c
+++ b/arch/arm/src/armv7-a/arm_initialstate.c
@@ -75,8 +75,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/arm/src/armv7-m/arm_initialstate.c
+++ b/arch/arm/src/armv7-m/arm_initialstate.c
@@ -63,8 +63,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/arm/src/armv7-r/arm_initialstate.c
+++ b/arch/arm/src/armv7-r/arm_initialstate.c
@@ -75,8 +75,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -63,8 +63,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/arm/src/common/arm_usestack.c
+++ b/arch/arm/src/common/arm_usestack.c
@@ -156,11 +156,8 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * water marks.
    */
 
-  if (tcb->pid != 0)
-    {
-      arm_stack_color((FAR void *)((uintptr_t)tcb->adj_stack_ptr -
-          tcb->adj_stack_size), tcb->adj_stack_size);
-    }
+  arm_stack_color((FAR void *)((uintptr_t)tcb->adj_stack_ptr -
+                  tcb->adj_stack_size), tcb->adj_stack_size);
 #endif /* CONFIG_STACK_COLORATION */
 
   return OK;

--- a/arch/avr/src/avr/up_initialstate.c
+++ b/arch/avr/src/avr/up_initialstate.c
@@ -75,8 +75,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure.  Zeroing

--- a/arch/avr/src/avr/up_usestack.c
+++ b/arch/avr/src/avr/up_usestack.c
@@ -111,10 +111,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, STACK_COLOR, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, STACK_COLOR, stack_size);
 #endif
 
   /* The AVR uses a push-down stack:  the stack grows toward loweraddresses

--- a/arch/avr/src/avr32/up_initialstate.c
+++ b/arch/avr/src/avr32/up_initialstate.c
@@ -73,8 +73,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure.  Zeroing

--- a/arch/avr/src/avr32/up_usestack.c
+++ b/arch/avr/src/avr32/up_usestack.c
@@ -111,10 +111,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, STACK_COLOR, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, STACK_COLOR, stack_size);
 #endif
 
   /* The AVR32 uses a push-down stack:  the stack grows

--- a/arch/hc/src/common/up_usestack.c
+++ b/arch/hc/src/common/up_usestack.c
@@ -110,10 +110,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The CPU12 uses a push-down stack: the stack grows

--- a/arch/hc/src/m9s12/m9s12_initialstate.c
+++ b/arch/hc/src/m9s12/m9s12_initialstate.c
@@ -72,8 +72,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */
@@ -98,14 +100,14 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Condition code register:
    *
-   *   Bit 0: C — Carry/Borrow status bit
-   *   Bit 1: V — Two’s complement overflow status bit
-   *   Bit 2: Z — Zero status bit
-   *   Bit 3: N — Negative status bit
-   *   Bit 4: I — Maskable interrupt control bit
-   *   Bit 5: H — Half-carry status bit
-   *   Bit 6: X — Non-maskable interrupt control bit
-   *   Bit 7: S — STOP instruction control bit
+   *   Bit 0: C Carry/Borrow status bit
+   *   Bit 1: V Two's complement overflow status bit
+   *   Bit 2: Z Zero status bit
+   *   Bit 3: N Negative status bit
+   *   Bit 4: I Maskable interrupt control bit
+   *   Bit 5: H Half-carry status bit
+   *   Bit 6: X Non-maskable interrupt control bit
+   *   Bit 7: S STOP instruction control bit
    */
 
 # ifdef CONFIG_SUPPRESS_INTERRUPTS

--- a/arch/mips/src/common/mips_usestack.c
+++ b/arch/mips/src/common/mips_usestack.c
@@ -131,10 +131,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* MIPS uses a push-down stack:  the stack grows toward loweraddresses in

--- a/arch/mips/src/mips32/mips_initialstate.c
+++ b/arch/mips/src/mips32/mips_initialstate.c
@@ -77,8 +77,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/misoc/src/lm32/lm32_initialstate.c
+++ b/arch/misoc/src/lm32/lm32_initialstate.c
@@ -75,8 +75,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/misoc/src/lm32/lm32_usestack.c
+++ b/arch/misoc/src/lm32/lm32_usestack.c
@@ -94,10 +94,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The i486 uses a push-down stack:  the stack grows toward loweraddresses

--- a/arch/misoc/src/minerva/minerva_initialstate.c
+++ b/arch/misoc/src/minerva/minerva_initialstate.c
@@ -79,8 +79,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/misoc/src/minerva/minerva_usestack.c
+++ b/arch/misoc/src/minerva/minerva_usestack.c
@@ -94,10 +94,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The i486 uses a push-down stack:  the stack grows toward loweraddresses

--- a/arch/or1k/src/common/up_initialstate.c
+++ b/arch/or1k/src/common/up_initialstate.c
@@ -77,8 +77,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/or1k/src/common/up_usestack.c
+++ b/arch/or1k/src/common/up_usestack.c
@@ -94,10 +94,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The i486 uses a push-down stack:  the stack grows toward loweraddresses

--- a/arch/renesas/src/common/up_usestack.c
+++ b/arch/renesas/src/common/up_usestack.c
@@ -96,10 +96,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The SH family uses a push-down stack:  the stack grows toward lower

--- a/arch/renesas/src/m16c/m16c_initialstate.c
+++ b/arch/renesas/src/m16c/m16c_initialstate.c
@@ -74,8 +74,10 @@ void up_initial_state(FAR struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (FAR void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/renesas/src/rx65n/rx65n_initialstate.c
+++ b/arch/renesas/src/rx65n/rx65n_initialstate.c
@@ -65,8 +65,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/renesas/src/sh1/sh1_initialstate.c
+++ b/arch/renesas/src/sh1/sh1_initialstate.c
@@ -92,8 +92,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/risc-v/src/common/riscv_usestack.c
+++ b/arch/risc-v/src/common/riscv_usestack.c
@@ -157,12 +157,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * water marks.
    */
 
-  if (tcb->pid != 0)
-    {
-      up_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
-                     sizeof(struct tls_info_s)),
-                     size_of_stack - sizeof(struct tls_info_s));
-    }
+  up_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
+                 sizeof(struct tls_info_s)),
+                 size_of_stack - sizeof(struct tls_info_s));
 #endif
 
   return OK;

--- a/arch/risc-v/src/rv32im/riscv_initialstate.c
+++ b/arch/risc-v/src/rv32im/riscv_initialstate.c
@@ -76,8 +76,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/risc-v/src/rv64gc/riscv_initialstate.c
+++ b/arch/risc-v/src/rv64gc/riscv_initialstate.c
@@ -76,8 +76,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/sim/src/sim/up_initialstate.c
+++ b/arch/sim/src/sim/up_initialstate.c
@@ -68,8 +68,10 @@ void up_initial_state(struct tcb_s *tcb)
 {
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(sim_getsp() -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(sim_getsp() -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)sim_getsp();
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   memset(&tcb->xcp, 0, sizeof(struct xcptcontext));

--- a/arch/sim/src/sim/up_usestack.c
+++ b/arch/sim/src/sim/up_usestack.c
@@ -136,12 +136,9 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
    * water marks.
    */
 
-  if (tcb->pid != 0)
-    {
-      up_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
-                     sizeof(struct tls_info_s)),
-                     adj_stack_size - sizeof(struct tls_info_s));
-    }
+  up_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
+                 sizeof(struct tls_info_s)),
+                 adj_stack_size - sizeof(struct tls_info_s));
 #endif
 
   return OK;

--- a/arch/x86/src/i486/up_initialstate.c
+++ b/arch/x86/src/i486/up_initialstate.c
@@ -73,8 +73,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/x86/src/i486/up_usestack.c
+++ b/arch/x86/src/i486/up_usestack.c
@@ -111,10 +111,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The i486 uses a push-down stack:  the stack grows toward loweraddresses

--- a/arch/x86_64/src/intel64/up_initialstate.c
+++ b/arch/x86_64/src/intel64/up_initialstate.c
@@ -62,8 +62,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, (void *)(g_idle_topstack -
-        CONFIG_IDLETHREAD_STACKSIZE), CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/x86_64/src/intel64/up_usestack.c
+++ b/arch/x86_64/src/intel64/up_usestack.c
@@ -96,10 +96,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The intel64 uses a push-down stack:  the stack grows toward lower

--- a/arch/xtensa/src/common/xtensa_initialstate.c
+++ b/arch/xtensa/src/common/xtensa_initialstate.c
@@ -77,7 +77,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb, g_idlestack, IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = g_idlestack;
+      tcb->adj_stack_ptr   = (char *)g_idlestack +
+                             CONFIG_IDLETHREAD_STACKSIZE;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/xtensa/src/common/xtensa_usestack.c
+++ b/arch/xtensa/src/common/xtensa_usestack.c
@@ -150,12 +150,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * water marks.
    */
 
-  if (tcb->pid != 0)
-    {
-      up_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
-                     sizeof(struct tls_info_s)),
-                     size_of_stack - sizeof(struct tls_info_s));
-    }
+  up_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
+                 sizeof(struct tls_info_s)),
+                 size_of_stack - sizeof(struct tls_info_s));
 #endif
 
   return OK;

--- a/arch/z16/src/common/z16_usestack.c
+++ b/arch/z16/src/common/z16_usestack.c
@@ -96,10 +96,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The ZNEO uses a push-down stack:  the stack grows toward lower

--- a/arch/z80/src/common/z80_usestack.c
+++ b/arch/z80/src/common/z80_usestack.c
@@ -95,10 +95,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
 #ifdef CONFIG_STACK_COLORATION
-  if (tcb->pid != 0)
-    {
-      memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
-    }
+  memset(tcb->stack_alloc_ptr, 0xaa, stack_size);
 #endif
 
   /* The Z80 uses a push-down stack:  the stack grows toward lower

--- a/arch/z80/src/z180/z180_initialstate.c
+++ b/arch/z80/src/z180/z180_initialstate.c
@@ -57,8 +57,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb,
-        (void *)CONFIG_STACK_BASE, CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)CONFIG_STACK_BASE;
+      tcb->adj_stack_ptr   = (void *)(CONFIG_STACK_BASE +
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */

--- a/arch/z80/src/z80/z80_initialstate.c
+++ b/arch/z80/src/z80/z80_initialstate.c
@@ -57,8 +57,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == 0)
     {
-      up_use_stack(tcb,
-        (void *)CONFIG_STACK_BASE, CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->stack_alloc_ptr = (void *)CONFIG_STACK_BASE;
+      tcb->adj_stack_ptr   = (void *)(CONFIG_STACK_BASE +
+                                      CONFIG_IDLETHREAD_STACKSIZE);
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
   /* Initialize the initial exception register context structure */


### PR DESCRIPTION
## Summary
Since tcb doesn't setup pid before sched call up_use_stack, the code fail to detect the idle thread. One possible fix is reorder the code in sched to initialize pid first, but it seem to break the task load from elf: https://github.com/apache/incubator-nuttx/pull/2000
so let's setup the idle thread stack info directly, and remove the idle thread detecton code from up_use_stack.

## Impact
all thread stack colorize correctly

## Testing
call pthread_attr_setstack with the preallocated stack, and then create the new thread. Without this PR, the stack usage from ps is wrong.
