### PR TITLE
arch: imx6: Fix a compile error with CONFIG_DEBUG_ASSERTIONS=y

### DIFF
--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -546,7 +546,7 @@ static int imx_transmit(FAR struct imx_driver_s *priv)
                        (uintptr_t)txdesc + sizeof(struct enet_desc_s));
 
 #if CONFIG_IMX_ENET_NTXBUFFERS > 1
-  DEBUGASSERT(priv->txtail != priv->txhead)
+  DEBUGASSERT(priv->txtail != priv->txhead);
 #endif
   DEBUGASSERT((txdesc->status1 & TXDESC_R) == 0);
 #endif


### PR DESCRIPTION
## Summary

- This commit fixes a compile error in imx_enet.c
  with CONFIG_DEBUG_ASSERTIONS=y

## Impact

- None

## Testing

- Tested with sabre-6quad:netnsh with QEMU
