### PR TITLE
sched/Kconfig: Minor grammar fixes in help text

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -726,10 +726,10 @@ config SCHED_CRITMONITOR
 	---help---
 		Enables logic that monitors the duration of time that a thread keeps
 		interrupts or pre-emption disabled.  These global locks can have
-		negative consequences to real timer performance:  Disabling interrupts
-		adds jitter in the time when a interrupt request is asserted until
-		the hardware can responds with the interrupt.  Disabling pre-emption
-		adds jitter in the timer from when the event is posted in the
+		negative consequences to real time performance:  Disabling interrupts
+		adds jitter in the time when an interrupt request is asserted until
+		the hardware can respond with the interrupt.  Disabling pre-emption
+		adds jitter in the time from when the event is posted in the
 		interrupt handler until the task that responds to the event can run.
 
 		If this option is selected, then the following interfaces must be
@@ -749,7 +749,7 @@ config SCHED_CRITMONITOR
 		in unknown units) can be obtained by subtracting a start time from
 		the current time.
 
-		The second interface simple converts an elapsed time into well known
+		The second interface simply converts an elapsed time into well known
 		units for presentation by the ProcFS file system.
 
 config SCHED_CPULOAD
@@ -760,15 +760,15 @@ config SCHED_CPULOAD
 		If this option is selected, the timer interrupt handler will monitor
 		if the system is IDLE or busy at the time of that the timer interrupt
 		occurs.  This is a very coarse measurement, but over a period of time,
-		it can very accurately determined the percentage of the time that the
+		it can very accurately determine the percentage of the time that the
 		CPU is IDLE.
 
-		The statistics collected in this could be used, for example in the
+		The statistics collected in this could be used, for example, in the
 		PROCFS file system to provide CPU load measurements when read.
 
 		Note that in tickless mode of operation (SCHED_TICKLESS) there is
 		no system timer interrupt and CPU load measurements will not be
-		possible unless you provide an alternative clock to driver the
+		possible unless you provide an alternative clock to drive the
 		sampling and select SCHED_CPULOAD_EXTCLK.
 
 if SCHED_CPULOAD


### PR DESCRIPTION
## Summary

sched/Kconfig: Minor grammar fixes in help text of SCHED_CRITMONITOR and SCHED_CPULOAD.

## Impact

None.

## Testing

None.