### PR TITLE
CI: Allow builds to pass even if final artifact upload fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,7 @@ jobs:
         with:
           name: linux-builds
           path: buildartifacts/
+        continue-on-error: true
 
   macOS:
     runs-on: macos-10.15
@@ -207,3 +208,4 @@ jobs:
         with:
           name: macos-builds
           path: buildartifacts/
+        continue-on-error: true


### PR DESCRIPTION
## Summary
We are seeing higher cases of artifact upload failures
in github.  Other projects are also seeing this as has been
reported at https://github.com/actions/upload-artifact/issues/116

There is a fix that was just merged in the base library:
https://github.com/actions/toolkit/pull/675

So Hopefully we can revert this before too long.

Signed-off-by: Brennan Ashton <bashton@brennanashton.com>

## Impact
Final build artifacts might not be uploaded, but this will not cause a build to fail.  I am using these build artifacts for analysis and testing so I would like to keep them enabled if possible.
