### PR TITLE
rptun: fix rptun rpmsg_unregister_callback fault

### DIFF
--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -786,6 +786,8 @@ void rpmsg_unregister_callback(FAR void *priv_,
 
           metal_list_del(&cb->node);
           kmm_free(cb);
+
+          break;
         }
     }
 


### PR DESCRIPTION

## Summary

rptun: fix rptun rpmsg_unregister_callback fault

## Impact

AMP IPC, rptun 

## Testing

