### PR TITLE
sched: mqueue: Remove an unnecessary comment in mq_send.c

### DIFF
--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -113,7 +113,7 @@ int file_mq_send(FAR struct file *mq, FAR const char *msg, size_t msglen,
     {
       /* No.. Not in an interrupt handler.  Is the message queue FULL? */
 
-      if (msgq->nmsgs >= msgq->maxmsgs) /* Message queue not-FULL? */
+      if (msgq->nmsgs >= msgq->maxmsgs)
         {
           /* Yes.. the message queue is full.  Wait for space to become
            * available in the message queue.


### PR DESCRIPTION
## Summary

- Remove an unnecessary comment in mq_send.c 

## Impact

- None

## Testing

- None
