### PR TITLE
SIGPIPE config fixes

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -180,7 +180,7 @@
 #endif
 
 #ifndef CONFIG_SIG_PIPE
-#  define SIGPIPE       11
+#  define SIGPIPE       13
 #else
 #  define SIGPIPE       CONFIG_SIG_PIPE
 #endif

--- a/include/signal.h
+++ b/include/signal.h
@@ -179,10 +179,10 @@
 #  define SIGTERM     CONFIG_SIG_TERM
 #endif
 
-#ifndef CONFIG_SIG_SIGPIPE
+#ifndef CONFIG_SIG_PIPE
 #  define SIGPIPE       11
 #else
-#  define SIGPIPE       CONFIG_SIG_SIGPIPE
+#  define SIGPIPE       CONFIG_SIG_PIPE
 #endif
 
 /* The following are non-standard signal definitions */

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1505,7 +1505,7 @@ endif # SIG_DEFAULT
 
 config SIG_PIPE
 	int "SIGPIPE"
-	default 11
+	default 13
 	---help---
 		The SIGPIPE signal is sent to a task termination event.
 		This signal is generated when write on a pipe with no one to read it.


### PR DESCRIPTION
## Summary
don't use the conflicting number with another signal
## Impact

## Testing
locally build tested