### PR TITLE
Make the number of queue/signal used by irq handler configurable

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1309,6 +1309,12 @@ endmenu # RTOS hooks
 
 menu "Signal Configuration"
 
+config SIG_PREALLOC_IRQ_ACTIONS
+	int "Number of pre-allocated irq actions"
+	default 8
+	---help---
+		The number of pre-allocated irq action structures.
+
 config SIG_EVTHREAD
 	bool "Support SIGEV_THHREAD"
 	default n

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1536,6 +1536,12 @@ config PREALLOC_MQ_MSGS
 		The number of pre-allocated message structures.  The system manages
 		a pool of preallocated message structures to minimize dynamic allocations
 
+config PREALLOC_MQ_IRQ_MSGS
+	int "Number of pre-allocated irq messages"
+	default 8
+	---help---
+		The number of pre-allocated irq message structures.
+
 config MQ_MAXMSGSIZE
 	int "Maximum message size"
 	default 32

--- a/sched/mqueue/mq_initialize.c
+++ b/sched/mqueue/mq_initialize.c
@@ -168,7 +168,7 @@ void nxmq_initialize(void)
    */
 
   g_msgfreeirqalloc =
-    mq_msgblockalloc(&g_msgfreeirq, NUM_INTERRUPT_MSGS,
+    mq_msgblockalloc(&g_msgfreeirq, CONFIG_PREALLOC_MQ_IRQ_MSGS,
                      MQ_ALLOC_IRQ);
 
   /* Allocate a block of message queue descriptors */

--- a/sched/mqueue/mqueue.h
+++ b/sched/mqueue/mqueue.h
@@ -53,12 +53,6 @@
 
 #define NUM_MSG_DESCRIPTORS  4
 
-/* This defines the number of messages to set aside for exclusive use by
- * interrupt handlers
- */
-
-#define NUM_INTERRUPT_MSGS   8
-
 /********************************************************************************
  * Public Type Definitions
  ********************************************************************************/

--- a/sched/signal/sig_initialize.c
+++ b/sched/signal/sig_initialize.c
@@ -230,7 +230,7 @@ void nxsig_initialize(void)
 
   g_sigpendingirqactionalloc =
     nxsig_alloc_block(&g_sigpendingirqaction,
-                      NUM_PENDING_INT_ACTIONS,
+                      CONFIG_SIG_PREALLOC_IRQ_ACTIONS,
                       SIG_ALLOC_IRQ);
   DEBUGASSERT(g_sigpendingirqactionalloc != NULL);
 
@@ -242,7 +242,7 @@ void nxsig_initialize(void)
 
   g_sigpendingirqsignalalloc =
     nxsig_alloc_pendingsignalblock(&g_sigpendingirqsignal,
-                                   NUM_INT_SIGNALS_PENDING,
+                                   CONFIG_SIG_PREALLOC_IRQ_ACTIONS,
                                    SIG_ALLOC_IRQ);
   DEBUGASSERT(g_sigpendingirqsignalalloc != NULL);
 }

--- a/sched/signal/signal.h
+++ b/sched/signal/signal.h
@@ -60,9 +60,7 @@
 
 #define NUM_SIGNAL_ACTIONS       4
 #define NUM_PENDING_ACTIONS      4
-#define NUM_PENDING_INT_ACTIONS  8
 #define NUM_SIGNALS_PENDING      4
-#define NUM_INT_SIGNALS_PENDING  8
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
## Summary
these structure can't be dynamically allocated in any irq handler so it's important to let the user extend the number as needed

## Impact
No, since the default value same as before

## Testing

