### PR TITLE
boards: Remove CINCPATH and CXXINCPATH

### DIFF
--- a/boards/arm/eoss3/quickfeather/scripts/Make.defs
+++ b/boards/arm/eoss3/quickfeather/scripts/Make.defs
@@ -24,12 +24,6 @@ include $(TOPDIR)/arch/arm/src/armv7-m/Toolchain.defs
 
 LDSCRIPT = ld.script
 
-CINCPATH := ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include}
-CXXINCPATH := ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include$(DELIM)cxx}
-
-ARCHINCLUDES += $(CINCPATH)
-ARCHXXINCLUDES += $(CINCPATH) $(CXXINCPATH)
-
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   ARCHSCRIPT = -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)}"
 else

--- a/boards/renesas/sh1/us7032evb1/scripts/Make.defs
+++ b/boards/renesas/sh1/us7032evb1/scripts/Make.defs
@@ -29,8 +29,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += -Os -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
 endif
 
-CINCPATH := ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include}
-
 ARCHCPUFLAGS = -m1 -fno-builtin
 ARCHPICFLAGS = -fpic
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef


### PR DESCRIPTION
## Summary
these macro doesn't need anymore with commit:
commit d32e9c38dfb0659a7f3c0cf586ba1584cd7eb3d6
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Sat Jul 11 18:37:40 2020 +0800

boards: Move the C/C++ search path to the common place

so all boards support uClibc++/libc++ automatically

## Impact
Should no any side effect.

## Testing

