### PR TITLE
rp2040: Continue to build even if PICO_SDK_PATH is not set

### DIFF
--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -61,8 +61,4 @@ CHIP_CSRCS += rp2040_pll.c
 
 ifneq ($(PICO_SDK_PATH),)
 include chip/boot2/Make.defs
-else
-ifeq ($(CONFIG_RP2040_FLASH_BOOT),y)
-$(error $$(PICO_SDK_PATH) must be specified for flash boot)
-endif
 endif

--- a/tools/rp2040/Config.mk
+++ b/tools/rp2040/Config.mk
@@ -25,7 +25,7 @@
 # POSTBUILD -- Perform post build operations
 
 ifeq ($(CONFIG_RP2040_UF2_BINARY),y)
-
+ifdef PICO_SDK_PATH
 define POSTBUILD
 	$(Q)echo "Generating: nuttx.uf2"; \
 
@@ -33,5 +33,9 @@ define POSTBUILD
 	tools$(DELIM)rp2040$(DELIM)elf2uf2$(HOSTEXEEXT) nuttx nuttx.uf2;
 	$(Q)([ $$? -eq 0 ] && echo nuttx.uf2 >> nuttx.manifest && echo "Done.")
 endef
-
+else
+define POSTBUILD
+	$(Q) echo "PICO_SDK_PATH must be specified for flash boot"
+endef
+endif
 endif


### PR DESCRIPTION
## Summary

- In the previous implementation, the build system stops if
  PICO_SDK_PATH is not set.
- However, this behavior is not good for CI. Because the path
  is only used to generate a flash image.
- This commit fixes this issue

## Impact

- rp2040 only

## Testing

- Tested with and without PICO_SDK_PATH
