### PR TITLE
risc-v: Don't use non existent "saved_status"

### DIFF
--- a/arch/risc-v/src/fe310/fe310_schedulesigaction.c
+++ b/arch/risc-v/src/fe310/fe310_schedulesigaction.c
@@ -166,7 +166,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               up_savestate(tcb->xcp.regs);
 
               sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                    tcb->xcp.saved_epc, tcb->xcp.saved_status,
+                    tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
                     g_current_regs[REG_EPC], g_current_regs[REG_INT_CTX]);
             }
         }
@@ -200,7 +200,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_INT_CTX]  = int_ctx;
 
           sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                tcb->xcp.saved_epc, tcb->xcp.saved_status,
+                tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
                 tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_INT_CTX]);
         }
     }

--- a/arch/risc-v/src/gap8/gap8_schedulesigaction.c
+++ b/arch/risc-v/src/gap8/gap8_schedulesigaction.c
@@ -162,7 +162,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               up_savestate(tcb->xcp.regs);
 
               sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                    tcb->xcp.saved_epc, tcb->xcp.saved_status,
+                    tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
                     g_current_regs[REG_EPC], g_current_regs[REG_STATUS]);
             }
         }
@@ -190,7 +190,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_EPC]      = (uint32_t)up_sigdeliver;
 
           sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                tcb->xcp.saved_epc, tcb->xcp.saved_status,
+                tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
                 tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_STATUS]);
         }
     }

--- a/arch/risc-v/src/k210/k210_schedulesigaction.c
+++ b/arch/risc-v/src/k210/k210_schedulesigaction.c
@@ -173,7 +173,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               up_savestate(tcb->xcp.regs);
 
               sinfo("PC/STATUS Saved: %016x/%016x New: %016x/%016x\n",
-                    tcb->xcp.saved_epc, tcb->xcp.saved_status,
+                    tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
                     CURRENT_REGS[REG_EPC], CURRENT_REGS[REG_INT_CTX]);
             }
         }
@@ -208,7 +208,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_INT_CTX]  = int_ctx;
 
           sinfo("PC/STATUS Saved: %016x/%016x New: %016x/%016x\n",
-                tcb->xcp.saved_epc, tcb->xcp.saved_status,
+                tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
                 tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_INT_CTX]);
         }
     }

--- a/arch/risc-v/src/nr5m100/nr5_schedulesigaction.c
+++ b/arch/risc-v/src/nr5m100/nr5_schedulesigaction.c
@@ -167,7 +167,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               up_savestate(tcb->xcp.regs);
 
               sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                    tcb->xcp.saved_epc, tcb->xcp.saved_status,
+                    tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
                     g_current_regs[REG_EPC], g_current_regs[REG_STATUS]);
             }
         }
@@ -200,7 +200,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           tcb->xcp.regs[REG_INT_CTX]  = int_ctx;
 
           sinfo("PC/STATUS Saved: %08x/%08x New: %08x/%08x\n",
-                tcb->xcp.saved_epc, tcb->xcp.saved_status,
+                tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
                 tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_STATUS]);
         }
     }


### PR DESCRIPTION
## Summary
It seems like a copy-and-paste leftover from mips.
Replace them with saved_int_ctx.
(Shouldn't these files inherit the copyright notice from mips?)

extracted from https://github.com/apache/incubator-nuttx/pull/2347
## Impact

## Testing
build tested with https://github.com/apache/incubator-nuttx/pull/2347