### PR TITLE
syscall/eventfd: correct the syscall prototype of eventfd(2) 

### DIFF
--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -19,7 +19,7 @@
 "connect","sys/socket.h","defined(CONFIG_NET)","int","int","FAR const struct sockaddr *","socklen_t"
 "dup","unistd.h","","int","int"
 "dup2","unistd.h","","int","int","int"
-"eventfd","sys/eventfd.h","defined(CONFIG_EVENT_FD)","unsigned int","int"
+"eventfd","sys/eventfd.h","defined(CONFIG_EVENT_FD)","int","unsigned int","int"
 "exec","nuttx/binfmt/binfmt.h","!defined(CONFIG_BINFMT_DISABLE) && !defined(CONFIG_BUILD_KERNEL)","int","FAR const char *","FAR char * const *","FAR const struct symtab_s *","int"
 "execv","unistd.h","!defined(CONFIG_BINFMT_DISABLE) && defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char * const []|FAR char * const *"
 "exit","stdlib.h","","void","int"


### PR DESCRIPTION

## Summary

syscall/eventfd: correct the syscall prototype of eventfd(2) 

## Impact

proxies/PROXY_eventfd.c:12:14: error: conflicting types for 'eventfd'
   12 | unsigned int eventfd(int parm1)
      |              ^~~~~~~
In file included from proxies/PROXY_eventfd.c:7:
nuttx/include/sys/eventfd.h:63:5: note: previous declaration of 'eventfd' was here
   63 | int eventfd(unsigned int count, int flags);
      |     ^~~~~~~

Change-Id: I7ed0b8b442eac72592dea0e5754a36fb60ca5f8d
Signed-off-by: chao.an <anchao@xiaomi.com>


## Testing

Protect build compile pass