### PR TITLE
Intel64 PRI/SCN.PTR fix

### DIFF
--- a/arch/renesas/include/sh1Ptypes.h
+++ b/arch/renesas/include/sh1Ptypes.h
@@ -76,11 +76,6 @@ typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
 #define __INT64_DEFINED
 
-/* A pointer is 4 bytes */
-
-typedef signed int         _intptr_t;
-typedef unsigned int       _uintptr_t;
-
 /* This is the size of the interrupt state save returned by
  * up_irq_save()
  */

--- a/arch/x86_64/include/intel64/inttypes.h
+++ b/arch/x86_64/include/intel64/inttypes.h
@@ -34,63 +34,63 @@
 #define PRId32      "d"
 #define PRId64      "ld"
 
-#define PRIdPTR     "lld"
+#define PRIdPTR     "ld"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      "i"
 #define PRIi64      "li"
 
-#define PRIiPTR     "lli"
+#define PRIiPTR     "li"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
 #define PRIo32      "o"
 #define PRIo64      "lo"
 
-#define PRIoPTR     "llo"
+#define PRIoPTR     "lo"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      "u"
 #define PRIu64      "lu"
 
-#define PRIuPTR     "llu"
+#define PRIuPTR     "lu"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
 #define PRIx32      "x"
 #define PRIx64      "lx"
 
-#define PRIxPTR     "llx"
+#define PRIxPTR     "lx"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      "X"
 #define PRIX64      "lX"
 
-#define PRIXPTR     "llX"
+#define PRIXPTR     "lX"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
 #define SCNd32      "d"
 #define SCNd64      "ld"
 
-#define SCNdPTR     "lld"
+#define SCNdPTR     "ld"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      "i"
 #define SCNi64      "li"
 
-#define SCNiPTR     "lli"
+#define SCNiPTR     "li"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
 #define SCNo32      "o"
 #define SCNo64      "lo"
 
-#define SCNoPTR     "llo"
+#define SCNoPTR     "lo"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
@@ -104,7 +104,7 @@
 #define SCNx32      "x"
 #define SCNx64      "lx"
 
-#define SCNxPTR     "x"
+#define SCNxPTR     "lx"
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x

--- a/arch/x86_64/include/intel64/types.h
+++ b/arch/x86_64/include/intel64/types.h
@@ -65,11 +65,6 @@ typedef unsigned long      _uint64_t;
 typedef _int64_t           _intmax_t;
 typedef _uint64_t          _uintmax_t;
 
-/* A pointer is 8 bytes */
-
-typedef signed long long         _intptr_t;
-typedef unsigned long long       _uintptr_t;
-
 #if defined(__SIZE_TYPE__)
 /* If __SIZE_TYPE__ is defined we define ssize_t based on size_t.
  * We simply change "unsigned" to "signed" for this single definition


### PR DESCRIPTION
## Summary
Also, remove unused and confusing _uintptr_t/_intptr_t.

Extracted from https://github.com/apache/incubator-nuttx/pull/2347
## Impact

## Testing
compile tested