### PR TITLE
tools/mkdeps.c: increase MAX_BUFFER to 8192

### DIFF
--- a/tools/mkdeps.c
+++ b/tools/mkdeps.c
@@ -59,7 +59,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define MAX_BUFFER  (4096)
+#define MAX_BUFFER  (8192)
 #define MAX_EXPAND  (2048)
 #define MAX_SHQUOTE (2048)
 


### PR DESCRIPTION

## Summary
tools/mkdeps.c: increase MAX_BUFFER to 8192

Compile may fail when the nuttx folder too long or the compiled file has too long CFLAGS

ERROR: CFLAG string is too long [4448/4096]

## Impact
Common compile

## Testing

