### PR TITLE
nrf52832: add errata mitigation code for various RADIO issues

### DIFF
--- a/arch/arm/src/nrf52/hardware/nrf52_ficr.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_ficr.h
@@ -1,35 +1,20 @@
-/*****************************************************************************
+/****************************************************************************
  * arch/arm/src/nrf52/hardware/nrf52_ficr.h
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author:  Alan Carvalho de Assis <acassis@gmail.com>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -98,7 +83,7 @@
 #define NRF52_FICR_NFC_TAGHEADER2_OFFSET 0x458  /* Default header for NFC Tag */
 #define NRF52_FICR_NFC_TAGHEADER3_OFFSET 0x45c  /* Default header for NFC Tag */
 
-/* FICR Register Addresses **************************************************************************/
+/* FICR Register Addresses **************************************************/
 
 #define NRF52_FICR_CODEPAGESIZE          (NRF52_FICR_BASE + NRF52_FICR_CODEPAGESIZE_OFFSET)
 #define NRF52_FICR_CODESIZE              (NRF52_FICR_BASE + NRF52_FICR_CODESIZE_OFFSET)
@@ -147,8 +132,19 @@
 #define NRF52_FICR_NFC_TAGHEADER2        (NRF52_FICR_BASE + NRF52_FICR_NFC_TAGHEADER2_OFFSET)
 #define NRF52_FICR_NFC_TAGHEADER3        (NRF52_FICR_BASE + NRF52_FICR_NFC_TAGHEADER3_OFFSET)
 
-/* FICR Register Bitfield Definitions **************************************************************/
+/* FICR Register Bitfield Definitions ***************************************/
 
-/* TODO: */
+/* These values are ASCII encoded definitions of each four letter
+ * combination. The datasheet does not list all values, so we added a few
+ * more.
+ */
+
+#define NRF52_FICR_INFO_VARIANT_AAAA     (0x41414141)
+#define NRF52_FICR_INFO_VARIANT_AAAB     (0x41414142)
+#define NRF52_FICR_INFO_VARIANT_AABA     (0x41414241)
+#define NRF52_FICR_INFO_VARIANT_AABB     (0x41414242)
+#define NRF52_FICR_INFO_VARIANT_AAB0     (0x41414230)
+#define NRF52_FICR_INFO_VARIANT_ABB0     (0x41424230)
+#define NRF52_FICR_INFO_VARIANT_AAE0     (0x41414530)
 
 #endif /* __ARCH_ARM_SRC_NRF52_HARDWARE_NRF52_FICR_H */

