### PR TITLE
xtensa/esp32: enables started flag if the wdt was turned on in bootloader

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wtd.h
+++ b/arch/xtensa/src/esp32/esp32_wtd.h
@@ -100,5 +100,6 @@ struct esp32_wtd_ops_s
 
 FAR struct esp32_wtd_dev_s *esp32_wtd_init(uint8_t wdt_id);
 int esp32_wtd_deinit(FAR struct esp32_wtd_dev_s *dev);
+bool esp32_wtd_is_running(FAR struct esp32_wtd_dev_s *dev);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_WTD_H */

--- a/arch/xtensa/src/esp32/esp32_wtd_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_wtd_lowerhalf.c
@@ -666,7 +666,6 @@ int esp32_wtd_initialize(FAR const char *devpath, uint8_t wdt)
 
   /* Initialize the elements of lower half state structure */
 
-  lower->started = false;
   lower->handler = NULL;
   lower->timeout = 0;
   lower->wtd     = esp32_wtd_init(wdt);
@@ -676,6 +675,8 @@ int esp32_wtd_initialize(FAR const char *devpath, uint8_t wdt)
       ret = -EINVAL;
       goto errout;
     }
+
+  lower->started = esp32_wtd_is_running(lower->wtd);
 
   ESP32_WTD_UNLOCK(lower->wtd);
 


### PR DESCRIPTION
## Summary

This PR aims to make an adjustment, so if the user has enabled the RTC WDT in the bootloader, it will not be necessary to restart the RTC WDT, which means, it will not be necessary to call the `start` ioctl again anymore.

## Impact

All ESP32 WDT users.

## Testing

The RTC WDT was enabled in the bootloader, then I ran the Watchdog Example suppressing the `start` call and I could confirm that the WDT ran properly.
