### PR TITLE
libc: Change OK/ERROR from macro to enum

### DIFF
--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -163,7 +163,9 @@ struct sam_qh_s
   uint8_t pad[8];              /* Padding to assure 32-byte alignment */
 };
 
-/* Internal representation of the EHCI Queue Element Transfer Descriptor (qTD) */
+/* Internal representation of the EHCI Queue Element Transfer Descriptor
+ * (qTD)
+ */
 
 struct sam_qtd_s
 {
@@ -2115,7 +2117,9 @@ static int sam_async_setup(struct sam_rhport_s *rhport,
           tokenbits |= QTD_TOKEN_PID_IN;
         }
 
-      /* Allocate a new Queue Element Transfer Descriptor (qTD) for the status */
+      /* Allocate a new Queue Element Transfer Descriptor (qTD) for the
+       * status
+       */
 
       qtd = sam_qtd_statusphase(tokenbits);
       if (qtd == NULL)
@@ -3927,7 +3931,9 @@ static int sam_free(FAR struct usbhost_driver_s *drvr, FAR uint8_t *buffer)
 {
   DEBUGASSERT(drvr && buffer);
 
-  /* No special action is require to free the transfer/descriptor buffer memory */
+  /* No special action is require to free the transfer/descriptor buffer
+   * memory
+   */
 
   kmm_free(buffer);
   return OK;
@@ -4072,7 +4078,9 @@ static int sam_ctrlin(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep0,
         req->index[1], req->index[0], len);
 #endif
 
-  /* We must have exclusive access to the EHCI hardware and data structures. */
+  /* We must have exclusive access to the EHCI hardware and data
+   * structures.
+   */
 
   ret = sam_takesem(&g_ehci.exclsem);
   if (ret < 0)
@@ -4172,7 +4180,9 @@ static ssize_t sam_transfer(FAR struct usbhost_driver_s *drvr,
 
   DEBUGASSERT(rhport && epinfo && buffer && buflen > 0);
 
-  /* We must have exclusive access to the EHCI hardware and data structures. */
+  /* We must have exclusive access to the EHCI hardware and data
+   * structures.
+   */
 
   ret = sam_takesem(&g_ehci.exclsem);
   if (ret < 0)
@@ -4282,7 +4292,9 @@ static int sam_asynch(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep,
 
   DEBUGASSERT(rhport && epinfo && buffer && buflen > 0);
 
-  /* We must have exclusive access to the EHCI hardware and data structures. */
+  /* We must have exclusive access to the EHCI hardware and data
+   * structures.
+   */
 
   ret = sam_takesem(&g_ehci.exclsem);
   if (ret < 0)
@@ -4713,7 +4725,9 @@ static int sam_reset(void)
       return -ETIMEDOUT;
     }
 
-  /* Now we can set the HCReset bit in the USBCMD register to initiate the reset */
+  /* Now we can set the HCReset bit in the USBCMD register to initiate the
+   * reset
+   */
 
   regval  = sam_getreg(&HCOR->usbcmd);
   regval |= EHCI_USBCMD_HCRESET;
@@ -5154,7 +5168,9 @@ FAR struct usbhost_connection_s *sam_ehci_initialize(int controller)
 
   sam_putreg(regval, &HCOR->usbcmd);
 
-  /* Start the host controller by setting the RUN bit in the USBCMD register. */
+  /* Start the host controller by setting the RUN bit in the USBCMD
+   * register.
+   */
 
   regval  = sam_getreg(&HCOR->usbcmd);
   regval |= EHCI_USBCMD_RUN;

--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -336,8 +336,8 @@ static int sam_qh_dump(struct sam_qh_s *qh, uint32_t **bp, void *arg);
 #else
 #  define sam_qtd_print(qtd)
 #  define sam_qh_print(qh)
-#  define sam_qtd_dump(qtd, bp, arg) OK
-#  define sam_qh_dump(qh, bp, arg)   OK
+#  define sam_qtd_dump(qtd, bp, arg)
+#  define sam_qh_dump(qh, bp, arg)
 #endif
 
 static inline uint8_t sam_ehci_speed(uint8_t usbspeed);

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -76,16 +76,6 @@
 #  endif
 #endif
 
-/* POSIX-like OS return values: */
-
-#if !defined(__cplusplus)
-#  undef  ERROR
-#  define ERROR -1
-#endif
-
-#undef  OK
-#define OK 0
-
 /* Scheduling Priorities.
  *
  * NOTES:
@@ -304,6 +294,14 @@ typedef uint64_t u_int64_t;
 /* Task entry point */
 
 typedef CODE int (*main_t)(int argc, FAR char *argv[]);
+
+/* POSIX-like OS return values: */
+
+enum
+{
+  ERROR = -1,
+  OK = 0,
+};
 
 #endif /* __ASSEMBLY__ */
 


### PR DESCRIPTION
## Summary
to avoid the conflict with 3rd party library(e.g. protobuf):
https://github.com/protocolbuffers/protobuf/blob/fdc35840b95f56c3aef44a3fc6ae5991f21620a5/src/google/protobuf/stubs/status.h#L47

## Impact
Improve the compatibility

## Testing

