### PR TITLE
stm32/hardware: remove redundand ifdefs to keep headers consistent

### DIFF
--- a/arch/arm/src/stm32/hardware/stm32f20xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f20xxx_syscfg.h
@@ -49,16 +49,16 @@
 
 /* Register Offsets *********************************************************************************/
 
-#define STM32_SYSCFG_MEMRMP_OFFSET    0x0000 /* SYSCFG memory remap register */
-#define STM32_SYSCFG_PMC_OFFSET       0x0004 /* SYSCFG peripheral mode configuration register */
+#define STM32_SYSCFG_MEMRMP_OFFSET    0x0000                    /* SYSCFG memory remap register */
+#define STM32_SYSCFG_PMC_OFFSET       0x0004                    /* SYSCFG peripheral mode configuration register */
 
 #define STM32_SYSCFG_EXTICR_OFFSET(p) (0x0008 + ((p) & 0x000c)) /* Registers are displaced by 4! */
-#define STM32_SYSCFG_EXTICR1_OFFSET   0x0008 /* SYSCFG external interrupt configuration register 1 */
-#define STM32_SYSCFG_EXTICR2_OFFSET   0x000c /* SYSCFG external interrupt configuration register 2 */
-#define STM32_SYSCFG_EXTICR3_OFFSET   0x0010 /* SYSCFG external interrupt configuration register 3 */
-#define STM32_SYSCFG_EXTICR4_OFFSET   0x0014 /* SYSCFG external interrupt configuration register 4 */
+#define STM32_SYSCFG_EXTICR1_OFFSET   0x0008                    /* SYSCFG external interrupt configuration register 1 */
+#define STM32_SYSCFG_EXTICR2_OFFSET   0x000c                    /* SYSCFG external interrupt configuration register 2 */
+#define STM32_SYSCFG_EXTICR3_OFFSET   0x0010                    /* SYSCFG external interrupt configuration register 3 */
+#define STM32_SYSCFG_EXTICR4_OFFSET   0x0014                    /* SYSCFG external interrupt configuration register 4 */
 
-#define STM32_SYSCFG_CMPCR_OFFSET     0x0020 /* Compensation cell control register */
+#define STM32_SYSCFG_CMPCR_OFFSET     0x0020                    /* Compensation cell control register */
 
 /* Register Addresses *******************************************************************************/
 

--- a/arch/arm/src/stm32/hardware/stm32f20xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f20xxx_syscfg.h
@@ -43,8 +43,6 @@
 #include <nuttx/config.h>
 #include "chip.h"
 
-#ifdef CONFIG_STM32_STM32F20XX
-
 /****************************************************************************************************
  * Pre-processor Definitions
  ****************************************************************************************************/
@@ -147,5 +145,4 @@
 #define SYSCFG_CMPCR_CMPPD            (1 << 0)  /* Bit 0: Compensation cell power-down */
 #define SYSCFG_CMPCR_READY            (1 << 8)  /* Bit 8: Compensation cell ready flag */
 
-#endif /* CONFIG_STM32_STM32F20XX */
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32F20XXX_SYSCFG_H */

--- a/arch/arm/src/stm32/hardware/stm32f30xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f30xxx_syscfg.h
@@ -43,8 +43,6 @@
 #include <nuttx/config.h>
 #include "chip.h"
 
-#ifdef CONFIG_STM32_STM32F30XX
-
 /****************************************************************************************************
  * Pre-processor Definitions
  ****************************************************************************************************/
@@ -173,5 +171,4 @@
 #define SYSCFG_CFGR2_BYPADDPAR        (1 << 4)  /* Bit 4: Bypass address bit 29 in parity calculation */
 #define SYSCFG_CFGR2_SRAM_PEF         (1 << 8)  /* Bit 8: SRAM parity error */
 
-#endif /* CONFIG_STM32_STM32F30XX */
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32F30XXX_SYSCFG_H */

--- a/arch/arm/src/stm32/hardware/stm32f30xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f30xxx_syscfg.h
@@ -49,16 +49,16 @@
 
 /* Register Offsets *********************************************************************************/
 
-#define STM32_SYSCFG_CFGR1_OFFSET      0x0000 /* SYSCFG configuration register 1 */
-#define STM32_SYSCFG_RCR_OFFSET        0x0004 /* SYSCFG CCM SRAM protection register */
+#define STM32_SYSCFG_CFGR1_OFFSET      0x0000                    /* SYSCFG configuration register 1 */
+#define STM32_SYSCFG_RCR_OFFSET        0x0004                    /* SYSCFG CCM SRAM protection register */
 
 #define STM32_SYSCFG_EXTICR_OFFSET(p)  (0x0008 + ((p) & 0x000c)) /* Registers are displaced by 4! */
-#define STM32_SYSCFG_EXTICR1_OFFSET    0x0008 /* SYSCFG external interrupt configuration register 1 */
-#define STM32_SYSCFG_EXTICR2_OFFSET    0x000c /* SYSCFG external interrupt configuration register 2 */
-#define STM32_SYSCFG_EXTICR3_OFFSET    0x0010 /* SYSCFG external interrupt configuration register 3 */
-#define STM32_SYSCFG_EXTICR4_OFFSET    0x0014 /* SYSCFG external interrupt configuration register 4 */
+#define STM32_SYSCFG_EXTICR1_OFFSET    0x0008                    /* SYSCFG external interrupt configuration register 1 */
+#define STM32_SYSCFG_EXTICR2_OFFSET    0x000c                    /* SYSCFG external interrupt configuration register 2 */
+#define STM32_SYSCFG_EXTICR3_OFFSET    0x0010                    /* SYSCFG external interrupt configuration register 3 */
+#define STM32_SYSCFG_EXTICR4_OFFSET    0x0014                    /* SYSCFG external interrupt configuration register 4 */
 
-#define STM32_SYSCFG_CFGR2_OFFSET      0x0018 /* SYSCFG configuration register 2 */
+#define STM32_SYSCFG_CFGR2_OFFSET      0x0018                    /* SYSCFG configuration register 2 */
 
 /* Register Addresses *******************************************************************************/
 
@@ -77,32 +77,32 @@
 
 /* SYSCFG memory remap register */
 
-#define SYSCFG_CFGR1_MEMMODE_SHIFT     (0)       /* Bits 1:0 MEM_MODE: Memory mapping selection */
+#define SYSCFG_CFGR1_MEMMODE_SHIFT     (0)                               /* Bits 1:0 MEM_MODE: Memory mapping selection */
 #define SYSCFG_CFGR1_MEMMODE_MASK      (3 << SYSCFG_CFGR1_MEMMODE_SHIFT)
 #  define SYSCFG_CFGR1_MEMMODE_FLASH   (0 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 00: Main Flash at 0x00000000 */
 #  define SYSCFG_CFGR1_MEMMODE_SYSTEM  (1 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 01: System Flash at 0x00000000 */
 #  define SYSCFG_CFGR1_MEMMODE_SRAM    (3 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 11: Embedded SRAM at 0x00000000 */
