### PR TITLE
risc-v/esp32c3: Build serial driver only when selected

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -104,6 +104,10 @@ config ESP32C3_CPU_FREQ_MHZ
 
 menu "ESP32-C3 Peripheral Support"
 
+config ESP32C3_UART
+	bool
+	default n
+
 config ESP32C3_WDT
 	bool
 	default n
@@ -116,11 +120,13 @@ config ESP32C3_GPIO_IRQ
 config ESP32C3_UART0
 	bool "UART0"
 	default y
+	select ESP32C3_UART
 	select UART0_SERIALDRIVER
 
 config ESP32C3_UART1
 	bool "UART1"
 	default n
+	select ESP32C3_UART
 	select UART1_SERIALDRIVER
 
 config ESP32C3_MWDT0

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -52,7 +52,11 @@ endif
 CHIP_CSRCS  = esp32c3_allocateheap.c esp32c3_start.c esp32c3_idle.c
 CHIP_CSRCS += esp32c3_irq.c esp32c3_timerisr.c
 CHIP_CSRCS += esp32c3_clockconfig.c esp32c3_gpio.c
-CHIP_CSRCS += esp32c3_serial.c esp32c3_lowputc.c
+CHIP_CSRCS += esp32c3_lowputc.c
+
+ifeq ($(CONFIG_ESP32C3_UART),y)
+CHIP_CSRCS += esp32c3_serial.c
+endif
 
 ifeq ($(CONFIG_ESP32C3_WDT),y)
 CHIP_CSRCS += esp32c3_wdt.c

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.h
@@ -98,4 +98,4 @@ void esp32c3_free_cpuint(uint8_t periphid);
 
 uint32_t *esp32c3_dispatch_irq(uint32_t mcause, uint32_t *regs);
 
-#endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_CPUINT_H */
+#endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_IRQ_H */

--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
@@ -18,6 +18,9 @@
  *
  ****************************************************************************/
 
+#ifndef __ARCH_RISCV_SRC_ESP32C3_ESP32C3_LOWPUTC_H
+#define __ARCH_RISCV_SRC_ESP32C3_ESP32C3_LOWPUTC_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
@@ -205,3 +208,5 @@ bool esp32c3_lowputc_is_tx_fifo_full(const struct esp32c3_uart_s *
  ****************************************************************************/
 
 void esp32c3_lowsetup(void);
+
+#endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_LOWPUTC_H */


### PR DESCRIPTION
## Summary
Minor improvement to the ESP32-C3 build system. Serial driver will only build when any of the UART peripherals are selected.
This PR also brings some minor fixes.

## Impact
No impact to current ESP32-C3 based boards.

## Testing
`esp32c3-devkit:nsh`