### PR TITLE
boards/arm/stm32/stm32f103-minimum: cleanup

### DIFF
--- a/boards/arm/stm32/stm32f103-minimum/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f103-minimum/src/stm32_bringup.c
@@ -288,7 +288,7 @@ int stm32_bringup(void)
   ret = stm32_at24_automount(AT24_MINOR);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: stm32_at24_automount failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: stm32_at24_automount() failed: %d\n", ret);
       return ret;
     }
 #endif /* HAVE_AT24 */
@@ -309,7 +309,7 @@ int stm32_bringup(void)
   ret = board_tone_initialize(0);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: stm32_tone_setup() failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: board_tone_initialize() failed: %d\n", ret);
     }
 #endif
 
@@ -319,7 +319,7 @@ int stm32_bringup(void)
   ret = board_apa102_initialize(0, 1);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: stm32_apa102init() failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: board_apa102_initialize() failed: %d\n", ret);
     }
 #endif
 
@@ -329,7 +329,7 @@ int stm32_bringup(void)
   ret = board_lm75_initialize(0, 1);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: stm32_lm75initialize() failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: board_lm75_initialize() failed: %d\n", ret);
     }
 #endif
 
@@ -349,7 +349,7 @@ int stm32_bringup(void)
   ret = board_hcsr04_initialize(0);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: stm32_hcsr04_initialize() failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: board_hcsr04_initialize() failed: %d\n", ret);
     }
 #endif
 
@@ -357,7 +357,7 @@ int stm32_bringup(void)
   ret = board_max6675_initialize(0, 1);
   if (ret < 0)
     {
-      serr("ERROR:  stm32_max6675initialize failed: %d\n", ret);
+      serr("ERROR:  board_max6675_initialize() failed: %d\n", ret);
     }
 #endif
 
@@ -403,7 +403,8 @@ int stm32_bringup(void)
   ret = board_nunchuck_initialize(0, 1);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: nunchuck_initialize() failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: board_nunchuck_initialize() failed: %d\n",
+             ret);
     }
 #endif
 
@@ -436,7 +437,8 @@ int stm32_bringup(void)
   ret = board_apds9960_initialize(0, 1);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: stm32_apds9960initialize() failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: board_apds9960_initialize() failed: %d\n",
+             ret);
     }
 #endif
 
@@ -446,7 +448,8 @@ int stm32_bringup(void)
   ret = board_veml6070_initialize(0, 1);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: stm32_veml6070initialize() failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: board_veml6070_initialize() failed: %d\n",
+             ret);
     }
 #endif
 
@@ -456,7 +459,7 @@ int stm32_bringup(void)
   ret = stm32_adc_setup();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: stm32_adc_setup failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: stm32_adc_setup() failed: %d\n", ret);
     }
 #endif
 
@@ -466,7 +469,8 @@ int stm32_bringup(void)
   ret = board_nrf24l01_initialize(1);
   if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: board_nrf24l01_initialize failed: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: board_nrf24l01_initialize() failed: %d\n",
+             ret);
     }
 #endif
 

--- a/boards/arm/stm32/stm32f103-minimum/src/stm32f103_minimum.h
+++ b/boards/arm/stm32/stm32f103-minimum/src/stm32f103_minimum.h
@@ -165,7 +165,7 @@
 #define STM32_LCD_CD      (GPIO_OUTPUT|GPIO_CNF_OUTPP|GPIO_MODE_50MHz|\
                            GPIO_OUTPUT_SET|GPIO_PORTA|GPIO_PIN2)
 
-/* PWN Configuration */
+/* PWM Configuration */
 
 #define STM32F103MINIMUM_PWMTIMER   3
 #define STM32F103MINIMUM_PWMCHANNEL 3
@@ -271,18 +271,6 @@ int stm32_mmcsd_initialize(int minor);
 #endif
 
 /****************************************************************************
- * Name: stm32_max6675initialize
- *
- * Description:
- *   Called to initialize MAX6675 temperature sensor
- *
- ****************************************************************************/
-
-#ifdef CONFIG_SENSORS_MAX6675
-int stm32_max6675initialize(FAR const char *devpath);
-#endif
-
-/****************************************************************************
  * Name: stm32_w25initialize
  *
  * Description:
@@ -310,18 +298,6 @@ int stm32_w25initialize(int minor);
 
 #ifdef CONFIG_RGBLED
 int stm32_rgbled_setup(void);
-#endif
-
-/****************************************************************************
- * Name: stm32_apa102init
- *
- * Description:
- *   Initialize and register the APA102 LED Strip driver
- *
- ****************************************************************************/
-
-#ifdef CONFIG_LEDS_APA102
-int stm32_apa102init(FAR const char *devpath);
 #endif
 
 /****************************************************************************
@@ -371,24 +347,6 @@ int stm32_pwm_setup(void);
 #endif
 
 /****************************************************************************
- * Name: stm32_wlinitialize
- *
- * Description:
- *   Initialize the NRF24L01 wireless module
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-#ifdef CONFIG_WL_NRF24L01
-void stm32_wlinitialize(void);
-#endif
-
-/****************************************************************************
  * Name: stm32_mfrc522initialize
  *
  * Description:
@@ -398,32 +356,6 @@ void stm32_wlinitialize(void);
 
 #ifdef CONFIG_CL_MFRC522
 int stm32_mfrc522initialize(FAR const char *devpath);
-#endif
-
-/****************************************************************************
- * Name: stm32_tone_setup
- *
- * Description:
- *   Function used to initialize a PWM and Oneshot timers to Audio Tone
- *   Generator.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_AUDIO_TONE
-int stm32_tone_setup(void);
-#endif
-
-/****************************************************************************
- * Name: stm32_veml6070initialize
- *
- * Description:
- *   Called to configure an I2C and to register VEML6070 for the
- *   stm32f103-minimum board.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_SENSORS_VEML6070
-int stm32_veml6070initialize(FAR const char *devpath);
 #endif
 
 #endif /* __ASSEMBLY__ */


### PR DESCRIPTION
## Summary
- Remove prototypes no longer needed after some code was moved to common folder
- Fix function names in syslog messages
- Minor typos

## Impact
Nothing should change

## Testing
stm32f103-minimum:nsh built and run. That doesn't test any of those peripherals. but at least it's still building.
