### PR TITLE
nrf52_spi: support unconnected MISO/MOSI pins

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -109,14 +109,6 @@ config NRF52_RTC
 	bool
 	default n
 
-config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
-	bool "SPI Master 1 Byte transfer anomaly workaround"
-	depends on NRF52_SPI_MASTER && ARCH_CHIP_NRF52832
-	default y
-	---help---
-		Enable the workaround to fix SPI Master 1 byte transfer bug
-		which occurs in NRF52832 revision 1 and revision 2.
-
 menu "NRF52 Peripheral Selection"
 
 config NRF52_I2C0_MASTER
@@ -598,3 +590,14 @@ config NRF52_SAADC_LIMITS
 endif # NRF52_SAADC
 
 endmenu # SAADC Configuration
+
+menu "SPI Configuration"
+
+config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
+	bool "Master 1 Byte transfer anomaly workaround"
+	depends on NRF52_SPI_MASTER && ARCH_CHIP_NRF52832
+	default y
+	---help---
+		Enable the workaround to fix SPI Master 1 byte transfer bug
+		which occurs in NRF52832 revision 1 and revision 2.
+endmenu

--- a/arch/arm/src/nrf52/hardware/nrf52_spi.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_spi.h
@@ -153,41 +153,14 @@
 #define SPIM_ENABLE_DIS             (0)        /* Disable SPIM */
 #define SPIM_ENABLE_EN              (0x7 << 0) /* Enable SPIM */
 
-/* PSELSCK Register */
+/* PSEL(MOSI/MISO/SCK/CSN) Register */
 
-#define SPIM_PSELSCK_PIN_SHIFT      (0)       /* Bits 0-4: SCK pin number */
-#define SPIM_PSELSCK_PIN_MASK       (0x1f << SPIM_PSELSCK_PIN_SHIFT)
-#define SPIM_PSELSCK_PORT_SHIFT     (5)       /* Bit 5: SCK port number */
-#define SPIM_PSELSCK_PORT_MASK      (0x1 << SPIM_PSELSCK_PORT_SHIFT)
-#define SPIM_PSELSCK_CONNECTED      (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSELSCK_RESET          (0xffffffff)
-
-/* PSELMOSI Register */
-
-#define SPIM_PSELMOSI_PIN_SHIFT     (0)       /* Bits 0-4: MOSI pin number */
-#define SPIM_PSELMOSI_PIN_MASK      (0x1f << SPIM_PSELMOSI_PIN_SHIFT)
-#define SPIM_PSELMOSI_PORT_SHIFT    (5)       /* Bit 5: MOSI port number */
-#define SPIM_PSELMOSI_PORT_MASK     (0x1 << SPIM_PSELMOSI_PORT_SHIFT)
-#define SPIM_PSELMOSI_CONNECTED     (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSELMOSI_RESET         (0xffffffff)
-
-/* PSELMISO Register */
-
-#define SPIM_PSELMISO_PIN_SHIFT     (0)       /* Bits 0-4: MISO pin number */
-#define SPIM_PSELMISO_PIN_MASK      (0x1f << SPIM_PSELMISO_PIN_SHIFT)
-#define SPIM_PSELMISO_PORT_SHIFT    (5)       /* Bit 5: MISO port number */
-#define SPIM_PSELMISO_PORT_MASK     (0x1 << SPIM_PSELMISO_PORT_SHIFT)
-#define SPIM_PSELMISO_CONNECTED     (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSELMISO_RESET         (0xffffffff)
-
-/* PSELCSN Register */
-
-#define SPIM_PSELCSN_PIN_SHIFT      (0)       /* Bits 0-4: CSN pin number */
-#define SPIM_PSELCSN_PIN_MASK       (0x1f << SPIM_PSELCSN_PIN_SHIFT)
-#define SPIM_PSELCSN_PORT_SHIFT     (5)       /* Bit 5: CSN port number */
-#define SPIM_PSELCSN_PORT_MASK      (0x1 << SPIM_PSELCSN_PORT_SHIFT)
-#define SPIM_PSELCSN_CONNECTED      (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSELCSN_RESET          (0xffffffff)
+#define SPIM_PSEL_PIN_SHIFT         (0)       /* Bits 0-4: pin number */
+#define SPIM_PSEL_PIN_MASK          (0x1f << SPIM_PSEL_PIN_SHIFT)
+#define SPIM_PSEL_PORT_SHIFT        (5)       /* Bit 5: port number */
+#define SPIM_PSEL_PORT_MASK         (0x1 << SPIM_PSEL_PORT_SHIFT)
+#define SPIM_PSEL_CONNECTED         (1 << 31) /* Bit 31: Connection */
+#define SPIM_PSEL_RESET             (0xffffffff)
 
 /* FREQUENCY Register */
 


### PR DESCRIPTION
## Summary

This is a retake on #1788, focusing on the underlying issue of having SPI be usable without MISO pin connected (useful for a write-only SPI LCD, for example). This adds the ability to work with no MISO/MOSI GPIO defined, which will not select this pin for SPI

## Impact

Add support for no MOSI/MISO pin on nRF52 SPI

## Testing

Can build without use of MISO/MOSI defined