### PR TITLE
pic32mz: Chip does not have ANSEL register on port K

### DIFF
--- a/arch/mips/src/pic32mz/pic32mz_lowinit.c
+++ b/arch/mips/src/pic32mz/pic32mz_lowinit.c
@@ -395,10 +395,6 @@ static inline void pic32mz_adcdisable(void)
   putreg32(0xffffffff, PIC32MZ_IOPORTJ_K1BASE +
                        PIC32MZ_IOPORT_ANSELCLR_OFFSET);
 #endif
-#if CHIP_NPORTS > 9
-  putreg32(0xffffffff, PIC32MZ_IOPORTK_K1BASE +
-                       PIC32MZ_IOPORT_ANSELCLR_OFFSET);
-#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
We were incorrectly setting `ANSEL` for port K which does not exit as part of `pic32mz_lowinit`.  This was verified in the datasheet to make sure it was not just a simulator limitation.

## Impact
Prevent possible undefined CPU behavior from writing to non existent register

## Testing
Simulator previously would halt.
```
❯ ./mipsel-softmmu/qemu-system-mipsel -machine pic32mz-explorer16     -nographic     -monitor none  -serial stdio     -kernel  ~/nuttx/wrk/nuttx/nuttx.hex -S -s
Board: Microchip Explorer16
Processor: microAptivP
RAM size: 512 kbytes
Load file: '/home/bashton/nuttx/wrk/nuttx/nuttx.hex', 235632 bytes
ACDEG
--- Write ffffffff to 1f860904: peripheral register not supported
```

now:
```
❯ ./mipsel-softmmu/qemu-system-mipsel -machine pic32mz-explorer16     -nographic     -monitor none  -serial stdio     -kernel  ~/nuttx/wrk/nuttx/nuttx.hex -S -s
Board: Microchip Explorer16
Processor: microAptivP
RAM size: 512 kbytes
Load file: '/home/bashton/nuttx/wrk/nuttx/nuttx.hex', 235616 bytes
ACDEG

NuttShell (NSH) NuttX-10.0.1
nsh> ?
help usage:  help [-v] [<cmd>]

  .         cd        exec      ls        mount     set       uname     
  [         cp        exit      mb        mv        sleep     umount    
  ?         cmp       false     mkdir     mw        source    unset     
  basename  dirname   help      mkfatfs   pwd       test      usleep    
  break     dd

```