### PR TITLE
nxstyle fixes + use consistent type for arm g_idle_topstack

### DIFF
--- a/arch/arm/src/c5471/c5471_watchdog.c
+++ b/arch/arm/src/c5471/c5471_watchdog.c
@@ -74,7 +74,7 @@
 #define C5471_DISABLE_VALUE2   (0xa0 << 22)
 
 #define CLOCK_KHZ              47500
-#define CLOCK_MHZx2            95
+#define CLOCK_MHZ_X2           95
 
 /* Macros to manage access to the watchdog timer */
 
@@ -99,7 +99,8 @@ static int     wdt_interrupt(int irq, void *context, FAR void *arg);
 static int     wdt_open(struct file *filep);
 static int     wdt_close(struct file *filep);
 static ssize_t wdt_read(struct file *filep, char *buffer, size_t buflen);
-static ssize_t wdt_write(struct file *filep, const char *buffer, size_t buflen);
+static ssize_t wdt_write(struct file *filep, const char *buffer,
+                         size_t buflen);
 static int     wdt_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 /****************************************************************************
@@ -184,7 +185,7 @@ static int wdt_setusec(uint32_t usec)
 
   do
     {
-      divisor = (CLOCK_MHZx2 * usec) / (prescaler * 2);
+      divisor = (CLOCK_MHZ_X2 * usec) / (prescaler * 2);
       wdinfo("divisor=0x%x prescaler=0x%x\n", divisor, prescaler);
 
       if (divisor >= 0x10000)
@@ -264,6 +265,7 @@ static ssize_t wdt_read(struct file *filep, char *buffer, size_t buflen)
       sprintf(buffer, "%08x %08x\n", c5471_wdt_cntl, c5471_wdt_count);
       return 18;
     }
+
   return 0;
 }
 
@@ -271,7 +273,8 @@ static ssize_t wdt_read(struct file *filep, char *buffer, size_t buflen)
  * Name: wdt_write
  ****************************************************************************/
 
-static ssize_t wdt_write(struct file *filep, const char *buffer, size_t buflen)
+static ssize_t wdt_write(struct file *filep, const char *buffer,
+                         size_t buflen)
 {
   wdinfo("buflen=%d\n", buflen);
   if (buflen)

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -212,7 +212,7 @@ EXTERN volatile uint32_t *g_current_regs[1];
  * CONFIG_RAM_END
  */
 
-EXTERN const uint32_t g_idle_topstack;
+EXTERN const uintptr_t g_idle_topstack;
 
 /* Address of the saved user stack pointer */
 

--- a/arch/arm/src/cxd56xx/cxd56_allocateheap.c
+++ b/arch/arm/src/cxd56xx/cxd56_allocateheap.c
@@ -69,7 +69,7 @@
  * aligned).
  */
 
-const uint32_t g_idle_topstack = (uint32_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
   CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************

--- a/arch/arm/src/dm320/dm320_serial.c
+++ b/arch/arm/src/dm320/dm320_serial.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * arch/arm/src/dm320/dm320_serial.c
  *
- *   Copyright (C) 2007-2009, 2012-2013, 2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2012-2013, 2017 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -178,7 +179,7 @@ static uart_dev_t g_uart1port =
   {
     .size   = CONFIG_UART1_TXBUFSIZE,
     .buffer = g_uart1txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart1priv,
 };
@@ -212,7 +213,8 @@ static inline uint16_t up_serialin(struct up_dev_s *priv, uint32_t offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, uint32_t offset, uint16_t value)
+static inline void up_serialout(struct up_dev_s *priv, uint32_t offset,
+                                uint16_t value)
 {
   putreg16(value, priv->uartbase + offset);
 }
@@ -410,14 +412,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -437,6 +440,7 @@ static int up_attach(struct uart_dev_s *dev)
 
       up_enable_irq(priv->irq);
     }
+
   return ret;
 }
 
@@ -445,8 +449,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -619,6 +623,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
     {
       priv->msr &= ~UART_MSR_RFTIE;
     }
+
   up_serialout(priv, UART_MSR, priv->msr);
 }
 
@@ -671,6 +676,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
     {
       priv->msr &= ~UART_MSR_TFTIE;
     }
+
   up_serialout(priv, UART_MSR, priv->msr);
 }
 
@@ -799,7 +805,6 @@ static inline void up_waittxready(void)
 
   for (tmp = 1000 ; tmp > 0 ; tmp--)
     {
-
       if ((getreg16(DM320_REGISTER_BASE + UART_SR) & UART_SR_TFTI) != 0)
         {
           break;

--- a/arch/arm/src/imx1/imx_serial.c
+++ b/arch/arm/src/imx1/imx_serial.c
@@ -100,7 +100,8 @@ struct up_dev_s
  ****************************************************************************/
 
 static inline uint32_t up_serialin(struct up_dev_s *priv, uint32_t offset);
-static inline void up_serialout(struct up_dev_s *priv, uint32_t offset, uint32_t value);
+static inline void up_serialout(struct up_dev_s *priv, uint32_t offset,
+                                uint32_t value);
 static inline void up_disableuartint(struct up_dev_s *priv, uint32_t *ucr1);
 static inline void up_restoreuartint(struct up_dev_s *priv, uint32_t ucr1);
 static inline void up_waittxready(struct up_dev_s *priv);
@@ -223,7 +224,7 @@ static struct uart_dev_s g_uart2port =
   {
     .size   = CONFIG_UART2_TXBUFSIZE,
     .buffer = g_uart2txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart2priv,
 };
@@ -385,7 +386,8 @@ static inline uint32_t up_serialin(struct up_dev_s *priv, uint32_t offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, uint32_t offset, uint32_t value)
+static inline void up_serialout(struct up_dev_s *priv, uint32_t offset,
+                                uint32_t value)
 {
   putreg32(value, priv->uartbase + offset);
 }
@@ -554,7 +556,7 @@ static int up_setup(struct uart_dev_s *dev)
    */
 
   tmp   = ((uint64_t)refclk << (16 - 4)) / config->baud;
-  DEBUGASSERT(tmp < 0x0000000100000000LL);
+  DEBUGASSERT(tmp < 0x0000000100000000ll);
   ratio = (b16_t)tmp;
 
   /* Pick a scale factor that gives us about 14 bits of accuracy.
@@ -679,9 +681,11 @@ static int up_setup(struct uart_dev_s *dev)
     {
       div = 6 - div;
     }
+
   regval = div << UART_UFCR_RFDIV_SHIFT;
 
-  /* Set the TX trigger level to interrupt when the TxFIFO has 2 or fewer characters.
+  /* Set the TX trigger level to interrupt when the TxFIFO has 2 or fewer
+   * characters.
    * Set the RX trigger level to interrupt when the RxFIFO has 1 character.
    */
 
@@ -731,14 +735,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -779,6 +784,7 @@ static int up_attach(struct uart_dev_s *dev)
       up_enable_irq(priv->irq);
     }
 #endif
+
   return ret;
 }
 
@@ -787,8 +793,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -959,6 +965,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
     {
       priv->ucr1 &= ~UART_UCR1_RRDYEN;
     }
+
   up_serialout(priv, UART_UCR1, priv->ucr1);
 }
 
@@ -1019,6 +1026,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
     {
       priv->ucr1 &= ~UART_UCR1_TXEMPTYEN;
     }
+
   up_serialout(priv, UART_UCR1, priv->ucr1);
 }
 

--- a/arch/arm/src/imx6/imx_serial.c
+++ b/arch/arm/src/imx6/imx_serial.c
@@ -349,7 +349,7 @@ static struct uart_dev_s g_uart2port =
   {
     .size   = CONFIG_UART2_TXBUFSIZE,
     .buffer = g_uart2txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart2priv,
 };
@@ -578,14 +578,15 @@ static void imx_shutdown(struct uart_dev_s *dev)
  * Name: imx_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/kinetis/kinetis_lpserial.c
+++ b/arch/arm/src/kinetis/kinetis_lpserial.c
@@ -85,7 +85,8 @@
 #if defined(HAVE_LPUART_DEVICE) && defined(USE_SERIALDRIVER)
 
 /* Which LPUART with be tty0/console and which tty1?  The console will always
- * be ttyS0.  If there is no console then will use the lowest numbered LPUART.
+ * be ttyS0.  If there is no console then will use the lowest numbered
+ * LPUART.
  */
 
 /* First pick the console and ttys0.  This could be any of LPUART0-4 */
@@ -130,7 +131,9 @@
 #  endif
 #endif
 
-/* Pick ttys1. This could be any of LPUART0-4 excluding the console/ttyS0 LPUART. */
+/* Pick ttys1. This could be any of LPUART0-4 excluding the console/ttyS0
+ * LPUART.
+ */
 
 #if defined(CONFIG_KINETIS_LPUART0) && !defined(LPUART0_ASSIGNED)
 #  define TTYS1_DEV             g_lpuart0port /* LPUART0 is ttyS1 */
@@ -149,7 +152,9 @@
 #  define LPUART4_ASSIGNED      1
 #endif
 
-/* Pick ttys2. This could be any of LPUART1-4 excluding the console/ttyS0 LPUART. */
+/* Pick ttys2. This could be any of LPUART1-4 excluding the console/ttyS0
+ * LPUART.
+ */
 
 #if defined(CONFIG_KINETIS_LPUART1) && !defined(LPUART1_ASSIGNED)
 #  define TTYS2_DEV             g_lpuart1port /* LPUART1 is ttyS2 */
@@ -165,7 +170,9 @@
 #  define LPUART4_ASSIGNED      1
 #endif
 
-/* Pick ttys3. This could be any of LPUART2-4 excluding the console/ttyS0 LPUART. */
+/* Pick ttys3. This could be any of LPUART2-4 excluding the console/ttyS0
+ * LPUART.
+ */
 
 #if defined(CONFIG_KINETIS_LPUART2) && !defined(LPUART2_ASSIGNED)
 #  define TTYS3_DEV             g_lpuart2port /* LPUART2 is ttyS3 */
@@ -178,7 +185,9 @@
 #  define LPUART4_ASSIGNED      1
 #endif
 
-/* Pick ttys3. This could be any of LPUART3-4 excluding the console/ttyS0 LPUART. */
+/* Pick ttys3. This could be any of LPUART3-4 excluding the console/ttyS0
+ * LPUART.
+ */
 
 #if defined(CONFIG_KINETIS_LPUART3) && !defined(LPUART3_ASSIGNED)
 #  define TTYS4_DEV             g_lpuart3port /* LPUART3 is ttyS4 */
@@ -338,7 +347,7 @@ static uart_dev_t g_lpuart0port =
   {
     .size   = CONFIG_LPUART0_TXBUFSIZE,
     .buffer = g_lpuart0txbuffer,
-   },
+  },
   .ops      = &g_lpuart_ops,
   .priv     = &g_lpuart0priv,
 };
@@ -377,7 +386,7 @@ static uart_dev_t g_lpuart1port =
   {
     .size   = CONFIG_LPUART1_TXBUFSIZE,
     .buffer = g_lpuart1txbuffer,
-   },
+  },
   .ops      = &g_lpuart_ops,
   .priv     = &g_lpuart1priv,
 };
@@ -416,7 +425,7 @@ static uart_dev_t g_lpuart2port =
   {
     .size   = CONFIG_LPUART2_TXBUFSIZE,
     .buffer = g_lpuart2txbuffer,
-   },
+  },
   .ops      = &g_lpuart_ops,
   .priv     = &g_lpuart2priv,
 };
@@ -455,7 +464,7 @@ static uart_dev_t g_lpuart3port =
   {
     .size   = CONFIG_LPUART3_TXBUFSIZE,
     .buffer = g_lpuart3txbuffer,
-   },
+  },
   .ops      = &g_lpuart_ops,
   .priv     = &g_lpuart3priv,
 };
@@ -494,7 +503,7 @@ static uart_dev_t g_lpuart4port =
   {
     .size   = CONFIG_LPUART4_TXBUFSIZE,
     .buffer = g_lpuart4txbuffer,
-   },
+  },
   .ops      = &g_lpuart_ops,
   .priv     = &g_lpuart4priv,
 };
@@ -533,7 +542,9 @@ static void kinetis_setuartint(struct kinetis_dev_s *priv)
   irqstate_t flags;
   uint32_t regval;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in ie */
+  /* Re-enable/re-disable interrupts corresponding to the state of bits in
+   * ie
+   */
 
   flags    = enter_critical_section();
   regval   = kinetis_serialin(priv, KINETIS_LPUART_CTRL_OFFSET);
@@ -551,7 +562,9 @@ static void kinetis_restoreuartint(struct kinetis_dev_s *priv, uint32_t ie)
 {
   irqstate_t flags;
 
-  /* Re-enable/re-disable interrupts corresponding to the state of bits in ie */
+  /* Re-enable/re-disable interrupts corresponding to the state of bits in
+   * ie
+   */
 
   flags    = enter_critical_section();
   priv->ie = ie & LPUART_CTRL_ALL_INTS;
@@ -645,7 +658,8 @@ static void kinetis_shutdown(struct uart_dev_s *dev)
  *   Configure the LPUART to operation in interrupt driven mode.  This
  *   method is called when the serial port is opened.  Normally, this is
  *   just after the setup() method is called, however, the serial
- *   console may operate in a non-interrupt driven mode during the boot phase.
+ *   console may operate in a non-interrupt driven mode during the boot
+ *   phase.
  *
  *   RX and TX interrupts are not enabled when by the attach method (unless
  *   the hardware supports multiple levels of interrupt enabling).  The RX
@@ -718,14 +732,15 @@ static int kinetis_interrupt(int irq, void *context, void *arg)
   DEBUGASSERT(dev != NULL && dev->priv != NULL);
   priv = (struct kinetis_dev_s *)dev->priv;
 
-  /* Read status register and qualify it with STAT bit corresponding CTRL IE bits */
+  /* Read status register and qualify it with STAT bit corresponding CTRL IE
+   * bits
+   */
 
   stat = kinetis_serialin(priv, KINETIS_LPUART_STAT_OFFSET);
   ctrl = kinetis_serialin(priv, KINETIS_LPUART_CTRL_OFFSET);
   stat &= LPUART_CTRL2STAT(ctrl);
   do
     {
-
       /* Handle errors.  This interrupt may be caused by:
        *
        * OR: Receiver Overrun Flag. To clear OR, when STAT read with OR set,
@@ -740,7 +755,6 @@ static int kinetis_interrupt(int irq, void *context, void *arg)
 
       if (stat & LPUART_STAT_ERRORS)
         {
-
           /* Only Overrun error does not need a read operation */
 
           if ((stat & LPUART_STAT_OR) != LPUART_STAT_OR)
@@ -781,7 +795,9 @@ static int kinetis_interrupt(int irq, void *context, void *arg)
           uart_xmitchars(dev);
         }
 
-      /* Read status register and requalify it with STAT bit corresponding CTRL IE bits */
+      /* Read status register and requalify it with STAT bit corresponding
+       * CTRL IE bits
+       */
 
       stat = kinetis_serialin(priv, KINETIS_LPUART_STAT_OFFSET);
       ctrl = kinetis_serialin(priv, KINETIS_LPUART_CTRL_OFFSET);
@@ -850,7 +866,7 @@ static int kinetis_ioctl(struct file *filep, int cmd, unsigned long arg)
       {
         if ((arg & SER_SINGLEWIRE_PULLUP) != 0)
           {
-            ret = -EINVAL; // Not supported
+            ret = -EINVAL; /* Not supported */
             break;
           }
 
@@ -888,9 +904,9 @@ static int kinetis_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         cfsetispeed(termiosp, priv->baud);
 
-        /* Note: CSIZE only supports 5-8 bits. The driver only support 8/9 bit
-         * modes and therefore is no way to report 9-bit mode, we always claim
-         * 8 bit mode.
+        /* Note: CSIZE only supports 5-8 bits. The driver only support 8/9
+         * bit modes and therefore is no way to report 9-bit mode, we always
+         * claim 8 bit mode.
          */
 
         termiosp->c_cflag =
@@ -1363,7 +1379,7 @@ unsigned int kinetis_lpuart_serialinit(unsigned int first)
   char devname[] = "/dev/ttySx";
 #endif
 
-/* Register the console */
+  /* Register the console */
 
 #ifdef HAVE_LPUART_CONSOLE
   uart_register("/dev/console", &CONSOLE_DEV);
@@ -1387,22 +1403,22 @@ unsigned int kinetis_lpuart_serialinit(unsigned int first)
 
 #else
 
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0])) - 2] = '0' + first++;
   uart_register(devname, &TTYS0_DEV);
 #ifdef TTYS1_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0])) - 2] = '0' + first++;
   uart_register(devname, &TTYS1_DEV);
 #endif
 #ifdef TTYS2_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0])) - 2] = '0' + first++;
   uart_register(devname, &TTYS2_DEV);
 #endif
 #ifdef TTYS3_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0])) - 2] = '0' + first++;
   uart_register(devname, &TTYS3_DEV);
 #endif
 #ifdef TTYS4_DEV
-  devname[(sizeof(devname)/sizeof(devname[0]))-2] = '0' + first++;
+  devname[(sizeof(devname) / sizeof(devname[0])) - 2] = '0' + first++;
   uart_register(devname, &TTYS4_DEV);
 #endif
 #endif

--- a/arch/arm/src/kl/kl_start.c
+++ b/arch/arm/src/kl/kl_start.c
@@ -135,6 +135,7 @@ void __start(void)
     {
       *dest++ = 0;
     }
