### PR TITLE
Fix git clone repository in README

### DIFF
--- a/boards/risc-v/fe310/hifive1-revb/README-qemu.txt
+++ b/boards/risc-v/fe310/hifive1-revb/README-qemu.txt
@@ -28,8 +28,8 @@ index c449421741..5a76600785 100644
 4. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://bitbucket.org/nuttx/nuttx.git
-  $ git clone https://bitbucket.org/nuttx/apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh hifive1-revb:nsh

--- a/boards/risc-v/fe310/hifive1-revb/README.txt
+++ b/boards/risc-v/fe310/hifive1-revb/README.txt
@@ -11,8 +11,8 @@
 3. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://bitbucket.org/nuttx/nuttx.git
-  $ git clone https://bitbucket.org/nuttx/apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh hifive1-revb:nsh

--- a/boards/risc-v/k210/maix-bit/README-qemu.txt
+++ b/boards/risc-v/k210/maix-bit/README-qemu.txt
@@ -26,8 +26,8 @@
 4. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://bitbucket.org/nuttx/nuttx.git
-  $ git clone https://bitbucket.org/nuttx/apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh maix-bit:nsh

--- a/boards/risc-v/k210/maix-bit/README.txt
+++ b/boards/risc-v/k210/maix-bit/README.txt
@@ -11,8 +11,8 @@
 3. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://bitbucket.org/nuttx/nuttx.git
-  $ git clone https://bitbucket.org/nuttx/apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh maix-bit:nsh

--- a/boards/risc-v/litex/arty_a7/README.txt
+++ b/boards/risc-v/litex/arty_a7/README.txt
@@ -8,8 +8,8 @@
 3. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://bitbucket.org/nuttx/nuttx.git
-  $ git clone https://bitbucket.org/nuttx/apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh arty_a7:nsh


### PR DESCRIPTION
## Summary

I fixed the README files in `boards/risc-v` directory because the paths of the git repository are old.

## Impact

None.

## Testing

Do nothing.