### PR TITLE
xtensa/esp32: fixes enable int function and gets apb clk frequency through function

### DIFF
--- a/arch/xtensa/src/esp32/esp32_tim.c
+++ b/arch/xtensa/src/esp32/esp32_tim.c
@@ -723,7 +723,7 @@ errout:
  * Name: esp32_tim_enableint
  *
  * Description:
- *   Enables an Edge Interrupt at the alarm if it is set.
+ *   Enables a level Interrupt at the alarm if it is set.
  *
  ****************************************************************************/
 
@@ -731,9 +731,25 @@ static int esp32_tim_enableint(FAR struct esp32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
-  /* Set the edge interrupt bit */
+  /* Set the level interrupt bit */
 
   esp32_tim_modifyreg32(dev, TIM_CONFIG_OFFSET, 0, TIMG_T0_LEVEL_INT_EN);
+
+  /* Timer 0 from group 0 or 1 */
+
+  if (((struct esp32_tim_priv_s *)dev)->base == TIMG_T0CONFIG_REG(0) ||
+    ((struct esp32_tim_priv_s *)dev)->base == TIMG_T0CONFIG_REG(1))
+    {
+      esp32_tim_modifyreg32(dev, TIM0_INT_ENA_OFFSET, 0,
+                                TIMG_T0_INT_ENA);
+    }
+  else
+    {
+      /* Timer 1 from group 0 or 1 */
+
+      esp32_tim_modifyreg32(dev, TIM1_INT_ENA_OFFSET, 0,
+                                TIMG_T1_INT_ENA);
+    }
 
   return OK;
 }
@@ -742,7 +758,7 @@ static int esp32_tim_enableint(FAR struct esp32_tim_dev_s *dev)
  * Name: esp32_tim_disableint
  *
  * Description:
- *   Disables an Edge Interrupt at the alarm if it is set.
+ *   Disables a level Interrupt at the alarm if it is set.
  *
  ****************************************************************************/
 
@@ -751,6 +767,22 @@ static int esp32_tim_disableint(FAR struct esp32_tim_dev_s *dev)
   DEBUGASSERT(dev);
 
   esp32_tim_modifyreg32(dev, TIM_CONFIG_OFFSET, TIMG_T0_LEVEL_INT_EN, 0);
+
+  /* Timer 0 from group 0 or 1 */
+
+  if (((struct esp32_tim_priv_s *)dev)->base == TIMG_T0CONFIG_REG(0) ||
+    ((struct esp32_tim_priv_s *)dev)->base == TIMG_T0CONFIG_REG(1))
+    {
+      esp32_tim_modifyreg32(dev, TIM0_INT_ENA_OFFSET, TIMG_T0_INT_ENA,
+                                0);
+    }
+  else
+    {
+      /* Timer 1 from group 0 or 1 */
+
+      esp32_tim_modifyreg32(dev, TIM1_INT_ENA_OFFSET, TIMG_T1_INT_ENA,
+                                0);
+    }
 
   return OK;
 }
@@ -835,7 +867,7 @@ static int esp32_tim_ackint(FAR struct esp32_tim_dev_s *dev)
  *
  * Description:
  *   Initialize TIMER device, if software real-time timer
- *   (CONFIG_ESP32_RT_TIMER) is enable, then timer0 can't
+ *   (CONFIG_ESP32_RT_TIMER) is enabled, then timer0 can't
  *   be initialized by this function directly.
  *
  ****************************************************************************/

--- a/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
@@ -37,6 +37,7 @@
 #include "xtensa.h"
 #include "hardware/esp32_soc.h"
 #include "esp32_tim.h"
+#include "esp32_clockconfig.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -47,7 +48,7 @@
 /* Lowest divider, Highest Frequency Best Resolution */
 #define ESP32_TIMER_PRESCALER   2
 /* Number of cycles to complete 1 microsecond */
-#define ESP32_1USECOND          ((TB_CLK_FREQ/ESP32_TIMER_PRESCALER)/1000000)
+#define ESP32_1USECOND          ((esp_clk_apb_freq()/ESP32_TIMER_PRESCALER)/1000000)
 #define ESP32_INIT_CNTR_VALUE   0    /* Initial counter value */
 #define ESP32_TIMER_MAX_USECOND 0xffffffff
 #define ESP32_TIMER_MAX         (ESP32_1USECOND*ESP32_TIMER_MAX_USECOND)

--- a/arch/xtensa/src/esp32/hardware/esp32_soc.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_soc.h
@@ -201,7 +201,6 @@
 #define TIMER_CLK_FREQ                          (80000000 >> 4) /* 80MHz divided by 16 */
 #define SPI_CLK_DIV                             4
 #define TICKS_PER_US_ROM                        26              /* CPU is 80MHz */
-#define TB_CLK_FREQ                             APB_CLK_FREQ
 
 #define DR_REG_DPORT_BASE                       0x3ff00000
 #define DR_REG_UART_BASE                        0x3ff40000

--- a/arch/xtensa/src/esp32/hardware/esp32_tim.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_tim.h
@@ -44,6 +44,8 @@
 #define TIM1_CLR_OFFSET			0x0080
 #define TIM0_INT_ST_OFFSET 		0x00A0
 #define TIM1_INT_ST_OFFSET 		0x007c
+#define TIM0_INT_ENA_OFFSET		0x0098
+#define TIM1_INT_ENA_OFFSET		0x0074
 #define LOW_32_MASK				0xffffffff
 
 /* WTD defines */


### PR DESCRIPTION
## Summary

Fix:

It's missing a configuration in the esp32_tim_enableint and esp32_tim_disableint

Improvement:

Get the APB clock frequency from a function instead of using a constant. So, if this frequency changes in the future, the timer driver will not be affected.

## Impact

All timers' users.

## Testing
Running Timer Example.
