### PR TITLE
tiva/cc13x2_cc26x2: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_rtc.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_rtc.h
@@ -1,10 +1,11 @@
-/********************************************************************************************************************
+/****************************************************************************
  * arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_rtc.h
  *
  *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
  *
- * Technical content derives from a TI header file that has a compatible BSD license:
+ * Technical content derives from a TI header file that has a compatible BSD
+ * license:
  *
  *   Copyright (c) 2015-2017, Texas Instruments Incorporated
  *   All rights reserved.
@@ -36,23 +37,23 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ********************************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_TIVA_HARDWARE_CC13X2_CC26X2_CC13X2_CC26X2_AON_RTC_H
 #define __ARCH_ARM_SRC_TIVA_HARDWARE_CC13X2_CC26X2_CC13X2_CC26X2_AON_RTC_H
 
-/********************************************************************************************************************
+/****************************************************************************
  * Included Files
- ********************************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include "hardware/tiva_memorymap.h"
 
-/********************************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ********************************************************************************************************************/
+ ****************************************************************************/
 
-/* AON RTC Register Offsets *****************************************************************************************/
+/* AON RTC Register Offsets *************************************************/
 
 #define TIVA_AON_RTC_CTL_OFFSET         0x0000  /* Control */
 #define TIVA_AON_RTC_EVFLAGS_OFFSET     0x0004  /* Event Flags, RTC Status */
@@ -69,7 +70,7 @@
 #define TIVA_AON_RTC_TIME_OFFSET        0x0030  /* Current  Counter Value */
 #define TIVA_AON_RTC_SYNCLF_OFFSET      0x0034  /* Synchronization to SCLK_LF */
 
-/* AON RTC Register Addresses ***************************************************************************************/
+/* AON RTC Register Addresses ***********************************************/
 
 #define TIVA_AON_RTC_CTL                (TIVA_AON_RTC_BASE + TIVA_AON_RTC_CTL_OFFSET)
 #define TIVA_AON_RTC_EVFLAGS            (TIVA_AON_RTC_BASE + TIVA_AON_RTC_EVFLAGS_OFFSET)
@@ -86,31 +87,31 @@
 #define TIVA_AON_RTC_TIME               (TIVA_AON_RTC_BASE + TIVA_AON_RTC_TIME_OFFSET)
 #define TIVA_AON_RTC_SYNCLF             (TIVA_AON_RTC_BASE + TIVA_AON_RTC_SYNCLF_OFFSET)
 
-/* AON RTC Bitfield Definitions *************************************************************************************/
+/* AON RTC Bitfield Definitions *********************************************/
 
 /* TIVA_AON_RTC_CTL */
 
-#define AON_RTC_CTL_EN                  (1 << 0)  /* Bit 0:  Enable RTC counter */
-#define AON_RTC_CTL_RTC_UPD_EN          (1 << 1)  /* Bit 1:  Enable 16-KHz RTC_UPD output */
-#define AON_RTC_CTL_RTC_4KHZ_EN         (1 << 2)  /* Bit 2:  Enabvle 4KHz reference output */
-#define AON_RTC_CTL_RESET               (1 << 7)  /* Bit 7:  RTC counter reset */
-#define AON_RTC_CTL_EV_DELAY_SHIFT      (8)       /* Bits 8-11:  Number SCLK_LF delay for events */
+#define AON_RTC_CTL_EN                  (1 << 0)                              /* Bit 0:  Enable RTC counter */
+#define AON_RTC_CTL_RTC_UPD_EN          (1 << 1)                              /* Bit 1:  Enable 16-KHz RTC_UPD output */
+#define AON_RTC_CTL_RTC_4KHZ_EN         (1 << 2)                              /* Bit 2:  Enabvle 4KHz reference output */
+#define AON_RTC_CTL_RESET               (1 << 7)                              /* Bit 7:  RTC counter reset */
+#define AON_RTC_CTL_EV_DELAY_SHIFT      (8)                                   /* Bits 8-11:  Number SCLK_LF delay for events */
 #define AON_RTC_CTL_EV_DELAY_MASK       (15 << AON_RTC_CTL_EV_DELAY_SHIFT)
