### PR TITLE
nRF52 SPI improvements

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -109,6 +109,14 @@ config NRF52_RTC
 	bool
 	default n
 
+config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
+	bool "SPI Master 1 Byte transfer anomaly workaround"
+	depends on NRF52_SPI_MASTER && ARCH_CHIP_NRF52832
+	default y
+	---help---
+		Enable the workaround to fix SPI Master 1 byte transfer bug
+		which occurs in NRF52832 revision 1 and revision 2.
+
 menu "NRF52 Peripheral Selection"
 
 config NRF52_I2C0_MASTER
@@ -590,14 +598,3 @@ config NRF52_SAADC_LIMITS
 endif # NRF52_SAADC
 
 endmenu # SAADC Configuration
-
-menu "SPI Configuration"
-
-config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
-	bool "Master 1 Byte transfer anomaly workaround"
-	depends on NRF52_SPI_MASTER && ARCH_CHIP_NRF52832
-	default y
-	---help---
-		Enable the workaround to fix SPI Master 1 byte transfer bug
-		which occurs in NRF52832 revision 1 and revision 2.
-endmenu

--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -109,14 +109,6 @@ config NRF52_RTC
 	bool
 	default n
 
-config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
-	bool "SPI Master 1 Byte transfer anomaly workaround"
-	depends on NRF52_SPI_MASTER && ARCH_CHIP_NRF52832
-	default y
-	---help---
-		Enable the workaround to fix SPI Master 1 byte transfer bug
-		which occurs in NRF52832 revision 1 and revision 2.
-
 menu "NRF52 Peripheral Selection"
 
 config NRF52_I2C0_MASTER
@@ -598,3 +590,14 @@ config NRF52_SAADC_LIMITS
 endif # NRF52_SAADC
 
 endmenu # SAADC Configuration
+
+menu "SPI Configuration"
+
+config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
+	bool "Master 1 Byte transfer anomaly workaround"
+	depends on NRF52_SPI_MASTER && ARCH_CHIP_NRF52832
+	default y
+	---help---
+		Enable the workaround to fix SPI Master 1 byte transfer bug
+		which occurs in NRF52832 revision 1 and revision 2.
+endmenu

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -159,3 +159,7 @@ endif
 ifeq ($(CONFIG_NRF52_SAADC),y)
 CHIP_CSRCS += nrf52_adc.c
 endif
+
+ifeq ($(CONFIG_PM),y)
+CHIP_CSRCS += nrf52_pminitialize.c
+endif

--- a/arch/arm/src/nrf52/hardware/nrf52_spi.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_spi.h
@@ -68,6 +68,7 @@
 #define NRF52_SPIM_PSELDCX_OFFSET         (0x056c) /* Pin select for DCX signal */
 #define NRF52_SPIM_DCXCNT_OFFSET          (0x0570) /* DCX configuration */
 #define NRF52_SPIM_ORC_OFFSET             (0x05c0) /* ORC */
+#define NRF52_SPIM_POWER_OFFSET           (0x0ffc) /* Hidden POWER register, for applying errata workaround */
 
 /* Register offsets for SPI slave (SPIS) ************************************/
 
@@ -153,41 +154,14 @@
 #define SPIM_ENABLE_DIS             (0)        /* Disable SPIM */
 #define SPIM_ENABLE_EN              (0x7 << 0) /* Enable SPIM */
 
-/* PSELSCK Register */
+/* PSEL* Registers */
 
