### PR TITLE
stm32/hardware/stm32_dac.h: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/stm32/hardware/stm32_dac.h
+++ b/arch/arm/src/stm32/hardware/stm32_dac.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32/hardware/stm32_dac.h
  *
  *   Copyright (C) 2011, 2013-2014 Gregory Nutt. All rights reserved.
@@ -31,23 +31,23 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32_HARDWARE_STM32_DAC_H
 #define __ARCH_ARM_SRC_STM32_HARDWARE_STM32_DAC_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include "chip.h"
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
-/* Register Offsets *****************************************************************/
+/* Register Offsets *********************************************************/
 
 #define STM32_DAC_CR_OFFSET       0x0000 /* DAC control register */
 #define STM32_DAC_SWTRIGR_OFFSET  0x0004 /* DAC software trigger register */
@@ -64,137 +64,138 @@
 #define STM32_DAC_DOR2_OFFSET     0x0030 /* DAC channel 2 data output register */
 #define STM32_DAC_SR_OFFSET       0x0034 /* DAC status register */
 
-/* Register Addresses ***************************************************************/
+/* Register Addresses *******************************************************/
 
 #if STM32_NDAC > 0
 /* DAC1 */
 
-#  define STM32_DAC1_CR           (STM32_DAC1_BASE+STM32_DAC_CR_OFFSET)
-#  define STM32_DAC1_SWTRIGR      (STM32_DAC1_BASE+STM32_DAC_SWTRIGR_OFFSET)
-#  define STM32_DAC1_DHR12R1      (STM32_DAC1_BASE+STM32_DAC_DHR12R1_OFFSET)
-#  define STM32_DAC1_DHR12L1      (STM32_DAC1_BASE+STM32_DAC_DHR12L1_OFFSET)
-#  define STM32_DAC1_DHR8R1       (STM32_DAC1_BASE+STM32_DAC_DHR8R1_OFFSET)
-#  define STM32_DAC1_DHR12R2      (STM32_DAC1_BASE+STM32_DAC_DHR12R2_OFFSET)
-#  define STM32_DAC1_DHR12L2      (STM32_DAC1_BASE+STM32_DAC_DHR12L2_OFFSET)
-#  define STM32_DAC1_DHR8R2       (STM32_DAC1_BASE+STM32_DAC_DHR8R2_OFFSET)
-#  define STM32_DAC1_DHR12RD      (STM32_DAC1_BASE+STM32_DAC_DHR12RD_OFFSET)
-#  define STM32_DAC1_DHR12LD      (STM32_DAC1_BASE+STM32_DAC_DHR12LD_OFFSET)
-#  define STM32_DAC1_DHR8RD       (STM32_DAC1_BASE+STM32_DAC_DHR8RD_OFFSET)
-#  define STM32_DAC1_DOR1         (STM32_DAC1_BASE+STM32_DAC_DOR1_OFFSET)
-#  define STM32_DAC1_DOR2         (STM32_DAC1_BASE+STM32_DAC_DOR2_OFFSET)
-#  define STM32_DAC1_SR           (STM32_DAC1_BASE+STM32_DAC_SR_OFFSET)
+#  define STM32_DAC1_CR           (STM32_DAC1_BASE + STM32_DAC_CR_OFFSET)
+#  define STM32_DAC1_SWTRIGR      (STM32_DAC1_BASE + STM32_DAC_SWTRIGR_OFFSET)
+#  define STM32_DAC1_DHR12R1      (STM32_DAC1_BASE + STM32_DAC_DHR12R1_OFFSET)
+#  define STM32_DAC1_DHR12L1      (STM32_DAC1_BASE + STM32_DAC_DHR12L1_OFFSET)
+#  define STM32_DAC1_DHR8R1       (STM32_DAC1_BASE + STM32_DAC_DHR8R1_OFFSET)
+#  define STM32_DAC1_DHR12R2      (STM32_DAC1_BASE + STM32_DAC_DHR12R2_OFFSET)
+#  define STM32_DAC1_DHR12L2      (STM32_DAC1_BASE + STM32_DAC_DHR12L2_OFFSET)
+#  define STM32_DAC1_DHR8R2       (STM32_DAC1_BASE + STM32_DAC_DHR8R2_OFFSET)
+#  define STM32_DAC1_DHR12RD      (STM32_DAC1_BASE + STM32_DAC_DHR12RD_OFFSET)
+#  define STM32_DAC1_DHR12LD      (STM32_DAC1_BASE + STM32_DAC_DHR12LD_OFFSET)
+#  define STM32_DAC1_DHR8RD       (STM32_DAC1_BASE + STM32_DAC_DHR8RD_OFFSET)
+#  define STM32_DAC1_DOR1         (STM32_DAC1_BASE + STM32_DAC_DOR1_OFFSET)
+#  define STM32_DAC1_DOR2         (STM32_DAC1_BASE + STM32_DAC_DOR2_OFFSET)
+#  define STM32_DAC1_SR           (STM32_DAC1_BASE + STM32_DAC_SR_OFFSET)
 
 #endif
 
 #if STM32_NDAC > 2
 /* DAC2 */
 
