### PR TITLE
arch: serial: fix typos and run nxstyle

### DIFF
--- a/arch/arm/src/efm32/efm32_leserial.c
+++ b/arch/arm/src/efm32/efm32_leserial.c
@@ -63,7 +63,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Some sanity checks *******************************************************/
+
 /* Is there at least one UART enabled and configured as a RS-232 device? */
 
 #ifndef HAVE_LEUART_DEVICE
@@ -76,8 +78,9 @@
 
 #ifdef USE_SERIALDRIVER
 
-/* Which LEUART with be ttyLE0/console and which ttyLE1?  The console will always
- * be ttyLE0.  If there is no console then will use the lowest numbered LEUART.
+/* Which LEUART with be ttyLE0/console and which ttyLE1?  The console will
+ * always be ttyLE0.  If there is no console then will use the lowest
+ * numbered LEUART.
  */
 
 /* First pick the console and ttys0.  This could be either LEUART0-1 */
@@ -150,7 +153,8 @@ struct efm32_leuart_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static inline uint32_t efm32_serialin(struct efm32_leuart_s *priv, int offset);
+static inline uint32_t efm32_serialin(struct efm32_leuart_s *priv,
+                                      int offset);
 static inline void efm32_serialout(struct efm32_leuart_s *priv, int offset,
                                    uint32_t value);
 static inline void efm32_setuartint(struct efm32_leuart_s *priv);
@@ -234,7 +238,7 @@ static struct uart_dev_s g_leuart0port =
   {
     .size    = CONFIG_LEUART0_TXBUFSIZE,
     .buffer  = g_leuart0txbuffer,
-   },
+  },
   .ops       = &g_leuart_ops,
   .priv      = &g_leuart0priv,
 };
@@ -269,7 +273,7 @@ static struct uart_dev_s g_leuart1port =
   {
     .size    = CONFIG_LEUART1_TXBUFSIZE,
     .buffer  = g_leuart1txbuffer,
-   },
+  },
   .ops       = &g_leuart_ops,
   .priv      = &g_leuart1priv,
 };
@@ -283,7 +287,8 @@ static struct uart_dev_s g_leuart1port =
  * Name: efm32_serialin
  ****************************************************************************/
 
-static inline uint32_t efm32_serialin(struct efm32_leuart_s *priv, int offset)
+static inline uint32_t efm32_serialin(struct efm32_leuart_s *priv,
+                                      int offset)
 {
   return getreg32(priv->config->uartbase + offset);
 }
@@ -293,7 +298,7 @@ static inline uint32_t efm32_serialin(struct efm32_leuart_s *priv, int offset)
  ****************************************************************************/
 
 static inline void efm32_serialout(struct efm32_leuart_s *priv, int offset,
-                                uint32_t value)
+                                   uint32_t value)
 {
   putreg32(value, priv->config->uartbase + offset);
 }
@@ -315,7 +320,9 @@ static void efm32_restoreuartint(struct efm32_leuart_s *priv, uint32_t ien)
 {
   irqstate_t flags;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in ien */
+  /* Re-enable/re-disable interrupts corresponding to the state of
+   * bits in ien.
+   */
 
   flags     = enter_critical_section();
   priv->ien = ien;
@@ -398,14 +405,15 @@ static void efm32_shutdown(struct uart_dev_s *dev)
  * Name: efm32_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -432,9 +440,9 @@ static int efm32_attach(struct uart_dev_s *dev)
  * Name: efm32_detach
  *
  * Description:
- *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   Detach UART interrupts.  This method is called when the serial port
+ *   is closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -616,8 +624,8 @@ static void efm32_rxint(struct uart_dev_s *dev, bool enable)
   flags = enter_critical_section();
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when there is anything in the Rx data register
+       * (or an Rx timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -638,7 +646,7 @@ static void efm32_rxint(struct uart_dev_s *dev, bool enable)
  * Name: efm32_rxavailable
  *
  * Description:
- *   Return true if the receive register is not empty
+ *   Return true if the receive register is not empty.
  *
  ****************************************************************************/
 
@@ -648,7 +656,8 @@ static bool efm32_rxavailable(struct uart_dev_s *dev)
 
   /* Return true if the receive data is available (RXDATAV). */
 
-  return (efm32_serialin(priv, EFM32_LEUART_STATUS_OFFSET) & LEUART_STATUS_RXDATAV) != 0;
+  return (efm32_serialin(priv, EFM32_LEUART_STATUS_OFFSET) &
+          LEUART_STATUS_RXDATAV) != 0;
 }
 
 /****************************************************************************
@@ -722,7 +731,8 @@ static bool efm32_txready(struct uart_dev_s *dev)
    * when it is full.
    */
 
-  return (efm32_serialin(priv, EFM32_LEUART_STATUS_OFFSET) & LEUART_STATUS_TXBL) != 0;
+  return (efm32_serialin(priv, EFM32_LEUART_STATUS_OFFSET) &
+          LEUART_STATUS_TXBL) != 0;
 }
 
 /****************************************************************************
@@ -741,7 +751,8 @@ static bool efm32_txempty(struct uart_dev_s *dev)
    * data is available in the transmit buffer.
    */
 
