### PR TITLE
Changes in the watchdog auto-monitor menu

### DIFF
--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -313,26 +313,21 @@ if WATCHDOG
 config WATCHDOG_DEVPATH
 	string "Watchdog Device Path"
 	default "/dev/watchdog0"
+	---help---
+		Please, check how your specific chip or board uses this symbol.
+		FYI: It's NOT used by the Auto-monitor feature.
 
-config WATCHDOG_AUTOMONITOR
+menuconfig WATCHDOG_AUTOMONITOR
 	bool "Auto-monitor"
 	---help---
 		The auto-monitor provides an OS-internal mechanism for automatically
-		start and repeatedly reset the counting after the watchdog is register.
+		start and repeatedly reset the WDTs that were previous selected.
+		Once the Auto-monitor is enabled, it will reset all
+		registered watchdog timers. If you start a specific WDT, the auto-monitor
+		will stop for that WDT and the application should take care of this from
+		now on.
 
 if WATCHDOG_AUTOMONITOR
-
-config WATCHDOG_AUTOMONITOR_TIMEOUT
-	int "Auto-monitor reset timeout(second)"
-	default 60
-
-config WATCHDOG_AUTOMONITOR_PING_INTERVAL
-	int "Auto-monitor keep a live interval"
-	default WATCHDOG_AUTOMONITOR_TIMEOUT
-	range 1 WATCHDOG_AUTOMONITOR_TIMEOUT
-	---help---
-		If the interval is same as WATCHDOG_AUTOMONITOR_TIMEOUT
-		the default value will change to (WATCHDOG_AUTOMONITOR_TIMEOUT / 2).
 
 choice
 	prompt "Auto-monitor keepalive by"
@@ -353,6 +348,24 @@ config WATCHDOG_AUTOMONITOR_BY_IDLE
 	depends on PM
 
 endchoice
+
+config WATCHDOG_AUTOMONITOR_TIMEOUT
+	int "Auto-monitor reset timeout(second)"
+	default 60
+
+if WATCHDOG_AUTOMONITOR_BY_TIMER || WATCHDOG_AUTOMONITOR_BY_WORKER
+
+config WATCHDOG_AUTOMONITOR_PING_INTERVAL
+	int "Auto-monitor keep a live interval"
+	default WATCHDOG_AUTOMONITOR_TIMEOUT
+	range 1 WATCHDOG_AUTOMONITOR_TIMEOUT
+	---help---
+		If the interval is same as WATCHDOG_AUTOMONITOR_TIMEOUT
+		the default value will change to (WATCHDOG_AUTOMONITOR_TIMEOUT / 2).
+		This interval will only be used by auto-monitor by Worker callback
+		or by Timer callback.
+
+endif # WATCHDOG_AUTOMONITOR_BY_TIMER || WATCHDOG_AUTOMONITOR_BY_WORKER
 
 endif # WATCHDOG_AUTOMONITOR
 


### PR DESCRIPTION
## Summary

I have some suggestions for change for the Watchdog Timer Support Menu.

1. The first suggestion is to set the Keep alive interval to depend on the Auto-Monitor choice. Because this interval is only really used by the Timer Callback option or Worker callback option. So it may cause confusion to NuttX users. 
2. Although the dev path is not within the Auto-monitor menu, It seems that the Watchdog Device Path is going to determine which WDT will be fed by the auto-monitor, which is not true. Because if the Auto-monitor is enabled, it will feed all WDTs registered as character drivers.

## Impact
All Auto-monitor users.

## Testing
N/A