### PR TITLE
ctype/iscntrl: correct the control character function 

### DIFF
--- a/include/ctype.h
+++ b/include/ctype.h
@@ -143,7 +143,7 @@ int isgraph(int c);
 #ifdef __cplusplus
 static inline int iscntrl(int c)
 {
-  return !isprint(c);
+  return c < 0x20 || c == 0x7f;
 }
 #else
 int iscntrl(int c);

--- a/libs/libc/ctype/lib_iscntrl.c
+++ b/libs/libc/ctype/lib_iscntrl.c
@@ -30,5 +30,5 @@
 
 int iscntrl(int c)
 {
-  return !isprint(c);
+  return c < 0x20 || c == 0x7f;
 }


### PR DESCRIPTION


## Summary

ctype/iscntrl: correct the control character function 

all the characters placed before the space on the ASCII table
and the 0x7F character (DEL) are control characters.

Change-Id: Id187b39ce50b80e9ebee85a7242716eb017575d7
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

## Testing

iscntrl(0x80)
