### PR TITLE
Add task name record for task trace

### DIFF
--- a/Documentation/components/drivers/character/note.rst
+++ b/Documentation/components/drivers/character/note.rst
@@ -180,6 +180,23 @@ Noteram Device (``/dev/note``)
 
   The header file ``include/nuttx/note/noteram_driver.h`` provides the interface definitions of the device.
 
+``/dev/note`` Data Structures
+--------------------------------
+
+.. c:struct:: noteram_get_taskname_s
+
+  .. code-block:: c
+
+    struct noteram_get_taskname_s
+    {
+      pid_t pid;
+      char taskname[CONFIG_TASK_NAME_SIZE + 1];
+    };
+
+  - ``pid`` : Task ID to get the task name.
+
+  - ``taskname`` : The task name string corresponding to given pid.
+
 ``/dev/note`` Ioctls
 --------------------
 
@@ -221,6 +238,15 @@ Noteram Device (``/dev/note``)
 
   :return: If success, 0 (``OK``) is returned and the given overwriter mode is set as the current settings.
     If failed, a negated ``errno`` is returned.
+
+.. c:macro:: NOTERAM_GETTASKNAME
+
+  Get task name string
+
+  :argument: A writable pointer to :c:struct:`noteram_get_taskname_s`
+
+  :return: If success, 0 (``OK``) is returned and the task name corresponding to given pid is stored into the given pointer.
+           If failed, a negated ``errno`` is returned.
 
 Filter control APIs
 ===================

--- a/Documentation/guides/tasktraceuser.rst
+++ b/Documentation/guides/tasktraceuser.rst
@@ -43,19 +43,26 @@ The following configurations are configurable parameters for trace.
     - Bit 2 = Enable IRQ instrumentation
     - Bit 3 = Enable collecting syscall arguments
 
-- ``CONFIG_SCHED_INSTRUMENTATION_NOTERAM_BUFSIZE``
+- ``CONFIG_SCHED_INSTRUMENTATION_HIRES``
+
+  - If enabled, use higher resolution system timer for instrumentation.
+
+- ``CONFIG_DRIVER_NOTERAM_BUFSIZE``
 
   - Specify the note buffer size in bytes.
     Higher value can hold more note records, but consumes more kernel memory.
 
-- ``CONFIG_SCHED_INSTRUMENTATION_NOTERAM_DEFAULT_NOOVERWRITE``
+- ``CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE``
+
+  - Specify the task name buffer size in bytes.
+    The buffer is used to hold the name of the task during instrumentation.
+    Trace dump can find and show a task name corresponding to given pid in the instrumentation data by using this buffer.
+    If 0 is specified, this feature is disabled and trace dump shows only the name of the newly created task.
+
+- ``CONFIG_DRIVER_NOTERAM_DEFAULT_NOOVERWRITE``
 
   - If enabled, stop overwriting old notes in the circular buffer when the buffer is full by default.
     This is useful to keep instrumentation data of the beginning of a system boot.
-
-- ``CONFIG_SCHED_INSTRUMENTATION_HIRES``
-
-  - If enabled, use higher resolution system timer for instrumentation.
 
 After the configuration, rebuild the NuttX kernel and application.
 

--- a/drivers/note/Kconfig
+++ b/drivers/note/Kconfig
@@ -55,6 +55,19 @@ config DRIVER_NOTERAM_BUFSIZE
 	---help---
 		The size of the in-memory, circular instrumentation buffer (in bytes).
 
+config DRIVER_NOTERAM_TASKNAME_BUFSIZE
+	int "Note RAM task name buffer size"
+	depends on DRIVER_NOTERAM
+	default 256 if TASK_NAME_SIZE > 0
+	default 0 if TASK_NAME_SIZE = 0
+	---help---
+		The size of the in-memory task name buffer (in bytes).
+		The buffer is used to hold the name of the task during instrumentation.
+		Trace dump can find and show a task name corresponding to given pid in
+		the instrumentation data by using this buffer.
+		If 0 is specified, this feature is disabled and trace dump shows only
+		the name of the newly created task.
+
 config DRIVER_NOTERAM_DEFAULT_NOOVERWRITE
 	bool "Disable overwrite by default"
 	depends on DRIVER_NOTERAM

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -44,8 +44,10 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <errno.h>
+#include <string.h>
 
 #include <nuttx/spinlock.h>
+#include <nuttx/sched.h>
 #include <nuttx/sched_note.h>
 #include <nuttx/note/noteram_driver.h>
 #include <nuttx/fs/fs.h>
