### PR TITLE
sched/sched/sched_waitid.c: Allow WNOHANG

### DIFF
--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -127,7 +127,12 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
    * distinguish any other events.
    */
 
-  if (options != WEXITED)
+  if ((options & WEXITED) == 0)
+    {
+      return -ENOSYS;
+    }
+
+  if ((options & ~(WEXITED | WNOHANG)) != 0)
     {
       return -ENOSYS;
     }


### PR DESCRIPTION
## Summary

Allow WNOHANG.
In the current implementation of waitid, WEXITED is mandatory and WNOHANG is optional.

## Impact

waitid

## Testing

Built with hifive1-revb:nsh (CONFIG_DEBUG_FEATURES=y, CONFIG_SCHED_HAVE_PARENT=y)
