### PR TITLE
Arch spi fixes

### DIFF
--- a/arch/arm/src/efm32/efm32_spi.c
+++ b/arch/arm/src/efm32/efm32_spi.c
@@ -1044,8 +1044,8 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
       regval |= setting;
       spi_putreg(config, EFM32_USART_FRAME_OFFSET, regval);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
       priv->nbits = nbits;
@@ -1105,8 +1105,8 @@ static int spi_hwfeatures(FAR struct spi_dev_s *dev,
 
       spi_putreg(config, EFM32_USART_CTRL_OFFSET, regval);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
       priv->lsbfirst = lsbfirst;

--- a/arch/arm/src/imxrt/imxrt_lpspi.c
+++ b/arch/arm/src/imxrt/imxrt_lpspi.c
@@ -1187,7 +1187,6 @@ static int imxrt_lpspi_hwfeatures(FAR struct spi_dev_s *dev,
   FAR struct imxrt_lpspidev_s *priv = (FAR struct imxrt_lpspidev_s *)dev;
   uint32_t setbits;
   uint32_t clrbits;
-  int savbits = nbits;
 
   spiinfo("features=%08x\n", features);
 
@@ -1204,7 +1203,7 @@ static int imxrt_lpspi_hwfeatures(FAR struct spi_dev_s *dev,
       clrbits = LPSPI_TCR_LSBF;
     }
 
-  imxrt_lpspi_modigyreg32(priv, IMXRT_LPSPI_TCR_OFFSET, clrbits, setbits);
+  imxrt_lpspi_modifyreg32(priv, IMXRT_LPSPI_TCR_OFFSET, clrbits, setbits);
 
   /* Other H/W features are not supported */
 

--- a/arch/arm/src/imxrt/imxrt_lpspi.c
+++ b/arch/arm/src/imxrt/imxrt_lpspi.c
@@ -1122,7 +1122,6 @@ static void imxrt_lpspi_setbits(FAR struct spi_dev_s *dev, int nbits)
 {
   FAR struct imxrt_lpspidev_s *priv = (FAR struct imxrt_lpspidev_s *)dev;
   uint32_t men;
-  int savbits = nbits;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -1148,12 +1147,11 @@ static void imxrt_lpspi_setbits(FAR struct spi_dev_s *dev, int nbits)
                               LPSPI_TCR_FRAMESZ_MASK,
                               LPSPI_TCR_FRAMESZ(nbits - 1));
 
-      /* Save the selection so the subsequence re-configurations
-       * will be faster
+      /* Save the selection so the subsequent re-configurations
+       * will be faster.
        */
 
-      priv->nbits = savbits;    /* nbits has been clobbered... save the signed
-                                 * value. */
+      priv->nbits = nbits;
 
       /* Re-enable LPSPI if it was enabled previously */
 

--- a/arch/arm/src/kinetis/kinetis_spi.c
+++ b/arch/arm/src/kinetis/kinetis_spi.c
@@ -813,7 +813,7 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       regval |= SPI_CTARM_FMSZ(nbits - 1);
       spi_putreg(priv, priv->ctarsel, regval);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be faster. */
 
       priv->nbits = nbits;
     }

--- a/arch/arm/src/kl/kl_spi.c
+++ b/arch/arm/src/kl/kl_spi.c
@@ -284,7 +284,9 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
   unsigned int spr;
   unsigned int sppr;
 
-  /* Check if the requested frequence is the same as the frequency selection */
+  /* Check if the requested frequence is the same as the frequency
+   * selection.
+   */
 
   if (priv->frequency == frequency)
     {
@@ -410,7 +412,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
 
       spi_putreg(priv, KL_SPI_C1_OFFSET, regval);
 
-      /* Save the mode so that subsequent re-configuratins will be faster */
+      /* Save the mode so that subsequent re-configurations will be faster */
 
       priv->mode = mode;
     }

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_spi.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_spi.c
@@ -228,9 +228,11 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
   uint32_t divisor;
   uint32_t actual;
 
-  /* Check if the requested frequence is the same as the frequency selection */
-
   DEBUGASSERT(priv && frequency <= SPI_CLOCK / 2);
+
+  /* Check if the requested frequence is the same as the frequency
+   * selection.
+   */
 
   if (priv->frequency == frequency)
     {
@@ -328,7 +330,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
 
       putreg32(regval, LPC17_40_SPI_CR);
 
-      /* Save the mode so that subsequent re-configuratins will be faster */
+      /* Save the mode so that subsequent re-configurations will be faster */
 
       priv->mode = mode;
     }
@@ -342,7 +344,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -368,7 +370,9 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       regval |= SPI_CR_BITENABLE;
       regval = getreg32(LPC17_40_SPI_CR);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
+       */
 
       priv->nbits = nbits;
     }

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ssp.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ssp.c
@@ -385,9 +385,11 @@ static uint32_t ssp_setfrequency(FAR struct spi_dev_s *dev,
   uint32_t regval;
   uint32_t actual;
 
-  /* Check if the requested frequency is the same as the frequency selection */
-
   DEBUGASSERT(priv && frequency <= SSP_CLOCK / 2);
+
+  /* Check if the requested frequency is the same as the frequency
+   * selection.
+   */
 
   if (priv->frequency == frequency)
     {
@@ -533,7 +535,7 @@ static void ssp_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -558,7 +560,9 @@ static void ssp_setbits(FAR struct spi_dev_s *dev, int nbits)
       regval |= ((nbits - 1) << SSP_CR0_DSS_SHIFT);
       ssp_putreg(priv, LPC17_40_SSP_CR0_OFFSET, regval);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
+       */
 
       priv->nbits = nbits;
     }
@@ -731,7 +735,9 @@ static void ssp_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
   uint32_t data;
   uint32_t rxpending = 0;
 
-  /* While there is remaining to be sent (and no synchronization error has occurred) */
+  /* While there is remaining to be sent (and no synchronization error
+   * has occurred)
+   */
 
   spiinfo("nwords: %d\n", nwords);
   u.pv = buffer;
@@ -752,7 +758,9 @@ static void ssp_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
           rxpending++;
         }
 
