### PR TITLE
boards/sim: add atexit(2) into naming list 

### DIFF
--- a/arch/sim/src/nuttx-names.in
+++ b/arch/sim/src/nuttx-names.in
@@ -31,6 +31,7 @@
 #endif
 
 NXSYMBOLS(__cxa_atexit)
+NXSYMBOLS(atexit)
 NXSYMBOLS(bind)
 NXSYMBOLS(calloc)
 NXSYMBOLS(clock_gettime)


### PR DESCRIPTION
## Summary

boards/sim: add atexit(2) into naming list 

## Impact

(gdb) b longjmp
Breakpoint 1 at 0x8270
(gdb) r
Starting program: nuttx/nuttx
[    0.000000] Assertion failed at file:task/task_onexit.c line: 99

Breakpoint 1, 0xf7b905e0 in siglongjmp () from /lib/i386-linux-gnu/libc.so.6
(gdb)
(gdb) bt
|#0  0xf7b905e0 in siglongjmp () from /lib/i386-linux-gnu/libc.so.6
|#1  0xf7f9c3dc in siglongjmp_alias () from /lib/i386-linux-gnu/libpthread.so.0
|#2  0x5655d668 in up_assert (filename=0x56641018 "task/task_onexit.c", line=99) at sim/up_head.c:132
|#3  0x56567413 in _assert (filename=0x56641018 "task/task_onexit.c", linenum=99) at assert/lib_assert.c:36
|#4  0x565f8cfd in on_exit (func=0x565f8c12 <exitfunc>, arg=0x565fd780 <simuart_restoremode>) at task/task_onexit.c:99
|#5  0x565f8c89 in atexit (func=0x565fd780 <simuart_restoremode>) at task/task_atexit.c:109
|#6  0x565fd819 in simuart_start () at sim/up_simuart.c:112
|#7  0x5656c844 in up_uartinit () at sim/up_uart.c:496
|#8  0x5656ba7a in up_initialize () at sim/up_initialize.c:234
|#9  0x5655da56 in nx_start () at init/nx_start.c:701
|#10 0x5655d5e9 in main (argc=1, argv=0xffffd6f4, envp=0xffffd6fc) at sim/up_head.c:96

Change-Id: Ifd7196b2de7bf9fc7cea764c19a5c0eacf08fdb6
Signed-off-by: chao.an <anchao@xiaomi.com>

## Testing

Simulator executes normally