### PR TITLE
arch/riscv: Remove MIPS references

### DIFF
--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -57,8 +57,9 @@
  * Pre-processor Macros
  ****************************************************************************/
 
-/* MIPS requires at least a 4-byte stack alignment.  For floating point use,
- * however, the stack must be aligned to 8-byte addresses.
+/* RISC-V requires at least a 4-byte stack alignment.
+ * For floating point use, however, the stack must be aligned to 8-byte
+ * addresses.
  */
 
 #if defined(CONFIG_LIBC_FLOATINGPOINT) || defined (CONFIG_ARCH_RV64GC)
@@ -224,7 +225,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size - 4;
 
-      /* The MIPS stack must be aligned at word (4 byte) boundaries; for
+      /* The RISC-V stack must be aligned at word (4 byte) boundaries; for
        * floating point use, the stack must be aligned to 8-byte addresses.
        * If necessary top_of_stack must be rounded down to the next
        * boundary to meet these alignment requirements.

--- a/arch/risc-v/src/common/riscv_stackframe.c
+++ b/arch/risc-v/src/common/riscv_stackframe.c
@@ -52,8 +52,9 @@
  * Pre-processor Macros
  ****************************************************************************/
 
-/* MIPS requires at least a 4-byte stack alignment.  For floating point use,
- * however, the stack must be aligned to 8-byte addresses.
+/* RISC-V requires at least a 4-byte stack alignment.
+ * For floating point use, however, the stack must be aligned to 8-byte
+ * addresses.
  */
 
 #if defined(CONFIG_LIBC_FLOATINGPOINT) || defined (CONFIG_ARCH_RV64GC)

--- a/arch/risc-v/src/common/riscv_usestack.c
+++ b/arch/risc-v/src/common/riscv_usestack.c
@@ -54,8 +54,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* MIPS requires at least a 4-byte stack alignment.  For floating point use,
- * however, the stack must be aligned to 8-byte addresses.
+/* RISC-V requires at least a 4-byte stack alignment.
+ * For floating point use, however, the stack must be aligned to 8-byte
+ * addresses.
  */
 
 #if defined(CONFIG_LIBC_FLOATINGPOINT) || defined (CONFIG_ARCH_RV64GC)
@@ -126,7 +127,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   tcb->stack_alloc_ptr = stack;
 
-  /* MIPS uses a push-down stack:  the stack grows toward loweraddresses in
+  /* RISC-V uses a push-down stack:  the stack grows toward loweraddresses in
    * memory.  The stack pointer register, points to the lowest, valid work
    * address (the "top" of the stack).  Items on the stack are referenced
    * as positive word offsets from sp.
@@ -134,9 +135,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size - 4;
 
-  /* The MIPS stack must be aligned at word (4 byte) or double word (8 byte)
-   * boundaries. If necessary top_of_stack must be rounded down to the
-   * next boundary
+  /* The RISC-V stack must be aligned at word (4 byte) or double word
+   * (8 byte) boundaries.  If necessary top_of_stack must be rounded down to
+   * the next boundary.
    */
 
   top_of_stack = STACK_ALIGN_DOWN(top_of_stack);

--- a/arch/risc-v/src/rv32im/riscv_copystate.c
+++ b/arch/risc-v/src/rv32im/riscv_copystate.c
@@ -70,7 +70,7 @@ void up_copystate(uint32_t *dest, uint32_t *src)
 {
   int i;
 
-  /* In the MIPS model, the state is copied from the stack to the TCB,
+  /* In the RISC-V model, the state is copied from the stack to the TCB,
    * but only a reference is passed to get the state from the TCB.  So the
    * following check avoids copying the TCB save area onto itself:
    */

--- a/arch/risc-v/src/rv32im/riscv_swint.c
+++ b/arch/risc-v/src/rv32im/riscv_swint.c
@@ -64,7 +64,7 @@ static void up_registerdump(const uint32_t *regs)
           regs[REG_S4], regs[REG_S5], regs[REG_S6], regs[REG_S7]);
   svcinfo("S8:%08x S9:%08x S10:%08x S11:%08x\n",
           regs[REG_S8], regs[REG_S9], regs[REG_S10], regs[REG_S11]);
-#ifdef MIPS32_SAVE_GP
+#ifdef RISCV_SAVE_GP
   svcinfo("GP:%08x SP:%08x FP:%08x TP:%08x RA:%08x\n",
           regs[REG_GP], regs[REG_SP], regs[REG_FP],
           regs[REG_TP], regs[REG_RA]);

--- a/arch/risc-v/src/rv32im/riscv_vfork.c
+++ b/arch/risc-v/src/rv32im/riscv_vfork.c
@@ -122,7 +122,7 @@ pid_t up_vfork(const struct vfork_s *context)
   struct task_tcb_s *child;
   size_t stacksize;
   uint32_t newsp;
-#ifdef CONFIG_MIPS32_FRAMEPOINTER
+#ifdef CONFIG_RISCV_FRAMEPOINTER
   uint32_t newfp;
 #endif
   uint32_t stackutil;
@@ -132,10 +132,10 @@ pid_t up_vfork(const struct vfork_s *context)
 
   sinfo("s0:%08x s1:%08x s2:%08x s3:%08x s4:%08x\n",
         context->s0, context->s1, context->s2, context->s3, context->s4);
-#ifdef CONFIG_MIPS32_FRAMEPOINTER
+#ifdef CONFIG_RISCV_FRAMEPOINTER
   sinfo("s5:%08x s6:%08x s7:%08x\n",
         context->s5, context->s6, context->s7);
