### PR TITLE
arch/sim: Fix typo error(HCITTY->BTUART)

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -551,7 +551,7 @@ config SIM_BTUART
 		target via HCI_CHANNEL_USER. This gives NuttX full
 		control of the device, but is abstracted from the
 		physical interface which is still handled by Linux.
-		Unlike SIM_HCISOCKET, HCITTY will wrap the bluetooth
+		Unlike SIM_HCISOCKET, BTUART will wrap the bluetooth
 		interface/controller as a TTY device, which provides
 		an option for developers to setup the bluetooth host in
 		userspace.

--- a/arch/sim/src/sim/up_idle.c
+++ b/arch/sim/src/sim/up_idle.c
@@ -115,7 +115,7 @@ void up_idle(void)
   bthcisock_loop();
 #endif
 
-#ifdef CONFIG_SIM_HCITTY
+#ifdef CONFIG_SIM_BTUART
   sim_btuart_loop();
 #endif
 


### PR DESCRIPTION
## Summary
up_idle can trigger sim_btuart_loop

## Impact

## Testing

