### PR TITLE
sched/sched/sched_waitid.c: Fix two bugs when CONFIG_SCHED_CHILD_STATUS is enabled

### DIFF
--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -178,15 +178,17 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
        */
 
       ctcb = nxsched_get_tcb((pid_t)id);
-
-#ifdef HAVE_GROUP_MEMBERS
-      if (ctcb == NULL || ctcb->group->tg_pgrpid != rtcb->group->tg_grpid)
-#else
-      if (ctcb == NULL || ctcb->group->tg_ppid != rtcb->pid)
-#endif
+      if (ctcb != NULL)
         {
-          ret = -ECHILD;
-          goto errout;
+#ifdef HAVE_GROUP_MEMBERS
+          if (ctcb->group->tg_pgrpid != rtcb->group->tg_grpid)
+#else
+          if (ctcb->group->tg_ppid != rtcb->pid)
+#endif
+            {
+              ret = -ECHILD;
+              goto errout;
+            }
         }
 
       /* Does this task retain child status? */


### PR DESCRIPTION
## Summary

 - Fix an error that occurs when a waiting task has already finished.
 - Discard the child entry after receiving SIGCHLD.

## Impact

 - waitid

## Testing

hifive1-revb:nsh (CONFIG_SCHED_HAVE_PARENT=y, CONFIG_SCHED_CHILD_STATUS=y, CONFIG_SIG_DEFAULT=y)
on QEMU

```
static int task_main(int argc, char *argv[])
{
  return 0;
}

int main(int argc, FAR char *argv[])
{
  siginfo_t info;
  int pid;
  int ret;

  pid = task_create("task", 224, 1024, task_main, NULL);

  sleep(1);

  ret = waitid(P_PID, pid, &info, WEXITED);

  assert(ret == 0);

  return 0;
}
```

```
static int task_main(int argc, char *argv[])
{
  sleep(1);
  return 0;
}

int main(int argc, FAR char *argv[])
{
  pid_t pid;
  siginfo_t info;
  int ret;

  pid = task_create("task1", 224, 1024, task_main, NULL);
  task_create("task2", 224, 1024, task_main, NULL);

  waitid(P_PID, pid, &info, WEXITED);
  waitid(P_ALL, 0, &info, WEXITED);
  ret = waitid(P_ALL, 0, &info, WEXITED | WNOHANG);

  assert(ret == -1);

  return 0;
}
```