### PR TITLE
Fix pause handler for SMP

### DIFF
--- a/TODO
+++ b/TODO
@@ -10,7 +10,7 @@ issues related to each board port.
 nuttx/:
 
  (16)  Task/Scheduler (sched/)
-  (3)  SMP
+  (2)  SMP
   (1)  Memory Management (mm/)
   (0)  Power Management (drivers/pm)
   (5)  Signals (sched/signal, arch/)
@@ -484,70 +484,6 @@ o SMP
   Prioity:     Medium.  This is a logical problem but I have never seen
                an bugs caused by this.  But I believe that failures are
                possible.
-
-  Title:       POSSIBLE FOR TWO CPUs TO HOLD A CRITICAL SECTION?
-  Description: The SMP design includes logic that will support multiple
-               CPUs holding a critical section.  Is this necessary?  How
-               can that occur?  I think it can occur in the following
-               situation:
-
-               The log below was reported is NuttX running on two cores
-               Cortex-A7 architecture in SMP mode.  You can notice see that
-               when nxsched_add_readytorun() was called, the g_cpu_irqset is 3.
-
-                 nxsched_add_readytorun: irqset cpu 1, me 0 btcbname init, irqset 1 irqcount 2.
-                 nxsched_add_readytorun: nxsched_add_readytorun line 338 g_cpu_irqset = 3.
-
-               This can happen, but only under a very certain condition.
-               g_cpu_irqset only exists to support this certain condition:
-
-                 a. A task running on CPU 0 takes the critical section.  So
-                    g_cpu_irqset == 0x1.
-
-                 b. A task exits on CPU 1 and a waiting, ready-to-run task
-                    is re-started on CPU 1.  This new task also holds the
-                    critical section.  So when the task is re-restarted on
-                    CPU 1, we than have g_cpu_irqset == 0x3
-
-               So we are in a very perverse state!  There are two tasks
-               running on two different CPUs and both hold the critical
-               section.  I believe that is a dangerous situation and there
-               could be undiscovered bugs that could happen in that case.
-               However, as of this moment, I have not heard of any specific
-               problems caused by this weird behavior.
-
-               A possible solution would be to add a new task state that
-               would exist only for SMP.
-
-               - Add a new SMP-only task list and state.  Say,
-                 g_csection_wait[].  It should be prioritized.
-               - When a task acquires the critical section, all tasks in
-                 g_readytorun[] that need the critical section would be
-                 moved to g_csection_wait[].
-               - When any task is unblocked for any reason and moved to the
-                 g_readytorun[] list, if that unblocked task needs the
-                 critical section, it would also be moved to the
-                 g_csection_wait[] list.  No task that needs the critical
-                 section can be in the ready-to-run list if the critical
-                 section is not available.
-               - When the task releases the critical section, all tasks in
-                 the g_csection_wait[] needs to be moved back to
-                 g_readytorun[].
-              - This may result in a context switch.  The tasks should be
-                 moved back to g_readytorun[] highest priority first.  If a
-                 context switch occurs and the critical section to re-taken
-                 by the re-started task, the lower priority tasks in
-                 g_csection_wait[] must stay in that list.
-
-               That is really not as much work as it sounds.  It is
-               something that could be done in 2-3 days of work if you know
-               what you are doing.  Getting the proper test setup and
-               verifying the change would be the more difficult task.
-
-Status:        Open
-Priority:      Unknown.  Might be high, but first we would need to confirm
-               that this situation can occur and that is actually causes
-               a failure.
 
 o Memory Management (mm/)
   ^^^^^^^^^^^^^^^^^^^^^^^

