### PR TITLE
[BACKPORT #2162] s/BUSY/EBUSY typo fix in samd2l2 i2c

### DIFF
--- a/arch/arm/src/samd2l2/sam_i2c_master.c
+++ b/arch/arm/src/samd2l2/sam_i2c_master.c
@@ -998,7 +998,7 @@ static int sam_i2c_transfer(FAR struct i2c_master_s *dev,
 
   /* Initiate the message transfer */
 
-  ret = -BUSY;
+  ret = -EBUSY;
 
   /* Initiate the transfer.  The rest will be handled from interrupt logic.
    * Interrupts must be disabled to prevent re-entrance from the interrupt


### PR DESCRIPTION
## Summary
Backport #2162

s/BUSY/EBUSY typo fix in samd2l2 i2c which ressulted in compile error
