### PR TITLE
include/stdio.h: Fix build errors with CONFIG_LIBCXX=y

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -164,7 +164,7 @@ FAR char *gets(FAR char *s);
 FAR char *gets_s(FAR char *s, rsize_t n);
 void   rewind(FAR FILE *stream);
 
-#ifndef CONFIG_STDIO_DISABLE_BUFFERING
+#if !defined(CONFIG_STDIO_DISABLE_BUFFERING) || defined(CONFIG_LIBCXX)
 void   setbuf(FAR FILE *stream, FAR char *buf);
 int    setvbuf(FAR FILE *stream, FAR char *buffer, int mode, size_t size);
 #endif


### PR DESCRIPTION
## Summary
include/stdio.h: Fix build errors with CONFIG_LIBCXX=y

A similar fix for another implementation:
    https://github.com/apache/incubator-nuttx/pull/1889

## Impact

## Testing
locally built and run for sim, with some other patches.
