### PR TITLE
[BACKPORT #1993 / #1997] libc: Fix fclose standard compliance and usage

### DIFF
--- a/libs/libc/unistd/lib_daemon.c
+++ b/libs/libc/unistd/lib_daemon.c
@@ -133,31 +133,16 @@ int daemon(int nochdir, int noclose)
         }
 
 #ifdef CONFIG_FILE_STREAM
-      /* Make sure the stdin, stdout, and stderr are closed */
+      /* Make sure the stdout, and stderr are flushed */
 
-      fclose(stdin);
-      fclose(stdout);
-      fclose(stderr);
+      fflush(stdout);
+      fflush(stderr);
 #endif
       /* Dup the fd to create standard fd 0-2 */
 
       dup2(fd, 0);
       dup2(fd, 1);
       dup2(fd, 2);
-
-      /* fdopen to get the stdin, stdout and stderr streams. The
-       * following logic depends on the fact that the library layer
-       * will allocate FILEs in order.  And since we closed stdin,
-       * stdout, and stderr above, that is what we should get.
-       *
-       * fd = 0 is stdin  (read-only)
-       * fd = 1 is stdout (write-only, append)
-       * fd = 2 is stderr (write-only, append)
-       */
-
-      fdopen(0, "r");
-      fdopen(1, "a");
-      fdopen(2, "a");
 
       /* We can close the original file descriptor now (unless it was
        * one of* 0-2)


### PR DESCRIPTION
## Summary
Backports:
#1993 libc: Skip close stdin/stdout/stderr in fclose
#1997 Remove all fclose with stdin, stdout and stderr

