### PR TITLE
arch/arm/src/stm32h7/stm32_ethernet.c: Fix typo in multicast address …

### DIFF
--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -2803,12 +2803,12 @@ static int stm32_addmac(struct net_driver_s *dev, const uint8_t *mac)
 
   if (hashindex > 31)
     {
-      registeraddress = STM32_ETH_MACHT0R;
+      registeraddress = STM32_ETH_MACHT1R;
       hashindex -= 32;
     }
   else
     {
-      registeraddress = STM32_ETH_MACHT1R;
+      registeraddress = STM32_ETH_MACHT0R;
     }
 
   temp  = stm32_getreg(registeraddress);


### PR DESCRIPTION
## Summary
Fix typo in multicast address hash table registers for STM32H7.

## Impact
Multicast reception on STM32H7 processors.

## Testing
Tested on STM32H743ZI.

