### PR TITLE
sched: Fix nx_waitid(), nx_waitpid(), nxtask_exithook() for SMP

### DIFF
--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -72,6 +72,14 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
   DEBUGASSERT(stat_loc);
 
+  /* NOTE: sched_lock() is not enough for SMP
+   * because the child task is running on another CPU
+   */
+
+#ifdef CONFIG_SMP
+  irqstate_t flags = enter_critical_section();
+#endif
+
   /* Disable pre-emption so that nothing changes in the following tests */
 
   sched_lock();
@@ -158,11 +166,15 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
   /* On success, return the PID */
 
-  sched_unlock();
-  return pid;
+  ret = pid;
 
 errout:
   sched_unlock();
+
+#ifdef CONFIG_SMP
+  leave_critical_section(flags);
+#endif
+
   return ret;
 }
 
@@ -198,6 +210,14 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
   sigemptyset(&set);
   nxsig_addset(&set, SIGCHLD);
+
+  /* NOTE: sched_lock() is not enough for SMP
+   * because the child task is running on another CPU
+   */
+
+#ifdef CONFIG_SMP
+  irqstate_t flags = enter_critical_section();
+#endif
 
   /* Disable pre-emption so that nothing changes while the loop executes */
 
@@ -438,11 +458,17 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
         }
     }
 
-  sched_unlock();
-  return pid;
+  /* On success, return the PID */
+
+  ret = pid;
 
 errout:
   sched_unlock();
+
+#ifdef CONFIG_SMP
+  leave_critical_section(flags);
+#endif
+
   return ret;
 }
 #endif /* CONFIG_SCHED_HAVE_PARENT */


### PR DESCRIPTION
## Summary

- I noticed waitpid_test stops with lc823450-xgevk:rndis
- The condition was CONFIG_DEBUG_ASSERTION=y
- Actually, the child task sent SIGCHILD but the parent couldn't catch the signal
- Then, I found that nx_waitid(), nx_waitpid() use sched_lock()
- However, a parent task and a child task are running on different CPUs
- So, sched_lock() is not enough and need to use a critical section
- Also, signal handling in nxtask_exithook() must be done in a critical section

## Impact

- SMP only

## Testing

- Tested with ostest with the following configurations
- lc823450-xgevk:rndis (CONFIG_DEBUG_ASSERTION=y and n)
- spresense:smp
- spresense:wifi_smp (NCPUS=2 and 4)
- sabre-6quad:smp (QEMU)
- esp32-core:smp (QEMU)
- maix-bit:smp (QEMU)
- sim:smp
