### PR TITLE
Deal with "sed -i" portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@
 /.clean_context
 /.config
 /.config.old
-/.config-e
 /.cproject
 /.gdbinit
 /.project
@@ -35,7 +34,6 @@
 /_SAVED_APPS_config
 /cscope.*
 /defconfig
-/defconfig.tmp-e
 /Make.defs
 /nuttx
 /nuttx-*

--- a/boards/risc-v/nr5m100/nr5m100-nexys4/README.txt
+++ b/boards/risc-v/nr5m100/nr5m100-nexys4/README.txt
@@ -143,7 +143,7 @@ Debugger
      shadowed variable warnings, so disable the -Werror flag also:
 
      cd openocd
-     sed -i 's/ -Werror//g' configure.ac
+     sed -i.bak 's/ -Werror//g' configure.ac
      ./bootstrap
      ./configure  --enable-jlink --enable-maintainer-mode --enable-ftdi --prefix=~/riscv CFLAGS=-g
 

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -505,7 +505,7 @@ gconfig: apps_preconfig
 
 savedefconfig: apps_preconfig
 	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --savedefconfig defconfig.tmp Kconfig
-	$(Q) sed -i -e "/CONFIG_APPS_DIR=/d" defconfig.tmp
+	$(Q) kconfig-tweak --file defconfig.tmp -u CONFIG_APPS_DIR
 	$(Q) grep "CONFIG_ARCH=" .config >> defconfig.tmp
 	$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp; true
 	$(Q) grep "CONFIG_ARCH_CHIP=" .config >> defconfig.tmp; true
@@ -577,10 +577,8 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 endif
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
-	$(call DELFILE, defconfig.tmp-e)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
-	$(call DELFILE, .config-e)
 	$(call DELFILE, .gdbinit)
 	$(call DELFILE, .clean_context)
 	$(Q) $(MAKE) -C tools -f Makefile.host clean

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -454,7 +454,7 @@ nconfig: apps_preconfig
 
 savedefconfig: apps_preconfig
 	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --savedefconfig defconfig.tmp Kconfig
-	$(Q) sed -i -e "/CONFIG_APPS_DIR=/d" defconfig.tmp
+	$(Q) kconfig-tweak --file defconfig.tmp -u CONFIG_APPS_DIR
 	$(Q) grep "CONFIG_ARCH=" .config >> defconfig.tmp
 	-$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp
 	-$(Q) grep "CONFIG_ARCH_CHIP=" .config >> defconfig.tmp
@@ -526,10 +526,8 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 endif
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
-	$(call DELFILE, defconfig.tmp-e)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
-	$(call DELFILE, .config-e)
 	$(call DELFILE, .clean_context)
 	$(Q) $(MAKE) -C tools -f Makefile.host clean
 

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -296,7 +296,7 @@ done
 
 if [ "X${defappdir}" = "Xy" ]; then
   # In-place edit can mess up permissions on Windows
-  # sed -i -e "/^CONFIG_APPS_DIR/d" "${dest_config}"
+  # sed -i.bak -e "/^CONFIG_APPS_DIR/d" "${dest_config}"
   sed -e "/^CONFIG_APPS_DIR/d" "${dest_config}" > "${dest_config}-temp"
   mv "${dest_config}-temp" "${dest_config}"
 

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -244,12 +244,11 @@ function configure {
     varname=`echo $setting | cut -d'=' -f1`
     if [ ! -z "$varname" ]; then
       echo "  Disabling $varname"
-      sed -i -e "/$varname/d" $nuttx/.config
+      kconfig-tweak --file $nuttx/.config -d $varname
     fi
 
     echo "  Enabling $toolchain"
-    sed -i -e "/$toolchain/d" $nuttx/.config
-    echo "$toolchain=y" >> $nuttx/.config
+    kconfig-tweak --file $nuttx/.config -e $toolchain
 
     makefunc olddefconfig
   fi


### PR DESCRIPTION
## Summary
An empty extension for sed -i is not widely available.

* Where it isn't available (eg. macOS's sed) "sed -i -e" will
  create a backup file with the "-e" suffix.

* Even GNU sed documentation says it's "not recommended".

## Impact

## Testing
