### PR TITLE
xtensa/esp32: allows the rtc wdt to be configured in bootloader and used later

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wtd.h
+++ b/arch/xtensa/src/esp32/esp32_wtd.h
@@ -41,7 +41,6 @@
 #define ESP32_WTD_STOP(d)                       ((d)->ops->stop(d))
 #define ESP32_WTD_LOCK(d)                       ((d)->ops->enablewp(d))
 #define ESP32_WTD_UNLOCK(d)                     ((d)->ops->disablewp(d))
-#define ESP32_WTD_INITCONF(d)                   ((d)->ops->initconf(d))
 #define ESP32_WTD_PRE(d, v)                     ((d)->ops->pre(d, v))
 #define ESP32_WTD_STO(d, v, s)                  ((d)->ops->settimeout(d, v, s))
 #define ESP32_WTD_FEED(d)                       ((d)->ops->feed(d))

--- a/arch/xtensa/src/esp32/esp32_wtd.h
+++ b/arch/xtensa/src/esp32/esp32_wtd.h
@@ -77,7 +77,6 @@ struct esp32_wtd_ops_s
 
   CODE int (*enablewp)(FAR struct esp32_wtd_dev_s *dev);
   CODE int (*disablewp)(FAR struct esp32_wtd_dev_s *dev);
-  CODE int (*initconf)(FAR struct esp32_wtd_dev_s *dev);
   CODE int (*pre)(FAR struct esp32_wtd_dev_s *dev, uint16_t value);
   CODE int (*settimeout)(FAR struct esp32_wtd_dev_s *dev,
                          uint32_t value, uint8_t stage);

--- a/arch/xtensa/src/esp32/esp32_wtd_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_wtd_lowerhalf.c
@@ -679,10 +679,6 @@ int esp32_wtd_initialize(FAR const char *devpath, uint8_t wdt)
 
   ESP32_WTD_UNLOCK(lower->wtd);
 
-  /* Ensure stages are disabled and Flash boot protection was disabled */
-
-  ESP32_WTD_INITCONF(lower->wtd);
-
   /* If it is a Main System Watchdog Timer configure the Prescale to
    * have a 500us period.
    */


### PR DESCRIPTION
## Summary

This PR is intended to remove an unnecessary initial configuration that was preventing the rtc wdt to be configured in the bootloader. 

## Impact

Now, it will be possible to configure the RTC in the bootloader as well as use it as a character driver after.
Important: For the correct behavior, it's recommended to call the ioctl `start` before calling the other wdt's ioctl, even if the RTC has already been initialized by the bootloader.
The explanation is that the start function enables a flag variable that indicates the RTC WDT was turned on. This flag may alter the logic of other functions.

## Testing
To test it, first, the RTC watchdog was enabled in the bootloader, then it was run the watchdog example with all 3 available WDTs (2 from Timers Module and 1 from the RTC).
It was observed a normal behavior. The bootloader configuration was kept and it was possible to reconfigure the watchdog after initialization, as expected.  
