### PR TITLE
gdbinit: add support for reporting total and used stack size

### DIFF
--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -67,6 +67,9 @@ define _examine_target
 
     set $_target_max_tasks = sizeof(g_pidhash) / sizeof(struct pidhash_s)
 
+    python if (type(gdb.lookup_global_symbol("up_check_tcbstack")) is gdb.Symbol) : \
+    gdb.execute("set $_target_has_stack_coloration = 1")
+
     printf "target examined \n"
     python print("_target_arch.name=" + _target_arch.name())
 
@@ -88,9 +91,15 @@ define _print_thread
     printf "  "
   end
 
-  printf "%d Thread 0x%x  (Name: %s, State: %s, Priority: %d) 0x%x in ", \
+  if ($_target_has_stack_coloration)
+    set $stack_used = up_check_tcbstack($tcb)
+  else
+    set $stack_used = 0
+  end
+
+  printf "%d Thread 0x%x  (Name: %s, State: %s, Priority: %d, Stack: %d/%d) PC: 0x%x in ", \
   $tcb->pid, $tcb, $tcb->name, g_statenames[$tcb->task_state], $tcb->sched_priority, \
-  $tcb->xcp.regs[$_pc_reg_idx]
+  $stack_used, $tcb->adj_stack_size, $tcb->xcp.regs[$_pc_reg_idx]
   python _symbol = gdb.execute("info symbol $tcb->xcp.regs[$_pc_reg_idx]", to_string=True); \
   print(_symbol.split()[0] + "()")
 end


### PR DESCRIPTION
## Summary

This checks if the required function is defined (when stack coloration
is enabled) and, if so, calls it to get used stack. Otherwise it just
reports zero used stack.

Output looks like: 
```
...
4 Thread 0x20013460  (Name: <pthread>, State: Stopped, Priority: 100, Stack: 456/4100) PC: 0x5500 in
...
```

## Impact

Debugging aid

## Testing

With and without stack coloration enabled.
