### PR TITLE
Use a few integer types from the compiler

### DIFF
--- a/arch/arm/include/inttypes.h
+++ b/arch/arm/include/inttypes.h
@@ -46,77 +46,77 @@
 
 #define PRId8       "d"
 #define PRId16      "d"
-#define PRId32      "d"
+#define PRId32      "ld"
 #define PRId64      "lld"
 
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
-#define PRIi32      "i"
+#define PRIi32      "li"
 #define PRIi64      "lli"
 
 #define PRIiPTR     "i"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
-#define PRIo32      "o"
+#define PRIo32      "lo"
 #define PRIo64      "llo"
 
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
-#define PRIu32      "u"
+#define PRIu32      "lu"
 #define PRIu64      "llu"
 
 #define PRIuPTR     "u"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
-#define PRIx32      "x"
+#define PRIx32      "lx"
 #define PRIx64      "llx"
 
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
-#define PRIX32      "X"
+#define PRIX32      "lX"
 #define PRIX64      "llX"
 
 #define PRIXPTR     "X"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
-#define SCNd32      "d"
+#define SCNd32      "ld"
 #define SCNd64      "lld"
 
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
-#define SCNi32      "i"
+#define SCNi32      "li"
 #define SCNi64      "lli"
 
 #define SCNiPTR     "i"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
-#define SCNo32      "o"
+#define SCNo32      "lo"
 #define SCNo64      "llo"
 
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
-#define SCNu32      "u"
+#define SCNu32      "lu"
 #define SCNu64      "llu"
 
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
-#define SCNx32      "x"
+#define SCNx32      "lx"
 #define SCNx64      "llx"
 
 #define SCNxPTR     "x"
@@ -128,7 +128,7 @@
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
-#define UINT32_C(x) x ## u
+#define UINT32_C(x) x ## ul
 #define UINT64_C(x) x ## ull
 
 #endif /* __ARCH_ARM_INCLUDE_INTTYPES_H */

--- a/arch/arm/include/types.h
+++ b/arch/arm/include/types.h
@@ -63,6 +63,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/arm/include/types.h
+++ b/arch/arm/include/types.h
@@ -56,8 +56,8 @@ typedef unsigned char      _uint8_t;
 typedef signed short       _int16_t;
 typedef unsigned short     _uint16_t;
 
-typedef signed int         _int32_t;
-typedef unsigned int       _uint32_t;
+typedef signed long        _int32_t;
+typedef unsigned long      _uint32_t;
 
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;

--- a/arch/avr/include/avr/types.h
+++ b/arch/avr/include/avr/types.h
@@ -79,6 +79,9 @@ typedef double double_t;
 
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A (near) size is 2 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/avr/include/avr32/types.h
+++ b/arch/avr/include/avr32/types.h
@@ -76,6 +76,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/hc/include/hc12/types.h
+++ b/arch/hc/include/hc12/types.h
@@ -85,6 +85,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is two bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/hc/include/hcs12/types.h
+++ b/arch/hc/include/hcs12/types.h
@@ -86,6 +86,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is two bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/mips/include/inttypes.h
+++ b/arch/mips/include/inttypes.h
@@ -46,89 +46,89 @@
 
 #define PRId8       "d"
 #define PRId16      "d"
-#define PRId32      "d"
+#define PRId32      "ld"
 #define PRId64      "lld"
 
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
-#define PRIi32      "i"
+#define PRIi32      "li"
 #define PRIi64      "lli"
 
 #define PRIiPTR     "i"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
-#define PRIo32      "o"
+#define PRIo32      "lo"
 #define PRIo64      "llo"
 
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
-#define PRIu32      "u"
+#define PRIu32      "lu"
 #define PRIu64      "llu"
 
 #define PRIuPTR     "u"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
-#define PRIx32      "x"
+#define PRIx32      "lx"
 #define PRIx64      "llx"
 
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
-#define PRIX32      "X"
+#define PRIX32      "lX"
 #define PRIX64      "llX"
 
 #define PRIXPTR     "X"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
