### PR TITLE
build: Fix testbuild.sh artifact copy on macOS

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -258,7 +258,7 @@ function build {
   if [ ${SAVEARTIFACTS} -eq 1 ]; then
     artifactconfigdir=$ARTIFACTDIR/$(echo $config | sed "s/:/\//")/
     mkdir -p $artifactconfigdir
-    xargs -a $nuttx/nuttx.manifest cp -t $artifactconfigdir
+    xargs -I "{}" cp "{}" $artifactconfigdir < $nuttx/nuttx.manifest
   fi
 
   # Ensure defconfig in the canonical form


### PR DESCRIPTION
## Summary
xargs for macOS does not support the '-a/--file-arg' flag so build artifacts were not getting stored.  This change passes it in via stdin which is more portable.

## Impact
Build artifacts are preserved when ./tools/testbuild.sh is used with the `-A` flag on macOS.

## Testing
Local Linux testing and macOS for CI.  We should see both linux-build and macos-build artiact bundles created by the CI system.

From a run against this PR:
![image](https://user-images.githubusercontent.com/173245/97532456-a24fbc00-1973-11eb-8784-c1633228995a.png)
