### PR TITLE
net/tcp: Optimize TCP handshake performance

### DIFF
--- a/arch/arm/src/c5471/c5471_ethernet.c
+++ b/arch/arm/src/c5471/c5471_ethernet.c
@@ -2017,7 +2017,7 @@ static void c5471_txavail_work(FAR void *arg)
         {
           /* If so, then poll the network for new XMIT data */
 
-          devif_poll(&priv->c_dev, c5471_txpoll);
+          devif_timer(&priv->c_dev, 0, c5471_txpoll);
         }
     }
 

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -1522,7 +1522,7 @@ static void imxrt_txavail_work(FAR void *arg)
            * new XMIT data.
            */
 
-          devif_poll(&priv->dev, imxrt_txpoll);
+          devif_timer(&priv->dev, 0, imxrt_txpoll);
         }
     }
 

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1299,7 +1299,7 @@ static void imxrt_txavail_work(FAR void *arg)
            * new XMIT data.
            */
 
-          devif_poll(&priv->dev, imxrt_txpoll);
+          devif_timer(&priv->dev, 0, imxrt_txpoll);
         }
     }
 

--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -1367,7 +1367,7 @@ static void kinetis_txavail_work(FAR void *arg)
            * new XMIT data.
            */
 
-          devif_poll(&priv->dev, kinetis_txpoll);
+          devif_timer(&priv->dev, 0, kinetis_txpoll);
         }
     }
 

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -1337,7 +1337,7 @@ static void kinetis_txavail_work(FAR void *arg)
            * new XMIT data.
            */
 
-          devif_poll(&priv->dev, kinetis_txpoll);
+          devif_timer(&priv->dev, 0, kinetis_txpoll);
         }
     }
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -1853,7 +1853,7 @@ static void lpc17_40_txavail_work(FAR void *arg)
         {
           /* If so, then poll the network layer for new XMIT data */
 
-          devif_poll(&priv->lp_dev, lpc17_40_txpoll);
+          devif_timer(&priv->lp_dev, 0, lpc17_40_txpoll);
         }
     }
 

--- a/arch/arm/src/lpc43xx/lpc43_ethernet.c
+++ b/arch/arm/src/lpc43xx/lpc43_ethernet.c
@@ -1285,7 +1285,7 @@ static void lpc43_dopoll(FAR struct lpc43_ethmac_s *priv)
 
       if (dev->d_buf)
         {
-          devif_poll(dev, lpc43_txpoll);
+          devif_timer(dev, 0, lpc43_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -1807,7 +1807,7 @@ static void lpc54_eth_dopoll(struct lpc54_ethdriver_s *priv)
       priv->eth_dev.d_buf = (uint8_t *)lpc54_pktbuf_alloc(priv);
       if (priv->eth_dev.d_buf != NULL)
         {
-          devif_poll(&priv->eth_dev, lpc54_eth_txpoll);
+          devif_timer(&priv->eth_dev, 0, lpc54_eth_txpoll);
 
           /* Make sure that the Tx buffer remaining after the poll is
            * freed.

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -1521,7 +1521,7 @@ static void s32k1xx_txavail_work(FAR void *arg)
            * new XMIT data.
            */
 
-          devif_poll(&priv->dev, s32k1xx_txpoll);
+          devif_timer(&priv->dev, 0, s32k1xx_txpoll);
         }
     }
 

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1340,7 +1340,7 @@ static void s32k1xx_txavail_work(FAR void *arg)
            * new XMIT data.
            */
 
-          devif_poll(&priv->dev, s32k1xx_txpoll);
+          devif_timer(&priv->dev, 0, s32k1xx_txpoll);
         }
     }
 

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -962,7 +962,7 @@ static void sam_dopoll(struct sam_emac_s *priv)
        * then poll the network for new XMIT data.
        */
 
-      devif_poll(dev, sam_txpoll);
+      devif_timer(dev, 0, sam_txpoll);
     }
 }
 

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -970,7 +970,7 @@ static void sam_dopoll(struct sam_emac_s *priv)
        * then poll the network for new XMIT data.
        */
 
-      devif_poll(dev, sam_txpoll);
+      devif_timer(dev, 0, sam_txpoll);
     }
 }
 

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -1311,7 +1311,7 @@ static void sam_dopoll(struct sam_emac_s *priv)
        * then poll the network for new XMIT data.
        */
 
-      devif_poll(dev, sam_txpoll);
+      devif_timer(dev, 0, sam_txpoll);
     }
 }
 

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -912,7 +912,7 @@ static void sam_dopoll(struct sam_gmac_s *priv)
        * then poll the network for new XMIT data.
        */
 
