### PR TITLE
tools/testbuild.sh: Don't support to change size_t type in datlist

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-NuttX TODO List (Last updated July 19, 2020)
+NuttX TODO List (Last updated October 20, 2020)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This file summarizes known NuttX bugs, limitations, inconsistencies with
@@ -18,7 +18,7 @@ nuttx/:
   (0)  Message Queues (sched/mqueue)
   (1)  Work Queues (sched/wqueue)
   (6)  Kernel/Protected Build
-  (3)  C++ Support
+  (2)  C++ Support
   (5)  Binary loaders (binfmt/)
  (17)  Network (net/, drivers/net)
   (4)  USB (drivers/usbdev, drivers/usbhost)
@@ -1076,23 +1076,6 @@ o Kernel/Protected Build
 
 o C++ Support
   ^^^^^^^^^^^
-
-  Title:       USE OF SIZE_T IN NEW OPERATOR
-  Description: The argument of the 'new' operators should take a type of
-               size_t (see libxx/libxx_new.cxx and libxx/libxx_newa.cxx).  But
-               size_t has an unknown underlying.  In the nuttx sys/types.h
-               header file, size_t is typed as uint32_t (which is determined by
-               architecture-specific logic).  But the C++ compiler may believe
-               that size_t is of a different type resulting in compilation errors
-               in the operator.  Using the underlying integer type Instead of
-               size_t seems to resolve the compilation issues.
-  Status:      Kind of open. There is a workaround. Setting CONFIG_ARCH_SIZET_LONG
-               =y will define the operators with argument of type unsigned long;
-               Setting CONFIG_ARCH_SIZET_LONG=n will define the operators with
-               argument of type unsigned int. But this is pretty ugly!  A better
-               solution would be to get a hold of the compilers definition of
-               size_t.
-  Priority:    Low.
 
   Title:       STATIC CONSTRUCTORS AND MULTITASKING
   Description: The logic that calls static constructors operates on the main

--- a/tools/README.txt
+++ b/tools/README.txt
@@ -1026,9 +1026,9 @@ testbuild.sh
   build descriptions consists of two comma separated values.  For example:
 
     stm32f429i-disco:nsh,CONFIG_ARMV7M_TOOLCHAIN_GNU_EABIL
-    arduino-due:nsh,CONFIG_ARMV7M_TOOLCHAIN_GNU_EABIL,-CONFIG_ARCH_SIZET_LONG
+    arduino-due:nsh,CONFIG_ARMV7M_TOOLCHAIN_GNU_EABIL
     /arm,CONFIG_ARMV7M_TOOLCHAIN_GNU_EABIL
-    /risc-v,CONFIG_RV32IM_TOOLCHAIN_GNU_RVGL,CONFIG_ARCH_SIZET_LONG
+    /risc-v,CONFIG_RV32IM_TOOLCHAIN_GNU_RVGL
 
   The first value is the usual configuration description of the form
   <board-name>:<configuration-name> or /<folder-name> and must correspond to a

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -219,14 +219,6 @@ function configure {
     sed -i -e "/$toolchain/d" $nuttx/.config
     echo "$toolchain=y" >> $nuttx/.config
 
-    if [ "X$sizet" == "Xuint" ]; then
-      echo "  Disabling CONFIG_ARCH_SIZET_LONG"
-      sed -i -e "/CONFIG_ARCH_SIZET_LONG/d" $nuttx/.config
-    elif [ "X$sizet" == "Xulong" ]; then
-      echo "  Enabling CONFIG_ARCH_SIZET_LONG"
-      sed -i -e "\$aCONFIG_ARCH_SIZET_LONG=y" $nuttx/.config
-    fi
-
     makefunc olddefconfig
   fi
 
@@ -297,17 +289,10 @@ function dotest {
     fi
 
     unset toolchain
-    unset sizet
     if [ "X$config" != "X$1" ]; then
       toolchain=`echo $1 | cut -d',' -f2`
       if [ -z "$toolchain" ]; then
         echo "  Warning: no tool configuration"
-      fi
-      archsizet=`echo $line | cut -d',' -f3`
-      if [ "X$archsizet" == "XCONFIG_ARCH_SIZET_LONG" ]; then
-        sizet=ulong
-      elif [ "X$archsizet" == "X-CONFIG_ARCH_SIZET_LONG" ]; then
-        sizet=uint
       fi
     fi
 


### PR DESCRIPTION
## Summary
since it doesn't need anymore with the follow patch:
```
commit e7d92600147c1bb1e5160360fde33e744e385544
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Mon Feb 17 20:19:25 2020 +0800

    arch: Customize the typedef of size_t instead of intptr_t

    To ensure size_t same as toolchain definition in the first place and
    rename CXX_NEWLONG to ARCH_SIZET_LONG.  The change also check whether
    __SIZE_TYPE__ exist before CONFIG_ARCH_SIZET_LONG so our definition
    can align with toolchain(gcc/clang) definition automatically.
```
## Impact
Same as before

## Testing

