### PR TITLE
boards/arm/stm32: add common and stm32f103-minimum support for WS2812

### DIFF
--- a/boards/arm/stm32/common/include/stm32_ws2812.h
+++ b/boards/arm/stm32/common/include/stm32_ws2812.h
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * boards/arm/stm32/common/include/stm32_ws2812.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __STM32_WS2812_H
+#define __STM32_WS2812_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_ws2812_initialize
+ *
+ * Description:
+ *   Initialize and register the WS2812 LED driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/leddrvN
+ *   spino - SPI port number
+ *   nleds - number of LEDs
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_ws2812_initialize(int devno, int spino, uint16_t nleds);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __STM32_WS2812_H

--- a/boards/arm/stm32/common/src/Make.defs
+++ b/boards/arm/stm32/common/src/Make.defs
@@ -26,6 +26,10 @@ ifeq ($(CONFIG_LEDS_APA102),y)
   CSRCS += stm32_apa102.c
 endif
 
+ifeq ($(CONFIG_WS2812),y)
+  CSRCS += stm32_ws2812.c
+endif
+
 ifeq ($(CONFIG_SENSORS_MAX6675),y)
   CSRCS += stm32_max6675.c
 endif

--- a/boards/arm/stm32/common/src/stm32_ws2812.c
+++ b/boards/arm/stm32/common/src/stm32_ws2812.c
@@ -1,0 +1,109 @@
+/****************************************************************************
+ * boards/arm/stm32/common/src/stm32_ws2812.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <debug.h>
+#include <stdio.h>
+
+#include <nuttx/spi/spi.h>
+#include <nuttx/leds/ws2812.h>
+
+#include "stm32.h"
+#include "stm32_spi.h"
+
+#ifdef CONFIG_WS2812
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_ws2812_initialize
+ *
+ * Description:
+ *   Initialize and register the WS2812 LED driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/leddrvN
+ *   spino - SPI port number
+ *   nleds - number of LEDs
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_ws2812_initialize(int devno, int spino, uint16_t nleds)
+{
+  FAR struct spi_dev_s *spi;
+  char devpath[13];
+  int ret;
+
+  spi = stm32_spibus_initialize(spino);
+  if (spi == NULL)
+    {
+      return -ENODEV;
+    }
+
+  /* Register the WS2812 driver at the specified location. */
+
+  snprintf(devpath, 13, "/dev/leddrv%d", devno);
+  ret = ws2812_leds_register(devpath, spi, nleds);
+  if (ret < 0)
+    {
+      lederr("ERROR: ws2812_leds_register(%s) failed: %d\n",
+             devpath, ret);
+      return ret;
+    }
+
+  return OK;
+}
+
+#endif

--- a/boards/arm/stm32/stm32f103-minimum/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f103-minimum/src/stm32_bringup.c
@@ -93,6 +93,10 @@
 #include "stm32_apa102.h"
 #endif
 
+#ifdef CONFIG_WS2812
+#include "stm32_ws2812.h"
+#endif
+
 #ifdef CONFIG_SENSORS_MAX6675
 #include "stm32_max6675.h"
 #endif
@@ -320,6 +324,16 @@ int stm32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: board_apa102_initialize() failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_WS2812
+  /* Configure and initialize the WS2812 LEDs. */
+
+  ret = board_ws2812_initialize(0, WS2812_SPI, WS2812_NLEDS);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: board_ws2812_initialize() failed: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/stm32/stm32f103-minimum/src/stm32f103_minimum.h
+++ b/boards/arm/stm32/stm32f103-minimum/src/stm32f103_minimum.h
@@ -197,6 +197,11 @@
 
 #define GPIO_INT1         (GPIO_INPUT|GPIO_CNF_INFLOAT|GPIO_PORTA|GPIO_PIN2)
 
+/* WS2812 LEDs */
+
+#define WS2812_NLEDS 2
+#define WS2812_SPI 1
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary
Add "common" STM32 board support for WS2812 LEDs and allow its use it in stm32f103-minimum.

I wasn't sure whether some of the "defines" for stm32f103_minimum should go in board.h or stm32f103_minimum.h (at this time I don't understand what goes where between those 2). Can that be double-checked?

## Impact
Only stm32f103_minimum if enabling WS2812. 

## Testing
Tested on a stm32f103_minimum with real LEDs and it's working.

Thanks!
