### PR TITLE
xtensa/esp32: Fix issues of force-sleep

### DIFF
--- a/arch/xtensa/src/esp32/esp32_clockconfig.c
+++ b/arch/xtensa/src/esp32/esp32_clockconfig.c
@@ -98,6 +98,34 @@ static inline void esp32_uart_tx_wait_idle(uint8_t uart_no)
  ****************************************************************************/
 
 extern uint32_t g_ticks_per_us_pro;
+#ifdef CONFIG_SMP
+extern uint32_t g_ticks_per_us_app;
+#endif
+
+/****************************************************************************
+ * Name:  esp32_update_cpu_freq
+ *
+ * Description:
+ *   Set the real CPU ticks per us to the ets, so that ets_delay_us
+ *   will be accurate. Call this function when CPU frequency is changed.
+ *
+ * Input Parameters:
+ *   ticks_per_us - CPU ticks per us
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void IRAM_ATTR esp32_update_cpu_freq(uint32_t ticks_per_us)
+{
+  /* Update scale factors used by esp_rom_delay_us */
+
+  g_ticks_per_us_pro = ticks_per_us;
+#ifdef CONFIG_SMP
+  g_ticks_per_us_app = ticks_per_us;
+#endif
+}
 
 /****************************************************************************
  * Name: esp32_set_cpu_freq

--- a/arch/xtensa/src/esp32/esp32_clockconfig.h
+++ b/arch/xtensa/src/esp32/esp32_clockconfig.h
@@ -47,6 +47,23 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name:  esp32_update_cpu_freq
+ *
+ * Description:
+ *   Set the real CPU ticks per us to the ets, so that ets_delay_us
+ *   will be accurate. Call this function when CPU frequency is changed.
+ *
+ * Input Parameters:
+ *   ticks_per_us - CPU ticks per us
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp32_update_cpu_freq(uint32_t ticks_per_us);
+
+/****************************************************************************
  * Name: esp32_set_cpu_freq
  *
  * Description:

--- a/arch/xtensa/src/esp32/esp32_idle.c
+++ b/arch/xtensa/src/esp32/esp32_idle.c
@@ -152,6 +152,12 @@ static void up_idlepm(void)
 
           pm_relax(PM_IDLE_DOMAIN, PM_NORMAL);
         }
+
+#ifdef CONFIG_WATCHDOG
+      /* Announce the power management state change to feed watchdog */
+
+      pm_changestate(PM_IDLE_DOMAIN, PM_NORMAL);
+#endif
     }
 }
 #else

--- a/arch/xtensa/src/esp32/esp32_pm.c
+++ b/arch/xtensa/src/esp32/esp32_pm.c
@@ -562,7 +562,7 @@ static int IRAM_ATTR esp32_sleep_start(uint32_t pd_flags)
 
   /* Save current frequency and switch to XTAL */
 
-  cur_freq = esp_clk_cpu_freq() / MHZ;
+  cur_freq = esp_rtc_clk_get_cpu_freq();
   esp32_rtc_cpu_freq_set_xtal();
 
   /* Enter sleep */
@@ -851,6 +851,7 @@ void esp32_sleep_enable_timer_wakeup(uint64_t time_in_us)
 
 int esp32_light_sleep_start(void)
 {
+  irqstate_t flags;
   uint32_t pd_flags;
   uint32_t flash_enable_time_us;
 #ifndef CONFIG_ESP32_SPIRAM
@@ -859,6 +860,7 @@ int esp32_light_sleep_start(void)
   struct rtc_vddsdio_config_s vddsdio_config;
   int ret = OK;
 
+  flags = enter_critical_section();
   s_config.rtc_ticks_at_sleep_start = esp32_rtc_time_get();
 
   /* Decide which power domains can be powered down */
@@ -896,7 +898,7 @@ int esp32_light_sleep_start(void)
 
   ret = esp32_light_sleep_inner(pd_flags, flash_enable_time_us,
                                                vddsdio_config);
-
+  leave_critical_section(flags);
   return ret;
 }
 