+
   showprogress('B');
 
   /* Move the initialized data section from his temporary holding spot in
@@ -147,6 +148,7 @@ void __start(void)
     {
       *dest++ = *src++;
     }
+
   showprogress('C');
 
   /* Perform early serial initialization */

--- a/arch/arm/src/kl/kl_start.c
+++ b/arch/arm/src/kl/kl_start.c
@@ -80,7 +80,7 @@
  * Public Data
  ****************************************************************************/
 
-const uint32_t g_idle_topstack = IDLE_STACK;
+const uintptr_t g_idle_topstack = IDLE_STACK;
 
 /****************************************************************************
  * Private Functions

--- a/arch/arm/src/lpc214x/lpc214x_serial.c
+++ b/arch/arm/src/lpc214x/lpc214x_serial.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * arch/arm/src/lpc214x/lpc214x_serial.c
  *
- *   Copyright (C) 2007-2009, 2012-2013, 2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2007-2009, 2012-2013, 2017 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -178,7 +179,7 @@ static uart_dev_t g_uart1port =
   {
     .size   = CONFIG_UART1_TXBUFSIZE,
     .buffer = g_uart1txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart1priv,
 };
@@ -214,7 +215,8 @@ static inline uint8_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint8_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint8_t value)
 {
   putreg8(value, priv->uartbase + offset);
 }
@@ -253,12 +255,16 @@ static inline void up_waittxready(struct up_dev_s *priv)
   int tmp;
 
   /* Limit how long we will wait for the TX available condition */
+
   for (tmp = 1000 ; tmp > 0 ; tmp--)
     {
       /* Check if the tranmitter holding register (THR) is empty */
-      if ((up_serialin(priv, LPC214X_UART_LSR_OFFSET) & LPC214X_LSR_THRE) != 0)
+
+      if ((up_serialin(priv, LPC214X_UART_LSR_OFFSET) &
+           LPC214X_LSR_THRE) != 0)
         {
           /* The THR is empty, return */
+
           break;
         }
     }
@@ -394,14 +400,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -430,8 +437,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -542,6 +549,7 @@ static int up_interrupt(int irq, void *context, void *arg)
             }
         }
     }
+
     return OK;
 }
 
@@ -644,6 +652,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
     {
       priv->ier &= ~LPC214X_IER_ERBFI;
     }
+
   up_serialout(priv, LPC214X_UART_IER_OFFSET, priv->ier);
 }
 
@@ -658,7 +667,8 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
 static bool up_rxavailable(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  return ((up_serialin(priv, LPC214X_UART_LSR_OFFSET) & LPC214X_LSR_RDR) != 0);
+  return ((up_serialin(priv, LPC214X_UART_LSR_OFFSET) &
+           LPC214X_LSR_RDR) != 0);
 }
 
 /****************************************************************************
@@ -696,6 +706,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
     {
       priv->ier &= ~LPC214X_IER_ETBEI;
     }
+
   up_serialout(priv, LPC214X_UART_IER_OFFSET, priv->ier);
 }
 
@@ -710,7 +721,8 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
 static bool up_txready(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  return ((up_serialin(priv, LPC214X_UART_LSR_OFFSET) & LPC214X_LSR_THRE) != 0);
+  return ((up_serialin(priv, LPC214X_UART_LSR_OFFSET) &
+           LPC214X_LSR_THRE) != 0);
 }
 
 /****************************************************************************
@@ -724,7 +736,8 @@ static bool up_txready(struct uart_dev_s *dev)
 static bool up_txempty(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  return ((up_serialin(priv, LPC214X_UART_LSR_OFFSET) & LPC214X_LSR_THRE) != 0);
+  return ((up_serialin(priv, LPC214X_UART_LSR_OFFSET) &
+           LPC214X_LSR_THRE) != 0);
 }
 
 /****************************************************************************

--- a/arch/arm/src/lpc2378/lpc23xx_serial.c
+++ b/arch/arm/src/lpc2378/lpc23xx_serial.c
@@ -177,7 +177,6 @@ static struct up_dev_s g_uart2priv =
   .parity    = CONFIG_UART2_PARITY,
   .bits      = CONFIG_UART2_BITS,
   .stopbits2 = CONFIG_UART2_2STOP,
-
 };
 
 static uart_dev_t g_uart2port =
@@ -229,7 +228,8 @@ static inline uint8_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint8_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint8_t value)
 {
   putreg8(value, priv->uartbase + offset);
 }
@@ -305,9 +305,9 @@ static inline void up_enablebreaks(struct up_dev_s *priv, bool enable)
 /****************************************************************************
  * Name: up_configbaud
  ****************************************************************************/
+
 static inline void up_configbaud(struct up_dev_s *priv)
 {
-
   /* In a buckled-up, embedded system, there is no reason to constantly
    * calculate the following.  The calculation can be skipped if the MULVAL,
    * DIVADDVAL, and DIVISOR values are provided in the configuration file.
@@ -347,12 +347,14 @@ static inline void up_configbaud(struct up_dev_s *priv)
 
   qtrclk = U0_PCLK >> 4;        /* TODO: Different Uart port with different clocking */
 
-  /* Try every valid multiplier, tmulval (or until a perfect match is found). */
+  /* Try every valid multiplier, tmulval
+   * (or until a perfect match is found).
+   */
 
   for (tmulval = 1; tmulval <= 15 && errval > 0; tmulval++)
     {
-      /* Try every valid pre-scale div, tdivaddval (or until a perfect match is
-       * found).
+      /* Try every valid pre-scale div, tdivaddval
+       * (or until a perfect match is found).
        */
 
       for (tdivaddval = 0; tdivaddval <= 15 && errval > 0; tdivaddval++)
@@ -408,6 +410,7 @@ static inline void up_configbaud(struct up_dev_s *priv)
 #else
 
   /* Configure the MS and LS DLAB registers */
+
   up_serialout(priv, UART_DLM_OFFSET, DLMVAL >> 8);
   up_serialout(priv, UART_DLL_OFFSET, DLLVAL & 0xff);
 
@@ -436,7 +439,8 @@ static int up_setup(struct uart_dev_s *dev)
 
   /* Clear fifos */
 
-  up_serialout(priv, UART_FCR_OFFSET, (FCR_RX_FIFO_RESET | FCR_TX_FIFO_RESET));
+  up_serialout(priv, UART_FCR_OFFSET,
+               (FCR_RX_FIFO_RESET | FCR_TX_FIFO_RESET));
 
   /* Set trigger */
 
@@ -484,10 +488,11 @@ static int up_setup(struct uart_dev_s *dev)
                (FCR_FIFO_TRIG8 | FCR_TX_FIFO_RESET |
                 FCR_RX_FIFO_RESET | FCR_FIFO_ENABLE));
 
-  /* The NuttX serial driver waits for the first THRE interrupt before sending
-   * serial data... However, it appears that the LPC2378 hardware too does not
-   * generate that interrupt until a transition from not-empty to empty.  So,
-   * the current kludge here is to send one NULL at startup to kick things off.
+  /* The NuttX serial driver waits for the first THRE interrupt before
+   * sending serial data... However, it appears that the LPC2378 hardware
+   * too does not generate that interrupt until a transition from not-empty
+   * to empty.  So, the current kludge here is to send one NULL at startup
+   * to kick things off.
    */
 
   up_serialout(priv, UART_THR_OFFSET, '\0');
@@ -514,14 +519,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -536,7 +542,8 @@ static int up_attach(struct uart_dev_s *dev)
   if (ret == OK)
     {
       /* Enable the interrupt (RX and TX interrupts are still disabled in the
-       * UART */
+       * UART
+       */
 
       up_enable_irq(priv->irq);
     }
@@ -549,8 +556,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -585,11 +592,14 @@ static int up_interrupt(int irq, void *context, void *arg)
   priv = (struct up_dev_s *)dev->priv;
 
   /* Loop until there are no characters to be transferred or, until we have
-   * been looping for a long time. */
+   * been looping for a long time.
+   */
 
   for (passes = 0; passes < 256; passes++)
     {
-      /* Get the current UART status and check for loop termination conditions */
+      /* Get the current UART status and check for loop termination
+       * conditions
+       */
 
       status = up_serialin(priv, UART_IIR_OFFSET);
 
@@ -597,7 +607,9 @@ static int up_interrupt(int irq, void *context, void *arg)
 
       if ((status & IIR_NO_INT) != 0)
         {
-          /* Break out of the loop when there is no longer a pending interrupt */
+          /* Break out of the loop when there is no longer a pending
+           * interrupt
+           */
 
           break;
         }
@@ -654,6 +666,7 @@ static int up_interrupt(int irq, void *context, void *arg)
           }
         }
     }
+
   return OK;
 }
 
@@ -758,6 +771,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
     {
       priv->ier &= ~IER_ERBFI;
     }
+
   up_serialout(priv, UART_IER_OFFSET, priv->ier);
 }
 
@@ -810,6 +824,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
     {
       priv->ier &= ~IER_ETBEI;
     }
+
   up_serialout(priv, UART_IER_OFFSET, priv->ier);
 }
 

--- a/arch/arm/src/lpc31xx/lpc31_serial.c
+++ b/arch/arm/src/lpc31xx/lpc31_serial.c
@@ -280,7 +280,9 @@ static inline void up_configbaud(void)
 
               if (tmperr < errval)
                 {
-                  /* Yes, save these settings as the new, candidate optimal settings */
+                  /* Yes, save these settings as the new, candidate optimal
+                   * settings
+                   */
 
                   mulval    = tmulval ;
                   divaddval = tdivaddval;
@@ -427,11 +429,11 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Description:
  *   Configure the UART to operation in interrupt driven mode.  This method
  *   is called when the serial port is opened.  Normally, this is just after
- *   he the setup() method is called, however, the serial console may operate in
+ *   he the setup() method is called, however, the serial console may operate
  *   in a non-interrupt driven mode during the boot phase.
  *
  *   RX and TX interrupts are not enabled when by the attach method (unless
- *   the hardware supports multiple levels of interrupt enabling).  The RX and TX
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
  *   and TX interrupts are not enabled until the txint() and rxint() methods
  *   are called.
  *
@@ -519,8 +521,8 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
         {
           /* Handle incoming, receive bytes (with or without timeout) */
 
-          case UART_IIR_INTID_RDA: /* Received Data Available */
-          case UART_IIR_INTID_TIMEOUT:  /* Character time-out */
+          case UART_IIR_INTID_RDA:     /* Received Data Available */
+          case UART_IIR_INTID_TIMEOUT: /* Character time-out */
             {
               uart_recvchars(dev);
               break;
@@ -565,6 +567,7 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
             }
         }
     }
+
     return OK;
 }
 
@@ -667,6 +670,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
     {
       priv->ier &= ~UART_IER_RDAINTEN;
     }
+
   putreg32(priv->ier, LPC31_UART_IER);
 }
 
@@ -717,6 +721,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
     {
       priv->ier &= ~UART_IER_THREINTEN;
     }
+
   putreg32(priv->ier, LPC31_UART_IER);
 }
 

--- a/arch/arm/src/lpc43xx/lpc43_allocateheap.c
+++ b/arch/arm/src/lpc43xx/lpc43_allocateheap.c
@@ -188,13 +188,16 @@
 #ifndef CONFIG_LPC43_BOOT_SRAM
 
 /* Configuration A */
+
 /* CONFIG_RAM_START should be set to the base of local SRAM, Bank 0. */
 
 #  if CONFIG_RAM_START != LPC43_LOCSRAM_BANK0_BASE
 #    error "CONFIG_RAM_START must be set to the base address of RAM bank 0"
 #  endif
 
-/* The configured RAM size should be equal to the size of local SRAM Bank 0. */
+/* The configured RAM size should be equal to the size of local SRAM Bank
+ * 0.
+ */
 
 #  if CONFIG_RAM_SIZE != LPC43_LOCSRAM_BANK0_SIZE
 #    error "CONFIG_RAM_SIZE must be set to size of local SRAM Bank 0"
@@ -213,13 +216,16 @@
 #else /* CONFIG_LPC43_BOOT_SRAM */
 
 /* Configuration B */
+
 /* CONFIG_RAM_START should be set to the base of local SRAM, Bank 1. */
 
 #  if CONFIG_RAM_START != LPC43_LOCSRAM_BANK1_BASE
 #    error "CONFIG_RAM_START must be set to the base address of RAM bank 1"
 #  endif
 
-/* The configured RAM size should be equal to the size of local SRAM Bank 1. */
+/* The configured RAM size should be equal to the size of local SRAM Bank
+ * 1.
+ */
 
 #  if CONFIG_RAM_SIZE != LPC43_LOCSRAM_BANK1_SIZE
 #    error "CONFIG_RAM_SIZE must be set to size of local SRAM Bank 1"
@@ -408,7 +414,8 @@ static void mem_addregion(FAR void *region_start, size_t region_size)
  *
  *     Kernel .data region.  Size determined at link time.
  *     Kernel .bss  region  Size determined at link time.
- *     Kernel IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
+ *     Kernel IDLE thread stack.  Size determined by
+ *     CONFIG_IDLETHREAD_STACKSIZE.
  *     Padding for alignment
  *     User .data region.  Size determined at link time.
  *     User .bss region  Size determined at link time.
@@ -425,7 +432,8 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+                               CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = CONFIG_RAM_END - ubase;
   int       log2;
 
@@ -492,7 +500,8 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+                               CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = CONFIG_RAM_END - ubase;
   int       log2;
 
@@ -538,36 +547,42 @@ void arm_addregion(void)
 #ifdef MM_USE_LOCSRAM_BANK1
   /* Add the SRAM to the user heap */
 
-  mem_addregion((FAR void *)LPC43_LOCSRAM_BANK1_BASE, LPC43_LOCSRAM_BANK1_SIZE);
+  mem_addregion((FAR void *)LPC43_LOCSRAM_BANK1_BASE,
+                            LPC43_LOCSRAM_BANK1_SIZE);
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
   /* Allow user-mode access to the SRAM heap */
 
-  lpc43_mpu_uheap((uintptr_t)LPC43_LOCSRAM_BANK1_BASE, LPC43_LOCSRAM_BANK1_SIZE);
+  lpc43_mpu_uheap((uintptr_t)LPC43_LOCSRAM_BANK1_BASE,
+                             LPC43_LOCSRAM_BANK1_SIZE);
 #endif
 #endif
 
 #ifdef MM_USE_AHBSRAM_BANK0
   /* Add the SRAM to the user heap */
 
-  mem_addregion((FAR void *)LPC43_AHBSRAM_BANK0_BASE, LPC43_AHBSRAM_BANK0_SIZE);
+  mem_addregion((FAR void *)LPC43_AHBSRAM_BANK0_BASE,
+                            LPC43_AHBSRAM_BANK0_SIZE);
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
   /* Allow user-mode access to the SRAM heap */
 
-  lpc43_mpu_uheap((uintptr_t)LPC43_AHBSRAM_BANK0_BASE, LPC43_AHBSRAM_BANK0_SIZE);
+  lpc43_mpu_uheap((uintptr_t)LPC43_AHBSRAM_BANK0_BASE,
+                             LPC43_AHBSRAM_BANK0_SIZE);
 #endif
 #endif
 
 #ifdef MM_USE_AHBSRAM_BANK1
   /* Add the SRAM to the user heap */
 
-  mem_addregion((FAR void *)LPC43_AHBSRAM_BANK1_BASE, LPC43_AHBSRAM_BANK1_SIZE);
+  mem_addregion((FAR void *)LPC43_AHBSRAM_BANK1_BASE,
+                            LPC43_AHBSRAM_BANK1_SIZE);
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
   /* Allow user-mode access to the SRAM heap */
 
-  lpc43_mpu_uheap((uintptr_t)LPC43_AHBSRAM_BANK1_BASE, LPC43_AHBSRAM_BANK1_SIZE);
+  lpc43_mpu_uheap((uintptr_t)LPC43_AHBSRAM_BANK1_BASE,
+                             LPC43_AHBSRAM_BANK1_SIZE);
 #endif
 #endif
 

--- a/arch/arm/src/lpc43xx/lpc43_allocateheap.c
+++ b/arch/arm/src/lpc43xx/lpc43_allocateheap.c
@@ -340,7 +340,8 @@
  * aligned).
  */
 
