### PR TITLE
stm32f0l0g0/stm32_dmamux.h: Fix errors in bitfield definitions

### DIFF
--- a/arch/arm/src/stm32f0l0g0/hardware/stm32_dmamux.h
+++ b/arch/arm/src/stm32f0l0g0/hardware/stm32_dmamux.h
@@ -36,7 +36,7 @@
 
 /* Register Offsets *****************************************************************/
 
-#define STM32_DMAMUX_CXCR_OFFSET(x)  (0x0000+0x0004*(x)) /* DMAMUX12 request line multiplexer channel x configuration register */
+#define STM32_DMAMUX_CXCR_OFFSET(x)  (0x0000+0x0004*(x)) /* DMAMUX1 request line multiplexer channel x configuration register */
 #define STM32_DMAMUX_C0CR_OFFSET     STM32_DMAMUX_CXCR_OFFSET(0)
 #define STM32_DMAMUX_C1CR_OFFSET     STM32_DMAMUX_CXCR_OFFSET(1)
 #define STM32_DMAMUX_C2CR_OFFSET     STM32_DMAMUX_CXCR_OFFSET(2)
@@ -45,16 +45,16 @@
 #define STM32_DMAMUX_C5CR_OFFSET     STM32_DMAMUX_CXCR_OFFSET(5)
 #define STM32_DMAMUX_C6CR_OFFSET     STM32_DMAMUX_CXCR_OFFSET(6)
                                                         /* 0x01C-0x07C: Reserved */
-#define STM32_DMAMUX_CSR_OFFSET      0x0080             /* DMAMUX12 request line multiplexer interrupt channel status register */
-#define STM32_DMAMUX_CFR_OFFSET      0x0084             /* DMAMUX12 request line multiplexer interrupt clear flag register */
+#define STM32_DMAMUX_CSR_OFFSET      0x0080             /* DMAMUX1 request line multiplexer interrupt channel status register */
+#define STM32_DMAMUX_CFR_OFFSET      0x0084             /* DMAMUX1 request line multiplexer interrupt clear flag register */
                                                         /* 0x088-0x0FC: Reserved */
-#define STM32_DMAMUX_RGXCR_OFFSET(x) (0x0100+0x004*(x)) /* DMAMUX12 request generator channel x configuration register */
+#define STM32_DMAMUX_RGXCR_OFFSET(x) (0x0100+0x004*(x)) /* DMAMUX1 request generator channel x configuration register */
 #define STM32_DMAMUX_RG0CR_OFFSET    STM32_DMAMUX_RGXCR_OFFSET(0)
 #define STM32_DMAMUX_RG1CR_OFFSET    STM32_DMAMUX_RGXCR_OFFSET(1)
 #define STM32_DMAMUX_RG2CR_OFFSET    STM32_DMAMUX_RGXCR_OFFSET(2)
 #define STM32_DMAMUX_RG3CR_OFFSET    STM32_DMAMUX_RGXCR_OFFSET(3)
-#define STM32_DMAMUX_RGSR_OFFSET     0x0140 /* DMAMUX12 request generator interrupt status register */
-#define STM32_DMAMUX_RGCFR_OFFSET    0x0144 /* DMAMUX12 request generator interrupt clear flag register */
+#define STM32_DMAMUX_RGSR_OFFSET     0x0140 /* DMAMUX1 request generator interrupt status register */
+#define STM32_DMAMUX_RGCFR_OFFSET    0x0144 /* DMAMUX1 request generator interrupt clear flag register */
                                             /* 0x148-0x3FC: Reserved */
 
 /* Register Addresses ***************************************************************/
@@ -82,48 +82,54 @@
 
 /* Register Bitfield Definitions ****************************************************/
 
-/* DMAMUX12 request line multiplexer channel x configuration register */
+/* DMAMUX1 request line multiplexer channel x configuration register */
 
-#define DMAMUX_CCR_DMAREQID_SHIFT (0)  /* Bits 0-6: DMA request identification */
+#define DMAMUX_CCR_DMAREQID_SHIFT (0)                              /* Bits 0-6: DMA request identification */
 #define DMAMUX_CCR_DMAREQID_MASK  (0x7f << DMAMUX_CCR_DMAREQID_SHIFT)
