### PR TITLE
wireless/bluetooth: fix the invalid life cycle of hci buffer 

### DIFF
--- a/arch/sim/src/sim/up_hcisocket.c
+++ b/arch/sim/src/sim/up_hcisocket.c
@@ -120,7 +120,9 @@ static int bthcisock_send(FAR const struct bt_driver_s *dev,
       return -1;
     }
 
+#ifndef CONFIG_WIRELESS_BLUETOOTH_HOST
   bt_buf_release(buf);
+#endif
 
   return buf->len;
 }

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1166,6 +1166,8 @@ static void priority_rx_work(FAR void *arg)
             wlerr("Unknown event 0x%02x\n", hdr->evt);
             break;
         }
+
+      bt_buf_release(buf);
 #else
       UNUSED(hdr);
 


### PR DESCRIPTION
## Summary

fix the invalid life cycle of hci buffer if WIRELESS_BLUETOOTH_HOST is enabled

Regression by:

https://github.com/apache/incubator-nuttx/pull/2070

5386f972fa8020b69798ab70325b7f4df0f20cf3

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

sim/bthcisock

## Testing

sim/bthcisock