### PR TITLE
Fix build break when CONFIG_TASK_NAME_SIZE == 0

### DIFF
--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -406,7 +406,7 @@ void sched_note_start(FAR struct tcb_s *tcb)
 
   length = SIZEOF_NOTE_START(namelen + 1);
 #else
-  length = SIZEOF_NOTE_START(0)
+  length = SIZEOF_NOTE_START(0);
 #endif
 
   /* Finish formatting the note */


### PR DESCRIPTION
## Summary
Fix build break when CONFIG_TASK_NAME_SIZE == 0

## Impact

## Testing
Tested with spresense:smp