-#define SYSCFG_CFGR1_USB_ITRMP         (1 << 5)  /* Bit 5:  USB interrupt remap */
-#define SYSCFG_CFGR1_TIM1_ITR3RMP      (1 << 6)  /* Bit 6:  Timer 1 ITR3 selection */
-#define SYSCFG_CFGR1_DAC_TRIGRMP       (1 << 7)  /* Bit 7:  DAC trigger remap (when TSEL = 001) */
-#define SYSCFG_CFGR1_ADC24_DMARMP      (1 << 8)  /* Bit 8:  ADC24 DMA remapping bit */
-#define SYSCFG_CFGR1_TIM16_DMARMP      (1 << 11) /* Bit 11: TIM16 DMA request remapping bit */
-#define SYSCFG_CFGR1_TIM17_DMARMP      (1 << 12) /* Bit 12: TIM17 DMA request remapping bit */
-#define SYSCFG_CFGR1_TIM6_DMARMP       (1 << 13) /* Bit 13: TIM6 DMA remap, or */
-#define SYSCFG_CFGR1_DAC1_DMARMP       (1 << 13) /* Bit 13: DAC channel DMA remap */
-#define SYSCFG_CFGR1_TIM7_DMARMP       (1 << 14) /* Bit 14: TIM7 DMA remap */
-#define SYSCFG_CFGR1_DAC2_DMARMP       (1 << 14) /* Bit 14: DAC channel2 DMA remap */
-#define SYSCFG_CFGR1_I2C_PBXFMP_SHIFT  (16)      /* Bits 16-19: Fast Mode Plus (FM+) driving capability */
+#define SYSCFG_CFGR1_USB_ITRMP         (1 << 5)                          /* Bit 5:  USB interrupt remap */
+#define SYSCFG_CFGR1_TIM1_ITR3RMP      (1 << 6)                          /* Bit 6:  Timer 1 ITR3 selection */
+#define SYSCFG_CFGR1_DAC_TRIGRMP       (1 << 7)                          /* Bit 7:  DAC trigger remap (when TSEL = 001) */
+#define SYSCFG_CFGR1_ADC24_DMARMP      (1 << 8)                          /* Bit 8:  ADC24 DMA remapping bit */
+#define SYSCFG_CFGR1_TIM16_DMARMP      (1 << 11)                         /* Bit 11: TIM16 DMA request remapping bit */
+#define SYSCFG_CFGR1_TIM17_DMARMP      (1 << 12)                         /* Bit 12: TIM17 DMA request remapping bit */
+#define SYSCFG_CFGR1_TIM6_DMARMP       (1 << 13)                         /* Bit 13: TIM6 DMA remap, or */
+#define SYSCFG_CFGR1_DAC1_DMARMP       (1 << 13)                         /* Bit 13: DAC channel DMA remap */
+#define SYSCFG_CFGR1_TIM7_DMARMP       (1 << 14)                         /* Bit 14: TIM7 DMA remap */
+#define SYSCFG_CFGR1_DAC2_DMARMP       (1 << 14)                         /* Bit 14: DAC channel2 DMA remap */
+#define SYSCFG_CFGR1_I2C_PBXFMP_SHIFT  (16)                              /* Bits 16-19: Fast Mode Plus (FM+) driving capability */
 #define SYSCFG_CFGR1_I2C_PBXFMP_MASK   (15 << SYSCFG_CFGR1_I2C_PBXFMP_SHIFT)
-#define SYSCFG_CFGR1_I2C1_FMP          (1 << 20) /* Bit 20: I2C1 fast mode Plus driving capability */
-#define SYSCFG_CFGR1_I2C2_FMP          (1 << 21) /* Bit 21: I2C2 fast mode Plus driving capability */
-#define SYSCFG_CFGR1_ENCMODE_SHIFT     (22)       /* Bits 22-23: Encoder mode */
+#define SYSCFG_CFGR1_I2C1_FMP          (1 << 20)                         /* Bit 20: I2C1 fast mode Plus driving capability */
+#define SYSCFG_CFGR1_I2C2_FMP          (1 << 21)                         /* Bit 21: I2C2 fast mode Plus driving capability */
+#define SYSCFG_CFGR1_ENCMODE_SHIFT     (22)                              /* Bits 22-23: Encoder mode */
 #define SYSCFG_CFGR1_ENCMODE_MASK      (3 << SYSCFG_CFGR1_ENCMODE_SHIFT)
 #  define SYSCFG_CFGR1_ENCMODE_NONE    (0 << SYSCFG_CFGR1_ENCMODE_SHIFT) /* No redirection */
 #  define SYSCFG_CFGR1_ENCMODE_TIM2    (1 << SYSCFG_CFGR1_ENCMODE_SHIFT) /* TIM2 I2C1-2 -> TIM15 IC1/2 */
 #  define SYSCFG_CFGR1_ENCMODE_TIM3    (2 << SYSCFG_CFGR1_ENCMODE_SHIFT) /* TIM3 I2C1-2 -> TIM15 IC1/2 */
 #  define SYSCFG_CFGR1_ENCMODE_TIM4    (3 << SYSCFG_CFGR1_ENCMODE_SHIFT) /* TIM4 I2C1-2 -> TIM15 IC1/2 */
-#define SYSCFG_CFGR1_FPUIE_SHIFT       (26)       /* Bits 26-31: Floating Point Unit interrupts enable bits */
+#define SYSCFG_CFGR1_FPUIE_SHIFT       (26)                              /* Bits 26-31: Floating Point Unit interrupts enable bits */
 #define SYSCFG_CFGR1_FPUIE_MASK        (63 << SYSCFG_CFGR1_FPUIE_SHIFT)
 #  define SYSCFG_CFGR1_FPUIE_INVALIDOP (1 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Invalid operation interrupt enable */
 #  define SYSCFG_CFGR1_FPUIE_DIVZERO   (2 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Divide-by-zero interrupt enable */

--- a/arch/arm/src/stm32/hardware/stm32f33xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f33xxx_syscfg.h
@@ -50,17 +50,17 @@
 
 /* Register Offsets *********************************************************************************/
 
