### PR TITLE
[BACKPORT #2251] ci: Remove depricated usage of set-env in GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
           command: docker pull docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux
 
       - name: Export NuttX Repo SHA
-        run:  echo "::set-env name=nuttx_sha::`git -C sources/nuttx rev-parse HEAD`"
+        run:  echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
       - name: Run builds
         uses: ./sources/testing/.github/actions/ci-container
         env:
@@ -193,7 +193,7 @@ jobs:
           key: ${{ runner.os }}-tools-${{ hashFiles('./sources/testing/cibuild.sh') }}
 
       - name: Export NuttX Repo SHA
-        run:  echo "::set-env name=nuttx_sha::`git -C sources/nuttx rev-parse HEAD`"
+        run:  echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
       - name: Run Builds
         run: |
           echo "::add-matcher::sources/nuttx/.github/gcc.json"


### PR DESCRIPTION
## Summary
Backport #2251 

## Impact

## Testing

