### PR TITLE
arch, boards, drivers, include, sched, wireless: Change spinlock APIs.

### DIFF
--- a/arch/arm/src/common/arm_modifyreg16.c
+++ b/arch/arm/src/common/arm_modifyreg16.c
@@ -64,10 +64,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/arm/src/common/arm_modifyreg32.c
+++ b/arch/arm/src/common/arm_modifyreg32.c
@@ -64,10 +64,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/arm/src/common/arm_modifyreg8.c
+++ b/arch/arm/src/common/arm_modifyreg8.c
@@ -64,10 +64,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/arm/src/cxd56xx/cxd56_gpioint.c
+++ b/arch/arm/src/cxd56xx/cxd56_gpioint.c
@@ -110,7 +110,7 @@ static int alloc_slot(int pin, bool isalloc)
                                      : CXD56_TOPREG_IOCAPP_INTSEL0;
   int offset = (pin < PIN_IS_CLK) ? 1 : 56;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   for (slot = 0; slot < MAX_SYS_SLOT; slot++)
     {
@@ -140,12 +140,12 @@ static int alloc_slot(int pin, bool isalloc)
         }
       else
         {
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return -ENXIO; /* no space */
         }
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   if (PIN_IS_CLK <= pin)
     {
@@ -305,13 +305,13 @@ static void invert_irq(int irq)
   irqstate_t flags;
   uint32_t val;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   val = getreg32(CXD56_INTC_INVERT);
   val ^= (1 << (irq - CXD56_IRQ_EXTINT));
   putreg32(val, CXD56_INTC_INVERT);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 static bool inverted_irq(int irq)
@@ -427,9 +427,9 @@ int cxd56_gpioint_config(uint32_t pin, uint32_t gpiocfg, xcpt_t isr,
       irq_attach(irq, NULL, NULL);
       g_isr[slot] = NULL;
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       g_bothedge &= ~(1 << slot);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       return irq;
     }
 
@@ -443,9 +443,9 @@ int cxd56_gpioint_config(uint32_t pin, uint32_t gpiocfg, xcpt_t isr,
     {
       /* set GPIO pseudo both edge interrupt */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       g_bothedge |= (1 << slot);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       /* detect the change from the current signal */
 

--- a/arch/arm/src/cxd56xx/cxd56_irq.c
+++ b/arch/arm/src/cxd56xx/cxd56_irq.c
@@ -476,14 +476,14 @@ void up_disable_irq(int irq)
       g_cpu_for_irq[irq] = -1;
 #endif
 
-      irqstate_t flags = spin_lock_irqsave();
+      irqstate_t flags = spin_lock_irqsave(NULL);
       irq -= CXD56_IRQ_EXTINT;
       bit  = 1 << (irq & 0x1f);
 
       regval  = getreg32(INTC_EN(irq));
       regval &= ~bit;
       putreg32(regval, INTC_EN(irq));
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       putreg32(bit, NVIC_IRQ_CLEAR(irq));
     }
   else
@@ -531,14 +531,14 @@ void up_enable_irq(int irq)
         }
 #endif
 
-      irqstate_t flags = spin_lock_irqsave();
+      irqstate_t flags = spin_lock_irqsave(NULL);
       irq -= CXD56_IRQ_EXTINT;
       bit  = 1 << (irq & 0x1f);
 
       regval  = getreg32(INTC_EN(irq));
       regval |= bit;
       putreg32(regval, INTC_EN(irq));
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       putreg32(bit, NVIC_IRQ_ENABLE(irq));
     }
   else

--- a/arch/arm/src/cxd56xx/cxd56_rtc.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc.c
@@ -431,7 +431,7 @@ int up_rtc_settime(FAR const struct timespec *tp)
   irqstate_t flags;
   uint64_t count;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
 #ifdef RTC_DIRECT_CONTROL
   /* wait until previous write request is completed */
@@ -454,7 +454,7 @@ int up_rtc_settime(FAR const struct timespec *tp)
   g_rtc_save->offset = (int64_t)count - (int64_t)cxd56_rtc_count();
 #endif
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   rtc_dumptime(tp, "Setting time");
 
@@ -482,12 +482,12 @@ uint64_t cxd56_rtc_count(void)
    * 1st post -> 2nd pre, and should be operated in atomic.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   val = (uint64_t)getreg32(CXD56_RTC0_RTPOSTCNT) << 15;
   val |= getreg32(CXD56_RTC0_RTPRECNT);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return val;
 }
@@ -509,12 +509,12 @@ uint64_t cxd56_rtc_almcount(void)
   uint64_t val;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   val = (uint64_t)getreg32(CXD56_RTC0_SETALMPOSTCNT(0)) << 15;
   val |= (getreg32(CXD56_RTC0_SETALMPRECNT(0)) & 0x7fff);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return val;
 }
@@ -555,7 +555,7 @@ int cxd56_rtc_setalarm(FAR struct alm_setalarm_s *alminfo)
     {
       /* The set the alarm */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       cbinfo->ac_cb  = alminfo->as_cb;
       cbinfo->ac_arg = alminfo->as_arg;
@@ -579,7 +579,7 @@ int cxd56_rtc_setalarm(FAR struct alm_setalarm_s *alminfo)
 
       while (RTCREG_ALM_BUSY_MASK & getreg32(CXD56_RTC0_ALMOUTEN(id)));
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       rtc_dumptime(&alminfo->as_time, "New Alarm time");
       ret = OK;
@@ -620,7 +620,7 @@ int cxd56_rtc_cancelalarm(enum alm_id_e alarmid)
     {
       /* Unset the alarm */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       cbinfo->ac_cb = NULL;
 
@@ -628,7 +628,7 @@ int cxd56_rtc_cancelalarm(enum alm_id_e alarmid)
 
       putreg32(0, CXD56_RTC0_ALMOUTEN(alarmid));
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       ret = OK;
     }

--- a/arch/arm/src/cxd56xx/cxd56_serial.c
+++ b/arch/arm/src/cxd56xx/cxd56_serial.c
@@ -288,7 +288,7 @@ static inline void up_disableuartint(FAR struct up_dev_s *priv,
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (ier)
     {
       *ier = priv->ier & UART_INTR_ALL;
@@ -296,7 +296,7 @@ static inline void up_disableuartint(FAR struct up_dev_s *priv,
 
   priv->ier &= ~UART_INTR_ALL;
   up_serialout(priv, CXD56_UART_IMSC, priv->ier);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -307,10 +307,10 @@ static inline void up_restoreuartint(FAR struct up_dev_s *priv, uint32_t ier)
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   priv->ier |= ier & UART_INTR_ALL;
   up_serialout(priv, CXD56_UART_IMSC, priv->ier);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -372,7 +372,7 @@ static void up_set_format(struct uart_dev_s *dev)
   uint32_t cr_en;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Get the original state of control register */
 
@@ -438,7 +438,7 @@ static void up_set_format(struct uart_dev_s *dev)
 #endif
   up_serialout(priv, CXD56_UART_CR, cr | cr_en);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif /* CONFIG_SUPPRESS_UART_CONFIG */
 
@@ -759,7 +759,7 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
 
           termiosp->c_cflag = ((priv->parity != 0) ? PARENB : 0) |
                               ((priv->parity == 1) ? PARODD : 0) |
@@ -793,7 +793,7 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
                 break;
             }
 
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
         }
         break;
 
@@ -808,7 +808,7 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
 
           switch (termiosp->c_cflag & CSIZE)
             {
@@ -853,25 +853,25 @@ static int up_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           up_set_format(dev);
 
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NLL, flags);
         }
         break;
 #endif
 
       case TIOCSBRK: /* BSD compatibility: Turn break on, unconditionally */
         {
-          irqstate_t flags = spin_lock_irqsave();
+          irqstate_t flags = spin_lock_irqsave(NULL);
           up_enablebreaks(priv, true);
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
         }
         break;
 
       case TIOCCBRK: /* BSD compatibility: Turn break off, unconditionally */
         {
           irqstate_t flags;
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
           up_enablebreaks(priv, false);
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
         }
         break;
 
@@ -922,7 +922,7 @@ static void up_rxint(FAR struct uart_dev_s *dev, bool enable)
   FAR struct up_dev_s *priv = (FAR struct up_dev_s *)dev->priv;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -935,7 +935,7 @@ static void up_rxint(FAR struct uart_dev_s *dev, bool enable)
     }
 
   up_serialout(priv, CXD56_UART_IMSC, priv->ier);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/cxd56xx/cxd56_uart.c
+++ b/arch/arm/src/cxd56xx/cxd56_uart.c
@@ -455,7 +455,7 @@ void cxd56_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
   uint32_t div;
   uint32_t lcr_h;
 
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   if (uartbase == CXD56_UART2_BASE)
     {
@@ -467,7 +467,7 @@ void cxd56_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
     }
   else
     {
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       return;
     }
 
@@ -494,7 +494,7 @@ void cxd56_setbaud(uintptr_t uartbase, uint32_t basefreq, uint32_t baud)
   putreg32(lcr_h, uartbase + CXD56_UART_LCR_H);
 
 finish:
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -587,7 +587,7 @@ static int imx_transmit(FAR struct imx_driver_s *priv)
 
   /* Make the following operations atomic */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Enable TX interrupts */
 
@@ -604,7 +604,7 @@ static int imx_transmit(FAR struct imx_driver_s *priv)
 
   putreg32(ENET_TDAR, IMX_ENET_TDAR);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
 #if CONFIG_IMX_ENET_NTXBUFFERS == 1
   priv->txbusy = false;

