### PR TITLE
tools: cxd56: mkspk: automate mkspk build

### DIFF
--- a/boards/arm/cxd56xx/spresense/scripts/Make.defs
+++ b/boards/arm/cxd56xx/spresense/scripts/Make.defs
@@ -35,7 +35,7 @@
 
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
-include $(TOPDIR)/boards/arm/cxd56xx/spresense/scripts/Config.mk
+include $(TOPDIR)/tools/cxd56/Config.mk
 include $(TOPDIR)/arch/arm/src/armv7-m/Toolchain.defs
 
 # Setup for the kind of memory that we are executing from

--- a/tools/Makefile.host
+++ b/tools/Makefile.host
@@ -261,6 +261,7 @@ ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) rm -rf *.dSYM
 endif
 	$(Q) $(MAKE) -C pic32 -f Makefile.host clean
+	$(Q) $(MAKE) -C cxd56 -f Makefile.host clean
 	$(call DELFILE, incdir)
 	$(call DELFILE, incdir.exe)
 	$(call CLEAN)

--- a/tools/cxd56/Config.mk
+++ b/tools/cxd56/Config.mk
@@ -1,5 +1,5 @@
 ############################################################################
-# board/arm/cxd56xx/spresense/script/Config.mk
+# tools/cxd56/Config.mk
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -24,18 +24,15 @@
 
 # POSTBUILD -- Perform post build operations
 
+
 ifeq ($(CONFIG_CXD56_BINARY),y)
+
 define POSTBUILD
-	$(Q) if [ ! -f "tools/cxd56/mkspk" ] ; then \
-		echo ""; \
-		echo "Please run the following command to build the needed tool"; \
-		echo ""; \
-		echo "cd tools/cxd56 && make && cd ../.."; \
-		echo ""; \
-		echo "run make again to create the nuttx.spk image."; \
-	else \
-		echo "Generating: $(NUTTXNAME).spk"; \
-		tools/cxd56/mkspk -c2 nuttx nuttx nuttx.spk; \
-	fi
+	$(Q)echo "Generating: $(NUTTXNAME).spk"; \
+
+	+$(Q) $(MAKE) -C $(TOPDIR)$(DELIM)tools$(DELIM)cxd56 -f Makefile.host
+	tools$(DELIM)cxd56$(DELIM)mkspk$(HOSTEXEEXT) -c2 nuttx nuttx nuttx.spk;
+	$(Q)([ $$? -eq 0 ] && echo "Done.")
 endef
+
 endif

--- a/tools/cxd56/Makefile.host
+++ b/tools/cxd56/Makefile.host
@@ -1,5 +1,5 @@
 ############################################################################
-# tools/mkspk/Makefile
+# tools/cxd56/Makefile.host
 #
 #   Copyright (C) 2011-2012 Gregory Nutt. All rights reserved.
 #   Author: Gregory Nutt <gnutt@nuttx.org>


### PR DESCRIPTION
## Summary
the mkspk tool will automaticaly be built if CONFIG_CXD56_BINARY
is set.

## Impact
CXD56 board (Sony Spresense)

## Testing
Test:
nuttx.spk was succesfully generated