-#define SCNd32      "d"
+#define SCNd32      "ld"
 #define SCNd64      "lld"
 
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
-#define SCNi32      "i"
+#define SCNi32      "li"
 #define SCNi64      "lli"
 
 #define SCNiPTR     "i"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
-#define SCNo32      "o"
+#define SCNo32      "lo"
 #define SCNo64      "llo"
 
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
-#define SCNu32      "u"
+#define SCNu32      "lu"
 #define SCNu64      "llu"
 
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
-#define SCNx32      "x"
+#define SCNx32      "lx"
 #define SCNx64      "llx"
 
 #define SCNxPTR     "x"
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
-#define INT32_C(x)  x
+#define INT32_C(x)  x ## l
 #define INT64_C(x)  x ## ll
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
-#define UINT32_C(x) x ## u
+#define UINT32_C(x) x ## ul
 #define UINT64_C(x) x ## ull
 
 #endif /* __ARCH_MIPS_INCLUDE_INTTYPES_H */

--- a/arch/mips/include/types.h
+++ b/arch/mips/include/types.h
@@ -76,6 +76,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/mips/include/types.h
+++ b/arch/mips/include/types.h
@@ -69,8 +69,8 @@ typedef unsigned char      _uint8_t;
 typedef signed short       _int16_t;
 typedef unsigned short     _uint16_t;
 
-typedef signed int         _int32_t;
-typedef unsigned int       _uint32_t;
+typedef signed long        _int32_t;
+typedef unsigned long      _uint32_t;
 
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;

--- a/arch/misoc/include/types.h
+++ b/arch/misoc/include/types.h
@@ -76,6 +76,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/or1k/include/types.h
+++ b/arch/or1k/include/types.h
@@ -79,6 +79,9 @@ typedef unsigned long long _uint64_t;
 
 #define __INT64_DEFINED    1
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/renesas/include/m16c/types.h
+++ b/arch/renesas/include/m16c/types.h
@@ -78,6 +78,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 2 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/renesas/include/rx65n/inttypes.h
+++ b/arch/renesas/include/rx65n/inttypes.h
@@ -41,89 +41,89 @@
 
 #define PRId8       "d"
 #define PRId16      "d"
-#define PRId32      "d"
+#define PRId32      "ld"
 #define PRId64      "lld"
 
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
-#define PRIi32      "i"
+#define PRIi32      "li"
 #define PRIi64      "lli"
 
 #define PRIiPTR     "i"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
-#define PRIo32      "o"
+#define PRIo32      "lo"
 #define PRIo64      "llo"
 
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
-#define PRIu32      "u"
+#define PRIu32      "lu"
 #define PRIu64      "llu"
 
 #define PRIuPTR     "u"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
-#define PRIx32      "x"
+#define PRIx32      "lx"
 #define PRIx64      "llx"
 
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
-#define PRIX32      "X"
+#define PRIX32      "lX"
 #define PRIX64      "llX"
 
 #define PRIXPTR     "X"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
-#define SCNd32      "d"
+#define SCNd32      "ld"
 #define SCNd64      "lld"
 
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
-#define SCNi32      "i"
+#define SCNi32      "li"
 #define SCNi64      "lli"
 
 #define SCNiPTR     "i"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
-#define SCNo32      "o"
+#define SCNo32      "lo"
 #define SCNo64      "llo"
 
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
-#define SCNu32      "u"
+#define SCNu32      "lu"
 #define SCNu64      "llu"
 
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
-#define SCNx32      "x"
+#define SCNx32      "lx"
 #define SCNx64      "llx"
 
 #define SCNxPTR     "x"
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
-#define INT32_C(x)  x
+#define INT32_C(x)  x ## l
 #define INT64_C(x)  x ## ll
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
-#define UINT32_C(x) x ## u
+#define UINT32_C(x) x ## ul
 #define UINT64_C(x) x ## ull
 
 #endif /* __ARCH_RENESAS_INCLUDE_RX65N_INTTYPES_H */