-#define STM32_SYSCFG_CFGR1_OFFSET      0x0000 /* SYSCFG configuration register 1 */
-#define STM32_SYSCFG_RCR_OFFSET        0x0004 /* SYSCFG CCM SRAM protection register */
+#define STM32_SYSCFG_CFGR1_OFFSET      0x0000                    /* SYSCFG configuration register 1 */
+#define STM32_SYSCFG_RCR_OFFSET        0x0004                    /* SYSCFG CCM SRAM protection register */
 
 #define STM32_SYSCFG_EXTICR_OFFSET(p)  (0x0008 + ((p) & 0x000c)) /* Registers are displaced by 4! */
-#define STM32_SYSCFG_EXTICR1_OFFSET    0x0008 /* SYSCFG external interrupt configuration register 1 */
-#define STM32_SYSCFG_EXTICR2_OFFSET    0x000c /* SYSCFG external interrupt configuration register 2 */
-#define STM32_SYSCFG_EXTICR3_OFFSET    0x0010 /* SYSCFG external interrupt configuration register 3 */
-#define STM32_SYSCFG_EXTICR4_OFFSET    0x0014 /* SYSCFG external interrupt configuration register 4 */
+#define STM32_SYSCFG_EXTICR1_OFFSET    0x0008                    /* SYSCFG external interrupt configuration register 1 */
+#define STM32_SYSCFG_EXTICR2_OFFSET    0x000c                    /* SYSCFG external interrupt configuration register 2 */
+#define STM32_SYSCFG_EXTICR3_OFFSET    0x0010                    /* SYSCFG external interrupt configuration register 3 */
+#define STM32_SYSCFG_EXTICR4_OFFSET    0x0014                    /* SYSCFG external interrupt configuration register 4 */
 
-#define STM32_SYSCFG_CFGR2_OFFSET      0x0018 /* SYSCFG configuration register 2 */
-#define STM32_SYSCFG_CFGR3_OFFSET      0x0050 /* SYSCFG configuration register 3 */
+#define STM32_SYSCFG_CFGR2_OFFSET      0x0018                    /* SYSCFG configuration register 2 */
+#define STM32_SYSCFG_CFGR3_OFFSET      0x0050                    /* SYSCFG configuration register 3 */
 
 /* Register Addresses *******************************************************************************/
 
@@ -80,31 +80,31 @@
 
 /* SYSCFG memory remap register */
 
-#define SYSCFG_CFGR1_MEMMODE_SHIFT     (0)       /* Bits 1:0 MEM_MODE: Memory mapping selection */
+#define SYSCFG_CFGR1_MEMMODE_SHIFT     (0)                               /* Bits 1:0 MEM_MODE: Memory mapping selection */
 #define SYSCFG_CFGR1_MEMMODE_MASK      (3 << SYSCFG_CFGR1_MEMMODE_SHIFT)
 #  define SYSCFG_CFGR1_MEMMODE_FLASH   (0 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 00: Main Flash at 0x00000000 */
 #  define SYSCFG_CFGR1_MEMMODE_SYSTEM  (1 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 01: System Flash at 0x00000000 */
 #  define SYSCFG_CFGR1_MEMMODE_SRAM    (3 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 11: Embedded SRAM at 0x00000000 */
-#define SYSCFG_CFGR1_TIM1_ITR3RMP      (1 << 6)  /* Bit 6:  Timer 1 ITR3 selection */
-#define SYSCFG_CFGR1_DAC_TRIGRMP       (1 << 7)  /* Bit 7:  DAC trigger remap (when TSEL = 001) */
-#define SYSCFG_CFGR1_TIM16_DMARMP      (1 << 11) /* Bit 11: TIM16 DMA request remapping bit */
-#define SYSCFG_CFGR1_TIM17_DMARMP      (1 << 12) /* Bit 12: TIM17 DMA request remapping bit */
-#define SYSCFG_CFGR1_TIM6_DMARMP       (1 << 13) /* Bit 13: TIM6 DMA remap, or */
-#define SYSCFG_CFGR1_DAC1CH1_DMARMP    (1 << 13) /* Bit 13: DAC1 channel1 DMA remap */
-#define SYSCFG_CFGR1_TIM7_DMARMP       (1 << 14) /* Bit 14: TIM7 DMA remap */
-#define SYSCFG_CFGR1_DAC1CH2_DMARMP    (1 << 14) /* Bit 14: DAC1 channel2 DMA remap */
-#define SYSCFG_CFGR1_DAC2CH1_DMARMP    (1 << 15) /* Bit 15: DAC2 channel1 DMA remap */
-#define SYSCFG_CFGR1_I2C_PBXFMP_SHIFT  (16)      /* Bits 16-19: Fast Mode Plus (FM+) driving capability */
+#define SYSCFG_CFGR1_TIM1_ITR3RMP      (1 << 6)                          /* Bit 6:  Timer 1 ITR3 selection */
+#define SYSCFG_CFGR1_DAC_TRIGRMP       (1 << 7)                          /* Bit 7:  DAC trigger remap (when TSEL = 001) */
+#define SYSCFG_CFGR1_TIM16_DMARMP      (1 << 11)                         /* Bit 11: TIM16 DMA request remapping bit */
+#define SYSCFG_CFGR1_TIM17_DMARMP      (1 << 12)                         /* Bit 12: TIM17 DMA request remapping bit */
+#define SYSCFG_CFGR1_TIM6_DMARMP       (1 << 13)                         /* Bit 13: TIM6 DMA remap, or */
+#define SYSCFG_CFGR1_DAC1CH1_DMARMP    (1 << 13)                         /* Bit 13: DAC1 channel1 DMA remap */
+#define SYSCFG_CFGR1_TIM7_DMARMP       (1 << 14)                         /* Bit 14: TIM7 DMA remap */
+#define SYSCFG_CFGR1_DAC1CH2_DMARMP    (1 << 14)                         /* Bit 14: DAC1 channel2 DMA remap */
+#define SYSCFG_CFGR1_DAC2CH1_DMARMP    (1 << 15)                         /* Bit 15: DAC2 channel1 DMA remap */
+#define SYSCFG_CFGR1_I2C_PBXFMP_SHIFT  (16)                              /* Bits 16-19: Fast Mode Plus (FM+) driving capability */
 #define SYSCFG_CFGR1_I2C_PBXFMP_MASK   (15 << SYSCFG_CFGR1_I2C_PBXFMP_SHIFT)