-const uint32_t g_idle_topstack = (uint32_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE;
+const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+    CONFIG_IDLETHREAD_STACKSIZE;
 
 #ifdef MM_HAVE_REGION
 static uint8_t g_mem_region_next = 0;

--- a/arch/arm/src/lpc54xx/lpc54_allocateheap.c
+++ b/arch/arm/src/lpc54xx/lpc54_allocateheap.c
@@ -60,7 +60,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
+
 /* Terminology.  In the flat build (CONFIG_BUILD_FLAT=y), there is only a
  * single heap access with the standard allocations (malloc/free).  This
  * heap is referred to as the user heap.  In the protected build
@@ -176,7 +178,8 @@ const uint32_t g_idle_topstack = (uint32_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE;
  *
  *     Kernel .data region.  Size determined at link time.
  *     Kernel .bss  region  Size determined at link time.
- *     Kernel IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
+ *     Kernel IDLE thread stack.  Size determined by
+ *     CONFIG_IDLETHREAD_STACKSIZE.
  *     Padding for alignment
  *     User .data region.  Size determined at link time.
  *     User .bss region  Size determined at link time.
@@ -197,7 +200,8 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+                    CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = CONFIG_RAM_END - ubase;
 
   DEBUGASSERT(ubase < (uintptr_t)CONFIG_RAM_END);
@@ -236,7 +240,8 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+                    CONFIG_MM_KERNEL_HEAPSIZE;
   DEBUGASSERT(ubase < (uintptr_t)CONFIG_RAM_END);
 
   /* Return the kernel heap settings (i.e., the part of the heap region
@@ -269,7 +274,8 @@ void arm_addregion(void)
     {
       /* Add the SRAM to the user heap */
 
-      heapstart = (FAR void *)(LPC54_SRAMCS0_BASE + CONFIG_LPC54_EMC_STATIC_CS0_OFFSET);
+      heapstart = (FAR void *)(LPC54_SRAMCS0_BASE +
+                               CONFIG_LPC54_EMC_STATIC_CS0_OFFSET);
       heapsize  = CONFIG_LPC54_EMC_STATIC_CS0_SIZE;
       kumm_addregion(heapstart, heapsize);
 
@@ -287,7 +293,8 @@ void arm_addregion(void)
     {
       /* Add the SRAM to the user heap */
 
-      heapstart = (FAR void *)(LPC54_SRAMCS1_BASE + CONFIG_LPC54_EMC_STATIC_CS1_OFFSET);
+      heapstart = (FAR void *)(LPC54_SRAMCS1_BASE +
+                               CONFIG_LPC54_EMC_STATIC_CS1_OFFSET);
       heapsize  = CONFIG_LPC54_EMC_STATIC_CS1_SIZE;
       kumm_addregion(heapstart, heapsize);
 
@@ -305,7 +312,8 @@ void arm_addregion(void)
     {
       /* Add the SRAM to the user heap */
 
-      heapstart = (FAR void *)(LPC54_SRAMCS2_BASE + CONFIG_LPC54_EMC_STATIC_CS2_OFFSET);
+      heapstart = (FAR void *)(LPC54_SRAMCS2_BASE +
+                               CONFIG_LPC54_EMC_STATIC_CS2_OFFSET);
       heapsize  = CONFIG_LPC54_EMC_STATIC_CS2_SIZE;
       kumm_addregion(heapstart, heapsize);
 
@@ -323,7 +331,8 @@ void arm_addregion(void)
     {
       /* Add the SRAM to the user heap */
 
-      heapstart = (FAR void *)(LPC54_SRAMCS3_BASE + CONFIG_LPC54_EMC_STATIC_CS3_OFFSET);
+      heapstart = (FAR void *)(LPC54_SRAMCS3_BASE +
+                               CONFIG_LPC54_EMC_STATIC_CS3_OFFSET);
       heapsize  = CONFIG_LPC54_EMC_STATIC_CS3_SIZE;
       kumm_addregion(heapstart, heapsize);
 
@@ -341,7 +350,8 @@ void arm_addregion(void)
     {
       /* Add the SDRAM to the user heap */
 
-      heapstart = (FAR void *)(LPC54_DRAMCS0_BASE + CONFIG_LPC54_EMC_DYNAMIC_CS0_OFFSET);
+      heapstart = (FAR void *)(LPC54_DRAMCS0_BASE +
+                               CONFIG_LPC54_EMC_DYNAMIC_CS0_OFFSET);
       heapsize  = CONFIG_LPC54_EMC_DYNAMIC_CS0_SIZE;
       kumm_addregion(heapstart, heapsize);
 
@@ -359,7 +369,8 @@ void arm_addregion(void)
     {
       /* Add the SDRAM to the user heap */
 
-      heapstart = (FAR void *)(LPC54_DRAMCS1_BASE + CONFIG_LPC54_EMC_DYNAMIC_CS1_OFFSET);
+      heapstart = (FAR void *)(LPC54_DRAMCS1_BASE +
+                               CONFIG_LPC54_EMC_DYNAMIC_CS1_OFFSET);
       heapsize  = CONFIG_LPC54_EMC_DYNAMIC_CS1_SIZE;
       kumm_addregion(heapstart, heapsize);
 
@@ -377,7 +388,8 @@ void arm_addregion(void)
     {
       /* Add the SDRAM to the user heap */
 
-      heapstart = (FAR void *)(LPC54_DRAMCS2_BASE + CONFIG_LPC54_EMC_DYNAMIC_CS2_OFFSET);
+      heapstart = (FAR void *)(LPC54_DRAMCS2_BASE +
+                               CONFIG_LPC54_EMC_DYNAMIC_CS2_OFFSET);
       heapsize  = CONFIG_LPC54_EMC_DYNAMIC_CS2_SIZE;
       kumm_addregion(heapstart, heapsize);
 
@@ -395,7 +407,8 @@ void arm_addregion(void)
     {
       /* Add the SDRAM to the user heap */
 
-      heapstart = (FAR void *)(LPC54_DRAMCS3_BASE + CONFIG_LPC54_EMC_DYNAMIC_CS3_OFFSET);
+      heapstart = (FAR void *)(LPC54_DRAMCS3_BASE +
+                               CONFIG_LPC54_EMC_DYNAMIC_CS3_OFFSET);
       heapsize  = CONFIG_LPC54_EMC_DYNAMIC_CS3_SIZE;
       kumm_addregion(heapstart, heapsize);
 

--- a/arch/arm/src/lpc54xx/lpc54_allocateheap.c
+++ b/arch/arm/src/lpc54xx/lpc54_allocateheap.c
@@ -143,7 +143,8 @@
  * aligned).
  */
 
-const uint32_t g_idle_topstack = (uint32_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE;
+const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+    CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************
  * Public Functions

--- a/arch/arm/src/max326xx/common/max326_start.c
+++ b/arch/arm/src/max326xx/common/max326_start.c
@@ -33,6 +33,10 @@
  *
  ****************************************************************************/
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
 #include <nuttx/config.h>
 
 #include <stdint.h>
@@ -113,7 +117,8 @@ const uint32_t g_idle_topstack = IDLE_STACK;
  *       done, the processor reserves space on the stack for the FP state,
  *       but does not save that state information to the stack.
  *
- *  Software must not change the value of the ASPEN bit or LSPEN bit while either:
+ *  Software must not change the value of the ASPEN bit or LSPEN bit while
+ *  either:
  *   - the CPACR permits access to CP10 and CP11, that give access to the FP
  *     extension, or
  *   - the CONTROL.FPCA bit is set to 1

--- a/arch/arm/src/max326xx/common/max326_start.c
+++ b/arch/arm/src/max326xx/common/max326_start.c
@@ -95,7 +95,7 @@
  * Public Data
  ****************************************************************************/
 
-const uint32_t g_idle_topstack = IDLE_STACK;
+const uintptr_t g_idle_topstack = IDLE_STACK;
 
 /****************************************************************************
  * Private Functions

--- a/arch/arm/src/nrf52/nrf52_allocateheap.c
+++ b/arch/arm/src/nrf52/nrf52_allocateheap.c
@@ -97,7 +97,8 @@
  * aligned).
  */
 
-const uint32_t g_idle_topstack = (uint32_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE;
+const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+    CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************
  * Public Functions

--- a/arch/arm/src/nrf52/nrf52_allocateheap.c
+++ b/arch/arm/src/nrf52/nrf52_allocateheap.c
@@ -132,7 +132,8 @@ const uint32_t g_idle_topstack = (uint32_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE;
  *
  *     Kernel .data region.  Size determined at link time.
  *     Kernel .bss  region  Size determined at link time.
- *     Kernel IDLE thread stack.  Size determined by CONFIG_IDLETHREAD_STACKSIZE.
+ *     Kernel IDLE thread stack.  Size determined by
+ *     CONFIG_IDLETHREAD_STACKSIZE.
  *     Padding for alignment
  *     User .data region.  Size determined at link time.
  *     User .bss region  Size determined at link time.
@@ -153,7 +154,8 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+                               CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = CONFIG_RAM_END - ubase;
 
   DEBUGASSERT(ubase < (uintptr_t)CONFIG_RAM_END);
@@ -192,7 +194,8 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend + CONFIG_MM_KERNEL_HEAPSIZE;
+  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
+                               CONFIG_MM_KERNEL_HEAPSIZE;
   DEBUGASSERT(ubase < (uintptr_t)CONFIG_RAM_END);
 
   /* Return the kernel heap settings (i.e., the part of the heap region

--- a/arch/arm/src/nuc1xx/nuc_start.c
+++ b/arch/arm/src/nuc1xx/nuc_start.c
@@ -77,7 +77,7 @@
  * Public Data
  ****************************************************************************/
 
-const uint32_t g_idle_topstack = IDLE_STACK;
+const uintptr_t g_idle_topstack = IDLE_STACK;
 
 /****************************************************************************
  * Private Functions

--- a/arch/arm/src/nuc1xx/nuc_start.c
+++ b/arch/arm/src/nuc1xx/nuc_start.c
@@ -128,6 +128,7 @@ void __start(void)
     {
       *dest++ = 0;
     }
+
   showprogress('B');
 
   /* Move the initialized data section from his temporary holding spot in
@@ -140,6 +141,7 @@ void __start(void)
     {
       *dest++ = *src++;
     }
+
   showprogress('C');
 
   /* Perform early serial initialization */

--- a/arch/arm/src/sam34/sam_udp.c
+++ b/arch/arm/src/sam34/sam_udp.c
@@ -96,6 +96,7 @@
 #endif
 
 /* Driver Definitions *******************************************************/
+
 /* Initial interrupt mask: Reset + Suspend + Correct Transfer */
 
 #define SAM_CNTR_SETUP      (USB_CNTR_RESETM|USB_CNTR_SUSPM|USB_CNTR_CTRM)
@@ -133,6 +134,7 @@
 #define sam_rqpeek(q)       ((q)->head)
 
 /* USB trace ****************************************************************/
+
 /* Trace error codes */
 
 #define SAM_TRACEERR_ALLOCFAIL            0x0001
@@ -223,17 +225,21 @@
 /****************************************************************************
  * Private Type Definitions
  ****************************************************************************/
+
 /* State of an endpoint */
 
 enum sam_epstate_e
 {
-                            /* --- All Endpoints --- */
+  /* --- All Endpoints --- */
+
   UDP_EPSTATE_DISABLED = 0, /* Endpoint is disabled */
   UDP_EPSTATE_STALLED,      /* Endpoint is stalled */
   UDP_EPSTATE_IDLE,         /* Endpoint is idle (i.e. ready for transmission) */
   UDP_EPSTATE_SENDING,      /* Endpoint is sending data */
   UDP_EPSTATE_RXSTOPPED,    /* OUT endpoint is stopped waiting for a read request */
-                            /* --- Endpoint 0 Only --- */
+
+  /* --- Endpoint 0 Only --- */
+
   UDP_EPSTATE_EP0DATAOUT,   /* Endpoint 0 is receiving SETUP OUT data */
   UDP_EPSTATE_EP0STATUSIN,  /* Endpoint 0 is sending SETUP status */
   UDP_EPSTATE_EP0ADDRESS    /* Address change is pending completion of status */
@@ -497,7 +503,8 @@ static const struct usb_epdesc_s g_ep0desc =
   .type          = USB_DESC_TYPE_ENDPOINT,
   .addr          = EP0,
   .attr          = USB_EP_ATTR_XFER_CONTROL,
-  .mxpacketsize  = {64, 0},
+  .mxpacketsize  =
+    {64, 0},
   .interval      = 0
 };
 
@@ -595,6 +602,7 @@ const struct trace_msg_t g_usb_trace_strings_intdecode[] =
 /****************************************************************************
  * Register Operations
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_printreg
  *
@@ -627,7 +635,8 @@ static void sam_checkreg(uintptr_t regaddr, uint32_t regval, bool iswrite)
   static uint32_t  count     = 0;
   static bool      prevwrite = false;
 
-  /* Is this the same value that we read from/wrote to the same register last time?
+  /* Is this the same value that we read from/wrote to the same register
+   * last time?
    * Are we polling the register?  If so, suppress the output.
    */
 
@@ -752,6 +761,7 @@ static void sam_dumpep(struct sam_usbdev_s *priv, uint8_t epno)
 /****************************************************************************
  * Request Helpers
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_req_dequeue
  ****************************************************************************/
@@ -778,7 +788,8 @@ static struct sam_req_s *sam_req_dequeue(struct sam_rqhead_s *queue)
  * Name: sam_req_enqueue
  ****************************************************************************/
 
-static void sam_req_enqueue(struct sam_rqhead_s *queue, struct sam_req_s *req)
+static void sam_req_enqueue(struct sam_rqhead_s *queue,
+                            struct sam_req_s *req)
 {
   req->flink = NULL;
   if (!queue->head)
@@ -907,10 +918,10 @@ static void sam_req_wrsetup(struct sam_usbdev_s *priv,
  *
  * Description:
  *   Process the next queued write request.  This function is called in one
- *   of three contexts:  (1) When the endpoint is IDLE and a new write request
- *   is submitted (with interrupts disabled), (2) from TXCOMP interrupt
- *   handling when the current FIFO Tx transfer completes, or (3) when resuming
- *   a stalled IN or control endpoint.
+ *   of three contexts:  (1) When the endpoint is IDLE and a new write
+ *   request is submitted (with interrupts disabled), (2) from TXCOMP
+ *   interrupt handling when the current FIFO Tx transfer completes, or
+ *   (3) when resuming a stalled IN or control endpoint.
  *
  *   Calling rules:
  *
@@ -1017,13 +1028,14 @@ static int sam_req_write(struct sam_usbdev_s *priv, struct sam_ep_s *privep)
        * this transfer.
        */
 
-      else if ((privreq->req.len == 0 || privep->zlpneeded) && !privep->zlpsent)
+      else if ((privreq->req.len == 0 || privep->zlpneeded) &&
+               !privep->zlpsent)
         {
           /* If we get here, then we sent the last of the data on the
            * previous pass and we need to send the zero length packet now.
            *
-           * A Zero Length Packet can be sent by setting just the TXPTKRDY flag
-           * in the UDP_EPTSETSTAx register
+           * A Zero Length Packet can be sent by setting just the TXPTKRDY
+           * flag in the UDP_EPTSETSTAx register
            */
 
           privep->epstate   = UDP_EPSTATE_SENDING;
@@ -1127,11 +1139,11 @@ static int sam_req_read(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
           usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EPOUTQEMPTY), epno);
 
           /* Disable further interrupts from this endpoint.  The RXDATABK0/1
-           * interrupt will pend until either another read request is received
-           * from the class driver or until the endpoint is reset because of
-           * no response.  Set a flag so that we know that we are in this
-           * perverse state and can re-enable endpoint interrupts when the
-           * next read request is received.
+           * interrupt will pend until either another read request is
+           * received from the class driver or until the endpoint is reset
+           * because of no response.  Set a flag so that we know that we are
+           * in this perverse state and can re-enable endpoint interrupts
+           * when the next read request is received.
            */
 
           sam_putreg(UDP_INT_EP(epno), SAM_UDP_IDR);
@@ -1190,8 +1202,8 @@ static int sam_req_read(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
    * cannot be cleared until all of the data has been taken from the RX
    * FIFO.
    *
-   * Also, we need to remember which bank we read last so the interrupt handler
-   * can determine the correct bank read sequence for future reads.
+   * Also, we need to remember which bank we read last so the interrupt
+   * handler can determine the correct bank read sequence for future reads.
    */
 
   privep->lastbank = bank;
@@ -1227,6 +1239,7 @@ static void sam_req_cancel(struct sam_ep_s *privep, int16_t result)
 /****************************************************************************
  * Interrupt Level Processing
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_ep0_read
  *
@@ -1456,10 +1469,12 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
                case USB_REQ_RECIPIENT_ENDPOINT:
                 {
                   epno = USB_EPNO(index.b[LSB]);
-                  usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EPGETSTATUS), epno);
+                  usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EPGETSTATUS),
+                           epno);
                   if (epno >= SAM_UDP_NENDPOINTS)
                     {
-                      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADEPGETSTATUS), epno);
+                      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADEPGETSTATUS),
+                               epno);
                       ep0result = UDP_EP0SETUP_STALL;
                     }
                   else
@@ -1482,18 +1497,21 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
                 {
                  if (index.w == 0)
                     {
-                      usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_DEVGETSTATUS), 0);
+                      usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_DEVGETSTATUS),
+                               0);
 
                       /* Features:  Remote Wakeup=YES; selfpowered=? */
 
                       response.w      = 0;
-                      response.b[LSB] = (priv->selfpowered << USB_FEATURE_SELFPOWERED) |
+                      response.b[LSB] = (priv->selfpowered <<
+                                         USB_FEATURE_SELFPOWERED) |
                                         (1 << USB_FEATURE_REMOTEWAKEUP);
                       nbytes          = 2; /* Response size: 2 bytes */
                     }
                   else
                     {
-                      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADDEVGETSTATUS), 0);
+                      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADDEVGETSTATUS),
+                               0);
                       ep0result = UDP_EP0SETUP_STALL;
                     }
                 }
@@ -1526,11 +1544,13 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
          * len:   zero, data = none
          */
 
-        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_CLEARFEATURE), priv->ctrl.type);
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) != USB_REQ_RECIPIENT_ENDPOINT)
+        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_CLEARFEATURE),
+                 priv->ctrl.type);
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) !=
+            USB_REQ_RECIPIENT_ENDPOINT)
           {
-            /* Let the class implementation handle all recipients (except for the
-             * endpoint recipient)
+            /* Let the class implementation handle all recipients
+             * (except for the endpoint recipient)
              */
 
             sam_ep0_dispatch(priv);
@@ -1569,17 +1589,22 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
          * len:   0; data = none
          */
 
-        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_SETFEATURE), priv->ctrl.type);
-        if (((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) == USB_REQ_RECIPIENT_DEVICE) &&
+        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_SETFEATURE),
+                 priv->ctrl.type);
+        if (((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) ==
+             USB_REQ_RECIPIENT_DEVICE) &&
             value.w == USB_FEATURE_TESTMODE)
           {
             /* Special case recipient=device test mode */
 
             uinfo("test mode: %d\n", index.w);
           }
