### PR TITLE
risc-v 64-bit: Fix SCN/PRI.PTR definitions

### DIFF
--- a/arch/risc-v/include/inttypes.h
+++ b/arch/risc-v/include/inttypes.h
@@ -47,8 +47,10 @@
 #if defined(__LP64__)
 #define _PRI32PREFIX
 #define _PRI64PREFIX "l"
+#define _PRIPTRPREFIX "l"
 #define _SCN32PREFIX
 #define _SCN64PREFIX "l"
+#define _SCNPTRPREFIX "l"
 #define INT32_C(x)  x
 #define INT64_C(x)  x ## l
 #define UINT32_C(x) x ## u
@@ -56,8 +58,10 @@
 #else /* defined(__LP64__) */
 #define _PRI32PREFIX "l"
 #define _PRI64PREFIX "ll"
+#define _PRIPTRPREFIX
 #define _SCN32PREFIX "l"
 #define _SCN64PREFIX "ll"
+#define _SCNPTRPREFIX
 #define INT32_C(x)  x ## l
 #define INT64_C(x)  x ## ll
 #define UINT32_C(x) x ## ul
@@ -69,77 +73,77 @@
 #define PRId32      _PRI32PREFIX "d"
 #define PRId64      _PRI64PREFIX "d"
 
-#define PRIdPTR     "d"
+#define PRIdPTR     _PRIPTRPREFIX "d"
 
 #define PRIi8       "i"
 #define PRIi16      "i"
 #define PRIi32      _PRI32PREFIX "i"
 #define PRIi64      _PRI64PREFIX "i"
 
-#define PRIiPTR     "i"
+#define PRIiPTR     _PRIPTRPREFIX "i"
 
 #define PRIo8       "o"
 #define PRIo16      "o"
 #define PRIo32      _PRI32PREFIX "o"
 #define PRIo64      _PRI64PREFIX "o"
 
-#define PRIoPTR     "o"
+#define PRIoPTR     _PRIPTRPREFIX "o"
 
 #define PRIu8       "u"
 #define PRIu16      "u"
 #define PRIu32      _PRI32PREFIX "u"
 #define PRIu64      _PRI64PREFIX "u"
 
-#define PRIuPTR     "u"
+#define PRIuPTR     _PRIPTRPREFIX "u"
 
 #define PRIx8       "x"
 #define PRIx16      "x"
 #define PRIx32      _PRI32PREFIX "x"
 #define PRIx64      _PRI64PREFIX "x"
 
-#define PRIxPTR     "x"
+#define PRIxPTR     _PRIPTRPREFIX "x"
 
 #define PRIX8       "X"
 #define PRIX16      "X"
 #define PRIX32      _PRI32PREFIX "X"
 #define PRIX64      _PRI64PREFIX "X"
 
-#define PRIXPTR     "X"
+#define PRIXPTR     _PRIPTRPREFIX "X"
 
 #define SCNd8       "hhd"
 #define SCNd16      "hd"
 #define SCNd32      _SCN32PREFIX "d"
 #define SCNd64      _SCN64PREFIX "d"
 
-#define SCNdPTR     "d"
+#define SCNdPTR     _SCNPTRPREFIX "d"
 
 #define SCNi8       "hhi"
 #define SCNi16      "hi"
 #define SCNi32      _SCN32PREFIX "i"
 #define SCNi64      _SCN64PREFIX "i"
 
-#define SCNiPTR     "i"
+#define SCNiPTR     _SCNPTRPREFIX "i"
 
 #define SCNo8       "hho"
 #define SCNo16      "ho"
 #define SCNo32      _SCN32PREFIX "o"
 #define SCNo64      _SCN64PREFIX "o"
 
-#define SCNoPTR     "o"
+#define SCNoPTR     _SCNPTRPREFIX "o"
 
 #define SCNu8       "hhu"
 #define SCNu16      "hu"
 #define SCNu32      _SCN32PREFIX "u"
 #define SCNu64      _SCN64PREFIX "u"
 
-#define SCNuPTR     "u"
+#define SCNuPTR     _SCNPTRPREFIX "u"
 
 #define SCNx8       "hhx"
 #define SCNx16      "hx"
 #define SCNx32      _SCN32PREFIX "x"
 #define SCNx64      _SCN64PREFIX "x"
 
-#define SCNxPTR     "x"
+#define SCNxPTR     _SCNPTRPREFIX "x"
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x


### PR DESCRIPTION
## Summary
risc-v 64-bit: Fix SCN/PRI.PTR definitions
extracted from https://github.com/apache/incubator-nuttx/pull/2347
## Impact

## Testing
compile-tested