-  return (efm32_serialin(priv, EFM32_LEUART_STATUS_OFFSET) & LEUART_STATUS_TXC) != 0;
+  return (efm32_serialin(priv, EFM32_LEUART_STATUS_OFFSET) &
+          LEUART_STATUS_TXC) != 0;
 }
 
 /****************************************************************************
@@ -757,23 +768,21 @@ static bool efm32_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before arm_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in efm32_consoleinit() and main clock iniialization
- *   performed in efm32_clkinitialize().
+ *   configuration performed in efm32_consoleinit() and main clock
+ *   initialization performed in efm32_clkinitialize().
  *
  ****************************************************************************/
 
 void arm_earlyserialinit(void)
 {
-  /* Disable interrupts from all UARTS.  The console is enabled in
-   * pic32mx_consoleinit()
-   */
+  /* Disable interrupts from all UARTS. */
 
   efm32_restoreuartint(TTYLE0_DEV.priv, 0);
 #ifdef TTYLE1_DEV
   efm32_restoreuartint(TTYLE1_DEV.priv, 0);
 #endif
 
-  /* Configuration whichever one is the console */
+  /* Configuration whichever one is the console. */
 
 #ifdef CONSOLE_DEV
   CONSOLE_DEV.isconsole = true;

--- a/arch/arm/src/efm32/efm32_serial.c
+++ b/arch/arm/src/efm32/efm32_serial.c
@@ -1129,16 +1129,14 @@ static bool efm32_txempty(struct uart_dev_s *dev)
  *   serial console will be available during bootup.  This must be called
  *   before arm_serialinit.  NOTE:  This function depends on GPIO pin
  *   configuration performed in efm32_consoleinit() and main clock
- *   iniialization performed in efm32_clkinitialize().
+ *   initialization performed in efm32_clkinitialize().
  *
  ****************************************************************************/
 
 #ifdef USE_EARLYSERIALINIT
 void arm_earlyserialinit(void)
 {
-  /* Disable interrupts from all UARTS.  The console is enabled in
-   * pic32mx_consoleinit()
-   */
+  /* Disable interrupts from all UARTS. */
 
   efm32_restoreuartint(TTYS0_DEV.priv, 0);
 #ifdef TTYS1_DEV
@@ -1154,7 +1152,7 @@ void arm_earlyserialinit(void)
   efm32_restoreuartint(TTYS4_DEV.priv, 0);
 #endif
 
-  /* Configuration whichever one is the console */
+  /* Configuration whichever one is the console. */
 
 #ifdef CONSOLE_DEV
   CONSOLE_DEV.isconsole = true;

--- a/arch/arm/src/kinetis/kinetis_serial.c
+++ b/arch/arm/src/kinetis/kinetis_serial.c
@@ -1988,9 +1988,7 @@ static void up_dma_rxcallback(DMA_HANDLE handle, void *arg, int result)
 #if defined(USE_EARLYSERIALINIT)
 void kinetis_uart_earlyserialinit(void)
 {
-  /* Disable interrupts from all UARTS.  The console is enabled in
-   * pic32mx_consoleinit()
-   */
+  /* Disable interrupts from all UARTS. */
 
   up_restoreuartint(TTYS0_DEV.priv, 0);
 #ifdef TTYS1_DEV
@@ -2009,7 +2007,7 @@ void kinetis_uart_earlyserialinit(void)
   up_restoreuartint(TTYS5_DEV.priv, 0);
 #endif
 
-  /* Configuration whichever one is the console */
+  /* Configuration whichever one is the console. */
 
 #ifdef HAVE_UART_CONSOLE
   CONSOLE_DEV.isconsole = true;

--- a/arch/arm/src/kl/kl_serial.c
+++ b/arch/arm/src/kl/kl_serial.c
@@ -67,6 +67,7 @@
  ****************************************************************************/
 
 /* Some sanity checks *******************************************************/
+
 /* Is there at least one UART enabled and configured as a RS-232 device? */
 
 #ifndef HAVE_UART_DEVICE
@@ -241,7 +242,7 @@ static uart_dev_t g_uart0port =
   {
     .size   = CONFIG_UART0_TXBUFSIZE,
     .buffer = g_uart0txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart0priv,
 };
@@ -271,7 +272,7 @@ static uart_dev_t g_uart1port =
   {
     .size   = CONFIG_UART1_TXBUFSIZE,
     .buffer = g_uart1txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart1priv,
 };
@@ -301,7 +302,7 @@ static uart_dev_t g_uart2port =
   {
     .size   = CONFIG_UART2_TXBUFSIZE,
     .buffer = g_uart2txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart2priv,
 };
@@ -324,7 +325,8 @@ static inline uint8_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint8_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint8_t value)
 {
   putreg8(value, priv->uartbase + offset);
 }
@@ -338,7 +340,9 @@ static void up_setuartint(struct up_dev_s *priv)
   irqstate_t flags;
   uint8_t regval;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in ie */
+  /* Re-enable/re-disable interrupts corresponding to the state of bits
+   * in ie.
+   */
 
   flags    = enter_critical_section();
   regval   = up_serialin(priv, KL_UART_C2_OFFSET);
@@ -356,7 +360,9 @@ static void up_restoreuartint(struct up_dev_s *priv, uint8_t ie)
 {
   irqstate_t flags;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in ie */
+  /* Re-enable/re-disable interrupts corresponding to the state of bits
+   * in ie.
+   */
 
   flags    = enter_critical_section();
   priv->ie = ie & UART_C2_ALLINTS;
@@ -413,7 +419,7 @@ static int up_setup(struct uart_dev_s *dev)
  *
  * Description:
  *   Disable the UART.  This method is called when the serial
- *   port is closed
+ *   port is closed.
  *
  ****************************************************************************/
 
@@ -434,14 +440,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -467,9 +474,9 @@ static int up_attach(struct uart_dev_s *dev)
  * Name: up_detach
  *
  * Description:
- *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   Detach UART interrupts.  This method is called when the serial port
+ *   is closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -566,7 +573,8 @@ static int up_interrupts(int irq, void *context, void *arg)
        * FE: Framing error. To clear FE, write a logic one to the FE flag.
        * NF: Noise flag. To clear NF, write logic one to the NF.
        * PF: Parity error flag. To clear PF, write a logic one to the PF.
-       * OR: Receiver Overrun Flag.  To clear OR, write a logic 1 to the OR flag.
+       * OR: Receiver Overrun Flag. To clear OR, write a logic 1 to the OR
+       *     flag.
        */
 
       if ((s1 & UART_S1_ERRORS) != 0)
@@ -810,9 +818,7 @@ static bool up_txready(struct uart_dev_s *dev)
 
 void arm_earlyserialinit(void)
 {
-  /* Disable interrupts from all UARTS.  The console is enabled in
-   * pic32mx_consoleinit()
-   */
+  /* Disable interrupts from all UARTS. */
 
   up_restoreuartint(TTYS0_DEV.priv, 0);
 #ifdef TTYS1_DEV
@@ -831,7 +837,7 @@ void arm_earlyserialinit(void)
   up_restoreuartint(TTYS5_DEV.priv, 0);
 #endif
 
-  /* Configuration whichever one is the console */
+  /* Configuration whichever one is the console. */
 
 #ifdef HAVE_SERIAL_CONSOLE
   CONSOLE_DEV.isconsole = true;

--- a/arch/arm/src/lpc54xx/lpc54_serial.c
+++ b/arch/arm/src/lpc54xx/lpc54_serial.c
@@ -68,7 +68,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Some sanity checks *******************************************************/
+
 /* Is there at least one USART enabled and configured as a RS-232 device? */
 
 #ifndef HAVE_USART_DEVICE
@@ -499,7 +501,7 @@ static uart_dev_t g_uart0port =
   {
     .size   = CONFIG_USART0_TXBUFSIZE,
     .buffer = g_uart0txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart0priv,
 };
@@ -541,7 +543,7 @@ static uart_dev_t g_uart1port =
   {
     .size   = CONFIG_USART1_TXBUFSIZE,
     .buffer = g_uart1txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart1priv,
 };
@@ -583,7 +585,7 @@ static uart_dev_t g_uart2port =
   {
     .size   = CONFIG_USART2_TXBUFSIZE,
     .buffer = g_uart2txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart2priv,
 };
@@ -625,7 +627,7 @@ static uart_dev_t g_uart3port =
   {
     .size   = CONFIG_USART3_TXBUFSIZE,
     .buffer = g_uart3txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart3priv,
 };
@@ -667,7 +669,7 @@ static uart_dev_t g_uart4port =
   {
     .size   = CONFIG_USART4_TXBUFSIZE,
     .buffer = g_uart4txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart4priv,
 };
@@ -709,7 +711,7 @@ static uart_dev_t g_uart5port =
   {
     .size   = CONFIG_USART5_TXBUFSIZE,
     .buffer = g_uart5txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart5priv,
 };
@@ -751,7 +753,7 @@ static uart_dev_t g_uart6port =
   {
     .size   = CONFIG_USART6_TXBUFSIZE,
     .buffer = g_uart6txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart6priv,
 };
@@ -793,7 +795,7 @@ static uart_dev_t g_uart7port =
   {
     .size   = CONFIG_USART7_TXBUFSIZE,
     .buffer = g_uart7txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart7priv,
 };
@@ -835,7 +837,7 @@ static uart_dev_t g_uart8port =
   {
     .size   = CONFIG_USART8_TXBUFSIZE,
     .buffer = g_uart8txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart8priv,
 };
@@ -877,7 +879,7 @@ static uart_dev_t g_uart9port =
   {
     .size   = CONFIG_USART9_TXBUFSIZE,
     .buffer = g_uart9txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart9priv,
 };
@@ -892,7 +894,7 @@ static uart_dev_t g_uart9port =
  ****************************************************************************/
 
 static inline uint32_t lpc54_serialin(struct lpc54_dev_s *priv,
-                                     unsigned int offset)
+                                      unsigned int offset)
 {
   return getreg32(priv->uartbase + offset);
 }
@@ -902,7 +904,7 @@ static inline uint32_t lpc54_serialin(struct lpc54_dev_s *priv,
  ****************************************************************************/
 
 static inline void lpc54_serialout(struct lpc54_dev_s *priv,
-                                  unsigned int offset, uint32_t value)
+                                   unsigned int offset, uint32_t value)
 {
   putreg32(value, priv->uartbase + offset);
 }
@@ -911,8 +913,9 @@ static inline void lpc54_serialout(struct lpc54_dev_s *priv,
  * Name: lpc54_modifyreg
  ****************************************************************************/
 
-static inline void lpc54_modifyreg(struct lpc54_dev_s *priv, unsigned int offset,
-                                   uint32_t setbits, uint32_t clrbits)
+static inline void lpc54_modifyreg(struct lpc54_dev_s *priv,
+                                   unsigned int offset, uint32_t setbits,
+                                   uint32_t clrbits)
 {
   irqstate_t flags;
   uintptr_t regaddr = priv->uartbase + offset;
@@ -932,7 +935,8 @@ static inline void lpc54_modifyreg(struct lpc54_dev_s *priv, unsigned int offset
  * Name: lpc54_fifoint_enable
  ****************************************************************************/
 
-static inline void lpc54_fifoint_enable(struct lpc54_dev_s *priv, uint32_t intset)
+static inline void lpc54_fifoint_enable(struct lpc54_dev_s *priv,
+                                        uint32_t intset)
 {
   lpc54_serialout(priv, LPC54_USART_FIFOINTENSET_OFFSET, intset);
 }
@@ -941,7 +945,8 @@ static inline void lpc54_fifoint_enable(struct lpc54_dev_s *priv, uint32_t intse
  * Name: lpc54_fifoint_disable
  ****************************************************************************/
 
-static inline void lpc54_fifoint_disable(struct lpc54_dev_s *priv, uint32_t intset)
+static inline void lpc54_fifoint_disable(struct lpc54_dev_s *priv,
+                                         uint32_t intset)
 {
   lpc54_serialout(priv, LPC54_USART_FIFOINTENCLR_OFFSET, intset);
 }
@@ -950,7 +955,8 @@ static inline void lpc54_fifoint_disable(struct lpc54_dev_s *priv, uint32_t ints
  * Name: lpc54_fifoint_disableall
  ****************************************************************************/
 
-static void lpc54_fifoint_disableall(struct lpc54_dev_s *priv, uint32_t *intset)
+static void lpc54_fifoint_disableall(struct lpc54_dev_s *priv,
+                                     uint32_t *intset)
 {
   irqstate_t flags;
 
@@ -994,7 +1000,7 @@ static int lpc54_setup(struct uart_dev_s *dev)
  *
  * Description:
  *   Disable the USART.  This method is called when the serial
- *   port is closed
+ *   port is closed.
  *
  ****************************************************************************/
 
@@ -1015,14 +1021,15 @@ static void lpc54_shutdown(struct uart_dev_s *dev)
  * Name: lpc54_attach
  *
  * Description:
- *   Configure the USART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the USART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -1048,9 +1055,9 @@ static int lpc54_attach(struct uart_dev_s *dev)
  * Name: lpc54_detach
  *
  * Description:
- *   Detach USART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   Detach USART interrupts.  This method is called when the serial port
+ *   is closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -1228,8 +1235,8 @@ static void lpc54_rxint(struct uart_dev_s *dev, bool enable)
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when there is anything in the Rx data register
+       * (or an Rx timeout occurs).
        */
 
       lpc54_fifoint_enable(priv, CCR_RX_EVENTS);
@@ -1360,17 +1367,15 @@ static bool lpc54_txempty(struct uart_dev_s *dev)
  *   Performs the low level USART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before lpc54_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in xmc_lowsetup() and main clock iniialization
- *   performed in xmc_clock_configure().
+ *   configuration performed in lpc54_lowsetup() and main clock
+ *   initialization performed in lpc54_clockconfig().
  *
  ****************************************************************************/
 
 #ifdef USE_EARLYSERIALINIT
 void lpc54_earlyserialinit(void)
 {
-  /* Disable interrupts from all USARTS.  The console is enabled in
-   * pic32mx_consoleinit()
-   */
+  /* Disable interrupts from all USARTS. */
 
   lpc54_fifoint_disableall(TTYS0_DEV.priv, NULL);
 #ifdef TTYS1_DEV
@@ -1401,7 +1406,7 @@ void lpc54_earlyserialinit(void)
   lpc54_fifoint_disableall(TTYS9_DEV.priv, NULL);
 #endif
 
-  /* Configuration whichever one is the console */
+  /* Configuration whichever one is the console. */
 
 #ifdef HAVE_USART_CONSOLE
   CONSOLE_DEV.isconsole = true;
@@ -1469,7 +1474,7 @@ void arm_serialinit(void)
  * Name: up_putc
  *
  * Description:
- *   Provide priority, low-level access to support OS debug  writes
+ *   Provide priority, low-level access to support OS debug writes.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/lpc54xx/lpc54_serial.h
+++ b/arch/arm/src/lpc54xx/lpc54_serial.h
@@ -44,7 +44,7 @@
 #include "lpc54_config.h"
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
@@ -54,8 +54,8 @@
  *   Performs the low level USART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before lpc54_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in xmc_lowsetup() and main clock iniialization
- *   performed in xmc_clock_configure().
+ *   configuration performed in lpc54_lowsetup() and main clock
+ *   initialization performed in lpc54_clockconfig().
  *
  ****************************************************************************/
 

--- a/arch/arm/src/max326xx/max32660/max32660_serial.c
+++ b/arch/arm/src/max326xx/max32660/max32660_serial.c
@@ -70,6 +70,7 @@
  ****************************************************************************/
 
 /* Some sanity checks *******************************************************/
+
 /* Is there at least one UART enabled and configured as a RS-232 device? */
 
 #ifndef HAVE_UART_DEVICE
@@ -237,7 +238,7 @@ static uart_dev_t g_uart0port =
   {
     .size   = CONFIG_UART0_TXBUFSIZE,
     .buffer = g_uart0txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart0priv,
 };
@@ -281,7 +282,7 @@ static uart_dev_t g_uart1port =
   {
     .size   = CONFIG_UART1_TXBUFSIZE,
     .buffer = g_uart1txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart1priv,
 };
@@ -315,8 +316,9 @@ static inline void max326_serialout(struct max326_dev_s *priv,
  * Name: max326_modifyreg
  ****************************************************************************/
 
-static inline void max326_modifyreg(struct max326_dev_s *priv, unsigned int offset,
-                                   uint32_t setbits, uint32_t clrbits)
+static inline void max326_modifyreg(struct max326_dev_s *priv,
+                                    unsigned int offset, uint32_t setbits,
+                                    uint32_t clrbits)
 {
   irqstate_t flags;
   uintptr_t regaddr = priv->uartbase + offset;
@@ -436,14 +438,15 @@ static void max326_shutdown(struct uart_dev_s *dev)
  * Name: max326_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -469,9 +472,9 @@ static int max326_attach(struct uart_dev_s *dev)
  * Name: max326_detach
  *
  * Description:
- *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   Detach UART interrupts.  This method is called when the serial port
+ *   is closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -632,7 +635,7 @@ static int max326_receive(struct uart_dev_s *dev, uint32_t *status)
 {
   struct max326_dev_s *priv = (struct max326_dev_s *)dev->priv;
 
-  /* Return receiver control information */
+  /* Return receiver control information. */
 
   if (status)
     {
@@ -641,7 +644,7 @@ static int max326_receive(struct uart_dev_s *dev, uint32_t *status)
 
   /* Then return the actual received data. */
 
- return max326_serialin(priv, MAX326_UART_FIFO_OFFSET);
+  return max326_serialin(priv, MAX326_UART_FIFO_OFFSET);
 }
 
 /****************************************************************************
@@ -659,8 +662,8 @@ static void max326_rxint(struct uart_dev_s *dev, bool enable)
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when there is anything in the Rx data register
+       * (or an Rx timeout occurs).
        */
 
 #ifdef CONFIG_DEBUG_FEATURES
@@ -795,24 +798,22 @@ static bool max326_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before max326_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in xmc_lowsetup() and main clock iniialization
- *   performed in xmc_clock_configure().
+ *   configuration performed in max326_lowsetup() and main clock
+ *   initialization performed in max326_clockconfig().
  *
  ****************************************************************************/
 
 #ifdef USE_EARLYSERIALINIT
 void max326_earlyserialinit(void)
 {
-  /* Disable interrupts from all UARTS.  The console is enabled in
-   * pic32mx_consoleinit()
-   */
+  /* Disable interrupts from all UARTS. */
 
   max326_int_disableall(TTYS0_DEV.priv, NULL);
 #ifdef TTYS1_DEV
   max326_int_disableall(TTYS1_DEV.priv, NULL);
 #endif
 
-  /* Configuration whichever one is the console */
+  /* Configuration whichever one is the console. */
 
 #ifdef HAVE_UART_CONSOLE
   CONSOLE_DEV.isconsole = true;

--- a/arch/arm/src/nrf52/nrf52_serial.c
+++ b/arch/arm/src/nrf52/nrf52_serial.c
@@ -749,8 +749,8 @@ static bool nrf52_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before nrf52_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in nrf52_lowsetup() and main clock iniialization
- *   performed in nrf_clock_configure().
+ *   configuration performed in nrf52_lowsetup() and main clock
+ *   initialization performed in nrf_clock_configure().
  *
  ****************************************************************************/
 

--- a/arch/arm/src/xmc4/xmc4_lowputc.h
+++ b/arch/arm/src/xmc4/xmc4_lowputc.h
@@ -86,8 +86,8 @@ void xmc4_lowsetup(void);
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before xmc4_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in xmc_lowsetup() and main clock iniialization
- *   performed in xmc_clock_configure().
+ *   configuration performed in xmc4_lowsetup() and main clock initialization
+ *   performed in xmc4_clock_configure().
  *
  ****************************************************************************/
 

--- a/arch/arm/src/xmc4/xmc4_serial.c
+++ b/arch/arm/src/xmc4/xmc4_serial.c
@@ -1028,17 +1028,15 @@ static bool xmc4_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before xmc4_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in xmc_lowsetup() and main clock iniialization
- *   performed in xmc_clock_configure().
+ *   configuration performed in xmc4_lowsetup() and main clock initialization
+ *   performed in xmc4_clock_configure().
  *
  ****************************************************************************/
 
 #if defined(USE_EARLYSERIALINIT)
 void xmc4_earlyserialinit(void)
 {
-  /* Disable interrupts from all UARTS.  The console is enabled in
-   * pic32mx_consoleinit()
-   */
+  /* Disable interrupts from all UARTS. */
 
   xmc4_restoreuartint(TTYS0_DEV.priv, 0);
 #ifdef TTYS1_DEV
@@ -1057,7 +1055,7 @@ void xmc4_earlyserialinit(void)
   xmc4_restoreuartint(TTYS5_DEV.priv, 0);
 #endif
 
-  /* Configuration whichever one is the console */
+  /* Configuration whichever one is the console. */
 
 #ifdef HAVE_UART_CONSOLE
   CONSOLE_DEV.isconsole = true;
@@ -1113,7 +1111,7 @@ void arm_serialinit(void)
  * Name: up_putc
  *
  * Description:
- *   Provide priority, low-level access to support OS debug  writes
+ *   Provide priority, low-level access to support OS debug writes.
  *
  ****************************************************************************/
 

--- a/arch/avr/src/at32uc3/at32uc3_serial.c
+++ b/arch/avr/src/at32uc3/at32uc3_serial.c
@@ -260,7 +260,7 @@ static uart_dev_t g_usart1port =
   {
     .size   = CONFIG_USART1_TXBUFSIZE,
     .buffer = g_usart1txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_usart1priv,
 };
@@ -290,7 +290,7 @@ static uart_dev_t g_usart2port =
   {
     .size   = CONFIG_USART2_TXBUFSIZE,
     .buffer = g_usart2txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_usart2priv,
 };
@@ -313,7 +313,8 @@ static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint32_t value)
 {
   putreg32(value, priv->usartbase + offset);
 }
@@ -390,14 +391,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the USART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the USART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -415,8 +417,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach USART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -554,6 +556,7 @@ static int up_receive(struct uart_dev_s *dev, uint32_t *status)
     {
       *status = priv->csr;
     }
+
   priv->csr = 0;
 
   /* Then return the actual received byte */
@@ -575,18 +578,18 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
 
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when there is anything in the Rx data register
+       * (or an Rx timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
 #  ifdef CONFIG_USART_ERRINTS
-        up_serialout(priv, AVR32_USART_IER_OFFSET,
-                     USART_INT_RXRDY | USART_INT_TIMEOUT | USART_INT_OVRE |
-                     USART_INT_FRAME | USART_INT_PARE);
+      up_serialout(priv, AVR32_USART_IER_OFFSET,
+                   USART_INT_RXRDY | USART_INT_TIMEOUT | USART_INT_OVRE |
+                   USART_INT_FRAME | USART_INT_PARE);
 #  else
-        up_serialout(priv, AVR32_USART_IER_OFFSET,
-                     USART_INT_RXRDY | USART_INT_TIMEOUT);
+      up_serialout(priv, AVR32_USART_IER_OFFSET,
+                   USART_INT_RXRDY | USART_INT_TIMEOUT);
 #  endif
 #endif
     }
@@ -602,7 +605,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
  * Name: up_rxavailable
  *
  * Description:
- *   Return true if the receive register is not empty
+ *   Return true if the receive register is not empty.
  *
  ****************************************************************************/
 
@@ -649,7 +652,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
   flags = enter_critical_section();
   if (enable)
     {
-      /* Set to receive an interrupt when the TX data register is empty */
+      /* Set to receive an interrupt when the TX data register is empty. */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
        up_serialout(priv, AVR32_USART_IER_OFFSET, USART_INT_TXRDY);
@@ -663,10 +666,11 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
     }
   else
     {
-      /* Disable the TX interrupt */
+      /* Disable the TX interrupt. */
 
        up_serialout(priv, AVR32_USART_IDR_OFFSET, USART_INT_TXRDY);
     }
+
   leave_critical_section(flags);
 }
 
@@ -704,8 +708,8 @@ static bool up_txready(struct uart_dev_s *dev)
  *   Performs the low level USART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before up_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in up_consoleinit() and main clock iniialization
- *   performed in up_clkinitialize().
+ *   configuration performed in up_consoleinit() and main clock
+ *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 

--- a/arch/mips/src/pic32mx/pic32mx_serial.c
+++ b/arch/mips/src/pic32mx/pic32mx_serial.c
@@ -68,6 +68,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* If we are not using the serial driver for the console, then we still must
  * provide some minimal implementation of up_putc.
  */
@@ -316,7 +317,9 @@ static void up_restoreuartint(struct uart_dev_s *dev, uint8_t im)
 {
   irqstate_t flags;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in im */
+  /* Re-enable/re-disable interrupts corresponding to the state
+   * of bits in im.
+   */
 
   flags = enter_critical_section();
   up_rxint(dev, RX_ENABLED(im));
@@ -398,14 +401,14 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
  *   RX and TX interrupts are not enabled by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are
+ *   hardware supports multiple levels of interrupt enabling).  The RX and
+ *   TX interrupts are not enabled until the txint() and rxint() methods are
  *   called.
  *
  ****************************************************************************/
@@ -423,9 +426,9 @@ static int up_attach(struct uart_dev_s *dev)
  * Name: up_detach
  *
  * Description:
- *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   Detach UART interrupts.  This method is called when the serial port
+ *   is closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -831,8 +834,8 @@ static bool up_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before up_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in up_consoleinit() and main clock iniialization
- *   performed in up_clkinitialize().
+ *   configuration performed in up_consoleinit() and main clock
+ *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 

--- a/arch/mips/src/pic32mz/pic32mz_serial.c
+++ b/arch/mips/src/pic32mz/pic32mz_serial.c
@@ -1085,8 +1085,8 @@ static bool up_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before up_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in up_consoleinit() and main clock iniialization
- *   performed in up_clkinitialize().
+ *   configuration performed in up_consoleinit() and main clock
+ *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/fe310/fe310_serial.c
+++ b/arch/risc-v/src/fe310/fe310_serial.c
@@ -610,8 +610,8 @@ static bool up_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before up_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in up_consoleinit() and main clock iniialization
- *   performed in up_clkinitialize().
+ *   configuration performed in up_consoleinit() and main clock
+ *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/gap8/gap8_uart.c
+++ b/arch/risc-v/src/gap8/gap8_uart.c
@@ -598,8 +598,8 @@ static bool up_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before up_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in up_consoleinit() and main clock iniialization
- *   performed in up_clkinitialize().
+ *   configuration performed in up_consoleinit() and main clock
+ *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/k210/k210_serial.c
+++ b/arch/risc-v/src/k210/k210_serial.c
@@ -610,8 +610,8 @@ static bool up_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before up_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in up_consoleinit() and main clock iniialization
- *   performed in up_clkinitialize().
+ *   configuration performed in up_consoleinit() and main clock
+ *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/litex/litex_serial.c
+++ b/arch/risc-v/src/litex/litex_serial.c
@@ -627,8 +627,8 @@ static bool up_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before up_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in up_consoleinit() and main clock iniialization
- *   performed in up_clkinitialize().
+ *   configuration performed in up_consoleinit() and main clock
+ *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/nr5m100/nr5_serial.c
+++ b/arch/risc-v/src/nr5m100/nr5_serial.c
@@ -747,8 +747,8 @@ static bool up_txempty(struct uart_dev_s *dev)
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
  *   before up_serialinit.  NOTE:  This function depends on GPIO pin
- *   configuration performed in up_consoleinit() and main clock iniialization
- *   performed in up_clkinitialize().
+ *   configuration performed in up_consoleinit() and main clock
+ *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 


### PR DESCRIPTION
##  Summary
Fix typos in many arch/\<arch\>/src/\<subarch\>/\<subarch\>_serial.c peripherals and run through nxstyle
## Impact
No functional change
## Testing

