### PR TITLE
xtensa/esp32: Fix the issue of WiFi internal malloc from PSRAM

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -116,7 +116,7 @@ config XTENSA_INTBACKTRACE
 	---help---
 		Add necessary logic to be able to have a full backtrace from an interrupt context.
 
-config XTENSA_USE_SEPARATE_IMEM
+config XTENSA_IMEM_USE_SEPARATE_HEAP
 	bool "Use a separate heap for internal memory"
 	default n
 	help
@@ -128,9 +128,17 @@ config XTENSA_USE_SEPARATE_IMEM
 		This separate heap will be part of the internal DRAM.  It starts right after .data
 		and ends at the configurable size given by the OPTION XTENSA_IMEM_REGION_SIZE.
 
+config XTENSA_IMEM_MAXIMIZE_HEAP_REGION
+	bool "Use a maximum separate heap for internal memory"
+	default n
+	depends on XTENSA_IMEM_USE_SEPARATE_HEAP
+	help
+		This separate heap will be part of the internal DRAM.  It starts right after .data
+		and ends at the (HEAP_REGION1_END - HEAP_REGION_OFFSET).
+
 config XTENSA_IMEM_REGION_SIZE
 	hex "DRAM region size for internal use"
-	depends on XTENSA_USE_SEPARATE_IMEM
+	depends on XTENSA_IMEM_USE_SEPARATE_HEAP && !XTENSA_IMEM_MAXIMIZE_HEAP_REGION
 	default 0x18000
 
 source arch/xtensa/src/lx6/Kconfig

--- a/arch/xtensa/include/arch.h
+++ b/arch/xtensa/include/arch.h
@@ -91,7 +91,7 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
 struct mallinfo; /* Forward reference, see malloc.h */
 
 /****************************************************************************
@@ -112,7 +112,7 @@ void xtensa_imm_initialize(void);
  *
  ****************************************************************************/
 
-FAR void *xtensa_imm_malloc(size_t size);
+void *xtensa_imm_malloc(size_t size);
 
 /****************************************************************************
  * Name: xtensa_imm_calloc
@@ -123,7 +123,7 @@ FAR void *xtensa_imm_malloc(size_t size);
  *
  ****************************************************************************/
 
-FAR void *xtensa_imm_calloc(size_t n, size_t elem_size);
+void *xtensa_imm_calloc(size_t n, size_t elem_size);
 
 /****************************************************************************
  * Name: xtensa_imm_realloc
@@ -133,7 +133,7 @@ FAR void *xtensa_imm_calloc(size_t n, size_t elem_size);
  *
  ****************************************************************************/
 
-FAR void *xtensa_imm_realloc(void *ptr, size_t size);
+void *xtensa_imm_realloc(void *ptr, size_t size);
 
 /****************************************************************************
  * Name: xtensa_imm_zalloc
@@ -143,7 +143,7 @@ FAR void *xtensa_imm_realloc(void *ptr, size_t size);
  *
  ****************************************************************************/
 
-FAR void *xtensa_imm_zalloc(size_t size);
+void *xtensa_imm_zalloc(size_t size);
 
 /****************************************************************************
  * Name: xtensa_imm_free
@@ -153,7 +153,7 @@ FAR void *xtensa_imm_zalloc(size_t size);
  *
  ****************************************************************************/
 
-void      xtensa_imm_free(FAR void *mem);
+void xtensa_imm_free(FAR void *mem);
 
 /****************************************************************************
  * Name: xtensa_imm_memalign
@@ -163,12 +163,12 @@ void      xtensa_imm_free(FAR void *mem);
  *   within that chunk that meets the alignment request and then frees any
  *   leading or trailing space.
  *
- *   The alignment argument must be a power of two (not checked).  8-byte
+ *   The alignment argument must be a power of two (not checked). 8-byte
  *   alignment is guaranteed by normal malloc calls.
  *
  ****************************************************************************/
 
