### PR TITLE
nrf52 GPIO: minor fixes

### DIFF
--- a/arch/arm/src/nrf52/nrf52_gpio.c
+++ b/arch/arm/src/nrf52/nrf52_gpio.c
@@ -184,7 +184,7 @@ static inline void nrf52_gpio_sense(nrf52_pinset_t cfgset,
     {
       regval |= GPIO_CNF_SENSE_HIGH;
     }
-  else
+  else if (mode == GPIO_SENSE_LOW)
     {
       regval |= GPIO_CNF_SENSE_LOW;
     }

--- a/arch/arm/src/nrf52/nrf52_gpiote.c
+++ b/arch/arm/src/nrf52/nrf52_gpiote.c
@@ -532,6 +532,14 @@ void nrf52_gpiote_set_task(uint32_t pinset, int channel,
 
 int nrf52_gpiote_init(void)
 {
+  /* Clear LATCH register(s) */
+
+  putreg32(0, NRF52_GPIO_P0_BASE + NRF52_GPIO_LATCH_OFFSET);
+
+#ifdef CONFIG_NRF52_HAVE_PORT1
+  putreg32(0, NRF52_GPIO_P1_BASE + NRF52_GPIO_LATCH_OFFSET);
+#endif
+
   /* Reset GPIOTE data */
 
   memset(&g_gpiote_ch_callbacks, 0, sizeof(g_gpiote_ch_callbacks));


### PR DESCRIPTION
## Summary

* Fix setting of SENSE LOW to pins
* Clear LATCH register on initialization

## Impact

SENSE_LOW was being applied for all pins not having SENSE specified

## Testing

SENSE works correctly (only set for specified pins)