### PR TITLE
boards/sim/sim/sim/src/etc/init.d/rcS: Make it conditional with FS_FAT

### DIFF
--- a/boards/sim/sim/sim/src/etc/init.d/rcS
+++ b/boards/sim/sim/sim/src/etc/init.d/rcS
@@ -24,6 +24,7 @@
 #define CONCAT(x, y)  CONCAT_(x, y)
 
 #ifdef CONFIG_NSH_ROMFSETC
+#ifdef CONFIG_FS_FAT
 
 /* Create a RAMDISK and mount it at /tmp */
 
@@ -31,4 +32,5 @@ mkrd -m CONFIG_NSH_FATDEVNO -s CONFIG_NSH_FATSECTSIZE CONFIG_NSH_FATNSECTORS
 mkfatfs CONCAT(/dev/ram, CONFIG_NSH_FATDEVNO)
 mount -t vfat CONCAT(/dev/ram, CONFIG_NSH_FATDEVNO) CONFIG_NSH_FATMOUNTPT
 
+#endif /* CONFIG_FS_FAT */
 #endif /* CONFIG_NSH_ROMFSETC */


### PR DESCRIPTION
## Summary
boards/sim/sim/sim/src/etc/init.d/rcS: Make it conditional with FS_FAT

ifdef out the guts of the script because it doesn't make sense
without FAT enabled.

## Impact

## Testing
build-tested on macOS with sim:libcxxtest and confirmed the script was generated as expected