### PR TITLE
arch/risc-v: Move csr.h to common place

### DIFF
--- a/arch/risc-v/include/arch.h
+++ b/arch/risc-v/include/arch.h
@@ -47,13 +47,14 @@
 #  include <stdint.h>
 #endif
 
+#include <arch/csr.h>
+
 #ifdef CONFIG_ARCH_RV32IM
-#  include "rv32im/csr.h"
-#  include "rv32im/arch.h"
+#  include <arch/rv32im/arch.h>
 #endif
 
 #ifdef CONFIG_ARCH_RV64GC
-#  include "rv64gc/arch.h"
+#  include <arch/rv64gc/arch.h>
 #endif
 
 /****************************************************************************

--- a/arch/risc-v/include/csr.h
+++ b/arch/risc-v/include/csr.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/include/rv32im/csr.h
+ * arch/risc-v/include/csr.h
  *
  *   Copyright (C) 2016 Ken Pettit. All rights reserved.
  *   Author: Ken Pettit <pettitkd@gmail.com>
@@ -34,8 +34,8 @@
  * through nuttx/irq.h
  */
 
-#ifndef __ARCH_RISCV_INCLUDE_RV32IM_CSR_H
-#define __ARCH_RISCV_INCLUDE_RV32IM_CSR_H
+#ifndef __ARCH_RISCV_INCLUDE_CSR_H
+#define __ARCH_RISCV_INCLUDE_CSR_H
 
 /****************************************************************************
  * Included Files
@@ -345,4 +345,4 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-#endif /* __ARCH_RISCV_INCLUDE_RV32IM_CSR_H */
+#endif /* __ARCH_RISCV_INCLUDE_CSR_H */


### PR DESCRIPTION
## Summary
since CSR definition is same for 32bit and 64bit arch

## Impact

## Testing