-#define SYSCFG_CFGR1_I2C1_FMP          (1 << 20) /* Bit 20: I2C1 fast mode Plus driving capability */
-#define SYSCFG_CFGR1_I2C2_FMP          (1 << 21) /* Bit 21: I2C2 fast mode Plus driving capability */
-#define SYSCFG_CFGR1_ENCMODE_SHIFT     (22)       /* Bits 22-23: Encoder mode */
+#define SYSCFG_CFGR1_I2C1_FMP          (1 << 20)                         /* Bit 20: I2C1 fast mode Plus driving capability */
+#define SYSCFG_CFGR1_I2C2_FMP          (1 << 21)                         /* Bit 21: I2C2 fast mode Plus driving capability */
+#define SYSCFG_CFGR1_ENCMODE_SHIFT     (22)                              /* Bits 22-23: Encoder mode */
 #define SYSCFG_CFGR1_ENCMODE_MASK      (3 << SYSCFG_CFGR1_ENCMODE_SHIFT)
 #  define SYSCFG_CFGR1_ENCMODE_NONE    (0 << SYSCFG_CFGR1_ENCMODE_SHIFT) /* No redirection */
 #  define SYSCFG_CFGR1_ENCMODE_TIM2    (1 << SYSCFG_CFGR1_ENCMODE_SHIFT) /* TIM2 I2C1-2 -> TIM15 IC1/2 */
 #  define SYSCFG_CFGR1_ENCMODE_TIM3    (2 << SYSCFG_CFGR1_ENCMODE_SHIFT) /* TIM3 I2C1-2 -> TIM15 IC1/2 */
 #  define SYSCFG_CFGR1_ENCMODE_TIM4    (3 << SYSCFG_CFGR1_ENCMODE_SHIFT) /* TIM4 I2C1-2 -> TIM15 IC1/2 */
-#define SYSCFG_CFGR1_FPUIE_SHIFT       (26)       /* Bits 26-31: Floating Point Unit interrupts enable bits */
+#define SYSCFG_CFGR1_FPUIE_SHIFT       (26)                              /* Bits 26-31: Floating Point Unit interrupts enable bits */
 #define SYSCFG_CFGR1_FPUIE_MASK        (63 << SYSCFG_CFGR1_FPUIE_SHIFT)
 #  define SYSCFG_CFGR1_FPUIE_INVALIDOP (1 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Invalid operation interrupt enable */
 #  define SYSCFG_CFGR1_FPUIE_DIVZERO   (2 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Divide-by-zero interrupt enable */
@@ -175,33 +175,33 @@
 
 /* SYSCFG configuration register 3 */
 
-#define SYSCFG_CFGR3_SPI1_RX_DMA_RMP_SHIFT   (0)  /* Bits 0-1: SPI1_RX_DMA remap */
+#define SYSCFG_CFGR3_SPI1_RX_DMA_RMP_SHIFT   (0)                                       /* Bits 0-1: SPI1_RX_DMA remap */
 #define SYSCFG_CFGR3_SPI1_RX_DMA_RMP_MASK    (3 << SYSCFG_CFGR3_SPI1_RX_DMA_RMP_SHIFT)
 #  define SYSCFG_CFGR3_SPI1_RX_DMA_RMP_0     (0 << SYSCFG_CFGR3_SPI1_RX_DMA_RMP_SHIFT) /* 00: SPI1_RX mapped on DMA1CH2 */
 #  define SYSCFG_CFGR3_SPI1_RX_DMA_RMP_1     (1 << SYSCFG_CFGR3_SPI1_RX_DMA_RMP_SHIFT) /* 01: SPI1_RX mapped on DMA1CH2 */
 #  define SYSCFG_CFGR3_SPI1_RX_DMA_RMP_2     (2 << SYSCFG_CFGR3_SPI1_RX_DMA_RMP_SHIFT) /* 10: SPI1_RX mapped on DMA1CH6 */
 #  define SYSCFG_CFGR3_SPI1_RX_DMA_RMP_3     (3 << SYSCFG_CFGR3_SPI1_RX_DMA_RMP_SHIFT) /* 11: SPI1_RX mapped on DMA1CH2 */
-#define SYSCFG_CFGR3_SPI1_TX_DMA_RMP_SHIFT   (2)  /* Bits 2-3: SPI1_TX_DMA remap */
+#define SYSCFG_CFGR3_SPI1_TX_DMA_RMP_SHIFT   (2)                                       /* Bits 2-3: SPI1_TX_DMA remap */
 #define SYSCFG_CFGR3_SPI1_TX_DMA_RMP_MASK    (3 << SYSCFG_CFGR3_SPI1_TX_DMA_RMP_SHIFT)
 #  define SYSCFG_CFGR3_SPI1_TX_DMA_RMP_0     (0 << SYSCFG_CFGR3_SPI1_TX_DMA_RMP_SHIFT) /* 00: SPI1_TX mapped on DMA1CH3 */
 #  define SYSCFG_CFGR3_SPI1_TX_DMA_RMP_1     (1 << SYSCFG_CFGR3_SPI1_TX_DMA_RMP_SHIFT) /* 01: SPI1_TX mapped on DMA1CH5 */
 #  define SYSCFG_CFGR3_SPI1_TX_DMA_RMP_2     (2 << SYSCFG_CFGR3_SPI1_TX_DMA_RMP_SHIFT) /* 10: SPI1_TX mapped on DMA1CH7 */
 #  define SYSCFG_CFGR3_SPI1_TX_DMA_RMP_3     (3 << SYSCFG_CFGR3_SPI1_TX_DMA_RMP_SHIFT) /* 11: SPI1_TX mapped on DMA1CH3 */
-#define SYSCFG_CFGR3_I2C1_RX_DMA_RMP_SHIFT   (4)  /* Bits 4-5: I2C1_RX_DMA remap */
+#define SYSCFG_CFGR3_I2C1_RX_DMA_RMP_SHIFT   (4)                                       /* Bits 4-5: I2C1_RX_DMA remap */
 #define SYSCFG_CFGR3_I2C1_RX_DMA_RMP_MASK    (3 << SYSCFG_CFGR3_I2C1_RX_DMA_RMP_SHIFT)
 #  define SYSCFG_CFGR3_I2C1_RX_DMA_RMP_0     (0 << SYSCFG_CFGR3_I2C1_RX_DMA_RMP_SHIFT) /* 00: I2C1_RX mapped on DMA1CH7 */
 #  define SYSCFG_CFGR3_I2C1_RX_DMA_RMP_1     (1 << SYSCFG_CFGR3_I2C1_RX_DMA_RMP_SHIFT) /* 01: I2C1_RX mapped on DMA1CH3 */
 #  define SYSCFG_CFGR3_I2C1_RX_DMA_RMP_2     (2 << SYSCFG_CFGR3_I2C1_RX_DMA_RMP_SHIFT) /* 10: I2C1_RX mapped on DMA1CH5 */
 #  define SYSCFG_CFGR3_I2C1_RX_DMA_RMP_3     (3 << SYSCFG_CFGR3_I2C1_RX_DMA_RMP_SHIFT) /* 11: I2C1_RX mapped on DMA1CH7 */
