### PR TITLE
net/tcp: correct the available iobs count if throttle is enabled 

### DIFF
--- a/net/tcp/tcp_recvwindow.c
+++ b/net/tcp/tcp_recvwindow.c
@@ -126,8 +126,8 @@ uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev)
        * available for TCP buffering.
        *
        * Assume that all of the available IOBs are can be used for buffering
-       * on this connection.  Also assume that at least one chain is available
-       * concatenate the IOBs.
+       * on this connection.  Also assume that at least one chain is
+       * available concatenate the IOBs.
        *
        * REVISIT:  In an environment with multiple, active read-ahead TCP
        * sockets (and perhaps multiple network devices) or if there are

--- a/net/tcp/tcp_recvwindow.c
+++ b/net/tcp/tcp_recvwindow.c
@@ -114,24 +114,6 @@ uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev)
   niob_avail    = iob_navail(true);
   nqentry_avail = iob_qentry_navail();
 
-  /* Are the read-ahead allocations throttled?  If so, then not all of these
-   * IOBs are available for read-ahead buffering.
-   *
-   * REVISIT: Should also check that there is at least one available IOB
-   * chain.
-   */
-
-#if CONFIG_IOB_THROTTLE > 0
-  if (niob_avail > CONFIG_IOB_THROTTLE)
-    {
-      niob_avail -= CONFIG_IOB_THROTTLE;
-    }
-  else
-    {
-      niob_avail = 0;
-    }
-#endif
-
   /* Is there a a queue entry and IOBs available for read-ahead buffering? */
 
   if (nqentry_avail > 0 && niob_avail > 0)


### PR DESCRIPTION
## Summary
net/tcp: correct the available iobs count if throttle is enabled 

The number of available iobs is already sub in iob_navail(true) on line 114

```
net/tcp/tcp_recvwindow.c:
...
 73 uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev)
...
114   niob_avail    = iob_navail(true);
```

Change-Id: I230927904d8db08ed8d95d7fa18c5c5fce08aa5e
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

enable CONFIG_IOB_THROTTLE

## Testing

set the CONFIG_IOB_THROTTLE > 0 and check the window edge
