### PR TITLE
arch/xtensa/src/esp32/esp32_gpio.c: Fix GPIO IRQ assert condition.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -357,7 +357,7 @@ void esp32_gpioirqenable(int irq, gpio_intrtype_t intrtype)
 #endif
   int pin;
 
-  DEBUGASSERT(irq <= ESP32_FIRST_GPIOIRQ && irq <= ESP32_LAST_GPIOIRQ);
+  DEBUGASSERT(irq >= ESP32_FIRST_GPIOIRQ && irq <= ESP32_LAST_GPIOIRQ);
 
   /* Convert the IRQ number to a pin number */
 
@@ -418,7 +418,7 @@ void esp32_gpioirqdisable(int irq)
   uint32_t regval;
   int pin;
 
-  DEBUGASSERT(irq <= ESP32_FIRST_GPIOIRQ && irq <= ESP32_LAST_GPIOIRQ);
+  DEBUGASSERT(irq >= ESP32_FIRST_GPIOIRQ && irq <= ESP32_LAST_GPIOIRQ);
 
   /* Convert the IRQ number to a pin number */
 


### PR DESCRIPTION
## Summary
Assert condition for GPIO IRQs wasn't correct.
## Impact
Fix an assertion.
## Testing

A simple GPIO IRQ example.