-#define DMAMUX_CCR_SOIE           (8)  /* Bit 8: Synchronization overrun interrupt enable */
-#define DMAMUX_CCR_EGE            (9)  /* Bit 9: Event generation enable */
-#define DMAMUX_CCR_SE             (16) /* Bit 16: Synchronization enable */
-#define DMAMUX_CCR_SPOL_SHIFT     (17) /* Bits 17-18: Synchronization polarity */
-#define DMAMUX_CCR_SPOL_MASK      (3 << DMAMUX_CCR_SPOL_SHIFT)
-#define DMAMUX_CCR_NBREQ_SHIFT    (19) /* Bits 19-23: Number of DMA request - 1 to forward */
+#define DMAMUX_CCR_SOIE           (8)                              /* Bit 8: Synchronization overrun interrupt enable */
+#define DMAMUX_CCR_EGE            (9)                              /* Bit 9: Event generation enable */
+#define DMAMUX_CCR_SE             (16)                             /* Bit 16: Synchronization enable */
+#define DMAMUX_CCR_SPOL_SHIFT     (17)                             /* Bits 17-18: Synchronization polarity */
+#define DMAMUX_CCR_SPOL_MASK      (0x3 << DMAMUX_CCR_SPOL_SHIFT)
+#  define DMAMUX_CCR_SPOL_NONE    (0x0 << DMAMUX_CCR_SPOL_SHIFT)   /* No event: No trigger detection or generation */
+#  define DMAMUX_CCR_SPOL_RISING  (0x1 << DMAMUX_CCR_SPOL_SHIFT)   /* Rising edge */
+#  define DMAMUX_CCR_SPOL_FALLING (0x2 << DMAMUX_CCR_SPOL_SHIFT)   /* Falling edge */
+#  define DMAMUX_CCR_SPOL_BOTH    (0x3 << DMAMUX_CCR_SPOL_SHIFT)   /* Both rising and falling edges */
+#define DMAMUX_CCR_NBREQ_SHIFT    (19)                             /* Bits 19-23: Number of DMA request - 1 to forward */
 #define DMAMUX_CCR_NBREQ_MASK     (0x1f << DMAMUX_CCR_NBREQ_SHIFT)
-#define DMAMUX_CCR_SYNCID_SHIFT   (24) /* Bits 24-26: Synchronization identification */
-#define DMAMUX_CCR_SYNCID_MASK    (7 << DMAMUX_CCR_SYNCID_SHIFT)
+#define DMAMUX_CCR_SYNCID_SHIFT   (24)                             /* Bits 24-28: Synchronization identification */
+#define DMAMUX_CCR_SYNCID_MASK    (0x1f << DMAMUX_CCR_SYNCID_SHIFT)
 
-/* DMAMUX12 request line multiplexer interrupt channel status register */
+/* DMAMUX1 request line multiplexer interrupt channel status register */
 
-#define DMAMUX1_CSR_SOF(x)         (1 << x) /* Synchronization overrun event flag */
+#define DMAMUX1_CSR_SOF(x)         (1 << (x)) /* Synchronization overrun event flag */
 
-/* DMAMUX12 request line multiplexer interrupt clear flag register */
+/* DMAMUX1 request line multiplexer interrupt clear flag register */
 
-#define DMAMUX1_CFR_SOF(x)         (1 << x) /* Clear synchronization overrun event flag */
+#define DMAMUX1_CFR_CSOF(x)        (1 << (x)) /* Clear synchronization overrun event flag */
 
-/* DMAMUX12 request generator channel x configuration register */
+/* DMAMUX1 request generator channel x configuration register */
 
-#define DMAMUX_RGCR_SIGID_SHIFT    (0)  /* Bits 0-4: Signal identifiaction
-                                         * WARNING: different length for DMAMUX1 and DMAMUX2 !
-                                         */
+#define DMAMUX_RGCR_SIGID_SHIFT    (0)                             /* Bits 0-4: Signal identification */
 #define DMAMUX_RGCR_SIGID_MASK     (0x1f << DMAMUX_RGCR_SIGID_SHIFT)
-#define DMAMUX_RGCR_OIE            (8)  /* Bit 8: Trigger overrun interrupt enable */
-#define DMAMUX_RGCR_GE             (16) /* Bit 16: DMA request generator channel X enable*/
-#define DMAMUX_RGCR_GPOL_SHIFT     (17) /* Bits 17-18: DMA request generator trigger polarity */
-#define DMAMUX_RGCR_GPOL_MASK      (7 << DMAMUX_RGCR_GPOL_SHIFT)
-#define DMAMUX_RGCR_GNBREQ_SHIFT   (17) /* Bits 19-23: Number of DMA requests to be generated -1 */
-#define DMAMUX_RGCR_GNBREQL_MASK   (7 << DMAMUX_RGCR_GNBREQ_SHIFT)
+#define DMAMUX_RGCR_OIE            (8)                             /* Bit 8: Trigger overrun interrupt enable */
+#define DMAMUX_RGCR_GE             (16)                            /* Bit 16: DMA request generator channel X enable*/
+#define DMAMUX_RGCR_GPOL_SHIFT     (17)                            /* Bits 17-18: DMA request generator trigger polarity */
+#define DMAMUX_RGCR_GPOL_MASK      (0x3 << DMAMUX_RGCR_GPOL_SHIFT)
+#  define DMAMUX_RGCR_GPOL_NONE    (0x0 << DMAMUX_RGCR_GPOL_SHIFT) /* No event: No trigger detection or generation */
+#  define DMAMUX_RGCR_GPOL_RISING  (0x1 << DMAMUX_RGCR_GPOL_SHIFT) /* Rising edge */
+#  define DMAMUX_RGCR_GPOL_FALLING (0x2 << DMAMUX_RGCR_GPOL_SHIFT) /* Falling edge */
+#  define DMAMUX_RGCR_GPOL_BOTH    (0x3 << DMAMUX_RGCR_GPOL_SHIFT) /* Both rising and falling edges */
+#define DMAMUX_RGCR_GNBREQ_SHIFT   (19)                            /* Bits 19-23: Number of DMA requests to be generated -1 */
+#define DMAMUX_RGCR_GNBREQL_MASK   (0x1f << DMAMUX_RGCR_GNBREQ_SHIFT)
 
