### PR TITLE
stdint.h: Use conversion macros for the definition of MIN and MAX constants

### DIFF
--- a/arch/arm/src/nrf52/nrf52_wdt_lowerhalf.c
+++ b/arch/arm/src/nrf52/nrf52_wdt_lowerhalf.c
@@ -347,7 +347,7 @@ static int nrf52_settimeout(FAR struct watchdog_lowerhalf_s *lower,
 
   if (timeout < 1 || timeout > WDT_MAXTIMEOUT)
     {
-      wderr("ERROR: Cannot represent timeout=%" PRId32 " > %d\n",
+      wderr("ERROR: Cannot represent timeout=%" PRId32 " > %" PRId32 "\n",
             timeout, WDT_MAXTIMEOUT);
       return -ERANGE;
     }

--- a/arch/z80/include/ez80/inttypes.h
+++ b/arch/z80/include/ez80/inttypes.h
@@ -114,10 +114,12 @@
 
 #  define INT8_C(x)   x
 #  define INT16_C(x)  x
+#  define INT24_C(x)  x
 #  define INT32_C(x)  x ## l
 
 #  define UINT8_C(x)  x
 #  define UINT16_C(x) x
+#  define UINT24_C(x) x
 #  define UINT32_C(x) x ## ul
 
 #else
@@ -190,10 +192,12 @@
 
 #  define INT8_C(x)   x
 #  define INT16_C(x)  x
+#  define INT24_C(x)  x
 #  define INT32_C(x)  x ## l
 
 #  define UINT8_C(x)  x
 #  define UINT16_C(x) x
+#  define UINT24_C(x) x
 #  define UINT32_C(x) x ## ul
 #endif
 

--- a/arch/z80/include/z180/inttypes.h
+++ b/arch/z80/include/z180/inttypes.h
@@ -112,10 +112,12 @@
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
+#define INT24_C(x)  x
 #define INT32_C(x)  x ## l
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
+#define UINT24_C(x) x
 #define UINT32_C(x) x ## ul
 
 #endif /* __ARCH_Z80_INCLUDE_Z180_INTTYPES_H */

--- a/arch/z80/include/z8/inttypes.h
+++ b/arch/z80/include/z8/inttypes.h
@@ -112,10 +112,12 @@
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
+#define INT24_C(x)  x
 #define INT32_C(x)  x ## l
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
+#define UINT24_C(x) x
 #define UINT32_C(x) x ## ul
 
 #endif /* __ARCH_Z80_INCLUDE_Z8_INTTYPES_H */

--- a/arch/z80/include/z80/inttypes.h
+++ b/arch/z80/include/z80/inttypes.h
@@ -112,10 +112,12 @@
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
+#define INT24_C(x)  x
 #define INT32_C(x)  x ## l
 
 #define UINT8_C(x)  x
 #define UINT16_C(x) x
+#define UINT24_C(x) x
 #define UINT32_C(x) x ## ul
 
 #endif /* __ARCH_Z80_INCLUDE_Z80_INTTYPES_H */

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -42,27 +42,27 @@
 /* Limits of exact-width integer types */
 
 #define INT8_MIN            (-INT8_MAX - 1)
-#define INT8_MAX            127
-#define UINT8_MAX           255
+#define INT8_MAX            INT8_C(127)
+#define UINT8_MAX           UINT8_C(255)
 
 #define INT16_MIN           (-INT16_MAX - 1)
-#define INT16_MAX           32767
-#define UINT16_MAX          65535u
+#define INT16_MAX           INT16_C(32767)
+#define UINT16_MAX          UINT16_C(65535)
 
 #ifdef __INT24_DEFINED
 #  define INT24_MIN         (-INT24_MAX - 1)
-#  define INT24_MAX         8388607
-#  define UINT24_MAX        16777215u
+#  define INT24_MAX         INT24_C(8388607)
+#  define UINT24_MAX        UINT24_C(16777215)
 #endif
 
 #define INT32_MIN           (-INT32_MAX - 1)
-#define INT32_MAX           2147483647
-#define UINT32_MAX          4294967295u
+#define INT32_MAX           INT32_C(2147483647)
+#define UINT32_MAX          UINT32_C(4294967295)
 
 #ifdef __INT64_DEFINED
-#  define INT64_MIN         (-INT64_MAX - 1ll)
-#  define INT64_MAX         9223372036854775807ll
-#  define UINT64_MAX        18446744073709551615ull
+#  define INT64_MIN         (-INT64_MAX - 1)
+#  define INT64_MAX         INT64_C(9223372036854775807)
+#  define UINT64_MAX        UINT64_C(18446744073709551615)
 #endif
 
 /* Limits of minimum-width integer types */


### PR DESCRIPTION
## Summary
Currently `stdint.h` defines the MIN and MAX macros with a suffix that may not be adequate for some CPU architectures.
E.g.: `UINT32_MAX` is `4294967295u`, but for RISC-V it should be defined as `4294967295ul`, so it also becomes consistent with the `PRIu32` definition for RISC-V (`lu`).
The motivation of this PR originated from the compilers warnings when using INT32_MAX constant with printf.

## Impact
EZ80 architecture defines `__INT24_DEFINED`, so it becomes necessary to define `INT24_C` and `UINT24_C`, which are not standardized but seems to be commonly defined in some compilers (e.g. LLVM).

For the other architectures, there should be no impact.

## Testing
Successful build and no more printf format warnings when using MIN and MAX macros.