-#  define STM32_DAC2_CR           (STM32_DAC2_BASE+STM32_DAC_CR_OFFSET)
-#  define STM32_DAC2_SWTRIGR      (STM32_DAC2_BASE+STM32_DAC_SWTRIGR_OFFSET)
-#  define STM32_DAC2_DHR12R1      (STM32_DAC2_BASE+STM32_DAC_DHR12R1_OFFSET)
-#  define STM32_DAC2_DHR12L1      (STM32_DAC2_BASE+STM32_DAC_DHR12L1_OFFSET)
-#  define STM32_DAC2_DHR8R1       (STM32_DAC2_BASE+STM32_DAC_DHR8R1_OFFSET)
-#  define STM32_DAC2_DHR12R2      (STM32_DAC2_BASE+STM32_DAC_DHR12R2_OFFSET)
-#  define STM32_DAC2_DHR12L2      (STM32_DAC2_BASE+STM32_DAC_DHR12L2_OFFSET)
-#  define STM32_DAC2_DHR8R2       (STM32_DAC2_BASE+STM32_DAC_DHR8R2_OFFSET)
-#  define STM32_DAC2_DHR12RD      (STM32_DAC2_BASE+STM32_DAC_DHR12RD_OFFSET)
-#  define STM32_DAC2_DHR12LD      (STM32_DAC2_BASE+STM32_DAC_DHR12LD_OFFSET)
-#  define STM32_DAC2_DHR8RD       (STM32_DAC2_BASE+STM32_DAC_DHR8RD_OFFSET)
-#  define STM32_DAC2_DOR1         (STM32_DAC2_BASE+STM32_DAC_DOR1_OFFSET)
-#  define STM32_DAC2_DOR2         (STM32_DAC2_BASE+STM32_DAC_DOR2_OFFSET)
-#  define STM32_DAC2_SR           (STM32_DAC2_BASE+STM32_DAC_SR_OFFSET)
+#  define STM32_DAC2_CR           (STM32_DAC2_BASE + STM32_DAC_CR_OFFSET)
+#  define STM32_DAC2_SWTRIGR      (STM32_DAC2_BASE + STM32_DAC_SWTRIGR_OFFSET)
+#  define STM32_DAC2_DHR12R1      (STM32_DAC2_BASE + STM32_DAC_DHR12R1_OFFSET)
+#  define STM32_DAC2_DHR12L1      (STM32_DAC2_BASE + STM32_DAC_DHR12L1_OFFSET)
+#  define STM32_DAC2_DHR8R1       (STM32_DAC2_BASE + STM32_DAC_DHR8R1_OFFSET)
+#  define STM32_DAC2_DHR12R2      (STM32_DAC2_BASE + STM32_DAC_DHR12R2_OFFSET)
+#  define STM32_DAC2_DHR12L2      (STM32_DAC2_BASE + STM32_DAC_DHR12L2_OFFSET)
+#  define STM32_DAC2_DHR8R2       (STM32_DAC2_BASE + STM32_DAC_DHR8R2_OFFSET)
+#  define STM32_DAC2_DHR12RD      (STM32_DAC2_BASE + STM32_DAC_DHR12RD_OFFSET)
+#  define STM32_DAC2_DHR12LD      (STM32_DAC2_BASE + STM32_DAC_DHR12LD_OFFSET)
+#  define STM32_DAC2_DHR8RD       (STM32_DAC2_BASE + STM32_DAC_DHR8RD_OFFSET)
+#  define STM32_DAC2_DOR1         (STM32_DAC2_BASE + STM32_DAC_DOR1_OFFSET)
+#  define STM32_DAC2_DOR2         (STM32_DAC2_BASE + STM32_DAC_DOR2_OFFSET)
+#  define STM32_DAC2_SR           (STM32_DAC2_BASE + STM32_DAC_SR_OFFSET)
 #endif
 
-/* Register Bitfield Definitions ****************************************************/
+/* Register Bitfield Definitions ********************************************/
 
 /* DAC control register */
+
 /* These definitions may be used for 16-bit values of either channel */
 
