### PR TITLE
Use nx_close() inside OS

### DIFF
--- a/fs/inode/fs_fileopen.c
+++ b/fs/inode/fs_fileopen.c
@@ -102,7 +102,7 @@ int file_open(FAR struct file *filep, FAR const char *path, int oflags, ...)
   ret = file_detach(fd, filep);
   if (ret < 0)
     {
-      close(fd);
+      nx_close(fd);
       return ret;
     }
 

--- a/sched/group/group_setupidlefiles.c
+++ b/sched/group/group_setupidlefiles.c
@@ -66,9 +66,8 @@
  *   tcb - tcb of the idle task.
  *
  * Returned Value:
- *   None
- *
- * Assumptions:
+ *   0 is returned on success; a negated errno value is returned on a
+ *   failure.
  *
  ****************************************************************************/
 
@@ -114,7 +113,7 @@ int group_setupidlefiles(FAR struct task_tcb_s *tcb)
       if (fd > 0)
         {
           sinfo("Open /dev/console fd: %d\n", fd);
-          close(fd);
+          nx_close(fd);
         }
       else
         {

--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -68,11 +68,11 @@ struct spawn_parms_s g_spawn_parms;
 
 static inline int nxspawn_close(FAR struct spawn_close_file_action_s *action)
 {
-  /* The return value from close() is ignored */
+  /* The return value from nx_close() is ignored */
 
   sinfo("Closing fd=%d\n", action->fd);
 
-  close(action->fd);
+  nx_close(action->fd);
   return OK;
 }
 
@@ -131,7 +131,7 @@ static inline int nxspawn_open(FAR struct spawn_open_file_action_s *action)
         }
 
       sinfo("Closing fd=%d\n", fd);
-      close(fd);
+      nx_close(fd);
     }
 
   return ret;


### PR DESCRIPTION
## Summary

Use nx_close() instead of close() inside OS to avoid setting errno and having a cancellation point.

## Impact

## Testing

