### PR TITLE
Replace all wget with curl

### DIFF
--- a/Documentation/quickstart/install.rst
+++ b/Documentation/quickstart/install.rst
@@ -120,7 +120,7 @@ ARM architecture:
 
       $ HOST_PLATFORM=x86_64-linux   # use "mac" for macOS.
       $ # For windows there is a zip instead (gcc-arm-none-eabi-9-2019-q4-major-win32.zip)
-      $ wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-${HOST_PLATFORM}.tar.bz2
+      $ curl -L -O https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-${HOST_PLATFORM}.tar.bz2
       $ tar xf gcc-arm-none-eabi-9-2019-q4-major-${HOST_PLATFORM}.tar.bz2
 
     Add the toolchain to your `PATH`:
@@ -162,8 +162,8 @@ Apache NuttX is actively developed on GitHub. There are two main repositories, `
 
        $ mkdir nuttx
        $ cd nuttx
-       $ wget https://github.com/apache/incubator-nuttx/tarball/master -O nuttx.tar.gz 
-       $ wget https://github.com/apache/incubator-nuttx-apps/tarball/master -O apps.tar.gz
+       $ curl -L https://github.com/apache/incubator-nuttx/tarball/master -o nuttx.tar.gz 
+       $ curl -L https://github.com/apache/incubator-nuttx-apps/tarball/master -o apps.tar.gz
        $ tar zxf nuttx.tar.gz
        $ tar zxf apps.tar.gz
        
@@ -179,7 +179,7 @@ Apache NuttX is actively developed on GitHub. There are two main repositories, `
     
        $ mkdir nuttx
        $ cd nuttx
-       $ wget https://downloads.apache.org/incubator/nuttx/9.1.0/apache-nuttx-9.1.0-incubating.tar.gz -O nuttx.tar.gz 
-       $ wget https://downloads.apache.org/incubator/nuttx/9.1.0/apache-nuttx-apps-9.1.0-incubating.tar.gz -O apps.tar.gz
+       $ curl -L https://downloads.apache.org/incubator/nuttx/9.1.0/apache-nuttx-9.1.0-incubating.tar.gz -o nuttx.tar.gz 
+       $ curl -L https://downloads.apache.org/incubator/nuttx/9.1.0/apache-nuttx-apps-9.1.0-incubating.tar.gz -o apps.tar.gz
        $ tar zxf nuttx.tar.gz
        $ tar zxf apps.tar.gz

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Cygwin configuration:
           gcc-core         byacc        libmpfr-dev
           gcc-g++          gperf        libmpc-dev
           flex             gdb          automake-1.15
-          libncurses-dev   libgmp-dev
+          libncurses-dev   libgmp-dev   curl
 
 After installing Cygwin, you will get lots of links for installed
 tools and shells.  I use the RXVT native shell.  It is fast and reliable
@@ -319,6 +319,7 @@ README.txt file in the tools repository.  This requires the following
 additional tools:
 
     pacman -S bison
+    pacman -S curl
     pacman -S gperf
     pacman -S ncurses-devel
     pacman -S automake-wrapper

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -186,7 +186,7 @@ WIRELESS_DRV_URL     = https://github.com/espressif/esp-wireless-drivers-3rdpart
 
 $(WIRELESS_DRV_ZIP):
 	$(Q) echo "Downloading: ESP Wireless Drivers"
-	$(Q) wget $(WIRELESS_DRV_URL)/$(WIRELESS_DRV_ZIP) -P chip/
+	$(Q) curl -L $(WIRELESS_DRV_URL)/$(WIRELESS_DRV_ZIP) -o chip/$(WIRELESS_DRV_ZIP)
 
 chip/$(WIRELESS_DRV_UNPACK): $(WIRELESS_DRV_ZIP)
 	$(Q) echo "Unpacking: ESP Wireless Drivers"

--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -43,7 +43,7 @@ LITTLEFS_VERSION ?= 2.2.1
 LITTLEFS_TARBALL = v$(LITTLEFS_VERSION).tar.gz
 
 $(LITTLEFS_TARBALL):
-	$(Q) wget -P littlefs https://github.com/ARMmbed/littlefs/archive/$(LITTLEFS_TARBALL)
+	$(Q) curl -L -o littlefs/$(LITTLEFS_TARBALL) https://github.com/ARMmbed/littlefs/archive/$(LITTLEFS_TARBALL)
 
 .littlefsunpack: $(LITTLEFS_TARBALL)
 	$(Q) tar zxf littlefs/$(LITTLEFS_TARBALL) -C littlefs

