### PR TITLE
drivers: audio: Introduce a driver-specific spinlock to cxd56.c

### DIFF
--- a/drivers/audio/cxd56.h
+++ b/drivers/audio/cxd56.h
@@ -32,6 +32,7 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 #include <nuttx/fs/ioctl.h>
+#include <nuttx/spinlock.h>
 
 #ifdef CONFIG_AUDIO
 
@@ -298,6 +299,7 @@ struct cxd56_dev_s
 #endif
   bool                    reserved;         /* True: Device is reserved */
   volatile int            result;           /* The result of the last transfer */
+  spinlock_t              lock;             /* Spinlock for SMP */
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- This commit introduces a driver-specific spinlock to cxd56.c
  to improve performance in SMP mode.

## Impact

- cxd56.c in SMP mode only

## Testing

- Tested with nxplayer and nxrecorder with the following configs
- spresense:wifi, spresense:wifi_smp
