### PR TITLE
arch/xtensa/Kconfig: Reduce the default value of the internal memory.

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -131,8 +131,7 @@ config XTENSA_USE_SEPARATE_IMEM
 config XTENSA_IMEM_REGION_SIZE
 	hex "DRAM region size for internal use"
 	depends on XTENSA_USE_SEPARATE_IMEM
-	range 0x2000 0x28000
-	default 0x28000
+	default 0x18000
 
 config XTENSA_IMEM_PROCFS
 	bool "Internal memory PROCFS support"


### PR DESCRIPTION
## Summary
The static memory for ESP32 is now divided at almost the middle to not override
the ROM data.  The old 0x28000 will take all of what's left for heap
region1.

## Impact
The whole internal heap is disabled by default.  So no impact.
## Testing
esp32 boards.
