### PR TITLE
tools: Fix nuttx-gdbinit for armv7-m with FPU

### DIFF
--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -48,9 +48,15 @@ define _examine_target
   if ($_target_examined == 0x0)
     _examine_arch
 
-    python gdb.execute("set $_target_has_fpu = 0")
-    python if (type(gdb.lookup_global_symbol("fpuconfig")) is gdb.Symbol) : \
-    gdb.execute("set $_target_has_fpu = 1")
+    set $_tcb0 = g_pidhash[0].tcb
+    set $_xcp_nregs = sizeof($_tcb0->xcp.regs) / sizeof($_tcb0->xcp.regs[0])
+    set $_target_has_fpu = 0
+
+    if ($_streq($_target_arch, "armv7e-m") == 1)
+      if ($_xcp_nregs != 19)
+        set $_target_has_fpu = 1
+      end
+    end
 
     python gdb.execute("set $_target_has_smp = 0")
     python if (type(gdb.lookup_global_symbol("g_assignedtasks")) is gdb.Symbol) : \


### PR DESCRIPTION
## Summary

- Brennan reported the script does not work with nucleo-h743zi:otg_fs_host
- Actually, the config uses FPU but the script did not detect it
- The script assumed that the nuttx contains fpuconfig symbol
- However, this assumption was incorrect
- This commit fixes this issue by detecting FPU with tcb->xcp.regs

## Impact

- Cortex-M targets

## Testing

- Tested with lm3s6965-ek:discover (Cortex-M3)
- Tested with spresense:wifi_smp (Cortex-M4F)
- Tested with sim:smp (x86_64)
