### PR TITLE
xtensa/esp32: Fix ESP32 SPI driver issues

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -1386,7 +1386,14 @@ static void esp32_spi_deinit(FAR struct spi_dev_s *dev)
       modifyreg32(DPORT_PERIP_CLK_EN_REG, priv->config->dma_clk_bit, 0);
     }
 
+  modifyreg32(DPORT_PERIP_RST_EN_REG, 0, priv->config->clk_bit);
   modifyreg32(DPORT_PERIP_CLK_EN_REG, priv->config->clk_bit, 0);
+
+  priv->frequency = 0;
+  priv->actual    = 0;
+  priv->mode      = SPIDEV_MODE0;
+  priv->nbits     = 0;
+  priv->dma_chan  = 0;
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -963,7 +963,17 @@ static void esp32_spislv_deinit(FAR struct spi_sctrlr_s *dev)
 
   esp32_gpioirqdisable(ESP32_PIN2IRQ(priv->config->cs_pin));
   esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_INT_EN_M);
+
+  modifyreg32(DPORT_PERIP_RST_EN_REG, 0, priv->config->clk_bit);
   modifyreg32(DPORT_PERIP_CLK_EN_REG, priv->config->clk_bit, 0);
+
+  priv->mode = SPIDEV_MODE0;
+  priv->nbits = 0;
+  priv->txlen = 0;
+  priv->rxlen = 0;
+  priv->process = false;
+  priv->txen = false;
+  priv->dma_chan = false;
 }
 
 /****************************************************************************
@@ -1353,6 +1363,10 @@ int esp32_spislv_sctrlr_uninitialize(FAR struct spi_sctrlr_s *sctrlr)
     }
 
   up_disable_irq(priv->cpuint);
+  esp32_detach_peripheral(priv->config->cpu,
+                          priv->config->periph,
+                          priv->cpuint);
+  esp32_free_cpuint(priv->cpuint);
 
   esp32_spislv_deinit(sctrlr);
 


### PR DESCRIPTION
## Summary

Fix ESP32 SPI driver issues:

1. reset SPI hardware when deinitializing
2. reset SPI priavte configuration data when deinitializing
3. free interrupt when deinitializing

## Impact

## Testing