-      /* Now, read the RX data from the RX FIFO while the RX FIFO is not empty */
+      /* Now, read the RX data from the RX FIFO while the RX FIFO is
+       * not empty.
+       */
 
       spiinfo("RX: rxpending: %d\n", rxpending);
       while (ssp_getreg(priv, LPC17_40_SSP_SR_OFFSET) & SSP_SR_RNE)

--- a/arch/arm/src/lpc2378/lpc23xx_spi.c
+++ b/arch/arm/src/lpc2378/lpc23xx_spi.c
@@ -234,7 +234,9 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
 
   DEBUGASSERT(frequency <= SPI_CLOCK / 2);
 
-  /* Check if the requested frequency is the same as the frequency selection */
+  /* Check if the requested frequency is the same as the frequency
+   * selection.
+   */
 
   DEBUGASSERT(priv != NULL);
   if (priv->frequency == frequency)
@@ -248,7 +250,9 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
 
   divisor = SPI_CLOCK / frequency;
 
-  /* The SPI CCR register must contain an even number greater than or equal to 8. */
+  /* The SPI CCR register must contain an even number greater than or equal
+   * to 8.
+   */
 
   if (divisor < 8)
     {
@@ -332,7 +336,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
 
       putreg32(regval, SPI_CR);
 
-      /* Save the mode so that subsequent re-configuratins will be faster */
+      /* Save the mode so that subsequent re-configurations will be faster */
 
       priv->mode = mode;
     }
@@ -346,7 +350,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -373,7 +377,9 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       regval |= SPI_CR_BITENABLE;
       putreg32(regval, SPI_CR);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
+       */
 
       priv->nbits = nbits;
     }

--- a/arch/arm/src/lpc43xx/lpc43_spi.c
+++ b/arch/arm/src/lpc43xx/lpc43_spi.c
@@ -219,7 +219,9 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
   uint32_t divisor;
   uint32_t actual;
 
-  /* Check if the requested frequence is the same as the frequency selection */
+  /* Check if the requested frequence is the same as the frequency
+   * selection.
+   */
 
   DEBUGASSERT(priv && frequency <= SPI_CLOCK / 2);
 
@@ -234,7 +236,9 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
 
   divisor = SPI_CLOCK / frequency;
 
