### PR TITLE
drivers/net/encx24j600.c: Correct setting of ifstate

### DIFF
--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -2272,11 +2272,8 @@ static int enc_ifup(struct net_driver_s *dev)
       wd_start(&priv->txpoll, ENC_WDDELAY,
                enc_polltimer, (wdparm_t)priv);
 
-      /* Mark the interface up and enable the Ethernet interrupt at the
-       * controller
-       */
+      /* Enable the Ethernet interrupt at the controller */
 
-      priv->ifstate = ENCSTATE_UP;
       priv->lower->enable(priv->lower);
     }
 


### PR DESCRIPTION


## Summary

The ifstate is already set in
  enc_ifup -> enc_reset -> enc_linkstatus

The ifstate after this call is either ENCSTATE_RUNNING or ENCSTATE_UP
If ifstate is ENCSTATE_RUNNING, it would be wrong to set it to ENCSTATE_UP;
this would lead to enc_txavail never invoking the driver callback, causing
very long latencies in sending.

## Impact

Very slow data transfer. This can be easily tested by pinging from NuttX board, ping round-trips will be hundreds of ms, even up to 1s, whereas pinging the nuttx board from outside will show just a few ms latencies.

## Testing

Tested with connecting Olimex MOD-ENC624J600 board to STM32F7 microcontroller's SPI bus and transferring data over ethernet.
