### PR TITLE
nrf52 ADC: minor fixes

### DIFF
--- a/arch/arm/src/nrf52/nrf52_adc.c
+++ b/arch/arm/src/nrf52/nrf52_adc.c
@@ -280,6 +280,10 @@ static int nrf52_adc_configure(FAR struct nrf52_adc_s *priv)
 
 static int nrf52_adc_calibrate(FAR struct nrf52_adc_s *priv)
 {
+  /* Clear Event */
+
+  nrf52_adc_putreg(priv, NRF52_SAADC_EVENTS_CALDONE_OFFSET, 0);
+
   /* Start calibration */
 
   nrf52_adc_putreg(priv, NRF52_SAADC_TASKS_CALOFFSET_OFFSET, 1);
@@ -648,7 +652,7 @@ static int nrf52_adc_chancfg(FAR struct nrf52_adc_s *priv, uint8_t chan,
 
   /* Configure negative input */
 
-  regval = nrf52_adc_chanpsel(cfg->p_psel);
+  regval = nrf52_adc_chanpsel(cfg->n_psel);
   nrf52_adc_putreg(priv, NRF52_SAADC_CHPSELN_OFFSET(chan), regval);
 
   /* Get channel configuration */
@@ -732,16 +736,16 @@ static int nrf52_adc_setup(FAR struct adc_dev_s *dev)
   DEBUGASSERT(dev);
   DEBUGASSERT(priv);
 
-  /* Enable ADC */
+  /* Disable ADC */
 
-  nrf52_adc_putreg(priv, NRF52_SAADC_ENABLE_OFFSET, 1);
+  nrf52_adc_putreg(priv, NRF52_SAADC_ENABLE_OFFSET, 0);
 
-  /* Calibrate ADC */
+  /* Configure ADC */
 
-  ret = nrf52_adc_calibrate(priv);
+  ret = nrf52_adc_configure(priv);
   if (ret < 0)
     {
-      aerr("ERROR: adc calibration failed: %d\n", ret);
+      aerr("ERROR: nrf52_adc_configure failed: %d\n", ret);
       goto errout;
     }
 
@@ -757,12 +761,16 @@ static int nrf52_adc_setup(FAR struct adc_dev_s *dev)
         }
     }
 
-  /* Confgiure ADC */
+  /* Enable ADC */
 
-  ret = nrf52_adc_configure(priv);
+  nrf52_adc_putreg(priv, NRF52_SAADC_ENABLE_OFFSET, 1);
+
+  /* Calibrate ADC */
+
+  ret = nrf52_adc_calibrate(priv);
   if (ret < 0)
     {
-      aerr("ERROR: nrf52_adc_configure failed: %d\n", ret);
+      aerr("ERROR: adc calibration failed: %d\n", ret);
       goto errout;
     }
 

--- a/arch/arm/src/nrf52/nrf52_adc.c
+++ b/arch/arm/src/nrf52/nrf52_adc.c
@@ -912,8 +912,8 @@ static int nrf52_adc_ioctl(FAR struct adc_dev_s *dev, int cmd,
  *
  ****************************************************************************/
 
-struct adc_dev_s *nrf52_adcinitialize(FAR struct nrf52_adc_channel_s *chan,
-                                      int channels)
+struct adc_dev_s *nrf52_adcinitialize(
+    FAR const struct nrf52_adc_channel_s *chan, int channels)
 {
   FAR struct adc_dev_s   *dev  = NULL;
   FAR struct nrf52_adc_s *priv = NULL;

--- a/arch/arm/src/nrf52/nrf52_adc.h
+++ b/arch/arm/src/nrf52/nrf52_adc.h
@@ -155,7 +155,8 @@ struct nrf52_adc_channel_s
  *
  ****************************************************************************/
 
-struct adc_dev_s *nrf52_adcinitialize(FAR struct nrf52_adc_channel_s *chan,
-                                      int channels);
+struct adc_dev_s *nrf52_adcinitialize(
+    FAR const struct nrf52_adc_channel_s *chan,
+    int channels);
 
 #endif  /* __ARCH_ARM_SRC_NRF52_NRF52_ADC_H */


### PR DESCRIPTION
## Summary

This introduces various minor fixes to ADC module:
* Ensure CALDONE event is set to zero before initiating calibration (avoid misdetection of calibration complete)
* Configuration of N channel was done using P channel configuration
* Calibration is now done after configuration
* Peripheral is now disabled during configuration

The last point is important and I think other peripherals may have the same issue. nRF52 shares register space between certain peripherals (which can obviously not be used simultaneously) and thus it is required that a peripheral is first configured and then enabled.

## Impact

ADC

## Testing

Using ADC and works correctly.