-#  define AON_RTC_CTL_EV_DELAY_D0       (0 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* No delay on event */
-#  define AON_RTC_CTL_EV_DELAY_D1       (1 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 1 clock cycle */
-#  define AON_RTC_CTL_EV_DELAY_D2       (2 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 2 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D4       (3 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 4 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D8       (4 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 8 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D16      (5 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 16 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D32      (6 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 32 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D48      (7 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 48 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D64      (8 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 64 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D80      (9 << AON_RTC_CTL_EV_DELAY_SHIFT)  /* Delay by 80 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D96      (10 << AON_RTC_CTL_EV_DELAY_SHIFT) /* Delay by 96 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D112     (11 << AON_RTC_CTL_EV_DELAY_SHIFT) /* Delay by 112 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D128     (12 << AON_RTC_CTL_EV_DELAY_SHIFT) /* Delay by 128 clock cycles */
-#  define AON_RTC_CTL_EV_DELAY_D144     (13 << AON_RTC_CTL_EV_DELAY_SHIFT) /* Delay by 144 clock cycles */
-#define AON_RTC_CTL_COMB_EV_MASK_SHIFT  (16)      /* Bits 16-18:  Select how delayed event form combined events */
+#  define AON_RTC_CTL_EV_DELAY_D0       (0 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* No delay on event */
+#  define AON_RTC_CTL_EV_DELAY_D1       (1 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 1 clock cycle */
+#  define AON_RTC_CTL_EV_DELAY_D2       (2 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 2 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D4       (3 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 4 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D8       (4 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 8 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D16      (5 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 16 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D32      (6 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 32 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D48      (7 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 48 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D64      (8 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 64 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D80      (9 << AON_RTC_CTL_EV_DELAY_SHIFT)     /* Delay by 80 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D96      (10 << AON_RTC_CTL_EV_DELAY_SHIFT)    /* Delay by 96 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D112     (11 << AON_RTC_CTL_EV_DELAY_SHIFT)    /* Delay by 112 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D128     (12 << AON_RTC_CTL_EV_DELAY_SHIFT)    /* Delay by 128 clock cycles */
+#  define AON_RTC_CTL_EV_DELAY_D144     (13 << AON_RTC_CTL_EV_DELAY_SHIFT)    /* Delay by 144 clock cycles */
+#define AON_RTC_CTL_COMB_EV_MASK_SHIFT  (16)                                  /* Bits 16-18:  Select how delayed event form combined events */
 #define AON_RTC_CTL_COMB_EV_MASK_MASK   (7 << AON_RTC_CTL_COMB_EV_MASK_SHIFT)
 #  define AON_RTC_CTL_COMB_EV_MASK_NONE (0 << AON_RTC_CTL_COMB_EV_MASK_SHIFT) /* No event for combined event */
 #  define AON_RTC_CTL_COMB_EV_MASK_CH0  (1 << AON_RTC_CTL_COMB_EV_MASK_SHIFT) /* Use Chan 0 delayed event to combine */
@@ -124,22 +125,27 @@
 #define AON_RTC_EVFLAGS_CH2             (1 << 16) /* Bit 16: Channel 2 event flag */
 
 /* TIVA_AON_RTC_SEC (32-bit value, units of seconds) */
+
 /* TIVA_AON_RTC_SUBSEC (32-bit value, b32 fractional seconds) */
+
 /* TIVA_AON_RTC_SUBSECINC (32-bit value) */
 
 /* TIVA_AON_RTC_CHCTL */
 
-#define AON_RTC_CHCTL_CH0_EN            (1 << 0)  /* Bit 0:  RTC Channel 0 enable */
-#define AON_RTC_CHCTL_CH1_EN            (1 << 8)  /* Bit 8:  RTC Channel 1 enable */
-#define AON_RTC_CHCTL_CH1_CAPT_EN       (1 << 9)  /* Bit 9:  Channel 1 mode */
+#define AON_RTC_CHCTL_CH0_EN            (1 << 0)                   /* Bit 0:  RTC Channel 0 enable */
+#define AON_RTC_CHCTL_CH1_EN            (1 << 8)                   /* Bit 8:  RTC Channel 1 enable */
+#define AON_RTC_CHCTL_CH1_CAPT_EN       (1 << 9)                   /* Bit 9:  Channel 1 mode */
 #  define AON_RTC_CHCTL_CH1_CAPT_CMP    (0)                        /* Compare mode */
 #  define AON_RTC_CHCTL_CH1_CAPT_CAPT   AON_RTC_CHCTL_CH1_CAPT_EN  /* Capture mode */
-#define AON_RTC_CHCTL_CH2_EN            (1 << 16) /* Bit 16: RTC Channel 2 Enable */
-#define AON_RTC_CHCTL_CH2_CONT_EN       (1 << 18) /* Bit 18: Enable Channel 2 Continuous Operation */
+#define AON_RTC_CHCTL_CH2_EN            (1 << 16)                  /* Bit 16: RTC Channel 2 Enable */
+#define AON_RTC_CHCTL_CH2_CONT_EN       (1 << 18)                  /* Bit 18: Enable Channel 2 Continuous Operation */
 
 /* TIVA_AON_RTC_CH0CMP (32-bit value) */
+
 /* TIVA_AON_RTC_CH1CMP (32-bit value) */
+
 /* TIVA_AON_RTC_CH2CMP (32-bit value) */
+
 /* TIVA_AON_RTC_CH2CMPINC (32-bit value) */
 
 /* TIVA_AON_RTC_CH1CAPT */


### PR DESCRIPTION
## Summary

arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_rtc.h:

    * Fix nxstyle errors.

## Impact

Removes nxstyle errors.

## Testing

nxstyle