### PR TITLE
sim/hcitty: add hcitty adapter

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -541,6 +541,20 @@ config SIM_HCISOCKET
 		control of the device, but is abstracted from the
 		physical interface which is still handled by Linux.
 
+config SIM_HCITTY
+	bool "Attach Host Bluetooth As TTY Device"
+	default false
+	depends on (DRIVERS_BLUETOOTH && HOST_LINUX && SIM_WALLTIME)
+	---help---
+		Attached the local bluetooth device to the simulation
+		target via HCI_CHANNEL_USER. This gives NuttX full
+		control of the device, but is abstracted from the
+		physical interface which is still handled by Linux.
+		Unlike SIM_HCISOCKET, HCITTY will wrap the bluetooth
+		interface/controller as a TTY device, which provides
+		an option for developers to setup the bluetooth host in
+		userspace.
+
 config SIM_I2CBUS
 	bool "Simulated I2C Bus"
 	default n

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -209,6 +209,11 @@ ifeq ($(CONFIG_SIM_HCISOCKET),y)
   CSRCS += up_hcisocket.c
 endif
 
+ifeq ($(CONFIG_SIM_HCITTY),y)
+  HOSTSRCS += up_hcisocket_host.c
+  CSRCS += up_hcitty.c
+endif
+
 ifeq ($(CONFIG_I2C_RESET),y)
   HOSTCFLAGS += -DCONFIG_I2C_RESET=1
 endif

--- a/arch/sim/src/sim/up_hcisocket_host.c
+++ b/arch/sim/src/sim/up_hcisocket_host.c
@@ -116,7 +116,7 @@ int bthcisock_host_avail(int fd)
  *
  ****************************************************************************/
 
