### PR TITLE
esp32_spiflash.c: Fix preprocessor condition.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -614,7 +614,7 @@ static void IRAM_ATTR spiflash_flushmapped(size_t start, size_t size)
           esp_spiram_writeback_cache();
 #endif
           Cache_Flush(0);
-#ifndef CONFIG_SMP
+#ifdef CONFIG_SMP
           Cache_Flush(1);
 #endif
         }


### PR DESCRIPTION

## Summary
 Fix preprocessor condition. `#ifndef` was used instead of `#ifdef`

## Impact
N/A
## Testing
N/A
