### PR TITLE
FLASH waiting cycles are configured based on HCLK.

### DIFF
--- a/arch/arm/src/stm32/stm32f10xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f10xxx_rcc.c
@@ -49,6 +49,24 @@
 
 #define HSERDY_TIMEOUT (100 * CONFIG_BOARD_LOOPSPERMSEC)
 
+/* The FLASH latency depends on the system clock.
+ *
+ * Calculate the wait cycles, based on STM32_SYSCLK_FREQUENCY:
+ * 0WS from 0-24MHz
+ * 1WS from 24-48MHz
+ * 2WS from 48-72MHz
+ */
+
+#if (STM32_SYSCLK_FREQUENCY <= 24000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_0
+#elif (STM32_SYSCLK_FREQUENCY <= 48000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_1
+#elif (STM32_SYSCLK_FREQUENCY <= 78000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_2
+#else
+#  error "STM32_SYSCLK_FREQUENCY is out of range!"
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -522,16 +540,11 @@ static void stm32_stdclockconfig(void)
   regval |= RCC_CR_HSEON;           /* Enable HSE */
   putreg32(regval, STM32_RCC_CR);
 
-  /* Set flash wait states
-   * Sysclk runs with 72MHz -> 2 waitstates.
-   * 0WS from 0-24MHz
-   * 1WS from 24-48MHz
-   * 2WS from 48-72MHz
-   */
+  /* Enable prefetch buffer and set FLASH wait states */
 
   regval  = getreg32(STM32_FLASH_ACR);
   regval &= ~FLASH_ACR_LATENCY_MASK;
-  regval |= (FLASH_ACR_LATENCY_2 | FLASH_ACR_PRTFBE);
+  regval |= (FLASH_ACR_LATENCY_SETTING | FLASH_ACR_PRTFBE);
   putreg32(regval, STM32_FLASH_ACR);
 
   /* Set up PLL input scaling (with source = PLL2) */
@@ -687,11 +700,11 @@ static void stm32_stdclockconfig(void)
 
 #ifndef CONFIG_STM32_VALUELINE
 
-  /* Enable FLASH prefetch buffer and 2 wait states */
+  /* Enable FLASH prefetch buffer and set FLASH wait states */
 
   regval  = getreg32(STM32_FLASH_ACR);
   regval &= ~FLASH_ACR_LATENCY_MASK;
-  regval |= (FLASH_ACR_LATENCY_2 | FLASH_ACR_PRTFBE);
+  regval |= (FLASH_ACR_LATENCY_SETTING | FLASH_ACR_PRTFBE);
   putreg32(regval, STM32_FLASH_ACR);
 
 #endif

--- a/arch/arm/src/stm32/stm32f10xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f10xxx_rcc.c
@@ -89,7 +89,8 @@ static inline void rcc_reset(void)
 
   putreg32(0, STM32_RCC_APB2RSTR);          /* Disable APB2 Peripheral Reset */
   putreg32(0, STM32_RCC_APB1RSTR);          /* Disable APB1 Peripheral Reset */
-  putreg32(RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN, STM32_RCC_AHBENR); /* FLITF and SRAM Clock ON */
+  putreg32(RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN,
+           STM32_RCC_AHBENR);               /* FLITF and SRAM Clock ON */
   putreg32(0, STM32_RCC_APB2ENR);           /* Disable APB2 Peripheral Clock */
   putreg32(0, STM32_RCC_APB1ENR);           /* Disable APB1 Peripheral Clock */
 
@@ -98,8 +99,9 @@ static inline void rcc_reset(void)
   putreg32(regval, STM32_RCC_CR);
 
   regval  = getreg32(STM32_RCC_CFGR);       /* Reset SW, HPRE, PPRE1, PPRE2, ADCPRE and MCO bits */
