### PR TITLE
This commit enables BMP180 suport for ESP32.

### DIFF
--- a/boards/xtensa/esp32/common/include/esp32_bmp180.h
+++ b/boards/xtensa/esp32/common/include/esp32_bmp180.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_bmp180.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_BMP180_H
+#define __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_BMP180_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_bmp180_initialize
+ *
+ * Description:
+ *   Initialize and register the BMP180 Pressure Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/pressN
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_bmp180_initialize(int devno, int busno);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_BMP180_H */

--- a/boards/xtensa/esp32/common/src/Make.defs
+++ b/boards/xtensa/esp32/common/src/Make.defs
@@ -30,6 +30,10 @@ ifeq ($(CONFIG_I2C_DRIVER),y)
   CSRCS += esp32_board_i2c.c
 endif
 
+ifeq ($(CONFIG_SENSORS_BMP180),y)
+  CSRCS += esp32_bmp180.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)

--- a/boards/xtensa/esp32/common/src/esp32_bmp180.c
+++ b/boards/xtensa/esp32/common/src/esp32_bmp180.c
@@ -1,0 +1,110 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_bmp180.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/sensors/bmp180.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#include "esp32_board_i2c.h"
+#include "esp32_i2c.h"
+#include "esp32_bmp180.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_bmp180_initialize
+ *
+ * Description:
+ *   Initialize and register the BMP180 Pressure Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/pressN
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_bmp180_initialize(int devno, int busno)
+{
+  struct i2c_master_s *i2c;
+  char devpath[12];
+  int ret;
+
+  sninfo("Initializing BMP180!\n");
+
+  /* Initialize BMP180 */
+
+  i2c = esp32_i2cbus_initialize(busno);
+
+  if (i2c)
+    {
+      /* Then try to register the barometer sensor in I2C0 */
+
+      snprintf(devpath, 12, "/dev/press%d", devno);
+      ret = bmp180_register(devpath, i2c);
+      if (ret < 0)
+        {
+          snerr("ERROR: Error registering BMP180 in I2C%d\n", busno);
+        }
+    }
+  else
+    {
+      ret = -ENODEV;
+    }
+
+  return ret;
+}
+

--- a/boards/xtensa/esp32/esp32-wrover-kit/README.txt
+++ b/boards/xtensa/esp32/esp32-wrover-kit/README.txt
@@ -92,3 +92,11 @@ A new image "esp32_qemu_image.bin" will be created.  It can be run as:
     -machine esp32 \
     -drive file=esp32_qemu_image.bin,if=mtd,format=raw
  
+External devices:
+=================
+
+  BMP180
+  ------
+
+  When using BMP180 (enabling CONFIG_SENSORS_BMP180), it's expected this device is wired to I2C0 bus.
+  The current bring-up routines doesn't allow BMP180 device to be used in I2C1 bus.

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -60,6 +60,10 @@
 #  include "esp32_board_i2c.h"
 #endif
 
+#ifdef CONFIG_SENSORS_BMP180
+#  include "esp32_bmp180.h"
+#endif
+
 #include "esp32-wrover-kit.h"
 
 /****************************************************************************
@@ -259,6 +263,19 @@ int esp32_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_SENSORS_BMP180
+  /* Try to register BMP180 device in I2C0 */
+
+  ret = board_bmp180_initialize(0, 0);
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize BMP180"
+                       "Driver for I2C0: %d\n", ret);
+      return ret;
+    }
+#endif
+
 #endif
 
   /* If we got here then perhaps not all initialization was successful, but
@@ -269,3 +286,4 @@ int esp32_bringup(void)
   UNUSED(ret);
   return OK;
 }
+


### PR DESCRIPTION
ESP32 BMP180 support in Nuttx.

## Summary

As ESP32 has 2 I2C interfaces and BMP180 is a I2C sensor, the criterias to use BMP180 in I2C0 or I2C1 are:

1- First, bring-up routines search for BMP180 in I2C0.
   If BMP180 is found in I2C0, then /dev/press0 is created.
2- If BMP180 cannot be registered in I2C0, bring-up routines search for it in I2C1.
   If BMP180 is found in I2C1, then /dev/press0 is created.

It means only one BMP180 could be suported in Nuttx. In my tests I've observed
that BMP180 example application doesn't seem to work with /dev/press1 BMP180 device,
therefore even BMP180 is found in I2C1, it'll be registered as /dev/press0 device.

## Impact
It doesn't impact on another modules.

## Testing

After this change, BMP180 could be successfully found (/dev/press0) and read bu bmp180 example, as seen below:

![esp32_bmp180_nuttx_support](https://user-images.githubusercontent.com/16869652/108652000-65b34d80-7499-11eb-9998-2d2aca956a25.png)

