### PR TITLE
sched: task: Fix nxtask_exit() for SMP

### DIFF
--- a/sched/task/task_exit.c
+++ b/sched/task/task_exit.c
@@ -102,6 +102,15 @@ int nxtask_exit(void)
 
   nxsched_remove_readytorun(dtcb);
 
+  /* If there are any pending tasks, then add them to the ready-to-run
+   * task list now
+   */
+
+  if (g_pendingtasks.head != NULL)
+    {
+      nxsched_merge_pending();
+    }
+
   /* Get the new task at the head of the ready to run list */
 
 #ifdef CONFIG_SMP
@@ -189,15 +198,6 @@ int nxtask_exit(void)
                   &g_cpu_schedlock);
     }
 #endif
-
-  /* If there are any pending tasks, then add them to the ready-to-run
-   * task list now
-   */
-
-  if (g_pendingtasks.head != NULL)
-    {
-      nxsched_merge_pending();
-    }
 
   return ret;
 }


### PR DESCRIPTION
## Summary

- I noticed that nxsched_merge_pending() is called outside a critical section
- The issue happens if a new rtcb does not hold a critical section
- Actually, global IRQ control is done in nxsched_resume_scheduler() in nxtask_exit()
- However, nxsched_merge_pending() was called after calling nxsched_resume_scheduler()
- This commit fixes the issue by moving nxsched_merge_pending() before the function
- NOTE: the sequence was changed for SMP but works for non-SMP as well

## Impact

- This commit affects both SMP and non-SMP

## Testing

- Tested with ostest with the following configurations
- spresense:wifi_smp (NCPUS=2 and 4)
- spresense:wifi (non SMP)
- sabre-6quad:smp (QEMU)
- esp32-core:smp (QEMU)
- maix-bit:smp (QEMU)
- sim:smp
- lc823450-xgevk:rndis

