### PR TITLE
sched/signal/sig_default.c: Fix a comment

### DIFF
--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -255,7 +255,7 @@ static void nxsig_abnormal_termination(int signo)
  * Name: nxsig_stop_task
  *
  * Description:
- *   This is the handler for the abnormal termination default action.
+ *   This is the handler for the stop default action.
  *
  * Input Parameters:
  *   Standard signal handler parameters


### PR DESCRIPTION
## Summary

Fix a comment.
I think the original text is a description of nxsig_abnormal_termination.

## Impact

No impact

## Testing