-#define DAC_CR_EN                (1 << 0)  /* Bit 0:  DAC channel enable */
-#define DAC_CR_BOFF              (1 << 1)  /* Bit 1:  1=DAC channel output buffer disable */
-#define DAC_CR_BOFF_EN           (0 << 1)  /* Bit 1:  0=DAC channel output buffer enable */
-#define DAC_CR_TEN               (1 << 2)  /* Bit 2:  DAC channel trigger enable */
-#define DAC_CR_TSEL_SHIFT        (3)       /* Bits 3-5: DAC channel trigger selection */
+#define DAC_CR_EN                (1 << 0)                    /* Bit 0:  DAC channel enable */
+#define DAC_CR_BOFF              (1 << 1)                    /* Bit 1:  1=DAC channel output buffer disable */
+#define DAC_CR_BOFF_EN           (0 << 1)                    /* Bit 1:  0=DAC channel output buffer enable */
+#define DAC_CR_TEN               (1 << 2)                    /* Bit 2:  DAC channel trigger enable */
+#define DAC_CR_TSEL_SHIFT        (3)                         /* Bits 3-5: DAC channel trigger selection */
 #define DAC_CR_TSEL_MASK         (7 << DAC_CR_TSEL_SHIFT)
-#  define DAC_CR_TSEL_TIM6       (0 << DAC_CR_TSEL_SHIFT) /* Timer 6 TRGO event */
+#  define DAC_CR_TSEL_TIM6       (0 << DAC_CR_TSEL_SHIFT)    /* Timer 6 TRGO event */
 #if defined(CONFIG_STM32_CONNECTIVITYLINE) || defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL_TIM3       (1 << DAC_CR_TSEL_SHIFT) /* Timer 3 TRGO event */
+#  define DAC_CR_TSEL_TIM3       (1 << DAC_CR_TSEL_SHIFT)    /* Timer 3 TRGO event */
 #else
-#  define DAC_CR_TSEL_TIM8       (1 << DAC_CR_TSEL_SHIFT) /* Timer 8 TRGO event */
+#  define DAC_CR_TSEL_TIM8       (1 << DAC_CR_TSEL_SHIFT)    /* Timer 8 TRGO event */
 #endif
-#  define DAC_CR_TSEL_TIM7       (2 << DAC_CR_TSEL_SHIFT) /* Timer 7 TRGO event */
+#  define DAC_CR_TSEL_TIM7       (2 << DAC_CR_TSEL_SHIFT)    /* Timer 7 TRGO event */
 #if defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL_TIM15      (3 << DAC_CR_TSEL_SHIFT) /* Timer 15 TRGO event, or */
-#  define DAC_CR_TSEL_HRT1TRG1   (3 << DAC_CR_TSEL_SHIFT) /* HRTIM1 DACTRG1 event */
+#  define DAC_CR_TSEL_TIM15      (3 << DAC_CR_TSEL_SHIFT)    /* Timer 15 TRGO event, or */
+#  define DAC_CR_TSEL_HRT1TRG1   (3 << DAC_CR_TSEL_SHIFT)    /* HRTIM1 DACTRG1 event */
 #else
-#  define DAC_CR_TSEL_TIM5       (3 << DAC_CR_TSEL_SHIFT) /* Timer 5 TRGO event */
+#  define DAC_CR_TSEL_TIM5       (3 << DAC_CR_TSEL_SHIFT)    /* Timer 5 TRGO event */
 #endif
-#  define DAC_CR_TSEL_TIM2       (4 << DAC_CR_TSEL_SHIFT) /* Timer 2 TRGO event */
+#  define DAC_CR_TSEL_TIM2       (4 << DAC_CR_TSEL_SHIFT)    /* Timer 2 TRGO event */
 #if defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL_HRT1TRG2   (5 << DAC_CR_TSEL_SHIFT) /* HRTIM1 DACTRG2 event, or */
-#  define DAC_CR_TSEL_HRT1TRG3   (5 << DAC_CR_TSEL_SHIFT) /* HRTIM1 DACTRG3 event */
+#  define DAC_CR_TSEL_HRT1TRG2   (5 << DAC_CR_TSEL_SHIFT)    /* HRTIM1 DACTRG2 event, or */
+#  define DAC_CR_TSEL_HRT1TRG3   (5 << DAC_CR_TSEL_SHIFT)    /* HRTIM1 DACTRG3 event */
 #else
-#  define DAC_CR_TSEL_TIM4       (5 << DAC_CR_TSEL_SHIFT) /* Timer 4 TRGO event */
+#  define DAC_CR_TSEL_TIM4       (5 << DAC_CR_TSEL_SHIFT)    /* Timer 4 TRGO event */
 #endif
