### PR TITLE
unistd/getopt: remove number of arguments limit

### DIFF
--- a/libs/libc/unistd/lib_getopt.c
+++ b/libs/libc/unistd/lib_getopt.c
@@ -134,7 +134,7 @@ int getopt(int argc, FAR char * const argv[], FAR const char *optstring)
 
   /* Verify input parameters. */
 
-  if (argv != NULL && optstring != NULL && argc > 1)
+  if (argv != NULL && optstring != NULL)
     {
       FAR char *optchar;
       int noarg_ret = '?';


### PR DESCRIPTION
## Summary
Remove number of arguments limit.
For commands without "-" arguments, ex:"ls", we should always let optind = 1 after getopt is called in order to get what follows
correctly.
## Impact

## Testing
Daily test.