-  /* The SPI CCR register must contain an even number greater than or equal to 8. */
+  /* The SPI CCR register must contain an even number greater than or equal
+   * to 8.
+   */
 
   if (divisor < 8)
     {
@@ -317,7 +321,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
 
       putreg32(regval, LPC43_SPI_CR);
 
-      /* Save the mode so that subsequent re-configuratins will be faster */
+      /* Save the mode so that subsequent re-configurations will be faster */
 
       priv->mode = mode;
     }
@@ -331,7 +335,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -357,7 +361,9 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       regval |= SPI_CR_BITENABLE;
       regval = getreg32(LPC43_SPI_CR);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
+       */
 
       priv->nbits = nbits;
     }

--- a/arch/arm/src/lpc43xx/lpc43_ssp.c
+++ b/arch/arm/src/lpc43xx/lpc43_ssp.c
@@ -432,7 +432,7 @@ static void ssp_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -461,7 +461,9 @@ static void ssp_setbits(FAR struct spi_dev_s *dev, int nbits)
       spiinfo("SSP Control Register 0 (CR0) after setting"
               "DSS: 0x%08X.\n", regval);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
+       */
 
       priv->nbits = nbits;
     }
@@ -550,7 +552,9 @@ static void ssp_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
   uint32_t datadummy = (priv->nbits > 8) ? 0xffff : 0xff;
   uint32_t rxpending = 0;
 
-  /* While there is remaining to be sent (and no synchronization error has occurred) */
+  /* While there is remaining to be sent (and no synchronization error
+   * has occurred)
+   */
 
   spiinfo("nwords: %d\n", nwords);
 
@@ -585,7 +589,9 @@ static void ssp_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
           rxpending++;
         }
 
-      /* Now, read the RX data from the RX FIFO while the RX FIFO is not empty */
+      /* Now, read the RX data from the RX FIFO while the RX FIFO is not
+       * empty.
+       */
 
       spiinfo("RX: rxpending: %d\n", rxpending);
       while (ssp_getreg(priv, LPC43_SSP_SR_OFFSET) & SSP_SR_RNE)
@@ -759,7 +765,9 @@ static inline FAR struct lpc43_sspdev_s *lpc43_ssp1initialize(void)
   /* Pins configuration */
 
 #ifdef PINCONF_SSP1_SCK
-  /* It is possible this is not configured if CLK0 is being used for clocking SPI */
+  /* It is possible this is not configured if CLK0 is being used for
+   * clocking SPI.
+   */
 
   lpc43_pin_config(PINCONF_SSP1_SCK);
 #endif

--- a/arch/arm/src/max326xx/max32660/max32660_spim.c
+++ b/arch/arm/src/max326xx/max32660/max32660_spim.c
@@ -708,7 +708,9 @@ static int spi_poll(struct max326_spidev_s *priv)
           inten |= SPI_INT_RXLEVEL;
         }
 
-      /* Break out if we've received all the bytes and we're not transmitting */
+      /* Break out if we've received all the bytes and we're not
+       * transmitting.
+       */
 
       if (priv->txbuffer == NULL && priv->rxbytes == length)
         {
@@ -716,7 +718,7 @@ static int spi_poll(struct max326_spidev_s *priv)
         }
     }
 
-  /* Break out once we've transmitted and received all of the data */
+  /* Break out once we've transmitted and received all of the data. */
 
   if (priv->rxbytes == length && priv->txbytes == length)
     {
@@ -1080,7 +1082,9 @@ static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
 
         spi_modify_ctrl2(priv, setbits, clrbits);
 
-        /* Save the mode so that subsequent re-configurations will be faster */
+        /* Save the mode so that subsequent re-configurations will be
+         * faster.
+         */
 
         priv->mode = mode;
     }
@@ -1121,8 +1125,8 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
 
       priv->data16 = (nbits > 8);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
       priv->nbits  = nbits;

