### PR TITLE
Config.mk: fix CATFILE macro to work when file list is empty (Linux)

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -463,7 +463,7 @@ define CATFILE
 endef
 else
 define CATFILE
-	$(Q) cat $(2) > $1
+	$(Q) if [ -z "$(strip $(2))" ]; then echo '' > $(1); else cat $(2) > $1; fi
 endef
 endif
 


### PR DESCRIPTION
## Summary

The change makes CATFILE work as expected for an empty list. Fixes #2401 

## Impact

Affected build (make depend) on Linux when CSRCS/ASRCS was empty.

## Testing

esp32-core:wapi on Linux
