### PR TITLE
lcd: Minor fixes to ssd1306 i2c driver

### DIFF
--- a/drivers/lcd/ssd1306_base.c
+++ b/drivers/lcd/ssd1306_base.c
@@ -927,7 +927,7 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
 
   /* Configure OLED SPI or I/O, must be delayed 1-10ms */
 
-  up_mdelay(5);
+  nxsig_usleep(5000);
 
   /* Configure the device */
 
@@ -1323,7 +1323,7 @@ static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
 
   ssd1306_select(priv, false);
 
-  up_mdelay(100);
+  nxsig_usleep(100000);
 
   priv->is_conf = true;
   return OK;

--- a/drivers/lcd/ssd1306_i2c.c
+++ b/drivers/lcd/ssd1306_i2c.c
@@ -68,7 +68,8 @@ int ssd1306_sendbyte(FAR struct ssd1306_dev_s *priv, uint8_t regval)
 {
   /* 8-bit data read sequence:
    *
-   *  Start - I2C_Write_Address - SSD1306_Reg_Address - SSD1306_Write_Data - STOP
+   *  Start - I2C_Write_Address - SSD1306_Reg_Address - SSD1306_Write_Data
+   *  - STOP
    */
 
   struct i2c_msg_s msg;
@@ -114,7 +115,8 @@ int ssd1306_sendbyte(FAR struct ssd1306_dev_s *priv, uint8_t regval)
  *
  ****************************************************************************/
 
-int ssd1306_sendblk(FAR struct ssd1306_dev_s *priv, uint8_t *data, uint8_t len)
+int ssd1306_sendblk(FAR struct ssd1306_dev_s *priv, uint8_t *data,
+                    uint8_t len)
 {
   struct i2c_msg_s msg[2];
   uint8_t transfer_mode;
@@ -122,7 +124,8 @@ int ssd1306_sendblk(FAR struct ssd1306_dev_s *priv, uint8_t *data, uint8_t len)
 
   /* 8-bit data read sequence:
    *
-   *  Start - I2C_Write_Address - Data transfer select - SSD1306_Write_Data - STOP
+   *  Start - I2C_Write_Address - Data transfer select - SSD1306_Write_Data
+   *  - STOP
    */
 
   /* Send the SSD1306 register address (with no STOP) */

--- a/drivers/lcd/ssd1306_i2c.c
+++ b/drivers/lcd/ssd1306_i2c.c
@@ -131,7 +131,7 @@ int ssd1306_sendblk(FAR struct ssd1306_dev_s *priv, uint8_t *data, uint8_t len)
 
   msg[0].frequency = CONFIG_SSD1306_I2CFREQ;  /* I2C frequency */
   msg[0].addr      = priv->addr;              /* 7-bit address */
-  msg[0].flags     = 0;                       /* Write transaction, beginning with START */
+  msg[0].flags     = I2C_M_NOSTOP;            /* Write transaction, beginning with START */
   msg[0].buffer    = &transfer_mode;          /* Transfer mode send */
   msg[0].length    = 1;                       /* Send the one byte register address */
 


### PR DESCRIPTION
## Summary
The sendblk function was missing NOSTOP on the first msg of the i2c transaction. This could cause an extra STOP to be inserted
in the transaction.

![image](https://user-images.githubusercontent.com/173245/97838443-0f759100-1c95-11eb-8cf1-d4a10b29faeb.png)


The driver uses up_mdelay for some timing where it should be using a sleep.

## Impact
Proper bulk write transaction is created and less busy time.

## Testing

Tested using a Adafruit 0.91 OLED display with this controller attached to the simulator.