### PR TITLE
arch/risc-v: Move CSR register bit definition to csr.h

### DIFF
--- a/arch/risc-v/include/csr.h
+++ b/arch/risc-v/include/csr.h
@@ -309,6 +309,22 @@
 #define CSR_DPC             0x7B1
 #define CSR_DSCRATCH        0x7B2
 
+/* In mstatus register */
+
+#define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
+#define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
+#define MSTATUS_MPPM  (0x3 << 11) /* Machine Previous Privilege (m-mode) */
+
+/* In mie (machine interrupt enable) register */
+
+#define MIE_MSIE      (0x1 << 3)  /* Machine Software Interrupt Enable */
+#define MIE_MTIE      (0x1 << 7)  /* Machine Timer Interrupt Enable */
+#define MIE_MEIE      (0x1 << 11) /* Machine External Interrupt Enable */
+
+/* In mip (machine interrupt pending) register */
+
+#define MIP_MTIP      (0x1 << 7)
+
 #define CSR_STR(csr) #csr
 
 #define READ_CSR(reg) \

--- a/arch/risc-v/include/fe310/irq.h
+++ b/arch/risc-v/include/fe310/irq.h
@@ -43,17 +43,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* In mstatus register */
-
-#define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
-#define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
-#define MSTATUS_MPPM  (0x3 << 11) /* Machine Previous Privilege (m-mode) */
-
-/* In mie (machine interrupt enable) register */
-
-#define MIE_MTIE      (0x1 << 7)  /* Machine Timer Interrupt Enable */
-#define MIE_MEIE      (0x1 << 11) /* Machine External Interrupt Enable */
-
 /* Map RISC-V exception code to NuttX IRQ */
 
 /* IRQ 0-15 : (exception:interrupt=0) */

--- a/arch/risc-v/include/k210/irq.h
+++ b/arch/risc-v/include/k210/irq.h
@@ -43,18 +43,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Machine Interrupt Enable bit in mstatus register */
-
-#define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
-#define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
-#define MSTATUS_MPPM  (0x3 << 11) /* Machine Previous Privilege (m-mode) */
-
-/* In mie (machine interrupt enable) register */
-
-#define MIE_MSIE      (0x1 << 3)  /* Machine Software Interrupt Enable */
-#define MIE_MTIE      (0x1 << 7)  /* Machine Timer Interrupt Enable */
-#define MIE_MEIE      (0x1 << 11) /* Machine External Interrupt Enable */
-
 /* Map RISC-V exception code to NuttX IRQ */
 
 /* IRQ 0-15 : (exception:interrupt=0) */

--- a/arch/risc-v/include/litex/irq.h
+++ b/arch/risc-v/include/litex/irq.h
@@ -31,19 +31,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* In mstatus register */
-
-#define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
-#define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
-#define MSTATUS_MPPM  (0x3 << 11) /* Machine Previous Privilege (m-mode) */
-
-/* In mie (machine interrupt enable) register */
-
-#define MIE_MSIE      (0x1 << 3)  /* Machine Software Interrupt Enable */
-#define MIE_MTIE      (0x1 << 7)  /* Machine Timer Interrupt Enable */
-#define MIE_MEIE      (0x1 << 11) /* Machine External Interrupt Enable */
-#define MIP_MTIP (1 << 7)
-
 /* Map RISC-V exception code to NuttX IRQ */
 
 /* IRQ 0-15 : (exception:interrupt=0) */

--- a/arch/risc-v/include/rv32im/irq.h
+++ b/arch/risc-v/include/rv32im/irq.h
@@ -36,17 +36,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* In mstatus register */
-
-#define MSTATUS_MIE   (0x1 << 3)  /* Machine Interrupt Enable */
-#define MSTATUS_MPIE  (0x1 << 7)  /* Machine Previous Interrupt Enable */
-#define MSTATUS_MPPM  (0x3 << 11) /* Machine Previous Privilege (m-mode) */
-
-/* In mie (machine interrupt enable) register */
-
-#define MIE_MTIE      (0x1 << 7)  /* Machine Timer Interrupt Enable */
-#define MIE_MEIE      (0x1 << 11) /* Machine External Interrupt Enable */
-
 /* Configuration ************************************************************/
 
 /* How many nested system calls should we support? */


### PR DESCRIPTION
## Summary
to avoid the macro duplication

## Impact
No function change.

## Testing
pass the build
