### PR TITLE
[Performance]net/tcp: send the ACK in time after obtain ahead buffer from iobs

### DIFF
--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -263,6 +263,10 @@ static int sixlowpan_tcp_header(FAR struct tcp_conn_s *conn,
 
       ipv6tcp->tcp.wnd[0] = recvwndo >> 8;
       ipv6tcp->tcp.wnd[1] = recvwndo & 0xff;
+
+      /* Update the Receiver Window */
+
+      conn->rcv_wnd = recvwndo;
     }
 
   /* Calculate TCP checksum. */

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -446,14 +446,14 @@ static uint16_t tcp_send_eventhandler(FAR struct net_driver_s *dev,
           sndlen = conn->mss;
         }
 
-      winleft = conn->winsize - sinfo->s_sent + sinfo->s_acked;
+      winleft = conn->snd_wnd - sinfo->s_sent + sinfo->s_acked;
       if (sndlen > winleft)
         {
           sndlen = winleft;
         }
 
-      ninfo("s_buflen=%zu s_sent=%zu mss=%u winsize=%u sndlen=%d\n",
-            sinfo->s_buflen, sinfo->s_sent, conn->mss, conn->winsize,
+      ninfo("s_buflen=%zu s_sent=%zu mss=%u snd_wnd=%u sndlen=%d\n",
+            sinfo->s_buflen, sinfo->s_sent, conn->mss, conn->snd_wnd,
             sndlen);
 
       if (sndlen > 0)

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -192,7 +192,8 @@ struct tcp_conn_s
   uint16_t rport;         /* The remoteTCP port, in network byte order */
   uint16_t mss;           /* Current maximum segment size for the
                            * connection */
-  uint16_t winsize;       /* Current window size of the connection */
+  uint16_t snd_wnd;       /* Sequence and acknowledgement numbers of last
+                           * window update */
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   uint32_t tx_unacked;    /* Number bytes sent but not yet ACKed */
 #else

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -273,6 +273,12 @@ struct tcp_conn_s
 
   FAR struct devif_callback_s *connevents;
 
+  /* Receiver callback to indicate that the data has been consumed and that
+   * an ACK should be send.
+   */
+
+  FAR struct devif_callback_s *rcv_ackcb;
+
   /* accept() is called when the TCP logic has created a connection
    *
    *   accept_private: This is private data that will be available to the

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -194,6 +194,7 @@ struct tcp_conn_s
                            * connection */
   uint16_t snd_wnd;       /* Sequence and acknowledgement numbers of last
                            * window update */
+  uint16_t rcv_wnd;       /* Receiver window available */
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   uint32_t tx_unacked;    /* Number bytes sent but not yet ACKed */
 #else

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -326,7 +326,7 @@ found:
 
   /* Update the connection's window size */
 
-  conn->winsize = ((uint16_t)tcp->wnd[0] << 8) + (uint16_t)tcp->wnd[1];
+  conn->snd_wnd = ((uint16_t)tcp->wnd[0] << 8) + (uint16_t)tcp->wnd[1];
 
   flags = 0;
 

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -366,6 +366,10 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
 
       tcp->wnd[0] = recvwndo >> 8;
       tcp->wnd[1] = recvwndo & 0xff;
+
+      /* Update the Receiver Window */
+
+      conn->rcv_wnd = recvwndo;
     }
 
   /* Finish the IP portion of the message and calculate checksums */

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -734,7 +734,7 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
   if ((conn->tcpstateflags & TCP_ESTABLISHED) &&
       (flags & (TCP_POLL | TCP_REXMIT)) &&
       !(sq_empty(&conn->write_q)) &&
-      conn->winsize > 0)
+      conn->snd_wnd > 0)
     {
       FAR struct tcp_wrbuffer_s *wrb;
       uint32_t predicted_seqno;
@@ -760,15 +760,15 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           sndlen = conn->mss;
         }
 
-      if (sndlen > conn->winsize)
+      if (sndlen > conn->snd_wnd)
         {
-          sndlen = conn->winsize;
+          sndlen = conn->snd_wnd;
         }
 
       ninfo("SEND: wrb=%p pktlen=%u sent=%u sndlen=%zu mss=%u "
-            "winsize=%u\n",
+            "snd_wnd=%u\n",
             wrb, TCP_WBPKTLEN(wrb), TCP_WBSENT(wrb), sndlen, conn->mss,
-            conn->winsize);
+            conn->snd_wnd);
 
       /* Set the sequence number for this segment.  If we are
        * retransmitting, then the sequence number will already

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -417,7 +417,7 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
 
       /* Check if we have "space" in the window */
 
-      if ((pstate->snd_sent - pstate->snd_acked + sndlen) < conn->winsize)
+      if ((pstate->snd_sent - pstate->snd_acked + sndlen) < conn->snd_wnd)
         {
           /* Set the sequence number for this packet.  NOTE:  The network
            * updates sndseq on receipt of ACK *before* this function is

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -299,7 +299,7 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
 
       /* Check if we have "space" in the window */
 
-      if ((pstate->snd_sent - pstate->snd_acked + sndlen) < conn->winsize)
+      if ((pstate->snd_sent - pstate->snd_acked + sndlen) < conn->snd_wnd)
         {
           uint32_t seqno;
 


### PR DESCRIPTION
## Summary

1. [Performance]net/tcp: send the ACK in time after obtain ahead buffer from iobs

    Request the TCP ACK to estimate the receive window after handle
    any data already buffered in a read-ahead buffer.

2. net/tcp: add a member to record the current receiving window
3. net/tcp: rename the winszie to snd_wnd to make the semantics more accurate

## Impact

TCP Performance

## Testing

HTTP Streaming
