### PR TITLE
Make CONFIG_HAVE_CXX14 an explicit config

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -65,14 +65,6 @@
 #  define CONFIG_HAVE_BUILTIN_POPCOUNT 1
 #endif
 
-/* C++ support */
-
-#if defined(__cplusplus) && __cplusplus >= 201402L
-#  define CONFIG_HAVE_CXX14 1
-#else
-#  undef CONFIG_HAVE_CXX14
-#endif
-
 /* Attributes
  *
  * GCC supports weak symbols which can be used to reduce code size because
@@ -316,10 +308,6 @@
 
 # pragma disable_warning 85
 
-/* C++ support */
-
-#  undef CONFIG_HAVE_CXX14
-
 /* Attributes
  *
  * SDCC does not support weak symbols
@@ -454,10 +442,6 @@
 
 #  define IOBJ
 #  define IPTR
-
-/* C++ support */
-
-#  undef CONFIG_HAVE_CXX14
 
 /* Attributes
  *
@@ -602,10 +586,6 @@
 #  pragma section = ".data_init"
 #  pragma section = ".text"
 
-/* C++ support */
-
-#  undef CONFIG_HAVE_CXX14
-
 /* ISO C11 supports anonymous (unnamed) structures and unions.  Does
  * ICCARM?
  */
@@ -622,7 +602,6 @@
 #  undef  CONFIG_HAVE_FUNCTIONNAME
 #  undef  CONFIG_HAVE_FILENAME
 #  undef  CONFIG_HAVE_WEAKFUNCTIONS
-#  undef CONFIG_HAVE_CXX14
 #  define weak_alias(name, aliasname)
 #  define weak_data
 #  define weak_function

--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -20,6 +20,14 @@ config HAVE_CXX
 		Toolchain supports C++ and CXX, CXXFLAGS, and COMPILEXX have been
 		defined in the configurations Make.defs file.
 
+config HAVE_CXX14
+	bool "C++14 support"
+	default n
+	depends on HAVE_CXX
+	---help---
+		C++14 support.
+		Namely, sized-versions of delete operator in libxx.
+
 if HAVE_CXX
 
 config HAVE_CXXINITIALIZE

--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -22,7 +22,7 @@ config HAVE_CXX
 
 config HAVE_CXX14
 	bool "C++14 support"
-	default n
+	default y
 	depends on HAVE_CXX
 	---help---
 		C++14 support.

--- a/libs/libxx/cxx.defs
+++ b/libs/libxx/cxx.defs
@@ -19,6 +19,10 @@
 ###########################################################################
 
 CXXSRCS += libxx_cxa_guard.cxx libxx_cxapurevirtual.cxx
-CXXSRCS += libxx_delete.cxx libxx_delete_sized.cxx libxx_deletea.cxx
-CXXSRCS += libxx_deletea_sized.cxx libxx_new.cxx libxx_newa.cxx
+CXXSRCS += libxx_delete.cxx libxx_deletea.cxx
+CXXSRCS += libxx_new.cxx libxx_newa.cxx
 CXXSRCS += libxx_stdthrow.cxx
+
+ifeq ($(CONFIG_HAVE_CXX14),y)
+CXXSRCS += libxx_delete_sized.cxx libxx_deletea_sized.cxx
+endif

--- a/libs/libxx/libxx_delete_sized.cxx
+++ b/libs/libxx/libxx_delete_sized.cxx
@@ -43,8 +43,6 @@
 
 #include "libxx.hxx"
 
-#ifdef CONFIG_HAVE_CXX14
-
 //***************************************************************************
 // Operators
 //***************************************************************************
@@ -67,5 +65,3 @@ void operator delete(FAR void *ptr, std::size_t size)
 {
   lib_free(ptr);
 }
-
-#endif /* CONFIG_HAVE_CXX14 */

--- a/libs/libxx/libxx_deletea_sized.cxx
+++ b/libs/libxx/libxx_deletea_sized.cxx
@@ -44,8 +44,6 @@
 
 #include "libxx.hxx"
 
-#ifdef CONFIG_HAVE_CXX14
-
 //***************************************************************************
 // Operators
 //***************************************************************************
@@ -58,5 +56,3 @@ void operator delete[](FAR void *ptr, std::size_t size)
 {
   lib_free(ptr);
 }
-
-#endif /* CONFIG_HAVE_CXX14 */


### PR DESCRIPTION
## Summary
Replace automatic detection in compiler.h with an explicit config.

While the following two are related, they are not always same.

     - if C++14 is enabled for the compiler to build the OS library (libxx)
      (this is what's detected in include/nuttx/compiler.h)
    
    - if the OS library should provide C++14 support
      (this is what we need to know here)
## Impact
c++14

## Testing
tested with a local app