### PR TITLE
Ssd1306 cleanup

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -356,14 +356,6 @@ config SSD1306_FREQUENCY
 	---help---
 		Selects the SPI bus frequency used with the SSD1306 device
 
-#config SSD1306_NINTERFACES
-#	int "Number of SSD1306 Devices"
-#	default 1
-#	---help---
-#		Specifies the number of physical SSD1306 devices that will be
-#		supported.  NOTE:  At present, this must be undefined or defined to
-#		be 1.
-
 endif # LCD_SSD1306_SPI
 
 if LCD_SSD1306_I2C

--- a/drivers/lcd/README.txt
+++ b/drivers/lcd/README.txt
@@ -35,7 +35,7 @@ LCD Header files
         int (*getvideoinfo)(FAR struct lcd_dev_s *dev,
                             FAR struct fb_videoinfo_s *vinfo);
         int (*getplaneinfo)(FAR struct lcd_dev_s *dev, unsigned int planeno,
-                           FAR struct lcd_planeinfo_s *pinfo);
+                            FAR struct lcd_planeinfo_s *pinfo);
 
       - The following are provided only if the video hardware supports RGB
         color mapping:
@@ -103,14 +103,14 @@ Re-usable LCD drivers reside in the drivers/lcd directory:
   ssd12989.c.  Generic LCD driver for LCDs based on the Solomon Systech
     SSD1289 LCD controller. Think of this as a template for an LCD driver
     that you will probably have to customize for any particular LCD
-    hardware. (see also boards/arm/stm32/hymini-stm32v/src/ssd1289.c below).
+    hardware. (See also boards/arm/stm32/hymini-stm32v/src/ssd1289.c below).
 
   st7567.c.  LCD Display Module, ST7567, Univision Technology Inc. Used
     with the LPCXpresso and Embedded Artists base board.
 
   memlcd.c.  Sharp Memory LCD Suite, LS013B7DH01, LS013B7DH03, etc.
     There are some more different models, they are basically controlled
-    by similar logics, thus this driver can be extended.  Example usage:
+    by similar logics, thus this driver can be extended.
 
   ra8875.c.  RAiO Technologies RA8875 LCD controller.  Contributed by
     Marten Svanfeldt.
@@ -120,7 +120,7 @@ Re-usable LCD drivers reside in the drivers/lcd directory:
   p14201.c.  Driver for RiT P14201 series display with SD1329 IC
     controller.  Based on the SD1329 controller.  This OLED is used with
     older versions of the TI/Luminary LM3S8962 Evaluation Kit.  Example
-    usage
+    usage:
 
       boards/arm/tiva/lm3s6965-ek/src
       boards/arm/tiva/lm3s8962-ek/src
@@ -138,9 +138,11 @@ Re-usable LCD drivers reside in the drivers/lcd directory:
       boards/arm/lpc71xx_40xx/lpcxpresso-lpc1768
 
   ssd1306.c.  OLED Display Modules based on the SSD1306 controllers.
-    This includes the UG-2864HSWEG01 and UG2832HSWEG04, Both from Univision
+    This includes the UG-2864HSWEG01 and UG2832HSWEG04, both from Univision
     Technology Inc.  The latter is used with the OLED1 module that comes
-    with the Atmel SAM4l Xplained Pro board.  Example usage:
+    with the Atmel SAM4l Xplained Pro board.  This driver also supports
+    Densitron Technologies DD-12864WO-4A which is based on SSD1309 LCD
+    controller. Example usage:
 
       boards/arm/stm32/stm32f4discovery
       boards/arm/sam34/sam4l-xplained
@@ -220,7 +222,7 @@ interface) that makes then less re-usable:
 
     boards/arm/stm32/stm32f4discovery/src/stm32_ug2864ambag01.c
     boards/arm/stm32/stm32f4discovery/src/stm32_ug2864hsweg01.c
-    boards/arm/sam34/sam4l-xplained/src/sa,_ug2832hsweg04.c
+    boards/arm/sam34/sam4l-xplained/src/sam_ug2832hsweg04.c
     boards/arm/lpc214x/zp214xpa/src/lpc2148_ug2864ambag01.c
 
   LCD controllers built-into the MCU:
@@ -231,7 +233,7 @@ interface) that makes then less re-usable:
     boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c.  1x6 segment LCD with
       bars using the segment LCD controller built-into the STM32L15X.
 
-  Alphnumeric/segment LCD Displays:
+  Alphanumeric/segment LCD Displays:
 
     boards/renesas/m16c/skp16c26/src/m16c_lcd.c.  Untested alphanumeric
       LCD driver.

--- a/drivers/lcd/ssd1306.h
+++ b/drivers/lcd/ssd1306.h
@@ -1,4 +1,4 @@
-/**************************************************************************************
+/****************************************************************************
  * drivers/lcd/ssd1306.h
  *
  *   Copyright (C) 2015 Alan Carvalho de Assis
@@ -31,14 +31,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __DRIVERS_LCD_SSD1306_H
 #define __DRIVERS_LCD_SSD1306_H
 
-/**************************************************************************************
+/****************************************************************************
  * Included Files
- **************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -48,24 +48,18 @@
 #include <nuttx/lcd/lcd.h>
 #include <nuttx/lcd/ssd1306.h>
 
-/**************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- **************************************************************************************/
-/* Configuration **********************************************************************/
+ ****************************************************************************/
+
+/* Configuration ************************************************************/
+
 /* Limitations of the current configuration that I hope to fix someday */
 
-#ifndef CONFIG_SSD1306_NINTERFACES
-#  define CONFIG_SSD1306_NINTERFACES 1
-#endif
-
-#if CONFIG_SSD1306_NINTERFACES != 1
-#  warning "This implementation supports only a single SSD1306 device"
-#  undef CONFIG_SSD1306_NINTERFACES
-#  define CONFIG_SSD1306_NINTERFACES 1
-#endif
-
-#if !defined(CONFIG_LCD_SH1106_OLED_132) && !defined(CONFIG_LCD_UG2864HSWEG01) && \
-    !defined(CONFIG_LCD_UG2832HSWEG04) && !defined(CONFIG_LCD_DD12864WO4A) && \
+#if !defined(CONFIG_LCD_SH1106_OLED_132) && \
+    !defined(CONFIG_LCD_UG2864HSWEG01) && \
+    !defined(CONFIG_LCD_UG2832HSWEG04) && \
+    !defined(CONFIG_LCD_DD12864WO4A) && \
     !defined(CONFIG_LCD_HILETGO)
 #  error "Unknown and unsupported SSD1306 LCD"
 #endif