-      devif_poll(dev, sam_txpoll);
+      devif_timer(dev, 0, sam_txpoll);
     }
 }
 

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -900,7 +900,7 @@ static void sam_dopoll(struct sam_gmac_s *priv)
        * then poll the network for new XMIT data.
        */
 
-      devif_poll(dev, sam_txpoll);
+      devif_timer(dev, 0, sam_txpoll);
     }
 }
 

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -1618,7 +1618,7 @@ static void sam_dopoll(struct sam_emac_s *priv, int qid)
        * then poll the network for new XMIT data.
        */
 
-      devif_poll(dev, sam_txpoll);
+      devif_timer(dev, 0, sam_txpoll);
     }
 }
 

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -1396,7 +1396,7 @@ static void stm32_dopoll(FAR struct stm32_ethmac_s *priv)
 
       if (dev->d_buf)
         {
-          devif_poll(dev, stm32_txpoll);
+          devif_timer(dev, 0, stm32_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -1435,7 +1435,7 @@ static void stm32_dopoll(struct stm32_ethmac_s *priv)
 
       if (dev->d_buf)
         {
-          devif_poll(dev, stm32_txpoll);
+          devif_timer(dev, 0, stm32_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -1451,7 +1451,7 @@ static void stm32_dopoll(struct stm32_ethmac_s *priv)
 
       if (dev->d_buf)
         {
-          devif_poll(dev, stm32_txpoll);
+          devif_timer(dev, 0, stm32_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -1561,7 +1561,7 @@ static void tiva_txavail_work(void *arg)
        * network for new Tx data
        */
 
-      devif_poll(&priv->ld_dev, tiva_txpoll);
+      devif_timer(&priv->ld_dev, 0, tiva_txpoll);
     }
 
   net_unlock();

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -1386,7 +1386,7 @@ static void tiva_dopoll(FAR struct tiva_ethmac_s *priv)
 
       if (dev->d_buf)
         {
-          devif_poll(dev, tiva_txpoll);
+          devif_timer(dev, 0, tiva_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -664,7 +664,7 @@ static int emac_txavail(struct net_driver_s *dev)
 
       /* If so, then poll the network for new XMIT data */
 
-      devif_poll(&priv->d_dev, emac_txpoll);
+      devif_timer(&priv->d_dev, 0, emac_txpoll);
     }
 
   leave_critical_section(flags);

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -1252,7 +1252,7 @@ static void pic32mx_poll(struct pic32mx_driver_s *priv)
           /* And perform the poll */
 
           priv->pd_polling = true;
-          devif_poll(&priv->pd_dev, pic32mx_txpoll);
+          devif_timer(&priv->pd_dev, 0, pic32mx_txpoll);
 
           /* Free any buffer left attached after the poll */
 

--- a/arch/mips/src/pic32mz/pic32mz_ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz_ethernet.c
@@ -1356,7 +1356,7 @@ static void pic32mz_poll(struct pic32mz_driver_s *priv)
           /* And perform the poll */
 
           priv->pd_polling = true;
-          devif_poll(&priv->pd_dev, pic32mz_txpoll);
+          devif_timer(&priv->pd_dev, 0, pic32mz_txpoll);
 
           /* Free any buffer left attached after the poll */
 

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -957,7 +957,7 @@ static void misoc_net_txavail_work(FAR void *arg)
         {
           /* If so, then poll the network for new XMIT data */
 
-          devif_poll(&priv->misoc_net_dev, misoc_net_txpoll);
+          devif_timer(&priv->misoc_net_dev, 0, misoc_net_txpoll);
         }
     }
 

--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -1181,7 +1181,7 @@ static void rx65n_dopoll(FAR struct rx65n_ethmac_s *priv)
 
       if (dev->d_buf)
         {
-          devif_poll(dev, rx65n_txpoll);
+          devif_timer(dev, 0, rx65n_txpoll);
 
           /* We will, most likely end up with a buffer to be freed.  But it
            * might not be the same one that we allocated above.

--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -303,7 +303,7 @@ static void netdriver_txavail_work(FAR void *arg)
   net_lock();
   if (IFF_IS_UP(dev->d_flags))
     {
-      devif_poll(dev, netdriver_txpoll);
+      devif_timer(dev, 0, netdriver_txpoll);
     }
 
   net_unlock();

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -1693,7 +1693,7 @@ static void emac_dopoll(struct esp32_emac_s *priv)
 
       dev->d_len = EMAC_BUF_LEN;
 
-      devif_poll(dev, emac_txpoll);
+      devif_timer(dev, 0, emac_txpoll);
 
       if (dev->d_buf)
         {

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -841,7 +841,7 @@ static void wlan_dopoll(FAR struct wlan_priv_s *priv)
 
   /* If so, then poll the network for new XMIT data */
 
-  devif_poll(dev, wlan_txpoll);
+  devif_timer(dev, 0, wlan_txpoll);
 
   dev->d_buf = NULL;
 }

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -2223,7 +2223,7 @@ static void ez80emac_txavail_work(FAR void *arg)
 
       /* If so, then poll the network for new XMIT data */
 
-      devif_poll(&priv->dev, ez80emac_txpoll);
+      devif_timer(&priv->dev, 0, ez80emac_txpoll);
     }
 
   net_unlock();

--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -1658,7 +1658,7 @@ static void dm9x_txavail_work(FAR void *arg)
         {
           /* If so, then poll the network for new XMIT data */
 
-          devif_poll(&priv->dm_dev, dm9x_txpoll);
+          devif_timer(&priv->dm_dev, 0, dm9x_txpoll);
         }
     }
 

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -2233,7 +2233,7 @@ static int enc_txavail(struct net_driver_s *dev)
            * poll the network for new XMIT data
            */
 
-          devif_poll(&priv->dev, enc_txpoll);
+          devif_timer(&priv->dev, 0, enc_txpoll);
         }
     }
 

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -2387,7 +2387,7 @@ static int enc_txavail(struct net_driver_s *dev)
            * poll the network for new XMIT data
            */
 
-          devif_poll(&priv->dev, enc_txpoll);
+          devif_timer(&priv->dev, 0, enc_txpoll);
         }
     }
 

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -1321,7 +1321,7 @@ static void ftmac100_txavail_work(FAR void *arg)
 
       /* If so, then poll the network for new XMIT data */
 
