### PR TITLE
drivers: wireless: Fix ASSERT() in _read_data_len() in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -865,18 +865,18 @@ retry:
 
   _write_data(dev, hdr, sizeof(hdr));
 
+  /* NOTE: busy wait 30us
+   * workaround to avoid an invalid frame response
+   */
+
+  up_udelay(30);
+
   /* Wait for data ready */
 
   while (!dev->lower->dready(NULL))
     {
       /* TODO: timeout */
     }
-
-  /* NOTE: busy wait 50us
-   * workaround to avoid an invalid frame response
-   */
-
-  up_udelay(50);
 
   /* Read frame response */
 


### PR DESCRIPTION
## Summary

- During stress test with spresense:wifi (non-SMP), I noticed
  sometimes ASSERT() happened in _read_data_len()
- Actually, up_udelay(50) has been added to avoid the ASSERT
- However, I finally noticed that it should be moved before
  calling dready()
- Also, I cofirmed that we can reduced the time from 50 to 30
- NOTE: we need at least 15us in my experience

## Impact

- gs2200m.c only

## Testing

- Tested with following configurations
- spresense:wifi, spresense:wifi_smp, stm32f4discovery:wifi