@@ -79,15 +73,15 @@
 #  undef CONFIG_LCD_RPORTRAIT
 #endif
 
-/**************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- **************************************************************************************/
+ ****************************************************************************/
 
 #ifndef CONFIG_NX_BGCOLOR
 #  define CONFIG_NX_BGCOLOR SSD1306_Y1_BLACK
 #endif
 
-/* SSD1306 Commands *******************************************************************/
+/* SSD1306 Commands *********************************************************/
 
 #define SSD1306_SETCOLL(ad)      (0x00 | ((ad) & 0x0f)) /* Set Lower Column Address: (00h - 0fh) */
 #define SSD1306_SETCOLH(ad)      (0x10 | ((ad) & 0x0f)) /* Set Higher Column Address: (10h - 1fh) */
@@ -144,11 +138,13 @@
 #define SSD1309_SETMEMORY        (0x20)
 #  define SSD1309_MEMADDR(ma)    ((ma) & 0x03)
 
-/* Color Properties *******************************************************************/
+/* Color Properties *********************************************************/
+
 /* Display Resolution
  *
- * The SSD1306 display controller can handle a resolution of 132x64. The UG-2864HSWEG01
- * on the base board is 128x64; the UG-2832HSWEG04 is 128x32.
+ * The SSD1306 display controller can handle a resolution of 132x64.
+ * The UG-2864HSWEG01 on the base board is 128x64; the UG-2832HSWEG04
+ * is 128x32.
  */
 
 #if defined(CONFIG_LCD_UG2864HSWEG01)
@@ -268,9 +264,9 @@
 #define LS_BIT                    (1 << 0)
 #define MS_BIT                    (1 << 7)
 
-/**************************************************************************************
+/****************************************************************************
  * Public Type Definition
- **************************************************************************************/
+ ****************************************************************************/
 
 /* This structure describes the state of the SSD1306 driver */
 
@@ -292,26 +288,27 @@ struct ssd1306_dev_s
 
   FAR const struct ssd1306_priv_s *board_priv; /* Board specific structure */
 
- /* The SSD1306 does not support reading from the display memory in SPI mode.
-  * Since there is 1 BPP and access is byte-by-byte, it is necessary to keep
-  * a shadow copy of the framebuffer memory. At 128x64, this amounts to 1KB.
-  */
+  /* The SSD1306 does not support reading from the display memory in SPI
+   * mode. Since there is 1 BPP and access is byte-by-byte, it is necessary
+   * to keep a shadow copy of the framebuffer memory. At 128x64, this
+   * amounts to 1 KB.
+   */
 
   uint8_t fb[SSD1306_DEV_FBSIZE];
 };
 
-/**************************************************************************************
+/****************************************************************************
  * Public Function Prototypes
- **************************************************************************************/
+ ****************************************************************************/
 
 int ssd1306_sendbyte(FAR struct ssd1306_dev_s *priv, uint8_t regval);
-int ssd1306_sendblk(FAR struct ssd1306_dev_s *priv, uint8_t *data, uint8_t len);
+int ssd1306_sendblk(FAR struct ssd1306_dev_s *priv, uint8_t *data,
+                    uint8_t len);
 
 #ifdef CONFIG_LCD_SSD1306_SPI
 void ssd1306_select(FAR struct ssd1306_dev_s *priv, bool cs);
 void ssd1306_cmddata(FAR struct ssd1306_dev_s *priv, bool cmd);
 void ssd1306_configspi(FAR struct spi_dev_s *spi);
-
 #else
 #  define ssd1306_select(priv, cs)
 #  define ssd1306_cmddata(priv, cmd)

--- a/drivers/lcd/ssd1306_base.c
+++ b/drivers/lcd/ssd1306_base.c
@@ -722,22 +722,25 @@ static int ssd1306_do_disponoff(struct ssd1306_dev_s *priv, bool on)
   return ret;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_setpower
  *
  * Description:
