### PR TITLE
drivers/pipes: nx_pipe syscall takes three params, also use nx_close …

### DIFF
--- a/drivers/pipes/fifo.c
+++ b/drivers/pipes/fifo.c
@@ -102,8 +102,8 @@ static const struct file_operations fifo_fops =
  *   bufsize - The size of the in-memory, circular buffer in bytes.
  *
  * Returned Value:
- *   0 is returned on success; otherwise, the negative error code return
- *   appropriately.
+ *   0 is returned on success; a negated errno value is returned on a
+ *   failure.
  *
  ****************************************************************************/
 

--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -179,10 +179,11 @@ static int pipe_close(FAR struct file *filep)
  *   fd[2] - The user provided array in which to catch the pipe file
  *   descriptors
  *   bufsize - The size of the in-memory, circular buffer in bytes.
+ *   flags - The file status flags.
  *
  * Returned Value:
- *   0 is returned on success; otherwise, -1 is returned with errno set
- *   appropriately.
+ *   0 is returned on success; a negated errno value is returned on a
+ *   failure.
  *
  ****************************************************************************/
 
@@ -268,7 +269,7 @@ int nx_pipe(int fd[2], size_t bufsize, int flags)
   return OK;
 
 errout_with_wrfd:
-  close(fd[1]);
+  nx_close(fd[1]);
 
 errout_with_driver:
   unregister_driver(devname);

--- a/include/nuttx/drivers/drivers.h
+++ b/include/nuttx/drivers/drivers.h
@@ -236,8 +236,8 @@ ssize_t bchlib_write(FAR void *handle, FAR const char *buffer, size_t offset,
  *   flags - The file status flags.
  *
  * Returned Value:
- *   0 is returned on success; otherwise, the negative error code return
- *   appropriately.
+ *   0 is returned on success; a negated errno value is returned on a
+ *   failure.
  *
  ****************************************************************************/
 
@@ -274,8 +274,8 @@ int nx_pipe(int fd[2], size_t bufsize, int flags);
  *   bufsize - The size of the in-memory, circular buffer in bytes.
  *
  * Returned Value:
- *   0 is returned on success; otherwise, the negative error code return
- *   appropriately.
+ *   0 is returned on success; a negated errno value is returned on a
+ *   failure.
  *
  ****************************************************************************/
 

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -255,7 +255,7 @@ SYSCALL_LOOKUP(telldir,                    1)
 #endif
 
 #if defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0
-  SYSCALL_LOOKUP(nx_pipe,                  2)
+  SYSCALL_LOOKUP(nx_pipe,                  3)
   SYSCALL_LOOKUP(nx_mkfifo,                3)
 #endif
 


### PR DESCRIPTION
## Summary

- Fix SYSCALL_LOOKUP for nx_pipe syscall
- Use nx_close() instead of close() to avoid setting errno and cancellation point
- Update some misleading comments

## Impact

## Testing

