### PR TITLE
vfs: Fix unsed label warning

### DIFF
--- a/fs/vfs/fs_unlink.c
+++ b/fs/vfs/fs_unlink.c
@@ -191,11 +191,14 @@ int nx_unlink(FAR const char *pathname)
   RELEASE_SEARCH(&desc);
   return OK;
 
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 errout_with_sem:
   inode_semgive();
-
+#endif
+#if !defined(CONFIG_DISABLE_MOUNTPOINT) || !defined(CONFIG_DISABLE_PSEUDOFS_OPERATIONS)
 errout_with_inode:
   inode_release(inode);
+#endif
 
 errout_with_search:
   RELEASE_SEARCH(&desc);


### PR DESCRIPTION
## Summary
PR #2618 snuck in while the CI was broken and broke master with the warning

```
vfs/fs_unlink.c:194:1: error: label 'errout_with_sem' defined but not used [-Werror=unused-label]
```
This change covers this and another possible unused label in the same function.

## Impact
This label is now conditionally defined.

## Testing
CI and local builds
