### PR TITLE
Move PRI/SCN macros for fast and least types to include/inttypes.h

### DIFF
--- a/arch/arm/include/inttypes.h
+++ b/arch/arm/include/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/avr/include/avr/inttypes.h
+++ b/arch/avr/include/avr/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "ld"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "ld"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "ld"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "li"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "li"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "li"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "lo"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "lo"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "lo"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "lu"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "lu"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "lu"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "lx"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "lx"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "lx"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "lX"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "lX"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "lX"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "ld"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "d"
-#define SCNdLEAST32 "ld"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "d"
-#define SCNdFAST32  "ld"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "i"
 #define SCNi32      "li"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "i"
-#define SCNiLEAST32 "li"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "i"
-#define SCNiFAST32  "li"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "lo"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "o"
-#define SCNoLEAST32 "lo"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "o"
-#define SCNoFAST32  "lo"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "lu"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "u"
-#define SCNuLEAST32 "lu"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "u"
-#define SCNuFAST32  "lu"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "x"
 #define SCNx32      "lx"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "x"
-#define SCNxLEAST32 "lx"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "x"
-#define SCNxFAST32  "lx"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/avr/include/avr32/inttypes.h
+++ b/arch/avr/include/avr32/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/hc/include/inttypes.h
+++ b/arch/hc/include/inttypes.h
@@ -51,32 +51,12 @@
 #  define PRId32      "ld"
 #  define PRId64      "lld"
 
-#  define PRIdLEAST8  "d"
-#  define PRIdLEAST16 "d"
-#  define PRIdLEAST32 "ld"
-#  define PRIdLEAST64 "lld"
-
-#  define PRIdFAST8   "d"
-#  define PRIdFAST16  "d"
-#  define PRIdFAST32  "ld"
-#  define PRIdFAST64  "lld"
-
 #  define PRIdPTR     "d"
 
 #  define PRIi8       "i"
 #  define PRIi16      "i"
 #  define PRIi32      "li"
 #  define PRIi64      "lli"
-
-#  define PRIiLEAST8  "i"
-#  define PRIiLEAST16 "i"
-#  define PRIiLEAST32 "li"
-#  define PRIiLEAST64 "lli"
-
-#  define PRIiFAST8   "i"
-#  define PRIiFAST16  "i"
-#  define PRIiFAST32  "li"
-#  define PRIiFAST64  "lli"
 
 #  define PRIiPTR     "i"
 
@@ -85,32 +65,12 @@
 #  define PRIo32      "lo"
 #  define PRIo64      "llo"
 
-#  define PRIoLEAST8  "o"
-#  define PRIoLEAST16 "o"
-#  define PRIoLEAST32 "lo"
-#  define PRIoLEAST64 "llo"
-
-#  define PRIoFAST8   "o"
-#  define PRIoFAST16  "o"
-#  define PRIoFAST32  "lo"
-#  define PRIoFAST64  "llo"
-
 #  define PRIoPTR     "o"
 
 #  define PRIu8       "u"
 #  define PRIu16      "u"
 #  define PRIu32      "lu"
 #  define PRIu64      "llu"
-
-#  define PRIuLEAST8  "u"
-#  define PRIuLEAST16 "u"
-#  define PRIuLEAST32 "lu"
-#  define PRIuLEAST64 "llu"
-
-#  define PRIuFAST8   "u"
-#  define PRIuFAST16  "u"
-#  define PRIuFAST32  "lu"
-#  define PRIuFAST64  "llu"
 
 #  define PRIuPTR     "u"
 
@@ -119,32 +79,12 @@
 #  define PRIx32      "lx"
 #  define PRIx64      "llx"
 
-#  define PRIxLEAST8  "x"
-#  define PRIxLEAST16 "x"
-#  define PRIxLEAST32 "lx"
-#  define PRIxLEAST64 "llx"
-
-#  define PRIxFAST8   "x"
-#  define PRIxFAST16  "x"
-#  define PRIxFAST32  "lx"
-#  define PRIxFAST64  "llx"
-
 #  define PRIxPTR     "x"
 
 #  define PRIX8       "X"
 #  define PRIX16      "X"
 #  define PRIX32      "lX"
 #  define PRIX64      "llX"
-
-#  define PRIXLEAST8  "X"
-#  define PRIXLEAST16 "X"
-#  define PRIXLEAST32 "lX"
-#  define PRIXLEAST64 "llX"
-
-#  define PRIXFAST8   "X"
-#  define PRIXFAST16  "X"
-#  define PRIXFAST32  "lX"
-#  define PRIXFAST64  "llX"
 
 #  define PRIXPTR     "X"
 
@@ -153,32 +93,12 @@
 #  define SCNd32      "ld"
 #  define SCNd64      "lld"
 
-#  define SCNdLEAST8  "hhd"
-#  define SCNdLEAST16 "d"
-#  define SCNdLEAST32 "ld"
-#  define SCNdLEAST64 "lld"
-
-#  define SCNdFAST8   "hhd"
-#  define SCNdFAST16  "d"
-#  define SCNdFAST32  "ld"
-#  define SCNdFAST64  "lld"
-
 #  define SCNdPTR     "d"
 
 #  define SCNi8       "hhi"
 #  define SCNi16      "i"
 #  define SCNi32      "li"
 #  define SCNi64      "lli"
-
-#  define SCNiLEAST8  "hhi"
-#  define SCNiLEAST16 "i"
-#  define SCNiLEAST32 "li"
-#  define SCNiLEAST64 "lli"
-
-#  define SCNiFAST8   "hhi"
-#  define SCNiFAST16  "i"
-#  define SCNiFAST32  "li"
-#  define SCNiFAST64  "lli"
 
 #  define SCNiPTR     "i"
 
@@ -187,16 +107,6 @@
 #  define SCNo32      "lo"
 #  define SCNo64      "llo"
 
-#  define SCNoLEAST8  "hho"
-#  define SCNoLEAST16 "o"
-#  define SCNoLEAST32 "lo"
-#  define SCNoLEAST64 "llo"
-
-#  define SCNoFAST8   "hho"
-#  define SCNoFAST16  "o"
-#  define SCNoFAST32  "lo"
-#  define SCNoFAST64  "llo"
-
 #  define SCNoPTR     "o"
 
 #  define SCNu8       "hhu"
@@ -204,32 +114,12 @@
 #  define SCNu32      "lu"
 #  define SCNu64      "llu"
 
-#  define SCNuLEAST8  "hhu"
-#  define SCNuLEAST16 "u"
-#  define SCNuLEAST32 "lu"
-#  define SCNuLEAST64 "llu"
-
-#  define SCNuFAST8   "hhu"
-#  define SCNuFAST16  "u"
-#  define SCNuFAST32  "lu"
-#  define SCNuFAST64  "llu"
-
 #  define SCNuPTR     "u"
 
 #  define SCNx8       "hhx"
 #  define SCNx16      "x"
 #  define SCNx32      "lx"
 #  define SCNx64      "llx"
-
-#  define SCNxLEAST8  "hhx"
-#  define SCNxLEAST16 "x"
-#  define SCNxLEAST32 "lx"
-#  define SCNxLEAST64 "llx"
-
-#  define SCNxFAST8   "hhx"
-#  define SCNxFAST16  "x"
-#  define SCNxFAST32  "lx"
-#  define SCNxFAST64  "llx"
 
 #  define SCNxPTR     "x"
 
@@ -250,32 +140,12 @@
 #  define PRId32      "d"
 #  define PRId64      "lld"
 
-#  define PRIdLEAST8  "d"
-#  define PRIdLEAST16 "d"
-#  define PRIdLEAST32 "d"
-#  define PRIdLEAST64 "lld"
-
-#  define PRIdFAST8   "d"
-#  define PRIdFAST16  "d"
-#  define PRIdFAST32  "d"
-#  define PRIdFAST64  "lld"
-
 #  define PRIdPTR     "d"
 
 #  define PRIi8       "i"
 #  define PRIi16      "i"
 #  define PRIi32      "i"
 #  define PRIi64      "lli"
-
-#  define PRIiLEAST8  "i"
-#  define PRIiLEAST16 "i"
-#  define PRIiLEAST32 "i"
-#  define PRIiLEAST64 "lli"
-
-#  define PRIiFAST8   "i"
-#  define PRIiFAST16  "i"
-#  define PRIiFAST32  "i"
-#  define PRIiFAST64  "lli"
 
 #  define PRIiPTR     "i"
 
