### PR TITLE
flashback to release all file descriptors in group to increase debugging time.

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -150,9 +150,9 @@ void files_releaselist(FAR struct filelist *list)
    * because there should not be any references in this context.
    */
 
-  for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
+  for (i = CONFIG_NFILE_DESCRIPTORS; i > 0; i--)
     {
-      _files_close(&list->fl_files[i]);
+      _files_close(&list->fl_files[i - 1]);
     }
 
   /* Destroy the semaphore */


### PR DESCRIPTION
## Summary
Flashback to release all file descriptors in group to increase debugging time.
## Impact
We will finally release stdin and stdout to prevent a failure to output the log while generating some log about other fd.
## Testing
daily test
