### PR TITLE
pthread/spinlock: move the structure prototype out of the definition

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -416,7 +416,6 @@ typedef int pthread_rwlockattr_t;
                                      0, 0, false}
 
 #ifdef CONFIG_PTHREAD_SPINLOCKS
-#ifndef __PTHREAD_SPINLOCK_T_DEFINED
 /* This (non-standard) structure represents a pthread spinlock */
 
 struct pthread_spinlock_s
@@ -426,7 +425,7 @@ struct pthread_spinlock_s
                                  * SP_UNLOCKED. */
   pthread_t sp_holder;          /* ID of the thread that holds the spinlock */
 };
-
+#ifndef __PTHREAD_SPINLOCK_T_DEFINED
 /* It is referenced via this standard type */
 
 typedef FAR struct pthread_spinlock_s pthread_spinlock_t;


### PR DESCRIPTION
## Summary

pthread/spinlock: move the structure prototype out of the definition


## Impact

pthread/pthread_spinlock.c: In function ‘pthread_spin_init’:
pthread/pthread_spinlock.c:114:11: error: dereferencing pointer to incomplete type ‘pthread_spinlock_t’ {aka ‘struct pthread_spinlock_s’}
  114 |       lock->sp_lock   = SP_UNLOCKED;
      |           ^~

Change-Id: I49dbb2682e36a17bb25a647c6468b7fb511e4a76
Signed-off-by: chao.an <anchao@xiaomi.com>

## Testing

Compile pass
