### PR TITLE
fs: Fix the race condition in file_dup

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -256,7 +256,8 @@ errout_with_sem:
  *
  ****************************************************************************/
 
-int files_allocate(FAR struct inode *inode, int oflags, off_t pos, int minfd)
+int files_allocate(FAR struct inode *inode, int oflags, off_t pos,
+                   FAR void *priv, int minfd)
 {
   FAR struct filelist *list;
   int ret;
@@ -282,7 +283,7 @@ int files_allocate(FAR struct inode *inode, int oflags, off_t pos, int minfd)
           list->fl_files[i].f_oflags = oflags;
           list->fl_files[i].f_pos    = pos;
           list->fl_files[i].f_inode  = inode;
-          list->fl_files[i].f_priv   = NULL;
+          list->fl_files[i].f_priv   = priv;
           _files_semgive(list);
           return i;
         }

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -387,7 +387,7 @@ void weak_function files_initialize(void);
  ****************************************************************************/
 
 int files_allocate(FAR struct inode *inode, int oflags, off_t pos,
-                   int minfd);
+                   FAR void *priv, int minfd);
 
 /****************************************************************************
  * Name: files_close

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -269,7 +269,7 @@ static mqd_t nxmq_vopen(FAR const char *mq_name, int oflags, va_list ap)
       return ret;
     }
 
-  ret = files_allocate(mq.f_inode, mq.f_oflags, mq.f_pos, 0);
+  ret = files_allocate(mq.f_inode, mq.f_oflags, mq.f_pos, mq.f_priv, 0);
   if (ret < 0)
     {
       file_mq_close(&mq);

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -204,7 +204,7 @@ int nx_vopen(FAR const char *path, int oflags, va_list ap)
 
   /* Associate the inode with a file structure */
 
-  fd = files_allocate(inode, oflags, 0, 0);
+  fd = files_allocate(inode, oflags, 0, NULL, 0);
   if (fd < 0)
     {
       ret = fd;

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -401,7 +401,7 @@ struct file
   int               f_oflags;   /* Open mode flags */
   off_t             f_pos;      /* File position */
   FAR struct inode *f_inode;    /* Driver or file system interface */
-  void             *f_priv;     /* Per file driver private data */
+  FAR void         *f_priv;     /* Per file driver private data */
 };
 
 /* This defines a list of files indexed by the file descriptor */


### PR DESCRIPTION
## Summary
NULL inode passed to files_allocate doesn't mark file struct in the allocated state, so other threads which invovle in file allocation(e.g. open or dup) may allocate the same file struct again.
Let's use a temp file struct to avoid the NULL inode case.

## Impact
Fix the race condition

## Testing

