### PR TITLE
WIP: Initial work to support BL602 chip

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -10,6 +10,12 @@ choice
 	prompt "RISC-V chip selection"
 	default ARCH_CHIP_NR5
 
+config ARCH_CHIP_BL60X
+	bool "Bouffalo Lab BL60x"
+	select ARCH_RV32IM
+	---help---
+		Bouffalo Lab BL602/4 Processor (RISC-V Core with BLE and WIFI).
+
 config ARCH_CHIP_FE310
 	bool "SiFive FE310"
 	select ARCH_RV32IM

--- a/arch/risc-v/include/bl60x/chip.h
+++ b/arch/risc-v/include/bl60x/chip.h
@@ -1,0 +1,24 @@
+/****************************************************************************
+ * arch/risc-v/include/bl60x/chip.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_INCLUDE_BL60X_CHIP_H
+#define __ARCH_RISCV_INCLUDE_BL60X_CHIP_H
+
+#endif /* __ARCH_RISCV_INCLUDE_BL60X_CHIP_H */

--- a/arch/risc-v/include/bl60x/irq.h
+++ b/arch/risc-v/include/bl60x/irq.h
@@ -1,0 +1,114 @@
+/****************************************************************************
+ * arch/risc-v/include/bl60x/irq.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_INCLUDE_BL60X_IRQ_H
+#define __ARCH_RISCV_INCLUDE_BL60X_IRQ_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <arch/irq.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* In mstatus register */
+
+#define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
+#define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
+#define MSTATUS_MPPM  (0x3 << 11) /* Machine Previous Privilege (m-mode) */
+
+/* In mie (machine interrupt enable) register */
+
+#define MIE_MSIE      (0x1 << 3)  /* Machine Software Interrupt Enable */
+#define MIE_MTIE      (0x1 << 7)  /* Machine Timer Interrupt Enable */
+#define MIE_MEIE      (0x1 << 11) /* Machine External Interrupt Enable */
+#define MIP_MTIP      (0x1 << 7)  /* Machine Timer Interrupt Pending */
+
+/* Map RISC-V exception code to NuttX IRQ */
+
+/* See the listing here for more information
+ * https://github.com/bouffalolab/bl_iot_sdk/blob/f8c47051ed9338b0f1036e55d8cb1eb56c86c089/components/bl602/bl602_std/bl602_std/RISCV/Device/Bouffalo/BL602/Startup/interrupt.c
+ */
+
+/* IRQ 0-15 : (exception:interrupt=0) */
+
+#define BL_IRQ_IAMISALIGNED    (0)       /* Instruction Address Misaligned */
+#define BL_IRQ_IAFAULT         (1)       /* Instruction Address Fault */
+#define BL_IRQ_IINSTRUCTION    (2)       /* Illegal Instruction */
+#define BL_IRQ_BPOINT          (3)       /* Break Point */
+#define BL_IRQ_LAMISALIGNED    (4)       /* Load Address Misaligned */
+#define BL_IRQ_LAFAULT         (5)       /* Load Access Fault */
+#define BL_IRQ_SAMISALIGNED    (6)       /* Store/AMO Address Misaligned */
+#define BL_IRQ_SAFAULT         (7)       /* Store/AMO Access Fault */
+#define BL_IRQ_ECALLU          (8)       /* Environment Call from U-mode */
+                                         /* 9-10: Reserved */
+
+#define BL_IRQ_ECALLM          (11)      /* Environment Call from M-mode */
+                                         /* 12-15: Reserved */
+
+#define BL_IRQ_CLIC_MSIP       (16 + 3)  /* Machine Software Interrupt */
+#define BL_IRQ_CLIC_MTIMER     (16 + 7)  /* Machine Timer Interrupt */
+#define BL_IRQ_CLIC_MEXT       (16 + 7)  /* Machine External Interrupt */
+#define BL_IRQ_CLIC_CSOFT      (16 + 8)
+#define BL_IRQ_BMX_ERR         (32 + 0)
+#define BL_IRQ_UART0           (32 + 29)
+#define BL_IRQ_UART0           (32 + 30)
+#define BL_IRQ_WIFI_IPC_PUBLIC (32 + 63)
+
+/* Total number of IRQs */
+
+#define NR_IRQS                (BL_IRQ_WIFI_IPC_PUBLIC + 1)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+EXTERN irqstate_t  up_irq_save(void);
+EXTERN void up_irq_restore(irqstate_t);
+EXTERN irqstate_t up_irq_enable(void);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_INCLUDE_BL60X_IRQ_H */