--- a/arch/arm/src/imxrt/imxrt_edma.c
+++ b/arch/arm/src/imxrt/imxrt_edma.c
@@ -268,10 +268,10 @@ static void imxrt_tcd_free(struct imxrt_edmatcd_s *tcd)
    * a TCD.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   sq_addlast((sq_entry_t *)tcd, &g_tcd_free);
   imxrt_givedsem();
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 
@@ -1224,7 +1224,7 @@ int imxrt_dmach_start(DMACH_HANDLE handle, edma_callback_t callback,
 
   /* Save the callback info.  This will be invoked when the DMA completes */
 
-  flags           = spin_lock_irqsave();
+  flags           = spin_lock_irqsave(NULL);
   dmach->callback = callback;
   dmach->arg      = arg;
   dmach->state    = IMXRT_DMA_ACTIVE;
@@ -1248,7 +1248,7 @@ int imxrt_dmach_start(DMACH_HANDLE handle, edma_callback_t callback,
       putreg8(regval8, IMXRT_EDMA_SERQ_OFFSET);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 
@@ -1276,9 +1276,9 @@ void imxrt_dmach_stop(DMACH_HANDLE handle)
   dmainfo("dmach: %p\n", dmach);
   DEBUGASSERT(dmach != NULL);
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   imxrt_dmaterminate(dmach, -EINTR);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1375,7 +1375,7 @@ void imxrt_dmasample(DMACH_HANDLE handle, struct imxrt_dmaregs_s *regs)
 
   /* eDMA Global Registers */
 
-  flags          = spin_lock_irqsave();
+  flags          = spin_lock_irqsave(NULL);
 
   regs->cr       = getreg32(IMXRT_EDMA_CR);   /* Control */
   regs->es       = getreg32(IMXRT_EDMA_ES);   /* Error Status */
@@ -1410,7 +1410,7 @@ void imxrt_dmasample(DMACH_HANDLE handle, struct imxrt_dmaregs_s *regs)
   regaddr        = IMXRT_DMAMUX_CHCFG(chan);
   regs->dmamux   = getreg32(regaddr);         /* Channel configuration */
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif /* CONFIG_DEBUG_DMA */
 

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -567,7 +567,7 @@ static int imxrt_transmit(FAR struct imxrt_driver_s *priv)
 
   /* Make the following operations atomic */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Enable TX interrupts */
 
@@ -584,7 +584,7 @@ static int imxrt_transmit(FAR struct imxrt_driver_s *priv)
 
   putreg32(ENET_TDAR, IMXRT_ENET_TDAR);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 

--- a/arch/arm/src/imxrt/imxrt_hprtc.c
+++ b/arch/arm/src/imxrt/imxrt_hprtc.c
@@ -536,7 +536,7 @@ int imxrt_hprtc_setalarm(FAR struct timespec *ts, hprtc_alarm_callback_t cb)
    * interrupted or preempted.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   now = imxrt_hprtc_time();
 
@@ -578,7 +578,7 @@ int imxrt_hprtc_setalarm(FAR struct timespec *ts, hprtc_alarm_callback_t cb)
   /* Unconditionally enable the RTC alarm interrupt */
 
   imxrt_hprtc_alarmenable();
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 #endif

--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -883,7 +883,7 @@ static inline void imxrt_disableuartint(struct imxrt_uart_s *priv,
   irqstate_t flags;
   uint32_t regval;
 
-  flags  = spin_lock_irqsave();
+  flags  = spin_lock_irqsave(NULL);
   regval = imxrt_serialin(priv, IMXRT_LPUART_CTRL_OFFSET);
 
   /* Return the current Rx and Tx interrupt state */
@@ -895,7 +895,7 @@ static inline void imxrt_disableuartint(struct imxrt_uart_s *priv,
 
   regval &= ~LPUART_ALL_INTS;
   imxrt_serialout(priv, IMXRT_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -912,12 +912,12 @@ static inline void imxrt_restoreuartint(struct imxrt_uart_s *priv,
    * enabled/disabled.
    */
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = imxrt_serialin(priv, IMXRT_LPUART_CTRL_OFFSET);
   regval &= ~LPUART_ALL_INTS;
   regval |= ie;
   imxrt_serialout(priv, IMXRT_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1313,7 +1313,7 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
              * implement TCSADRAIN / TCSAFLUSH
              */
 
-            flags  = spin_lock_irqsave();
+            flags  = spin_lock_irqsave(NULL);
             imxrt_disableuartint(priv, &ie);
             ret = imxrt_setup(dev);
 
@@ -1321,7 +1321,7 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
 
             imxrt_restoreuartint(priv, ie);
             priv->ie = ie;
-            spin_unlock_irqrestore(flags);
+            spin_unlock_irqrestore(NULL, flags);
           }
       }
       break;
@@ -1334,7 +1334,7 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
         irqstate_t flags;
         struct imxrt_uart_s *priv = (struct imxrt_uart_s *)dev->priv;
 
-        flags  = spin_lock_irqsave();
+        flags  = spin_lock_irqsave(NULL);
         regval   = imxrt_serialin(priv, IMXRT_LPUART_CTRL_OFFSET);
 
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
@@ -1360,7 +1360,7 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         imxrt_serialout(priv, IMXRT_LPUART_CTRL_OFFSET, regval);
 
-        spin_unlock_irqrestore(flags);
+        spin_unlock_irqrestore(NULL, flags);
       }
       break;
 #endif
@@ -1374,7 +1374,7 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
         irqstate_t flags;
         struct imxrt_uart_s *priv = (struct imxrt_uart_s *)dev->priv;
 
-        flags  = spin_lock_irqsave();
+        flags  = spin_lock_irqsave(NULL);
         ctrl   = imxrt_serialin(priv, IMXRT_LPUART_CTRL_OFFSET);
         stat   = imxrt_serialin(priv, IMXRT_LPUART_STAT_OFFSET);
         regval = ctrl;
@@ -1410,7 +1410,7 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
         imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, stat);
         imxrt_serialout(priv, IMXRT_LPUART_CTRL_OFFSET, ctrl);
 
-        spin_unlock_irqrestore(flags);
+        spin_unlock_irqrestore(NULL, flags);
       }
       break;
 #endif
@@ -1461,7 +1461,7 @@ static void imxrt_rxint(struct uart_dev_s *dev, bool enable)
 
   /* Enable interrupts for data available at Rx */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1477,7 +1477,7 @@ static void imxrt_rxint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   imxrt_serialout(priv, IMXRT_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1529,7 +1529,7 @@ static void imxrt_txint(struct uart_dev_s *dev, bool enable)
 
   /* Enable interrupt for TX complete */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1545,7 +1545,7 @@ static void imxrt_txint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   imxrt_serialout(priv, IMXRT_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/imxrt/imxrt_wdog.c
+++ b/arch/arm/src/imxrt/imxrt_wdog.c
@@ -251,12 +251,12 @@ static int imxrt_wdog_stop(FAR struct watchdog_lowerhalf_s *lower)
 
 static int imxrt_wdog_keepalive(FAR struct watchdog_lowerhalf_s *lower)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   putreg16(WDOG_KEEP_ALIVE_KEY1, IMXRT_WDOG1_WSR);
   putreg16(WDOG_KEEP_ALIVE_KEY2, IMXRT_WDOG1_WSR);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return OK;
 }
@@ -326,7 +326,7 @@ static int imxrt_wdog_settimeout(FAR struct watchdog_lowerhalf_s *lower,
 
   priv->timeout = timeout;
 
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   /* write timer value to WCR WT register */
 
@@ -340,7 +340,7 @@ static int imxrt_wdog_settimeout(FAR struct watchdog_lowerhalf_s *lower,
   putreg16(WDOG_KEEP_ALIVE_KEY1, IMXRT_WDOG1_WSR);
   putreg16(WDOG_KEEP_ALIVE_KEY2, IMXRT_WDOG1_WSR);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return OK;
 }

--- a/arch/arm/src/lc823450/lc823450_dma.c
+++ b/arch/arm/src/lc823450/lc823450_dma.c
@@ -140,7 +140,7 @@ static int dma_interrupt_core(void *context)
 
   pdmach = (struct lc823450_phydmach_s *)context;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   q_ent = pdmach->req_q.tail;
   DEBUGASSERT(q_ent != NULL);
   dmach = (struct lc823450_dmach_s *)q_ent;
@@ -150,14 +150,14 @@ static int dma_interrupt_core(void *context)
       /* finish one transfer */
 
       sq_remlast(&pdmach->req_q);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       if (dmach->callback)
         dmach->callback((DMA_HANDLE)dmach, dmach->arg, 0);
     }
   else
     {
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 
   up_disable_clk(LC823450_CLOCK_DMA);
@@ -214,14 +214,14 @@ static int phydmastart(struct lc823450_phydmach_s *pdmach)
   struct lc823450_dmach_s *dmach;
   sq_entry_t *q_ent;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   q_ent = pdmach->req_q.tail;
 
   if (!q_ent)
     {
       pdmach->inprogress = 0;
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       return 0;
     }
 
@@ -284,7 +284,7 @@ static int phydmastart(struct lc823450_phydmach_s *pdmach)
 
   modifyreg32(DMACCFG(dmach->chn), 0, DMACCFG_ITC | DMACCFG_E);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return 0;
 }
 
@@ -614,7 +614,7 @@ int lc823450_dmastart(DMA_HANDLE handle, dma_callback_t callback, void *arg)
 
   /* select physical channel */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   sq_addfirst(&dmach->q_ent, &g_dma.phydmach[dmach->chn].req_q);
 
@@ -628,7 +628,7 @@ int lc823450_dmastart(DMA_HANDLE handle, dma_callback_t callback, void *arg)
       phydmastart(&g_dma.phydmach[dmach->chn]);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return OK;
 }
@@ -645,7 +645,7 @@ void lc823450_dmastop(DMA_HANDLE handle)
 
   DEBUGASSERT(dmach != NULL);
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   modifyreg32(DMACCFG(dmach->chn), DMACCFG_ITC | DMACCFG_E, 0);
 
@@ -661,6 +661,6 @@ void lc823450_dmastop(DMA_HANDLE handle)
       sq_rem(&dmach->q_ent, &pdmach->req_q);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return;
 }

--- a/arch/arm/src/lc823450/lc823450_dvfs2.c
+++ b/arch/arm/src/lc823450/lc823450_dvfs2.c
@@ -434,7 +434,7 @@ static void lc823450_dvfs_do_auto(uint32_t idle[])
 
 void lc823450_dvfs_get_idletime(uint64_t idletime[])
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   /* First, copy g_idle_totaltime to the caller */
 
@@ -454,7 +454,7 @@ void lc823450_dvfs_get_idletime(uint64_t idletime[])
     }
 #endif
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -510,7 +510,7 @@ void lc823450_dvfs_tick_callback(void)
 
 void lc823450_dvfs_enter_idle(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   int me = up_cpu_index();
 
@@ -550,7 +550,7 @@ void lc823450_dvfs_enter_idle(void)
   lc823450_dvfs_set_div(_dvfs_cur_idx, 1);
 
 exit_with_error:
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -560,7 +560,7 @@ exit_with_error:
 
 void lc823450_dvfs_exit_idle(int irq)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   int me = up_cpu_index();
   uint64_t d;
@@ -603,7 +603,7 @@ exit_with_error:
 
   _dvfs_cpu_is_active[me] = 1;
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -635,7 +635,7 @@ int lc823450_dvfs_set_freq(int freq)
       return -1;
     }
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   switch (freq)
     {
@@ -663,6 +663,6 @@ int lc823450_dvfs_set_freq(int freq)
       lc823450_dvfs_set_div(idx, 0);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return ret;
 }

