### PR TITLE
Added printing of log priority in syslog.

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -142,6 +142,12 @@ config SYSLOG_TIMESTAMP_BUFFER
 	---help---
 		Buffer size to store syslog formatted timestamps.
 
+config SYSLOG_PRIORITY
+	bool "Prepend priority to syslog message"
+	default n
+	---help---
+		Prepend log priority (severity) to syslog message.
+
 config SYSLOG_PREFIX
 	bool "Prepend prefix to syslog message"
 	default n

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -51,6 +51,18 @@
 #include <nuttx/syslog/syslog.h>
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if defined(CONFIG_SYSLOG_PRIORITY)
+static FAR const char * g_priority_str[] =
+  {
+    "EMERG", "ALERT", "CRIT", "ERROR",
+    "WARN", "NOTICE", "INFO", "DEBUG"
+  };
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -158,6 +170,10 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #endif
 #else
   ret = 0;
+#endif
+
+#if defined(CONFIG_SYSLOG_PRIORITY)
+  ret += lib_sprintf(&stream.public, "[%6s] ", g_priority_str[priority]);
 #endif
 
 #if defined(CONFIG_SYSLOG_PREFIX)


### PR DESCRIPTION
## Summary
Adds the ability to print the message priority in syslog.

## Impact
None. Defaults to the old behaviour.

## Testing
Tested both configurations (with and without priority logging) on custom STM32F4 target, and the messages are formatted correctly.
