### PR TITLE
bt_hcicore.c: Fix wrong order of bt_send() and setting last command sent

### DIFF
--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1002,11 +1002,6 @@ static int hci_tx_kthread(int argc, FAR char *argv[])
 
       g_btdev.ncmd = 0;
 
-      wlinfo("Sending command %04x buf %p to driver\n",
-             buf->u.hci.opcode, buf);
-
-      btdev->send(btdev, buf);
-
       /* Clear out any existing sent command */
 
       if (g_btdev.sent_cmd)
@@ -1017,6 +1012,11 @@ static int hci_tx_kthread(int argc, FAR char *argv[])
         }
 
       g_btdev.sent_cmd = buf;
+
+      wlinfo("Sending command %04x buf %p to driver\n",
+             buf->u.hci.opcode, buf);
+
+      btdev->send(btdev, buf);
     }
 
   return EXIT_SUCCESS;  /* Can't get here */


### PR DESCRIPTION
## Summary

In `hci_tx_kthread()` of `bt_hcicore.c` the `g_btdev.sent_cmd = buf;` line was after the actual send and this breaks the `cmd_complete` handling since this assumes by the time it is called this variable is already set. This is due to the fact that the response is generated on the same callback that handles the reception of this message.

## Impact

Fixes HCI initialization failure (#2084)

## Testing

sim:bluetooth (uses bt_null driver)

