### PR TITLE
Fix vairous issues found in bt uart shim driver

### DIFF
--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -111,22 +111,6 @@ static ssize_t hciuart_write(FAR const struct btuart_lowerhalf_s *lower,
 static ssize_t hciuart_rxdrain(FAR const struct btuart_lowerhalf_s *lower);
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-/* This structure is the configuration of the HCI UART shim */
-
-static struct btuart_lowerhalf_s g_lowerstatic =
-{
-  .rxattach = hciuart_rxattach,
-  .rxenable = hciuart_rxenable,
-  .setbaud = hciuart_setbaud,
-  .read = hciuart_read,
-  .write = hciuart_write,
-  .rxdrain = hciuart_rxdrain
-};
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -460,7 +444,12 @@ FAR struct btuart_lowerhalf_s *bt_uart_shim_getdevice(FAR const char *path)
 
   /* Hook the routines in */
 
-  memcpy(&n->lower, &g_lowerstatic, sizeof(struct btuart_lowerhalf_s));
+  n->lower.rxattach = hciuart_rxattach;
+  n->lower.rxenable = hciuart_rxenable;
+  n->lower.setbaud  = hciuart_setbaud;
+  n->lower.read     = hciuart_read;
+  n->lower.write    = hciuart_write;
+  n->lower.rxdrain  = hciuart_rxdrain;
 
   /* Put materials into poll structure */
 

--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -58,7 +58,6 @@
 #include <nuttx/kthread.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/serial/tioctl.h>
-#include <nuttx/wireless/bluetooth/bt_uart.h>
 #include <nuttx/wireless/bluetooth/bt_uart_shim.h>
 #include <termios.h>
 
@@ -431,7 +430,7 @@ static int hcicollecttask(int argc, FAR char **argv)
  *
  ****************************************************************************/
 
-FAR void *bt_uart_shim_getdevice(FAR char *path)
+FAR struct btuart_lowerhalf_s *bt_uart_shim_getdevice(FAR const char *path)
 {
   FAR struct hciuart_state_s *s;
   int ret;
@@ -474,5 +473,5 @@ FAR void *bt_uart_shim_getdevice(FAR char *path)
                                     CONFIG_BLUETOOTH_TXCONN_PRIORITY,
                                     1024, hcicollecttask, NULL);
 
-  return g_n;
+  return (FAR struct btuart_lowerhalf_s *)g_n;
 }

--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -480,7 +480,8 @@ FAR struct btuart_lowerhalf_s *bt_uart_shim_getdevice(FAR const char *path)
 
   s->serialmontask = kthread_create("BT HCI Rx",
                                     CONFIG_BLUETOOTH_TXCONN_PRIORITY,
-                                    1024, hcicollecttask, argv);
+                                    CONFIG_DEFAULT_TASK_STACKSIZE,
+                                    hcicollecttask, argv);
 
   return (FAR struct btuart_lowerhalf_s *)n;
 }

--- a/include/nuttx/wireless/bluetooth/bt_uart_shim.h
+++ b/include/nuttx/wireless/bluetooth/bt_uart_shim.h
@@ -41,8 +41,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-#include <nuttx/compiler.h>
+#include <nuttx/wireless/bluetooth/bt_uart.h>
 
 #ifdef CONFIG_BLUETOOTH_UART_SHIM
 
@@ -50,7 +49,7 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-FAR void *bt_uart_shim_getdevice(FAR char *path);
+FAR struct btuart_lowerhalf_s *bt_uart_shim_getdevice(FAR const char *path);
 
 #endif
 #endif


### PR DESCRIPTION
## Summary
bt_uart_shim: Correct the prototype of bt_uart_shim_getdevice
bt_uart_shim: Support the multiple instances
bt_uart_shim: Don't hardcode the thread stack size
bt_uart_shim: Remove g_lowerstatic static variable
bt_uart_shim: Make CONFIG_SERIAL_TERMIOS optional
bt_uart_shim: Setup pollfd with file* correctly

## Impact

## Testing
Please ignore nxstyle warning which is fixed by: #2607
