### PR TITLE
net/devif/devif_callback.c: remove harmful debug check

### DIFF
--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -99,7 +99,6 @@ static void devif_callback_free(FAR struct net_driver_s *dev,
 
           /* Remove the structure from the device event list */
 
-          DEBUGASSERT(curr);
           if (curr != NULL)
             {
               if (prev)


### PR DESCRIPTION

## Summary

net/devif/devif_callback.c: remove harmful debug check
Cause of curr maybe NULL, and following logic can handle this

## Impact

## Testing

