### PR TITLE
tools/esp32: Remove some duplicated output.

### DIFF
--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -39,18 +39,14 @@ else
 endif
 
 define POSTBUILD
-	@echo "MKIMAGE: ESP32 binary"
-	$(Q) if ! esptool.py version ; then \
+	$(Q)echo "MKIMAGE: ESP32 binary"
+	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
 		echo ""; \
-		echo "Please install ESP-IDF tools"; \
+		echo "esptool.py not found.  Please run: \"pip install esptool.py\""; \
+		echo "Or run: \"make -C tools/esp32\" to install all IDF tools."; \
 		echo ""; \
-		echo "Check https://docs.espressif.com/projects/esp-idf/en/v4.0/get-started/index.html#installation-step-by-step or run the following command"; \
-		echo ""; \
-		echo "cd tools/esp32 && make && cd ../.."; \
-		echo ""; \
-		echo "run make again to create the nuttx.bin image."; \
+		echo "Run make again to create the nuttx.bin image."; \
 	else \
-		echo "Generating: $(NUTTXNAME).bin (ESP32 compatible)"; \
 		esptool.py --chip esp32 elf2image --flash_mode dio --flash_size 4MB -o $(NUTTXNAME).bin nuttx; \
 		echo "Generated: $(NUTTXNAME).bin (ESP32 compatible)"; \
 	fi

--- a/tools/esp32/mk_qemu_img.sh
+++ b/tools/esp32/mk_qemu_img.sh
@@ -44,9 +44,9 @@ printf "\tBootloader: %s\n" "${BOOTLOADER}"
 printf "\tPartition Table: %s\n" "${PARTITION_TABLE}"
 
 dd if=/dev/zero bs=1024 count=4096 of=esp32_qemu_image.bin && \
-  dd if="${BOOTLOADER}" bs=1 seek="$(printf '%d' 0x1000)" of=esp32_qemu_image.bin conv=notrunc && \
-  dd if="${PARTITION_TABLE}" bs=1 seek="$(printf '%d' 0x8000)" of=esp32_qemu_image.bin conv=notrunc && \
-  dd if="${NUTTXNAME}".bin bs=1 seek="$(printf '%d' 0x10000)" of=esp32_qemu_image.bin conv=notrunc
+dd if="${BOOTLOADER}" bs=1 seek="$(printf '%d' 0x1000)" of=esp32_qemu_image.bin conv=notrunc && \
+dd if="${PARTITION_TABLE}" bs=1 seek="$(printf '%d' 0x8000)" of=esp32_qemu_image.bin conv=notrunc && \
+dd if="${NUTTXNAME}".bin bs=1 seek="$(printf '%d' 0x10000)" of=esp32_qemu_image.bin conv=notrunc
 
 if [ ${?} -ne 0 ]; then
   printf "Failed to generate esp32_qemu_image.bin.\n"


### PR DESCRIPTION
## Summary
Redirect the first check of esptool to /dev/null as it will be printed twice when esptool is called to convert the binary.
Rephrase a little the part that explains what to do in case esptool is missing.
## Impact
N/A
## Testing
N/A
