### PR TITLE
fs/readdir: Must reserve a byte for the NUL terminator

### DIFF
--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -334,7 +334,7 @@ static int binfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 
       finfo("Entry %d: \"%s\"\n", index, name);
       dir->fd_dir.d_type = DTYPE_FILE;
-      strncpy(dir->fd_dir.d_name, name, NAME_MAX + 1);
+      strncpy(dir->fd_dir.d_name, name, NAME_MAX);
 
       /* The application list is terminated by an entry with a NULL name.
        * Therefore, there is at least one more entry in the list.

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -1285,7 +1285,7 @@ static int cromfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 
   name = (FAR char *)cromfs_offset2addr(fs, node->cn_name);
   finfo("Entry %lu: %s\n", (unsigned long)offset, name);
-  strncpy(dir->fd_dir.d_name, name, NAME_MAX + 1);
+  strncpy(dir->fd_dir.d_name, name, NAME_MAX);
 
   switch (node->cn_mode & S_IFMT)
     {

--- a/fs/dirent/fs_readdir.c
+++ b/fs/dirent/fs_readdir.c
@@ -61,7 +61,7 @@ static inline int readpseudodir(struct fs_dirent_s *idir)
   /* Copy the inode name into the dirent structure */
 
   strncpy(idir->fd_dir.d_name, idir->u.pseudo.fd_next->i_name,
-          NAME_MAX + 1);
+          NAME_MAX);
 
   /* If the node has file operations, we will say that it is a file. */
 

--- a/fs/nxffs/nxffs_dirent.c
+++ b/fs/nxffs/nxffs_dirent.c
@@ -150,7 +150,7 @@ int nxffs_readdir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir)
 
       finfo("Offset %jd: \"%s\"\n", (intmax_t)entry.hoffset, entry.name);
       dir->fd_dir.d_type = DTYPE_FILE;
-      strncpy(dir->fd_dir.d_name, entry.name, NAME_MAX + 1);
+      strncpy(dir->fd_dir.d_name, entry.name, NAME_MAX);
 
       /* Discard this entry and set the next offset. */
 

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1756,7 +1756,7 @@ static int proc_readdir(struct fs_dirent_s *dir)
       /* Save the filename and file type */
 
       dir->fd_dir.d_type = node->dtype;
-      strncpy(dir->fd_dir.d_name, node->name, NAME_MAX + 1);
+      strncpy(dir->fd_dir.d_name, node->name, NAME_MAX);
 
       /* Set up the next directory entry offset.  NOTE that we could use the
        * standard f_pos instead of our own private index.

--- a/fs/procfs/fs_skeleton.c
+++ b/fs/procfs/fs_skeleton.c
@@ -456,7 +456,7 @@ static int skel_readdir(FAR struct fs_dirent_s *dir)
       /* TODO:  Specify the type of entry */
 
       dir->fd_dir.d_type = DTYPE_FILE;
-      strncpy(dir->fd_dir.d_name, filename, NAME_MAX + 1);
+      strncpy(dir->fd_dir.d_name, filename, NAME_MAX);
 
       /* Set up the next directory entry offset.  NOTE that we could use the
        * standard f_pos instead of our own private index.

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -656,7 +656,7 @@ static int smartfs_readdir(struct fs_dirent_s *dir)
 
           dir->fd_dir.d_type = DTYPE_DIRECTORY;
           strncpy(dir->fd_dir.d_name, level1->mount->fs_blkdriver->i_name,
-                  NAME_MAX + 1);
+                  NAME_MAX);
 
           /* Advance to next entry */
 
@@ -669,7 +669,7 @@ static int smartfs_readdir(struct fs_dirent_s *dir)
 
           dir->fd_dir.d_type = g_direntry[level1->base.index].type;
           strncpy(dir->fd_dir.d_name, g_direntry[level1->base.index++].name,
-                  NAME_MAX + 1);
+                  NAME_MAX);
         }
       else if (level1->base.level == 3)
         {
@@ -677,7 +677,7 @@ static int smartfs_readdir(struct fs_dirent_s *dir)
 
           dir->fd_dir.d_type = g_direntry[level1->base.index].type;
           strncpy(dir->fd_dir.d_name, g_direntry[level1->direntry].name,
-                  NAME_MAX + 1);
+                  NAME_MAX);
           level1->base.index++;
         }
 

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -341,7 +341,7 @@ static int spiffs_readdir_callback(FAR struct spiffs_s *fs,
 
       strncpy(entryp->d_name,
               (FAR char *)objhdr.name + SPIFFS_LEADING_SLASH_SIZE,
-              NAME_MAX + 1);
+              NAME_MAX);
       entryp->d_type = objhdr.type;
       return OK;
     }

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -2057,7 +2057,7 @@ static int tmpfs_readdir(FAR struct inode *mountpt,
 
       /* Copy the entry name */
 
-      strncpy(dir->fd_dir.d_name, tde->tde_name, NAME_MAX + 1);
+      strncpy(dir->fd_dir.d_name, tde->tde_name, NAME_MAX);
 
       /* Save the index for next time */
 

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -1629,7 +1629,7 @@ static int unionfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
        * directories.
        */
 
-      strncpy(dir->fd_dir.d_name, um->um_prefix, NAME_MAX + 1);
+      strncpy(dir->fd_dir.d_name, um->um_prefix, NAME_MAX);
 
       /* Describe this as a read only directory */
 
@@ -1703,7 +1703,7 @@ static int unionfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
                    * be multiple directories.
                    */
 
-                  strncpy(dir->fd_dir.d_name, um->um_prefix, NAME_MAX + 1);
+                  strncpy(dir->fd_dir.d_name, um->um_prefix, NAME_MAX);
 
                   /* Describe this as a read only directory */
 


### PR DESCRIPTION
## Summary
fs/readdir: Must reserve a byte for the NUL terminator
## Impact

## Testing