--- a/arch/arm/src/lc823450/lc823450_gpio.c
+++ b/arch/arm/src/lc823450/lc823450_gpio.c
@@ -224,12 +224,12 @@ int lc823450_gpio_mux(uint16_t gpiocfg)
 
   if (port <= (GPIO_PORT5 >> GPIO_PORT_SHIFT))
     {
-      irqstate_t flags = spin_lock_irqsave();
+      irqstate_t flags = spin_lock_irqsave(NULL);
       val = getreg32(PMDCNT0 + (port * 4));
       val &= ~(3 << (2 * pin));
       val |= (mux << (2 *pin));
       putreg32(val, PMDCNT0 + (port * 4));
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
   else
     {
@@ -272,7 +272,7 @@ int lc823450_gpio_config(uint16_t gpiocfg)
 
       /* Handle the GPIO configuration by the basic mode of the pin */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       /* pull up/down specified */
 
@@ -297,7 +297,7 @@ int lc823450_gpio_config(uint16_t gpiocfg)
             break;
         }
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 #ifdef CONFIG_IOEX
   else if (port <= (GPIO_PORTEX >> GPIO_PORT_SHIFT))
@@ -385,7 +385,7 @@ void lc823450_gpio_write(uint16_t gpiocfg, bool value)
 
       regaddr = lc823450_get_gpio_data(port);
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       /* Write the value (0 or 1).  To the data register */
 
@@ -402,7 +402,7 @@ void lc823450_gpio_write(uint16_t gpiocfg, bool value)
 
       putreg32(regval, regaddr);
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 #ifdef CONFIG_IOEX
   else if (port <= (GPIO_PORTEX >> GPIO_PORT_SHIFT))

--- a/arch/arm/src/lc823450/lc823450_irq.c
+++ b/arch/arm/src/lc823450/lc823450_irq.c
@@ -669,7 +669,7 @@ void up_enable_irq(int irq)
        * set the bit in the System Handler Control and State Register.
        */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       if (irq >= LC823450_IRQ_NIRQS)
         {
@@ -692,7 +692,7 @@ void up_enable_irq(int irq)
           putreg32(regval, regaddr);
         }
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 
   /* lc823450_dumpnvic("enable", irq); */
@@ -817,7 +817,7 @@ int lc823450_irq_srctype(int irq, enum lc823450_srctype_e srctype)
   port = (irq & 0x70) >> 4;
   gpio = irq & 0xf;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   regaddr = INTC_REG(EXTINTCND_BASE, port);
   regval = getreg32(regaddr);
@@ -827,7 +827,7 @@ int lc823450_irq_srctype(int irq, enum lc823450_srctype_e srctype)
 
   putreg32(regval, regaddr);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return OK;
 }

--- a/arch/arm/src/lc823450/lc823450_syscontrol.c
+++ b/arch/arm/src/lc823450/lc823450_syscontrol.c
@@ -131,7 +131,7 @@ void mod_stby_regs(uint32_t enabits, uint32_t disbits)
 void up_enable_clk(enum clock_e clk)
 {
   irqstate_t flags;
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   DEBUGASSERT(clk < LC823450_CLOCK_NUM);
 
@@ -141,7 +141,7 @@ void up_enable_clk(enum clock_e clk)
                   0, lc823450_clocks[clk].regmask);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -151,7 +151,7 @@ void up_enable_clk(enum clock_e clk)
 void up_disable_clk(enum clock_e clk)
 {
   irqstate_t flags;
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   DEBUGASSERT(clk < LC823450_CLOCK_NUM);
 
@@ -168,7 +168,7 @@ void up_disable_clk(enum clock_e clk)
       lc823450_clocks[clk].count = 0;
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/lc823450/lc823450_timer.c
+++ b/arch/arm/src/lc823450/lc823450_timer.c
@@ -182,7 +182,7 @@ static void hrt_queue_refresh(void)
   struct hrt_s *tmp;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   elapsed = (uint64_t)getreg32(MT20CNT) * (1000 * 1000) * 10 / XT1OSC_CLK;
 
   for (pent = hrt_timer_queue.head; pent; pent = dq_next(pent))
@@ -201,9 +201,9 @@ cont:
       if (tmp->usec <= 0)
         {
           dq_rem(pent, &hrt_timer_queue);
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           nxsem_post(&tmp->sem);
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
           goto cont;
         }
       else
@@ -212,7 +212,7 @@ cont:
         }
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 
@@ -227,7 +227,7 @@ static void hrt_usleep_setup(void)
   struct hrt_s *head;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   head = container_of(hrt_timer_queue.head, struct hrt_s, ent);
   if (head == NULL)
     {
@@ -235,7 +235,7 @@ static void hrt_usleep_setup(void)
 
       modifyreg32(MCLKCNTEXT1, MCLKCNTEXT1_MTM2C_CLKEN, 0x0);
       modifyreg32(MCLKCNTEXT1, MCLKCNTEXT1_MTM2_CLKEN, 0x0);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       return;
     }
 
@@ -257,7 +257,7 @@ static void hrt_usleep_setup(void)
   /* Enable MTM2-Ch0 */
 
   putreg32(1, MT2OPR);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 
@@ -296,7 +296,7 @@ static void hrt_usleep_add(struct hrt_s *phrt)
 
   hrt_queue_refresh();
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* add phrt to hrt_timer_queue */
 
@@ -318,7 +318,7 @@ static void hrt_usleep_add(struct hrt_s *phrt)
       dq_addlast(&phrt->ent, &hrt_timer_queue);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   hrt_usleep_setup();
 }
@@ -696,7 +696,7 @@ int up_rtc_gettime(FAR struct timespec *tp)
   irqstate_t   flags;
   uint64_t f;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Get the elapsed time */
 
@@ -707,7 +707,7 @@ int up_rtc_gettime(FAR struct timespec *tp)
   f = up_get_timer_fraction();
   elapsed += f;
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   tmrinfo("elapsed = %lld \n", elapsed);
 

--- a/arch/arm/src/max326xx/max32660/max32660_dma.c
+++ b/arch/arm/src/max326xx/max32660/max32660_dma.c
@@ -280,7 +280,7 @@ DMA_HANDLE max326_dma_channel(void)
    * allocation.  Just check each channel until a free one is found (on not).
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   for (i = 0; i < 0; i++)
     {
       struct max326_dmach_s *dmach = &g_max326_dmach[i];
@@ -292,12 +292,12 @@ DMA_HANDLE max326_dma_channel(void)
           /* No.. allocate this channel */
 
           dmach->inuse = true;
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return (DMA_HANDLE)dmach;
         }
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return (DMA_HANDLE)NULL;
 }
 

--- a/arch/arm/src/max326xx/max32660/max32660_gpio.c
+++ b/arch/arm/src/max326xx/max32660/max32660_gpio.c
@@ -255,7 +255,7 @@ int max326_gpio_config(max326_pinset_t pinset)
 
   /* Modification of all registers must be atomic */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* First, force the pin configuration to the default generic input state.
    * So that we know we are starting from a known state.
@@ -416,7 +416,7 @@ int max326_gpio_config(max326_pinset_t pinset)
       putreg32(regval, MAX326_GPIO0_WAKEEN);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 
@@ -439,7 +439,7 @@ void max326_gpio_write(max326_pinset_t pinset, bool value)
 
   /* Modification of registers must be atomic */
 
-  flags  = spin_lock_irqsave();
+  flags  = spin_lock_irqsave(NULL);
   regval = getreg32(MAX326_GPIO0_OUT);
   if (value)
     {
@@ -451,7 +451,7 @@ void max326_gpio_write(max326_pinset_t pinset, bool value)
     }
 
   putreg32(regval, MAX326_GPIO0_OUT);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/max326xx/max32660/max32660_lowputc.c
+++ b/arch/arm/src/max326xx/max32660/max32660_lowputc.c
@@ -454,18 +454,18 @@ void arm_lowputc(char ch)
        * atomic.
        */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       if ((getreg32(CONSOLE_BASE + MAX326_UART_STAT_OFFSET) &
            UART_STAT_TXFULL) == 0)
         {
           /* Send the character */
 
           putreg32((uint32_t)ch, CONSOLE_BASE + MAX326_UART_FIFO_OFFSET);
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return;
         }
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 #endif
 }

--- a/arch/arm/src/max326xx/max32660/max32660_rtc.c
+++ b/arch/arm/src/max326xx/max32660/max32660_rtc.c
@@ -471,7 +471,7 @@ int up_rtc_settime(FAR const struct timespec *tp)
 
   /* Enable write access to RTC configuration registers */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   max326_rtc_wrenable(true);
 
   /* We need to disable the RTC in order to write to the SEC and SSEC
@@ -495,7 +495,7 @@ int up_rtc_settime(FAR const struct timespec *tp)
   max326_rtc_enable(true);
   max326_rtc_wrenable(false);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 
@@ -534,7 +534,7 @@ int max326_rtc_setalarm(FAR struct timespec *ts,
 
   /* Is there already something waiting on the ALARM? */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (g_alarmcb == NULL)
     {
       /* Get the time as a fixed precision number.
@@ -629,7 +629,7 @@ int max326_rtc_setalarm(FAR struct timespec *ts,
     }
 
 errout_with_lock:
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return ret;
 }
 #endif
@@ -729,7 +729,7 @@ int max326_rtc_cancelalarm(void)
   uint32_t regval;
   int ret = -ENODATA;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   if (g_alarmcb != NULL)
     {
@@ -757,7 +757,7 @@ int max326_rtc_cancelalarm(void)
       ret = OK;
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return ret;
 }
 #endif

--- a/arch/arm/src/max326xx/max32660/max32660_serial.c
+++ b/arch/arm/src/max326xx/max32660/max32660_serial.c
@@ -344,11 +344,11 @@ static inline void max326_int_enable(struct max326_dev_s *priv,
   irqstate_t flags;
   uint32_t regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = max326_serialin(priv, MAX326_UART_INTEN_OFFSET);
   regval |= intset;
   max326_serialout(priv, MAX326_UART_INTEN_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -361,11 +361,11 @@ static inline void max326_int_disable(struct max326_dev_s *priv,
   irqstate_t flags;
   uint32_t regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = max326_serialin(priv, MAX326_UART_INTEN_OFFSET);
   regval &= ~intset;
   max326_serialout(priv, MAX326_UART_INTEN_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -377,14 +377,14 @@ static void max326_int_disableall(struct max326_dev_s *priv,
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (intset)
     {
       *intset = max326_serialin(priv, MAX326_UART_INTEN_OFFSET);
     }
 
   max326_serialout(priv, MAX326_UART_INTEN_OFFSET, 0);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/max326xx/max32660/max32660_wdt.c
+++ b/arch/arm/src/max326xx/max32660/max32660_wdt.c
@@ -375,7 +375,7 @@ static int max326_start(FAR struct watchdog_lowerhalf_s *lower)
 
   /* Perform the reset sequence */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   max326_wdog_reset(priv);
 
   /* Enable reset or interrupt */
@@ -388,7 +388,7 @@ static int max326_start(FAR struct watchdog_lowerhalf_s *lower)
   ctrl |= WDT0_CTRL_WDTEN;
   putreg32(ctrl, MAX326_WDT0_CTRL);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 
@@ -420,14 +420,14 @@ static int max326_stop(FAR struct watchdog_lowerhalf_s *lower)
 
   /* Disable the watchdog timer, reset, and interrupts */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   ctrl  = getreg32(MAX326_WDT0_CTRL);
   ctrl &= ~(WDT0_CTRL_WDTEN | WDT0_CTRL_INTEN | WDT0_CTRL_RSTEN);
 
   up_disable_irq(MAX326_IRQ_WDT0);
   irq_detach(MAX326_IRQ_WDT0);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 
@@ -458,9 +458,9 @@ static int max326_keepalive(FAR struct watchdog_lowerhalf_s *lower)
 
   /* Reset WDT timer */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   max326_wdog_reset(priv);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return OK;
 }
