### PR TITLE
Fix pthread cmdline issue

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -689,7 +689,7 @@ static ssize_t proc_cmdline(FAR struct proc_file_s *procfile,
     {
       FAR struct pthread_tcb_s *ptcb = (FAR struct pthread_tcb_s *)tcb;
 
-      linesize   = snprintf(procfile->line, STATUS_LINELEN, " 0x%p\n",
+      linesize   = snprintf(procfile->line, STATUS_LINELEN, " %p\n",
                             ptcb->arg);
       copysize   = procfs_memcpy(procfile->line, linesize, buffer,
                                  remaining, &offset);

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -26,6 +26,7 @@
 
 #include <sys/types.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
 #include <pthread.h>
 #include <sched.h>
@@ -58,16 +59,6 @@
 const pthread_attr_t g_default_pthread_attr = PTHREAD_ATTR_INITIALIZER;
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-#if CONFIG_TASK_NAME_SIZE > 0
-/* This is the name for name-less pthreads */
-
-static const char g_pthreadname[] = "<pthread>";
-#endif
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -98,8 +89,8 @@ static inline void pthread_argsetup(FAR struct pthread_tcb_s *tcb,
 #if CONFIG_TASK_NAME_SIZE > 0
   /* Copy the pthread name into the TCB */
 
-  strncpy(tcb->cmn.name, g_pthreadname, CONFIG_TASK_NAME_SIZE);
-  tcb->cmn.name[CONFIG_TASK_NAME_SIZE] = '\0';
+  snprintf(tcb->cmn.name, CONFIG_TASK_NAME_SIZE,
+           "pt-%p", tcb->cmn.entry.pthread);
 #endif /* CONFIG_TASK_NAME_SIZE */
 
   /* For pthreads, args are strictly pass-by-value; that actual


### PR DESCRIPTION
## Summary
- fs/procfs: Avoid the duplicated 0x prefix in pthread cmdline
- pthread: Change the default name from <pthread> to <0xyyyyyyyy>
Before change:
```
   63    20 100 RR       pthread --- Waiting  Signal    00000000 006148 000744  12.1%    0.0% <pthread> 0x0x341de68c
```
After change:
```
   63    20 100 RR       pthread --- Waiting  Signal    00000000 006148 000744  12.1%    0.0% <0x34187c00> 0x341de68c
```
Note, you can still change pthread name through pthread_setname_np, this patch just modify the default behaviour.

## Impact
The content from: /proc/xxx/cmdline

## Testing