--- a/arch/renesas/include/rx65n/types.h
+++ b/arch/renesas/include/rx65n/types.h
@@ -54,8 +54,8 @@ typedef unsigned char      _uint8_t;
 typedef signed short       _int16_t;
 typedef unsigned short     _uint16_t;
 
-typedef signed int         _int32_t;
-typedef unsigned int       _uint32_t;
+typedef signed long        _int32_t;
+typedef unsigned long      _uint32_t;
 
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;

--- a/arch/renesas/include/rx65n/types.h
+++ b/arch/renesas/include/rx65n/types.h
@@ -61,6 +61,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/renesas/include/sh1/types.h
+++ b/arch/renesas/include/sh1/types.h
@@ -76,6 +76,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/risc-v/include/inttypes.h
+++ b/arch/risc-v/include/inttypes.h
@@ -47,88 +47,88 @@
 #define PRId8       "d"
 #define PRId16      "d"
 #define PRId32      "d"
-#define PRId64      "lld"
+#define PRId64      "ld"
 
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
-#define PRIi64      "lli"
+#define PRIi64      "li"
 
 #define PRIiPTR     "i"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
 #define PRIo32      "o"
-#define PRIo64      "llo"
+#define PRIo64      "lo"
 
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
-#define PRIu64      "llu"
+#define PRIu64      "lu"
 
 #define PRIuPTR     "u"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
 #define PRIx32      "x"
-#define PRIx64      "llx"
+#define PRIx64      "lx"
 
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
-#define PRIX64      "llX"
+#define PRIX64      "lX"
 
 #define PRIXPTR     "X"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
 #define SCNd32      "d"
-#define SCNd64      "lld"
+#define SCNd64      "ld"
 
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
-#define SCNi64      "lli"
+#define SCNi64      "li"
 
 #define SCNiPTR     "i"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
 #define SCNo32      "o"
-#define SCNo64      "llo"
+#define SCNo64      "lo"
 
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
 #define SCNu32      "u"
-#define SCNu64      "llu"
+#define SCNu64      "lu"
 
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
-#define SCNx64      "llx"
+#define SCNx64      "lx"
 
 #define SCNxPTR     "x"
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
 #define INT32_C(x)  x
-#define INT64_C(x)  x ## ll
+#define INT64_C(x)  x ## l
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
 #define UINT32_C(x) x ## u
-#define UINT64_C(x) x ## ull
+#define UINT64_C(x) x ## ul
 
 #endif /* __ARCH_RISCV_INCLUDE_INTTYPES_H */

--- a/arch/risc-v/include/inttypes.h
+++ b/arch/risc-v/include/inttypes.h
@@ -44,91 +44,107 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#if defined(__LP64__)
+#define _PRI32PREFIX
+#define _PRI64PREFIX "l"
+#define _SCN32PREFIX
+#define _SCN64PREFIX "l"
+#define INT32_C(x)  x
+#define INT64_C(x)  x ## l
+#define UINT32_C(x) x ## u
+#define UINT64_C(x) x ## ul
+#else /* defined(__LP64__) */
+#define _PRI32PREFIX "l"
+#define _PRI64PREFIX "ll"
+#define _SCN32PREFIX "l"
+#define _SCN64PREFIX "ll"
+#define INT32_C(x)  x ## l
+#define INT64_C(x)  x ## ll
+#define UINT32_C(x) x ## ul
+#define UINT64_C(x) x ## ull
+#endif /* defined(__LP64__) */
+
 #define PRId8       "d"
 #define PRId16      "d"
-#define PRId32      "d"
-#define PRId64      "ld"
+#define PRId32      _PRI32PREFIX "d"
+#define PRId64      _PRI64PREFIX "d"
 
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
-#define PRIi32      "i"
-#define PRIi64      "li"
+#define PRIi32      _PRI32PREFIX "i"
+#define PRIi64      _PRI64PREFIX "i"
 
 #define PRIiPTR     "i"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
-#define PRIo32      "o"
-#define PRIo64      "lo"
+#define PRIo32      _PRI32PREFIX "o"
+#define PRIo64      _PRI64PREFIX "o"
 
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
-#define PRIu32      "u"
-#define PRIu64      "lu"
+#define PRIu32      _PRI32PREFIX "u"
+#define PRIu64      _PRI64PREFIX "u"
 
 #define PRIuPTR     "u"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
