### PR TITLE
testbuild.sh: Add -C option to skip tree cleanness check

### DIFF
--- a/tools/README.txt
+++ b/tools/README.txt
@@ -1002,6 +1002,7 @@ testbuild.sh
          Default $WD/../nuttx, where $WD is the parent directory of
          the directory where this script is.
       -p only print the list of configs without running any builds
+      -C Skip tree cleanness check.
       -G Use "git clean -xfdq" instead of "make distclean" to clean the tree.
          This option may speed up the builds. However, note that:
            * This assumes that your trees are git based.

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -50,6 +50,7 @@ unset JOPTION
 PRINTLISTONLY=0
 GITCLEAN=0
 SAVEARTIFACTS=0
+CHECKCLEAN=1
 
 case $(uname -s) in
   Darwin*)
@@ -84,6 +85,7 @@ function showusage {
   echo "  -t <topdir> provides the absolute path to top nuttx/ directory.  Default ../nuttx"
   echo "  -p only print the list of configs without running any builds"
   echo "  -A store the build executable artifact in ARTIFACTDIR (defaults to ../buildartifacts"
+  echo "  -C Skip tree cleanness check."
   echo "  -G Use \"git clean -xfdq\" instead of \"make distclean\" to clean the tree."
   echo "     This option may speed up the builds. However, note that:"
   echo "       * This assumes that your trees are git based."
@@ -137,6 +139,9 @@ while [ ! -z "$1" ]; do
     ;;
   -A )
     SAVEARTIFACTS=1
+    ;;
+  -C )
+    CHECKCLEAN=0
     ;;
   -h )
     showusage
@@ -208,14 +213,16 @@ function distclean {
 
       # Ensure nuttx and apps directory in clean state even with --ignored
 
-      if [ -d $nuttx/.git ] || [ -d $APPSDIR/.git ]; then
-        if [[ -n $(git -C $nuttx status --ignored -s) ]]; then
-          git -C $nuttx status --ignored
-          fail=1
-        fi
-        if [[ -n $(git -C $APPSDIR status --ignored -s) ]]; then
-          git -C $APPSDIR status --ignored
-          fail=1
+      if [ ${CHECKCLEAN} -ne 0 ]; then
+        if [ -d $nuttx/.git ] || [ -d $APPSDIR/.git ]; then
+          if [[ -n $(git -C $nuttx status --ignored -s) ]]; then
+            git -C $nuttx status --ignored
+            fail=1
+          fi
+          if [[ -n $(git -C $APPSDIR status --ignored -s) ]]; then
+            git -C $APPSDIR status --ignored
+            fail=1
+          fi
         fi
       fi
     fi
@@ -269,14 +276,16 @@ function build {
 
   # Ensure nuttx and apps directory in clean state
 
-  if [ -d $nuttx/.git ] || [ -d $APPSDIR/.git ]; then
-    if [[ -n $(git -C $nuttx status -s) ]]; then
-      git -C $nuttx status
-      fail=1
-    fi
-    if [[ -n $(git -C $APPSDIR status -s) ]]; then
-      git -C $APPSDIR status
-      fail=1
+  if [ ${CHECKCLEAN} -ne 0 ]; then
+    if [ -d $nuttx/.git ] || [ -d $APPSDIR/.git ]; then
+      if [[ -n $(git -C $nuttx status -s) ]]; then
+        git -C $nuttx status
+        fail=1
+      fi
+      if [[ -n $(git -C $APPSDIR status -s) ]]; then
+        git -C $APPSDIR status
+        fail=1
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary
Build-testing a dirty tree is convenient during development.

## Impact

## Testing
i used this for local build testing