### PR TITLE
eZ80: fix a variety of build errors

### DIFF
--- a/arch/z80/include/ez80/irq.h
+++ b/arch/z80/include/ez80/irq.h
@@ -218,23 +218,23 @@
 /* Byte offsets */
 
 #  define XCPT_I_OFFSET  (3*XCPT_I)      /* Offset 0: Saved 24-bit interrupt vector register */
-#    define XCPT_IF_OFFSET (2*XCPT_I+1)  /* Offset 1: Saved flags. P set if interrupts enabled */
-#    define XCPT_IA_OFFSET (2*XCPT_I+2)  /* Offset 2: Saved lower 8-bits of interrupt vector register */
+#    define XCPT_IF_OFFSET (3*XCPT_I+0)  /* Offset 0: Saved flags. P set if interrupts enabled */
+#    define XCPT_IA_OFFSET (3*XCPT_I+1)  /* Offset 1: Saved lower 8-bits of interrupt vector register */
 #  define XCPT_BC_OFFSET   (3*XCPT_BC)   /* Offset 3: Saved 24-bit BC register */
-#    define XCPT_C_OFFSET  (3*XCPT_BC+1) /* Offset 4: Saved 8-bit C register */
-#    define XCPT_B_OFFSET  (3*XCPT_BC+2) /* Offset 5: Saved 8-bit D register */
+#    define XCPT_C_OFFSET  (3*XCPT_BC+0) /* Offset 3: Saved 8-bit C register */
+#    define XCPT_B_OFFSET  (3*XCPT_BC+1) /* Offset 4: Saved 8-bit B register */
 #  define XCPT_DE_OFFSET   (3*XCPT_DE)   /* Offset 6: Saved 24-bit DE register */
-#    define XCPT_E_OFFSET  (3*XCPT_DE+1) /* Offset 7: Saved 8-bit E register */
-#    define XCPT_D_OFFSET  (3*XCPT_DE+2) /* Offset 8: Saved 8-bit D register */
+#    define XCPT_E_OFFSET  (3*XCPT_DE+0) /* Offset 6: Saved 8-bit E register */
+#    define XCPT_D_OFFSET  (3*XCPT_DE+1) /* Offset 7: Saved 8-bit D register */
 #  define XCPT_IX_OFFSET   (3*XCPT_IX)   /* Offset 9: Saved 24-bit IX register */
 #  define XCPT_IY_OFFSET   (3*XCPT_IY)   /* Offset 12: Saved 24-bit IY register */
 #  define XCPT_SP_OFFSET   (3*XCPT_SP)   /* Offset 15: Saved 24-bit SP at time of interrupt */
 #  define XCPT_HL_OFFSET   (3*XCPT_HL)   /* Offset 18: Saved 24-bit HL register */
-#    define XCPT_L_OFFSET  (3*XCPT_HL+1) /* Offset 19: Saved 8-bit L register */
-#    define XCPT_H_OFFSET  (3*XCPT_HL+2) /* Offset 20: Saved 8-bit H register */
+#    define XCPT_L_OFFSET  (3*XCPT_HL+0) /* Offset 18: Saved 8-bit L register */
+#    define XCPT_H_OFFSET  (3*XCPT_HL+1) /* Offset 19: Saved 8-bit H register */
 #  define XCPT_AF_OFFSET   (3*XCPT_AF)   /* Offset 21: Saved AF register */
-#    define XCPT_F_OFFSET  (3*XCPT_AF+1) /* Offset 22: Saved AF register */
-#    define XCPT_A_OFFSET  (3*XCPT_AF+2) /* Offset 23: Saved 8-bit A register */
+#    define XCPT_F_OFFSET  (3*XCPT_AF+0) /* Offset 21: Saved AF register */
+#    define XCPT_A_OFFSET  (3*XCPT_AF+1) /* Offset 22: Saved 8-bit A register */
 #  define XCPT_PC_OFFSET   (3*XCPT_PC)   /* Offset 24: Offset to 24-bit PC at time of interrupt */
 #  define XCPTCONTEXT_SIZE (3*XCPTCONTEXT_REGS)
 #endif