-#define PRIx32      "x"
-#define PRIx64      "lx"
+#define PRIx32      _PRI32PREFIX "x"
+#define PRIx64      _PRI64PREFIX "x"
 
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
-#define PRIX32      "X"
-#define PRIX64      "lX"
+#define PRIX32      _PRI32PREFIX "X"
+#define PRIX64      _PRI64PREFIX "X"
 
 #define PRIXPTR     "X"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
-#define SCNd32      "d"
-#define SCNd64      "ld"
+#define SCNd32      _SCN32PREFIX "d"
+#define SCNd64      _SCN64PREFIX "d"
 
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
-#define SCNi32      "i"
-#define SCNi64      "li"
+#define SCNi32      _SCN32PREFIX "i"
+#define SCNi64      _SCN64PREFIX "i"
 
 #define SCNiPTR     "i"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
-#define SCNo32      "o"
-#define SCNo64      "lo"
+#define SCNo32      _SCN32PREFIX "o"
+#define SCNo64      _SCN64PREFIX "o"
 
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
-#define SCNu32      "u"
-#define SCNu64      "lu"
+#define SCNu32      _SCN32PREFIX "u"
+#define SCNu64      _SCN64PREFIX "u"
 
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
-#define SCNx32      "x"
-#define SCNx64      "lx"
+#define SCNx32      _SCN32PREFIX "x"
+#define SCNx64      _SCN64PREFIX "x"
 
 #define SCNxPTR     "x"
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
-#define INT32_C(x)  x
-#define INT64_C(x)  x ## l
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
-#define UINT32_C(x) x ## u
-#define UINT64_C(x) x ## ul
 
 #endif /* __ARCH_RISCV_INCLUDE_INTTYPES_H */

--- a/arch/risc-v/include/types.h
+++ b/arch/risc-v/include/types.h
@@ -72,8 +72,8 @@ typedef unsigned short     _uint16_t;
 typedef signed int         _int32_t;
 typedef unsigned int       _uint32_t;
 
-typedef signed long long   _int64_t;
-typedef unsigned long long _uint64_t;
+typedef signed long        _int64_t;
+typedef unsigned long      _uint64_t;
 #define __INT64_DEFINED
 
 #ifdef __LP64__

--- a/arch/risc-v/include/types.h
+++ b/arch/risc-v/include/types.h
@@ -84,6 +84,9 @@ typedef unsigned long long _uint64_t;
 #endif /* __LP64__ */
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 #ifdef __LP64__
 /* A size is 8 bytes */
 

--- a/arch/risc-v/include/types.h
+++ b/arch/risc-v/include/types.h
@@ -69,11 +69,19 @@ typedef unsigned char      _uint8_t;
 typedef signed short       _int16_t;
 typedef unsigned short     _uint16_t;
 
+#ifdef __LP64__
 typedef signed int         _int32_t;
 typedef unsigned int       _uint32_t;
 
 typedef signed long        _int64_t;
 typedef unsigned long      _uint64_t;
+#else /* __LP64__ */
+typedef signed long        _int32_t;
+typedef unsigned long      _uint32_t;
+
+typedef signed long long   _int64_t;
+typedef unsigned long long _uint64_t;
+#endif /* __LP64__ */
 #define __INT64_DEFINED
 
 #ifdef __LP64__

--- a/arch/sim/include/inttypes.h
+++ b/arch/sim/include/inttypes.h
@@ -44,7 +44,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_HOST_MACOS)
+#if defined(__APPLE_CC__) || !defined(_LP64)
 #  define _PRI64PREFIX "ll"
 #  define _SCN64PREFIX "ll"
 #  define INT64_C(x)  x ## ll

--- a/arch/sim/include/inttypes.h
+++ b/arch/sim/include/inttypes.h
@@ -76,8 +76,6 @@
 #  define PRIu32      "u"
 #  define PRIu64      _PRI64PREFIX "u"
 
