### PR TITLE
CI: Only use approved GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,13 +142,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Pull
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 10
-          command: docker pull docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux
-
+        run: docker pull docker.pkg.github.com/apache/incubator-nuttx-testing/nuttx-ci-linux
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
       - name: Run builds

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -23,31 +23,15 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      - name: Generate requirements.txt file
-        run: |
-          cd Documentation/
-          pip3 install pipenv
-          pipenv lock -r > requirements.txt
-      - uses: ammaraskar/sphinx-problem-matcher@master
-      - uses: ammaraskar/sphinx-action@master
-        with:
-          docs-folder: "Documentation/"
-      - uses: actions/upload-artifact@v2
-        with:
-          name: sphinx-docs
-          path: Documentation/_build/html/
-  linkcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-      - uses: ammaraskar/sphinx-problem-matcher@master
-      - name: Run linkcheck
+      - name: Generate Documentation
         run: |
           cd Documentation/
           pip3 install pipenv
           pipenv install
+          pipenv run make html
           # This step flakes frequently so still annotate errors but dont fail the build
           pipenv run make linkcheck || true
+      - uses: actions/upload-artifact@v2
+        with:
+          name: sphinx-docs
+          path: Documentation/_build/html/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,4 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 🧹 YAML Lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_YAML: true
+          FILTER_REGEX_INCLUDE: .*\.github/.*


### PR DESCRIPTION
## Summary
Apache Infrastructure recently made a change to the GitHub projects so that they cannot use actions that are not under the Apache org, GitHub org, or verified.   We were using some outside of this and this prevented builds from running.

More details:

Policy:

* https://infra.apache.org/github-actions-secrets.html

Discussion builds@apache.org:

* https://lists.apache.org/thread.html/r435c45dfc28ec74e28314aa9db8a216a2b45ff7f27b15932035d3f65%40%3Cbuilds.apache.org%3E

Discussion users@infra.apache.org:

* https://lists.apache.org/thread.html/r900f8f9a874006ed8121bdc901a0d1acccbb340882c1f94dad61a5e9%40%3Cusers.infra.apache.org%3E

## Impact
One drawback is that the docker pull retry action had to be dropped.  We can implement this via bash if needed.

## Testing
CI Runs

