### PR TITLE
graphics: nxmu: Fix a compile warning with CONFIG_DEBUG_ASSERTIONS=y

### DIFF
--- a/graphics/nxmu/nxmu_sendclient.c
+++ b/graphics/nxmu/nxmu_sendclient.c
@@ -73,7 +73,7 @@ int nxmu_sendclient(FAR struct nxmu_conn_s *conn, FAR const void *msg,
 {
   int ret;
 
-  DEBUGASSERT(conn != NULL && conn->swrmq != NULL && msg != NULL);
+  DEBUGASSERT(conn != NULL && msg != NULL);
 
   /* Send the message to the client */
 


### PR DESCRIPTION
## Summary

- This commit fixes a compile warning in nxmu_sendclient.c
- Actually, conn->swrmq will be checked in nxmq_send()

## Impact

- None

## Testing

- Built with spresense:wifi