-#  define PRIuMAX     "llu"
-
 #  define PRIx8       "x"
 #  define PRIx16      "x"
 #  define PRIx32      "x"
@@ -93,21 +91,15 @@
 #  define SCNd32      "d"
 #  define SCNd64      _SCN64PREFIX "d"
 
-#  define SCNdMAX     "lld"
-
 #  define SCNi8       "hhi"
 #  define SCNi16      "hi"
 #  define SCNi32      "i"
 #  define SCNi64      _SCN64PREFIX "i"
 
-#  define SCNiMAX     "lli"
-
 #  define SCNo8       "hho"
 #  define SCNo16      "ho"
 #  define SCNo32      "o"
 #  define SCNo64      _SCN64PREFIX "o"
-
-#  define SCNoMAX     "llo"
 
 #  define SCNu8       "hhu"
 #  define SCNu16      "hu"

--- a/arch/sim/include/inttypes.h
+++ b/arch/sim/include/inttypes.h
@@ -118,17 +118,17 @@
 #  define UINT64_C(x) x ## ull
 
 #if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
-#  define PRIdPTR     "lld"
-#  define PRIiPTR     "lli"
-#  define PRIoPTR     "llo"
-#  define PRIuPTR     "llu"
-#  define PRIxPTR     "llx"
-#  define PRIXPTR     "llX"
-#  define SCNdPTR     "lld"
-#  define SCNiPTR     "lli"
-#  define SCNoPTR     "llo"
-#  define SCNuPTR     "llu"
-#  define SCNxPTR     "llx"
+#  define PRIdPTR     "ld"
+#  define PRIiPTR     "li"
+#  define PRIoPTR     "lo"
+#  define PRIuPTR     "lu"
+#  define PRIxPTR     "lx"
+#  define PRIXPTR     "lX"
+#  define SCNdPTR     "ld"
+#  define SCNiPTR     "li"
+#  define SCNoPTR     "lo"
+#  define SCNuPTR     "lu"
+#  define SCNxPTR     "lx"
 #else
 #  define PRIdPTR     "d"
 #  define PRIiPTR     "i"

--- a/arch/sim/include/inttypes.h
+++ b/arch/sim/include/inttypes.h
@@ -44,78 +44,88 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#if defined(CONFIG_HOST_MACOS)
+#  define _PRI64PREFIX "ll"
+#  define _SCN64PREFIX "ll"
+#  define INT64_C(x)  x ## ll
+#  define UINT64_C(x) x ## ull
+#else
+#  define _PRI64PREFIX "l"
+#  define _SCN64PREFIX "l"
+#  define INT64_C(x)  x ## l
+#  define UINT64_C(x) x ## ul
+#endif
+
 #  define PRId8       "d"
 #  define PRId16      "d"
 #  define PRId32      "d"
-#  define PRId64      "lld"
+#  define PRId64      _PRI64PREFIX "d"
 
 #  define PRIi8       "i"
 #  define PRIi16      "i"
 #  define PRIi32      "i"
-#  define PRIi64      "lli"
+#  define PRIi64      _PRI64PREFIX "i"
 
 #  define PRIo8       "o"
 #  define PRIo16      "o"
 #  define PRIo32      "o"
-#  define PRIo64      "llo"
+#  define PRIo64      _PRI64PREFIX "o"
 
 #  define PRIu8       "u"
 #  define PRIu16      "u"
 #  define PRIu32      "u"
-#  define PRIu64      "llu"
+#  define PRIu64      _PRI64PREFIX "u"
 
 #  define PRIuMAX     "llu"
 
 #  define PRIx8       "x"
 #  define PRIx16      "x"
 #  define PRIx32      "x"
-#  define PRIx64      "llx"
+#  define PRIx64      _PRI64PREFIX "x"
 
 #  define PRIX8       "X"
 #  define PRIX16      "X"
 #  define PRIX32      "X"
-#  define PRIX64      "llX"
+#  define PRIX64      _PRI64PREFIX "X"
 
 #  define SCNd8       "hhd"
 #  define SCNd16      "hd"
 #  define SCNd32      "d"
