### PR TITLE
sim: fix input handling and add simulated buttons support from mouse

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -302,6 +302,13 @@ config SIM_AJOYSTICK
 	---help---
 		Support an X11 mouse-based analog joystick emulation.  Also needs INPUT=y
 
+config SIM_BUTTONS
+	bool "X11 mouse-based button emulation"
+	depends on SIM_X11FB
+	---help---
+		Support an X11 mouse-based button emulation
+		(left-click mapped to button press). Also needs INPUT=y
+
 config SIM_NOINPUT
 	bool "No input device"
 

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -148,6 +148,9 @@ else ifeq ($(CONFIG_SIM_AJOYSTICK),y)
   CSRCS += up_ajoystick.c
   HOSTCFLAGS += -DCONFIG_SIM_AJOYSTICK=1
   HOSTSRCS += up_x11eventloop.c
+else ifeq ($(CONFIG_SIM_BUTTONS),y)
+  HOSTCFLAGS += -DCONFIG_SIM_BUTTONS=1
+  HOSTSRCS += up_x11eventloop.c
 endif
 endif
 

--- a/arch/sim/src/sim/up_idle.c
+++ b/arch/sim/src/sim/up_idle.c
@@ -93,7 +93,8 @@ void up_idle(void)
 
   up_uartloop();
 
-#if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK)
+#if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK) || \
+    defined(CONFIG_SIM_BUTTONS)
   /* Drive the X11 event loop */
 
   up_x11events();

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -301,7 +301,8 @@ int sim_tsc_uninitialize(void);
 
 /* up_eventloop.c ***********************************************************/
 
-#if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK)
+#if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK) || \
+    defined(CONFIG_ARCH_BUTTONS)
 void up_x11events(void);
 void up_buttonevent(int x, int y, int buttons);
 #endif

--- a/arch/sim/src/sim/up_x11eventloop.c
+++ b/arch/sim/src/sim/up_x11eventloop.c
@@ -58,11 +58,13 @@ extern Display *g_display;
  * Name: up_buttonmap
  ****************************************************************************/
 
-static int up_buttonmap(int state)
+static int up_buttonmap(int state, int button)
 {
   int buttons = 0;
 
-  /* Remove any X11 dependencies.  Just maps ButtonNMask to bit N. */
+  /* "state" is a bitmask representing the state prior to the event, so
+   * translate that first to our button bitmap
+   */
 
   if ((state & Button1Mask) != 0)
     {
@@ -77,6 +79,23 @@ static int up_buttonmap(int state)
   if ((state & Button3Mask) != 0)
     {
       buttons |= 4;
+    }
+
+  /* button represents the button which changed state, so change the
+   * corresponding bit now
+   */
+
+  switch(button)
+    {
+      case Button1:
+        buttons ^= 1;
+        break;
+      case Button2:
+        buttons ^= 2;
+        break;
+      case Button3:
+        buttons ^= 4;
+        break;
     }
 
   return buttons;
@@ -115,7 +134,7 @@ void up_x11events(void)
           case MotionNotify : /* Enabled by ButtonMotionMask */
             {
               up_buttonevent(event.xmotion.x, event.xmotion.y,
-                             up_buttonmap(event.xmotion.state));
+                             up_buttonmap(event.xmotion.state, 0));
             }
             break;
 
@@ -123,7 +142,8 @@ void up_x11events(void)
           case ButtonRelease: /* Enabled by ButtonReleaseMask */
             {
               up_buttonevent(event.xbutton.x, event.xbutton.y,
-                             up_buttonmap(event.xbutton.state));
+                             up_buttonmap(event.xbutton.state,
+                                          event.xbutton.button));
             }
             break;
 

--- a/arch/sim/src/sim/up_x11eventloop.c
+++ b/arch/sim/src/sim/up_x11eventloop.c
@@ -85,7 +85,7 @@ static int up_buttonmap(int state, int button)
    * corresponding bit now
    */
 
