### PR TITLE
xtensa/esp32: Fix rt-timer issues

### DIFF
--- a/arch/xtensa/src/esp32/esp32_rt_timer.h
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.h
@@ -35,6 +35,18 @@
 #define RT_TIMER_REPEAT     (1 << 0)    /* Timer is repeat */
 
 /**
+ * RT timer state
+ */
+
+enum rt_timer_state_e
+{
+  RT_TIMER_IDLE,            /* Timer is not counting */
+  RT_TIMER_READY,           /* Timer is counting */
+  RT_TIMER_TIMEOUT,         /* Timer is timeout */
+  RT_TIMER_DELETE           /* Timer is to be delete */
+};
+
+/**
  * RT timer data structure
  */
 
@@ -45,7 +57,7 @@ struct rt_timer_s
   void (*callback)(void *arg);  /* Callback function */
   void *arg;                    /* Private data */
   uint16_t flags;               /* Support feature */
-  bool started;                 /* Mark if timer is started */
+  enum rt_timer_state_e state;  /* Mark if timer is started */
   struct list_node list;        /* Working list */
 };
 


### PR DESCRIPTION
## Summary

Fix rt-timer process competition issue.

## Impact

1. function "stop" should really stop repeat timer
2. delete timer really in rt-timer task to avoid resource being broken 
3. timer triggers when stopping/deleting it and skip it in ISR

## Testing

