### PR TITLE
[BACKPORT #1585] sched/task: do not migrate the task state to INVALID which still on used in task/nxmq_recover()

### DIFF
--- a/sched/task/task_terminate.c
+++ b/sched/task/task_terminate.c
@@ -158,7 +158,6 @@ int nxtask_terminate(pid_t pid, bool nonblocking)
   /* Remove the task from the task list */
 
   dq_rem((FAR dq_entry_t *)dtcb, tasklist);
-  dtcb->task_state = TSTATE_TASK_INVALID;
 
   /* At this point, the TCB should no longer be accessible to the system */
 


### PR DESCRIPTION
## Summary
Backport #1585
Do not migrate the task state to INVALID which still on used in task/nxmq_recover()

