### PR TITLE
syscall/syscall.csv: Increase number of arguments for prctl()

### DIFF
--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -75,7 +75,7 @@
 "posix_spawn","spawn.h","!defined(CONFIG_BINFMT_DISABLE) && defined(CONFIG_LIBC_EXECFUNCS) && !defined(CONFIG_LIB_ENVPATH)","int","FAR pid_t *","FAR const char *","FAR const posix_spawn_file_actions_t *","FAR const posix_spawnattr_t *","FAR char * const []|FAR char * const *","FAR char * const []|FAR char * const *"
 "posix_spawnp","spawn.h","!defined(CONFIG_BINFMT_DISABLE) && defined(CONFIG_LIBC_EXECFUNCS) && defined(CONFIG_LIB_ENVPATH)","int","FAR pid_t *","FAR const char *","FAR const posix_spawn_file_actions_t *","FAR const posix_spawnattr_t *","FAR char * const []|FAR char * const *","FAR char * const []|FAR char * const *"
 "ppoll","poll.h","","int","FAR struct pollfd *","nfds_t","FAR const struct timespec *","FAR const sigset_t *"
-"prctl","sys/prctl.h", "CONFIG_TASK_NAME_SIZE > 0","int","int","...","uintptr_t"
+"prctl","sys/prctl.h", "CONFIG_TASK_NAME_SIZE > 0","int","int","...","uintptr_t","uintptr_t"
 "pread","unistd.h","","ssize_t","int","FAR void *","size_t","off_t"
 "pselect","sys/select.h","","int","int","FAR fd_set *","FAR fd_set *","FAR fd_set *","FAR const struct timespec *","FAR const sigset_t *"
 "pthread_cancel","pthread.h","!defined(CONFIG_DISABLE_PTHREAD)","int","pthread_t"


### PR DESCRIPTION
Handle PR_SET_NAME and PR_GET_NAME

## Summary
Increase number of arguments for the prctl() (pthread_setname_np()) syscall, so it does not drop the third (PID) argument.

## Impact
prctl() PR_SET_NAME/PR_GET_NAME and pthread_setname() starts working in protected build.

## Testing
phtread_setname_np() and prctl() called from task to set name.
Name read in another task using prctl() and /proc/pid/status.
