### PR TITLE
Xtensa: Get full backtrace from interrupts.

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -108,6 +108,13 @@ config XTENSA_BTDEPTH
 	---help---
 		This is the depth of the backtrace.
 
+config XTENSA_INTBACKTRACE
+	bool "Full backtrace from interrupts"
+	default n
+	depends on XTENSA_DUMPBT_ON_ASSERT
+	---help---
+		Add necessary logic to be able to have a full backtrace from an interrupt context.
+
 config XTENSA_USE_SEPARATE_IMEM
 	bool "Use a separate heap for internal memory"
 	default n

--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -134,7 +134,7 @@
 #  define XCPTCONTEXT_REGS  _REG_OVLY_START
 #endif
 
-#define XCPTCONTEXT_SIZE    (4 * XCPTCONTEXT_REGS)
+#define XCPTCONTEXT_SIZE    ((4 * XCPTCONTEXT_REGS) + 0x20)
 
 /****************************************************************************
  * Public Types

--- a/arch/xtensa/src/common/xtensa_backtrace.S
+++ b/arch/xtensa/src/common/xtensa_backtrace.S
@@ -30,18 +30,19 @@
 #include "xtensa_abi.h"
 
 /*
- * This is how the stack looks like when calling the function below:
+ * This is how the call stack looks like when calling the function below
+ * from xtensa_dumpstate():
  *
  *         High Addr
  *     ..................
  *     |    i-3 BSA     |
- *     |   i-1 locals   | Function B
+ *     |   i-1 locals   | xtensa_assert()
  *     .................. i-1 SP
  *     |    i-2 BSA     |
- *     |    i locals    | Function A (Start of backtrace)
+ *     |    i locals    | xtensa_dumpstate()
  *     ------------------ i SP
  *     |    i-1 BSA     |
- *     |   i+1 locals   | Backtracing function (e.g. xtensa_btdump())
+ *     |   i+1 locals   | xtensa_btdump()
  *     ------------------ i+1 SP
  *     |     i BSA      |
  *     |   i+2 locals   | xtensa_backtrace_start()
@@ -56,7 +57,7 @@
  * Name: xtensa_backtrace_start
  *
  * Description:
- *   Get the first frame of the current stack's backtrace
+ *   Get the first frame of the current stack's backtrace.
  *
  *   Given the following function call flow (B -> A -> X -> xtensa_backtrace_start),
  *   this function will do the following:

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -98,7 +98,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
   DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
 #endif
   start = alloc + sizeof(struct tls_info_s);
-  end   = (alloc + size + 3) & ~3;
+  end   = (alloc + size + 15) & ~15;
 
   /* Get the adjusted size based on the top and bottom of the stack */
 

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -253,7 +253,7 @@ xtensa_context_save:
 	 * to avoid the window spill.
 	 */
 
-	l32i	r3, a2, (4 * REG_A3)			/* Recover original a3 */
+	l32i	a3, a2, (4 * REG_A3)			/* Recover original a3 */
 	call0	_xtensa_context_save			/* Save full register state */
 
 	/* Recover the return address and return zero */

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -126,12 +126,14 @@ _xtensa_context_save:
 	s32i	a10, a2, (4 * REG_A10)
 	s32i	a11, a2, (4 * REG_A11)
 
-	/* Call0 ABI callee-saved regs a12-15 */
+	/* Call0 ABI callee-saved regs a12-15 do not need to be saved here */
 
+#ifndef __XTENSA_CALL0_ABI__
 	s32i	a12, a2, (4 * REG_A12)
 	s32i	a13, a2, (4 * REG_A13)
 	s32i	a14, a2, (4 * REG_A14)
 	s32i	a15, a2, (4 * REG_A15)
+#endif
 
 	rsr		a3, SAR
 	s32i	a3, a2, (4 * REG_SAR)
@@ -482,10 +484,12 @@ _xtensa_context_restore:
 
 	/* Call0 ABI callee-saved regs a12-15 */
 
+#ifndef __XTENSA_CALL0_ABI__
 	l32i	a12, a2, (4 * REG_A12)
 	l32i	a13, a2, (4 * REG_A13)
 	l32i	a14, a2, (4 * REG_A14)
 	l32i	a15, a2, (4 * REG_A15)