-/* DMAMUX12 request generator interrupt status register */
+/* DMAMUX1 request generator interrupt status register */
 
-#define DMAMUX1_RGSR_SOF(x)        (1 << x) /* Trigger overrun event flag */
+#define DMAMUX1_RGSR_OF(x)         (1 << (x)) /* Trigger overrun event flag */
 
-/* DMAMUX12 request generator interrupt clear flag register */
+/* DMAMUX1 request generator interrupt clear flag register */
 
-#define DMAMUX1_RGCFR_SOF(x)       (1 << x) /* Clear trigger overrun event flag */
+#define DMAMUX1_RGCFR_COF(x)       (1 << (x)) /* Clear trigger overrun event flag */
 
 /* DMA channel mapping
  *
@@ -133,7 +139,7 @@
  * X - free bits
  */
 
-#define DMAMAP_MAP(d,c)           ((d) << 8 | c)
+#define DMAMAP_MAP(d,c)           ((d) << 8 | (c))
 #define DMAMAP_CONTROLLER(m)      ((m) >> 8 & 0x07)
 #define DMAMAP_REQUEST(m)         ((m) >> 0 & 0xff)
 
@@ -146,7 +152,7 @@
 #if defined(CONFIG_STM32F0L0G0_STM32G0)
 #  include "chip/stm32g0_dmamux.h"
 #else
-#  error "Unsupported STM32 M0 sub family"
+#  error "Unsupported STM32 F0/L0/G0 sub family"
 #endif
 
 #endif /* __ARCH_ARM_SRC_STM32F0L0G0_HARDWARE_STM32_DMAMUX_H */


### PR DESCRIPTION
## Summary

Fix errors in DMAMUX register bitfield definitions.

Used reference manual for STM32G071CB. The F0 and L0 families do not appear to have a DMAMUX.

arch/arm/src/stm32f0l0g0/hardware/stm32_dmamux.h:

    * Remove all mentions of DMAMUX12 from comments. This family has
      at most DMAMUX1 only.

    * Add missing defines DMAMUX_CCR_SPOL_NONE,
      DMAMUX_CCR_SPOL_RISING, DMAMUX_CCR_SPOL_FALLING, and
      DMAMUX_CCR_SPOL_BOTH.

    * DMAMUX_CCR_SYNCID_SHIFT: Fix comment. Was "Bits 24-26" (3 bits)
      but datasheet shows bits 24-28 (5 bits).

    * DMAMUX_CCR_SYNCID_MASK: Fix mask. Was 0x7 (3 bits) but datasheet
      shows (5 bits) 0x1f.

    * DMAMUX1_CSR_SOF(x): Add parenthesis around macro parameter
      expansion.

    * DMAMUX1_CFR_SOF(x): Rename to DMAMUX1_CFR_CSOF(x) for
      consistency with datasheet and add parenthesis around macro
      parameter expansion.

    * DMAMUX_RGCR_GPOL_MASK: Fix incorrect mask. Was 0x7 (3 bits) but
      datasheet shows only 2 bits (0x3).

    * Add missing defines DMAMUX_RGCR_GPOL_NONE,
      DMAMUX_RGCR_GPOL_RISING, DMAMUX_RGCR_GPOL_FALLING, and
      DMAMUX_RGCR_GPOL_BOTH.

    * DMAMUX_RGCR_GNBREQ_SHIFT: Fix incorrect value. Was 17 (collision
      with DMAMUX_RGCR_GPOL_SHIFT) but datasheet and comment both show
      this bitfield at bits 19-23.

    * DMAMUX_RGCR_GNBREQL_MASK: Fix incorrect mask. Was 0x7 (3 bits)
      but datasheet shows 5 bits (0x1f).

    * DMAMUX1_RGSR_SOF(x): Rename to DMAMUX1_RGSR_OF(x) for
      consistency with datasheet and add parenthesis around macro
      parameter expansion.

    * DMAMUX1_RGCFR_SOF(x): Rename to DMAMUX1_RGCFR_COF(x) for
      consistency with datasheet and add parenthesis around macro
      parameter expansion.

    * DMAMAP_MAP(d,c): Add parenthesis around macro parameter
      expansion.

    * Fix nxstyle errors.

## Impact

Corrects bitfield mistakes.

## Testing

nxstyle