--- a/arch/arm/src/s32k1xx/s32k1xx_lpspi.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpspi.c
@@ -1147,7 +1147,6 @@ static int s32k1xx_lpspi_hwfeatures(FAR struct spi_dev_s *dev,
   FAR struct s32k1xx_lpspidev_s *priv = (FAR struct s32k1xx_lpspidev_s *)dev;
   uint32_t setbits;
   uint32_t clrbits;
-  int savbits = nbits;
 
   spiinfo("features=%08x\n", features);
 
@@ -1164,7 +1163,7 @@ static int s32k1xx_lpspi_hwfeatures(FAR struct spi_dev_s *dev,
       clrbits = LPSPI_TCR_LSBF;
     }
 
-  s32k1xx_lpspi_modigyreg32(priv, S32K1XX_LPSPI_TCR_OFFSET, clrbits, setbits);
+  s32k1xx_lpspi_modifyreg32(priv, S32K1XX_LPSPI_TCR_OFFSET, clrbits, setbits);
 
   /* Other H/W features are not supported */
 

--- a/arch/arm/src/s32k1xx/s32k1xx_lpspi.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpspi.c
@@ -1084,7 +1084,6 @@ static void s32k1xx_lpspi_setbits(FAR struct spi_dev_s *dev, int nbits)
   FAR struct s32k1xx_lpspidev_s *priv = (FAR struct s32k1xx_lpspidev_s *)dev;
   uint32_t regval;
   uint32_t men;
-  int savbits = nbits;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -1111,10 +1110,9 @@ static void s32k1xx_lpspi_setbits(FAR struct spi_dev_s *dev, int nbits)
 
       s32k1xx_lpspi_putreg32(priv, S32K1XX_LPSPI_TCR_OFFSET, regval);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be faster. */
 
-      priv->nbits = savbits;    /* nbits has been clobbered... save the signed
-                                 * value. */
+      priv->nbits = nbits;
 
       /* Re-enable LPSPI if it was enabled previously */
 

--- a/arch/arm/src/sam34/sam_spi.c
+++ b/arch/arm/src/sam34/sam_spi.c
@@ -1149,7 +1149,7 @@ static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -1164,7 +1164,7 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
   unsigned int offset;
 
   spiinfo("cs=%d nbits=%d\n", spics->cs, nbits);
-  DEBUGASSERT(spics && nbits > 7 && nbits < 17);
+  DEBUGASSERT(nbits > 7 && nbits < 17);
 
   /* Has the number of bits changed? */
 
@@ -1180,7 +1180,7 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
 
       spiinfo("csr[offset=%02x]=%08x\n", offset, regval);
 
-      /* Save the selection so the subsequence re-configurations will be
+      /* Save the selection so the subsequent re-configurations will be
        * faster.
        */
 

--- a/arch/arm/src/sama5/sam_spi.c
+++ b/arch/arm/src/sama5/sam_spi.c
@@ -1137,7 +1137,7 @@ static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -1152,7 +1152,7 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
   unsigned int offset;
 
   spiinfo("cs=%d nbits=%d\n", spics->cs, nbits);
-  DEBUGASSERT(spics && nbits > 7 && nbits < 17);
+  DEBUGASSERT(nbits > 7 && nbits < 17);
 
   /* NOTE:  The logic in spi_send and in spi_exchange only handles 8-bit
    * data at the present time.  So the following extra assertion is a
@@ -1175,8 +1175,8 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
 
       spiinfo("csr[offset=%02x]=%08x\n", offset, regval);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
       spics->nbits = nbits;

--- a/arch/arm/src/samd2l2/sam_spi.c
+++ b/arch/arm/src/samd2l2/sam_spi.c
@@ -859,7 +859,9 @@ static uint32_t spi_setfrequency(struct spi_dev_s *dev, uint32_t frequency)
       frequency = maxfreq;
     }
 
-  /* Check if the requested frequency is the same as the frequency selection */
+  /* Check if the requested frequency is the same as the frequency
+   * selection.
+   */
 
   if (priv->frequency == frequency)
     {
@@ -868,7 +870,7 @@ static uint32_t spi_setfrequency(struct spi_dev_s *dev, uint32_t frequency)
       return priv->actual;
     }
 
-  /* For synchronous mode, the BAUAD rate (Fbaud) is generated from the
+  /* For synchronous mode, the BAUD rate (Fbaud) is generated from the
    * source clock frequency (Fref) as follows:
    *
    *   Fbaud = Fref / (2 * (BAUD + 1))
@@ -1017,8 +1019,9 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
   struct sam_spidev_s *priv = (struct sam_spidev_s *)dev;
   uint32_t regval;
 
+  DEBUGASSERT(priv != NULL);
   spiinfo("sercom=%d nbits=%d\n", priv->sercom, nbits);
-  DEBUGASSERT(priv && nbits > 7 && nbits < 10);
+  DEBUGASSERT(nbits > 7 && nbits < 10);
 
   /* Has the number of bits changed? */
 
@@ -1036,7 +1039,9 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
 
       spi_putreg32(priv, regval, SAM_SPI_CTRLB_OFFSET);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
+       */
 
       priv->nbits = nbits;
     }

