### PR TITLE
libc/machine/arch: fix build break if enable armv8 ELF 

### DIFF
--- a/libs/libc/machine/arm/armv8-m/Make.defs
+++ b/libs/libc/machine/arm/armv8-m/Make.defs
@@ -87,7 +87,7 @@ ifeq ($(LIBM_ARCH_TRUNC),y)
 CSRCS += arch_trunc.c
 endif
 
+endif # CONFIG_ARMV8M_LIBM
+
 DEPPATH += --dep-path machine/arm/armv8-m
 VPATH += :machine/arm/armv8-m
-
-endif # CONFIG_ARMV8M_LIBM


### PR DESCRIPTION


## Summary

libc/machine/arch: fix build break if enable armv8 ELF 

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

enable CONFIG_ELF and build success