### PR TITLE
Added formatted timestamps in syslog.

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -111,6 +111,37 @@ config SYSLOG_TIMESTAMP_REALTIME
 		CLOCK_MONOTONIC, if enabled, will be used or the system timer
 		is not.
 
+config SYSLOG_TIMESTAMP_FORMATTED
+	bool "Formatted syslog time"
+	default n
+	depends on SYSLOG_TIMESTAMP_REALTIME
+	---help---
+		Syslog timestamp will be formatted according to the
+		SYSLOG_TIMESTAMP_FORMAT format string.		
+
+config SYSLOG_TIMESTAMP_LOCALTIME
+	bool "Use local-time timestamp"
+	default n
+	depends on SYSLOG_TIMESTAMP_FORMATTED
+	---help---
+		If selected local time will be used for the timestamps.
+		Else, timestamps will be in UTC.
+
+config SYSLOG_TIMESTAMP_FORMAT
+	string "Time format"
+	default "%e/%m/%y %H:%M:%S"
+	depends on SYSLOG_TIMESTAMP_FORMATTED
+	---help---
+		Formatter string for syslog timestamp printing.
+		Uses the standard "strftime" format specifiers.
+
+config SYSLOG_TIMESTAMP_BUFFER
+	int "Formatted timestamp buffer size"
+	default 64
+	depends on SYSLOG_TIMESTAMP_FORMATTED
+	---help---
+		Buffer size to store syslog formatted timestamps.
+
 config SYSLOG_PREFIX
 	bool "Prepend prefix to syslog message"
 	default n


### PR DESCRIPTION
## Summary
Adds the ability to have formatted timestamps in syslog, using the standard C date specifiers (`strftime`).

## Impact
The default formatting remains as is, so there should be no impact on current projects.

## Testing
Tested the patch on NuttX-v10.0.1 on custom STM32F4-based board, and works as expected.  
I do plan to do more extensive testing on all possible configurations of syslog timestamping.

---

The current implementation does not look very elegant or efficient to me.  
I think it can be improved. Maybe a `lib_strftime` is needed? Maybe `localtime` can be avoided?