--- a/arch/xtensa/src/esp32/esp32_pm.c
+++ b/arch/xtensa/src/esp32/esp32_pm.c
@@ -581,7 +581,14 @@ static int IRAM_ATTR esp32_sleep_start(uint32_t pd_flags)
 
   /* Restore CPU frequency */
 
-  esp32_configure_cpu_freq(cur_freq);
+  if (esp32_configure_cpu_freq(cur_freq) != OK)
+    {
+      pwrwarn("WARNING: Faile to restore CPU frequency"
+              "Configure cpu frequency %d.\n", cur_freq);
+    }
+
+  /* Re-enable UART output */
+
   esp32_resume_uarts();
 
   return result;

--- a/arch/xtensa/src/esp32/esp32_pm.c
+++ b/arch/xtensa/src/esp32/esp32_pm.c
@@ -577,11 +577,11 @@ static int IRAM_ATTR esp32_sleep_start(uint32_t pd_flags)
       esp32_timer_wakeup_prepare();
     }
 
-  esp32_rtc_sleep_start(s_config.wakeup_triggers, 0);
+  result = esp32_rtc_sleep_start(s_config.wakeup_triggers, 0);
 
   /* Restore CPU frequency */
 
-  result = esp32_configure_cpu_freq(cur_freq);
+  esp32_configure_cpu_freq(cur_freq);
   esp32_resume_uarts();
 
   return result;

--- a/arch/xtensa/src/esp32/esp32_pm.c
+++ b/arch/xtensa/src/esp32/esp32_pm.c
@@ -853,7 +853,9 @@ int esp32_light_sleep_start(void)
 {
   uint32_t pd_flags;
   uint32_t flash_enable_time_us;
+#ifndef CONFIG_ESP32_SPIRAM
   uint32_t vddsdio_pd_sleep_duration;
+#endif
   struct rtc_vddsdio_config_s vddsdio_config;
   int ret = OK;
 
@@ -876,6 +878,7 @@ int esp32_light_sleep_start(void)
   flash_enable_time_us = VDD_SDIO_POWERUP_TO_FLASH_READ_US
                          + CONFIG_ESP32_DEEP_SLEEP_WAKEUP_DELAY;
 
+#ifndef CONFIG_ESP32_SPIRAM
   vddsdio_pd_sleep_duration = MAX(FLASH_PD_MIN_SLEEP_TIME_US,
               flash_enable_time_us + LIGHT_SLEEP_TIME_OVERHEAD_US
                                         + LIGHT_SLEEP_MIN_TIME_US);
@@ -885,6 +888,7 @@ int esp32_light_sleep_start(void)
       pd_flags |= RTC_SLEEP_PD_VDDSDIO;
       s_config.sleep_time_adjustment += flash_enable_time_us;
     }
+#endif
 
   esp32_get_vddsdio_config(&vddsdio_config);
 

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -23,8 +23,10 @@
  ****************************************************************************/
 
 #include <stdint.h>
+#include <assert.h>
 
 #include "esp32_rtc.h"
+#include "esp32_clockconfig.h"
 #include "hardware/esp32_rtccntl.h"
 #include "hardware/esp32_dport.h"
 #include "hardware/esp32_i2s.h"
