### PR TITLE
bluetooth: Fix bt_buff lifecycle

### DIFF
--- a/arch/sim/src/sim/up_hcisocket.c
+++ b/arch/sim/src/sim/up_hcisocket.c
@@ -120,8 +120,6 @@ static int bthcisock_send(FAR const struct bt_driver_s *dev,
       return -1;
     }
 
-  bt_buf_release(buf);
-
   return buf->len;
 }
 

--- a/wireless/bluetooth/bt_conn.c
+++ b/wireless/bluetooth/bt_conn.c
@@ -178,7 +178,7 @@ static int conn_tx_kthread(int argc, FAR char *argv[])
         }
 
       wlinfo("passing buf %p len %u to driver\n", buf, buf->len);
-      g_btdev.btdev->send(g_btdev.btdev, buf);
+      bt_send(g_btdev.btdev, buf);
       bt_buf_release(buf);
     }
 

--- a/wireless/bluetooth/bt_hcicore.h
+++ b/wireless/bluetooth/bt_hcicore.h
@@ -302,6 +302,25 @@ int bt_driver_register(FAR const struct bt_driver_s *btdev);
 
 void bt_driver_unregister(FAR const struct bt_driver_s *btdev);
 
+/****************************************************************************
+ * Name: bt_send
+ *
+ * Description:
+ *   Add the provided buffer 'buf' to the head selected buffer list 'list'
+ *
+ * Input Parameters:
+ *   btdev - An instance of the low-level drivers interface structure.
+ *   buf   - The buffer to be sent by the driver
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ *
+ ****************************************************************************/
+
+int bt_send(FAR const struct bt_driver_s *btdev,
+            FAR struct bt_buf_s *buf);
+
 #ifdef CONFIG_WIRELESS_BLUETOOTH_HOST
 /****************************************************************************
  * Name: bt_hci_cmd_create

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -615,7 +615,6 @@ drop:
 
   /* Release our reference on the buffer */
 
-  bt_buf_release(buf);
   net_unlock();
 }
 
@@ -1222,7 +1221,8 @@ static int  btnet_req_hci_data(FAR struct btnet_driver_s *priv,
           return -ENOMEM;
         }
 
-      g_btdev.btdev->send(g_btdev.btdev, buf);
+      bt_send(g_btdev.btdev, buf);
+      bt_buf_release(buf);
 
       /* Transfer the frame to the Bluetooth stack. */
 


### PR DESCRIPTION
## Summary
The bluetooth buffer lifecycle was not handled correctly in both the case where a userspace stack was used and with the NuttX bluetooth stack.  With the NuttX stack there were cases were a packet could be referenced when it was freed, also with the simulator there was an additional free that should not have been used.  When using the userspace stack an additional free was required by the send interface.

## Impact
Both the NuttX and the userspace stack should be fully supported.  This also means there is no special case handling of the buffer between the configurations.

## Testing
Both the `sim:nimble` and sim:bthcisock`  configurations were run and the buffer counts instrumented to make sure they were not unexpectedly growing.

`sim:nimble` configuration.
```
NuttShell (NSH) NuttX-10.0.1
nsh> ifup bnep0
ifup bnep0...OK
nsh> nimble &
nimble [5:255]
hci init
port init
gap init
gatt init
ans init
ias init
lls init
tps init
hci_sock task init
ble_host task init
nsh> hci sock task
host task
advertise
poweroff
```
Start of Linux `btmon` log
```
= Close Index: 04:D3:B0:FC:BE:16                            [hci0] 24266.997385
@ MGMT Event: Index Removed (0x0005) plen 0        {0x0001} [hci0] 24266.997662
= Open Index: 04:D3:B0:FC:BE:16                             [hci0] 24266.997682
= Index Info: 04:D3:B0:FC:BE:16 (Intel Corp.)               [hci0] 24266.997683
@ RAW Close: nuttx                                        {0x0002} 24266.997685
@ USER Open: nuttx (privileged) version 2.22       {0x0002} [hci0] 24266.997685
= bluetoothd: Endpoint unregistered: sender=:1.107 path=/Media..   24266.997975
= bluetoothd: Endpoint unregistered: sender=:1.107 path=/Media..   24266.997982
< HCI Command: Reset (0x03|0x0003) plen 0            #17961 [hci0] 24279.734468
> HCI Event: Command Complete (0x0e) plen 4          #17962 [hci0] 24279.841819
      Reset (0x03|0x0003) ncmd 2
        Status: Success (0x00)
