### PR TITLE
tools: Fix version.sh

### DIFF
--- a/tools/version.sh
+++ b/tools/version.sh
@@ -88,9 +88,12 @@ OUTFILE=$1
 if [ -z ${VERSION} ] ; then
   VERSION=`git -C ${WD} describe 2>/dev/null | tail -1 | cut -d'-' -f2`
 
-  if [[ ! ${VERSION} =~ ([0-9]+).([0-9]+).([0-9]+) ]] ; then
-    VERSION=`git -C ${WD} tag --sort=v:refname | tail -1 | cut -d'-' -f2`
+  # If the VERSION does not match X.Y.Z, retrieve version from the tag
+
+  if [[ ! ${VERSION} =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]] ; then
+    VERSION=`git -C ${WD} tag --sort=v:refname | grep -E "[0-9]+\.[0-9]+\.[0-9]+" | tail -1 | cut -d'-' -f2`
   fi
+
 fi
 
 # Make sure we know what is going on


### PR DESCRIPTION
## Summary

- The latest version.sh retrieves version information from git tag
- However, if a repository contains private tags, it will fail
- This commit fixes this issue
- See https://github.com/apache/incubator-nuttx/pull/2557

## Impact

- version.sh only

## Testing

- Tested with https://github.com/masayuki2009/incubator-nuttx
