### PR TITLE
libc: Move stack check stuff from libc/stdlib/ to libc/assert/

### DIFF
--- a/libs/libc/assert/Make.defs
+++ b/libs/libc/assert/Make.defs
@@ -20,6 +20,10 @@
 
 CSRCS += lib_assert.c
 
+ifeq ($(CONFIG_STACK_CANARIES),y)
+CSRCS += lib_stackchk.c
+endif
+
 # Add the assert directory to the build
 
 DEPPATH += --dep-path assert

--- a/libs/libc/assert/lib_stackchk.c
+++ b/libs/libc/assert/lib_stackchk.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/stdlib/lib_stackchk.c
+ * libs/libc/assert/lib_stackchk.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -36,10 +36,6 @@ ifeq ($(CONFIG_PSEUDOTERM_SUSV1),y)
 CSRCS += lib_ptsname.c lib_ptsnamer.c
 endif
 
-ifeq ($(CONFIG_STACK_CANARIES),y)
-CSRCS += lib_stackchk.c
-endif
-
 ifeq ($(CONFIG_PSEUDOTERM),y)
 CSRCS += lib_unlockpt.c
 endif


### PR DESCRIPTION
## Summary
since the new location is more reasonable

## Impact
no runtime change

## Testing
pass the build
