### PR TITLE
xtensa/esp32: Optimize IRAM usage based on esp-idf

### DIFF
--- a/boards/xtensa/esp32/esp32-core/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-core/scripts/esp32_flash.ld
@@ -54,13 +54,10 @@ SECTIONS
 
     _iram_text_start = ABSOLUTE(.);
     *(.iram1 .iram1.*)
-    *libphy.a:(.literal .text .literal.* .text.*)
     *librtc.a:(.literal .text .literal.* .text.*)
-    *libpp.a:(.literal .text .literal.* .text.*)
-    *libhal.a:(.literal .text .literal.* .text.*)
     *libarch.a:esp32_spiflash.*(.literal .text .literal.* .text.*)
     *(.wifirxiram .wifirxiram.*)
-    *(.wifirxiram .wifi0iram.*)
+    *(.wifi0iram  .wifi0iram.*)
     _iram_text_end = ABSOLUTE(.);
 
     /* Module text area starts at the end of iram0_0_seg */
@@ -116,6 +113,7 @@ SECTIONS
     KEEP (*(.gnu.linkonce.s2.*))
     KEEP (*(.jcr))
     *(.dram1 .dram1.*)
+    *libphy.a:(.rodata  .rodata.*)
     *libarch.a:esp32_spiflash.*(.rodata  .rodata.*)
     . = ALIGN(4);
     _edata = ABSOLUTE(.);


### PR DESCRIPTION
## Summary

Optimize IRAM usage based on esp-idf.

From [linker.lf](https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/linker.lf) & [esp32_fragments.lf](https://github.com/espressif/esp-idf/blob/master/components/esp32/ld/esp32_fragments.lf), we can know following data/text should be placed into IRAM instead of SPI Flash:

- libphy.a (RODATA)
- librtc.a (TEXT)
- libpp.a (wifi_iram & wifi_rx_iram)

## Impact

Decrease about 87KB IRAM space cost from Wi-Fi related libs.

## Testing

Using Iperf to test.