### PR TITLE
fs: Skip call fs_checkfd if fd < 3 in fs_fdopen

### DIFF
--- a/fs/vfs/fs_fdopen.c
+++ b/fs/vfs/fs_fdopen.c
@@ -115,7 +115,7 @@ int fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb,
 {
   FAR struct streamlist *slist;
   FAR FILE              *stream;
-  int                    ret;
+  int                    ret = OK;
 
   /* Check input parameters */
 
@@ -164,7 +164,7 @@ int fs_fdopen(int fd, int oflags, FAR struct tcb_s *tcb,
    * more checks.
    */
 
-  else
+  else if (fd >= 3)
     {
       ret = fs_checkfd(tcb, fd, oflags);
     }


### PR DESCRIPTION
## Summary
since the stdin, stdout and stderr may initialize later
in userspace if CONFIG_DEV_CONSOLE isn't enabled.
Note: it isn't bigger issue here to skip the check because
vfs will check the validation again in read and write syscall
See the discussion here: https://github.com/apache/incubator-nuttx-apps/pull/521

## Impact
Handle the usb console in a more standardized way

## Testing
Need tested with https://github.com/apache/incubator-nuttx-apps/pull/523
