### PR TITLE
bluetooth: fix outgoing buffer freeing

### DIFF
--- a/arch/sim/src/sim/up_hcisocket.c
+++ b/arch/sim/src/sim/up_hcisocket.c
@@ -120,8 +120,6 @@ static int bthcisock_send(FAR const struct bt_driver_s *dev,
       return -1;
     }
 
-  bt_buf_release(buf);
-
   return buf->len;
 }
 

--- a/wireless/bluetooth/bt_hcicore.h
+++ b/wireless/bluetooth/bt_hcicore.h
@@ -302,6 +302,25 @@ int bt_driver_register(FAR const struct bt_driver_s *btdev);
 
 void bt_driver_unregister(FAR const struct bt_driver_s *btdev);
 
+/****************************************************************************
+ * Name: bt_send
+ *
+ * Description:
+ *   Send the provided buffer to the bluetooth driver
+ *
+ * Input Parameters:
+ *   btdev - An instance of the low-level drivers interface structure.
+ *   buf   - The buffer to be sent by the driver
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ *
+ ****************************************************************************/
+
+int bt_send(FAR const struct bt_driver_s *btdev,
+            FAR struct bt_buf_s *buf);
+
 #ifdef CONFIG_WIRELESS_BLUETOOTH_HOST
 /****************************************************************************
  * Name: bt_hci_cmd_create

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -1222,9 +1222,9 @@ static int  btnet_req_hci_data(FAR struct btnet_driver_s *priv,
           return -ENOMEM;
         }
 
-      g_btdev.btdev->send(g_btdev.btdev, buf);
-
       /* Transfer the frame to the Bluetooth stack. */
+
+      bt_send(g_btdev.btdev, buf);
 
       NETDEV_TXDONE(&priv->bd_dev.r_dev);
     }


### PR DESCRIPTION
## Summary

This fixes a regression introduced in #2070 where the outgoing HCI message buffer was not freed anymore. At the same time, that PR introduced this buffer freeing step for the simulated HCI socket, right after it was sent to the real BT stack, since when NuttX's own bluetooth stack is disabled, at this point the buffer needs to be freed. These two changes compensated each other when NuttX's stack was disabled, but when enabled it resulted in the buffer being released at the wrong time.

This reinstates the buffer freeing at the correct place needed for NuttX BLE stack and conditions the freeing of the buffer in the simulated HCI socket to only be done when NuttX stack is disabled.

## Impact

Fixes regression, observed when NuttX's BLE stack is used with the sim HCI socket.

## Testing

sim:bthcisock