### PR TITLE
fs: Let files_allocate return -EMFILE instead ERROR

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -336,7 +336,7 @@ int files_allocate(FAR struct inode *inode, int oflags, off_t pos, int minfd)
     }
 
   _files_semgive(list);
-  return ERROR;
+  return -EMFILE;
 }
 
 /****************************************************************************

--- a/fs/vfs/fs_dupfd.c
+++ b/fs/vfs/fs_dupfd.c
@@ -60,7 +60,7 @@ int file_dup(FAR struct file *filep, int minfd)
   fd2 = files_allocate(NULL, 0, 0, minfd);
   if (fd2 < 0)
     {
-      return -EMFILE;
+      return fd2;
     }
 
   ret = fs_getfilep(fd2, &filep2);

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -207,7 +207,7 @@ int nx_vopen(FAR const char *path, int oflags, va_list ap)
   fd = files_allocate(inode, oflags, 0, 0);
   if (fd < 0)
     {
-      ret = -EMFILE;
+      ret = fd;
       goto errout_with_inode;
     }
 


### PR DESCRIPTION
## Summary
since the internal function normally return the error code directly

## Impact
No real change

## Testing

