### PR TITLE
serial: should include <signal.h> explicitly

### DIFF
--- a/drivers/serial/serial_dma.c
+++ b/drivers/serial/serial_dma.c
@@ -42,6 +42,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <debug.h>
+#include <signal.h>
 
 #include <nuttx/serial/serial.h>
 


### PR DESCRIPTION


## Summary
serial: should include <signal.h> explicitly

## Impact

## Testing

