### PR TITLE
arch/sim/hci: reuse the reserved fields of hci buffer

### DIFF
--- a/arch/sim/src/sim/up_hcisocket.c
+++ b/arch/sim/src/sim/up_hcisocket.c
@@ -177,7 +177,7 @@ int bthcisock_register(int dev_id)
  *
  ****************************************************************************/
 
-int bthcisock_loop()
+int bthcisock_loop(void)
 {
   uint8_t type;
   int len;

--- a/arch/sim/src/sim/up_hcisocket.c
+++ b/arch/sim/src/sim/up_hcisocket.c
@@ -92,19 +92,19 @@ struct bt_buf_s *read_buf = NULL;
 static int bthcisock_send(FAR const struct bt_driver_s *dev,
                           FAR struct bt_buf_s *buf)
 {
-  uint8_t pkt_type;
+  uint8_t *pkt_type = bt_buf_provide(buf, BLUETOOTH_H4_HDRLEN);
 
   switch (buf->type)
     {
       case BT_CMD:
         {
-          pkt_type = HCI_COMMAND_PKT;
+          *pkt_type = HCI_COMMAND_PKT;
           break;
         }
 
       case BT_ACL_OUT:
         {
-          pkt_type = HCI_ACLDATA_PKT;
+          *pkt_type = HCI_ACLDATA_PKT;
           break;
         }
 
@@ -115,7 +115,7 @@ static int bthcisock_send(FAR const struct bt_driver_s *dev,
         }
     }
 
-  if (bthcisock_host_send(bt_fd, pkt_type, buf->data, buf->len) < 0)
+  if (bthcisock_host_send(bt_fd, buf->data, buf->len) < 0)
     {
       return -1;
     }
@@ -197,7 +197,7 @@ int bthcisock_loop(void)
        * to copy from
        */
 
-      read_buf = bt_buf_alloc(BT_DUMMY, NULL, BLUETOOTH_H4_HDRLEN);
+      read_buf = bt_buf_alloc(BT_DUMMY, NULL, 0);
       if (read_buf == NULL)
         {
           wlerr("ERROR: Failed to allocate buffer\n");
@@ -205,14 +205,15 @@ int bthcisock_loop(void)
         }
     }
 
-  len = bthcisock_host_read(bt_fd, &type, read_buf->data,
+  len = bthcisock_host_read(bt_fd, read_buf->data,
                             BLUETOOTH_MAX_FRAMELEN);
   if (len < 0)
     {
       return OK;
     }
 
-  read_buf->len = len;
+  type = *(uint8_t *)bt_buf_extend(read_buf, len);
+  bt_buf_consume(read_buf, BLUETOOTH_H4_HDRLEN);
 
   switch (type)
     {

--- a/arch/sim/src/sim/up_hcisocket_host.c
+++ b/arch/sim/src/sim/up_hcisocket_host.c
@@ -63,6 +63,43 @@ struct sockaddr_hci
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: bthcisock_host_avail
+ *
+ * Description:
+ *   Monitor the host user channel to see if I/O is possible on socket.
+ *
+ * Input Parameters:
+ *   fd: Host Bluetooth socket fd
+ *
+ * Returned Value:
+ *   TRUE is returned on I/O available
+ *
+ ****************************************************************************/
+
+int bthcisock_host_avail(int fd)
+{
+  struct timeval tv;
+  fd_set fdset;
+
+  /* We can't do anything if we failed to open the user channel */
+
+  if (fd < 0)
+    {
+      return 0;
+    }
+
+  /* Wait for data on the user channel (or a timeout) */
+
+  tv.tv_sec  = 0;
+  tv.tv_usec = 0;
+
+  FD_ZERO(&fdset);
+  FD_SET(fd, &fdset);
+
+  return select(fd + 1, &fdset, NULL, NULL, &tv) > 0;
+}
+
+/****************************************************************************
  * Name: bthcisock_host_send
  *
  * Description:
@@ -189,4 +226,24 @@ int bthcisock_host_open(int dev_idx)
     }
 
   return fd;
+}
+
+/****************************************************************************
+ * Name: bthcisock_host_close
+ *
+ * Description:
+ *   Close a User Channel HCI socket on the Host for the given device idx.
+ *
+ * Input Parameters:
+ *   fd: The resources associated with the open user channel are freed.
+ *
+ * Returned Value:
+ *   Zero is returned on success; a negated errno value is returned on any
+ *   failure.
+ *
+ ****************************************************************************/
+
+int bthcisock_host_close(int fd)
+{
+  return close(fd);
 }

--- a/arch/sim/src/sim/up_hcisocket_host.c
+++ b/arch/sim/src/sim/up_hcisocket_host.c
@@ -106,10 +106,9 @@ int bthcisock_host_avail(int fd)
  *   Send a Bluetooth packet out via the host user socket.
  *
  * Input Parameters:
- *   fd: Host Bluetooth socket fd
- *   pkt_type: Packet type as known to the Linux Bluetooth stack
+ *   fd  : Host Bluetooth socket fd
  *   data: Pointer to the HCI packet
- *   len: Length of packet
+ *   len : Length of packet
  *
  * Returned Value:
  *   Zero is returned on success; a negated errno value is returned on any
@@ -117,19 +116,15 @@ int bthcisock_host_avail(int fd)
  *
  ****************************************************************************/
 
-int bthcisock_host_send(int fd, uint8_t pkt_type, uint8_t *data, size_t len)
+int bthcisock_host_send(int fd, void *data, size_t len)
 {
-  struct iovec iv[2];
-
-  iv[0].iov_base = &pkt_type;
-  iv[0].iov_len = 1;
-  iv[1].iov_base = data;
-  iv[1].iov_len = len;
-
-  while (writev(fd, iv, 2) < 0)
+  while (write(fd, data, len) < 0)
     {
       if (errno == EAGAIN || errno == EINTR)
-        continue;
+        {
+          continue;
+        }
+
       return -1;
     }
 
@@ -143,9 +138,9 @@ int bthcisock_host_send(int fd, uint8_t pkt_type, uint8_t *data, size_t len)
  *   Read from the Host HCI socket interface.
  *
  * Input Parameters:
- *   fd: Host Bluetooth socket fd
+ *   fd  : Host Bluetooth socket fd
  *   data: Pointer to store HCI packet
- *   len: Maximum length of packet
+ *   len : Maximum length of packet
  *
  * Returned Value:
  *   Zero is returned on success; a negated errno value is returned on any
@@ -153,17 +148,11 @@ int bthcisock_host_send(int fd, uint8_t pkt_type, uint8_t *data, size_t len)
  *
  ****************************************************************************/
 
-int bthcisock_host_read(int fd, uint8_t *type, void *buf, size_t len)
+int bthcisock_host_read(int fd, void *data, size_t len)
 {
   int err;
-  struct iovec iv[2];
 
-  iv[0].iov_base = type;
-  iv[0].iov_len = 1;
-  iv[1].iov_base = buf;
-  iv[1].iov_len = len;
-
-  while ((err = readv(fd, iv, 2)) < 0 && (errno == EINTR));
+  while ((err = read(fd, data, len)) < 0 && (errno == EINTR));
 
   if (err <= 0)
     {
@@ -172,9 +161,9 @@ int bthcisock_host_read(int fd, uint8_t *type, void *buf, size_t len)
       return -1;
     }
 
-  /* Return the number of bytes written to buf so remove the header byte */
+  /* Return the number of bytes written to data */
 
-  return (err - 1);
+  return err;
 }
 
 /****************************************************************************

--- a/arch/sim/src/sim/up_hcisocket_host.h
+++ b/arch/sim/src/sim/up_hcisocket_host.h
@@ -33,8 +33,8 @@
  ****************************************************************************/
 
 int bthcisock_host_open(int dev_idx);
-int bthcisock_host_send(int fd, uint8_t pkt_type, uint8_t *data, size_t len);
-int bthcisock_host_read(int fd, uint8_t *type, void *buf, size_t len);
+int bthcisock_host_send(int fd, void *data, size_t len);
+int bthcisock_host_read(int fd, void *data, size_t len);
 int bthcisock_host_avail(int fd);
 int bthcisock_host_close(int fd);
 

--- a/arch/sim/src/sim/up_hcisocket_host.h
+++ b/arch/sim/src/sim/up_hcisocket_host.h
@@ -32,8 +32,10 @@
  * Public Function Prototypes
  ****************************************************************************/
 
+int bthcisock_host_open(int dev_idx);
 int bthcisock_host_send(int fd, uint8_t pkt_type, uint8_t *data, size_t len);
 int bthcisock_host_read(int fd, uint8_t *type, void *buf, size_t len);
-int bthcisock_host_open(int dev_idx);
+int bthcisock_host_avail(int fd);
+int bthcisock_host_close(int fd);
 
 #endif /* _ARCH_SIM_SRC_SIM_HCISOCKET_HOST_H_ */


### PR DESCRIPTION
## Summary

arch/sim/hci: reuse the reserved fields of hci buffer
sim/host/hcisocket: add avail/close interface

## Impact

sim/bthcisock

## Testing

./tools/configure.sh sim/bthcisock