-  regval &= ~(RCC_CFGR_SW_MASK | RCC_CFGR_HPRE_MASK | RCC_CFGR_PPRE1_MASK |
-              RCC_CFGR_PPRE2_MASK | RCC_CFGR_ADCPRE_MASK | RCC_CFGR_MCO_MASK);
+  regval &= ~(RCC_CFGR_SW_MASK | RCC_CFGR_HPRE_MASK | RCC_CFGR_PPRE1_MASK
+              | RCC_CFGR_PPRE2_MASK | RCC_CFGR_ADCPRE_MASK
+              | RCC_CFGR_MCO_MASK);
   putreg32(regval, STM32_RCC_CFGR);
 
   regval  = getreg32(STM32_RCC_CR);         /* Reset HSEON, CSSON and PLLON bits */
@@ -189,7 +191,8 @@ static inline void rcc_enableahb(void)
 #ifdef CONFIG_STM32_ETHMAC
   /* Ethernet clock enable */
 
-  regval |= (RCC_AHBENR_ETHMACEN | RCC_AHBENR_ETHMACTXEN | RCC_AHBENR_ETHMACRXEN);
+  regval |= (RCC_AHBENR_ETHMACEN | RCC_AHBENR_ETHMACTXEN
+             | RCC_AHBENR_ETHMACRXEN);
 #endif
 #endif
 
@@ -646,39 +649,40 @@ static void stm32_stdclockconfig(void)
   /* If the PLL is using the HSE, or the HSE is the system clock */
 
 #if (STM32_CFGR_PLLSRC == RCC_CFGR_PLLSRC) || (STM32_SYSCLK_SW == RCC_CFGR_SW_HSE)
-  {
-    volatile int32_t timeout;
+    {
+      volatile int32_t timeout;
 
-    /* Enable External High-Speed Clock (HSE) */
+      /* Enable External High-Speed Clock (HSE) */
 
-    regval  = getreg32(STM32_RCC_CR);
-    regval &= ~RCC_CR_HSEBYP;         /* Disable HSE clock bypass */
-    regval |= RCC_CR_HSEON;           /* Enable HSE */
-    putreg32(regval, STM32_RCC_CR);
+      regval  = getreg32(STM32_RCC_CR);
+      regval &= ~RCC_CR_HSEBYP;         /* Disable HSE clock bypass */
+      regval |= RCC_CR_HSEON;           /* Enable HSE */
+      putreg32(regval, STM32_RCC_CR);
 
-    /* Wait until the HSE is ready (or until a timeout elapsed) */
+      /* Wait until the HSE is ready (or until a timeout elapsed) */
 
-    for (timeout = HSERDY_TIMEOUT; timeout > 0; timeout--)
-      {
-        /* Check if the HSERDY flag is the set in the CR */
+      for (timeout = HSERDY_TIMEOUT; timeout > 0; timeout--)
+        {
+          /* Check if the HSERDY flag is the set in the CR */
 
-        if ((getreg32(STM32_RCC_CR) & RCC_CR_HSERDY) != 0)
-          {
-            /* If so, then break-out with timeout > 0 */
+          if ((getreg32(STM32_RCC_CR) & RCC_CR_HSERDY) != 0)
+            {
+              /* If so, then break-out with timeout > 0 */
 
-            break;
-          }
-      }
+              break;
+            }
+        }
 
-    if (timeout == 0)
-      {
-        /* In the case of a timeout starting the HSE, we really don't have a
-         * strategy.  This is almost always a hardware failure or misconfiguration.
-         */
+      if (timeout == 0)
+        {
+          /* In the case of a timeout starting the HSE, we really don't have
+           * a strategy.  This is almost always a hardware failure or
+           * misconfiguration.
+           */
 
-        return;
-      }
-  }
+          return;
+        }
+    }
 
   /* If this is a value-line part and we are using the HSE as the PLL */
 

--- a/arch/arm/src/stm32/stm32f20xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f20xxx_rcc.c
@@ -55,6 +55,27 @@
 
 #define HSERDY_TIMEOUT (100 * CONFIG_BOARD_LOOPSPERMSEC)
 