-#  define DAC_CR_TSEL_EXT9       (6 << DAC_CR_TSEL_SHIFT) /* External line9 */
-#  define DAC_CR_TSEL_SW         (7 << DAC_CR_TSEL_SHIFT) /* Software trigger */
-#define DAC_CR_WAVE_SHIFT        (6)       /* Bits 6-7: DAC channel noise/triangle wave generation  */
+#  define DAC_CR_TSEL_EXT9       (6 << DAC_CR_TSEL_SHIFT)    /* External line9 */
+#  define DAC_CR_TSEL_SW         (7 << DAC_CR_TSEL_SHIFT)    /* Software trigger */
+#define DAC_CR_WAVE_SHIFT        (6)                         /* Bits 6-7: DAC channel noise/triangle wave generation  */
 #define DAC_CR_WAVE_MASK         (3 << DAC_CR_WAVE_SHIFT)
-#  define DAC_CR_WAVE_DISABLED   (0 << DAC_CR_WAVE_SHIFT) /* Wave generation disabled */
-#  define DAC_CR_WAVE_NOISE      (1 << DAC_CR_WAVE_SHIFT) /* Noise wave generation enabled */
-#  define DAC_CR_WAVE_TRIANGLE   (2 << DAC_CR_WAVE_SHIFT) /* Triangle wave generation enabled */
-#define DAC_CR_MAMP_SHIFT        (8)       /* Bits 8-11: DAC channel mask/amplitude selector */
+#  define DAC_CR_WAVE_DISABLED   (0 << DAC_CR_WAVE_SHIFT)    /* Wave generation disabled */
+#  define DAC_CR_WAVE_NOISE      (1 << DAC_CR_WAVE_SHIFT)    /* Noise wave generation enabled */
+#  define DAC_CR_WAVE_TRIANGLE   (2 << DAC_CR_WAVE_SHIFT)    /* Triangle wave generation enabled */
+#define DAC_CR_MAMP_SHIFT        (8)                         /* Bits 8-11: DAC channel mask/amplitude selector */
 #define DAC_CR_MAMP_MASK         (15 << DAC_CR_MAMP_SHIFT)
-#  define DAC_CR_MAMP_AMP1       (0 << DAC_CR_MAMP_SHIFT)  /* Unmask bit0 of LFSR/triangle amplitude=1 */
-#  define DAC_CR_MAMP_AMP3       (1 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[1:0] of LFSR/triangle amplitude=3 */
-#  define DAC_CR_MAMP_AMP7       (2 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[2:0] of LFSR/triangle amplitude=7 */
-#  define DAC_CR_MAMP_AMP15      (3 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[3:0] of LFSR/triangle amplitude=15 */
-#  define DAC_CR_MAMP_AMP31      (4 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[4:0] of LFSR/triangle amplitude=31 */
-#  define DAC_CR_MAMP_AMP63      (5 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[5:0] of LFSR/triangle amplitude=63 */
-#  define DAC_CR_MAMP_AMP127     (6 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[6:0] of LFSR/triangle amplitude=127 */
-#  define DAC_CR_MAMP_AMP255     (7 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[7:0] of LFSR/triangle amplitude=255 */
-#  define DAC_CR_MAMP_AMP511     (8 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[8:0] of LFSR/triangle amplitude=511 */
-#  define DAC_CR_MAMP_AMP1023    (9 << DAC_CR_MAMP_SHIFT)  /* Unmask bits[9:0] of LFSR/triangle amplitude=1023 */
-#  define DAC_CR_MAMP_AMP2047    (10 << DAC_CR_MAMP_SHIFT) /* Unmask bits[10:0] of LFSR/triangle amplitude=2047 */
-#  define DAC_CR_MAMP_AMP4095    (11 << DAC_CR_MAMP_SHIFT) /* Unmask bits[11:0] of LFSR/triangle amplitude=4095 */
-#define DAC_CR_DMAEN             (1 << 12) /* Bit 12: DAC channel DMA enable */
-#define DAC_CR_DMAUDRIE          (1 << 13) /* Bit 13: DAC channel DMA Underrun Interrupt enable */
+#  define DAC_CR_MAMP_AMP1       (0 << DAC_CR_MAMP_SHIFT)    /* Unmask bit0 of LFSR/triangle amplitude=1 */
+#  define DAC_CR_MAMP_AMP3       (1 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[1:0] of LFSR/triangle amplitude=3 */
+#  define DAC_CR_MAMP_AMP7       (2 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[2:0] of LFSR/triangle amplitude=7 */
+#  define DAC_CR_MAMP_AMP15      (3 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[3:0] of LFSR/triangle amplitude=15 */
+#  define DAC_CR_MAMP_AMP31      (4 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[4:0] of LFSR/triangle amplitude=31 */
+#  define DAC_CR_MAMP_AMP63      (5 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[5:0] of LFSR/triangle amplitude=63 */
+#  define DAC_CR_MAMP_AMP127     (6 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[6:0] of LFSR/triangle amplitude=127 */
+#  define DAC_CR_MAMP_AMP255     (7 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[7:0] of LFSR/triangle amplitude=255 */
+#  define DAC_CR_MAMP_AMP511     (8 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[8:0] of LFSR/triangle amplitude=511 */
+#  define DAC_CR_MAMP_AMP1023    (9 << DAC_CR_MAMP_SHIFT)    /* Unmask bits[9:0] of LFSR/triangle amplitude=1023 */
+#  define DAC_CR_MAMP_AMP2047    (10 << DAC_CR_MAMP_SHIFT)   /* Unmask bits[10:0] of LFSR/triangle amplitude=2047 */
+#  define DAC_CR_MAMP_AMP4095    (11 << DAC_CR_MAMP_SHIFT)   /* Unmask bits[11:0] of LFSR/triangle amplitude=4095 */
+#define DAC_CR_DMAEN             (1 << 12)                   /* Bit 12: DAC channel DMA enable */
+#define DAC_CR_DMAUDRIE          (1 << 13)                   /* Bit 13: DAC channel DMA Underrun Interrupt enable */
 
 /* These definitions may be used with the full, 32-bit register */
 
