### PR TITLE
s/BUSY/EBUSY typo fix, which ressulted in compile error

### DIFF
--- a/arch/arm/src/samd2l2/sam_i2c_master.c
+++ b/arch/arm/src/samd2l2/sam_i2c_master.c
@@ -998,7 +998,7 @@ static int sam_i2c_transfer(FAR struct i2c_master_s *dev,
 
   /* Initiate the message transfer */
 
-  ret = -BUSY;
+  ret = -EBUSY;
 
   /* Initiate the transfer.  The rest will be handled from interrupt logic.
    * Interrupts must be disabled to prevent re-entrance from the interrupt


### PR DESCRIPTION
## Summary
EBUSY was misspelled as BUSY

## Impact
Compile error when using i2c master on SAMD2L2

## Testing

