### PR TITLE
nrf52_i2c: add support for I2C_M_NOSTOP and I2C_M_NOSTART flags

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -626,3 +626,11 @@ config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
 		Enable the workaround to fix SPI Master 1 byte transfer bug
 		which occurs in NRF52832 revision 1 and revision 2.
 endmenu
+
+menu "I2C Master Configuration"
+
+config NRF52_I2C_MASTER_DISABLE_NOSTART
+	bool "Disable the I2C Master NOSTART flag support"
+	default n
+
+endmenu


### PR DESCRIPTION
## Summary
Add support for I2C_M_NOSTOP and I2C_M_NOSTART flags.
NRF52 hardware doesn't allow direct control of START/STOP bits, so the only solution is to combine messages into one.

## Impact

## Testing
Tested with SSD1306 and XX24XX EEPROM