--- a/arch/risc-v/src/bl60x/Kconfig
+++ b/arch/risc-v/src/bl60x/Kconfig
@@ -1,0 +1,28 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+comment "BL60x Configuration Options"
+
+menu "BL60x Peripheral Support"
+
+# These "hidden" settings determine whether a peripheral option is available
+# for the selected MCU
+
+config BL_HAVE_UART0
+	bool
+	default y
+	select BL_SERIALDRIVER
+	select ARCH_HAVE_SERIAL_TERMIOS
+
+# These are the peripheral selections proper
+
+config BL_UART0
+	bool "UART0"
+	default y
+	select ARCH_HAVE_UART0
+	select ARCH_HAVE_SERIAL_TERMIOS
+	select BL_UART
+
+endmenu

--- a/arch/risc-v/src/bl60x/Make.defs
+++ b/arch/risc-v/src/bl60x/Make.defs
@@ -1,0 +1,53 @@
+############################################################################
+# arch/risc-v/src/bl60x/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Specify our HEAD assembly file.  This will be linked as
+# the first object file, so it will appear at address 0
+HEAD_ASRC = bl_vectors.S
+
+# Specify our general Assembly files
+CHIP_ASRCS = bl_head.S riscv_syscall.S
+
+ifeq ($(CONFIG_ARCH_SETJMP_H),y)
+CMN_ASRCS  += riscv_setjmp.S
+endif
+
+# Specify C code within the common directory to be included
+CMN_CSRCS  += riscv_initialize.c riscv_swint.c
+CMN_CSRCS  += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
+CMN_CSRCS  += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
+CMN_CSRCS  += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mdelay.c
+CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c
+CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c bl_schedulesigaction.c
+CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
+
+ifeq ($(CONFIG_STACK_COLORATION),y)
+CMN_CSRCS += riscv_checkstack.c
+endif
+
+ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
+CMN_CSRCS  += riscv_vfork.c
+endif
+
+# Specify our C code within this directory to be included
+CHIP_CSRCS  = bl_allocateheap.c bl_clockconfig.c
+CHIP_CSRCS += bl_idle.c bl_irq.c bl_irq_dispatch.c
+CHIP_CSRCS += bl_lowputc.c bl_serial.c
+CHIP_CSRCS += bl_start.c bl_timerisr.c

--- a/arch/risc-v/src/bl60x/bl.h
+++ b/arch/risc-v/src/bl60x/bl.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL60X_BL_H
+#define __ARCH_RISCV_SRC_BL60X_BL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <arch/irq.h>
+#include "riscv_internal.h"
+#include "chip.h"
+#include "bl_lowputc.h"
+
+#endif /* __ARCH_RISCV_SRC_BL60X_BL_H */

--- a/arch/risc-v/src/bl60x/bl_allocateheap.c
+++ b/arch/risc-v/src/bl60x/bl_allocateheap.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_allocateheap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <arch/board/board.h>
+
+#include "bl.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_addregion
+ ****************************************************************************/
+
+void up_addregion(void)
+{
+}

--- a/arch/risc-v/src/bl60x/bl_clockconfig.c
+++ b/arch/risc-v/src/bl60x/bl_clockconfig.c
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_clockconfig.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <arch/board/board.h>
+
+#include "riscv_arch.h"
+#include "bl_clockconfig.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl_get_hfclk
+ ****************************************************************************/
+
+uint32_t bl_get_hfclk(void)
+{
+#warning "Not Implemented"
+  return 100000000UL;
+}
+
+/****************************************************************************
+ * Name: bl_clockconfig
+ ****************************************************************************/
+
+void bl_clockconfig(void)
+{
+#warning "Not Implemented"
+  /* TODO */
+}

--- a/arch/risc-v/src/bl60x/bl_clockconfig.h
+++ b/arch/risc-v/src/bl60x/bl_clockconfig.h
@@ -1,0 +1,65 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_clockconfig.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL60X_BL_CLOCKCONFIG_H
+#define __ARCH_RISCV_SRC_BL60X_BL_CLOCKCONFIG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "bl_memorymap.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+EXTERN uint32_t bl_get_hfclk(void);
+EXTERN void bl_clockconfig(void);
+
+#if defined(__cplusplus)
+}
+#endif
+#undef EXTERN
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_BL60X_BL_CLOCKCONFIG_H */

--- a/arch/risc-v/src/bl60x/bl_config.h
+++ b/arch/risc-v/src/bl60x/bl_config.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_config.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL60X_BL_CONFIG_H
+#define __ARCH_RISCV_SRC_BL60X_BL_CONFIG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <arch/chip/chip.h>
+#include <arch/board/board.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#undef HAVE_UART_DEVICE
+#if defined(CONFIG_BL_UART0) || defined(CONFIG_BL_UART1)
+#  define HAVE_UART_DEVICE 1
+#endif
+
+#if defined(CONFIG_UART0_SERIAL_CONSOLE) && defined(CONFIG_BL_UART0)
+#  undef CONFIG_UART1_SERIAL_CONSOLE
+#  define HAVE_SERIAL_CONSOLE 1
+#elif defined(CONFIG_UART1_SERIAL_CONSOLE) && defined(CONFIG_BL_UART1)
+#  undef CONFIG_UART0_SERIAL_CONSOLE
+#  define HAVE_SERIAL_CONSOLE 1
+#else
+#  undef CONFIG_UART0_SERIAL_CONSOLE
+#  undef CONFIG_UART1_SERIAL_CONSOLE
+#  undef HAVE_SERIAL_CONSOLE
+#endif
+
+#endif /* __ARCH_RISCV_SRC_BL60X_BL_CONFIG_H */