@@ -284,32 +154,12 @@
 #  define PRIo32      "o"
 #  define PRIo64      "llo"
 
-#  define PRIoLEAST8  "o"
-#  define PRIoLEAST16 "o"
-#  define PRIoLEAST32 "o"
-#  define PRIoLEAST64 "llo"
-
-#  define PRIoFAST8   "o"
-#  define PRIoFAST16  "o"
-#  define PRIoFAST32  "o"
-#  define PRIoFAST64  "llo"
-
 #  define PRIoPTR     "o"
 
 #  define PRIu8       "u"
 #  define PRIu16      "u"
 #  define PRIu32      "u"
 #  define PRIu64      "llu"
-
-#  define PRIuLEAST8  "u"
-#  define PRIuLEAST16 "u"
-#  define PRIuLEAST32 "u"
-#  define PRIuLEAST64 "llu"
-
-#  define PRIuFAST8   "u"
-#  define PRIuFAST16  "u"
-#  define PRIuFAST32  "u"
-#  define PRIuFAST64  "llu"
 
 #  define PRIuPTR     "u"
 
@@ -318,32 +168,12 @@
 #  define PRIx32      "x"
 #  define PRIx64      "llx"
 
-#  define PRIxLEAST8  "x"
-#  define PRIxLEAST16 "x"
-#  define PRIxLEAST32 "x"
-#  define PRIxLEAST64 "llx"
-
-#  define PRIxFAST8   "x"
-#  define PRIxFAST16  "x"
-#  define PRIxFAST32  "x"
-#  define PRIxFAST64  "llx"
-
 #  define PRIxPTR     "x"
 
 #  define PRIX8       "X"
 #  define PRIX16      "X"
 #  define PRIX32      "X"
 #  define PRIX64      "llX"
-
-#  define PRIXLEAST8  "X"
-#  define PRIXLEAST16 "X"
-#  define PRIXLEAST32 "X"
-#  define PRIXLEAST64 "llX"
-
-#  define PRIXFAST8   "X"
-#  define PRIXFAST16  "X"
-#  define PRIXFAST32  "X"
-#  define PRIXFAST64  "llX"
 
 #  define PRIXPTR     "X"
 
@@ -352,32 +182,12 @@
 #  define SCNd32      "d"
 #  define SCNd64      "lld"
 
-#  define SCNdLEAST8  "hhd"
-#  define SCNdLEAST16 "hd"
-#  define SCNdLEAST32 "d"
-#  define SCNdLEAST64 "lld"
-
-#  define SCNdFAST8   "hhd"
-#  define SCNdFAST16  "hd"
-#  define SCNdFAST32  "d"
-#  define SCNdFAST64  "lld"
-
 #  define SCNdPTR     "d"
 
 #  define SCNi8       "hhi"
 #  define SCNi16      "hi"
 #  define SCNi32      "i"
 #  define SCNi64      "lli"
-
-#  define SCNiLEAST8  "hhi"
-#  define SCNiLEAST16 "hi"
-#  define SCNiLEAST32 "i"
-#  define SCNiLEAST64 "lli"
-
-#  define SCNiFAST8   "hhi"
-#  define SCNiFAST16  "hi"
-#  define SCNiFAST32  "i"
-#  define SCNiFAST64  "lli"
 
 #  define SCNiPTR     "i"
 
@@ -386,16 +196,6 @@
 #  define SCNo32      "o"
 #  define SCNo64      "llo"
 
-#  define SCNoLEAST8  "hho"
-#  define SCNoLEAST16 "ho"
-#  define SCNoLEAST32 "o"
-#  define SCNoLEAST64 "llo"
-
-#  define SCNoFAST8   "hho"
-#  define SCNoFAST16  "ho"
-#  define SCNoFAST32  "o"
-#  define SCNoFAST64  "llo"
-
 #  define SCNoPTR     "o"
 
 #  define SCNu8       "hhu"
@@ -403,32 +203,12 @@
 #  define SCNu32      "u"
 #  define SCNu64      "llu"
 
-#  define SCNuLEAST8  "hhu"
-#  define SCNuLEAST16 "hu"
-#  define SCNuLEAST32 "u"
-#  define SCNuLEAST64 "llu"
-
-#  define SCNuFAST8   "hhu"
-#  define SCNuFAST16  "hu"
-#  define SCNuFAST32  "u"
-#  define SCNuFAST64  "llu"
-
 #  define SCNuPTR     "u"
 
 #  define SCNx8       "hhx"
 #  define SCNx16      "hx"
 #  define SCNx32      "x"
 #  define SCNx64      "llx"
-
-#  define SCNxLEAST8  "hhx"
-#  define SCNxLEAST16 "hx"
-#  define SCNxLEAST32 "x"
-#  define SCNxLEAST64 "llx"
-
-#  define SCNxFAST8   "hhx"
-#  define SCNxFAST16  "hx"
-#  define SCNxFAST32  "x"
-#  define SCNxFAST64  "llx"
 
 #  define SCNxPTR     "x"
 

--- a/arch/mips/include/inttypes.h
+++ b/arch/mips/include/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/misoc/include/inttypes.h
+++ b/arch/misoc/include/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/or1k/include/inttypes.h
+++ b/arch/or1k/include/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/renesas/include/m16c/inttypes.h
+++ b/arch/renesas/include/m16c/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "ld"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "ld"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "ld"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "li"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "li"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "li"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "lo"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "lo"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "lo"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "lu"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "lu"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "lu"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "lx"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "lx"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "lx"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "lX"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "lX"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "lX"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "ld"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "d"
-#define SCNdLEAST32 "ld"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "d"
-#define SCNdFAST32  "ld"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "i"
 #define SCNi32      "li"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "i"
-#define SCNiLEAST32 "li"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "i"
-#define SCNiFAST32  "li"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "lo"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "o"
-#define SCNoLEAST32 "lo"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "o"
-#define SCNoFAST32  "lo"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "lu"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "u"
-#define SCNuLEAST32 "lu"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "u"
-#define SCNuFAST32  "lu"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "x"
 #define SCNx32      "lx"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "x"
-#define SCNxLEAST32 "lx"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "x"
-#define SCNxFAST32  "lx"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/renesas/include/rx65n/inttypes.h
+++ b/arch/renesas/include/rx65n/inttypes.h
@@ -44,32 +44,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -78,32 +58,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -112,32 +72,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -146,32 +86,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -180,16 +100,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -197,32 +107,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/renesas/include/sh1/inttypes.h
+++ b/arch/renesas/include/sh1/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/risc-v/include/inttypes.h
+++ b/arch/risc-v/include/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/sim/include/inttypes.h
+++ b/arch/sim/include/inttypes.h
@@ -49,60 +49,20 @@
 #  define PRId32      "d"
 #  define PRId64      "lld"
 
-#  define PRIdLEAST8  "d"
-#  define PRIdLEAST16 "d"
-#  define PRIdLEAST32 "d"
-#  define PRIdLEAST64 "lld"
-
-#  define PRIdFAST8   "d"
-#  define PRIdFAST16  "d"
-#  define PRIdFAST32  "d"
-#  define PRIdFAST64  "lld"
-
 #  define PRIi8       "i"
 #  define PRIi16      "i"
 #  define PRIi32      "i"
 #  define PRIi64      "lli"
-
-#  define PRIiLEAST8  "i"
-#  define PRIiLEAST16 "i"
-#  define PRIiLEAST32 "i"
-#  define PRIiLEAST64 "lli"
-
-#  define PRIiFAST8   "i"
-#  define PRIiFAST16  "i"
-#  define PRIiFAST32  "i"
-#  define PRIiFAST64  "lli"
 
 #  define PRIo8       "o"
 #  define PRIo16      "o"
 #  define PRIo32      "o"
 #  define PRIo64      "llo"
 
-#  define PRIoLEAST8  "o"
-#  define PRIoLEAST16 "o"
-#  define PRIoLEAST32 "o"
-#  define PRIoLEAST64 "llo"
-
-#  define PRIoFAST8   "o"
-#  define PRIoFAST16  "o"
-#  define PRIoFAST32  "o"
-#  define PRIoFAST64  "llo"
-
 #  define PRIu8       "u"
 #  define PRIu16      "u"
 #  define PRIu32      "u"
 #  define PRIu64      "llu"
