### PR TITLE
Update checkrelease script to check readme.md instead of .txt

### DIFF
--- a/tools/checkrelease.sh
+++ b/tools/checkrelease.sh
@@ -99,8 +99,8 @@ function check_required_files() {
       echo " - NOTICE file not present."
       MISSING_FILE=1
     fi
-    if [ ! -f "$RELEASE_DIR/README.txt" ]; then
-      echo " - README.txt file not present."
+    if [ ! -f "$RELEASE_DIR/README.md" ]; then
+      echo " - README.md file not present."
       MISSING_FILE=1
     fi
     if [ ! -f "$RELEASE_DIR/DISCLAIMER-WIP" ]; then


### PR DESCRIPTION
## Summary
When the readme was converted to markdown the extension to look for in in the release verification script was not updated and would fail like this:
```
Checking apache-nuttx-10.0.0-incubating.tar.gz for required files:
 - README.txt file not present.
```

This corrects the filename.
## Impact
The release checking script now passes.

## Testing
Here it is running against the latest staged RC
```
❯ ./tools/checkrelease.sh --release 10.0.0-RC0
<<TRIM>>
Checking apache-nuttx-10.0.0-incubating.tar.gz sha512...
 OK: apache-nuttx-10.0.0-incubating.tar.gz sha512 hash matches.

Checking apache-nuttx-10.0.0-incubating.tar.gz GPG signature:
<<TRIM>>
Primary key fingerprint: 3554 D784 58CE B695 4B02  0E12 E1B6 E30D B05D 6280
     Subkey fingerprint: 66C4 832A 165E CC93 5489  5A20 9750 ED7E 692B 99E2
 OK: apache-nuttx-10.0.0-incubating.tar.gz gpg signature matches.

Checking apache-nuttx-10.0.0-incubating.tar.gz for required files:
 OK: all required files exist in nuttx.

Checking apache-nuttx-apps-10.0.0-incubating.tar.gz sha512...
 OK: apache-nuttx-apps-10.0.0-incubating.tar.gz sha512 hash matches.

Checking apache-nuttx-apps-10.0.0-incubating.tar.gz GPG signature:
<<TRIM>>
 OK: apache-nuttx-apps-10.0.0-incubating.tar.gz gpg signature matches.

Checking apache-nuttx-apps-10.0.0-incubating.tar.gz for required files:
 OK: all required files exist in apps.

Trying to build nuttx sim:nsh...
 OK: we were able to build sim:nsh.
```