### PR TITLE
BL602: Add support for system reset modes

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -47,6 +47,7 @@ config ARCH_CHIP_GAP8
 config ARCH_CHIP_BL602
 	bool "BouffaloLab BL602"
 	select ARCH_RV32IM
+	select ARCH_HAVE_RESET
 	---help---
 		BouffaloLab BL602(rv32imfc)
 

--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -59,7 +59,7 @@ ifeq ($(CONFIG_ONESHOT),y)
 CHIP_CSRCS  += bl602_oneshot_lowerhalf.c
 endif
 
-CHIP_CSRCS += bl602_glb.c bl602_gpio.c bl602_hbn.c
+CHIP_CSRCS += bl602_glb.c bl602_gpio.c bl602_hbn.c bl602_systemreset.c
 
 # INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)chip$(DELIM)hardware}
 

--- a/arch/risc-v/src/bl602/bl602_systemreset.c
+++ b/arch/risc-v/src/bl602/bl602_systemreset.c
@@ -1,0 +1,140 @@
+/****************************************************************************
+ * arch/risc-v/src/bl602/bl602_systemreset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include "riscv_arch.h"
+
+#include "hardware/bl602_glb.h"
+#include "hardware/bl602_hbn.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl602_chip_reset
+ *
+ * Description:
+ *   Control the different reset modes
+ *
+ * Input Parameters:
+ *   mask - Reset bitmask use these defines
+ *          SWRST_CFG2_CTRL_SYS_RESET, SWRST_CFG2_CTRL_CPU_RESET,
+ *          SWRST_CFG2_CTRL_PWRON_RST
+ *
+ ****************************************************************************/
+
+static void bl602_chip_reset(uint32_t mask)
+{
+  /* Reset the root clock */
+
+  modifyreg32(BL602_HBN_GLB, HBN_GLB_HBN_ROOT_CLK_SEL_MASK, 0);
+
+  /* Clear root clock dividers */
+
+  modifyreg32(
+      BL602_CLK_CFG0,
+      CLK_CFG0_REG_BCLK_DIV_MASK | CLK_CFG0_REG_HCLK_DIV_MASK,
+      0
+  );
+
+  /* This register should toggled on-off on changes to root clock.
+   * details of this register are not documented, but is clear from ROM
+   */
+
+  putreg32(1, 0x40000ffc);
+  putreg32(0, 0x40000ffc);
+
+  /* Trigger reset
+   * NOTE: The reset seems to be rising _edge_ triggered so the reset
+   *       bit should be cleared first otherwise the reset will not
+   *       trigger if it has previously fired.
+   */
+
+  modifyreg32(
+      BL602_SWRST_CFG2,
+      (SWRST_CFG2_CTRL_SYS_RESET | SWRST_CFG2_CTRL_CPU_RESET | \
+       SWRST_CFG2_CTRL_PWRON_RST),
+      0
+  );
+
+  modifyreg32(
+      BL602_SWRST_CFG2,
+      (SWRST_CFG2_CTRL_SYS_RESET | SWRST_CFG2_CTRL_CPU_RESET | \
+       SWRST_CFG2_CTRL_PWRON_RST),
+      mask
+  );
+
+  /* Wait for the reset */
+
+  for (; ; );
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_systemreset
+ *
+ * Description:
+ *   Internal reset logic.
+ *
+ ****************************************************************************/
+
+void up_systemreset(void)
+{
+  bl602_chip_reset(SWRST_CFG2_CTRL_SYS_RESET | SWRST_CFG2_CTRL_CPU_RESET);
+}
+
+/****************************************************************************
+ * Name: bl602_cpu_reset
+ *
+ * Description:
+ *   Reset only the CPU
+ *
+ ****************************************************************************/
+
+void bl602_cpu_reset(void)
+{
+  bl602_chip_reset(SWRST_CFG2_CTRL_CPU_RESET);
+}
+
+/****************************************************************************
+ * Name: bl602_por_reset
+ *
+ * Description:
+ *   Trigger Power-on-Reset
+ *
+ ****************************************************************************/
+
+void bl602_por_reset(void)
+{
+  bl602_chip_reset(
+    SWRST_CFG2_CTRL_SYS_RESET | \
+    SWRST_CFG2_CTRL_CPU_RESET | \
+    SWRST_CFG2_CTRL_PWRON_RST);
+}

--- a/arch/risc-v/src/bl602/bl602_systemreset.h
+++ b/arch/risc-v/src/bl602/bl602_systemreset.h
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * arch/risc-v/src/bl602/bl602_hbn.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_BL602_BL602_SYSTEMREST_H
+#define __ARCH_RISCV_SRC_BL602_BL602_SYSTEMREST_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define bl602_sys_reset() up_systemreset()
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bl602_cpu_reset
+ *
+ * Description:
+ *   Reset only the CPU
+ *
+ ****************************************************************************/
+
+void bl602_cpu_reset(void);
+
+/****************************************************************************
+ * Name: bl602_por_reset
+ *
+ * Description:
+ *   Trigger Power-on-Reset
+ *
+ ****************************************************************************/
+
+void bl602_por_reset(void);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_BL602_BL602_SYSTEMREST_H */

--- a/boards/risc-v/bl602/bl602evb/src/Makefile
+++ b/boards/risc-v/bl602/bl602evb/src/Makefile
@@ -24,6 +24,9 @@ CSRCS  = bl602_bringup.c bl602_boot.c
 
 ifeq ($(CONFIG_LIB_BOARDCTL),y)
 CSRCS += bl602_appinit.c
+ifeq ($(CONFIG_BOARDCTL_RESET),y)
+  CSRCS += bl602_reset.c
+endif
 endif
 
 include $(TOPDIR)/boards/Board.mk

--- a/boards/risc-v/bl602/bl602evb/src/bl602_reset.c
+++ b/boards/risc-v/bl602/bl602evb/src/bl602_reset.c
@@ -1,0 +1,86 @@
+/****************************************************************************
+ * boards/risc-v/bl602/evb/src/bl602_reset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#include <bl602_systemreset.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_reset
+ *
+ * Description:
+ *   Reset board.  Support for this function is required by board-level
+ *   logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ * Input Parameters:
+ *   status - Status information provided with the reset event.  This
+ *            meaning of this status information is board-specific.  If not
+ *            used by a board, the value zero may be provided in calls to
+ *            board_reset().
+ *            Valid inputs:
+ *               0 -- sys reset (default nsh reboot cmd)
+ *               1 -- cpu reset
+ *               2 -- por reset
+ *
+ * Returned Value:
+ *   If this function returns, then it was not possible to power-off the
+ *   board due to some constraints.  The return value int this case is a
+ *   board-specific reason for the failure to shutdown.
+ *
+ ****************************************************************************/
+
+int board_reset(int status)
+{
+  switch (status)
+    {
+      case 0:
+        up_systemreset();
+        break;
+
+      case 1:
+        bl602_cpu_reset();
+        break;
+
+      case 2:
+        bl602_por_reset();
+        break;
+
+      default:
+        return -EINVAL;
+    }
+
+  /* If we get here something went very wrong in the reset */
+
+  return -EIO;
+}
+


### PR DESCRIPTION
## Summary
This adds support for issuing software rests on the bl602 chip.

## Impact
Add support for issuing software resets.

## Testing
Enabled the reboot nsh builtin command and programmed the EVKB board.

```
NuttShell (NSH) NuttX-10.0.1
nsh> uname -a
NuttX 10.0.1 c647faa117-dirty Dec 31 2020 10:52:08 risc-v bl602evb
nsh> reboot

NuttShell (NSH) NuttX-10.0.1
nsh> uname -a
NuttX 10.0.1 c647faa117-dirty Dec 31 2020 10:52:08 risc-v bl602evb
nsh> 
```