@@ -622,21 +624,22 @@ void IRAM_ATTR esp32_rtc_update_to_xtal(int freq, int div)
 {
   uint32_t value = (((freq * MHZ) >> 12) & UINT16_MAX)
                    | ((((freq * MHZ) >> 12) & UINT16_MAX) << 16);
-  putreg32(value, RTC_APB_FREQ_REG);
+  esp32_update_cpu_freq(freq);
 
   /* set divider from XTAL to APB clock */
 
   REG_SET_FIELD(APB_CTRL_SYSCLK_CONF_REG, APB_CTRL_PRE_DIV_CNT, div - 1);
 
-  /* switch clock source */
-
-  REG_SET_FIELD(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_SOC_CLK_SEL,
-                RTC_CNTL_SOC_CLK_SEL_XTL);
-
   /* adjust ref_tick */
 
   modifyreg32(APB_CTRL_XTAL_TICK_CONF_REG, 0,
              (freq * MHZ) / REF_CLK_FREQ - 1);
+
+  /* switch clock source */
+
+  REG_SET_FIELD(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_SOC_CLK_SEL,
+                RTC_CNTL_SOC_CLK_SEL_XTL);
+  putreg32(value, RTC_APB_FREQ_REG);
 
   /* lower the voltage */
 
@@ -1153,6 +1156,77 @@ void IRAM_ATTR esp32_rtc_cpu_freq_set_xtal(void)
 }
 
 /****************************************************************************
+ * Name: esp_rtc_clk_get_cpu_freq
+ *
+ * Description:
+ *   Get the currently used CPU frequency configuration.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   CPU frequency
+ *
+ ****************************************************************************/
+
+int IRAM_ATTR esp_rtc_clk_get_cpu_freq(void)
+{
+  uint32_t source_freq_mhz;
+  uint32_t div;
+  uint32_t soc_clk_sel;
+  uint32_t cpuperiod_sel;
+  int freq_mhz = 0;
+
+  soc_clk_sel = REG_GET_FIELD(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_SOC_CLK_SEL);
+  switch (soc_clk_sel)
+    {
+      case RTC_CNTL_SOC_CLK_SEL_XTL:
+        {
+          div = REG_GET_FIELD(APB_CTRL_SYSCLK_CONF_REG,
+                              APB_CTRL_PRE_DIV_CNT) + 1;
+          source_freq_mhz = (uint32_t) esp32_rtc_clk_xtal_freq_get();
+          freq_mhz = source_freq_mhz / div;
+        }
+        break;
+
+      case RTC_CNTL_SOC_CLK_SEL_PLL:
+        {
+          cpuperiod_sel = REG_GET_FIELD(DPORT_CPU_PER_CONF_REG,
+                                        DPORT_CPUPERIOD_SEL);
+          if (cpuperiod_sel == DPORT_CPUPERIOD_SEL_80)
+            {
+              freq_mhz = 80;
+            }
+          else if (cpuperiod_sel == DPORT_CPUPERIOD_SEL_160)
+            {
+              freq_mhz = 160;
+            }
+          else if (cpuperiod_sel == DPORT_CPUPERIOD_SEL_240)
+            {
+              freq_mhz = 240;
+            }
+          else
+            {
+              DEBUGASSERT(0);
+            }
+        }
+        break;
+
+      case RTC_CNTL_SOC_CLK_SEL_8M:
+        {
+          freq_mhz = 8;
+        }
+        break;
+
+      case RTC_CNTL_SOC_CLK_SEL_APLL:
+        default:
+          DEBUGASSERT(0);
+    }
+
+  return freq_mhz;
+}
+
+/****************************************************************************
  * Name: esp32_rtc_sleep_init
  *
  * Description:
@@ -1325,6 +1399,17 @@ void IRAM_ATTR esp32_rtc_sleep_init(uint32_t flags)
   else
     {
       modifyreg32(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_CK8M_FORCE_PU, 0);
+    }
+
+  /* Keep the RTC8M_CLK on in light_sleep mode if the
+   * ledc low-speed channel is clocked by RTC8M_CLK.
+   */
+
+  if (!cfg.deep_slp && GET_PERI_REG_MASK(RTC_CNTL_CLK_CONF_REG,
+                                         RTC_CNTL_DIG_CLK8M_EN_M))
+    {
+      REG_CLR_BIT(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_CK8M_FORCE_PD);
+      REG_SET_BIT(RTC_CNTL_CLK_CONF_REG, RTC_CNTL_CK8M_FORCE_PU);
     }
 
   /* enable VDDSDIO control by state machine */

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -1353,9 +1353,10 @@ void IRAM_ATTR esp32_rtc_sleep_init(uint32_t flags)
  *
  ****************************************************************************/
 
