### PR TITLE
arch/risc-v: Don't declare riscv_addregion if CONFIG_MM_REGIONS is < 1.

### DIFF
--- a/arch/risc-v/src/bl602/bl602_allocateheap.c
+++ b/arch/risc-v/src/bl602/bl602_allocateheap.c
@@ -38,14 +38,6 @@ extern uint8_t _heap_size;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_addregion
- ****************************************************************************/
-
-void up_addregion(void)
-{
-}
-
-/****************************************************************************
  * Name: up_allocate_heap
  *
  * Description:
@@ -65,3 +57,19 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
   *heap_start = (FAR void *)&_heap_start;
   *heap_size  = (size_t)&_heap_size;
 }
+
+/****************************************************************************
+ * Name: riscv_addregion
+ *
+ * Description:
+ *   RAM may be added in non-contiguous chunks.  This routine adds all chunks
+ *   that may be used for heap.
+ *
+ ****************************************************************************/
+
+#if CONFIG_MM_REGIONS > 1
+void riscv_addregion(void)
+{
+}
+#endif
+

--- a/arch/risc-v/src/common/riscv_initialize.c
+++ b/arch/risc-v/src/common/riscv_initialize.c
@@ -114,7 +114,7 @@ void up_initialize(void)
 
   /* Add any extra memory fragments to the memory manager */
 
-  up_addregion();
+  riscv_addregion();
 
 #ifdef CONFIG_PM
   /* Initialize the power management subsystem.  This MCU-specific function

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -172,7 +172,12 @@ void up_boot(void);
 
 /* Memory allocation ********************************************************/
 
-void up_addregion(void);
+#if CONFIG_MM_REGIONS > 1
+void riscv_addregion(void);
+#else
+# define riscv_addregion()
+#endif
+
 void up_allocate_heap(FAR void **heap_start, size_t *heap_size);
 
 /* IRQ initialization *******************************************************/

--- a/arch/risc-v/src/fe310/fe310_allocateheap.c
+++ b/arch/risc-v/src/fe310/fe310_allocateheap.c
@@ -45,9 +45,16 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_addregion
+ * Name: riscv_addregion
+ *
+ * Description:
+ *   RAM may be added in non-contiguous chunks.  This routine adds all chunks
+ *   that may be used for heap.
+ *
  ****************************************************************************/
 
-void up_addregion(void)
+#if CONFIG_MM_REGIONS > 1
+void riscv_addregion(void)
 {
 }
+#endif

--- a/arch/risc-v/src/gap8/gap8_allocateheap.c
+++ b/arch/risc-v/src/gap8/gap8_allocateheap.c
@@ -82,7 +82,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 }
 
 /****************************************************************************
- * Name: up_addregion
+ * Name: riscv_addregion
  *
  * Description:
  *   RAM may be added in non-contiguous chunks.  This routine adds all chunks
@@ -90,7 +90,9 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  *
  ****************************************************************************/
 
-void up_addregion(void)
+#if CONFIG_MM_REGIONS > 1
+void riscv_addregion(void)
 {
   /* TODO: add L1 memorie */
 }
+#endif

--- a/arch/risc-v/src/k210/k210_allocateheap.c
+++ b/arch/risc-v/src/k210/k210_allocateheap.c
@@ -94,9 +94,17 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
 #endif
 
 /****************************************************************************
- * Name: up_addregion
+ * Name: riscv_addregion
+ *
+ * Description:
+ *   RAM may be added in non-contiguous chunks.  This routine adds all chunks
+ *   that may be used for heap.
+ *
  ****************************************************************************/
 
-void up_addregion(void)
+#if CONFIG_MM_REGIONS > 1
+void riscv_addregion(void)
 {
 }
+#endif
+

--- a/arch/risc-v/src/litex/litex_allocateheap.c
+++ b/arch/risc-v/src/litex/litex_allocateheap.c
@@ -33,9 +33,17 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_addregion
+ * Name: riscv_addregion
+ *
+ * Description:
+ *   RAM may be added in non-contiguous chunks.  This routine adds all chunks
+ *   that may be used for heap.
+ *
  ****************************************************************************/
 
-void up_addregion(void)
+#if CONFIG_MM_REGIONS > 1
+void riscv_addregion(void)
 {
 }
+#endif
+

--- a/arch/risc-v/src/nr5m100/nr5_allocateheap.c
+++ b/arch/risc-v/src/nr5m100/nr5_allocateheap.c
@@ -49,7 +49,7 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_addregion
+ * Name: riscv_addregion
  *
  * Description:
  *   RAM may be added in non-contiguous chunks.  This routine adds all chunks
@@ -57,6 +57,9 @@
  *
  ************************************************************************************/
 
-void up_addregion(void)
+#if CONFIG_MM_REGIONS > 1
+void riscv_addregion(void)
 {
 }
+#endif
+


### PR DESCRIPTION
## Summary
Don't declare `riscv_addregion` if `CONFIG_MM_REGIONS` is < 1, so we won't have to provide a dummy stub for every chip.  
Also rename the function from `up_addregion` to `riscv_addregion` since it's not exported outside the arch directory.

## Impact
Just renaming.

## Testing

CI build should be enough.