### PR TITLE
sched/timer: add support of CLOCK_MONOTONIC

### DIFF
--- a/sched/timer/timer.h
+++ b/sched/timer/timer.h
@@ -50,6 +50,7 @@ struct posix_timer_s
 {
   FAR struct posix_timer_s *flink;
 
+  clockid_t        pt_clock;       /* Specifies the clock to use as the timing base. */
   uint8_t          pt_flags;       /* See PT_FLAGS_* definitions */
   uint8_t          pt_crefs;       /* Reference count */
   pid_t            pt_owner;       /* Creator of timer */

--- a/sched/timer/timer_create.c
+++ b/sched/timer/timer_create.c
@@ -124,8 +124,7 @@ static FAR struct posix_timer_s *timer_allocate(void)
  *   value of the timer ID.
  *
  *   Each implementation defines a set of clocks that can be used as timing
- *   bases for per-thread timers. All implementations shall support a
- *   clock_id of CLOCK_REALTIME.
+ *   bases for per-thread timers.
  *
  * Input Parameters:
  *   clockid - Specifies the clock to use as the timing base.
@@ -157,9 +156,13 @@ int timer_create(clockid_t clockid, FAR struct sigevent *evp,
 {
   FAR struct posix_timer_s *ret;
 
-  /* Sanity checks.  Also, we support only CLOCK_REALTIME */
+  /* Sanity checks. */
 
-  if (timerid == NULL || clockid != CLOCK_REALTIME)
+  if (timerid == NULL || (clockid != CLOCK_REALTIME
+#ifdef CONFIG_CLOCK_MONOTONIC
+      && clockid != CLOCK_MONOTONIC
+#endif /* CONFIG_CLOCK_MONOTONIC */
+      ))
     {
       set_errno(EINVAL);
       return ERROR;
@@ -176,6 +179,7 @@ int timer_create(clockid_t clockid, FAR struct sigevent *evp,
 
   /* Initialize the timer instance */
 
+  ret->pt_clock = clockid;
   ret->pt_crefs = 1;
   ret->pt_owner = getpid();
   ret->pt_delay = 0;

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -285,12 +285,9 @@ int timer_settime(timer_t timerid, int flags,
 
   if ((flags & TIMER_ABSTIME) != 0)
     {
-      /* Calculate a delay corresponding to the absolute time in 'value'.
-       * NOTE:  We have internal knowledge the clock_abstime2ticks only
-       * returns an error if clockid != CLOCK_REALTIME.
-       */
+      /* Calculate a delay corresponding to the absolute time in 'value' */
 
-      clock_abstime2ticks(CLOCK_REALTIME, &value->it_value, &delay);
+      clock_abstime2ticks(timer->pt_clock, &value->it_value, &delay);
     }
   else
     {


### PR DESCRIPTION

## Summary

sched/timer: add support of CLOCK_MONOTONIC

## Impact

Reference here:
https://pubs.opengroup.org/onlinepubs/009695399/functions/timer_create.html

```
DESCRIPTION
...
  Each implementation shall define a set of clocks that can be
  used as timing bases for per-process timers. All implementations
  shall support a clock_id of CLOCK_REALTIME.

  *** If the Monotonic Clock option is supported, implementations shall
  support a clock_id of CLOCK_MONOTONIC. ***
...

```
Change-Id: Ia8e7302ed4a7e9ec11a0059bd68e9674ea942001
Signed-off-by: chao.an <anchao@xiaomi.com>

## Testing

call timer_create(2) with clock id CLOCK_MONOTONIC