### PR TITLE
arch/stm32h7: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/stm32h7/stm32_rtc.c
+++ b/arch/arm/src/stm32h7/stm32_rtc.c
@@ -860,16 +860,20 @@ static int stm32_rtc_getalarmdatetime(rtc_alarmreg_t reg, FAR struct tm *tp)
    * ranges of values correspond between struct tm and the time register.
    */
 
-  tmp = (data & (RTC_ALRMR_SU_MASK | RTC_ALRMR_ST_MASK)) >> RTC_ALRMR_SU_SHIFT;
+  tmp = (data & (RTC_ALRMR_SU_MASK | RTC_ALRMR_ST_MASK)) >>
+        RTC_ALRMR_SU_SHIFT;
   tp->tm_sec = rtc_bcd2bin(tmp);
 
-  tmp = (data & (RTC_ALRMR_MNU_MASK | RTC_ALRMR_MNT_MASK)) >> RTC_ALRMR_MNU_SHIFT;
+  tmp = (data & (RTC_ALRMR_MNU_MASK | RTC_ALRMR_MNT_MASK)) >>
+        RTC_ALRMR_MNU_SHIFT;
   tp->tm_min = rtc_bcd2bin(tmp);
 
-  tmp = (data & (RTC_ALRMR_HU_MASK | RTC_ALRMR_HT_MASK)) >> RTC_ALRMR_HU_SHIFT;
+  tmp = (data & (RTC_ALRMR_HU_MASK | RTC_ALRMR_HT_MASK)) >>
+        RTC_ALRMR_HU_SHIFT;
   tp->tm_hour = rtc_bcd2bin(tmp);
 
-  tmp = (data & (RTC_ALRMR_DU_MASK | RTC_ALRMR_DT_MASK)) >> RTC_ALRMR_DU_SHIFT;
+  tmp = (data & (RTC_ALRMR_DU_MASK | RTC_ALRMR_DT_MASK)) >>
+        RTC_ALRMR_DU_SHIFT;
   tp->tm_mday = rtc_bcd2bin(tmp);
 
   return OK;
@@ -1790,7 +1794,8 @@ int stm32_rtc_setperiodic(FAR const struct timespec *period,
 #elif defined(CONFIG_STM32H7_RTC_LSICLOCK)
 #  error "Periodic wakeup not available for LSI (and it is too inaccurate!)"
 #elif defined(CONFIG_STM32H7_RTC_LSECLOCK)
-  const uint32_t rtc_div16_max_msecs = 16 * 1000 * 0xffffu / STM32_LSE_FREQUENCY;
+  const uint32_t rtc_div16_max_msecs = 16 * 1000 * 0xffffu /
+                                       STM32_LSE_FREQUENCY;
 #else
 #  error "No clock for RTC!"
 #endif

--- a/arch/arm/src/stm32h7/stm32_rtc.h
+++ b/arch/arm/src/stm32h7/stm32_rtc.h
@@ -4,7 +4,8 @@
  *   Copyright (C) 2011 Uros Platise. All rights reserved.
  *   Copyright (C) 2011-2013, 2015-2019 Gregory Nutt. All rights reserved.
  *   Authors: Uros Platise <uros.platise@isotel.eu> (Original for the F1)
- *            Gregory Nutt <gnutt@nuttx.org> (On-going support and development)
+ *            Gregory Nutt <gnutt@nuttx.org> (On-going support and
+ *                                            development)
  *            David Sidrane <david.sidrane@nscdg.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,9 +48,9 @@
 
 #include "chip.h"
 
-/* The STMH7 family use a more traditional Realtime Clock/Calendar (RTCC) with
- * broken-out data/time in BCD format.  The backup registers are integrated into
- * the RTCC in these families.
+/* The STMH7 family use a more traditional Realtime Clock/Calendar (RTCC)
+ * with broken-out data/time in BCD format.  The backup registers are
+ * integrated into the RTCC in these families.
  */
 
 #include "hardware/stm32_rtcc.h"
@@ -98,7 +99,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
@@ -106,9 +107,9 @@ extern "C"
  *
  * Description:
  *   Get the current date and time from the date/time RTC.  This interface
- *   is only supported by the date/time RTC hardware implementation.
- *   It is used to replace the system timer.  It is only used by the RTOS
- *   during initialization to set up the system time when CONFIG_RTC and
+ *   is only supported by the date/time RTC hardware implementation.  It is
+ *   used to replace the system timer.  It is only used by the RTOS during
+ *   initialization to set up the system time when CONFIG_RTC and
  *   CONFIG_RTC_DATETIME are selected (and CONFIG_RTC_HIRES is not).
  *
  *   NOTE: The sub-second accuracy is returned through 'nsec'.


### PR DESCRIPTION
## Summary

Fix nxstyle errors in:
arch/arm/src/stm32h7/stm32_rtc.c
arch/arm/src/stm32h7/stm32_rtc.h

## Impact

Removes nxstyle errors.

## Testing

nxstyle