-#  define SCNd64      "lld"
+#  define SCNd64      _SCN64PREFIX "d"
 
 #  define SCNdMAX     "lld"
 
 #  define SCNi8       "hhi"
 #  define SCNi16      "hi"
 #  define SCNi32      "i"
-#  define SCNi64      "lli"
+#  define SCNi64      _SCN64PREFIX "i"
 
 #  define SCNiMAX     "lli"
 
 #  define SCNo8       "hho"
 #  define SCNo16      "ho"
 #  define SCNo32      "o"
-#  define SCNo64      "llo"
+#  define SCNo64      _SCN64PREFIX "o"
 
 #  define SCNoMAX     "llo"
 
 #  define SCNu8       "hhu"
 #  define SCNu16      "hu"
 #  define SCNu32      "u"
-#  define SCNu64      "llu"
+#  define SCNu64      _SCN64PREFIX "u"
 
 #  define SCNx8       "hhx"
 #  define SCNx16      "hx"
 #  define SCNx32      "x"
-#  define SCNx64      "llx"
+#  define SCNx64      _SCN64PREFIX "x"
 
 #  define INT8_C(x)   x
 #  define INT16_C(x)  x
 #  define INT32_C(x)  x
-#  define INT64_C(x)  x ## ll
 
 #  define UINT8_C(x)  x
 #  define UINT16_C(x) x
 #  define UINT32_C(x) x ## u
-#  define UINT64_C(x) x ## ull
 
 #if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
 #  define PRIdPTR     "ld"

--- a/arch/sim/include/types.h
+++ b/arch/sim/include/types.h
@@ -72,8 +72,18 @@ typedef unsigned short     _uint16_t;
 typedef signed int         _int32_t;
 typedef unsigned int       _uint32_t;
 
+/* Note about host OS types:
+ * - int64_t is long long for 64-bit macOS
+ * - int64_t is long for Ubuntu x86-64
+ */
+
+#if defined(CONFIG_HOST_MACOS) || !defined(_LP64)
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
+#else
+typedef signed long        _int64_t;
+typedef unsigned long      _uint64_t;
+#endif
 #define __INT64_DEFINED
 
 #if defined(__APPLE_CC__)

--- a/arch/sim/include/types.h
+++ b/arch/sim/include/types.h
@@ -76,6 +76,14 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+#if defined(__APPLE_CC__)
+typedef signed long        _intmax_t;
+typedef unsigned long      _uintmax_t;
+#else
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+#endif
+
 #if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
 /* 64-bit build on 64-bit machine: A size is 8 bytes */
 

--- a/arch/sim/include/types.h
+++ b/arch/sim/include/types.h
@@ -75,9 +75,16 @@ typedef unsigned int       _uint32_t;
 /* Note about host OS types:
  * - int64_t is long long for 64-bit macOS
  * - int64_t is long for Ubuntu x86-64
+ *
+ * Note for sim/macOS modules:
+ * For sim/macOS, usually x86_64-elf-gcc from homebrew is used
+ * as MODULECC. It seems to be configured as __INT64_TYPE__ == long int.
+ * The __APPLE_CC__ check below is to workaround it.
+ * (The host cc defines __APPLE_CC__, while x86_64-elf-gcc doesn't.)
+ * XXX It is a problem if you need C++ symbols in symtabs for modules.
  */
 
-#if defined(CONFIG_HOST_MACOS) || !defined(_LP64)
+#if defined(__APPLE_CC__) || !defined(_LP64)
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #else

--- a/arch/x86/include/i486/types.h
+++ b/arch/x86/include/i486/types.h
@@ -77,6 +77,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/x86_64/include/intel64/inttypes.h
+++ b/arch/x86_64/include/intel64/inttypes.h
@@ -32,88 +32,88 @@
 #define PRId8       "d"
 #define PRId16      "d"
 #define PRId32      "d"
-#define PRId64      "lld"
+#define PRId64      "ld"
 
 #define PRIdPTR     "lld"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
