### PR TITLE
esp32_flash.ld: Avoid having too many sections

### DIFF
--- a/boards/xtensa/esp32/esp32-core/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-core/scripts/esp32_flash.ld
@@ -136,6 +136,7 @@ SECTIONS
     __XT_EXCEPTION_TABLE_ = ABSOLUTE(.);
     *(.xt_except_table)
     *(.gcc_except_table)
+    *(.gcc_except_table.*)
     *(.gnu.linkonce.e.*)
     *(.gnu.version_r)
     *(.eh_frame)


### PR DESCRIPTION
## Summary
Fixes an issue I saw when trying libcxx.

esptool.py has a limit of 16 sections.

It complains like:

    A fatal error occurred: Invalid segment count 23 (max 16).
    Usually this indicates a linker script problem.

## Impact
esp32-only

## Testing
helloxx on qemu, with some other patches
