### PR TITLE
sched: Implement getpid and gettid correctly

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -27,6 +27,7 @@
 SYSCALL_LOOKUP1(_exit,                     1)
 SYSCALL_LOOKUP(exit,                       1)
 SYSCALL_LOOKUP(getpid,                     0)
+SYSCALL_LOOKUP(gettid,                     0)
 
 #ifdef CONFIG_SCHED_HAVE_PARENT
   SYSCALL_LOOKUP(getppid,                  0)

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -29,7 +29,6 @@ CSRCS += lib_getrusage.c lib_utimes.c
 CSRCS += lib_setrlimit.c lib_getrlimit.c
 CSRCS += lib_setpriority.c lib_getpriority.c
 CSRCS += lib_futimes.c lib_futimens.c
-CSRCS += lib_gettid.c
 
 ifneq ($(CONFIG_SCHED_USER_IDENTITY),y)
 CSRCS += lib_setuid.c lib_setgid.c lib_getuid.c lib_getgid.c

--- a/sched/task/Make.defs
+++ b/sched/task/Make.defs
@@ -22,7 +22,7 @@ CSRCS += task_create.c task_init.c task_setup.c task_activate.c
 CSRCS += task_start.c task_delete.c task_exit.c task_exithook.c
 CSRCS += task_getgroup.c task_getpid.c task_prctl.c task_recover.c
 CSRCS += task_restart.c task_spawnparms.c task_setcancelstate.c
-CSRCS += task_cancelpt.c task_terminate.c exit.c
+CSRCS += task_cancelpt.c task_terminate.c task_gettid.c exit.c
 
 ifeq ($(CONFIG_SCHED_HAVE_PARENT),y)
 CSRCS += task_getppid.c

--- a/sched/task/task_gettid.c
+++ b/sched/task/task_gettid.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/unistd/lib_gettid.c
+ * sched/task/task_gettid.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,6 +24,11 @@
 
 #include <sys/types.h>
 #include <unistd.h>
+#include <sched.h>
+#include <errno.h>
+
+#include "sched/sched.h"
+#include "task/task.h"
 
 /****************************************************************************
  * Public Functions
@@ -45,5 +50,42 @@
 
 pid_t gettid(void)
 {
-  return getpid();
+  FAR struct tcb_s *rtcb;
+
+  /* Get the TCB at the head of the ready-to-run task list.  That
+   * will usually be the currently executing task.  There are two
+   * exceptions to this:
+   *
+   * 1. Early in the start-up sequence, the ready-to-run list may be
+   *    empty!  In this case, of course, the CPU0 start-up/IDLE thread with
+   *    pid == 0 must be running, and
+   * 2. As described above, during certain context-switching conditions the
+   *    task at the head of the ready-to-run list may not actually be
+   *    running.
+   */
+
+  rtcb = this_task();
+  if (rtcb != NULL)
+    {
+      /* Check if the task is actually running */
+
+      if (rtcb->task_state == TSTATE_TASK_RUNNING)
+        {
+          /* Yes.. Return the task ID from the TCB at the head of the
+           * ready-to-run task list
+           */
+
+          return rtcb->pid;
+        }
+
+      /* No.. return -ESRCH to indicate this condition */
+
+      return (pid_t)-ESRCH;
+    }
+
+  /* We must have been called earlier in the start up sequence from the
+   * start-up/IDLE thread before the ready-to-run list has been initialized.
+   */
+
+  return 0;
 }

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -39,6 +39,7 @@
 "getppid","unistd.h","defined(CONFIG_SCHED_HAVE_PARENT)","pid_t"
 "getsockname","sys/socket.h","defined(CONFIG_NET)","int","int","FAR struct sockaddr *","FAR socklen_t *"
 "getsockopt","sys/socket.h","defined(CONFIG_NET)","int","int","int","int","FAR void *","FAR socklen_t *"
+"gettid","unistd.h","","pid_t"
 "getuid","unistd.h","defined(CONFIG_SCHED_USER_IDENTITY)","uid_t"
 "if_indextoname","net/if.h","defined(CONFIG_NETDEV_IFINDEX)","FAR char *","unsigned int","FAR char *"
 "if_nametoindex","net/if.h","defined(CONFIG_NETDEV_IFINDEX)","unsigned int","FAR const char *"


### PR DESCRIPTION
## Summary
prepare to implement the right semantics:
getpid should return the main thread id
gettid should return the current thread id
See the discussion here: https://github.com/apache/incubator-nuttx/issues/2499

## Impact
No, the behaviour same as before

## Testing

