### PR TITLE
fs/mqueue/Kconfig: Fix typo

### DIFF
--- a/fs/mqueue/Kconfig
+++ b/fs/mqueue/Kconfig
@@ -6,7 +6,7 @@
 if !DISABLE_MQUEUE
 
 config FS_MQUEUE_MPATH
-	string "Path to message queuee"
+	string "Path to message queue"
 	default "/var/mqueue"
 	---help---
 		The path to where POSIX message queues will exist in the VFS namespace.


### PR DESCRIPTION
## Summary

Fix typo in Kconfig description string: "queuee" -> "queue"

## Impact

None.

## Testing

None.