-
-#  define PRIuLEAST8  "u"
-#  define PRIuLEAST16 "u"
-#  define PRIuLEAST32 "u"
-#  define PRIuLEAST64 "llu"
-
-#  define PRIuFAST8   "u"
-#  define PRIuFAST16  "u"
-#  define PRIuFAST32  "u"
-#  define PRIuFAST64  "llu"
 
 #  define PRIuMAX     "llu"
 
@@ -111,45 +71,15 @@
 #  define PRIx32      "x"
 #  define PRIx64      "llx"
 
-#  define PRIxLEAST8  "x"
-#  define PRIxLEAST16 "x"
-#  define PRIxLEAST32 "x"
-#  define PRIxLEAST64 "llx"
-
-#  define PRIxFAST8   "x"
-#  define PRIxFAST16  "x"
-#  define PRIxFAST32  "x"
-#  define PRIxFAST64  "llx"
-
 #  define PRIX8       "X"
 #  define PRIX16      "X"
 #  define PRIX32      "X"
 #  define PRIX64      "llX"
 
-#  define PRIXLEAST8  "X"
-#  define PRIXLEAST16 "X"
-#  define PRIXLEAST32 "X"
-#  define PRIXLEAST64 "llX"
-
-#  define PRIXFAST8   "X"
-#  define PRIXFAST16  "X"
-#  define PRIXFAST32  "X"
-#  define PRIXFAST64  "llX"
-
 #  define SCNd8       "hhd"
 #  define SCNd16      "hd"
 #  define SCNd32      "d"
 #  define SCNd64      "lld"
-
-#  define SCNdLEAST8  "hhd"
-#  define SCNdLEAST16 "hd"
-#  define SCNdLEAST32 "d"
-#  define SCNdLEAST64 "lld"
-
-#  define SCNdFAST8   "hhd"
-#  define SCNdFAST16  "hd"
-#  define SCNdFAST32  "d"
-#  define SCNdFAST64  "lld"
 
 #  define SCNdMAX     "lld"
 

--- a/arch/sim/include/inttypes.h
+++ b/arch/sim/include/inttypes.h
@@ -44,412 +44,213 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#  define PRId8       "d"
+#  define PRId16      "d"
+#  define PRId32      "d"
+#  define PRId64      "lld"
+
+#  define PRIdLEAST8  "d"
+#  define PRIdLEAST16 "d"
+#  define PRIdLEAST32 "d"
+#  define PRIdLEAST64 "lld"
+
+#  define PRIdFAST8   "d"
+#  define PRIdFAST16  "d"
+#  define PRIdFAST32  "d"
+#  define PRIdFAST64  "lld"
+
+#  define PRIi8       "i"
+#  define PRIi16      "i"
+#  define PRIi32      "i"
+#  define PRIi64      "lli"
+
+#  define PRIiLEAST8  "i"
+#  define PRIiLEAST16 "i"
+#  define PRIiLEAST32 "i"
+#  define PRIiLEAST64 "lli"
+
+#  define PRIiFAST8   "i"
+#  define PRIiFAST16  "i"
+#  define PRIiFAST32  "i"
+#  define PRIiFAST64  "lli"
+
+#  define PRIo8       "o"
+#  define PRIo16      "o"
+#  define PRIo32      "o"
+#  define PRIo64      "llo"
+
+#  define PRIoLEAST8  "o"
+#  define PRIoLEAST16 "o"
+#  define PRIoLEAST32 "o"
+#  define PRIoLEAST64 "llo"
+
+#  define PRIoFAST8   "o"
+#  define PRIoFAST16  "o"
+#  define PRIoFAST32  "o"
+#  define PRIoFAST64  "llo"
+
+#  define PRIu8       "u"
+#  define PRIu16      "u"
+#  define PRIu32      "u"
+#  define PRIu64      "llu"
+
+#  define PRIuLEAST8  "u"
+#  define PRIuLEAST16 "u"
+#  define PRIuLEAST32 "u"
+#  define PRIuLEAST64 "llu"
+
+#  define PRIuFAST8   "u"
+#  define PRIuFAST16  "u"
+#  define PRIuFAST32  "u"
+#  define PRIuFAST64  "llu"
+
+#  define PRIuMAX     "llu"
+
+#  define PRIx8       "x"
+#  define PRIx16      "x"
+#  define PRIx32      "x"
+#  define PRIx64      "llx"
+
+#  define PRIxLEAST8  "x"
+#  define PRIxLEAST16 "x"
+#  define PRIxLEAST32 "x"
+#  define PRIxLEAST64 "llx"
+
+#  define PRIxFAST8   "x"
+#  define PRIxFAST16  "x"
+#  define PRIxFAST32  "x"
+#  define PRIxFAST64  "llx"
+
+#  define PRIX8       "X"
+#  define PRIX16      "X"
+#  define PRIX32      "X"
+#  define PRIX64      "llX"
+
+#  define PRIXLEAST8  "X"
+#  define PRIXLEAST16 "X"
+#  define PRIXLEAST32 "X"
+#  define PRIXLEAST64 "llX"
+
+#  define PRIXFAST8   "X"
+#  define PRIXFAST16  "X"
+#  define PRIXFAST32  "X"
+#  define PRIXFAST64  "llX"
+
+#  define SCNd8       "hhd"
+#  define SCNd16      "hd"
+#  define SCNd32      "d"
+#  define SCNd64      "lld"
+
+#  define SCNdLEAST8  "hhd"
+#  define SCNdLEAST16 "hd"
+#  define SCNdLEAST32 "d"
+#  define SCNdLEAST64 "lld"
+
+#  define SCNdFAST8   "hhd"
+#  define SCNdFAST16  "hd"
+#  define SCNdFAST32  "d"
+#  define SCNdFAST64  "lld"
+
+#  define SCNdMAX     "lld"
+
+#  define SCNi8       "hhi"
+#  define SCNi16      "hi"
+#  define SCNi32      "i"
+#  define SCNi64      "lli"
+
+#  define SCNiLEAST8  "hhi"
+#  define SCNiLEAST16 "hi"
+#  define SCNiLEAST32 "i"
+#  define SCNiLEAST64 "lli"
+
+#  define SCNiFAST8   "hhi"
+#  define SCNiFAST16  "hi"
+#  define SCNiFAST32  "i"
+#  define SCNiFAST64  "lli"
+
+#  define SCNiMAX     "lli"
+
+#  define SCNo8       "hho"
+#  define SCNo16      "ho"
+#  define SCNo32      "o"
+#  define SCNo64      "llo"
+
+#  define SCNoLEAST8  "hho"
+#  define SCNoLEAST16 "ho"
+#  define SCNoLEAST32 "o"
+#  define SCNoLEAST64 "llo"
+
+#  define SCNoFAST8   "hho"
+#  define SCNoFAST16  "ho"
+#  define SCNoFAST32  "o"
+#  define SCNoFAST64  "llo"
+
+#  define SCNoMAX     "llo"
+
+#  define SCNu8       "hhu"
+#  define SCNu16      "hu"
+#  define SCNu32      "u"
+#  define SCNu64      "llu"
+
+#  define SCNuLEAST8  "hhu"
+#  define SCNuLEAST16 "hu"
+#  define SCNuLEAST32 "u"
+#  define SCNuLEAST64 "llu"
+
+#  define SCNuFAST8   "hhu"
+#  define SCNuFAST16  "hu"
+#  define SCNuFAST32  "u"
+#  define SCNuFAST64  "llu"
+
+#  define SCNx8       "hhx"
+#  define SCNx16      "hx"
+#  define SCNx32      "x"
+#  define SCNx64      "llx"
+
+#  define SCNxLEAST8  "hhx"
+#  define SCNxLEAST16 "hx"
+#  define SCNxLEAST32 "x"
+#  define SCNxLEAST64 "llx"
+
+#  define SCNxFAST8   "hhx"
+#  define SCNxFAST16  "hx"
+#  define SCNxFAST32  "x"
+#  define SCNxFAST64  "llx"
+
+#  define INT8_C(x)   x
+#  define INT16_C(x)  x
+#  define INT32_C(x)  x
+#  define INT64_C(x)  x ## ll
+
+#  define UINT8_C(x)  x
+#  define UINT16_C(x) x
+#  define UINT32_C(x) x ## u
+#  define UINT64_C(x) x ## ull
+
 #if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
