### PR TITLE
esp32_dma_init: Fix a dubious assertion

### DIFF
--- a/arch/xtensa/src/esp32/esp32_dma.c
+++ b/arch/xtensa/src/esp32/esp32_dma.c
@@ -69,7 +69,7 @@ uint32_t esp32_dma_init(struct esp32_dmadesc_s *dmadesc, uint32_t num,
   DEBUGASSERT(pbuf && len);
   if (isrx)
     {
-      DEBUGASSERT((len % 3) == 0);
+      DEBUGASSERT((len & 3) == 0);
     }
 
   for (i = 0; i < num; i++)


### PR DESCRIPTION
## Summary
Requiring the size to be a multiple of 3 is a very strange restriction.
It doesn't even work with the default value of SPI_SLAVE_BUFSIZE.
I guess it was a typo.

## Impact

## Testing