-#define DAC_CR_EN1                (1 << 0)  /* Bit 0:  DAC channel 1 enable */
-#define DAC_CR_BOFF1              (1 << 1)  /* Bit 1:  DAC channel 1 output buffer disable */
-#define DAC_CR_TEN1               (1 << 2)  /* Bit 2:  DAC channel 1 trigger enable */
-#define DAC_CR_TSEL1_SHIFT        (3)       /* Bits 3-5: DAC channel 1 trigger selection */
+#define DAC_CR_EN1                (1 << 0)                   /* Bit 0:  DAC channel 1 enable */
+#define DAC_CR_BOFF1              (1 << 1)                   /* Bit 1:  DAC channel 1 output buffer disable */
+#define DAC_CR_TEN1               (1 << 2)                   /* Bit 2:  DAC channel 1 trigger enable */
+#define DAC_CR_TSEL1_SHIFT        (3)                        /* Bits 3-5: DAC channel 1 trigger selection */
 #define DAC_CR_TSEL1_MASK         (7 << DAC_CR_TSEL1_SHIFT)
-#  define DAC_CR_TSEL1_TIM6       (0 << DAC_CR_TSEL1_SHIFT) /* Timer 6 TRGO event */
+#  define DAC_CR_TSEL1_TIM6       (0 << DAC_CR_TSEL1_SHIFT)  /* Timer 6 TRGO event */
 #if defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL1_TIM3       (1 << DAC_CR_TSEL1_SHIFT) /* Timer 3 TRGO event */
+#  define DAC_CR_TSEL1_TIM3       (1 << DAC_CR_TSEL1_SHIFT)  /* Timer 3 TRGO event */
 #else
-#  define DAC_CR_TSEL1_TIM8       (1 << DAC_CR_TSEL1_SHIFT) /* Timer 8 TRGO event */
+#  define DAC_CR_TSEL1_TIM8       (1 << DAC_CR_TSEL1_SHIFT)  /* Timer 8 TRGO event */
 #endif
-#  define DAC_CR_TSEL1_TIM7       (2 << DAC_CR_TSEL1_SHIFT) /* Timer 7 TRGO event */
+#  define DAC_CR_TSEL1_TIM7       (2 << DAC_CR_TSEL1_SHIFT)  /* Timer 7 TRGO event */
 #if defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL1_TIM15      (3 << DAC_CR_TSEL1_SHIFT) /* Timer 15 TRGO event, or */
-#  define DAC_CR_TSEL1_HRT1TRG1   (3 << DAC_CR_TSEL1_SHIFT) /* HRTIM1 DACTRG1 event (DAC1 only) */
+#  define DAC_CR_TSEL1_TIM15      (3 << DAC_CR_TSEL1_SHIFT)  /* Timer 15 TRGO event, or */
+#  define DAC_CR_TSEL1_HRT1TRG1   (3 << DAC_CR_TSEL1_SHIFT)  /* HRTIM1 DACTRG1 event (DAC1 only) */
 #else
