### PR TITLE
boards/arm/stm32/common: devpath not long enough for apa102 and veml6070

### DIFF
--- a/boards/arm/stm32/common/src/stm32_apa102.c
+++ b/boards/arm/stm32/common/src/stm32_apa102.c
@@ -82,7 +82,7 @@
 int board_apa102_initialize(int devno, int spino)
 {
   FAR struct spi_dev_s *spi;
-  char devpath[12];
+  char devpath[13];
   int ret;
 
   spi = stm32_spibus_initialize(spino);
@@ -93,7 +93,7 @@ int board_apa102_initialize(int devno, int spino)
 
   /* Register the APA102 Driver at the specified location. */
 
-  snprintf(devpath, 12, "/dev/leddrv%d", devno);
+  snprintf(devpath, 13, "/dev/leddrv%d", devno);
   ret = apa102_register(devpath, spi);
   if (ret < 0)
     {

--- a/boards/arm/stm32/common/src/stm32_veml6070.c
+++ b/boards/arm/stm32/common/src/stm32_veml6070.c
@@ -83,7 +83,7 @@
 int board_veml6070_initialize(int devno, int busno)
 {
   FAR struct i2c_master_s *i2c;
-  char devpath[13];
+  char devpath[14];
   int ret;
 
   sninfo("Initializing VEML6070!\n");
@@ -99,7 +99,7 @@ int board_veml6070_initialize(int devno, int busno)
 
   /* Then register the light sensor */
 
-  snprintf(devpath, 13, "/dev/uvlight%d", devno);
+  snprintf(devpath, 14, "/dev/uvlight%d", devno);
   ret = veml6070_register(devpath, i2c, VEML6070_I2C_DATA_LSB_CMD_ADDR);
   if (ret < 0)
     {

--- a/drivers/leds/apa102.c
+++ b/drivers/leds/apa102.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/sensors/apa102.c
+ * drivers/leds/apa102.c
  * Character driver to control LED strips with APA102.
  *
  *   Copyright (C) 2017 Gregory Nutt. All rights reserved.


### PR DESCRIPTION
## Summary
The devno couldn't fit in the string.
The example apps for [apa102](https://github.com/apache/incubator-nuttx-apps/blob/2a462c78aa5f4ea6dc374eedd86bc85f9f79a0c4/examples/apa102/apa102_main.c) and [veml6070](https://github.com/apache/incubator-nuttx-apps/blob/2a462c78aa5f4ea6dc374eedd86bc85f9f79a0c4/examples/veml6070/veml6070_main.c) wouldn't work and this should fix it.

Also header path updated in drivers/leds/apa102.c

## Impact
Anyone using these devpaths from the app space would see the device name changed (e.g. `/dev/leddrv0` instead of `/dev/leddrv`). If someone was relying on the devpath without the number, they may be impacted, but it was a bug, so I think it should be fixed.
Note: stm32f103-minimum is the only in-tree board that uses these 2 functions so it's unlikely to affect anyone.

## Testing
apa102 app tested and it no longer says `ERROR: Failed to open /dev/leddrv0`

Thanks!