@@ -62,6 +64,21 @@ struct noteram_info_s
   unsigned int ni_overwrite;
   uint8_t ni_buffer[CONFIG_DRIVER_NOTERAM_BUFSIZE];
 };
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+struct noteram_taskname_info_s
+{
+  uint8_t size;
+  uint8_t pid[2];
+  char name[1];
+};
+
+struct noteram_taskname_s
+{
+  int buffer_used;
+  char buffer[CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE];
+};
+#endif
 
 /****************************************************************************
  * Private Function Prototypes
@@ -99,6 +116,10 @@ static struct noteram_info_s g_noteram_info =
 #endif
 };
 
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+static struct noteram_taskname_s g_noteram_taskname;
+#endif
+
 #ifdef CONFIG_SMP
 static volatile spinlock_t g_noteram_lock;
 #endif
@@ -106,6 +127,170 @@ static volatile spinlock_t g_noteram_lock;
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: noteram_find_taskname
+ *
+ * Description:
+ *   Find task name info corresponding to the specified PID
+ *
+ * Input Parameters:
+ *   PID - Task ID
+ *
+ * Returned Value:
+ *   Pointer to the task name info
+ *   If the corresponding info doesn't exist in the buffer, NULL is returned.
+ *
+ ****************************************************************************/
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+static FAR struct noteram_taskname_info_s *noteram_find_taskname(pid_t pid)
+{
+  int n;
+  FAR struct noteram_taskname_info_s *ti;
+
+  for (n = 0; n < g_noteram_taskname.buffer_used; )
+    {
+      ti = (FAR struct noteram_taskname_info_s *)
+            &g_noteram_taskname.buffer[n];
+      if (ti->pid[0] + (ti->pid[1] << 8) == pid)
+        {
+          return ti;
+        }
+
+      n += ti->size;
+    }
+
+  return NULL;
+}
+#endif
+
+/****************************************************************************
+ * Name: noteram_record_taskname
+ *
+ * Description:
+ *   Record the task name info of the specified task
+ *
+ * Input Parameters:
+ *   PID - Task ID
+ *   name - task name
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+static void noteram_record_taskname(pid_t pid, const char *name)
+{
+  FAR struct noteram_taskname_info_s *ti;
+  size_t tilen;
+  size_t namelen;
+
+  namelen = strlen(name);
+  DEBUGASSERT(namelen <= CONFIG_TASK_NAME_SIZE);
+  tilen = sizeof(struct noteram_taskname_info_s) + namelen;
+  DEBUGASSERT(tilen <= UCHAR_MAX);
+
+  if (g_noteram_taskname.buffer_used + tilen >
+      CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE)
+    {
+      /* No space in the buffer - ignored */
+
+      return;
+    }
+
+  ti = (FAR struct noteram_taskname_info_s *)
+        &g_noteram_taskname.buffer[g_noteram_taskname.buffer_used];
+  ti->size = tilen;
+  ti->pid[0] = pid & 0xff;
+  ti->pid[1] = (pid >> 8) & 0xff;
+  strncpy(ti->name, name, namelen + 1);
+  g_noteram_taskname.buffer_used += tilen;
+}
+#endif
+
+/****************************************************************************
+ * Name: noteram_remove_taskname
+ *
+ * Description:
+ *   Remove the task name info corresponding to the specified PID
+ *
+ * Input Parameters:
+ *   PID - Task ID
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+static void noteram_remove_taskname(pid_t pid)
+{
+  FAR struct noteram_taskname_info_s *ti;
+  size_t tilen;
+  char *src;
+  int sindex;
+
+  ti = noteram_find_taskname(pid);
+  if (ti == NULL)
+    {
+      return;
+    }
+
+  tilen = ti->size;
+  src = (char *)ti + tilen;
+  sindex = src - g_noteram_taskname.buffer;
+
+  memcpy(ti, src, g_noteram_taskname.buffer_used - sindex);
+  g_noteram_taskname.buffer_used -= tilen;
+}
+#endif
+
+/****************************************************************************
+ * Name: noteram_get_taskname
+ *
+ * Description:
+ *   Get the task name string of the specified PID
+ *
+ * Input Parameters:
+ *   PID - Task ID
+ *
+ * Returned Value:
+ *   Pointer to the task name string
+ *   If the corresponding name doesn't exist in the buffer, NULL is returned.
+ *
+ ****************************************************************************/
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+static const char *noteram_get_taskname(pid_t pid)
+{
+  irqstate_t irq_mask;
+  const char *ret = NULL;
+  FAR struct noteram_taskname_info_s *ti;
+  FAR struct tcb_s *tcb;
+
+  irq_mask = enter_critical_section();
+
+  ti = noteram_find_taskname(pid);
+  if (ti != NULL)
+    {
+      ret = ti->name;
+    }
+  else
+    {
+      tcb = nxsched_get_tcb(pid);
+      if (tcb != NULL)
+        {
+          noteram_record_taskname(pid, tcb->name);
+          ret = tcb->name;
+        }
+    }
+
+  leave_critical_section(irq_mask);
+  return ret;
+}
+#endif
 
 /****************************************************************************
  * Name: noteram_buffer_clear
@@ -134,6 +319,10 @@ static void noteram_buffer_clear(void)
     {
       g_noteram_info.ni_overwrite = NOTERAM_MODE_OVERWRITE_DISABLE;
     }
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+  g_noteram_taskname.buffer_used = 0;
+#endif
 
   leave_critical_section(flags);
 }
@@ -254,6 +443,17 @@ static void noteram_remove(void)
   note   = (FAR struct note_common_s *)&g_noteram_info.ni_buffer[tail];
   length = note->nc_length;
   DEBUGASSERT(length <= noteram_length());
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+  if (note->nc_type == NOTE_STOP)
+    {
+      /* The name of the task is no longer needed because the task is deleted
+       * and the corresponding notes are lost.
+       */
+
+      noteram_remove_taskname(note->nc_pid[0] + (note->nc_pid[1] << 8));
+    }
+#endif
 
   /* Increment the tail index to remove the entire note from the circular
    * buffer.
@@ -534,6 +734,42 @@ static int noteram_ioctl(struct file *filep, int cmd, unsigned long arg)
           }
         break;
 
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+      /* NOTERAM_GETTASKNAME
+       *      - Get task name string
+       *        Argument: A writable pointer to struct note_get_taskname_s
+       *        Result:   If -ESRCH, the corresponding task name doesn't
+       *                  exist.
+       */
+
+      case NOTERAM_GETTASKNAME:
+        {
+          struct noteram_get_taskname_s *param;
+          const char *taskname;
+
+        if (arg == 0)
+          {
+            ret = -EINVAL;
+            break;
+          }
+
+          param = (struct noteram_get_taskname_s *)arg;
+          taskname = noteram_get_taskname(param->pid);
+          if (taskname != NULL)
+            {
+              strncpy(param->taskname, taskname, CONFIG_TASK_NAME_SIZE + 1);
+              param->taskname[CONFIG_TASK_NAME_SIZE] = '\0';
+              ret = 0;
+            }
+          else
+            {
+              param->taskname[0] = '\0';
+              ret = -ESRCH;
+            }
+        }
+        break;
+#endif
+
       default:
           break;
     }