--- a/arch/risc-v/src/bl60x/bl_head.S
+++ b/arch/risc-v/src/bl60x/bl_head.S
@@ -1,0 +1,204 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_head.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <arch/rv32im/irq.h>
+
+#include "chip.h"
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+  .global exception_common
+
+  /* Imported symbols */
+
+  .extern __trap_vec
+
+  .section .text
+  .global __start
+
+__start:
+
+  /* Set stack pointer to the idle thread stack */
+
+  lui  sp, %hi(BL_IDLESTACK_TOP)
+  addi sp, sp, %lo(BL_IDLESTACK_TOP)
+
+  /* Disable all interrupts (i.e. timer, external) in mie */
+
+  csrw mie, zero
+
+  /* Initialize the Machine Trap Vector */
+
+  lui  t0, %hi(__trap_vec)
+  addi t0, t0, %lo(__trap_vec)
+  csrw  mtvec, t0
+
+  /* Jump to __bl_start */
+
+  jal  x1, __bl_start
+
+  /* We shouldn't return from __bl_start */
+
+  .global _init
+  .global _fini
+
+_init:
+_fini:
+
+  /* These don't have to do anything since we use init_array/fini_array. */
+
+  ret
+
+/****************************************************************************
+ * Name: exception_common
+ ****************************************************************************/
+
+exception_common:
+
+  addi sp, sp, -XCPTCONTEXT_SIZE
+
+  sw   x1,  1*4(sp)  /* ra */
+  sw   x3,  3*4(sp)  /* gp */
+  sw   x4,  4*4(sp)  /* tp */
+  sw   x5,  5*4(sp)  /* t0 */
+  sw   x6,  6*4(sp)  /* t1 */
+  sw   x7,  7*4(sp)  /* t2 */
+  sw   x8,  8*4(sp)  /* s0 */
+  sw   x9,  9*4(sp)  /* s1 */
+  sw   x10, 10*4(sp) /* a0 */
+  sw   x11, 11*4(sp) /* a1 */
+  sw   x12, 12*4(sp) /* a2 */
+  sw   x13, 13*4(sp) /* a3 */
+  sw   x14, 14*4(sp) /* a4 */
+  sw   x15, 15*4(sp) /* a5 */
+  sw   x16, 16*4(sp) /* a6 */
+  sw   x17, 17*4(sp)  /* a7 */
+  sw   x18, 18*4(sp)  /* s2 */
+  sw   x19, 19*4(sp)  /* s3 */
+  sw   x20, 20*4(sp)  /* s4 */
+  sw   x21, 21*4(sp)  /* s5 */
+  sw   x22, 22*4(sp)  /* s6 */
+  sw   x23, 23*4(sp)  /* s7 */
+  sw   x24, 24*4(sp)  /* s8 */
+  sw   x25, 25*4(sp)  /* s9 */
+  sw   x26, 26*4(sp)  /* s10 */
+  sw   x27, 27*4(sp)  /* s11 */
+  sw   x28, 28*4(sp)  /* t3 */
+  sw   x29, 29*4(sp)  /* t4 */
+  sw   x30, 30*4(sp)  /* t5 */
+  sw   x31, 31*4(sp)  /* t6 */
+
+  csrr s0, mstatus
+  sw   s0,  32*4(sp)  /* mstatus */
+
+  addi s0, sp, XCPTCONTEXT_SIZE
+  sw   s0,  2*4(sp)   /* original SP */
+
+  /* Setup arg0(exception cause), arg1(context) */
+
+  csrr a0, mcause  /* exception cause */
+  csrr s0, mepc
+  sw   s0, 0(sp)   /* exception PC */
+
+  mv   a1, sp      /* context = sp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+  /* Switch to interrupt stack */
+
+  lui  sp, %hi(g_intstackbase)
+  addi sp, sp, %lo(g_intstackbase)
+#endif
+
+  /* Call interrupt handler in C */
+
+  jal  x1, bl_dispatch_irq
+
+  /* If context switch is needed, return a new sp */
+
+  mv   sp, a0
+  lw   s0, 0(sp)    /* restore mepc */
+  csrw mepc, s0
+
+  lw   s0, 32*4(sp) /* restore mstatus */
+  csrw mstatus, s0
+
+  lw  x3,  3*4(sp)  /* gp */
+  lw  x4,  4*4(sp)  /* tp */
+  lw  x5,  5*4(sp)  /* t0 */
+  lw  x6,  6*4(sp)  /* t1 */
+  lw  x7,  7*4(sp)  /* t2 */
+  lw  x8,  8*4(sp)  /* s0 */
+  lw  x9,  9*4(sp)  /* s1 */
+  lw x10, 10*4(sp)  /* a0 */
+  lw x11, 11*4(sp)  /* a1 */
+  lw x12, 12*4(sp)  /* a2 */
+  lw x13, 13*4(sp)  /* a3 */
+  lw x14, 14*4(sp)  /* a4 */
+  lw x15, 15*4(sp)  /* a5 */
+  lw x16, 16*4(sp)  /* a6 */
+  lw x17, 17*4(sp)  /* a7 */
+  lw x18, 18*4(sp)  /* s2 */
+  lw x19, 19*4(sp)  /* s3 */
+  lw x20, 20*4(sp)  /* s4 */
+  lw x21, 21*4(sp)  /* s5 */
+  lw x22, 22*4(sp)  /* s6 */
+  lw x23, 23*4(sp)  /* s7 */
+  lw x24, 24*4(sp)  /* s8 */
+  lw x25, 25*4(sp)  /* s9 */
+  lw x26, 26*4(sp)  /* s10 */
+  lw x27, 27*4(sp)  /* s11 */
+  lw x28, 28*4(sp)  /* t3 */
+  lw x29, 29*4(sp)  /* t4 */
+  lw x30, 30*4(sp)  /* t5 */
+  lw x31, 31*4(sp)  /* t6 */
+
+  lw  x1,  1*4(sp)  /* ra */
+
+  lw  sp,  2*4(sp)  /* restore original sp */
+
+  /* Return from Machine Interrupt */
+
+  mret
+
+/************************************************************************************
+ *  Name: g_intstackalloc and g_intstackbase
+ ************************************************************************************/
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+  .bss
+  .align  4
+  .global g_intstackalloc
+  .global g_intstackbase
+  .type   g_intstackalloc, object
+  .type   g_intstackbase, object
+g_intstackalloc:
+  .skip  ((CONFIG_ARCH_INTERRUPTSTACK & ~3))
+g_intstackbase:
+  .skip  4
+  .size  g_intstackbase, 4
+  .size  g_intstackalloc, (CONFIG_ARCH_INTERRUPTSTACK & ~3)
+#endif

