### PR TITLE
Revert "board/sim: Remove the too strict warning"

### DIFF
--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -69,7 +69,7 @@
 #if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
 typedef unsigned long xcpt_reg_t;
 #else
-typedef int xcpt_reg_t;
+typedef unsigned int xcpt_reg_t;
 #endif
 
 /* This struct defines the way the registers are stored */

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -59,8 +59,8 @@ ifeq ($(CONFIG_CXX_EXCEPTION),)
   ARCHCPUFLAGSXX += -fno-exceptions -fcheck-new
 endif
 ARCHPICFLAGS = -fpic
-ARCHWARNINGS = -Wstrict-prototypes -Wundef
-ARCHWARNINGSXX = -Wundef
+ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
+ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 
 # Add -fvisibility=hidden
 # Because we don't want export nuttx's symbols to share libraries

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -46,6 +46,17 @@ distclean::
 CXXFLAGS += ${shell $(DEFINE) "$(CC)" __GLIBCXX__}
 CXXFLAGS += ${shell $(DEFINE) "$(CC)" _LIBCPP_BUILDING_LIBRARY}
 
+# Workaround the following warning with "c++ (Ubuntu 9.3.0-10ubuntu2) 9.3.0"
+#
+# libcxx/src/barrier.cpp: In constructor 'std::__1::__barrier_algorithm_base::__barrier_algorithm_base(ptrdiff_t&)':
+# libcxx/src/barrier.cpp:35:9: warning: declaration of '__expected' shadows a member of 'std::__1::__barrier_algorithm_base' [-Wshadow]
+#    35 |         : __expected(__expected)
+#       |         ^
+# libcxx/src/barrier.cpp:29:24: note: shadowed declaration is here
+#    29 |     ptrdiff_t&         __expected;
+#       |                        ^~~~~~~~~~
+libcxx/src/barrier.cpp_CXXFLAGS += -Wno-shadow
+
 CPPSRCS += $(notdir $(wildcard libcxx/src/*.cpp))
 CPPSRCS += $(notdir $(wildcard libcxx/src/experimental/*.cpp))
 CPPSRCS += $(notdir $(wildcard libcxx/src/filesystem/*.cpp))

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -58,6 +58,9 @@ CXXFLAGS += ${shell $(DEFINE) "$(CC)" _LIBCPP_BUILDING_LIBRARY}
 libcxx/src/barrier.cpp_CXXFLAGS += -Wno-shadow
 libcxx/src/locale.cpp_CXXFLAGS += -Wno-shadow
 
+libcxx/src/filesystem/directory_iterator.cpp_CXXFLAGS += -Wno-shadow
+libcxx/src/filesystem/operations.cpp_CXXFLAGS += -Wno-shadow
+
 CPPSRCS += $(notdir $(wildcard libcxx/src/*.cpp))
 CPPSRCS += $(notdir $(wildcard libcxx/src/experimental/*.cpp))
 CPPSRCS += $(notdir $(wildcard libcxx/src/filesystem/*.cpp))

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -56,6 +56,7 @@ CXXFLAGS += ${shell $(DEFINE) "$(CC)" _LIBCPP_BUILDING_LIBRARY}
 #    29 |     ptrdiff_t&         __expected;
 #       |                        ^~~~~~~~~~
 libcxx/src/barrier.cpp_CXXFLAGS += -Wno-shadow
+libcxx/src/locale.cpp_CXXFLAGS += -Wno-shadow
 
 CPPSRCS += $(notdir $(wildcard libcxx/src/*.cpp))
 CPPSRCS += $(notdir $(wildcard libcxx/src/experimental/*.cpp))


### PR DESCRIPTION
## Summary

Extracted from https://github.com/apache/incubator-nuttx/pull/2063

    Revert "board/sim: Remove the too strict warning"
    
    This reverts commit e70bff723b5e2eecb741f43bb2ecc5a220d3bf8c.
    
    * These warnings sometimes find real bugs. There are ways to disable
      the specific warnings for the specific code (eg. libcxx) selectively.
    
    * It doesn't make much sense to disable these warnings only on sim.
      There are many boards with -Wall -Wshadow. Because the sim is
      mainly for development and testing, it should be less forgiving
      than real boards.
## Impact

## Testing
Tested with the rest of https://github.com/apache/incubator-nuttx/pull/2063
