### PR TITLE
Fix comments on armv7-a smp

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-NuttX TODO List (Last updated October 20, 2020)
+NuttX TODO List (Last updated November 20, 2020)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This file summarizes known NuttX bugs, limitations, inconsistencies with
@@ -10,7 +10,7 @@ issues related to each board port.
 nuttx/:
 
  (16)  Task/Scheduler (sched/)
-  (5)  SMP
+  (3)  SMP
   (1)  Memory Management (mm/)
   (0)  Power Management (drivers/pm)
   (5)  Signals (sched/signal, arch/)
@@ -467,37 +467,6 @@ o SMP
   Status:      Open
   Priority:    Medium for SMP system.  Not critical to single CPU systems.
                NOTE:  There are no known bugs from this potential problem.
-
-  Title:       CORTEX-A GIC SGI INTERRUPT MASKING
-  Description: In the ARMv7-A GICv2 architecture, the inter-processor
-               interrupts (SGIs) are non maskable and will occur even if
-               interrupts are disabled.  This adds a lot of complexity
-               to the ARMV7-A critical section design.
-
-               Masayuki Ishikawa has suggested the use of the GICv2 ICCMPR
-               register to control SGI interrupts.  This register (much like
-               the ARMv7-M BASEPRI register) can be used to mask interrupts
-               by interrupt priority.  Since SGIs may be assigned priorities
-               the ICCMPR should be able to block execution of SGIs as well.
-
-               Such an implementation would be very similar to the BASEPRI
-               (vs PRIMASK) implementation for the ARMv7-M:  (1) The
-               up_irq_save() and up_irq_restore() registers would have to
-               set/restore the ICCMPR register, (2) register setup logic in
-               arch/arm/src/armv7-a for task start-up and signal dispatch
-               would have to set the ICCMPR correctly, and (3) the 'xcp'
-               structure would have to be extended to hold the ICCMPR
-               register;  logic would have to added be save/restore the
-               ICCMPR register in the 'xcp' structure on each interrupt and
-               context switch.
-
-               This would also be an essential part of a high priority,
-               nested interrupt implementation (unrelated).
-  Status:      Open
-  Priority:    Low.  There are no known issues with the current non-maskable
-               SGI implementation.  This change would, however, lead to
-               simplification in the design and permit commonality with
-               other, non-GIC implementations.
 
   Title:       ISSUES WITH ACCESSING CPU INDEX
   Description: The CPU number is accessed usually with the macro this_cpu().

