### PR TITLE
Revert "fs/nxffs: Fix scan good block slowly and scan an invalid block"

### DIFF
--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -495,11 +495,7 @@ int nxffs_limits(FAR struct nxffs_volume_s *volume)
         }
       else
         {
-          volume->ioblock += 1;
-          volume->iooffset = SIZEOF_NXFFS_BLOCK_HDR;
-
-          offset = volume->ioblock * volume->geo.blocksize +
-                   volume->iooffset;
+          offset += nerased + 1;
           nerased = 0;
         }
     }


### PR DESCRIPTION
## Summary
This reverts commit 97be116a39fee62b8f7027fd93d93789a6d04abb which came in as #1431 

This commit broke nxffs.  This leaves the first block as empty which
then exposes another bug where when the pack is called because we
have reached the end of flash and need to look for deleted inodes
we search the first block find no inode and assume that there
are no more inodes.  This then results in corrupting the filesystem
by writing over existing inodes.

This can be seen by runing the sim:nxffs configuration.
Prior to this commit the first pass of writing files would look like
this:
```
NXFFS Dump:
  BLOCK:OFFS  TYPE  STATE   LENGTH
      0:5     INODE OK       2680
      0:78    DATA  OK        424
      1:5     DATA  OK        497
      2:5     DATA  OK        497
      3:5     DATA  OK        497
      4:5     DATA  OK        497
      5:5     DATA  OK        268
      5:283   INODE OK       7410
      5:425   DATA  OK         77
      6:5     DATA  OK        497
```
With this commit:
```
NXFFS Dump:
  BLOCK:OFFS  TYPE  STATE   LENGTH
      0:0     BLOCK ERASED    512
      1:5     INODE OK       6394
      1:39    DATA  OK        463
      2:5     DATA  OK        497
      3:5     DATA  OK        497
```
Signed-off-by: Brennan Ashton <bashton@brennanashton.com>

## Impact
`sim:nxffs` configuration does not result in corrupting the filesystem.

## Testing
Running the simulator build as well as inspecting the raw filesystem.