### PR TITLE
arch/risc-v: Remove nx_start prototype from riscv_internal.h

### DIFF
--- a/arch/risc-v/src/bl602/bl602_start.c
+++ b/arch/risc-v/src/bl602/bl602_start.c
@@ -22,11 +22,12 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 #include <stdint.h>
 
-#include <nuttx/config.h>
+#include <nuttx/init.h>
 #include <nuttx/arch.h>
-
 #include <arch/board/board.h>
 
 #include "riscv_arch.h"

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -228,10 +228,6 @@ void up_earlyserialinit(void);
 void rpmsg_serialinit(void);
 #endif
 
-/* The OS start routine    **************************************************/
-
-void nx_start(void);
-
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION

--- a/arch/risc-v/src/fe310/fe310_start.c
+++ b/arch/risc-v/src/fe310/fe310_start.c
@@ -34,10 +34,11 @@
  * Included Files
  ****************************************************************************/
 
-#include <stdint.h>
-
 #include <nuttx/config.h>
 
+#include <stdint.h>
+
+#include <nuttx/init.h>
 #include <arch/board/board.h>
 
 #include "fe310_clockconfig.h"

--- a/arch/risc-v/src/k210/k210_start.c
+++ b/arch/risc-v/src/k210/k210_start.c
@@ -36,6 +36,7 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/init.h>
 #include <nuttx/arch.h>
 #include <arch/board/board.h>
 

--- a/arch/risc-v/src/litex/litex_start.c
+++ b/arch/risc-v/src/litex/litex_start.c
@@ -22,10 +22,11 @@
  * Included Files
  ****************************************************************************/
 
-#include <stdint.h>
-
 #include <nuttx/config.h>
 
+#include <stdint.h>
+
+#include <nuttx/init.h>
 #include <arch/board/board.h>
 
 #include "litex_clockconfig.h"


### PR DESCRIPTION
## Summary
Remove the nx_start prototype from riscv_internal.h.
This function is already declared in `include/nuttx/init.h` include this file instead.

## Impact
N/A
## Testing
Built few RISC-V boards with no warnings.  CI build should spot any missed issue.