- *   Enable/disable LCD panel power (0: full off - CONFIG_LCD_MAXPOWER: full on). On
- *   backlit LCDs, this setting may correspond to the backlight setting.
+ *   Enable/disable LCD panel power:
+ *     0: full off
+ *     CONFIG_LCD_MAXPOWER: full on
+ *   On backlit LCDs, this setting may correspond to the backlight setting.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 static int ssd1306_setpower(FAR struct lcd_dev_s *dev, int power)
 {
   struct ssd1306_dev_s *priv = (struct ssd1306_dev_s *)dev;
   int ret;
 
+  DEBUGASSERT(priv);
   lcdinfo("power: %d [%d]\n", power, priv->on ? CONFIG_LCD_MAXPOWER : 0);
-  DEBUGASSERT(priv && (unsigned)power <= CONFIG_LCD_MAXPOWER);
+  DEBUGASSERT((unsigned)power <= CONFIG_LCD_MAXPOWER);
 
   if (power <= 0)
     {

--- a/drivers/lcd/ssd1306_base.c
+++ b/drivers/lcd/ssd1306_base.c
@@ -1,21 +1,22 @@
-/**************************************************************************************
+/****************************************************************************
  * drivers/lcd/ssd1306_base.c
- * Driver for Univision UG-2864HSWEG01 OLED display or UG-2832HSWEG04 both with the
- * Univision SSD1306 controller in SPI mode and Densitron DD-12864WO-4A with SSD1309
- * in SPI mode.
+ *
+ * Driver for Univision UG-2864HSWEG01 OLED display or UG-2832HSWEG04 both
+ * with the Univision SSD1306 controller in SPI mode and Densitron
+ * DD-12864WO-4A with SSD1309 in SPI mode.
  *
  *   Copyright (C) 2012-2013, 2015, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * References:
- *   1. Product Specification (Preliminary), Part Name: OEL Display Module, Part ID:
+ *   1. Product Specification, Part Name: OEL Display Module, Part ID:
  *      UG-2864HSWEG01, Doc No: SAS1-9046-B, Univision Technology Inc.
- *   2. Product Specification, Part Name: OEL Display Module, Part ID: UG-2832HSWEG04,
- *      Doc No.: SAS1-B020-B, Univision Technology Inc.
- *   3. SSD1306, 128 X 64 Dot Matrix OLED/PLED, Preliminary Segment/Common Driver with
- *      Controller,  Solomon Systech
- *   4. SSD1309, 128 x 64 Dot Matrix OLED/PLED Segment/Common Driver with Controller,
- *      Solomon Systech
+ *   2. Product Specification, Part Name: OEL Display Module, Part ID:
+ *      UG-2832HSWEG04, Doc No.: SAS1-B020-B, Univision Technology Inc.
+ *   3. SSD1306, 128 X 64 Dot Matrix OLED/PLED, Preliminary Segment/Common
+ *      Driver with Controller, Solomon Systech
+ *   4. SSD1309, 128 x 64 Dot Matrix OLED/PLED Segment/Common Driver with
+ *      Controller, Solomon Systech
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,8 +45,9 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- **************************************************************************************/
-/**************************************************************************************
+ ****************************************************************************/
+
+/****************************************************************************
  * Device memory organization:
  *
  *          +----------------------------+
@@ -77,30 +79,30 @@
  *  Page 7  |    |   |   |   |     |     |
  *  --------+----+---+---+---+-...-+-----+
  *
- *  -----------------------------------+---------------------------------------
- *  Landscape Display:                 | Reverse Landscape Display:
- *  --------+-----------------------+  |  --------+---------------------------+
- *          |       Column          |  |          |         Column            |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  Page 0  | 0 | 1 | 2 |     | 127 |  |  Page 7  | 127 | 126 | 125 |     | 0 |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  Page 1  | V                     |  |  Page 6  |                         ^ |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  Page 2  | V                     |  |  Page 5  |                         ^ |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  Page 3  | V                     |  |  Page 4  |                         ^ |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  Page 4  | V                     |  |  Page 3  |                         ^ |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  Page 5  | V                     |  |  Page 2  |                         ^ |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  Page 6  | V                     |  |  Page 1  |                         ^ |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  Page 7  | V                     |  |  Page 0  |                         ^ |
- *  --------+---+---+---+-...-+-----+  |  --------+-----+-----+-----+-...-+---+
- *  -----------------------------------+---------------------------------------
+ *  ----------------------------------+--------------------------------------
+ *  Landscape Display:                | Reverse Landscape Display:
+ *  --------+----------------------+  |  --------+--------------------------+
+ *          |       Column         |  |          |         Column           |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  Page 0  | 0 | 1 | 2 |    | 127 |  |  Page 7  | 127 | 126 | 125 |    | 0 |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  Page 1  | V                    |  |  Page 6  |                        ^ |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  Page 2  | V                    |  |  Page 5  |                        ^ |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  Page 3  | V                    |  |  Page 4  |                        ^ |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  Page 4  | V                    |  |  Page 3  |                        ^ |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  Page 5  | V                    |  |  Page 2  |                        ^ |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  Page 6  | V                    |  |  Page 1  |                        ^ |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  Page 7  | V                    |  |  Page 0  |                        ^ |
+ *  --------+---+---+---+-..-+-----+  |  --------+-----+-----+-----+-..-+---+
+ *  ----------------------------------+--------------------------------------
  *
- *  -----------------------------------+---------------------------------------
+ *  -----------------------------------+-------------------------------------
  *  Portrait Display:                  | Reverse Portrait Display:
  *  -----------+---------------------+ |  -----------+---------------------+
  *             |         Page        | |             |       Page          |
@@ -115,12 +117,12 @@
  *  -----------+---+---+---+-...-+---+ |  -----------+---+---+---+-...-+---+
  *  Column 127 |                     | |  Column 0   | <   <   <    <    < |
  *  -----------+---+---+---+-...-+---+ |  -----------+---+---+---+-...-+---+
- *  -----------------------------------+----------------------------------------
- **************************************************************************************/
+ *  -----------------------------------+-------------------------------------
+ ****************************************************************************/
 
-/**************************************************************************************
+/****************************************************************************
  * Included Files
- **************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -143,22 +145,23 @@
 
 #ifdef CONFIG_LCD_SSD1306
 
-/**************************************************************************************
+/****************************************************************************
  * Private Function Prototypes
- **************************************************************************************/
+ ****************************************************************************/
 
 /* LCD Data Transfer Methods */
 
 static int ssd1306_putrun(fb_coord_t row, fb_coord_t col,
                           FAR const uint8_t *buffer, size_t npixels);
-static int ssd1306_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
-                          size_t npixels);
+static int ssd1306_getrun(fb_coord_t row, fb_coord_t col,
+                          FAR uint8_t *buffer, size_t npixels);
 
 /* LCD Configuration */
 
 static int ssd1306_getvideoinfo(FAR struct lcd_dev_s *dev,
                                 FAR struct fb_videoinfo_s *vinfo);
-static int ssd1306_getplaneinfo(FAR struct lcd_dev_s *dev, unsigned int planeno,
+static int ssd1306_getplaneinfo(FAR struct lcd_dev_s *dev,
+                                unsigned int planeno,
                                 FAR struct lcd_planeinfo_s *pinfo);
 
 /* LCD RGB Mapping */
@@ -178,15 +181,16 @@ static int ssd1306_getplaneinfo(FAR struct lcd_dev_s *dev, unsigned int planeno,
 static int  ssd1306_getpower(struct lcd_dev_s *dev);
 static int  ssd1306_setpower(struct lcd_dev_s *dev, int power);
 static int  ssd1306_getcontrast(struct lcd_dev_s *dev);
-static int  ssd1306_setcontrast(struct lcd_dev_s *dev, unsigned int contrast);
+static int  ssd1306_setcontrast(struct lcd_dev_s *dev,
+                                unsigned int contrast);
 
 static int  ssd1306_do_disponoff(struct ssd1306_dev_s *priv, bool on);
 static int  ssd1306_configuredisplay(struct ssd1306_dev_s *priv);
 static int  ssd1306_redrawfb(struct ssd1306_dev_s *priv);
 
-/**************************************************************************************
+/****************************************************************************
  * Private Data
- **************************************************************************************/
+ ****************************************************************************/
 
 /* This is working memory allocated by the LCD driver for each LCD device
  * and for each color plane.  This memory will hold one raster line of data.
@@ -231,6 +235,7 @@ static const struct lcd_dev_s g_oleddev_dev =
   .getplaneinfo = ssd1306_getplaneinfo,
 
   /* LCD RGB Mapping -- Not supported */
+
   /* Cursor Controls -- Not supported */
 
   /* LCD Specific Controls */
@@ -241,15 +246,17 @@ static const struct lcd_dev_s g_oleddev_dev =
   .setcontrast  = ssd1306_setcontrast,
 };
 
-/* This is the OLED driver instance (only a single device is supported for now) */
+/* This is the OLED driver instance. Only a single device is supported
+ * for now.
+ */
 
 static struct ssd1306_dev_s g_oleddev;
 
-/**************************************************************************************
+/****************************************************************************
  * Private Functions
- **************************************************************************************/
+ ****************************************************************************/
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_putrun
  *
  * Description:
@@ -262,14 +269,13 @@ static struct ssd1306_dev_s g_oleddev;
  *   npixels - The number of pixels to write to the LCD
  *             (range: 0 < npixels <= xres-col)
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 #if defined(CONFIG_LCD_LANDSCAPE) || defined(CONFIG_LCD_RLANDSCAPE)
-static int ssd1306_putrun(fb_coord_t row, fb_coord_t col, FAR const uint8_t *buffer,
+static int ssd1306_putrun(fb_coord_t row, fb_coord_t col,
+                          FAR const uint8_t *buffer,
                           size_t npixels)
 {
-  /* Because of this line of code, we will only be able to support a single UG device */
-
   FAR struct ssd1306_dev_s *priv = (FAR struct ssd1306_dev_s *)&g_oleddev;
   FAR uint8_t *fbptr;
   FAR uint8_t *ptr;
@@ -287,7 +293,8 @@ static int ssd1306_putrun(fb_coord_t row, fb_coord_t col, FAR const uint8_t *buf
   /* Clip the run to the display */
 
   pixlen = npixels;
-  if ((unsigned int)col + (unsigned int)pixlen > (unsigned int)SSD1306_DEV_XRES)
+  if ((unsigned int)col + (unsigned int)pixlen >
+      (unsigned int)SSD1306_DEV_XRES)
     {
       pixlen = (int)SSD1306_DEV_XRES - (int)col;
     }
@@ -305,7 +312,7 @@ static int ssd1306_putrun(fb_coord_t row, fb_coord_t col, FAR const uint8_t *buf
    */
 
 #ifdef SSD1306_DEV_REVERSEY
-  row = (SSD1306_DEV_YRES-1) - row;
+  row = (SSD1306_DEV_YRES - 1) - row;
 #endif
 
   /* If the column is switched then the start of the run is the mirror of
@@ -322,7 +329,7 @@ static int ssd1306_putrun(fb_coord_t row, fb_coord_t col, FAR const uint8_t *buf
    */
 
 #ifdef SSD1306_DEV_REVERSEX
-  col  = (SSD1306_DEV_XRES-1) - col;
+  col  = (SSD1306_DEV_XRES - 1) - col;
   col -= (pixlen - 1);
 #endif
 
@@ -432,6 +439,7 @@ static int ssd1306_putrun(fb_coord_t row, fb_coord_t col, FAR const uint8_t *buf
   ssd1306_cmddata(priv, true);
 
   /* Set the starting position for the run */
+
   /* Set the column address to the XOFFSET value */
 
   ret = ssd1306_sendbyte(priv, SSD1306_SETCOLL(devcol & 0x0f));
@@ -475,7 +483,7 @@ static int ssd1306_putrun(fb_coord_t row, fb_coord_t col, FAR const uint8_t *buf
 #  error "Configuration not implemented"
 #endif
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_getrun
  *
  * Description:
@@ -490,14 +498,12 @@ static int ssd1306_putrun(fb_coord_t row, fb_coord_t col, FAR const uint8_t *buf
  *  npixels - The number of pixels to read from the LCD
  *            (range: 0 < npixels <= xres-col)
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 #if defined(CONFIG_LCD_LANDSCAPE) || defined(CONFIG_LCD_RLANDSCAPE)
-static int ssd1306_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
-                      size_t npixels)
+static int ssd1306_getrun(fb_coord_t row, fb_coord_t col,
+                          FAR uint8_t *buffer, size_t npixels)
 {
-  /* Because of this line of code, we will only be able to support a single UG device */
-
   FAR struct ssd1306_dev_s *priv = &g_oleddev;
   FAR uint8_t *fbptr;
   uint8_t page;
@@ -512,7 +518,8 @@ static int ssd1306_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
   /* Clip the run to the display */
 
   pixlen = npixels;
-  if ((unsigned int)col + (unsigned int)pixlen > (unsigned int)SSD1306_DEV_XRES)
+  if ((unsigned int)col + (unsigned int)pixlen >
+      (unsigned int)SSD1306_DEV_XRES)
     {
       pixlen = (int)SSD1306_DEV_XRES - (int)col;
     }
@@ -530,7 +537,7 @@ static int ssd1306_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
    */
 
 #ifdef SSD1306_DEV_REVERSEY
-  row = (SSD1306_DEV_YRES-1) - row;
+  row = (SSD1306_DEV_YRES - 1) - row;
 #endif
 
   /* If the column is switched then the start of the run is the mirror of
@@ -547,10 +554,11 @@ static int ssd1306_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
    */
 
 #ifdef SSD1306_DEV_REVERSEX
-  col  = (SSD1306_DEV_XRES-1) - col;
+  col = (SSD1306_DEV_XRES - 1) - col;
 #endif
 
   /* Then transfer the display data from the shadow frame buffer memory */
+
   /* Get the page number.  The range of 64 lines is divided up into eight
    * pages of 8 lines each.
    */
@@ -637,49 +645,54 @@ static int ssd1306_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
 #  error "Configuration not implemented"
 #endif
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_getvideoinfo
  *
  * Description:
  *   Get information about the LCD video controller configuration.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 static int ssd1306_getvideoinfo(FAR struct lcd_dev_s *dev,
                                 FAR struct fb_videoinfo_s *vinfo)
 {
   DEBUGASSERT(dev && vinfo);
   lcdinfo("fmt: %d xres: %d yres: %d nplanes: %d\n",
-          g_videoinfo.fmt, g_videoinfo.xres, g_videoinfo.yres, g_videoinfo.nplanes);
+          g_videoinfo.fmt, g_videoinfo.xres, g_videoinfo.yres,
+          g_videoinfo.nplanes);
   memcpy(vinfo, &g_videoinfo, sizeof(struct fb_videoinfo_s));
   return OK;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_getplaneinfo
  *
  * Description:
  *   Get information about the configuration of each LCD color plane.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
-static int ssd1306_getplaneinfo(FAR struct lcd_dev_s *dev, unsigned int planeno,
+static int ssd1306_getplaneinfo(FAR struct lcd_dev_s *dev,
+                                unsigned int planeno,
                                 FAR struct lcd_planeinfo_s *pinfo)
 {
   DEBUGASSERT(pinfo && planeno == 0);
+
   lcdinfo("planeno: %d bpp: %d\n", planeno, g_planeinfo.bpp);
   memcpy(pinfo, &g_planeinfo, sizeof(struct lcd_planeinfo_s));
   return OK;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_getpower
  *
  * Description:
- *   Get the LCD panel power status (0: full off - CONFIG_LCD_MAXPOWER: full on. On
- *   backlit LCDs, this setting may correspond to the backlight setting.
+ *   Get the LCD panel power status:
+ *     0: full off
+ *     CONFIG_LCD_MAXPOWER: full on
+ *   On backlit LCDs, this setting may correspond to the backlight setting.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 static int ssd1306_getpower(FAR struct lcd_dev_s *dev)
 {
@@ -690,13 +703,13 @@ static int ssd1306_getpower(FAR struct lcd_dev_s *dev)
   return priv->on ? CONFIG_LCD_MAXPOWER : 0;
 }
 
- /**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_do_disponoff
  *
  * Description:
  *   Enable/disable LCD panel power
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 static int ssd1306_do_disponoff(struct ssd1306_dev_s *priv, bool on)
 {
@@ -809,13 +822,13 @@ static int ssd1306_setpower(FAR struct lcd_dev_s *dev, int power)
   return OK;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_getcontrast
  *
  * Description:
  *   Get the current contrast setting (0-CONFIG_LCD_MAXCONTRAST).
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 static int ssd1306_getcontrast(struct lcd_dev_s *dev)
 {
@@ -826,13 +839,13 @@ static int ssd1306_getcontrast(struct lcd_dev_s *dev)
   return priv->contrast;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_setcontrast
  *
  * Description:
  *   Set LCD panel contrast (0-CONFIG_LCD_MAXCONTRAST).
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 static int ssd1306_setcontrast(struct lcd_dev_s *dev, unsigned int contrast)
 {
@@ -892,13 +905,13 @@ static int ssd1306_setcontrast(struct lcd_dev_s *dev, unsigned int contrast)
   return OK;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_configuredisplay
  *
  * Description:
  *   Setup LCD display.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
 {
@@ -920,19 +933,25 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
 
 #ifdef IS_SSD1309
 
-  ret = ssd1306_sendbyte(priv, SSD1309_PROTOFF);         /* Unlock driver IC */
+  /* Unlock driver IC */
+
+  ret = ssd1306_sendbyte(priv, SSD1309_PROTOFF);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_DISPOFF);         /* Display off 0xae */
+  /* Display off 0xae */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_DISPOFF);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1309_SETMEMORY);       /* Set page addressing mode: 0x0, 0x01 or 0x02 */
+  /* Set page addressing mode: 0x0, 0x01 or 0x02 */
+
+  ret = ssd1306_sendbyte(priv, SSD1309_SETMEMORY);
   if (ret < 0)
     {
       return ret;
@@ -944,79 +963,105 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_SETCOLL(0));      /* Set lower column address 0x00 */
+  /* Set lower column address 0x00 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_SETCOLL(0));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_SETCOLH(0));      /* Set higher column address 0x10 */
+  /* Set higher column address 0x10 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_SETCOLH(0));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_STARTLINE(0));    /* Set display start line 0x40 */
+  /* Set display start line 0x40 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_STARTLINE(0));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_PAGEADDR(0));     /* Set page address (Can ignore) */
+  /* Set page address (Can ignore) */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_PAGEADDR(0));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CONTRAST_MODE);   /* Contrast control 0x81 */
+  /* Contrast control 0x81 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CONTRAST_MODE);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv ,SSD1306_CONTRAST(SSD1309_DEV_CONTRAST));  /* Default contrast 0xff */
+  /* Default contrast 0xff */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CONTRAST(SSD1309_DEV_CONTRAST));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_REMAPPLEFT);      /* Set segment remap left 95 to 0 | 0xa1 */
+  /* Set segment remap left 95 to 0 | 0xa1 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_REMAPPLEFT);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_EDISPOFF);        /* Normal display off 0xa4 (Can ignore) */
+  /* Normal display off 0xa4 (Can ignore) */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_EDISPOFF);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_NORMAL);          /* Normal (un-reversed) display mode 0xa6 */
+  /* Normal (un-reversed) display mode 0xa6 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_NORMAL);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_MRATIO_MODE);     /* Multiplex ratio 0xa8 */
+  /* Multiplex ratio 0xa8 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_MRATIO_MODE);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_MRATIO(SSD1306_DEV_DUTY));  /* Duty = 1/64 or 1/32 */
+  /* Duty = 1/64 or 1/32 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_MRATIO(SSD1306_DEV_DUTY));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_SCANFROMCOM0);    /* Com scan direction: Scan from COM[0] to COM[n-1] */
+  /* Com scan direction: Scan from COM[0] to COM[n-1] */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_SCANFROMCOM0);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_DISPOFFS_MODE);   /* Set display offset 0xd3 */
+  /* Set display offset 0xd3 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_DISPOFFS_MODE);
   if (ret < 0)
     {
       return ret;
@@ -1028,49 +1073,63 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CLKDIV_SET);      /* Set clock divider 0xd5 */
+  /* Set clock divider 0xd5 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CLKDIV_SET);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CLKDIV(7,0));     /* 0x70 */
+  /* 0x70 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CLKDIV(7, 0));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CHRGPER_SET);     /* Set pre-charge period 0xd9 */
+  /* Set pre-charge period 0xd9 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CHRGPER_SET);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CHRGPER(0x0f,0x0a)); /* 0xfa: Fh cycles for discharge and Ah cycles for pre-charge */
+  /* 0xfa: Fh cycles for discharge and Ah cycles for pre-charge */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CHRGPER(0x0f, 0x0a));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CMNPAD_CONFIG);   /* Set common pads / set com pins hardware configuration 0xda */
+  /* Set common pads / set com pins hardware configuration 0xda */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CMNPAD_CONFIG);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CMNPAD(SSD1306_DEV_CMNPAD)); /* 0x12 or 0x02 */
+  /* 0x12 or 0x02 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CMNPAD(SSD1306_DEV_CMNPAD));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_VCOM_SET);        /* set vcomh 0xdb */
+  /* set vcomh 0xdb */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_VCOM_SET);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_VCOM(0x3C));
+  ret = ssd1306_sendbyte(priv, SSD1306_VCOM(0x3c));
   if (ret < 0)
     {
       return ret;
@@ -1078,91 +1137,89 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
 
 #else
 
-  ret = ssd1306_sendbyte(priv, SSD1306_DISPOFF);          /* Display off 0xae */
+  /* Display off 0xae */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_DISPOFF);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_SETCOLL(0));       /* Set lower column address 0x00 */
+  /* Set lower column address 0x00 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_SETCOLL(0));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_SETCOLH(0));       /* Set higher column address 0x10 */
+  /* Set higher column address 0x10 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_SETCOLH(0));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_STARTLINE(0));     /* Set display start line 0x40 */
+  /* Set display start line 0x40 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_STARTLINE(0));
   if (ret < 0)
     {
       return ret;
     }
 
-#if 0
-  ret = ssd1306_sendbyte(priv, SSD1306_PAGEADDR(0));    /* Set page address  (Can ignore) */
-  if (ret < 0)
-    {
-      return ret;
-    }
-#endif
+  /* Contrast control 0x81 */
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CONTRAST_MODE);    /* Contrast control 0x81 */
+  ret = ssd1306_sendbyte(priv, SSD1306_CONTRAST_MODE);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CONTRAST(SSD1306_DEV_CONTRAST));  /* Default contrast 0xCF */
+  /* Default contrast 0xcf */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CONTRAST(SSD1306_DEV_CONTRAST));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_REMAPPLEFT);       /* Set segment remap left 95 to 0 | 0xa1 */
+  /* Set segment remap left 95 to 0 | 0xa1 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_REMAPPLEFT);
   if (ret < 0)
     {
       return ret;
     }
 
-#if 0
-  ret = ssd1306_sendbyte(priv, SSD1306_EDISPOFF);       /* Normal display off 0xa4 (Can ignore) */
-  if (ret < 0)
-    {
-      return ret;
-    }
-#endif
+  /* Normal (un-reversed) display mode 0xa6 */
 
