### PR TITLE
drivers/leds/apa102: remove/fix references to I2C/LM-75 (comments only)

### DIFF
--- a/drivers/leds/apa102.c
+++ b/drivers/leds/apa102.c
@@ -139,6 +139,7 @@ static inline void apa102_write32(FAR struct apa102_dev_s *priv,
   apa102_configspi(priv->spi);
 
   /* Note: APA102 doesn't use chip select */
+
   /* Send 32 bits (4 bytes) */
 
   SPI_SEND(priv->spi, (value & 0xff));
@@ -181,7 +182,8 @@ static int apa102_close(FAR struct file *filep)
  * Name: apa102_read
  ****************************************************************************/
 
-static ssize_t apa102_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
+static ssize_t apa102_read(FAR struct file *filep, FAR char *buffer,
+                          size_t buflen)
 {
   return -ENOSYS;
 }
@@ -217,7 +219,8 @@ static ssize_t apa102_write(FAR struct file *filep, FAR const char *buffer,
 
   if ((buflen % 4) != 0)
     {
-      snerr("ERROR: Each LED uses 4 bytes, so (buflen % 4) needs to be 0!\n");
+      snerr("ERROR: Each LED uses 4 bytes, so (buflen % 4)"
+            " needs to be 0!\n");
       return -1;
     }
 
@@ -240,7 +243,7 @@ static ssize_t apa102_write(FAR struct file *filep, FAR const char *buffer,
 
   apa102_write32(priv, APA102_END_FRAME);
 
-  for (i = 0; i < (1 + nleds/32); i++)
+  for (i = 0; i < (1 + nleds / 32); i++)
     {
       apa102_write32(priv, 0);
     }

--- a/drivers/leds/apa102.c
+++ b/drivers/leds/apa102.c
@@ -168,7 +168,7 @@ static int apa102_open(FAR struct file *filep)
  * Name: apa102_close
  *
  * Description:
- *   This routine is called when the LM-75 device is closed.
+ *   This routine is called when the APA102 device is closed.
  *
  ****************************************************************************/
 
@@ -262,11 +262,8 @@ static ssize_t apa102_write(FAR struct file *filep, FAR const char *buffer,
  *
  * Input Parameters:
  *   devpath - The full path to the driver to register. E.g., "/dev/temp0"
- *   i2c     - An instance of the I2C interface to use to communicate with
+ *   spi     - An instance of the SPI interface to use to communicate with
  *             APA102
- *   addr    - The I2C address of the LM-75.  The base I2C address of the
- *             APA102 is 0x48.  Bits 0-3 can be controlled to get 8 unique
- *             addresses from 0x48 through 0x4f.
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.


### PR DESCRIPTION
Just fixing wrong comments from copy-paste.

Thanks!
