### PR TITLE
fs/inode/fs_files.c: fix DEBUGASSERT in romfs

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -184,7 +184,7 @@ int file_dup2(FAR struct file *filep1, FAR struct file *filep2)
   temp.f_oflags = filep1->f_oflags;
   temp.f_pos    = filep1->f_pos;
   temp.f_inode  = inode;
-  temp.f_priv   = filep1->f_priv;
+  temp.f_priv   = NULL;
 
   /* Call the open method on the file, driver, mountpoint so that it
    * can maintain the correct open counts.


### PR DESCRIPTION

## Summary
fs/inode/fs_files.c: fix DEBUGASSERT in romfs

up_assert: Assertion failed at file:romfs/fs_romfs.c line: 643

newp->f_priv should be NULL.

## Impact

## Testing

