### PR TITLE
Update l3gd20 sensor driver with new sensor driver model

### DIFF
--- a/boards/arm/stm32/common/include/stm32_l3gd20.h
+++ b/boards/arm/stm32/common/include/stm32_l3gd20.h
@@ -62,7 +62,8 @@ extern "C"
  *   Initialize and register the L3GD20 3 axis gyroscope sensor driver.
  *
  * Input Parameters:
- *   devno - The device number, used to build the device path as /dev/gyroN
+ *   devno - The device number, used to build the device path as
+ *           /dev/sensor/gyro_uncalN
  *   busno - The SPI bus number
  *
  * Returned Value:

--- a/boards/arm/stm32/common/src/stm32_l3gd20.c
+++ b/boards/arm/stm32/common/src/stm32_l3gd20.c
@@ -86,7 +86,8 @@ static int l3gd20_attach(FAR struct l3gd20_config_s *cfg, xcpt_t irq)
  *   Initialize and register the L3GD20 3 axis gyroscope sensor driver.
  *
  * Input Parameters:
- *   devno - The device number, used to build the device path as /dev/gyroN
+ *   devno - The device number, used to build the device path as
+ *           /dev/sensor/gyro_uncalN
  *   busno - The SPI bus number
  *
  * Returned Value:
@@ -98,7 +99,6 @@ int board_l3gd20_initialize(int devno, int busno)
 {
   int ret = 0;
   struct spi_dev_s *spi;
-  char devpath[12];
 
   /* Configure DREADY IRQ input */
 
@@ -116,8 +116,7 @@ int board_l3gd20_initialize(int devno, int busno)
 
   /* Then register the gyro */
 
-  snprintf(devpath, 12, "/dev/gyro%d", devno);
-  ret = l3gd20_register(devpath, spi, &g_l3gd20_config);
+  ret = l3gd20_register(devno, spi, &g_l3gd20_config);
   if (ret != OK)
     {
       goto errout;

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -222,8 +222,18 @@ config SENSORS_L3GD20
 	bool "STMicro L3GD20 Gyroscope Sensor support"
 	default n
 	select SPI
+	select SCHED_HPWORK if SENSORS_L3GD20_BUFFER_SIZE > 0
 	---help---
 		Enable driver support for the STMicro L3GD20 gyroscope sensor.
+
+config SENSORS_L3GD20_BUFFER_SIZE
+	int "size of buffer"
+	default 1
+	depends on SENSORS_L3GD20
+	---help---
+		The size of the circular buffer used. If the value equal to zero,
+		indicates that the circular buffer is disabled.
+
 
 config SENSOR_KXTJ9
 	bool "Kionix KXTJ9 Accelerometer support"

--- a/include/nuttx/sensors/l3gd20.h
+++ b/include/nuttx/sensors/l3gd20.h
@@ -229,16 +229,6 @@ struct l3gd20_config_s
   int (*attach)(FAR struct l3gd20_config_s *, xcpt_t);
 };
 
-/* Data returned by reading from the L3GD20 is returned in this format. */
-
-struct l3gd20_sensor_data_s
-{
-  int16_t x_gyr;              /* Measurement result for x axis */
-  int16_t y_gyr;              /* Measurement result for y axis */
-  int16_t z_gyr;              /* Measurement result for z axis */
-  int8_t temperature;         /* Measurement result for temperature sensor */
-};
-
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -258,8 +248,9 @@ extern "C"
  *   Register the L3DF20 character device as 'devpath'.
  *
  * Input Parameters:
- *   devpath - The full path to the driver to register, e.g., "/dev/gyr0".
- *   i2c     - An SPI driver instance.
+ *   devno   - The device number, used to build the device path
+ *             as /dev/sensor/gyro_uncalN
+ *   spi     - An SPI driver instance.
  *   config  - configuration for the L3GD20 driver. For details see
  *             description above.
  *
@@ -268,7 +259,7 @@ extern "C"
  *
  ****************************************************************************/
 
-int l3gd20_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
+int l3gd20_register(int devno, FAR struct spi_dev_s *spi,
                     FAR struct l3gd20_config_s *config);
 
 #undef EXTERN


### PR DESCRIPTION
## Summary
Support l3gd20 sensor with new sensor model on stm32f429i-discovery board.
## Impact
We can test l3gd20 gyroscope sensor on stm32f429i-discovery board.
## Testing
daily test
