### PR TITLE
arch: esp32: Fix a memory leak when discarding a large packet.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -483,28 +483,26 @@ static int wlan_rx_done(void *buffer, uint16_t len, void *eb)
   struct wlan_rxbuf *rxbuf;
   irqstate_t flags;
   FAR struct wlan_priv_s *priv = &g_wlan_priv;
+  int ret = 0;
 
   if (!priv->ifup)
     {
-      return 0;
+      goto out;
     }
 
   if (len > WLAN_BUF_SIZE)
     {
       nwarn("ERROR: Wlan receive %d larger than %d\n",
              len, WLAN_BUF_SIZE);
-      return -EINVAL;
+      ret = -EINVAL;
+      goto out;
     }
 
   rxbuf = wlan_alloc_buffer(priv);
   if (!rxbuf)
     {
-      if (eb)
-        {
-          esp_wifi_free_eb(eb);
-        }
-
-      return -ENOBUFS;
+      ret = -ENOBUFS;
+      goto out;
     }
 
   memcpy(rxbuf->buffer, buffer, len);
@@ -525,6 +523,14 @@ static int wlan_rx_done(void *buffer, uint16_t len, void *eb)
     }
 
   return 0;
+
+out:
+  if (eb)
+    {
+      esp_wifi_free_eb(eb);
+    }
+
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- Recently I noticed that ESP32-DevKitC-32D suddenly stops
  during receiving ping packets from PC after 10-20mins
- Actually, sometimes memory leak happened when some device
  sent a big broadcast packet periodically on the network
- This commit fixes this issue by calling esp_wifi_free_eb()
   in the case that the packet exceeds WLAN_BUF_SIZE.
- Also, this commit applies the same logic in the case that
   the Wi-Fi interface is down

## Impact

- None

## Testing

- Tested with esp32-devkitc:wapi

