### PR TITLE
fix build break with CONFIG_AUDIO_MULTI_SESSION enabled

### DIFF
--- a/audio/audio.c
+++ b/audio/audio.c
@@ -808,7 +808,7 @@ static inline void audio_message(FAR struct audio_upperhalf_s *upper,
   if (upper->usermq != NULL)
     {
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-      msg.session = session;
+      msg->session = session;
 #endif
       nxmq_send(upper->usermq, (FAR const char *)msg, sizeof(*msg),
                 CONFIG_AUDIO_BUFFER_DEQUEUE_PRIO);


### PR DESCRIPTION
N/A

Change-Id: Idfa87031e09f26bd4ca57b5c220ce0ca849f80c4
Signed-off-by: danguanghua <danguanghua@xiaomi.com>

## Summary

## Impact

## Testing

