### PR TITLE
drivers/syslog: Prepend Process ID to syslog message 

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -154,6 +154,12 @@ config SYSLOG_PRIORITY
 	---help---
 		Prepend log priority (severity) to syslog message.
 
+config SYSLOG_PROCESSID
+	bool "Prepend Process ID to syslog message"
+	default n
+	---help---
+		Prepend Process ID to syslog message.
+
 config SYSLOG_PREFIX
 	bool "Prepend prefix to syslog message"
 	default n

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -176,6 +176,12 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   ret += lib_sprintf(&stream.public, "[%6s] ", g_priority_str[priority]);
 #endif
 
+#if defined(CONFIG_SYSLOG_PROCESSID)
+  /* Pre-pend the Process ID */
+
+  ret += lib_sprintf(&stream.public, "[%2d] ", (int)getpid());
+#endif
+
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
   /* Set the terminal style according to message priority. */
 


### PR DESCRIPTION

## Summary

drivers/syslog: Prepend Process ID to syslog message 

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

syslog

## Testing

```
[   14.618783] Test Initializing...
[   14.618872] Test initialized
->
[   14.618783] [7] Test Initializing...
[   14.618872] [7] Test initialized
```


