### PR TITLE
drivers/leds/ws2812: make frequency selection more flexible

### DIFF
--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -41,22 +41,21 @@
 
 /* In order to meet the signaling timing requirements, the waveforms required
  * to represent a 0/1 symbol are created by specific SPI bytes defined here.
- * 
+ *
  * Only two target frequencies: 4 MHz and 8 MHz. However, given the tolerance
  * allowed in the WS2812 timing specs, two ranges around those target
- * frequencies can be used for better flexibility. Extreme frequencies rounded
- * to the nearest multiple of 100 kHz which meets the specs. Try to avoid
- * using the extreme frequencies.
- * 
+ * frequencies can be used for better flexibility. Extreme frequencies
+ * rounded to the nearest multiple of 100 kHz which meets the specs.
+ * Try to avoid using the extreme frequencies.
+ *
  * If using an LED different to the WS2812 (e.g. WS2812B) check its timing
  * specs, which may vary slightly, to decide which frequency is safe to use.
- * 
+ *
  * WS2812 specs:
  * T0H range: 200ns - 500ns
  * T1H range: 550ns - 850ns
  * Reset: low signal >50us
  */
-
 
 #if CONFIG_WS2812_FREQUENCY >= 3600000 && CONFIG_WS2812_FREQUENCY <= 5000000
 #  define WS2812_ZERO_BYTE  0b01000000 /* 200ns at 5 MHz, 278ns at 3.6 MHz */


### PR DESCRIPTION
## Summary
Previously only 4 MHz and 8 MHz were allowed. Given the tolerance allowed in the WS2812 timing spec, frequency ranges round those two can be used too which is useful for boards in which it is difficult to generate those specific frequencies.

For example, I was trying to add support for the stm32f103-minimum board and 4.5 MHz and 9 MHz are easier to generate than 4 MHz and 8 MHz.

Related: good article about the timing specs of these LEDs
https://cpldcpu.wordpress.com/2014/01/14/light_ws2812-library-v2-0-part-i-understanding-the-ws2812/

## Impact
Everything is identical for the 4 MHz and 8 MHz cases, which were the only frequencies allowed previously. So no changes for users already using this driver.

## Testing
Tested 4.5 MHz and 9 MHz on a stm32f103-minimum board plus similar Inolux IN-PI554FCH LEDs and it worked correctly.

Thanks!