### PR TITLE
arch/riscv: Fix files names in headers that were still using the old 'up_' prefix.

### DIFF
--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv32im/up_assert.c
+ * arch/risc-v/src/rv32im/riscv_assert.c
  *
  *   Copyright (C) 2011-2015, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_blocktask.c
+++ b/arch/risc-v/src/rv32im/riscv_blocktask.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv32im/up_blocktask.c
+ * arch/risc-v/src/rv32im/riscv_blocktask.c
  *
  *   Copyright (C) 2011, 2013-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_copystate.c
+++ b/arch/risc-v/src/rv32im/riscv_copystate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv32im/up_copystate.c
+ * arch/risc-v/src/rv32im/riscv_copystate.c
  *
  *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_doirq.c
+++ b/arch/risc-v/src/rv32im/riscv_doirq.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv32im/up_doirq.c
+ * arch/risc-v/src/rv32im/riscv_doirq.c
  *
  *   Copyright (C) 2011, 2014-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_fpu.S
+++ b/arch/risc-v/src/rv32im/riscv_fpu.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/risc-v/src/rv32im/up_fpu.S
+ * arch/risc-v/src/rv32im/riscv_fpu.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/risc-v/src/rv32im/riscv_initialstate.c
+++ b/arch/risc-v/src/rv32im/riscv_initialstate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv32im/up_initialstate.c
+ * arch/risc-v/src/rv32im/riscv_initialstate.c
  *
  *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_releasepending.c
+++ b/arch/risc-v/src/rv32im/riscv_releasepending.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  arch/risc-v/src/rv32im/up_releasepending.c
+ *  arch/risc-v/src/rv32im/riscv_releasepending.c
  *
  *   Copyright (C) 2011, 2014-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_reprioritizertr.c
+++ b/arch/risc-v/src/rv32im/riscv_reprioritizertr.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  arch/risc-v/src/rv32im/up_reprioritizertr.c
+ *  arch/risc-v/src/rv32im/riscv_reprioritizertr.c
  *
  *   Copyright (C) 2011, 2013-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv32im/riscv_sigdeliver.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv32im/up_sigdeliver.c
+ * arch/risc-v/src/rv32im/riscv_sigdeliver.c
  *
  *   Copyright (C) 2011, 2015, 2018-2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_syscall.S
+++ b/arch/risc-v/src/rv32im/riscv_syscall.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/riscv/src/rv32im/up_syscall.S
+ * arch/riscv/src/rv32im/riscv_syscall.S
  *
  *   Copyright (C) 2011, 2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv32im/riscv_unblocktask.c
+++ b/arch/risc-v/src/rv32im/riscv_unblocktask.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  arch/risc-v/src/rv32im/up_unblocktask.c
+ *  arch/risc-v/src/rv32im/riscv_unblocktask.c
  *
  *   Copyright (C) 2011, 2013-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_assert.c
+++ b/arch/risc-v/src/rv64gc/riscv_assert.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_assert.c
+ * arch/risc-v/src/rv64gc/riscv_assert.c
  *
  *   Copyright (C) 2011-2015, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_blocktask.c
+++ b/arch/risc-v/src/rv64gc/riscv_blocktask.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_blocktask.c
+ * arch/risc-v/src/rv64gc/riscv_blocktask.c
  *
  *   Copyright (C) 2011, 2013-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_copystate.c
+++ b/arch/risc-v/src/rv64gc/riscv_copystate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_copystate.c
+ * arch/risc-v/src/rv64gc/riscv_copystate.c
  *
  *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_fault.c
+++ b/arch/risc-v/src/rv64gc/riscv_fault.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_fault.c
+ * arch/risc-v/src/rv64gc/riscv_fault.c
  *
  *   Copyright (C) 2020 Masayuki Ishikawa. All rights reserved.
  *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>

--- a/arch/risc-v/src/rv64gc/riscv_initialstate.c
+++ b/arch/risc-v/src/rv64gc/riscv_initialstate.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_initialstate.c
+ * arch/risc-v/src/rv64gc/riscv_initialstate.c
  *
  *   Copyright (C) 2011 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_releasepending.c
+++ b/arch/risc-v/src/rv64gc/riscv_releasepending.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  arch/risc-v/src/rv64gc/up_releasepending.c
+ *  arch/risc-v/src/rv64gc/riscv_releasepending.c
  *
  *   Copyright (C) 2011, 2014-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_reprioritizertr.c
+++ b/arch/risc-v/src/rv64gc/riscv_reprioritizertr.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  arch/risc-v/src/rv64gc/up_reprioritizertr.c
+ *  arch/risc-v/src/rv64gc/riscv_reprioritizertr.c
  *
  *   Copyright (C) 2011, 2013-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_sigdeliver.c
+ * arch/risc-v/src/rv64gc/riscv_sigdeliver.c
  *
  *   Copyright (C) 2011, 2015, 2018-2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_signal_dispatch.c
+++ b/arch/risc-v/src/rv64gc/riscv_signal_dispatch.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_signal_dispatch.c
+ * arch/risc-v/src/rv64gc/riscv_signal_dispatch.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/risc-v/src/rv64gc/riscv_signal_handler.S
+++ b/arch/risc-v/src/rv64gc/riscv_signal_handler.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_signal_handler.S
+ * arch/risc-v/src/rv64gc/riscv_signal_handler.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/arch/risc-v/src/rv64gc/riscv_swint.c
+++ b/arch/risc-v/src/rv64gc/riscv_swint.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/riscv/src/rv64gc/up_swint.c
+ * arch/riscv/src/rv64gc/riscv_swint.c
  *
  *   Copyright (C) 2011-2012, 2015, 2019 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>

--- a/arch/risc-v/src/rv64gc/riscv_testset.S
+++ b/arch/risc-v/src/rv64gc/riscv_testset.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/up_testset.S
+ * arch/risc-v/src/rv64gc/riscv_testset.S
  *
  *   Copyright (C) 2020 Masayuki Ishikawa. All rights reserved.
  *   Author: Masayuki Ishikawa <masayuki.ishikawa@gmail.com>

--- a/arch/risc-v/src/rv64gc/riscv_unblocktask.c
+++ b/arch/risc-v/src/rv64gc/riscv_unblocktask.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- *  arch/risc-v/src/rv64gc/up_unblocktask.c
+ *  arch/risc-v/src/rv64gc/riscv_unblocktask.c
  *
  *   Copyright (C) 2011, 2013-2015 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>


### PR DESCRIPTION
## Summary
Fix file names in headers that were still using the old 'up_' prefix.
## Impact
N/A
## Testing
N/A