--- a/arch/risc-v/src/bl60x/bl_idle.c
+++ b/arch/risc-v/src/bl60x/bl_idle.c
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_idle.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <arch/board/board.h>
+
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_idle
+ *
+ * Description:
+ *   up_idle() is the logic that will be executed when there is no other
+ *   ready-to-run task.  This is processor idle time and will continue until
+ *   some interrupt occurs to cause a context switch from the idle task.
+ *
+ *   Processing in this state may be processor-specific. e.g., this is where
+ *   power management operations might be performed.
+ *
+ ****************************************************************************/
+
+void up_idle(void)
+{
+#if defined(CONFIG_SUPPRESS_INTERRUPTS) || defined(CONFIG_SUPPRESS_TIMER_INTS)
+  /* If the system is idle and there are no timer interrupts, then process
+   * "fake" timer interrupts. Hopefully, something will wake up.
+   */
+
+  nxsched_process_timer();
+#else
+
+  /* This would be an appropriate place to put some MCU-specific logic to
+   * sleep in a reduced power mode until an interrupt occurs to save power
+   */
+
+  asm("WFI");
+
+#endif
+}

--- a/arch/risc-v/src/bl60x/bl_irq.c
+++ b/arch/risc-v/src/bl60x/bl_irq.c
@@ -1,0 +1,147 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_irq.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <arch/irq.h>
+#include <arch/board/board.h>
+
+#include "riscv_internal.h"
+#include "riscv_arch.h"
+
+#include "bl.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_irqinitialize
+ ****************************************************************************/
+
+void up_irqinitialize(void)
+{
+#warning "Not Implemented"
+}
+
+/****************************************************************************
+ * Name: up_disable_irq
+ *
+ * Description:
+ *   Disable the IRQ specified by 'irq'
+ *
+ ****************************************************************************/
+
+void up_disable_irq(int irq)
+{
+#warning "Not implemented"
+}
+
+/****************************************************************************
+ * Name: up_enable_irq
+ *
+ * Description:
+ *   Enable the IRQ specified by 'irq'
+ *
+ ****************************************************************************/
+
+void up_enable_irq(int irq)
+{
+#warning "Not Implemented"
+}
+
+/****************************************************************************
+ * Name: up_get_newintctx
+ *
+ * Description:
+ *   Return initial mstatus when a task is created.
+ *
+ ****************************************************************************/
+
+uint32_t up_get_newintctx(void)
+{
+#warning "Not Implemented"
+  return 0;
+}
+
+/****************************************************************************
+ * Name: up_ack_irq
+ *
+ * Description:
+ *   Acknowledge the IRQ
+ *
+ ****************************************************************************/
+
+void up_ack_irq(int irq)
+{
+}
+
+/****************************************************************************
+ * Name: up_irq_save
+ *
+ * Description:
+ *   Return the current interrupt state and disable interrupts
+ *
+ ****************************************************************************/
+
+irqstate_t up_irq_save(void)
+{
+  irqstate_t state;
+#warning "Not Implemented"
+  return state;
+}
+
+/****************************************************************************
+ * Name: up_irq_restore
+ *
+ * Description:
+ *   Restore previous IRQ mask state
+ *
+ ****************************************************************************/
+
+void up_irq_restore(irqstate_t flags)
+{
+#error "Not Implemented"
+}
+
+/****************************************************************************
+ * Name: up_irq_enable
+ *
+ * Description:
+ *   Return the current interrupt state and enable interrupts
+ *
+ ****************************************************************************/
+
+irqstate_t up_irq_enable(void)
+{
+  irqstate_t state;
+#warning "Not Implemented"
+  return state;
+}

