### PR TITLE
fs: change geometry sizes from `size_t` to `uint32_t`

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_emmc.c
+++ b/arch/arm/src/cxd56xx/cxd56_emmc.c
@@ -103,12 +103,13 @@ struct cxd56_emmc_state_s
 static int       cxd56_emmc_open(FAR struct inode *inode);
 static int       cxd56_emmc_close(FAR struct inode *inode);
 static ssize_t   cxd56_emmc_read(FAR struct inode *inode,
-                                 unsigned char *buffer, size_t start_sector,
+                                 unsigned char *buffer,
+                                 blkcnt_t start_sector,
                                  unsigned int nsectors);
 #if !defined(CONFIG_MMCSD_READONLY)
 static ssize_t   cxd56_emmc_write(FAR struct inode *inode,
                                   const unsigned char *buffer,
-                                  size_t start_sector,
+                                  blkcnt_t start_sector,
                                   unsigned int nsectors);
 #endif
 static int       cxd56_emmc_geometry(FAR struct inode *inode,
@@ -348,7 +349,7 @@ static int emmc_checkresponse(void)
 
   if (resp & R1STATUS_ALL_ERR)
     {
-      ferr("Response error %08x\n", resp);
+      ferr("Response error %08" PRIx32 "\n", resp);
       return -EIO;
     }
 
@@ -734,7 +735,7 @@ static int cxd56_emmc_readsectors(FAR struct cxd56_emmc_state_s *priv,
   if (idsts &
       (EMMC_IDSTS_FBE | EMMC_IDSTS_DU | EMMC_IDSTS_CES | EMMC_IDSTS_AIS))
     {
-      ferr("DMA status failed. %08x\n", idsts);
+      ferr("DMA status failed. %08" PRIx32 "\n", idsts);
       ret = -EIO;
     }
 
@@ -747,7 +748,7 @@ finish:
 
 #if !defined(CONFIG_MMCSD_READONLY)
 static int cxd56_emmc_writesectors(FAR struct cxd56_emmc_state_s *priv,
-                                   const void *buf, size_t start_sector,
+                                   const void *buf, blkcnt_t start_sector,
                                    unsigned int nsectors)
 {
   struct emmc_dma_desc_s *descs;
@@ -797,7 +798,7 @@ static int cxd56_emmc_writesectors(FAR struct cxd56_emmc_state_s *priv,
   if (idsts &
       (EMMC_IDSTS_FBE | EMMC_IDSTS_DU | EMMC_IDSTS_CES | EMMC_IDSTS_AIS))
     {
-      ferr("DMA status error. %08x\n", idsts);
+      ferr("DMA status error. %08" PRIx32 "\n", idsts);
       ret = -EIO;
     }
 
@@ -866,7 +867,7 @@ static int cxd56_emmc_close(FAR struct inode *inode)
 }
 
 static ssize_t cxd56_emmc_read(FAR struct inode *inode,
-                               unsigned char *buffer, size_t start_sector,
+                               unsigned char *buffer, blkcnt_t start_sector,
                                unsigned int nsectors)
 {
   FAR struct cxd56_emmc_state_s *priv;
@@ -875,7 +876,7 @@ static ssize_t cxd56_emmc_read(FAR struct inode *inode,
   DEBUGASSERT(inode && inode->i_private);
   priv = (FAR struct cxd56_emmc_state_s *)inode->i_private;
 
-  finfo("Read sector %d (%d sectors) to %p\n",
+  finfo("Read sector %" PRIu32 " (%u sectors) to %p\n",
         start_sector, nsectors, buffer);
 
   ret = cxd56_emmc_readsectors(priv, buffer, start_sector, nsectors);
@@ -891,7 +892,7 @@ static ssize_t cxd56_emmc_read(FAR struct inode *inode,
 #if !defined(CONFIG_MMCSD_READONLY)
 static ssize_t cxd56_emmc_write(FAR struct inode *inode,
                                 const unsigned char *buffer,
-                                size_t start_sector,
+                                blkcnt_t start_sector,
                                 unsigned int nsectors)
 {
   FAR struct cxd56_emmc_state_s *priv;
@@ -900,7 +901,7 @@ static ssize_t cxd56_emmc_write(FAR struct inode *inode,
   DEBUGASSERT(inode && inode->i_private);
   priv = (FAR struct cxd56_emmc_state_s *)inode->i_private;
 
-  finfo("Write %p to sector %d (%d sectors)\n", buffer,
+  finfo("Write %p to sector %" PRIu32 " (%u sectors)\n", buffer,
         start_sector, nsectors);
 
   ret = cxd56_emmc_writesectors(priv, buffer, start_sector, nsectors);

--- a/arch/arm/src/lc823450/lc823450_mmcl.c
+++ b/arch/arm/src/lc823450/lc823450_mmcl.c
@@ -61,9 +61,9 @@ struct mmcl_dev_s
 static int     mmcl_open(FAR struct inode *inode);
 static int     mmcl_close(FAR struct inode *inode);
 static ssize_t mmcl_read(FAR struct inode *inode, unsigned char *buffer,
-                         size_t start_sector, unsigned int nsectors);
+                         blkcnt_t start_sector, unsigned int nsectors);
 static ssize_t mmcl_write(FAR struct inode *inode,
-                          const unsigned char *buffer, size_t start_sector,
+                          const unsigned char *buffer, blkcnt_t start_sector,
                           unsigned int nsectors);
 static int     mmcl_geometry(FAR struct inode *inode,
                              struct geometry *geometry);
@@ -122,12 +122,12 @@ static int mmcl_close(FAR struct inode *inode)
  ****************************************************************************/
 
 static ssize_t mmcl_read(FAR struct inode *inode, unsigned char *buffer,
-  size_t start_sector, unsigned int nsectors)
+  blkcnt_t start_sector, unsigned int nsectors)
 {
   ssize_t nread;
   struct mmcl_dev_s *dev;
 
-  finfo("sector: %d nsectors: %d\n", start_sector, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u\n", start_sector, nsectors);
 
   DEBUGASSERT(inode && inode->i_private);
   dev = (struct mmcl_dev_s *)inode->i_private;
@@ -135,7 +135,7 @@ static ssize_t mmcl_read(FAR struct inode *inode, unsigned char *buffer,
   nread = MTD_BREAD(dev->mtd, start_sector, nsectors, buffer);
   if (nread != nsectors)
     {
-      finfo("Read %d blocks starting at block %d failed: %d\n",
+      finfo("Read %u blocks starting at block %" PRIu32 " failed: %d\n",
             nsectors, start_sector, nread);
       return -EIO;
     }
@@ -151,13 +151,13 @@ static ssize_t mmcl_read(FAR struct inode *inode, unsigned char *buffer,
  ****************************************************************************/
 
 static ssize_t mmcl_write(FAR struct inode *inode,
-                          const unsigned char *buffer, size_t start_sector,
+                          const unsigned char *buffer, blkcnt_t start_sector,
                           unsigned int nsectors)
 {
   ssize_t nwrite;
   struct mmcl_dev_s *dev;
 
-  finfo("sector: %d nsectors: %d\n", start_sector, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u\n", start_sector, nsectors);
 
   DEBUGASSERT(inode && inode->i_private);
   dev = (struct mmcl_dev_s *)inode->i_private;
@@ -165,7 +165,7 @@ static ssize_t mmcl_write(FAR struct inode *inode,
   nwrite = MTD_BWRITE(dev->mtd, start_sector, nsectors, buffer);
   if (nwrite != nsectors)
     {
-      finfo("Write %d blocks starting at block %d failed: %d\n",
+      finfo("Write %u blocks starting at block %" PRIu32 " failed: %d\n",
             nsectors, start_sector, nwrite);
       return -EIO;
     }
@@ -199,7 +199,7 @@ static int mmcl_geometry(FAR struct inode *inode, struct geometry *geometry)
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
 
-      finfo("nsectors: %d sectorsize: %d\n",
+      finfo("nsectors: %" PRIu32 " sectorsize: %" PRIi16 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
@@ -85,9 +85,9 @@ static int     eeed_close(FAR struct inode *inode);
 #endif
 
 static ssize_t eeed_read(FAR struct inode *inode, FAR unsigned char *buffer,
-                 size_t start_sector, unsigned int nsectors);
+                 blkcnt_t start_sector, unsigned int nsectors);
 static ssize_t eeed_write(FAR struct inode *inode,
-                 FAR const unsigned char *buffer, size_t start_sector,
+                 FAR const unsigned char *buffer, blkcnt_t start_sector,
                  unsigned int nsectors);
 
 static int     eeed_geometry(FAR struct inode *inode,
@@ -215,15 +215,15 @@ static int eeed_close(FAR struct inode *inode)
  ******************************************************************************/
 
 static ssize_t eeed_read(FAR struct inode *inode, unsigned char *buffer,
-                       size_t start_sector, unsigned int nsectors)
+                       blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct eeed_struct_s *dev;
 
   DEBUGASSERT(inode && inode->i_private);
   dev = (FAR struct eeed_struct_s *)inode->i_private;
 
-  finfo("sector: %d nsectors: %d sectorsize: %d\n",
-        start_sector, dev->eeed_sectsize, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u sectorsize: %d\n",
+        start_sector, nsectors, dev->eeed_sectsize);
 
   if (start_sector < dev->eeed_nsectors &&
       start_sector + nsectors <= dev->eeed_nsectors)
@@ -251,15 +251,15 @@ static ssize_t eeed_read(FAR struct inode *inode, unsigned char *buffer,
  ******************************************************************************/
 
 static ssize_t eeed_write(FAR struct inode *inode, const unsigned char *buffer,
-                        size_t start_sector, unsigned int nsectors)
+                        blkcnt_t start_sector, unsigned int nsectors)
 {
   struct eeed_struct_s *dev;
 
   DEBUGASSERT(inode && inode->i_private);
   dev = (struct eeed_struct_s *)inode->i_private;
 
-  finfo("sector: %d nsectors: %d sectorsize: %d\n",
-        start_sector, dev->eeed_sectsize, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u sectorsize: %d\n",
+        start_sector, nsectors, dev->eeed_sectsize);
 
   if (start_sector < dev->eeed_nsectors &&
            start_sector + nsectors <= dev->eeed_nsectors)
@@ -312,7 +312,7 @@ static int eeed_geometry(FAR struct inode *inode, struct geometry *geometry)
 
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
-      finfo("nsectors: %d sectorsize: %d\n",
+      finfo("nsectors: %" PRIu32 " sectorsize: %" PRIu16 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/drivers/loop/losetup.c
+++ b/drivers/loop/losetup.c
@@ -75,10 +75,10 @@ static int     loop_semtake(FAR struct loop_struct_s *dev);
 static int     loop_open(FAR struct inode *inode);
 static int     loop_close(FAR struct inode *inode);
 static ssize_t loop_read(FAR struct inode *inode, FAR unsigned char *buffer,
-                       size_t start_sector, unsigned int nsectors);
+                       blkcnt_t start_sector, unsigned int nsectors);
 static ssize_t loop_write(FAR struct inode *inode,
                           FAR const unsigned char *buffer,
-                          size_t start_sector, unsigned int nsectors);
+                          blkcnt_t start_sector, unsigned int nsectors);
 static int     loop_geometry(FAR struct inode *inode,
                              FAR struct geometry *geometry);
 
@@ -194,7 +194,7 @@ static int loop_close(FAR struct inode *inode)
  ****************************************************************************/
 
 static ssize_t loop_read(FAR struct inode *inode, FAR unsigned char *buffer,
-                         size_t start_sector, unsigned int nsectors)
+                         blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct loop_struct_s *dev;
   ssize_t nbytesread;
@@ -248,7 +248,7 @@ static ssize_t loop_read(FAR struct inode *inode, FAR unsigned char *buffer,
 
 static ssize_t loop_write(FAR struct inode *inode,
                           FAR const unsigned char *buffer,
-                          size_t start_sector, unsigned int nsectors)
+                          blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct loop_struct_s *dev;
   ssize_t nbyteswritten;

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -212,9 +212,9 @@ static ssize_t mmcsd_flush(FAR void *dev, FAR const uint8_t *buffer,
 static int     mmcsd_open(FAR struct inode *inode);
 static int     mmcsd_close(FAR struct inode *inode);
 static ssize_t mmcsd_read(FAR struct inode *inode, FAR unsigned char *buffer,
-                 size_t startsector, unsigned int nsectors);
+                 blkcnt_t startsector, unsigned int nsectors);
 static ssize_t mmcsd_write(FAR struct inode *inode,
-                 FAR const unsigned char *buffer, size_t startsector,
+                 FAR const unsigned char *buffer, blkcnt_t startsector,
                  unsigned int nsectors);
 static int     mmcsd_geometry(FAR struct inode *inode,
                  FAR struct geometry *geometry);
@@ -2224,7 +2224,7 @@ static int mmcsd_close(FAR struct inode *inode)
  ****************************************************************************/
 
 static ssize_t mmcsd_read(FAR struct inode *inode, unsigned char *buffer,
-                          size_t startsector, unsigned int nsectors)
+                          blkcnt_t startsector, unsigned int nsectors)
 {
   FAR struct mmcsd_state_s *priv;
 #if !defined(CONFIG_DRVR_READAHEAD) && defined(CONFIG_MMCSD_MULTIBLOCK_DISABLE)
@@ -2235,7 +2235,7 @@ static ssize_t mmcsd_read(FAR struct inode *inode, unsigned char *buffer,
 
   DEBUGASSERT(inode && inode->i_private);
   priv = (FAR struct mmcsd_state_s *)inode->i_private;
-  finfo("startsector: %d nsectors: %d sectorsize: %d\n",
+  finfo("startsector: %" PRIu32 " nsectors: %u sectorsize: %d\n",
         startsector, nsectors, priv->blocksize);
 
   if (nsectors > 0)
@@ -2304,7 +2304,7 @@ static ssize_t mmcsd_read(FAR struct inode *inode, unsigned char *buffer,
 
 static ssize_t mmcsd_write(FAR struct inode *inode,
                            FAR const unsigned char *buffer,
-                           size_t startsector, unsigned int nsectors)
+                           blkcnt_t startsector, unsigned int nsectors)
 {
   FAR struct mmcsd_state_s *priv;
 #if defined(CONFIG_MMCSD_MULTIBLOCK_DISABLE)
@@ -2420,7 +2420,7 @@ static int mmcsd_geometry(FAR struct inode *inode, struct geometry *geometry)
           finfo("available: true mediachanged: %s writeenabled: %s\n",
                  geometry->geo_mediachanged ? "true" : "false",
                  geometry->geo_writeenabled ? "true" : "false");
-          finfo("nsectors: %lu sectorsize: %d\n",
+          finfo("nsectors: %lu sectorsize: %" PRIi16 "\n",
                  (unsigned long)geometry->geo_nsectors,
                  geometry->geo_sectorsize);
 

--- a/drivers/mmcsd/mmcsd_spi.c
+++ b/drivers/mmcsd/mmcsd_spi.c
@@ -181,10 +181,10 @@ static int      mmcsd_xmitblock(FAR struct mmcsd_slot_s *slot,
 static int       mmcsd_open(FAR struct inode *inode);
 static int       mmcsd_close(FAR struct inode *inode);
 static ssize_t   mmcsd_read(FAR struct inode *inode, unsigned char *buffer,
-                   size_t start_sector, unsigned int nsectors);
+                   blkcnt_t start_sector, unsigned int nsectors);
 #if !defined(CONFIG_MMCSD_READONLY)
 static ssize_t   mmcsd_write(FAR struct inode *inode,
-                   const unsigned char *buffer, size_t start_sector,
+                   const unsigned char *buffer, blkcnt_t start_sector,
                    unsigned int nsectors);
 #endif
 static int       mmcsd_geometry(FAR struct inode *inode,
@@ -1156,7 +1156,7 @@ static int mmcsd_close(FAR struct inode *inode)
  ****************************************************************************/
 
 static ssize_t mmcsd_read(FAR struct inode *inode, unsigned char *buffer,
-                          size_t start_sector, unsigned int nsectors)
+                          blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct mmcsd_slot_s *slot;
   FAR struct spi_dev_s *spi;
@@ -1166,7 +1166,7 @@ static ssize_t mmcsd_read(FAR struct inode *inode, unsigned char *buffer,
   int    i;
   int ret;
 
-  finfo("start_sector=%d nsectors=%d\n", start_sector, nsectors);
+  finfo("start_sector=%" PRIu32 " nsectors=%u\n", start_sector, nsectors);
 
 #ifdef CONFIG_DEBUG_FEATURES
   if (!buffer)
@@ -1317,7 +1317,7 @@ errout_with_eio:
 #if !defined(CONFIG_MMCSD_READONLY)
 static ssize_t mmcsd_write(FAR struct inode *inode,
                            FAR const unsigned char *buffer,
-                           size_t start_sector, unsigned int nsectors)
+                           blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct mmcsd_slot_s *slot;
   FAR struct spi_dev_s *spi;
@@ -1327,7 +1327,7 @@ static ssize_t mmcsd_write(FAR struct inode *inode,
   int i;
   int ret;
 
-  finfo("start_sector=%d nsectors=%d\n", start_sector, nsectors);
+  finfo("start_sector=%" PRIu32 " nsectors=%u\n", start_sector, nsectors);
 
 #ifdef CONFIG_DEBUG_FEATURES
   if (!buffer)
@@ -1593,8 +1593,8 @@ static int mmcsd_geometry(FAR struct inode *inode, struct geometry *geometry)
   finfo("geo_available:     %d\n", geometry->geo_available);
   finfo("geo_mediachanged:  %d\n", geometry->geo_mediachanged);
   finfo("geo_writeenabled:  %d\n", geometry->geo_writeenabled);
-  finfo("geo_nsectors:      %d\n", geometry->geo_nsectors);
-  finfo("geo_sectorsize:    %d\n", geometry->geo_sectorsize);
+  finfo("geo_nsectors:      %" PRIu32 "\n", geometry->geo_nsectors);
+  finfo("geo_sectorsize:    %" PRIi16 "\n", geometry->geo_sectorsize);
 
   return OK;
 }

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -84,11 +84,11 @@ static int     ftl_close(FAR struct inode *inode);
 static ssize_t ftl_reload(FAR void *priv, FAR uint8_t *buffer,
                  off_t startblock, size_t nblocks);
 static ssize_t ftl_read(FAR struct inode *inode, FAR unsigned char *buffer,
-                 size_t start_sector, unsigned int nsectors);
+                 blkcnt_t start_sector, unsigned int nsectors);
 static ssize_t ftl_flush(FAR void *priv, FAR const uint8_t *buffer,
                  off_t startblock, size_t nblocks);
 static ssize_t ftl_write(FAR struct inode *inode,
-                 FAR const unsigned char *buffer, size_t start_sector,
+                 FAR const unsigned char *buffer, blkcnt_t start_sector,
                  unsigned int nsectors);
 static int     ftl_geometry(FAR struct inode *inode,
                  FAR struct geometry *geometry);
@@ -204,11 +204,11 @@ static ssize_t ftl_reload(FAR void *priv, FAR uint8_t *buffer,
  ****************************************************************************/
 
 static ssize_t ftl_read(FAR struct inode *inode, unsigned char *buffer,
-                        size_t start_sector, unsigned int nsectors)
+                        blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct ftl_struct_s *dev;
 
-  finfo("sector: %zu nsectors: %d\n", start_sector, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u\n", start_sector, nsectors);
 
   DEBUGASSERT(inode && inode->i_private);
 
@@ -438,11 +438,11 @@ static ssize_t ftl_flush(FAR void *priv, FAR const uint8_t *buffer,
 
 static ssize_t ftl_write(FAR struct inode *inode,
                          FAR const unsigned char *buffer,
-                         size_t start_sector, unsigned int nsectors)
+                         blkcnt_t start_sector, unsigned int nsectors)
 {
   struct ftl_struct_s *dev;
 
-  finfo("sector: %zu nsectors: %d\n", start_sector, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u\n", start_sector, nsectors);
 
   DEBUGASSERT(inode && inode->i_private);
   dev = (struct ftl_struct_s *)inode->i_private;
@@ -479,7 +479,7 @@ static int ftl_geometry(FAR struct inode *inode,
 
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
-      finfo("nsectors: %zu sectorsize: %zu\n",
+      finfo("nsectors: %" PRIu32 " sectorsize: %u\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -410,9 +410,9 @@ static int     smart_close(FAR struct inode *inode);
 static ssize_t smart_reload(struct smart_struct_s *dev, FAR uint8_t *buffer,
                  off_t startblock, size_t nblocks);
 static ssize_t smart_read(FAR struct inode *inode, unsigned char *buffer,
-                 size_t start_sector, unsigned int nsectors);
+                 blkcnt_t start_sector, unsigned int nsectors);
 static ssize_t smart_write(FAR struct inode *inode,
-                 FAR const unsigned char *buffer, size_t start_sector,
+                 FAR const unsigned char *buffer, blkcnt_t start_sector,
                  unsigned int nsectors);
 static int     smart_geometry(FAR struct inode *inode,
                  FAR struct geometry *geometry);
@@ -891,11 +891,11 @@ static ssize_t smart_reload(struct smart_struct_s *dev, FAR uint8_t *buffer,
  ****************************************************************************/
 
 static ssize_t smart_read(FAR struct inode *inode, unsigned char *buffer,
-                          size_t start_sector, unsigned int nsectors)
+                          blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct smart_struct_s *dev;
 
-  finfo("SMART: sector: %d nsectors: %d\n", start_sector, nsectors);
+  finfo("SMART: sector: %" PRIu32 " nsectors: %u\n", start_sector, nsectors);
 
   DEBUGASSERT(inode && inode->i_private);
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
@@ -915,7 +915,7 @@ static ssize_t smart_read(FAR struct inode *inode, unsigned char *buffer,
 
 static ssize_t smart_write(FAR struct inode *inode,
                 FAR const unsigned char *buffer,
-                size_t start_sector, unsigned int nsectors)
+                blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct smart_struct_s *dev;
   off_t  alignedblock;
@@ -931,7 +931,7 @@ static ssize_t smart_write(FAR struct inode *inode,
   off_t  mtdstartblock;
   off_t  mtdblockcount;
 
-  finfo("sector: %d nsectors: %d\n", start_sector, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u\n", start_sector, nsectors);
 
   DEBUGASSERT(inode && inode->i_private);
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
@@ -1062,7 +1062,7 @@ static int smart_geometry(FAR struct inode *inode, struct geometry *geometry)
 
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
-      finfo("nsectors: %d sectorsize: %d\n",
+      finfo("nsectors: %" PRIu32 " sectorsize: %" PRIi16 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/drivers/ramdisk.c
+++ b/drivers/ramdisk.c
@@ -84,9 +84,9 @@ static int     rd_close(FAR struct inode *inode);
 #endif
 
 static ssize_t rd_read(FAR struct inode *inode, FAR unsigned char *buffer,
-                 size_t start_sector, unsigned int nsectors);
+                 blkcnt_t start_sector, unsigned int nsectors);
 static ssize_t rd_write(FAR struct inode *inode,
-                 FAR const unsigned char *buffer, size_t start_sector,
+                 FAR const unsigned char *buffer, blkcnt_t start_sector,
                  unsigned int nsectors);
 static int     rd_geometry(FAR struct inode *inode,
                  FAR struct geometry *geometry);
@@ -225,15 +225,15 @@ static int rd_close(FAR struct inode *inode)
  ****************************************************************************/
 
 static ssize_t rd_read(FAR struct inode *inode, unsigned char *buffer,
-                       size_t start_sector, unsigned int nsectors)
+                       blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct rd_struct_s *dev;
 
   DEBUGASSERT(inode && inode->i_private);
   dev = (FAR struct rd_struct_s *)inode->i_private;
 
-  finfo("sector: %zd nsectors: %d sectorsize: %d\n",
-        start_sector, dev->rd_sectsize, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u sectorsize: %d\n",
+        start_sector, nsectors, dev->rd_sectsize);
 
   if (start_sector < dev->rd_nsectors &&
       start_sector + nsectors <= dev->rd_nsectors)
@@ -259,15 +259,15 @@ static ssize_t rd_read(FAR struct inode *inode, unsigned char *buffer,
  ****************************************************************************/
 
 static ssize_t rd_write(FAR struct inode *inode, const unsigned char *buffer,
-                        size_t start_sector, unsigned int nsectors)
+                        blkcnt_t start_sector, unsigned int nsectors)
 {
   struct rd_struct_s *dev;
 
   DEBUGASSERT(inode && inode->i_private);
   dev = (struct rd_struct_s *)inode->i_private;
 
-  finfo("sector: %zd nsectors: %d sectorsize: %d\n",
-        start_sector, dev->rd_sectsize, nsectors);
+  finfo("sector: %" PRIu32 " nsectors: %u sectorsize: %d\n",
+        start_sector, nsectors, dev->rd_sectsize);
 
   if (!RDFLAG_IS_WRENABLED(dev->rd_flags))
     {
@@ -314,7 +314,7 @@ static int rd_geometry(FAR struct inode *inode, struct geometry *geometry)
 
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
-      finfo("nsectors: %zd sectorsize: %zd\n",
+      finfo("nsectors: %" PRIu32 " sectorsize: %" PRIi16 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/drivers/usbhost/usbhost_storage.c
+++ b/drivers/usbhost/usbhost_storage.c
@@ -170,10 +170,10 @@ static inline void usbhost_requestsensecbw(FAR struct usbmsc_cbw_s *cbw);
 static inline void usbhost_testunitreadycbw(FAR struct usbmsc_cbw_s *cbw);
 static inline void usbhost_readcapacitycbw(FAR struct usbmsc_cbw_s *cbw);
 static inline void usbhost_inquirycbw (FAR struct usbmsc_cbw_s *cbw);
-static inline void usbhost_readcbw (size_t startsector, uint16_t blocksize,
+static inline void usbhost_readcbw (blkcnt_t startsector, uint16_t blocksize,
                                     unsigned int nsectors,
                                     FAR struct usbmsc_cbw_s *cbw);
-static inline void usbhost_writecbw(size_t startsector, uint16_t blocksize,
+static inline void usbhost_writecbw(blkcnt_t startsector, uint16_t blocksize,
                                     unsigned int nsectors,
                                     FAR struct usbmsc_cbw_s *cbw);
 
@@ -231,11 +231,11 @@ static int usbhost_disconnected(FAR struct usbhost_class_s *usbclass);
 static int usbhost_open(FAR struct inode *inode);
 static int usbhost_close(FAR struct inode *inode);
 static ssize_t usbhost_read(FAR struct inode *inode,
-                            FAR unsigned char *buffer, size_t startsector,
+                            FAR unsigned char *buffer, blkcnt_t startsector,
                             unsigned int nsectors);
 static ssize_t usbhost_write(FAR struct inode *inode,
                              FAR const unsigned char *buffer,
-                             size_t startsector, unsigned int nsectors);
+                             blkcnt_t startsector, unsigned int nsectors);
 static int usbhost_geometry(FAR struct inode *inode,
                             FAR struct geometry *geometry);
 static int usbhost_ioctl(FAR struct inode *inode, int cmd,
@@ -629,7 +629,7 @@ static inline void usbhost_inquirycbw (FAR struct usbmsc_cbw_s *cbw)
 }
 
 static inline void
-usbhost_readcbw (size_t startsector, uint16_t blocksize,
+usbhost_readcbw (blkcnt_t startsector, uint16_t blocksize,
                  unsigned int nsectors, FAR struct usbmsc_cbw_s *cbw)
 {
   FAR struct scsicmd_read10_s *rd10;
@@ -651,7 +651,7 @@ usbhost_readcbw (size_t startsector, uint16_t blocksize,
 }
 
 static inline void
-usbhost_writecbw(size_t startsector, uint16_t blocksize,
+usbhost_writecbw(blkcnt_t startsector, uint16_t blocksize,
                  unsigned int nsectors, FAR struct usbmsc_cbw_s *cbw)
 {
   FAR struct scsicmd_write10_s *wr10;
@@ -2024,7 +2024,7 @@ static int usbhost_close(FAR struct inode *inode)
  ****************************************************************************/
 
 static ssize_t usbhost_read(FAR struct inode *inode, unsigned char *buffer,
-                            size_t startsector, unsigned int nsectors)
+                            blkcnt_t startsector, unsigned int nsectors)
 {
   FAR struct usbhost_state_s *priv;
   FAR struct usbhost_hubport_s *hport;
@@ -2037,7 +2037,7 @@ static ssize_t usbhost_read(FAR struct inode *inode, unsigned char *buffer,
   DEBUGASSERT(priv->usbclass.hport);
   hport = priv->usbclass.hport;
 
-  uinfo("startsector: %d nsectors: %d sectorsize: %d\n",
+  uinfo("startsector: %" PRIu32 " nsectors: %u sectorsize: %" PRIu16 "\n",
         startsector, nsectors, priv->blocksize);
 
   /* Check if the mass storage device is still connected */
@@ -2137,14 +2137,14 @@ static ssize_t usbhost_read(FAR struct inode *inode, unsigned char *buffer,
 
 static ssize_t usbhost_write(FAR struct inode *inode,
                              FAR const unsigned char *buffer,
-                             size_t startsector, unsigned int nsectors)
+                             blkcnt_t startsector, unsigned int nsectors)
 {
   FAR struct usbhost_state_s *priv;
   FAR struct usbhost_hubport_s *hport;
   ssize_t nbytes;
   int ret;
 
-  uinfo("sector: %zu nsectors: %u\n", startsector, nsectors);
+  uinfo("sector: %" PRIu32 " nsectors: %u\n", startsector, nsectors);
 
   DEBUGASSERT(inode && inode->i_private);
   priv = (FAR struct usbhost_state_s *)inode->i_private;
@@ -2271,7 +2271,7 @@ static int usbhost_geometry(FAR struct inode *inode,
           geometry->geo_sectorsize    = priv->blocksize;
           usbhost_givesem(&priv->exclsem);
 
-          uinfo("nsectors: %ld sectorsize: %d\n",
+          uinfo("nsectors: %ld sectorsize: %" PRIi16 "n",
                  (long)geometry->geo_nsectors, geometry->geo_sectorsize);
         }
     }

--- a/fs/driver/fs_blockpartition.c
+++ b/fs/driver/fs_blockpartition.c
@@ -54,9 +54,9 @@ struct part_struct_s
 static int     part_open(FAR struct inode *inode);
 static int     part_close(FAR struct inode *inode);
 static ssize_t part_read(FAR struct inode *inode, FAR unsigned char *buffer,
-                 size_t start_sector, unsigned int nsectors);
+                 blkcnt_t start_sector, unsigned int nsectors);
 static ssize_t part_write(FAR struct inode *inode,
-                 FAR const unsigned char *buffer, size_t start_sector,
+                 FAR const unsigned char *buffer, blkcnt_t start_sector,
                  unsigned int nsectors);
 static int     part_geometry(FAR struct inode *inode,
                  FAR struct geometry *geometry);
@@ -139,7 +139,7 @@ static int part_close(FAR struct inode *inode)
  ****************************************************************************/
 
 static ssize_t part_read(FAR struct inode *inode, unsigned char *buffer,
-                         size_t start_sector, unsigned int nsectors)
+                         blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct part_struct_s *dev = inode->i_private;
   FAR struct inode *parent = dev->parent;
@@ -163,7 +163,7 @@ static ssize_t part_read(FAR struct inode *inode, unsigned char *buffer,
 
 static ssize_t part_write(FAR struct inode *inode,
                           FAR const unsigned char *buffer,
-                          size_t start_sector, unsigned int nsectors)
+                          blkcnt_t start_sector, unsigned int nsectors)
 {
   FAR struct part_struct_s *dev = inode->i_private;
   FAR struct inode *parent = dev->parent;

--- a/fs/partition/partition.h
+++ b/fs/partition/partition.h
@@ -39,8 +39,8 @@ struct partition_state_s
 {
   FAR struct mtd_dev_s *mtd;
   FAR struct inode *blk;
-  size_t nblocks;
-  size_t blocksize;
+  blkcnt_t nblocks;
+  blksize_t blocksize;
   size_t erasesize;
 };
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -206,11 +206,11 @@ struct file_operations
 #ifndef CONFIG_DISABLE_MOUNTPOINT
 struct geometry
 {
-  bool   geo_available;    /* true: The device is available */
-  bool   geo_mediachanged; /* true: The media has changed since last query */
-  bool   geo_writeenabled; /* true: It is okay to write to this device */
-  size_t geo_nsectors;     /* Number of sectors on the device */
-  size_t geo_sectorsize;   /* Size of one sector */
+  bool      geo_available;    /* true: The device is available */
+  bool      geo_mediachanged; /* true: The media has changed since last query */
+  bool      geo_writeenabled; /* true: It is okay to write to this device */
+  blkcnt_t  geo_nsectors;     /* Number of sectors on the device */
+  blksize_t geo_sectorsize;   /* Size of one sector */
 };
 
 /* This structure is provided by block devices when they register with the
@@ -225,9 +225,9 @@ struct block_operations
   int     (*open)(FAR struct inode *inode);
   int     (*close)(FAR struct inode *inode);
   ssize_t (*read)(FAR struct inode *inode, FAR unsigned char *buffer,
-            size_t start_sector, unsigned int nsectors);
+            blkcnt_t start_sector, unsigned int nsectors);
   ssize_t (*write)(FAR struct inode *inode, FAR const unsigned char *buffer,
-            size_t start_sector, unsigned int nsectors);
+            blkcnt_t start_sector, unsigned int nsectors);
   int     (*geometry)(FAR struct inode *inode, FAR struct geometry
                       *geometry);
   int     (*ioctl)(FAR struct inode *inode, int cmd, unsigned long arg);


### PR DESCRIPTION
## Summary

This change reflects that the geometry isn't related to the largest allocatable unit on the platform but is related to geometries of SD cards (32 bit) and FAT32 file systems (also 32 bit).

## Impact

On platforms where `size_t` is not 32 bits this allows larger SD cards to be mounted as FAT32 file systems. On the eZ80, for example, `size_t` is 24 bits. The most significant bits get discarded when transferring from the SD card's sector count to the geometry, and don't match the sector count in the FAT32 header.

## Testing

A 16GB SD card can be mounted on an eZ80 device after this change.

Compilation checks with:
  - stm32f769i-disco:netnsh, CONFIG_DEV_LOOP=y, CONFIG_MTD=y, CONFIG_EEPROM=y, CONFIG_USBHOST=y, CONFIG_USBHOST_MSC=y, CONFIG_FS_SMARTFS=y, CONFIG_MTD_SMART=y, CONFIG_FS_LITTLEFS=y
  - spresense:nsh, CONFIG_CXD56_EMMC=y
  - s32k144evb:nsh, CONFIG_S32K1XX_EEEPROM=y
  - lc823450-xgevk:usb