-#define PRIi64      "lli"
+#define PRIi64      "li"
 
 #define PRIiPTR     "lli"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
 #define PRIo32      "o"
-#define PRIo64      "llo"
+#define PRIo64      "lo"
 
 #define PRIoPTR     "llo"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
-#define PRIu64      "llu"
+#define PRIu64      "lu"
 
 #define PRIuPTR     "llu"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
 #define PRIx32      "x"
-#define PRIx64      "llx"
+#define PRIx64      "lx"
 
 #define PRIxPTR     "llx"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
-#define PRIX64      "llX"
+#define PRIX64      "lX"
 
 #define PRIXPTR     "llX"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
 #define SCNd32      "d"
-#define SCNd64      "lld"
+#define SCNd64      "ld"
 
 #define SCNdPTR     "lld"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
-#define SCNi64      "lli"
+#define SCNi64      "li"
 
 #define SCNiPTR     "lli"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
 #define SCNo32      "o"
-#define SCNo64      "llo"
+#define SCNo64      "lo"
 
 #define SCNoPTR     "llo"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
 #define SCNu32      "u"
-#define SCNu64      "llu"
+#define SCNu64      "lu"
 
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
-#define SCNx64      "llx"
+#define SCNx64      "lx"
 
 #define SCNxPTR     "x"
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
 #define INT32_C(x)  x
-#define INT64_C(x)  x ## ll
+#define INT64_C(x)  x ## l
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
 #define UINT32_C(x) x ## u
-#define UINT64_C(x) x ## ull
+#define UINT64_C(x) x ## ul
 
 #endif /* __ARCH_X86_64_INCLUDE_INTEL64_INTTYPES_H */

--- a/arch/x86_64/include/intel64/types.h
+++ b/arch/x86_64/include/intel64/types.h
@@ -58,8 +58,8 @@ typedef unsigned short     _uint16_t;
 typedef signed int         _int32_t;
 typedef unsigned int       _uint32_t;
 
-typedef signed long long   _int64_t;
-typedef unsigned long long _uint64_t;
+typedef signed long        _int64_t;
+typedef unsigned long      _uint64_t;
 #define __INT64_DEFINED
 
 /* A pointer is 8 bytes */

--- a/arch/x86_64/include/intel64/types.h
+++ b/arch/x86_64/include/intel64/types.h
@@ -62,6 +62,9 @@ typedef signed long        _int64_t;
 typedef unsigned long      _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A pointer is 8 bytes */
 
 typedef signed long long         _intptr_t;

--- a/arch/xtensa/include/types.h
+++ b/arch/xtensa/include/types.h
@@ -76,6 +76,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/xtensa/include/types.h
+++ b/arch/xtensa/include/types.h
@@ -69,8 +69,8 @@ typedef unsigned char      _uint8_t;
 typedef signed short       _int16_t;
 typedef unsigned short     _uint16_t;
 
-typedef signed long        _int32_t;
-typedef unsigned long      _uint32_t;
+typedef signed int         _int32_t;
+typedef unsigned int       _uint32_t;
 
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;

--- a/arch/z16/include/types.h
+++ b/arch/z16/include/types.h
@@ -72,6 +72,9 @@ typedef unsigned short     _uint16_t;
 typedef signed int         _int32_t;
 typedef unsigned int       _uint32_t;
 
+typedef _int32_t           _intmax_t;
+typedef _uint32_t          _uintmax_t;
+
 /* A size is 4 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/z80/include/ez80/types.h
+++ b/arch/z80/include/ez80/types.h
@@ -84,6 +84,9 @@ typedef unsigned int       _uint24_t;
 typedef signed long        _int32_t;
 typedef unsigned long      _uint32_t;
 
+typedef _int32_t           _intmax_t;
+typedef _uint32_t          _uintmax_t;
+
 /* A pointer is 2 or 3 bytes, depending upon if the ez80 is in z80
  * compatibility mode or not
  *

--- a/arch/z80/include/z180/types.h
+++ b/arch/z80/include/z180/types.h
@@ -84,6 +84,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 2 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/z80/include/z8/types.h
+++ b/arch/z80/include/z8/types.h
@@ -88,6 +88,9 @@ typedef unsigned int       _uint16_t;
 typedef signed long        _int32_t;
 typedef unsigned long      _uint32_t;
 
+typedef _int32_t           _intmax_t;
+typedef _uint32_t          _uintmax_t;
+
 /* A size is 2 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/arch/z80/include/z80/types.h
+++ b/arch/z80/include/z80/types.h
@@ -84,6 +84,9 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+
 /* A size is 2 bytes */
 
 #if defined(__SIZE_TYPE__)

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -306,6 +306,21 @@
 #define SCNxFAST64  SCNx64
 #endif
 
