### PR TITLE
STM32L4 TIMER: Add some helper functions 

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_tim.c
+++ b/arch/arm/src/stm32l4/stm32l4_tim.c
@@ -254,8 +254,7 @@ static inline void stm32l4_putreg32(FAR struct stm32l4_tim_dev_s *dev,
 /* Timer helpers */
 
 static void stm32l4_tim_reload_counter(FAR struct stm32l4_tim_dev_s *dev);
-static void stm32l4_tim_enable(FAR struct stm32l4_tim_dev_s *dev);
-static void stm32l4_tim_disable(FAR struct stm32l4_tim_dev_s *dev);
+static void stm32l4_tim_enable(FAR struct stm32l4_tim_dev_s *dev, bool state);
 static void stm32l4_tim_reset(FAR struct stm32l4_tim_dev_s *dev);
 #if defined(HAVE_TIM1_GPIOCONFIG) || defined(HAVE_TIM2_GPIOCONFIG) || \
     defined(HAVE_TIM3_GPIOCONFIG) || defined(HAVE_TIM4_GPIOCONFIG) || \
@@ -264,6 +263,7 @@ static void stm32l4_tim_reset(FAR struct stm32l4_tim_dev_s *dev);
     defined(HAVE_TIM17_GPIOCONFIG)
 static void stm32l4_tim_gpioconfig(uint32_t cfg, enum stm32l4_tim_channel_e mode);
 #endif
+static void stm32l4_tim_dumpregs(FAR struct stm32l4_tim_dev_s *dev);
 
 /* Timer methods */
 
@@ -311,6 +311,8 @@ static const struct stm32l4_tim_ops_s stm32l4_tim_ops =
   .disableint = stm32l4_tim_disableint,
   .ackint     = stm32l4_tim_ackint,
   .checkint   = stm32l4_tim_checkint,
+  .enable     = stm32l4_tim_enable,
+  .dump_regs  = stm32l4_tim_dumpregs,
 };
 
 #ifdef CONFIG_STM32L4_TIM1
@@ -504,22 +506,19 @@ static void stm32l4_tim_reload_counter(FAR struct stm32l4_tim_dev_s *dev)
  * Name: stm32l4_tim_enable
  ************************************************************************************/
 
-static void stm32l4_tim_enable(FAR struct stm32l4_tim_dev_s *dev)
+static void stm32l4_tim_enable(FAR struct stm32l4_tim_dev_s *dev, bool state)
 {
   uint16_t val = stm32l4_getreg16(dev, STM32L4_BTIM_CR1_OFFSET);
-  val |= ATIM_CR1_CEN;
-  stm32l4_tim_reload_counter(dev);
-  stm32l4_putreg16(dev, STM32L4_BTIM_CR1_OFFSET, val);
-}
 
-/************************************************************************************
- * Name: stm32l4_tim_disable
- ************************************************************************************/
-
-static void stm32l4_tim_disable(FAR struct stm32l4_tim_dev_s *dev)
-{
-  uint16_t val = stm32l4_getreg16(dev, STM32L4_BTIM_CR1_OFFSET);
-  val &= ~ATIM_CR1_CEN;
+  if(state)
+    {
+      val |= ATIM_CR1_CEN;
+      stm32l4_tim_reload_counter(dev);
+    }
+  else
+    {
+      val &= ~ATIM_CR1_CEN;
+    }
   stm32l4_putreg16(dev, STM32L4_BTIM_CR1_OFFSET, val);
 }
 
