### PR TITLE
net/wireless: add country code control support

### DIFF
--- a/include/nuttx/wireless/wireless.h
+++ b/include/nuttx/wireless/wireless.h
@@ -140,10 +140,14 @@
 
 #define SIOCSIWPMKSA        _WLIOC(0x0036)  /* PMKSA cache operation */
 
+/* Country code extension */
+
+#define SIOCSIWCOUNTRY      _WLIOC(0x0037)  /* Country code extension */
+
 /* Device-specific network IOCTL commands *******************************************/
 
 #define WL_NETFIRST         0x0000          /* First network command */
-#define WL_NNETCMDS         0x0037          /* Number of network commands */
+#define WL_NNETCMDS         0x0038          /* Number of network commands */
 
 /* Reserved for Bluetooth network devices (see bt_ioctls.h) */
 


### PR DESCRIPTION

## Summary

net/wireless: add country code control support

Change-Id: Ie3917815e9004bae9c1116916bc4eadb752f6e44
Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

N/A

## Testing

N/A