-FAR void *xtensa_imm_memalign(size_t alignment, size_t size);
+void *xtensa_imm_memalign(size_t alignment, size_t size);
 
 /****************************************************************************
  * Name: xtensa_imm_heapmember
@@ -180,11 +180,11 @@ FAR void *xtensa_imm_memalign(size_t alignment, size_t size);
  *   mem - The address to check
  *
  * Return Value:
- *   true if the address is a member of the internal heap.  false if not
+ *   true if the address is a member of the internal heap. false if not
  *
  ****************************************************************************/
 
-bool      xtensa_imm_heapmember(FAR void *mem);
+bool xtensa_imm_heapmember(FAR void *mem);
 
 /****************************************************************************
  * Name: xtensa_imm_mallinfo
@@ -195,7 +195,7 @@ bool      xtensa_imm_heapmember(FAR void *mem);
  *
  ****************************************************************************/
 
-int       xtensa_imm_mallinfo(FAR struct mallinfo *info);
+int xtensa_imm_mallinfo(FAR struct mallinfo *info);
 #endif
 
 #undef EXTERN

--- a/arch/xtensa/include/arch.h
+++ b/arch/xtensa/include/arch.h
@@ -94,11 +94,107 @@ extern "C"
 #ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
 struct mallinfo; /* Forward reference, see malloc.h */
 
-void      xtensa_imm_initialize(void);
+/****************************************************************************
+ * Name: xtensa_imm_initialize
+ *
+ * Description:
+ *   Initialize the internal heap.
+ *
+ ****************************************************************************/
+
+void xtensa_imm_initialize(void);
+
+/****************************************************************************
+ * Name: xtensa_imm_malloc
+ *
+ * Description:
+ *   Allocate memory from the internal heap.
+ *
+ ****************************************************************************/
+
 FAR void *xtensa_imm_malloc(size_t size);
+
+/****************************************************************************
+ * Name: xtensa_imm_calloc
+ *
+ * Description:
+ *   Calculates the size of the allocation and
+ *   allocate memory the internal heap.
+ *
+ ****************************************************************************/
+
+FAR void *xtensa_imm_calloc(size_t n, size_t elem_size);
+
+/****************************************************************************
+ * Name: xtensa_imm_realloc
+ *
+ * Description:
+ *   Reallocate memory from the internal heap.
+ *
+ ****************************************************************************/
+
+FAR void *xtensa_imm_realloc(void *ptr, size_t size);
+
+/****************************************************************************
+ * Name: xtensa_imm_zalloc
+ *
+ * Description:
+ *   Allocate and zero memory from the internal heap.
+ *
+ ****************************************************************************/
+
+FAR void *xtensa_imm_zalloc(size_t size);
+
+/****************************************************************************
+ * Name: xtensa_imm_free
+ *
+ * Description:
+ *   Free memory from the internal heap.
+ *
+ ****************************************************************************/
+
 void      xtensa_imm_free(FAR void *mem);
+
+/****************************************************************************
+ * Name: xtensa_imm_memalign
+ *
+ * Description:
+ *   memalign requests more than enough space from malloc, finds a region
+ *   within that chunk that meets the alignment request and then frees any
+ *   leading or trailing space.
+ *
+ *   The alignment argument must be a power of two (not checked).  8-byte
+ *   alignment is guaranteed by normal malloc calls.
+ *
+ ****************************************************************************/
+
 FAR void *xtensa_imm_memalign(size_t alignment, size_t size);
+
+/****************************************************************************
+ * Name: xtensa_imm_heapmember
+ *
+ * Description:
+ *   Check if an address lies in the internal heap.
+ *
+ * Parameters:
+ *   mem - The address to check
+ *
+ * Return Value:
+ *   true if the address is a member of the internal heap.  false if not
+ *
+ ****************************************************************************/
+
 bool      xtensa_imm_heapmember(FAR void *mem);
+
+/****************************************************************************
+ * Name: xtensa_imm_mallinfo
+ *
+ * Description:
+ *   mallinfo returns a copy of updated current heap information for the
+ *   user heap.
+ *
+ ****************************************************************************/
+
 int       xtensa_imm_mallinfo(FAR struct mallinfo *info);
 #endif
 

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -150,7 +150,7 @@ void up_initialize(void)
 
   /* Initialize the internal heap */
 