--- a/arch/risc-v/src/bl60x/bl_irq_dispatch.c
+++ b/arch/risc-v/src/bl60x/bl_irq_dispatch.c
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_irq_dispatch.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <assert.h>
+
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <arch/board/board.h>
+
+#include "riscv_arch.h"
+#include "riscv_internal.h"
+
+#include "bl.h"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+volatile uint32_t * g_current_regs;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * bl_dispatch_irq
+ ****************************************************************************/
+
+void *bl_dispatch_irq(uint32_t vector, uint32_t *regs)
+{
+#warning "Not Implemented"
+  return regs;
+}

--- a/arch/risc-v/src/bl60x/bl_lowputc.c
+++ b/arch/risc-v/src/bl60x/bl_lowputc.c
@@ -1,0 +1,104 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_lowputc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include <arch/board/board.h>
+
+#include "riscv_internal.h"
+#include "riscv_arch.h"
+
+#include "bl_config.h"
+#include "hardware/bl_memorymap.h"
+#include "hardware/bl_uart.h"
+#include "bl_clockconfig.h"
+#include "bl.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Select UART parameters for the selected console */
+
+#ifdef HAVE_SERIAL_CONSOLE
+#  if defined(CONFIG_UART0_SERIAL_CONSOLE)
+#    define BL_CONSOLE_BASE        BL_UART0_BASE
+#    define BL_CONSOLE_BAUD        CONFIG_UART0_BAUD
+#    define HAVE_UART
+#  elif defined(CONFIG_UART1_SERIAL_CONSOLE)
+#    define BL_CONSOLE_BASE        BL_UART1_BASE
+#    define BL_CONSOLE_BAUD        CONFIG_UART1_BAUD
+#    define HAVE_UART
+#  endif
+#endif /* HAVE_CONSOLE */
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_lowputc
+ *
+ * Description:
+ *   Output one byte on the serial console
+ *
+ ****************************************************************************/
+
+void up_lowputc(char ch)
+{
+#ifdef HAVE_SERIAL_CONSOLE
+  /* Wait until the TX data register is empty */
+
+  /* Then send the character */
+
+#endif /* HAVE_CONSOLE */
+}
+
+/****************************************************************************
+ * Name: bl_lowsetup
+ *
+ * Description:
+ *   This performs basic initialization of the UART used for the serial
+ *   console.  Its purpose is to get the console output available as soon
+ *   as possible.
+ *
+ ****************************************************************************/
+
+void bl_lowsetup(void)
+{
+#if defined(HAVE_UART)
+
+  /* Enable and configure the selected console device */
+
+#if defined(HAVE_SERIAL_CONSOLE) && !defined(CONFIG_SUPPRESS_UART_CONFIG)
+
+  /* Set Baudrate */
+
+  /* Enable TX */
+
+#endif /* HAVE_SERIAL_CONSOLE && !CONFIG_SUPPRESS_UART_CONFIG */
+#endif /* HAVE_UART */
+}

--- a/arch/risc-v/src/bl60x/bl_lowputc.h
+++ b/arch/risc-v/src/bl60x/bl_lowputc.h
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_lowputc.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL60X_BL_LOWPUTC_H
+#define __ARCH_RISCV_SRC_BL60X_BL_LOWPUTC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "chip.h"
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: bl_lowsetup
+ ****************************************************************************/
+
+EXTERN void bl_lowsetup(void);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_BL60X_BL_LOWPUTC_H */

