### PR TITLE
arch: esp32: Fix compile errors with CONFIG_SMP=y

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -616,8 +616,8 @@ static void IRAM_ATTR spiflash_flushmapped(size_t start, size_t size)
           Cache_Flush(0);
 #ifndef CONFIG_SMP
           Cache_Flush(1);
-        }
 #endif
+        }
     }
 }
 

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -755,7 +755,7 @@ static void *esp_spin_lock_create(void)
   spinlock_t *lock;
   int tmp;
 
-  tmp = sizeof(struct spinlock_t);
+  tmp = sizeof(*lock);
   lock = kmm_malloc(tmp);
   if (!lock)
     {
@@ -3901,11 +3901,7 @@ static unsigned long esp_random_ulong(void)
 
 uint32_t IRAM_ATTR esp_dport_access_reg_read(uint32_t reg)
 {
-#ifdef CONFIG_SMP
-  DEBUGASSERT(0);
-#else
   return getreg32(reg);
-#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- This commit fixes compile errors in esp32_spiflash.c and
  esp32_wifi_adapter.c with CONFIG_SMP=y

## Impact

- SMP only

## Testing

- Tested with esp32-devkitc:wapi
- NOTE: the following configs need to be added.
  +CONFIG_SMP=y
  +CONFIG_SMP_IDLETHREAD_STACKSIZE=3072
  +CONFIG_SMP_NCPUS=2
  +CONFIG_SPINLOCK_IRQ=y
