### PR TITLE
arch: tiva: Fix lm3s_ethernet.c with DEBUGASSERT

### DIFF
--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -641,7 +641,7 @@ static int tiva_txpoll(struct net_driver_s *dev)
   ninfo("Poll result: d_len=%d\n", priv->ld_dev.d_len);
   if (priv->ld_dev.d_len > 0)
     {
-      DEBUGASSERT(!!(tiva_ethin(priv, TIVA_MAC_TR_OFFSET) & MAC_TR_NEWTX));
+      DEBUGASSERT(!(tiva_ethin(priv, TIVA_MAC_TR_OFFSET) & MAC_TR_NEWTX));
 
       /* Look up the destination MAC address and add it to the Ethernet
        * header.


### PR DESCRIPTION
## Summary

- This commit fixes DEBUGASSERT in lm3s_ethernet.c

## Impact

- lm3s_ethernet.c only

## Testing

- Tested with lm3s6965-ek:discover with QEMU
