### PR TITLE
stm32/stm32_can.c: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/stm32/stm32_can.c
+++ b/arch/arm/src/stm32/stm32_can.c
@@ -69,6 +69,7 @@
  ****************************************************************************/
 
 /* Delays *******************************************************************/
+
 /* Time out for INAK bit */
 
 #define INAK_TIMEOUT 65535
@@ -294,7 +295,7 @@ static uint32_t stm32can_vgetreg(uint32_t addr)
         {
           /* Yes.. then show how many times the value repeated */
 
-          caninfo("[repeats %d more times]\n", count-3);
+          caninfo("[repeats %d more times]\n", count - 3);
         }
 
       /* Save the new address, value, and count */
@@ -844,11 +845,15 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
 
           DEBUGASSERT(bt != NULL);
           regval       = stm32can_getreg(priv, STM32_CAN_BTR_OFFSET);
-          bt->bt_sjw   = ((regval & CAN_BTR_SJW_MASK) >> CAN_BTR_SJW_SHIFT) + 1;
-          bt->bt_tseg1 = ((regval & CAN_BTR_TS1_MASK) >> CAN_BTR_TS1_SHIFT) + 1;
-          bt->bt_tseg2 = ((regval & CAN_BTR_TS2_MASK) >> CAN_BTR_TS2_SHIFT) + 1;
+          bt->bt_sjw   = ((regval & CAN_BTR_SJW_MASK) >>
+                          CAN_BTR_SJW_SHIFT) + 1;
+          bt->bt_tseg1 = ((regval & CAN_BTR_TS1_MASK) >>
+                          CAN_BTR_TS1_SHIFT) + 1;
+          bt->bt_tseg2 = ((regval & CAN_BTR_TS2_MASK) >>
+                          CAN_BTR_TS2_SHIFT) + 1;
 
-          brp          = ((regval & CAN_BTR_BRP_MASK) >> CAN_BTR_BRP_SHIFT) + 1;
+          brp          = ((regval & CAN_BTR_BRP_MASK) >>
+                          CAN_BTR_BRP_SHIFT) + 1;
           bt->bt_baud  = STM32_PCLK1_FREQUENCY /
                          (brp * (bt->bt_tseg1 + bt->bt_tseg2 + 1));
           ret = OK;
@@ -865,11 +870,11 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
        *                    to indicate thenature of the error.
        *   Dependencies:   None
        *
-       * REVISIT: There is probably a limitation here:  If there are multiple
-       * threads trying to send CAN packets, when one of these threads
-       * reconfigures the bitrate, the MCAN hardware will be reset and the
-       * context of operation will be lost.  Hence, this IOCTL can only safely
-       * be executed in quiescent time periods.
+       * REVISIT: There is probably a limitation here:  If there are
+       * multiple threads trying to send CAN packets, when one of these
+       * threads reconfigures the bitrate, the MCAN hardware will be reset
+       * and the context of operation will be lost.  Hence, this IOCTL can
+       * only safely be executed in quiescent time periods.
        */
 
       case CANIOC_SET_BITTIMING:
@@ -889,8 +894,9 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
 
           regval = stm32can_getreg(priv, STM32_CAN_BTR_OFFSET);
 
-          /* Extract bit timing data */
-          /* tmp is in clocks per bit time */
+          /* Extract bit timing data
+           * tmp is in clocks per bit time
+           */
 
           tmp = STM32_PCLK1_FREQUENCY / bt->bt_baud;
 
@@ -913,7 +919,7 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
 
           else
             {
-              brp = (tmp + (can_bit_quanta/2)) / can_bit_quanta;
+              brp = (tmp + (can_bit_quanta / 2)) / can_bit_quanta;
               DEBUGASSERT(brp >= 1 && brp <= CAN_BTR_BRP_MAX);
             }
 
