### PR TITLE
sim inttypes.h: Remove PRI/SCN macros for fast and least types

### DIFF
--- a/arch/sim/include/inttypes.h
+++ b/arch/sim/include/inttypes.h
@@ -88,32 +88,12 @@
 #  define SCNi32      "i"
 #  define SCNi64      "lli"
 
-#  define SCNiLEAST8  "hhi"
-#  define SCNiLEAST16 "hi"
-#  define SCNiLEAST32 "i"
-#  define SCNiLEAST64 "lli"
-
-#  define SCNiFAST8   "hhi"
-#  define SCNiFAST16  "hi"
-#  define SCNiFAST32  "i"
-#  define SCNiFAST64  "lli"
-
 #  define SCNiMAX     "lli"
 
 #  define SCNo8       "hho"
 #  define SCNo16      "ho"
 #  define SCNo32      "o"
 #  define SCNo64      "llo"
-
-#  define SCNoLEAST8  "hho"
-#  define SCNoLEAST16 "ho"
-#  define SCNoLEAST32 "o"
-#  define SCNoLEAST64 "llo"
-
-#  define SCNoFAST8   "hho"
-#  define SCNoFAST16  "ho"
-#  define SCNoFAST32  "o"
-#  define SCNoFAST64  "llo"
 
 #  define SCNoMAX     "llo"
 
@@ -122,30 +102,10 @@
 #  define SCNu32      "u"
 #  define SCNu64      "llu"
 
-#  define SCNuLEAST8  "hhu"
-#  define SCNuLEAST16 "hu"
-#  define SCNuLEAST32 "u"
-#  define SCNuLEAST64 "llu"
-
-#  define SCNuFAST8   "hhu"
-#  define SCNuFAST16  "hu"
-#  define SCNuFAST32  "u"
-#  define SCNuFAST64  "llu"
-
 #  define SCNx8       "hhx"
 #  define SCNx16      "hx"
 #  define SCNx32      "x"
 #  define SCNx64      "llx"
-
-#  define SCNxLEAST8  "hhx"
-#  define SCNxLEAST16 "hx"
-#  define SCNxLEAST32 "x"
-#  define SCNxLEAST64 "llx"
-
-#  define SCNxFAST8   "hhx"
-#  define SCNxFAST16  "hx"
-#  define SCNxFAST32  "x"
-#  define SCNxFAST64  "llx"
 
 #  define INT8_C(x)   x
 #  define INT16_C(x)  x


### PR DESCRIPTION
I forgot to remove some of them
in https://github.com/apache/incubator-nuttx/pull/2227 .
This commit removes them.

## Summary

## Impact

## Testing

