### PR TITLE
build system: add missing --obj-path to MKDEP

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -165,9 +165,9 @@ makekdepfile: $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds)
 	$(call DELFILE, $^)
 
 .depend: Makefile $(SRCS) $(TOPDIR)$(DELIM).config
-	$(Q) $(MAKE) makedepfile
+	$(Q) $(MAKE) makedepfile OBJPATH="bin"
 ifneq ($(CONFIG_BUILD_FLAT),y)
-	$(Q) $(MAKE) makekdepfile CFLAGS="$(CFLAGS) $(KDEFINE)"
+	$(Q) $(MAKE) makekdepfile CFLAGS="$(CFLAGS) $(KDEFINE)" OBJPATH="kbin"
 endif
 ifeq ($(CONFIG_LIB_ZONEINFO_ROMFS),y)
 	$(Q) $(MAKE) -C zoneinfo depend BIN=$(BIN)

--- a/libs/libnx/Makefile
+++ b/libs/libnx/Makefile
@@ -244,9 +244,9 @@ makekdepfile: $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds)
 	$(call DELFILE, $^)
 
 .depend: Makefile gensources $(SRCS) $(TOPDIR)$(DELIM).config
-	$(Q) $(MAKE) makedepfile
+	$(Q) $(MAKE) makedepfile OBJPATH="bin"
 ifneq ($(CONFIG_BUILD_FLAT),y)
-	$(Q) $(MAKE) makekdepfile CFLAGS="$(CFLAGS) $(KDEFINE)"
+	$(Q) $(MAKE) makekdepfile CFLAGS="$(CFLAGS) $(KDEFINE)" OBJPATH="kbin"
 endif
 	$(Q) touch $@
 

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -91,9 +91,9 @@ makekdepfile: $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds)
 	$(call DELFILE, $^)
 
 .depend: Makefile $(SRCS) $(TOPDIR)$(DELIM).config
-	$(Q) $(MAKE) makedepfile
+	$(Q) $(MAKE) makedepfile OBJPATH="bin"
 ifneq ($(CONFIG_BUILD_FLAT),y)
-	$(Q) $(MAKE) makekdepfile CFLAGS="$(CFLAGS) $(KDEFINE)"
+	$(Q) $(MAKE) makekdepfile CFLAGS="$(CFLAGS) $(KDEFINE)" OBJPATH="kbin"
 endif
 	$(Q) touch $@
 

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -202,20 +202,22 @@ endif
 
 # Per-file dependency generation rules
 
+OBJPATH ?= .
+
 %.dds: %.S
-	$(Q) $(MKDEP) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $< > $@
+	$(Q) $(MKDEP) --obj-path $(OBJPATH) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $< > $@
 
 %.ddc: %.c
-	$(Q) $(MKDEP) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $< > $@
+	$(Q) $(MKDEP) --obj-path $(OBJPATH) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CC)" -- $(CFLAGS) -- $< > $@
 
 %.ddp: %.cpp
-	$(Q) $(MKDEP) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $< > $@
+	$(Q) $(MKDEP) --obj-path $(OBJPATH) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $< > $@
 
 %.ddx: %.cxx
-	$(Q) $(MKDEP) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $< > $@
+	$(Q) $(MKDEP) --obj-path $(OBJPATH) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CXX)" -- $(CXXFLAGS) -- $< > $@
 
 %.ddh: %.c
-	$(Q) $(MKDEP) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CC)" -- $(HOSTCFLAGS) -- $< > $@
+	$(Q) $(MKDEP) --obj-path $(OBJPATH) --obj-suffix $(OBJEXT) $(DEPPATH) "$(CC)" -- $(HOSTCFLAGS) -- $< > $@
 
 # INCDIR - Convert a list of directory paths to a list of compiler include
 #   directories


### PR DESCRIPTION
## Summary

After last addition of parallel dependency generation, --obj-path was not passed to mkdep, which is necessary
for certain cases where the Make.dep is placed in a subdirectory.

## Impact

Fixes #2428 

## Testing

Local dependency generation of affected targets