@@ -1105,11 +1111,13 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
       case CANIOC_SET_NART:
         {
           uint32_t regval;
+
           ret = stm32can_enterinitmode(priv);
           if (ret != 0)
             {
               return ret;
             }
+
           regval = stm32can_getreg(priv, STM32_CAN_MCR_OFFSET);
           if (arg == 1)
             {
@@ -1119,6 +1127,7 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
             {
               regval &= ~CAN_MCR_NART;
             }
+
           stm32can_putreg(priv, STM32_CAN_MCR_OFFSET, regval);
           return stm32can_exitinitmode(priv);
         }
@@ -1127,11 +1136,13 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
       case CANIOC_SET_ABOM:
         {
           uint32_t regval;
+
           ret = stm32can_enterinitmode(priv);
           if (ret != 0)
             {
               return ret;
             }
+
           regval = stm32can_getreg(priv, STM32_CAN_MCR_OFFSET);
           if (arg == 1)
             {
@@ -1141,6 +1152,7 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
             {
               regval &= ~CAN_MCR_ABOM;
             }
+
           stm32can_putreg(priv, STM32_CAN_MCR_OFFSET, regval);
           return stm32can_exitinitmode(priv);
         }
@@ -1255,7 +1267,8 @@ static int stm32can_send(FAR struct can_dev_s *dev,
       regval |= msg->cm_hdr.ch_id << CAN_TIR_STID_SHIFT;
     }
 #else
-  regval |= ( ( (uint32_t) msg->cm_hdr.ch_id << CAN_TIR_STID_SHIFT) & CAN_TIR_STID_MASK );
+  regval |= (((uint32_t) msg->cm_hdr.ch_id << CAN_TIR_STID_SHIFT) &
+             CAN_TIR_STID_MASK);
 
 #ifdef CONFIG_CAN_USE_RTR
   regval |= (msg->cm_hdr.ch_rtr ? CAN_TIR_RTR : 0);
@@ -1745,16 +1758,16 @@ static int stm32can_bittiming(FAR struct stm32_can_s *priv)
         }
     }
 
-  /* Otherwise, nquanta is CAN_BIT_QUANTA, ts1 is CONFIG_STM32_CAN_TSEG1, ts2 is
-   * CONFIG_STM32_CAN_TSEG2 and we calculate brp to achieve CAN_BIT_QUANTA quanta
-   * in the bit time
+  /* Otherwise, nquanta is CAN_BIT_QUANTA, ts1 is CONFIG_STM32_CAN_TSEG1,
+   * ts2 is CONFIG_STM32_CAN_TSEG2 and we calculate brp to achieve
+   * CAN_BIT_QUANTA quanta in the bit time
    */
 
   else
     {
       ts1 = CONFIG_STM32_CAN_TSEG1;
       ts2 = CONFIG_STM32_CAN_TSEG2;
-      brp = (tmp + (CAN_BIT_QUANTA/2)) / CAN_BIT_QUANTA;
+      brp = (tmp + (CAN_BIT_QUANTA / 2)) / CAN_BIT_QUANTA;
       DEBUGASSERT(brp >= 1 && brp <= CAN_BTR_BRP_MAX);
     }
 
@@ -1773,7 +1786,8 @@ static int stm32can_bittiming(FAR struct stm32_can_s *priv)
   tmp = ((brp - 1) << CAN_BTR_BRP_SHIFT) | ((ts1 - 1) << CAN_BTR_TS1_SHIFT) |
         ((ts2 - 1) << CAN_BTR_TS2_SHIFT) | ((1 - 1) << CAN_BTR_SJW_SHIFT);
 #ifdef CONFIG_CAN_LOOPBACK
-//tmp |= (CAN_BTR_LBKM | CAN_BTR_SILM);
+  /* tmp |= (CAN_BTR_LBKM | CAN_BTR_SILM); */
+
   tmp |= CAN_BTR_LBKM;
 #endif
 


### PR DESCRIPTION
## Summary

arch/arm/src/stm32/stm32_can.c:

    * Fix nxstyle errors.

## Impact

Removes nxstyle errors.

## Testing

nxstyle