### PR TITLE
pic32mx7 cannot perform context switch

### DIFF
--- a/arch/mips/src/pic32mx/pic32mx_irq.c
+++ b/arch/mips/src/pic32mx/pic32mx_irq.c
@@ -113,7 +113,7 @@ void up_irqinitialize(void)
 
   /* Set the Software Interrupt0 to a special priority */
 
-  up_prioritize_irq(PIC32MX_IRQSRC_CS0, (CHIP_SW0_PRIORITY << 2));
+  up_prioritize_irq(PIC32MX_IRQ_CS0, (CHIP_SW0_PRIORITY << 2));
 
   /* Set the BEV bit in the STATUS register */
 


### PR DESCRIPTION
## Summary
There was a bug with the pic32mx irq registration logic for CS0 where it would not get priority set correctly a never trigger `up_swint0` on the context switch system call.
There was a debug assertion that was checking this logic and it is clear that this is the correct one to use for this call from the comment in the irq header
```
#define PIC32MX_IRQ_U5          51 /* Vector: 51, UART5 */
#define PIC32MX_IRQ_BAD         52 /* Not a real IRQ number */
#define NR_IRQS                 52

/* Interrupt numbers.  These should be used for enabling and disabling
 * interrupt sources.  Note that there are more interrupt sources than
 * interrupt vectors and interrupt priorities.  An offset of 128 is
 * used so that there is no overlap with the IRQ numbers and to avoid
 * errors due to misuse.
 */

#define PIC32MX_IRQSRC0_FIRST   (128+0)
#define PIC32MX_IRQSRC_CT       (128+0)  /* Vector: 0, Core Timer Interrupt */
#define PIC32MX_IRQSRC_CS0      (128+1)  /* Vector: 1, Core Software Interrupt 0 */
```

## Impact
pic32mx7 should now be able to make context switches and actually function.

## Testing
This was debugged an verified on with the qemu simulator (with some additional patches to the simulator).
Prior to this patch:
```
nx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
uart_register: Registering /dev/ttyS1
nx_start_application: Starting init thread
nx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
uart_register: Registering /dev/ttyS1
nx_start_application: Starting init thread
nx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
uart_register: Registering /dev/ttyS1
nx_start_application: Starting init thread
nx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
uart_register: Registering /dev/ttyS1
nx_start_application: Starting init thread
nx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
uart_register: Registering /dev/ttyS1
group_setupidlefiles: ERROR: Failed to open /dev/console: -24
up_assert: Assertion failed at file:init/nx_start.c line: 752
up_dumpstate: sp:         a0001c14
up_dumpstate: stack base: a0001cac
up_dumpstate: stack size: 00001000
up_stackdump: a0001c00: 9d03ab8c a0001c24 9d03a7b8 a0001c00 a0001c00 a0001c1c 9d00ccbc a0001c14
up_stackdump: a0001c20: a0001cac 9d03abec 00001000 a00003fc a0001c14 a0001cac 00001000 a0001c44
up_stackdump: a0001c40: 9d00b780 00000000 9d03a7b8 9d03a7e4 9d03985c 000002f0 9d001ba4 a0001c64
up_stackdump: a0001c60: 9d006260 9d03985c 000002f0 a0001ff0 ffffffe8 a0001c7c 9d000500 9d03985c
up_stackdump: a0001c80: 000002f0 ffffffff 00000000 00000010 00000000 00000000 a000038c a0001cac
up_stackdump: a0001ca0: 0001e354 00000000 00000000 00000000 00000008 80000000 00000020 80000008
```
After this patch:
```
❯ ./mipsel-softmmu/qemu-system-mipsel   -machine pic32mx7-explorer16
-nographic -monitor none   -serial stdio   -kernel
~/nuttx/wrk/nuttx/nuttx.hex
Board: Microchip Explorer16
Processor: M4K
RAM size: 128 kbytes
Load file: '/home/bashton/nuttx/wrk/nuttx/nuttx.hex', 250312 bytes
nx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
uart_register: Registering /dev/ttyS1
nx_start_application: Starting init thread

NuttShell (NSH) NutnxtX_s-1tart0: .0.1
nsh> CPU0: Beginning Idle Loop

nsh> uname -a
NuttX 10.0.1 198649273f-dirty Feb 21 2021 18:53:48 mips pic32mx-starterkit
```