### PR TITLE
USB: Do not try to print NULL format strings for verbose trace messages when disabled

### DIFF
--- a/drivers/usbhost/usbhost_trace.c
+++ b/drivers/usbhost/usbhost_trace.c
@@ -170,6 +170,7 @@ void usbhost_trace_common(uint32_t event)
             }
         }
     }
+
   leave_critical_section(flags);
 }
 #endif /* CONFIG_USBHOST_TRACE */
@@ -202,7 +203,10 @@ void usbhost_trace1(uint16_t id, uint32_t u23)
   /* Get the format associated with the trace */
 
   fmt = usbhost_trformat1(id);
-  DEBUGASSERT(fmt);
+  if (fmt == NULL)
+    {
+      return;
+    }
 
   /* Just print the data using syslog() */
 
@@ -220,7 +224,10 @@ void usbhost_trace2(uint16_t id, uint8_t u7, uint16_t u16)
   /* Get the format associated with the trace */
 
   fmt = usbhost_trformat2(id);
-  DEBUGASSERT(fmt);
+  if (fmt == NULL)
+    {
+      return;
+    }
 
   /* Just print the data using syslog() */
 


### PR DESCRIPTION
## Summary
Right now if usb tracing is enabled but verbose is disabled a debug assert will be triggered when ever a verbose trace point is hit because the return format pointer would be NULL (by design).  Instead of trying to print the NULL message, just return early.  This does not change any normal functionality.

## Impact
USB tracing can be enabled in non-verbose mode with debug asserts on.

## Testing
nucleo-h745iz:otg_fs_host with debug asserts enabled and trace on.  Prior this change it would hit the assert right away.  
