### PR TITLE
tools/version.sh: Fix the version retrieved from git-tag

### DIFF
--- a/tools/version.sh
+++ b/tools/version.sh
@@ -91,7 +91,7 @@ if [ -z ${VERSION} ] ; then
   # If the VERSION does not match X.Y.Z, retrieve version from the tag
 
   if [[ ! ${VERSION} =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]] ; then
-    VERSION=`git -C ${WD} tag --sort=v:refname | grep -E "[0-9]+\.[0-9]+\.[0-9]+" | tail -1 | cut -d'-' -f2`
+    VERSION=`git -C ${WD} tag --sort=v:refname | grep -E "nuttx-[0-9]+\.[0-9]+\.[0-9]+" | tail -1 | cut -d'-' -f2`
   fi
 
 fi


### PR DESCRIPTION
## Summary
Fix an issue the wrong version could be retrieved from a private tag.

## Impact
The git-tag for the nuttx official version must be `nuttx-X.Y.Z`.

## Testing

