### PR TITLE
include/nuttx/clock.h: Fix wrong comment

### DIFF
--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -124,7 +124,7 @@
  * the system timer is given by USEC_PER_TICK.  This is the expected number
  * of microseconds between calls from the processor-specific logic to
  * nxsched_process_timer().  The default value of USEC_PER_TICK is 10000
- * microseconds (100KHz).  However, this default setting can be overridden
+ * microseconds (100 Hz).  However, this default setting can be overridden
  * by defining the interval in microseconds as CONFIG_USEC_PER_TICK in the
  * NuttX configuration file.
  *


### PR DESCRIPTION
## Summary

Fix a misleading comment: In include/nuttx/clock.h, the docstring for USEC_PER_TICK mistakenly said that the default value of USEC_PER_TICK, 10000, corresponded to 100 KHz. However, it is actually 100 Hz.

## Impact

No functional changes. Fixes a comment only.

## Testing

nxstyle