### PR TITLE
configure.sh: fix '/configure.sh -e board:config menuconfig' build break

### DIFF
--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -189,7 +189,7 @@ fi
 
 if [ -r ${dest_config} ]; then
   if [ "X${enforce_distclean}" = "Xy" ]; then
-    make -C ${TOPDIR} distclean $*
+    make -C ${TOPDIR} distclean
   else
     if cmp -s ${src_config} ${backup_config}; then
       echo "No configuration change."
@@ -197,7 +197,7 @@ if [ -r ${dest_config} ]; then
     fi
 
     if [ "X${distclean}" = "Xy" ]; then
-      make -C ${TOPDIR} distclean $*
+      make -C ${TOPDIR} distclean
     else
       echo "Already configured!"
       echo "Please 'make distclean' and try again."


### PR DESCRIPTION
## Summary
If boardconfig changed, '/configure.sh -e board:config menuconfig'
would finally call 'make distclean menuconfig' which results in
build break. It also applies to nconfig and qconfig.

## Impact

## Testing
Test passed with sim configs and custom boards configs.
