### PR TITLE
sim/hcitty: remove the poll lock to avoid invalid wait

### DIFF
--- a/arch/sim/src/sim/up_hcitty.c
+++ b/arch/sim/src/sim/up_hcitty.c
@@ -126,14 +126,7 @@ static inline void bthcitty_post(FAR sem_t *sem)
 static void bthcitty_pollnotify(FAR struct bthcitty_s *dev,
                                 pollevent_t eventset)
 {
-  int ret;
   int i;
-
-  ret = nxsem_wait_uninterruptible(&dev->fdslock);
-  if (ret < 0)
-    {
-      return;
-    }
 
   for (i = 0; i < CONFIG_HCI_NPOLLWAITERS; i++)
     {
@@ -150,7 +143,6 @@ static void bthcitty_pollnotify(FAR struct bthcitty_s *dev,
         }
     }
 
-  nxsem_post(&dev->fdslock);
   bthcitty_post(&dev->recvsem);
 }
 


### PR DESCRIPTION


## Summary

sim/hcitty: remove the poll lock to avoid invalid wait

it it unnecessary to protect pollnotify() since the wakeup
source comes from idle thread

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

sim:bthcisock

