### PR TITLE
nrf52 PWM: fix missing trailing comma (build failure)

### DIFF
--- a/arch/arm/src/nrf52/nrf52_pwm.c
+++ b/arch/arm/src/nrf52/nrf52_pwm.c
@@ -153,7 +153,7 @@ struct nrf52_pwm_s g_nrf52_pwm0 =
 struct nrf52_pwm_s g_nrf52_pwm1 =
 {
   .ops     = &g_nrf52_pwmops,
-  .base    = NRF52_PWM1_BASE
+  .base    = NRF52_PWM1_BASE,
 #ifdef CONFIG_NRF52_PWM1_CH0
   .ch0_pin = NRF52_PWM1_CH0_PIN,
 #endif


### PR DESCRIPTION
## Summary

Fix missing trailing comma in nRF52 PWM code

## Impact

Build fix

## Testing

Build OK