### PR TITLE
xtensa/esp32: Add SPI Flash hardware encryption I/O support

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.h
+++ b/arch/xtensa/src/esp32/esp32_spiflash.h
@@ -78,6 +78,22 @@ FAR struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(void);
 
 FAR struct mtd_dev_s *esp32_spiflash_get_mtd(void);
 
+/****************************************************************************
+ * Name: esp32_spiflash_get_mtd
+ *
+ * Description:
+ *   Get ESP32 SPI Flash encryption raw MTD.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   ESP32 SPI Flash encryption raw MTD data pointer.
+ *
+ ****************************************************************************/
+
+FAR struct mtd_dev_s *esp32_spiflash_encrypt_get_mtd(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/arch/xtensa/src/esp32/hardware/esp32_dport.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_dport.h
@@ -4387,4 +4387,12 @@
 #define DPORT_DATE_S  0
 #define DPORT_DPORT_DATE_VERSION 0x1605190
 
+/* SPI Flash MMU table regitser base address for PRO CPU */
+
+#define DPORT_PRO_FLASH_MMU_TABLE_REG       (DR_REG_DPORT_BASE + 0x10000)
+
+/* SPI Flash MMU table regitser base address for APP CPU */
+
+#define DPORT_APP_FLASH_MMU_TABLE_REG       (DR_REG_DPORT_BASE + 0x12000)
+
 #endif /* __ARCH_XTENSA_SRC_ESP32_HARDWARE_ESP32_DPORT_H */

--- a/arch/xtensa/src/esp32/hardware/esp32_soc.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_soc.h
@@ -275,6 +275,11 @@
 #define SOC_EXTRAM_DATA_LOW     0x3f800000
 #define SOC_EXTRAM_DATA_HIGH    0x3fc00000
 
+/* Virtual address 0 */
+
+#define VADDR0_START_ADDR       SOC_DROM_LOW
+#define VADDR0_END_ADDR         (SOC_DROM_HIGH - 1)
+
 /* Interrupt hardware source table
  * This table is decided by hardware, don't touch this.
  */
@@ -775,6 +780,15 @@ extern int rom_i2c_writeReg(int block, int block_id, int reg_add,
 #define FE2_TX_INF_FORCE_PD_M       (BIT(9))
 #define FE2_TX_INF_FORCE_PD_V       1
 #define FE2_TX_INF_FORCE_PD_S       9
+
+/* RO data page in MMU index */
+
+#define DROM0_PAGES_START           0
+#define DROM0_PAGES_END             64
+
+/* MMU invaild value */
+
+#define INVALID_MMU_VAL             0x100
 
 /****************************************************************************
  * Inline Functions

--- a/boards/xtensa/esp32/esp32-core/Kconfig
+++ b/boards/xtensa/esp32/esp32-core/Kconfig
@@ -63,6 +63,22 @@ choice
         depends on FS_LITTLEFS
 endchoice
 
+config ESP32_SPIFLASH_ENCRYPTION_TEST
+	bool "SPI Flash encryption test"
+	default n
+	depends on ESP32_SPIFLASH
+	select DEBUG_ASSERTIONS
+	help
+		Enable SPI Flash encryption test. This option will also select
+		DEBUG_ASSERTIONS to enable kernel assert macro.
+
+config ESP32_SPIFLASH_TEST_ADDRESS
+	hex "SPI Flash test address"
+	default 0x180000
+	depends on ESP32_SPIFLASH_ENCRYPTION_TEST
+	help
+		SPI Flash encryption test read/write address.
+
 if PM
 
 config PM_ALARM_SEC

--- a/boards/xtensa/esp32/esp32-core/scripts/esp32_rom.ld
+++ b/boards/xtensa/esp32/esp32-core/scripts/esp32_rom.ld
@@ -1851,6 +1851,7 @@ PROVIDE ( g_rom_flashchip = 0x3ffae270 );
 PROVIDE ( g_rom_spiflash_dummy_len_plus = 0x3ffae290 );
 PROVIDE ( esp_rom_spiflash_read_user_cmd = 0x400621b0 );
 PROVIDE ( esp_rom_spiflash_write_encrypted_enable = 0x40062df4 );
+PROVIDE ( esp_rom_spiflash_write_encrypted_disable = 0x40062e60 );
 PROVIDE ( esp_rom_spiflash_prepare_encrypted_data = 0x40062e1c );
 
 PROVIDE ( esp_rom_printf   = ets_printf );

--- a/boards/xtensa/esp32/esp32-core/src/esp32-core.h
+++ b/boards/xtensa/esp32/esp32-core/src/esp32-core.h
@@ -118,5 +118,25 @@ int esp32_timer_driver_init(void);
 int esp32_wtd_driver_init(void);
 #endif
 
+/****************************************************************************
+ * Name: esp32_spiflash_encrypt_test
+ *
+ * Description:
+ *   Test ESP32 SPI Flash driver read/write with encryption.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32_SPIFLASH_ENCRYPTION_TEST
+
+void esp32_spiflash_encrypt_test(void);
+
+#endif
+
 #endif /* __ASSEMBLY__ */
 #endif /* __BOARDS_XTENSA_ESP32_ESP32_CORE_SRC_ESP32_CORE_H */

--- a/boards/xtensa/esp32/esp32-core/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-core/src/esp32_bringup.c
@@ -162,6 +162,11 @@ int esp32_bringup(void)
 #endif
 
 #ifdef CONFIG_ESP32_SPIFLASH
+
+#ifdef CONFIG_ESP32_SPIFLASH_ENCRYPTION_TEST
+  esp32_spiflash_encrypt_test();
+#endif 
+
   ret = esp32_spiflash_init();
   if (ret)
     {

--- a/boards/xtensa/esp32/esp32-core/src/esp32_spiflash.c
+++ b/boards/xtensa/esp32/esp32-core/src/esp32_spiflash.c
@@ -99,3 +99,164 @@ int esp32_spiflash_init(void)
   return ret;
 }
 
+/****************************************************************************
+ * Name: esp32_spiflash_encrypt_test
+ *
+ * Description:
+ *   Test ESP32 SPI Flash driver read/write with encryption.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32_SPIFLASH_ENCRYPTION_TEST
+
+void esp32_spiflash_encrypt_test(void)
+{
+  int i;
+  int ret;
+  uint8_t *wbuf;
+  uint8_t *rbuf;
+  struct mtd_geometry_s geo;
+  uint32_t erase_block;
+  uint32_t erase_nblocks;
+  uint32_t rw_block;
+  uint32_t rw_nblocks;
+  struct mtd_dev_s *mtd = esp32_spiflash_get_mtd();
+  struct mtd_dev_s *enc_mtd = esp32_spiflash_encrypt_get_mtd();
+  const uint32_t address = CONFIG_ESP32_SPIFLASH_TEST_ADDRESS;
+  const uint32_t size = 4096;
+
+  ret = MTD_IOCTL(enc_mtd, MTDIOC_GEOMETRY,
+                  (unsigned long)(uintptr_t)&geo);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to get GEO errno =%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  wbuf = kmm_malloc(size);
+  if (!wbuf)
+    {
+      ferr("ERROR: Failed to alloc %d heap\n", size);
+      DEBUGASSERT(0);
+    }
+
+  rbuf = kmm_malloc(size);
+  if (!rbuf)
+    {
+      ferr("ERROR: Failed to alloc %d heap\n", size);
+      DEBUGASSERT(0);
+    }
+
+  for (i = 0; i < size; i++)
+    {
+      wbuf[i] = (uint8_t)random();
+    }
+
+  erase_block = address / geo.erasesize;
+  erase_nblocks = size / geo.erasesize;
+
+  rw_block = address / geo.blocksize;
+  rw_nblocks = size / geo.blocksize;
+
+  ret = MTD_ERASE(enc_mtd, erase_block, erase_nblocks);
+  if (ret != erase_nblocks)
+    {
+      ferr("ERROR: Failed to erase block errno=%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  ret = MTD_BWRITE(enc_mtd, rw_block, rw_nblocks, wbuf);
+  if (ret != rw_nblocks)
+    {
+      ferr("ERROR: Failed to encrypt write errno=%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  memset(rbuf, 0, size);
+  ret = MTD_BREAD(enc_mtd, rw_block, rw_nblocks, rbuf);
+  if (ret != rw_nblocks)
+    {
+      ferr("ERROR: Failed to decrypt read errno=%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  if (memcmp(wbuf, rbuf, size))
+    {
+      ferr("ASSERT: Encrypted and decrypted data is not same\n");
+      DEBUGASSERT(0);
+    }
+
+  memset(rbuf, 0, size);
+  ret = MTD_BREAD(mtd, rw_block, rw_nblocks, rbuf);
+  if (ret != rw_nblocks)
+    {
+      ferr("ERROR: Failed to read errno=%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  if (!memcmp(wbuf, rbuf, size))
+    {
+      ferr("ASSERT: Encrypted and normal data is same\n");
+      DEBUGASSERT(0);
+    }
+
+  for (i = 0; i < size; i++)
+    {
+      wbuf[i] = (uint8_t)random();
+    }
+
+  ret = MTD_ERASE(enc_mtd, erase_block, erase_nblocks);
+  if (ret != erase_nblocks)
+    {
+      ferr("ERROR: Failed to erase errno=%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  ret = MTD_BWRITE(mtd, rw_block, rw_nblocks, wbuf);
+  if (ret != rw_nblocks)
+    {
+      ferr("ERROR: Failed to write errno=%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  memset(rbuf, 0, size);
+  ret = MTD_BREAD(enc_mtd, rw_block, rw_nblocks, rbuf);
+  if (ret != rw_nblocks)
+    {
+      ferr("ERROR: Failed to decrypt read errno=%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  if (!memcmp(wbuf, rbuf, size))
+    {
+      ferr("ASSERT: Normal and decrypted data is same\n");
+      DEBUGASSERT(0);
+    }
+
+  memset(rbuf, 0, size);
+  ret = MTD_BREAD(mtd, rw_block, rw_nblocks, rbuf);
+  if (ret != rw_nblocks)
+    {
+      ferr("ERROR: Failed to read errno=%d\n", ret);
+      DEBUGASSERT(0);
+    }
+
+  if (memcmp(wbuf, rbuf, size))
+    {
+      ferr("ASSERT: Normal and normal data is not same\n");
+      DEBUGASSERT(0);
+    }
+
+  kmm_free(wbuf);
+  kmm_free(rbuf);
+
+  finfo("INFO: ESP32 SPI Flash encryption test successfully\n");
+}
+
+#endif /* CONFIG_ESP32_SPIFLASH_ENCRYPTION_TEST */


### PR DESCRIPTION
## Summary

Add SPI Flash hardware encryption I/O support.

## Impact

## Testing

Add board level testing code `void esp32_spiflash_encrypt_test(void)`. When enable option `ESP32_SPIFLASH_ENCRYPTION_TEST`, board initialization will run this.

