### PR TITLE
lpc17xx_40xx/lpc17_40_i2c.c: Propagate I2C I/O errors

### DIFF
--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
@@ -242,7 +242,9 @@ static int lpc17_40_i2c_start(struct lpc17_40_i2cdev_s *priv)
            lpc17_40_i2c_timeout, (wdparm_t)priv);
   nxsem_wait(&priv->wait);
 
-  return priv->nmsg;
+  /* Remaining messages should be zero or an error occurred */
+
+  return priv->nmsg ? -ENXIO : OK;
 }
 
 /****************************************************************************


### PR DESCRIPTION
Check if all messages were transferred, if not, return -ENXIO.

This is particularly useful when the slave returns an unexpected NAK,
the application code should catch the error to avoid failing silently.