### PR TITLE
RISCV minor fix

### DIFF
--- a/arch/risc-v/src/rv32im/Toolchain.defs
+++ b/arch/risc-v/src/rv32im/Toolchain.defs
@@ -77,9 +77,9 @@ endif
 ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
   CROSSDEV ?= riscv64-unknown-elf-
   ifeq ($(CONFIG_ARCH_FPU),y)
-      ARCHCPUFLAGS = -march=rv32imf -mabi=ilp32f
+      ARCHCPUFLAGS = -march=rv32imfc -mabi=ilp32f
   else
-      ARCHCPUFLAGS = -march=rv32im -mabi=ilp32
+      ARCHCPUFLAGS = -march=rv32imc -mabi=ilp32
   endif
   ifeq ($(CONFIG_RV32IM_HW_MULDIV),y)
     ARCHCPUFLAGS += -mdiv

--- a/arch/risc-v/src/rv32im/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/rv32im/riscv_schedulesigaction.c
@@ -32,8 +32,8 @@
 #include <nuttx/arch.h>
 
 #include "sched/sched.h"
-#include "up_internal.h"
-#include "up_arch.h"
+#include "riscv_internal.h"
+#include "riscv_arch.h"
 
 #ifndef CONFIG_DISABLE_SIGNALS
 


### PR DESCRIPTION
## Summary
1.fix typo in riscv_scheduleaction.c in rv32im
2.set compressed instruction enabled as default in rv32im
## Impact

## Testing

