### PR TITLE
bluetooth: Don't call rxdrain in the success path

### DIFF
--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -254,14 +254,6 @@ static void btuart_rxwork(FAR void *arg)
 
   wlinfo("Full packet received\n");
 
-  /* Drain any un-read bytes from the Rx buffer */
-
-  nread = lower->rxdrain(lower);
-  if (nread > 0)
-    {
-      wlwarn("WARNING: Discarded %ld bytes\n", (long)nread);
-    }
-
   /* Pass buffer to the stack */
 
   BT_DUMP("Received",  buf->data, buf->len);


### PR DESCRIPTION
## Summary
because the physical uart bus may receive the next packat asynchronously

## Impact
Avoid the packet loss

## Testing
Please ignore nxstyle warning which is fixed by: https://github.com/apache/incubator-nuttx/pull/2607