-  ret = ssd1306_sendbyte(priv, SSD1306_NORMAL);           /* Normal (un-reversed) display mode 0xa6 */
+  ret = ssd1306_sendbyte(priv, SSD1306_NORMAL);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_MRATIO_MODE);      /* Multiplex ratio 0xa8 */
+  /* Multiplex ratio 0xa8 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_MRATIO_MODE);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_MRATIO(SSD1306_DEV_DUTY));  /* Duty = 1/64 or 1/32 */
+  /* Duty = 1/64 or 1/32 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_MRATIO(SSD1306_DEV_DUTY));
   if (ret < 0)
     {
       return ret;
     }
 
-#if 0
-  ret = ssd1306_sendbyte(priv, SSD1306_SCANTOCOM0);     /* Com scan direction: Scan from COM[n-1] to COM[0] (Can ignore) */
-  if (ret < 0)
-    {
-      return ret;
-    }
-#endif
+  /* Set display offset 0xd3 */
 
-  ret = ssd1306_sendbyte(priv, SSD1306_DISPOFFS_MODE);    /* Set display offset 0xd3 */
+  ret = ssd1306_sendbyte(priv, SSD1306_DISPOFFS_MODE);
   if (ret < 0)
     {
       return ret;
@@ -1174,43 +1231,57 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CLKDIV_SET);       /* Set clock divider 0xd5 */
+  /* Set clock divider 0xd5 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CLKDIV_SET);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CLKDIV(8, 0));     /* 0x80 */
+  /* 0x80 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CLKDIV(8, 0));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CHRGPER_SET);      /* Set pre-charge period 0xd9 */
+  /* Set pre-charge period 0xd9 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CHRGPER_SET);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CHRGPER(0x0f, 1)); /* 0xf1 or 0x22 Enhanced mode */
+  /* 0xf1 or 0x22 Enhanced mode */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CHRGPER(0x0f, 1));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CMNPAD_CONFIG);    /* Set common pads / set com pins hardware configuration 0xda */
+  /* Set common pads / set com pins hardware configuration 0xda */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CMNPAD_CONFIG);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CMNPAD(SSD1306_DEV_CMNPAD)); /* 0x12 or 0x02 */
+  /* 0x12 or 0x02 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CMNPAD(SSD1306_DEV_CMNPAD));
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_VCOM_SET);         /* set vcomh 0xdb */
+  /* set vcomh 0xdb */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_VCOM_SET);
   if (ret < 0)
     {
       return ret;
@@ -1222,34 +1293,27 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CHRPUMP_SET);      /* Set Charge Pump enable/disable 0x8d ssd1306 */
+  /* Set Charge Pump enable/disable 0x8d ssd1306 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CHRPUMP_SET);
   if (ret < 0)
     {
       return ret;
     }
 
-  ret = ssd1306_sendbyte(priv, SSD1306_CHRPUMP_ON);       /* 0x14 close 0x10 */
+  /* 0x14 close 0x10 */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_CHRPUMP_ON);
   if (ret < 0)
     {
       return ret;
     }
 