--- a/arch/arm/src/armv7-a/arm_cpupause.c
+++ b/arch/arm/src/armv7-a/arm_cpupause.c
@@ -205,6 +205,7 @@ int up_cpu_paused(int cpu)
 int arm_pause_handler(int irq, FAR void *context, FAR void *arg)
 {
   int cpu = this_cpu();
+  int ret = OK;
 
   /* Check for false alarms.  Such false could occur as a consequence of
    * some deadlock breaking logic that might have already serviced the SG2
@@ -214,10 +215,21 @@ int arm_pause_handler(int irq, FAR void *context, FAR void *arg)
 
   if (spin_islocked(&g_cpu_paused[cpu]))
     {
-      return up_cpu_paused(cpu);
+      /* NOTE: up_cpu_paused() needs to be executed in a critical section
+       * to ensure that this CPU holds g_cpu_irqlock. However, adding
+       * a critical section in up_cpu_paused() is not a good idea,
+       * because it is also called in enter_critical_section() to break
+       * a deadlock
+       */
+
+      irqstate_t flags = enter_critical_section();
+
+      ret = up_cpu_paused(cpu);
+
+      leave_critical_section(flags);
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/arch/arm/src/cxd56xx/cxd56_cpupause.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpupause.c
@@ -283,6 +283,7 @@ int up_cpu_paused(int cpu)
 int arm_pause_handler(int irq, void *c, FAR void *arg)
 {
   int cpu = up_cpu_index();
+  int ret = OK;
 
   DPRINTF("cpu%d will be paused \n", cpu);
 
@@ -297,10 +298,21 @@ int arm_pause_handler(int irq, void *c, FAR void *arg)
 
   if (spin_islocked(&g_cpu_paused[cpu]))
     {
-      return up_cpu_paused(cpu);
+      /* NOTE: up_cpu_paused() needs to be executed in a critical section
+       * to ensure that this CPU holds g_cpu_irqlock. However, adding
+       * a critical section in up_cpu_paused() is not a good idea,
+       * because it is also called in enter_critical_section() to break
+       * a deadlock
+       */
+
+      irqstate_t flags = enter_critical_section();
+
+      ret = up_cpu_paused(cpu);
+
+      leave_critical_section(flags);
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/arch/arm/src/lc823450/lc823450_cpupause.c
+++ b/arch/arm/src/lc823450/lc823450_cpupause.c
@@ -190,6 +190,7 @@ int up_cpu_paused(int cpu)
 int lc823450_pause_handler(int irq, void *c, FAR void *arg)
 {
   int cpu = up_cpu_index();
+  int ret = OK;
 
   /* Clear : Pause IRQ */
 
@@ -211,10 +212,21 @@ int lc823450_pause_handler(int irq, void *c, FAR void *arg)
 
   if (spin_islocked(&g_cpu_paused[cpu]))
     {
-      return up_cpu_paused(cpu);
+      /* NOTE: up_cpu_paused() needs to be executed in a critical section
+       * to ensure that this CPU holds g_cpu_irqlock. However, adding
+       * a critical section in up_cpu_paused() is not a good idea,
+       * because it is also called in enter_critical_section() to break
+       * a deadlock
+       */
+
+      irqstate_t flags = enter_critical_section();
+
+      ret = up_cpu_paused(cpu);
+
+      leave_critical_section(flags);
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -192,7 +192,18 @@ void xtensa_pause_handler(void)
 
   if (spin_islocked(&g_cpu_paused[cpu]))
     {
+      /* NOTE: up_cpu_paused() needs to be executed in a critical section
+       * to ensure that this CPU holds g_cpu_irqlock. However, adding
+       * a critical section in up_cpu_paused() is not a good idea,
+       * because it is also called in enter_critical_section() to break
+       * a deadlock
+       */
+
+      irqstate_t flags = enter_critical_section();
+
       up_cpu_paused(cpu);
+
+      leave_critical_section(flags);
     }
 }
 


### PR DESCRIPTION
## Summary

- This PR consists of the following 6 commits
- commit 1: arch: cxd56xx: Fix the pause handler for SMP
  - I noticed that sched_add_readytorun() runs on multiple CPUs simultaneously
  - Finally, I found the root cause which was described in TODO
  - Actually, the task newly scheduled on remote CPU did not acquire g_cpu_irqlock
  - This commit fixes this issue by adding a critical section to the pause handler
  - Which will acquire g_cpu_irqlock on the remote CPU explicitly
- commit 2: arch: armv7-a: Fix the pause handler for SMP
  - Apply the same logic added to cxd56_cpupause.c
- commit 3: arch: lc823450: Fix the pause handler for SMP
  - Apply the same logic added to cxd56_cpupause.c
- commit 4: arch: k210: Fix the pause handler for SMP
  - Apply the same logic added to cxd56_cpupause.c
- commit 5: arch: xtensa: Fix the pause handler for SMP
  - Apply the same logic added to cxd56_cpupause.c
- commit 6: Update TODO regarding SMP
  - 'POSSIBLE FOR TWO CPUs TO HOLD A CRITICAL SECTION' was resolved

## Impact

- SMP only

## Testing

- Tested with spresense:wifi_smp (NCPUS=2 and 4)
  - Run smp, ostest, nxplayer
- Tested with sabre-6quad:smp (QEMU and dev board)
  - Run smp and ostest
- Tested with lc823450-xgevk:rndis
  - Run smp and ostest
- Tested with maix-bit:smp (QEMU)
  - Run smp and ostest
- Tested with esp32-core:smp (QEMU)
  - Run smp and ostest
