### PR TITLE
stm32f412:Corrected Pin count

### DIFF
--- a/arch/arm/include/stm32/chip.h
+++ b/arch/arm/include/stm32/chip.h
@@ -1772,7 +1772,7 @@
 #  define STM32_NSDIO                    1   /* One SDIO interface */
 #  define STM32_NLCD                     0   /* No LCD */
 #  define STM32_NUSBOTG                  1   /* USB OTG FS (only) */
-#  define STM32_NGPIO                    32  /* GPIOA-B */
+#  define STM32_NGPIO                    34  /* GPIOA-B (sans PB11) and 3 Bits of C */
 #  define STM32_NADC                     1   /* One 12-bit ADC1, 16 channels */
 #  define STM32_NDAC                     0   /* No DAC */
 #  define STM32_NCAPSENSE                0   /* No capacitive sensing channels */


### PR DESCRIPTION
## Summary

   Port C was not working because the GPIO pin count was
   wrong. The 48 pin packages has 34 GPIO (Not counting PH0 & PH1)
   It is GPIOA GPIO B (sans PB11) and GPIOC PC13-PC15

## Impact

 Port C was not working in master

## Testing

PX4 GPS