@@ -534,7 +533,7 @@ static void stm32l4_tim_disable(FAR struct stm32l4_tim_dev_s *dev)
 static void stm32l4_tim_reset(FAR struct stm32l4_tim_dev_s *dev)
 {
   ((struct stm32l4_tim_priv_s *)dev)->mode = STM32L4_TIM_MODE_DISABLED;
-  stm32l4_tim_disable(dev);
+  stm32l4_tim_enable(dev, false);
 }
 
 /************************************************************************************
@@ -560,6 +559,53 @@ static void stm32l4_tim_gpioconfig(uint32_t cfg, enum stm32l4_tim_channel_e mode
     }
 }
 #endif
+
+/************************************************************************************
+ * Name: stm32l4_tim_dumpregs
+ ************************************************************************************/
+
+static void stm32l4_tim_dumpregs(FAR struct stm32l4_tim_dev_s *dev)
+{
+  struct stm32l4_tim_priv_s *priv = (struct stm32l4_tim_priv_s *)dev;
+  {
+    /* data */
+  };
+  
+  ainfo("  CR1: %04x CR2:  %04x SMCR:  %04x DIER:  %04x\n",
+          stm32l4_getreg16(dev, STM32L4_GTIM_CR1_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_CR2_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_SMCR_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_DIER_OFFSET));
+  ainfo("   SR: %04x EGR:  0000 CCMR1: %04x CCMR2: %04x\n",
+          stm32l4_getreg16(dev, STM32L4_GTIM_SR_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_CCMR1_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_CCMR2_OFFSET));
+  ainfo(" CCER: %04x CNT:  %04x PSC:   %04x ARR:   %04x\n",
+          stm32l4_getreg16(dev, STM32L4_GTIM_CCER_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_CNT_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_PSC_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_ARR_OFFSET));
+  ainfo(" CCR1: %04x CCR2: %04x CCR3:  %04x CCR4:  %04x\n",
+          stm32l4_getreg16(dev, STM32L4_GTIM_CCR1_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_CCR2_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_CCR3_OFFSET),
+          stm32l4_getreg16(dev, STM32L4_GTIM_CCR4_OFFSET));
+
+  if (priv->base == STM32L4_TIM1_BASE || priv->base == STM32L4_TIM8_BASE)
+    {
+      ainfo("  RCR: %04x BDTR: %04x DCR:   %04x DMAR:  %04x\n",
+            stm32l4_getreg16(dev, STM32L4_ATIM_RCR_OFFSET),
+            stm32l4_getreg16(dev, STM32L4_ATIM_BDTR_OFFSET),
+            stm32l4_getreg16(dev, STM32L4_ATIM_DCR_OFFSET),
+            stm32l4_getreg16(dev, STM32L4_ATIM_DMAR_OFFSET));
+    }
+  else
+    {
+      ainfo("  DCR: %04x DMAR: %04x\n",
+            stm32l4_getreg16(dev, STM32L4_GTIM_DCR_OFFSET),
+            stm32l4_getreg16(dev, STM32L4_GTIM_DMAR_OFFSET));
+    }
+}
 
 /************************************************************************************
  * Name: stm32l4_tim_setmode
@@ -599,8 +645,10 @@ static int stm32l4_tim_setmode(FAR struct stm32l4_tim_dev_s *dev,
 
       case STM32L4_TIM_MODE_DOWN:
         val |= ATIM_CR1_DIR;
+        break;
 
       case STM32L4_TIM_MODE_UP:
+        val &= ~ATIM_CR1_DIR;
         break;
 
       case STM32L4_TIM_MODE_UPDOWN:
@@ -650,7 +698,7 @@ static int stm32l4_tim_setclock(FAR struct stm32l4_tim_dev_s *dev,
 
   if (freq == 0)
     {
-      stm32l4_tim_disable(dev);
+      stm32l4_tim_enable(dev, false);
       return 0;
     }
 
@@ -754,7 +802,6 @@ static int stm32l4_tim_setclock(FAR struct stm32l4_tim_dev_s *dev,
     }
 
   stm32l4_putreg16(dev, STM32L4_BTIM_PSC_OFFSET, prescaler);
-  stm32l4_tim_enable(dev);
 
   return prescaler;
 }

--- a/arch/arm/src/stm32l4/stm32l4_tim.h
+++ b/arch/arm/src/stm32l4/stm32l4_tim.h
@@ -58,6 +58,7 @@
 /* Helpers *******************************************************************/
 
 #define STM32L4_TIM_SETMODE(d,mode)       ((d)->ops->setmode(d,mode))
+#define STM32L4_TIM_SETFREQ(d,freq)       ((d)->ops->setfreq(d,freq))
 #define STM32L4_TIM_SETCLOCK(d,freq)      ((d)->ops->setclock(d,freq))
 #define STM32L4_TIM_GETCLOCK(d)           ((d)->ops->getclock(d))
 #define STM32L4_TIM_SETPERIOD(d,period)   ((d)->ops->setperiod(d,period))