--- a/arch/arm/src/nrf52/hardware/nrf52_temp.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_temp.h
@@ -1,0 +1,98 @@
+/****************************************************************************
+ * arch/arm/src/nrf52/hardware/nrf52_temp.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_NRF52_HARDWARE_NRF52_TEMP_H
+#define __ARCH_ARM_SRC_NRF52_HARDWARE_NRF52_TEMP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Register offsets *********************************************************/
+
+#define NRF52_TEMP_TASKS_START_OFFSET     0x000000  /* Start temperature measurement */
+#define NRF52_TEMP_TASKS_STOP_OFFSET      0x000004  /* Stop temperature measurement */
+#define NRF52_TEMP_EVENTS_DATARDY_OFFSET  0x000100  /* Temperature measurement complete, data ready */
+#define NRF52_TEMP_INTENSET_OFFSET        0x000304  /* Enable interrupt */
+#define NRF52_TEMP_INTENCLR_OFFSET        0x000308  /* Disable interrupt */
+#define NRF52_TEMP_TEMP_OFFSET            0x000508  /* Temperature in degC */
+
+#define NRF52_TEMP_A0_OFFSET              0x000520  /* Slope of 1st piece wise linear function */
+#define NRF52_TEMP_A1_OFFSET              0x000524  /* Slope of 2nd piece wise linear function */
+#define NRF52_TEMP_A2_OFFSET              0x000528  /* Slope of 3rd piece wise linear function */
+#define NRF52_TEMP_A3_OFFSET              0x00052C  /* Slope of 4th piece wise linear function */
+#define NRF52_TEMP_A4_OFFSET              0x000530  /* Slope of 5th piece wise linear function */
+#define NRF52_TEMP_A5_OFFSET              0x000534  /* Slope of 6th piece wise linear function */
+
+#define NRF52_TEMP_B0_OFFSET              0x000540  /* y-intercept of 1st piece wise linear function */
+#define NRF52_TEMP_B1_OFFSET              0x000544  /* y-intercept of 2nd piece wise linear function */
+#define NRF52_TEMP_B2_OFFSET              0x000548  /* y-intercept of 3rd piece wise linear function */
+#define NRF52_TEMP_B3_OFFSET              0x00054C  /* y-intercept of 4th piece wise linear function */
+#define NRF52_TEMP_B4_OFFSET              0x000550  /* y-intercept of 5th piece wise linear function */
+#define NRF52_TEMP_B5_OFFSET              0x000554  /* y-intercept of 6th piece wise linear function */
+
+#define NRF52_TEMP_T0_OFFSET              0x000560  /* End point of 1st piece wise linear function */
+#define NRF52_TEMP_T1_OFFSET              0x000564  /* End point of 2nd piece wise linear function */
+#define NRF52_TEMP_T2_OFFSET              0x000568  /* End point of 3rd piece wise linear function */
+#define NRF52_TEMP_T3_OFFSET              0x00056C  /* End point of 4th piece wise linear function */
+#define NRF52_TEMP_T4_OFFSET              0x000570  /* End point of 5th piece wise linear function */
+
+/* Register definitions *****************************************************/
+
+#define NRF52_TEMP_TASKS_START     (NRF52_TEMP_BASE + NRF52_TEMP_TASKS_START_OFFSET)
+#define NRF52_TEMP_TASKS_STOP      (NRF52_TEMP_BASE + NRF52_TEMP_TASKS_STOP_OFFSET)
+#define NRF52_TEMP_EVENTS_DATARDY  (NRF52_TEMP_BASE + NRF52_TEMP_EVENTS_DATARDY_OFFSET)
+#define NRF52_TEMP_INTENSET        (NRF52_TEMP_BASE + NRF52_TEMP_INTENSET_OFFSET)
+#define NRF52_TEMP_INTENCLR        (NRF52_TEMP_BASE + NRF52_TEMP_INTENCLR_OFFSET)
+#define NRF52_TEMP_TEMP            (NRF52_TEMP_BASE + NRF52_TEMP_TEMP_OFFSET)
+
+#define NRF52_TEMP_A0              (NRF52_TEMP_BASE + NRF52_TEMP_A0_OFFSET)
+#define NRF52_TEMP_A1              (NRF52_TEMP_BASE + NRF52_TEMP_A1_OFFSET)
+#define NRF52_TEMP_A2              (NRF52_TEMP_BASE + NRF52_TEMP_A2_OFFSET)
+#define NRF52_TEMP_A3              (NRF52_TEMP_BASE + NRF52_TEMP_A3_OFFSET)
+#define NRF52_TEMP_A4              (NRF52_TEMP_BASE + NRF52_TEMP_A4_OFFSET)
+#define NRF52_TEMP_A5              (NRF52_TEMP_BASE + NRF52_TEMP_A5_OFFSET)
+
+#define NRF52_TEMP_B0              (NRF52_TEMP_BASE + NRF52_TEMP_B0_OFFSET)
+#define NRF52_TEMP_B1              (NRF52_TEMP_BASE + NRF52_TEMP_B1_OFFSET)
+#define NRF52_TEMP_B2              (NRF52_TEMP_BASE + NRF52_TEMP_B2_OFFSET)
+#define NRF52_TEMP_B3              (NRF52_TEMP_BASE + NRF52_TEMP_B3_OFFSET)
+#define NRF52_TEMP_B4              (NRF52_TEMP_BASE + NRF52_TEMP_B4_OFFSET)
+#define NRF52_TEMP_B5              (NRF52_TEMP_BASE + NRF52_TEMP_B5_OFFSET)
+
+#define NRF52_TEMP_T0              (NRF52_TEMP_BASE + NRF52_TEMP_T0_OFFSET)
+#define NRF52_TEMP_T1              (NRF52_TEMP_BASE + NRF52_TEMP_T1_OFFSET)
+#define NRF52_TEMP_T2              (NRF52_TEMP_BASE + NRF52_TEMP_T2_OFFSET)
+#define NRF52_TEMP_T3              (NRF52_TEMP_BASE + NRF52_TEMP_T3_OFFSET)
+#define NRF52_TEMP_T4              (NRF52_TEMP_BASE + NRF52_TEMP_T4_OFFSET)
+
+/* Register bit definitions *************************************************/
+
+#define NRF52_TEMP_INTENSET_DATARDY  (1 << 0)  /* Read: Enabled */
+
+#define NRF52_TEMP_INTENCLR_DATARDY  (1 << 0)  /* Read: Enabled */
+
+#endif // __ARCH_ARM_SRC_NRF52_HARDWARE_NRF52_TEMP_H