-        else if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) != USB_REQ_RECIPIENT_ENDPOINT)
+        else if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) !=
+                 USB_REQ_RECIPIENT_ENDPOINT)
           {
-            /* The class driver handles all recipients except recipient=endpoint */
+            /* The class driver handles all recipients except
+             * recipient=endpoint
+             */
 
             sam_ep0_dispatch(priv);
             ep0result = UDP_EP0SETUP_DISPATCHED;
@@ -1617,7 +1642,8 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
          * len:   0; data = none
          */
 
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) != USB_REQ_RECIPIENT_DEVICE ||
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) !=
+            USB_REQ_RECIPIENT_DEVICE ||
             index.w != 0 || len.w != 0 || value.w > 127)
           {
             usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADSETADDRESS), 0);
@@ -1630,7 +1656,8 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
              * be set when the zero-length packet transfer completes.
              */
 
-            usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EP0SETUPSETADDRESS), value.w);
+            usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EP0SETUPSETADDRESS),
+                     value.w);
             priv->devaddr = value.w;
             ep0result     = UDP_EP0SETUP_ADDRESS;
           }
@@ -1643,6 +1670,7 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
        * index: 0 or language ID;
        * len:   descriptor len; data = descriptor
        */
+
     case USB_REQ_SETDESCRIPTOR:
       /* type:  host-to-device; recipient = device
        * value: descriptor type and index
@@ -1651,10 +1679,14 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
        */
 
       {
-        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_GETSETDESC), priv->ctrl.type);
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) == USB_REQ_RECIPIENT_DEVICE)
+        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_GETSETDESC),
+                 priv->ctrl.type);
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) ==
+            USB_REQ_RECIPIENT_DEVICE)
           {
-            /* The request seems valid... let the class implementation handle it */
+            /* The request seems valid... let the class implementation handle
+             * it
+             */
 
             sam_ep0_dispatch(priv);
             ep0result = UDP_EP0SETUP_DISPATCHED;
@@ -1675,11 +1707,15 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
        */
 
       {
-        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_GETCONFIG), priv->ctrl.type);
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) == USB_REQ_RECIPIENT_DEVICE &&
+        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_GETCONFIG),
+                 priv->ctrl.type);
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) ==
+            USB_REQ_RECIPIENT_DEVICE &&
             value.w == 0 && index.w == 0 && len.w == 1)
           {
-            /* The request seems valid... let the class implementation handle it */
+            /* The request seems valid... let the class implementation handle
+             * it
+             */
 
             sam_ep0_dispatch(priv);
             ep0result = UDP_EP0SETUP_DISPATCHED;
@@ -1701,12 +1737,14 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
 
       {
         usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_SETCONFIG), priv->ctrl.type);
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) == USB_REQ_RECIPIENT_DEVICE &&
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) ==
+            USB_REQ_RECIPIENT_DEVICE &&
             index.w == 0 && len.w == 0)
           {
-             /* The request seems valid... let the class implementation handle it.
-              * If the class implementation accepts it new configuration, it will
-              * call sam_ep_configure() to configure the endpoints.
+             /* The request seems valid... let the class implementation
+              * handle it.
+              * If the class implementation accepts it new configuration, it
+              * will call sam_ep_configure() to configure the endpoints.
               */
 
              sam_ep0_dispatch(priv);
@@ -1726,6 +1764,7 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
        * index: interface;
        * len:   1; data = alt interface
        */
+
     case USB_REQ_SETINTERFACE:
       /* type:  host-to-device; recipient = interface
        * value: alternate setting
@@ -1756,7 +1795,8 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
 
     default:
       {
-        usbtrace(TRACE_DEVERROR(SAM_TRACEERR_INVALIDCTRLREQ), priv->ctrl.req);
+        usbtrace(TRACE_DEVERROR(SAM_TRACEERR_INVALIDCTRLREQ),
+                 priv->ctrl.req);
         ep0result = UDP_EP0SETUP_STALL;
       }
       break;
@@ -1943,7 +1983,8 @@ static void sam_ep_bankinterrupt(struct sam_usbdev_s *priv,
   else
     {
       usbtrace(TRACE_DEVERROR(SAM_TRACEERR_RXDATABKERR), privep->epstate);
-      sam_csr_clrbits(epno, bank ? UDPEP_CSR_RXDATABK1 : UDPEP_CSR_RXDATABK0);
+      sam_csr_clrbits(epno,
+                      bank ? UDPEP_CSR_RXDATABK1 : UDPEP_CSR_RXDATABK0);
     }
 }
 
@@ -2023,7 +2064,6 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
         }
     }
 
-
   /* OUT packet received.
    *
    * OUT packets are received in two banks. The hardware does not provide
@@ -2061,7 +2101,7 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
       sam_ep_bankinterrupt(priv, privep, csr, 0);
     }
 
-  /* 3. and 7. - Only read bank 1*/
+  /* 3. and 7. - Only read bank 1 */
 
   else if (!bk0 && bk1)
     {
@@ -2121,7 +2161,8 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
 
      /* ISO error */
 
-      if (eptype == UDPEP_CSR_EPTYPE_ISOIN || eptype == UDPEP_CSR_EPTYPE_ISOOUT)
+      if (eptype == UDPEP_CSR_EPTYPE_ISOIN ||
+          eptype == UDPEP_CSR_EPTYPE_ISOOUT)
         {
           privep->epstate = UDP_EPSTATE_IDLE;
           sam_req_complete(privep, -EIO);
@@ -2165,23 +2206,24 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
            * before processing the SETUP command.
            */
 
-          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EP0SETUPOUT), priv->ctrl.req);
+          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EP0SETUPOUT),
+                   priv->ctrl.req);
           privep->epstate = UDP_EPSTATE_EP0DATAOUT;
 
           /* Clear the CSR:DIR bit to support the host-to-device data OUT
            * data transfer.  This bit must be cleared before CSR:RXSETUP is
            * cleared at the end of the SETUP stage.
            *
-           * NOTE: Clearing this bit seems to be unnecessary.  I think it must
-           * be cleared when RXSETUP is set.
+           * NOTE: Clearing this bit seems to be unnecessary.  I think it
+           * must be cleared when RXSETUP is set.
            */
 
           sam_csr_clrbits(epno, UDPEP_CSR_DIR);
 
-          /* Clear the RXSETUP indication. RXSETUP cannot be cleared before the
-           * SETUP packet has been read in from the FIFO.  Otherwise, the USB
-           * device would accept the next Data OUT transfer and overwrite the
-           * SETUP packet in the FIFO.
+          /* Clear the RXSETUP indication. RXSETUP cannot be cleared before
+           * the SETUP packet has been read in from the FIFO.  Otherwise,
+           * the USB device would accept the next Data OUT transfer and
+           * overwrite the SETUP packet in the FIFO.
            */
 
           sam_csr_clrbits(epno, UDPEP_CSR_RXSETUP);
@@ -2327,8 +2369,8 @@ static int sam_udp_interrupt(int irq, void *context, FAR void *arg)
        *
        * In this state UDPCK and MCK must be enabled.
        *
-       * Warning: Each time an ENDBUSRES interrupt is triggered, the Interrupt
-       * Mask Register and UDPEP_CSR registers have been reset.
+       * Warning: Each time an ENDBUSRES interrupt is triggered, the
+       * Interrupt Mask Register and UDPEP_CSR registers have been reset.
        */
 
       if ((pending & UDP_ISR_ENDBUSRES) != 0)
@@ -2447,6 +2489,7 @@ static void sam_csr_clrbits(uint8_t epno, uint32_t clrbits)
 /****************************************************************************
  * Suspend/Resume Helpers
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_suspend
  ****************************************************************************/
@@ -2488,9 +2531,9 @@ static void sam_suspend(struct sam_usbdev_s *priv)
 
 static void sam_resume(struct sam_usbdev_s *priv)
 {
-  /* This function is called when either (1) a WKUP interrupt is received from
-   * the host PC, or (2) the class device implementation calls the wakeup()
-   * method.
+  /* This function is called when either (1) a WKUP interrupt is received
+   * from the host PC, or (2) the class device implementation calls the
+   * wakeup() method.
    */
 
   /* Don't do anything if the device was not suspended */
@@ -2505,7 +2548,9 @@ static void sam_resume(struct sam_usbdev_s *priv)
 
       sam_enableclks();
 
-      /* Restore full power -- whatever that means for this particular board */
+      /* Restore full power -- whatever that means for this particular
+       * board
+       */
 
       sam_udp_suspend((struct usbdev_s *)priv, true);
 
@@ -2675,13 +2720,14 @@ static int sam_ep_resume(struct sam_ep_s *privep)
 
       sam_putreg(UDP_RSTEP(epno), SAM_UDP_RSTEP);
 
-      /* We need to add a delay between setting and clearing the endpoint reset
-       * bit in SAM_UDP_RSTEP. Without the delay the USB controller will (may?)
-       * not reset the endpoint.
+      /* We need to add a delay between setting and clearing the endpoint
+       * reset bit in SAM_UDP_RSTEP. Without the delay the USB controller
+       * will (may?) not reset the endpoint.
        *
        * If the endpoint is not being reset, the Data Toggle (DTGLE) bit will
        * not to be cleared which will cause the next transaction to fail if
-       * DTGLE is 1. If that happens the host will time-out and reset the bus.
+       * DTGLE is 1. If that happens the host will time-out and reset the
+       * bus.
        *
        * Adding this delay may also fix the USBMSC_STALL_RACEWAR in
        * usbmsc_scsi.c, however this has not been verified yet.
@@ -2689,7 +2735,6 @@ static int sam_ep_resume(struct sam_ep_s *privep)
 
       up_udelay(10);
       sam_putreg(0, SAM_UDP_RSTEP);
-
 
       /* Copy any requests in the pending request queue to the working
        * request queue.
@@ -2834,6 +2879,7 @@ static int sam_ep_configure_internal(struct sam_ep_s *privep,
   privep->epstate      = UDP_EPSTATE_IDLE;
 
   /* Initialize the endpoint hardware */
+
   /* Disable the endpoint */
 
   csr = SAM_UDPEP_CSR(epno);
@@ -2937,6 +2983,7 @@ static int sam_ep_configure_internal(struct sam_ep_s *privep,
 /****************************************************************************
  * Endpoint operations
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_ep_configure
  *
@@ -3154,7 +3201,8 @@ static int sam_ep_submit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
 #ifdef CONFIG_DEBUG_USB
   if (!priv->driver)
     {
-      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_NOTCONFIGURED), priv->usbdev.speed);
+      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_NOTCONFIGURED),
+               priv->usbdev.speed);
       uerr("ERROR: driver=%p\n", priv->driver);
       return -ESHUTDOWN;
     }
@@ -3333,6 +3381,7 @@ static int sam_ep_stallresume(struct usbdev_ep_s *ep, bool resume)
 /****************************************************************************
  * Device Controller Operations
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_allocep
  *
@@ -3366,8 +3415,9 @@ static struct usbdev_ep_s *sam_allocep(struct usbdev_s *dev, uint8_t epno,
 
   if (epno > 0)
     {
-      /* Otherwise, we will return the endpoint structure only for the requested
-       * 'logical' endpoint.  All of the other checks will still be performed.
+      /* Otherwise, we will return the endpoint structure only for the
+       * requested 'logical' endpoint.  All of the other checks will still
+       * be performed.
        *
        * First, verify that the logical endpoint is in the range supported by
        * by the hardware.
@@ -3505,14 +3555,14 @@ static int sam_wakeup(struct usbdev_s *dev)
    *  - "The device must force a K state from 1 to 15 ms to resume the host
    *
    * "Before sending a K state to the host, MCK, UDPCK and the transceiver
-   *  must be enabled. Then to enable the remote wake-up feature, the RMWUPE bit
-   *  in the UDP_GLB_STAT register must be enabled. To force the K state on the
-   *  line, a transition of the ESR bit from 0 to 1 has to be done in the
-   *  UDP_GLB_STAT register. This transition must be accomplished by first
-   *  writing a 0 in the ESR bit and then writing a 1.
+   *  must be enabled. Then to enable the remote wake-up feature, the RMWUPE
+   *  bit in the UDP_GLB_STAT register must be enabled. To force the K state
+   *  on the line, a transition of the ESR bit from 0 to 1 has to be done in
+   *  the UDP_GLB_STAT register. This transition must be accomplished by
+   *  first writing a 0 in the ESR bit and then writing a 1.
    *
-   * " The K state is automatically generated and released according to the USB
-   *   2.0 specification."
+   * " The K state is automatically generated and released according to the
+   *  USB 2.0 specification."
    */
 
   /* Make sure that the ESR bit is zero */
@@ -3524,7 +3574,7 @@ static int sam_wakeup(struct usbdev_s *dev)
 
   /* Wait 5msec in case we just entered the resume state */
 
-  nxsig_usleep(5*1000);
+  nxsig_usleep(5 * 1000);
 
   /* Set the ESR bit to send the remote resume */
 
@@ -3790,8 +3840,8 @@ static void sam_hw_setup(struct sam_usbdev_s *priv)
 
   sam_putreg(UDP_INT_ALL, SAM_UDP_IDR);
 
-  /* Disable the 1.5 KOhm integrated pull-up on DDP and make sure that the UDP
-   * transceiver is not disabled
+  /* Disable the 1.5 KOhm integrated pull-up on DDP and make sure that the
+   * UDP transceiver is not disabled
    */
 
   sam_putreg(0, SAM_UDP_TXVC);
@@ -3876,6 +3926,7 @@ static void sam_sw_shutdown(struct sam_usbdev_s *priv)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
 /****************************************************************************
  * Name: arm_usbinitialize
  * Description:
@@ -3976,8 +4027,8 @@ void arm_usbuninitialize(void)
  * Name: usbdev_register
  *
  * Description:
- *   Register a USB device class driver. The class driver's bind() method will be
- *   called to bind it to a USB device driver.
+ *   Register a USB device class driver. The class driver's bind() method
+ *   will be called to bind it to a USB device driver.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/sama5/sam_dbgu.c
+++ b/arch/arm/src/sama5/sam_dbgu.c
@@ -269,14 +269,15 @@ static void dbgu_shutdown(struct uart_dev_s *dev)
  * Name: dbgu_attach
  *
  * Description:
- *   Configure the DBGU to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the DBGU to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -304,8 +305,8 @@ static int dbgu_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach DBGU interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception
- *   is the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -348,14 +349,16 @@ static int dbgu_interrupt(int irq, void *context, FAR void *arg)
     {
       handled = false;
 
-      /* Get the DBGU/DBGU status (we are only interested in the unmasked interrupts). */
+      /* Get the DBGU/DBGU status (we are only interested in the unmasked
+       * interrupts).
+       */
 
       priv->sr = getreg32(SAM_DBGU_SR);  /* Save for error reporting */
       imr      = getreg32(SAM_DBGU_IMR); /* Interrupt mask */
       pending  = priv->sr & imr;         /* Mask out disabled interrupt sources */
 
-      /* Handle an incoming, receive byte.  RXRDY: At least one complete character
-       * has been received and US_RHR has not yet been read.
+      /* Handle an incoming, receive byte.  RXRDY: At least one complete
+       * character has been received and US_RHR has not yet been read.
        */
 
       if ((pending & DBGU_INT_RXRDY) != 0)
@@ -460,8 +463,8 @@ static void dbgu_rxint(struct uart_dev_s *dev, bool enable)
 {
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when their is anything in the Rx data register
+       * (or an Rx timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS

--- a/arch/arm/src/sama5/sam_udphs.c
+++ b/arch/arm/src/sama5/sam_udphs.c
@@ -99,6 +99,7 @@
 #undef CONFIG_SAMA5_UDPHS_SCATTERGATHER
 
 /* Driver Definitions *******************************************************/
+
 /* Initial interrupt mask: Reset + Suspend + Correct Transfer */
 
 #define SAM_CNTR_SETUP     (USB_CNTR_RESETM|USB_CNTR_SUSPM|USB_CNTR_CTRM)
@@ -134,6 +135,7 @@
 #define sam_rqpeek(q)         ((q)->head)
 
 /* USB trace ****************************************************************/
+
 /* Trace error codes */
 
 #define SAM_TRACEERR_ALLOCFAIL            0x0001
@@ -227,17 +229,21 @@
 /****************************************************************************
  * Private Type Definitions
  ****************************************************************************/
+
 /* State of an endpoint */
 
 enum sam_epstate_e
 {
-                              /* --- All Endpoints --- */
+  /* --- All Endpoints --- */
+
   UDPHS_EPSTATE_DISABLED = 0, /* Endpoint is disabled */
   UDPHS_EPSTATE_STALLED,      /* Endpoint is stalled */
   UDPHS_EPSTATE_IDLE,         /* Endpoint is idle (i.e. ready for transmission) */
   UDPHS_EPSTATE_SENDING,      /* Endpoint is sending data */
   UDPHS_EPSTATE_RECEIVING,    /* Endpoint is receiving data */
-                              /* --- Endpoint 0 Only --- */
+
+  /* --- Endpoint 0 Only --- */
+
   UDPHS_EPSTATE_EP0DATAOUT,   /* Endpoint 0 is receiving SETUP OUT data */
   UDPHS_EPSTATE_EP0STATUSIN,  /* Endpoint 0 is sending SETUP status */
   UDPHS_EPSTATE_EP0ADDRESS    /* Address change is pending completion of status */
@@ -544,7 +550,8 @@ static const struct usb_epdesc_s g_ep0desc =
   .type          = USB_DESC_TYPE_ENDPOINT,
   .addr          = EP0,
   .attr          = USB_EP_ATTR_XFER_CONTROL,
-  .mxpacketsize  = {64, 0},
+  .mxpacketsize  =
+    {64, 0},
   .interval      = 0
 };
 
@@ -556,7 +563,6 @@ static struct sam_dtd_s g_dtdpool[CONFIG_SAMA5_UDPHS_NDTDS]
                         __attribute__ ((aligned(16)));
 #endif
 #endif
-
 
 /* Device error strings that may be enabled for more descriptive USB trace
  * output.
@@ -655,6 +661,7 @@ const struct trace_msg_t g_usb_trace_strings_intdecode[] =
 /****************************************************************************
  * Register Operations
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_printreg
  *
@@ -687,7 +694,8 @@ static void sam_checkreg(uintptr_t regaddr, uint32_t regval, bool iswrite)
   static uint32_t  count     = 0;
   static bool      prevwrite = false;
 
-  /* Is this the same value that we read from/wrote to the same register last time?
+  /* Is this the same value that we read from/wrote to the same register
+   * last time?
    * Are we polling the register?  If so, suppress the output.
    */
 
@@ -829,6 +837,7 @@ static void sam_dumpep(struct sam_usbdev_s *priv, int epno)
 /****************************************************************************
  * DMA
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_dtd_alloc
  *
@@ -933,8 +942,9 @@ static void sam_dma_single(uint8_t epno, struct sam_req_s *privreq,
  *
  ****************************************************************************/
 
-static void sam_dma_wrsetup(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
-                          struct sam_req_s *privreq)
+static void sam_dma_wrsetup(struct sam_usbdev_s *priv,
+                            struct sam_ep_s *privep,
+                            struct sam_req_s *privreq)
 {
   uint32_t regval;
   int remaining;
@@ -1068,6 +1078,7 @@ static void sam_dma_rdsetup(struct sam_usbdev_s *priv,
 /****************************************************************************
  * Request Helpers
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_req_dequeue
  ****************************************************************************/
@@ -1094,7 +1105,8 @@ static struct sam_req_s *sam_req_dequeue(struct sam_rqhead_s *queue)
  * Name: sam_req_enqueue
  ****************************************************************************/
 
-static void sam_req_enqueue(struct sam_rqhead_s *queue, struct sam_req_s *req)
+static void sam_req_enqueue(struct sam_rqhead_s *queue,
+                            struct sam_req_s *req)
 {
   req->flink = NULL;
   if (!queue->head)
@@ -1114,7 +1126,8 @@ static void sam_req_enqueue(struct sam_rqhead_s *queue, struct sam_req_s *req)
  ****************************************************************************/
 
 static inline void
-sam_req_abort(struct sam_ep_s *privep, struct sam_req_s *privreq, int16_t result)
+sam_req_abort(struct sam_ep_s *privep, struct sam_req_s *privreq,
+              int16_t result)
 {
   usbtrace(TRACE_DEVERROR(SAM_TRACEERR_REQABORTED),
            (uint16_t)USB_EPNO(privep->ep.eplog));
@@ -1216,7 +1229,8 @@ static void sam_req_wrsetup(struct sam_usbdev_s *priv,
 
   /* Write access to the FIFO is not possible if TXDRY is set */
 
-  DEBUGASSERT((sam_getreg(SAM_UDPHS_EPTSTA(epno)) & UDPHS_EPTSTA_TXRDY) == 0);
+  DEBUGASSERT((sam_getreg(SAM_UDPHS_EPTSTA(epno)) & UDPHS_EPTSTA_TXRDY)
+              == 0);
 
   /* Get the number of bytes remaining to be sent. */
 
@@ -1282,10 +1296,10 @@ static void sam_req_wrsetup(struct sam_usbdev_s *priv,
  *
  * Description:
  *   Process the next queued write request.  This function is called in one
- *   of three contexts:  (1) When the endpoint is IDLE and a new write request
- *   is submitted (with interrupts disabled), (2) from interrupt handling
- *   when the current transfer completes (either DMA or FIFO), or (3) when
- *   resuming a stalled IN or control endpoint.
+ *   of three contexts:  (1) When the endpoint is IDLE and a new write
+ *   request is submitted (with interrupts disabled), (2) from interrupt
+ *   handling when the current transfer completes (either DMA or FIFO),
+ *   or (3) when resuming a stalled IN or control endpoint.
  *
  *   Calling rules:
  *
@@ -1391,7 +1405,8 @@ static int sam_req_write(struct sam_usbdev_s *priv, struct sam_ep_s *privep)
        * this transfer.
        */
 
-      else if ((privreq->req.len == 0 || privep->zlpneeded) && !privep->zlpsent)
+      else if ((privreq->req.len == 0 || privep->zlpneeded) &&
+               !privep->zlpsent)
         {
           /* If we get here, then we sent the last of the data on the
            * previous pass and we need to send the zero length packet now.
@@ -1615,7 +1630,9 @@ static int sam_req_read(struct sam_usbdev_s *priv, struct sam_ep_s *privep,
       privreq->req.xfrd += recvsize;
       privreq->inflight  = 0;
 
-      /* If this was not a DMA transfer, read the incoming data from the FIFO */
+      /* If this was not a DMA transfer, read the incoming data from the
+       * FIFO
+       */
 
       if ((SAM_EPSET_DMA & SAM_EP_BIT(epno)) == 0)
         {
@@ -1720,6 +1737,7 @@ static void sam_req_cancel(struct sam_ep_s *privep, int16_t result)
 /****************************************************************************
  * Interrupt Level Processing
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_ep0_read
  *
@@ -1924,10 +1942,12 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
                case USB_REQ_RECIPIENT_ENDPOINT:
                 {
                   epno = USB_EPNO(index.b[LSB]);
-                  usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EPGETSTATUS), epno);
+                  usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EPGETSTATUS),
+                           epno);
                   if (epno >= SAM_UDPHS_NENDPOINTS)
                     {
-                      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADEPGETSTATUS), epno);
+                      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADEPGETSTATUS),
+                               epno);
                       ep0result = UDPHS_EP0SETUP_STALL;
                     }
                   else
@@ -1950,18 +1970,21 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
                 {
                  if (index.w == 0)
                     {
-                      usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_DEVGETSTATUS), 0);
+                      usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_DEVGETSTATUS),
+                               0);
 
                       /* Features:  Remote Wakeup=YES; selfpowered=? */
 
                       response.w      = 0;
-                      response.b[LSB] = (priv->selfpowered << USB_FEATURE_SELFPOWERED) |
+                      response.b[LSB] = (priv->selfpowered <<
+                                         USB_FEATURE_SELFPOWERED) |
                                         (1 << USB_FEATURE_REMOTEWAKEUP);
                       nbytes          = 2; /* Response size: 2 bytes */
                     }
                   else
                     {
-                      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADDEVGETSTATUS), 0);
+                      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADDEVGETSTATUS),
+                               0);
                       ep0result = UDPHS_EP0SETUP_STALL;
                     }
                 }
@@ -1994,11 +2017,13 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
          * len:   zero, data = none
          */
 
-        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_CLEARFEATURE), priv->ctrl.type);
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) != USB_REQ_RECIPIENT_ENDPOINT)
+        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_CLEARFEATURE),
+                 priv->ctrl.type);
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) !=
+            USB_REQ_RECIPIENT_ENDPOINT)
           {
-            /* Let the class implementation handle all recipients (except for the
-             * endpoint recipient)
+            /* Let the class implementation handle all recipients
+             * (except for the endpoint recipient)
              */
 
             sam_ep0_dispatch(priv);
@@ -2038,17 +2063,22 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
          * len:   0; data = none
          */
 
-        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_SETFEATURE), priv->ctrl.type);
-        if (((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) == USB_REQ_RECIPIENT_DEVICE) &&
+        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_SETFEATURE),
+                 priv->ctrl.type);
+        if (((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) ==
+            USB_REQ_RECIPIENT_DEVICE) &&
             value.w == USB_FEATURE_TESTMODE)
           {
             /* Special case recipient=device test mode */
 
             uinfo("test mode: %d\n", index.w);
           }