@@ -583,6 +819,22 @@ void sched_note_add(FAR const void *note, size_t notelen)
       up_irq_restore(flags);
       return;
     }
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+  /* Record the name if the new task was created */
+
+    {
+      FAR struct note_start_s *note_st;
+
+      note_st = (FAR struct note_start_s *)note;
+      if (note_st->nst_cmn.nc_type == NOTE_START)
+        {
+          noteram_record_taskname(note_st->nst_cmn.nc_pid[0] +
+                                  (note_st->nst_cmn.nc_pid[1] << 8),
+                                  note_st->nst_name);
+        }
+    }
+#endif
 
   /* Get the index to the head of the circular buffer */
 

--- a/include/nuttx/note/noteram_driver.h
+++ b/include/nuttx/note/noteram_driver.h
@@ -27,6 +27,7 @@
 
 #include <nuttx/config.h>
 #include <nuttx/fs/ioctl.h>
+#include <sys/types.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -43,12 +44,21 @@
  * NOTERAM_SETMODE
  *              - Set overwrite mode
  *                Argument: A read-only pointer to unsigned int
+ * NOTERAM_GETTASKNAME
+ *              - Get task name string
+ *                Argument: A writable pointer to struct
+ *                          noteram_get_taskname_s
+ *                Result:   If -ESRCH, the corresponding task name doesn't
+ *                          exist.
  */
 
 #ifdef CONFIG_DRIVER_NOTERAM
 #define NOTERAM_CLEAR           _NOTERAMIOC(0x01)
 #define NOTERAM_GETMODE         _NOTERAMIOC(0x02)
 #define NOTERAM_SETMODE         _NOTERAMIOC(0x03)
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+#define NOTERAM_GETTASKNAME     _NOTERAMIOC(0x04)
+#endif
 #endif
 
 /* Overwrite mode definitions */