< HCI Command: Read Local Ve.. (0x04|0x0001) plen 0  #17963 [hci0] 24279.849736
> HCI Event: Command Complete (0x0e) plen 12         #17964 [hci0] 24279.850724
      Read Local Version Information (0x04|0x0001) ncmd 1
        Status: Success (0x00)
        HCI version: Bluetooth 5.1 (0x0a) - Revision 256 (0x0100)
        LMP version: Bluetooth 5.1 (0x0a) - Subversion 256 (0x0100)
        Manufacturer: Intel Corp. (2)
< HCI Command: Read Local Su.. (0x04|0x0003) plen 0  #17965 [hci0] 24279.859516
> HCI Event: Command Complete (0x0e) plen 12         #17966 [hci0] 24279.860728
      Read Local Supported Features (0x04|0x0003) ncmd 1
        Status: Success (0x00)
        Features: 0xbf 0xfe 0x0f 0xfe 0xdb 0xff 0x7b 0x87
          3 slot packets
          5 slot packets
          Encryption
          Slot offset
          Timing accuracy
          Role switch
          Sniff mode
          Power control requests
          Channel quality driven data rate (CQDDR)
          SCO link
          HV2 packets
          HV3 packets
          u-law log synchronous data
          A-law log synchronous data
          CVSD synchronous data
          Paging parameter negotiation
          Power control
          Transparent synchronous data
          Enhanced Data Rate ACL 2 Mbps mode
          Enhanced Data Rate ACL 3 Mbps mode
          Enhanced inquiry scan
          Interlaced inquiry scan
          Interlaced page scan
          RSSI with inquiry results
          Extended SCO link (EV3 packets)
          EV4 packets
          EV5 packets
          AFH capable slave
          AFH classification slave
          LE Supported (Controller)
          3-slot Enhanced Data Rate ACL packets
          5-slot Enhanced Data Rate ACL packets
          Sniff subrating
          Pause encryption
          AFH capable master
          AFH classification master
          Enhanced Data Rate eSCO 2 Mbps mode
          Enhanced Data Rate eSCO 3 Mbps mode
          3-slot Enhanced Data Rate eSCO packets
          Extended Inquiry Response
          Simultaneous LE and BR/EDR (Controller)
          Secure Simple Pairing
          Encapsulated PDU
          Erroneous Data Reporting
          Non-flushable Packet Boundary Flag
          Link Supervision Timeout Changed Event
          Inquiry TX Power Level
          Enhanced Power Control
          Extended features
< HCI Command: Set Event Mask (0x03|0x0001) plen 8   #17967 [hci0] 24279.869456
        Mask: 0x2000800002008090
          Disconnection Complete
          Encryption Change
          Hardware Error
          Data Buffer Overflow
          Encryption Key Refresh Complete
          LE Meta
> HCI Event: Command Complete (0x0e) plen 4          #17968 [hci0] 24279.870722
      Set Event Mask (0x03|0x0001) ncmd 1
        Status: Success (0x00)
< HCI Command: Set Event Mas.. (0x03|0x0063) plen 8  #17969 [hci0] 24279.879614
        Mask: 0x0000000000800000
          Authenticated Payload Timeout Expired
```

`sim:bthcisock` configuration running a scan
```
NuttShell (NSH) NuttX-10.0.1
nsh> ifup bnep0
ifup bnep0...OK
nsh> bt bnep0 scan start -d
nsh> bt bnep0 scan get
Scan result:
 1.	addr:           20:f2:e7:c2:3a:ac type: 1
	rssi:            -76
	response type:   3
	advertiser data: 02 01 1a 03 03 6f fd 17 16 6f fd dd ec 71 78 e8
	                 90 aa e2 38 b9 e6 0f aa 28 7a a9 5c d8 22 de
 2.	addr:           6e:c6:72:de:94:a6 type: 1
	rssi:            -79
	response type:   2
	advertiser data: 03 03 6f fd 17 16 6f fd 63 9d 3a bf d1 0a 21 cf
	                 ec 9e f1 31 d0 44 f2 32 67 ec 5c 82
 3.	addr:           6e:c6:72:de:94:a6 type: 1
	rssi:            -79
	response type:   4
	advertiser data: 4.	addr:           f0:99:19:89:03:ae type: 0
	rssi:            -63
	response type:   0
	advertiser data: 02 01 06 05 ff 87 00 0c 98
 5.	addr:           f0:99:19:89:03:ae type: 0
	rssi:            -64
	response type:   4
