### PR TITLE
Remove ARCROSSDEV leftovers

### DIFF
--- a/boards/arm/nrf52/nrf52832-mdk/scripts/Make.defs
+++ b/boards/arm/nrf52/nrf52832-mdk/scripts/Make.defs
@@ -35,8 +35,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 

--- a/boards/arm/nrf52/nrf52832-sparkfun/scripts/Make.defs
+++ b/boards/arm/nrf52/nrf52832-sparkfun/scripts/Make.defs
@@ -35,8 +35,8 @@ CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(ARCROSSDEV)ar rcs
-NM = $(ARCROSSDEV)nm
+AR = $(CROSSDEV)ar rcs
+NM = $(CROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 


### PR DESCRIPTION
It has been removed while ago.
cf. https://github.com/apache/incubator-nuttx/commit/5efa93ec26fd8a3fd85b24a2008bb743f96027fb

## Summary

## Impact

## Testing

