### PR TITLE
build: Makefile should reference CONFIG_HOST_xxx

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -181,7 +181,7 @@ endif
 ifeq ($(CONFIG_SIM_NETDEV_TAP),y)
   CSRCS += up_netdriver.c
   HOSTCFLAGS += -DNETDEV_BUFSIZE=$(CONFIG_NET_ETH_PKTSIZE)
-ifneq ($(HOSTOS),Cygwin)
+ifneq ($(CONFIG_WINDOWS_CYGWIN),y)
   HOSTSRCS += up_tapdev.c
 ifeq ($(CONFIG_SIM_NET_BRIDGE),y)
   HOSTCFLAGS += -DCONFIG_SIM_NET_BRIDGE
@@ -190,10 +190,10 @@ endif
 ifeq ($(CONFIG_SIM_NET_HOST_ROUTE),y)
   HOSTCFLAGS += -DCONFIG_SIM_NET_HOST_ROUTE
 endif
-else # HOSTOS != Cygwin
+else # CONFIG_WINDOWS_CYGWIN != y
   HOSTSRCS += up_wpcap.c
   STDLIBS = /lib/w32api/libws2_32.a /lib/w32api/libiphlpapi.a
-endif # HOSTOS != Cygwin
+endif # CONFIG_WINDOWS_CYGWIN != y
 else ifeq ($(CONFIG_SIM_NETDEV_VPNKIT),y)
   CSRCS += up_netdriver.c
   HOSTCFLAGS += -DCONFIG_SIM_NETDEV_VPNKIT_PATH=\"$(CONFIG_SIM_NETDEV_VPNKIT_PATH)\"
@@ -252,7 +252,7 @@ OBJS = $(AOBJS) $(COBJS) $(HOSTOBJS)
 
 # Override in Make.defs if linker is not 'ld'
 
-ifneq ($(HOSTOS),Darwin)
+ifneq ($(CONFIG_HOST_MACOS),y)
   ARCHSCRIPT += -T nuttx.ld
   LDSTARTGROUP ?= --start-group
   LDENDGROUP ?= --end-group

--- a/boards/arm/c5471/c5471evm/scripts/Make.defs
+++ b/boards/arm/c5471/c5471evm/scripts/Make.defs
@@ -40,7 +40,7 @@ else
 endif
 
 ifeq ($(OLDGCC),n)
-ifneq ($(HOSTOS),Cygwin)
+ifneq ($(CONFIG_WINDOWS_CYGWIN),y)
   OBJCOPYARGS = -R .note -R .note.gnu.build-id -R .comment
 endif
 endif

--- a/boards/arm/lpc214x/mcu123-lpc214x/scripts/Make.defs
+++ b/boards/arm/lpc214x/mcu123-lpc214x/scripts/Make.defs
@@ -40,7 +40,7 @@ else
 endif
 
 ifeq ($(OLDGCC),n)
-ifneq ($(HOSTOS),Cygwin)
+ifneq ($(CONFIG_WINDOWS_CYGWIN),y)
   OBJCOPYARGS = -R .note -R .note.gnu.build-id -R .comment
 endif
 endif

--- a/boards/arm/lpc214x/zp214xpa/scripts/Make.defs
+++ b/boards/arm/lpc214x/zp214xpa/scripts/Make.defs
@@ -40,7 +40,7 @@ else
 endif
 
 ifeq ($(OLDGCC),n)
-ifneq ($(HOSTOS),Cygwin)
+ifneq ($(CONFIG_WINDOWS_CYGWIN),y)
   OBJCOPYARGS = -R .note -R .note.gnu.build-id -R .comment
 endif
 endif

--- a/boards/arm/lpc2378/olimex-lpc2378/scripts/Make.defs
+++ b/boards/arm/lpc2378/olimex-lpc2378/scripts/Make.defs
@@ -60,7 +60,7 @@ else
 endif
 
 ifeq ($(OLDGCC),n)
-ifneq ($(HOSTOS),Cygwin)
+ifneq ($(CONFIG_WINDOWS_CYGWIN),y)
   OBJCOPYARGS = -R .note -R .note.gnu.build-id -R .comment
 endif
 endif

--- a/boards/arm/str71x/olimex-strp711/scripts/Make.defs
+++ b/boards/arm/str71x/olimex-strp711/scripts/Make.defs
@@ -40,7 +40,7 @@ else
 endif
 
 ifeq ($(OLDGCC),n)
-ifneq ($(HOSTOS),Cygwin)
+ifneq ($(CONFIG_WINDOWS_CYGWIN),y)
   OBJCOPYARGS = -R .note -R .note.gnu.build-id -R .comment
 endif
 endif

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -21,8 +21,6 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 
-HOSTOS = ${shell uname -o 2>/dev/null || uname -s 2>/dev/null || echo "Other"}
-
 # NuttX is sometimes built as a native target.
 # In that case, the __NuttX__ macro is predefined by the compiler.
 # https://github.com/NuttX/buildroot

--- a/boards/x86/qemu/qemu-i486/scripts/Make.defs
+++ b/boards/x86/qemu/qemu-i486/scripts/Make.defs
@@ -21,8 +21,6 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 
-HOSTOS = ${shell uname -o 2>/dev/null || uname -s 2>/dev/null || echo "Other"}
-
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION = -g
 endif
@@ -52,7 +50,7 @@ endif
 # We have to use a cross-development toolchain under Cygwin because the native
 # Cygwin toolchains don't generate ELF binaries.
 
-ifeq ($(HOSTOS),Cygwin)
+ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
 CROSSDEV = i486-nuttx-elf-
 endif
 

--- a/boards/x86_64/intel64/qemu-intel64/scripts/Make.defs
+++ b/boards/x86_64/intel64/qemu-intel64/scripts/Make.defs
@@ -21,8 +21,6 @@
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 
-HOSTOS = ${shell uname -o 2>/dev/null || echo "Other"}
-
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION = -g
 endif
@@ -46,7 +44,7 @@ ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 # We have to use a cross-development toolchain under Cygwin because the native
 # Cygwin toolchains don't generate ELF binaries.
 
-ifeq ($(HOSTOS),Cygwin)
+ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
 CROSSDEV = i486-nuttx-elf-
 endif
 

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -56,9 +56,7 @@ MODULESTRIP ?= $(STRIP)
 # Define HOSTCC on the make command line if it differs from these defaults
 # Define HOSTCFLAGS with -g on the make command line to build debug versions
 
-HOSTOS = ${shell uname -o 2>/dev/null || uname -s 2>/dev/null || echo "Other"}
-
-ifeq ($(HOSTOS),MinGW)
+ifeq ($(CONFIG_WINDOWS_MSYS),y)
 
 # In the Windows native environment, the MinGW GCC compiler is used
 
@@ -76,7 +74,7 @@ HOSTCC ?= cc
 HOSTCFLAGS ?= -O2 -Wall -Wstrict-prototypes -Wshadow
 HOSTCFLAGS += -DHAVE_STRTOK_C=1
 
-ifeq ($(HOSTOS),Cygwin)
+ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
 HOSTCFLAGS += -DHOST_CYGWIN=1
 endif
 endif
@@ -88,7 +86,7 @@ ASMEXT ?= .S
 OBJEXT ?= .o
 LIBEXT ?= .a
 
-ifeq ($(HOSTOS),Cygwin)
+ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
   EXEEXT ?= .exe
 endif
 


### PR DESCRIPTION
## Summary
to unify the host detection logic.

## Impact
build on cygwin and msys2

## Testing