-
-#  define PRId8       "d"
-#  define PRId16      "d"
-#  define PRId32      "d"
-#  define PRId64      "lld"
-
-#  define PRIdLEAST8  "d"
-#  define PRIdLEAST16 "d"
-#  define PRIdLEAST32 "d"
-#  define PRIdLEAST64 "lld"
-
-#  define PRIdFAST8   "d"
-#  define PRIdFAST16  "d"
-#  define PRIdFAST32  "d"
-#  define PRIdFAST64  "lld"
-
 #  define PRIdPTR     "lld"
-
-#  define PRIi8       "i"
-#  define PRIi16      "i"
-#  define PRIi32      "i"
-#  define PRIi64      "lli"
-
-#  define PRIiLEAST8  "i"
-#  define PRIiLEAST16 "i"
-#  define PRIiLEAST32 "i"
-#  define PRIiLEAST64 "lli"
-
-#  define PRIiFAST8   "i"
-#  define PRIiFAST16  "i"
-#  define PRIiFAST32  "i"
-#  define PRIiFAST64  "lli"
-
 #  define PRIiPTR     "lli"
-
-#  define PRIo8       "o"
-#  define PRIo16      "o"
-#  define PRIo32      "o"
-#  define PRIo64      "llo"
-
-#  define PRIoLEAST8  "o"
-#  define PRIoLEAST16 "o"
-#  define PRIoLEAST32 "o"
-#  define PRIoLEAST64 "llo"
-
-#  define PRIoFAST8   "o"
-#  define PRIoFAST16  "o"
-#  define PRIoFAST32  "o"
-#  define PRIoFAST64  "llo"
-
 #  define PRIoPTR     "llo"
-
-#  define PRIu8       "u"
-#  define PRIu16      "u"
-#  define PRIu32      "u"
-#  define PRIu64      "llu"
-
-#  define PRIuLEAST8  "u"
-#  define PRIuLEAST16 "u"
-#  define PRIuLEAST32 "u"
-#  define PRIuLEAST64 "llu"
-
-#  define PRIuFAST8   "u"
-#  define PRIuFAST16  "u"
-#  define PRIuFAST32  "u"
-#  define PRIuFAST64  "llu"
-
-#  define PRIuMAX     "llu"
 #  define PRIuPTR     "llu"
-
-#  define PRIx8       "x"
-#  define PRIx16      "x"
-#  define PRIx32      "x"
-#  define PRIx64      "llx"
-
-#  define PRIxLEAST8  "x"
-#  define PRIxLEAST16 "x"
-#  define PRIxLEAST32 "x"
-#  define PRIxLEAST64 "llx"
-
-#  define PRIxFAST8   "x"
-#  define PRIxFAST16  "x"
-#  define PRIxFAST32  "x"
-#  define PRIxFAST64  "llx"
-
 #  define PRIxPTR     "llx"
-
-#  define PRIX8       "X"
-#  define PRIX16      "X"
-#  define PRIX32      "X"
-#  define PRIX64      "llX"
-
-#  define PRIXLEAST8  "X"
-#  define PRIXLEAST16 "X"
-#  define PRIXLEAST32 "X"
-#  define PRIXLEAST64 "llX"
-
-#  define PRIXFAST8   "X"
-#  define PRIXFAST16  "X"
-#  define PRIXFAST32  "X"
-#  define PRIXFAST64  "llX"
-
 #  define PRIXPTR     "llX"
-
-#  define SCNd8       "hhd"
-#  define SCNd16      "hd"
-#  define SCNd32      "d"
-#  define SCNd64      "lld"
-
-#  define SCNdLEAST8  "hhd"
-#  define SCNdLEAST16 "hd"
-#  define SCNdLEAST32 "d"
-#  define SCNdLEAST64 "lld"
-
-#  define SCNdFAST8   "hhd"
-#  define SCNdFAST16  "hd"
-#  define SCNdFAST32  "d"
-#  define SCNdFAST64  "lld"
-
-#  define SCNdMAX     "lld"
 #  define SCNdPTR     "lld"
-
-#  define SCNi8       "hhi"
-#  define SCNi16      "hi"
-#  define SCNi32      "i"
-#  define SCNi64      "lli"
-
-#  define SCNiLEAST8  "hhi"
-#  define SCNiLEAST16 "hi"
-#  define SCNiLEAST32 "i"
-#  define SCNiLEAST64 "lli"
-
-#  define SCNiFAST8   "hhi"
-#  define SCNiFAST16  "hi"
-#  define SCNiFAST32  "i"
-#  define SCNiFAST64  "lli"
-
-#  define SCNiMAX     "lli"
 #  define SCNiPTR     "lli"
-
-#  define SCNo8       "hho"
-#  define SCNo16      "ho"
-#  define SCNo32      "o"
-#  define SCNo64      "llo"
-
-#  define SCNoLEAST8  "hho"
-#  define SCNoLEAST16 "ho"
-#  define SCNoLEAST32 "o"
-#  define SCNoLEAST64 "llo"
-
-#  define SCNoFAST8   "hho"
-#  define SCNoFAST16  "ho"
-#  define SCNoFAST32  "o"
-#  define SCNoFAST64  "llo"
-
-#  define SCNoMAX     "llo"
 #  define SCNoPTR     "llo"
-
-#  define SCNu8       "hhu"
-#  define SCNu16      "hu"
-#  define SCNu32      "u"
-#  define SCNu64      "llu"
-
-#  define SCNuLEAST8  "hhu"
-#  define SCNuLEAST16 "hu"
-#  define SCNuLEAST32 "u"
-#  define SCNuLEAST64 "llu"
-
-#  define SCNuFAST8   "hhu"
-#  define SCNuFAST16  "hu"
-#  define SCNuFAST32  "u"
-#  define SCNuFAST64  "llu"
-
 #  define SCNuPTR     "llu"
-
-#  define SCNx8       "hhx"
-#  define SCNx16      "hx"
-#  define SCNx32      "x"
-#  define SCNx64      "llx"
-
-#  define SCNxLEAST8  "hhx"
-#  define SCNxLEAST16 "hx"
-#  define SCNxLEAST32 "x"
-#  define SCNxLEAST64 "llx"
-
-#  define SCNxFAST8   "hhx"
-#  define SCNxFAST16  "hx"
-#  define SCNxFAST32  "x"
-#  define SCNxFAST64  "llx"
-
 #  define SCNxPTR     "llx"
-
-#  define INT8_C(x)   x
-#  define INT16_C(x)  x
-#  define INT32_C(x)  x
-#  define INT64_C(x)  x ## ll
-
-#  define UINT8_C(x)  x
-#  define UINT16_C(x) x
-#  define UINT32_C(x) x ## u
-#  define UINT64_C(x) x ## ull
-
 #else
-
-#  define PRId8       "d"
-#  define PRId16      "d"
-#  define PRId32      "d"
-#  define PRId64      "lld"
-
-#  define PRIdLEAST8  "d"
-#  define PRIdLEAST16 "d"
-#  define PRIdLEAST32 "d"
-#  define PRIdLEAST64 "lld"
-
-#  define PRIdFAST8   "d"
-#  define PRIdFAST16  "d"
-#  define PRIdFAST32  "d"
-#  define PRIdFAST64  "lld"
-
 #  define PRIdPTR     "d"
-
-#  define PRIi8       "i"
-#  define PRIi16      "i"
-#  define PRIi32      "i"
-#  define PRIi64      "lli"
-
-#  define PRIiLEAST8  "i"
-#  define PRIiLEAST16 "i"
-#  define PRIiLEAST32 "i"
-#  define PRIiLEAST64 "lli"
-
-#  define PRIiFAST8   "i"
-#  define PRIiFAST16  "i"
-#  define PRIiFAST32  "i"
-#  define PRIiFAST64  "lli"
-
 #  define PRIiPTR     "i"
-
-#  define PRIo8       "o"
-#  define PRIo16      "o"
-#  define PRIo32      "o"
-#  define PRIo64      "llo"
-
-#  define PRIoLEAST8  "o"
-#  define PRIoLEAST16 "o"
-#  define PRIoLEAST32 "o"
-#  define PRIoLEAST64 "llo"
-
-#  define PRIoFAST8   "o"
-#  define PRIoFAST16  "o"
-#  define PRIoFAST32  "o"
-#  define PRIoFAST64  "llo"
-
 #  define PRIoPTR     "o"