-#if 0
-  ret = ssd1306_sendbyte(priv, SSD1306_DCDC_MODE);      /* DC/DC control mode: on (SSD1306 Not supported) */
-  if (ret < 0)
-    {
-      return ret;
-    }
-
-  ret = ssd1306_sendbyte(priv, SSD1306_DCDC_ON);
-  if (ret < 0)
-    {
-      return ret;
-    }
-#endif
 #endif
 
-  ret = ssd1306_sendbyte(priv, SSD1306_DISPON);           /* Display ON 0xaf */
+  /* Display ON 0xaf */
+
+  ret = ssd1306_sendbyte(priv, SSD1306_DISPON);
   if (ret < 0)
     {
       return ret;
@@ -1265,7 +1329,7 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
   return OK;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_redrawfb
  *
  * Description:
@@ -1277,7 +1341,7 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
  * Assumptions:
  *   Caller has selected the OLED section.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 static int ssd1306_redrawfb(struct ssd1306_dev_s *priv)
 {
@@ -1338,39 +1402,40 @@ static int ssd1306_redrawfb(struct ssd1306_dev_s *priv)
   return OK;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Public Functions
- **************************************************************************************/
+ ****************************************************************************/
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_initialize
  *
  * Description:
- *   Initialize the UG-2864HSWEG01 video hardware.  The initial state of the
- *   OLED is fully initialized, display memory cleared, and the OLED ready
+ *   Initialize the video hardware.  The initial state of the OLED is
+ *   fully initialized, display memory cleared, and the OLED ready
  *   to use, but with the power setting at 0 (full off == sleep mode).
  *
  * Input Parameters:
  *
- *   spi - A reference to the SPI driver instance.
- *   devno - A value in the range of 0 through CONFIG_SSD1306_NINTERFACES-1.
- *     This allows support for multiple OLED devices.
+ *   dev - A reference to the SPI/I2C driver instance.
+ *   board_priv - Board specific structure.
+ *   devno - A device number when there are multiple OLED devices.
+ *     Currently must be zero.
  *
  * Returned Value:
  *
  *   On success, this function returns a reference to the LCD object for
  *   the specified OLED.  NULL is returned on any failure.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_LCD_SSD1306_SPI
 FAR struct lcd_dev_s *ssd1306_initialize(FAR struct spi_dev_s *dev,
-                                         FAR const struct ssd1306_priv_s *board_priv,
-                                         unsigned int devno)
+                          FAR const struct ssd1306_priv_s *board_priv,
+                          unsigned int devno)
 #else
 FAR struct lcd_dev_s *ssd1306_initialize(FAR struct i2c_master_s *dev,
-                                         FAR const struct ssd1306_priv_s *board_priv,
-                                         unsigned int devno)
+                          FAR const struct ssd1306_priv_s *board_priv,
+                          unsigned int devno)
 #endif
 {
   FAR struct ssd1306_dev_s *priv = &g_oleddev;
@@ -1411,20 +1476,22 @@ FAR struct lcd_dev_s *ssd1306_initialize(FAR struct i2c_master_s *dev,
   return &priv->dev;
 }
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_fill
  *
  * Description:
- *   This non-standard method can be used to clear the entire display by writing one
- *   color to the display.  This is much faster than writing a series of runs.
+ *   This non-standard method can be used to clear the entire display by
+ *   writing one color to the display.  This is much faster than writing a
+ *   series of runs.
  *
  * Input Parameters:
- *   priv   - Reference to private driver structure
+ *   dev   - Reference to LCD object
+ *   color - Desired color
  *
  * Assumptions:
  *   Caller has selected the OLED section.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 int ssd1306_fill(FAR struct lcd_dev_s *dev, uint8_t color)
 {

--- a/include/nuttx/lcd/ssd1306.h
+++ b/include/nuttx/lcd/ssd1306.h
@@ -1,22 +1,22 @@
-/**************************************************************************************
+/****************************************************************************
  * include/nuttx/lcd/ssd1306.h
  *
- * Driver for Univision UG-2864HSWEG01 OLED display or UG-2832HSWEG04 both with the
- * Univision SSD1306 controller in SPI mode and Densitron DD-12864WO-4A with SSD1309
- * in SPI mode.
+ * Driver for Univision UG-2864HSWEG01 OLED display or UG-2832HSWEG04 both
+ * with the Univision SSD1306 controller in SPI mode and Densitron
+ * DD-12864WO-4A with SSD1309 in SPI mode.
  *
  *   Copyright (C) 2012-2013, 2015, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * References:
- *   1. Product Specification (Preliminary), Part Name: OEL Display Module, Part ID:
+ *   1. Product Specification, Part Name: OEL Display Module, Part ID:
  *      UG-2864HSWEG01, Doc No: SAS1-9046-B, Univision Technology Inc.
- *   2. Product Specification, Part Name: OEL Display Module, Part ID: UG-2832HSWEG04,
- *      Doc No.: SAS1-B020-B, Univision Technology Inc.
- *   3. SSD1306, 128 X 64 Dot Matrix OLED/PLED, Preliminary Segment/Common Driver with
- *      Controller,  Solomon Systech
- *   4. SSD1309, 128 x 64 Dot Matrix OLED/PLED Segment/Common Driver with Controller,
- *      Solomon Systech
+ *   2. Product Specification, Part Name: OEL Display Module, Part ID:
+ *      UG-2832HSWEG04, Doc No.: SAS1-B020-B, Univision Technology Inc.
+ *   3. SSD1306, 128 X 64 Dot Matrix OLED/PLED, Preliminary Segment/Common
+ *      Driver with Controller, Solomon Systech
+ *   4. SSD1309, 128 x 64 Dot Matrix OLED/PLED Segment/Common Driver with
+ *      Controller, Solomon Systech
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,14 +45,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __INCLUDE_NUTTX_SSD1306_H
 #define __INCLUDE_NUTTX_SSD1306_H
 
-/**************************************************************************************
+/****************************************************************************
  * Included Files
- **************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -62,24 +62,32 @@
 
 #ifdef CONFIG_LCD_SSD1306
 
-/**************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- **************************************************************************************/
-/* Configuration **********************************************************************/
-/* UG-2864HSWEG01 Configuration Settings:
+ ****************************************************************************/
+
+/* Configuration ************************************************************/
+
+/* SSD1306 configuration settings:
  *
- * CONFIG_UG2864HSWEG01_SPIMODE - Controls the SPI mode
- * CONFIG_UG2864HSWEG01_FREQUENCY - Define to use a different bus frequency
- * CONFIG_UG2864HSWEG01_NINTERFACES - Specifies the number of physical UG-2864HSWEG01
- *   devices that will be supported.
+ * CONFIG_SSD1306_SPIMODE - Controls the SPI mode
+ * CONFIG_SSD1306_FREQUENCY - Define to use a different bus frequency
+ *
+ * LCD panel selection settings:
+ *
+ * CONFIG_LCD_UG2864HSWEG01   - Enable UG-2864HSWEG01 support
+ * CONFIG_LCD_UG2832HSWEG04   - Enable UG-2832HSWEG04 support
+ * CONFIG_LCD_DD12864WO4A     - Enable DD-12864WO-4A support
+ * CONFIG_LCD_HILETGO         - Enable HiletGo 129x64 OLED support
+ * CONFIG_LCD_SH1106_OLED_132 - Enable SH1106 132x28 support
  *
  * Required LCD driver settings:
  *
- * CONFIG_LCD_UG28HSWEG01 - Enable UG-2864HSWEG01 support
- * CONFIG_LCD_MAXCONTRAST should be 255, but any value >0 and <=255 will be accepted.
+ * CONFIG_LCD_MAXCONTRAST should be 255, but any value >0 and <=255
+ *   will be accepted.
  * CONFIG_LCD_MAXPOWER must be 1
  *
- * Option LCD driver settings:
+ * Optional LCD driver settings:
  * CONFIG_LCD_LANDSCAPE, CONFIG_LCD_PORTRAIT, CONFIG_LCD_RLANDSCAPE, and
  *   CONFIG_LCD_RPORTRAIT - Display orientation.
  *
@@ -90,27 +98,23 @@
 /* SPI Interface
  *
  * "The serial interface consists of serial clock SCL, serial data SI, A0 and
- *  CS . SI is shifted into an 8-bit shift register on every rising edge of
- *  SCL in the order of D7, D6, … and D0. A0 is sampled on every eighth clock
- *  and the data byte in the shift register is written to the display data RAM
- *  or command register in the same clock."
+ *  CS. SI is shifted into an 8-bit shift register on every rising edge of
+ *  SCL in the order of D7, D6, … and D0. A0 is sampled on every eighth
+ *  clock and the data byte in the shift register is written to the display
+ *  data RAM or command register in the same clock."
  *
  * MODE 3:
  *   Clock polarity:  High (CPOL=1)
  *   Clock phase:     Sample on trailing (rising edge) (CPHA 1)
  */
 
-#ifdef LCD_SSD1306_SPI
-
-#ifndef CONFIG_UG2864HSWEG01_SPIMODE
-#  define CONFIG_UG2864HSWEG01_SPIMODE SPIDEV_MODE3
-#endif
+#ifdef CONFIG_LCD_SSD1306_SPI
 
 /* "This module determines whether the input data is interpreted as data or
- * command. When A0 = “H”, the inputs at D7 - D0 are interpreted as data and be
- * written to display RAM. When A0 = “L”, the inputs at D7 - D0 are interpreted
- * as command, they will be decoded and be written to the corresponding command
- * registers.
+ * command. When A0 = H, the inputs at D7 - D0 are interpreted as data and be
+ * written to display RAM. When A0 = L, the inputs at D7 - D0 are interpreted
+ * as command, they will be decoded and be written to the corresponding
+ * command registers."
  */
 
 #ifndef CONFIG_SPI_CMDDATA
@@ -131,21 +135,13 @@
 
 #endif /* CONFIG_LCD_SSD1306_I2C */
 
-/* CONFIG_UG2864HSWEG01_NINTERFACES determines the number of physical interfaces
- * that will be supported.
- */
-
-#ifndef CONFIG_UG2864HSWEG01_NINTERFACES
-#  define CONFIG_UG2864HSWEG01_NINTERFACES 1
-#endif
-
 /* Check contrast selection */
 
 #if !defined(CONFIG_LCD_MAXCONTRAST)
 #  define CONFIG_LCD_MAXCONTRAST 255
 #endif
 
-#if CONFIG_LCD_MAXCONTRAST <= 0|| CONFIG_LCD_MAXCONTRAST > 255
+#if CONFIG_LCD_MAXCONTRAST <= 0 || CONFIG_LCD_MAXCONTRAST > 255
 #  error "CONFIG_LCD_MAXCONTRAST exceeds supported maximum"
 #endif
 
@@ -199,50 +195,50 @@
 #define SSD1306_Y1_BLACK  0
 #define SSD1306_Y1_WHITE  1
 
-/**************************************************************************************
+/****************************************************************************
  * Public Types
- **************************************************************************************/
+ ****************************************************************************/
 
 struct ssd1306_priv_s
 {
-  bool (*set_vcc) (bool on); /* Allow board to control display power. Return true if
-                                request state set successfully. */
+  bool (*set_vcc) (bool on); /* Allow board to control display power. Return
+                              * true if request state set successfully. */
 };
 
-/**************************************************************************************
+/****************************************************************************
  * Public Data
- **************************************************************************************/
+ ****************************************************************************/
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-/**************************************************************************************
+/****************************************************************************
  * Public Function Prototypes
- **************************************************************************************/
+ ****************************************************************************/
 
-/**************************************************************************************
+/****************************************************************************
  * Name:  ssd1306initialize
  *
  * Description:
- *   Initialize the UG-2864HSWEG01 video hardware.  The initial state of the
- *   OLED is fully initialized, display memory cleared, and the OLED ready
- *   to use, but with the power setting at 0 (full off == sleep mode).
+ *   Initialize the video hardware.  The initial state of the OLED is
+ *   fully initialized, display memory cleared, and the OLED ready to
+ *   use, but with the power setting at 0 (full off == sleep mode).
  *
  * Input Parameters:
  *
  *   dev - A reference to the SPI/I2C driver instance.
  *   board_priv - Board specific structure.
- *   devno - A value in the range of 0 through CONFIG_UG2864HSWEG01_NINTERFACES-1.
- *     This allows support for multiple OLED devices.
+ *   devno - A device number when there are multiple OLED devices.
+ *     Currently must be zero.
  *
  * Returned Value:
  *
  *   On success, this function returns a reference to the LCD object for
  *   the specified OLED.  NULL is returned on any failure.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 struct lcd_dev_s;    /* See include/nuttx/lcd/lcd.h */
 struct spi_dev_s;    /* See include/nuttx/spi/spi.h */
@@ -250,28 +246,30 @@ struct i2c_master_s; /* See include/nuttx/i2c/i2c_master.h */
 
 #ifdef CONFIG_LCD_SSD1306_SPI
 FAR struct lcd_dev_s *ssd1306_initialize(FAR struct spi_dev_s *dev,
-                                         FAR const struct ssd1306_priv_s *board_priv,
-                                         unsigned int devno);
+                          FAR const struct ssd1306_priv_s *board_priv,
+                          unsigned int devno);
 #else
 FAR struct lcd_dev_s *ssd1306_initialize(FAR struct i2c_master_s *dev,
-                                         FAR const struct ssd1306_priv_s *board_priv,
-                                         unsigned int devno);
+                          FAR const struct ssd1306_priv_s *board_priv,
+                          unsigned int devno);
 #endif
 
