### PR TITLE
net/procfs: handle opendir("/proc/net/") correctly

### DIFF
--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -431,7 +431,7 @@ static int netprocfs_opendir(FAR const char *relpath,
 
   level1->base.level = 1;
 
-  if (strcmp(relpath, "net") == 0)
+  if (strcmp(relpath, "net") == 0 || strcmp(relpath, "net/") == 0)
     {
       /* Count the number of network devices */
 


### PR DESCRIPTION
## Summary

net/procfs: handle opendir("/proc/net/") correctly

## Impact

opendir("/proc/net/") 

## Testing

opendir("/proc/net/") 