-
-#  define PRIu8       "u"
-#  define PRIu16      "u"
-#  define PRIu32      "u"
-#  define PRIu64      "llu"
-
-#  define PRIuLEAST8  "u"
-#  define PRIuLEAST16 "u"
-#  define PRIuLEAST32 "u"
-#  define PRIuLEAST64 "llu"
-
-#  define PRIuFAST8   "u"
-#  define PRIuFAST16  "u"
-#  define PRIuFAST32  "u"
-#  define PRIuFAST64  "llu"
-
-#  define PRIuMAX     "llu"
 #  define PRIuPTR     "u"
-
-#  define PRIx8       "x"
-#  define PRIx16      "x"
-#  define PRIx32      "x"
-#  define PRIx64      "llx"
-
-#  define PRIxLEAST8  "x"
-#  define PRIxLEAST16 "x"
-#  define PRIxLEAST32 "x"
-#  define PRIxLEAST64 "llx"
-
-#  define PRIxFAST8   "x"
-#  define PRIxFAST16  "x"
-#  define PRIxFAST32  "x"
-#  define PRIxFAST64  "llx"
-
 #  define PRIxPTR     "x"
-
-#  define PRIX8       "X"
-#  define PRIX16      "X"
-#  define PRIX32      "X"
-#  define PRIX64      "llX"
-
-#  define PRIXLEAST8  "X"
-#  define PRIXLEAST16 "X"
-#  define PRIXLEAST32 "X"
-#  define PRIXLEAST64 "llX"
-
-#  define PRIXFAST8   "X"
-#  define PRIXFAST16  "X"
-#  define PRIXFAST32  "X"
-#  define PRIXFAST64  "llX"
-
 #  define PRIXPTR     "X"
-
-#  define SCNd8       "hhd"
-#  define SCNd16      "hd"
-#  define SCNd32      "d"
-#  define SCNd64      "lld"
-
-#  define SCNdLEAST8  "hhd"
-#  define SCNdLEAST16 "hd"
-#  define SCNdLEAST32 "d"
-#  define SCNdLEAST64 "lld"
-
-#  define SCNdFAST8   "hhd"
-#  define SCNdFAST16  "hd"
-#  define SCNdFAST32  "d"
-#  define SCNdFAST64  "lld"
-
-#  define SCNdMAX     "lld"
 #  define SCNdPTR     "d"
-
-#  define SCNi8       "hhi"
-#  define SCNi16      "hi"
-#  define SCNi32      "i"
-#  define SCNi64      "lli"
-
-#  define SCNiLEAST8  "hhi"
-#  define SCNiLEAST16 "hi"
-#  define SCNiLEAST32 "i"
-#  define SCNiLEAST64 "lli"
-
-#  define SCNiFAST8   "hhi"
-#  define SCNiFAST16  "hi"
-#  define SCNiFAST32  "i"
-#  define SCNiFAST64  "lli"
-
-#  define SCNiMAX     "lli"
 #  define SCNiPTR     "i"
-
-#  define SCNo8       "hho"
-#  define SCNo16      "ho"
-#  define SCNo32      "o"
-#  define SCNo64      "llo"
-
-#  define SCNoLEAST8  "hho"
-#  define SCNoLEAST16 "ho"
-#  define SCNoLEAST32 "o"
-#  define SCNoLEAST64 "llo"
-
-#  define SCNoFAST8   "hho"
-#  define SCNoFAST16  "ho"
-#  define SCNoFAST32  "o"
-#  define SCNoFAST64  "llo"
-
-#  define SCNoMAX     "llo"
 #  define SCNoPTR     "o"
-
-#  define SCNu8       "hhu"
-#  define SCNu16      "hu"
-#  define SCNu32      "u"
-#  define SCNu64      "llu"
-
-#  define SCNuLEAST8  "hhu"
-#  define SCNuLEAST16 "hu"
-#  define SCNuLEAST32 "u"
-#  define SCNuLEAST64 "llu"
-
-#  define SCNuFAST8   "hhu"
-#  define SCNuFAST16  "hu"
-#  define SCNuFAST32  "u"
-#  define SCNuFAST64  "llu"
-
 #  define SCNuPTR     "u"
-
-#  define SCNx8       "hhx"
-#  define SCNx16      "hx"
-#  define SCNx32      "x"
-#  define SCNx64      "llx"
-
-#  define SCNxLEAST8  "hhx"
-#  define SCNxLEAST16 "hx"
-#  define SCNxLEAST32 "x"
-#  define SCNxLEAST64 "llx"
-
-#  define SCNxFAST8   "hhx"
-#  define SCNxFAST16  "hx"
-#  define SCNxFAST32  "x"
-#  define SCNxFAST64  "llx"
-
 #  define SCNxPTR     "x"
-
-#  define INT8_C(x)   x
-#  define INT16_C(x)  x
-#  define INT32_C(x)  x
-#  define INT64_C(x)  x ## ll
-
-#  define UINT8_C(x)  x
-#  define UINT16_C(x) x
-#  define UINT32_C(x) x ## u
-#  define UINT64_C(x) x ## ull
-
 #endif
 
 #endif /* __ARCH_SIM_INCLUDE_INTTYPES_H */

--- a/arch/x86/include/i486/inttypes.h
+++ b/arch/x86/include/i486/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/x86_64/include/intel64/inttypes.h
+++ b/arch/x86_64/include/intel64/inttypes.h
@@ -34,32 +34,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "lld"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "lli"
 
@@ -68,32 +48,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "llo"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "llu"
 
@@ -102,32 +62,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "llx"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "llX"
 
@@ -136,32 +76,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "lld"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "lli"
 
@@ -170,16 +90,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "llo"
 
 #define SCNu8       "hhu"
@@ -187,32 +97,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/xtensa/include/inttypes.h
+++ b/arch/xtensa/include/inttypes.h
@@ -49,32 +49,12 @@
 #define PRId32      "d"
 #define PRId64      "lld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-#define PRIdLEAST64 "lld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-#define PRIdFAST64  "lld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "lli"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-#define PRIiLEAST64 "lli"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
-#define PRIiFAST64  "lli"
 
 #define PRIiPTR     "i"
 
@@ -83,32 +63,12 @@
 #define PRIo32      "o"
 #define PRIo64      "llo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-#define PRIoLEAST64 "llo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-#define PRIoFAST64  "llo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "llu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-#define PRIuLEAST64 "llu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
-#define PRIuFAST64  "llu"
 
 #define PRIuPTR     "u"
 
@@ -117,32 +77,12 @@
 #define PRIx32      "x"
 #define PRIx64      "llx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-#define PRIxLEAST64 "llx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-#define PRIxFAST64  "llx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "llX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-#define PRIXLEAST64 "llX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
-#define PRIXFAST64  "llX"
 
 #define PRIXPTR     "X"
 
@@ -151,32 +91,12 @@
 #define SCNd32      "d"
 #define SCNd64      "lld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-#define SCNdLEAST64 "lld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-#define SCNdFAST64  "lld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "lli"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-#define SCNiLEAST64 "lli"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
-#define SCNiFAST64  "lli"
 
 #define SCNiPTR     "i"
 
@@ -185,16 +105,6 @@
 #define SCNo32      "o"
 #define SCNo64      "llo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-#define SCNoLEAST64 "llo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-#define SCNoFAST64  "llo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
@@ -202,32 +112,12 @@
 #define SCNu32      "u"
 #define SCNu64      "llu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-#define SCNuLEAST64 "llu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-#define SCNuFAST64  "llu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
 #define SCNx64      "llx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-#define SCNxLEAST64 "llx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
-#define SCNxFAST64  "llx"
 
 #define SCNxPTR     "x"
 

--- a/arch/z16/include/inttypes.h
+++ b/arch/z16/include/inttypes.h
@@ -48,27 +48,11 @@
 #define PRId16      "d"
 #define PRId32      "d"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "d"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "d"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "i"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "i"
 
 #define PRIiPTR     "i"
 
@@ -76,27 +60,11 @@
 #define PRIo16      "o"
 #define PRIo32      "o"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "o"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "o"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "u"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "u"
 
 #define PRIuPTR     "u"
 
