### PR TITLE
usrsock.h: add reserved value to usrsock struct

### DIFF
--- a/include/nuttx/net/usrsock.h
+++ b/include/nuttx/net/usrsock.h
@@ -243,6 +243,7 @@ begin_packed_struct struct usrsock_message_req_ack_s
   struct usrsock_message_common_s head;
 
   uint8_t xid;
+  uint8_t reserved;
   int32_t result;
 } end_packed_struct;
 


### PR DESCRIPTION

## Summary
usrsock.h: add reserved value to usrsock struct

access (struct usrsock_message_req_ack_s)->result can caused
unaligend-access, add reserved value to avoid this

## Impact

## Testing

