### PR TITLE
drivers: wireless: Change retry condition in gs2200m_hal_write()

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -969,11 +969,12 @@ retry:
 
   _read_data(dev, res, sizeof(res));
 
-  /* In case of NOK, retry */
+  /* In case of NOK or 0x0, retry */
 
-  if (WR_RESP_NOK == res[1])
+  if (WR_RESP_NOK == res[1] || 0x0 == res[1])
     {
-      wlwarn("*** warning: WR_RESP_NOK received.. retrying. (n=%d) \n", n);
+      wlwarn("*** warning: 0x%x received.. retrying. (n=%d) \n",
+             res[1], n);
       nxsig_usleep(10 * 1000);
 
       if (WR_MAX_RETRY < n)


### PR DESCRIPTION
## Summary

- During Wi-Fi stress test, I noticed that ASSERT() happened
  in gs2200m_hal_write(). Actually, this happens in 20-40 hours.
- In this case, resp[1] was always 0x0 which is not defined
  in the spec.
- In the previous implementation, retry was only done in case of
  WR_RESP_NOK. (0x13)
- This commit changes this condition and it reties in case of
  0x0 as well

## Impact

- gs2200m driver

## Testing

- Tested with spresense:wifi_smp and stm32f4discovery:wifi
