### PR TITLE
ci: Don't fail the build due to linkcheck failure

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -49,4 +49,5 @@ jobs:
         cd Documentation/
         pip3 install pipenv
         pipenv install
-        pipenv run make linkcheck
+        # This step flakes frequently so still annotate errors but dont fail the build
+        pipenv run make linkcheck || true


### PR DESCRIPTION
## Summary
The linkcheck for the documentation fails fairly regularly due to rate limits (github) or servers with hight error rates.

## Impact
The build will no longer fail, but we will still get the error in the annotations so we can keep an eye on it especially near releases.

## Testing
CI
