### PR TITLE
audio: uninitialize usermq to NULL when the device has not

### DIFF
--- a/audio/audio.c
+++ b/audio/audio.c
@@ -187,7 +187,6 @@ static int audio_open(FAR struct file *filep)
   /* Save the new open count on success */
 
   upper->crefs = tmp;
-  upper->usermq = NULL;
   ret = OK;
 
 errout_with_sem:
@@ -244,6 +243,7 @@ static int audio_close(FAR struct file *filep)
       audinfo("calling shutdown\n");
 
       lower->ops->shutdown(lower);
+      upper->usermq = NULL;
     }
 
   ret = OK;


### PR DESCRIPTION
N/A

be opened anymore. There is no need to update usermq to NULL
in audio_open.

Change-Id: I0c20bfa40a4fcd5c8cae0cf09bb55e113435ea62
Signed-off-by: danguanghua <danguanghua@xiaomi.com>

## Summary

## Impact

## Testing

