### PR TITLE
[BACKPORT] Documentation: support versioned docs

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -23,7 +23,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -j auto
+SPHINXOPTS    ?= -j auto -A nuttx_versions="latest,${NUTTX_VERSIONS}"
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/Documentation/_static/custom.css
+++ b/Documentation/_static/custom.css
@@ -78,3 +78,16 @@ kbd {
   -webkit-border-radius: 3px;
   text-shadow: 0 1px 0 #fff;
 }
+
+span.menuselection
+{
+  margin: 0px 0.1em;
+  padding: 0.1em 0.1em;
+  border-radius: 3px;
+  border: 1px solid rgb(204, 204, 204);
+}
+
+div.version-selector
+{
+  margin-bottom: 1em;
+}

--- a/Documentation/_templates/layout.html
+++ b/Documentation/_templates/layout.html
@@ -37,9 +37,9 @@
        more modern -->
        
   <div class="version-selector">
-    <select>
-    {% for nuttx_version in nuttx_versions %}
-      <option value="{{ nuttx_version }}" {% if nuttx_version == version %}selected="selected"{% endif %}>{{ nuttx_version }}</option>
+    <select onchange="javascript:location.href = this.value;">
+    {% for nuttx_version in nuttx_versions.split(',') %}
+    <option value="{{ url_root }}../{{ nuttx_version }}" {% if nuttx_version == version %}selected="selected"{% endif %}>{{ nuttx_version }}</option>
     {% endfor %}
     </select>
   </div>

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -74,10 +74,12 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-# list of documentation versions to offer (besides latest)
+# list of documentation versions to offer (besides latest). this will be
+# overriden by command line option but we can provide a sane default
+# this way
 
 html_context = dict()
-html_context['nuttx_versions'] = ['latest']
+html_context['nuttx_versions'] = 'latest'
 
 # TODO: append other options using releases detected from git (or maybe just
 # a few hand-selected ones, or maybe just a "stable" option)


### PR DESCRIPTION
## Summary

10.0 misses this change, which will make 10.x documentation not populate version selector correctly on documentation website

## Impact

Documentation

## Testing

CI