### PR TITLE
boards/sim: enable run-time type identification 

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -36,7 +36,10 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
 endif
 
 ARCHCPUFLAGS = -fno-builtin
-ARCHCPUFLAGSXX = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
+ARCHCPUFLAGSXX = -fno-builtin -nostdinc++ -fcheck-new
+ifeq ($(CONFIG_CXX_EXCEPTION),)
+  ARCHCPUFLAGSXX += -fno-exceptions
+endif
 ARCHPICFLAGS = -fpic
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef


### PR DESCRIPTION
## Summary

boards/sim: enable run-time type identification 
sim: enable garbage collection of unused input sections. 

correct some cxx compilation options

## Impact

llvm libcxx compile

## Testing

enable CONFIG_LIBCXX and compile with rtti cxx source code