### PR TITLE
Fix typo in "repetitions" word

### DIFF
--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -2358,7 +2358,7 @@ The new features (some still incomplete) include:
     to LCD GRAM memory.
 
   * I2C tool. Extended to support to include a verify command and
-    repititions and auto-address increment for most commands.
+    repetitions and auto-address increment for most commands.
 
   * USB terminal example.  Line oriented serial bridge connects a host
     USB serial terminal to a host UART serial terminal.

--- a/boards/arm/sama5/sama5d3-xplained/README.txt
+++ b/boards/arm/sama5/sama5d3-xplained/README.txt
@@ -2149,12 +2149,12 @@ I2C Tool
     Where <cmd> is one of:
 
       Show help     : ?
-      List buses   : bus
+      List buses    : bus
       List devices  : dev [OPTIONS] <first> <last>
-      Read register : get [OPTIONS] [<repititions>]
+      Read register : get [OPTIONS] [<repetitions>]
       Show help     : help
-      Write register: set [OPTIONS] <value> [<repititions>]
-      Verify access : verf [OPTIONS] [<value>] [<repititions>]
+      Write register: set [OPTIONS] <value> [<repetitions>]
+      Verify access : verf [OPTIONS] [<value>] [<repetitions>]
 
     Where common "sticky" OPTIONS include:
       [-a addr] is the I2C device address (hex).  Default: 03 Current: 03
@@ -2162,7 +2162,7 @@ I2C Tool
       [-r regaddr] is the I2C device register address (hex).  Default: 00 Current: 00
       [-w width] is the data width (8 or 16 decimal).  Default: 8 Current: 8
       [-s|n], send/don't send start between command and data.  Default: -n Current: -n
-      [-i|j], Auto increment|don't increment regaddr on repititions.  Default: NO Current: NO
+      [-i|j], Auto increment|don't increment regaddr on repetitions.  Default: NO Current: NO
       [-f freq] I2C frequency.  Default: 100000 Current: 100000
 
     NOTES:

--- a/boards/arm/sama5/sama5d3x-ek/README.txt
+++ b/boards/arm/sama5/sama5d3x-ek/README.txt
@@ -2286,12 +2286,12 @@ I2C Tool
     Where <cmd> is one of:
 
       Show help     : ?
-      List buses   : bus
+      List buses    : bus
       List devices  : dev [OPTIONS] <first> <last>
-      Read register : get [OPTIONS] [<repititions>]
+      Read register : get [OPTIONS] [<repetitions>]
       Show help     : help
-      Write register: set [OPTIONS] <value> [<repititions>]
-      Verify access : verf [OPTIONS] [<value>] [<repititions>]
+      Write register: set [OPTIONS] <value> [<repetitions>]
+      Verify access : verf [OPTIONS] [<value>] [<repetitions>]
 
     Where common "sticky" OPTIONS include:
       [-a addr] is the I2C device address (hex).  Default: 03 Current: 03
@@ -2299,7 +2299,7 @@ I2C Tool
       [-r regaddr] is the I2C device register address (hex).  Default: 00 Current: 00
       [-w width] is the data width (8 or 16 decimal).  Default: 8 Current: 8
       [-s|n], send/don't send start between command and data.  Default: -n Current: -n
-      [-i|j], Auto increment|don't increment regaddr on repititions.  Default: NO Current: NO
+      [-i|j], Auto increment|don't increment regaddr on repetitions.  Default: NO Current: NO
       [-f freq] I2C frequency.  Default: 100000 Current: 100000
 
     NOTES:

--- a/boards/arm/sama5/sama5d4-ek/README.txt
+++ b/boards/arm/sama5/sama5d4-ek/README.txt
@@ -2549,12 +2549,12 @@ I2C Tool
     Where <cmd> is one of:
 
       Show help     : ?
-      List buses   : bus
+      List buses    : bus
       List devices  : dev [OPTIONS] <first> <last>
-      Read register : get [OPTIONS] [<repititions>]
+      Read register : get [OPTIONS] [<repetitions>]
       Show help     : help
-      Write register: set [OPTIONS] <value> [<repititions>]
-      Verify access : verf [OPTIONS] [<value>] [<repititions>]
+      Write register: set [OPTIONS] <value> [<repetitions>]
+      Verify access : verf [OPTIONS] [<value>] [<repetitions>]
 
     Where common "sticky" OPTIONS include:
       [-a addr] is the I2C device address (hex).  Default: 03 Current: 03
@@ -2562,7 +2562,7 @@ I2C Tool
       [-r regaddr] is the I2C device register address (hex).  Default: 00 Current: 00
       [-w width] is the data width (8 or 16 decimal).  Default: 8 Current: 8
       [-s|n], send/don't send start between command and data.  Default: -n Current: -n
-      [-i|j], Auto increment|don't increment regaddr on repititions.  Default: NO Current: NO
+      [-i|j], Auto increment|don't increment regaddr on repetitions.  Default: NO Current: NO
       [-f freq] I2C frequency.  Default: 100000 Current: 100000
 
     NOTES:

--- a/boards/arm/samv7/same70-xplained/README.txt
+++ b/boards/arm/samv7/same70-xplained/README.txt
@@ -1579,12 +1579,12 @@ Configuration sub-directories
          Where <cmd> is one of:
 
            Show help     : ?
-           List buses   : bus
+           List buses    : bus
            List devices  : dev [OPTIONS] <first> <last>
-           Read register : get [OPTIONS] [<repititions>]
+           Read register : get [OPTIONS] [<repetitions>]
            Show help     : help
