### PR TITLE
Add project GitHub Security Policy page

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 10.0.x  | :heavy_check_mark: |
+| 9.1.x   | :heavy_check_mark: |
+| < 9.1   | :x:                |
+
+## Reporting a Vulnerability
+
+If you think you have found a possible vulnerability please reach out to the _private_ project mailing list
+private@nuttx.apache.org or the Apache Security list security@apache.org.
+
+Please **DO NOT** create a GitHub issue or email the project dev list as they are public.
+This project follows the Apache Vulnerability Handling Policy docuemnted [here](https://www.apache.org/security/committers.html#vulnerability-handling)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Get help using NuttX or contribute to the project on our mailing lists:
     * View the archives at:
       <https://www.mail-archive.com/commits@nuttx.apache.org/>
 
+## Reporting Security Issues
+
+Found a vulnerability? See our security policy [here](.github/SECURITY.md).
+
 ## Issue Tracker
 
 ### Bug Reports:


### PR DESCRIPTION
## Summary
This adds a short security page that lists the versions that we are supporting security fixes on as well as how to report issues.

You can see this feature documented here:
https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository

## Impact
Help make sure issues are reported correctly.

## Testing
![image](https://user-images.githubusercontent.com/173245/102444646-8c0ec580-3fde-11eb-990d-072459c443a8.png)

