### PR TITLE
esp32_wifi_adapter.c: file mode for open doesn't make sense for O_RDONLY

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -3111,7 +3111,7 @@ static int32_t esp_nvs_get_blob(uint32_t handle,
       return -1;
     }
 
-  fd = open(dir, O_RDONLY, NVS_FILE_MODE);
+  fd = open(dir, O_RDONLY);
   if (fd < 0)
     {
       if (errno == ENOENT)


### PR DESCRIPTION
## Summary
Don't bother to specify mode_t for open with O_RDONLY

## Impact

## Testing
tested on esp32-devkitc