### PR TITLE
[BACKPORT #2083] Update gs2200m driver

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -2450,6 +2450,8 @@ static int gs2200m_ioctl_accept(FAR struct gs2200m_dev_s *dev,
                                 FAR struct gs2200m_accept_msg *msg)
 {
   FAR struct pkt_dat_s *pkt_dat;
+  struct gs2200m_name_msg nmsg;
+  enum pkt_type_e r;
   uint8_t c;
   char s_cid;
   char c_cid;
@@ -2485,6 +2487,15 @@ static int gs2200m_ioctl_accept(FAR struct gs2200m_dev_s *dev,
     {
       _notif_q_push(dev, c_cid);
     }
+
+  /* Obtain remote address info */
+
+  nmsg.local = 0;
+  nmsg.cid = msg->cid;
+  r = gs2200m_get_cstatus(dev, &nmsg);
+  ASSERT(TYPE_OK == r);
+
+  msg->addr = nmsg.addr;
 
   wlinfo("+++ end: type=%d (msg->cid=%c) \n", msg->type, msg->cid);
 

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -2674,7 +2674,15 @@ static int gs2200m_ioctl_ifreq(FAR struct gs2200m_dev_s *dev,
                dev->net_dev.d_mac.ether.ether_addr_octet, 6);
         break;
 
-      case SIOCSIFADDR:
+      case SIOCGIFADDR:
+        getreq = true;
+        memcpy(&inaddr->sin_addr,
+               &dev->net_dev.d_ipaddr,
+               sizeof(dev->net_dev.d_ipaddr)
+               );
+        break;
+
+    case SIOCSIFADDR:
         memcpy(&dev->net_dev.d_ipaddr,
                &inaddr->sin_addr, sizeof(inaddr->sin_addr)
                );

--- a/include/nuttx/wireless/gs2200m.h
+++ b/include/nuttx/wireless/gs2200m.h
@@ -94,6 +94,7 @@ struct gs2200m_bind_msg
 
 struct gs2200m_accept_msg
 {
+  struct sockaddr_in addr;
   char     cid;
   uint8_t  type;
 };

--- a/include/nuttx/wireless/gs2200m.h
+++ b/include/nuttx/wireless/gs2200m.h
@@ -79,6 +79,7 @@ struct gs2200m_connect_msg
 {
   char     cid;
   uint8_t  type;
+  uint16_t lport;
   char     addr[17];
   char     port[6];
 };


### PR DESCRIPTION
## Summary
Backports #2083
- This PR updates gs2200m wifi driver and consists of the following 3 commits
- commit 1 : drivers: wireless: Fix to handle UDP connect() with bind() in gs2200m.c
  - This commit fixes to handle UDP connect() with bind() to a local port.
- commit 2: drivers: wireless: Fix to handle address info in accept() in gs2200m.c
  - This commit fixes to handle address info in accept()
- commit 3: drivers: wireless: Add support for ioctl(fd, SIOCGIFADDR, ...) to gs2200m.c
  - This commit adds support for ioctl(fd, SIOCGIFADDR, ...) to gs2200m.c