+#endif
 
 	ret
 

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -217,17 +217,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       uintptr_t top_of_stack;
       size_t size_of_stack;
 
-#ifdef CONFIG_STACK_COLORATION
-      /* If stack debug is enabled, then fill the stack with a
-       * recognizable value that we can use later to test for high
-       * water marks.
-       */
-
-      up_stack_color((FAR void *)tcb->stack_alloc_ptr +
-                     sizeof(struct tls_info_s),
-                     stack_size - sizeof(struct tls_info_s));
-#endif
-
       /* XTENSA uses a push-down stack:  the stack grows toward lower
        * addresses in memory.  The stack pointer register points to the
        * lowest, valid working address (the "top" of the stack).  Items on
@@ -284,6 +273,17 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       return OK;
     }
 
+#ifdef CONFIG_STACK_COLORATION
+      /* If stack debug is enabled, then fill the stack with a
+       * recognizable value that we can use later to test for high
+       * water marks.
+       */
+
+      up_stack_color((FAR void *)tcb->stack_alloc_ptr +
+                     sizeof(struct tls_info_s),
+                     tcb->adj_stack_size - sizeof(struct tls_info_s));
+#endif
+
   return ERROR;
 }
 
@@ -300,8 +300,8 @@ void up_stack_color(FAR void *stackbase, size_t nbytes)
 {
   /* Take extra care that we do not write outsize the stack boundaries */
 
-  uint32_t *stkptr = (uint32_t *)(((uintptr_t)stackbase + 3) & ~3);
-  uintptr_t stkend = (((uintptr_t)stackbase + nbytes) & ~3);
+  uint32_t *stkptr = (uint32_t *)(((uintptr_t)stackbase + 15) & ~15);
+  uintptr_t stkend = (((uintptr_t)stackbase + nbytes) & ~15);
   size_t    nwords = (stkend - (uintptr_t)stackbase) >> 2;
 
   /* Set the entire stack to the coloration value */

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -187,6 +187,29 @@ g_intstackbase:
 	and		a6, a6, a3				/* a6 = Set of pending, enabled interrupts for this level */
 	beqz	a6, 1f						/* Nothing to do */
 
+  /* At this point, the exception frame should have been allocated and filled,
+   * and current sp points to the interrupt stack (if enabled). Copy the
+   * pre-exception's base save area below the current SP.
+   */
+
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+  rsr  a0, EXCSAVE_1 + \level - 1  /* Get exception frame pointer stored in EXCSAVE_x */
+  l32i a3, a0, (4 * REG_A0)        /* Copy pre-exception a0 (return address) */
+  s32e a3, sp, -16
+  l32i a3, a0, (4 * REG_A1)        /* Copy pre-exception a1 (stack pointer) */
+  s32e a3, sp, -12
+
+  /* Backtracing only needs a0 and a1, no need to create full base save area.
+   * Also need to change current frame's return address to point to pre-exception's
+   * last run instruction.
+   */
+
+  rsr a0, EPC_1 + \level - 1  /* return address */
+  movi a4, 0xc0000000         /* constant with top 2 bits set (call size) */
+  or a0, a0, a4               /* set top 2 bits */
+  addx2 a0, a4, a0            /* clear top bit -- simulating call4 size   */
+#endif
+  
 	/* Call xtensa_int_decode passing the address of the register save area
 	 * as a parameter (A7).
 	 */
@@ -270,7 +293,7 @@ g_intstackbase:
 
 _xtensa_level1_handler:
 
-	mov		a0, sp							              /* sp == a1 */
+	mov		a0, sp							              /* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)   /* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			        /* Save pre-interrupt SP */
 	rsr		a0, PS						                /* Save interruptee's PS */
@@ -279,6 +302,10 @@ _xtensa_level1_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_1					            /* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+  wsr sp, EXCSAVE_1
+#endif
 
 	/* Save rest of interrupt context. */
 
@@ -369,7 +396,7 @@ _xtensa_level1_handler:
 
 _xtensa_level2_handler:
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_2						/* Save interruptee's PS */
@@ -378,6 +405,10 @@ _xtensa_level2_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_2					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+  wsr sp, EXCSAVE_2
+#endif
 
 	/* Save rest of interrupt context. */
 
@@ -430,7 +461,7 @@ _xtensa_level2_handler:
 
 _xtensa_level3_handler:
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_3						/* Save interruptee's PS */
@@ -439,6 +470,10 @@ _xtensa_level3_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_3					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+  wsr sp, EXCSAVE_3
+#endif
 
 	/* Save rest of interrupt context. */
 
@@ -491,7 +526,7 @@ _xtensa_level3_handler:
 
 _xtensa_level4_handler:
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_4						/* Save interruptee's PS */
@@ -500,6 +535,10 @@ _xtensa_level4_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_4					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+  wsr sp, EXCSAVE_4
+#endif
 
 	/* Save rest of interrupt context. */
 
@@ -552,7 +591,7 @@ _xtensa_level4_handler:
 
 _xtensa_level5_handler:
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_5						/* Save interruptee's PS */
@@ -561,6 +600,10 @@ _xtensa_level5_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_5					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+  wsr sp, EXCSAVE_5
+#endif
 
 	/* Save rest of interrupt context. */
 
@@ -613,7 +656,7 @@ _xtensa_level5_handler:
 
 _xtensa_level6_handler:
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_6						/* Save interruptee's PS */
@@ -622,6 +665,10 @@ _xtensa_level6_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_6					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+  wsr sp, EXCSAVE_6
+#endif
 
 	/* Save rest of interrupt context. */
 
@@ -713,7 +760,7 @@ _xtensa_level2_handler:
 #if 1
 	/* For now, just panic */
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_2						/* Save interruptee's PS */
@@ -747,7 +794,7 @@ _xtensa_level3_handler:
 #if 1
 	/* For now, just panic */
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_3						/* Save interruptee's PS */
@@ -783,7 +830,7 @@ _xtensa_level4_handler:
 #if 1
 	/* For now, just panic */
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_4						/* Save interruptee's PS */
@@ -819,7 +866,7 @@ _xtensa_level5_handler:
 #if 1
 	/* For now, just panic */
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_5						/* Save interruptee's PS */
@@ -855,7 +902,7 @@ _xtensa_level6_handler:
 #if 1
 	/* For now, just panic */
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, EPS_6						/* Save interruptee's PS */

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -193,7 +193,7 @@ _xtensa_user_handler:
 
 	/* Allocate exception frame and save minimal context. */
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, PS							/* Save interruptee's PS */
@@ -224,7 +224,24 @@ _xtensa_user_handler:
 	movi	a0, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE
 #endif
 	wsr		a0, PS
-	rsync
+
+  /* Create pseudo base save area. At this point, sp is still pointing to the
+   * allocated and filled exception stack frame.
+   */
+
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+  l32i    a3, sp, (4 * REG_A0)     /* Copy pre-exception a0 (return address) */
+  s32e    a3, sp, -16
+  l32i    a3, sp, (4 * REG_A1)     /* Copy pre-exception a1 (stack pointer) */
+  s32e    a3, sp, -12
+  rsr     a0, EPC_1                /* return address for debug backtrace */
+  movi    a4, 0xc0000000           /* constant with top 2 bits set (call size) */
+  rsync                            /* wait for WSR.PS to complete */
+  or      a0, a0, a4               /* set top 2 bits */
+  addx2   a0, a4, a0               /* clear top bit -- thus simulating call4 size */
+#else
+  rsync                            /* wait for WSR.PS to complete */
+#endif
 
 	/* Call xtensa_user, passing both the EXCCAUSE and a pointer to the
 	 * beginning of the register save area.
@@ -284,7 +301,7 @@ _xtensa_syscall_handler:
 
 	/* Allocate stack frame and save A0, A1, and PS */
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, PS							/* Save interruptee's PS */
@@ -451,7 +468,7 @@ _xtensa_coproc_handler:
 
 	/* For now, just panic */
 
-	mov		a0, sp							/* sp == a1 */
+	mov		a0, sp							/* Save SP in A0 */
 	addi	sp, sp, -(4 * XCPTCONTEXT_SIZE)	/* Allocate interrupt stack frame */
 	s32i	a0, sp, (4 * REG_A1)			/* Save pre-interrupt SP */
 	rsr		a0, PS							/* Save interruptee's PS */


### PR DESCRIPTION
## Summary
The main addition of this PR is the ability to have a full backtrace from interrupt handlers.
## Impact
N/A the option is disabled by default.
## Testing
Tested on ESP32 boards.
