### PR TITLE
Add $(OBJS) and $(BIN) to CLEAN macro to clean objects also in subdirectories

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -471,10 +471,12 @@ define CLEAN
 	$(Q) if exist *$(LIBEXT) (del /f /q *$(LIBEXT))
 	$(Q) if exist *~ (del /f /q *~)
 	$(Q) if exist (del /f /q  .*.swp)
+	$(Q) if exist $(OBJS) (del /f /q $(OBJS))
+	$(Q) if exist $(BIN) (del /f /q  $(BIN))
 endef
 else
 define CLEAN
-	$(Q) rm -f *$(OBJEXT) *$(LIBEXT) *~ .*.swp
+	$(Q) rm -f *$(OBJEXT) *$(LIBEXT) *~ .*.swp $(OBJS) $(BIN)
 endef
 endif
 


### PR DESCRIPTION
## Summary

This change supersedes #1843 which was stalled for some time and I found this change is simpler and solves the problem of object files not being cleaned when sources from sub-directories are added (typically for third party code where you can't place a Make.defs file at the same level of each source file to be built).

Ideally only $(OBJS) should be necessary and not *$(OBJEXT) but in #1843 it was mentioned that it was better to leave both cases.

## Impact

Should not break anything, only potentially removes object files not removed just with *$(OBJEXT)

## Testing

Fixed problem of left object files when compiling source files in subdirectory

