### PR TITLE
[BACKPORT #2263] libc/stdio: Preallocate the stdin, stdout and stderr

### DIFF
--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -469,6 +469,9 @@ struct file_struct
   FAR unsigned char      *fs_bufend;    /* Pointer to 1 past end of buffer */
   FAR unsigned char      *fs_bufpos;    /* Current position in buffer */
   FAR unsigned char      *fs_bufread;   /* Pointer to 1 past last buffered read char. */
+#  if CONFIG_STDIO_BUFFER_SIZE > 0
+  unsigned char           fs_buffer[CONFIG_STDIO_BUFFER_SIZE];
+#  endif
 #endif
   uint16_t                fs_oflags;    /* Open mode flags */
   uint8_t                 fs_flags;     /* Stream flags */
@@ -481,6 +484,7 @@ struct file_struct
 struct streamlist
 {
   sem_t                   sl_sem;   /* For thread safety */
+  struct file_struct      sl_std[3];
   FAR struct file_struct *sl_head;
   FAR struct file_struct *sl_tail;
 };

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -78,9 +78,9 @@
 
 /* The first three _iob entries are reserved for standard I/O */
 
-#define stdin      (nxsched_get_streams()->sl_head)
-#define stdout     (nxsched_get_streams()->sl_head->fs_next)
-#define stderr     (nxsched_get_streams()->sl_head->fs_next->fs_next)
+#define stdin      (&nxsched_get_streams()->sl_std[0])
+#define stdout     (&nxsched_get_streams()->sl_std[1])
+#define stderr     (&nxsched_get_streams()->sl_std[2])
 
 /* Path to the directory where temporary files can be created */
 

--- a/libs/libc/misc/lib_stream.c
+++ b/libs/libc/misc/lib_stream.c
@@ -85,6 +85,15 @@ void lib_stream_initialize(FAR struct task_group_s *group)
   _SEM_INIT(&list->sl_sem, 0, 1);
   list->sl_head = NULL;
   list->sl_tail = NULL;
+
+  /* Initialize stdin, stdout and stderr stream */
+
+  list->sl_std[0].fs_fd = -1;
+  lib_sem_initialize(&list->sl_std[0]);
+  list->sl_std[1].fs_fd = -1;
+  lib_sem_initialize(&list->sl_std[1]);
+  list->sl_std[2].fs_fd = -1;
+  lib_sem_initialize(&list->sl_std[2]);
 }
 #endif /* CONFIG_FILE_STREAM */
 
@@ -147,6 +156,14 @@ void lib_stream_release(FAR struct task_group_s *group)
           group_free(group, stream);
         }
     }
+
+  /* Destroy stdin, stdout and stderr stream */
+
+#ifndef CONFIG_STDIO_DISABLE_BUFFERING
+  _SEM_DESTROY(&list->sl_std[0].fs_sem);
+  _SEM_DESTROY(&list->sl_std[1].fs_sem);
+  _SEM_DESTROY(&list->sl_std[2].fs_sem);
+#endif
 }
 
 #endif /* CONFIG_FILE_STREAM */


### PR DESCRIPTION
## Summary
Backports #2263 