@@ -173,8 +174,11 @@ struct stm32l4_tim_ops_s
 {
   /* Basic Timers */
 
+  void (*enable)(FAR struct stm32l4_tim_dev_s *dev);
+  void (*disable)(FAR struct stm32l4_tim_dev_s *dev);
   int  (*setmode)(FAR struct stm32l4_tim_dev_s *dev,
                   enum stm32l4_tim_mode_e mode);
+  int  (*setfreq)(FAR struct stm32l4_tim_dev_s *dev, uint32_t freq);
   int  (*setclock)(FAR struct stm32l4_tim_dev_s *dev, uint32_t freq);
   uint32_t (*getclock)(FAR struct stm32l4_tim_dev_s *dev);
   void (*setperiod)(FAR struct stm32l4_tim_dev_s *dev, uint32_t period);
@@ -197,8 +201,9 @@ struct stm32l4_tim_ops_s
   void (*disableint)(FAR struct stm32l4_tim_dev_s *dev, int source);
   void (*ackint)(FAR struct stm32l4_tim_dev_s *dev, int source);
   int  (*checkint)(FAR struct stm32l4_tim_dev_s *dev, int source);
-  void (*enable)(FAR struct stm32l4_tim_dev_s *dev);
-  void (*disable)(FAR struct stm32l4_tim_dev_s *dev);
+
+  /* Debug */
+
   void (*dump_regs)(FAR struct stm32l4_tim_dev_s *dev);
 };
 

--- a/arch/arm/src/stm32l4/stm32l4_tim.h
+++ b/arch/arm/src/stm32l4/stm32l4_tim.h
@@ -71,6 +71,8 @@
 #define STM32L4_TIM_DISABLEINT(d,s)       ((d)->ops->disableint(d,s))
 #define STM32L4_TIM_ACKINT(d,s)           ((d)->ops->ackint(d,s))
 #define STM32L4_TIM_CHECKINT(d,s)         ((d)->ops->checkint(d,s))
+#define STM32L4_TIM_ENABLE(d,s)           ((d)->ops->enable(d,s))
+#define STM32L4_TIM_DUMPREGS(d)           ((d)->ops->dump_regs(d))
 
 /************************************************************************************
  * Public Types
@@ -192,6 +194,8 @@ struct stm32l4_tim_ops_s
   void (*disableint)(FAR struct stm32l4_tim_dev_s *dev, int source);
   void (*ackint)(FAR struct stm32l4_tim_dev_s *dev, int source);
   int  (*checkint)(FAR struct stm32l4_tim_dev_s *dev, int source);
+  void (*enable)(FAR struct stm32l4_tim_dev_s *dev, bool state);
+  void (*dump_regs)(FAR struct stm32l4_tim_dev_s *dev);
 };
 
 /************************************************************************************

--- a/arch/arm/src/stm32l4/stm32l4_tim.h
+++ b/arch/arm/src/stm32l4/stm32l4_tim.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/*****************************************************************************
  * arch/arm/src/stm32l4/stm32l4_tim.h
  *
  *   Copyright (C) 2011 Uros Platise. All rights reserved.
@@ -37,25 +37,25 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ *****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32L4_STM32L4_TIM_H
 #define __ARCH_ARM_SRC_STM32L4_STM32L4_TIM_H
 
-/************************************************************************************
+/*****************************************************************************
  * Included Files
- ************************************************************************************/
+ *****************************************************************************/
 
 #include <nuttx/config.h>
 
 #include "chip.h"
 #include "hardware/stm32l4_tim.h"
 
-/************************************************************************************
+/*****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ *****************************************************************************/
 
-/* Helpers **************************************************************************/
+/* Helpers *******************************************************************/
 
 #define STM32L4_TIM_SETMODE(d,mode)       ((d)->ops->setmode(d,mode))
 #define STM32L4_TIM_SETCLOCK(d,freq)      ((d)->ops->setclock(d,freq))
@@ -71,12 +71,13 @@
 #define STM32L4_TIM_DISABLEINT(d,s)       ((d)->ops->disableint(d,s))
 #define STM32L4_TIM_ACKINT(d,s)           ((d)->ops->ackint(d,s))
 #define STM32L4_TIM_CHECKINT(d,s)         ((d)->ops->checkint(d,s))
-#define STM32L4_TIM_ENABLE(d,s)           ((d)->ops->enable(d,s))
+#define STM32L4_TIM_ENABLE(d)             ((d)->ops->enable(d))
+#define STM32L4_TIM_DISABLE(d)            ((d)->ops->disable(d))
 #define STM32L4_TIM_DUMPREGS(d)           ((d)->ops->dump_regs(d))
 
-/************************************************************************************
+/*****************************************************************************
  * Public Types
- ************************************************************************************/
+ *****************************************************************************/
 
 #ifndef __ASSEMBLY__
 
@@ -117,7 +118,7 @@ enum stm32l4_tim_mode_e
 #if 0
   STM32L4_TIM_MODE_CK_INT_TRIG  = 0x0400,
   STM32L4_TIM_MODE_CK_EXT       = 0x0800,
