### PR TITLE
Don't typedef wchar_t for C++

### DIFF
--- a/boards/arm/eoss3/quickfeather/scripts/Make.defs
+++ b/boards/arm/eoss3/quickfeather/scripts/Make.defs
@@ -52,7 +52,7 @@ ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN_CLANGL),y)
   ARCHCFLAGS += -nostdlib -ffreestanding
-  ARCHCXXFLAGS += -nostdlib -ffreestanding -DCONFIG_WCHAR_BUILTIN
+  ARCHCXXFLAGS += -nostdlib -ffreestanding
 else
   ARCHCFLAGS += -funwind-tables
   ARCHCXXFLAGS += -fno-rtti -funwind-tables

--- a/boards/arm/stm32/nucleo-f446re/scripts/Make.defs
+++ b/boards/arm/stm32/nucleo-f446re/scripts/Make.defs
@@ -59,7 +59,7 @@ ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN_CLANGL),y)
   ARCHCFLAGS += -nostdlib -ffreestanding
-  ARCHCXXFLAGS += -nostdlib -ffreestanding -DCONFIG_WCHAR_BUILTIN
+  ARCHCXXFLAGS += -nostdlib -ffreestanding
 else
   ARCHCXXFLAGS += -fno-rtti
   ifneq ($(CONFIG_DEBUG_NOOPT),y)

--- a/boards/arm/stm32/nucleo-f4x1re/scripts/Make.defs
+++ b/boards/arm/stm32/nucleo-f4x1re/scripts/Make.defs
@@ -65,7 +65,7 @@ ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN_CLANGL),y)
   ARCHCFLAGS += -nostdlib -ffreestanding
-  ARCHCXXFLAGS += -nostdlib -ffreestanding DCONFIG_WCHAR_BUILTIN
+  ARCHCXXFLAGS += -nostdlib -ffreestanding
 else
   ARCHCXXFLAGS += -fno-rtti
   ifneq ($(CONFIG_DEBUG_NOOPT),y)

--- a/boards/arm/stm32/stm32f4discovery/scripts/Make.defs
+++ b/boards/arm/stm32/stm32f4discovery/scripts/Make.defs
@@ -46,7 +46,7 @@ ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN_CLANGL),y)
   ARCHCFLAGS += -nostdlib -ffreestanding
-  ARCHCXXFLAGS += -nostdlib -ffreestanding -DCONFIG_WCHAR_BUILTIN
+  ARCHCXXFLAGS += -nostdlib -ffreestanding
 else
   ARCHCFLAGS += -funwind-tables
   ARCHCXXFLAGS += -fno-rtti -funwind-tables

--- a/boards/arm/stm32f7/stm32f746g-disco/scripts/Make.defs
+++ b/boards/arm/stm32f7/stm32f746g-disco/scripts/Make.defs
@@ -54,7 +54,7 @@ ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN_CLANGL),y)
   ARCHCFLAGS += -nostdlib -ffreestanding
-  ARCHCXXFLAGS += -nostdlib -ffreestanding -DCONFIG_WCHAR_BUILTIN
+  ARCHCXXFLAGS += -nostdlib -ffreestanding
 else
   ARCHCXXFLAGS += -fno-rtti
   ifneq ($(CONFIG_DEBUG_NOOPT),y)

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -178,10 +178,9 @@ typedef int16_t      key_t;
 
 typedef intptr_t     ptrdiff_t;
 
-#ifndef CONFIG_WCHAR_BUILTIN
+#if !defined(__cplusplus)
 /* Wide, 16-bit character types.  wchar_t is a built-in type in C++ and
- * its declaration here may cause compilation errors on some compilers
- * if -DCONFIG_WCHAR_BUILTIN is not included in the CXXFLAGS.
+ * its declaration here may cause compilation errors on some compilers.
  *
  * REVISIT: wchar_t belongs in stddef.h
  */

--- a/tools/ide_exporter.py
+++ b/tools/ide_exporter.py
@@ -957,7 +957,6 @@ if __name__ == '__main__':
             lib_prj.make_output_dir(lib_name)
             if lib_name == 'libxx':
                 lib_prj.add_misc('cxx_misc')
-                lib_prj.add_define('cxx_def', 'CONFIG_WCHAR_BUILTIN')
             else:
                 lib_prj.add_misc('c_misc')
 


### PR DESCRIPTION
## Summary
wchar_t is a builtin type for C++.
Retire CONFIG_WCHAR_BUILTIN hack.

## Impact
C++

## Testing
build tested sim on macOS