-        else if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) != USB_REQ_RECIPIENT_ENDPOINT)
+        else if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) !=
+                 USB_REQ_RECIPIENT_ENDPOINT)
           {
-            /* The class driver handles all recipients except recipient=endpoint */
+            /* The class driver handles all recipients except
+             * recipient=endpoint
+             */
 
             sam_ep0_dispatch(priv);
             ep0result = UDPHS_EP0SETUP_DISPATCHED;
@@ -2087,7 +2117,8 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
          * len:   0; data = none
          */
 
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) != USB_REQ_RECIPIENT_DEVICE ||
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) !=
+            USB_REQ_RECIPIENT_DEVICE ||
             index.w != 0 || len.w != 0 || value.w > 127)
           {
             usbtrace(TRACE_DEVERROR(SAM_TRACEERR_BADSETADDRESS), 0);
@@ -2100,7 +2131,8 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
              * be set when the zero-length packet transfer completes.
              */
 
-            usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EP0SETUPSETADDRESS), value.w);
+            usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EP0SETUPSETADDRESS),
+                     value.w);
             priv->devaddr = value.w;
             ep0result     = UDPHS_EP0SETUP_ADDRESS;
           }
@@ -2113,6 +2145,7 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
        * index: 0 or language ID;
        * len:   descriptor len; data = descriptor
        */
+
     case USB_REQ_SETDESCRIPTOR:
       /* type:  host-to-device; recipient = device
        * value: descriptor type and index
@@ -2121,10 +2154,14 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
        */
 
       {
-        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_GETSETDESC), priv->ctrl.type);
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) == USB_REQ_RECIPIENT_DEVICE)
+        usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_GETSETDESC),
+                 priv->ctrl.type);
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) ==
+            USB_REQ_RECIPIENT_DEVICE)
           {
-            /* The request seems valid... let the class implementation handle it */
+            /* The request seems valid... let the class implementation
+             * handle it
+             */
 
             sam_ep0_dispatch(priv);
             ep0result = UDPHS_EP0SETUP_DISPATCHED;
@@ -2146,10 +2183,13 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
 
       {
         usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_GETCONFIG), priv->ctrl.type);
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) == USB_REQ_RECIPIENT_DEVICE &&
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) ==
+            USB_REQ_RECIPIENT_DEVICE &&
             value.w == 0 && index.w == 0 && len.w == 1)
           {
-            /* The request seems valid... let the class implementation handle it */
+            /* The request seems valid... let the class implementation
+             * handle it
+             */
 
             sam_ep0_dispatch(priv);
             ep0result = UDPHS_EP0SETUP_DISPATCHED;
@@ -2171,12 +2211,14 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
 
       {
         usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_SETCONFIG), priv->ctrl.type);
-        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) == USB_REQ_RECIPIENT_DEVICE &&
+        if ((priv->ctrl.type & USB_REQ_RECIPIENT_MASK) ==
+            USB_REQ_RECIPIENT_DEVICE &&
             index.w == 0 && len.w == 0)
           {
-             /* The request seems valid... let the class implementation handle it.
-              * If the class implementation accespts it new configuration, it will
-              * call sam_ep_configure() to configure the endpoints.
+             /* The request seems valid... let the class implementation
+              * handle it.
+              * If the class implementation accespts it new configuration,
+              * it will call sam_ep_configure() to configure the endpoints.
               */
 
              sam_ep0_dispatch(priv);
@@ -2196,6 +2238,7 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
        * index: interface;
        * len:   1; data = alt interface
        */
+
     case USB_REQ_SETINTERFACE:
       /* type:  host-to-device; recipient = interface
        * value: alternate setting
@@ -2226,7 +2269,8 @@ static void sam_ep0_setup(struct sam_usbdev_s *priv)
 
     default:
       {
-        usbtrace(TRACE_DEVERROR(SAM_TRACEERR_INVALIDCTRLREQ), priv->ctrl.req);
+        usbtrace(TRACE_DEVERROR(SAM_TRACEERR_INVALIDCTRLREQ),
+                 priv->ctrl.req);
         ep0result = UDPHS_EP0SETUP_STALL;
       }
       break;
@@ -2618,8 +2662,8 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
           len = GETUINT16(priv->ctrl.len);
           if (len == pktsize)
             {
-              /* Copy the OUT data from the EP0 FIFO into a special EP0 buffer
-               * and clear RXRDYTXKL in order to receive more data.
+              /* Copy the OUT data from the EP0 FIFO into a special EP0
+               * buffer and clear RXRDYTXKL in order to receive more data.
                */
 
               sam_ep0_read(priv->ep0out, len);
@@ -2631,7 +2675,8 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
             }
           else
             {
-              usbtrace(TRACE_DEVERROR(SAM_TRACEERR_EP0SETUPOUTSIZE), pktsize);
+              usbtrace(TRACE_DEVERROR(SAM_TRACEERR_EP0SETUPOUTSIZE),
+                       pktsize);
 
               /* STALL and discard received data. */
 
@@ -2663,8 +2708,8 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
               sam_putreg(regval, SAM_UDPHS_IEN);
             }
 
-          /* Discard any received data and clear UDPHS_EPTSTA_RXRDYTXKL so that we
-           * may receive more data.
+          /* Discard any received data and clear UDPHS_EPTSTA_RXRDYTXKL
+           * so that we may receive more data.
            */
 
           sam_putreg(UDPHS_EPTSTA_RXRDYTXKL, SAM_UDPHS_EPTCLRSTA(epno));
@@ -2705,8 +2750,8 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
 
       /* If a request transfer was pending, complete it. Handle the case
        * where during the status phase of a control write transfer, the host
-       * receives the device ZLP and ack it, but the ack is not received by the
-       * device
+       * receives the device ZLP and ack it, but the ack is not received by
+       * the device
        */
 
       if (privep->epstate == UDPHS_EPSTATE_RECEIVING ||
@@ -2744,7 +2789,8 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
                * complete before processing the SETUP command.
                */
 
-              usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EP0SETUPOUT), priv->ctrl.req);
+              usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_EP0SETUPOUT),
+                       priv->ctrl.req);
               privep->epstate = UDPHS_EPSTATE_EP0DATAOUT;
             }
           else
@@ -2772,8 +2818,8 @@ static void sam_ep_interrupt(struct sam_usbdev_s *priv, int epno)
 static int sam_udphs_interrupt(int irq, void *context, FAR void *arg)
 {
   /* For now there is only one USB controller, but we will always refer to
-   * it using a pointer to make any future ports to multiple UDPHS controllers
-   * easier.
+   * it using a pointer to make any future ports to multiple UDPHS
+   * controllers easier.
    */
 
   struct sam_usbdev_s *priv = &g_udphs;
@@ -2802,7 +2848,8 @@ static int sam_udphs_interrupt(int irq, void *context, FAR void *arg)
 
       if ((pending == UDPHS_INT_DETSUSPD) != 0)
         {
-          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_DETSUSPD), (uint16_t)pending);
+          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_DETSUSPD),
+                   (uint16_t)pending);
 
           /* Enable wakeup interrupts */
 
@@ -2813,7 +2860,8 @@ static int sam_udphs_interrupt(int irq, void *context, FAR void *arg)
 
           /* Acknowledge interrupt */
 
-          sam_putreg(UDPHS_INT_DETSUSPD | UDPHS_INT_WAKEUP, SAM_UDPHS_CLRINT);
+          sam_putreg(UDPHS_INT_DETSUSPD | UDPHS_INT_WAKEUP,
+                     SAM_UDPHS_CLRINT);
           sam_suspend(priv);
         }
 
@@ -2823,7 +2871,8 @@ static int sam_udphs_interrupt(int irq, void *context, FAR void *arg)
         {
           /* Acknowledge interrupt */
 
-          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_INTSOF), (uint16_t)pending);
+          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_INTSOF),
+                   (uint16_t)pending);
           sam_putreg(UDPHS_INT_INTSOF, SAM_UDPHS_CLRINT);
         }
 
@@ -2832,12 +2881,14 @@ static int sam_udphs_interrupt(int irq, void *context, FAR void *arg)
       else if ((pending & UDPHS_INT_WAKEUP) != 0 ||
                (pending & UDPHS_INT_ENDOFRSM) != 0)
         {
-          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_WAKEUP), (uint16_t)pending);
+          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_WAKEUP),
+                   (uint16_t)pending);
           sam_resume(priv);
 
           /* Acknowledge interrupt */
 
-          sam_putreg(UDPHS_INT_WAKEUP | UDPHS_INT_ENDOFRSM | UDPHS_INT_DETSUSPD,
+          sam_putreg(UDPHS_INT_WAKEUP | UDPHS_INT_ENDOFRSM |
+                     UDPHS_INT_DETSUSPD,
                      SAM_UDPHS_CLRINT);
 
           /* Enable suspend interrupts */
@@ -2888,7 +2939,8 @@ static int sam_udphs_interrupt(int irq, void *context, FAR void *arg)
 
       if ((pending & UDPHS_INT_ENDRESET) != 0)
         {
-          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_ENDRESET), (uint16_t)pending);
+          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_ENDRESET),
+                   (uint16_t)pending);
 
           /* Handle the reset */
 