-#define SPIM_PSELSCK_PIN_SHIFT      (0)       /* Bits 0-4: SCK pin number */
-#define SPIM_PSELSCK_PIN_MASK       (0x1f << SPIM_PSELSCK_PIN_SHIFT)
-#define SPIM_PSELSCK_PORT_SHIFT     (5)       /* Bit 5: SCK port number */
-#define SPIM_PSELSCK_PORT_MASK      (0x1 << SPIM_PSELSCK_PORT_SHIFT)
-#define SPIM_PSELSCK_CONNECTED      (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSELSCK_RESET          (0xffffffff)
-
-/* PSELMOSI Register */
-
-#define SPIM_PSELMOSI_PIN_SHIFT     (0)       /* Bits 0-4: MOSI pin number */
-#define SPIM_PSELMOSI_PIN_MASK      (0x1f << SPIM_PSELMOSI_PIN_SHIFT)
-#define SPIM_PSELMOSI_PORT_SHIFT    (5)       /* Bit 5: MOSI port number */
-#define SPIM_PSELMOSI_PORT_MASK     (0x1 << SPIM_PSELMOSI_PORT_SHIFT)
-#define SPIM_PSELMOSI_CONNECTED     (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSELMOSI_RESET         (0xffffffff)
-
-/* PSELMISO Register */
-
-#define SPIM_PSELMISO_PIN_SHIFT     (0)       /* Bits 0-4: MISO pin number */
-#define SPIM_PSELMISO_PIN_MASK      (0x1f << SPIM_PSELMISO_PIN_SHIFT)
-#define SPIM_PSELMISO_PORT_SHIFT    (5)       /* Bit 5: MISO port number */
-#define SPIM_PSELMISO_PORT_MASK     (0x1 << SPIM_PSELMISO_PORT_SHIFT)
-#define SPIM_PSELMISO_CONNECTED     (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSELMISO_RESET         (0xffffffff)
-
-/* PSELCSN Register */
-
-#define SPIM_PSELCSN_PIN_SHIFT      (0)       /* Bits 0-4: CSN pin number */
-#define SPIM_PSELCSN_PIN_MASK       (0x1f << SPIM_PSELCSN_PIN_SHIFT)
-#define SPIM_PSELCSN_PORT_SHIFT     (5)       /* Bit 5: CSN port number */
-#define SPIM_PSELCSN_PORT_MASK      (0x1 << SPIM_PSELCSN_PORT_SHIFT)
-#define SPIM_PSELCSN_CONNECTED      (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSELCSN_RESET          (0xffffffff)
+#define SPIM_PSEL_PIN_SHIFT         (0)       /* Bits 0-4: SCK pin number */
+#define SPIM_PSEL_PIN_MASK          (0x1f << SPIM_PSELSCK_PIN_SHIFT)
+#define SPIM_PSEL_PORT_SHIFT        (5)       /* Bit 5: SCK port number */
+#define SPIM_PSEL_PORT_MASK         (0x1 << SPIM_PSELSCK_PORT_SHIFT)
+#define SPIM_PSEL_CONNECTED         (1 << 31) /* Bit 31: Connection */
+#define SPIM_PSEL_RESET             (0xffffffff)
 
 /* FREQUENCY Register */
 

--- a/arch/arm/src/nrf52/hardware/nrf52_spi.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_spi.h
@@ -153,14 +153,41 @@
 #define SPIM_ENABLE_DIS             (0)        /* Disable SPIM */
 #define SPIM_ENABLE_EN              (0x7 << 0) /* Enable SPIM */
 
-/* PSEL(MOSI/MISO/SCK/CSN) Register */
+/* PSELSCK Register */
 
