### PR TITLE
drivers:mtd:w25qxxxjv.c: use different protect bits and address lengts

### DIFF
--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -5945,9 +5945,9 @@ static int smart_fsck_directory(FAR struct smart_struct_s *dev,
               (const char *) (cur + sizeof(struct smart_entry_header_s)),
               dev->namesize);
       entryname[dev->namesize] = '\0';
-#endif
       finfo("Check entry (name=%s flags=%02x logsector=%02x)\n",
             entryname, entry->flags, entry->firstsector);
+#endif
 
       if (entry->flags & SMARTFS_DIRENT_ACTIVE)
         {
@@ -5969,8 +5969,10 @@ static int smart_fsck_directory(FAR struct smart_struct_s *dev,
 
       if (ret != OK)
         {
+#ifdef CONFIG_DEBUG_FS_INFO
           finfo("Remove entry (name=%s flags=%02x)\n",
                 entryname, entry->flags);
+#endif
 
           if ((cur + (2 * entrysize)) <= bottom)
             {


### PR DESCRIPTION
Different w25qxxxjv chips has different protect bits (3 or 4 bits) and different address lengths (3 or 4 bytes).

## Testing

Tested with w25q256jv on stm32H743.

fstest 
```
End of loop memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       cd850    cd850
ordblks         4        4
mxordblk    75600    75600
uordblks    2a3c0    2a3f0
fordblks    a3490    a3460

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       cd850    cd850
ordblks         4        4
mxordblk    75600    75600
uordblks    2a3c0    2a3c0
fordblks    a3490    a3490
```

```
nsh>smart_test -s 100 /mnt/log0
Creating file /mnt/log0 for write mode
Writing test data.  2000 lines to write
1999
Done.
Performing 100 random seek tests
100
Append test passed
Creating circular log with 40000 records
Performing 0 circular log record update tests

Pass
```