@@ -2912,7 +2964,8 @@ static int sam_udphs_interrupt(int irq, void *context, FAR void *arg)
         {
           /* Acknowledge interrupt */
 
-          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_UPSTRRES), (uint16_t)pending);
+          usbtrace(TRACE_INTDECODE(SAM_TRACEINTID_UPSTRRES),
+                   (uint16_t)pending);
           sam_putreg(UDPHS_INT_UPSTRRES, SAM_UDPHS_CLRINT);
         }
 
@@ -2958,6 +3011,7 @@ static int sam_udphs_interrupt(int irq, void *context, FAR void *arg)
 /****************************************************************************
  * Suspend/Resume Helpers
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_suspend
  ****************************************************************************/
@@ -3004,9 +3058,9 @@ static void sam_suspend(struct sam_usbdev_s *priv)
 
 static void sam_resume(struct sam_usbdev_s *priv)
 {
-  /* This function is called when either (1) a WKUP interrupt is received from
-   * the host PC, or (2) the class device implementation calls the wakeup()
-   * method.
+  /* This function is called when either (1) a WKUP interrupt is received
+   * from the host PC, or (2) the class device implementation calls the
+   * wakeup() method.
    */
 
   /* Don't do anything if the device was not suspended */
@@ -3027,7 +3081,9 @@ static void sam_resume(struct sam_usbdev_s *priv)
 
       priv->devstate = priv->prevstate;
 
-      /* Restore full power -- whatever that means for this particular board */
+      /* Restore full power -- whatever that means for this particular
+       * board
+       */
 
       sam_usbsuspend((struct usbdev_s *)priv, true);
 
@@ -3225,7 +3281,8 @@ static int sam_ep_configure_internal(struct sam_ep_s *privep,
 
   epno      = USB_EPNO(desc->addr);
   dirin     = (desc->addr & USB_DIR_MASK) == USB_REQ_DIR_IN;
-  eptype    = (desc->attr & USB_EP_ATTR_XFERTYPE_MASK) >> USB_EP_ATTR_XFERTYPE_SHIFT;
+  eptype    = (desc->attr & USB_EP_ATTR_XFERTYPE_MASK) >>
+              USB_EP_ATTR_XFERTYPE_SHIFT;
   maxpacket = GETUINT16(desc->mxpacketsize);
   nbtrans   = 1;
 
@@ -3235,6 +3292,7 @@ static int sam_ep_configure_internal(struct sam_ep_s *privep,
   if (priv->usbdev.speed == USB_SPEED_HIGH)
     {
       /* HS Interval, 125us */
+
       /* MPS: Bits 12:11 specify NB_TRANS, as USB 2.0 Spec. */
 
       nbtrans = ((maxpacket >> 11) & 3);
@@ -3252,14 +3310,15 @@ static int sam_ep_configure_internal(struct sam_ep_s *privep,
        maxpacket &= 0x7ff;
     }
 
-   /* Initialize the endpoint structure */
+  /* Initialize the endpoint structure */
 
-   privep->ep.eplog     = desc->addr;              /* Includes direction */
-   privep->ep.maxpacket = maxpacket;
-   privep->epstate      = UDPHS_EPSTATE_IDLE;
-   privep->bank         = SAM_UDPHS_NBANKS(epno);
+  privep->ep.eplog     = desc->addr;              /* Includes direction */
+  privep->ep.maxpacket = maxpacket;
+  privep->epstate      = UDPHS_EPSTATE_IDLE;
+  privep->bank         = SAM_UDPHS_NBANKS(epno);
 
   /* Initialize the endpoint hardware */
+
   /* Disable the endpoint */
 
   sam_putreg(UDPHS_EPTCTL_SHRTPCKT | UDPHS_EPTCTL_BUSYBANK |
@@ -3374,6 +3433,7 @@ static int sam_ep_configure_internal(struct sam_ep_s *privep,
 /****************************************************************************
  * Endpoint operations
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_ep_configure
  *
@@ -3579,7 +3639,8 @@ static int sam_ep_submit(struct usbdev_ep_s *ep, struct usbdev_req_s *req)
 #ifdef CONFIG_DEBUG_FEATURES
   if (!priv->driver)
     {
-      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_NOTCONFIGURED), priv->usbdev.speed);
+      usbtrace(TRACE_DEVERROR(SAM_TRACEERR_NOTCONFIGURED),
+               priv->usbdev.speed);
       uerr("ERROR: driver=%p\n", priv->driver);
       return -ESHUTDOWN;
     }
@@ -3806,6 +3867,7 @@ static int sam_ep_stall(struct usbdev_ep_s *ep, bool resume)
 /****************************************************************************
  * Device Controller Operations
  ****************************************************************************/
+
 /****************************************************************************
  * Name: sam_allocep
  *
@@ -3838,10 +3900,11 @@ static struct usbdev_ep_s *sam_allocep(struct usbdev_s *dev, uint8_t epno,
 
   if (epno > 0)
     {
-      /* Otherwise, we will return the endpoint structure only for the requested
-       * 'logical' endpoint.  All of the other checks will still be performed.
+      /* Otherwise, we will return the endpoint structure only for the
+       * requested 'logical' endpoint.  All of the other checks will still
+       * be performed.
        *
-       * First, verify that the logical endpoint is in the range supported by
+       * First, verify that the logical endpoint is in the range supported
        * by the hardware.
        */
 
@@ -3963,8 +4026,8 @@ static int sam_wakeup(struct usbdev_s *dev)
 
   /* Activate a remote wakeup.  Setting this bit forces an external interrupt
    * on the UDPHS controller for Remote Wake UP purposes.  An Upstream Resume
-   * is sent only after the UDPHS bus has been in SUSPEND state for at least 5
-   * ms.
+   * is sent only after the UDPHS bus has been in SUSPEND state for at least
+   * 5 ms.
    */
 
   regval  = sam_getreg(SAM_UDPHS_CTRL);
@@ -4192,8 +4255,8 @@ static void sam_hw_setup(struct sam_usbdev_s *priv)
    *
    * Paragraph 33.5.1.  "One transceiver is shared with the USB High Speed
    *   Device (port A). The selection between Host Port A and USB Device is
-   *   controlled by the UDPHS enable bit (EN_UDPHS) located in the UDPHS_CTRL
-   *   control register.
+   *   controlled by the UDPHS enable bit (EN_UDPHS) located in the
+   *   UDPHS_CTRL control register.
    *
    *  "In the case the port A is driven by the USB High Speed Device, the ...
    *   transceiver is automatically selected for Device operation once the
@@ -4396,6 +4459,7 @@ static void sam_sw_shutdown(struct sam_usbdev_s *priv)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
 /****************************************************************************
  * Name: arm_usbinitialize
  * Description:
@@ -4496,8 +4560,8 @@ void arm_usbuninitialize(void)
  * Name: usbdev_register
  *
  * Description:
- *   Register a USB device class driver. The class driver's bind() method will be
- *   called to bind it to a USB device driver.
+ *   Register a USB device class driver. The class driver's bind() method
+ *   will be called to bind it to a USB device driver.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/samd2l2/sam_serial.c
+++ b/arch/arm/src/samd2l2/sam_serial.c
@@ -68,6 +68,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* If we are not using the serial driver for the console, then we still must
  * provide some minimal implementation of up_putc.
  */
@@ -477,7 +478,7 @@ static uart_dev_t g_usart4port =
   {
     .size   = CONFIG_USART4_TXBUFSIZE,
     .buffer = g_usart4txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_usart4priv,
 };
@@ -510,7 +511,7 @@ static uart_dev_t g_usart5port =
   {
     .size   = CONFIG_USART5_TXBUFSIZE,
     .buffer = g_usart5txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_usart5priv,
 };
@@ -848,7 +849,9 @@ static void sam_rxint(struct uart_dev_s *dev, bool enable)
 
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register */
+      /* Receive an interrupt when their is anything in the Rx data
+       * register
+       */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
       sam_serialout8(priv, SAM_USART_INTENSET_OFFSET, USART_INT_RXC);
@@ -871,7 +874,8 @@ static void sam_rxint(struct uart_dev_s *dev, bool enable)
 static bool sam_rxavailable(struct uart_dev_s *dev)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)dev->priv;
-  return ((sam_serialin8(priv, SAM_USART_INTFLAG_OFFSET) & USART_INT_RXC) != 0);
+  return ((sam_serialin8(priv, SAM_USART_INTFLAG_OFFSET) & USART_INT_RXC)
+          != 0);
 }
 
 /****************************************************************************
@@ -929,7 +933,9 @@ static void sam_txint(struct uart_dev_s *dev, bool enable)
     }
   else
     {
-      /* Disable the TX interrupt. Only disable DRE, TXC will disable itself! */
+      /* Disable the TX interrupt. Only disable DRE, TXC will disable
+       * itself!
+       */
 
       sam_serialout8(priv, SAM_USART_INTENCLR_OFFSET, USART_INT_DRE);
     }
@@ -948,7 +954,8 @@ static void sam_txint(struct uart_dev_s *dev, bool enable)
 static bool sam_txempty(struct uart_dev_s *dev)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)dev->priv;
-  return ((sam_serialin8(priv, SAM_USART_INTFLAG_OFFSET) & USART_INT_DRE) != 0);
+  return ((sam_serialin8(priv, SAM_USART_INTFLAG_OFFSET) & USART_INT_DRE)
+          != 0);
 }
 
 /****************************************************************************

--- a/arch/arm/src/samd2l2/sam_start.c
+++ b/arch/arm/src/samd2l2/sam_start.c
@@ -77,7 +77,7 @@
  * Public Data
  ****************************************************************************/
 
-const uint32_t g_idle_topstack = IDLE_STACK;
+const uintptr_t g_idle_topstack = IDLE_STACK;
 
 /****************************************************************************
  * Private Functions

--- a/arch/arm/src/samd2l2/sam_start.c
+++ b/arch/arm/src/samd2l2/sam_start.c
@@ -138,7 +138,9 @@ void __start(void)
 
   sam_clockconfig();
 
-  /* Configure the uart early so that we can get debug output as soon as possible */
+  /* Configure the uart early so that we can get debug output as soon as
+   * possible
+   */
 
   sam_lowsetup();
   showprogress('A');

--- a/arch/arm/src/samd2l2/sam_usb.c
+++ b/arch/arm/src/samd2l2/sam_usb.c
@@ -2270,7 +2270,9 @@ static void sam_resume(struct sam_usbdev_s *priv)
 
       sam_enableclks();
 
-      /* Restore full power -- whatever that means for this particular board */
+      /* Restore full power -- whatever that means for this particular
+       * board
+       */
 
       sam_usb_suspend((struct usbdev_s *)priv, true);
 

--- a/arch/arm/src/samd5e5/sam_serial.c
+++ b/arch/arm/src/samd5e5/sam_serial.c
@@ -67,6 +67,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* If we are not using the serial driver for the console, then we still must
  * provide some minimal implementation of up_putc.
  */
@@ -512,7 +513,7 @@ static uart_dev_t g_usart4port =
   {
     .size   = CONFIG_USART4_TXBUFSIZE,
     .buffer = g_usart4txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_usart4priv,
 };
@@ -537,7 +538,7 @@ static uart_dev_t g_usart5port =
   {
     .size   = CONFIG_USART5_TXBUFSIZE,
     .buffer = g_usart5txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_usart5priv,
 };
@@ -562,7 +563,7 @@ static uart_dev_t g_usart6port =
   {
     .size   = CONFIG_USART6_TXBUFSIZE,
     .buffer = g_usart6txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_usart6priv,
 };
@@ -587,7 +588,7 @@ static uart_dev_t g_usart7port =
   {
     .size   = CONFIG_USART7_TXBUFSIZE,
     .buffer = g_usart7txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_usart7priv,
 };
@@ -907,7 +908,9 @@ static void sam_rxint(struct uart_dev_s *dev, bool enable)
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
-      /* Receive an interrupt when their is anything in the Rx data register */
+      /* Receive an interrupt when their is anything in the Rx data
+       * register
+       */
 
       sam_serialout8(priv, SAM_USART_INTENSET_OFFSET, USART_INT_RXC);
 #endif
@@ -929,7 +932,8 @@ static void sam_rxint(struct uart_dev_s *dev, bool enable)
 static bool sam_rxavailable(struct uart_dev_s *dev)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)dev->priv;
-  return ((sam_serialin8(priv, SAM_USART_INTFLAG_OFFSET) & USART_INT_RXC) != 0);
+  return ((sam_serialin8(priv, SAM_USART_INTFLAG_OFFSET) & USART_INT_RXC)
+          != 0);
 }
 
 /****************************************************************************
@@ -997,7 +1001,8 @@ static void sam_txint(struct uart_dev_s *dev, bool enable)
 static bool sam_txempty(struct uart_dev_s *dev)
 {
   struct sam_dev_s *priv = (struct sam_dev_s *)dev->priv;
-  return ((sam_serialin8(priv, SAM_USART_INTFLAG_OFFSET) & USART_INT_DRE) != 0);
+  return ((sam_serialin8(priv, SAM_USART_INTFLAG_OFFSET) & USART_INT_DRE)
+          != 0);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32f0l0g0/stm32_start.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_start.c
@@ -65,7 +65,7 @@
  * Public Data
  ****************************************************************************/
 
-const uint32_t g_idle_topstack = IDLE_STACK;
+const uintptr_t g_idle_topstack = IDLE_STACK;
 
 /****************************************************************************
  * Private Functions

--- a/arch/arm/src/str71x/str71x_serial.c
+++ b/arch/arm/src/str71x/str71x_serial.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * arch/arm/src/str71x/str71x_serial.c
  *
- *   Copyright (C) 2008-2009, 2012-2013, 2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2008-2009, 2012-2013, 2017 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -202,9 +203,9 @@
 #  define RXENABLE_BITS STR71X_UARTIER_RNE
 #endif
 
-/* Which ever model is used, there seems to be some timing disconnects between
- * Rx FIFO not full and Rx FIFO half full indications.  Best bet is to use
- * both.
+/* Which ever model is used, there seems to be some timing disconnects
+ * between Rx FIFO not full and Rx FIFO half full indications.  Best bet
+ * is to use both.
  */
 
 #define RXAVAILABLE_BITS (STR71X_UARTSR_RNE|STR71X_UARTSR_RHF)
@@ -232,7 +233,8 @@ struct up_dev_s
 /* Internal Helpers */
 
 static inline uint16_t up_serialin(struct up_dev_s *priv, int offset);
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint16_t value);
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint16_t value);
 static inline void up_disableuartint(struct up_dev_s *priv, uint16_t *ier);
 static inline void up_restoreuartint(struct up_dev_s *priv, uint16_t ier);
 #ifdef HAVE_CONSOLE
@@ -351,7 +353,7 @@ static uart_dev_t g_uart1port =
   {
     .size   = CONFIG_UART1_TXBUFSIZE,
     .buffer = g_uart1txbuffer,
-   },
+  },
   .ops      = &g_uart_ops,
   .priv     = &g_uart1priv,
 };
@@ -434,7 +436,8 @@ static inline uint16_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint16_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint16_t value)
 {
   putreg16(value, priv->uartbase + offset);
 }
@@ -482,6 +485,7 @@ static inline void up_waittxnotfull(struct up_dev_s *priv)
       if ((up_serialin(priv, STR71X_UART_SR_OFFSET) & STR71X_UARTSR_TF) == 0)
         {
           /* The TX FIFO is not full... return */
+
           break;
         }
     }
@@ -509,7 +513,7 @@ static int up_setup(struct uart_dev_s *dev)
   /* Set the BAUD rate */
 
   divisor = 16 * priv->baud;
-  baud    =  (STR71X_PCLK1 + divisor/2) / divisor;
+  baud    =  (STR71X_PCLK1 + divisor / 2) / divisor;
   up_serialout(priv, STR71X_UART_BR_OFFSET, baud);
 
   /* Get mode setting */
@@ -591,14 +595,15 @@ static void up_shutdown(struct uart_dev_s *dev)
  * Name: up_attach
  *
  * Description:
- *   Configure the UART to operation in interrupt driven mode.  This method is
- *   called when the serial port is opened.  Normally, this is just after the
+ *   Configure the UART to operation in interrupt driven mode.  This method
+ *   is called when the serial port is opened.  Normally, this is just after
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
@@ -627,8 +632,8 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach UART interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.  The
+ *   exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
@@ -788,6 +793,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
     {
       priv->ier &= ~RXENABLE_BITS;
     }
+
   up_serialout(priv, STR71X_UART_IER_OFFSET, priv->ier);
 }
 
