### PR TITLE
arch/xtensa/src/esp32/esp32_tim.c: Fix build when debug is enabled.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_tim.c
+++ b/arch/xtensa/src/esp32/esp32_tim.c
@@ -935,7 +935,7 @@ FAR struct esp32_tim_dev_s *esp32_tim0_init(void)
 
   if (tim->inuse == true)
     {
-      tmrerr("ERROR: TIMER %d is already in use\n", timer);
+      tmrerr("ERROR: Timer0 is already in use\n");
       tim = NULL;
     }
 


### PR DESCRIPTION
## Summary
A non-existent variable was used in the debug message.
## Impact
Fix build when timer's debug is enabled.
## Testing
N/A