+/* intmax_t/uintmax_t */
+
+#define PRIdMAX     "jd"
+#define PRIiMAX     "ji"
+#define PRIoMAX     "jo"
+#define PRIuMAX     "ju"
+#define PRIxMAX     "jx"
+#define PRIXMAX     "jX"
+
+#define SCNdMAX     "jd"
+#define SCNiMAX     "ji"
+#define SCNoMAX     "jo"
+#define SCNuMAX     "ju"
+#define SCNxMAX     "jx"
+
 /****************************************************************************
  * Type Definitions
  ****************************************************************************/

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -147,19 +147,6 @@
 #  define UINTMAX_MIN       UINT64_MIN
 #  define UINTMAX_MAX       UINT64_MAX
 
-#  define PRIdMAX           PRId64
-#  define PRIiMAX           PRIi64
-#  define PRIoMAX           PRIo64
-#  define PRIuMAX           PRIu64
-#  define PRIxMAX           PRIx64
-#  define PRIXMAX           PRIX64
-
-#  define SCNdMAX           SCNd64
-#  define SCNiMAX           SCNi64
-#  define SCNoMAX           SCNo64
-#  define SCNuMAX           SCNu64
-#  define SCNxMAX           SCNx64
-
 #  define INTMAX_C(x)       INT64_C(x)
 #  define UINTMAX_C(x)      UINT64_C(x)
 #else
@@ -168,19 +155,6 @@
 
 #  define UINTMAX_MIN       UINT32_MIN
 #  define UINTMAX_MAX       UINT32_MAX
-
-#  define PRIdMAX           PRId32
-#  define PRIiMAX           PRIi32
-#  define PRIoMAX           PRIo32
-#  define PRIuMAX           PRIu32
-#  define PRIxMAX           PRIx32
-#  define PRIXMAX           PRIX32
-
-#  define SCNdMAX           SCNd32
-#  define SCNiMAX           SCNi32
-#  define SCNoMAX           SCNo32
-#  define SCNuMAX           SCNu32
-#  define SCNxMAX           SCNx32
 
 #  define INTMAX_C(x)       INT32_C(x)
 #  define UINTMAX_C(x)      UINT32_C(x)

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -300,13 +300,8 @@ typedef _uint_farptr_t      uint_farptr_t;
 
 /* Greatest-width integer types */
 
-#ifdef __INT64_DEFINED
-typedef _int64_t            intmax_t;
-typedef _uint64_t           uintmax_t;
-#else
-typedef _int32_t            intmax_t;
-typedef _uint32_t           uintmax_t;
-#endif
+typedef _intmax_t           intmax_t;
+typedef _uintmax_t          uintmax_t;
 
 #endif /* CONFIG_ARCH_STDINT_H */
 #endif /* __INCLUDE_STDINT_H */


### PR DESCRIPTION
## Summary
The main motivaion is to allow to use -Wformat compiler warnings.
Otherwise, it complains on long vs long long differences for intmax_t.

Note: The compiler only knows the printf format and the host OS types.
It doesn't know NuttX types.

Note: On both of 64-bit macOS and Ubuntu x86_64, the host intmax_t
is "long int" while NuttX's intmax_t without this change is
"signed long long". While they are both 64-bit integers, clang -Wformat
complains on the difference.

## Impact
all archs, especially 64-bit ones

## Testing
tested with local app on sim/macOS