### PR TITLE
graphics: nxmu: Fix hard fault in nxmu_server.c

### DIFF
--- a/graphics/nxmu/nxmu_server.c
+++ b/graphics/nxmu/nxmu_server.c
@@ -86,10 +86,10 @@ static inline void nxmu_connect(FAR struct nxmu_conn_s *conn)
    * client
    */
 
-  ret = nxmq_open(mqname, O_WRONLY, 0, NULL, &conn->swrmq);
-  if (ret < 0)
+  conn->swrmq = nxmq_open(mqname, O_WRONLY);
+  if (conn->swrmq < 0)
     {
-      gerr("ERROR: nxmq_open(%s) failed: %d\n", mqname, ret);
+      gerr("ERROR: nxmq_open(%s) failed: %d\n", mqname, conn->swrmq);
       outmsg.msgid = NX_CLIMSG_DISCONNECTED;
     }
 
@@ -190,12 +190,11 @@ static inline int nxmu_setup(FAR const char *mqname, FAR NX_DRIVERTYPE *dev,
   attr.mq_msgsize = NX_MXSVRMSGLEN;
   attr.mq_flags   = 0;
 
-  ret = nxmq_open(mqname, O_RDONLY | O_CREAT,
-                  0666, &attr, &nxmu->conn.crdmq);
-  if (ret < 0)
+  nxmu->conn.crdmq = nxmq_open(mqname, O_RDONLY | O_CREAT, 0666, &attr);
+  if (nxmu->conn.crdmq < 0)
     {
-      gerr("ERROR: nxmq_open(%s) failed: %d\n", mqname, ret);
-      return ret;
+      gerr("ERROR: nxmq_open(%s) failed: %d\n", mqname, nxmu->conn.crdmq);
+      return nxmu->conn.crdmq;
     }
 
   /* NOTE that the outgoing client MQ (cwrmq) is not initialized.  The
@@ -207,12 +206,12 @@ static inline int nxmu_setup(FAR const char *mqname, FAR NX_DRIVERTYPE *dev,
    * the server message loop.
    */
 
-  ret = nxmq_open(mqname, O_WRONLY, 0, NULL, &nxmu->conn.swrmq);
-  if (ret < 0)
+  nxmu->conn.swrmq = nxmq_open(mqname, O_WRONLY);
+  if (nxmu->conn.swrmq < 0)
     {
-      gerr("ERROR: nxmq_open(%s) failed: %d\n", mqname, ret);
-      nxmq_close(nxmu->conn.crdmq);
-      return ret;
+      gerr("ERROR: nxmq_open(%s) failed: %d\n", mqname, nxmu->conn.swrmq);
+      mq_close(nxmu->conn.crdmq);
+      return nxmu->conn.swrmq;
     }
 
   /* The server is now "connected" to itself via the background window */


### PR DESCRIPTION
## Summary

- Recently I noticed that the nxhello caused hard fault
- Finally, I found that mq_open() had been changed to nxmq_open()
  but the calling convention was not correct.
- This commit fixes this issue.

## Impact

- nxmu_server.c only

## Testing

- Tested with nxhello, nxlines & nxdemo with the following configs
- spresense:wifi, spresense:wifi_smp
