### PR TITLE
Driver-specific spinlock for cxd56_serial.c

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -30,7 +30,11 @@
 #include <sys/types.h>
 #include <stdint.h>
 
-#ifdef CONFIG_SPINLOCK
+#ifndef CONFIG_SPINLOCK
+typedef struct
+{
+} spinlock_t;
+#else
 
 /* The architecture specific spinlock.h header file must also provide the
  * following:


### PR DESCRIPTION
## Summary

- This PR consists of the following 2 commits
- commit 1: include: nuttx: Introduce spinlock_t for #ifndef CONFIG_SPINLOCK
   - This commit introduces spinlock_t for #ifndef CONFIG_SPINLOCK
      which is useful for the non-SMP case because it does not consume
      memory
- commit 2: arch: cxd56xx: Introduce driver specific spinlock in cxd56_serial.c
  - This commit introduces driver-specific spinlock in cxd56_serial.c
      to improve performance
- NOTE: https://github.com/apache/incubator-nuttx/issues/2213

## Impact

- SMP only

## Testing

- Tested with spresense:wifi and spresense:wifi_smp