### PR TITLE
boards/cxd56xx: Remove HOSTCC and HOSTCFLAGS from Make.defs

### DIFF
--- a/boards/arm/cxd56xx/spresense/scripts/Make.defs
+++ b/boards/arm/cxd56xx/spresense/scripts/Make.defs
@@ -121,7 +121,3 @@ endif
 ifneq ($(CONFIG_ASMP_MEMSIZE),)
   LDFLAGS += --defsym=__reserved_ramsize=$(CONFIG_ASMP_MEMSIZE)
 endif
-
-HOSTCC = gcc
-HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
-


### PR DESCRIPTION
## Summary
since all host toolchain definition is moved to the common place(tools/Config.mk)

## Impact
No functional change

## Testing
all cxd56xx config pass the build

