### PR TITLE
sched/sched/sched_waitpid.c: Fix return value

### DIFF
--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -332,6 +332,7 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
               /* The child has exited. Return the saved exit status */
 
               *stat_loc = child->ch_status << 8;
+              pid = child->ch_pid;
 
               /* Discard the child entry and break out of the loop */
 


### PR DESCRIPTION
## Summary

waitpid should return the process ID of the child whose state has changed even if pid is -1.

## Impact

waitpid, wait

## Testing

hifive1-revb:nsh (CONFIG_SCHED_HAVE_PARENT=y, CONFIG_SCHED_CHILD_STATUS=y, CONFIG_SIG_DEFAULT=y)
on QEMU

```
static int task_main(int argc, char *argv[])
{
  return 0;
}

int main(int argc, FAR char *argv[])
{
  pid_t tpid;
  pid_t wpid;
  int status;

  tpid = task_create("task", 100, 1024, task_main, NULL);

  sleep(1);
  wpid = waitpid(-1, &status, WNOHANG);
  printf("%d %d\n", tpid, wpid);

  return 0;
}
```