### PR TITLE
[BACKPORT #2339] Revert "fs/nxffs: Fix scan good block slowly and scan an invalid block"

### DIFF
--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -495,11 +495,7 @@ int nxffs_limits(FAR struct nxffs_volume_s *volume)
         }
       else
         {
-          volume->ioblock += 1;
-          volume->iooffset = SIZEOF_NXFFS_BLOCK_HDR;
-
-          offset = volume->ioblock * volume->geo.blocksize +
-                   volume->iooffset;
+          offset += nerased + 1;
           nerased = 0;
         }
     }


### PR DESCRIPTION
## Summary
Backport #2339 to restore correct nxffs functionality.