@@ -104,27 +72,11 @@
 #define PRIx16      "x"
 #define PRIx32      "x"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "x"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "x"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "X"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "X"
 
 #define PRIXPTR     "X"
 
@@ -132,27 +84,11 @@
 #define SCNd16      "hd"
 #define SCNd32      "d"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "hd"
-#define SCNdLEAST32 "d"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "hd"
-#define SCNdFAST32  "d"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "hi"
-#define SCNiLEAST32 "i"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "hi"
-#define SCNiFAST32  "i"
 
 #define SCNiPTR     "i"
 
@@ -160,41 +96,17 @@
 #define SCNo16      "ho"
 #define SCNo32      "o"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "ho"
-#define SCNoLEAST32 "o"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "ho"
-#define SCNoFAST32  "o"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
 #define SCNu32      "u"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "hu"
-#define SCNuLEAST32 "u"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "hu"
-#define SCNuFAST32  "u"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      "x"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "hx"
-#define SCNxLEAST32 "x"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "hx"
-#define SCNxFAST32  "x"
 
 #define SCNxPTR     "x"
 

--- a/arch/z80/include/ez80/inttypes.h
+++ b/arch/z80/include/ez80/inttypes.h
@@ -50,27 +50,11 @@
 #  define PRId16      "d"
 #  define PRId32      "ld"
 
-#  define PRIdLEAST8  "d"
-#  define PRIdLEAST16 "d"
-#  define PRIdLEAST32 "ld"
-
-#  define PRIdFAST8   "d"
-#  define PRIdFAST16  "d"
-#  define PRIdFAST32  "ld"
-
 #  define PRIdPTR     "d"
 
 #  define PRIi8       "i"
 #  define PRIi16      "i"
 #  define PRIi32      "li"
-
-#  define PRIiLEAST8  "i"
-#  define PRIiLEAST16 "i"
-#  define PRIiLEAST32 "li"
-
-#  define PRIiFAST8   "i"
-#  define PRIiFAST16  "i"
-#  define PRIiFAST32  "li"
 
 #  define PRIiPTR     "i"
 
@@ -78,27 +62,11 @@
 #  define PRIo16      "o"
 #  define PRIo32      "lo"
 
-#  define PRIoLEAST8  "o"
-#  define PRIoLEAST16 "o"
-#  define PRIoLEAST32 "lo"
-
-#  define PRIoFAST8   "o"
-#  define PRIoFAST16  "o"
-#  define PRIoFAST32  "lo"
-
 #  define PRIoPTR     "o"
 
 #  define PRIu8       "u"
 #  define PRIu16      "u"
 #  define PRIu32      "lu"
-
-#  define PRIuLEAST8  "u"
-#  define PRIuLEAST16 "u"
-#  define PRIuLEAST32 "lu"
-
-#  define PRIuFAST8   "u"
-#  define PRIuFAST16  "u"
-#  define PRIuFAST32  "lu"
 
 #  define PRIuPTR     "u"
 
@@ -106,27 +74,11 @@
 #  define PRIx16      "x"
 #  define PRIx32      "lx"
 
-#  define PRIxLEAST8  "x"
-#  define PRIxLEAST16 "x"
-#  define PRIxLEAST32 "lx"
-
-#  define PRIxFAST8   "x"
-#  define PRIxFAST16  "x"
-#  define PRIxFAST32  "lx"
-
 #  define PRIxPTR     "x"
 
 #  define PRIX8       "X"
 #  define PRIX16      "X"
 #  define PRIX32      "lX"
-
-#  define PRIXLEAST8  "X"
-#  define PRIXLEAST16 "X"
-#  define PRIXLEAST32 "lX"
-
-#  define PRIXFAST8   "X"
-#  define PRIXFAST16  "X"
-#  define PRIXFAST32  "lX"
 
 #  define PRIXPTR     "X"
 
@@ -134,27 +86,11 @@
 #  define SCNd16      "hd"
 #  define SCNd32      "ld"
 
-#  define SCNdLEAST8  "hhd"
-#  define SCNdLEAST16 "hd"
-#  define SCNdLEAST32 "ld"
-
-#  define SCNdFAST8   "hhd"
-#  define SCNdFAST16  "hd"
-#  define SCNdFAST32  "ld"
-
 #  define SCNdPTR     "hd"
 
 #  define SCNi8       "hhi"
 #  define SCNi16      "hi"
 #  define SCNi32      "li"
-
-#  define SCNiLEAST8  "hhi"
-#  define SCNiLEAST16 "hi"
-#  define SCNiLEAST32 "li"
-
-#  define SCNiFAST8   "hhi"
-#  define SCNiFAST16  "hi"
-#  define SCNiFAST32  "li"
 
 #  define SCNiPTR     "hi"
 
@@ -162,41 +98,17 @@
 #  define SCNo16      "ho"
 #  define SCNo32      "lo"
 
-#  define SCNoLEAST8  "hho"
-#  define SCNoLEAST16 "ho"
-#  define SCNoLEAST32 "lo"
-
-#  define SCNoFAST8   "hho"
-#  define SCNoFAST16  "ho"
-#  define SCNoFAST32  "lo"
-
 #  define SCNoPTR     "ho"
 
 #  define SCNu8       "hhu"
 #  define SCNu16      "hu"
 #  define SCNu32      "lu"
 
-#  define SCNuLEAST8  "hhu"
-#  define SCNuLEAST16 "hu"
-#  define SCNuLEAST32 "lu"
-
-#  define SCNuFAST8   "hhu"
-#  define SCNuFAST16  "hu"
-#  define SCNuFAST32  "lu"
-
 #  define SCNuPTR     "hu"
 
 #  define SCNx8       "hhx"
 #  define SCNx16      "hx"
 #  define SCNx32      "lx"
-
-#  define SCNxLEAST8  "hhx"
-#  define SCNxLEAST16 "hx"
-#  define SCNxLEAST32 "lx"
-
-#  define SCNxFAST8   "hhx"
-#  define SCNxFAST16  "hx"
-#  define SCNxFAST32  "lx"
 
 #  define SCNxPTR     "hx"
 
@@ -214,27 +126,11 @@
 #  define PRId16      "d"
 #  define PRId32      "ld"
 
-#  define PRIdLEAST8  "d"
-#  define PRIdLEAST16 "d"
-#  define PRIdLEAST32 "ld"
-
-#  define PRIdFAST8   "d"
-#  define PRIdFAST16  "d"
-#  define PRIdFAST32  "ld"
-
 #  define PRIdPTR     "d"
 
 #  define PRIi8       "i"
 #  define PRIi16      "i"
 #  define PRIi32      "li"
-
-#  define PRIiLEAST8  "i"
-#  define PRIiLEAST16 "i"
-#  define PRIiLEAST32 "li"
-
-#  define PRIiFAST8   "i"
-#  define PRIiFAST16  "i"
-#  define PRIiFAST32  "li"
 
 #  define PRIiPTR     "i"
 
@@ -242,27 +138,11 @@
 #  define PRIo16      "o"
 #  define PRIo32      "lo"
 
-#  define PRIoLEAST8  "o"
-#  define PRIoLEAST16 "o"
-#  define PRIoLEAST32 "lo"
-
-#  define PRIoFAST8   "o"
-#  define PRIoFAST16  "o"
-#  define PRIoFAST32  "lo"
-
 #  define PRIoPTR     "o"
 
 #  define PRIu8       "u"
 #  define PRIu16      "u"
 #  define PRIu32      "lu"
-
-#  define PRIuLEAST8  "u"
-#  define PRIuLEAST16 "u"
-#  define PRIuLEAST32 "lu"
-
-#  define PRIuFAST8   "u"
-#  define PRIuFAST16  "u"
-#  define PRIuFAST32  "lu"
 
 #  define PRIuPTR     "u"
 
@@ -270,27 +150,11 @@
 #  define PRIx16      "x"
 #  define PRIx32      "lx"
 
-#  define PRIxLEAST8  "x"
-#  define PRIxLEAST16 "x"
-#  define PRIxLEAST32 "lx"
-
-#  define PRIxFAST8   "x"
-#  define PRIxFAST16  "x"
-#  define PRIxFAST32  "lx"
-
 #  define PRIxPTR     "x"
 
 #  define PRIX8       "X"
 #  define PRIX16      "X"
 #  define PRIX32      "lX"