--- a/arch/arm/src/samd5e5/sam_spi.c
+++ b/arch/arm/src/samd5e5/sam_spi.c
@@ -953,7 +953,9 @@ static uint32_t spi_setfrequency(struct spi_dev_s *dev, uint32_t frequency)
       frequency = maxfreq;
     }
 
-  /* Check if the requested frequency is the same as the frequency selection */
+  /* Check if the requested frequency is the same as the frequency
+   * selection.
+   */
 
   if (priv->frequency == frequency)
     {
@@ -962,7 +964,7 @@ static uint32_t spi_setfrequency(struct spi_dev_s *dev, uint32_t frequency)
       return priv->actual;
     }
 
-  /* For synchronous mode, the BAUAD rate (Fbaud) is generated from the
+  /* For synchronous mode, the BAUD rate (Fbaud) is generated from the
    * source clock frequency (Fref) as follows:
    *
    *   Fbaud = Fref / (2 * (BAUD + 1))
@@ -1099,7 +1101,7 @@ static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -1111,8 +1113,9 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
   struct sam_spidev_s *priv = (struct sam_spidev_s *)dev;
   uint32_t regval;
 
+  DEBUGASSERT(priv != NULL);
   spiinfo("sercom=%d nbits=%d\n", priv->sercom, nbits);
-  DEBUGASSERT(priv && nbits > 7 && nbits < 10);
+  DEBUGASSERT(nbits > 7 && nbits < 10);
 
   /* Has the number of bits changed? */
 
@@ -1130,7 +1133,9 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
 
       spi_putreg32(priv, regval, SAM_SPI_CTRLB_OFFSET);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
+       */
 
       priv->nbits = nbits;
     }

--- a/arch/arm/src/samv7/sam_qspi.c
+++ b/arch/arm/src/samv7/sam_qspi.c
@@ -1281,7 +1281,7 @@ static void qspi_setmode(struct qspi_dev_s *dev, enum qspi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -1310,8 +1310,8 @@ static void qspi_setbits(struct qspi_dev_s *dev, int nbits)
 
       spiinfo("MR=%08x\n", regval);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
       priv->nbits = nbits;

--- a/arch/arm/src/samv7/sam_spi.c
+++ b/arch/arm/src/samv7/sam_spi.c
@@ -1378,7 +1378,7 @@ static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -1393,7 +1393,7 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
   unsigned int offset;
 
   spiinfo("cs=%d nbits=%d\n", spics->cs, nbits);
-  DEBUGASSERT(spics && nbits > 7 && nbits < 17);
+  DEBUGASSERT(nbits > 7 && nbits < 17);
 
   /* Has the number of bits changed? */
 
@@ -1409,7 +1409,7 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
 
       spiinfo("csr[offset=%02x]=%08x\n", offset, regval);
 
-      /* Save the selection so the subsequence re-configurations will be
+      /* Save the selection so that subsequent re-configurations will be
        * faster.
        */
 

--- a/arch/arm/src/samv7/sam_spi_slave.c
+++ b/arch/arm/src/samv7/sam_spi_slave.c
@@ -703,7 +703,7 @@ static void spi_setmode(struct sam_spidev_s *priv, enum spi_smode_e mode)
  *
  * Input Parameters:
  *   priv   - SPI device data structure
- *   nbits  - The number of bits requests
+ *   nbits  - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -730,8 +730,8 @@ static void spi_setbits(struct sam_spidev_s *priv, int nbits)
 
       spiinfo("csr0=%08x\n", regval);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
       priv->nbits = nbits;

--- a/arch/arm/src/stm32/stm32_spi.c
+++ b/arch/arm/src/stm32/stm32_spi.c
@@ -1520,7 +1520,7 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       spi_modifycr1(priv, setbits, clrbits);
       spi_modifycr1(priv, SPI_CR1_SPE, 0);
 #endif
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be faster. */
 
       priv->nbits = nbits;
     }
