### PR TITLE
boards/sim/sim/sim/src/sim_touchscreen.c: add missing nx_disconnect

### DIFF
--- a/boards/sim/sim/sim/src/sim_touchscreen.c
+++ b/boards/sim/sim/sim/src/sim_touchscreen.c
@@ -205,9 +205,11 @@ int sim_tsc_setup(int minor)
       pthread_attr_setstacksize(&attr, CONFIG_SIM_LISTENER_STACKSIZE);
 
       ret = pthread_create(&thread, &attr, sim_listener, NULL);
+      pthread_attr_destroy(&attr);
       if (ret != 0)
         {
           gerr("ERROR: pthread_create failed: %d\n", ret);
+          nx_disconnect(g_simtc.hnx);
           return -ret;
         }
 


### PR DESCRIPTION
## Summary
Adds one missing nx_disconnect() on error return path and one pthread_attr_destroy() (Latter not really needed on NuttX, but good style to include for portability and in case attribute object's representation ever changes)
## Impact

## Testing

