### PR TITLE
sched/wqueue/notifier: protect the work notifier with critical section 

### DIFF
--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -65,7 +65,7 @@ struct work_notifier_entry_s
 
   /* Additional payload needed to manage the notification */
 
-  int16_t key;                  /* Unique ID for the notification */
+  uint32_t key;                 /* Unique ID for the notification */
 };
 
 /****************************************************************************
@@ -86,10 +86,6 @@ static dq_queue_t g_notifier_free;
 
 static dq_queue_t g_notifier_pending;
 
-/* Used for lookup key generation */
-
-static uint16_t g_notifier_key;
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -103,7 +99,7 @@ static uint16_t g_notifier_key;
  *
  ****************************************************************************/
 
-static FAR struct work_notifier_entry_s *work_notifier_find(int16_t key)
+static FAR struct work_notifier_entry_s *work_notifier_find(uint32_t key)
 {
   FAR struct work_notifier_entry_s *notifier;
   FAR dq_entry_t *entry;
@@ -118,7 +114,7 @@ static FAR struct work_notifier_entry_s *work_notifier_find(int16_t key)
 
       /* Is this the one we were looking for? */
 
-      if (notifier->key ==  key)
+      if (notifier->key == key)
         {
           /* Yes.. return a reference to it */
 
@@ -137,24 +133,16 @@ static FAR struct work_notifier_entry_s *work_notifier_find(int16_t key)
  *
  ****************************************************************************/
 
-static int16_t work_notifier_key(void)
+static uint32_t work_notifier_key(void)
 {
-  int16_t key;
+  static uint32_t notifier_key;
 
-  /* Loop until a unique key is generated.  Range 1-INT16_MAX. */
-
-  do
+  if (++notifier_key == 0)
     {
-      if (g_notifier_key >= INT16_MAX)
-        {
-          g_notifier_key = 0;
-        }
-
-      key = (int16_t)++g_notifier_key;
+      notifier_key = 1;
     }
-  while (work_notifier_find(key) != NULL);
 
-  return key;
+  return notifier_key;
 }
 
 /****************************************************************************
@@ -299,8 +287,6 @@ int work_notifier_teardown(int key)
   FAR struct work_notifier_entry_s *notifier;
   irqstate_t flags;
   int ret = OK;
-
-  DEBUGASSERT(key > 0 && key <= INT16_MAX);
 
   /* Disable interrupts very briefly. */
 


### PR DESCRIPTION


## Summary

sched/wqueue/notifier: protect the work notifier with critical section 

replace the semaphore to avoid the notifier holding the lock in the interrupt context

ASSERT:

```
libs/libc/assert/lib_assert.c:36   :_assert
sched/semphore/sem_wait.c:113      :nxsem_wait
sched/semphore/sem_wait.c:222      :nxsem_wait_uniterruptible
sched/wqueue/kwork_notifier.c:371  :work_notifier_signal
mm/iob/iob_free.c:188              :iob_free
drivers/syslog/syslog_stream.c:272 :syslogstream_destroy
...
sched/irq/irq_dispatch.c:183       :irq_dispatch
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

call syslog() on interrupt context

## Testing

