### PR TITLE
build: Deprecate NUTTXNAME build variable

### DIFF
--- a/boards/renesas/rx65n/rx65n-grrose/README.txt
+++ b/boards/renesas/rx65n/rx65n-grrose/README.txt
@@ -410,8 +410,8 @@ Below are the steps mentioned to flash NuttX binary using Renesas flash programm
 1.In order to flash using Renesas flash programmer tool, nuttx.mot file should be generated.
 2. Add the following lines in tools/Makefile.unix file :
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
-	@echo "CP: $(NUTTXNAME).mot"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) $(BIN) -O srec -I elf32-rx-be-ns $(NUTTXNAME).mot
+	@echo "CP: nuttx.mot"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) $(BIN) -O srec -I elf32-rx-be-ns nuttx.mot
 endif
 3. Add CONFIG_MOTOROLA_SREC=y in defconfig file or choose make menucofig->Build Setup-> Binary Output Format->
    Select Motorola SREC format.

--- a/boards/renesas/rx65n/rx65n-rsk2mb/README.txt
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/README.txt
@@ -383,8 +383,8 @@ Below are the steps mentioned to flash NuttX binary using Renesas flash programm
 1.In order to flash using Renesas flash programmer tool, nuttx.mot file should be generated.
 2. Add the following lines in tools/Makefile.unix file :
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
-	@echo "CP: $(NUTTXNAME).mot"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) $(BIN) -O srec -I elf32-rx-be-ns $(NUTTXNAME).mot
+	@echo "CP: nuttx.mot"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) $(BIN) -O srec -I elf32-rx-be-ns nuttx.mot
 endif
 3. Add CONFIG_MOTOROLA_SREC=y in defconfig file or choose make menucofig->Build Setup-> Binary Output Format->
    Select Motorola SREC format.

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -143,8 +143,7 @@ endif
 
 # This is the name of the final target (relative to the top level directory)
 
-NUTTXNAME = nuttx
-BIN       = $(NUTTXNAME)$(EXEEXT)
+BIN = nuttx$(EXEEXT)
 
 all: $(BIN)
 .PHONY: dirlinks context clean_context config oldconfig menuconfig nconfig qconfig gconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean
@@ -424,31 +423,31 @@ endif
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f $(BIN) /tftpboot/$(BIN).${CONFIG_ARCH}; \
 	fi
-	$(Q) echo $(BIN) > $(NUTTXNAME).manifest
-	$(Q) printf "%s\n" *.map >> $(NUTTXNAME).manifest
+	$(Q) echo $(BIN) > nuttx.manifest
+	$(Q) printf "%s\n" *.map >> nuttx.manifest
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
-	@echo "CP: $(NUTTXNAME).hex"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(NUTTXNAME).hex
-	$(Q) echo $(NUTTXNAME).hex >> $(NUTTXNAME).manifest
+	@echo "CP: nuttx.hex"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) nuttx.hex
+	$(Q) echo nuttx.hex >> nuttx.manifest
 endif
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
-	@echo "CP: $(NUTTXNAME).srec"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) $(NUTTXNAME).srec
-	$(Q) echo $(NUTTXNAME).srec >> $(NUTTXNAME).manifest
+	@echo "CP: nuttx.srec"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) nuttx.srec
+	$(Q) echo nuttx.srec >> nuttx.manifest
 endif
 ifeq ($(CONFIG_RAW_BINARY),y)
-	@echo "CP: $(NUTTXNAME).bin"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
-	$(Q) echo $(NUTTXNAME).bin >> $(NUTTXNAME).manifest
+	@echo "CP: nuttx.bin"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) nuttx.bin
+	$(Q) echo nuttx.bin >> nuttx.manifest
 endif
 ifeq ($(CONFIG_UBOOT_UIMAGE),y)
 	@echo "MKIMAGE: uImage"
 	$(Q) mkimage -A $(CONFIG_ARCH) -O linux -C none -T kernel -a $(CONFIG_UIMAGE_LOAD_ADDRESS) \
-		-e $(CONFIG_UIMAGE_ENTRY_POINT) -n $(BIN) -d $(NUTTXNAME).bin uImage
+		-e $(CONFIG_UIMAGE_ENTRY_POINT) -n $(BIN) -d nuttx.bin uImage
 	$(Q) if [ -w /tftpboot ] ; then \
 		cp -f uImage /tftpboot/uImage; \
 	fi
-	$(Q) echo "uImage" >> $(NUTTXNAME).manifest
+	$(Q) echo "uImage" >> nuttx.manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -128,8 +128,7 @@ endif
 
 # This is the name of the final target (relative to the top level directory)
 
-NUTTXNAME = nuttx
-BIN       = $(NUTTXNAME)$(EXEEXT)
+BIN = nuttx$(EXEEXT)
 
 all: $(BIN)
 .PHONY: dirlinks context clean_context configenv config oldconfig menuconfig nconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean
@@ -392,22 +391,22 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
 	$(Q) $(MAKE) -C $(ARCH_SRC) EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
-	$(Q) echo $(BIN) > $(NUTTXNAME).manifest
-	$(Q) printf '%s\n' *.map >> $(NUTTXNAME).manifest
+	$(Q) echo $(BIN) > nuttx.manifest
+	$(Q) printf '%s\n' *.map >> nuttx.manifest
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
-	@echo "CP: $(NUTTXNAME).hex"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) $(NUTTXNAME).hex
-	$(Q) echo $(NUTTXNAME).hex >> $(NUTTXNAME).manifest
+	@echo "CP: nuttx.hex"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) nuttx.hex
+	$(Q) echo nuttx.hex >> nuttx.manifest
 endif
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
-	@echo "CP: $(NUTTXNAME).srec"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) $(NUTTXNAME).srec
-	$(Q) echo $(NUTTXNAME).srec >> $(NUTTXNAME).manifest
+	@echo "CP: nuttx.srec"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O srec $(BIN) nuttx.srec
+	$(Q) echo nuttx.srec >> nuttx.manifest
 endif
 ifeq ($(CONFIG_RAW_BINARY),y)
