### PR TITLE
arch/spinlock: implement the default test-and-set semantics

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -128,7 +128,28 @@
  *
  ****************************************************************************/
 
+#if defined(CONFIG_ARCH_HAVE_TESTSET)
 spinlock_t up_testset(volatile FAR spinlock_t *lock);
+#elif !defined(CONFIG_SMP)
+static inline spinlock_t up_testset(volatile FAR spinlock_t *lock)
+{
+  irqstate_t flags;
+  spinlock_t ret;
+
+  flags = up_irq_save();
+
+  ret = *lock;
+
+  if (ret == SP_UNLOCKED)
+    {
+      *lock = SP_LOCKED;
+    }
+
+  up_irq_restore(flags);
+
+  return ret;
+}
+#endif
 
 /****************************************************************************
  * Name: spin_initialize

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -232,7 +232,6 @@ menu "Tasks and Scheduling"
 config SPINLOCK
 	bool "Support Spinlocks"
 	default n
-	depends on ARCH_HAVE_TESTSET
 	---help---
 		Enables support for spinlocks.  Spinlocks are used primarily for
 		synchronization in SMP configurations but are available for general
@@ -275,6 +274,7 @@ config SMP
 	bool "Symmetric Multi-Processing (SMP)"
 	default n
 	depends on ARCH_HAVE_MULTICPU
+	depends on ARCH_HAVE_TESTSET
 	select SPINLOCK
 	select SCHED_RESUMESCHEDULER
 	select IRQCOUNT


### PR DESCRIPTION
## Summary

arch/spinlock: implement the default test-and-set semantics

use the default testset implement on single core platform that does not support test-and-set,
more flexibility for SMP drivers(using spinlock) if configured in a single-core mode.

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

spinlock

## Testing

spin_lock()
spin_unlock()
