### PR TITLE
fs: Remove the softlink check from unlink

### DIFF
--- a/fs/vfs/fs_unlink.c
+++ b/fs/vfs/fs_unlink.c
@@ -114,13 +114,7 @@ int unlink(FAR const char *pathname)
    * or a soft link, then rm should remove the node.
    */
 
-#ifdef CONFIG_PSEUDOFS_SOFTLINKS
-  /* A soft link is the only "specal" file that we can remove via unlink(). */
-
-  if (!INODE_IS_SPECIAL(inode) || INODE_IS_SOFTLINK(inode))
-#else
   if (!INODE_IS_SPECIAL(inode))
-#endif
     {
       /* If this is a pseudo-file node (i.e., it has no operations)
        * then unlink should remove the node.


### PR DESCRIPTION
## Summary
since the softlink is a special node too(include/nuttx/fs.h):
```
#define FSNODEFLAG_TYPE_MASK       0x0000000f /* Isolates type field      */
#define   FSNODEFLAG_TYPE_DRIVER   0x00000000 /*   Character driver       */
#define   FSNODEFLAG_TYPE_BLOCK    0x00000001 /*   Block driver           */
#define   FSNODEFLAG_TYPE_MOUNTPT  0x00000002 /*   Mount point            */
#define FSNODEFLAG_TYPE_SPECIAL    0x00000008 /* Special OS type          */
#define   FSNODEFLAG_TYPE_NAMEDSEM 0x00000008 /*   Named semaphore        */
#define   FSNODEFLAG_TYPE_MQUEUE   0x00000009 /*   Message Queue          */
#define   FSNODEFLAG_TYPE_SHM      0x0000000a /*   Shared memory region   */
#define   FSNODEFLAG_TYPE_MTD      0x0000000b /*   Named MTD driver       */
#define   FSNODEFLAG_TYPE_SOFTLINK 0x0000000c /*   Soft link              */
#define FSNODEFLAG_DELETED         0x00000010 /* Unlinked                 */

#define INODE_IS_TYPE(i,t) \
  (((i)->i_flags & FSNODEFLAG_TYPE_MASK) == (t))
#define INODE_IS_SPECIAL(i) \
  (((i)->i_flags & FSNODEFLAG_TYPE_SPECIAL) != 0)
```

## Impact
No function change

## Testing

