### PR TITLE
esp32/esp32_spiflash.c: Fix the value of the page start address when invalidating the cache

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -594,7 +594,7 @@ static void IRAM_ATTR spiflash_flushmapped(size_t start, size_t size)
   uint32_t addr;
   uint32_t page;
 
-  page_start = MMU_ALIGNDOWN_SIZE(size);
+  page_start = MMU_ALIGNDOWN_SIZE(start);
   size += (start - page_start);
   size = MMU_ALIGNUP_SIZE(size);
 


### PR DESCRIPTION
## Summary
Fix the value of the page start address when invalidating the cache.  The value was incorrectly set to be the `size` instead of `start`.
## Impact
Fix a bug that will make invalidating the cache happen more frequently.
## Testing
esp32-devkitc:spiflash

Some NXStyle issues are expected due to the ROM functions usage.