-#define SYSCFG_CFGR3_I2C1_TX_DMA_RMP_SHIFT   (6)  /* Bits 6-7: I2C1_TX_DMA remap */
+#define SYSCFG_CFGR3_I2C1_TX_DMA_RMP_SHIFT   (6)                                       /* Bits 6-7: I2C1_TX_DMA remap */
 #define SYSCFG_CFGR3_I2C1_TX_DMA_RMP_MASK    (3 << SYSCFG_CFGR3_I2C1_TX_DMA_RMP_SHIFT)
 #  define SYSCFG_CFGR3_I2C1_TX_DMA_RMP_0     (0 << SYSCFG_CFGR3_I2C1_TX_DMA_RMP_SHIFT) /* 00: I2C1_TX mapped on DMA1CH6 */
 #  define SYSCFG_CFGR3_I2C1_TX_DMA_RMP_1     (1 << SYSCFG_CFGR3_I2C1_TX_DMA_RMP_SHIFT) /* 01: I2C1_TX mapped on DMA1CH2 */
 #  define SYSCFG_CFGR3_I2C1_TX_DMA_RMP_2     (2 << SYSCFG_CFGR3_I2C1_TX_DMA_RMP_SHIFT) /* 10: I2C1_TX mapped on DMA1CH4 */
 #  define SYSCFG_CFGR3_I2C1_TX_DMA_RMP_3     (3 << SYSCFG_CFGR3_I2C1_TX_DMA_RMP_SHIFT) /* 11: I2C1_TX mapped on DMA1CH6 */
-#define SYSCFG_CFGR3_ADC2_DMA_RMP            (8)  /* Bits 8: ADC2 mapped on DMA1CH1 remap */
-#define SYSCFG_CFGR3_DAC1_TRIG3_RMP          (1 << 16)  /* Bit 16: HRTIM1_DAC1_TRIG1 remap */
-#define SYSCFG_CFGR3_DAC1_TRIG3_RMP          (1 << 16)  /* Bit 16: HRTIM1_DAC1_TRIG1 remap */
-#define SYSCFG_CFGR3_DAC1_TRIG5_RMP          (1 << 17)  /* Bit 17: HRTIM1_DAC1_TRIG2 remap */
+#define SYSCFG_CFGR3_ADC2_DMA_RMP            (8)                                       /* Bits 8: ADC2 mapped on DMA1CH1 remap */
+#define SYSCFG_CFGR3_DAC1_TRIG3_RMP          (1 << 16)                                 /* Bit 16: HRTIM1_DAC1_TRIG1 remap */
+#define SYSCFG_CFGR3_DAC1_TRIG3_RMP          (1 << 16)                                 /* Bit 16: HRTIM1_DAC1_TRIG1 remap */
+#define SYSCFG_CFGR3_DAC1_TRIG5_RMP          (1 << 17)                                 /* Bit 17: HRTIM1_DAC1_TRIG2 remap */
 
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32F33XXX_SYSCFG_H */

--- a/arch/arm/src/stm32/hardware/stm32f33xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f33xxx_syscfg.h
@@ -44,8 +44,6 @@
 #include <nuttx/config.h>
 #include "chip.h"
 
-#ifdef CONFIG_STM32_STM32F33XX
-
 /****************************************************************************************************
  * Pre-processor Definitions
  ****************************************************************************************************/
@@ -206,5 +204,4 @@
 #define SYSCFG_CFGR3_DAC1_TRIG3_RMP          (1 << 16)  /* Bit 16: HRTIM1_DAC1_TRIG1 remap */
 #define SYSCFG_CFGR3_DAC1_TRIG5_RMP          (1 << 17)  /* Bit 17: HRTIM1_DAC1_TRIG2 remap */
 
-#endif /* CONFIG_STM32_STM32F33XX */
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32F33XXX_SYSCFG_H */

--- a/arch/arm/src/stm32/hardware/stm32f37xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f37xxx_syscfg.h
@@ -50,15 +50,15 @@
 
 /* Register Offsets *********************************************************************************/
 
-#define STM32_SYSCFG_CFGR1_OFFSET      0x0000 /* SYSCFG configuration register 1 */
+#define STM32_SYSCFG_CFGR1_OFFSET      0x0000                    /* SYSCFG configuration register 1 */
 
 #define STM32_SYSCFG_EXTICR_OFFSET(p)  (0x0008 + ((p) & 0x000c)) /* Registers are displaced by 4! */
-#define STM32_SYSCFG_EXTICR1_OFFSET    0x0008 /* SYSCFG external interrupt configuration register 1 */
-#define STM32_SYSCFG_EXTICR2_OFFSET    0x000c /* SYSCFG external interrupt configuration register 2 */
-#define STM32_SYSCFG_EXTICR3_OFFSET    0x0010 /* SYSCFG external interrupt configuration register 3 */
-#define STM32_SYSCFG_EXTICR4_OFFSET    0x0014 /* SYSCFG external interrupt configuration register 4 */
+#define STM32_SYSCFG_EXTICR1_OFFSET    0x0008                    /* SYSCFG external interrupt configuration register 1 */
+#define STM32_SYSCFG_EXTICR2_OFFSET    0x000c                    /* SYSCFG external interrupt configuration register 2 */
+#define STM32_SYSCFG_EXTICR3_OFFSET    0x0010                    /* SYSCFG external interrupt configuration register 3 */
+#define STM32_SYSCFG_EXTICR4_OFFSET    0x0014                    /* SYSCFG external interrupt configuration register 4 */
 
-#define STM32_SYSCFG_CFGR2_OFFSET      0x0018 /* SYSCFG configuration register 2 */
+#define STM32_SYSCFG_CFGR2_OFFSET      0x0018                    /* SYSCFG configuration register 2 */
 
 /* Register Addresses *******************************************************************************/
 
@@ -76,33 +76,32 @@
 
 /* SYSCFG memory remap register */
 
-#define SYSCFG_CFGR1_MEMMODE_SHIFT     (0)       /* Bits 1:0 MEM_MODE: Memory mapping selection */
+#define SYSCFG_CFGR1_MEMMODE_SHIFT     (0)                               /* Bits 1:0 MEM_MODE: Memory mapping selection */
 #define SYSCFG_CFGR1_MEMMODE_MASK      (3 << SYSCFG_CFGR1_MEMMODE_SHIFT)
 #  define SYSCFG_CFGR1_MEMMODE_FLASH   (0 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 00: Main Flash at 0x00000000 */
 #  define SYSCFG_CFGR1_MEMMODE_SYSTEM  (1 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 01: System Flash at 0x00000000 */
 #  define SYSCFG_CFGR1_MEMMODE_SRAM    (3 << SYSCFG_CFGR1_MEMMODE_SHIFT) /* 11: Embedded SRAM at 0x00000000 */
