### PR TITLE
sched: pthread: Fix potential bugs in pthread_condclockwait.c

### DIFF
--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -275,6 +275,10 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
 
                   status = nxsem_wait((FAR sem_t *)&cond->sem);
 
+                  /* We no longer need the watchdog */
+
+                  wd_cancel(&rtcb->waitdog);
+
                   /* Did we get the condition semaphore. */
 
                   if (status < 0)
@@ -326,17 +330,13 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
                   ret           = status;
                 }
             }
-
-          /* Re-enable pre-emption (It is expected that interrupts
-           * have already been re-enabled in the above logic)
-           */
-
-          sched_unlock();
         }
 
-      /* We no longer need the watchdog */
+      /* Re-enable pre-emption (It is expected that interrupts
+       * have already been re-enabled in the above logic)
+       */
 
-      wd_cancel(&rtcb->waitdog);
+      sched_unlock();
     }
 
   leave_cancellation_point();


### PR DESCRIPTION
## Summary

- I found potential bugs in pthread_condclockwait.c
- Actually, sched_unlock() and wd_cancel() were misplaced.
- This commit fixes this issue

## Impact

- pthread_cond_clockwait() only

## Testing

- Tested with ostest with the following configs
- sabre-6quad:nsh, sabre-6quad:smp, sim:ostest
