### PR TITLE
audio: libsamplerate: add initial audio Sample Rate Converter

### DIFF
--- a/libs/libc/Kconfig
+++ b/libs/libc/Kconfig
@@ -6,6 +6,7 @@
 comment "Standard C Library Options"
 
 source libs/libc/stdio/Kconfig
+source libs/libc/audio/Kconfig
 source libs/libc/math/Kconfig
 source libs/libc/machine/Kconfig
 source libs/libc/stdlib/Kconfig

--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -149,7 +149,7 @@ endif
 
 # Context
 
-context:
+context::
 ifeq ($(CONFIG_LIB_ZONEINFO_ROMFS),y)
 	$(Q) $(MAKE) -C zoneinfo context BIN=$(BIN)
 endif
@@ -166,11 +166,11 @@ ifeq ($(CONFIG_LIB_ZONEINFO_ROMFS),y)
 endif
 	$(Q) touch $@
 
-depend: .depend
+depend:: .depend
 
 # Clean most derived files, retaining the configuration
 
-clean:
+clean::
 	$(Q) $(MAKE) -C bin  clean
 	$(Q) $(MAKE) -C kbin clean
 	$(Q) $(MAKE) -C zoneinfo clean BIN=$(BIN)
@@ -180,7 +180,7 @@ clean:
 
 # Deep clean -- removes all traces of the configuration
 
-distclean: clean
+distclean:: clean
 	$(Q) $(MAKE) -C bin  distclean
 	$(Q) $(MAKE) -C kbin distclean
 	$(Q) $(MAKE) -C zoneinfo distclean BIN=$(BIN)

--- a/libs/libc/audio/Kconfig
+++ b/libs/libc/audio/Kconfig
@@ -1,0 +1,7 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+
+source libs/libc/audio/libsrc/Kconfig

--- a/libs/libc/audio/Make.defs
+++ b/libs/libc/audio/Make.defs
@@ -36,6 +36,8 @@
 ifeq ($(CONFIG_AUDIO),y)
 CSRCS += lib_buffer.c
 
+include audio/libsrc/Make.defs
+
 # Add the audio/ directory to the build
 
 DEPPATH += --dep-path audio