-/************************************************************************************************
+/****************************************************************************
  * Name:  ssd1306_fill
  *
  * Description:
- *   This non-standard method can be used to clear the entire display by writing one
- *   color to the display.  This is much faster than writing a series of runs.
+ *   This non-standard method can be used to clear the entire display by
+ *   writing one color to the display.  This is much faster than writing a
+ *   series of runs.
  *
  * Input Parameters:
- *   priv   - Reference to private driver structure
+ *   dev   - Reference to LCD object
+ *   color - Desired color
  *
  * Assumptions:
  *   Caller has selected the OLED section.
  *
- **************************************************************************************/
+ ****************************************************************************/
 
 int ssd1306_fill(FAR struct lcd_dev_s *dev, uint8_t color);
 


### PR DESCRIPTION
## Summary
Code cleanup for SSD1306 OLED driver:
- some comments edited for typos and other obvious corrections
- some commented out code removed
- references to non-existent CONFIG* macros removed/corrected to real ones
- one accidental #ifdef LCD_SSD1306_SPI changed to #ifdef CONFIG_LCD_SSD1306_SPI 
  (only affects compile-time pre-processor checks)
- fix one DEBUGASSERT (checked ptr != NULL after dereferencing the ptr)
- nxstyle changes

## Impact
No functional change

## Testing

