### PR TITLE
stm32l4: correct macros STM32L4_CAN_MCR_OFFSET, etc... to match defines.

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_can.c
+++ b/arch/arm/src/stm32l4/stm32l4_can.c
@@ -1092,7 +1092,7 @@ static int stm32l4can_ioctl(FAR struct can_dev_s *dev, int cmd,
               return ret;
             }
 
-          regval = stm32l4can_getreg(priv, STM32_CAN_MCR_OFFSET);
+          regval = stm32l4can_getreg(priv, STM32L4_CAN_MCR_OFFSET);
           if (arg == 1)
             {
               regval |= CAN_MCR_NART;
@@ -1102,7 +1102,7 @@ static int stm32l4can_ioctl(FAR struct can_dev_s *dev, int cmd,
               regval &= ~CAN_MCR_NART;
             }
 
-          stm32l4can_putreg(priv, STM32_CAN_MCR_OFFSET, regval);
+          stm32l4can_putreg(priv, STM32L4_CAN_MCR_OFFSET, regval);
           return stm32l4can_exitinitmode(priv);
         }
         break;
@@ -1116,7 +1116,7 @@ static int stm32l4can_ioctl(FAR struct can_dev_s *dev, int cmd,
               return ret;
             }
 
-          regval = stm32l4can_getreg(priv, STM32_CAN_MCR_OFFSET);
+          regval = stm32l4can_getreg(priv, STM32L4_CAN_MCR_OFFSET);
           if (arg == 1)
             {
               regval |= CAN_MCR_ABOM;
@@ -1126,7 +1126,7 @@ static int stm32l4can_ioctl(FAR struct can_dev_s *dev, int cmd,
               regval &= ~CAN_MCR_ABOM;
             }
 
-          stm32l4can_putreg(priv, STM32_CAN_MCR_OFFSET, regval);
+          stm32l4can_putreg(priv, STM32L4_CAN_MCR_OFFSET, regval);
           return stm32l4can_exitinitmode(priv);
         }
         break;


### PR DESCRIPTION
It seems that part of the patch
stm32l4: correct build of stm32l4_can.c to respect L4 variant
has been lost on its way to mainline.

Signed-off-by: Pavel Pisa <ppisa@pikron.com>