### PR TITLE
signal.h: fix compile failed when open TTY_SIGINT

### DIFF
--- a/include/signal.h
+++ b/include/signal.h
@@ -166,17 +166,46 @@
 #  endif
 #endif
 
-#ifdef CONFIG_SIG_SIGSTOP_ACTION
-#  define SIGSTOP     CONFIG_SIG_STOP
-#  define SIGTSTP     CONFIG_SIG_TSTP
-#  define SIGCONT     CONFIG_SIG_CONT
+#ifndef CONFIG_SIG_STOP
+#  define SIGSTOP       6
+#else
+#  define SIGSTOP       CONFIG_SIG_STOP
 #endif
 
-#ifdef CONFIG_SIG_SIGKILL_ACTION
-#  define SIGKILL     CONFIG_SIG_KILL
-#  define SIGINT      CONFIG_SIG_INT
-#  define SIGQUIT     CONFIG_SIG_QUIT
-#  define SIGTERM     CONFIG_SIG_TERM
+#ifndef CONFIG_SIG_TSTP
+#  define SIGTSTP       7
+#else
+#  define SIGTSTP       CONFIG_SIG_TSTP
+#endif
+
+#ifndef CONFIG_SIG_CONT
+#  define SIGCONT       8
+#else
+#  define SIGCONT       CONFIG_SIG_CONT
+#endif
+
+#ifndef CONFIG_SIG_KILL
+#  define SIGKILL       9
+#else
+#  define SIGKILL       CONFIG_SIG_KILL
+#endif
+
+#ifndef CONFIG_SIG_INT
+#  define SIGINT        10
+#else
+#  define SIGINT        CONFIG_SIG_INT
+#endif
+
+#ifndef CONFIG_SIG_QUIT
+#  define SIGQUIT       11
+#else
+#  define SIGQUIT       CONFIG_SIG_QUIT
+#endif
+
+#ifndef CONFIG_SIG_TERM
+#  define SIGTERM       12
+#else
+#  define SIGTERM       CONFIG_SIG_TERM
 #endif
 
 #ifndef CONFIG_SIG_PIPE

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1448,14 +1448,12 @@ if SIG_DEFAULT
 config SIG_STOP
 	int "SIGSTOP"
 	default 6
-	depends on SIG_SIGSTOP_ACTION
 	---help---
 		Suspend/pause a task.  SIGSTOP may not be caught or ignored.
 
 config SIG_TSTP
 	int "SIGTSTP"
 	default 7
-	depends on SIG_SIGSTOP_ACTION
 	---help---
 		Suspend/pause a task.  Unlike SIGSTOP, this signal can be caught or
 		ignored.
@@ -1463,7 +1461,6 @@ config SIG_TSTP
 config SIG_CONT
 	int "SIGCONT"
 	default 8
-	depends on SIG_SIGSTOP_ACTION
 	---help---
 		Resume a suspended/paused task.  SIGSTOP only has an action when
 		send to a stopped task.  SIGCONT is ignored by other task.  SIGCONT
@@ -1472,7 +1469,6 @@ config SIG_CONT
 config SIG_KILL
 	int "SIGKILL"
 	default 9
-	depends on SIG_SIGKILL_ACTION
 	---help---
 		The SIGKILL signal is sent to cause a task termination event.
 		SIGKILL may not be caught or ignored.
@@ -1480,7 +1476,6 @@ config SIG_KILL
 config SIG_INT
 	int "SIGINT"
 	default 10
-	depends on SIG_SIGKILL_ACTION
 	---help---
 		The SIGINT signal is sent to cause a task termination event.
 		SIGINT may be ignored or caught by the receiving task.
@@ -1488,7 +1483,6 @@ config SIG_INT
 config SIG_QUIT
 	int "SIGQUIT"
 	default 11
-	depends on SIG_SIGKILL_ACTION
 	---help---
 		The SIGINT signal is sent to cause a task termination event.
 		SIGQUIT may be ignored or caught by the receiving task.
@@ -1496,7 +1490,6 @@ config SIG_QUIT
 config SIG_TERM
 	int "SIGTERM"
 	default 12
-	depends on SIG_SIGKILL_ACTION
 	---help---
 		The SIGINT signal is sent to cause a task termination event.
 		SIGTERM may be ignored or caught by the receiving task.


### PR DESCRIPTION
## Summary
In file included from string/lib_strsignal.c:40:0:
string/lib_strsignal.c: In function ‘strsignal’:
string/lib_strsignal.c:142:12: error: ‘CONFIG_SIG_STOP’ undeclared (first use in this function); did you mean ‘CONFIG_SIG_PIPE’?
       case SIGSTOP:
            ^
string/lib_strsignal.c:142:12: note: each undeclared identifier is reported only once for each function it appears in
string/lib_strsignal.c:147:12: error: ‘CONFIG_SIG_STP’ undeclared (first use in this function); did you mean ‘CONFIG_SIG_STOP’?
       case SIGSTP:

## Impact
SIGSTOP/SIGTSTP/SIGCONT/SIGKILL/SIGINT/SIGQUIT/SIGTERM can be used regardless CONFIG_SIG_SIGSTOP_ACTION and CONFIG_SIG_SIGKILL_ACTION setting.

## Testing
lib_strsignal.c can pass build even when CONFIG_SIG_SIGSTOP_ACTION equal false