-#  define DAC_CR_TSEL1_TIM5       (3 << DAC_CR_TSEL1_SHIFT) /* Timer 5 TRGO event */
+#  define DAC_CR_TSEL1_TIM5       (3 << DAC_CR_TSEL1_SHIFT)  /* Timer 5 TRGO event */
 #endif
-#  define DAC_CR_TSEL1_TIM2       (4 << DAC_CR_TSEL1_SHIFT) /* Timer 2 TRGO event */
+#  define DAC_CR_TSEL1_TIM2       (4 << DAC_CR_TSEL1_SHIFT)  /* Timer 2 TRGO event */
 #if defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL1_HRT1TRG2   (5 << DAC_CR_TSEL1_SHIFT)  /* HRTIM1 DACTRG2 event (DAC1), or */
-#  define DAC_CR_TSEL1_HRT1TRG3   (5 << DAC_CR_TSEL1_SHIFT)  /* HRTIM1 DACTRG3 event (DAC2) */
+#  define DAC_CR_TSEL1_HRT1TRG2   (5 << DAC_CR_TSEL1_SHIFT)   /* HRTIM1 DACTRG2 event (DAC1), or */
+#  define DAC_CR_TSEL1_HRT1TRG3   (5 << DAC_CR_TSEL1_SHIFT)   /* HRTIM1 DACTRG3 event (DAC2) */
 #else
-#  define DAC_CR_TSEL1_TIM4       (5 << DAC_CR_TSEL1_SHIFT) /* Timer 4 TRGO event */
+#  define DAC_CR_TSEL1_TIM4       (5 << DAC_CR_TSEL1_SHIFT)  /* Timer 4 TRGO event */
 #endif
-#  define DAC_CR_TSEL1_EXT9       (6 << DAC_CR_TSEL1_SHIFT) /* External line9 */
-#  define DAC_CR_TSEL1_SW         (7 << DAC_CR_TSEL1_SHIFT) /* Software trigger */
-#define DAC_CR_WAVE1_SHIFT        (6)       /* Bits 6-7: DAC channel 1 noise/triangle wave generation  */
+#  define DAC_CR_TSEL1_EXT9       (6 << DAC_CR_TSEL1_SHIFT)  /* External line9 */
+#  define DAC_CR_TSEL1_SW         (7 << DAC_CR_TSEL1_SHIFT)  /* Software trigger */
+#define DAC_CR_WAVE1_SHIFT        (6)                        /* Bits 6-7: DAC channel 1 noise/triangle wave generation  */
 #define DAC_CR_WAVE1_MASK         (3 << DAC_CR_WAVE1_SHIFT)
-#  define DAC_CR_WAVE1_DISABLED   (0 << DAC_CR_WAVE1_SHIFT) /* Wave generation disabled */
-#  define DAC_CR_WAVE1_NOISE      (1 << DAC_CR_WAVE1_SHIFT) /* Noise wave generation enabled */
-#  define DAC_CR_WAVE1_TRIANGLE   (2 << DAC_CR_WAVE1_SHIFT) /* Triangle wave generation enabled */
-#define DAC_CR_MAMP1_SHIFT        (8)       /* Bits 8-11: DAC channel 1 mask/amplitude selector */
+#  define DAC_CR_WAVE1_DISABLED   (0 << DAC_CR_WAVE1_SHIFT)  /* Wave generation disabled */
+#  define DAC_CR_WAVE1_NOISE      (1 << DAC_CR_WAVE1_SHIFT)  /* Noise wave generation enabled */
+#  define DAC_CR_WAVE1_TRIANGLE   (2 << DAC_CR_WAVE1_SHIFT)  /* Triangle wave generation enabled */
+#define DAC_CR_MAMP1_SHIFT        (8)                        /* Bits 8-11: DAC channel 1 mask/amplitude selector */
 #define DAC_CR_MAMP1_MASK         (15 << DAC_CR_MAMP1_SHIFT)
 #  define DAC_CR_MAMP1_AMP1       (0 << DAC_CR_MAMP1_SHIFT)  /* Unmask bit0 of LFSR/triangle amplitude=1 */
 #  define DAC_CR_MAMP1_AMP3       (1 << DAC_CR_MAMP1_SHIFT)  /* Unmask bits[1:0] of LFSR/triangle amplitude=3 */
