### PR TITLE
net/icmp: add sanity check to avoid wild data length

### DIFF
--- a/net/icmp/icmp_sendto.c
+++ b/net/icmp/icmp_sendto.c
@@ -317,6 +317,14 @@ ssize_t icmp_sendto(FAR struct socket *psock, FAR const void *buf,
       goto errout;
     }
 
+  /* Sanity check if the request len is greater than the net payload len */
+
+  if (len > NETDEV_PKTSIZE(dev) - (NET_LL_HDRLEN(dev) + IPv4_HDRLEN))
+    {
+      nerr("ERROR: Invalid packet length\n");
+      return -EINVAL;
+    }
+
   /* If we are no longer processing the same ping ID, then flush any pending
    * packets from the read-ahead buffer.
    *

--- a/net/icmpv6/icmpv6_sendto.c
+++ b/net/icmpv6/icmpv6_sendto.c
@@ -308,6 +308,14 @@ ssize_t icmpv6_sendto(FAR struct socket *psock, FAR const void *buf,
       goto errout;
     }
 
+  /* Sanity check if the request len is greater than the net payload len */
+
+  if (len > NETDEV_PKTSIZE(dev) - (NET_LL_HDRLEN(dev) + IPv6_HDRLEN))
+    {
+      nerr("ERROR: Invalid packet length\n");
+      return -EINVAL;
+    }
+
   /* If we are no longer processing the same ping ID, then flush any pending
    * packets from the read-ahead buffer.
    *


### PR DESCRIPTION
## Summary
net/icmp: add sanity check to avoid wild data length

net device buffer overflow if the icmp packet is too large

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

icmp ping

## Testing
ping <ip addr> -s 1500
