### PR TITLE
sched/sched/sched_waitpid.c: Discard the correct child entry

### DIFF
--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -442,7 +442,7 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
             {
               /* Recover the exiting child */
 
-              child = group_exit_child(rtcb->group);
+              child = group_find_child(rtcb->group, info.si_pid);
               DEBUGASSERT(child != NULL);
 
               /* Discard the child entry, if we have one */


### PR DESCRIPTION
## Summary

 - Discard the correct child entry after receiving SIGCHLD.

## Impact

 - waitpid, wait

## Testing

hifive1-revb:nsh (CONFIG_SCHED_HAVE_PARENT=y, CONFIG_SCHED_CHILD_STATUS=y, CONFIG_SIG_DEFAULT=y)
on QEMU

```
static int task_main(int argc, char *argv[])
{
  sleep(1);
  return 0;
}

int main(int argc, FAR char *argv[])
{
  pid_t pid1;
  pid_t pid2;
  int status;

  task_create("task1", 224, 1024, task_main, NULL);
  task_create("task2", 224, 1024, task_main, NULL);

  pid1 = waitpid(-1, &status, 0);
  pid2 = waitpid(-1, &status, 0);

  assert(pid1 != pid2);

  return 0;
}
```