-
-#  define PRIXLEAST8  "X"
-#  define PRIXLEAST16 "X"
-#  define PRIXLEAST32 "lX"
-
-#  define PRIXFAST8   "X"
-#  define PRIXFAST16  "X"
-#  define PRIXFAST32  "lX"
 
 #  define PRIXPTR     "X"
 
@@ -298,27 +162,11 @@
 #  define SCNd16      "hd"
 #  define SCNd32      "ld"
 
-#  define SCNdLEAST8  "hhd"
-#  define SCNdLEAST16 "hd"
-#  define SCNdLEAST32 "ld"
-
-#  define SCNdFAST8   "hhd"
-#  define SCNdFAST16  "hd"
-#  define SCNdFAST32  "ld"
-
 #  define SCNdPTR     "d"
 
 #  define SCNi8       "hhi"
 #  define SCNi16      "hi"
 #  define SCNi32      "li"
-
-#  define SCNiLEAST8  "hhi"
-#  define SCNiLEAST16 "hi"
-#  define SCNiLEAST32 "li"
-
-#  define SCNiFAST8   "hhi"
-#  define SCNiFAST16  "hi"
-#  define SCNiFAST32  "li"
 
 #  define SCNiPTR     "i"
 
@@ -326,41 +174,17 @@
 #  define SCNo16      "ho"
 #  define SCNo32      "lo"
 
-#  define SCNoLEAST8  "hho"
-#  define SCNoLEAST16 "ho"
-#  define SCNoLEAST32 "lo"
-
-#  define SCNoFAST8   "hho"
-#  define SCNoFAST16  "ho"
-#  define SCNoFAST32  "lo"
-
 #  define SCNoPTR     "o"
 
 #  define SCNu8       "hhu"
 #  define SCNu16      "hu"
 #  define SCNu32      "lu"
 
-#  define SCNuLEAST8  "hhu"
-#  define SCNuLEAST16 "hu"
-#  define SCNuLEAST32 "lu"
-
-#  define SCNuFAST8   "hhu"
-#  define SCNuFAST16  "hu"
-#  define SCNuFAST32  "lu"
-
 #  define SCNuPTR     "u"
 
 #  define SCNx8       "hhx"
 #  define SCNx16      "hx"
 #  define SCNx32      "lx"
-
-#  define SCNxLEAST8  "hhx"
-#  define SCNxLEAST16 "hx"
-#  define SCNxLEAST32 "lx"
-
-#  define SCNxFAST8   "hhx"
-#  define SCNxFAST16  "hx"
-#  define SCNxFAST32  "lx"
 
 #  define SCNxPTR     "x"
 

--- a/arch/z80/include/z180/inttypes.h
+++ b/arch/z80/include/z180/inttypes.h
@@ -48,27 +48,11 @@
 #define PRId16      "d"
 #define PRId32      "ld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "ld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "ld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "li"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "li"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "li"
 
 #define PRIiPTR     "i"
 
@@ -76,27 +60,11 @@
 #define PRIo16      "o"
 #define PRIo32      "lo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "lo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "lo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "lu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "lu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "lu"
 
 #define PRIuPTR     "u"
 
@@ -104,27 +72,11 @@
 #define PRIx16      "x"
 #define PRIx32      "lx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "lx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "lx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "lX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "lX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "lX"
 
 #define PRIXPTR     "X"
 
@@ -132,27 +84,11 @@
 #define SCNd16      "d"
 #define SCNd32      "ld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "d"
-#define SCNdLEAST32 "ld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "d"
-#define SCNdFAST32  "ld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "i"
 #define SCNi32      "li"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "i"
-#define SCNiLEAST32 "li"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "i"
-#define SCNiFAST32  "li"
 
 #define SCNiPTR     "i"
 
@@ -160,41 +96,17 @@
 #define SCNo16      "o"
 #define SCNo32      "lo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "o"
-#define SCNoLEAST32 "lo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "o"
-#define SCNoFAST32  "lo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "u"
 #define SCNu32      "lu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "u"
-#define SCNuLEAST32 "lu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "u"
-#define SCNuFAST32  "lu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "x"
 #define SCNx32      "lx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "x"
-#define SCNxLEAST32 "lx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "x"
-#define SCNxFAST32  "lx"
 
 #define SCNxPTR     "x"
 

--- a/arch/z80/include/z8/inttypes.h
+++ b/arch/z80/include/z8/inttypes.h
@@ -48,27 +48,11 @@
 #define PRId16      "d"
 #define PRId32      "ld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "ld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "ld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "li"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "li"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "li"
 
 #define PRIiPTR     "i"
 
@@ -76,27 +60,11 @@
 #define PRIo16      "o"
 #define PRIo32      "lo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "lo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "lo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "lu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "lu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "lu"
 
 #define PRIuPTR     "u"
 
@@ -104,27 +72,11 @@
 #define PRIx16      "x"
 #define PRIx32      "lx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "lx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "lx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "lX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "lX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "lX"
 
 #define PRIXPTR     "X"
 
@@ -132,27 +84,11 @@
 #define SCNd16      "d"
 #define SCNd32      "ld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "d"
-#define SCNdLEAST32 "ld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "d"
-#define SCNdFAST32  "ld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "i"
 #define SCNi32      "li"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "i"
-#define SCNiLEAST32 "li"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "i"
-#define SCNiFAST32  "li"
 
 #define SCNiPTR     "i"
 
@@ -160,41 +96,17 @@
 #define SCNo16      "o"
 #define SCNo32      "lo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "o"
-#define SCNoLEAST32 "lo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "o"
-#define SCNoFAST32  "lo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "u"
 #define SCNu32      "lu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "u"
-#define SCNuLEAST32 "lu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "u"
-#define SCNuFAST32  "lu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "x"
 #define SCNx32      "lx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "x"
-#define SCNxLEAST32 "lx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "x"
-#define SCNxFAST32  "lx"
 
 #define SCNxPTR     "x"
 

--- a/arch/z80/include/z80/inttypes.h
+++ b/arch/z80/include/z80/inttypes.h
@@ -48,27 +48,11 @@
 #define PRId16      "d"
 #define PRId32      "ld"
 
-#define PRIdLEAST8  "d"
-#define PRIdLEAST16 "d"
-#define PRIdLEAST32 "ld"
-
-#define PRIdFAST8   "d"
-#define PRIdFAST16  "d"
-#define PRIdFAST32  "ld"
-
 #define PRIdPTR     "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "li"
-
-#define PRIiLEAST8  "i"
-#define PRIiLEAST16 "i"
-#define PRIiLEAST32 "li"
-
-#define PRIiFAST8   "i"
-#define PRIiFAST16  "i"
-#define PRIiFAST32  "li"
 
 #define PRIiPTR     "i"
 
@@ -76,27 +60,11 @@
 #define PRIo16      "o"
 #define PRIo32      "lo"
 
-#define PRIoLEAST8  "o"
-#define PRIoLEAST16 "o"
-#define PRIoLEAST32 "lo"
-
-#define PRIoFAST8   "o"
-#define PRIoFAST16  "o"
-#define PRIoFAST32  "lo"
-
 #define PRIoPTR     "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "lu"
-
-#define PRIuLEAST8  "u"
-#define PRIuLEAST16 "u"
-#define PRIuLEAST32 "lu"
-
-#define PRIuFAST8   "u"
-#define PRIuFAST16  "u"
-#define PRIuFAST32  "lu"
 
 #define PRIuPTR     "u"
 
@@ -104,27 +72,11 @@
 #define PRIx16      "x"
 #define PRIx32      "lx"
 
-#define PRIxLEAST8  "x"
-#define PRIxLEAST16 "x"
-#define PRIxLEAST32 "lx"
-
-#define PRIxFAST8   "x"
-#define PRIxFAST16  "x"
-#define PRIxFAST32  "lx"
-
 #define PRIxPTR     "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "lX"
-
-#define PRIXLEAST8  "X"
-#define PRIXLEAST16 "X"
-#define PRIXLEAST32 "lX"
-
-#define PRIXFAST8   "X"
-#define PRIXFAST16  "X"
-#define PRIXFAST32  "lX"
 
 #define PRIXPTR     "X"
 
@@ -132,27 +84,11 @@
 #define SCNd16      "d"
 #define SCNd32      "ld"
 