-#define SPIM_PSEL_PIN_SHIFT         (0)       /* Bits 0-4: pin number */
-#define SPIM_PSEL_PIN_MASK          (0x1f << SPIM_PSEL_PIN_SHIFT)
-#define SPIM_PSEL_PORT_SHIFT        (5)       /* Bit 5: port number */
-#define SPIM_PSEL_PORT_MASK         (0x1 << SPIM_PSEL_PORT_SHIFT)
-#define SPIM_PSEL_CONNECTED         (1 << 31) /* Bit 31: Connection */
-#define SPIM_PSEL_RESET             (0xffffffff)
+#define SPIM_PSELSCK_PIN_SHIFT      (0)       /* Bits 0-4: SCK pin number */
+#define SPIM_PSELSCK_PIN_MASK       (0x1f << SPIM_PSELSCK_PIN_SHIFT)
+#define SPIM_PSELSCK_PORT_SHIFT     (5)       /* Bit 5: SCK port number */
+#define SPIM_PSELSCK_PORT_MASK      (0x1 << SPIM_PSELSCK_PORT_SHIFT)
+#define SPIM_PSELSCK_CONNECTED      (1 << 31) /* Bit 31: Connection */
+#define SPIM_PSELSCK_RESET          (0xffffffff)
+
+/* PSELMOSI Register */
+
+#define SPIM_PSELMOSI_PIN_SHIFT     (0)       /* Bits 0-4: MOSI pin number */
+#define SPIM_PSELMOSI_PIN_MASK      (0x1f << SPIM_PSELMOSI_PIN_SHIFT)
+#define SPIM_PSELMOSI_PORT_SHIFT    (5)       /* Bit 5: MOSI port number */
+#define SPIM_PSELMOSI_PORT_MASK     (0x1 << SPIM_PSELMOSI_PORT_SHIFT)
+#define SPIM_PSELMOSI_CONNECTED     (1 << 31) /* Bit 31: Connection */
+#define SPIM_PSELMOSI_RESET         (0xffffffff)
+
+/* PSELMISO Register */
+
+#define SPIM_PSELMISO_PIN_SHIFT     (0)       /* Bits 0-4: MISO pin number */
+#define SPIM_PSELMISO_PIN_MASK      (0x1f << SPIM_PSELMISO_PIN_SHIFT)
+#define SPIM_PSELMISO_PORT_SHIFT    (5)       /* Bit 5: MISO port number */
+#define SPIM_PSELMISO_PORT_MASK     (0x1 << SPIM_PSELMISO_PORT_SHIFT)
+#define SPIM_PSELMISO_CONNECTED     (1 << 31) /* Bit 31: Connection */
+#define SPIM_PSELMISO_RESET         (0xffffffff)
+
+/* PSELCSN Register */
+
+#define SPIM_PSELCSN_PIN_SHIFT      (0)       /* Bits 0-4: CSN pin number */
+#define SPIM_PSELCSN_PIN_MASK       (0x1f << SPIM_PSELCSN_PIN_SHIFT)
+#define SPIM_PSELCSN_PORT_SHIFT     (5)       /* Bit 5: CSN port number */
+#define SPIM_PSELCSN_PORT_MASK      (0x1 << SPIM_PSELCSN_PORT_SHIFT)
+#define SPIM_PSELCSN_CONNECTED      (1 << 31) /* Bit 31: Connection */
+#define SPIM_PSELCSN_RESET          (0xffffffff)
 
 /* FREQUENCY Register */
 

--- a/arch/arm/src/nrf52/nrf52_pminitialize.c
+++ b/arch/arm/src/nrf52/nrf52_pminitialize.c
@@ -1,0 +1,55 @@
+/****************************************************************************
+ * arch/arm/src/nrf52/nrf52_pminitialize.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/power/pm.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm_pminitialize
+ *
+ * Description:
+ *   This function is called by MCU-specific logic at power-on reset in
+ *   order to provide one-time initialization the power management subsystem.
+ *   This function must be called *very* early in the initialization sequence
+ *   *before* any other device drivers are initialized (since they may
+ *   attempt to register with the power management subsystem).
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void arm_pminitialize(void)
+{
+  /* Then initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+}

--- a/include/nuttx/power/pm.h
+++ b/include/nuttx/power/pm.h
@@ -232,7 +232,7 @@ struct pm_governor_s
    *
    *   NOTE: since this will be called from pm_initialize(), the system
    *   is in very early boot state when this callback is invoked. Thus,
-   *   only ver basic initialization should be performed (e.g. no memory
+   *   only very basic initialization should be performed (e.g. no memory
    *   should be allocated).
    *
    **************************************************************************/

