### PR TITLE
[BACKPORT BT] Backports various fixes to Bluetooth stack

### DIFF
--- a/include/nuttx/wireless/bluetooth/bt_hci.h
+++ b/include/nuttx/wireless/bluetooth/bt_hci.h
@@ -12,30 +12,31 @@
  *   All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * modification, are permitted provided that the following conditions are
+ * met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  *
  * 3. Neither the name of the copyright holder nor the names of its
- *    contributors may be used to endorse or promote products derived from this
- *    software without specific prior written permission.
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
 
@@ -64,9 +65,16 @@
 
 /* HCI Error Codes */
 
+#define BT_HCI_SUCCESS                    0x00
+#define BT_HCI_PENDING                    0x00
+#define BT_HCI_ERR_UNKNOWN_COMMAND        0x01
+#define BT_HCI_ERR_CONNECTION_TIMEOUT     0x08
 #define BT_HCI_ERR_AUTHENTICATION_FAIL    0x05
+#define BT_HCI_ERR_COMMAND_DISALLOWED     0x0C
+#define BT_HCI_ERR_INVALID_PARAMETERS     0x12
 #define BT_HCI_ERR_REMOTE_USER_TERM_CONN  0x13
 #define BT_HCI_ERR_UNSUPP_REMOTE_FEATURE  0x1a
+#define BT_HCI_ERR_INSTANT_PASSED         0x28
 #define BT_HCI_ERR_PAIRING_NOT_SUPPORTED  0x29
 #define BT_HCI_ERR_UNACCEPT_CONN_PARAMS   0x3b
 
@@ -129,8 +137,11 @@
 #define BT_HCI_OP_READ_LOCAL_FEATURES         BT_OP(BT_OGF_INFO, 0x0003)
 #define BT_HCI_OP_READ_BUFFER_SIZE            BT_OP(BT_OGF_INFO, 0x0005)
 #define BT_HCI_OP_READ_BD_ADDR                BT_OP(BT_OGF_INFO, 0x0009)
+#define BT_HCI_OP_LE_SET_EVENT_MASK           BT_OP(BT_OGF_LE, 0x0001)
 #define BT_HCI_OP_LE_READ_BUFFER_SIZE         BT_OP(BT_OGF_LE, 0x0002)
 #define BT_HCI_OP_LE_READ_LOCAL_FEATURES      BT_OP(BT_OGF_LE, 0x0003)
+
+#define BT_HCI_OP_LE_SET_RAND_ADDR            BT_OP(BT_OGF_LE, 0x0005)
 
 /* Advertising types */
 
@@ -157,7 +168,12 @@
 #  define BT_LE_SCAN_FILTER_DUP_ENABLE        0x01
 #define BT_HCI_OP_LE_CREATE_CONN              BT_OP(BT_OGF_LE, 0x000d)
 #define BT_HCI_OP_LE_CREATE_CONN_CANCEL       BT_OP(BT_OGF_LE, 0x000e)
+#define BT_HCI_OP_LE_READ_WHITE_LIST_SIZE     BT_OP(BT_OGF_LE, 0x000f)
+#define BT_HCI_OP_LE_CLEAR_WHITE_LIST         BT_OP(BT_OGF_LE, 0x0010)
+#define BT_HCI_OP_LE_ADD_DEV_TO_WHITE_LIST    BT_OP(BT_OGF_LE, 0x0011)
+#define BT_HCI_OP_LE_REM_DEV_FROM_WHITE_LIST  BT_OP(BT_OGF_LE, 0x0012)
 #define BT_HCI_OP_LE_CONN_UPDATE              BT_OP(BT_OGF_LE, 0x0013)
+#define BT_HCI_OP_LE_READ_REMOTE_FEATURES     BT_OP(BT_OGF_LE, 0x0016)
 #define BT_HCI_OP_LE_ENCRYPT                  BT_OP(BT_OGF_LE, 0x0017)
 #define BT_HCI_OP_LE_RAND                     BT_OP(BT_OGF_LE, 0x0018)
 #define BT_HCI_OP_LE_START_ENCRYPTION         BT_OP(BT_OGF_LE, 0x0019)
@@ -173,11 +189,19 @@
 #define BT_HCI_EVT_NUM_COMPLETED_PACKETS      0x13
 #define BT_HCI_EVT_ENCRYPT_KEY_REFRESH_COMPLETE 0x30
 #define BT_HCI_EVT_LE_META_EVENT              0x3e
+
 #define BT_HCI_EVT_LE_CONN_COMPLETE           0x01
 #  define BT_HCI_ROLE_MASTER                  0x00
 #  define BT_HCI_ROLE_SLAVE                   0x01
 #define BT_HCI_EVT_LE_ADVERTISING_REPORT      0x02
