### PR TITLE
arch/stm32f7: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/stm32f7/stm32_pwr.c
+++ b/arch/arm/src/stm32f7/stm32_pwr.c
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32f7/stm32_pwr.c
  *
  *   Copyright (C) 2011 Uros Platise. All rights reserved.
@@ -34,11 +34,11 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/arch.h>
@@ -52,15 +52,15 @@
 
 #if defined(CONFIG_STM32F7_PWR)
 
-/************************************************************************************
+/****************************************************************************
  * Private Data
- ************************************************************************************/
+ ****************************************************************************/
 
 static uint16_t g_bkp_writable_counter = 0;
 
-/************************************************************************************
+/****************************************************************************
  * Private Functions
- ************************************************************************************/
+ ****************************************************************************/
 
 static inline uint16_t stm32_pwr_getreg(uint8_t offset)
 {
@@ -72,22 +72,25 @@ static inline void stm32_pwr_putreg(uint8_t offset, uint16_t value)
   putreg32((uint32_t)value, STM32_PWR_BASE + (uint32_t)offset);
 }
 
-static inline void stm32_pwr_modifyreg(uint8_t offset, uint16_t clearbits, uint16_t setbits)
+static inline void stm32_pwr_modifyreg(uint8_t offset, uint16_t clearbits,
+                                       uint16_t setbits)
 {
-  modifyreg32(STM32_PWR_BASE + (uint32_t)offset, (uint32_t)clearbits, (uint32_t)setbits);
+  modifyreg32(STM32_PWR_BASE + (uint32_t)offset,
+              (uint32_t)clearbits,
+              (uint32_t)setbits);
 }
 
-/************************************************************************************
+/****************************************************************************
  * Public Functions
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_initbkp
  *
  * Description:
- *   Insures the referenced count access to the backup domain (RTC registers,
- *   RTC backup data registers and backup SRAM is consistent with the HW state
- *   without relying on a variable.
+ *   Insures the referenced count access to the backup domain (RTC
+ *   registers, RTC backup data registers and backup SRAM is consistent with
+ *   the HW state without relying on a variable.
  *
  *   NOTE: This function should only be called by SoC Start up code.
  *
@@ -97,7 +100,7 @@ static inline void stm32_pwr_modifyreg(uint8_t offset, uint16_t clearbits, uint1
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_initbkp(bool writable)
 {
@@ -115,16 +118,17 @@ void stm32_pwr_initbkp(bool writable)
   stm32_pwr_enablebkp(writable);
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_enablebkp
  *
  * Description:
- *   Enables access to the backup domain (RTC registers, RTC backup data registers
- *   and backup SRAM).
+ *   Enables access to the backup domain (RTC registers, RTC backup data
+ *   registers and backup SRAM).
  *
- *   NOTE: Reference counting is used in order to supported nested calls to this
- *   function.  As a consequence, every call to stm32_pwr_enablebkp(true) must
- *   be followed by a matching call to stm32_pwr_enablebkp(false).
+ *   NOTE: Reference counting is used in order to supported nested calls to
+ *   this function.  As a consequence, every call to
+ *   stm32_pwr_enablebkp(true) must be followed by a matching call to
+ *   stm32_pwr_enablebkp(false).
  *
  * Input Parameters:
  *   writable - True: enable ability to write to backup domain registers
@@ -132,7 +136,7 @@ void stm32_pwr_initbkp(bool writable)
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_enablebkp(bool writable)
 {
@@ -157,6 +161,7 @@ void stm32_pwr_enablebkp(bool writable)
     {
       g_bkp_writable_counter--;
     }
+
   /* Enable or disable the ability to write */
 
   if (waswritable && g_bkp_writable_counter == 0)
@@ -174,7 +179,7 @@ void stm32_pwr_enablebkp(bool writable)
       stm32_pwr_putreg(STM32_PWR_CR1_OFFSET, regval);
 
       wait = true;
-	}
+    }
 
   leave_critical_section(flags);
 
@@ -186,16 +191,17 @@ void stm32_pwr_enablebkp(bool writable)
     }
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_enablebreg
  *
  * Description:
- *   Enables the Backup regulator, the Backup regulator (used to maintain backup
- *   SRAM content in Standby and VBAT modes) is enabled. If BRE is reset, the backup
- *   regulator is switched off. The backup SRAM can still be used but its content will
- *   be lost in the Standby and VBAT modes. Once set, the application must wait that
- *   the Backup Regulator Ready flag (BRR) is set to indicate that the data written
- *   into the RAM will be maintained in the Standby and VBAT modes.
+ *   Enables the Backup regulator, the Backup regulator (used to maintain
+ *   backup SRAM content in Standby and VBAT modes) is enabled. If BRE is
+ *   reset, the backup regulator is switched off. The backup SRAM can still
+ *   be used but its content will be lost in the Standby and VBAT modes.
+ *   Once set, the application must wait until the Backup Regulator Ready
+ *   flag (BRR) is set to indicate that the data written into the RAM will
+ *   be maintained in the Standby and VBAT modes.
  *
  * Input Parameters:
  *   region - state to set it to