-int bthcisock_host_send(int fd, void *data, size_t len)
+int bthcisock_host_send(int fd, const void *data, size_t len)
 {
   while (write(fd, data, len) < 0)
     {

--- a/arch/sim/src/sim/up_hcisocket_host.h
+++ b/arch/sim/src/sim/up_hcisocket_host.h
@@ -33,7 +33,7 @@
  ****************************************************************************/
 
 int bthcisock_host_open(int dev_idx);
-int bthcisock_host_send(int fd, void *data, size_t len);
+int bthcisock_host_send(int fd, const void *data, size_t len);
 int bthcisock_host_read(int fd, void *data, size_t len);
 int bthcisock_host_avail(int fd);
 int bthcisock_host_close(int fd);

--- a/arch/sim/src/sim/up_hcitty.c
+++ b/arch/sim/src/sim/up_hcitty.c
@@ -1,0 +1,457 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_hcitty.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/fs/fs.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/nuttx.h>
+
+#include <string.h>
+#include <stdio.h>
+#include <poll.h>
+#include <queue.h>
+
+#include <nuttx/wireless/bluetooth/bt_uart.h>
+#include <nuttx/wireless/bluetooth/bt_hci.h>
+
+#include "up_internal.h"
+#include "up_hcisocket_host.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define CONFIG_HCI_RECVBUF_SIZE    1024
+#define CONFIG_HCI_SENDBUF_SIZE    1024
+#define CONFIG_HCI_NPOLLWAITERS    2
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+union bt_hdr_u
+{
+  struct bt_hci_cmd_hdr_s cmd;
+  struct bt_hci_acl_hdr_s acl;
+  struct bt_hci_evt_hdr_s evt;
+  struct bt_hci_iso_hdr_s iso;
+};
+
+struct bthcitty_s
+{
+  sq_entry_t              link;
+  uint8_t                 recvbuf[CONFIG_HCI_RECVBUF_SIZE];
+  size_t                  recvpos;
+  size_t                  recvlen;
+  sem_t                   recvsem;
+  sem_t                   recvlock;
+
+  uint8_t                 sendbuf[CONFIG_HCI_SENDBUF_SIZE];
+  size_t                  sendlen;
+  sem_t                   sendlock;
+
+  sem_t                   fdslock;
+  FAR struct pollfd       *fds[CONFIG_HCI_NPOLLWAITERS];
+
+  unsigned short          id;
+  int                     fd;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int      bthcitty_open  (FAR struct file *filep);
+static int      bthcitty_close (FAR struct file *filep);
+static ssize_t  bthcitty_read  (FAR struct file *filep,
+                               FAR char *buffer, size_t buflen);
+static ssize_t  bthcitty_write (FAR struct file *filep,
+                               FAR const char *buffer, size_t buflen);
+static int      bthcitty_ioctl (FAR struct file *filep,
+                               int cmd, unsigned long arg);
+static int      bthcitty_poll  (FAR struct file *filep,
+                               FAR struct pollfd *fds, bool setup);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations g_hcitty_ops =
+{
+  .open   = bthcitty_open,
+  .close  = bthcitty_close,
+  .read   = bthcitty_read,
+  .write  = bthcitty_write,
+  .ioctl  = bthcitty_ioctl,
+  .poll   = bthcitty_poll
+};
+
+static sq_queue_t g_hcitty_list;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static inline void bthcitty_post(FAR sem_t *sem)
+{
+  int semcount;
+
+  nxsem_get_value(sem, &semcount);
+  if (semcount < 1)
+    {
+      nxsem_post(sem);
+    }
+}
+
+static void bthcitty_pollnotify(FAR struct bthcitty_s *dev,
+                                pollevent_t eventset)
+{
+  int ret;
+  int i;
+
+  ret = nxsem_wait_uninterruptible(&dev->fdslock);
+  if (ret < 0)
+    {
+      return;
+    }
+
+  for (i = 0; i < CONFIG_HCI_NPOLLWAITERS; i++)
+    {
+      FAR struct pollfd *fds = dev->fds[i];
+
+      if (fds)
+        {
+          fds->revents |= (fds->events & eventset);
+
+          if (fds->revents != 0)
+            {
+              bthcitty_post(fds->sem);
+            }
+        }
+    }
+
+  bthcitty_post(&dev->recvsem);
+
+  nxsem_post(&dev->fdslock);
+}
+
+static int bthcitty_open(FAR struct file *filep)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct bthcitty_s *dev = inode->i_private;
+  int ret;
+  int fd;
+
+  fd = bthcisock_host_open(dev->id);
+  if (fd < 0)
+    {
+      return fd;
+    }
+
+  dev->sendlen = 0;
+  dev->recvpos = 0;
+  dev->recvlen = 0;
+  dev->fd = fd;
+
+  return OK;
+}
+
+static int bthcitty_close(FAR struct file *filep)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct bthcitty_s *dev = inode->i_private;
+
+  bthcisock_host_close(dev->fd);
+
+  dev->fd = -1;
+
+  bthcitty_pollnotify(dev, POLLIN | POLLOUT);
+
+  return 0;
+}
+
+static ssize_t bthcitty_read(FAR struct file *filep,
+                             FAR char *buffer, size_t buflen)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct bthcitty_s *dev = inode->i_private;
+  size_t len = dev->recvlen;
+  int ret;
+
+  ret = nxsem_wait_uninterruptible(&dev->recvlock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  if (dev->recvpos >= dev->recvlen)
+    {
+      while (!bthcisock_host_avail(dev->fd))
+        {
+          nxsem_wait_uninterruptible(&dev->recvsem);
+        }
+
+      len = bthcisock_host_read(dev->fd, dev->recvbuf,
+                                CONFIG_HCI_RECVBUF_SIZE);
+      if (len <= 0)
+        {
+          nxsem_post(&dev->recvlock);
+          return len;
+        }
+
+      dev->recvpos = 0;
+      dev->recvlen = len;
+    }
+
+  if (buflen > dev->recvlen - dev->recvpos)
+    {
+      buflen = dev->recvlen - dev->recvpos;
+    }
+
+  memcpy(buffer, dev->recvbuf + dev->recvpos, buflen);
+  dev->recvpos += buflen;
+
+  nxsem_post(&dev->recvlock);
+
+  return buflen;
+}
+
+static ssize_t bthcitty_write(FAR struct file *filep,
+                              FAR const char *buffer, size_t buflen)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct bthcitty_s *dev = inode->i_private;
+  FAR union bt_hdr_u *hdr;
+  size_t pktlen;
+  size_t hdrlen;
+  int ret;
+
+  ret = nxsem_wait_uninterruptible(&dev->sendlock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  if (dev->sendlen + buflen > CONFIG_HCI_SENDBUF_SIZE)
+    {
+      ret = -EINVAL;
+      goto err;
+    }
+
+  memcpy(dev->sendbuf + dev->sendlen, buffer, buflen);
+  dev->sendlen += buflen;
+
+  hdr = (FAR union bt_hdr_u *)(dev->sendbuf + 1);
+
+  while (1)
+    {
+      switch (dev->sendbuf[0])
+        {
+          case H4_CMD:
+            hdrlen = sizeof(struct bt_hci_cmd_hdr_s);
+            pktlen = hdr->cmd.param_len;
+            break;
+          case H4_ACL:
+            hdrlen = sizeof(struct bt_hci_acl_hdr_s);
+            pktlen = hdr->acl.len;
+            break;
+          case H4_ISO:
+            hdrlen = sizeof(struct bt_hci_iso_hdr_s);
+            pktlen = hdr->iso.len;
+            break;
+          default:
+            ret = -EINVAL;
+            goto err;
+        }
+
+      /* Reassembly is incomplete ? */
+
+      hdrlen += H4_HEADER_SIZE;
+
+      if (dev->sendlen < hdrlen)
+        {
+          goto out;
+        }
+
+      pktlen += hdrlen;
+      if (dev->sendlen < pktlen)
+        {
+          goto out;
+        }
+
+      /* Got the full packet, send out */
+
+      ret = bthcisock_host_send(dev->fd, dev->sendbuf, pktlen);
+      if (ret < 0)
+        {
+          goto err;
+        }
+
+      dev->sendlen -= pktlen;
+      if (dev->sendlen == 0)
+        {
+          goto out;
+        }
+
+      memmove(dev->sendbuf, dev->sendbuf + pktlen, dev->sendlen);
+    }
+
+err:
+  dev->sendlen = 0;
+out:
+  nxsem_post(&dev->sendlock);
+  return ret < 0 ? ret : buflen;
+}
+
+static int bthcitty_ioctl(FAR struct file *filep,
+                          int cmd, unsigned long arg)
+{
+  return OK;
+}
+
+static int bthcitty_poll(FAR struct file *filep,
+                         FAR struct pollfd *fds, bool setup)
+{
+  FAR struct inode *inode = filep->f_inode;
+  FAR struct bthcitty_s *dev = inode->i_private;
+  pollevent_t eventset;
+  int ret;
+  int i;
+
+  ret = nxsem_wait_uninterruptible(&dev->fdslock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  if (setup)
+    {
+      for (i = 0; i < CONFIG_HCI_NPOLLWAITERS; i++)
+        {
+          /* Find an available slot */
+
+          if (!dev->fds[i])
+            {
+              /* Bind the poll structure and this slot */
+
+              dev->fds[i]  = fds;
+              fds->priv    = &dev->fds[i];
+              break;
+            }
+        }
+
+      if (i >= CONFIG_HCI_NPOLLWAITERS)
+        {
+          fds->priv = NULL;
+          ret = -EBUSY;
+        }
+
+      if (bthcisock_host_avail(dev->fd))
+        {
+          eventset |= (fds->events & POLLIN);
+        }
+
+      eventset |= (fds->events & POLLOUT);
+
+      if (eventset)
+        {
+          bthcitty_pollnotify(dev, eventset);
+        }
+    }
+  else if (fds->priv != NULL)
+    {
+      for (i = 0; i < CONFIG_HCI_NPOLLWAITERS; i++)
+        {
+          if (fds == dev->fds[i])
+            {
+              dev->fds[i] = NULL;
+              fds->priv = NULL;
+              break;
+            }
+        }
+    }
+
+  nxsem_post(&dev->fdslock);
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void bthcitty_loop(void)
+{
+  FAR struct bthcitty_s *dev;
+  FAR sq_entry_t *entry;
+
+  for (entry = sq_peek(&g_hcitty_list); entry; entry = sq_next(entry))
+    {
+      dev = container_of(entry, struct bthcitty_s, link);
+      if (bthcisock_host_avail(dev->fd))
+        {
+          bthcitty_pollnotify(dev, POLLIN);
+        }
+    }
+}
+
+int bthcitty_register(int dev_id)
+{
+  FAR struct bthcitty_s *dev;
+  unsigned char name[16];
+  int ret;
+
+  snprintf(name, sizeof(name), "/dev/ttyHCI%d", dev_id);
+
+  dev = (FAR struct bthcitty_s *)kmm_zalloc(sizeof(struct bthcitty_s));
+  if (dev == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  dev->fd = -1;
+  dev->id = dev_id;
+
+  nxsem_init(&dev->recvlock, 0, 1);
+  nxsem_init(&dev->sendlock, 0, 1);
+  nxsem_init(&dev->recvsem, 0, 0);
+  nxsem_init(&dev->fdslock, 0, 1);
+
+  nxsem_set_protocol(&dev->recvsem, SEM_PRIO_NONE);
+
+  ret = register_driver(name, &g_hcitty_ops, 0666, dev);
+  if (ret < 0)
+    {
+      nxsem_destroy(&dev->recvlock);
+      nxsem_destroy(&dev->sendlock);
+      nxsem_destroy(&dev->recvsem);
+      nxsem_destroy(&dev->fdslock);
+      kmm_free(dev);
+      return ret;
+    }
+
+  sq_addlast(&dev->link, &g_hcitty_list);
+
+  return 0;
+}

--- a/arch/sim/src/sim/up_idle.c
+++ b/arch/sim/src/sim/up_idle.c
@@ -115,6 +115,10 @@ void up_idle(void)
   bthcisock_loop();
 #endif
 
+#ifdef CONFIG_SIM_HCITTY
+  bthcitty_loop();
+#endif
+
 #ifdef CONFIG_SIM_SOUND
   sim_audio_loop();
 #endif

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -397,6 +397,13 @@ int bthcisock_register(int dev_id);
 int bthcisock_loop(void);
 #endif
 
+/* up_hcitty.c **************************************************************/
+
+#ifdef CONFIG_SIM_HCITTY
+int bthcitty_register(int dev_id);
+void bthcitty_loop(void);
+#endif
+
 /* up_audio.c ***************************************************************/
 
 #ifdef CONFIG_SIM_SOUND

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -348,6 +348,16 @@ int sim_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_SIM_HCITTY
+  /* Register the Host Bluetooth network device via HCI socket */
+
+  ret = bthcitty_register(0);  /* Use HCI0 */
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: bthcitty_register() failed: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_SIM_I2CBUS
   /* Initialize the i2c master bus device */
 


### PR DESCRIPTION
## Summary

sim/hcitty: add hcitty adapter

add support to attach the devices via HCI TTY to Bluetooth Host

Reference:

https://github.com/apache/incubator-nuttx/blob/master/drivers/wireless/bluetooth/bt_uart_shim.c

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

Depends on:  https://github.com/apache/incubator-nuttx/pull/2691

## Testing

attach the devices via HCI TTY to Bluetooth Host