### PR TITLE
drivers: wireless: Fix _read_data() in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -828,19 +828,17 @@ static void _write_data(FAR struct gs2200m_dev_s *dev,
 
 /****************************************************************************
  * Name: _read_data
- * NOTE: See 3.2.2.1 SPI Byte Stuffing for the idle character
+ * NOTE: See 3.2.2.2 SPI Command Response (SPI-DMA)
  ****************************************************************************/
 
 static void _read_data(FAR struct gs2200m_dev_s *dev,
                        FAR uint8_t  *buff,
                        FAR uint16_t len)
 {
-  uint8_t req = 0xf5; /* idle character */
-
   memset(buff, 0, len);
 
   SPI_SELECT(dev->spi, SPIDEV_WIRELESS(0), true);
-  SPI_EXCHANGE(dev->spi, &req, buff, len);
+  SPI_RECVBLOCK(dev->spi, buff, len);
   SPI_SELECT(dev->spi, SPIDEV_WIRELESS(0), false);
 }
 


### PR DESCRIPTION
## Summary

- During reviewing the GS2200M document, I noticed that
   _read_data() implementation is incorrect.
- Actually, we do not use "SPI Byte Stuffing for SPI-NO-DMA"
  but use "SPI Command Response (SPI-DMA)", so the sequence
  should use SPI_RECVBLOCK().

## Impact

- gs2200m.c only

## Testing

- Tested with stm32f4discovery:wifi and spresense:wifi_smp