@@ -203,7 +209,7 @@ void stm32_pwr_enablebkp(bool writable)
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_enablebreg(bool region)
 {
@@ -220,33 +226,35 @@ void stm32_pwr_enablebreg(bool region)
     }
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_setvos
  *
  * Description:
  *   Set voltage scaling.
  *
  * Input Parameters:
- *   vos - Properly aligned voltage scaling select bits for the PWR_CR register.
+ *   vos - Properly aligned voltage scaling select bits for the PWR_CR
+ *   register.
  *
  * Returned Value:
  *   None
  *
  * Assumptions:
- *   At present, this function is called only from initialization logic.  If used
- *   for any other purpose that protection to assure that its operation is atomic
- *   will be required.
+ *   At present, this function is called only from initialization logic.  If
+ *   used for any other purpose that protection to assure that its operation
+ *   is atomic will be required.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_setvos(uint16_t vos)
 {
   uint16_t regval;
 
-  /* The following sequence is required to program the voltage regulator ranges:
+  /* The following sequence is required to program the voltage regulator
+   * ranges:
    * 1. Check VDD to identify which ranges are allowed...
-   * 2. Configure the voltage scaling range by setting the VOS bits in the PWR_CR1
-   *    register.
+   * 2. Configure the voltage scaling range by setting the VOS bits in the
+   *    PWR_CR1 register.
    */
 
   regval  = stm32_pwr_getreg(STM32_PWR_CR1_OFFSET);
@@ -255,7 +263,7 @@ void stm32_pwr_setvos(uint16_t vos)
   stm32_pwr_putreg(STM32_PWR_CR1_OFFSET, regval);
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_setpvd
  *
  * Description:
@@ -268,11 +276,11 @@ void stm32_pwr_setvos(uint16_t vos)
  *   None
  *
  * Assumptions:
- *   At present, this function is called only from initialization logic.  If used
- *   for any other purpose that protection to assure that its operation is atomic
- *   will be required.
+ *   At present, this function is called only from initialization logic.  If
+ *   used for any other purpose that protection to assure that its operation
+ *   is atomic will be required.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_setpvd(uint16_t pls)
 {
@@ -289,13 +297,13 @@ void stm32_pwr_setpvd(uint16_t pls)
   stm32_pwr_putreg(STM32_PWR_CR1_OFFSET, regval);
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_enablepvd
  *
  * Description:
  *   Enable the Programmable Voltage Detector
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_enablepvd(void)
 {
@@ -304,13 +312,13 @@ void stm32_pwr_enablepvd(void)
   stm32_pwr_modifyreg(STM32_PWR_CR1_OFFSET, 0, PWR_CR1_PVDE);
 }
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_disablepvd
  *
  * Description:
  *   Disable the Programmable Voltage Detector
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_disablepvd(void)
 {

--- a/arch/arm/src/stm32f7/stm32_pwr.h
+++ b/arch/arm/src/stm32f7/stm32_pwr.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32f7/stm32_pwr.h
  *
  *   Copyright (C) 2016-2017 Gregory Nutt. All rights reserved.
@@ -32,14 +32,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32F7_STM32_PWR_H
 #define __ARCH_ARM_SRC_STM32F7_STM32_PWR_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
@@ -48,9 +48,9 @@
 #include "chip.h"
 #include "hardware/stm32_pwr.h"
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 
@@ -63,17 +63,17 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_initbkp
  *
  * Description:
- *   Insures the referenced count access to the backup domain (RTC registers,
- *   RTC backup data registers and backup SRAM is consistent with the HW state
- *   without relying on a variable.
+ *   Insures the referenced count access to the backup domain (RTC
+ *   registers, RTC backup data registers and backup SRAM is consistent with
+ *   the HW state without relying on a variable.
  *
  *   NOTE: This function should only be called by SoC Start up code.
  *
@@ -84,16 +84,16 @@ extern "C"
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_initbkp(bool writable);
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_enablebkp
  *
  * Description:
- *   Enables access to the backup domain (RTC registers, RTC backup data registers
- *   and backup SRAM).
+ *   Enables access to the backup domain (RTC registers, RTC backup data
+ *   registers and backup SRAM).
  *
  * Input Parameters:
  *   writable - True: enable ability to write to backup domain registers
@@ -101,20 +101,21 @@ void stm32_pwr_initbkp(bool writable);
  * Returned Value:
  *   none
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_enablebkp(bool writable);
 
-/************************************************************************************
+/****************************************************************************
  * Name: stm32_pwr_enablebreg
  *
  * Description:
- *   Enables the Backup regulator, the Backup regulator (used to maintain backup
- *   SRAM content in Standby and VBAT modes) is enabled. If BRE is reset, the backup
- *   regulator is switched off. The backup SRAM can still be used but its content will
- *   be lost in the Standby and VBAT modes. Once set, the application must wait that
- *   the Backup Regulator Ready flag (BRR) is set to indicate that the data written
- *   into the RAM will be maintained in the Standby and VBAT modes.
+ *   Enables the Backup regulator, the Backup regulator (used to maintain
+ *   backup SRAM content in Standby and VBAT modes) is enabled. If BRE is
+ *   reset, the backup regulator is switched off. The backup SRAM can still
+ *   be used but its content will be lost in the Standby and VBAT modes.
+ *   Once set, the application must wait until the Backup Regulator Ready
+ *   flag (BRR) is set to indicate that the data written into the RAM will
+ *   be maintained in the Standby and VBAT modes.
  *
  * Input Parameters:
  *   region - state to set it to
@@ -122,7 +123,7 @@ void stm32_pwr_enablebkp(bool writable);
  * Returned Value:
  *   None
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 void stm32_pwr_enablebreg(bool region);
 

--- a/arch/arm/src/stm32f7/stm32_usbhost.h
+++ b/arch/arm/src/stm32f7/stm32_usbhost.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32f7/stm32_usbhost.h
  *
  *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
@@ -31,7 +31,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32F7_STM32_USBHOST_H
 #define __ARCH_ARM_SRC_STM32F7_STM32_USBHOST_H
@@ -61,9 +61,9 @@
  *    debug.  Depends on CONFIG_DEBUG_FEATURES.
  */
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <stdbool.h>
@@ -71,9 +71,9 @@
 #if (defined(CONFIG_STM32F7_OTGFS) || defined(CONFIG_STM32F7_OTGFSHS)) && \
     defined(CONFIG_USBHOST)
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 
@@ -86,31 +86,34 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/***********************************************************************************
+/****************************************************************************
  * Name: stm32_usbhost_vbusdrive
  *
  * Description:
- *   Enable/disable driving of VBUS 5V output.  This function must be provided be
- *   each platform that implements the STM32 OTG FS host interface
+ *   Enable/disable driving of VBUS 5V output.  This function must be
+ *   provided be each platform that implements the STM32 OTG FS host
+ *   interface
  *
- *   "On-chip 5 V VBUS generation is not supported. For this reason, a charge pump
- *    or, if 5 V are available on the application board, a basic power switch, must
- *    be added externally to drive the 5 V VBUS line. The external charge pump can
- *    be driven by any GPIO output. When the application decides to power on VBUS
- *    using the chosen GPIO, it must also set the port power bit in the host port
- *    control and status register (PPWR bit in OTG_FS_HPRT).
+ *   "On-chip 5 V VBUS generation is not supported. For this reason, a
+ *    charge pump or, if 5 V are available on the application board, a basic
+ *    power switch, must be added externally to drive the 5 V VBUS line. The
+ *    external charge pump can be driven by any GPIO output. When the
+ *    application decides to power on VBUS using the chosen GPIO, it must
+ *    also set the port power bit in the host port control and status
+ *    register (PPWR bit in OTG_FS_HPRT).
  *
- *   "The application uses this field to control power to this port, and the core
- *    clears this bit on an overcurrent condition."
+ *   "The application uses this field to control power to this port, and the
+ *    core clears this bit on an overcurrent condition."
  *
  * Input Parameters:
- *   iface - For future growth to handle multiple USB host interface.  Should be zero.
+ *   iface - For future growth to handle multiple USB host interface.
+ *           Should be zero.
  *   enable - true: enable VBUS power; false: disable VBUS power
  *
  * Returned Value:
  *   None
  *
- ***********************************************************************************/
+ ****************************************************************************/
 
 void stm32_usbhost_vbusdrive(int iface, bool enable);
 


### PR DESCRIPTION
## Summary

Fix nxstyle errors in:

- arch/arm/src/stm32f7/stm32_pwr.c,
- arch/arm/src/stm32f7/stm32_pwr.h, and
- arch/arm/src/stm32f7/stm32_usbhost.h.

## Impact

Removes nxstyle errors.

## Testing

nxstyle