### PR TITLE
tiva/cc13x2_cc26x2: Merge related comments

### DIFF
--- a/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_flash.h
+++ b/arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_flash.h
@@ -729,21 +729,15 @@
 #define FLASH_FTCTL_TEST_EN                  (1 << 1)  /* Bit 1 */
 #define FLASH_FTCTL_WDATA_BLK_CLR            (1 << 16) /* Bit 16 */
 
-/* TIVA_FLASH_FWPWRITE0 (32-bit value) */
-
-/* TIVA_FLASH_FWPWRITE1 (32-bit value) */
-
-/* TIVA_FLASH_FWPWRITE2 (32-bit value) */
-
-/* TIVA_FLASH_FWPWRITE3 (32-bit value) */
-
-/* TIVA_FLASH_FWPWRITE4 (32-bit value) */
-
-/* TIVA_FLASH_FWPWRITE5 (32-bit value) */
-
-/* TIVA_FLASH_FWPWRITE6 (32-bit value) */
-
-/* TIVA_FLASH_FWPWRITE7 (32-bit value) */
+/* TIVA_FLASH_FWPWRITE0 (32-bit value)
+ * TIVA_FLASH_FWPWRITE1 (32-bit value)
+ * TIVA_FLASH_FWPWRITE2 (32-bit value)
+ * TIVA_FLASH_FWPWRITE3 (32-bit value)
+ * TIVA_FLASH_FWPWRITE4 (32-bit value)
+ * TIVA_FLASH_FWPWRITE5 (32-bit value)
+ * TIVA_FLASH_FWPWRITE6 (32-bit value)
+ * TIVA_FLASH_FWPWRITE7 (32-bit value)
+ */
 
 /* TIVA_FLASH_FWPWRITE_ECC */
 
@@ -1001,17 +995,17 @@
 #define FLASH_FSM_EXECUTE_SUSPEND_NOW_SHIFT  (16)      /* Bits 16-19 */
 #define FLASH_FSM_EXECUTE_SUSPEND_NOW_MASK   (15 << FLASH_FSM_EXECUTE_SUSPEND_NOW_SHIFT)
 
-/* TIVA_FLASH_FSM_SECTOR1 (32-bit value) */
+/* TIVA_FLASH_FSM_SECTOR1 (32-bit value)
+ * TIVA_FLASH_FSM_SECTOR2 (32-bit value)
+ */
 
-/* TIVA_FLASH_FSM_SECTOR2 (32-bit value) */
+/* TIVA_FLASH_FSM_BSLE0 (32-bit value)
+ * TIVA_FLASH_FSM_BSLE1 (32-bit value)
+ */
 
-/* TIVA_FLASH_FSM_BSLE0 (32-bit value) */
-
-/* TIVA_FLASH_FSM_BSLE1 (32-bit value) */
-
-/* TIVA_FLASH_FSM_BSLP0 (32-bit value) */
-
-/* TIVA_FLASH_FSM_BSLP1 (32-bit value) */
+/* TIVA_FLASH_FSM_BSLP0 (32-bit value)
+ * TIVA_FLASH_FSM_BSLP1 (32-bit value)
+ */
 
 /* TIVA_FLASH_FSM_PGM128 */
 


### PR DESCRIPTION
## Summary

In arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_flash.h, merge comments when they are section separators for similar/related registers:

- TIVA_FLASH_FWPWRITE*
- TIVA_FLASH_FSM_SECTOR1*
- TIVA_FLASH_FSM_BSLE*
- TIVA_FLASH_FSM_BSLP*

Per feedback from @btashton in [PR-2244](https://github.com/apache/incubator-nuttx/pull/2244)

## Impact

Makes the intent of the comments more clear.

## Testing

nxstyle