### PR TITLE
nrf52: Add a static copy buffer for i2c NOSTART transfers

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -632,5 +632,24 @@ menu "I2C Master Configuration"
 config NRF52_I2C_MASTER_DISABLE_NOSTART
 	bool "Disable the I2C Master NOSTART flag support"
 	default n
+	---help---
+		To combine two i2c messages that are part of a
+		single transaction (NO_STOP-NO_START) the nrf52
+		hardware requires these be joined into a single
+		transfer. This can be expensive and some devices
+		can get away with multi-part transfers as separate
+		transfers.  Enable this at your own risk!
+
+config NRF52_I2C_MASTER_COPY_BUF_SIZE
+	int "Static buffer size for NOSTART flag support"
+	depends on !NRF52_I2C_MASTER_DISABLE_NOSTART
+	default 4
+	---help---
+		To combine two i2c messages that are part of a
+		single transaction (NO_STOP-NO_START) the nrf52
+		hardware requires these be joined into a single
+		transfer. This static buffer will be used if the
+		transaction will fit otherwise it will fall back
+		on malloc.
 
 endmenu


### PR DESCRIPTION
## Summary
This is a continuation of #2674 which allows for the driver to use a static buffer for small transfers instead of having to malloc.

## Impact
Should improve the performance of the i2c driver for smaller transfers.

## Testing
nrf52 Feather with i2ctool talking to MPU-6050

Here is a write to a SSD1327 display setting  the two byte column address.
```
NuttShell (NSH) NuttX-10.0.1
nsh> i2c set -b 0 -a 0x3d -r 0x15 -w 16 0x0000
```
![image](https://user-images.githubusercontent.com/173245/104858534-ce287100-58d4-11eb-91d2-31c08e7ab81c.png)