+#define BT_HCI_EVT_LE_CONN_UPDATE             0x03
+#define BT_HCI_EVT_LE_READ_REM_FEAT_COMPLETE  0x04
 #define BT_HCI_EVT_LE_LTK_REQUEST             0x05
+
+/* Packet boundary flags for ACL packets */
+
+#define BT_HCI_ACL_CONTINUATION               0x0001
+#define BT_HCI_ACL_NEW                        0x0002
 
 /****************************************************************************
  * Public Types
@@ -202,7 +226,9 @@ begin_packed_struct struct bt_hci_evt_hdr_s
 
 begin_packed_struct struct bt_hci_acl_hdr_s
 {
-  uint16_t handle;
+  uint16_t handle          : 12;
+  uint16_t packet_boundary : 2;
+  uint16_t broadcast       : 2;
   uint16_t len;
 } end_packed_struct;
 
@@ -221,6 +247,11 @@ begin_packed_struct struct bt_hci_cp_disconnect_s
 begin_packed_struct struct bt_hci_cp_set_event_mask_s
 {
   uint8_t events[8];
+} end_packed_struct;
+
+begin_packed_struct struct bt_hci_cp_set_ctl_to_host_flow_s
+{
+  uint8_t enable;
 } end_packed_struct;
 
 begin_packed_struct struct bt_hci_cp_host_buffer_size_s
@@ -249,6 +280,11 @@ begin_packed_struct struct bt_hci_cp_write_le_host_supp_s
   uint8_t simul;
 } end_packed_struct;
 
+begin_packed_struct struct bt_hci_le_read_remote_features_s
+{
+  uint16_t conn;
+} end_packed_struct;
+
 begin_packed_struct struct bt_hci_rp_read_local_version_info_s
 {
   uint8_t status;
@@ -265,6 +301,13 @@ begin_packed_struct struct bt_hci_rp_read_local_features_s
   uint8_t features[8];
 } end_packed_struct;
 
+begin_packed_struct struct bt_hci_rp_le_read_remote_features_s
+{
+  uint8_t status;
+  uint16_t conn;
+  uint8_t features[8];
+} end_packed_struct;
+
 begin_packed_struct struct bt_hci_rp_read_buffer_size_s
 {
   uint8_t status;
@@ -277,7 +320,7 @@ begin_packed_struct struct bt_hci_rp_read_buffer_size_s
 begin_packed_struct struct bt_hci_rp_read_bd_addr_s
 {
   uint8_t status;
-  bt_addr_t bdaddr;
+  struct bt_addr_s bdaddr;
 } end_packed_struct;
 
 begin_packed_struct struct bt_hci_rp_le_read_buffer_size_s
@@ -415,6 +458,12 @@ begin_packed_struct struct bt_hci_evt_encrypt_change_s
   uint8_t encrypt;
 } end_packed_struct;
 
+begin_packed_struct struct hci_evt_cmd_disallowed_s
+{
+  uint8_t ncmd;
+  uint16_t opcode;
+} end_packed_struct;
+
 begin_packed_struct struct hci_evt_cmd_complete_s
 {
   uint8_t ncmd;
@@ -457,7 +506,16 @@ begin_packed_struct struct bt_hci_evt_le_conn_complete_s
   uint8_t clock_accuracy;
 } end_packed_struct;
 
-begin_packed_struct struct bt_hci_ev_le_advertising_info_s
+begin_packed_struct struct bt_hci_evt_le_conn_update_s
+{
+  uint8_t status;
+  uint16_t handle;
+  uint16_t interval;
+  uint16_t latency;
+  uint16_t timeout;
+} end_packed_struct;
+
+begin_packed_struct struct bt_hci_ev_le_advertising_report_s
 {
   uint8_t evt_type;
   bt_addr_le_t addr;

--- a/net/bluetooth/Kconfig
+++ b/net/bluetooth/Kconfig
@@ -38,10 +38,10 @@ config NET_BLUETOOTH_BACKLOG
 	default 8
 	range 0 255
 	---help---
-		As frames are received, then are help in an RX queue.  They remain
+		As frames are received, they are held in an RX queue.  They remain
 		in the RX queue until application logic reads the queue frames.  To
 		prevent overrun, the maximum backlog may be set to a nonzero value.
-		What the backlog of queue frames reaches that count, the olds frame
+		When the backlog of queue frames reaches that count, the old frame
 		will be freed, preventing overrun at the cost of losing the oldest
 		frames.
 

--- a/wireless/bluetooth/bt_conn.c
+++ b/wireless/bluetooth/bt_conn.c
@@ -298,7 +298,7 @@ void bt_conn_receive(FAR struct bt_conn_s *conn, FAR struct bt_buf_s *buf,
 
   switch (flags)
     {
-      case 0x02:
+      case BT_HCI_ACL_NEW:
 
         /* First packet */
 
