### PR TITLE
xtensa/esp32: Add ESP32 EFUSE char driver

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -58,6 +58,12 @@ config ESP32_BT
 	---help---
 		No yet implemented
 
+config ESP32_EFUSE
+	bool "EFUSE support"
+	default n
+	---help---
+		Enable ESP32 efuse support.
+
 config ESP32_EMAC
 	bool "Ethernet MAC"
 	default n

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -128,6 +128,12 @@ CHIP_CSRCS += esp32_psram.c
 CHIP_CSRCS += esp32_himem.c
 endif
 
+ifeq ($(CONFIG_ESP32_EFUSE),y)
+CHIP_CSRCS += esp32_efuse_table.c
+CHIP_CSRCS += esp32_efuse_utils.c
+CHIP_CSRCS += esp32_efuse.c
+endif
+
 ifeq ($(CONFIG_ESP32_EMAC),y)
 CHIP_CSRCS += esp32_emac.c
 endif

--- a/arch/xtensa/src/esp32/esp32_efuse.c
+++ b/arch/xtensa/src/esp32/esp32_efuse.c
@@ -1,0 +1,376 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_efuse.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+#include <debug.h>
+#include <assert.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/efuse/esp_efuse.h>
+
+#include "hardware/esp32_soc.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Character driver methods */
+
+static int     efuse_open(FAR struct file *filep);
+static int     efuse_close(FAR struct file *filep);
+static ssize_t efuse_read(FAR struct file *filep, FAR char *buffer,
+                          size_t buflen);
+static ssize_t efuse_write(FAR struct file *filep, FAR const char *buffer,
+                           size_t buflen);
+static int     efuse_ioctl(FAR struct file *filep, int cmd,
+                           unsigned long arg);
+
+/* This structure is used for access control and batch writing mode */
+
+struct efuse_access_s
+{
+  sem_t   exclsem;            /* Supports mutual exclusion */
+  bool    batch_writing_mode; /* Controls batch writing */
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations g_efusefops =
+{
+  efuse_open,
+  efuse_close,
+  efuse_read,
+  efuse_write,
+  NULL,
+  efuse_ioctl,
+  NULL
+};
+
+/****************************************************************************
+ * Private functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int esp_efuse_init(void)
+{
+  FAR struct efuse_access_s *priv;
+  int ret;
+
+  /* Allocate a new efuse access instance */
+
+  priv = (FAR struct efuse_access_s *)
+    kmm_zalloc(sizeof(struct efuse_access_s));
+
+  if (!priv)
+    {
+      merr("ERROR: Failed to allocate device structure\n");
+      return -ENOMEM;
+    }
+
+  /* Initialize the semaphore that enforces mutually exclusive access */
+
+  nxsem_init(&priv->exclsem, 0, 1);
+
+  /* Initially batch mode is deactivated */
+
+  priv->batch_writing_mode = false;
+
+  /* Register the character driver */
+
+  ret = register_driver("/dev/efuse", &g_efusefops, 0666, priv);
+  if (ret < 0)
+    {
+      merr("ERROR: Failed to register driver: %d\n", ret);
+      kmm_free(priv);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: efuse_open
+ *
+ * Description:
+ *   This function is called whenever the LM-75 device is opened.
+ *
+ ****************************************************************************/
+
+static int efuse_open(FAR struct file *filep)
+{
+  return OK;
+}
+
+/****************************************************************************
+ * Name: efuse_close
+ *
+ * Description:
+ *   This routine is called when the LM-75 device is closed.
+ *
+ ****************************************************************************/
+
+static int efuse_close(FAR struct file *filep)
+{
+  return OK;
+}
+
+/****************************************************************************
+ * Name: efuse_read
+ ****************************************************************************/
+
+static ssize_t efuse_read(FAR struct file *filep, FAR char *buffer,
+                          size_t buflen)
+{
+  return -ENOSYS;
+}
+
+/****************************************************************************
+ * Name: efuse_write
+ ****************************************************************************/
+
+static ssize_t efuse_write(FAR struct file *filep, FAR const char *buffer,
+                          size_t buflen)
+{
+  return -ENOSYS;
+}
+
+/****************************************************************************
+ * Name: efuse_ioctl
+ ****************************************************************************/
+
+static int efuse_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct efuse_access_s *priv = inode->i_private;
+  int ret   = OK;
+
+  switch (cmd)
+    {
+      /* Read a blob */
+
+      case EFUSEIOC_READ_FIELD_BLOB:
+        {
+          FAR struct esp_efuse_par_id *param =
+                     (FAR struct esp_efuse_par_id *)((uintptr_t)arg);
+
+          DEBUGASSERT(param != NULL);
+
+          if (param->field == NULL || param->size == 0)
+            {
+              merr("Error: This field is null or its size is 0\n");
+              return -EINVAL;
+            }
+
+          esp_efuse_read_field_blob(param->field, param->data, param->size);
+        }
+        break;
+
+      /* Read a bit */
+
+      case EFUSEIOC_READ_FIELD_BIT:
+        {
+          FAR struct esp_efuse_par_id *param =
+                     (FAR struct esp_efuse_par_id *)((uintptr_t)arg);
+
+          DEBUGASSERT(param != NULL);
+
+          /* Read the field bit */
+
+          esp_efuse_read_field_blob(param->field, param->data, 1);
+        }
+        break;
+
+      /* Write a blob */
+
+      case EFUSEIOC_WRITE_FIELD_BLOB:
+        {
+          FAR struct esp_efuse_par_id *param =
+                     (FAR struct esp_efuse_par_id *)((uintptr_t)arg);
+
+          DEBUGASSERT(param != NULL);
+
+          if (param->field == NULL || param->size == 0)
+            {
+              merr("Error: This field is null or its size is 0\n");
+              return -EINVAL;
+            }
+
+          /* Get exclusive access */
+
+          nxsem_wait_uninterruptible(&priv->exclsem);
+
+          /* Write the blob data to the field */
+
+          esp_efuse_write_field_blob(param->field, param->data, param->size);
+
+          /* Burn the EFUSEs */
+
+          esp_efuse_burn_efuses();
+
+          nxsem_post(&priv->exclsem);
+        }
+        break;
+
+      /* Write a bit */
+
+      case EFUSEIOC_WRITE_FIELD_BIT:
+        {
+          FAR struct esp_efuse_par_id *param =
+                     (FAR struct esp_efuse_par_id *)((uintptr_t)arg);
+          uint8_t existing = 0;
+          const uint8_t one = 1;
+
+          DEBUGASSERT(param != NULL);
+
+          if (param->field == NULL || param->field[0]->bit_count != 1)
+            {
+              merr("Error: This field is not 1 bit long\n");
+              return -EINVAL;
+            }
+
+          /* Read existing bit, if it is already 1 */
+
+          esp_efuse_read_field_blob(param->field, &existing, 1);
+
+          if (existing)
+            {
+              merr("Error: The fuse is already burned\n");
+              return -EINVAL;
+            }
+
+          /* Get exclusive access */
+
+          nxsem_wait_uninterruptible(&priv->exclsem);
+
+          /* Write the register field */
+
+          esp_efuse_write_field_blob(param->field, &one, 1);
+
+          /* Burn the EFUSEs */
+
+          esp_efuse_burn_efuses();
+
+          nxsem_post(&priv->exclsem);
+        }
+        break;
+
+      /* Read a register from efuse */
+
+      case EFUSEIOC_READ_REG:
+        {
+          FAR struct esp_efuse_par *param =
+                     (FAR struct esp_efuse_par *)((uintptr_t)arg);
+
+          DEBUGASSERT(param != NULL);
+
+          *param->data = esp_efuse_read_reg(param->block,
+                                           param->reg);
+        }
+        break;
+
+      /* Write a register to efuse */
+
+      case EFUSEIOC_WRITE_REG:
+        {
+          FAR struct esp_efuse_par *param =
+                     (FAR struct esp_efuse_par *)((uintptr_t)arg);
+
+          DEBUGASSERT(param != NULL);
+
+          /* Get exclusive access */
+
+          nxsem_wait_uninterruptible(&priv->exclsem);
+
+          /* Write the efuse register */
+
+          esp_efuse_write_reg(param->block, param->reg, *param->data);
+
+          /* Burn the EFUSEs */
+
+          esp_efuse_burn_efuses();
+
+          nxsem_post(&priv->exclsem);
+        }
+        break;
+
+      /* Read a block */
+
+      case EFUSEIOC_READ_BLOCK:
+        {
+          FAR struct esp_efuse_par *param =
+                     (FAR struct esp_efuse_par *)((uintptr_t)arg);
+
+          DEBUGASSERT(param != NULL);
+
+          nxsem_wait_uninterruptible(&priv->exclsem);
+
+          /* Write the key data at the block */
+
+          esp_efuse_read_block(param->block, (void *) param->data,
+                                param->bit_offset, param->bit_size);
+
+          nxsem_post(&priv->exclsem);
+        }
+        break;
+
+      /* Write a block */
+
+      case EFUSEIOC_WRITE_BLOCK:
+        {
+          FAR struct esp_efuse_par *param =
+                     (FAR struct esp_efuse_par *)((uintptr_t)arg);
+
+          DEBUGASSERT(param != NULL);
+
+          /* Get exclusive access */
+
+          nxsem_wait_uninterruptible(&priv->exclsem);
+
+          /* Write the key data at the block */
+
+          esp_efuse_write_block(param->block, param->data,
+                                param->bit_offset, param->bit_size);
+
+          /* Burn the EFUSEs */
+
+          esp_efuse_burn_efuses();
+
+          nxsem_post(&priv->exclsem);
+        }
+        break;
+
+      default:
+        {
+          minfo("Unrecognized cmd: %d\n", cmd);
+          ret = -ENOTTY;
+        }
+        break;
+    }
+
+  return ret;
+}
+

--- a/arch/xtensa/src/esp32/esp32_efuse.h
+++ b/arch/xtensa/src/esp32/esp32_efuse.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_efuse.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Type of eFuse blocks for ESP32 */
+
+typedef enum
+{
+  EFUSE_BLK0 = 0,     /* Reserved. */
+  EFUSE_BLK1 = 1,     /* Used for Flash Encryption. */
+  EFUSE_BLK2 = 2,     /* Used for Secure Boot. */
+  EFUSE_BLK3 = 3,     /* Uses for the purpose of the user. */
+  EFUSE_BLK_MAX
+} esp_efuse_block_t;
+
+/* This is type of function that will handle the efuse field register.
+ *
+ *  num_reg          The register number in the block.
+ *  efuse_block      Block number.
+ *  bit_start        Start bit in the register.
+ *  bit_count        The number of bits used in the register.
+ *  arr              A pointer to an array or variable.
+ *  bits_counter     Counter bits.
+ *
+ * return
+ *  - OK: The operation was successfully completed.
+ *  - other efuse component errors.
+ */
+
+typedef int (*efuse_func_proc_t) (unsigned int num_reg,
+                                  esp_efuse_block_t efuse_block,
+                                  int starting_bit_num_in_reg,
+                                  int num_bits_used_in_reg,
+                                  void *arr, int *bits_counter);
+

--- a/arch/xtensa/src/esp32/esp32_efuse_table.c
+++ b/arch/xtensa/src/esp32/esp32_efuse_table.c
@@ -1,0 +1,644 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_efuse_table.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <stddef.h>
+#include <nuttx/efuse/esp_efuse.h>
+#include "esp32_efuse.h"
+
+#define MAX_BLK_LEN 256
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* The last free bit in the block is counted over the entire file */
+
+#define LAST_FREE_BIT_BLK1 MAX_BLK_LEN
+#define LAST_FREE_BIT_BLK2 MAX_BLK_LEN
+#define LAST_FREE_BIT_BLK3 192
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+static const esp_efuse_desc_t MAC_FACTORY[] =
+{
+  {
+    EFUSE_BLK0, 72, 8    /* Factory MAC addr [0], */
+  },
+  {
+    EFUSE_BLK0, 64, 8    /* Factory MAC addr [1], */
+  },
+  {
+    EFUSE_BLK0, 56, 8    /* Factory MAC addr [2], */
+  },
+  {
+    EFUSE_BLK0, 48, 8    /* Factory MAC addr [3], */
+  },
+  {
+    EFUSE_BLK0, 40, 8    /* Factory MAC addr [4], */
+  },
+  {
+    EFUSE_BLK0, 32, 8    /* Factory MAC addr [5], */
+  },
+};
+
+static const esp_efuse_desc_t MAC_FACTORY_CRC[] =
+{
+  {
+    EFUSE_BLK0, 80, 8    /* CRC8 for factory MAC address */
+  },
+};
+
+static const esp_efuse_desc_t MAC_CUSTOM_CRC[] =
+{
+  {
+    EFUSE_BLK3, 0, 8     /* CRC8 for custom MAC address */
+  },
+};
+
+static const esp_efuse_desc_t MAC_CUSTOM[] =
+{
+  {
+    EFUSE_BLK3, 8, 48    /* Custom MAC */
+  },
+};
+
+static const esp_efuse_desc_t MAC_CUSTOM_VER[] =
+{
+  {
+    EFUSE_BLK3, 184, 8   /* Custom MAC version */
+  },
+};
+
+static const esp_efuse_desc_t SECURE_BOOT_KEY[] =
+{
+  {
+    EFUSE_BLK2, 0, MAX_BLK_LEN  /* Security boot. Key.
+                                 * (length = "None" - 256.
+                                 * "3/4" - 192. "REPEAT" - 128)
+                                 */
+  },
+};
+
+static const esp_efuse_desc_t ABS_DONE_0[] =
+{
+  {
+    EFUSE_BLK0, 196, 1   /* Secure boot is enabled for bootloader image.
+                          * EFUSE_RD_ABS_DONE_0
+                          */
+  },
+};
+
+static const esp_efuse_desc_t ENCRYPT_FLASH_KEY[] =
+{
+  {
+    EFUSE_BLK1, 0, MAX_BLK_LEN   /* Flash encrypt. Key.
+                                  * (length = "None" - 256.
+                                  * "3/4" - 192. "REPEAT" - 128)
+                                  */
+  },
+};
+
+static const esp_efuse_desc_t ENCRYPT_CONFIG[] =
+{
+  {
+    EFUSE_BLK0, 188, 4   /* Flash encrypt. EFUSE_FLASH_CRYPT_CONFIG_M */
+  },
+};
+
+static const esp_efuse_desc_t DISABLE_DL_ENCRYPT[] =
+{
+  {
+    EFUSE_BLK0, 199, 1   /* Flash encrypt. Disable UART bootloader
+                          * encryption. EFUSE_DISABLE_DL_ENCRYPT
+                          */
+  },
+};
+
+static const esp_efuse_desc_t DISABLE_DL_DECRYPT[] =
+{
+  {
+    EFUSE_BLK0, 200, 1   /* Flash encrypt. Disable UART bootloader
+                          * decryption. EFUSE_DISABLE_DL_DECRYPT
+                          */
+  },
+};
+
+static const esp_efuse_desc_t DISABLE_DL_CACHE[] =
+{
+  {
+    EFUSE_BLK0, 201, 1   /* Flash encrypt. Disable UART bootloader MMU
+                          * cache. EFUSE_DISABLE_DL_CACHE
+                          */
+  },
+};
+
+static const esp_efuse_desc_t FLASH_CRYPT_CNT[] =
+{
+  {
+    EFUSE_BLK0, 20, 7    /* Flash encrypt. Flash encryption is enabled
+                          * if this field has an odd number of bits set.
+                          * EFUSE_FLASH_CRYPT_CNT
+                          */
+  },
+};
+
+static const esp_efuse_desc_t DISABLE_JTAG[] =
+{
+  {
+    EFUSE_BLK0, 198, 1   /* Disable JTAG. EFUSE_RD_DISABLE_JTAG */
+  },
+};
+
+static const esp_efuse_desc_t CONSOLE_DEBUG_DISABLE[] =
+{
+  {
+    EFUSE_BLK0, 194, 1   /* Disable ROM BASIC interpreter fallback.
+                          * EFUSE_RD_CONSOLE_DEBUG_DISABLE
+                          */
+  },
+};
+
+static const esp_efuse_desc_t UART_DOWNLOAD_DIS[] =
+{
+  {
+    EFUSE_BLK0, 27, 1    /* Disable UART download mode.
+                          * Valid for ESP32 V3 and newer
+                          */
+  },
+};
+
+static const esp_efuse_desc_t WR_DIS_FLASH_CRYPT_CNT[] =
+{
+  {
+    EFUSE_BLK0, 2, 1     /* Flash encrypt. Write protection
+                          * FLASH_CRYPT_CNT
+                          */
+  },
+};
+
+static const esp_efuse_desc_t WR_DIS_BLK1[] =
+{
+  {
+    EFUSE_BLK0, 7, 1     /* Flash encrypt. Write protection encryption key.
+                          * EFUSE_WR_DIS_BLK1
+                          */
+  },
+};
+
+static const esp_efuse_desc_t WR_DIS_BLK2[] =
+{
+  {
+    EFUSE_BLK0, 8, 1     /* Security boot. Write protection security key.
+                          * EFUSE_WR_DIS_BLK2
+                          */
+  },
+};
+
+static const esp_efuse_desc_t WR_DIS_BLK3[] =
+{
+  {
+    EFUSE_BLK0, 9, 1     /* Write protection for EFUSE_BLK3.
+                          * EFUSE_WR_DIS_BLK3
+                          */
+  },
+};
+
+static const esp_efuse_desc_t RD_DIS_BLK1[] =
+{
+  {
+    EFUSE_BLK0, 16, 1    /* Flash encrypt. efuse_key_read_protected.
+                          * EFUSE_RD_DIS_BLK1
+                          */
+  },
+};
+
+static const esp_efuse_desc_t RD_DIS_BLK2[] =
+{
+  {
+    EFUSE_BLK0, 17, 1    /* Security boot. efuse_key_read_protected.
+                          * EFUSE_RD_DIS_BLK2
+                          */
+  },
+};
+
+static const esp_efuse_desc_t RD_DIS_BLK3[] =
+{
+  {
+    EFUSE_BLK0, 18, 1    /* Read protection for EFUSE_BLK3.
+                          * EFUSE_RD_DIS_BLK3
+                          */
+  },
+};
+
+static const esp_efuse_desc_t CHIP_VER_DIS_APP_CPU[] =
+{
+  {
+    EFUSE_BLK0, 96, 1    /* EFUSE_RD_CHIP_VER_DIS_APP_CPU */
+  },
+};
+
+static const esp_efuse_desc_t CHIP_VER_DIS_BT[] =
+{
+  {
+    EFUSE_BLK0, 97, 1    /* EFUSE_RD_CHIP_VER_DIS_BT */
+  },
+};
+
+static const esp_efuse_desc_t CHIP_VER_PKG[] =
+{
+  {
+    EFUSE_BLK0, 105, 3   /* EFUSE_RD_CHIP_VER_PKG */
+  },
+};
+
+static const esp_efuse_desc_t CHIP_CPU_FREQ_LOW[] =
+{
+  {
+    EFUSE_BLK0, 108, 1   /* EFUSE_RD_CHIP_CPU_FREQ_LOW */
+  },
+};
+
+static const esp_efuse_desc_t CHIP_CPU_FREQ_RATED[] =
+{
+  {
+    EFUSE_BLK0, 109, 1   /* EFUSE_RD_CHIP_CPU_FREQ_RATED */
+  },
+};
+
+static const esp_efuse_desc_t CHIP_VER_REV1[] =
+{
+  {
+    EFUSE_BLK0, 111, 1   /* EFUSE_RD_CHIP_VER_REV1 */
+  },
+};
+
+static const esp_efuse_desc_t CHIP_VER_REV2[] =
+{
+  {
+    EFUSE_BLK0, 180, 1   /* EFUSE_RD_CHIP_VER_REV2 */
+  },
+};
+
+static const esp_efuse_desc_t XPD_SDIO_REG[] =
+{
+  {
+    EFUSE_BLK0, 142, 1   /* EFUSE_RD_XPD_SDIO_REG */
+  },
+};
+
+static const esp_efuse_desc_t SDIO_TIEH[] =
+{
+  {
+    EFUSE_BLK0, 143, 1   /* EFUSE_RD_SDIO_TIEH */
+  },
+};
+
+static const esp_efuse_desc_t SDIO_FORCE[] =
+{
+  {
+    EFUSE_BLK0, 144, 1   /* EFUSE_RD_SDIO_FORCE */
+  },
+};
+
+static const esp_efuse_desc_t ADC_VREF_AND_SDIO_DREF[] =
+{
+  {
+    EFUSE_BLK0, 136, 6   /* EFUSE_RD_ADC_VREF[0..4] or SDIO_DREFH[0 1] */
+  },
+};
+
+static const esp_efuse_desc_t ADC1_TP_LOW[] =
+{
+  {
+    EFUSE_BLK3, 96, 7    /* TP_REG EFUSE_RD_ADC1_TP_LOW */
+  },
+};
+
+static const esp_efuse_desc_t ADC2_TP_LOW[] =
+{
+  {
+    EFUSE_BLK3, 112, 7   /* TP_REG EFUSE_RD_ADC2_TP_LOW */
+  },
+};
+
+static const esp_efuse_desc_t ADC1_TP_HIGH[] =
+{
+  {
+    EFUSE_BLK3, 103, 9   /* TP_REG EFUSE_RD_ADC1_TP_HIGH */
+  },
+};
+
+static const esp_efuse_desc_t ADC2_TP_HIGH[] =
+{
+  {
+    EFUSE_BLK3, 119, 9   /* TP_REG EFUSE_RD_ADC2_TP_HIGH */
+  },
+};
+
+static const esp_efuse_desc_t SECURE_VERSION[] =
+{
+  {
+    EFUSE_BLK3, 128, 32  /* Secure version for anti-rollback */
+  },
+};
+
+/* */
+
+const esp_efuse_desc_t *ESP_EFUSE_MAC_FACTORY[] =
+{
+  &MAC_FACTORY[0],      /* Factory MAC addr [0] */
+  &MAC_FACTORY[1],      /* Factory MAC addr [1] */
+  &MAC_FACTORY[2],      /* Factory MAC addr [2] */
+  &MAC_FACTORY[3],      /* Factory MAC addr [3] */
+  &MAC_FACTORY[4],      /* Factory MAC addr [4] */
+  &MAC_FACTORY[5],      /* Factory MAC addr [5] */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_MAC_FACTORY_CRC[] =
+{
+  &MAC_FACTORY_CRC[0],  /* CRC8 for factory MAC address */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_MAC_CUSTOM_CRC[] =
+{
+  &MAC_CUSTOM_CRC[0],   /* CRC8 for custom MAC address. */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_MAC_CUSTOM[] =
+{
+  &MAC_CUSTOM[0],       /* Custom MAC */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_MAC_CUSTOM_VER[] =
+{
+  &MAC_CUSTOM_VER[0],   /* Custom MAC version */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_SECURE_BOOT_KEY[] =
+{
+  &SECURE_BOOT_KEY[0],  /* Security boot. Key.
+                         * (length = "None" - 256.
+                         * "3/4" - 192. "REPEAT" - 128)
+                         */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_ABS_DONE_0[] =
+{
+  &ABS_DONE_0[0],       /* Secure boot is enabled for bootloader image.
+                         * EFUSE_RD_ABS_DONE_0
+                         */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_ENCRYPT_FLASH_KEY[] =
+{
+  &ENCRYPT_FLASH_KEY[0], /* Flash encrypt. Key.
+                          * (length = "None" - 256.
+                          * "3/4" - 192. "REPEAT" - 128)
+                          */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_ENCRYPT_CONFIG[] =
+{
+  &ENCRYPT_CONFIG[0],   /* Flash encrypt. EFUSE_FLASH_CRYPT_CONFIG_M */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_DISABLE_DL_ENCRYPT[] =
+{
+  &DISABLE_DL_ENCRYPT[0],  /* Flash encrypt. Disable UART bootloader
+                            * encryption. EFUSE_DISABLE_DL_ENCRYPT.
+                            */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_DISABLE_DL_DECRYPT[] =
+{
+  &DISABLE_DL_DECRYPT[0],  /* Flash encrypt. Disable UART bootloader
+                            * decryption. EFUSE_DISABLE_DL_DECRYPT.
+                            */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_DISABLE_DL_CACHE[] =
+{
+  &DISABLE_DL_CACHE[0],    /* Flash encrypt. Disable UART bootloader
+                            * MMU cache. EFUSE_DISABLE_DL_CACHE.
+                            */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_FLASH_CRYPT_CNT[] =
+{
+  &FLASH_CRYPT_CNT[0],     /* Flash encrypt. Flash encryption is enabled
+                            * if this field has an odd number of bits set.
+                            * EFUSE_FLASH_CRYPT_CNT.
+                            */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_DISABLE_JTAG[] =
+{
+  &DISABLE_JTAG[0],        /* Disable JTAG. EFUSE_RD_DISABLE_JTAG. */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_CONSOLE_DEBUG_DISABLE[] =
+{
+  &CONSOLE_DEBUG_DISABLE[0],    /* Disable ROM BASIC interpreter fallback.
+                                 * EFUSE_RD_CONSOLE_DEBUG_DISABLE.
+                                 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_UART_DOWNLOAD_DIS[] =
+{
+  &UART_DOWNLOAD_DIS[0],        /* Disable UART download mode. Valid for
+                                 * ESP32 V3 and newer
+                                 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_WR_DIS_FLASH_CRYPT_CNT[] =
+{
+  &WR_DIS_FLASH_CRYPT_CNT[0],   /* Flash encrypt. Write protection
+                                 * FLASH_CRYPT_CNT
+                                 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_WR_DIS_BLK1[] =
+{
+  &WR_DIS_BLK1[0],              /* Flash encrypt. Write protection
+                                 * encryption key. EFUSE_WR_DIS_BLK1 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_WR_DIS_BLK2[] =
+{
+  &WR_DIS_BLK2[0],              /* Security boot. Write protection security
+                                 * key. EFUSE_WR_DIS_BLK2 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_WR_DIS_BLK3[] =
+{
+  &WR_DIS_BLK3[0],              /* Write protection for EFUSE_BLK3.
+                                 * EFUSE_WR_DIS_BLK3
+                                 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_RD_DIS_BLK1[] =
+{
+  &RD_DIS_BLK1[0],              /* Flash encrypt. efuse_key_read_protected.
+                                 * EFUSE_RD_DIS_BLK1
+                                 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_RD_DIS_BLK2[] =
+{
+  &RD_DIS_BLK2[0],              /* Security boot. efuse_key_read_protected.
+                                 * EFUSE_RD_DIS_BLK2
+                                 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_RD_DIS_BLK3[] =
+{
+  &RD_DIS_BLK3[0],              /* Read protection for EFUSE_BLK3.
+                                 * EFUSE_RD_DIS_BLK3
+                                 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_DIS_APP_CPU[] =
+{
+  &CHIP_VER_DIS_APP_CPU[0],     /* EFUSE_RD_CHIP_VER_DIS_APP_CPU */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_DIS_BT[] =
+{
+  &CHIP_VER_DIS_BT[0],          /* EFUSE_RD_CHIP_VER_DIS_BT */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_PKG[] =
+{
+  &CHIP_VER_PKG[0],             /* EFUSE_RD_CHIP_VER_PKG */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_CHIP_CPU_FREQ_LOW[] =
+{
+  &CHIP_CPU_FREQ_LOW[0],        /* EFUSE_RD_CHIP_CPU_FREQ_LOW */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_CHIP_CPU_FREQ_RATED[] =
+{
+  &CHIP_CPU_FREQ_RATED[0],      /* EFUSE_RD_CHIP_CPU_FREQ_RATED */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_REV1[] =
+{
+  &CHIP_VER_REV1[0],            /* EFUSE_RD_CHIP_VER_REV1 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_REV2[] =
+{
+  &CHIP_VER_REV2[0],            /* EFUSE_RD_CHIP_VER_REV2 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_XPD_SDIO_REG[] =
+{
+  &XPD_SDIO_REG[0],             /* EFUSE_RD_XPD_SDIO_REG */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_SDIO_TIEH[] =
+{
+  &SDIO_TIEH[0],                /* EFUSE_RD_SDIO_TIEH */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_SDIO_FORCE[] =
+{
+  &SDIO_FORCE[0],               /* EFUSE_RD_SDIO_FORCE */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_ADC_VREF_AND_SDIO_DREF[] =
+{
+  &ADC_VREF_AND_SDIO_DREF[0],   /* EFUSE_RD_ADC_VREF[0..4] or
+                                 * SDIO_DREFH[0 1]
+                                 */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_ADC1_TP_LOW[] =
+{
+  &ADC1_TP_LOW[0],              /* TP_REG EFUSE_RD_ADC1_TP_LOW */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_ADC2_TP_LOW[] =
+{
+  &ADC2_TP_LOW[0],              /* TP_REG EFUSE_RD_ADC2_TP_LOW */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_ADC1_TP_HIGH[] =
+{
+  &ADC1_TP_HIGH[0],             /* TP_REG EFUSE_RD_ADC1_TP_HIGH */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_ADC2_TP_HIGH[] =
+{
+  &ADC2_TP_HIGH[0],             /* TP_REG EFUSE_RD_ADC2_TP_HIGH */
+  NULL
+};
+
+const esp_efuse_desc_t *ESP_EFUSE_SECURE_VERSION[] =
+{
+  &SECURE_VERSION[0],           /* Secure version for anti-rollback */
+  NULL
+};
+

--- a/arch/xtensa/src/esp32/esp32_efuse_utils.c
+++ b/arch/xtensa/src/esp32/esp32_efuse_utils.c
@@ -1,0 +1,586 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_efuse_utils.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <debug.h>
+#include <errno.h>
+#include <assert.h>
+#include <string.h>
+#include <nuttx/efuse/esp_efuse.h>
+
+#include "xtensa.h"
+#include "esp32_efuse.h"
+#include "esp32_clockconfig.h"
+#include "hardware/efuse_reg.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define EFUSE_CONF_WRITE   0x5a5a /* eFuse_pgm_op_ena, force no rd/wr dis. */
+#define EFUSE_CONF_READ    0x5aa5 /* eFuse_read_op_ena, release force. */
+#define EFUSE_CMD_PGM      0x02   /* Command to program. */
+#define EFUSE_CMD_READ     0x01   /* Command to read. */
+
+#define MIN(a, b)          ((a) < (b) ? (a) : (b))
+
+/* Range addresses to read blocks */
+
+const esp_efuse_range_addr_t range_read_addr_blocks[] =
+{
+  {
+    /* range address of EFUSE_BLK0 */
+
+    EFUSE_BLK0_RDATA0_REG, EFUSE_BLK0_RDATA6_REG
+  },
+  {
+    /* range address of EFUSE_BLK1 */
+
+    EFUSE_BLK1_RDATA0_REG, EFUSE_BLK1_RDATA7_REG
+  },
+  {
+    /* range address of EFUSE_BLK2 */
+
+    EFUSE_BLK2_RDATA0_REG, EFUSE_BLK2_RDATA7_REG
+  },
+  {
+    /* range address of EFUSE_BLK3 */
+
+    EFUSE_BLK3_RDATA0_REG, EFUSE_BLK3_RDATA7_REG
+  }
+};
+
+/* Range addresses to write blocks */
+
+const esp_efuse_range_addr_t range_write_addr_blocks[] =
+{
+  {
+    /* range address of EFUSE_BLK0 */
+
+    EFUSE_BLK0_WDATA0_REG, EFUSE_BLK0_WDATA6_REG
+  },
+  {
+    /* range address of EFUSE_BLK1 */
+
+    EFUSE_BLK1_WDATA0_REG, EFUSE_BLK1_WDATA7_REG
+  },
+  {
+    /* range address of EFUSE_BLK2 */
+
+    EFUSE_BLK2_WDATA0_REG, EFUSE_BLK2_WDATA7_REG
+  },
+  {
+    /* range address of EFUSE_BLK3 */
+
+    EFUSE_BLK3_WDATA0_REG, EFUSE_BLK3_WDATA7_REG
+  }
+};
+
+void esp_efuse_write_reg(uint32_t blk, uint32_t num_reg, uint32_t value);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int esp_efuse_set_timing(void)
+{
+  uint32_t apb_freq_mhz = esp_clk_apb_freq() / 1000000;
+  uint32_t clk_sel0;
+  uint32_t clk_sel1;
+  uint32_t dac_clk_div;
+
+  if (apb_freq_mhz <= 26)
+    {
+      clk_sel0 = 250;
+      clk_sel1 = 255;
+      dac_clk_div = 52;
+    }
+  else
+    {
+      if (apb_freq_mhz <= 40)
+        {
+          clk_sel0 = 160;
+          clk_sel1 = 255;
+          dac_clk_div = 80;
+        }
+      else
+        {
+          clk_sel0 = 80;
+          clk_sel1 = 128;
+          dac_clk_div = 100;
+        }
+    }
+
+  REG_SET_FIELD(EFUSE_DAC_CONF_REG, EFUSE_DAC_CLK_DIV, dac_clk_div);
+  REG_SET_FIELD(EFUSE_CLK_REG, EFUSE_CLK_SEL0, clk_sel0);
+  REG_SET_FIELD(EFUSE_CLK_REG, EFUSE_CLK_SEL1, clk_sel1);
+  return OK;
+}
+
+/* efuse read operation: copies data from physical efuses to efuse read
+ * registers.
+ */
+
+void esp_efuse_clear_program_regs(void)
+{
+  putreg32(EFUSE_CONF_READ, EFUSE_CONF_REG);
+}
+
+/* Burn values written to the efuse write registers */
+
+void esp_efuse_burn_efuses(void)
+{
+  esp_efuse_set_timing();
+
+  /* Permanently update values written to the efuse write registers */
+
+  putreg32(EFUSE_CONF_WRITE, EFUSE_CONF_REG);
+  putreg32(EFUSE_CMD_PGM, EFUSE_CMD_REG);
+
+  while (getreg32(EFUSE_CMD_REG) != 0)
+    {
+    };
+
+  putreg32(EFUSE_CONF_READ, EFUSE_CONF_REG);
+  putreg32(EFUSE_CMD_READ, EFUSE_CMD_REG);
+
+  while (getreg32(EFUSE_CMD_REG) != 0)
+    {
+    };
+}
+
+/* Reset efuse */
+
+void esp_efuse_reset(void)
+{
+}
+
+/* return mask with required the number of ones with shift */
+
+static uint32_t get_mask(uint32_t bit_count, uint32_t shift)
+{
+  uint32_t mask;
+
+  if (bit_count != 32)
+    {
+      mask = (1 << bit_count) - 1;
+    }
+  else
+    {
+      mask = 0xffffffff;
+    }
+
+  return mask << shift;
+}
+
+/* return the register number in the array
+ * return -1 if all registers for field was selected
+ */
+
+static int get_reg_num(int bit_start, int bit_count, int i_reg)
+{
+  int num_reg = i_reg + bit_start / 32;
+
+  if (num_reg > (bit_start + bit_count - 1) / 32)
+    {
+      return -1;
+    }
+
+  return num_reg;
+}
+
+/* returns the starting bit number in the register */
+
+static int get_starting_bit_num_in_reg(int bit_start, int i_reg)
+{
+  return (i_reg == 0) ? bit_start % 32 : 0;
+}
+
+/* Returns the number of bits in the register */
+
+static int get_count_bits_in_reg(int bit_start, int bit_count, int i_reg)
+{
+  int ret_count = 0;
+  int num_reg = 0;
+  int last_used_bit = (bit_start + bit_count - 1);
+
+  for (int num_bit = bit_start; num_bit <= last_used_bit; ++num_bit)
+    {
+      ++ret_count;
+      if ((((num_bit + 1) % 32) == 0) || (num_bit == last_used_bit))
+        {
+          if (i_reg == num_reg++)
+            {
+              return ret_count;
+            }
+
+          ret_count = 0;
+        }
+    }
+
+  return 0;
+}
+
+/* get the length of the field in bits */
+
+int esp_efuse_get_field_size(const esp_efuse_desc_t *field[])
+{
+  int bits_counter = 0;
+
+  if (field != NULL)
+    {
+      int i = 0;
+
+      while (field[i] != NULL)
+        {
+          bits_counter += field[i]->bit_count;
+          ++i;
+        }
+    }
+
+  return bits_counter;
+}
+
+/* check range of bits for any coding scheme */
+
+static bool check_range_of_bits(esp_efuse_block_t blk,
+                                int offset_in_bits, int size_bits)
+{
+  int max_num_bit = offset_in_bits + size_bits;
+
+  if (max_num_bit > 256)
+    {
+      return false;
+    }
+
+  return true;
+}
+
+/* Returns the number of array elements for placing these bits in an array
+ * with the length of each element equal to size_of_base.
+ */
+
+int esp_efuse_get_number_of_items(int bits, int size_of_base)
+{
+  return  bits / size_of_base + (bits % size_of_base > 0 ? 1 : 0);
+}
+
+/* fill efuse register from array */
+
+static uint32_t fill_reg(int bit_start_in_reg, int bit_count_in_reg,
+                         uint8_t *blob, int *filled_bits_blob)
+{
+  uint32_t reg_to_write = 0;
+  uint32_t temp_blob_32;
+  int shift_reg;
+  int shift_bit = (*filled_bits_blob) % 8;
+
+  if (shift_bit != 0)
+    {
+      temp_blob_32 = blob[(*filled_bits_blob) / 8] >> shift_bit;
+      shift_bit = ((8 - shift_bit) < bit_count_in_reg) ?
+                   (8 - shift_bit) : bit_count_in_reg;
+
+      reg_to_write = temp_blob_32 & get_mask(shift_bit, 0);
+      (*filled_bits_blob) += shift_bit;
+      bit_count_in_reg -= shift_bit;
+    }
+
+  shift_reg = shift_bit;
+
+  while (bit_count_in_reg > 0)
+    {
+      temp_blob_32 = blob[(*filled_bits_blob) / 8];
+      shift_bit = (bit_count_in_reg > 8) ? 8 : bit_count_in_reg;
+      reg_to_write |= (temp_blob_32 & get_mask(shift_bit, 0)) << shift_reg;
+      (*filled_bits_blob) += shift_bit;
+      bit_count_in_reg -= shift_bit;
+      shift_reg += 8;
+    };
+
+  return reg_to_write << bit_start_in_reg;
+}
+
+/* This function processes the field by calling the passed function */
+
+int esp_efuse_process(const esp_efuse_desc_t *field[], void *ptr,
+                      size_t ptr_size_bits, efuse_func_proc_t func_proc)
+{
+  int err = OK;
+  int bits_counter = 0;
+  int field_len;
+  int req_size;
+  int i = 0;
+
+  /* get and check size */
+
+  field_len = esp_efuse_get_field_size(field);
+  req_size = (ptr_size_bits == 0) ? field_len : \
+              MIN(ptr_size_bits, field_len);
+
+  while (err == OK && req_size > bits_counter && field[i] != NULL)
+    {
+      int i_reg = 0;
+      int num_reg;
+
+      if (check_range_of_bits(field[i]->efuse_block, field[i]->bit_start,
+                              field[i]->bit_count) == false)
+        {
+          minfo("Range of data does not match the coding scheme");
+          err = -EINVAL;
+        }
+
+      while (err == OK && req_size > bits_counter &&
+             (num_reg = get_reg_num(field[i]->bit_start,
+                                    field[i]->bit_count, i_reg)) != -1)
+        {
+          int start_bit = get_starting_bit_num_in_reg(field[i]->bit_start,
+                                                      i_reg);
+          int num_bits = get_count_bits_in_reg(field[i]->bit_start,
+                                               field[i]->bit_count,
+                                               i_reg);
+
+          if ((bits_counter + num_bits) > req_size)
+            {
+              /* Limits the length of the field */
+
+              num_bits = req_size - bits_counter;
+            }
+
+          minfo("EFUSE_BLK%d__DATA%d_REG is used %d bits starting"
+                " with %d bit", (int)field[i]->efuse_block, num_reg,
+                num_bits, start_bit);
+
+          err = func_proc(num_reg, field[i]->efuse_block, start_bit,
+                          num_bits, ptr, &bits_counter);
+          ++i_reg;
+        }
+
+      i++;
+    }
+
+  DEBUGASSERT(bits_counter <= req_size);
+  return err;
+}
+
+/* Fill registers from array for writing */
+
+int esp_efuse_write_blob(uint32_t num_reg, uint32_t block, int bit_start,
+                         int bit_count, void *arr_in, int *bits_counter)
+{
+  uint32_t reg_to_write = fill_reg(bit_start, bit_count, (uint8_t *) arr_in,
+                                   bits_counter);
+
+  esp_efuse_write_reg(block, num_reg, reg_to_write);
+
+  return OK;
+}
+
+/* Read efuse register */
+
+uint32_t esp_efuse_read_reg(uint32_t blk, uint32_t num_reg)
+{
+  DEBUGASSERT(blk >= 0 && blk < EFUSE_BLK_MAX);
+  uint32_t value;
+  uint32_t max_num_reg = (range_read_addr_blocks[blk].end -
+                          range_read_addr_blocks[blk].start) /
+                          sizeof(uint32_t);
+
+  DEBUGASSERT(num_reg <= max_num_reg);
+
+  value = getreg32(range_read_addr_blocks[blk].start + num_reg * 4);
+  return value;
+}
+
+/* Read efuse register and write this value to array. */
+
+int esp_efuse_fill_buff(uint32_t num_reg, uint32_t efuse_block,
+                        int bit_start, int bit_count, void *arr_out,
+                        int *bits_counter)
+{
+  uint8_t *blob = (uint8_t *) arr_out;
+  uint32_t reg = esp_efuse_read_reg(efuse_block, num_reg);
+  uint64_t reg_of_aligned_bits = (reg >> bit_start) & get_mask(bit_count, 0);
+  int sum_shift = 0;
+  int shift_bit = (*bits_counter) % 8;
+
+  if (shift_bit != 0)
+    {
+      blob[(*bits_counter) / 8] |= (uint8_t)(reg_of_aligned_bits << \
+                                   shift_bit);
+      shift_bit = ((8 - shift_bit) < bit_count) ? (8 - shift_bit) : \
+                  bit_count;
+      (*bits_counter) += shift_bit;
+      bit_count -= shift_bit;
+    }
+
+  while (bit_count > 0)
+    {
+      sum_shift += shift_bit;
+      blob[(*bits_counter) / 8] |= (uint8_t)(reg_of_aligned_bits >> \
+                                   sum_shift);
+      shift_bit = (bit_count > 8) ? 8 : bit_count;
+      (*bits_counter) += shift_bit;
+      bit_count -= shift_bit;
+    };
+
+  return OK;
+}
+
+/* Write efuse register */
+
+void esp_efuse_write_reg(uint32_t blk, uint32_t num_reg, uint32_t value)
+{
+  unsigned int max_num_reg;
+  uint32_t addr_wr_reg;
+  uint32_t reg_to_write;
+
+  DEBUGASSERT(blk >= 0 && blk < EFUSE_BLK_MAX);
+
+  max_num_reg = (range_read_addr_blocks[blk].end -
+                 range_read_addr_blocks[blk].start) /
+                 sizeof(uint32_t);
+
+  DEBUGASSERT(num_reg <= max_num_reg);
+
+  addr_wr_reg = range_write_addr_blocks[blk].start + num_reg * 4;
+  reg_to_write = getreg32(addr_wr_reg) | value;
+
+  /* The register can be written in parts so we combine the new value
+   * with the one already available.
+   */
+
+  putreg32(reg_to_write, addr_wr_reg);
+}
+
+/* Read value from EFUSE, writing it into an array */
+
+int esp_efuse_read_field_blob(const esp_efuse_desc_t *field[], void *dst,
+                              size_t dst_size_bits)
+{
+  int err = OK;
+
+  if (field == NULL || dst == NULL || dst_size_bits == 0)
+    {
+      err = -EINVAL;
+    }
+  else
+    {
+      memset((uint8_t *)dst, 0,
+             esp_efuse_get_number_of_items(dst_size_bits, 8));
+
+      err = esp_efuse_process(field, dst, dst_size_bits,
+                              esp_efuse_fill_buff);
+    }
+
+  return err;
+}
+
+/* Write array to EFUSE */
+
+int esp_efuse_write_field_blob(const esp_efuse_desc_t *field[],
+                               const void *src, size_t src_size_bits)
+{
+  int  err = OK;
+
+  if (field == NULL || src == NULL || src_size_bits == 0)
+    {
+      err = -EINVAL;
+    }
+  else
+    {
+      err = esp_efuse_process(field, (void *)src, src_size_bits,
+                              esp_efuse_write_blob);
+    }
+
+  return err;
+}
+
+/* This function reads the key from the efuse block, starting at the offset
+ * and the required size.
+ */
+
+int esp_efuse_read_block(uint32_t blk, void *dst_key, size_t offset_in_bits,
+                         size_t size_bits)
+{
+  int err = OK;
+
+  if (blk == EFUSE_BLK0 || blk >= EFUSE_BLK_MAX || dst_key == NULL ||
+      size_bits == 0)
+    {
+      err = -EINVAL;
+    }
+  else
+    {
+      const esp_efuse_desc_t field_desc[] =
+        {
+          {
+            blk, offset_in_bits, size_bits
+          },
+        };
+
+      const esp_efuse_desc_t *field[] =
+        {
+          &field_desc[0],
+          NULL
+        };
+
+      err = esp_efuse_read_field_blob(field, dst_key, size_bits);
+    }
+
+  return err;
+}
+
+/* Write a key to a block */
+
+int esp_efuse_write_block(uint32_t blk, const void *src_key,
+                          size_t offset_in_bits, size_t size_bits)
+{
+  int err = OK;
+
+  if (blk == EFUSE_BLK0 || blk >= EFUSE_BLK_MAX || \
+      src_key == NULL || size_bits == 0)
+    {
+      err = -EINVAL;
+    }
+  else
+    {
+      const esp_efuse_desc_t field_desc[] =
+        {
+          {
+            blk, offset_in_bits, size_bits
+          },
+        };
+
+      const esp_efuse_desc_t *field[] =
+        {
+          &field_desc[0],
+          NULL
+        };
+
+      err = esp_efuse_write_field_blob(field, src_key, size_bits);
+    }
+
+  return err;
+}
+

--- a/arch/xtensa/src/esp32/hardware/efuse_reg.h
+++ b/arch/xtensa/src/esp32/hardware/efuse_reg.h
@@ -21,6 +21,12 @@
 #ifndef __ARCH_XTENSA_INCLUDE_EFUSE_REG_H
 #define __ARCH_XTENSA_INCLUDE_EFUSE_REG_H
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "esp32_soc.h"
+
 #define EFUSE_BLK0_RDATA0_REG          (DR_REG_EFUSE_BASE + 0x000)
 
 /* EFUSE_RD_FLASH_CRYPT_CNT : RO ;bitpos:[26:20] ;default: 7'b0 ;

--- a/arch/xtensa/src/esp32/hardware/esp32_soc.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_soc.h
@@ -216,6 +216,7 @@
 #define DR_REG_RTCIO_BASE                       0x3ff48400
 #define DR_REG_SARADC_BASE                      0x3ff48800
 #define DR_REG_IO_MUX_BASE                      0x3ff49000
+#define DR_REG_EFUSE_BASE                       0x3ff5a000
 #define DR_REG_RTCMEM0_BASE                     0x3ff61000
 #define DR_REG_RTCMEM1_BASE                     0x3ff62000
 #define DR_REG_RTCMEM2_BASE                     0x3ff63000

--- a/include/nuttx/efuse/esp_efuse.h
+++ b/include/nuttx/efuse/esp_efuse.h
@@ -1,0 +1,184 @@
+/****************************************************************************
+ * include/nuttx/efuse/esp_efuse.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_EFUSE_EFUSE_H
+#define __INCLUDE_NUTTX_EFUSE_EFUSE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/fs/ioctl.h>
+
+#include <signal.h>
+
+#ifdef CONFIG_ESP32_EFUSE
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Command:     EFUSEIOC_READ_FIELD_BLOB
+ * Description: Read a blob of bits from an efuse field.
+ * Arguments:   A structure containing the field[], a dst pointer, and size
+ *              of bits to be read from efuses.
+ * Return:      Zero (OK) on success.  Minus one will be returned on failure
+ *              with the errno value set appropriately.
+ */
+
+#define EFUSEIOC_READ_FIELD_BLOB      _EFUSEIOC(0x0001)
+
+/* Command:     EFUSEIOC_READ_FIELD_BIT
+ * Description: Read of state of an efuse bit.
+ * Arguments:   A structure containing the field to be read.
+ * Return:      Zero (OK) on success.  Minus one will be returned on failure
+ *              with the errno value set appropriately.
+ */
+
+#define EFUSEIOC_READ_FIELD_BIT       _EFUSEIOC(0x0002)
+
+/* Command:     EFUSEIOC_WRITE_FIELD_BLOB
+ * Description: Write a blob of bits to an efuse's field
+ * Arguments:   A structure containing the field[], the src memory and the
+ *              amount of bits to write.
+ * Return:      Zero (OK) on success.  Minus one will be returned on failure
+ *              with the errno value set appropriately.
+ */
+
+#define EFUSEIOC_WRITE_FIELD_BLOB     _EFUSEIOC(0x0003)
+
+/* Command:     EFUSEIOC_WRITE_FIELD_BIT
+ * Description: Write a bit to an efuse (burn it).
+ * Arguments:   A structure containing bit field.
+ * Return:      Zero (OK) on success.  Minus one will be returned on failure
+ *              with the errno value set appropriately.
+ */
+
+#define EFUSEIOC_WRITE_FIELD_BIT      _EFUSEIOC(0x0004)
+
+/* Command:     EFUSEIOC_READ_REG
+ * Description: Read an efuse register.
+ * Arguments:   A structure containing the block number and the register to
+ *              be read.
+ * Return:      Zero (OK) on success.  Minus one will be returned on failure
+ *              with the errno value set appropriately.
+ */
+
+#define EFUSEIOC_READ_REG             _EFUSEIOC(0x0005)
+
+/* Command:     EFUSEIOC_WRITE_REG
+ * Description: Write an efuse register.
+ * Arguments:   A structure containing the block number, the register to
+ *              write and value to be written.
+ * Return:      Zero (OK) on success.  Minus one will be returned on failure
+ *              with the errno value set appropriately.
+ */
+
+#define EFUSEIOC_WRITE_REG            _EFUSEIOC(0x0006)
+
+/* Command:     EFUSEIOC_READ_BLOCK
+ * Description: Read a key from efuse's block.
+ * Arguments:   A structure containing the block number, the dst_key pointer,
+ *              the offset in bits and the amount of bits to read.
+ * Return:      Zero (OK) on success.  Minus one will be returned on failure
+ *              with the errno value set appropriately.
+ */
+
+#define EFUSEIOC_READ_BLOCK           _EFUSEIOC(0x0007)
+
+/* Command:     EFUSEIOC_WRITE_BLOCK
+ * Description: Write a key to efuse's block.
+ * Arguments:   A structure containing the block number, the src_key pointer,
+ *              the offset in bits and the amount of bits to write.
+ * Return:      Zero (OK) on success.  Minus one will be returned on failure
+ *              with the errno value set appropriately.
+ */
+
+#define EFUSEIOC_WRITE_BLOCK          _EFUSEIOC(0x0008)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Structure eFuse field */
+
+struct esp_efuse_desc_s
+{
+  uint32_t   efuse_block:8;  /* Block of eFuse */
+  uint8_t    bit_start;      /* Start bit [0..255] */
+  uint16_t   bit_count;      /* Length of bit field [1..-] */
+};
+
+/* Type definition for an eFuse field */
+
+typedef struct esp_efuse_desc_s esp_efuse_desc_t;
+
+/* Structure range address by blocks */
+
+typedef struct
+{
+  uint32_t start;
+  uint32_t end;
+} esp_efuse_range_addr_t;
+
+/* Structs with the parameters passed to the IOCTLs */
+
+struct esp_efuse_par
+{
+  uint32_t block;
+  uint32_t reg;
+  uint32_t *data;
+  size_t   bit_offset;
+  size_t   bit_size;
+};
+
+struct esp_efuse_par_id
+{
+  esp_efuse_desc_t **field;
+  uint8_t *data;
+  size_t  size;
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int esp_efuse_init(void);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_ESP32_EFUSE */
+#endif /* __INCLUDE_NUTTX_EFUSE_EFUSE_H */

--- a/include/nuttx/efuse/esp_efuse_table.h
+++ b/include/nuttx/efuse/esp_efuse_table.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * include/nuttx/efuse/esp_efuse_table.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+extern const esp_efuse_desc_t *ESP_EFUSE_MAC_FACTORY[];
+extern const esp_efuse_desc_t *ESP_EFUSE_MAC_FACTORY_CRC[];
+extern const esp_efuse_desc_t *ESP_EFUSE_MAC_CUSTOM_CRC[];
+extern const esp_efuse_desc_t *ESP_EFUSE_MAC_CUSTOM[];
+extern const esp_efuse_desc_t *ESP_EFUSE_MAC_CUSTOM_VER[];
+extern const esp_efuse_desc_t *ESP_EFUSE_SECURE_BOOT_KEY[];
+extern const esp_efuse_desc_t *ESP_EFUSE_ABS_DONE_0[];
+extern const esp_efuse_desc_t *ESP_EFUSE_ENCRYPT_FLASH_KEY[];
+extern const esp_efuse_desc_t *ESP_EFUSE_ENCRYPT_CONFIG[];
+extern const esp_efuse_desc_t *ESP_EFUSE_DISABLE_DL_ENCRYPT[];
+extern const esp_efuse_desc_t *ESP_EFUSE_DISABLE_DL_DECRYPT[];
+extern const esp_efuse_desc_t *ESP_EFUSE_DISABLE_DL_CACHE[];
+extern const esp_efuse_desc_t *ESP_EFUSE_FLASH_CRYPT_CNT[];
+extern const esp_efuse_desc_t *ESP_EFUSE_DISABLE_JTAG[];
+extern const esp_efuse_desc_t *ESP_EFUSE_CONSOLE_DEBUG_DISABLE[];
+extern const esp_efuse_desc_t *ESP_EFUSE_UART_DOWNLOAD_DIS[];
+extern const esp_efuse_desc_t *ESP_EFUSE_WR_DIS_FLASH_CRYPT_CNT[];
+extern const esp_efuse_desc_t *ESP_EFUSE_WR_DIS_BLK1[];
+extern const esp_efuse_desc_t *ESP_EFUSE_WR_DIS_BLK2[];
+extern const esp_efuse_desc_t *ESP_EFUSE_WR_DIS_BLK3[];
+extern const esp_efuse_desc_t *ESP_EFUSE_RD_DIS_BLK1[];
+extern const esp_efuse_desc_t *ESP_EFUSE_RD_DIS_BLK2[];
+extern const esp_efuse_desc_t *ESP_EFUSE_RD_DIS_BLK3[];
+extern const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_DIS_APP_CPU[];
+extern const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_DIS_BT[];
+extern const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_PKG[];
+extern const esp_efuse_desc_t *ESP_EFUSE_CHIP_CPU_FREQ_LOW[];
+extern const esp_efuse_desc_t *ESP_EFUSE_CHIP_CPU_FREQ_RATED[];
+extern const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_REV1[];
+extern const esp_efuse_desc_t *ESP_EFUSE_CHIP_VER_REV2[];
+extern const esp_efuse_desc_t *ESP_EFUSE_XPD_SDIO_REG[];
+extern const esp_efuse_desc_t *ESP_EFUSE_SDIO_TIEH[];
+extern const esp_efuse_desc_t *ESP_EFUSE_SDIO_FORCE[];
+extern const esp_efuse_desc_t *ESP_EFUSE_ADC_VREF_AND_SDIO_DREF[];
+extern const esp_efuse_desc_t *ESP_EFUSE_ADC1_TP_LOW[];
+extern const esp_efuse_desc_t *ESP_EFUSE_ADC2_TP_LOW[];
+extern const esp_efuse_desc_t *ESP_EFUSE_ADC1_TP_HIGH[];
+extern const esp_efuse_desc_t *ESP_EFUSE_ADC2_TP_HIGH[];
+extern const esp_efuse_desc_t *ESP_EFUSE_SECURE_VERSION[];
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -101,6 +101,7 @@
 #define _NOTERAMBASE    (0x2d00) /* Noteram device ioctl commands*/
 #define _RCIOCBASE      (0x2e00) /* Remote Control device ioctl commands */
 #define _HIMEMBASE      (0x2f00) /* Himem device ioctl commands*/
+#define _EFUSEBASE      (0x3000) /* Efuse device ioctl commands*/
 #define _WLIOCBASE      (0x8b00) /* Wireless modules ioctl network commands */
 
 /* boardctl() commands share the same number space */
@@ -550,6 +551,11 @@
 
 #define _HIMEMIOCVALID(c)   (_IOC_TYPE(c) == _HIMEMBASE)
 #define _HIMEMIOC(nr)       _IOC(_HIMEMBASE, nr)
+
+/* Efuse drivers ************************************************************/
+
+#define _EFUSEIOCVALID(c)   (_IOC_TYPE(c) == _EFUSEBASE)
+#define _EFUSEIOC(nr)       _IOC(_EFUSEBASE, nr)
 
 /* Wireless driver network ioctl definitions ********************************/
 


### PR DESCRIPTION
## Summary
Add ESP32 EFUSE char driver
## Impact
ESP32 users will be able to read/burn the EFUSEs
## Testing
Tested on esp32-wrover-kit board

NOTE: Coding Style check will fail because mixed case issues