### PR TITLE
Add debug.h selection choice to support include chip debug.h

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -495,11 +495,26 @@ config ARCH_SETJMP_H
 		ARCH_SETJMP_H=y and providing. If ARCH_SETJMP_H, is not defined, then
 		the setjmp.h header file will stay out-of-the-way in include/nuttx/.
 
+choice
+	prompt "debug.h selection"
+	default ARCH_NONE_DEBUG_H
+
+config ARCH_NONE_DEBUG_H
+	bool "None"
+	---help---
+		No debug.h under include/arch/ and include/arch/chip.
+
 config ARCH_DEBUG_H
 	bool "debug.h"
-	default n
 	---help---
-		The debug.h contains architecture dependent debugging primitives
+		The debug.h under include/arch contains architecture dependent debugging primitives
+
+config ARCH_CHIP_DEBUG_H
+	bool "chip debug.h"
+	---help---
+		The debug.h under include/arch/chip contains architecture dependent debugging primitives
+
+endchoice # debug.h selection
 
 endmenu # Customize Header Files
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -46,6 +46,9 @@
 #ifdef CONFIG_ARCH_DEBUG_H
 # include <arch/debug.h>
 #endif
+#ifdef CONFIG_ARCH_CHIP_DEBUG_H
+# include <arch/chip/debug.h>
+#endif
 
 #include <syslog.h>
 


### PR DESCRIPTION
## Summary
Add Select debug.h choice which may be under include/arch or include/arch/chip.

## Impact

## Testing
Test and verify with using chip debug.h and none debug.h locally.