-      devif_poll(&priv->ft_dev, ftmac100_txpoll);
+      devif_timer(&priv->ft_dev, 0, ftmac100_txpoll);
     }
 
   net_unlock();

--- a/drivers/net/lan91c111.c
+++ b/drivers/net/lan91c111.c
@@ -1228,7 +1228,7 @@ static void lan91c111_txavail_work(FAR void *arg)
         {
           /* If so, then poll the network for new XMIT data */
 
-          devif_poll(dev, lan91c111_txpoll);
+          devif_timer(dev, 0, lan91c111_txpoll);
         }
     }
 

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -385,7 +385,7 @@ static void lo_txavail_work(FAR void *arg)
           /* If so, then poll the network for new XMIT data */
 
           priv->lo_txdone = false;
-          devif_poll(&priv->lo_dev, lo_txpoll);
+          devif_timer(&priv->lo_dev, 0, lo_txpoll);
         }
       while (priv->lo_txdone);
     }

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -1091,7 +1091,7 @@ static void net_rpmsg_drv_txavail_work(FAR void *arg)
         {
           /* If so, then poll the network for new XMIT data */
 
-          devif_poll(dev, net_rpmsg_drv_txpoll);
+          devif_timer(dev, 0, net_rpmsg_drv_txpoll);
         }
     }
 

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -917,7 +917,7 @@ static void skel_txavail_work(FAR void *arg)
 
       /* If so, then poll the network for new XMIT data */
 
-      devif_poll(&priv->sk_dev, skel_txpoll);
+      devif_timer(&priv->sk_dev, 0, skel_txpoll);
     }
 
   net_unlock();

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -502,7 +502,7 @@ static int slip_txtask(int argc, FAR char *argv[])
             {
               /* No, perform the normal TX poll */
 
-              devif_poll(&priv->dev, slip_txpoll);
+              devif_timer(&priv->dev, 0, slip_txpoll);
             }
 
           net_unlock();

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -967,7 +967,7 @@ static void tun_txavail_work(FAR void *arg)
       /* Poll the network for new XMIT data */
 
       priv->dev.d_buf = priv->read_buf;