@@ -208,41 +209,41 @@
 #  define DAC_CR_MAMP1_AMP1023    (9 << DAC_CR_MAMP1_SHIFT)  /* Unmask bits[9:0] of LFSR/triangle amplitude=1023 */
 #  define DAC_CR_MAMP1_AMP2047    (10 << DAC_CR_MAMP1_SHIFT) /* Unmask bits[10:0] of LFSR/triangle amplitude=2047 */
 #  define DAC_CR_MAMP1_AMP4095    (11 << DAC_CR_MAMP1_SHIFT) /* Unmask bits[11:0] of LFSR/triangle amplitude=4095 */
-#define DAC_CR_DMAEN1             (1 << 12) /* Bit 12: DAC channel 1 DMA enable */
-#define DAC_CR_DMAUDRIE1          (1 << 13) /* Bit 13: DAC channel 1 DMA Underrun Interrupt enable */
+#define DAC_CR_DMAEN1             (1 << 12)                  /* Bit 12: DAC channel 1 DMA enable */
+#define DAC_CR_DMAUDRIE1          (1 << 13)                  /* Bit 13: DAC channel 1 DMA Underrun Interrupt enable */
 
-#define DAC_CR_EN2                (1 << 16) /* Bit 16: DAC channel 2 enable */
-#define DAC_CR_BOFF2              (1 << 17) /* Bit 17: DAC channel 2 output buffer disable */
-#define DAC_CR_TEN2               (1 << 18) /* Bit 18: DAC channel 2 trigger enable */
-#define DAC_CR_TSEL2_SHIFT        (19)       /* Bits 19-21: DAC channel 2 trigger selection */
+#define DAC_CR_EN2                (1 << 16)                  /* Bit 16: DAC channel 2 enable */
+#define DAC_CR_BOFF2              (1 << 17)                  /* Bit 17: DAC channel 2 output buffer disable */
+#define DAC_CR_TEN2               (1 << 18)                  /* Bit 18: DAC channel 2 trigger enable */
+#define DAC_CR_TSEL2_SHIFT        (19)                       /* Bits 19-21: DAC channel 2 trigger selection */
 #define DAC_CR_TSEL2_MASK         (7 << DAC_CR_TSEL2_SHIFT)
-#  define DAC_CR_TSEL2_TIM6       (0 << DAC_CR_TSEL2_SHIFT) /* Timer 6 TRGO event */
+#  define DAC_CR_TSEL2_TIM6       (0 << DAC_CR_TSEL2_SHIFT)  /* Timer 6 TRGO event */
 #if defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL2_TIM3       (1 << DAC_CR_TSEL2_SHIFT) /* Timer 3 TRGO event */
+#  define DAC_CR_TSEL2_TIM3       (1 << DAC_CR_TSEL2_SHIFT)  /* Timer 3 TRGO event */
 #else
-#  define DAC_CR_TSEL2_TIM8       (1 << DAC_CR_TSEL2_SHIFT) /* Timer 8 TRGO event */
+#  define DAC_CR_TSEL2_TIM8       (1 << DAC_CR_TSEL2_SHIFT)  /* Timer 8 TRGO event */
 #endif
-#  define DAC_CR_TSEL2_TIM7       (2 << DAC_CR_TSEL2_SHIFT) /* Timer 7 TRGO event */
+#  define DAC_CR_TSEL2_TIM7       (2 << DAC_CR_TSEL2_SHIFT)  /* Timer 7 TRGO event */
 #if defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL2_TIM15      (3 << DAC_CR_TSEL2_SHIFT) /* Timer 15 TRGO event, or */
-#  define DAC_CR_TSEL2_HRT1TRG1   (3 << DAC_CR_TSEL2_SHIFT) /* HRTIM1 DACTRG1 event */
+#  define DAC_CR_TSEL2_TIM15      (3 << DAC_CR_TSEL2_SHIFT)  /* Timer 15 TRGO event, or */
+#  define DAC_CR_TSEL2_HRT1TRG1   (3 << DAC_CR_TSEL2_SHIFT)  /* HRTIM1 DACTRG1 event */
 #else
-#  define DAC_CR_TSEL2_TIM5       (3 << DAC_CR_TSEL2_SHIFT) /* Timer 5 TRGO event */
+#  define DAC_CR_TSEL2_TIM5       (3 << DAC_CR_TSEL2_SHIFT)  /* Timer 5 TRGO event */
 #endif
-#  define DAC_CR_TSEL2_TIM2       (4 << DAC_CR_TSEL2_SHIFT) /* Timer 2 TRGO event */
+#  define DAC_CR_TSEL2_TIM2       (4 << DAC_CR_TSEL2_SHIFT)  /* Timer 2 TRGO event */
 #if defined(CONFIG_STM32_STM32F33XX)