-#ifdef MIPS32_SAVE_GP
+#ifdef RISCV_SAVE_GP
   sinfo("fp:%08x sp:%08x ra:%08x gp:%08x\n",
         context->fp, context->sp, context->ra, context->gp);
 #else
@@ -145,7 +145,7 @@ pid_t up_vfork(const struct vfork_s *context)
 #else
   sinfo("s5:%08x s6:%08x s7:%08x s8:%08x\n",
         context->s5, context->s6, context->s7, context->s8);
-#ifdef MIPS32_SAVE_GP
+#ifdef RISCV_SAVE_GP
   sinfo("sp:%08x ra:%08x gp:%08x\n",
         context->sp, context->ra, context->gp);
 #else
@@ -188,7 +188,7 @@ pid_t up_vfork(const struct vfork_s *context)
   argv = up_stack_frame((FAR struct tcb_s *)child, argsize);
   memcpy(argv, parent->adj_stack_ptr, argsize);
 
-  /* How much of the parent's stack was utilized?  The MIPS uses
+  /* How much of the parent's stack was utilized?  The RISC-V uses
    * a push-down stack so that the current stack pointer should
    * be lower than the initial, adjusted stack pointer.  The
    * stack usage should be the difference between those two.
@@ -211,7 +211,7 @@ pid_t up_vfork(const struct vfork_s *context)
 
   /* Was there a frame pointer in place before? */
 
-#ifdef CONFIG_MIPS32_FRAMEPOINTER
+#ifdef CONFIG_RISCV_FRAMEPOINTER
   if (context->fp <= (uint32_t)parent->adj_stack_ptr &&
       context->fp >= (uint32_t)parent->adj_stack_ptr - stacksize)
     {
@@ -249,13 +249,13 @@ pid_t up_vfork(const struct vfork_s *context)
   child->cmn.xcp.regs[REG_S5]  = context->s5;  /* Volatile register s5 */
   child->cmn.xcp.regs[REG_S6]  = context->s6;  /* Volatile register s6 */
   child->cmn.xcp.regs[REG_S7]  = context->s7;  /* Volatile register s7 */
-#ifdef CONFIG_MIPS32_FRAMEPOINTER
+#ifdef CONFIG_RISCV_FRAMEPOINTER
   child->cmn.xcp.regs[REG_FP]  = newfp;        /* Frame pointer */
 #else
   child->cmn.xcp.regs[REG_S8]  = context->s8;  /* Volatile register s8 */
 #endif
   child->cmn.xcp.regs[REG_SP]  = newsp;        /* Stack pointer */
-#ifdef MIPS32_SAVE_GP
+#ifdef RISCV_SAVE_GP
   child->cmn.xcp.regs[REG_GP]  = newsp;        /* Global pointer */
 #endif
 

--- a/arch/risc-v/src/rv32im/riscv_vfork.h
+++ b/arch/risc-v/src/rv32im/riscv_vfork.h
@@ -33,8 +33,8 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_MIPS_SRC_MIPS32_VFORK_H
-#define __ARCH_MIPS_SRC_MIPS32_VFORK_H
+#ifndef __ARCH_RISCV_SRC_RVIM32_VFORK_H
+#define __ARCH_RISCV_SRC_RVIM32_VFORK_H
 
 /****************************************************************************
  * Included Files
@@ -84,7 +84,7 @@
 #define VFORK_S6_OFFSET   (6*4)   /* Saved register s6 */
 #define VFORK_S7_OFFSET   (7*4)   /* Saved register s7 */
 
-#ifdef CONFIG_MIPS32_FRAMEPOINTER
+#ifdef CONFIG_RISCV_FRAMEPOINTER
 #  define VFORK_FP_OFFSET (8*4)   /* Frame pointer */
 #else
 #  define VFORK_S8_OFFSET (8*4)   /* Saved register s8 */
@@ -92,7 +92,7 @@
 
 #define VFORK_SP_OFFSET   (9*4)   /* Stack pointer*/
 #define VFORK_RA_OFFSET   (10*4)  /* Return address*/
-#ifdef MIPS32_SAVE_GP
+#ifdef RISCV_SAVE_GP
 #  define VFORK_GP_OFFSET (11*4)   /* Global pointer */
 #  define VFORK_SIZEOF    (12*4)
 #else
@@ -116,14 +116,14 @@ struct vfork_s
   uint32_t s5;   /* Saved register s5 */
   uint32_t s6;   /* Saved register s6 */
   uint32_t s7;   /* Saved register s7 */
-#ifdef CONFIG_MIPS32_FRAMEPOINTER
+#ifdef CONFIG_RISCV_FRAMEPOINTER
   uint32_t fp;   /* Frame pointer */
 #else
   uint32_t s8;   /* Saved register s8 */
 #endif
   uint32_t sp;   /* Stack pointer */
   uint32_t ra;   /* Return address */
-#ifdef MIPS32_SAVE_GP
+#ifdef RISCV_SAVE_GP
   uint32_t gp;   /* Global pointer */
 #endif
 
@@ -131,4 +131,4 @@ struct vfork_s
 };
 #endif
 
-#endif /* __ARCH_MIPS_SRC_MIPS32_VFORK_H */
+#endif /* __ARCH_RISCVRC_RVIM32_VFORK_H */


### PR DESCRIPTION
## Summary
Remove references left from the MIPS port.
## Impact
N/A, the macros replaces are not defined for now.
## Testing
N/A
