### PR TITLE
Fix minor issue in bt uart driver

### DIFF
--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -255,14 +255,6 @@ static void btuart_rxwork(FAR void *arg)
 
   wlinfo("Full packet received\n");
 
-  /* Drain any un-read bytes from the Rx buffer */
-
-  nread = lower->rxdrain(lower);
-  if (nread > 0)
-    {
-      wlwarn("WARNING: Discarded %ld bytes\n", (long)nread);
-    }
-
   /* Pass buffer to the stack */
 
   BT_DUMP("Received", buf->data, buf->len);

--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -184,9 +184,9 @@ static void btuart_rxwork(FAR void *arg)
 {
   FAR struct btuart_upperhalf_s *upper;
   FAR const struct btuart_lowerhalf_s *lower;
-  static FAR struct bt_buf_s *buf;
-  static unsigned int hdrlen;
-  static int remaining;
+  FAR struct bt_buf_s *buf;
+  unsigned int hdrlen;
+  int remaining;
   ssize_t nread;
   uint8_t type;
 
@@ -197,9 +197,6 @@ static void btuart_rxwork(FAR void *arg)
   /* Beginning of a new packet.
    * Read the first byte to get the packet type.
    */
-
-  buf    = NULL;
-  hdrlen = 0;
 
   nread = btuart_read(upper, &type, 1, 0);
   if (nread != 1)


### PR DESCRIPTION
## Summary
bluetooth: Remove static variables in btuart_rxwork
bluetooth: Fix the minor typo in bt_uart driver

## Impact
No function change.

## Testing
Please ignore nxstyle warning which is fixed by: https://github.com/apache/incubator-nuttx/pull/2607