--- a/arch/z80/include/inttypes.h
+++ b/arch/z80/include/inttypes.h
@@ -40,7 +40,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <arch/chip/types.h>
+#include <arch/chip/inttypes.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/z80/src/common/z80_doirq.c
+++ b/arch/z80/src/common/z80_doirq.c
@@ -47,6 +47,8 @@ FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
 {
   board_autoled_on(LED_INIRQ);
 
+  DECL_SAVESTATE();
+
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
 
   IRQ_ENTER(regs);
@@ -61,8 +63,6 @@ FAR chipreg_t *z80_doirq(uint8_t irq, FAR chipreg_t *regs)
 
   if (irq < NR_IRQS)
     {
-      DECL_SAVESTATE();
-
       /* Indicate that we have entered IRQ processing logic */
 
       IRQ_ENTER(irq, regs);

--- a/arch/z80/src/common/z80_stackframe.c
+++ b/arch/z80/src/common/z80_stackframe.c
@@ -105,7 +105,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Reset the initial stack pointer */
 
-  tcb->xcp.regs[REG_RSP] = (chipreg_t)tcb->adj_stack_ptr;
+  tcb->xcp.regs[XCPT_SP] = (chipreg_t)tcb->adj_stack_ptr;
 
   /* And return a pointer to the allocated memory */
 

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -89,8 +89,8 @@
  * into that region.
  */
 
-extern uintptr_t __RAM_ADDR_U_INIT_PARAM;
-#define ETH_RAMADDR ((uintptr_t)&__RAM_ADDR_U_INIT_PARAM << 16) + 0x00c000
+extern uintptr_t _RAM_ADDR_U_INIT_PARAM;
+#define ETH_RAMADDR ((uintptr_t)&_RAM_ADDR_U_INIT_PARAM << 16) + 0x00c000
 
 #if CONFIG_NET_ETH_PKTSIZE > 1518
 #  error "MAXF size too big for this device"
@@ -930,7 +930,7 @@ static int ez80emac_miiconfigure(FAR struct ez80emac_driver_s *priv)
   ninfo("  MII_ADVERTISE: %04x\n", ez80emac_miiread(priv, MII_ADVERTISE));
   ninfo("  MII_LPA:       %04x\n", ez80emac_miiread(priv, MII_LPA));
   ninfo("  MII_EXPANSION: %04x\n", ez80emac_miiread(priv, MII_EXPANSION));
-  ninfo("EMAC CFG1:         %02x\n", inp(EZ80_EMAC_CFG11));
+  ninfo("EMAC CFG1:         %02x\n", inp(EZ80_EMAC_CFG1));
   return OK;
 }
 #endif

--- a/arch/z80/src/ez80/switch.h
+++ b/arch/z80/src/ez80/switch.h
@@ -139,10 +139,6 @@ int ez80_saveusercontext(FAR chipreg_t *regs);
 
 void ez80_restorecontext(FAR chipreg_t *regs);
 
-/* Defined in ez80_sigsetup.c */
-
-void ez80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver, chipreg_t *regs);
-
 /* Defined in ez80_registerdump.c */
 
 void ez80_registerdump(void);


### PR DESCRIPTION
## Summary

A small number of issues prevent successful builds of arch z80, chip eZ80. Most are compile-time problems, typos and the like, though the change to `irq.h` is required to correctly initialise a new task's register area - without this change the init task starts with interrupts disabled.

## Impact

The eZ80 sub-arch can build (with Clang) and run at least as far as the application entry point being invoked.

## Testing

Built with the ZDS-II toolchain under WIne to check modifications didn't conflict with ZDS builds - some further changes are required to build under ZDS-II as files outside the z80 arch subtree are not all C89 compliant.

Built with Clang (modified build system not included in this patch) and executed successfully on a custom eZ80 board.