@@ -1818,10 +1818,10 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
 
       /* If this bus uses a in driver buffers we will incur 2 copies,
        * The copy cost is << less the non DMA transfer time and having
-       * the buffer in the driver ensures DMA can be used. This is bacause
+       * the buffer in the driver ensures DMA can be used. This is because
        * the API does not support passing the buffer extent so the only
        * extent is buffer + the transfer size. These can sizes be less than
-       * the cache line size, and not aligned and tyicaly greater then 4
+       * the cache line size, and not aligned and typically greater then 4
        * bytes, which is about the break even point for the DMA IO overhead.
        */
 

--- a/arch/arm/src/stm32f0l0g0/stm32_spi.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_spi.c
@@ -1095,7 +1095,6 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
   FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)dev;
   uint16_t setbits;
   uint16_t clrbits;
-  int savbits = nbits;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -1157,9 +1156,9 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       spi_modifycr(STM32_SPI_CR1_OFFSET, priv, SPI_CR1_SPE, 0);
 #endif
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will be faster. */
 
-      priv->nbits = savbits; /* nbits has been clobbered... save the signed value. */
+      priv->nbits = nbits;
     }
 }
 

--- a/arch/arm/src/stm32f0l0g0/stm32_spi.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_spi.c
@@ -1068,7 +1068,9 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
         spi_modifycr(STM32_SPI_CR1_OFFSET, priv, setbits, clrbits);
         spi_modifycr(STM32_SPI_CR1_OFFSET, priv, SPI_CR1_SPE, 0);
 
-        /* Save the mode so that subsequent re-configurations will be faster */
+        /* Save the mode so that subsequent re-configurations will be
+         * faster.
+         */
 
         priv->mode = mode;
     }
@@ -1156,7 +1158,9 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       spi_modifycr(STM32_SPI_CR1_OFFSET, priv, SPI_CR1_SPE, 0);
 #endif
 
-      /* Save the selection so that subsequent re-configurations will be faster. */
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
+       */
 
       priv->nbits = nbits;
     }
@@ -1256,7 +1260,9 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
   spi_writeword(priv, (uint16_t)(wd & 0xffff));
   ret = (uint32_t)spi_readword(priv);
 
-  /* Check and clear any error flags (Reading from the SR clears the error flags) */
+  /* Check and clear any error flags (Reading from the SR clears the error
+   * flags)
+   */
 
   regval = spi_getreg(priv, STM32_SPI_SR_OFFSET);
 
@@ -1618,7 +1624,9 @@ static int spi_pm_prepare(FAR struct pm_callback_s *cb, int domain,
 
       if (sval <= 0)
         {
-          /* Exclusive lock is held, do not allow entry to deeper PM states. */
+          /* Exclusive lock is held, do not allow entry to deeper PM
+           * states.
+           */
 
           return -EBUSY;
         }

--- a/arch/arm/src/stm32f7/stm32_spi.c
+++ b/arch/arm/src/stm32f7/stm32_spi.c
@@ -1476,7 +1476,6 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
   FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)dev;
   uint16_t setbits;
   uint16_t clrbits;
-  int savbits = nbits;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -1513,9 +1512,11 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       spi_modifycr2(priv, setbits, clrbits);
       spi_modifycr1(priv, SPI_CR1_SPE, 0);
 
-      /* Save the selection so the subsequence re-configurations will be faster */
+      /* Save the selection so that subsequent re-configurations will
+       * be faster.
+       */
 
-      priv->nbits = savbits; /* nbits has been clobbered... save the signed value. */
+      priv->nbits = nbits;
     }
 }
 

