### PR TITLE
arch/arm/src/imxrt/imxrt_usdhc.c: fixed no DMA build error

### DIFF
--- a/arch/arm/src/imxrt/imxrt_usdhc.c
+++ b/arch/arm/src/imxrt/imxrt_usdhc.c
@@ -335,7 +335,7 @@ static void imxrt_blocksetup(FAR struct sdio_dev_s *dev,
 static int  imxrt_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
               size_t nbytes);
 static int  imxrt_sendsetup(FAR struct sdio_dev_s *dev,
-              FAR const uint8_t *buffer, uint32_t nbytes);
+              FAR const uint8_t *buffer, size_t nbytes);
 #endif
 
 static int  imxrt_cancel(FAR struct sdio_dev_s *dev);


### PR DESCRIPTION
## Summary

Declaration of imxrt_sendsetup function had  a different data type for nbytes than its definition, which was causing the build to fail while DMA was not enabled.

## Testing

Tested on Teensy-4.1:

```
NuttShell (NSH) NuttX-9.1.1
nsh> 
nsh> ls dev
/dev:
 console
 mmcsd0
 null
 ttyACM0
 ttyS0
nsh> mount -t vfat /dev/mmcsd0 /mnt
nsh> cat mnt/test.txt
hello world, how are u?

ddfdfsc 44545 
nsh> 
```