### PR TITLE
net/local: Add an option to specify the prefix of named pipe

### DIFF
--- a/net/local/Kconfig
+++ b/net/local/Kconfig
@@ -15,6 +15,12 @@ config NET_LOCAL
 
 if NET_LOCAL
 
+config NET_LOCAL_PATH_PREFIX
+	string "Path prefix to Unix domain sockets"
+	default "/var/socket"
+	---help---
+		The path prefix to where Unix domain sockets will exist in the VFS namespace.
+
 config NET_LOCAL_STREAM
 	bool "Unix domain stream sockets"
 	default y

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -83,12 +83,14 @@ static inline void local_cs_name(FAR struct local_conn_s *conn,
 {
   if (conn->lc_instance_id < 0)
     {
-      snprintf(path, LOCAL_FULLPATH_LEN - 1, "%s" LOCAL_CS_SUFFIX,
+      snprintf(path, LOCAL_FULLPATH_LEN - 1,
+               CONFIG_NET_LOCAL_PATH_PREFIX "%s" LOCAL_CS_SUFFIX,
                conn->lc_path);
     }
   else
     {
-      snprintf(path, LOCAL_FULLPATH_LEN - 1, "%s" LOCAL_CS_SUFFIX "%" PRIx32,
+      snprintf(path, LOCAL_FULLPATH_LEN - 1,
+               CONFIG_NET_LOCAL_PATH_PREFIX "%s" LOCAL_CS_SUFFIX "%" PRIx32,
                conn->lc_path, conn->lc_instance_id);
     }
 
@@ -110,12 +112,14 @@ static inline void local_sc_name(FAR struct local_conn_s *conn,
 {
   if (conn->lc_instance_id < 0)
     {
-      snprintf(path, LOCAL_FULLPATH_LEN - 1, "%s" LOCAL_SC_SUFFIX,
+      snprintf(path, LOCAL_FULLPATH_LEN - 1,
+               CONFIG_NET_LOCAL_PATH_PREFIX "%s" LOCAL_SC_SUFFIX,
                conn->lc_path);
     }
   else
     {
-      snprintf(path, LOCAL_FULLPATH_LEN - 1, "%s" LOCAL_SC_SUFFIX "%" PRIx32,
+      snprintf(path, LOCAL_FULLPATH_LEN - 1,
+               CONFIG_NET_LOCAL_PATH_PREFIX "%s" LOCAL_SC_SUFFIX "%" PRIx32,
                conn->lc_path, conn->lc_instance_id);
     }
 
@@ -134,8 +138,8 @@ static inline void local_sc_name(FAR struct local_conn_s *conn,
 #ifdef CONFIG_NET_LOCAL_DGRAM
 static inline void local_hd_name(FAR const char *inpath, FAR char *outpath)
 {
-  snprintf(outpath, LOCAL_FULLPATH_LEN - 1, "%s" LOCAL_HD_SUFFIX,
-          inpath);
+  snprintf(outpath, LOCAL_FULLPATH_LEN - 1,
+           CONFIG_NET_LOCAL_PATH_PREFIX "%s" LOCAL_HD_SUFFIX, inpath);
   outpath[LOCAL_FULLPATH_LEN - 1] = '\0';
 }
 #endif /* CONFIG_NET_LOCAL_DGRAM */


### PR DESCRIPTION
## Summary
to avoid the user create socket under the real filesystem
which isn't supported by nuttx VFS yet.

## Impact
path like this "/tmp/test" don't fail anymore.

## Testing

