### PR TITLE
net/callback: remove the assert check of conn instance 

### DIFF
--- a/net/bluetooth/bluetooth_sendto.c
+++ b/net/bluetooth/bluetooth_sendto.c
@@ -93,7 +93,7 @@ static uint16_t bluetooth_sendto_eventhandler(FAR struct net_driver_s *dev,
   int hdrlen;
   int ret;
 
-  DEBUGASSERT(pvpriv != NULL && dev != NULL && pvconn != NULL);
+  DEBUGASSERT(pvpriv != NULL && dev != NULL);
 
   /* Ignore polls from non Bluetooth network drivers */
 

--- a/net/ieee802154/ieee802154_sendto.c
+++ b/net/ieee802154/ieee802154_sendto.c
@@ -282,7 +282,7 @@ static uint16_t ieee802154_sendto_eventhandler(FAR struct net_driver_s *dev,
   int hdrlen;
   int ret;
 
-  DEBUGASSERT(pvpriv != NULL && dev != NULL && pvconn != NULL);
+  DEBUGASSERT(pvpriv != NULL && dev != NULL);
 
   /* Ignore polls from non IEEE 802.15.4 network drivers */
 

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -312,6 +312,15 @@ static uint16_t tcp_send_eventhandler(FAR struct net_driver_s *dev,
       return flags;
     }
 
+  /* Check if the IEEE802.15.4 network driver went down */
+
+  if ((flags & NETDEV_DOWN) != 0)
+    {
+      nwarn("WARNING: Device is down\n");
+      sinfo->s_result = -ENOTCONN;
+      goto end_wait;
+    }
+
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the one that we are bound to.
    */
@@ -321,15 +330,6 @@ static uint16_t tcp_send_eventhandler(FAR struct net_driver_s *dev,
     {
       ninfo("Not the connected device\n");
       return flags;
-    }
-
-  /* Check if the IEEE802.15.4 network driver went down */
-
-  if ((flags & NETDEV_DOWN) != 0)
-    {
-      nwarn("WARNING: Device is down\n");
-      sinfo->s_result = -ENOTCONN;
-      goto end_wait;
     }
 
   ninfo("flags: %04x acked: %u sent: %u\n",

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -81,9 +81,9 @@ static uint16_t tcp_close_eventhandler(FAR struct net_driver_s *dev,
   FAR struct tcp_close_s *pstate = (FAR struct tcp_close_s *)pvpriv;
   FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
 
-  DEBUGASSERT(pstate != NULL && conn != NULL);
+  DEBUGASSERT(pstate != NULL);
 
-  ninfo("conn: %p flags: %04x\n", conn, flags);
+  ninfo("flags: %04x\n", flags);
 
   /* TCP_DISCONN_EVENTS:
    *   TCP_CLOSE:    The remote host has closed the connection

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -327,6 +327,30 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
   FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
   FAR struct socket *psock = (FAR struct socket *)pvpriv;
 
+  /* Check for a loss of connection */
+
+  if ((flags & TCP_DISCONN_EVENTS) != 0)
+    {
+      ninfo("Lost connection: %04x\n", flags);
+
+      /* We could get here recursively through the callback actions of
+       * tcp_lost_connection().  So don't repeat that action if we have
+       * already been disconnected.
+       */
+
+      if (psock->s_conn != NULL && _SS_ISCONNECTED(psock->s_flags))
+        {
+          /* Report not connected */
+
+          tcp_lost_connection(psock, psock->s_sndcb, flags);
+        }
+
+      /* Free write buffers and terminate polling */
+
+      psock_lost_connection(psock, psock->s_conn, !!(flags & NETDEV_DOWN));
+      return flags;
+    }
+
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the one that we are bound to.
    */
@@ -492,30 +516,6 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           ninfo("ACK: wrb=%p seqno=%u pktlen=%u sent=%u\n",
                 wrb, TCP_WBSEQNO(wrb), TCP_WBPKTLEN(wrb), TCP_WBSENT(wrb));
         }
-    }
-
-  /* Check for a loss of connection */
-
-  else if ((flags & TCP_DISCONN_EVENTS) != 0)
-    {
-      ninfo("Lost connection: %04x\n", flags);
-
-      /* We could get here recursively through the callback actions of
-       * tcp_lost_connection().  So don't repeat that action if we have
-       * already been disconnected.
-       */
-
-      if (psock->s_conn != NULL && _SS_ISCONNECTED(psock->s_flags))
-        {
-          /* Report not connected */
-
-          tcp_lost_connection(psock, psock->s_sndcb, flags);
-        }
-
-      /* Free write buffers and terminate polling */
-
-      psock_lost_connection(psock, conn, !!(flags & NETDEV_DOWN));
-      return flags;
     }
 
   /* Check if we are being asked to retransmit data */

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -236,19 +236,6 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
   FAR struct sendfile_s *pstate = (FAR struct sendfile_s *)pvpriv;
   int ret;
 
-  /* The TCP socket is connected and, hence, should be bound to a device.
-   * Make sure that the polling device is the own that we are bound to.
-   */
-
-  DEBUGASSERT(conn->dev != NULL);
-  if (dev != conn->dev)
-    {
-      return flags;
-    }
-
-  ninfo("flags: %04x acked: %d sent: %d\n",
-        flags, pstate->snd_acked, pstate->snd_sent);
-
   /* Check for a loss of connection */
 
   if ((flags & TCP_DISCONN_EVENTS) != 0)
@@ -275,6 +262,20 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
       pstate->snd_sent = -ENOTCONN;
       goto end_wait;
     }
+
+  /* The TCP socket is connected and, hence, should be bound to a device.
+   * Make sure that the polling device is the own that we are bound to.
+   */
+
+  DEBUGASSERT(conn);
+  DEBUGASSERT(conn->dev != NULL);
+  if (dev != conn->dev)
+    {
+      return flags;
+    }
+
+  ninfo("flags: %04x acked: %d sent: %d\n",
+        flags, pstate->snd_acked, pstate->snd_sent);
 
   /* We get here if (1) not all of the data has been ACKed, (2) we have been
    * asked to retransmit data, (3) the connection is still healthy, and (4)

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -500,8 +500,8 @@ static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
-                         size_t len, int flags, FAR const struct sockaddr *to,
-                         socklen_t tolen)
+                         size_t len, int flags,
+                         FAR const struct sockaddr *to, socklen_t tolen)
 {
   FAR struct udp_conn_s *conn;
   FAR struct udp_wrbuffer_s *wrb;
@@ -696,7 +696,8 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
               addr6->sin6_family = AF_INET6;
               addr6->sin6_port   = conn->rport;
-              net_ipv6addr_copy(addr6->sin6_addr.s6_addr, conn->u.ipv6.raddr);
+              net_ipv6addr_copy(addr6->sin6_addr.s6_addr,
+                                conn->u.ipv6.raddr);
             }
 #endif /* CONFIG_NET_IPv6 */
         }


### PR DESCRIPTION
## Summary

net/callback: remove the assert check of conn instance 

## Impact

remove the connection assertion since the instance will be invalid
if the network device has been taken down.

net/netdev/netdev_ioctl.c:

1847 void netdev_ifdown(FAR struct net_driver_s *dev)
1848 {
...
1871       /* Notify clients that the network has been taken down */
1872
1873       devif_dev_event(dev, NULL, NETDEV_DOWN);
...
1883 }

## Testing

no assertion if the net interface get down