### PR TITLE
xtensa/esp32: Fix SPI master DMA RX buffer memcpy size error

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -865,7 +865,8 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
                                    FAR void *rxbuffer,
                                    uint32_t nwords)
 {
-  uint32_t bytes = nwords * (priv->nbits / 8);
+  const uint32_t total = nwords * (priv->nbits / 8);
+  uint32_t bytes = total;
   uint8_t *tp;
   uint8_t *rp;
   uint32_t n;
@@ -880,9 +881,9 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
 #ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
   if (esp32_ptr_extram(txbuffer))
     {
-      alloctp = xtensa_imm_malloc(bytes);
+      alloctp = xtensa_imm_malloc(total);
       DEBUGASSERT(alloctp != NULL);
-      memcpy(alloctp, txbuffer, bytes);
+      memcpy(alloctp, txbuffer, total);
       tp = alloctp;
     }
   else
@@ -894,7 +895,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
 #ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
   if (esp32_ptr_extram(rxbuffer))
     {
-      allocrp = xtensa_imm_malloc(bytes);
+      allocrp = xtensa_imm_malloc(total);
       DEBUGASSERT(allocrp != NULL);
       rp = allocrp;
     }
@@ -966,7 +967,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
 #ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
   if (esp32_ptr_extram(rxbuffer))
     {
-      memcpy(rxbuffer, allocrp, bytes);
+      memcpy(rxbuffer, allocrp, total);
       xtensa_imm_free(allocrp);
     }
 #endif


### PR DESCRIPTION
## Summary

Fix SPI master DMA RX buffer memcpy size error

## Impact

## Testing

Test by ESP32 self transmission.