-void IRAM_ATTR esp32_rtc_sleep_start(uint32_t wakeup_opt,
+int IRAM_ATTR esp32_rtc_sleep_start(uint32_t wakeup_opt,
                                      uint32_t reject_opt)
 {
+  int reject;
   REG_SET_FIELD(RTC_CNTL_WAKEUP_STATE_REG, RTC_CNTL_WAKEUP_ENA, wakeup_opt);
   putreg32((uint32_t)reject_opt, RTC_CNTL_SLP_REJECT_CONF_REG);
 
@@ -1368,6 +1369,8 @@ void IRAM_ATTR esp32_rtc_sleep_start(uint32_t wakeup_opt,
 
   /* In deep sleep mode, we never get here */
 
+  reject = REG_GET_FIELD(RTC_CNTL_INT_RAW_REG, RTC_CNTL_SLP_REJECT_INT_RAW);
+
   modifyreg32(RTC_CNTL_INT_CLR_REG, 0,
               RTC_CNTL_SLP_REJECT_INT_CLR | RTC_CNTL_SLP_WAKEUP_INT_CLR);
 
@@ -1375,4 +1378,5 @@ void IRAM_ATTR esp32_rtc_sleep_start(uint32_t wakeup_opt,
 
   REG_SET_FIELD(RTC_CNTL_BIAS_CONF_REG, RTC_CNTL_DBG_ATTEN,
                 RTC_CNTL_DBG_ATTEN_DEFAULT);
+  return reject;
 }

--- a/arch/xtensa/src/esp32/esp32_rtc.h
+++ b/arch/xtensa/src/esp32/esp32_rtc.h
@@ -259,6 +259,22 @@ void esp32_rtc_wait_for_slow_cycle(void);
 void esp32_rtc_cpu_freq_set_xtal(void);
 
 /****************************************************************************
+ * Name: esp_rtc_clk_get_cpu_freq
+ *
+ * Description:
+ *   Get the currently used CPU frequency configuration.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   CPU frequency
+ *
+ ****************************************************************************/
+
+int esp_rtc_clk_get_cpu_freq(void);
+
+/****************************************************************************
  * Name: esp32_rtc_sleep_init
  *
  * Description:

--- a/arch/xtensa/src/esp32/esp32_rtc.h
+++ b/arch/xtensa/src/esp32/esp32_rtc.h
@@ -289,7 +289,7 @@ void esp32_rtc_sleep_init(uint32_t flags);
  *
  ****************************************************************************/
 
-void esp32_rtc_sleep_start(uint32_t wakeup_opt, uint32_t reject_opt);
+int esp32_rtc_sleep_start(uint32_t wakeup_opt, uint32_t reject_opt);
 
 #ifdef __cplusplus
 }

--- a/boards/xtensa/esp32/esp32-core/scripts/esp32_rom.ld
+++ b/boards/xtensa/esp32/esp32-core/scripts/esp32_rom.ld
@@ -188,6 +188,7 @@ PROVIDE ( ets_isr_unmask = 0x40006808 );
 PROVIDE ( ets_post = 0x4000673c );
 PROVIDE ( ets_printf = 0x40007d54 );
 PROVIDE ( g_ticks_per_us_pro = 0x3ffe01e0 );
+PROVIDE ( g_ticks_per_us_app = 0x3ffe40f0 );
 PROVIDE ( ets_readySet_ = 0x3ffe01f0 );
 PROVIDE ( ets_run = 0x400066bc );
 PROVIDE ( ets_secure_boot_check = 0x4005cb40 );


### PR DESCRIPTION
## Summary

Fix issues of  force-sleep.

## Impact

1. improve the stability of "force-sleep" function.
2. fixed the issues of using "force-sleep" when enable "PSRAM".
3. remove redundant configuration cpu frequency operation.

## Testing

Using "incubator-nuttx/boards/xtensa/esp32/esp32-core/configs/pm" defconfig to test.