```
Start of `btmon` log:
```
= Close Index: 04:D3:B0:FC:BE:16                            [hci0] 24154.008304
@ MGMT Event: Index Removed (0x0005) plen 0        {0x0001} [hci0] 24154.008540
= Open Index: 04:D3:B0:FC:BE:16                             [hci0] 24154.008575
= Index Info: 04:D3:B0:FC:BE:16 (Intel Corp.)               [hci0] 24154.008582
@ RAW Close: nuttx                                        {0x0002} 24154.008588
@ USER Open: nuttx (privileged) version 2.22       {0x0002} [hci0] 24154.008591
= bluetoothd: Endpoint unregistered: sender=:1.107 path=/Media..   24154.011166
= bluetoothd: Endpoint unregistered: sender=:1.107 path=/Media..   24154.011214
< HCI Command: Reset (0x03|0x0003) plen 0            #17769 [hci0] 24154.011032
> HCI Event: Command Complete (0x0e) plen 4          #17770 [hci0] 24154.021095
      Reset (0x03|0x0003) ncmd 2
        Status: Success (0x00)
< HCI Command: Read Local Su.. (0x04|0x0003) plen 0  #17771 [hci0] 24154.026722
> HCI Event: Command Complete (0x0e) plen 12         #17772 [hci0] 24154.027045
      Read Local Supported Features (0x04|0x0003) ncmd 1
        Status: Success (0x00)
        Features: 0xbf 0xfe 0x0f 0xfe 0xdb 0xff 0x7b 0x87
          3 slot packets
          5 slot packets
          Encryption
          Slot offset
          Timing accuracy
          Role switch
          Sniff mode
          Power control requests
          Channel quality driven data rate (CQDDR)
          SCO link
          HV2 packets
          HV3 packets
          u-law log synchronous data
          A-law log synchronous data
          CVSD synchronous data
          Paging parameter negotiation
          Power control
          Transparent synchronous data
          Enhanced Data Rate ACL 2 Mbps mode
          Enhanced Data Rate ACL 3 Mbps mode
          Enhanced inquiry scan
          Interlaced inquiry scan
          Interlaced page scan
          RSSI with inquiry results
          Extended SCO link (EV3 packets)
          EV4 packets
          EV5 packets
          AFH capable slave
          AFH classification slave
          LE Supported (Controller)
          3-slot Enhanced Data Rate ACL packets
          5-slot Enhanced Data Rate ACL packets
          Sniff subrating
          Pause encryption
          AFH capable master
          AFH classification master
          Enhanced Data Rate eSCO 2 Mbps mode
          Enhanced Data Rate eSCO 3 Mbps mode
          3-slot Enhanced Data Rate eSCO packets
          Extended Inquiry Response
          Simultaneous LE and BR/EDR (Controller)
          Secure Simple Pairing
          Encapsulated PDU
          Erroneous Data Reporting
          Non-flushable Packet Boundary Flag
          Link Supervision Timeout Changed Event
          Inquiry TX Power Level
          Enhanced Power Control
          Extended features
< HCI Command: Read Local Ve.. (0x04|0x0001) plen 0  #17773 [hci0] 24154.036963
> HCI Event: Command Complete (0x0e) plen 12         #17774 [hci0] 24154.038108
      Read Local Version Information (0x04|0x0001) ncmd 1
        Status: Success (0x00)
        HCI version: Bluetooth 5.1 (0x0a) - Revision 256 (0x0100)
        LMP version: Bluetooth 5.1 (0x0a) - Subversion 256 (0x0100)
        Manufacturer: Intel Corp. (2)
< HCI Command: Read BD ADDR (0x04|0x0009) plen 0     #17775 [hci0] 24154.047219
> HCI Event: Command Complete (0x0e) plen 10         #17776 [hci0] 24154.048092
      Read BD ADDR (0x04|0x0009) ncmd 1
        Status: Success (0x00)
        Address: 04:D3:B0:FC:BE:16 (Intel Corporate)
```