@@ -323,7 +323,7 @@ void bt_conn_receive(FAR struct bt_conn_s *conn, FAR struct bt_buf_s *buf,
 
         break;
 
-      case 0x01:
+      case BT_HCI_ACL_CONTINUATION:
 
         /* Continuation */
 

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1002,11 +1002,6 @@ static int hci_tx_kthread(int argc, FAR char *argv[])
 
       g_btdev.ncmd = 0;
 
-      wlinfo("Sending command %04x buf %p to driver\n",
-             buf->u.hci.opcode, buf);
-
-      btdev->send(btdev, buf);
-
       /* Clear out any existing sent command */
 
       if (g_btdev.sent_cmd)
@@ -1017,6 +1012,11 @@ static int hci_tx_kthread(int argc, FAR char *argv[])
         }
 
       g_btdev.sent_cmd = buf;
+
+      wlinfo("Sending command %04x buf %p to driver\n",
+             buf->u.hci.opcode, buf);
+
+      btdev->send(btdev, buf);
     }
 
   return EXIT_SUCCESS;  /* Can't get here */

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -791,7 +791,7 @@ done:
 
 static void le_adv_report(FAR struct bt_buf_s *buf)
 {
-  FAR struct bt_hci_ev_le_advertising_info_s *info;
+  FAR struct bt_hci_ev_le_advertising_report_s *info;
   uint8_t num_reports = buf->data[0];
 
   wlinfo("Adv number of reports %u\n", num_reports);
@@ -830,10 +830,14 @@ static void le_adv_report(FAR struct bt_buf_s *buf)
 
       /* Get next report iteration by moving pointer to right offset in buf
        * according to spec 4.2, Vol 2, Part E, 7.7.65.2.
+       *
+       * TODO: multiple reports are stored as multiple arrays not one array
+       * of structs. If num_reports > 0 this will not WORK!
        */
 
-      info = bt_buf_consume(buf,
-                            sizeof(*info) + info->length + sizeof(rssi));
+      /* Note that info already contains one byte which accounts for RSSI */
+
+      info = bt_buf_consume(buf, sizeof(*info) + info->length);
     }
 }
 
@@ -1909,8 +1913,8 @@ send_set_param:
   set_param = bt_buf_extend(buf, sizeof(*set_param));
 
   memset(set_param, 0, sizeof(*set_param));
-  set_param->min_interval = BT_HOST2LE16(0x0800);
-  set_param->max_interval = BT_HOST2LE16(0x0800);
+  set_param->min_interval = BT_HOST2LE16(300);
+  set_param->max_interval = BT_HOST2LE16(300);
   set_param->type         = type;
   set_param->channel_map  = 0x07;
 

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -1064,8 +1064,6 @@ int bt_netdev_register(FAR const struct bt_driver_s *btdev)
 
   nxsem_init(&priv->bd_exclsem, 0, 1);
 
-  DEBUGASSERT(priv->bd_txpoll != NULL);
-
   /* Set the network mask. */
 
   btnet_netmask(netdev);

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -885,11 +885,11 @@ static int btnet_req_data(FAR struct radio_driver_s *netdev,
   FAR struct iob_s *iob;
   bt_addr_le_t peer;
 
-  wlinfo("Received framelist\n");
-  DEBUGASSERT(priv != NULL && meta != NULL && framelist != NULL);
-
   priv   = (FAR struct btnet_driver_s *)netdev;
   btmeta = (FAR struct bluetooth_frame_meta_s *)meta;
+
+  wlinfo("Received framelist\n");
+  DEBUGASSERT(priv != NULL && meta != NULL && framelist != NULL);
 
   /* Create a connection structure for this peer if one does not already
    * exist.


### PR DESCRIPTION
## Summary
This backports these PRs:
#2100 bt_netdev: remove invalid assert breaking build when debugging is enabled
#2105 bt_hcicore.c: Fix wrong order of bt_send() and setting last command sent
#2153 Bluetooth Networking fixes:

> bt_netdev.c: wrong placement of DEBUGASSERT (checks pointer before being set)
> bt_hci: add various definitions, better expose some fields
> bt_hcicore.c: fix handling of advertising report; use correct advertising interval
> bt_conn.c: use definition names instead of hardcoded numbers


