### PR TITLE
arch/risc-v: Remove incorrect ARM references.

### DIFF
--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -111,7 +111,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 
   size  = end - start;
 
-  /* The ARM uses a push-down stack:  the stack grows toward lower addresses
+  /* RISC-V uses a push-down stack:  the stack grows toward lower addresses
    * in memory.  We need to start at the lowest address in the stack memory
    * allocation and search to higher addresses.  The first word we encounter
    * that does not have the magic value is the high water mark.

--- a/arch/risc-v/src/nr5m100/nr5_timer.c
+++ b/arch/risc-v/src/nr5m100/nr5_timer.c
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arm/risc-v/src/nr5m100/nr5_timer.c
+ * arch/risc-v/src/nr5m100/nr5_timer.c
  *
  *   Copyright (C) 2011-2012 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>


### PR DESCRIPTION
## Summary
Remove incorrect ARM references.
## Impact
N/A
## Testing
N/A