--- a/libs/libc/audio/libsrc/0001-add-audio-quality-options.patch
+++ b/libs/libc/audio/libsrc/0001-add-audio-quality-options.patch
@@ -1,0 +1,82 @@
+From 8d709a69b23efc52030824ae21db889589467d8c Mon Sep 17 00:00:00 2001
+From: Alin Jerpelea <alin.jerpelea@sony.com>
+Date: Mon, 16 Nov 2020 09:44:17 +0100
+Subject: [PATCH] add audio quality options
+
+Many NuttX boards have limited rerources and will have to use
+compile time quality options to reduce resource usage
+
+Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>
+---
+ src/src_sinc.c | 30 +++++++++++++++++++++++++-----
+ 1 files changed, 25 insertions(+), 5 deletions(-)
+
+diff --git a/src/src_sinc.c b/src/src_sinc.c
+index 0a22708..b81326e 100644
+--- a/src/src_sinc.c
++++ b/src/src_sinc.c
+@@ -40,9 +40,17 @@ typedef int32_t increment_t ;
+ typedef float	coeff_t ;
+ typedef int _CHECK_SHIFT_BITS[2 * (SHIFT_BITS < sizeof (increment_t) * 8 - 1) - 1]; /* sanity check. */
+ 
+-#include "fastest_coeffs.h"
+-#include "mid_qual_coeffs.h"
+-#include "high_qual_coeffs.h"
++#if CONFIG_AUDIO_SRC_QUALITY == 2
++  #include "fastest_coeffs.h"
++#elif CONFIG_AUDIO_SRC_QUALITY == 1
++  #include "mid_qual_coeffs.h"
++#elif if CONFIG_AUDIO_SRC_QUALITY == 0
++  #include "high_qual_coeffs.h"
++#else
++  #include "fastest_coeffs.h"
++  #include "mid_qual_coeffs.h"
++  #include "high_qual_coeffs.h"
++#endif
+ 
+ typedef struct
+ {	int		sinc_magic_marker ;
+@@ -206,6 +214,19 @@ sinc_filter_new (int converter_type, int channels)
+ 	if (priv)
+ 	{
+ 		priv->sinc_magic_marker = SINC_MAGIC_MARKER ;
++#if CONFIG_AUDIO_SRC_QUALITY == 2
++		priv->coeffs = fastest_coeffs.coeffs ;
++		priv->coeff_half_len = ARRAY_LEN (fastest_coeffs.coeffs) - 2 ;
++		priv->index_inc = fastest_coeffs.increment ;
++#elif CONFIG_AUDIO_SRC_QUALITY == 1
++		priv->coeffs = slow_mid_qual_coeffs.coeffs ;
++		priv->coeff_half_len = ARRAY_LEN (slow_mid_qual_coeffs.coeffs) - 2 ;
++		priv->index_inc = slow_mid_qual_coeffs.increment ;
++#elif CONFIG_AUDIO_SRC_QUALITY == 0
++		priv->coeffs = slow_high_qual_coeffs.coeffs ;
++		priv->coeff_half_len = ARRAY_LEN (slow_high_qual_coeffs.coeffs) - 2 ;
++		priv->index_inc = slow_high_qual_coeffs.increment ;
++#else
+ 		switch (converter_type)
+ 		{
+ 		case SRC_SINC_FASTEST :
+@@ -213,19 +234,18 @@ sinc_filter_new (int converter_type, int channels)
+ 			priv->coeff_half_len = ARRAY_LEN (fastest_coeffs.coeffs) - 2 ;
+ 			priv->index_inc = fastest_coeffs.increment ;
+ 			break ;
+-
+ 		case SRC_SINC_MEDIUM_QUALITY :
+ 			priv->coeffs = slow_mid_qual_coeffs.coeffs ;
+ 			priv->coeff_half_len = ARRAY_LEN (slow_mid_qual_coeffs.coeffs) - 2 ;
+ 			priv->index_inc = slow_mid_qual_coeffs.increment ;
+ 			break ;
+-
+ 		case SRC_SINC_BEST_QUALITY :
+ 			priv->coeffs = slow_high_qual_coeffs.coeffs ;
+ 			priv->coeff_half_len = ARRAY_LEN (slow_high_qual_coeffs.coeffs) - 2 ;
+ 			priv->index_inc = slow_high_qual_coeffs.increment ;
+ 			break ;
+ 		}
++#endif
+ 
+ 		priv->b_len = 3 * (int) lrint ((priv->coeff_half_len + 2.0) / priv->index_inc * SRC_MAX_RATIO + 1) ;
+ 		priv->b_len = MAX (priv->b_len, 4096) ;
+-- 
+2.17.1
+

--- a/libs/libc/audio/libsrc/Kconfig
+++ b/libs/libc/audio/libsrc/Kconfig
@@ -1,0 +1,23 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config AUDIO_SRC
+       bool "Audio Samplerate Convertor Library"
+       default n
+       ---help---
+               Enable build for various SRC functions
+
+if AUDIO_SRC
+
+config AUDIO_SRC_QUALITY
+       int "Audio Conversion Quality [0/1/2]"
+       default 2
+       ---help---
+               Audio Conversion Quality [0/1/2]
+               0 Slowest conversion speed with best quality.
+               1 Medium conversion speed with medium qulity
+               2 Fastest conversion with lowest Quality
+
+endif # LIBSRC

--- a/libs/libc/audio/libsrc/Make.defs
+++ b/libs/libc/audio/libsrc/Make.defs
@@ -1,0 +1,53 @@
+############################################################################
+# audio/libsrc/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_AUDIO_SRC),y)
+
+PACKAGE=libsamplerate
+VERSION=0.1.9
+
+libsamplerate:
+	$(Q) wget https://codeload.github.com/libsndfile/libsamplerate/zip/master -O libsamplerate.zip
+	$(Q) unzip -o libsamplerate.zip
+	$(Q) mv libsamplerate-master libsamplerate
+	$(Q) patch -Np1 -d libsamplerate <audio/libsrc/0001-add-audio-quality-options.patch
+	$(Q) cp -rf libsamplerate/src/samplerate.h $(TOPDIR)$(DELIM)include$(DELIM)nuttx$(DELIM)audio$(DELIM)
+
+context:: libsamplerate
+
+CSRCS += samplerate.c
+CSRCS += src_sinc.c
+CSRCS += src_linear.c
+CSRCS += src_zoh.c
+
+CFLAGS += -DPACKAGE=\"$(PACKAGE)\" -DVERSION=\"$(VERSION)\"
+
+VPATH += libsamplerate/src
+SUBDIRS += libsamplerate/src
+DEPPATH += --dep-path libsamplerate/src
+
+distclean::
+	$(call DELDIR, $(TOPDIR)$(DELIM)include$(DELIM)nuttx$(DELIM)audio$(DELIM)samplerate.h)
+	$(call DELDIR, libsamplerate)
+	$(call DELFILE, libsamplerate.zip)
+
+endif
+
+

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -112,9 +112,7 @@ CLEANDIRS += syscall
 endif
 endif
 
-ifeq ($(CONFIG_LIB_ZONEINFO_ROMFS),y)
 CONTEXTDIRS += libs$(DELIM)libc
-endif
 
 ifeq ($(CONFIG_NX),y)
 KERNDEPDIRS += graphics


### PR DESCRIPTION
## Summary
Add audio sample rate conversion library from
http://www.mega-nerd.com/SRC/index.html

Source:
https://github.com/libsndfile/libsamplerate

Add needed patches for NuttX OS and embedded boards.

NOTE:
We must use master branch until next stable release

## Impact
Sony spresense board

## Testing
Tested on speresense board