-#  define DAC_CR_TSEL2_HRT1TRG2   (5 << DAC_CR_TSEL2_SHIFT) /* HRTIM1 DACTRG2 event */
+#  define DAC_CR_TSEL2_HRT1TRG2   (5 << DAC_CR_TSEL2_SHIFT)  /* HRTIM1 DACTRG2 event */
 #else
-#  define DAC_CR_TSEL2_TIM4       (5 << DAC_CR_TSEL2_SHIFT) /* Timer 4 TRGO event */
+#  define DAC_CR_TSEL2_TIM4       (5 << DAC_CR_TSEL2_SHIFT)  /* Timer 4 TRGO event */
 #endif
-#  define DAC_CR_TSEL2_EXT9       (6 << DAC_CR_TSEL2_SHIFT) /* External line9 */
-#  define DAC_CR_TSEL2_SW         (7 << DAC_CR_TSEL2_SHIFT) /* Software trigger */
-#define DAC_CR_WAVE2_SHIFT        (22)       /* Bit 22-23: DAC channel 2 noise/triangle wave generation enable */
+#  define DAC_CR_TSEL2_EXT9       (6 << DAC_CR_TSEL2_SHIFT)  /* External line9 */
+#  define DAC_CR_TSEL2_SW         (7 << DAC_CR_TSEL2_SHIFT)  /* Software trigger */
+#define DAC_CR_WAVE2_SHIFT        (22)                       /* Bit 22-23: DAC channel 2 noise/triangle wave generation enable */
 #define DAC_CR_WAVE2_MASK         (3 << DAC_CR_WAVE2_SHIFT)
-#  define DAC_CR_WAVE2_DISABLED   (0 << DAC_CR_WAVE2_SHIFT) /* Wave generation disabled */
-#  define DAC_CR_WAVE2_NOISE      (1 << DAC_CR_WAVE2_SHIFT) /* Noise wave generation enabled */
-#  define DAC_CR_WAVE2_TRIANGLE   (2 << DAC_CR_WAVE2_SHIFT) /* Triangle wave generation enabled */
-#define DAC_CR_MAMP2_SHIFT        (24)      /* Bit 24-27: DAC channel 2 mask/amplitude selector */
+#  define DAC_CR_WAVE2_DISABLED   (0 << DAC_CR_WAVE2_SHIFT)  /* Wave generation disabled */
+#  define DAC_CR_WAVE2_NOISE      (1 << DAC_CR_WAVE2_SHIFT)  /* Noise wave generation enabled */
+#  define DAC_CR_WAVE2_TRIANGLE   (2 << DAC_CR_WAVE2_SHIFT)  /* Triangle wave generation enabled */
+#define DAC_CR_MAMP2_SHIFT        (24)                       /* Bit 24-27: DAC channel 2 mask/amplitude selector */
 #define DAC_CR_MAMP2_MASK         (15 << DAC_CR_MAMP2_SHIFT)
 #  define DAC_CR_MAMP2_AMP1       (0 << DAC_CR_MAMP2_SHIFT)  /* Unmask bit0 of LFSR/triangle amplitude=1 */
 #  define DAC_CR_MAMP2_AMP3       (1 << DAC_CR_MAMP2_SHIFT)  /* Unmask bits[1:0] of LFSR/triangle amplitude=3 */
@@ -256,8 +257,8 @@
 #  define DAC_CR_MAMP2_AMP1023    (9 << DAC_CR_MAMP2_SHIFT)  /* Unmask bits[9:0] of LFSR/triangle amplitude=1023 */
 #  define DAC_CR_MAMP2_AMP2047    (10 << DAC_CR_MAMP2_SHIFT) /* Unmask bits[10:0] of LFSR/triangle amplitude=2047 */
 #  define DAC_CR_MAMP2_AMP4095    (11 << DAC_CR_MAMP2_SHIFT) /* Unmask bits[11:0] of LFSR/triangle amplitude=4095 */
-#define DAC_CR_DMAEN2             (1 << 28) /* Bit 28: DAC channel 2 DMA enable */
-#define DAC_CR_DMAUDRIE2          (1 << 29) /* Bit 29: DAC channel 2 DMA underrun interrupt enable */
+#define DAC_CR_DMAEN2             (1 << 28)                  /* Bit 28: DAC channel 2 DMA enable */
+#define DAC_CR_DMAUDRIE2          (1 << 29)                  /* Bit 29: DAC channel 2 DMA underrun interrupt enable */
 
 /* DAC software trigger register */
 


### PR DESCRIPTION
## Summary

arch/arm/src/stm32/hardware/stm32_dac.h:

- Fix nxstyle errors.

## Impact

Removes nxstyle complaints.

## Testing

nxstyle