### PR TITLE
sched: sched: Don't call sched_lock()/unlock() in nx_waitid()/waitpid() for SMP

### DIFF
--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -152,11 +152,11 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
 
 #ifdef CONFIG_SMP
   irqstate_t flags = enter_critical_section();
-#endif
-
+#else
   /* Disable pre-emption so that nothing changes while the loop executes */
 
   sched_lock();
+#endif
 
   /* Verify that this task actually has children and that the requested
    * TCB is actually a child of this task.
@@ -417,10 +417,11 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
     }
 
 errout:
-  sched_unlock();
 
 #ifdef CONFIG_SMP
   leave_critical_section(flags);
+#else
+  sched_unlock();
 #endif
 
   return ret;

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -78,11 +78,11 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
 #ifdef CONFIG_SMP
   irqstate_t flags = enter_critical_section();
-#endif
-
+#else
   /* Disable pre-emption so that nothing changes in the following tests */
 
   sched_lock();
+#endif
 
   /* Get the TCB corresponding to this PID */
 
@@ -169,10 +169,11 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
   ret = pid;
 
 errout:
-  sched_unlock();
 
 #ifdef CONFIG_SMP
   leave_critical_section(flags);
+#else
+  sched_unlock();
 #endif
 
   return ret;
@@ -217,11 +218,11 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
 #ifdef CONFIG_SMP
   irqstate_t flags = enter_critical_section();
-#endif
-
+#else
   /* Disable pre-emption so that nothing changes while the loop executes */
 
   sched_lock();
+#endif
 
   /* Verify that this task actually has children and that the requested PID
    * is actually a child of this task.
@@ -464,10 +465,11 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
   ret = pid;
 
 errout:
-  sched_unlock();
 
 #ifdef CONFIG_SMP
   leave_critical_section(flags);
+#else
+  sched_unlock();
 #endif
 
   return ret;


### PR DESCRIPTION
## Summary

- Calling sched_lock()/unlock() is unnecessary for SMP
  because we've been using the critical section API

## Impact

- SMP only

## Testing

- Tested with smp and ostest with the following configurations
- sabre-6quad:smp (QEMU, dev board)
- spresense:smp, spresense:wifi_smp
- sim:smp, sim:ostest
- maix-bit:smp (QEMU)
- esp32-devkitc:smp (QEMU)
- lc823450-xgevk:rndis
