### PR TITLE
sys/resource: include-able from C++ files

### DIFF
--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -115,10 +115,24 @@ struct rusage
  * Public Function Prototypes
  ****************************************************************************/
 
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 int  getpriority(int which, id_t who);
 int  getrlimit(int resource, FAR struct rlimit *rlp);
 int  getrusage(int who, FAR struct rusage *r_usage);
 int  setpriority(int which, id_t who, int value);
 int  setrlimit(int resource, FAR const struct rlimit *rlp);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* __INCLUDE_SYS_RESOURCE_H */

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -63,7 +63,7 @@
 #define RUSAGE_CHILDREN 1           /* Returns information about children of
                                      * the current process */
 
-/* Possible values for the resource argument of getrlimit() and setrlimit(): */
+/* Possible values for the resource argument of getrlimit() and setrlimit() */
 
 #define RLIMIT_CORE     1           /* Limit on size of core dump file */
 #define RLIMIT_CPU      2           /* Limit on CPU time per process. */
@@ -89,8 +89,8 @@
  * Type Definitions
  ****************************************************************************/
 
-/* All resource limits are represented with this type.  It must be an unsigned
- * integral type.
+/* All resource limits are represented with this type.
+ * It must be an unsigned integral type.
  */
 
 typedef uint32_t rlim_t;


### PR DESCRIPTION
## Summary

sys/resource: include-able from C++ files

## Impact

Include from C++ source code.

## Testing

Compile pass if include from C++ code

