### PR TITLE
boards/risc-v/k210: Fix arch flag since NuttX don't support FPU

### DIFF
--- a/boards/risc-v/k210/maix-bit/scripts/Make.defs
+++ b/boards/risc-v/k210/maix-bit/scripts/Make.defs
@@ -56,7 +56,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
 endif
 
-ARCHCPUFLAGS = -march=rv64gc -mabi=lp64 -mcmodel=medany
+ARCHCPUFLAGS = -march=rv64imac -mabi=lp64 -mcmodel=medany
 ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections
 ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef


### PR DESCRIPTION
## Summary
NuttX don't support FPU for risc-v now, let's fix the arch flag to avoid compiler generate hardware float instruction, it would cause fault (e.g. libdsp & dsptest)
## Impact
None
## Testing
Tested on maix-bit:nsh \ maix-bit:smp with float operation
