### PR TITLE
drivers: mtd: w25qxxxjv.c : W25Q256's sector count is 8192

### DIFF
--- a/drivers/mtd/w25qxxxjv.c
+++ b/drivers/mtd/w25qxxxjv.c
@@ -246,7 +246,7 @@
 
 #define W25Q256_SECTOR_SIZE         (4 * 1024)
 #define W25Q256_SECTOR_SHIFT        (12)
-#define W25Q256_SECTOR_COUNT        (8196)
+#define W25Q256_SECTOR_COUNT        (8192)
 #define W25Q256_PAGE_SIZE           (256)
 #define W25Q256_PAGE_SHIFT          (8)
 


### PR DESCRIPTION
"The W25Q256JV has 8,192 erasable  sectors"