--- a/libs/libc/audio/libsrc/Make.defs
+++ b/libs/libc/audio/libsrc/Make.defs
@@ -24,7 +24,7 @@ PACKAGE=libsamplerate
 VERSION=0.1.9
 
 libsamplerate:
-	$(Q) wget https://codeload.github.com/libsndfile/libsamplerate/zip/master -O libsamplerate.zip
+	$(Q) curl -L https://codeload.github.com/libsndfile/libsamplerate/zip/master -o libsamplerate.zip
 	$(Q) unzip -o libsamplerate.zip
 	$(Q) mv libsamplerate-master libsamplerate
 	$(Q) cp -rf libsamplerate/src/samplerate.h $(TOPDIR)$(DELIM)include$(DELIM)nuttx$(DELIM)audio$(DELIM)

--- a/libs/libc/zoneinfo/Makefile
+++ b/libs/libc/zoneinfo/Makefile
@@ -98,10 +98,10 @@ tzbin:
 	mkdir tzbin
 
 tzcode-latest.tar.gz:
-	$(Q) wget --retr-symlinks ftp://ftp.iana.org/tz/tzcode-latest.tar.gz
+	$(Q) curl -L -O ftp://ftp.iana.org/tz/tzcode-latest.tar.gz
 
 tzdata-latest.tar.gz:
-	$(Q) wget --retr-symlinks ftp://ftp.iana.org/tz/tzdata-latest.tar.gz
+	$(Q) curl -L -O ftp://ftp.iana.org/tz/tzdata-latest.tar.gz
 
 .tzunpack: tzcode tzcode-latest.tar.gz tzdata-latest.tar.gz
 	$(Q) tar zx -C tzcode -f tzcode-latest.tar.gz

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -21,7 +21,7 @@
 VERSION=11.0.0
 
 libcxx-$(VERSION).src.tar.xz:
-	$(Q) wget https://github.com/llvm/llvm-project/releases/download/llvmorg-$(VERSION)/libcxx-$(VERSION).src.tar.xz
+	$(Q) curl -O -L https://github.com/llvm/llvm-project/releases/download/llvmorg-$(VERSION)/libcxx-$(VERSION).src.tar.xz
 
 libcxx: libcxx-$(VERSION).src.tar.xz
 	$(Q) tar -xf libcxx-$(VERSION).src.tar.xz

--- a/libs/libxx/uClibc++.defs
+++ b/libs/libxx/uClibc++.defs
@@ -21,7 +21,7 @@
 VERSION=0.2.5
 
 $(TOPDIR)/include/uClibc++:
-	$(Q) wget https://git.busybox.net/uClibc++/snapshot/uClibc++-$(VERSION).tar.gz
+	$(Q) curl -O -L https://git.busybox.net/uClibc++/snapshot/uClibc++-$(VERSION).tar.gz
 	$(Q) tar -xzf uClibc++-$(VERSION).tar.gz
 	$(Q) $(DELFILE) uClibc++-$(VERSION).tar.gz
 	$(Q) mv uClibc++-$(VERSION) uClibc++

--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -60,7 +60,7 @@ LIBMETAL_HDRS_SEDEXP := \
 	 s/cmakedefine/undef/g"
 
 libmetal.zip:
-	$(Q) wget https://github.com/OpenAMP/libmetal/archive/v$(VERSION).zip -O libmetal.zip
+	$(Q) curl -L https://github.com/OpenAMP/libmetal/archive/v$(VERSION).zip -o libmetal.zip
 	$(Q) unzip -o libmetal.zip
 	$(Q) mv libmetal-$(VERSION) libmetal
 	$(Q) patch -p0 < 0001-system-nuttx-change-clock_systimespec-to-clock_systi.patch

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -30,7 +30,7 @@ CSRCS += open-amp/lib/virtio/virtio.c
 CSRCS += open-amp/lib/virtio/virtqueue.c
 
 open-amp.zip:
-	$(Q) wget https://github.com/OpenAMP/open-amp/archive/v$(VERSION).zip -O open-amp.zip
+	$(Q) curl -L https://github.com/OpenAMP/open-amp/archive/v$(VERSION).zip -o open-amp.zip
 	$(Q) unzip -o open-amp.zip
 	$(Q) mv open-amp-$(VERSION) open-amp
 	$(Q) patch -p0 < 0001-rpmsg-remove-the-address-check-in-rpmsg_send-rpmsg_t.patch


### PR DESCRIPTION
## Summary
See https://github.com/apache/incubator-nuttx-apps/pull/534

Note: wget in `tools\checkrelease.sh` is still here.
## Impact
None
## Testing
Tested with stm32f429i-disco on Mac