@@ -802,7 +808,8 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
 static bool up_rxavailable(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  return ((up_serialin(priv, STR71X_UART_SR_OFFSET) & RXAVAILABLE_BITS) != 0);
+  return ((up_serialin(priv, STR71X_UART_SR_OFFSET) &
+           RXAVAILABLE_BITS) != 0);
 }
 
 /****************************************************************************
@@ -844,6 +851,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
 
       priv->ier &= ~STR71X_UARTSR_THE;
     }
+
   up_serialout(priv, STR71X_UART_IER_OFFSET, priv->ier);
 }
 
@@ -858,7 +866,8 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
 static bool up_txready(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  return ((up_serialin(priv, STR71X_UART_SR_OFFSET) & STR71X_UARTSR_TF) == 0);
+  return ((up_serialin(priv, STR71X_UART_SR_OFFSET) &
+           STR71X_UARTSR_TF) == 0);
 }
 
 /****************************************************************************
@@ -872,7 +881,8 @@ static bool up_txready(struct uart_dev_s *dev)
 static bool up_txempty(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  return ((up_serialin(priv, STR71X_UART_SR_OFFSET) & STR71X_UARTSR_TE) != 0);
+  return ((up_serialin(priv, STR71X_UART_SR_OFFSET) &
+           STR71X_UARTSR_TE) != 0);
 }
 
 /****************************************************************************

--- a/arch/hc/include/hc12/types.h
+++ b/arch/hc/include/hc12/types.h
@@ -102,7 +102,7 @@ typedef signed short       _ssize_t;
 typedef unsigned short     _size_t;
 #endif
 
-/* This is the size of the interrupt state save returned by up_irq_save()*/
+/* This is the size of the interrupt state save returned by up_irq_save() */
 
 typedef unsigned int       irqstate_t;
 

--- a/arch/hc/include/hcs12/types.h
+++ b/arch/hc/include/hcs12/types.h
@@ -103,7 +103,7 @@ typedef signed short       _ssize_t;
 typedef unsigned short     _size_t;
 #endif
 
-/* This is the size of the interrupt state save returned by up_irq_save()*/
+/* This is the size of the interrupt state save returned by up_irq_save() */
 
 typedef unsigned char      irqstate_t;
 

--- a/arch/hc/src/m9s12/m9s12_serial.c
+++ b/arch/hc/src/m9s12/m9s12_serial.c
@@ -1,7 +1,8 @@
 /****************************************************************************
  * arch/hc/src/m9s12/m9s12_serial.c
  *
- *   Copyright (C) 2009, 2011-2012, 2016-2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2009, 2011-2012, 2016-2017 Gregory Nutt.
+ *   All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -242,7 +243,8 @@ static inline uint8_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint8_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint8_t value)
 {
   putreg8(value, priv->uartbase + offset);
 }
@@ -332,7 +334,7 @@ static inline void up_waittxnotfull(struct up_dev_s *priv)
 
 static int up_setup(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
 #ifndef CONFIG_SUPPRESS_SCI_CONFIG
   uint8_t cr1;
 #endif
@@ -367,7 +369,7 @@ static int up_setup(struct uart_dev_s *dev)
       default:
         break;
       case 1:
-        cr1 |= SCI_CR1_PE|SCI_CR1_PT;
+        cr1 |= SCI_CR1_PE | SCI_CR1_PT;
         break;
       case 2:
         cr1 |= SCI_CR1_PE;
@@ -382,7 +384,7 @@ static int up_setup(struct uart_dev_s *dev)
    */
 
   priv->im = 0;
-  up_serialout(priv, HCS12_SCI_CR2_OFFSET, (SCI_CR2_TE|SCI_CR2_RE));
+  up_serialout(priv, HCS12_SCI_CR2_OFFSET, (SCI_CR2_TE | SCI_CR2_RE));
   return OK;
 }
 
@@ -396,7 +398,7 @@ static int up_setup(struct uart_dev_s *dev)
 
 static void up_shutdown(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   up_disablesciint(priv, NULL);
 }
 
@@ -409,15 +411,16 @@ static void up_shutdown(struct uart_dev_s *dev)
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
 static int up_attach(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   int ret;
 
   /* Attach and enable the IRQ */
@@ -425,13 +428,14 @@ static int up_attach(struct uart_dev_s *dev)
   ret = irq_attach(priv->irq, up_interrupt, dev);
   if (ret == OK)
     {
-       /* Enable the Rx interrupt (the TX interrupt is still disabled
-        * until we have something to send).
-        */
+      /* Enable the Rx interrupt (the TX interrupt is still disabled
+       * until we have something to send).
+       */
 
-       priv->im = SCI_CR2_RIE;
-       up_setsciint(priv);
+      priv->im = SCI_CR2_RIE;
+      up_setsciint(priv);
     }
+
   return ret;
 }
 
@@ -447,7 +451,7 @@ static int up_attach(struct uart_dev_s *dev)
 
 static void up_detach(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   up_disablesciint(priv, NULL);
   irq_detach(priv->irq);
 }
@@ -473,7 +477,7 @@ static int up_interrupt(int irq, void *context, void *arg)
   bool               handled;
 
   DEBUGASSERT(dev != NULL && dev->priv != NULL);
-  priv = (struct up_dev_s*)dev->priv;
+  priv = (struct up_dev_s *)dev->priv;
 
   /* Loop until there are no characters to be transferred or,
    * until we have been looping for a long time.
@@ -492,23 +496,24 @@ static int up_interrupt(int irq, void *context, void *arg)
 
       if ((mis & SCI_SR1_RDRF) != 0)
         {
-           /* Rx buffer not empty ... process incoming bytes */
+          /* Rx buffer not empty ... process incoming bytes */
 
-           uart_recvchars(dev);
-           handled = true;
+          uart_recvchars(dev);
+          handled = true;
         }
 
       /* Handle outgoing, transmit bytes */
 
       if ((mis & SCI_SR1_TDRE) != 0)
         {
-           /* Tx FIFO not full ... process outgoing bytes */
+          /* Tx FIFO not full ... process outgoing bytes */
 
-           uart_xmitchars(dev);
-           handled = true;
+          uart_xmitchars(dev);
+          handled = true;
         }
     }
-    return OK;
+
+  return OK;
 }
 
 /****************************************************************************
@@ -549,7 +554,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
 static int up_receive(struct uart_dev_s *dev, uint32_t *status)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   int rxd;
 
   /* Return the error indications */
@@ -580,7 +585,7 @@ static int up_receive(struct uart_dev_s *dev, uint32_t *status)
 
 static void up_rxint(struct uart_dev_s *dev, bool enable)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
 
   if (enable)
     {
@@ -610,7 +615,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
 
 static bool up_rxavailable(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   return ((up_serialin(priv, HCS12_SCI_SR1_OFFSET) & SCI_SR1_RDRF) != 0);
 }
 
@@ -624,7 +629,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
 
 static void up_send(struct uart_dev_s *dev, int ch)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   uint8_t regval;
 
   if (priv->bits == 9)
@@ -638,6 +643,7 @@ static void up_send(struct uart_dev_s *dev, int ch)
         {
           regval |= SCI_DRH_T8;
         }
+
       up_serialout(priv, HCS12_SCI_DRH_OFFSET, regval);
     }
 
@@ -654,7 +660,7 @@ static void up_send(struct uart_dev_s *dev, int ch)
 
 static void up_txint(struct uart_dev_s *dev, bool enable)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
   flags = enter_critical_section();
@@ -692,7 +698,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
 
 static bool up_txready(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   return ((up_serialin(priv, HCS12_SCI_SR1_OFFSET) & SCI_SR1_TDRE) != 0);
 }
 
@@ -706,7 +712,7 @@ static bool up_txready(struct uart_dev_s *dev)
 
 static bool up_txempty(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   return ((up_serialin(priv, HCS12_SCI_SR1_OFFSET) & SCI_SR1_TC) != 0);
 }
 
@@ -779,7 +785,7 @@ void up_serialinit(void)
 int up_putc(int ch)
 {
 #ifdef HAVE_CONSOLE
-  struct up_dev_s *priv = (struct up_dev_s*)CONSOLE_DEV.priv;
+  struct up_dev_s *priv = (struct up_dev_s *)CONSOLE_DEV.priv;
   uint32_t im;
 
   up_disablesciint(priv, &im);

--- a/arch/renesas/src/sh1/sh1_serial.c
+++ b/arch/renesas/src/sh1/sh1_serial.c
@@ -138,14 +138,14 @@
 
 struct up_dev_s
 {
-          uint32_t scibase;   /* Base address of SCI registers */
-          uint32_t baud;      /* Configured baud */
- volatile  uint8_t scr;       /* Saved SCR value */
- volatile  uint8_t ssr;       /* Saved SR value (only used during interrupt processing) */
-           uint8_t irq;       /* Base IRQ associated with this SCI */
-           uint8_t parity;    /* 0=none, 1=odd, 2=even */
-           uint8_t bits;      /* Number of bits (7 or 8) */
-              bool stopbits2; /* true: Configure with 2 stop bits instead of 1 */
+  uint32_t scibase;     /* Base address of SCI registers */
+  uint32_t baud;        /* Configured baud */
+  volatile uint8_t scr; /* Saved SCR value */
+  volatile uint8_t ssr; /* Saved SR value (only used during interrupt processing) */
+  uint8_t irq;          /* Base IRQ associated with this SCI */
+  uint8_t parity;       /* 0=none, 1=odd, 2=even */
+  uint8_t bits;         /* Number of bits (7 or 8) */
+  bool stopbits2;       /* true: Configure with 2 stop bits instead of 1 */
 };
 
 /****************************************************************************
@@ -251,7 +251,7 @@ static uart_dev_t g_sci1port =
   {
     .size   = CONFIG_SCI1_TXBUFSIZE,
     .buffer = g_sci1txbuffer,
-   },
+  },
   .ops      = &g_sci_ops,
   .priv     = &g_sci1priv,
 };
@@ -274,7 +274,8 @@ static inline uint8_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint8_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint8_t value)
 {
   putreg8(value, priv->scibase + offset);
 }
@@ -333,6 +334,7 @@ static inline void up_waittxready(struct up_dev_s *priv)
       if ((up_serialin(priv, SH1_SCI_SSR_OFFSET) & SH1_SCISSR_TDRE) != 0)
         {
           /* The TDR is empty... return */
+
           break;
         }
     }
