### PR TITLE
boards: Allow boards to extend clean and distclean by a double colon target

### DIFF
--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -125,16 +125,14 @@ depend: .depend
 
 context::
 
-clean:
+clean::
 	$(call DELFILE, libboard$(LIBEXT))
 	$(call DELFILE, $(ETCSRC))
 	$(call DELDIR, $(ETCDIR))
 	$(call CLEAN)
-	$(EXTRA_CLEAN)
 
-distclean: clean
+distclean:: clean
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
-	$(EXTRA_DISTCLEAN)
 
 -include Make.dep

--- a/boards/xtensa/esp32/esp32-core/src/Makefile
+++ b/boards/xtensa/esp32/esp32-core/src/Makefile
@@ -79,9 +79,7 @@ endif
 SCRIPTIN = $(SCRIPTDIR)$(DELIM)esp32.template.ld
 SCRIPTOUT = $(SCRIPTDIR)$(DELIM)esp32_out.ld
 
-EXTRA_DISTCLEAN = $(call DELFILE, $(SCRIPTOUT))
-
-.PHONY = context
+.PHONY = context distclean
 
 include $(TOPDIR)/boards/Board.mk
 
@@ -89,3 +87,7 @@ $(SCRIPTOUT): $(SCRIPTIN) $(CONFIGFILE)
 	$(Q) $(CC) -isystem $(TOPDIR)/include -C -P -x c -E $(SCRIPTIN) -o $@
 
 context:: $(SCRIPTOUT)
+
+distclean::
+	$(call DELFILE, $(SCRIPTOUT))
+


### PR DESCRIPTION
## Summary
Allow boards to extend clean and distclean by a double colon target instead of calling a variable.
This gives a better separation of the makefiles and helps with readability when the extended clean and distclean targets have multiple commands.
## Impact
Impacts boards.  However, no board expect the ESP32 uses the distclean target, so only ESP32 baords are affected.
## Testing
Various tests with ESP32 configs.
