### PR TITLE
fix: arch/.../stm32h7x3xx_memorymap.h invalid address map for fdcan

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_memorymap.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_memorymap.h
@@ -125,11 +125,11 @@
 #define STM32_DAC1_BASE        0x40007400     /* 0x40007400-0x400077ff: DAC */
 #define STM32_UART7_BASE       0x40007800     /* 0x40007800-0x40007bff: UART7 */
 #define STM32_UART8_BASE       0x40007c00     /* 0x40007c00-0x40007fff: UART8 */
-#define STM32_CRS_BASE         0x40008400     /* 0x40007c00-0x40007fff: CRS */
+#define STM32_CRS_BASE         0x40008400     /* 0x40008400-0x400087ff: CRS */
 #define STM32_SWPMI_BASE       0x40008800     /* 0x40008800 - 0x40008bff SWPMI Section */
 #define STM32_OPAMP_BASE       0x40009000     /* 0x40009000 - 0x400093ff OPAMP Section */
-#define STM32_MDIOS_BASE       0x4000a000     /* 0x40009400 - 0x400097ff MDIOS Section */
-#define STM32_FDCAN1_BASE      0x40008400     /* 0x4000a000 - 0x4000a3ff FDCAN1 Section */
+#define STM32_MDIOS_BASE       0x40009400     /* 0x40009400 - 0x400097ff MDIOS Section */
+#define STM32_FDCAN1_BASE      0x4000a000     /* 0x4000a000 - 0x4000a3ff FDCAN1 Section */
 #define STM32_FDCAN2_BASE      0x4000a400     /* 0x4000a400 - 0x4000A7ff FDCAN2 Section */
 #define STM32_CANCCU_BASE      0x4000a800     /* 0x4000a800 - 0x4000abff CAN CCU Section */
 #define STM32_CANRAM_BASE      0x4000ac00     /* 0x4000ac00 - 0x4000d3ff CAN Message RAM */


### PR DESCRIPTION
## Summary
The used register layout defined in arch/arm/src/stm32h7/hardware/stm32h7x3xx_memorymap.h is not matching the documentation.

The reference manual [RM0433](https://www.st.com/resource/en/reference_manual/dm00314099-stm32h742-stm32h743-753-and-stm32h750-value-line-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf) on page 134/3319 states following addresses
* MDIOS  0x40009400
* FDCAN1 0x4000A000

The source code does not match this specification, however the comment next to it is stating the correct addresses.
I corrected both addresses, aswell as an invalid comment for `CRS_BASE` (where the define is valid, but not the comment).

(I'm not sure if I should have created an issue first/in parallel, but making the changes myself was just as fast, as I needed them anyway)

## Impact
The `MDIOS_BASE` is not used throughout NuttX (checked by full-text search) and the CAN-FD driver is not implemented yet.

Therefore this change has no effect to the current software, but prevents hidden errors on an eventual implementation of a CAN-FD driver caused by an invalid address map.

## Testing
Using the newly assigned address (`FDCAN1_BASE`) in a minimal CAN-FD driver functions as desired.