--- a/include/nuttx/power/pm.h
+++ b/include/nuttx/power/pm.h
@@ -1,37 +1,20 @@
 /****************************************************************************
- * include/nuttx/power/pm.h
- * NuttX Power Management Interfaces
+ * arch/arm/src/nrf52/nrf52_pminitialize.c
  *
- *   Copyright (C) 2011-2012, 2015-2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *   Author: Matias Nitsche <mnitsche@dc.uba.ar>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -227,8 +210,8 @@ struct pm_governor_s
    *
    * Description:
    *   Invoked by the PM system during initialization, to allow the governor
-   *   to initialize its internal data. This can be left to NULL if not needed
-   *   by the governor.
+   *   to initialize its internal data. This can be left to NULL if not
+   *   needed by the governor.
    *
    *   NOTE: since this will be called from pm_initialize(), the system
    *   is in very early boot state when this callback is invoked. Thus,
@@ -379,8 +362,9 @@ int pm_unregister(FAR struct pm_callback_s *callbacks);
  *     higher priorities.  Higher priority activity can prevent the system
  *     from entering reduced power states for a longer period of time.
  *
- *     As an example, a button press might be higher priority activity because
- *     it means that the user is actively interacting with the device.
+ *     As an example, a button press might be higher priority activity
+ *     because it means that the user is actively interacting with the
+ *     device.
  *
  * Returned Value:
  *   None.
@@ -405,7 +389,8 @@ void pm_activity(int domain, int priority);
  *   domain - The domain of the PM activity
  *   state - The state want to stay.
  *
- *     As an example, media player might stay in normal state during playback.
+ *     As an example, media player might stay in normal state during
+ *     playback.
  *
  * Returned Value:
  *   None.
@@ -465,15 +450,15 @@ uint32_t pm_staycount(int domain, enum pm_state_e state);
  *
  * Description:
  *   This function is called from the MCU-specific IDLE loop to monitor the
- *   the power management conditions.  This function returns the "recommended"
- *   power management state based on the PM configuration and activity
- *   reported in the last sampling periods.  The power management state is
- *   not automatically changed, however.  The IDLE loop must call
+ *   the power management conditions.  This function returns the
+ *   "recommended" power management state based on the PM configuration and
+ *   activity reported in the last sampling periods.  The power management
+ *   state is not automatically changed, however.  The IDLE loop must call
  *   pm_changestate() in order to make the state change.
  *
- *   These two steps are separated because the platform-specific IDLE loop may
- *   have additional situational information that is not available to the
- *   the PM sub-system.  For example, the IDLE loop may know that the
+ *   These two steps are separated because the platform-specific IDLE loop
+ *   may have additional situational information that is not available to
+ *   the the PM sub-system.  For example, the IDLE loop may know that the
  *   battery charge level is very low and may force lower power states
  *   even if there is activity.
  *


### PR DESCRIPTION
## Summary

This PR does:
* A rework of #2189 which left SPI non-functional (thus the revert of that commit), including the same feature of not having to define MISO/MOSI but with a couple of required fixes found when inspecting the issue
* Support for sending more than 256 bytes of data by using DMA list feature which basically makes the SPI peripheral auto-increment the DMA pointer after each transfer. This means arbitrarily long transfers can be done in one go
* Support power management operations: disable SPI peripheral and re-enable when going into/coming back from SLEEP/STANDBY
  * There is an errata (89) of nRF52 (which applies to all chip revisions) which adds 400uA static current consumption when using SPIM and GPIOTE (which is actually needed due to another workaround for SPI but can be active if used to process pin interrupts). To reduce impact of this problem, power managment can now be used to disable SPI when going to sleep. The workaround for errata 89 is to put the SPIM peripheral into a specific state once it is disabled and is thus done here.

## Impact

As above, various fixes and improvements.

## Testing

Monitored correct state change in and out of sleep and SPI functions correctly.
