### PR TITLE
Heap is defined in linkerscript for FLAT builds.

### DIFF
--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -240,6 +240,8 @@ EXTERN uint32_t _sdata;           /* Start of .data */
 EXTERN uint32_t _edata;           /* End+1 of .data */
 EXTERN uint32_t _sbss;            /* Start of .bss */
 EXTERN uint32_t _ebss;            /* End+1 of .bss */
+EXTERN uint32_t _sheap;           /* Start of heap */
+EXTERN uint32_t _eheap;           /* End+1 of heap */
 
 /* Sometimes, functions must be executed from RAM.  In this case, the
  * following macro may be used (with GCC!) to specify a function that will

--- a/arch/arm/src/stm32/stm32_allocateheap.c
+++ b/arch/arm/src/stm32/stm32_allocateheap.c
@@ -700,8 +700,8 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
   /* Return the heap settings */
 
   board_autoled_on(LED_HEAPALLOCATE);
-  *heap_start = (FAR void *)g_idle_topstack;
-  *heap_size  = SRAM1_END - g_idle_topstack;
+  *heap_start = (FAR void *)((uintptr_t)&_sheap);
+  *heap_size  = (uintptr_t)&_eheap - (uintptr_t)&_sheap;
 
   /* Colorize the heap for debug */
 

--- a/arch/arm/src/stm32/stm32_start.c
+++ b/arch/arm/src/stm32/stm32_start.c
@@ -60,13 +60,12 @@
 
 /* .data is positioned first in the primary RAM followed immediately by .bss.
  * The IDLE thread stack lies just after .bss and has size give by
- * CONFIG_IDLETHREAD_STACKSIZE;  The heap then begins just after the IDLE.
+ * CONFIG_IDLETHREAD_STACKSIZE;
  * ARM EABI requires 64 bit stack alignment.
  */
 
 #define IDLE_STACKSIZE (CONFIG_IDLETHREAD_STACKSIZE & ~7)
 #define IDLE_STACK     ((uintptr_t)&_ebss + IDLE_STACKSIZE)
-#define HEAP_BASE      ((uintptr_t)&_ebss + IDLE_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -77,12 +76,11 @@
  * stack starts at the end of BSS and is of size CONFIG_IDLETHREAD_STACKSIZE.
  * The IDLE thread is the thread that the system boots on and, eventually,
  * becomes the IDLE, do nothing task that runs only when there is nothing
- * else to run.  The heap continues from there until the end of memory.
- * g_idle_topstack is a read-only variable the provides this computed
- * address.
+ * else to run. g_idle_topstack is a read-only variable the provides this
+ *  computed address.
  */
 
-const uintptr_t g_idle_topstack = HEAP_BASE;
+const uintptr_t g_idle_topstack = IDLE_STACK;
 
 /****************************************************************************
  * Private Function prototypes

--- a/boards/arm/stm32/stm32f4discovery/scripts/ld.script
+++ b/boards/arm/stm32/stm32f4discovery/scripts/ld.script
@@ -49,7 +49,8 @@
 MEMORY
 {
   flash (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
-  sram (rwx) : ORIGIN = 0x20000000, LENGTH = 112K
+  sram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
+  hram (rwx) : ORIGIN = 0x20005000, LENGTH = 92K
 }
 
 OUTPUT_ARCH(arm)
@@ -108,6 +109,13 @@ SECTIONS
         . = ALIGN(4);
         _ebss = ABSOLUTE(.);
     } > sram
+
+    .heap (NOLOAD) : ALIGN(4) {
+        _sheap = ABSOLUTE(.);
+        . = ORIGIN(hram) + LENGTH(hram);
+        . = ALIGN(4);
+        _eheap = ABSOLUTE(.);
+    } > hram
 
     /* Stabs debugging sections. */
 


### PR DESCRIPTION
## Summary
Currently the heap regions are hardcoded. The code makes assumptions on how the memory regions should be mapped, and calculates the boundaries according to the MCU's available memory.

This creates problems in many cases, where the uses needs a "non-standard" memory map. See issue #2002.

This PR is about refactoring the heap configuration, and have the user define the Heap in the linkerscript. That way anyone will be able to adapt the memory map to their actual needs. NuttX will be able to support any arbitrary memory configuration, and no assumptions will be made about the final application.

## Impact
Linkerscripts need to be updated, so they define the new `.heap` region.

## Testing
None yet.

---

Note! This is a draft PR, just a proposition. Please review the concept behind the changes, and not the actual changes.  
I am only working on STM32 for now, and I chose STM32F4Discovery board as the "reference board" for these changes.  
Nxstyle errors are ignored for the moment.

Things to do:  
- [ ] Also adapt the heap configuration in `PROTECTED` & `KERNEL` builds.
- [ ] Add support for multiple heap regions.
- [ ] Add support for memories external to the MCU.
- [ ] Update all linker scripts.
- [ ] Eventually update other MCU families.