### PR TITLE
boards: sabre-6quad: Update Make.defs to remove unused code

### DIFF
--- a/boards/arm/imx6/sabre-6quad/scripts/Make.defs
+++ b/boards/arm/imx6/sabre-6quad/scripts/Make.defs
@@ -54,7 +54,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ARCHCPUFLAGS = -mcpu=cortex-a9 -mfpu=vfpv4-d16
-ARCHCFLAGS = -fno-builtin
+ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections
 ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
@@ -85,6 +85,8 @@ ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
 else
   LDELFFLAGS += -T $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld
 endif
+
+LDFLAGS += --gc-sections
 
 ifneq ($(CROSSDEV),arm-nuttx-elf-)
   LDFLAGS += -nostartfiles -nodefaultlibs


### PR DESCRIPTION
## Summary

- Add -ffunction-sections -fdata-sections to ARCHCFLAG
- Add --gc-sections to LDFLAGS

## Impact

- sabre-6quad only

## Testing

- Tested with nsh and smp configurations