@@ -389,7 +391,7 @@ static inline void up_setbrr(struct up_dev_s *priv, unsigned int baud)
 static int up_setup(struct uart_dev_s *dev)
 {
 #ifndef CONFIG_SUPPRESS_SCI_CONFIG
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   uint8_t smr;
 
   /* Disable the transmitter and receiver */
@@ -410,7 +412,7 @@ static int up_setup(struct uart_dev_s *dev)
 
   if (priv->parity == 1)
     {
-      smr |= (SH1_SCISMR_PE|SH1_SCISMR_OE);
+      smr |= (SH1_SCISMR_PE | SH1_SCISMR_OE);
     }
   else if (priv->parity == 2)
     {
@@ -457,7 +459,7 @@ static int up_setup(struct uart_dev_s *dev)
 
 static void up_shutdown(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   up_disablesciint(priv, NULL);
 }
 
@@ -470,15 +472,16 @@ static void up_shutdown(struct uart_dev_s *dev)
  *   the setup() method is called, however, the serial console may operate in
  *   a non-interrupt driven mode during the boot phase.
  *
- *   RX and TX interrupts are not enabled when by the attach method (unless the
- *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   RX and TX interrupts are not enabled when by the attach method (unless
+ *   the hardware supports multiple levels of interrupt enabling).  The RX
+ *   and TX interrupts are not enabled until the txint() and rxint() methods
+ *   are called.
  *
  ****************************************************************************/
 
 static int up_attach(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   int ret;
 
   /* Attach the RDR full IRQ (RXI) that is enabled by the RIE SCR bit */
@@ -486,14 +489,17 @@ static int up_attach(struct uart_dev_s *dev)
   ret = irq_attach(priv->irq + SH1_RXI_IRQ_OFFSET, up_interrupt, dev);
   if (ret == OK)
     {
-      /* The RIE interrupt enable also enables the receive error interrupt (ERI) */
+      /* The RIE interrupt enable also enables the receive error interrupt
+       * (ERI)
+       */
 
       ret = irq_attach(priv->irq + SH1_ERI_IRQ_OFFSET, up_interrupt, dev);
       if (ret == OK)
         {
           /* Attach the TDR empty IRQ (TXI) enabled by the TIE SCR bit */
 
-          ret = irq_attach(priv->irq + SH1_TXI_IRQ_OFFSET, up_interrupt, dev);
+          ret = irq_attach(priv->irq + SH1_TXI_IRQ_OFFSET, up_interrupt,
+                           dev);
           if (ret == OK)
             {
 #ifdef CONFIG_ARCH_IRQPRIO
@@ -524,14 +530,14 @@ static int up_attach(struct uart_dev_s *dev)
  *
  * Description:
  *   Detach SCI interrupts.  This method is called when the serial port is
- *   closed normally just before the shutdown method is called.  The exception is
- *   the serial console which is never shutdown.
+ *   closed normally just before the shutdown method is called.
+ *   The exception is the serial console which is never shutdown.
  *
  ****************************************************************************/
 
 static void up_detach(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
 
   /* Disable all SCI interrupts */
 
@@ -571,7 +577,7 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
   struct up_dev_s *priv;
 
   DEBUGASSERT(dev != NULL && dev->priv != NULL);
-  priv = (struct up_dev_s*)dev->priv;
+  priv = (struct up_dev_s *)dev->priv;
 
   /* Get the current SCI status  */
 
@@ -589,30 +595,34 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
 
       if ((priv->ssr & SH1_SCISSR_RDRF) != 0)
         {
-           /* Rx data register not empty ... process incoming bytes */
+          /* Rx data register not empty ... process incoming bytes */
 
-           uart_recvchars(dev);
+          uart_recvchars(dev);
         }
 
-      /* Clear all read related events (probably already done in up_receive)) */
+      /* Clear all read related events (probably already done in
+       * up_receive))
+       */
 
-      priv->ssr &= ~(SH1_SCISSR_RDRF|SH1_SCISSR_ORER|SH1_SCISSR_FER|SH1_SCISSR_PER);
+      priv->ssr &= ~(SH1_SCISSR_RDRF | SH1_SCISSR_ORER | SH1_SCISSR_FER |
+                     SH1_SCISSR_PER);
     }
 
   /* Handle outgoing, transmit bytes (TDRE: Transmit Data Register Empty)
-   * when TIE is enabled.  TIE is only enabled when the driver is waiting with
-   * buffered data.  Since TDRE is usually true,
+   * when TIE is enabled.  TIE is only enabled when the driver is waiting
+   * with buffered data.  Since TDRE is usually true,
    */
 
-  if ((priv->ssr & SH1_SCISSR_TDRE) != 0 && (priv->scr & SH1_SCISCR_TIE) != 0)
+  if ((priv->ssr & SH1_SCISSR_TDRE) != 0 &&
+      (priv->scr & SH1_SCISCR_TIE) != 0)
     {
-       /* Tx data register empty ... process outgoing bytes */
+      /* Tx data register empty ... process outgoing bytes */
 
-       uart_xmitchars(dev);
+      uart_xmitchars(dev);
 
-       /* Clear the TDR empty flag (Possibly done in up_send, will have not
-        * effect if the TDR is still empty)
-        */
+      /* Clear the TDR empty flag (Possibly done in up_send, will have not
+       * effect if the TDR is still empty)
+       */
 
       priv->ssr &= ~SH1_SCISSR_TDRE;
     }
@@ -639,7 +649,7 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
 
 static int up_receive(struct uart_dev_s *dev, unsigned int *status)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   uint8_t rdr;
   uint8_t ssr;
 
@@ -647,12 +657,13 @@ static int up_receive(struct uart_dev_s *dev, unsigned int *status)
 
   rdr  = up_serialin(priv, SH1_SCI_RDR_OFFSET);
 
-  /* Clear all read related status in  real ssr (so that when when rxavailable
-   * is called again, it will return false.
+  /* Clear all read related status in  real ssr (so that when when
+   * rxavailable is called again, it will return false.
    */
 
   ssr = up_serialin(priv, SH1_SCI_SSR_OFFSET);
-  ssr &= ~(SH1_SCISSR_RDRF|SH1_SCISSR_ORER|SH1_SCISSR_FER|SH1_SCISSR_PER);
+  ssr &= ~(SH1_SCISSR_RDRF | SH1_SCISSR_ORER | SH1_SCISSR_FER |
+           SH1_SCISSR_PER);
   up_serialout(priv, SH1_SCI_SSR_OFFSET, ssr);
 
   /* For status, return the SSR at the time that the interrupt was received */
@@ -674,7 +685,7 @@ static int up_receive(struct uart_dev_s *dev, unsigned int *status)
 
 static void up_rxint(struct uart_dev_s *dev, bool enable)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
   /* Disable interrupts to prevent asynchronous accesses */
@@ -716,7 +727,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
 {
   /* Return true if the RDR full bit is set in the SSR */
 
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   return ((up_serialin(priv, SH1_SCI_SSR_OFFSET) & SH1_SCISSR_RDRF) != 0);
 }
 
@@ -730,7 +741,7 @@ static bool up_rxavailable(struct uart_dev_s *dev)
 
 static void up_send(struct uart_dev_s *dev, int ch)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   uint8_t ssr;
 
   /* Write the data to the TDR */
@@ -754,7 +765,7 @@ static void up_send(struct uart_dev_s *dev, int ch)
 
 static void up_txint(struct uart_dev_s *dev, bool enable)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
   /* Disable interrupts to prevent asynchronous accesses */
@@ -809,7 +820,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
 
 static bool up_txready(struct uart_dev_s *dev)
 {
-  struct up_dev_s *priv = (struct up_dev_s*)dev->priv;
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   return (up_serialin(priv, SH1_SCI_SSR_OFFSET) & SH1_SCISSR_TDRE) != 0;
 }
 
@@ -888,7 +899,7 @@ void up_consoleinit(void)
 int up_putc(int ch)
 {
 #ifdef HAVE_CONSOLE
-  struct up_dev_s *priv = (struct up_dev_s*)CONSOLE_DEV.priv;
+  struct up_dev_s *priv = (struct up_dev_s *)CONSOLE_DEV.priv;
   uint8_t  scr;
 
   up_disablesciint(priv, &scr);

--- a/arch/z80/include/z8/types.h
+++ b/arch/z80/include/z8/types.h
@@ -62,7 +62,8 @@
  * the user prefers to use the definitions provided by their toolchain header
  * files
  *
- * These are the sizes of the types supported by the ZiLOG Z8Encore! compiler:
+ * These are the sizes of the types supported by the ZiLOG Z8Encore!
+ * compiler:
  *
  *   int    - 16-bits
  *   short  - 16-bits

--- a/boards/arm/samd2l2/arduino-m0/src/sam_usb.c
+++ b/boards/arm/samd2l2/arduino-m0/src/sam_usb.c
@@ -111,11 +111,11 @@ void weak_function sam_usbinitialize(void)
  * Name:  sam_usbsuspend
  *
  * Description:
- *   Board logic must provide the sam_usbsuspend logic if the USBDEV driver is
- *   used.
+ *   Board logic must provide the sam_usbsuspend logic if the USBDEV driver
+ *   is used.
  *   This function is called whenever the USB enters or leaves suspend mode.
- *   This is an opportunity for the board logic to shutdown clocks, power, etc.
- *   while the USB is suspended.
+ *   This is an opportunity for the board logic to shutdown clocks, power,
+ *   etc. while the USB is suspended.
  *
  ****************************************************************************/
 

--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -80,6 +80,7 @@ struct mtd_partition_s
 
   struct mtd_dev_s child;       /* The "child" MTD vtable that manages the
                                  * sub-region */
+
   /* Other implementation specific data may follow here */
 
   FAR struct mtd_dev_s *parent; /* The "parent" MTD driver that manages the
@@ -323,8 +324,8 @@ static ssize_t part_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t part_read(FAR struct mtd_dev_s *dev, off_t offset, size_t nbytes,
-                         FAR uint8_t *buffer)
+static ssize_t part_read(FAR struct mtd_dev_s *dev, off_t offset,
+                         size_t nbytes, FAR uint8_t *buffer)
 {
   FAR struct mtd_partition_s *priv = (FAR struct mtd_partition_s *)dev;
   off_t newoffset;
@@ -361,8 +362,8 @@ static ssize_t part_read(FAR struct mtd_dev_s *dev, off_t offset, size_t nbytes,
  ****************************************************************************/
 
 #ifdef CONFIG_MTD_BYTE_WRITE
-static ssize_t part_write(FAR struct mtd_dev_s *dev, off_t offset, size_t nbytes,
-                          FAR const uint8_t *buffer)
+static ssize_t part_write(FAR struct mtd_dev_s *dev, off_t offset,
+                          size_t nbytes, FAR const uint8_t *buffer)
 {
   FAR struct mtd_partition_s *priv = (FAR struct mtd_partition_s *)dev;
   off_t newoffset;
@@ -373,7 +374,9 @@ static ssize_t part_write(FAR struct mtd_dev_s *dev, off_t offset, size_t nbytes
 
   if (priv->parent->write)
     {
-      /* Make sure that write would not extend past the end of the partition */
+      /* Make sure that write would not extend past the end of the
+       * partition
+       */
 
       if (!part_bytecheck(priv, offset + nbytes - 1))
         {
@@ -413,8 +416,8 @@ static int part_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
           FAR struct mtd_geometry_s *geo = (FAR struct mtd_geometry_s *)arg;
           if (geo)
             {
-              /* Populate the geometry structure with information needed to know
-               * the capacity and how to access the device.
+              /* Populate the geometry structure with information needed to
+               * know the capacity and how to access the device.
                */
 
               geo->blocksize    = priv->blocksize;
@@ -442,7 +445,8 @@ static int part_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
                    * return the sum to the caller.
                    */
 
-                  *ppv = (FAR void *)(base + priv->firstblock * priv->blocksize);
+                  *ppv = (FAR void *)(base +
+                                      priv->firstblock * priv->blocksize);
                 }
             }
         }
@@ -497,7 +501,8 @@ static int part_procfs_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Allocate a container to hold the task and attribute selection */
 
-  attr = (FAR struct part_procfs_file_s *)kmm_zalloc(sizeof(struct part_procfs_file_s));
+  attr = (FAR struct part_procfs_file_s *)
+         kmm_zalloc(sizeof(struct part_procfs_file_s));
   if (!attr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -571,7 +576,8 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer,
       if (attr->nextpart == g_pfirstpartition)
         {
 #ifdef CONFIG_MTD_PARTITION_NAMES
-          total = snprintf(buffer, buflen, "%-*s  Start    Size   MTD\n", PART_NAME_MAX, "Name");
+          total = snprintf(buffer, buflen, "%-*s  Start    Size   MTD\n",
+                           PART_NAME_MAX, "Name");
 #else
           total = snprintf(buffer, buflen, "  Start    Size   MTD\n");
 #endif
@@ -591,8 +597,8 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer,
               return 0;
             }
 
-          /* Get the number of blocks per erase.  There must be an even number
-           * of blocks in one erase blocks.
+          /* Get the number of blocks per erase.  There must be an even
+           * number of blocks in one erase blocks.
            */
 
           blkpererase = geo.erasesize / geo.blocksize;
@@ -625,11 +631,13 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer,
 
           ret = snprintf(&buffer[total], buflen - total, "%s%7d %7d   %s\n",
                   partname, attr->nextpart->firstblock / blkpererase,
-                  attr->nextpart->neraseblocks, attr->nextpart->parent->name);
+                  attr->nextpart->neraseblocks,
+                  attr->nextpart->parent->name);
 #else
           ret = snprintf(&buffer[total], buflen - total, "%7d %7d   %s\n",
                   attr->nextpart->firstblock / blkpererase,
-                  attr->nextpart->neraseblocks, attr->nextpart->parent->name);
+                  attr->nextpart->neraseblocks,
+                  attr->nextpart->parent->name);
 #endif
 
           if (ret + total < buflen)
@@ -672,7 +680,8 @@ static ssize_t part_procfs_read(FAR struct file *filep, FAR char *buffer,
  *
  ****************************************************************************/
 
-static int part_procfs_dup(FAR const struct file *oldp, FAR struct file *newp)
+static int part_procfs_dup(FAR const struct file *oldp,
+                           FAR struct file *newp)
 {
   FAR struct part_procfs_file_s *oldattr;
   FAR struct part_procfs_file_s *newattr;
@@ -686,7 +695,8 @@ static int part_procfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   /* Allocate a new container to hold the task and attribute selection */
 
-  newattr = (FAR struct part_procfs_file_s *)kmm_zalloc(sizeof(struct part_procfs_file_s));
+  newattr = (FAR struct part_procfs_file_s *)
+            kmm_zalloc(sizeof(struct part_procfs_file_s));
   if (!newattr)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -753,7 +763,8 @@ static int part_procfs_stat(const char *relpath, struct stat *buf)
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock,
+FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd,
+                                    off_t firstblock,
                                     off_t nblocks)
 {
   FAR struct mtd_partition_s *part;
@@ -808,7 +819,8 @@ FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock,
 
   /* Allocate a partition device structure */
 
-  part = (FAR struct mtd_partition_s *)kmm_zalloc(sizeof(struct mtd_partition_s));
+  part = (FAR struct mtd_partition_s *)
+         kmm_zalloc(sizeof(struct mtd_partition_s));
   if (!part)
     {
       ferr("ERROR: Failed to allocate memory for the partition device\n");
@@ -851,12 +863,14 @@ FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd, off_t firstblock,
       struct mtd_partition_s *plast;
 
       /* Add the partition to the end of the list */
+
       part->pnext = NULL;
 
       plast = g_pfirstpartition;
       while (plast->pnext != NULL)
         {
           /* Get pointer to next partition */
+
           plast = plast->pnext;
         }
 

--- a/fs/procfs/fs_procfsiobinfo.c
+++ b/fs/procfs/fs_procfsiobinfo.c
@@ -294,7 +294,7 @@ static ssize_t iobinfo_read(FAR struct file *filep, FAR char *buffer,
   /* The first line is the headers */
 
   linesize  = snprintf(iobfile->line, IOBINFO_LINELEN,
-                        "                           TOTAL           TOTAL\n");
+                       "                           TOTAL           TOTAL\n");
 
   copysize  = procfs_memcpy(iobfile->line, linesize, buffer, buflen,
                             &offset);
@@ -306,7 +306,8 @@ static ssize_t iobinfo_read(FAR struct file *filep, FAR char *buffer,
       buflen    -= copysize;
 
       linesize  = snprintf(iobfile->line, IOBINFO_LINELEN,
-                        "        USER            CONSUMED        PRODUCED\n");
+                           "        USER            CONSUMED        "
+                           "PRODUCED\n");
 
       copysize  = procfs_memcpy(iobfile->line, linesize, buffer, buflen,
                                 &offset);

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -310,7 +310,8 @@ void lib_rawsostream(FAR struct lib_rawsostream_s *outstream, int fd);
  * Name: lib_lowoutstream
  *
  * Description:
- *   Initializes a stream for use with low-level, architecture-specific output.
+ *   Initializes a stream for use with low-level, architecture-specific
+ *   output.
  *   Defined in ib/stdio/lib_lowoutstream.c
  *
  * Input Parameters:

--- a/libs/libc/time/lib_strftime.c
+++ b/libs/libc/time/lib_strftime.c
@@ -77,7 +77,8 @@ static const char * const g_abbrev_wdayname[7] =
 
 static const char * const g_wdayname[7] =
 {
-  "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+  "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday",
+  "Saturday"
 };
 
 static const char * const g_abbrev_monthname[12] =
@@ -120,8 +121,10 @@ static const char * const g_monthname[12] =
  *   %e     Like %d, the day of the month as a decimal number, but a leading
  *          zero is replaced by a space.
  *   %h     Equivalent to %b.  (SU)
- *   %H     The hour as a decimal number using a 24-hour clock (range 00 to 23).
- *   %I     The  hour as a decimal number using a 12-hour clock (range 01 to 12).
+ *   %H     The hour as a decimal number using a 24-hour clock
+ *          (range 00 to 23).
+ *   %I     The  hour as a decimal number using a 12-hour clock
+ *          (range 01 to 12).
  *   %j     The day of the year as a decimal number (range 001 to 366).
  *   %k     The hour (24-hour clock) as a decimal number (range  0  to  23);
  *          single digits are preceded by a blank.  (See also %H.)  (TZ)
@@ -207,7 +210,9 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
 
            case 'h':
 
-           /* %b: The abbreviated month name according to the current locale. */
+           /* %b: The abbreviated month name according to the current
+            * locale.
+            */
 
            case 'b':
              {
@@ -231,7 +236,9 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
-           /* %y: The year as a decimal number without a century (range 00 to 99). */
+           /* %y: The year as a decimal number without a century
+            * (range 00 to 99).
+            */
 
            case 'y':
              {
@@ -247,7 +254,9 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
-           /* %d: The day of the month as a decimal number (range 01 to 31). */
+           /* %d: The day of the month as a decimal number
+            * (range 01 to 31).
+            */
 
            case 'd':
              {
@@ -255,8 +264,8 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
-           /* %e: Like %d, the day of the month as a decimal number, but a leading
-            * zero is replaced by a space.
+           /* %e: Like %d, the day of the month as a decimal number, but
+            * a leading zero is replaced by a space.
             */
 
            case 'e':
@@ -265,7 +274,9 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
-           /* %H: The hour as a decimal number using a 24-hour clock (range 00  to 23). */
+           /* %H: The hour as a decimal number using a 24-hour clock
+            * (range 00  to 23).
+            */
 
            case 'H':
              {
@@ -273,7 +284,9 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
-           /* %I: The  hour as a decimal number using a 12-hour clock (range 01 to 12). */
+           /* %I: The  hour as a decimal number using a 12-hour clock
+            * (range 01 to 12).
+            */
 
            case 'I':
              {
@@ -281,21 +294,23 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
-           /* %j: The day of the year as a decimal number (range 001 to 366). */
+           /* %j: The day of the year as a decimal number
+            * (range 001 to 366).
+            */
 
            case 'j':
              {
                if (tm->tm_mon < 12)
                  {
                    value = clock_daysbeforemonth(tm->tm_mon,
-                                                 clock_isleapyear(tm->tm_year)) +
-                                                 tm->tm_mday;
+                           clock_isleapyear(tm->tm_year)) + tm->tm_mday;
                    len   = snprintf(dest, chleft, "%03d", value);
                  }
              }
              break;
 
-           /* %k: The hour (24-hour clock) as a decimal number (range  0  to  23);
+           /* %k: The hour (24-hour clock) as a decimal number
+            * (range  0  to  23);
             * single digits are preceded by a blank.
             */
 
@@ -305,7 +320,8 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
-           /* %l: The  hour  (12-hour  clock) as a decimal number (range 1 to 12);
+           /* %l: The  hour  (12-hour  clock) as a decimal number
+            * (range 1 to 12);
             * single digits are preceded by a blank.
             */
 
@@ -374,18 +390,20 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
-           /* %s: The number of seconds since the Epoch, that is, since 1970-01-01
-            * 00:00:00 UTC.  Hmmm... mktime argume is not 'const'.
+           /* %s: The number of seconds since the Epoch, that is,
+            * since 1970-01-01 00:00:00 UTC.
+            * Hmmm... mktime argume is not 'const'.
             */
 
            case 's':
              {
-               len = snprintf(dest, chleft, "%d", mktime((FAR struct tm *)tm));
+               len = snprintf(dest, chleft, "%d",
+                              mktime((FAR struct tm *)tm));
              }
              break;
 
-           /* %S: The second as a decimal number (range 00 to 60).  (The range  is
-            * up to 60 to allow for occasional leap seconds.)
+           /* %S: The second as a decimal number (range 00 to 60).
+            * (The range is up to 60 to allow for occasional leap seconds.)
             */
 
            case 'S':

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -379,7 +379,8 @@ int local_create_fifos(FAR struct local_conn_s *conn)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_LOCAL_DGRAM
-int local_create_halfduplex(FAR struct local_conn_s *conn, FAR const char *path)
+int local_create_halfduplex(FAR struct local_conn_s *conn,
+                            FAR const char *path)
 {
   char fullpath[LOCAL_FULLPATH_LEN];
 

--- a/net/procfs/netdev_statistics.c
+++ b/net/procfs/netdev_statistics.c
@@ -72,11 +72,13 @@ static int netprocfs_inet6draddress(FAR struct netprocfs_file_s *netfile);
 static int netprocfs_blank_line(FAR struct netprocfs_file_s *netfile);
 #endif
 #ifdef CONFIG_NETDEV_STATISTICS
-static int netprocfs_rxstatistics_header(FAR struct netprocfs_file_s *netfile);
+static int netprocfs_rxstatistics_header(
+    FAR struct netprocfs_file_s *netfile);
 static int netprocfs_rxstatistics(FAR struct netprocfs_file_s *netfile);
 static int netprocfs_rxpackets_header(FAR struct netprocfs_file_s *netfile);
 static int netprocfs_rxpackets(FAR struct netprocfs_file_s *netfile);
-static int netprocfs_txstatistics_header(FAR struct netprocfs_file_s *netfile);
+static int netprocfs_txstatistics_header(
+    FAR struct netprocfs_file_s *netfile);
 static int netprocfs_txstatistics(FAR struct netprocfs_file_s *netfile);
 static int netprocfs_errors(FAR struct netprocfs_file_s *netfile);
 #endif /* CONFIG_NETDEV_STATISTICS */
@@ -380,7 +382,8 @@ static int netprocfs_blank_line(FAR struct netprocfs_file_s *netfile)
  ****************************************************************************/
 
 #ifdef CONFIG_NETDEV_STATISTICS
-static int netprocfs_rxstatistics_header(FAR struct netprocfs_file_s *netfile)
+static int netprocfs_rxstatistics_header(
+    FAR struct netprocfs_file_s *netfile)
 {
   DEBUGASSERT(netfile != NULL);
   return snprintf(netfile->line, NET_LINELEN , "\tRX: %-8s %-8s %-8s\n",
@@ -492,7 +495,8 @@ static int netprocfs_rxpackets(FAR struct netprocfs_file_s *netfile)
  ****************************************************************************/
 
 #ifdef CONFIG_NETDEV_STATISTICS
-static int netprocfs_txstatistics_header(FAR struct netprocfs_file_s *netfile)
+static int netprocfs_txstatistics_header(
+    FAR struct netprocfs_file_s *netfile)
 {
   DEBUGASSERT(netfile != NULL);
 
@@ -515,7 +519,8 @@ static int netprocfs_txstatistics(FAR struct netprocfs_file_s *netfile)
   dev = netfile->dev;
   stats = &dev->d_statistics;
 
-  return snprintf(netfile->line, NET_LINELEN, "\t    %08lx %08lx %08lx %08lx\n",
+  return snprintf(netfile->line, NET_LINELEN,
+                  "\t    %08lx %08lx %08lx %08lx\n",
                   (unsigned long)stats->tx_packets,
                   (unsigned long)stats->tx_done,
                   (unsigned long)stats->tx_errors,


### PR DESCRIPTION
## Summary
nxstyle fixes extracted from https://github.com/apache/incubator-nuttx/pull/2222

"arm: Use a consistent type (uintptr_t) for g_idle_topstack" is included here
because it happened to include nxstyle fix. (and i'm too lazy to separate them)
## Impact

## Testing