-#define SYSCFG_CFGR1_TIM16_DMARMP      (1 << 11) /* Bit 11: TIM16 DMA request remapping bit */
-#define SYSCFG_CFGR1_TIM17_DMARMP      (1 << 12) /* Bit 12: TIM17 DMA request remapping bit */
-#define SYSCFG_CFGR1_TIM6_DMARMP       (1 << 13) /* Bit 13: TIM6 DMA remap, or */
-#define SYSCFG_CFGR1_DAC1_CH1_DMARMP   (1 << 13) /* Bit 13: DAC 1 channel 2 DMA remap */
-#define SYSCFG_CFGR1_TIM7_DMARMP       (1 << 14) /* Bit 14: TIM7 DMA remap */
-#define SYSCFG_CFGR1_DAC1_CH2_DMARMP   (1 << 14) /* Bit 14: DAC 1 channel 2 DMA remap */
-#define SYSCFG_CFGR1_TIM18_DMARMP      (1 << 15) /* Bit 15: TIM18 DMA remap */
-#define SYSCFG_CFGR1_DAC2_CH1_DMARMP   (1 << 15) /* Bit 15: DAC 2 channel 1 DMA remap */
-#define SYSCFG_CFGR1_I2C_PBXFMP_SHIFT  (16)      /* Bits 16-19: Fast Mode Plus (FM+) driving capability */
+#define SYSCFG_CFGR1_TIM16_DMARMP      (1 << 11)                         /* Bit 11: TIM16 DMA request remapping bit */
+#define SYSCFG_CFGR1_TIM17_DMARMP      (1 << 12)                         /* Bit 12: TIM17 DMA request remapping bit */
+#define SYSCFG_CFGR1_TIM6_DMARMP       (1 << 13)                         /* Bit 13: TIM6 DMA remap, or */
+#define SYSCFG_CFGR1_DAC1_CH1_DMARMP   (1 << 13)                         /* Bit 13: DAC 1 channel 2 DMA remap */
+#define SYSCFG_CFGR1_TIM7_DMARMP       (1 << 14)                         /* Bit 14: TIM7 DMA remap */
+#define SYSCFG_CFGR1_DAC1_CH2_DMARMP   (1 << 14)                         /* Bit 14: DAC 1 channel 2 DMA remap */
+#define SYSCFG_CFGR1_TIM18_DMARMP      (1 << 15)                         /* Bit 15: TIM18 DMA remap */
+#define SYSCFG_CFGR1_DAC2_CH1_DMARMP   (1 << 15)                         /* Bit 15: DAC 2 channel 1 DMA remap */
+#define SYSCFG_CFGR1_I2C_PBXFMP_SHIFT  (16)                              /* Bits 16-19: Fast Mode Plus (FM+) driving capability */
 #define SYSCFG_CFGR1_I2C_PBXFMP_MASK   (15 << SYSCFG_CFGR1_I2C_PBXFMP_SHIFT)
-#define SYSCFG_CFGR1_I2C1_FMP          (1 << 20) /* Bit 20: I2C1 fast mode Plus driving capability */
-#define SYSCFG_CFGR1_I2C2_FMP          (1 << 21) /* Bit 21: I2C2 fast mode Plus driving capability */
-#define SYSCFG_CFGR1_VBAT              (1 << 24) /* Bit 24: VBat monitor enable */
-#define SYSCFG_CFGR1_FPUIE_SHIFT       (26)       /* Bits 26-31: Floating Point Unit interrupts enable bits */
+#define SYSCFG_CFGR1_I2C1_FMP          (1 << 20)                         /* Bit 20: I2C1 fast mode Plus driving capability */
+#define SYSCFG_CFGR1_I2C2_FMP          (1 << 21)                         /* Bit 21: I2C2 fast mode Plus driving capability */
+#define SYSCFG_CFGR1_VBAT              (1 << 24)                         /* Bit 24: VBat monitor enable */
+#define SYSCFG_CFGR1_FPUIE_SHIFT       (26)                              /* Bits 26-31: Floating Point Unit interrupts enable bits */
 #define SYSCFG_CFGR1_FPUIE_MASK        (63 << SYSCFG_CFGR1_FPUIE_SHIFT)
-#  define SYSCFG_CFGR1_FPUIE_INVALIDOP (1 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Invalid operation interrupt enable */
-#  define SYSCFG_CFGR1_FPUIE_DIVZERO   (2 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Divide-by-zero interrupt enable */
-#  define SYSCFG_CFGR1_FPUIE_UNDERFLOW (4 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Underflow interrupt enable */
-#  define SYSCFG_CFGR1_FPUIE_OVERFLOW  (8 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Overflow interrupt enable */
-#  define SYSCFG_CFGR1_FPUIE_DENORMAL  (16 << SYSCFG_CFGR1_FPUIE_SHIFT) /* Input denormal interrupt enable */
-#  define SYSCFG_CFGR1_FPUIE_INEXACT   (32 << SYSCFG_CFGR1_FPUIE_SHIFT) /* Inexact interrupt enable */
-
+#  define SYSCFG_CFGR1_FPUIE_INVALIDOP (1 << SYSCFG_CFGR1_FPUIE_SHIFT)   /* Invalid operation interrupt enable */
+#  define SYSCFG_CFGR1_FPUIE_DIVZERO   (2 << SYSCFG_CFGR1_FPUIE_SHIFT)   /* Divide-by-zero interrupt enable */
+#  define SYSCFG_CFGR1_FPUIE_UNDERFLOW (4 << SYSCFG_CFGR1_FPUIE_SHIFT)   /* Underflow interrupt enable */
+#  define SYSCFG_CFGR1_FPUIE_OVERFLOW  (8 << SYSCFG_CFGR1_FPUIE_SHIFT)   /* Overflow interrupt enable */
+#  define SYSCFG_CFGR1_FPUIE_DENORMAL  (16 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Input denormal interrupt enable */
+#  define SYSCFG_CFGR1_FPUIE_INEXACT   (32 << SYSCFG_CFGR1_FPUIE_SHIFT)  /* Inexact interrupt enable */
 
 /* SYSCFG external interrupt configuration register 1-4 */
 

--- a/arch/arm/src/stm32/hardware/stm32f37xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f37xxx_syscfg.h
@@ -44,8 +44,6 @@
 #include <nuttx/config.h>
 #include "chip.h"
 
-#ifdef CONFIG_STM32_STM32F37XX
-
 /****************************************************************************************************
  * Pre-processor Definitions
  ****************************************************************************************************/
