### PR TITLE
net/tcp: fallback to unthrottle pool to avoid deadlock 

### DIFF
--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -256,7 +256,7 @@ static int sixlowpan_tcp_header(FAR struct tcp_conn_s *conn,
     {
       /* Update the TCP received window based on I/O buffer availability */
 
-      uint16_t recvwndo = tcp_get_recvwindow(dev);
+      uint16_t recvwndo = tcp_get_recvwindow(dev, conn);
 
       /* Set the TCP Window */
 

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1430,14 +1430,16 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
  *   Calculate the TCP receive window for the specified device.
  *
  * Input Parameters:
- *   dev - The device whose TCP receive window will be updated.
+ *   dev  - The device whose TCP receive window will be updated.
+ *   conn - The TCP connection structure holding connection information.
  *
  * Returned Value:
  *   The value of the TCP receive window to use.
  *
  ****************************************************************************/
 
-uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev);
+uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev,
+                            FAR struct tcp_conn_s *conn);
 
 /****************************************************************************
  * Name: psock_tcp_cansend

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -146,16 +146,16 @@ uint16_t tcp_callback(FAR struct net_driver_s *dev,
 #endif
 
   /* Preserve the TCP_ACKDATA, TCP_CLOSE, and TCP_ABORT in the response.
-   * These is needed by the network to handle responses and buffer state.  The
-   * TCP_NEWDATA indication will trigger the ACK response, but must be
+   * These is needed by the network to handle responses and buffer state.
+   * The TCP_NEWDATA indication will trigger the ACK response, but must be
    * explicitly set in the callback.
    */
 
   ninfo("flags: %04x\n", flags);
 
-  /* Perform the data callback.  When a data callback is executed from 'list',
-   * the input flags are normally returned, however, the implementation
-   * may set one of the following:
+  /* Perform the data callback.  When a data callback is executed from
+   * 'list', the input flags are normally returned, however, the
+   * implementation may set one of the following:
    *
    *   TCP_CLOSE   - Gracefully close the current connection
    *   TCP_ABORT   - Abort (reset) the current connection on an error that
@@ -175,10 +175,10 @@ uint16_t tcp_callback(FAR struct net_driver_s *dev,
   flags = devif_conn_event(dev, conn, flags, conn->list);
 
   /* There may be no new data handler in place at them moment that the new
-   * incoming data is received.  If the new incoming data was not handled, then
-   * either (1) put the unhandled incoming data in the read-ahead buffer (if
-   * enabled) or (2) suppress the ACK to the data in the hope that it will
-   * be re-transmitted at a better time.
+   * incoming data is received.  If the new incoming data was not handled,
+   * then either (1) put the unhandled incoming data in the read-ahead
+   * buffer (if enabled) or (2) suppress the ACK to the data in the hope
+   * that it will be re-transmitted at a better time.
    */
 
   if ((flags & TCP_NEWDATA) != 0)
@@ -261,6 +261,7 @@ uint16_t tcp_datahandler(FAR struct tcp_conn_s *conn, FAR uint8_t *buffer,
           iob = iob_tryalloc(throttled, IOBUSER_NET_TCP_READAHEAD);
         }
 #endif
+
       if (iob == NULL)
         {
           nerr("ERROR: Failed to create new I/O buffer chain\n");

--- a/net/tcp/tcp_recvwindow.c
+++ b/net/tcp/tcp_recvwindow.c
@@ -145,8 +145,8 @@ uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev,
        * TCP buffering.
        *
        * Assume that all of the available IOBs are can be used for buffering
-       * on this connection.  Also assume that at least one chain is available
-       * concatenate the IOBs.
+       * on this connection.  Also assume that at least one chain is
+       * available concatenate the IOBs.
        *
        * REVISIT:  In an environment with multiple, active read-ahead TCP
        * sockets (and perhaps multiple network devices) or if there are

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -360,7 +360,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
     {
       /* Update the TCP received window based on I/O buffer availability */
 
-      uint16_t recvwndo = tcp_get_recvwindow(dev);
+      uint16_t recvwndo = tcp_get_recvwindow(dev, conn);
 
       /* Set the TCP Window */
 


### PR DESCRIPTION
## Summary

net/tcp: fallback to unthrottle pool to avoid deadlock 

Add a fallback mechanism to ensure that there are still available
iobs for an free connection, Guarantees all connections will have
a minimum threshold iob to keep the connection not be hanged.

Change-Id: I59bed98d135ccd1f16264b9ccacdd1b0d91261de
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

TCP receive deadlock

## Testing

HTTP streaming