-  STM32L4_TIM_MODE_CK_EXT_TRIG  = 0x0C00,
+  STM32L4_TIM_MODE_CK_EXT_TRIG  = 0x0c00,
 #endif
 
   /* Clock sources, OR'ed with CK_EXT */
@@ -150,7 +151,9 @@ enum stm32l4_tim_channel_e
 
   /* Output Compare Modes */
 
-  STM32L4_TIM_CH_OUTPWM         = 0x04,  /* Enable standard PWM mode, active high when counter < compare */
+  STM32L4_TIM_CH_OUTPWM         = 0x04,  /* Enable standard PWM mode, active
+                                          * high when counter < compare
+                                          */
 #if 0
   STM32L4_TIM_CH_OUTCOMPARE     = 0x06,
 #endif
@@ -194,13 +197,14 @@ struct stm32l4_tim_ops_s
   void (*disableint)(FAR struct stm32l4_tim_dev_s *dev, int source);
   void (*ackint)(FAR struct stm32l4_tim_dev_s *dev, int source);
   int  (*checkint)(FAR struct stm32l4_tim_dev_s *dev, int source);
-  void (*enable)(FAR struct stm32l4_tim_dev_s *dev, bool state);
+  void (*enable)(FAR struct stm32l4_tim_dev_s *dev);
+  void (*disable)(FAR struct stm32l4_tim_dev_s *dev);
   void (*dump_regs)(FAR struct stm32l4_tim_dev_s *dev);
 };
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/*****************************************************************************
+ * Public functions
+ *****************************************************************************/
 
 /* Power-up timer and get its structure */
 
@@ -210,7 +214,7 @@ FAR struct stm32l4_tim_dev_s *stm32l4_tim_init(int timer);
 
 int stm32l4_tim_deinit(FAR struct stm32l4_tim_dev_s *dev);
 
-/****************************************************************************
+/*****************************************************************************
  * Name: stm32l4_timer_initialize
  *
  * Description:
@@ -218,14 +222,15 @@ int stm32l4_tim_deinit(FAR struct stm32l4_tim_dev_s *dev);
  *   register the timer drivers at 'devpath'
  *
  * Input Parameters:
- *   devpath - The full path to the timer device. This should be of the form /dev/timer0
+ *   devpath - The full path to the timer device. This should be of the form
+ *             /dev/timer0
  *   timer - the timer number.
  *
  * Returned Value:
  *   Zero (OK) is returned on success; A negated errno value is returned
  *   to indicate the nature of any failure.
  *
- ****************************************************************************/
+ *****************************************************************************/
 
 #ifdef CONFIG_TIMER
 int stm32l4_timer_initialize(FAR const char *devpath, int timer);

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spwm.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spwm.c
@@ -359,7 +359,6 @@ static int spwm_tim6_setup(FAR struct spwm_s *spwm)
 {
   FAR struct stm32l4_tim_dev_s *tim = NULL;
   uint64_t freq = 0;
-  uint32_t per = 0;
   int ret = OK;
 
   /* Get TIM6 interface */
@@ -380,18 +379,8 @@ static int spwm_tim6_setup(FAR struct spwm_s *spwm)
    */
 
   freq = spwm->samples * spwm->waveform_freq;
-  per = BOARD_TIM6_FREQUENCY / freq;
-  if (per > 0xffff)
-    {
-      printf("ERROR: can not achieve TIM6 frequency\n");
-      ret = -1;
-      goto errout;
-    }
 
-  /* TODO: TIM_SETFREQ */
-
-  STM32L4_TIM_SETCLOCK(tim, BOARD_TIM6_FREQUENCY);
-  STM32L4_TIM_SETPERIOD(tim, per);
+  STM32L4_TIM_SETFREQ(tim, freq);
   STM32L4_TIM_ENABLE(tim);
 
   /* Attach TIM6 ram vector */

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spwm.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spwm.c
@@ -392,6 +392,7 @@ static int spwm_tim6_setup(FAR struct spwm_s *spwm)
 
   STM32L4_TIM_SETCLOCK(tim, BOARD_TIM6_FREQUENCY);
   STM32L4_TIM_SETPERIOD(tim, per);
+  STM32L4_TIM_ENABLE(tim);
 
   /* Attach TIM6 ram vector */
 


### PR DESCRIPTION
## Summary

Add helper functions to
  * enable/disable timer
  * set timer frequency
  * dump timer registers

## Impact

The timer is no longer enabled at the end of stm32l4_tim_setclock()

## Testing

Tested with SPWM example on nucleo-l432kc board. This example was changed to enable timer after configure timer clock.