### PR TITLE
nRF52: FIX wrong bitmask for DRIVE setting

### DIFF
--- a/arch/arm/src/nrf52/nrf52_gpio.h
+++ b/arch/arm/src/nrf52/nrf52_gpio.h
@@ -95,7 +95,7 @@
  */
 
 #define GPIO_DRIVE_SHIFT        (9)      /* Bits 9-11: Pin pull-up mode */
-#define GPIO_DRIVE_MASK         (0x3 << GPIO_DRIVE_SHIFT)
+#define GPIO_DRIVE_MASK         (0x7 << GPIO_DRIVE_SHIFT)
 #  define GPIO_DRIVE_S0S1       (0 << GPIO_DRIVE_SHIFT) /* Standard '0', standard '1' */
 #  define GPIO_DRIVE_H0S1       (1 << GPIO_DRIVE_SHIFT) /* High drive '0', standard '1' */
 #  define GPIO_DRIVE_S0H1       (2 << GPIO_DRIVE_SHIFT) /* */


### PR DESCRIPTION
## Summary

This bug made certain values of DRIVE setting
to be wrongly applied (which can be dangerous
under certain situations since for example H0D1
was mapped to H0H1). All GPIO_DRIVE_* definitions
with value higher than 3 (which means, values with
a D setting in either side) were being mapped to the 
values with both sides connected.

## Impact

Prevents wrong configuration of drive setting.

## Testing

Fixed wrong behaviour of pin with H0D1 setting.
