### PR TITLE
board: nucleo-l432kc: Add missing i2c_master_s definition

### DIFF
--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_appinit.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_appinit.c
@@ -123,8 +123,11 @@ int board_app_initialize(uintptr_t arg)
 #ifdef HAVE_RTC_DRIVER
   FAR struct rtc_lowerhalf_s *rtclower;
 #endif
-#ifdef HAVE_I2C_DRIVER
-  FAR struct i2c_master_s *i2c;
+#ifdef CONFIG_STM32L4_I2C1
+  FAR struct i2c_master_s *i2c1;
+#endif
+#ifdef CONFIG_STM32L4_I2C3
+  FAR struct i2c_master_s *i2c3;
 #endif
 #ifdef CONFIG_SENSORS_QENCODER
   int index;


### PR DESCRIPTION
## Summary
On previous pull-request #2837, I mistake to omit a few of code changes. So I add missing changes. This missing cause build error.
 
## Impact
Just added missing definition of two i2c_master_s structure on stm32_appinit.c

## Testing
Build and Real board test was success and double checked my mistake.