### PR TITLE
libs/libxx: use built-in __aeabi_atexit() if LIBSUPCXX is enabled 

### DIFF
--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -35,10 +35,12 @@
 
 include $(TOPDIR)/Make.defs
 
-CXXSRCS = libxx_cxa_atexit.cxx libxx_eabi_atexit.cxx
+CXXSRCS = libxx_cxa_atexit.cxx
 
 ifeq ($(CONFIG_CXX_LIBSUPCXX),y)
 CXXSRCS += libxx_impure.cxx
+else
+CXXSRCS += libxx_eabi_atexit.cxx
 endif
 
 # Include the uClibc++ Make.defs file if selected.  If it is included,


### PR DESCRIPTION

## Summary

libs/libxx: use built-in __aeabi_atexit() if LIBSUPCXX is enabled 

ld error caused by multiple definition:

ld: arm-none-eabi/lib/thumb/v8-m.main+fp/hard/libsupc++.a(atexit_arm.o): in function `__aeabi_atexit':
atexit_arm.cc:(.text.__aeabi_atexit+0x0): multiple definition of `__aeabi_atexit';
nuttx/staging/libxx.a(libxx_eabi_atexit.o):nuttx/libs/libxx/libxx_eabi_atexit.cxx:75: first defined here

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

Build Pass
