### PR TITLE
libs: libxx: Fix compile errors with CONFIG_DEBUG_ERROR=y

### DIFF
--- a/libs/libxx/libxx_new.cxx
+++ b/libs/libxx/libxx_new.cxx
@@ -93,7 +93,7 @@ FAR void *operator new(std::size_t nbytes, FAR void *ptr)
 {
 
 #ifdef CONFIG_DEBUG_ERROR
-  if (ptr == nullptr)
+  if (ptr == 0)
     {
       _err("ERROR: Failed to placement new\n");
     }

--- a/libs/libxx/libxx_newa.cxx
+++ b/libs/libxx/libxx_newa.cxx
@@ -101,7 +101,7 @@ FAR void *operator new[](std::size_t nbytes, FAR void *ptr)
 {
 
 #ifdef CONFIG_DEBUG_ERROR
-  if (ptr == nullptr)
+  if (ptr == 0)
     {
       _err("ERROR: Failed to placement new[]\n");
     }


### PR DESCRIPTION
## Summary

- This commit fixes compile errors in libxx_new.cxx and libxx_newa.cxx

## Impact

- None

## Testing

- Build with spresense:nsh with CONFIG_DEBUG_ERROR=y