-  switch(button)
+  switch (button)
     {
       case Button1:
         buttons ^= 1;

--- a/arch/sim/src/sim/up_x11framebuffer.c
+++ b/arch/sim/src/sim/up_x11framebuffer.c
@@ -136,7 +136,8 @@ static inline int up_x11createframe(void)
 
   /* Release queued events on the display */
 
-#if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK)
+#if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK) || \
+    defined(CONFIG_SIM_BUTTONS)
   XAllowEvents(g_display, AsyncBoth, CurrentTime);
 
   /* Grab mouse button 1, enabling mouse-related events */
@@ -219,7 +220,8 @@ static void up_x11uninitX(void)
 
   /* Un-grab the mouse buttons */
 
-#if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK)
+#if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK) || \
+    defined(CONFIG_SIM_BUTTONS)
   XUngrabButton(g_display, Button1, AnyModifier, g_window);
 #endif
 

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -2068,6 +2068,8 @@ config ARCH_BOARD_SPRESENSE
 
 config ARCH_BOARD_SIM
 	bool "User mode simulation"
+	select ARCH_HAVE_BUTTONS
+	select ARCH_HAVE_IRQBUTTONS
 	depends on ARCH_SIM
 	---help---
 		A user-mode port of NuttX to the x86 Linux/Cygwin platform is available.

--- a/boards/sim/sim/sim/src/Makefile
+++ b/boards/sim/sim/sim/src/Makefile
@@ -80,4 +80,8 @@ ifneq ($(CONFIG_NSH_CUSTOMROMFS),y)
 endif
 endif
 
+ifeq ($(CONFIG_ARCH_BUTTONS),y)
+  CSRCS += sim_buttons.c
+endif
+
 include $(TOPDIR)/boards/Board.mk

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -47,6 +47,10 @@
 #include <nuttx/lcd/lcd_dev.h>
 #endif
 
+#if defined(CONFIG_BUTTONS_LOWER) && defined(CONFIG_SIM_BUTTONS)
+#include <nuttx/input/buttons.h>
+#endif
+
 #include "up_internal.h"
 #include "sim.h"
 
@@ -378,6 +382,14 @@ int sim_bringup(void)
 #endif
     }
 #endif
+#endif
+
+#if defined(CONFIG_BUTTONS_LOWER) && defined(CONFIG_SIM_BUTTONS)
+  ret = btn_lower_initialize("/dev/buttons");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: btn_lower_initialize() failed: %d\n", ret);
+    }
 #endif
 
   return ret;

--- a/boards/sim/sim/sim/src/sim_buttons.c
+++ b/boards/sim/sim/sim/src/sim_buttons.c
@@ -1,0 +1,143 @@
+/****************************************************************************
+ * boards/sim/sim/sim/scripts/sim_buttons.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+#include <errno.h>
+#include <syslog.h>
+#include "up_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+uint32_t g_buttons = 0;
+xcpt_t g_handler = NULL;
+FAR void *g_arg = 0;
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_button_initialize
+ *
+ * Description:
+ *   board_button_initialize() must be called to initialize button resources.
+ *   After that, board_buttons() may be called to collect the current state
+ *   of all buttons or board_button_irq() may be called to register button
+ *   interrupt handlers.
+ *
+ ****************************************************************************/
+
+uint32_t board_button_initialize(void)
+{
+  /* For now this just supports the mouse click */
+
+  return 1;
+}
+
+/****************************************************************************
+ * Name: board_buttons
+ ****************************************************************************/
+
+uint32_t board_buttons(void)
+{
+  return g_buttons;
+}
+
+/****************************************************************************
+ * Button support.
+ *
+ * Description:
+ *   board_button_initialize() must be called to initialize button resources.
+ *   After that, board_buttons() may be called to collect the current
+ *   state of all buttons or board_button_irq() may be called to register
+ *   button interrupt handlers.
+ *
+ *   After board_button_initialize() has been called, board_buttons()
+ *   may be called to collect the state of all buttons.  board_buttons()
+ *   returns an 32-bit bit set with each bit associated with a button.
+ *   See the BUTTON_*_BIT definitions in board.h for the meaning of each
+ *   bit.
+ *
+ *   board_button_irq() may be called to register an interrupt handler that
+ *    will be called when a button is depressed or released.  The ID value
+ *   is a button enumeration value that uniquely identifies a button
+ *   resource. See the BUTTON_* definitions in board.h for the meaning of
+ *   enumeration value.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_IRQBUTTONS
+int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+{
+  int ret = -EINVAL;
+
+  if (id == 0)
+    {
+      g_handler = irqhandler;
+      g_arg = arg;
+    }
+
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: up_buttonevent
+ ****************************************************************************/
+
+void up_buttonevent(int x, int y, int buttons)
+{
+  bool changed = g_buttons != buttons;
+  g_buttons = buttons;
+
+  if (changed && g_handler)
+    {
+      /* Emulate the interrupt */
+
+      g_handler(0, NULL, g_arg);
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes handling of input on simulator, to correctly indicate which button was pressed (affects touchscreen input). Also, a simulated button device is added from left mouse-click.

NOTE: this will fail style check due to X11 mixed-case variables

## Impact

sim input

## Testing

Tested touchscreen input and button input in sim