--- a/arch/arm/src/stm32f7/stm32_spi.c
+++ b/arch/arm/src/stm32f7/stm32_spi.c
@@ -1545,11 +1545,8 @@ static int spi_hwfeatures(FAR struct spi_dev_s *dev,
 #endif
 
 #ifdef CONFIG_SPI_BITORDER
-  uint16_t setbitscr1;
-  uint16_t clrbitscr1;
-  uint16_t setbitscr2;
-  uint16_t clrbitscr2;
-  int savbits = nbits;
+  uint16_t setbits;
+  uint16_t clrbits;
 
   spiinfo("features=%08x\n", features);
 
@@ -1791,13 +1788,15 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
 
   DEBUGASSERT(priv != NULL);
 
-  /* Convert the number of word to a number of bytes */
+  /* Convert the number of word to a number of bytes. */
 
   size_t nbytes = (priv->nbits > 8) ? nwords << 1 : nwords;
 
 #ifdef CONFIG_STM32F7_SPI_DMATHRESHOLD
 
-  /* If this is a small SPI transfer, then let spi_exchange_nodma() do the work. */
+  /* If this is a small SPI transfer, then let spi_exchange_nodma()
+   * do the work.
+   */
 
   if (nbytes <= CONFIG_STM32F7_SPI_DMATHRESHOLD)
     {
@@ -1847,10 +1846,10 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
 
       /* If this bus uses a in driver buffers we will incur 2 copies,
        * The copy cost is << less the non DMA transfer time and having
-       * the buffer in the driver ensures DMA can be used. This is bacause
+       * the buffer in the driver ensures DMA can be used. This is because
        * the API does not support passing the buffer extent so the only
        * extent is buffer + the transfer size. These can sizes be less than
-       * the cache line size, and not aligned and tyicaly greater then 4
+       * the cache line size, and not aligned and typically greater then 4
        * bytes, which is about the break even point for the DMA IO overhead.
        */
 
@@ -2081,7 +2080,9 @@ static int spi_pm_prepare(FAR struct pm_callback_s *cb, int domain,
 
       if (sval <= 0)
         {
-          /* Exclusive lock is held, do not allow entry to deeper PM states. */
+          /* Exclusive lock is held, do not allow entry to deeper
+           * PM states.
+           */
 
           return -EBUSY;
         }

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -1594,7 +1594,6 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
   FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)dev;
   uint32_t setbits = 0;
   uint32_t clrbits = 0;
-  int savbits = nbits;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -1633,11 +1632,11 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, clrbits, setbits);
       spi_enable(priv, true);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
-      priv->nbits = savbits;  /* nbits has been clobbered... save the signed value */
+      priv->nbits = nbits;
     }
 }
 

--- a/arch/arm/src/stm32h7/stm32_spi_slave.c
+++ b/arch/arm/src/stm32h7/stm32_spi_slave.c
@@ -1028,7 +1028,6 @@ static void spi_setbits(FAR struct spi_sctrlr_s *sctrlr, int nbits)
   FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)sctrlr;
   uint32_t setbits = 0;
   uint32_t clrbits = 0;
-  int savbits = nbits;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -1065,7 +1064,7 @@ static void spi_setbits(FAR struct spi_sctrlr_s *sctrlr, int nbits)
 
       spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, clrbits, setbits);
 
-      priv->nbits = savbits;
+      priv->nbits = nbits;
     }
 }
 

--- a/arch/arm/src/stm32l4/stm32l4_spi.c
+++ b/arch/arm/src/stm32l4/stm32l4_spi.c
@@ -1149,7 +1149,6 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
   FAR struct stm32l4_spidev_s *priv = (FAR struct stm32l4_spidev_s *)dev;
   uint16_t setbits;
   uint16_t clrbits;
-  int savbits = nbits;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -1187,11 +1186,11 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       spi_modifycr(STM32L4_SPI_CR2_OFFSET, priv, setbits, clrbits);
       spi_modifycr(STM32L4_SPI_CR1_OFFSET, priv, SPI_CR1_SPE, 0);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster.  nbits has been clobbered... save the signed value.
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
-      priv->nbits = savbits;
+      priv->nbits = nbits;
     }
 }
 

--- a/arch/arm/src/tiva/common/tiva_ssi.c
+++ b/arch/arm/src/tiva/common/tiva_ssi.c
@@ -1277,7 +1277,7 @@ static void ssi_setmodeinternal(struct tiva_ssidev_s *priv,
       ssi_putreg(priv, TIVA_SSI_CR0_OFFSET, regval);
       spiinfo("CR0: %08x\n", regval);
 
-      /* Save the mode so that subsequent re-configuratins will be faster */
+      /* Save the mode so that subsequent re-configurations will be faster */
 
       priv->mode = mode;
     }

--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -1251,7 +1251,7 @@ static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -1265,7 +1265,7 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
   uint32_t regval;
 
   spiinfo("cs=%d nbits=%d\n", spics->cs, nbits);