-#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
   xtensa_imm_initialize();
 #endif
 

--- a/arch/xtensa/src/common/xtensa_mm.h
+++ b/arch/xtensa/src/common/xtensa_mm.h
@@ -34,7 +34,7 @@
  * Pre-processor Macros
  ****************************************************************************/
 
-#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
 #  define UMM_MALLOC(s)      xtensa_imm_malloc(s)
 #  define UMM_MEMALIGN(a,s)  xtensa_imm_memalign(a,s)
 #  define UMM_FREE(p)        xtensa_imm_free(p)

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -285,6 +285,7 @@ config ESP32_SPIRAM
 	bool "SPI RAM Support"
 	default n
 	select ARCH_HAVE_HEAP2
+	select XTENSA_IMEM_USE_SEPARATE_HEAP
 
 if ESP32_SPIRAM && SMP
 

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -103,7 +103,7 @@ endif
 
 CHIP_CSRCS += esp32_rtc.c
 
-ifeq ($(CONFIG_XTENSA_USE_SEPARATE_IMEM),y)
+ifeq ($(CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP),y)
 CHIP_CSRCS += esp32_imm.c
 endif
 

--- a/arch/xtensa/src/esp32/esp32_imm.c
+++ b/arch/xtensa/src/esp32/esp32_imm.c
@@ -84,6 +84,46 @@ FAR void *xtensa_imm_malloc(size_t size)
 }
 
 /****************************************************************************
+ * Name: xtensa_imm_calloc
+ *
+ * Description:
+ *   Calculates the size of the allocation and
+ *   allocate memory the internal heap.
+ *
+ ****************************************************************************/
+
+FAR void *xtensa_imm_calloc(size_t n, size_t elem_size)
+{
+  return mm_calloc(&g_iheap, n, elem_size);
+}
+
+/****************************************************************************
+ * Name: xtensa_imm_realloc
+ *
+ * Description:
+ *   Reallocate memory from the internal heap.
+ *
+ ****************************************************************************/
+
+FAR void *xtensa_imm_realloc(void *ptr, size_t size)
+{
+  return mm_realloc(&g_iheap, ptr, size);
+}
+
+/****************************************************************************
+ * Name: xtensa_imm_zalloc
+ *
+ * Description:
+ *   Allocate and zero memory from the internal heap.
+ *
+ ****************************************************************************/
+
+FAR void *xtensa_imm_zalloc(size_t size)
+{
+  return mm_zalloc(&g_iheap, size);
+}
+
+/****************************************************************************
  * Name: xtensa_imm_free
  *
  * Description:

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -870,14 +870,14 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
   uint8_t *rp;
   uint32_t n;
   uint32_t regval;
-#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
   uint8_t *alloctp;
   uint8_t *allocrp;
 #endif
 
   /* If the buffer comes from PSRAM, allocate a new one from DRAM */
 
-#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
   if (esp32_ptr_extram(txbuffer))
     {
       alloctp = xtensa_imm_malloc(total);
@@ -891,7 +891,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       tp = (uint8_t *)txbuffer;
     }
 
-#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
   if (esp32_ptr_extram(rxbuffer))
     {
       allocrp = xtensa_imm_malloc(total);
@@ -963,7 +963,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       rp += n;
     }
 
-#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
   if (esp32_ptr_extram(rxbuffer))
     {
       memcpy(rxbuffer, allocrp, total);
@@ -971,7 +971,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
     }
 #endif
 
-#ifdef CONFIG_XTENSA_USE_SEPARATE_IMEM
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
   if (esp32_ptr_extram(txbuffer))
     {
       xtensa_imm_free(alloctp);


### PR DESCRIPTION
## Summary

`SPIRAM` is not DMA-capable, while WiFi `internal malloc` from heap must be DMA-capable, We must avoid `internal malloc` from the heap of `PSRAM`

## Impact

If WiFi `internal malloc` from `PSRAM`, it will cause the system block.

## Testing

ESP32
