### PR TITLE
libcxx: Undefine __GLIBC__ to avoid sim environment conflict with the host

### DIFF
--- a/libs/libxx/0001-libcxx-Port-to-NuttX-https-nuttx.apache.org-RTOS.patch
+++ b/libs/libxx/0001-libcxx-Port-to-NuttX-https-nuttx.apache.org-RTOS.patch
@@ -1,4 +1,4 @@
-From 10891b1c9eda0c87e33b0c0ba87f17a83930093c Mon Sep 17 00:00:00 2001
+From 6d1a82a048f2359062957ad8ab689a06355b746b Mon Sep 17 00:00:00 2001
 From: Xiang Xiao <xiaoxiang@xiaomi.com>
 Date: Fri, 2 Oct 2020 13:25:43 +0800
 Subject: [PATCH] [libcxx] Port to NuttX(https://nuttx.apache.org/) RTOS
@@ -9,19 +9,19 @@ Co-authored-by: YAMAMOTO Takashi <yamamoto@midokura.com>
 
 Differential Revision: https://reviews.llvm.org/D88718
 ---
- include/__config                | 31 +++++++++++++++++++++++++-
+ include/__config                | 32 +++++++++++++++++++++++++-
  include/__locale                |  2 ++
  include/support/nuttx/xlocale.h | 18 +++++++++++++++
  src/include/config_elast.h      |  4 ++++
  src/locale.cpp                  |  2 +-
- 5 files changed, 55 insertions(+), 2 deletions(-)
+ 5 files changed, 56 insertions(+), 2 deletions(-)
  create mode 100644 include/support/nuttx/xlocale.h
 
 diff --git a/include/__config libcxx/include/__config
-index 575147cead4..32036094017 100644
+index eeef9c53a9f..e1c2ddb7161 100644
 --- a/include/__config
 +++ libcxx/include/__config
-@@ -10,6 +10,34 @@
+@@ -10,6 +10,35 @@
  #ifndef _LIBCPP_CONFIG
  #define _LIBCPP_CONFIG
  
@@ -43,6 +43,7 @@ index 575147cead4..32036094017 100644
 +#undef __linux__
 +#undef __APPLE__
 +#undef __FreeBSD__
++#undef __GLIBC__
 +#undef __NetBSD__
 +#undef _WIN32
 +#undef __sun__
@@ -56,7 +57,7 @@ index 575147cead4..32036094017 100644
  #if defined(_MSC_VER) && !defined(__clang__)
  #  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
  #    define _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
-@@ -1125,6 +1153,7 @@ _LIBCPP_FUNC_VIS extern "C" void __sanitizer_annotate_contiguous_container(
+@@ -1117,6 +1146,7 @@ _LIBCPP_FUNC_VIS extern "C" void __sanitizer_annotate_contiguous_container(
  #  if defined(__FreeBSD__) || \
        defined(__wasi__) || \
        defined(__NetBSD__) || \
@@ -64,7 +65,7 @@ index 575147cead4..32036094017 100644
        defined(__linux__) || \
        defined(__GNU__) || \
        defined(__APPLE__) || \
-@@ -1227,7 +1256,7 @@ _LIBCPP_FUNC_VIS extern "C" void __sanitizer_annotate_contiguous_container(
+@@ -1219,7 +1249,7 @@ _LIBCPP_FUNC_VIS extern "C" void __sanitizer_annotate_contiguous_container(
  #  endif
  #endif
  
@@ -74,10 +75,10 @@ index 575147cead4..32036094017 100644
  #define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
  #endif
 diff --git a/include/__locale libcxx/include/__locale
-index 6d10fa4d3d6..fb391861f23 100644
+index 125adcf68c8..ebededf066b 100644
 --- a/include/__locale
 +++ libcxx/include/__locale
-@@ -21,6 +21,8 @@
+@@ -22,6 +22,8 @@
  #if defined(_LIBCPP_MSVCRT_LIKE)
  # include <cstring>
  # include <support/win32/locale_win32.h>
@@ -130,7 +131,7 @@ index 501cbc4ffeb..3113f9fb5cd 100644
  // No _LIBCPP_ELAST needed on Fuchsia
  #elif defined(__wasi__)
 diff --git a/src/locale.cpp libcxx/src/locale.cpp
-index b9180880e49..25699f29ec9 100644
+index 5fdc14992f8..ed93727b544 100644
 --- a/src/locale.cpp
 +++ libcxx/src/locale.cpp
 @@ -30,7 +30,7 @@


### PR DESCRIPTION
## Summary
Remove accidently in PR: https://github.com/apache/incubator-nuttx/pull/2243

## Impact
without this patch, libcxx can't pass the compile with toolchain's libm.

## Testing

