### PR TITLE
sched/task: setup the scheduling policy to task

### DIFF
--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -368,6 +368,16 @@ static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
       tcb->flags         &= ~TCB_FLAG_TTYPE_MASK;
       tcb->flags         |= ttype;
 
+      /* Set the appropriate scheduling policy in the TCB */
+
+      tcb->flags         &= ~TCB_FLAG_POLICY_MASK;
+#if CONFIG_RR_INTERVAL > 0
+      tcb->flags         |= TCB_FLAG_SCHED_RR;
+      tcb->timeslice      = MSEC2TICK(CONFIG_RR_INTERVAL);
+#else
+      tcb->flags         |= TCB_FLAG_SCHED_FIFO;
+#endif
+
 #ifdef CONFIG_CANCELLATION_POINTS
       /* Set the deferred cancellation type */
 


### PR DESCRIPTION
## Summary

sched/task: setup the scheduling policy to task

## Impact

kthread_create / nxtask_create

## Testing

enable  CONFIG_RR_INTERVAL 


before:
```
ap> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED    CPU COMMAND
    0     0   0 FIFO     Kthread N-- Ready              00000000 003072 001408  45.8%   98.9% Idle Task
    1     1 253 FIFO     Kthread --- Waiting  Signal    00000000 003060 000432  14.1%    0.0% hpwork
    2     1 253 FIFO     Kthread --- Waiting  Signal    00000000 003060 000432  14.1%    0.0% hpwork
    3     1 253 FIFO     Kthread --- Waiting  Signal    00000000 003060 000432  14.1%    0.0% hpwork
    4     1 100 FIFO     Kthread --- Waiting  Signal    00000000 004084 001704  41.7%    0.0% lpwork
    9     6 253 RR       pthread --- Waiting  Semaphore 00000000 008168 000496   6.0%    0.0% ....
   10     6 100 RR       pthread --- Waiting  Signal    00000000 003076 000480  15.6%    0.0% ....
   11     6 252 RR       pthread --- Waiting  MQ empty  00000000 010216 001472  14.4%    0.0% ....
   12     6 252 RR       pthread --- Waiting  MQ empty  00000000 008168 000684   8.3%    0.0% ....
   13     6 252 RR       pthread --- Waiting  Semaphore 00000000 004072 001584  38.8%    0.0% ....
   14     6 224 FIFO     Kthread --- Waiting  Signal    00000002 004060 000512  12.6%    0.0% ....
   17    -1 100 FIFO     Task    --- Running            00000000 004084 001568  38.3%    0.5% init
   19     9  80 FIFO     Task    --- Waiting  Semaphore 00000000 004084 000640  15.6%    0.0% usrsock
   21     6 101 RR       pthread --- Waiting  MQ empty  00000000 004100 000560  13.6%    0.0% ....
   22     6 253 RR       pthread --- Waiting  MQ empty  00000000 004072 001496  36.7%    0.0% ....
```

after: 
```
ap> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED    CPU COMMAND
    0     0   0 FIFO     Kthread N-- Ready              00000000 003072 001408  45.8%   98.9% Idle Task
    1     1 253 RR       Kthread --- Waiting  Signal    00000000 003060 000432  14.1%    0.0% hpwork
    2     1 253 RR       Kthread --- Waiting  Signal    00000000 003060 000432  14.1%    0.0% hpwork
    3     1 253 RR       Kthread --- Waiting  Signal    00000000 003060 000432  14.1%    0.0% hpwork
    4     1 100 RR       Kthread --- Waiting  Signal    00000000 004084 001704  41.7%    0.0% lpwork
    9     6 253 RR       pthread --- Waiting  Semaphore 00000000 008168 000496   6.0%    0.0% ....
   10     6 100 RR       pthread --- Waiting  Signal    00000000 003076 000480  15.6%    0.0% ....
   11     6 252 RR       pthread --- Waiting  MQ empty  00000000 010216 001472  14.4%    0.0% ....
   12     6 252 RR       pthread --- Waiting  MQ empty  00000000 008168 000684   8.3%    0.0% ....
   13     6 252 RR       pthread --- Waiting  Semaphore 00000000 004072 001584  38.8%    0.0% ....
   14     6 224 RR       Kthread --- Waiting  Signal    00000002 004060 000512  12.6%    0.0% ....
   17    -1 100 RR       Task    --- Running            00000000 004084 001568  38.3%    0.5% init
   19     9  80 RR       Task    --- Waiting  Semaphore 00000000 004084 000640  15.6%    0.0% usrsock
   21     6 101 RR       pthread --- Waiting  MQ empty  00000000 004100 000560  13.6%    0.0% ....
   22     6 253 RR       pthread --- Waiting  MQ empty  00000000 004072 001496  36.7%    0.0% ....
```