### PR TITLE
libc/stdlib: Fix range check in strtoul(l)

### DIFF
--- a/libs/libc/stdlib/lib_strtoul.c
+++ b/libs/libc/stdlib/lib_strtoul.c
@@ -69,8 +69,9 @@
 unsigned long strtoul(FAR const char *nptr, FAR char **endptr, int base)
 {
   unsigned long accum = 0;
-  unsigned long prev;
+  unsigned long limit;
   int value;
+  int last_digit;
   char sign = 0;
 
   if (nptr)
@@ -98,22 +99,24 @@ unsigned long strtoul(FAR const char *nptr, FAR char **endptr, int base)
         }
       else
         {
+          limit = ULONG_MAX / base;
+          last_digit = ULONG_MAX % base;
+
           /* Accumulate each "digit" */
 
           while (lib_isbasedigit(*nptr, base, &value))
             {
-              prev = accum;
-              accum = accum * base + value;
-              nptr++;
-
               /* Check for overflow */
 
-              if (accum < prev)
+              if (accum > limit || (accum == limit && value > last_digit))
                 {
                   set_errno(ERANGE);
                   accum = ULONG_MAX;
                   break;
                 }
+
+              accum = accum * base + value;
+              nptr++;
             }
 
           if (sign == '-')

--- a/libs/libc/stdlib/lib_strtoull.c
+++ b/libs/libc/stdlib/lib_strtoull.c
@@ -68,11 +68,13 @@
  *
  ****************************************************************************/
 
-unsigned long long strtoull(FAR const char *nptr, FAR char **endptr, int base)
+unsigned long long strtoull(FAR const char *nptr,
+                            FAR char **endptr, int base)
 {
   unsigned long long accum = 0;
-  unsigned long long prev;
+  unsigned long long limit;
   int value;
+  int last_digit;
   char sign = 0;
 
   if (nptr)
@@ -100,22 +102,24 @@ unsigned long long strtoull(FAR const char *nptr, FAR char **endptr, int base)
         }
       else
         {
+          limit = ULLONG_MAX / base;
+          last_digit = ULLONG_MAX % base;
+
           /* Accumulate each "digit" */
 
           while (lib_isbasedigit(*nptr, base, &value))
             {
-              prev = accum;
-              accum = accum * base + value;
-              nptr++;
-
               /* Check for overflow */
 
-              if (accum < prev)
+              if (accum > limit || (accum == limit && value > last_digit))
                 {
                   set_errno(ERANGE);
                   accum = ULLONG_MAX;
                   break;
                 }
+
+              accum = accum * base + value;
+              nptr++;
             }
 
           if (sign == '-')


### PR DESCRIPTION
## Summary
The previous implementation of strtoul(l) is flawed. The range check assumed that when overflow happens, the truncated value is smaller than the original value. As a counter example, passing "10000000000" to strtol will not trigger ERANGE, but return a truncated value. This patch adds more accurate range checks.