### PR TITLE
net/ip: do not drop the udp packet from IP layer

### DIFF
--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -237,16 +237,6 @@ int ipv4_input(FAR struct net_driver_s *dev)
     }
   else
 #endif
-#ifdef CONFIG_NET_ICMP
-  /* In other cases, the device must be assigned a non-zero IP address. */
-
-  if (net_ipv4addr_cmp(dev->d_ipaddr, INADDR_ANY))
-    {
-      nwarn("WARNING: No IP address assigned\n");
-      goto drop;
-    }
-  else
-#endif
 #if defined(CONFIG_NET_BROADCAST) && defined(NET_UDP_HAVE_STACK)
   /* The address is not the broadcast address and we have been assigned a
    * address.  So there is also the possibility that the destination address
@@ -307,6 +297,7 @@ int ipv4_input(FAR struct net_driver_s *dev)
             }
           else
 #endif
+          if (ipv4->proto != IP_PROTO_UDP)
             {
               /* Not destined for us and not forwardable... Drop the
                * packet.
@@ -322,6 +313,15 @@ int ipv4_input(FAR struct net_driver_s *dev)
             }
         }
     }
+#ifdef CONFIG_NET_ICMP
+  /* In other cases, the device must be assigned a non-zero IP address. */
+
+  else if (net_ipv4addr_cmp(dev->d_ipaddr, INADDR_ANY))
+    {
+      nwarn("WARNING: No IP address assigned\n");
+      goto drop;
+    }
+#endif
 
   if (ipv4_chksum(dev) != 0xffff)
     {

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -207,11 +207,11 @@ int ipv4_input(FAR struct net_driver_s *dev)
   if ((ipv4->ipoffset[0] & 0x3f) != 0 || ipv4->ipoffset[1] != 0)
     {
 #ifdef CONFIG_NET_STATISTICS
-       g_netstats.ipv4.drop++;
-       g_netstats.ipv4.fragerr++;
+      g_netstats.ipv4.drop++;
+      g_netstats.ipv4.fragerr++;
 #endif
-       nwarn("WARNING: IP fragment dropped\n");
-       goto drop;
+      nwarn("WARNING: IP fragment dropped\n");
+      goto drop;
     }
 
   /* Get the destination IP address in a friendlier form */
@@ -314,6 +314,7 @@ int ipv4_input(FAR struct net_driver_s *dev)
         }
     }
 #ifdef CONFIG_NET_ICMP
+
   /* In other cases, the device must be assigned a non-zero IP address. */
 
   else if (net_ipv4addr_cmp(dev->d_ipaddr, INADDR_ANY))

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -409,22 +409,6 @@ int ipv6_input(FAR struct net_driver_s *dev)
        * address by its IPv6 nexthdr field.
        */
     }
-
-  /* In other cases, the device must be assigned a non-zero IP address
-   * (the all zero address is the "unspecified" address.
-   */
-
-  else
-#endif
-#ifdef CONFIG_NET_ICMPv6
-  if (net_ipv6addr_cmp(dev->d_ipv6addr, g_ipv6_unspecaddr))
-    {
-      nwarn("WARNING: No IP address assigned\n");
-      goto drop;
-    }
-
-  /* Check if the packet is destined for out IP address */
-
   else
 #endif
     {
@@ -449,6 +433,7 @@ int ipv6_input(FAR struct net_driver_s *dev)
             }
           else
 #endif
+          if (nxthdr != IP_PROTO_UDP)
             {
               /* Not destined for us and not forwardable... drop the packet. */
 
@@ -457,6 +442,18 @@ int ipv6_input(FAR struct net_driver_s *dev)
             }
         }
     }
+#ifdef CONFIG_NET_ICMPv6
+
+  /* In other cases, the device must be assigned a non-zero IP address
+   * (the all zero address is the "unspecified" address.
+   */
+
+  if (net_ipv6addr_cmp(dev->d_ipv6addr, g_ipv6_unspecaddr))
+    {
+      nwarn("WARNING: No IP address assigned\n");
+      goto drop;
+    }
+#endif
 
   /* Now process the incoming packet according to the protocol specified in
    * the next header IPv6 field.

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -391,8 +391,8 @@ int ipv6_input(FAR struct net_driver_s *dev)
     {
 #ifdef CONFIG_NET_IPFORWARD_BROADCAST
 
-      /* Packets sent to ffx0 are reserved, ffx1 are interface-local, and ffx2
-       * are interface-local, and therefore, should not be forwarded
+      /* Packets sent to ffx0 are reserved, ffx1 are interface-local, and
+       * ffx2 are interface-local, and therefore, should not be forwarded
        */
 
       if ((ipv6->destipaddr[0] & HTONS(0xff0f) != HTONS(0xff00)) &&
@@ -435,9 +435,11 @@ int ipv6_input(FAR struct net_driver_s *dev)
 #endif
           if (nxthdr != IP_PROTO_UDP)
             {
-              /* Not destined for us and not forwardable... drop the packet. */
+              /* Not destined for us and not forwardable...
+               * drop the packet.
+               */
 
-              nwarn("WARNING: Not destined for us; not forwardable... Dropping!\n");
+              nwarn("WARNING: Not destined for us... Dropping!\n");
               goto drop;
             }
         }


### PR DESCRIPTION

## Summary

net/ip: do not drop the udp packet from IP layer

this change to support receive the udp data from the specified
port without obtaining the address.

e.g: disable the Bootstrap flag on dhcpc handshake

Reference:
RFC1542: Clarifications and Extensions for the Bootstrap Protocol.

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

Related:
https://github.com/apache/incubator-nuttx-apps/pull/579

## Testing

