### PR TITLE
xtensa/esp32: Avoid init PSRAM when SPIRAM is not enabled and fix remaining SEPARATE typo

### DIFF
--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -150,7 +150,7 @@ void up_initialize(void)
 
   /* Initialize the internal heap */
 
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   xtensa_imm_initialize();
 #endif
 

--- a/arch/xtensa/src/common/xtensa_mm.h
+++ b/arch/xtensa/src/common/xtensa_mm.h
@@ -34,7 +34,7 @@
  * Pre-processor Macros
  ****************************************************************************/
 
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
 #  define UMM_MALLOC(s)      xtensa_imm_malloc(s)
 #  define UMM_MEMALIGN(a,s)  xtensa_imm_memalign(a,s)
 #  define UMM_FREE(p)        xtensa_imm_free(p)

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -579,6 +579,7 @@ endchoice # ESP32_SPIRAM_SPEED
 
 config ESP32_SPIRAM_BOOT_INIT
 	bool "Initialize SPI RAM during startup"
+	depends on ESP32_SPIRAM
 	default "y"
 	help
 	    If this is enabled, the SPI RAM will be enabled during initial

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -99,7 +99,7 @@ endif
 
 CHIP_CSRCS += esp32_rtc.c
 
-ifeq ($(CONFIG_XTENSA_USE_SEPERATE_IMEM),y)
+ifeq ($(CONFIG_XTENSA_USE_SEPARATE_IMEM),y)
 CHIP_CSRCS += esp32_imm.c
 endif
 

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -93,13 +93,15 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  *
  ****************************************************************************/
 
-#if CONFIG_MM_REGIONS > 1 && defined(CONFIG_ESP32_SPIRAM)
+#if CONFIG_MM_REGIONS > 1
 void xtensa_add_region(void)
 {
+#if defined(CONFIG_ESP32_SPIRAM)
   /* Check for any additional memory regions */
 
-#if defined(CONFIG_HEAP2_BASE) && defined(CONFIG_HEAP2_SIZE)
-  umm_addregion((FAR void *)CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE);
+#  if defined(CONFIG_HEAP2_BASE) && defined(CONFIG_HEAP2_SIZE)
+    umm_addregion((FAR void *)CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE);
+#  endif
 #endif
 }
 #endif

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -93,7 +93,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  *
  ****************************************************************************/
 
-#if CONFIG_MM_REGIONS > 1
+#if CONFIG_MM_REGIONS > 1 && defined(CONFIG_ESP32_SPIRAM)
 void xtensa_add_region(void)
 {
   /* Check for any additional memory regions */

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -869,14 +869,14 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
   uint8_t *rp;
   uint32_t n;
   uint32_t regval;
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   uint8_t *alloctp;
   uint8_t *allocrp;
 #endif
 
   /* If the buffer comes from PSRAM, allocate a new one from DRAM */
 
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   if (esp32_ptr_extram(txbuffer))
     {
       alloctp = xtensa_imm_malloc(total);
@@ -890,7 +890,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       tp = (uint8_t *)txbuffer;
     }
 
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   if (esp32_ptr_extram(rxbuffer))
     {
       allocrp = xtensa_imm_malloc(total);
@@ -962,7 +962,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       rp += n;
     }
 
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   if (esp32_ptr_extram(rxbuffer))
     {
       memcpy(rxbuffer, allocrp, total);
@@ -970,7 +970,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
     }
 #endif
 
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   if (esp32_ptr_extram(txbuffer))
     {
       xtensa_imm_free(alloctp);

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -1051,7 +1051,7 @@ static ssize_t esp32_read(FAR struct mtd_dev_s *dev, off_t offset,
   finfo("esp32_read(%p, 0x%x, %d, %p)\n", dev, offset, nbytes, buffer);
 #endif
 
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   if (esp32_ptr_extram(buffer))
     {
       tmpbuff = xtensa_imm_malloc(nbytes);
@@ -1085,7 +1085,7 @@ static ssize_t esp32_read(FAR struct mtd_dev_s *dev, off_t offset,
 #endif
 
 error_with_buffer:
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   if (esp32_ptr_extram(buffer))
     {
       memcpy(buffer, tmpbuff, (ret == OK) ? nbytes : 0);
@@ -1170,7 +1170,7 @@ static ssize_t esp32_write(FAR struct mtd_dev_s *dev, off_t offset,
       return -EINVAL;
     }
 
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   if (esp32_ptr_extram(buffer))
     {
       tmpbuff = xtensa_imm_malloc(nbytes);
@@ -1210,7 +1210,7 @@ static ssize_t esp32_write(FAR struct mtd_dev_s *dev, off_t offset,
 #endif
 
 error_with_buffer:
-#ifdef CONFIG_XTENSA_USE_SEPERATE_IMEM
+#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
   if (esp32_ptr_extram(buffer))
     {
       xtensa_imm_free(tmpbuff);


### PR DESCRIPTION
## Summary
Avoid init PSRAM when SPIRAM is not enabled and fix remaining SEPARATE typo
## Impact
Protect against wrong configuration
## Testing
esp32-core