-      devif_poll(&priv->dev, tun_txpoll);
+      devif_timer(&priv->dev, 0, tun_txpoll);
     }
 
   net_unlock();

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -872,7 +872,7 @@ static void cdcecm_txavail_work(FAR void *arg)
 
   if (self->bifup)
     {
-      devif_poll(&self->dev, cdcecm_txpoll);
+      devif_timer(&self->dev, 0, cdcecm_txpoll);
     }
 
   net_unlock();

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -1177,7 +1177,7 @@ static void rndis_txavail_work(FAR void *arg)
 
   if (rndis_allocnetreq(priv))
     {
-      devif_poll(&priv->netdev, rndis_txpoll);
+      devif_timer(&priv->netdev, 0, rndis_txpoll);
       if (priv->net_req != NULL)
         {
           rndis_freenetreq(priv);

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -2496,7 +2496,7 @@ static void cdcmbim_txavail_work(void *arg)
 
   if (priv->bifup)
     {
-      (void)devif_poll(&priv->netdev, cdcmbim_txpoll);
+      (void)devif_timer(&priv->netdev, 0, cdcmbim_txpoll);
     }
 
   net_unlock();

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -797,7 +797,7 @@ static void bcmf_txavail_work(FAR void *arg)
 
       priv->bc_dev.d_buf = priv->cur_tx_frame->data;
       priv->bc_dev.d_len = 0;
-      devif_poll(&priv->bc_dev, bcmf_txpoll);
+      devif_timer(&priv->bc_dev, 0, bcmf_txpoll);
     }
 
 exit_unlock:

--- a/drivers/wireless/ieee802154/xbee/xbee_netdev.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_netdev.c
@@ -876,7 +876,7 @@ static void xbeenet_txavail_work(FAR void *arg)
 
       /* Then poll the network for new XMIT data */
 
-      devif_poll(&priv->xd_dev.r_dev, xbeenet_txpoll_callback);
+      devif_timer(&priv->xd_dev.r_dev, 0, xbeenet_txpoll_callback);
     }
 
   net_unlock();

--- a/drivers/wireless/spirit/drivers/spirit_netdev.c
+++ b/drivers/wireless/spirit/drivers/spirit_netdev.c
@@ -1812,7 +1812,7 @@ static void spirit_txpoll_work(FAR void *arg)
     {
       /* Perform a normal, asynchronous poll for new TX data */
 
-      devif_poll(&priv->radio.r_dev, spirit_txpoll_callback);
+      devif_timer(&priv->radio.r_dev, 0, spirit_txpoll_callback);
     }
 
   net_unlock();

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -1283,7 +1283,7 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
 
   conn->tx_unacked = 1;    /* TCP length of the SYN is one. */
   conn->nrtx       = 0;
-  conn->timer      = 1;    /* Send the SYN next time around. */
+  conn->timer      = 0;    /* Send the SYN immediately. */
   conn->rto        = TCP_RTO;
   conn->sa         = 0;
   conn->sv         = 16;   /* Initial value of the RTT variance. */

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -41,6 +41,7 @@
 #include <nuttx/net/tcp.h>
 
 #include "devif/devif.h"
+#include "netdev/netdev.h"
 #include "socket/socket.h"
 #include "tcp/tcp.h"
 
