### PR TITLE
Blockproxy comments fixes, unlink to nx_unlink

### DIFF
--- a/fs/driver/driver.h
+++ b/fs/driver/driver.h
@@ -130,16 +130,8 @@ int block_proxy(FAR struct file *filep, FAR const char *blkdev, int oflags);
  * Returned Value:
  *   If zero, non-zero inode pointer is returned on success.  This
  *   is the inode pointer of the nameless block driver that mediates
- *   accesses to the mtd driver.
- *
- *   Errors that may be returned:
- *
- *     ENOMEM - Failed to create a temporary path name.
- *
- *   Plus:
- *
- *     - Errors reported from ftl_initialize()
- *     - Errors reported from open() or unlink()
+ *   accesses to the mtd driver. A negated errno value is returned on
+ *   any failure.
  *
  ****************************************************************************/
 

--- a/fs/driver/driver.h
+++ b/fs/driver/driver.h
@@ -99,22 +99,14 @@ int find_blockdriver(FAR const char *pathname, int mountflags,
  *   oriented accessed to the block driver.
  *
  * Input Parameters:
+ *   filep  - The caller provided location in which to return the 'struct
+ *            file' instance.
  *   blkdev - The path to the block driver
  *   oflags - Character driver open flags
  *
  * Returned Value:
- *   If positive, non-zero file descriptor is returned on success.  This
- *   is the file descriptor of the nameless character driver that mediates
- *   accesses to the block driver.
- *
- *   Errors that may be returned:
- *
- *     ENOMEM - Failed to create a temporary path name.
- *
- *   Plus:
- *
- *     - Errors reported from bchdev_register()
- *     - Errors reported from open() or unlink()
+ *   Zero (OK) is returned on success.  On failure, a negated errno value is
+ *   returned.
  *
  ****************************************************************************/
 

--- a/fs/driver/fs_blockproxy.c
+++ b/fs/driver/fs_blockproxy.c
@@ -186,10 +186,9 @@ int block_proxy(FAR struct file *filep, FAR const char *blkdev, int oflags)
    * a problem here!)
    */
 
-  ret = unlink(chardev);
+  ret = nx_unlink(chardev);
   if (ret < 0)
     {
-      ret = -errno;
       ferr("ERROR: Failed to unlink %s: %d\n", chardev, ret);
       goto errout_with_chardev;
     }
@@ -200,7 +199,7 @@ int block_proxy(FAR struct file *filep, FAR const char *blkdev, int oflags)
   return OK;
 
 errout_with_bchdev:
-  unlink(chardev);
+  nx_unlink(chardev);
 
 errout_with_chardev:
   kmm_free(chardev);

--- a/fs/driver/fs_blockproxy.c
+++ b/fs/driver/fs_blockproxy.c
@@ -128,22 +128,14 @@ static FAR char *unique_chardev(void)
  *   oriented accessed to the block driver.
  *
  * Input Parameters:
+ *   filep  - The caller provided location in which to return the 'struct
+ *            file' instance.
  *   blkdev - The path to the block driver
  *   oflags - Character driver open flags
  *
  * Returned Value:
- *   If positive, non-zero file descriptor is returned on success.  This
- *   is the file descriptor of the nameless character driver that mediates
- *   accesses to the block driver.
- *
- *   Errors that may be returned:
- *
- *     ENOMEM - Failed to create a temporary path name.
- *
- *   Plus:
- *
- *     - Errors reported from bchdev_register()
- *     - Errors reported from open() or unlink()
+ *   Zero (OK) is returned on success.  On failure, a negated errno value is
+ *   returned.
  *
  ****************************************************************************/
 
@@ -202,9 +194,7 @@ int block_proxy(FAR struct file *filep, FAR const char *blkdev, int oflags)
       goto errout_with_chardev;
     }
 
-  /* Free the allocate character driver name and return the open file
-   * descriptor.
-   */
+  /* Free the allocated character driver name. */
 
   kmm_free(chardev);
   return OK;

--- a/fs/driver/fs_mtdproxy.c
+++ b/fs/driver/fs_mtdproxy.c
@@ -131,16 +131,8 @@ static FAR char *unique_blkdev(void)
  * Returned Value:
  *   If zero, non-zero inode pointer is returned on success.  This
  *   is the inode pointer of the nameless block driver that mediates
- *   accesses to the mtd driver.
- *
- *   Errors that may be returned:
- *
- *     ENOMEM - Failed to create a temporary path name.
- *
- *   Plus:
- *
- *     - Errors reported from ftl_initialize()
- *     - Errors reported from open() or unlink()
+ *   accesses to the mtd driver. A negated errno value is returned on
+ *   any failure.
  *
  ****************************************************************************/
 
@@ -193,7 +185,7 @@ int mtd_proxy(FAR const char *mtddev, int mountflags,
    */
 
 out_with_fltdev:
-  unlink(blkdev);
+  nx_unlink(blkdev);
 out_with_blkdev:
   kmm_free(blkdev);
   return ret;

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -115,8 +115,7 @@ static int file_vopen(FAR struct file *filep,
   /* If the inode is block driver, then we may return a character driver
    * proxy for the block driver.  block_proxy() will instantiate a BCH
    * character driver wrapper around the block driver, open(), then
-   * unlink() the character driver.  On success, block_proxy() will
-   * return the file descriptor of the opened character driver.
+   * unlink() the character driver.
    *
    * NOTE: This will recurse to open the character driver proxy.
    */
@@ -128,7 +127,7 @@ static int file_vopen(FAR struct file *filep,
       inode_release(inode);
       RELEASE_SEARCH(&desc);
 
-      /* Get the file descriptor of the opened character driver proxy */
+      /* Get the file structure of the opened character driver proxy */
 
       return block_proxy(filep, path, oflags);
     }


### PR DESCRIPTION
## Summary
Update some misleading comments, now that block_proxy() no longer returns a file descriptor
Avoid unlink() in internal OS code, replace with nx_unlink() on two instances.
## Impact
No functional change intended
## Testing
Compile tested only
