### PR TITLE
arch: S32K/Kinetis: Fix RTC settime prescaler

### DIFF
--- a/arch/arm/src/kinetis/kinetis_rtc.c
+++ b/arch/arm/src/kinetis/kinetis_rtc.c
@@ -174,12 +174,12 @@ static void rtc_dumptime(FAR struct tm *tp, FAR const char *msg)
 #if defined(CONFIG_RTC_ALARM)
 static int kinetis_rtc_interrupt(int irq, void *context, FAR void *arg)
 {
- uint16_t rtc_sr;
+  uint16_t rtc_sr;
 
   /* if alarm */
 
-  rtc_sr = getreg32( KINETIS_RTC_SR);
-  if (rtc_sr & RTC_SR_TAF )
+  rtc_sr = getreg32(KINETIS_RTC_SR);
+  if (rtc_sr & RTC_SR_TAF)
     {
       if (g_alarmcb != NULL)
         {
@@ -209,7 +209,7 @@ static int kinetis_rtc_interrupt(int irq, void *context, FAR void *arg)
 #endif
 
 /****************************************************************************
- * Name: RTC_Reset
+ * Name: rtc_reset
  *
  * Description:
  *    Reset the RTC to known state
@@ -222,16 +222,16 @@ static int kinetis_rtc_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static inline void RTC_Reset(void)
+static inline void rtc_reset(void)
 {
-    putreg32(( RTC_CR_SWR | getreg32(KINETIS_RTC_CR)),KINETIS_RTC_CR);
-    putreg32((~RTC_CR_SWR & getreg32(KINETIS_RTC_CR)),KINETIS_RTC_CR);
+  putreg32((RTC_CR_SWR | getreg32(KINETIS_RTC_CR)), KINETIS_RTC_CR);
+  putreg32((~RTC_CR_SWR & getreg32(KINETIS_RTC_CR)), KINETIS_RTC_CR);
 
-   /* Set TSR register to 0x1 to avoid the timer invalid (TIF) bit being
-    * set in the SR register
-    */
+  /* Set TSR register to 0x1 to avoid the timer invalid (TIF) bit being
+   * set in the SR register
+   */
 
-    putreg32(1,KINETIS_RTC_TSR);
+  putreg32(1, KINETIS_RTC_TSR);
 }
 
 /****************************************************************************
@@ -243,7 +243,7 @@ static inline void RTC_Reset(void)
  *
  * Description:
  *   Initialize the hardware RTC irq.
-*    This only needs to be called once when first used.
+ *   This only needs to be called once when first used.
  *
  * Input Parameters:
  *   None
@@ -260,11 +260,11 @@ int up_rtc_irq_attach(void)
 
   if (!rtc_irq_state)
     {
-      rtc_irq_state=true;
+      rtc_irq_state = true;
 
       /* Clear TAF if pending */
 
-      rtc_sr = getreg32( KINETIS_RTC_SR);
+      rtc_sr = getreg32(KINETIS_RTC_SR);
       if ((rtc_sr & RTC_SR_TAF) != 0)
         {
           putreg32(0, KINETIS_RTC_TAR);
@@ -324,8 +324,8 @@ int up_rtc_initialize(void)
        */
 
       regval = getreg32(KINETIS_RTC_MCLR);
-      if ((CONFIG_RTC_MAGICL == regval ) &&
-          (CONFIG_RTC_MAGICH == getreg32(KINETIS_RTC_MCHR)) )
+      if ((CONFIG_RTC_MAGICL == regval) &&
+          (CONFIG_RTC_MAGICH == getreg32(KINETIS_RTC_MCHR)))
 #endif
         {
           rtc_valid = true;
@@ -343,7 +343,7 @@ int up_rtc_initialize(void)
   else
     {
       rtcinfo("Do setup\n");
-      RTC_Reset();
+      rtc_reset();
 
 #ifdef KINETIS_RTC_GEN2
       /* Configure the RTC to be initialized */
@@ -354,7 +354,7 @@ int up_rtc_initialize(void)
 
       /* Setup the update mode and supervisor access mode */
 
-      putreg32((~(RTC_CR_UM|RTC_CR_SUP) & getreg32(KINETIS_RTC_CR)),
+      putreg32((~(RTC_CR_UM | RTC_CR_SUP) & getreg32(KINETIS_RTC_CR)),
                KINETIS_RTC_CR);
 
       /* Disable counters (just in case) */
@@ -363,12 +363,12 @@ int up_rtc_initialize(void)
 
       /* Enable oscilator - must have Vbat else hard fault */
 
-      putreg32((BOARD_RTC_CAP | RTC_CR_OSCE ), KINETIS_RTC_CR);
+      putreg32((BOARD_RTC_CAP | RTC_CR_OSCE), KINETIS_RTC_CR);
 
-     /* TODO - add capability to accurately tune RTC
-      * This is a per individual board customization and requires
-      * parameters to be configurable and stored in non-volatile eg flash.
-      */
+      /* TODO - add capability to accurately tune RTC
+       * This is a per individual board customization and requires
+       * parameters to be configurable and stored in non-volatile eg flash.
+       */
 
       /* TODO: delay some time (1024 cycles? would be 30ms) */
     }
@@ -489,7 +489,7 @@ int up_rtc_settime(FAR const struct timespec *tp)
   uint32_t prescaler;
 
   seconds = tp->tv_sec;
-  prescaler = tp->tv_nsec * (CONFIG_RTC_FREQUENCY / 1000000000);
+  prescaler = tp->tv_nsec / (1000000000 / CONFIG_RTC_FREQUENCY);
 
   flags = enter_critical_section();
 
@@ -587,7 +587,7 @@ int kinetis_rtc_cancelalarm(void)
 }
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Name: kinetis_rtc_rdalarm
  *
  * Description:
@@ -599,7 +599,7 @@ int kinetis_rtc_cancelalarm(void)
  * Returned Value:
  *   Zero (OK) on success; a negated errno on failure
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_RTC_ALARM
 int kinetis_rtc_rdalarm(FAR struct timespec *tp)

--- a/arch/arm/src/s32k1xx/s32k1xx_rtc.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_rtc.c
@@ -304,7 +304,7 @@ int up_rtc_settime(FAR const struct timespec *ts)
 
   seconds = ts->tv_sec;
 #ifdef CONFIG_RTC_HIRES
-  prescaler = ts->tv_nsec * (CONFIG_RTC_FREQUENCY / 1000000000);
+  prescaler = ts->tv_nsec / (1000000000 / CONFIG_RTC_FREQUENCY);
 #else
   prescaler = 0;
 #endif


### PR DESCRIPTION
## Summary
Original RTC settime prescaler formula used (CONFIG_RTC_FREQUENCY / 1000000000).
Which for example with an 32768Hz clock always results in zero due to integer logic.

## Impact
Minimal only prescaler line has changed

## Testing
Tested on UCANS32K146 