--- a/arch/risc-v/src/bl60x/bl_memorymap.h
+++ b/arch/risc-v/src/bl60x/bl_memorymap.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_memorymap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef _ARCH_RISCV_SRC_BL60X_BL_MEMORYMAP_H
+#define _ARCH_RISCV_SRC_BL60X_BL_MEMORYMAP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "hardware/bl_memorymap.h"
+#include "hardware/bl_uart.h"
+#include "hardware/bl_clic.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Idle thread stack starts from _ebss */
+
+#ifndef __ASSEMBLY__
+#define BL_IDLESTACK_BASE  (uint32_t)&_ebss
+#else
+#define BL_IDLESTACK_BASE  _ebss
+#endif
+
+#define BL_IDLESTACK_SIZE (CONFIG_IDLETHREAD_STACKSIZE & ~3)
+#define BL_IDLESTACK_TOP  (BL_IDLESTACK_BASE + BL_IDLESTACK_SIZE)
+
+#endif /* _ARCH_RISCV_SRC_BL60X_BL_MEMORYMAP_H */

--- a/arch/risc-v/src/bl60x/bl_schedulesigaction.c
+++ b/arch/risc-v/src/bl60x/bl_schedulesigaction.c
@@ -1,0 +1,195 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_schedulesigaction.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <sched.h>
+#include <debug.h>
+
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
+#include <arch/bl/irq.h>
+
+#include "sched/sched.h"
+#include "riscv_internal.h"
+#include "riscv_arch.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_schedule_sigaction
+ *
+ * Description:
+ *   This function is called by the OS when one or more
+ *   signal handling actions have been queued for execution.
+ *   The architecture specific code must configure things so
+ *   that the 'sigdeliver' callback is executed on the thread
+ *   specified by 'tcb' as soon as possible.
+ *
+ *   This function may be called from interrupt handling logic.
+ *
+ *   This operation should not cause the task to be unblocked
+ *   nor should it cause any immediate execution of sigdeliver.
+ *   Typically, a few cases need to be considered:
+ *
+ *   (1) This function may be called from an interrupt handler
+ *       During interrupt processing, all xcptcontext structures
+ *       should be valid for all tasks.  That structure should
+ *       be modified to invoke sigdeliver() either on return
+ *       from (this) interrupt or on some subsequent context
+ *       switch to the recipient task.
+ *   (2) If not in an interrupt handler and the tcb is NOT
+ *       the currently executing task, then again just modify
+ *       the saved xcptcontext structure for the recipient
+ *       task so it will invoke sigdeliver when that task is
+ *       later resumed.
+ *   (3) If not in an interrupt handler and the tcb IS the
+ *       currently executing task -- just call the signal
+ *       handler now.
+ *
+ ****************************************************************************/
+
+void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
+{
+  irqstate_t flags;
+  uint32_t int_ctx;
+
+  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+
+  /* Make sure that interrupts are disabled */
+
+  flags = enter_critical_section();
+
+  /* Refuse to handle nested signal actions */
+
+  if (!tcb->xcp.sigdeliver)
+    {
+      /* First, handle some special cases when the signal is
+       * being delivered to the currently executing task.
+       */
+
+      sinfo("rtcb=0x%p g_current_regs=0x%p\n",
+            this_task(), g_current_regs);
+
+      if (tcb == this_task())
+        {
+          /* CASE 1:  We are not in an interrupt handler and
+           * a task is signalling itself for some reason.
+           */
+
+          if (!g_current_regs)
+            {
+              /* In this case just deliver the signal now. */
+
+              sigdeliver(tcb);
+            }
+
+          /* CASE 2:  We are in an interrupt handler AND the
+           * interrupted task is the same as the one that
+           * must receive the signal, then we will have to modify
+           * the return state as well as the state in the TCB.
+           *
+           * Hmmm... there looks like a latent bug here: The following
+           * logic would fail in the strange case where we are in an
+           * interrupt handler, the thread is signalling itself, but
+           * a context switch to another task has occurred so that
+           * g_current_regs does not refer to the thread of this_task()!
+           */
+
+          else
+            {
+              /* Save the return EPC and STATUS registers.  These will be
+               * restored by the signal trampoline after the signals have
+               * been delivered.
+               */
+
+              tcb->xcp.sigdeliver       = sigdeliver;
+              tcb->xcp.saved_epc        = g_current_regs[REG_EPC];
+              tcb->xcp.saved_int_ctx    = g_current_regs[REG_INT_CTX];
+
+              /* Then set up to vector to the trampoline with interrupts
+               * disabled
+               */
+
+              g_current_regs[REG_EPC]     = (uint32_t)up_sigdeliver;
+
+              int_ctx                     = g_current_regs[REG_INT_CTX];
+              int_ctx                    &= ~MSTATUS_MPIE;
+
+              g_current_regs[REG_INT_CTX] = int_ctx;
+
+              /* And make sure that the saved context in the TCB
+               * is the same as the interrupt return context.
+               */
+
+              up_savestate(tcb->xcp.regs);
+
+              sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
+                    " New: %08" PRIx32 "/%08" PRIx32 "\n",
+                    tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
+                    g_current_regs[REG_EPC], g_current_regs[REG_INT_CTX]);
+            }
+        }
+
+      /* Otherwise, we are (1) signaling a task is not running
+       * from an interrupt handler or (2) we are not in an
+       * interrupt handler and the running task is signalling
+       * some non-running task.
+       */
+
+      else
+        {
+          /* Save the return EPC and STATUS registers.  These will be
+           * restored by the signal trampoline after the signals have
+           * been delivered.
+           */
+
+          tcb->xcp.sigdeliver       = sigdeliver;
+          tcb->xcp.saved_epc        = tcb->xcp.regs[REG_EPC];
+          tcb->xcp.saved_int_ctx    = tcb->xcp.regs[REG_INT_CTX];
+
+          /* Then set up to vector to the trampoline with interrupts
+           * disabled
+           */
+
+          tcb->xcp.regs[REG_EPC]      = (uint32_t)up_sigdeliver;
+
+          int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
+          int_ctx                    &= ~MSTATUS_MPIE;
+
+          tcb->xcp.regs[REG_INT_CTX]  = int_ctx;
+
+          sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
+                " New: %08" PRIx32 "/%08" PRIx32 "\n",
+                tcb->xcp.saved_epc, tcb->xcp.saved_int_ctx,
+                tcb->xcp.regs[REG_EPC], tcb->xcp.regs[REG_INT_CTX]);
+        }
+    }
+
+  leave_critical_section(flags);
+}

