### PR TITLE
stm32f7/stm32_serial.c: fix console re-initialisation if DMA enabled

### DIFF
--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -3661,7 +3661,7 @@ void arm_serialinit(void)
   minor = 1;
 #endif
 
-#ifdef SERIAL_HAVE_CONSOLE_DMA
+#if defined(SERIAL_HAVE_CONSOLE_RXDMA) || defined(SERIAL_HAVE_CONSOLE_TXDMA)
   /* If we need to re-initialise the console to enable DMA do that here. */
 
   up_dma_setup(&g_uart_devs[CONSOLE_UART - 1]->dev);


### PR DESCRIPTION
## Summary
Without this patch if serial console is configured to work with DMA (RX or TX) on stm32f7, it can cause a hardfault if something tries to write to console on boot.
issue #1598 

## Impact
stm32f7 boards now can correctly use serial console with enabled DMA

## Testing
Tested with stm32f7 custom board within project based on PX4 