@@ -57,6 +67,20 @@
 #define NOTERAM_MODE_OVERWRITE_DISABLE      0
 #define NOTERAM_MODE_OVERWRITE_ENABLE       1
 #define NOTERAM_MODE_OVERWRITE_OVERFLOW     2
+#endif
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* This is the type of the argument passed to the NOTERAM_GETTASKNAME ioctl */
+
+#if CONFIG_DRIVER_NOTERAM_TASKNAME_BUFSIZE > 0
+struct noteram_get_taskname_s
+{
+  pid_t pid;
+  char taskname[CONFIG_TASK_NAME_SIZE + 1];
+};
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Currently, trace dump can show the task name of only newly created task because only `struct note_start_s` has the task name information.
This PR adds the function to record the task name corresponding to the given pid which is used while instrumentation.
By this extension, trace dump command can show all task names.

Before:
```
<noname>-3   [0]   2.300000000: sys_sched_unlock()
<noname>-3   [0]   2.300000000: sys_sched_unlock -> 0x0
<noname>-3   [0]   2.300000000: sys_nxsched_get_streams()
<noname>-3   [0]   2.300000000: sys_nxsched_get_streams -> 0xd029edc
<noname>-3   [0]   2.300000000: sys_ioctl(arg0: 0x1, arg1: 0x118, arg2: 0x5)
<noname>-3   [0]   2.300000000: sys_ioctl -> 0xffffffff
<noname>-3   [0]   2.300000000: sys_waitpid(arg0: 0x5, arg1: 0xd02a6e4, arg2: 0x4)
<noname>-3   [0]   2.300000000: sched_switch: prev_comm=<noname> prev_pid=3 prev_state=S ==> next_comm=trace next_pid=5
   trace-5   [0]   2.300000000: irq_handler_entry: irq=11
   trace-5   [0]   2.300000000: irq_handler_exit: irq=11
   trace-5   [0]   2.300000000: sys_open(arg0: 0xd01aa0c, arg1: 0x0, arg2: 0x1)
   trace-5   [0]   2.300000000: sys_open -> 0x3
   trace-5   [0]   2.300000000: sys_nxsched_get_streams()
   trace-5   [0]   2.300000000: sys_nxsched_get_streams -> 0xd02bfcc
   trace-5   [0]   2.300000000: sys_ioctl(arg0: 0x3, arg1: 0x2c01, arg2: 0xd02c888)
   trace-5   [0]   2.300000000: sys_ioctl -> 0x0
   trace-5   [0]   2.300000000: sys_ioctl(arg0: 0x3, arg1: 0x2c02, arg2: 0xd02c888)
```

After:
```
    init-3   [0]   1.660000000: sys_sched_unlock -> 0x0
    init-3   [0]   1.660000000: sys_nxsched_get_streams()
    init-3   [0]   1.660000000: sys_nxsched_get_streams -> 0xd029edc
    init-3   [0]   1.660000000: sys_ioctl(arg0: 0x1, arg1: 0x118, arg2: 0x5)
    init-3   [0]   1.660000000: sys_ioctl -> 0xffffffff
    init-3   [0]   1.660000000: sys_waitpid(arg0: 0x5, arg1: 0xd02a6e4, arg2: 0x4)
    init-3   [0]   1.660000000: sched_switch: prev_comm=init prev_pid=3 prev_state=S ==> next_comm=trace next_pid=5
   trace-5   [0]   1.660000000: irq_handler_entry: irq=11
   trace-5   [0]   1.660000000: irq_handler_exit: irq=11
   trace-5   [0]   1.660000000: sys_open(arg0: 0xd01ab44, arg1: 0x0, arg2: 0x1)
   trace-5   [0]   1.660000000: sys_open -> 0x3
   trace-5   [0]   1.660000000: sys_nxsched_get_streams()
   trace-5   [0]   1.660000000: sys_nxsched_get_streams -> 0xd02bfcc
   trace-5   [0]   1.660000000: sys_ioctl(arg0: 0x3, arg1: 0x2c01, arg2: 0xd02c888)
   trace-5   [0]   1.660000000: sys_ioctl -> 0x0
   trace-5   [0]   1.660000000: sys_ioctl(arg0: 0x3, arg1: 0x2c02, arg2: 0xd02c888)
```

## Impact
- New kernel configuration `DRIVER_NOTERAM_TASKNAME_BUFSIZE` is added.

## Testing
Tested with spresense:smp
