### PR TITLE
Add time ticket related APIs to support hot sleep function 

### DIFF
--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -437,6 +437,22 @@ int clock_cpuload(int pid, FAR struct cpuload_s *cpuload);
 #endif
 
 /****************************************************************************
+ * Name:  clock_systime_steps
+ *
+ * Description:
+ *   Add system time by idle ticks.
+ *
+ * Input Parameters:
+ *   ticks - Idle ticks
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void clock_systime_steps(sclock_t ticks);
+
+/****************************************************************************
  * Name:  nxsched_oneshot_extclk
  *
  * Description:

--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -170,6 +170,39 @@ int wd_cancel(FAR struct wdog_s *wdog);
 
 int wd_gettime(FAR struct wdog_s *wdog);
 
+/****************************************************************************
+ * Name: wd_getidletime
+ *
+ * Description:
+ *   This function returns the idle time.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The time in system ticks remaining for idle.
+ *   Zero means system is busy.
+ *
+ ****************************************************************************/
+
+int wd_getidletime(void);
+
+/****************************************************************************
+ * Name: wd_setsleepticks
+ *
+ * Description:
+ *   This function will update watchdogs' lag.
+ *
+ * Input Parameters:
+ *   ticks - sleep ticks
+ *
+ * Returned Value:
+ *   Zero means success.
+ *
+ ****************************************************************************/
+
+int wd_setsleepticks(clock_t ticks);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/sched/clock/clock_systime_ticks.c
+++ b/sched/clock/clock_systime_ticks.c
@@ -154,3 +154,34 @@ clock_t clock_systime_ticks(void)
 # endif /* CONFIG_SYSTEM_TIME64 */
 #endif /* CONFIG_SCHED_TICKLESS */
 }
+
+/****************************************************************************
+ * Name:  clock_systime_steps
+ *
+ * Description:
+ *   Add system time by idle ticks.
+ *
+ * Input Parameters:
+ *   ticks - Idle ticks
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void clock_systime_steps(sclock_t ticks)
+{
+#ifdef CONFIG_SCHED_TICKLESS
+
+  serr("Not supoort adjusting system tick\n");
+
+#else /* CONFIG_SCHED_TICKLESS */
+  irqstate_t flags;
+  flags = enter_critical_section();
+
+  /* Adjust the current system time */
+
+  g_system_timer += ticks;
+  leave_critical_section(flags);
+#endif /* CONFIG_SCHED_TICKLESS */
+}

--- a/sched/wdog/Make.defs
+++ b/sched/wdog/Make.defs
@@ -19,6 +19,7 @@
 ############################################################################
 
 CSRCS += wd_initialize.c wd_start.c wd_cancel.c wd_gettime.c wd_recover.c
+CSRCS += wd_getidletime.c wd_setsleepticks.c
 
 # Include wdog build support
 

--- a/sched/wdog/wd_getidletime.c
+++ b/sched/wdog/wd_getidletime.c
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * sched/wdog/wd_getidletime.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/wdog.h>
+#include <nuttx/irq.h>
+
+#include "wdog/wdog.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: wd_getidletime
+ *
+ * Description:
+ *   This function returns the idle time.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The time in system ticks remaining for idle.
+ *   Zero means system is busy.
+ *
+ ****************************************************************************/
+
+int wd_getidletime(void)
+{
+  int        idletime = -1;
+  irqstate_t flags;
+
+  flags = enter_critical_section();
+
+  FAR struct wdog_s *curr = (FAR struct wdog_s *)g_wdactivelist.head;
+
+  idletime = (curr ? curr->lag : 0);
+
+  leave_critical_section(flags);
+  return idletime;
+}

--- a/sched/wdog/wd_setsleepticks.c
+++ b/sched/wdog/wd_setsleepticks.c
@@ -1,0 +1,65 @@
+/****************************************************************************
+ * sched/wdog/wd_setsleepticks.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/wdog.h>
+#include <nuttx/irq.h>
+
+#include "wdog/wdog.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: wd_setsleepticks
+ *
+ * Description:
+ *   This function will update watchdogs' lag.
+ *
+ * Input Parameters:
+ *   ticks - sleep ticks
+ *
+ * Returned Value:
+ *   Zero means success.
+ *
+ ****************************************************************************/
+
+int wd_setsleepticks(clock_t ticks)
+{
+  irqstate_t flags;
+  FAR struct wdog_s * curr;
+
+  flags = enter_critical_section();
+
+  for (curr = (FAR struct wdog_s *)(g_wdactivelist.head);
+       curr; curr = curr->next)
+    {
+      curr->lag -= ticks;
+    }
+
+  leave_critical_section(flags);
+  return 0;
+}


### PR DESCRIPTION
## Summary
Add time ticket related APIs to support hot sleep function

## Impact
For watchdog, add two new APIs with below functions
   - Get idle time for hot sleep
   - Update watchdogs' lag after resume

For system clock, add a new API to sync system time with idle ticks after resume

## Testing
Built in with these three APIs

