### PR TITLE
Documentation: support versioned docs

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -23,7 +23,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -j auto
+SPHINXOPTS    ?= -j auto -A nuttx_versions="latest,${NUTTX_VERSIONS}"
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/Documentation/_static/custom.css
+++ b/Documentation/_static/custom.css
@@ -86,3 +86,8 @@ span.menuselection
   border-radius: 3px;
   border: 1px solid rgb(204, 204, 204);
 }
+
+div.version-selector
+{
+  margin-bottom: 1em;
+}

--- a/Documentation/_templates/layout.html
+++ b/Documentation/_templates/layout.html
@@ -37,9 +37,9 @@
        more modern -->
 
   <div class="version-selector">
-    <select>
-    {% for nuttx_version in nuttx_versions %}
-      <option value="{{ nuttx_version }}" {% if nuttx_version == version %}selected="selected"{% endif %}>{{ nuttx_version }}</option>
+    <select onchange="javascript:location.href = this.value;">
+    {% for nuttx_version in nuttx_versions.split(',') %}
+    <option value="{{ url_root }}../{{ nuttx_version }}" {% if nuttx_version == version %}selected="selected"{% endif %}>{{ nuttx_version }}</option>
     {% endfor %}
     </select>
   </div>

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -74,10 +74,12 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-# list of documentation versions to offer (besides latest)
+# list of documentation versions to offer (besides latest). this will be
+# overriden by command line option but we can provide a sane default
+# this way
 
 html_context = dict()
-html_context['nuttx_versions'] = ['latest']
+html_context['nuttx_versions'] = 'latest'
 
 # TODO: append other options using releases detected from git (or maybe just
 # a few hand-selected ones, or maybe just a "stable" option)


### PR DESCRIPTION
## Summary

This makes the version selector in the documentation to be functional. On a local build the selector will always show "latest" and will not be usable, but the Makefile now will now read the NUTTX_VERSIONS environment variable, which can be either empty (the usual) or have a list of comma-separated nuttx version names (eg: "10.0,10.1"). This will populate the selector and the documentation will go to <base url>/<version>. The "latest" version is always defined and does not need to be added to NUTTX_VERSIONS. 

To complete support for this, a change needs to be done on the website to pass the list of versions to expose via this variable.

By supporting this via an environment variable, every version of the documentation will have links to all exposed versions (since it is not a hardcoded list in the documentation). So to have this on final 10.0 release, we would have to merge this before generating the final tag.

## Impact

Documenation

## Testing

Tested by defining NUTTX_VERSIONS locally.