+/* The FLASH latency depends on the system clock.
+ *
+ * Calculate the wait cycles, based on STM32_SYSCLK_FREQUENCY:
+ * 0WS from 0-30MHz
+ * 1WS from 30-60MHz
+ * 2WS from 60-90MHz
+ * 3WS from 90-120MHz
+ */
+
+#if (STM32_SYSCLK_FREQUENCY <= 30000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_0
+#elif (STM32_SYSCLK_FREQUENCY <= 60000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_1
+#elif (STM32_SYSCLK_FREQUENCY <= 90000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_2
+#elif (STM32_SYSCLK_FREQUENCY <= 120000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_3
+#else
+#  error "STM32_SYSCLK_FREQUENCY is out of range!"
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -646,10 +667,10 @@ static void stm32_stdclockconfig(void)
       while ((getreg32(STM32_RCC_CR) & RCC_CR_PLLRDY) == 0);
 
       /* Enable FLASH prefetch, instruction cache, data cache,
-       * and 5 wait states.
+       * and set FLASH wait states.
        */
 
-      regval = (FLASH_ACR_LATENCY_5
+      regval = (FLASH_ACR_LATENCY_SETTING
 #ifdef CONFIG_STM32_FLASH_ICACHE
                 | FLASH_ACR_ICEN
 #endif

--- a/arch/arm/src/stm32/stm32f30xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f30xxx_rcc.c
@@ -89,7 +89,8 @@ static inline void rcc_reset(void)
 
   putreg32(0, STM32_RCC_APB2RSTR);          /* Disable APB2 Peripheral Reset */
   putreg32(0, STM32_RCC_APB1RSTR);          /* Disable APB1 Peripheral Reset */
-  putreg32(RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN, STM32_RCC_AHBENR); /* FLITF and SRAM Clock ON */
+  putreg32(RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN,
+           STM32_RCC_AHBENR);               /* FLITF and SRAM Clock ON */
   putreg32(0, STM32_RCC_APB2ENR);           /* Disable APB2 Peripheral Clock */
   putreg32(0, STM32_RCC_APB1ENR);           /* Disable APB1 Peripheral Clock */
 
@@ -555,40 +556,40 @@ static void stm32_stdclockconfig(void)
   /* If the PLL is using the HSE, or the HSE is the system clock */
 
 #if (STM32_CFGR_PLLSRC == RCC_CFGR_PLLSRC) || (STM32_SYSCLK_SW == RCC_CFGR_SW_HSE)
-  {
-    volatile int32_t timeout;
+    {
+      volatile int32_t timeout;
 
-    /* Enable External High-Speed Clock (HSE) */
+      /* Enable External High-Speed Clock (HSE) */
 
-    regval  = getreg32(STM32_RCC_CR);
-    regval &= ~RCC_CR_HSEBYP;         /* Disable HSE clock bypass */
-    regval |= RCC_CR_HSEON;           /* Enable HSE */
-    putreg32(regval, STM32_RCC_CR);
+      regval  = getreg32(STM32_RCC_CR);
+      regval &= ~RCC_CR_HSEBYP;         /* Disable HSE clock bypass */
+      regval |= RCC_CR_HSEON;           /* Enable HSE */
+      putreg32(regval, STM32_RCC_CR);
 
-    /* Wait until the HSE is ready (or until a timeout elapsed) */
+      /* Wait until the HSE is ready (or until a timeout elapsed) */
 
-    for (timeout = HSERDY_TIMEOUT; timeout > 0; timeout--)
-      {
-        /* Check if the HSERDY flag is the set in the CR */
+      for (timeout = HSERDY_TIMEOUT; timeout > 0; timeout--)
+        {
+          /* Check if the HSERDY flag is the set in the CR */
 
-        if ((getreg32(STM32_RCC_CR) & RCC_CR_HSERDY) != 0)
-          {
-            /* If so, then break-out with timeout > 0 */
+          if ((getreg32(STM32_RCC_CR) & RCC_CR_HSERDY) != 0)
+            {
+              /* If so, then break-out with timeout > 0 */
 
-            break;
-          }
-      }
+              break;
+            }
+        }
 
-    if (timeout == 0)
-      {
-        /* In the case of a timeout starting the HSE, we really don't have a
-         * strategy.  This is almost always a hardware failure or
-         * misconfiguration.
-         */
+      if (timeout == 0)
+        {
+          /* In the case of a timeout starting the HSE, we really don't have
+           * a strategy.  This is almost always a hardware failure or
+           * misconfiguration.
+           */
 
-        return;
-      }
-  }
+          return;
+        }
+    }
 
 # if defined(CONFIG_STM32_VALUELINE) && (STM32_CFGR_PLLSRC == RCC_CFGR_PLLSRC)
   /* If this is a value-line part and we are using the HSE as the PLL */
@@ -607,6 +608,7 @@ static void stm32_stdclockconfig(void)
 
 #ifndef CONFIG_STM32_VALUELINE
   /* Value-line devices don't implement flash prefetch/waitstates */
+
   /* Enable FLASH prefetch buffer and set FLASH wait states */
 
   regval  = getreg32(STM32_FLASH_ACR);
@@ -638,6 +640,7 @@ static void stm32_stdclockconfig(void)
 
 #if STM32_SYSCLK_SW == RCC_CFGR_SW_PLL
   /* If we are using the PLL, configure and start it */
+
   /* Set the PLL divider and multiplier */
 
   regval = getreg32(STM32_RCC_CFGR);

--- a/arch/arm/src/stm32/stm32f30xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f30xxx_rcc.c
@@ -49,6 +49,24 @@
 
 #define HSERDY_TIMEOUT (100 * CONFIG_BOARD_LOOPSPERMSEC)
 
+/* The FLASH latency depends on the system clock.
+ *
+ * Calculate the wait cycles, based on STM32_SYSCLK_FREQUENCY:
+ * 0WS from 0-24MHz
+ * 1WS from 24-48MHz
+ * 2WS from 48-72MHz
+ */
+
+#if (STM32_SYSCLK_FREQUENCY <= 24000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_0
+#elif (STM32_SYSCLK_FREQUENCY <= 48000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_1
+#elif (STM32_SYSCLK_FREQUENCY <= 72000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_2
+#else
+#  error "STM32_SYSCLK_FREQUENCY is out of range!"
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -431,16 +449,11 @@ static void stm32_stdclockconfig(void)
   regval |= RCC_CR_HSEON;           /* Enable HSE */
   putreg32(regval, STM32_RCC_CR);
 
-  /* Set flash wait states
-   * Sysclk runs with 72MHz -> 2 waitstates.
-   * 0WS from 0-24MHz
-   * 1WS from 24-48MHz
-   * 2WS from 48-72MHz
-   */
+  /* Enable FLASH prefetch buffer and set FLASH wait states */
 
   regval  = getreg32(STM32_FLASH_ACR);
   regval &= ~FLASH_ACR_LATENCY_MASK;
-  regval |= (FLASH_ACR_LATENCY_2 | FLASH_ACR_PRTFBE);
+  regval |= (FLASH_ACR_LATENCY_SETTING | FLASH_ACR_PRTFBE);
   putreg32(regval, STM32_FLASH_ACR);
 
   /* Set up PLL input scaling (with source = PLL2) */
@@ -594,11 +607,11 @@ static void stm32_stdclockconfig(void)
 
 #ifndef CONFIG_STM32_VALUELINE
   /* Value-line devices don't implement flash prefetch/waitstates */
-  /* Enable FLASH prefetch buffer and 2 wait states */
+  /* Enable FLASH prefetch buffer and set FLASH wait states */
 
   regval  = getreg32(STM32_FLASH_ACR);
   regval &= ~FLASH_ACR_LATENCY_MASK;
-  regval |= (FLASH_ACR_LATENCY_2 | FLASH_ACR_PRTFBE);
+  regval |= (FLASH_ACR_LATENCY_SETTING | FLASH_ACR_PRTFBE);
   putreg32(regval, STM32_FLASH_ACR);
 #endif
 

--- a/arch/arm/src/stm32/stm32f33xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f33xxx_rcc.c
@@ -90,7 +90,8 @@ static inline void rcc_reset(void)
 
   putreg32(0, STM32_RCC_APB2RSTR);          /* Disable APB2 Peripheral Reset */
   putreg32(0, STM32_RCC_APB1RSTR);          /* Disable APB1 Peripheral Reset */
-  putreg32(RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN, STM32_RCC_AHBENR); /* FLITF and SRAM Clock ON */
+  putreg32(RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN,
+           STM32_RCC_AHBENR);               /* FLITF and SRAM Clock ON */
   putreg32(0, STM32_RCC_APB2ENR);           /* Disable APB2 Peripheral Clock */
   putreg32(0, STM32_RCC_APB1ENR);           /* Disable APB1 Peripheral Clock */
 
@@ -109,8 +110,9 @@ static inline void rcc_reset(void)
   putreg32(regval, STM32_RCC_CFGR2);
 
   regval  = getreg32(STM32_RCC_CFGR3);       /* Reset all U[S]ARTs, I2C1, TIM1 and HRTIM1 bits */
-  regval &= ~(RCC_CFGR3_USART1SW_MASK | RCC_CFGR3_USART2SW_MASK | RCC_CFGR3_USART3SW_MASK | \
-              RCC_CFGR3_I2C1SW | RCC_CFGR3_TIM1SW | RCC_CFGR3_HRTIM1SW);
+  regval &= ~(RCC_CFGR3_USART1SW_MASK | RCC_CFGR3_USART2SW_MASK | \
+              RCC_CFGR3_USART3SW_MASK | RCC_CFGR3_I2C1SW | \
+              RCC_CFGR3_TIM1SW | RCC_CFGR3_HRTIM1SW);
   putreg32(regval, STM32_RCC_CFGR3);
 
   regval  = getreg32(STM32_RCC_CR);         /* Reset HSEON, CSSON and PLLON bits */
@@ -374,40 +376,40 @@ static void stm32_stdclockconfig(void)
   /* If the PLL is using the HSE, or the HSE is the system clock */
 
 #if (STM32_CFGR_PLLSRC == RCC_CFGR_PLLSRC) || (STM32_SYSCLK_SW == RCC_CFGR_SW_HSE)
-  {
-    volatile int32_t timeout;
+    {
+      volatile int32_t timeout;
 
-    /* Enable External High-Speed Clock (HSE) */
+      /* Enable External High-Speed Clock (HSE) */
 
-    regval  = getreg32(STM32_RCC_CR);
-    regval &= ~RCC_CR_HSEBYP;         /* Disable HSE clock bypass */
-    regval |= RCC_CR_HSEON;           /* Enable HSE */
-    putreg32(regval, STM32_RCC_CR);
+      regval  = getreg32(STM32_RCC_CR);
+      regval &= ~RCC_CR_HSEBYP;         /* Disable HSE clock bypass */
+      regval |= RCC_CR_HSEON;           /* Enable HSE */
+      putreg32(regval, STM32_RCC_CR);
 
-    /* Wait until the HSE is ready (or until a timeout elapsed) */
+      /* Wait until the HSE is ready (or until a timeout elapsed) */
 
-    for (timeout = HSERDY_TIMEOUT; timeout > 0; timeout--)
-      {
-        /* Check if the HSERDY flag is the set in the CR */
+      for (timeout = HSERDY_TIMEOUT; timeout > 0; timeout--)
+        {
+          /* Check if the HSERDY flag is the set in the CR */
 
-        if ((getreg32(STM32_RCC_CR) & RCC_CR_HSERDY) != 0)
-          {
-            /* If so, then break-out with timeout > 0 */
+          if ((getreg32(STM32_RCC_CR) & RCC_CR_HSERDY) != 0)
+            {
+              /* If so, then break-out with timeout > 0 */
 
-            break;
-          }
-      }
+              break;
+            }
+        }
 
-    if (timeout == 0)
-      {
-        /* In the case of a timeout starting the HSE, we really don't have a
-         * strategy.  This is almost always a hardware failure or
-         * misconfiguration.
-         */
+      if (timeout == 0)
+        {
+          /* In the case of a timeout starting the HSE, we really don't have
+           * a strategy.  This is almost always a hardware failure or
+           * misconfiguration.
+           */
 
-        return;
-      }
-  }
+          return;
+        }
+    }
 
 #endif
 
@@ -434,6 +436,7 @@ static void stm32_stdclockconfig(void)
 
 #if STM32_SYSCLK_SW == RCC_CFGR_SW_PLL
   /* If we are using the PLL, configure and start it */
+
   /* Set the PLL divider and multiplier */
 
   regval = getreg32(STM32_RCC_CFGR);

--- a/arch/arm/src/stm32/stm32f37xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f37xxx_rcc.c
@@ -50,6 +50,24 @@
 
 #define HSERDY_TIMEOUT (100 * CONFIG_BOARD_LOOPSPERMSEC)
 
+/* The FLASH latency depends on the system clock.
+ *
+ * Calculate the wait cycles, based on STM32_SYSCLK_FREQUENCY:
+ * 0WS from 0-24MHz
+ * 1WS from 24-48MHz
+ * 2WS from 48-72MHz
+ */
+
+#if (STM32_SYSCLK_FREQUENCY <= 24000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_0
+#elif (STM32_SYSCLK_FREQUENCY <= 48000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_1
+#elif (STM32_SYSCLK_FREQUENCY <= 72000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_2
+#else
+#  error "STM32_SYSCLK_FREQUENCY is out of range!"
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -527,11 +545,11 @@ static void stm32_stdclockconfig(void)
 
 # endif
 
-  /* Enable FLASH prefetch buffer and 2 wait states */
+  /* Enable FLASH prefetch buffer and set FLASH wait states */
 
   regval  = getreg32(STM32_FLASH_ACR);
   regval &= ~FLASH_ACR_LATENCY_MASK;
-  regval |= (FLASH_ACR_LATENCY_2 | FLASH_ACR_PRTFBE);
+  regval |= (FLASH_ACR_LATENCY_SETTING | FLASH_ACR_PRTFBE);
   putreg32(regval, STM32_FLASH_ACR);
 
   /* Set the HCLK source/divider */

--- a/arch/arm/src/stm32/stm32f37xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f37xxx_rcc.c
@@ -90,7 +90,8 @@ static inline void rcc_reset(void)
 
   putreg32(0, STM32_RCC_APB2RSTR);          /* Disable APB2 Peripheral Reset */
   putreg32(0, STM32_RCC_APB1RSTR);          /* Disable APB1 Peripheral Reset */
-  putreg32(RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN, STM32_RCC_AHBENR); /* FLITF and SRAM Clock ON */
+  putreg32(RCC_AHBENR_FLITFEN | RCC_AHBENR_SRAMEN,
+           STM32_RCC_AHBENR);               /* FLITF and SRAM Clock ON */
   putreg32(0, STM32_RCC_APB2ENR);           /* Disable APB2 Peripheral Clock */
   putreg32(0, STM32_RCC_APB1ENR);           /* Disable APB1 Peripheral Clock */
 
@@ -124,7 +125,6 @@ static inline void rcc_reset(void)
 
   putreg32(0, STM32_RCC_CIR);               /* Disable all interrupts */
 }
-
 
 /****************************************************************************
  * Name: rcc_enableahb
@@ -498,39 +498,40 @@ static void stm32_stdclockconfig(void)
   /* If the PLL is using the HSE, or the HSE is the system clock */
 
 #if (STM32_CFGR_PLLSRC == RCC_CFGR_PLLSRC) || (STM32_SYSCLK_SW == RCC_CFGR_SW_HSE)
-  {
-    volatile int32_t timeout;
+    {
+      volatile int32_t timeout;
 
-    /* Enable External High-Speed Clock (HSE) */
+      /* Enable External High-Speed Clock (HSE) */
 
-    regval  = getreg32(STM32_RCC_CR);
-    regval &= ~RCC_CR_HSEBYP;         /* Disable HSE clock bypass */
-    regval |= RCC_CR_HSEON;           /* Enable HSE */
-    putreg32(regval, STM32_RCC_CR);
+      regval  = getreg32(STM32_RCC_CR);
+      regval &= ~RCC_CR_HSEBYP;         /* Disable HSE clock bypass */
+      regval |= RCC_CR_HSEON;           /* Enable HSE */
+      putreg32(regval, STM32_RCC_CR);
 
-    /* Wait until the HSE is ready (or until a timeout elapsed) */
+      /* Wait until the HSE is ready (or until a timeout elapsed) */
 
-    for (timeout = HSERDY_TIMEOUT; timeout > 0; timeout--)
-      {
-        /* Check if the HSERDY flag is the set in the CR */
+      for (timeout = HSERDY_TIMEOUT; timeout > 0; timeout--)
+        {
+          /* Check if the HSERDY flag is the set in the CR */
 
-        if ((getreg32(STM32_RCC_CR) & RCC_CR_HSERDY) != 0)
-          {
-            /* If so, then break-out with timeout > 0 */
+          if ((getreg32(STM32_RCC_CR) & RCC_CR_HSERDY) != 0)
+            {
+              /* If so, then break-out with timeout > 0 */
 
-            break;
-          }
-      }
+              break;
+            }
+        }
 
-    if (timeout == 0)
-      {
-        /* In the case of a timeout starting the HSE, we really don't have a
-         * strategy.  This is almost always a hardware failure or misconfiguration.
-         */
+      if (timeout == 0)
+        {
+          /* In the case of a timeout starting the HSE, we really don't have
+           * a strategy.  This is almost always a hardware failure or
+           * misconfiguration.
+           */
 
-        return;
-      }
-  }
+          return;
+        }
+    }
 
   /* If this is a value-line part and we are using the HSE as the PLL */
 
@@ -575,6 +576,7 @@ static void stm32_stdclockconfig(void)
 
 #if STM32_SYSCLK_SW == RCC_CFGR_SW_PLL
   /* If we are using the PLL, configure and start it */
+
   /* Set the PLL divider and multiplier */
 
   regval = getreg32(STM32_RCC_CFGR);

--- a/arch/arm/src/stm32/stm32f40xxx_rcc.c
+++ b/arch/arm/src/stm32/stm32f40xxx_rcc.c
@@ -68,6 +68,33 @@
 
 #define HSE_DIVISOR (STM32_HSE_FREQUENCY + 500000) / 1000000
 
+/* The FLASH latency depends on the system clock.
+ *
+ * Calculate the wait cycles, based on STM32_SYSCLK_FREQUENCY:
+ * 0WS from 0-30MHz
+ * 1WS from 30-60MHz
+ * 2WS from 60-90MHz
+ * 3WS from 90-120MHz
+ * 4WS from 120-150MHz
+ * 5WS from 150-180MHz
+ */
+
+#if (STM32_SYSCLK_FREQUENCY <= 30000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_0
+#elif (STM32_SYSCLK_FREQUENCY <= 60000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_1
+#elif (STM32_SYSCLK_FREQUENCY <= 90000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_2
+#elif (STM32_SYSCLK_FREQUENCY <= 120000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_3
+#elif (STM32_SYSCLK_FREQUENCY <= 150000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_4
+#elif (STM32_SYSCLK_FREQUENCY <= 180000000)
+#  define FLASH_ACR_LATENCY_SETTING  FLASH_ACR_LATENCY_5
+#else
+#  error "STM32_SYSCLK_FREQUENCY is out of range!"
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -778,10 +805,10 @@ static void stm32_stdclockconfig(void)
 #endif
 
       /* Enable FLASH prefetch, instruction cache, data cache,
-       * and 5 wait states.
+       * and set FLASH wait states.
        */
 
-      regval = (FLASH_ACR_LATENCY_5
+      regval = (FLASH_ACR_LATENCY_SETTING
 #ifdef CONFIG_STM32_FLASH_ICACHE
                 | FLASH_ACR_ICEN
 #endif


### PR DESCRIPTION
## Summary
STM32 need a specific number of wait cycles to access the FLASH, which depends on the system clock.  
Previously the maximum number was always selected. With this commit the correct value is selected based on the actual system clock.

## Impact
No impact on applications running on the maximum frequency.
For lower frequencies there will be a performance improvement, as there will not be any unneeded waiting cycles while reading from the FLASH.

## Testing
Tested on an STM32F427. Builds and runs with the correct value selected.


_Note. There are nxstyle issues, unrelated to the actual changes introduced by this commit. Please review the actual code changes, and then I will try to fix those issues too._

