### PR TITLE
arch/arm/src/stm32/stm32_adc.c: do not allow negative ref count

### DIFF
--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -2792,7 +2792,7 @@ static void adc_reset(FAR struct adc_dev_s *dev)
 
   if (priv->initialized > 0)
     {
-      return;
+      goto out;
     }
 
 #ifdef HAVE_HSI_CONTROL
@@ -2814,7 +2814,7 @@ static void adc_reset(FAR struct adc_dev_s *dev)
 #ifdef HAVE_ADC_CMN_DATA
   if (adccmn_lock(priv, true) < 0)
     {
-      return;
+      goto out;
     }
 
   if (priv->cmn->initialized == 0)
@@ -2833,6 +2833,7 @@ static void adc_reset(FAR struct adc_dev_s *dev)
   adccmn_lock(priv, false);
 #endif
 
+out:
   leave_critical_section(flags);
 }
 
@@ -2982,9 +2983,14 @@ static void adc_shutdown(FAR struct adc_dev_s *dev)
 {
   FAR struct stm32_dev_s *priv = (FAR struct stm32_dev_s *)dev->ad_priv;
 
-  /* Shutdown the ADC device only when not in use */
+  /* Decrement count only when ADC device is in use */
 
-  priv->initialized -= 1;
+  if (priv->initialized > 0)
+    {
+      priv->initialized -= 1;
+    }
+
+  /* Shutdown the ADC device only when not in use */
 
   if (priv->initialized > 0)
     {


### PR DESCRIPTION
## Summary
When HAVE_HSI_CONTROL, adc_reset_hsi_disable() calls adc_reset()
followed by adc_shutdown() and this combination is called before
adc_setup() by upper level ADC driver. Without this patch,
priv->initialized wraps from 0 to 255 in this case.

## Impact
read() from /dev/adc0 was hanging forever on STM32L1 that used HSI as ADC dedicated clock.

## Testing
Tested with a proprietary STM32L1 board.