-	@echo "CP: $(NUTTXNAME).bin"
-	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) $(NUTTXNAME).bin
-	$(Q) echo $(NUTTXNAME).bin >> $(NUTTXNAME).manifest
+	@echo "CP: nuttx.bin"
+	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) nuttx.bin
+	$(Q) echo nuttx.bin >> nuttx.manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 

--- a/tools/cxd56/Config.mk
+++ b/tools/cxd56/Config.mk
@@ -28,11 +28,11 @@
 ifeq ($(CONFIG_CXD56_BINARY),y)
 
 define POSTBUILD
-	$(Q)echo "Generating: $(NUTTXNAME).spk"; \
+	$(Q)echo "Generating: nuttx.spk"; \
 
 	+$(Q) $(MAKE) -C $(TOPDIR)$(DELIM)tools$(DELIM)cxd56 -f Makefile.host
 	tools$(DELIM)cxd56$(DELIM)mkspk$(HOSTEXEEXT) -c2 nuttx nuttx nuttx.spk;
-	$(Q)([ $$? -eq 0 ] && echo nuttx.spk >> $(NUTTXNAME).manifest && echo "Done.")
+	$(Q)([ $$? -eq 0 ] && echo nuttx.spk >> nuttx.manifest && echo "Done.")
 endef
 
 endif

--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -33,7 +33,7 @@ else
 endif
 
 ifeq ($(CONFIG_ESP32_QEMU_IMAGE),y)
-	MK_QEMU_IMG=$(TOPDIR)/tools/esp32/mk_qemu_img.sh $(BOOTLOADER) $(PARTITION_TABLE) $(NUTTXNAME)
+	MK_QEMU_IMG=$(TOPDIR)/tools/esp32/mk_qemu_img.sh $(BOOTLOADER) $(PARTITION_TABLE)
 else
 	MK_QEMU_IMG=
 endif
@@ -47,8 +47,8 @@ define POSTBUILD
 		echo ""; \
 		echo "Run make again to create the nuttx.bin image."; \
 	else \
-		esptool.py --chip esp32 elf2image --flash_mode dio --flash_size 4MB -o $(NUTTXNAME).bin nuttx; \
-		echo "Generated: $(NUTTXNAME).bin (ESP32 compatible)"; \
+		esptool.py --chip esp32 elf2image --flash_mode dio --flash_size 4MB -o nuttx.bin nuttx; \
+		echo "Generated: nuttx.bin (ESP32 compatible)"; \
 	fi
 	$(MK_QEMU_IMG)
 endef

--- a/tools/esp32/mk_qemu_img.sh
+++ b/tools/esp32/mk_qemu_img.sh
@@ -20,7 +20,7 @@
 ############################################################################
 
 SCRIPT_NAME=$(basename "${0}")
-USAGE="USAGE: ${SCRIPT_NAME} <bootloader_img> <partition_table_img> [nuttx_name]"
+USAGE="USAGE: ${SCRIPT_NAME} <bootloader_img> <partition_table_img>"
 
 # Make sure we have the required argument(s)
 
@@ -32,12 +32,6 @@ fi
 
 BOOTLOADER=${1}
 PARTITION_TABLE=${2}
-NUTTXNAME=${3}
-
-if [ -z "${NUTTXNAME}" ]; then
-  NUTTXNAME="nuttx"
-  printf "NUTTXNAME not provided, assuming \"%s\".\n" "${NUTTXNAME}"
-fi
 
 printf "Generating esp32_qemu_image.bin...\n"
 printf "\tBootloader: %s\n" "${BOOTLOADER}"
@@ -46,7 +40,7 @@ printf "\tPartition Table: %s\n" "${PARTITION_TABLE}"
 dd if=/dev/zero bs=1024 count=4096 of=esp32_qemu_image.bin && \
 dd if="${BOOTLOADER}" bs=1 seek="$(printf '%d' 0x1000)" of=esp32_qemu_image.bin conv=notrunc && \
 dd if="${PARTITION_TABLE}" bs=1 seek="$(printf '%d' 0x8000)" of=esp32_qemu_image.bin conv=notrunc && \
-dd if="${NUTTXNAME}".bin bs=1 seek="$(printf '%d' 0x10000)" of=esp32_qemu_image.bin conv=notrunc
+dd if=nuttx.bin bs=1 seek="$(printf '%d' 0x10000)" of=esp32_qemu_image.bin conv=notrunc
 
 if [ ${?} -ne 0 ]; then
   printf "Failed to generate esp32_qemu_image.bin.\n"
@@ -57,4 +51,4 @@ printf "Generated esp32_qemu_image.bin successfully!\n"
 printf "You can use QEMU for executing it with the following command line:\n"
 printf "\tqemu-system-xtensa -nographic -machine esp32 -drive file=esp32_qemu_image.bin,if=mtd,format=raw\n"
 
-echo "esp32_qemu_image.bin" >> "${NUTTXNAME}".manifest
+echo "esp32_qemu_image.bin" >> nuttx.manifest


### PR DESCRIPTION
## Summary
`NUTTXNAME` is used only as an alias for "nuttx", not an actual configuration property.
Its definition might erroneously imply that the name of binary image may be configurable, which is not the case, since the binary image is referenced throughout the project as `nuttx$(EXEEXT)`.

## Impact
No impact, every reference to `NUTTXNAME` has been substituted for `nuttx`.

## Testing
Successful build after change.
