### PR TITLE
bt_netdev: remove invalid assert breaking build when debugging is enabled

### DIFF
--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -1064,8 +1064,6 @@ int bt_netdev_register(FAR const struct bt_driver_s *btdev)
 
   nxsem_init(&priv->bd_exclsem, 0, 1);
 
-  DEBUGASSERT(priv->bd_txpoll != NULL);
-
   /* Set the network mask. */
 
   btnet_netmask(netdev);


### PR DESCRIPTION
## Summary

Disable a DEBUGASSERT which does not seem to be valid anymore.

## Impact

Fixes build with debug assertions enabled

## Testing

Built