@@ -162,5 +160,4 @@
 #define SYSCFG_CFGR2_PVDLOCK          (1 << 2)  /* Bit 2: PVD lock enable */
 #define SYSCFG_CFGR2_SRAM_PEF         (1 << 8)  /* Bit 8: SRAM parity error */
 
-#endif /* CONFIG_STM32_STM32F37XX */
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32F37XXX_SYSCFG_H */

--- a/arch/arm/src/stm32/hardware/stm32f40xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f40xxx_syscfg.h
@@ -52,18 +52,18 @@
 
 /* Register Offsets *********************************************************************************/
 
-#define STM32_SYSCFG_MEMRMP_OFFSET    0x0000 /* SYSCFG memory remap register */
-#define STM32_SYSCFG_PMC_OFFSET       0x0004 /* SYSCFG peripheral mode configuration register */
+#define STM32_SYSCFG_MEMRMP_OFFSET    0x0000                    /* SYSCFG memory remap register */
+#define STM32_SYSCFG_PMC_OFFSET       0x0004                    /* SYSCFG peripheral mode configuration register */
 
 #define STM32_SYSCFG_EXTICR_OFFSET(p) (0x0008 + ((p) & 0x000c)) /* Registers are displaced by 4! */
-#define STM32_SYSCFG_EXTICR1_OFFSET   0x0008 /* SYSCFG external interrupt configuration register 1 */
-#define STM32_SYSCFG_EXTICR2_OFFSET   0x000c /* SYSCFG external interrupt configuration register 2 */
-#define STM32_SYSCFG_EXTICR3_OFFSET   0x0010 /* SYSCFG external interrupt configuration register 3 */
-#define STM32_SYSCFG_EXTICR4_OFFSET   0x0014 /* SYSCFG external interrupt configuration register 4 */
+#define STM32_SYSCFG_EXTICR1_OFFSET   0x0008                    /* SYSCFG external interrupt configuration register 1 */
+#define STM32_SYSCFG_EXTICR2_OFFSET   0x000c                    /* SYSCFG external interrupt configuration register 2 */
+#define STM32_SYSCFG_EXTICR3_OFFSET   0x0010                    /* SYSCFG external interrupt configuration register 3 */
+#define STM32_SYSCFG_EXTICR4_OFFSET   0x0014                    /* SYSCFG external interrupt configuration register 4 */
 
-#define STM32_SYSCFG_CMPCR_OFFSET     0x0020 /* Compensation cell control register */
+#define STM32_SYSCFG_CMPCR_OFFSET     0x0020                    /* Compensation cell control register */
 #if defined(CONFIG_STM32_STM32F446)
-#  define STM32_SYSCFG_CFGR_OFFSET    0x002c /* SYSCFG configuration register */
+#  define STM32_SYSCFG_CFGR_OFFSET    0x002c                    /* SYSCFG configuration register */
 #endif
 
 /* Register Addresses *******************************************************************************/

--- a/arch/arm/src/stm32/hardware/stm32f40xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32f40xxx_syscfg.h
@@ -46,8 +46,6 @@
 #include <nuttx/config.h>
 #include "chip.h"
 
-#ifdef CONFIG_STM32_STM32F4XXX
-
 /****************************************************************************************************
  * Pre-processor Definitions
  ****************************************************************************************************/
@@ -198,5 +196,4 @@
 #  define SYSCFG_CFGR_FMPI2C1_SDA    (1 << 1)  /* Bit 8: Forces FM+ drive capability on SDA */
 #endif
 
-#endif /* CONFIG_STM32_STM32F4XXX */
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32F40XXX_SYSCFG_H */

--- a/arch/arm/src/stm32/hardware/stm32g47xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32g47xxx_syscfg.h
@@ -28,8 +28,6 @@
 #include <nuttx/config.h>
 #include "chip.h"
 
-#ifdef CONFIG_STM32_STM32G47XX
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -167,5 +165,4 @@
 #define SYSCFG_SKR_KEY_MASK              (0xff << SYSCFG_SKR_KEY_SHIFT)
 #  define SYSCFG_SKR_KEY(n)              (((n) << SYSCFG_SKR_KEY_SHIFT) & SYSCFG_SKR_KEY_MASK)
 
-#endif /* CONFIG_STM32_STM32G47XX */
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32G47XXX_SYSCFG_H */

--- a/arch/arm/src/stm32/hardware/stm32g47xxx_vrefbuf.h
+++ b/arch/arm/src/stm32/hardware/stm32g47xxx_vrefbuf.h
@@ -28,8 +28,6 @@
 #include <nuttx/config.h>
 #include "chip.h"
 
-#ifdef CONFIG_STM32_STM32G47XX
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -64,5 +62,4 @@
 #define VREFBUF_CCR_TRIM_SHIFT            (0)
 #define VREFBUF_CCR_TRIM_MASK             (0x3f)                         /* 6-bit unsigned trim code */
 
-#endif /* CONFIG_STM32_STM32G47XX */
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32G47XXX_VREFBUF_H */

--- a/arch/arm/src/stm32/hardware/stm32gxxxxx_dac.h
+++ b/arch/arm/src/stm32/hardware/stm32gxxxxx_dac.h
@@ -28,8 +28,6 @@
 #include <nuttx/config.h>
 #include "chip.h"
 
-#ifdef CONFIG_STM32_STM32G47XX
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -488,5 +486,4 @@
 #define DAC_STR_STINCDATA_SHIFT        (16)                           /* DAC channel 1 Sawtooth increment value (12.4 bit format) */
 #define DAC_STR_STINCDATA_MASK         (0xffff << DAC_STR_STINCDATA_SHIFT)
 
-#endif /* CONFIG_STM32_STM32G47XX */
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32GXXXXX_DAC_H */

--- a/arch/arm/src/stm32/hardware/stm32l15xxx_syscfg.h
+++ b/arch/arm/src/stm32/hardware/stm32l15xxx_syscfg.h
@@ -51,14 +51,14 @@
 
 /* Register Offsets *********************************************************************************/
 
-#define STM32_SYSCFG_MEMRMP_OFFSET     0x0000 /* SYSCFG memory remap register */
-#define STM32_SYSCFG_PMC_OFFSET        0x0004 /* SYSCFG peripheral mode configuration register */
+#define STM32_SYSCFG_MEMRMP_OFFSET     0x0000                    /* SYSCFG memory remap register */
+#define STM32_SYSCFG_PMC_OFFSET        0x0004                    /* SYSCFG peripheral mode configuration register */
 
 #define STM32_SYSCFG_EXTICR_OFFSET(p)  (0x0008 + ((p) & 0x000c)) /* Registers are displaced by 4! */