--- a/arch/risc-v/src/bl60x/bl_start.c
+++ b/arch/risc-v/src/bl60x/bl_start.c
@@ -1,0 +1,125 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_init.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+#include <nuttx/config.h>
+
+#include <arch/board/board.h>
+
+#include "bl_clockconfig.h"
+#include "bl.h"
+#include "chip.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_FEATURES
+#  define showprogress(c) up_lowputc(c)
+#else
+#  define showprogress(c)
+#endif
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* g_idle_topstack: _sbss is the start of the BSS region as defined by the
+ * linker script. _ebss lies at the end of the BSS region. The idle task
+ * stack starts at the end of BSS and is of size CONFIG_IDLETHREAD_STACKSIZE.
+ * The IDLE thread is the thread that the system boots on and, eventually,
+ * becomes the IDLE, do nothing task that runs only when there is nothing
+ * else to run.  The heap continues from there until the end of memory.
+ * g_idle_topstack is a read-only variable the provides this computed
+ * address.
+ */
+
+uint32_t g_idle_topstack = BL_IDLESTACK_TOP;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl_start
+ ****************************************************************************/
+
+void __bl_start(void)
+{
+  const uint32_t *src;
+  uint32_t *dest;
+
+  /* Clear .bss.  We'll do this inline (vs. calling memset) just to be
+   * certain that there are no issues with the state of global variables.
+   */
+
+  for (dest = &_sbss; dest < &_ebss; )
+    {
+      *dest++ = 0;
+    }
+
+  /* Move the initialized data section from his temporary holding spot in
+   * FLASH into the correct place in SRAM.  The correct place in SRAM is
+   * give by _sdata and _edata.  The temporary location is in FLASH at the
+   * end of all of the other read-only data (.text, .rodata) at _eronly.
+   */
+
+  /* for vexriscv the full image is loaded in ddr ram */
+
+  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+    {
+      *dest++ = *src++;
+    }
+
+  /* Setup PLL */
+
+  bl_clockconfig();
+
+  /* Configure the UART so we can get debug output */
+
+  bl_lowsetup();
+
+  showprogress('A');
+
+#ifdef USE_EARLYSERIALINIT
+  up_earlyserialinit();
+#endif
+
+  showprogress('B');
+
+  /* Do board initialization */
+
+  bl_boardinitialize();
+
+  showprogress('C');
+
+  /* Call nx_start() */
+
+  nx_start();
+
+  /* Shouldn't get here */
+
+  for (; ; );
+}