--- a/arch/arm/src/nrf52/nrf52832_errdata.c
+++ b/arch/arm/src/nrf52/nrf52832_errdata.c
@@ -54,6 +54,8 @@
 #include "chip.h"
 #include "hardware/nrf52_utils.h"
 #include "hardware/nrf52_rng.h"
+#include "hardware/nrf52_ficr.h"
+#include "hardware/nrf52_temp.h"
 #include "arm_internal.h"
 
 /****************************************************************************
@@ -100,6 +102,20 @@ static void nrf52832_errdata_16(void)
     }
 }
 
+static void nrf52832_errdata_102(void)
+{
+  uint32_t regval = getreg32(NRF52_FICR_INFO_VARIANT);
+
+  /* Also addresses erratas 106, 146. Revision 1 chips are affected */
+
+  if (regval == NRF52_FICR_INFO_VARIANT_AAB0 ||
+      regval == NRF52_FICR_INFO_VARIANT_ABB0)
+    {
+      *(volatile uint32_t *) 0x40001774 =
+          ((*(volatile uint32_t *) 0x40001774) & 0xfffffffe) | 0x01000000;
+    }
+}
+
 static void nrf52832_errdata_66_temp(void)
 {
   /* Workaround for Errata 66 "TEMP: Linearity specification not met with
@@ -109,38 +125,30 @@ static void nrf52832_errdata_66_temp(void)
 
   if (errata_66())
     {
-      uint32_t temp_offset      = 0x520;
-      uint32_t temp_ficr_offset = 0x404;
       int i;
 
       /* slot A : 6 totals */
 
       for (i = 0; i < 6; i++)
         {
-          putreg32(getreg32(NRF52_FICR_BASE + temp_ficr_offset + i * 4),
-                            NRF52_TEMP_BASE + temp_offset + i * 4);
+          putreg32(getreg32(NRF52_FICR_TEMP_A0 + i * 4),
+                   NRF52_TEMP_A0 + i * 4);
         }
 
       /* Slot B : 6 totals */
 
-      temp_offset      = 0x540;
-      temp_ficr_offset = 0x41c;
-
       for (i = 0 ; i < 6; i++)
         {
-          putreg32(getreg32(NRF52_FICR_BASE + temp_ficr_offset + i * 4),
-                   NRF52_TEMP_BASE + temp_offset + i * 4);
+          putreg32(getreg32(NRF52_FICR_TEMP_B0 + i * 4),
+                   NRF52_TEMP_B0 + i * 4);
         }
 
       /* slot C : 5 totals */
 
-      temp_offset      = 0x560;
-      temp_ficr_offset = 0x434;
-
       for (i = 0; i < 5; i++)
         {
-          putreg32(getreg32(NRF52_FICR_BASE + temp_ficr_offset + i * 4),
-                   NRF52_TEMP_BASE + temp_offset + i * 4);
+          putreg32(getreg32(NRF52_FICR_TEMP_T0 + i * 4),
+                   NRF52_TEMP_T0 + i * 4);
         }
     }
 }
@@ -154,4 +162,6 @@ void nrf52832_errdata_init(void)
   nrf52832_errdata_16();
 
   nrf52832_errdata_66_temp();
+
+  nrf52832_errdata_102();
 }


### PR DESCRIPTION
## Summary

This change applies workaround code recommended by Nordic to deal with various RADIO silicon bugs.
It also improves the existing workarounds by using register definitions instead of hard coded values.

nrf52_ficr.h converted to Apache license (Alan and Greg are copyright holders).

## Impact

Avoids hardware bugs

## Testing

Normal RADIO peripheral use

