### PR TITLE
s32k1xx:Support ramfunc

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -236,8 +236,9 @@ config ARCH_CHIP_S32K1XX
 	bool "NXP S32K1XX"
 	select ARCH_HAVE_MPU
 	select ARM_HAVE_MPU_UNIFIED
+	select ARCH_HAVE_RAMFUNCS
 	---help---
-		NPX LPC54XX architectures (ARM Cortex-M0+ and Cortex-M4F).
+		NPX S32K1XX architectures (ARM Cortex-M0+ and Cortex-M4F).
 
 config ARCH_CHIP_SAMA5
 	bool "Atmel SAMA5"

--- a/arch/arm/src/s32k1xx/s32k1xx_start.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_start.c
@@ -332,6 +332,20 @@ void __start(void)
     }
 #endif
 
+  /* Copy any necessary code sections from FLASH to RAM.  The correct
+   * destination in SRAM is given by _sramfuncs and _eramfuncs.  The
+   * temporary location is in flash after the data initialization code
+   * at _framfuncs.  This should be done before s32k1xx_clockconfig() is
+   * called (in case it has some dependency on initialized C variables).
+   */
+
+#ifdef CONFIG_ARCH_RAMFUNCS
+  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+    {
+      *dest++ = *src++;
+    }
+#endif
+
   /* Configure the clocking and the console uart so that we can get debug
    * output as soon as possible.  NOTE: That this logic must not assume that
    * .bss or .data have been initialized.


### PR DESCRIPTION
## Summary

Added support for ramfuncs on the s32k1xx

## Impact

None. Behind a Kconfig Knob 

## Testing

px4 nxp_ucans32k146  CAN bootloader