### PR TITLE
Avoid messing the final binary nuttx.(bin,hex,...) compilation msg

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -424,22 +424,22 @@ endif
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f $(BIN) /tftpboot/$(BIN).${CONFIG_ARCH}; \
 	fi
-	echo $(BIN) > $(NUTTXNAME).manifest
-	printf "%s\n" *.map >> $(NUTTXNAME).manifest
+	$(Q) echo $(BIN) > $(NUTTXNAME).manifest
+	$(Q) printf "%s\n" *.map >> $(NUTTXNAME).manifest
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: $(NUTTXNAME).hex"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(NUTTXNAME).hex
-	echo $(NUTTXNAME).hex >> $(NUTTXNAME).manifest
+	$(Q) echo $(NUTTXNAME).hex >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
 	@echo "CP: $(NUTTXNAME).srec"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) $(NUTTXNAME).srec
-	echo $(NUTTXNAME).srec >> $(NUTTXNAME).manifest
+	$(Q) echo $(NUTTXNAME).srec >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: $(NUTTXNAME).bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
-	echo $(NUTTXNAME).bin >> $(NUTTXNAME).manifest
+	$(Q) echo $(NUTTXNAME).bin >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	@echo "MKIMAGE: uImage"
@@ -448,7 +448,7 @@ ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f uImage /tftpboot/uImage; \
 	fi
-	echo "uImage" >> $(NUTTXNAME).manifest
+	$(Q) echo "uImage" >> $(NUTTXNAME).manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -392,22 +392,22 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
 	$(Q) $(MAKE) -C $(ARCH_SRC) EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
-	echo $(BIN) > $(NUTTXNAME).manifest
-	printf '%s\n' *.map >> $(NUTTXNAME).manifest
+	$(Q) echo $(BIN) > $(NUTTXNAME).manifest
+	$(Q) printf '%s\n' *.map >> $(NUTTXNAME).manifest
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: $(NUTTXNAME).hex"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(NUTTXNAME).hex
-	echo $(NUTTXNAME).hex >> $(NUTTXNAME).manifest
+	$(Q) echo $(NUTTXNAME).hex >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
 	@echo "CP: $(NUTTXNAME).srec"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) $(NUTTXNAME).srec
-	echo $(NUTTXNAME).srec >> $(NUTTXNAME).manifest
+	$(Q) echo $(NUTTXNAME).srec >> $(NUTTXNAME).manifest
 endif
 ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: $(NUTTXNAME).bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
-	echo $(NUTTXNAME).bin >> $(NUTTXNAME).manifest
+	$(Q) echo $(NUTTXNAME).bin >> $(NUTTXNAME).manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 


### PR DESCRIPTION
## Summary
Make the final CP: nuttx.bin message easy to spot to confirm that compilation finished correct.
## Impact
User will be be able to see the generated binaries easily. Please refer to #2219 
## Testing
esp32-core:nsh