-  DEBUGASSERT(spics && nbits > 7 && nbits < 17);
+  DEBUGASSERT(nbits > 7 && nbits < 17);
 
   /* Has the number of bits changed? */
 
@@ -1280,7 +1280,7 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
 
       spiinfo("SCTR = %08x\n", regval);
 
-      /* Save the selection so the subsequence re-configs will be faster */
+      /* Save the selection so that subsequent re-configs will be faster. */
 
       spics->nbits = nbits;
     }

--- a/arch/avr/src/avr/up_spi.c
+++ b/arch/avr/src/avr/up_spi.c
@@ -308,7 +308,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
 
       SPSR = regval;
 
-      /* Save the mode so that subsequent re-configuratins will be faster */
+      /* Save the mode so that subsequent re-configurations will be faster */
 
       priv->mode = mode;
     }
@@ -322,7 +322,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests (only nbits == 8 is supported)
+ *   nbits - The number of bits requested (only nbits == 8 is supported)
  *
  * Returned Value:
  *   none

--- a/arch/mips/src/pic32mx/pic32mx_spi.c
+++ b/arch/mips/src/pic32mx/pic32mx_spi.c
@@ -615,7 +615,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
       spi_putreg(priv, PIC32MX_SPI_CON_OFFSET, regval);
       spiinfo("CON: %08x\n", regval);
 
-      /* Save the mode so that subsequent re-configuratins will be faster */
+      /* Save the mode so that subsequent re-configurations will be faster */
 
       priv->mode = mode;
     }
@@ -629,7 +629,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -642,11 +642,11 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
   uint32_t setting;
   uint32_t regval;
 
+  DEBUGASSERT(priv != NULL);
   spiinfo("Old nbits: %d New nbits: %d\n", priv->nbits, nbits);
+  DEBUGASSERT(nbits > 7 && nbits < 17);
 
   /* Has the number of bits changed? */
-
-  DEBUGASSERT(priv && nbits > 7 && nbits < 17);
 
   if (nbits != priv->nbits)
     {
@@ -676,8 +676,8 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       regval = spi_getreg(priv, PIC32MX_SPI_CON_OFFSET);
       spiinfo("CON: %08x\n", regval);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
       priv->nbits = nbits;

--- a/arch/mips/src/pic32mz/pic32mz_spi.c
+++ b/arch/mips/src/pic32mz/pic32mz_spi.c
@@ -1368,7 +1368,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -1411,8 +1411,8 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       regval |= setting;
       spi_putreg(priv, PIC32MZ_SPI_CON_OFFSET, regval);
 
-      /* Save the selection so the subsequence re-configurations will be
-       * faster
+      /* Save the selection so that subsequent re-configurations will be
+       * faster.
        */
 
       priv->nbits = nbits;

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -791,16 +791,14 @@ static void esp32_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
 
   if (nbits != priv->nbits)
     {
-      /**
-       * Save the selection so the subsequence re-configurations
+      /* Save the selection so that subsequent re-configurations
        * will be faster.
        */
 
       priv->nbits = nbits;
 
-      /**
-       * Each DMA transmission will set these value according to
-       * calculate buffer length.
+      /* Each DMA transmission will set these value according to
+       * calculated buffer length.
        */
 
       if (!priv->dma_chan)

--- a/arch/z16/src/z16f/z16f_espi.c
+++ b/arch/z16/src/z16f/z16f_espi.c
@@ -514,7 +514,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  * Input Parameters:
  *   dev -  Device-specific state data
- *   nbits - The number of bits requests
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
@@ -548,7 +548,7 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
       spi_putreg8(priv, regval, Z16F_ESPI_MODE);
       spiinfo("ESPI MODE: %02x\n", regval);
 
-      /* Save the selection so the subsequence re-configurations will be
+      /* Save the selection so that subsequent re-configurations will be
        * faster.
        */
 


### PR DESCRIPTION
## Summary
For most SPI peripherals:
- fix some NULL pointer checks (checking after using pointer)
- fix incorrect comment about nbits variable being clobbered, clean code to not use unnecessary temp variable
- fix some CONFIG_SPI_BITORDER code that did not even compile
- typos and nxstyle fixes
## Impact
No functional change
## Testing
Not tested, note that CONFIG_SPI_BITORDER might be still broken for some arch as never used apparently