@@ -322,6 +323,10 @@ int psock_tcp_connect(FAR struct socket *psock,
       ret = psock_setup_callbacks(psock, &state);
       if (ret >= 0)
         {
+          /* Notify the device driver that new connection is available. */
+
+          netdev_txnotify_dev(((FAR struct tcp_conn_s *)psock->s_conn)->dev);
+
           /* Wait for either the connect to complete or for an error/timeout
            * to occur. NOTES:  net_lockedwait will also terminate if a signal
            * is received.

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -811,8 +811,7 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
 
   /* Receive additional data from read-ahead buffer, send the ACK timely. */
 
-  else if (state.ir_recvlen > 0 && conn->rcv_wnd == 0 &&
-           conn->rcv_ackcb == NULL)
+  if (conn->rcv_wnd == 0 && conn->rcv_ackcb == NULL)
     {
       conn->rcv_ackcb = tcp_callback_alloc(conn);
       if (conn->rcv_ackcb)


### PR DESCRIPTION
## Summary

arch/netdev: try tcp timer in every txavail call
net/tcp/handshake: send the SYN immediately
net/tcp: send the ack on nonblock mode 

In the current implementation, the first transmission of the new
connection handshake is depends entirely by tcp_timer(), which will
caused 0.5s - 1s delay each time in connect().

This patch is mainly to improve the performance of TCP handshake.

Original:

nsh> tcp_client
[    1.536100] TCP connect start.
[    2.000200] TCP connect end. DIFF: tick: 4641, 464ms.
[    3.000300] TCP connect start.
[    4.000400] TCP connect end. DIFF: tick: 10001, 1000ms.
[    5.000500] TCP connect start.
[    6.000600] TCP connect end. DIFF: tick: 10001, 1000ms.
[    7.000700] TCP connect start.
[    8.000800] TCP connect end. DIFF: tick: 10001, 1000ms.

Optimized:

nsh> tcp_client
[    3.263600] TCP connect start.
[    3.263700] TCP connect end. DIFF: tick: 1, 0ms.
[    4.263800] TCP connect start.
[    4.263800] TCP connect end. DIFF: tick: 0, 0ms.
[    5.263900] TCP connect start.
[    5.263900] TCP connect end. DIFF: tick: 0, 0ms.
[    6.264000] TCP connect start.
[    6.264000] TCP connect end. DIFF: tick: 0, 0ms.
[    7.264100] TCP connect start.
[    7.264100] TCP connect end. DIFF: tick: 0, 0ms.

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

TCP connect()

## Testing

tcp_client.c (Run in NuttX):

```
#include <stdio.h>
#include <sys/types.h>
#include <sys/socket.h>
#include <sys/socket.h>
#include <netinet/in.h>
#include <arpa/inet.h>

int main(int argc, char **argv)
{
  struct sockaddr_in serveraddr = { 0 };
  int len = sizeof(serveraddr);
  int start_ts;
  int end_ts;
  int ret;
  int fd;

  while (1) {
    fd = socket(AF_INET, SOCK_STREAM, 0);

    if (fd < 0)
      return fd;

    serveraddr.sin_family = AF_INET;
    serveraddr.sin_addr.s_addr = inet_addr("192.168.31.28");
    serveraddr.sin_port = htons(atoi("8888"));

    start_ts = (int)clock_systime_ticks();
    syslog(LOG_INFO, "TCP connect start.\n");

    ret = connect(fd, (struct sockaddr*)&serveraddr, len);
    if (ret < 0)
      goto bail;

    end_ts = (int)clock_systime_ticks();
    syslog(LOG_INFO, "TCP connect end. DIFF: tick: %d, %dms.\n",
        end_ts - start_ts, TICK2MSEC(end_ts - start_ts));

    sleep(1);
    close(fd);
  }

bail:
  close(fd);

  return 0;
}
```
tcp_server.c (another host):

```
#include <stdio.h>
#include <sys/types.h>
#include <sys/socket.h>
#include <sys/socket.h>
#include <netinet/in.h>
#include <arpa/inet.h>

int main()
{
  struct sockaddr_in serveraddr = {0}, clientaddr = {0};
  int len = sizeof(serveraddr);
  int clientfd;
  int ret;
  int fd;

  fd = socket(AF_INET, SOCK_STREAM, 0);
  if (fd < 0)
    return fd;

  serveraddr.sin_family = AF_INET;
  serveraddr.sin_addr.s_addr = inet_addr("0.0.0.0");
  serveraddr.sin_port = htons(8888);

  ret = bind(fd, (struct sockaddr*)&serveraddr, len);
  if (ret < 0)
    goto bail;

  listen(fd, 10);

  while (1) {
    clientfd = accept(fd, (struct sockaddr*)&clientaddr, &len);
    usleep(500*1000);
    close(clientfd);
  }

bail:
  close(fd);

  return 0;
}
```

Result:

Original:

```
nsh> tcp_client
[    1.536100] TCP connect start.
[    2.000200] TCP connect end. DIFF: tick: 4641, 464ms.
[    3.000300] TCP connect start.
[    4.000400] TCP connect end. DIFF: tick: 10001, 1000ms.
[    5.000500] TCP connect start.
[    6.000600] TCP connect end. DIFF: tick: 10001, 1000ms.
[    7.000700] TCP connect start.
[    8.000800] TCP connect end. DIFF: tick: 10001, 1000ms.
[    9.000900] TCP connect start.
[   10.001000] TCP connect end. DIFF: tick: 10001, 1000ms.
[   11.001100] TCP connect start.
[   12.001200] TCP connect end. DIFF: tick: 10001, 1000ms.
```

Optimized:

```
nsh> tcp_client
[    3.263600] TCP connect start.
[    3.263700] TCP connect end. DIFF: tick: 1, 0ms.
[    4.263800] TCP connect start.
[    4.263800] TCP connect end. DIFF: tick: 0, 0ms.
[    5.263900] TCP connect start.
[    5.263900] TCP connect end. DIFF: tick: 0, 0ms.
[    6.264000] TCP connect start.
[    6.264000] TCP connect end. DIFF: tick: 0, 0ms.
[    7.264100] TCP connect start.
[    7.264100] TCP connect end. DIFF: tick: 0, 0ms.
[    8.264200] TCP connect start.
[    8.264200] TCP connect end. DIFF: tick: 0, 0ms.
[    9.264300] TCP connect start.
[    9.264300] TCP connect end. DIFF: tick: 0, 0ms.
[   10.264400] TCP connect start.
[   10.264400] TCP connect end. DIFF: tick: 0, 0ms.
```