### PR TITLE
tools: Add 'handle SIGUSR1' to nuttx-gdbinit for the NuttX sim SMP

### DIFF
--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -22,6 +22,9 @@
 # usage: gdb -ix=./tools/nuttx-gdbinit nuttx
 # new commands: info_nxthreads, nxthread pid, nxcontinue, nxthread_all_bt
 
+# Do not stop with SIGUSR1 which is used for the NuttX sim SMP
+handle SIGUSR1 "nostop" "pass" "noprint"
+
 set $_current_tcb = 0x0
 set $_target_examined = 0x0
 


### PR DESCRIPTION
## Summary

- The NuttX sim SMP uses SIGUSR1 for IPI
- However, gdb traps the signal by default
- With this commit, gdb just ignores this signal

## Impact

- NuttX sim SMP only

## Testing

- Tested with sim:smp

