### PR TITLE
xtensa/esp32: Add extern modifier to ROM function declaration

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -55,9 +55,9 @@ static volatile spinlock_t g_appcpu_interlock SP_SECTION;
  * ROM function prototypes
  ****************************************************************************/
 
-void Cache_Flush(int cpu);
-void Cache_Read_Enable(int cpu);
-void ets_set_appcpu_boot_addr(uint32_t start);
+extern void Cache_Flush(int cpu);
+extern void Cache_Read_Enable(int cpu);
+extern void ets_set_appcpu_boot_addr(uint32_t start);
 
 /****************************************************************************
  * Private Functions

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -173,7 +173,7 @@ struct spiflash_cachestate_s
  * ROM function prototypes
  ****************************************************************************/
 
-void Cache_Flush(int cpu);
+extern void Cache_Flush(int cpu);
 
 /****************************************************************************
  * Private Functions Prototypes

--- a/arch/xtensa/src/esp32/rom/esp32_efuse.h
+++ b/arch/xtensa/src/esp32/rom/esp32_efuse.h
@@ -33,32 +33,32 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Public Function Prototypes
+ * ROM function prototypes
  ****************************************************************************/
 
 /****************************************************************************
  * Name: ets_efuse_read_op
  ****************************************************************************/
 
-void ets_efuse_read_op(void);
+extern void ets_efuse_read_op(void);
 
 /****************************************************************************
  * Name: ets_efuse_program_op
  ****************************************************************************/
 
-void ets_efuse_program_op(void);
+extern void ets_efuse_program_op(void);
 
 /****************************************************************************
  * Name: ets_efuse_get_8m_clock
  ****************************************************************************/
 
-uint32_t ets_efuse_get_8m_clock(void);
+extern uint32_t ets_efuse_get_8m_clock(void);
 
 /****************************************************************************
  * name: ets_efuse_get_spiconfig
  ****************************************************************************/
 
-uint32_t ets_efuse_get_spiconfig(void);
+extern uint32_t ets_efuse_get_spiconfig(void);
 
 #define EFUSE_SPICFG_SPI_DEFAULTS      0
 #define EFUSE_SPICFG_HSPI_DEFAULTS     1


### PR DESCRIPTION
## Summary
Some ROM function declarations are missing the `extern` modifier. Although the compiler does not raise any error on multiple function declarations, the presence of the `extern` modifier makes it clearer that the symbol resolution will be delegated to link time.

## Impact
No impact, new build generates identical map files.

## Testing
Successful build for every ESP32 configuration.
