### PR TITLE
arch/stm32: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.h
+++ b/arch/arm/src/stm32/stm32_eth.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32/stm32_eth.h
  *
  *   Copyright (C) 2009, 2011, 2015 Gregory Nutt. All rights reserved.
@@ -31,14 +31,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32_STM32_ETH_H
 #define __ARCH_ARM_SRC_STM32_STM32_ETH_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -50,9 +50,9 @@
 
 #ifndef __ASSEMBLY__
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #if defined(__cplusplus)
@@ -63,38 +63,40 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Function: stm32_ethinitialize
  *
  * Description:
- *   Initialize the Ethernet driver for one interface.  If the STM32 chip supports
- *   multiple Ethernet controllers, then board specific logic must implement
- *   arm_netinitialize() and call this function to initialize the desired interfaces.
+ *   Initialize the Ethernet driver for one interface.  If the STM32 chip
+ *   supports multiple Ethernet controllers, then board specific logic must
+ *   implement arm_netinitialize() and call this function to initialize the
+ *   desired interfaces.
  *
  * Input Parameters:
- *   intf - In the case where there are multiple EMACs, this value identifies which
- *   EMAC is to be initialized.
+ *   intf - In the case where there are multiple EMACs, this value
+ *   identifies which EMAC is to be initialized.
  *
  * Returned Value:
  *   OK on success; Negated errno on failure.
  *
  * Assumptions:
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #if STM32_NETHERNET > 1 || defined(CONFIG_NETDEV_LATEINIT)
 int stm32_ethinitialize(int intf);
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Function: stm32_phy_boardinitialize
  *
  * Description:
- *   Some boards require specialized initialization of the PHY before it can be used.
- *   This may include such things as configuring GPIOs, resetting the PHY, etc.  If
- *   CONFIG_STM32_PHYINIT is defined in the configuration then the board specific
- *   logic must provide stm32_phyinitialize();  The STM32 Ethernet driver will call
- *   this function one time before it first uses the PHY.
+ *   Some boards require specialized initialization of the PHY before it can
+ *   be used. This may include such things as configuring GPIOs, resetting
+ *   the PHY, etc.  If CONFIG_STM32_PHYINIT is defined in the configuration
+ *   then the board specific logic must provide stm32_phyinitialize();  The
+ *   STM32 Ethernet driver will call this function one time before it first
+ *   uses the PHY.
  *
  * Input Parameters:
  *   intf - Always zero for now.
@@ -104,7 +106,7 @@ int stm32_ethinitialize(int intf);
  *
  * Assumptions:
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_STM32_PHYINIT
 int stm32_phy_boardinitialize(int intf);


### PR DESCRIPTION
## Summary

arch/arm/src/stm32/stm32_eth.h:

    * Fix nxstyle errors.

## Impact

Removes nxstyle errors.

## Testing

nxstyle