### PR TITLE
esp32_free_cpuint: Fix an assertion

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpuint.c
+++ b/arch/xtensa/src/esp32/esp32_cpuint.c
@@ -520,7 +520,7 @@ void esp32_free_cpuint(int cpuint)
   uint32_t *freeints;
   uint32_t bitmask;
 
-  DEBUGASSERT(cpuint >= 0 && cpuint < ESP32_CPUINT_NEDGEPERIPHS);
+  DEBUGASSERT(cpuint >= 0 && cpuint <= ESP32_CPUINT_MAX);
 
   /* Mark the CPU interrupt as available */
 


### PR DESCRIPTION
## Summary
The original assertion was wrong because:

* cpuint numbers for edge interrupts are not dense
  (while ESP32_CPUINT_NEDGEPERIPHS is 4, EPS32_CPUINT_EDGESET is not 0xf.)

* This function is used for level interrupts too

## Impact

## Testing

