### PR TITLE
xtensa/esp32: Added driver api to reload counter instantly

### DIFF
--- a/arch/xtensa/src/esp32/esp32_tim.h
+++ b/arch/xtensa/src/esp32/esp32_tim.h
@@ -46,6 +46,7 @@
 #define ESP32_TIM_GETCONFIG(d, v)                  ((d)->ops->getconfig(d, v))
 #define ESP32_TIM_GETCTR(d, v)                     ((d)->ops->getcounter(d, v))
 #define ESP32_TIM_SETCTR(d, v)                     ((d)->ops->setcounter(d, v))
+#define ESP32_TIM_RLD_NOW(d)                       ((d)->ops->reloadnow(d))
 #define ESP32_TIM_GETALRVL(d, v)                   ((d)->ops->getalarmvalue(d, v))
 #define ESP32_TIM_SETALRVL(d, v)                   ((d)->ops->setalarmvalue(d, v))
 #define ESP32_TIM_SETALRM(d, e)                    ((d)->ops->setalarm(d, e))
@@ -101,6 +102,7 @@ struct esp32_tim_ops_s
   CODE int (*getconfig)(FAR struct esp32_tim_dev_s *dev, uint32_t *value);
   CODE int (*getcounter)(FAR struct esp32_tim_dev_s *dev, uint64_t *value);
   CODE int (*setcounter)(FAR struct esp32_tim_dev_s *dev, uint64_t value);
+  CODE int (*reloadnow)(FAR struct esp32_tim_dev_s *dev);
   CODE int (*getalarmvalue)(FAR struct esp32_tim_dev_s *dev,
                             uint64_t *value);
   CODE int (*setalarmvalue)(FAR struct esp32_tim_dev_s *dev, uint64_t value);


### PR DESCRIPTION
## Summary

This PR does 2 things:

* Adds a driver API to reload the counter instantly (by software), instead of only doing this at an alarm event (by hardware).
* Refactors the clear function

For more details about the counter reloading, take a look at section _64-bit Time-base Counter_ from TRM

## Impact

All the ESP32 timers' low-level driver users

## Testing

We could use the get counter API to see that the counter really changed its value instantly. 
