### PR TITLE
esp32 Kconfig: Move ESP32_SPIFLASH_xxx configs to the common place

### DIFF
--- a/boards/xtensa/esp32/common/Kconfig
+++ b/boards/xtensa/esp32/common/Kconfig
@@ -8,3 +8,38 @@ config ESP32_QEMU_IMAGE
 	default n
 	---help---
 		Create a binary flash image used for QEMU.
+
+choice ESP32_SPIFLASH_FS
+  prompt "SPIFLASH File System"
+  default ESP32_SPIFLASH_SMARTFS
+  depends on ESP32_SPIFLASH
+
+  config ESP32_SPIFLASH_SMARTFS
+        bool "SmartFS"
+        depends on FS_SMARTFS
+  config ESP32_SPIFLASH_NXFFS
+        bool "NXFFS"
+        depends on FS_NXFFS
+  config ESP32_SPIFLASH_SPIFFS
+        bool "SPIFFS"
+        depends on FS_SPIFFS
+  config ESP32_SPIFLASH_LITTLEFS
+        bool "LittleFS"
+        depends on FS_LITTLEFS
+endchoice
+
+config ESP32_SPIFLASH_ENCRYPTION_TEST
+	bool "SPI Flash encryption test"
+	default n
+	depends on ESP32_SPIFLASH
+	select DEBUG_ASSERTIONS
+	help
+		Enable SPI Flash encryption test. This option will also select
+		DEBUG_ASSERTIONS to enable kernel assert macro.
+
+config ESP32_SPIFLASH_TEST_ADDRESS
+	hex "SPI Flash test address"
+	default 0x180000
+	depends on ESP32_SPIFLASH_ENCRYPTION_TEST
+	help
+		SPI Flash encryption test read/write address.

--- a/boards/xtensa/esp32/esp32-devkitc/Kconfig
+++ b/boards/xtensa/esp32/esp32-devkitc/Kconfig
@@ -40,41 +40,6 @@ config ESP32_DEVKITC_RUN_IRAM
 
 source boards/xtensa/esp32/common/Kconfig
 
-choice
-  prompt "SPIFLASH File System"
-  default ESP32_SPIFLASH_SMARTFS
-  depends on ESP32_SPIFLASH
-
-  config ESP32_SPIFLASH_SMARTFS
-        bool "SmartFS"
-        depends on FS_SMARTFS
-  config ESP32_SPIFLASH_NXFFS
-        bool "NXFFS"
-        depends on FS_NXFFS
-  config ESP32_SPIFLASH_SPIFFS
-        bool "SPIFFS"
-        depends on FS_SPIFFS
-  config ESP32_SPIFLASH_LITTLEFS
-        bool "LittleFS"
-        depends on FS_LITTLEFS
-endchoice
-
-config ESP32_SPIFLASH_ENCRYPTION_TEST
-	bool "SPI Flash encryption test"
-	default n
-	depends on ESP32_SPIFLASH
-	select DEBUG_ASSERTIONS
-	help
-		Enable SPI Flash encryption test. This option will also select
-		DEBUG_ASSERTIONS to enable kernel assert macro.
-
-config ESP32_SPIFLASH_TEST_ADDRESS
-	hex "SPI Flash test address"
-	default 0x180000
-	depends on ESP32_SPIFLASH_ENCRYPTION_TEST
-	help
-		SPI Flash encryption test read/write address.
-
 if PM
 
 config PM_ALARM_SEC


### PR DESCRIPTION
## Summary
esp32 Kconfig: Move ESP32_SPIFLASH_xxx configs to the common place
These are referenced by other boards than esp32-devkitc as well.

## Impact

## Testing
checked .config for a few esp32 configs locally.