--- a/arch/arm/src/common/arm_interruptcontext.c
+++ b/arch/arm/src/common/arm_interruptcontext.c
@@ -60,12 +60,6 @@
 bool up_interrupt_context(void)
 {
 #ifdef CONFIG_SMP
-  /* REVISIT:  Currently up_irq_save() will not disable the Software
-   * Generated Interrupts (SGIs) for the case of ARMv7-A architecture using
-   * the GIC.  So this will not be sufficient in that case, at least not
-   * until we add support for the ICCMPR.
-   */
-
   irqstate_t flags = up_irq_save();
 #endif
 

--- a/boards/arm/imx6/sabre-6quad/README.txt
+++ b/boards/arm/imx6/sabre-6quad/README.txt
@@ -592,24 +592,7 @@ Debugging with QEMU
 
 The nuttx ELF image can be debugged with QEMU.
 
-1. Before debugging, following change (enabling wfi instruction in up_idle)
-   is recommended to reduce CPU usage on host PC.
-
-diff --git a/arch/arm/src/common/up_idle.c b/arch/arm/src/common/up_idle.c
-index 45fab0b7c6..c54c1178a1 100644
---- a/arch/arm/src/common/up_idle.c
-+++ b/arch/arm/src/common/up_idle.c
-@@ -71,7 +71,7 @@ void up_idle(void)
-
-   /* Sleep until an interrupt occurs to save power */
-
--#if 0
-+#if 1
-   asm("WFI");  /* For example */
- #endif
- #endif
-
-2. Also, to debug the nuttx (ELF) with symbols, following change must
+1. To debug the nuttx (ELF) with symbols, following change must
    be applied to defconfig.
 
 diff --git a/boards/arm/imx6/sabre-6quad/configs/nsh/defconfig b/boards/arm/imx6/sabre-6quad/configs/nsh/defconfig
@@ -624,6 +607,33 @@ index b15becbb51..3ad4d13ad7 100644
 +CONFIG_DEBUG_SYMBOLS=y
  CONFIG_DEV_ZERO=y
 
+2. Please note that QEMU does not report PL310 (L2CC) related
+   registers correctly, so if you enable CONFIG_DEBUG_ASSERTION
+   the nuttx will stop with DEBUGASSERT(). To avoid this,
+   comment out the following lines.
+
+--- a/arch/arm/src/armv7-a/arm_l2cc_pl310.c
++++ b/arch/arm/src/armv7-a/arm_l2cc_pl310.c
+@@ -333,7 +333,7 @@ void arm_l2ccinitialize(void)
+ #if defined(CONFIG_ARMV7A_ASSOCIATIVITY_8WAY)
+   DEBUGASSERT((getreg32(L2CC_ACR) & L2CC_ACR_ASS) == 0);
+ #elif defined(CONFIG_ARMV7A_ASSOCIATIVITY_16WAY)
+- DEBUGASSERT((getreg32(L2CC_ACR) & L2CC_ACR_ASS) == L2CC_ACR_ASS);
++ //DEBUGASSERT((getreg32(L2CC_ACR) & L2CC_ACR_ASS) == L2CC_ACR_ASS);
+ #else
+ # error No associativity selected
+ #endif
+@@ -345,8 +345,8 @@ void arm_l2ccinitialize(void)
+   DEBUGASSERT((getreg32(L2CC_ACR) & L2CC_ACR_WAYSIZE_MASK) ==
+               L2CC_ACR_WAYSIZE_32KB);
+ #elif defined(CONFIG_ARMV7A_WAYSIZE_64KB)
+- DEBUGASSERT((getreg32(L2CC_ACR) & L2CC_ACR_WAYSIZE_MASK) ==
+- L2CC_ACR_WAYSIZE_64KB);
++ // DEBUGASSERT((getreg32(L2CC_ACR) & L2CC_ACR_WAYSIZE_MASK) ==
++ // L2CC_ACR_WAYSIZE_64KB);
+ #elif defined(CONFIG_ARMV7A_WAYSIZE_128KB)
+   DEBUGASSERT((getreg32(L2CC_ACR) & L2CC_ACR_WAYSIZE_MASK) ==
+               L2CC_ACR_WAYSIZE_128KB);
 
 3. Run QEMU
 

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -353,10 +353,6 @@ try_again_in_irq:
                    * and try again.  Briefly re-enabling interrupts should
                    * be sufficient to permit processing the pending pause
                    * request.
-                   *
-                   * NOTE: This should never happen on architectures like
-                   * the Cortex-A; the inter-CPU interrupt (SGI) is not
-                   * maskable.
                    */
 
                   up_irq_restore(ret);


### PR DESCRIPTION
## Summary

- This PR consists of 2 commits
- commit 1: armv7-a: Fix comments on Cortex-A SGI
  - I noticed that Cortex-A SGI can be masked
  - We thought the SGI is not maskable
  - Although I can not remember how I tested it before
  - It actually works as expected now
- commit 2: boards: sabre-6quad: Fix README.txt
  - Remove comments on up_idle() which is old information
  - Add L2CC info with QEMU

## Impact

- No impact

## Testing

- Tested with sabre-6quad:smp (QEMU and dev board)
- Add the following code in up_idle() before calling asm("WFI");
```
    +  if (0 != up_cpu_index())
    +    {
    +      up_irq_save();
    +    }
```
 - Run the hello app, you can see "Hello, World!!"
 - But nsh will freeze soon because arm_pause_handler is not called.