-#define STM32_SYSCFG_EXTICR1_OFFSET    0x0008 /* SYSCFG external interrupt configuration register 1 */
-#define STM32_SYSCFG_EXTICR2_OFFSET    0x000c /* SYSCFG external interrupt configuration register 2 */
-#define STM32_SYSCFG_EXTICR3_OFFSET    0x0010 /* SYSCFG external interrupt configuration register 3 */
-#define STM32_SYSCFG_EXTICR4_OFFSET    0x0014 /* SYSCFG external interrupt configuration register 4 */
+#define STM32_SYSCFG_EXTICR1_OFFSET    0x0008                    /* SYSCFG external interrupt configuration register 1 */
+#define STM32_SYSCFG_EXTICR2_OFFSET    0x000c                    /* SYSCFG external interrupt configuration register 2 */
+#define STM32_SYSCFG_EXTICR3_OFFSET    0x0010                    /* SYSCFG external interrupt configuration register 3 */
+#define STM32_SYSCFG_EXTICR4_OFFSET    0x0014                    /* SYSCFG external interrupt configuration register 4 */
 
 /* Register Addresses *******************************************************************************/
 
@@ -75,31 +75,31 @@
 
 /* SYSCFG memory remap register */
 
-#define SYSCFG_MEMRMP_MEMMODE_SHIFT     (0)       /* Bits 0-1: Memory mapping selection */
+#define SYSCFG_MEMRMP_MEMMODE_SHIFT     (0)                                 /* Bits 0-1: Memory mapping selection */
 #define SYSCFG_MEMRMP_MEMMODE_MASK      (3 << SYSCFG_MEMRMP_MEMMODE_SHIFT)
-#  define SYSCFG_MEMRMP_MEMMODE_FLASH   (0 << SYSCFG_MEMRMP_MEMMODE_SHIFT) /* 00: Main Flash memory mapped at 0x00000000 */
-#  define SYSCFG_MEMRMP_MEMMODE_SYSTEM  (1 << SYSCFG_MEMRMP_MEMMODE_SHIFT) /* 01: System Flash memory mapped at 0x00000000 */
-#  define SYSCFG_MEMRMP_MEMMODE_FSMC    (2 << SYSCFG_MEMRMP_MEMMODE_SHIFT) /* 10: FSMC */
-#  define SYSCFG_MEMRMP_MEMMODE_SRAM    (3 << SYSCFG_MEMRMP_MEMMODE_SHIFT) /* 11: SRAM mapped at 0x00000000 */
-                                                  /* Bits 2-7: Reserved */
-#define SYSCFG_MEMRMP_BOOTMODE_SHIFT    (0)       /* Bits 8-9: Boot mode selected by the boot pins */
+#  define SYSCFG_MEMRMP_MEMMODE_FLASH   (0 << SYSCFG_MEMRMP_MEMMODE_SHIFT)  /* 00: Main Flash memory mapped at 0x00000000 */
+#  define SYSCFG_MEMRMP_MEMMODE_SYSTEM  (1 << SYSCFG_MEMRMP_MEMMODE_SHIFT)  /* 01: System Flash memory mapped at 0x00000000 */
+#  define SYSCFG_MEMRMP_MEMMODE_FSMC    (2 << SYSCFG_MEMRMP_MEMMODE_SHIFT)  /* 10: FSMC */
+#  define SYSCFG_MEMRMP_MEMMODE_SRAM    (3 << SYSCFG_MEMRMP_MEMMODE_SHIFT)  /* 11: SRAM mapped at 0x00000000 */
+                                                                            /* Bits 2-7: Reserved */
+#define SYSCFG_MEMRMP_BOOTMODE_SHIFT    (0)                                 /* Bits 8-9: Boot mode selected by the boot pins */
 #define SYSCFG_MEMRMP_BOOTMODE_MASK     (3 << SYSCFG_MEMRMP_BOOTMODE_SHIFT)
 #  define SYSCFG_MEMRMP_BOOTMODE_FLASH  (0 << SYSCFG_MEMRMP_BOOTMODE_SHIFT) /* 00: Main Flash memory boot mode */
 #  define SYSCFG_MEMRMP_BOOTMODE_SYSTEM (1 << SYSCFG_MEMRMP_BOOTMODE_SHIFT) /* 01: System Flash memory boot mode */
 #  define SYSCFG_MEMRMP_BOOTMODE_SRAM   (3 << SYSCFG_MEMRMP_BOOTMODE_SHIFT) /* 11: Embedded SRAM boot mode */
-                                                  /* Bits 10-31: Reserved */
+                                                                            /* Bits 10-31: Reserved */
 
 /* SYSCFG peripheral mode configuration register */
 
-#define SYSCFG_PMC_USBPU                (1 << 0)  /* Bit 0: USB pull-up enable on DP line */
-#define SYSCFG_PMC_LCDCAPA_SHIFT        (1)       /* Bits 1-5: LCD  decoupling capacitance connection */
+#define SYSCFG_PMC_USBPU                (1 << 0)                           /* Bit 0: USB pull-up enable on DP line */
+#define SYSCFG_PMC_LCDCAPA_SHIFT        (1)                                /* Bits 1-5: LCD  decoupling capacitance connection */
 #define SYSCFG_PMC_LCDCAPA_MASK         (0x1f << SYSCFG_PMC_LCDCAPA_SHIFT)
 #  define SYSCFG_PMC_LCDCAPA_PB2        (0x01 << SYSCFG_PMC_LCDCAPA_SHIFT) /* Bit 1: Controls VLCDrail2 on PB2/LCD_VCAP2 */
 #  define SYSCFG_PMC_LCDCAPA_PB12       (0x02 << SYSCFG_PMC_LCDCAPA_SHIFT) /* Bit 2: Controls VLCDrail1 on PB12/LCD_VCAP1 */
 #  define SYSCFG_PMC_LCDCAPA_PB0        (0x04 << SYSCFG_PMC_LCDCAPA_SHIFT) /* Bit 3: Controls VLCDrail3 on PB0/LCD_VCAP3 */
 #  define SYSCFG_PMC_LCDCAPA_PE11       (0x08 << SYSCFG_PMC_LCDCAPA_SHIFT) /* Bit 4: Controls VLCDrail1 on PE11/LCD_VCAP1 */
 #  define SYSCFG_PMC_LCDCAPA_PE12       (0x10 << SYSCFG_PMC_LCDCAPA_SHIFT) /* Bit 5: Controls VLCDrail3 on PE12/LCD_VCAP3 */
-                                                  /* Bits 6-31: Reserved */
+                                                                           /* Bits 6-31: Reserved */
 
 /* SYSCFG external interrupt configuration register 1-4 */
 


### PR DESCRIPTION
## Summary
stm32/hardware: remove redundand ifdefs to keep headers consistent

## Impact

## Testing
Build test