-           Write register: set [OPTIONS] <value> [<repititions>]
-           Verify access : verf [OPTIONS] [<value>] [<repititions>]
+           Write register: set [OPTIONS] <value> [<repetitions>]
+           Verify access : verf [OPTIONS] [<value>] [<repetitions>]
 
          Where common "sticky" OPTIONS include:
            [-a addr] is the I2C device address (hex).  Default: 03 Current: 03
@@ -1592,7 +1592,7 @@ Configuration sub-directories
            [-r regaddr] is the I2C device register address (hex).  Default: 00 Current: 00
            [-w width] is the data width (8 or 16 decimal).  Default: 8 Current: 8
            [-s|n], send/don't send start between command and data.  Default: -n Current: -n
-           [-i|j], Auto increment|don't increment regaddr on repititions.  Default: NO Current: NO
+           [-i|j], Auto increment|don't increment regaddr on repetitions.  Default: NO Current: NO
            [-f freq] I2C frequency.  Default: 400000 Current: 400000
 
          NOTES:

--- a/boards/arm/samv7/samv71-xult/README.txt
+++ b/boards/arm/samv7/samv71-xult/README.txt
@@ -2276,12 +2276,12 @@ Configuration sub-directories
          Where <cmd> is one of:
 
            Show help     : ?
-           List buses   : bus
+           List buses    : bus
            List devices  : dev [OPTIONS] <first> <last>
-           Read register : get [OPTIONS] [<repititions>]
+           Read register : get [OPTIONS] [<repetitions>]
            Show help     : help
-           Write register: set [OPTIONS] <value> [<repititions>]
-           Verify access : verf [OPTIONS] [<value>] [<repititions>]
+           Write register: set [OPTIONS] <value> [<repetitions>]
+           Verify access : verf [OPTIONS] [<value>] [<repetitions>]
 
          Where common "sticky" OPTIONS include:
            [-a addr] is the I2C device address (hex).  Default: 03 Current: 03
@@ -2289,7 +2289,7 @@ Configuration sub-directories
            [-r regaddr] is the I2C device register address (hex).  Default: 00 Current: 00
            [-w width] is the data width (8 or 16 decimal).  Default: 8 Current: 8
            [-s|n], send/don't send start between command and data.  Default: -n Current: -n
-           [-i|j], Auto increment|don't increment regaddr on repititions.  Default: NO Current: NO
+           [-i|j], Auto increment|don't increment regaddr on repetitions.  Default: NO Current: NO
            [-f freq] I2C frequency.  Default: 400000 Current: 400000
 
          NOTES:

--- a/boards/arm/tiva/tm4c123g-launchpad/README.txt
+++ b/boards/arm/tiva/tm4c123g-launchpad/README.txt
@@ -2,8 +2,8 @@ README
 ======
 
 README for NuttX port to the Tiva TM4C123G LaunchPad.  The Tiva TM4C123G
-LaunchPad Evaluation Board is a low-cost evaluation platform for ARM®
-Cortex™-M4F-based microcontrollers from Texas Instruments.
+LaunchPad Evaluation Board is a low-cost evaluation platform for ARM
+Cortex-M4F-based microcontrollers from Texas Instruments.
 
 Contents
 ========
@@ -184,12 +184,12 @@ I2C Tool
     Where <cmd> is one of:
 
       Show help     : ?
-      List buses   : bus
+      List buses    : bus
       List devices  : dev [OPTIONS] <first> <last>
-      Read register : get [OPTIONS] [<repititions>]
+      Read register : get [OPTIONS] [<repetitions>]
       Show help     : help
-      Write register: set [OPTIONS] <value> [<repititions>]
-      Verify access : verf [OPTIONS] [<value>] [<repititions>]
+      Write register: set [OPTIONS] <value> [<repetitions>]
+      Verify access : verf [OPTIONS] [<value>] [<repetitions>]
 
     Where common "sticky" OPTIONS include:
       [-a addr] is the I2C device address (hex).  Default: 03 Current: 03
@@ -197,7 +197,7 @@ I2C Tool
       [-r regaddr] is the I2C device register address (hex).  Default: 00 Current: 00
       [-w width] is the data width (8 or 16 decimal).  Default: 8 Current: 8
       [-s|n], send/don't send start between command and data.  Default: -n Current: -n
-      [-i|j], Auto increment|don't increment regaddr on repititions.  Default: NO Current: NO
+      [-i|j], Auto increment|don't increment regaddr on repetitions.  Default: NO Current: NO
       [-f freq] I2C frequency.  Default: 100000 Current: 100000
 
     NOTES:

--- a/include/nuttx/wireless/ieee802154/ieee802154_mac.h
+++ b/include/nuttx/wireless/ieee802154/ieee802154_mac.h
@@ -743,7 +743,7 @@ struct ieee802154_frame_meta_s
 
   enum ieee802154_uwbprf_e uwbprf;
 
-  /* The UWB preamble symbol repititions
+  /* The UWB preamble symbol repetitions
    *  Should be one of:
    *    0, 16, 64, 1024, 4096
    */
@@ -848,7 +848,7 @@ struct ieee802154_data_ind_s
 
   enum ieee802154_uwbprf_e uwb_prf;
 
-  /* The UWB preamble symbol repititions
+  /* The UWB preamble symbol repetitions
    *  Should be one of:
    *    0, 16, 64, 1024, 4096
    */


### PR DESCRIPTION
## Summary
Fix several typos in the "repetitions" word.

## Impact
No impact.

## Testing
Not applicable.