-#define SCNdLEAST8  "hhd"
-#define SCNdLEAST16 "d"
-#define SCNdLEAST32 "ld"
-
-#define SCNdFAST8   "hhd"
-#define SCNdFAST16  "d"
-#define SCNdFAST32  "ld"
-
 #define SCNdPTR     "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "i"
 #define SCNi32      "li"
-
-#define SCNiLEAST8  "hhi"
-#define SCNiLEAST16 "i"
-#define SCNiLEAST32 "li"
-
-#define SCNiFAST8   "hhi"
-#define SCNiFAST16  "i"
-#define SCNiFAST32  "li"
 
 #define SCNiPTR     "i"
 
@@ -160,41 +96,17 @@
 #define SCNo16      "o"
 #define SCNo32      "lo"
 
-#define SCNoLEAST8  "hho"
-#define SCNoLEAST16 "o"
-#define SCNoLEAST32 "lo"
-
-#define SCNoFAST8   "hho"
-#define SCNoFAST16  "o"
-#define SCNoFAST32  "lo"
-
 #define SCNoPTR     "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "u"
 #define SCNu32      "lu"
 
-#define SCNuLEAST8  "hhu"
-#define SCNuLEAST16 "u"
-#define SCNuLEAST32 "lu"
-
-#define SCNuFAST8   "hhu"
-#define SCNuFAST16  "u"
-#define SCNuFAST32  "lu"
-
 #define SCNuPTR     "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "x"
 #define SCNx32      "lx"
-
-#define SCNxLEAST8  "hhx"
-#define SCNxLEAST16 "x"
-#define SCNxLEAST32 "lx"
-
-#define SCNxFAST8   "hhx"
-#define SCNxFAST16  "x"
-#define SCNxFAST32  "lx"
 
 #define SCNxPTR     "x"
 

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -60,12 +60,13 @@
  *  modifier, suitable for use within the format argument of a formatted
  *  input/output function when converting the corresponding integer type.
  *  These macros have the general form of PRI (character string literals for
- *  the fprintf() and fwprintf() family of functions) or SCN (character string
- *  literals for the fscanf() and fwscanf() family of functions), followed by
- *  the conversion specifier, followed by a name corresponding to a similar
- *  type name in <stdint.h>. In these names, N represents the width of the
- *  type as described in <stdint.h>. For example, PRIdFAST32 can be used in a
- *  format string to print the value of an integer of type int_fast32_t.
+ *  the fprintf() and fwprintf() family of functions) or SCN (character
+ *  string literals for the fscanf() and fwscanf() family of functions),
+ *  followed by the conversion specifier, followed by a name corresponding
+ *  to a similar type name in <stdint.h>. In these names, N represents the
+ *  width of the type as described in <stdint.h>. For example, PRIdFAST32
+ *  can be used in a format string to print the value of an integer of type
+ *  int_fast32_t.
  *
  * "The fprintf() macros for signed integers are:
  *

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -147,6 +147,164 @@
  * implementation does not have a suitable modifier for the type.
  */
 
+/* On NuttX, least and fast types are aliases of the exact type.
+ * (See stdint.h)
+ */
+
+#define PRIdLEAST8  PRId8
+#define PRIdLEAST16 PRId16
+#define PRIdLEAST32 PRId32
+#if defined(PRId64)
+#define PRIdLEAST64 PRId64
+#endif
+
+#define PRIdFAST8   PRId8
+#define PRIdFAST16  PRId16
+#define PRIdFAST32  PRId32
+#if defined(PRId64)
+#define PRIdFAST64  PRId64
+#endif
+
+#define PRIiLEAST8  PRIi8
+#define PRIiLEAST16 PRIi16
+#define PRIiLEAST32 PRIi32
+#if defined(PRIi64)
+#define PRIiLEAST64 PRIi64
+#endif
+
+#define PRIiFAST8   PRIi8
+#define PRIiFAST16  PRIi16
+#define PRIiFAST32  PRIi32
+#if defined(PRIi64)
+#define PRIiFAST64  PRIi64
+#endif
+
+#define PRIoLEAST8  PRIo8
+#define PRIoLEAST16 PRIo16
+#define PRIoLEAST32 PRIo32
+#if defined(PRIo64)
+#define PRIoLEAST64 PRIo64
+#endif
+
+#define PRIoFAST8   PRIo8
+#define PRIoFAST16  PRIo16
+#define PRIoFAST32  PRIo32
+#if defined(PRIo64)
+#define PRIoFAST64  PRIo64
+#endif
+
+#define PRIuLEAST8  PRIu8
+#define PRIuLEAST16 PRIu16
+#define PRIuLEAST32 PRIu32
+#if defined(PRIu64)
+#define PRIuLEAST64 PRIu64
+#endif
+
+#define PRIuFAST8   PRIu8
+#define PRIuFAST16  PRIu16
+#define PRIuFAST32  PRIu32
+#if defined(PRIu64)
+#define PRIuFAST64  PRIu64
+#endif
+
+#define PRIxLEAST8  PRIx8
+#define PRIxLEAST16 PRIx16
+#define PRIxLEAST32 PRIx32
+#if defined(PRIx64)
+#define PRIxLEAST64 PRIx64
+#endif
+
+#define PRIxFAST8   PRIx8
+#define PRIxFAST16  PRIx16
+#define PRIxFAST32  PRIx32
+#if defined(PRIx64)
+#define PRIxFAST64  PRIx64
+#endif
+
+#define PRIXLEAST8  PRIX8
+#define PRIXLEAST16 PRIX16
+#define PRIXLEAST32 PRIX32
+#if defined(PRIX64)
+#define PRIXLEAST64 PRIX64
+#endif
+
+#define PRIXFAST8   PRIX8
+#define PRIXFAST16  PRIX16
+#define PRIXFAST32  PRIX32
+#if defined(PRIX64)
+#define PRIXFAST64  PRIX64
+#endif
+
+#define SCNdLEAST8  SCNd8
+#define SCNdLEAST16 SCNd16
+#define SCNdLEAST32 SCNd32
+#if defined(SCNd64)
+#define SCNdLEAST64 SCNd64
+#endif
+
+#define SCNdFAST8   SCNd8
+#define SCNdFAST16  SCNd16
+#define SCNdFAST32  SCNd32
+#if defined(SCNd64)
+#define SCNdFAST64  SCNd64
+#endif
+
+#define SCNiLEAST8  SCNi8
+#define SCNiLEAST16 SCNi16
+#define SCNiLEAST32 SCNi32
+#if defined(SCNi64)
+#define SCNiLEAST64 SCNi64
+#endif
+
+#define SCNiFAST8   SCNi8
+#define SCNiFAST16  SCNi16
+#define SCNiFAST32  SCNi32
+#if defined(SCNi64)
+#define SCNiFAST64  SCNi64
+#endif
+
+#define SCNoLEAST8  SCNo8
+#define SCNoLEAST16 SCNo16
+#define SCNoLEAST32 SCNo32
+#if defined(SCNo64)
+#define SCNoLEAST64 SCNo64
+#endif
+
+#define SCNoFAST8   SCNo8
+#define SCNoFAST16  SCNo16
+#define SCNoFAST32  SCNo32
+#if defined(SCNo64)
+#define SCNoFAST64  SCNo64
+#endif
+
+#define SCNuLEAST8  SCNu8
+#define SCNuLEAST16 SCNu16
+#define SCNuLEAST32 SCNu32
+#if defined(SCNu64)
+#define SCNuLEAST64 SCNu64
+#endif
+
+#define SCNuFAST8   SCNu8
+#define SCNuFAST16  SCNu16
+#define SCNuFAST32  SCNu32
+#if defined(SCNu64)
+#define SCNuFAST64  SCNu64
+#endif
+
+#define SCNxLEAST8  SCNx8
+#define SCNxLEAST16 SCNx16
+#define SCNxLEAST32 SCNx32
+#if defined(SCNx64)
+#define SCNxLEAST64 SCNx64
+#endif
+
+#define SCNxFAST8   SCNx8
+#define SCNxFAST16  SCNx16
+#define SCNxFAST32  SCNx32
+#if defined(SCNx64)
+#define SCNxFAST64  SCNx64
+#endif
+
 /****************************************************************************
  * Type Definitions
  ****************************************************************************/


### PR DESCRIPTION
## Summary
Move PRI/SCN macros for fast and least types to include/inttypes.h

## Impact
mostly mechanical

## Testing
sim/macOS locally
the CI will build-test others