@@ -552,7 +552,7 @@ static int max326_settimeout(FAR struct watchdog_lowerhalf_s *lower,
 
   /* Reset WDT timer */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   max326_wdog_reset(priv);
 
   /* Convert the timeout value in milliseconds to time exponent used by the
@@ -574,7 +574,7 @@ static int max326_settimeout(FAR struct watchdog_lowerhalf_s *lower,
   ctrl |= (WDT0_CTRL_INTPERIOD(exp) | WDT0_CTRL_RSTPERIOD(exp));
   putreg32(ctrl, MAX326_WDT0_CTRL);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 
@@ -607,7 +607,7 @@ static xcpt_t max326_capture(FAR struct watchdog_lowerhalf_s *lower,
 
   /* Get the old handler */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   oldhandler = priv->handler;
 
   /* Save the new handler */
@@ -628,7 +628,7 @@ static xcpt_t max326_capture(FAR struct watchdog_lowerhalf_s *lower,
       max326_int_enable(priv);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return oldhandler;
 }
 

--- a/arch/arm/src/nrf52/nrf52_gpio.c
+++ b/arch/arm/src/nrf52/nrf52_gpio.c
@@ -288,7 +288,7 @@ int nrf52_gpio_config(nrf52_pinset_t cfgset)
 
       pin = GPIO_PIN_DECODE(cfgset);
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       /* First, configure the port as a generic input so that we have a
        * known starting point and consistent behavior during the re-
@@ -323,7 +323,7 @@ int nrf52_gpio_config(nrf52_pinset_t cfgset)
           ret = -EINVAL;
         }
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
   else
     {

--- a/arch/arm/src/s32k1xx/s32k1xx_edma.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_edma.c
@@ -268,10 +268,10 @@ static void s32k1xx_tcd_free(struct s32k1xx_edmatcd_s *tcd)
    * a TCD.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   sq_addlast((sq_entry_t *)tcd, &g_tcd_free);
   s32k1xx_givedsem();
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif
 
@@ -1194,7 +1194,7 @@ int s32k1xx_dmach_start(DMACH_HANDLE handle, edma_callback_t callback,
 
   /* Save the callback info.  This will be invoked when the DMA completes */
 
-  flags           = spin_lock_irqsave();
+  flags           = spin_lock_irqsave(NULL);
   dmach->callback = callback;
   dmach->arg      = arg;
   dmach->state    = S32K1XX_DMA_ACTIVE;
@@ -1218,7 +1218,7 @@ int s32k1xx_dmach_start(DMACH_HANDLE handle, edma_callback_t callback,
       putreg8(regval8, S32K1XX_EDMA_SERQ_OFFSET);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 
@@ -1246,9 +1246,9 @@ void s32k1xx_dmach_stop(DMACH_HANDLE handle)
   dmainfo("dmach: %p\n", dmach);
   DEBUGASSERT(dmach != NULL);
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   s32k1xx_dmaterminate(dmach, -EINTR);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1346,7 +1346,7 @@ void s32k1xx_dmasample(DMACH_HANDLE handle, struct s32k1xx_dmaregs_s *regs)
 
   /* eDMA Global Registers */
 
-  flags          = spin_lock_irqsave();
+  flags          = spin_lock_irqsave(NULL);
 
   regs->cr       = getreg32(S32K1XX_EDMA_CR);   /* Control */
   regs->es       = getreg32(S32K1XX_EDMA_ES);   /* Error Status */
@@ -1381,7 +1381,7 @@ void s32k1xx_dmasample(DMACH_HANDLE handle, struct s32k1xx_dmaregs_s *regs)
   regaddr        = S32K1XX_DMAMUX_CHCFG(chan);
   regs->dmamux   = getreg32(regaddr);         /* Channel configuration */
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif /* CONFIG_DEBUG_DMA */
 

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -562,7 +562,7 @@ static int s32k1xx_transmit(FAR struct s32k1xx_driver_s *priv)
 
   /* Make the following operations atomic */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Enable TX interrupts */
 
@@ -579,7 +579,7 @@ static int s32k1xx_transmit(FAR struct s32k1xx_driver_s *priv)
 
   putreg32(ENET_TDAR, S32K1XX_ENET_TDAR);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 

--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -444,7 +444,7 @@ static inline void s32k1xx_disableuartint(struct s32k1xx_uart_s *priv,
   irqstate_t flags;
   uint32_t regval;
 
-  flags  = spin_lock_irqsave();
+  flags  = spin_lock_irqsave(NULL);
   regval = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET);
 
   /* Return the current Rx and Tx interrupt state */
@@ -456,7 +456,7 @@ static inline void s32k1xx_disableuartint(struct s32k1xx_uart_s *priv,
 
   regval &= ~LPUART_ALL_INTS;
   s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -473,12 +473,12 @@ static inline void s32k1xx_restoreuartint(struct s32k1xx_uart_s *priv,
    * enabled/disabled.
    */
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET);
   regval &= ~LPUART_ALL_INTS;
   regval |= ie;
   s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -894,7 +894,7 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
         irqstate_t flags;
         struct s32k1xx_uart_s *priv = (struct s32k1xx_uart_s *)dev->priv;
 
-        flags  = spin_lock_irqsave();
+        flags  = spin_lock_irqsave(NULL);
         ctrl   = s32k1xx_serialin(priv, S32K1XX_LPUART_CTRL_OFFSET);
         stat   = s32k1xx_serialin(priv, S32K1XX_LPUART_STAT_OFFSET);
         regval = ctrl;
@@ -930,7 +930,7 @@ static int s32k1xx_ioctl(struct file *filep, int cmd, unsigned long arg)
         s32k1xx_serialout(priv, S32K1XX_LPUART_STAT_OFFSET, stat);
         s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, ctrl);
 
-        spin_unlock_irqrestore(flags);
+        spin_unlock_irqrestore(NULL, flags);
       }
       break;
 #endif
@@ -981,7 +981,7 @@ static void s32k1xx_rxint(struct uart_dev_s *dev, bool enable)
 
   /* Enable interrupts for data available at Rx */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -997,7 +997,7 @@ static void s32k1xx_rxint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1049,7 +1049,7 @@ static void s32k1xx_txint(struct uart_dev_s *dev, bool enable)
 
   /* Enable interrupt for TX complete */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (enable)
     {
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -1065,7 +1065,7 @@ static void s32k1xx_txint(struct uart_dev_s *dev, bool enable)
   regval &= ~LPUART_ALL_INTS;
   regval |= priv->ie;
   s32k1xx_serialout(priv, S32K1XX_LPUART_CTRL_OFFSET, regval);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32/stm32_hciuart.c
+++ b/arch/arm/src/stm32/stm32_hciuart.c
@@ -1895,7 +1895,7 @@ static void hciuart_rxattach(const struct btuart_lowerhalf_s *lower,
 
   /* If the callback is NULL, then we are detaching */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (callback == NULL)
     {
       uint32_t intset;
@@ -1918,7 +1918,7 @@ static void hciuart_rxattach(const struct btuart_lowerhalf_s *lower,
       state->callback = callback;
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1983,7 +1983,7 @@ static void hciuart_rxenable(const struct btuart_lowerhalf_s *lower,
        * "           "    USART_SR_ORE  Overrun Error Detected
        */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       if (enable)
         {
           /* Receive an interrupt when their is anything in the Rx data
@@ -1999,7 +1999,7 @@ static void hciuart_rxenable(const struct btuart_lowerhalf_s *lower,
           hciuart_disableints(config, intset);
         }
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 #endif
 }
@@ -2198,9 +2198,9 @@ static ssize_t hciuart_write(const struct btuart_lowerhalf_s *lower,
    * USART_CR3_CTSIE  USART_SR_CTS  CTS flag               (not used)
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   hciuart_disableints(config, USART_CR1_TXEIE);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   /* Loop until all of the user data have been moved to the Tx buffer */
 
@@ -2293,9 +2293,9 @@ static ssize_t hciuart_write(const struct btuart_lowerhalf_s *lower,
 
   if (state->txhead != state->txtail)
     {
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       hciuart_enableints(config, USART_CR1_TXEIE);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 
   return ntotal;
@@ -2629,7 +2629,7 @@ void stm32_serial_dma_poll(void)
 {
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
 #ifdef CONFIG_STM32_HCIUART1_RXDMA
   if (g_hciusart1_config.state->rxdmastream != NULL)
@@ -2680,6 +2680,6 @@ void stm32_serial_dma_poll(void)
     }
 #endif
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 #endif

--- a/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
@@ -79,13 +79,13 @@ void cc13xx_periph_enablepwr(uint32_t peripheral)
 
   /* Remember that this peripheral needs power in this domain */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   g_domain_usage[dndx] |= (1 << pndx);
 
   /* Make sure that power is enabled in that domain */
 
   prcm_powerdomain_on(domain);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   /* Wait for the power domain to be ready.  REVISIT:  This really should be
    * in the critical section but this could take too long.
@@ -113,7 +113,7 @@ void cc13xx_periph_disablepwr(uint32_t peripheral)
 
   /* This peripheral no longer needs power in this domain */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   g_domain_usage[dndx] &= ~(1 << pndx);
 
   /* If there are no peripherals needing power in this domain, then turn off
@@ -126,5 +126,5 @@ void cc13xx_periph_disablepwr(uint32_t peripheral)
                            PRCM_DOMAIN_SERIAL : PRCM_DOMAIN_PERIPH);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
@@ -77,7 +77,7 @@ int tiva_configgpio(pinconfig_t pinconfig)
 
   /* The following requires exclusive access to the GPIO registers */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
 #ifdef CONFIG_TIVA_GPIO_IRQS
   /* Mask and clear any pending GPIO interrupt */
@@ -136,7 +136,7 @@ int tiva_configgpio(pinconfig_t pinconfig)
       putreg32(regval, TIVA_GPIO_DOE);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 

--- a/arch/arm/src/tiva/common/tiva_hciuart.c
+++ b/arch/arm/src/tiva/common/tiva_hciuart.c
@@ -1242,7 +1242,7 @@ static void hciuart_rxattach(const struct btuart_lowerhalf_s *lower,
 
   /* If the callback is NULL, then we are detaching */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (callback == NULL)
     {
       uint32_t intset;
@@ -1264,7 +1264,7 @@ static void hciuart_rxattach(const struct btuart_lowerhalf_s *lower,
       state->callback = callback;
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -1292,7 +1292,7 @@ static void hciuart_rxenable(const struct btuart_lowerhalf_s *lower,
       uint32_t intset;
       irqstate_t flags;
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       if (enable)
         {
           /* Receive an interrupt when their is anything in the Rx data
@@ -1308,7 +1308,7 @@ static void hciuart_rxenable(const struct btuart_lowerhalf_s *lower,
           hciuart_disableints(config, intset);
         }
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 }
 
@@ -1494,9 +1494,9 @@ static ssize_t hciuart_write(const struct btuart_lowerhalf_s *lower,
 
   /* Make sure that the Tx Interrupts are disabled. */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   hciuart_disableints(config, UART_IM_TXIM);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   /* Loop until all of the user data have been moved to the Tx buffer */
 
@@ -1591,9 +1591,9 @@ static ssize_t hciuart_write(const struct btuart_lowerhalf_s *lower,
 
   if (state->txhead != state->txtail)
     {
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       hciuart_enableints(config, UART_IM_TXIM);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 
   return ntotal;

--- a/arch/or1k/src/common/up_modifyreg16.c
+++ b/arch/or1k/src/common/up_modifyreg16.c
@@ -64,10 +64,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/or1k/src/common/up_modifyreg32.c
+++ b/arch/or1k/src/common/up_modifyreg32.c
@@ -64,10 +64,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/or1k/src/common/up_modifyreg8.c
+++ b/arch/or1k/src/common/up_modifyreg8.c
@@ -64,10 +64,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/risc-v/src/bl602/bl602_timerisr.c
+++ b/arch/risc-v/src/bl602/bl602_timerisr.c
@@ -84,7 +84,7 @@ static inline void bl602_clint_time_cmp_write(uint64_t v)
 
 static void bl602_reload_mtimecmp(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   uint64_t current;
   uint64_t next;
@@ -103,7 +103,7 @@ static void bl602_reload_mtimecmp(void)
 
   bl602_clint_time_cmp_write(next);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/common/riscv_modifyreg32.c
+++ b/arch/risc-v/src/common/riscv_modifyreg32.c
@@ -64,10 +64,10 @@ void modifyreg32(uintptr_t addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = spin_lock_irqsave();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/risc-v/src/fe310/fe310_gpio.c
+++ b/arch/risc-v/src/fe310/fe310_gpio.c
@@ -159,7 +159,7 @@ int fe310_gpio_config(uint16_t gpiocfg)
 
   uint32_t pin  = fe310_gpio_getpin(gpiocfg);
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Disable IOF for the pin to be used as GPIO */
 
@@ -194,7 +194,7 @@ int fe310_gpio_config(uint16_t gpiocfg)
         break;
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return ret;
 }

--- a/arch/risc-v/src/fe310/fe310_timerisr.c
+++ b/arch/risc-v/src/fe310/fe310_timerisr.c
@@ -80,7 +80,7 @@ static bool _b_tick_started = false;
 
 static void fe310_reload_mtimecmp(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   uint64_t current;
   uint64_t next;
@@ -98,7 +98,7 @@ static void fe310_reload_mtimecmp(void)
   next = current + TICK_COUNT;
   putreg64(next, FE310_CLINT_MTIMECMP);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/k210/k210_timerisr.c
+++ b/arch/risc-v/src/k210/k210_timerisr.c
@@ -80,7 +80,7 @@ static bool _b_tick_started = false;
 
 static void k210_reload_mtimecmp(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   uint64_t current;
   uint64_t next;
@@ -100,7 +100,7 @@ static void k210_reload_mtimecmp(void)
 
   putreg64(next, K210_CLINT_MTIMECMP);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/litex/litex_timerisr.c
+++ b/arch/risc-v/src/litex/litex_timerisr.c
@@ -133,7 +133,7 @@ static inline void litex_clint_time_cmp_write(uint64_t v)
 
 static void litex_reload_mtimecmp(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   uint64_t current;
   uint64_t next;
@@ -156,7 +156,7 @@ static void litex_reload_mtimecmp(void)
   csr_set(mie, MIE_MTIE);
   csr_clear(mip, MIP_MTIP);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_himem.c
+++ b/arch/xtensa/src/esp32/esp32_himem.c
@@ -360,11 +360,11 @@ int esp_himem_alloc(size_t size, esp_himem_handle_t *handle_out)
       goto nomem;
     }
 
-  spinlock_flags = spin_lock_irqsave();
+  spinlock_flags = spin_lock_irqsave(NULL);
 
   ok = allocate_blocks(blocks, r->block);
 
-  spin_unlock_irqrestore(spinlock_flags);
+  spin_unlock_irqrestore(NULL, spinlock_flags);
   if (!ok)
     {
       goto nomem;
@@ -400,13 +400,13 @@ int esp_himem_free(esp_himem_handle_t handle)
 
   /* Mark blocks as free */
 
-  spinlock_flags = spin_lock_irqsave();
+  spinlock_flags = spin_lock_irqsave(NULL);
   for (i = 0; i < handle->block_ct; i++)
     {
       g_ram_descriptor[handle->block[i]].is_alloced = false;
     }
 
-  spin_unlock_irqrestore(spinlock_flags);
+  spin_unlock_irqrestore(NULL, spinlock_flags);
 
   /* Free handle */
 
@@ -442,7 +442,7 @@ int esp_himem_alloc_map_range(size_t size,
   r->block_start = -1;
 
   start_free = 0;
-  spinlock_flags = spin_lock_irqsave();
+  spinlock_flags = spin_lock_irqsave(NULL);
 
   for (i = 0; i < g_rangeblockcnt; i++)
     {
@@ -469,7 +469,7 @@ int esp_himem_alloc_map_range(size_t size,
       /* Couldn't find enough free blocks */
 
       free(r);
-      spin_unlock_irqrestore(spinlock_flags);
+      spin_unlock_irqrestore(NULL, spinlock_flags);
       return -ENOMEM;
     }
 
@@ -480,7 +480,7 @@ int esp_himem_alloc_map_range(size_t size,
       g_range_descriptor[r->block_start + i].is_alloced = 1;
     }
 
-  spin_unlock_irqrestore(spinlock_flags);
+  spin_unlock_irqrestore(NULL, spinlock_flags);
 
   /* All done. */
 
@@ -509,14 +509,14 @@ int esp_himem_free_map_range(esp_himem_rangehandle_t handle)
 
   /* We should be good to free this. Mark blocks as free. */
 
-  spinlock_flags = spin_lock_irqsave();
+  spinlock_flags = spin_lock_irqsave(NULL);
 
   for (i = 0; i < handle->block_ct; i++)
     {
       g_range_descriptor[i + handle->block_start].is_alloced = 0;
     }
 
-  spin_unlock_irqrestore(spinlock_flags);
+  spin_unlock_irqrestore(NULL, spinlock_flags);
   free(handle);
   return OK;
 }
@@ -572,7 +572,7 @@ int esp_himem_map(esp_himem_handle_t handle,
 
   /* Map and mark as mapped */
 
-  spinlock_flags = spin_lock_irqsave();
+  spinlock_flags = spin_lock_irqsave(NULL);
 
   for (i = 0; i < blockcount; i++)
     {
@@ -583,7 +583,7 @@ int esp_himem_map(esp_himem_handle_t handle,
                         handle->block[i + ram_block];
     }
 
-  spin_unlock_irqrestore(spinlock_flags);
+  spin_unlock_irqrestore(NULL, spinlock_flags);
 
   for (i = 0; i < blockcount; i++)
     {
@@ -624,7 +624,7 @@ int esp_himem_unmap(esp_himem_rangehandle_t range, void *ptr,
   HIMEM_CHECK(range_block + blockcount > range->block_ct,
               "range out of bounds for handle", -EINVAL);
 
-  spinlock_flags = spin_lock_irqsave();
+  spinlock_flags = spin_lock_irqsave(NULL);
 
   for (i = 0; i < blockcount; i++)
     {
@@ -637,7 +637,7 @@ int esp_himem_unmap(esp_himem_rangehandle_t range, void *ptr,
     }
 
   esp_spiram_writeback_cache();
-  spin_unlock_irqrestore(spinlock_flags);
+  spin_unlock_irqrestore(NULL, spinlock_flags);
   return OK;
 }
 

--- a/arch/xtensa/src/esp32/esp32_idle.c
+++ b/arch/xtensa/src/esp32/esp32_idle.c
@@ -88,7 +88,7 @@ static void up_idlepm(void)
 
   if (newstate != oldstate)
     {
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       /* Perform board-specific, state-dependent logic here */
 
@@ -110,7 +110,7 @@ static void up_idlepm(void)
           oldstate = newstate;
         }
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       /* MCU-specific power management logic */
 

--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -190,7 +190,7 @@ unsigned int IRAM_ATTR cache_sram_mmu_set(int cpu_no, int pid,
    * the flash guards to make sure the cache is disabled.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   spi_disable_cache(0, &statecpu0);
 
@@ -227,7 +227,7 @@ unsigned int IRAM_ATTR cache_sram_mmu_set(int cpu_no, int pid,
   spi_enable_cache(1, statecpu1);
 #endif
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return 0;
 }
 

--- a/boards/arm/imxrt/imxrt1020-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1020-evk/src/imxrt_ethernet.c
@@ -247,7 +247,7 @@ int arch_phy_irq(FAR const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Configure the interrupt */
 
@@ -282,7 +282,7 @@ int arch_phy_irq(FAR const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 #endif /* GPIO_ENET_IRQ */

--- a/boards/arm/imxrt/imxrt1050-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1050-evk/src/imxrt_ethernet.c
@@ -255,7 +255,7 @@ int arch_phy_irq(FAR const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Configure the interrupt */
 
@@ -290,7 +290,7 @@ int arch_phy_irq(FAR const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 #endif /* CONFIG_IMXRT_GPIO1_0_15_IRQ */

--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_ethernet.c
@@ -248,7 +248,7 @@ int arch_phy_irq(FAR const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Configure the interrupt */
 
@@ -283,7 +283,7 @@ int arch_phy_irq(FAR const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 #endif /* CONFIG_IMXRT_GPIO1_0_15_IRQ */

--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c
@@ -232,7 +232,7 @@ int arch_phy_irq(FAR const char *intf, xcpt_t handler, void *arg,
    * following operations are atomic.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Configure the interrupt */
 
@@ -267,7 +267,7 @@ int arch_phy_irq(FAR const char *intf, xcpt_t handler, void *arg,
 
   /* Return the old handler (so that it can be restored) */
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 #endif /* CONFIG_IMXRT_GPIO1_0_15_IRQ */

--- a/boards/arm/max326xx/max32660-evsys/src/max326_button.c
+++ b/boards/arm/max326xx/max32660-evsys/src/max326_button.c
@@ -120,7 +120,7 @@ int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
        * following operations are atomic.
        */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       /* Are we attaching or detaching? */
 
@@ -139,7 +139,7 @@ int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
           irq_detach(BUTTON_IRQ);
         }
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       ret = OK;
     }
 

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_gs2200m.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_gs2200m.c
@@ -103,7 +103,7 @@ static int gs2200m_irq_attach(xcpt_t handler, FAR void *arg)
 
 static void gs2200m_irq_enable(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
   uint32_t dready = 0;
 
   wlinfo("== ec:%" PRId32 " called=%" PRId32 " \n",
@@ -123,7 +123,7 @@ static void gs2200m_irq_enable(void)
 
   _enable_count++;
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   if (dready)
     {
@@ -140,7 +140,7 @@ static void gs2200m_irq_enable(void)
 
 static void gs2200m_irq_disable(void)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   wlinfo("== ec:%" PRId32 " called=%" PRId32 " \n",
          _enable_count, _n_called++);
@@ -153,7 +153,7 @@ static void gs2200m_irq_disable(void)
                          false, NULL, NULL);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -162,7 +162,7 @@ static void gs2200m_irq_disable(void)
 
 static uint32_t gs2200m_dready(int *ec)
 {
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
 
   uint32_t r = stm32_gpioread(GPIO_GS2200M_INT);
 
@@ -173,7 +173,7 @@ static uint32_t gs2200m_dready(int *ec)
       *ec = _enable_count;
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return r;
 }
 

--- a/drivers/audio/cxd56.c
+++ b/drivers/audio/cxd56.c
@@ -1275,7 +1275,7 @@ static void _process_audio_with_src(cxd56_dmahandle_t hdl, uint16_t err_code)
 
   /* Trigger new DMA job */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   if (err_code == CXD56_AUDIO_ECODE_DMA_TRANS)
     {
@@ -1286,10 +1286,10 @@ static void _process_audio_with_src(cxd56_dmahandle_t hdl, uint16_t err_code)
         {
           msg.msg_id = AUDIO_MSG_STOP;
           msg.u.data = 0;
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           ret = file_mq_send(&dev->mq, (FAR const char *)&msg,
                              sizeof(msg), CONFIG_CXD56_MSG_PRIO);
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
           if (ret != OK)
             {
               auderr("ERROR: file_mq_send to stop failed (%d)\n", ret);
@@ -1310,9 +1310,9 @@ static void _process_audio_with_src(cxd56_dmahandle_t hdl, uint16_t err_code)
           struct ap_buffer_s *apb;
 
           apb = dq_get(&dev->up_runq);
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           dev->dev.upper(dev->dev.priv, AUDIO_CALLBACK_DEQUEUE, apb, OK);
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
 
           /* End of data? */
 
@@ -1320,10 +1320,10 @@ static void _process_audio_with_src(cxd56_dmahandle_t hdl, uint16_t err_code)
             {
               msg.msg_id = AUDIO_MSG_STOP;
               msg.u.data = 0;
-              spin_unlock_irqrestore(flags);
+              spin_unlock_irqrestore(NULL, flags);
               ret = file_mq_send(&dev->mq, (FAR const char *)&msg,
                                  sizeof(msg), CONFIG_CXD56_MSG_PRIO);
-              flags = spin_lock_irqsave();
+              flags = spin_lock_irqsave(NULL);
               if (ret != OK)
                 {
                   auderr("ERROR: file_mq_send to stop failed (%d)\n", ret);
@@ -1340,17 +1340,17 @@ static void _process_audio_with_src(cxd56_dmahandle_t hdl, uint16_t err_code)
 
       msg.msg_id = AUDIO_MSG_DATA_REQUEST;
       msg.u.data = 0;
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       ret = file_mq_send(&dev->mq, (FAR const char *) &msg,
                          sizeof(msg), CONFIG_CXD56_MSG_PRIO);
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       if (ret != OK)
         {
           auderr("ERROR: file_mq_send to request failed (%d)\n", ret);
         }
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 #else
@@ -1365,19 +1365,19 @@ static void _process_audio(cxd56_dmahandle_t hdl, uint16_t err_code)
 
   /* Trigger new DMA job */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   if (dq_count(&dev->up_runq) > 0)
     {
       FAR struct ap_buffer_s *apb;
 
       apb = (struct ap_buffer_s *) dq_get(&dev->up_runq);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       dev->dev.upper(dev->dev.priv, AUDIO_CALLBACK_DEQUEUE, apb, OK);
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   if (err_code == CXD56_AUDIO_ECODE_DMA_TRANS)
     {
@@ -3177,7 +3177,7 @@ static int cxd56_start_dma(FAR struct cxd56_dev_s *dev)
   uint32_t size;
   int ret = OK;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 #ifdef CONFIG_AUDIO_CXD56_SRC
   FAR struct ap_buffer_s *src_apb;
 
@@ -3190,9 +3190,9 @@ static int cxd56_start_dma(FAR struct cxd56_dev_s *dev)
 
       audwarn("Underrun \n");
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       ret = cxd56_stop_dma(dev);
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       audwarn("STOP DMA due to underrun \n");
       if (ret != CXD56_AUDIO_ECODE_OK)
         {
@@ -3259,9 +3259,9 @@ static int cxd56_start_dma(FAR struct cxd56_dev_s *dev)
             {
               /* Turn on amplifier */
 
-              spin_unlock_irqrestore(flags);
+              spin_unlock_irqrestore(NULL, flags);
               board_external_amp_mute_control(false);
-              flags = spin_lock_irqsave();
+              flags = spin_lock_irqsave(NULL);
 
               /* Mask interrupts */
 
@@ -3377,10 +3377,10 @@ static int cxd56_start_dma(FAR struct cxd56_dev_s *dev)
               msg.msg_id = AUDIO_MSG_STOP;
               msg.u.data = 0;
 
-              spin_unlock_irqrestore(flags);
+              spin_unlock_irqrestore(NULL, flags);
               ret = file_mq_send(&dev->mq, (FAR const char *)&msg,
                                  sizeof(msg), CONFIG_CXD56_MSG_PRIO);
-              flags = spin_lock_irqsave();
+              flags = spin_lock_irqsave(NULL);
 
               if (ret != OK)
                 {
@@ -3393,7 +3393,7 @@ static int cxd56_start_dma(FAR struct cxd56_dev_s *dev)
     }
 
 exit:
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return ret;
 }
@@ -3422,12 +3422,12 @@ static int cxd56_enqueuebuffer(FAR struct audio_lowerhalf_s *lower,
   else
     {
 #endif
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       apb->dq_entry.flink = NULL;
       dq_put(&priv->up_pendq, &apb->dq_entry);
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       if (priv->mq.f_inode != NULL)
         {

--- a/drivers/audio/cxd56_src.c
+++ b/drivers/audio/cxd56_src.c
@@ -115,18 +115,18 @@ static struct ap_buffer_s *cxd56_src_get_apb()
   struct ap_buffer_s *src_apb;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   if (dq_count(g_src.inq) == 0)
     {
       size_t bufsize = sizeof(struct ap_buffer_s) +
                               CONFIG_CXD56_AUDIO_BUFFER_SIZE;
 
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       src_apb = kmm_zalloc(bufsize);
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       if (!src_apb)
         {
@@ -148,7 +148,7 @@ static struct ap_buffer_s *cxd56_src_get_apb()
 
 errorout_with_lock:
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return src_apb;
 }
@@ -186,9 +186,9 @@ static int cxd56_src_process(FAR struct ap_buffer_s *apb)
       src_apb->nbytes = apb->nbytes;
       src_apb->flags |= AUDIO_APB_SRC_FINAL;
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       dq_put(g_src.outq, &src_apb->dq_entry);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       goto exit;
     }
@@ -290,9 +290,9 @@ static int cxd56_src_process(FAR struct ap_buffer_s *apb)
 
               /* Put in out queue to be DMA'd */
 
-              flags = spin_lock_irqsave();
+              flags = spin_lock_irqsave(NULL);
               dq_put(g_src.outq, &src_apb->dq_entry);
-              spin_unlock_irqrestore(flags);
+              spin_unlock_irqrestore(NULL, flags);
 
 #ifdef DUMP_DATA
               write(dump_file_post, src_apb->samp, src_apb->nbytes);
@@ -321,9 +321,9 @@ static int cxd56_src_process(FAR struct ap_buffer_s *apb)
 
           src_apb->nbytes += g_src.bytewidth * src_nframes * g_src.channels;
 
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
           dq_put_back(g_src.inq, &src_apb->dq_entry);
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
 
           apb->curbyte += (float_in_left * g_src.bytewidth);
         }

--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -547,7 +547,7 @@ static void  wm8776_senddone(FAR struct i2s_dev_s *i2s,
    * against that possibility.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Add the completed buffer to the end of our doneq.  We do not yet
    * decrement the reference count.
@@ -565,7 +565,7 @@ static void  wm8776_senddone(FAR struct i2s_dev_s *i2s,
   /* REVISIT:  This can be overwritten */
 
   priv->result = result;
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   /* Now send a message to the worker thread, informing it that there are
    * buffers in the done queue that need to be cleaned up.
@@ -600,13 +600,13 @@ static void wm8776_returnbuffers(FAR struct wm8776_dev_s *priv)
    * use interrupt controls to protect against that possibility.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   while (dq_peek(&priv->doneq) != NULL)
     {
       /* Take the next buffer from the queue of completed transfers */
 
       apb = (FAR struct ap_buffer_s *)dq_remfirst(&priv->doneq);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       audinfo("Returning: apb=%p curbyte=%d nbytes=%d flags=%04x\n",
               apb, apb->curbyte, apb->nbytes, apb->flags);
@@ -641,10 +641,10 @@ static void wm8776_returnbuffers(FAR struct wm8776_dev_s *priv)
 #else
       priv->dev.upper(priv->dev.priv, AUDIO_CALLBACK_DEQUEUE, apb, OK);
 #endif
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -697,9 +697,9 @@ static int wm8776_sendbuffer(FAR struct wm8776_dev_s *priv)
        * to avoid a possible race condition.
        */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       priv->inflight++;
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       shift  = (priv->bpsamp == 8) ? 14 - 3 : 14 - 4;
       shift -= (priv->nchannels > 1) ? 1 : 0;

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -110,7 +110,7 @@ static int i2c_bitbang_transfer(FAR struct i2c_master_s *dev,
 
   /* Lock to enforce timings */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   for (i = 0; i < count; i++)
     {
@@ -239,7 +239,7 @@ out:
   i2c_bitbang_set_scl(priv, true, false);
   i2c_bitbang_set_sda(priv, true);
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return ret;
 }

--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -394,7 +394,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         if (arg && dev->gp_pintype >= GPIO_INTERRUPT_PIN)
           {
             pid = getpid();
-            flags = spin_lock_irqsave();
+            flags = spin_lock_irqsave(NULL);
             for (i = 0; i < CONFIG_DEV_GPIO_NSIGNALS; i++)
               {
                 FAR struct gpio_signal_s *signal = &dev->gp_signals[i];
@@ -409,7 +409,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
                   }
               }
 
-            spin_unlock_irqrestore(flags);
+            spin_unlock_irqrestore(NULL, flags);
 
             if (i == 0)
               {
@@ -444,7 +444,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         if (dev->gp_pintype >= GPIO_INTERRUPT_PIN)
           {
             pid = getpid();
-            flags = spin_lock_irqsave();
+            flags = spin_lock_irqsave(NULL);
             for (i = 0; i < CONFIG_DEV_GPIO_NSIGNALS; i++)
               {
                 if (pid == dev->gp_signals[i].gp_pid)
@@ -470,7 +470,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
                   }
                 }
 
-            spin_unlock_irqrestore(flags);
+            spin_unlock_irqrestore(NULL, flags);
 
             if (i == 0 && j == 0)
               {

--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -136,7 +136,7 @@ hciuart_rxattach(FAR const struct btuart_lowerhalf_s *lower,
 
   /* If the callback is NULL, then we are detaching */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   if (callback == NULL)
     {
       /* Disable Rx callbacks and detach the Rx callback */
@@ -153,7 +153,7 @@ hciuart_rxattach(FAR const struct btuart_lowerhalf_s *lower,
       state->callback = callback;
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -175,7 +175,7 @@ static void hciuart_rxenable(FAR const struct btuart_lowerhalf_s *lower,
   FAR struct hciuart_config_s *config = (FAR struct hciuart_config_s *)lower;
   FAR struct hciuart_state_s *s = &config->state;
 
-  irqstate_t flags = spin_lock_irqsave();
+  irqstate_t flags = spin_lock_irqsave(NULL);
   if (enable != s->enabled)
     {
       wlinfo(enable ? "Enable\n" : "Disable\n");
@@ -183,7 +183,7 @@ static void hciuart_rxenable(FAR const struct btuart_lowerhalf_s *lower,
 
   s->enabled = enable;
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************

--- a/include/nuttx/irq.h
+++ b/include/nuttx/irq.h
@@ -32,6 +32,7 @@
 # include <assert.h>
 # ifdef CONFIG_SMP
 #  include <stdbool.h>
+#  include <nuttx/spinlock.h>
 # endif
 #endif
 
@@ -274,30 +275,38 @@ void leave_critical_section(irqstate_t flags);
  *
  * Description:
  *   If SMP is are enabled:
- *     Disable local interrupts and take the global spinlock (g_irq_spin)
+ *     If the argument lock is not specified (i.e. NULL),
+ *     disable local interrupts and take the global spinlock (g_irq_spin)
  *     if the call counter (g_irq_spin_count[cpu]) equals to 0. Then the
- *     counter on the CPU is increment to allow nested call.
+ *     counter on the CPU is increment to allow nested call and return
+ *     the interrupt state.
+ *
+ *     If the argument lock is specified,
+ *     disable local interrupts and take the lock spinlock and return
+ *     the interrupt state.
  *
  *     NOTE: This API is very simple to protect data (e.g. H/W register
  *     or internal data structure) in SMP mode. But do not use this API
  *     with kernel APIs which suspend a caller thread. (e.g. nxsem_wait)
  *
  *   If SMP is not enabled:
- *     This function is equivalent to enter_critical_section().
+ *     This function is equivalent to up_irq_save().
  *
  * Input Parameters:
- *   None
+ *   lock - Caller specific spinlock. If specified NULL, g_irq_spin is used
+ *          and can be nested. Otherwise, nested call for the same lock
+ *          would cause a deadlock
  *
  * Returned Value:
  *   An opaque, architecture-specific value that represents the state of
- *   the interrupts prior to the call to spin_lock_irqsave();
+ *   the interrupts prior to the call to spin_lock_irqsave(lock);
  *
  ****************************************************************************/
 
 #if defined(CONFIG_SMP)
-irqstate_t spin_lock_irqsave(void);
+irqstate_t spin_lock_irqsave(spinlock_t *lock);
 #else
-#  define spin_lock_irqsave() enter_critical_section()
+#  define spin_lock_irqsave(l) up_irq_save()
 #endif
 
 /****************************************************************************
@@ -305,17 +314,24 @@ irqstate_t spin_lock_irqsave(void);
  *
  * Description:
  *   If SMP is enabled:
- *     Decrement the call counter (g_irq_spin_count[cpu]) and if it
+ *     If the argument lock is not specified (i.e. NULL),
+ *     decrement the call counter (g_irq_spin_count[cpu]) and if it
  *     decrements to zero then release the spinlock (g_irq_spin) and
  *     restore the interrupt state as it was prior to the previous call to
- *     spin_lock_irqsave().
+ *     spin_lock_irqsave(NULL).
+ *
+ *     If the argument lock is specified, release the the lock and
+ *     restore the interrupt state as it was prior to the previous call to
+ *     spin_lock_irqsave(lock).
  *
  *   If SMP is not enabled:
- *     This function is equivalent to leave_critical_section().
+ *     This function is equivalent to up_irq_restore().
  *
  * Input Parameters:
+ *   lock - Caller specific spinlock. If specified NULL, g_irq_spin is used.
+ *
  *   flags - The architecture-specific value that represents the state of
- *           the interrupts prior to the call to spin_lock_irqsave();
+ *           the interrupts prior to the call to spin_lock_irqsave(lock);
  *
  * Returned Value:
  *   None
@@ -323,9 +339,9 @@ irqstate_t spin_lock_irqsave(void);
  ****************************************************************************/
 
 #if defined(CONFIG_SMP)
-void spin_unlock_irqrestore(irqstate_t flags);
+void spin_unlock_irqrestore(spinlock_t *lock, irqstate_t flags);
 #else
-#  define spin_unlock_irqrestore(f) leave_critical_section(f)
+#  define spin_unlock_irqrestore(l, f) up_irq_restore(f)
 #endif
 
 #undef EXTERN

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -126,12 +126,12 @@ int clock_gettime(clockid_t clock_id, struct timespec *tp)
            * was last set, this gives us the current time.
            */
 
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
 
           ts.tv_sec  += (uint32_t)g_basetime.tv_sec;
           ts.tv_nsec += (uint32_t)g_basetime.tv_nsec;
 
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
 
           /* Handle carry to seconds. */
 

--- a/sched/group/group_exitinfo.c
+++ b/sched/group/group_exitinfo.c
@@ -82,14 +82,14 @@ int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo)
   irqstate_t flags;
 
   DEBUGASSERT(bininfo != NULL);
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Get the TCB associated with the PID */
 
   tcb = nxsched_get_tcb(pid);
   if (tcb == NULL)
     {
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
       return -ESRCH;
     }
 
@@ -102,7 +102,7 @@ int group_exitinfo(pid_t pid, FAR struct binary_s *bininfo)
 
   group->tg_bininfo = bininfo;
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 

--- a/sched/group/group_tlsalloc.c
+++ b/sched/group/group_tlsalloc.c
@@ -69,7 +69,7 @@ int tls_alloc(void)
    * avoid concurrent modification of the group TLS index set.
    */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   for (candidate = 0; candidate < CONFIG_TLS_NELEM; candidate++)
     {
       /* Is this candidate index available? */
@@ -84,7 +84,7 @@ int tls_alloc(void)
         }
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   /* Check if found a valid TLS data index. */
 

--- a/sched/group/group_tlsfree.c
+++ b/sched/group/group_tlsfree.c
@@ -73,11 +73,11 @@ int tls_free(int tlsindex)
        */
 
       mask  = (1 << tlsindex);
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
 
       DEBUGASSERT((group->tg_tlsset & mask) != 0);
       group->tg_tlsset &= ~mask;
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
 
       ret = OK;
     }

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -53,39 +53,55 @@ static volatile uint8_t g_irq_spin_count[CONFIG_SMP_NCPUS];
  *
  * Description:
  *   If SMP is enabled:
- *     Disable local interrupts and take the global spinlock (g_irq_spin)
+ *     If the argument lock is not specified (i.e. NULL),
+ *     disable local interrupts and take the global spinlock (g_irq_spin)
  *     if the call counter (g_irq_spin_count[cpu]) equals to 0. Then the
- *     counter on the CPU is increment to allow nested call.
+ *     counter on the CPU is increment to allow nested call and return
+ *     the interrupt state.
+ *
+ *     If the argument lock is specified,
+ *     disable local interrupts and take the lock spinlock and return
+ *     the interrupt state.
  *
  *     NOTE: This API is very simple to protect data (e.g. H/W register
  *     or internal data structure) in SMP mode. But do not use this API
  *     with kernel APIs which suspend a caller thread. (e.g. nxsem_wait)
  *
  *   If SMP is not enabled:
- *     This function is equivalent to enter_critical_section().
+ *     This function is equivalent to up_irq_save().
  *
  * Input Parameters:
- *   None
+ *   lock - Caller specific spinlock. If specified NULL, g_irq_spin is used
+ *          and can be nested. Otherwise, nested call for the same lock
+ *          would cause a deadlock
  *
  * Returned Value:
  *   An opaque, architecture-specific value that represents the state of
- *   the interrupts prior to the call to spin_lock_irqsave();
+ *   the interrupts prior to the call to spin_lock_irqsave(lock);
  *
  ****************************************************************************/
 
-irqstate_t spin_lock_irqsave(void)
+irqstate_t spin_lock_irqsave(spinlock_t *lock)
 {
   irqstate_t ret;
   ret = up_irq_save();
 
-  int me = this_cpu();
-  if (0 == g_irq_spin_count[me])
+  if (NULL == lock)
     {
-      spin_lock(&g_irq_spin);
+      int me = this_cpu();
+      if (0 == g_irq_spin_count[me])
+        {
+          spin_lock(&g_irq_spin);
+        }
+
+      g_irq_spin_count[me]++;
+      DEBUGASSERT(0 != g_irq_spin_count[me]);
+    }
+  else
+    {
+      spin_lock(lock);
     }
 
-  g_irq_spin_count[me]++;
-  DEBUGASSERT(0 != g_irq_spin_count[me]);
   return ret;
 }
 
@@ -94,33 +110,47 @@ irqstate_t spin_lock_irqsave(void)
  *
  * Description:
  *   If SMP is enabled:
- *     Decrement the call counter (g_irq_spin_count[cpu]) and if it
+ *     If the argument lock is not specified (i.e. NULL),
+ *     decrement the call counter (g_irq_spin_count[cpu]) and if it
  *     decrements to zero then release the spinlock (g_irq_spin) and
  *     restore the interrupt state as it was prior to the previous call to
- *     spin_lock_irqsave().
+ *     spin_lock_irqsave(NULL).
+ *
+ *     If the argument lock is specified, release the the lock and
+ *     restore the interrupt state as it was prior to the previous call to
+ *     spin_lock_irqsave(lock).
  *
  *   If SMP is not enabled:
- *     This function is equivalent to leave_critical_section().
+ *     This function is equivalent to up_irq_restore().
  *
  * Input Parameters:
+ *   lock - Caller specific spinlock. If specified NULL, g_irq_spin is used.
+ *
  *   flags - The architecture-specific value that represents the state of
- *           the interrupts prior to the call to spin_lock_irqsave();
+ *           the interrupts prior to the call to spin_lock_irqsave(lock);
  *
  * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-void spin_unlock_irqrestore(irqstate_t flags)
+void spin_unlock_irqrestore(spinlock_t *lock, irqstate_t flags)
 {
   int me = this_cpu();
 
-  DEBUGASSERT(0 < g_irq_spin_count[me]);
-  g_irq_spin_count[me]--;
-
-  if (0 == g_irq_spin_count[me])
+  if (NULL == lock)
     {
-      spin_unlock(&g_irq_spin);
+      DEBUGASSERT(0 < g_irq_spin_count[me]);
+      g_irq_spin_count[me]--;
+
+      if (0 == g_irq_spin_count[me])
+        {
+          spin_unlock(&g_irq_spin);
+        }
+    }
+  else
+    {
+      spin_unlock(lock);
     }
 
   up_irq_restore(flags);

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -534,9 +534,9 @@ _sa_handler_t nxsig_default(FAR struct tcb_s *tcb, int signo, bool defaction)
         {
           /* nxsig_addset() is not atomic (but neither is sigaction()) */
 
-          flags = spin_lock_irqsave();
+          flags = spin_lock_irqsave(NULL);
           nxsig_addset(&group->tg_sigdefault, signo);
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
         }
     }
 
@@ -546,9 +546,9 @@ _sa_handler_t nxsig_default(FAR struct tcb_s *tcb, int signo, bool defaction)
        * atomic (but neither is sigaction()).
        */
 
-      flags = spin_lock_irqsave();
+      flags = spin_lock_irqsave(NULL);
       nxsig_delset(&group->tg_sigdefault, signo);
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
 
   return handler;

--- a/wireless/bluetooth/bt_atomic.c
+++ b/wireless/bluetooth/bt_atomic.c
@@ -52,10 +52,10 @@ bt_atomic_t bt_atomic_incr(FAR bt_atomic_t *ptr)
   irqstate_t flags;
   bt_atomic_t value;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   value = *ptr;
   *ptr  = value + 1;
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return value;
 }
@@ -65,10 +65,10 @@ bt_atomic_t bt_atomic_decr(FAR bt_atomic_t *ptr)
   irqstate_t flags;
   bt_atomic_t value;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   value = *ptr;
   *ptr  = value - 1;
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return value;
 }
@@ -78,10 +78,10 @@ bt_atomic_t bt_atomic_setbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno)
   irqstate_t flags;
   bt_atomic_t value;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   value = *ptr;
   *ptr  = value | (1 << bitno);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return value;
 }
@@ -91,10 +91,10 @@ bt_atomic_t bt_atomic_clrbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno)
   irqstate_t flags;
   bt_atomic_t value;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   value = *ptr;
   *ptr  = value & ~(1 << bitno);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return value;
 }
@@ -104,10 +104,10 @@ bool bt_atomic_testsetbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno)
   irqstate_t flags;
   bt_atomic_t value;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   value = *ptr;
   *ptr  = value | (1 << bitno);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return (value & (1 << bitno)) != 0;
 }
@@ -117,10 +117,10 @@ bool bt_atomic_testclrbit(FAR bt_atomic_t *ptr, bt_atomic_t bitno)
   irqstate_t flags;
   bt_atomic_t value;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   value = *ptr;
   *ptr  = value & ~(1 << bitno);
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 
   return (value & (1 << bitno)) != 0;
 }

--- a/wireless/bluetooth/bt_buf.c
+++ b/wireless/bluetooth/bt_buf.c
@@ -243,7 +243,7 @@ FAR struct bt_buf_s *bt_buf_alloc(enum bt_buf_type_e type,
    * then try the list of messages reserved for interrupt handlers
    */
 
-  flags = spin_lock_irqsave(); /* Always necessary in SMP mode */
+  flags = spin_lock_irqsave(NULL); /* Always necessary in SMP mode */
   if (up_interrupt_context())
     {
 #if CONFIG_BLUETOOTH_BUFFER_PREALLOC > CONFIG_BLUETOOTH_BUFFER_IRQRESERVE
@@ -254,7 +254,7 @@ FAR struct bt_buf_s *bt_buf_alloc(enum bt_buf_type_e type,
           buf            = g_buf_free;
           g_buf_free     = buf->flink;
 
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           pool           = POOL_BUFFER_GENERAL;
         }
       else
@@ -267,13 +267,13 @@ FAR struct bt_buf_s *bt_buf_alloc(enum bt_buf_type_e type,
           buf            = g_buf_free_irq;
           g_buf_free_irq = buf->flink;
 
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           pool           = POOL_BUFFER_IRQ;
         }
       else
 #endif
         {
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           return NULL;
         }
     }
@@ -290,7 +290,7 @@ FAR struct bt_buf_s *bt_buf_alloc(enum bt_buf_type_e type,
           buf           = g_buf_free;
           g_buf_free    = buf->flink;
 
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           pool          = POOL_BUFFER_GENERAL;
         }
       else
@@ -300,7 +300,7 @@ FAR struct bt_buf_s *bt_buf_alloc(enum bt_buf_type_e type,
            * will have to allocate one from the kernel memory pool.
            */
 
-          spin_unlock_irqrestore(flags);
+          spin_unlock_irqrestore(NULL, flags);
           buf = (FAR struct bt_buf_s *)
                     kmm_malloc((sizeof (struct bt_buf_s)));
 
@@ -430,10 +430,10 @@ void bt_buf_release(FAR struct bt_buf_s *buf)
        * list from interrupt handlers.
        */
 
-      flags      = spin_lock_irqsave();
+      flags      = spin_lock_irqsave(NULL);
       buf->flink = g_buf_free;
       g_buf_free = buf;
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
   else
 #endif
@@ -449,10 +449,10 @@ void bt_buf_release(FAR struct bt_buf_s *buf)
        * list from interrupt handlers.
        */
 
-      flags          = spin_lock_irqsave();
+      flags          = spin_lock_irqsave(NULL);
       buf->flink     = g_buf_free_irq;
       g_buf_free_irq = buf;
-      spin_unlock_irqrestore(flags);
+      spin_unlock_irqrestore(NULL, flags);
     }
   else
 #endif

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -143,7 +143,7 @@ static void bt_enqueue_bufwork(FAR struct bt_bufferlist_s *list,
 {
   irqstate_t flags;
 
-  flags      = spin_lock_irqsave();
+  flags      = spin_lock_irqsave(NULL);
   buf->flink = list->head;
   if (list->head == NULL)
     {
@@ -151,7 +151,7 @@ static void bt_enqueue_bufwork(FAR struct bt_bufferlist_s *list,
     }
 
   list->head = buf;
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 
 /****************************************************************************
@@ -176,7 +176,7 @@ static FAR struct bt_buf_s *
   FAR struct bt_buf_s *buf;
   irqstate_t flags;
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
   buf   = list->tail;
   if (buf != NULL)
     {
@@ -205,7 +205,7 @@ static FAR struct bt_buf_s *
       buf->flink = NULL;
     }
 
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return buf;
 }
 

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -808,7 +808,7 @@ static int btnet_ifdown(FAR struct net_driver_s *netdev)
 
   /* Disable interruption */
 
-  flags = spin_lock_irqsave();
+  flags = spin_lock_irqsave(NULL);
 
   /* Cancel the TX poll timer and TX timeout timers */
 
@@ -822,7 +822,7 @@ static int btnet_ifdown(FAR struct net_driver_s *netdev)
   /* Mark the device "down" */
 
   priv->bd_bifup = false;
-  spin_unlock_irqrestore(flags);
+  spin_unlock_irqrestore(NULL, flags);
   return OK;
 }
 


### PR DESCRIPTION
## Summary

- This commit changes spinlock APIs (spin_lock_irqsave/spin_unlock_irqrestore)
- In the previous implementation, the global spinlock (i.e. g_irq_spin) was used.
- This commit allows to use caller specific spinlock but also supports to use
  g_irq_spin for backword compatibility (In this case, NULL must be specified)
- NOTE: see https://github.com/apache/incubator-nuttx/issues/2213

## Impact

- None

## Testing

- Tested with the following configurations
- spresnse:wifi, spresense:wifi_smp
- esp32-devkitc:smp (QEMU), sabre6-quad:smp (QEMU)
- maxi-bit:smp (QEMU), sim:smp
- stm32f4discovery:wifi
