### PR TITLE
include/stdio.h: remove depends on setbuf setvbuf

### DIFF
--- a/include/cxx/cstdio
+++ b/include/cxx/cstdio
@@ -76,10 +76,8 @@ namespace std
   using ::fwrite;
   using ::gets;
   using ::gets_s;
-#ifndef CONFIG_STDIO_DISABLE_BUFFERING
   using ::setbuf;
   using ::setvbuf;
-#endif
   using ::ungetc;
 
   // Operations on the stdout stream, buffers, paths, and the whole printf-family

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -164,10 +164,8 @@ FAR char *gets(FAR char *s);
 FAR char *gets_s(FAR char *s, rsize_t n);
 void   rewind(FAR FILE *stream);
 
-#ifndef CONFIG_STDIO_DISABLE_BUFFERING
 void   setbuf(FAR FILE *stream, FAR char *buf);
 int    setvbuf(FAR FILE *stream, FAR char *buffer, int mode, size_t size);
-#endif
 
 int    ungetc(int c, FAR FILE *stream);
 

--- a/libs/libc/stdio/Make.defs
+++ b/libs/libc/stdio/Make.defs
@@ -62,14 +62,11 @@ CSRCS += lib_stdsostream.c lib_perror.c lib_feof.c lib_ferror.c
 CSRCS += lib_rawinstream.c lib_rawoutstream.c lib_rawsistream.c
 CSRCS += lib_rawsostream.c lib_remove.c lib_rewind.c lib_clearerr.c
 CSRCS += lib_scanf.c lib_vscanf.c lib_fscanf.c lib_vfscanf.c lib_tmpfile.c
+CSRCS += lib_setbuf.c lib_setvbuf.c
 
 endif
 
 CSRCS += lib_tempnam.c lib_tmpnam.c
-
-ifneq ($(CONFIG_STDIO_DISABLE_BUFFERING),y)
-CSRCS += lib_setbuf.c lib_setvbuf.c
-endif
 
 # Other support that depends on specific, configured features.
 


### PR DESCRIPTION
## Summary

include/stdio.h: remove depends on setbuf setvbuf.
Cause the fuction realize will handle this.

## Impact

## Testing

