### PR TITLE
nRF52 fixes

### DIFF
--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -621,6 +621,7 @@ menu "SPI Configuration"
 config NRF52_SPI_MASTER_WORKAROUND_1BYTE_TRANSFER
 	bool "Master 1 Byte transfer anomaly workaround"
 	depends on NRF52_SPI_MASTER && ARCH_CHIP_NRF52832
+	select NRF52_PPI
 	default y
 	---help---
 		Enable the workaround to fix SPI Master 1 byte transfer bug

--- a/arch/arm/src/nrf52/nrf52_rtc.c
+++ b/arch/arm/src/nrf52/nrf52_rtc.c
@@ -93,6 +93,7 @@ static int nrf52_rtc_ackint(FAR struct nrf52_rtc_dev_s *dev, uint8_t s);
 static int nrf52_rtc_enableevt(FAR struct nrf52_rtc_dev_s *dev, uint8_t evt);
 static int nrf52_rtc_disableevt(FAR struct nrf52_rtc_dev_s *dev,
                                 uint8_t evt);
+static uint32_t nrf52_rtc_getbase(FAR struct nrf52_rtc_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -117,6 +118,7 @@ struct nrf52_rtc_ops_s nrf52_rtc_ops =
   .ackint     = nrf52_rtc_ackint,
   .enableevt  = nrf52_rtc_enableevt,
   .disableevt = nrf52_rtc_disableevt,
+  .getbase    = nrf52_rtc_getbase,
 };
 
 #ifdef CONFIG_NRF52_RTC0
@@ -722,6 +724,18 @@ static int nrf52_rtc_disableevt(FAR struct nrf52_rtc_dev_s *dev, uint8_t evt)
 
 errout:
   return ret;
+}
+
+/****************************************************************************
+ * Name: nrf52_rtc_getbase
+ ****************************************************************************/
+
+static uint32_t nrf52_rtc_getbase(FAR struct nrf52_rtc_dev_s *dev)
+{
+  FAR struct nrf52_rtc_priv_s *rtc = (FAR struct nrf52_rtc_priv_s *)dev;
+  DEBUGASSERT(dev);
+
+  return rtc->base;
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf52/nrf52_rtc.h
+++ b/arch/arm/src/nrf52/nrf52_rtc.h
@@ -50,6 +50,15 @@
 #define NRF52_RTC_ACKINT(d, s)            ((d)->ops->ackint(d, s))
 #define NRF52_RTC_ENABLEEVT(d, s)         ((d)->ops->enableevt(d, s))
 #define NRF52_RTC_DISABLEEVT(d, s)        ((d)->ops->disableevt(d, s))
+#define NRF52_RTC_GETBASE(d)              ((d)->ops->getbase(d))
+
+/* These are defined for direct access to registers, which is needed in some
+ * critical parts where access speed is important
+ */
+
+#define NRF52_RTC_GETCOUNTER_REG(base)    (getreg32(base + NRF52_RTC_COUNTER_OFFSET))
+#define NRF52_RTC_SETCC_REG(base, ch, cc) (putreg32(cc, base + NRF52_RTC_CC_OFFSET(ch)))
+#define NRF52_RTC_GETCC_REG(base, ch)     (getreg32(base + NRF52_RTC_CC_OFFSET(ch)))
 
 /****************************************************************************
  * Public Types
@@ -116,6 +125,10 @@ struct nrf52_rtc_ops_s
 
   CODE int (*enableevt)(FAR struct nrf52_rtc_dev_s *dev, uint8_t evt);
   CODE int (*disableevt)(FAR struct nrf52_rtc_dev_s *dev, uint8_t evt);
+
+  /* Utility */
+
+  CODE uint32_t (*getbase)(FAR struct nrf52_rtc_dev_s *dev);
 };
 
 /****************************************************************************

--- a/arch/arm/src/nrf52/nrf52_spi.c
+++ b/arch/arm/src/nrf52/nrf52_spi.c
@@ -1223,7 +1223,7 @@ static void nrf52_spi_sndblock(FAR struct spi_dev_s *dev,
                                FAR const void *txbuffer,
                                size_t nwords)
 {
-  spiinfo("txbuffer=%p nwords=%d\n", txbuffer, nwords);
+  spiinfo("txbuffer=%p nwords=%zu\n", txbuffer, nwords);
   return nrf52_spi_exchange(dev, txbuffer, NULL, nwords);
 }
 
@@ -1249,8 +1249,8 @@ static void nrf52_spi_recvblock(FAR struct spi_dev_s *dev,
                                 FAR void *rxbuffer,
                                 size_t nwords)
 {
-  spiinfo("txbuffer=%p nwords=%d\n", txbuffer, nwords);
-  return nrf52_spi_exchange(dev, rxbuffer, NULL, nwords);
+  spiinfo("txbuffer=%p nwords=%zu\n", rxbuffer, nwords);
+  return nrf52_spi_exchange(dev, NULL, rxbuffer, nwords);
 }
 #endif /* CONFIG_SPI_EXCHANGE */
 


### PR DESCRIPTION
## Summary

- Improve SPI use of PPI peripheral (for workaround) by using PPI API, which internally checks we're not using an already used channel. Also, this works better when on PPI API header the number of available PPI channels is reduced because they are reserved (such as when using Nordic SDC).
- When !SPI_EXCHANGE, the RX transfer had the parameter swapped which resulted in no reception of data
- Tickless RTC code was dealing with the edge case (minimum settable timeout) with code which was not fast enough to properly work. This now uses more direct interaction with registers. This has solved a never-ending usleep() I had (with a low timeout period, under intensive interrupts scenario)

## Impact

Fixes some bugs, improves code to avoid future problems

## Testing

nrf52832-mdk with custom config (derived from unmerged nrf52832-mdk:sdc).