--- a/arch/risc-v/src/bl60x/bl_timerisr.c
+++ b/arch/risc-v/src/bl60x/bl_timerisr.c
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_timerisr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <time.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/clock.h>
+#include <arch/board/board.h>
+
+#include "riscv_arch.h"
+
+#include "bl.h"
+#include "bl_clockconfig.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define TICK_COUNT (bl_get_hfclk() / TICK_PER_SEC)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  bl_timerisr
+ ****************************************************************************/
+
+static int bl_timerisr(int irq, void *context, FAR void *arg)
+{
+  /* TODO: Reload timer */
+
+  /* Process timer interrupt */
+
+  nxsched_process_timer();
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_timer_initialize
+ *
+ * Description:
+ *   This function is called during start-up to initialize
+ *   the timer interrupt.
+ *
+ ****************************************************************************/
+
+void up_timer_initialize(void)
+{
+#if 0
+  /* Attach timer interrupt handler */
+
+  irq_attach(BL_IRQ_TIMER, bl_timerisr, NULL);
+
+  /* TODO: Reload timer */
+
+  /* And enable the timer interrupt */
+
+  up_enable_irq(BL_IRQ_TIMER);
+#endif
+}

--- a/arch/risc-v/src/bl60x/bl_vectors.S
+++ b/arch/risc-v/src/bl60x/bl_vectors.S
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/bl_vectors.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/************************************************************************************
+ * Included Files
+ ************************************************************************************/
+
+  .section .text.vec
+  .global  __reset_vec
+  .global  __trap_vec
+
+/****************************************************************************
+ * Name: __reset_vec
+ ****************************************************************************/
+
+__reset_vec:
+  jal  __start
+
+/****************************************************************************
+ * Name: exception_common
+ ****************************************************************************/
+
+__trap_vec:
+  j    exception_common
+  nop

--- a/arch/risc-v/src/bl60x/chip.h
+++ b/arch/risc-v/src/bl60x/chip.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/chip.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL60X_CHIP_H
+#define __ARCH_RISCV_SRC_BL60X_CHIP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "bl_memorymap.h"
+
+#endif /* __ARCH_RISCV_SRC_BL60X_CHIP_H */

--- a/arch/risc-v/src/bl60x/hardware/bl_clic.h
+++ b/arch/risc-v/src/bl60x/hardware/bl_clic.h
@@ -1,0 +1,37 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/hardware/bl_clint.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL60X_HARDWARE_BL_CLINT_H
+#define __ARCH_RISCV_SRC_BL60X_HARDWARE_BL_CLINT_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BL_CLIC_MSIP           (BL_CLIC_CTRL_BASE + 0x0000)  /* size 4 */
+#define BL_CLIC_MTIMECMP       (BL_CLIC_CTRL_BASE + 0x4000)  /* size 8 */
+#define BL_CLIC_MTIME          (BL_CLIC_CTRL_BASE + 0xBFF8)  /* size 8 */
+
+#define BL_CLIC_INTIP          (BL_CLIC_HART0_BASE + 0x000)
+#define BL_CLIC_INTIE          (BL_CLIC_HART0_BASE + 0x400)
+#define BL_CLIC_INTCFG         (BL_CLIC_HART0_BASE + 0x800)
+#define BL_CLIC_CFG            (BL_CLIC_HART0_BASE + 0xC00)
+
+#endif /* __ARCH_RISCV_SRC_BL60X_HARDWARE_BL_CLINT_H */

--- a/arch/risc-v/src/bl60x/hardware/bl_memorymap.h
+++ b/arch/risc-v/src/bl60x/hardware/bl_memorymap.h
@@ -1,0 +1,33 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/hardware/bl_memorymap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL60X_HARDWARE_BL_MEMORYMAP_H
+#define __ARCH_RISCV_SRC_BL60X_HARDWARE_BL_MEMORYMAP_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Register Base Address ****************************************************/
+
+#define BL_CLIC_CTRL_BASE      0x02000000
+#define BL_CLIC_HART0_BASE     0x02800000
+
+#endif /* __ARCH_RISCV_SRC_BL60X_HARDWARE_BL_MEMORYMAP_H */

--- a/arch/risc-v/src/bl60x/hardware/bl_uart.h
+++ b/arch/risc-v/src/bl60x/hardware/bl_uart.h
@@ -1,0 +1,28 @@
+/****************************************************************************
+ * arch/risc-v/src/bl60x/hardware/bl_uart.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef ARCH_RISCV_SRC_BL60X_CHIP_BL_UART_H
+#define ARCH_RISCV_SRC_BL60X_CHIP_BL_UART_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#endif /* __ARCH_RISCV_SRC_BL60X_CHIP_BL_UART_H */


### PR DESCRIPTION
## Summary
This is a WIP PR to start adding support for the Bouffalo Lab BL602/4 RISC-V BLE 5.0 and WIFI chip.

**NOTE** -- I have some modules available in the USA if you are interested in contributing and do not want to wait for international shipping from China.  If you are outside the USA it is probably just as fast to order directly from China, but I am also happy to ship.

## Impact
Initial support for the BL602 with DT-BL10 dev board

## Testing
None.
