### PR TITLE
Store artifacts durring build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,8 +161,13 @@ jobs:
             export CCACHE_DIR=`pwd`/ccache
             mkdir $CCACHE_DIR
             cd sources/testing
-            ./cibuild.sh -c testlist/${{matrix.boards}}.dat
+            export ARTIFACTDIR=`pwd`/../../buildartifacts
+            ./cibuild.sh -A -c testlist/${{matrix.boards}}.dat
             ccache -s
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-builds
+          path: buildartifacts/
 
   macOS:
     runs-on: macos-10.15
@@ -195,5 +200,10 @@ jobs:
           export CCACHE_DIR=`pwd`/ccache
           mkdir $CCACHE_DIR
           cd sources/testing
-          ./cibuild.sh -i -c testlist/${{matrix.boards}}.dat
+          export ARTIFACTDIR=`pwd`/../../buildartifacts
+          ./cibuild.sh -i -A -c testlist/${{matrix.boards}}.dat
           ccache -s
+      - uses: actions/upload-artifact@v2
+        with:
+          name: macos-builds
+          path: buildartifacts/

--- a/boards/xtensa/esp32/esp32-core/scripts/Config.mk
+++ b/boards/xtensa/esp32/esp32-core/scripts/Config.mk
@@ -56,6 +56,7 @@ define POSTBUILD
 		dd if=$(PARTITION_TABLE) bs=1 seek=$(shell printf "%d" 0x8000) of=flash_image.bin conv=notrunc && \
 		dd if=$(NUTTXNAME).bin bs=1 seek=$(shell printf "%d" 0x10000) of=flash_image.bin conv=notrunc && \
 		echo "Generated: flash_image.bin (it can be run with 'qemu-system-xtensa -nographic -machine esp32 -drive file=flash_image.bin,if=mtd,format=raw')"; \
+		echo "flash_image.bin" >> $(NUTTXNAME).manifest; \
 	fi
 endef
 endif

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -424,17 +424,22 @@ endif
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f $(BIN) /tftpboot/$(BIN).${CONFIG_ARCH}; \
 	fi
+	echo $(BIN) > $(NUTTXNAME).manifest
+	printf "%s\n" *.map >> $(NUTTXNAME).manifest
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: $(NUTTXNAME).hex"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(NUTTXNAME).hex
+	echo $(NUTTXNAME).hex >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
 	@echo "CP: $(NUTTXNAME).srec"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) $(NUTTXNAME).srec
+	echo $(NUTTXNAME).srec >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: $(NUTTXNAME).bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
+	echo $(NUTTXNAME).bin >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	@echo "MKIMAGE: uImage"
@@ -443,6 +448,7 @@ ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f uImage /tftpboot/uImage; \
 	fi
+	echo "uImage" >> $(NUTTXNAME).manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -392,17 +392,22 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
 	$(Q) $(MAKE) -C $(ARCH_SRC) EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
+	echo $(BIN) > $(NUTTXNAME).manifest
+	printf '%s\n' *.map >> $(NUTTXNAME).manifest
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: $(NUTTXNAME).hex"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(NUTTXNAME).hex
+	echo $(NUTTXNAME).hex >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
 	@echo "CP: $(NUTTXNAME).srec"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) $(NUTTXNAME).srec
+	echo $(NUTTXNAME).srec >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: $(NUTTXNAME).bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
+	echo $(NUTTXNAME).bin >> $(NUTTXNAME).manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 

--- a/tools/cxd56/Config.mk
+++ b/tools/cxd56/Config.mk
@@ -32,7 +32,7 @@ define POSTBUILD
 
 	+$(Q) $(MAKE) -C $(TOPDIR)$(DELIM)tools$(DELIM)cxd56 -f Makefile.host
 	tools$(DELIM)cxd56$(DELIM)mkspk$(HOSTEXEEXT) -c2 nuttx nuttx nuttx.spk;
-	$(Q)([ $$? -eq 0 ] && echo "Done.")
+	$(Q)([ $$? -eq 0 ] && echo nuttx.spk >> $(NUTTXNAME).manifest && echo "Done.")
 endef
 
 endif

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -38,6 +38,9 @@ nuttx=$WD/../nuttx
 progname=$0
 fail=0
 APPSDIR=$WD/../apps
+if [ -z $ARTIFACTDIR ]; then
+  ARTIFACTDIR=$WD/../buildartifacts
+fi
 MAKE_FLAGS=-k
 EXTRA_FLAGS="EXTRAFLAGS="
 MAKE=make
@@ -46,6 +49,7 @@ unset HOPTION
 unset JOPTION
 PRINTLISTONLY=0
 GITCLEAN=0
+SAVEARTIFACTS=0
 
 case $(uname -s) in
   Darwin*)
@@ -77,8 +81,9 @@ function showusage {
   echo "  -x exit on build failures"
   echo "  -j <ncpus> passed on to make.  Default:  No -j make option."
   echo "  -a <appsdir> provides the relative path to the apps/ directory.  Default ../apps"
-  echo "  -t <topdir> provides the absolute path to top nuttx/ directory.  Default $PWD/../nuttx"
+  echo "  -t <topdir> provides the absolute path to top nuttx/ directory.  Default ../nuttx"
   echo "  -p only print the list of configs without running any builds"
+  echo "  -A store the build executable artifact in ARTIFACTDIR (defaults to ../buildartifacts"
   echo "  -G Use \"git clean -xfdq\" instead of \"make distclean\" to clean the tree."
   echo "     This option may speed up the builds. However, note that:"
   echo "       * This assumes that your trees are git based."
@@ -129,6 +134,9 @@ while [ ! -z "$1" ]; do
     ;;
   -G )
     GITCLEAN=1
+    ;;
+  -A )
+    SAVEARTIFACTS=1
     ;;
   -h )
     showusage
@@ -247,6 +255,11 @@ function configure {
 function build {
   echo "  Building NuttX..."
   makefunc
+  if [ ${SAVEARTIFACTS} -eq 1 ]; then
+    artifactconfigdir=$ARTIFACTDIR/$(echo $config | sed "s/:/\//")/
+    mkdir -p $artifactconfigdir
+    xargs -a $nuttx/nuttx.manifest cp -t $artifactconfigdir
+  fi
 
   # Ensure defconfig in the canonical form
 


### PR DESCRIPTION
## Summary
Setting up some plumbing for being able to store the build artifacts for processing afterwards for things like testing and metrics.

A new option `-A` is added to `tools/testbuild.sh` that will take the created build executable and store it in a folder for the config that generated it under `$ARTIFACTDIR` which can be set via an environment variable or defaulted to `$(TOPDIR)/buildartifacts`

This is also helpful for local testing because you can now run `tools/testbuild.sh -A sim.dat` and have all of the simulation targets generated without having to rebuild along the way.

A zip is created for the artifacts in each run. ~~Unfortunately GitHub Actions does not provides a way capture all of the runs data together so it is a zip for every `.dat` file we build against.~~ this was wrong it helpfully merges them it the name given to the artifact is the same  in this case `builds`. So in this case 100+ elf files are sorted in a tree based on config.

## Impact
Artifacts should be able to be attached to the CI run.

## Testing
CI