### PR TITLE
This commit implements I2C support for ESP32 (wrover kit).

### DIFF
--- a/boards/xtensa/esp32/common/include/esp32_board_i2c.h
+++ b/boards/xtensa/esp32/common/include/esp32_board_i2c.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/include/esp32_board_i2c.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_I2C_H
+#define __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_I2C_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_I2C_DRIVER
+
+/****************************************************************************
+ * Name: esp32_i2c_register
+ *
+ * Description:
+ *   registar an ESP32 I2C interface.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   to indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+int esp32_i2c_register(int bus);
+
+#endif /* CONFIG_I2C_DRIVER */
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_I2C_H */

--- a/boards/xtensa/esp32/common/src/Make.defs
+++ b/boards/xtensa/esp32/common/src/Make.defs
@@ -26,7 +26,10 @@ ifeq ($(CONFIG_WATCHDOG),y)
   CSRCS += esp32_board_wdt.c
 endif
 
+ifeq ($(CONFIG_I2C_DRIVER),y)
+  CSRCS += esp32_board_i2c.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)
-

--- a/boards/xtensa/esp32/common/src/esp32_board_i2c.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_i2c.c
@@ -1,0 +1,76 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_board_i2c.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <sys/types.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#include "esp32_board_i2c.h"
+#include "esp32_i2c.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32_i2c_register
+ *
+ * Description:
+ *   registar an ESP32 I2C interface.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   to indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+int esp32_i2c_register(int bus)
+{
+  FAR struct i2c_master_s *i2c;
+  int ret;
+
+  i2c = esp32_i2cbus_initialize(bus);
+
+  if (i2c == NULL)
+    {
+     syslog(LOG_ERR, "ERROR: Failed to get I2C%d interface\n", bus);
+    }
+  else
+    {
+      ret = i2c_register(i2c, bus);
+      if (ret < 0)
+        {
+          syslog(LOG_ERR, "ERROR: Failed to register I2C%d driver: %d\n",
+                 bus, ret);
+          esp32_i2cbus_uninitialize(i2c);
+        }
+
+      return ret;
+    }
+
+  return -1;
+}
+

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -56,6 +56,10 @@
 #  include "esp32_board_wdt.h"
 #endif
 
+#ifdef CONFIG_ESP32_I2C
+#  include "esp32_board_i2c.h"
+#endif
+
 #include "esp32-wrover-kit.h"
 
 /****************************************************************************
@@ -231,6 +235,30 @@ int esp32_bringup(void)
       syslog(LOG_ERR, "Failed to initialize GPIO Driver: %d\n", ret);
       return ret;
     }
+#endif
+
+#ifdef CONFIG_I2C_DRIVER
+
+#ifdef CONFIG_ESP32_I2C0
+  ret = esp32_i2c_register(0);
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize I2C Driver for I2C0: %d\n", ret);
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_ESP32_I2C1
+  ret = esp32_i2c_register(1);
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize I2C Driver for I2C1: %d\n", ret);
+      return ret;
+    }
+#endif
+
 #endif
 
   /* If we got here then perhaps not all initialization was successful, but


### PR DESCRIPTION
This change fixes I2C (0 and 1) usage with Nuttx + ESP32

## Summary

I2C register function for I2Cs in ESP32 was missing. Therefore, it wasn't possible to enable I2C (0 and/or 1)
before this fix.
To sum up, this fix implements a I2C register function in ESP32 bring-up routines (esp32_bringup.c) and call if for I2C0 and/or
I2C1 during ESP32 bringup (these function callings are conditionedby CONFIG_ESP32_I2C (to check if I2C support has been configured),CONFIG_ESP32_I2C0 (to check if I2C0 support has been configured) and CONFIG_ESP32_I2C1 (to check if I2C1 support has been configured).

## Impact
This chage has no impact on another modules except from I2C modules.

## Testing
Once this fix is implemented, /dev/i2c0 and/or /dev/i2c1 interfaces become available and work fine.
In the figure below, it shows /dev/i2c0 and/or /dev/i2c1 available and a successful scan in i2c (in this case, I've wired a BMP180 sensor to i2c0, which uses I2C address 0x77.
![i2c_test_esp32_nuttx](https://user-images.githubusercontent.com/16869652/108617135-3eea0e00-73ea-11eb-9503-25a75f271fd3.jpeg)



