### PR TITLE
builtin: execute app whose filename is longer than NAME_MAX

### DIFF
--- a/libs/libc/builtin/lib_builtin_isavail.c
+++ b/libs/libc/builtin/lib_builtin_isavail.c
@@ -82,7 +82,7 @@ int builtin_isavail(FAR const char *appname)
 
   for (i = 0; (name = builtin_getname(i)) != NULL; i++)
     {
-      if (strncmp(name, appname, NAME_MAX) == 0)
+      if (strcmp(name, appname) == 0)
         {
           return i;
         }


### PR DESCRIPTION
## Summary

We should can run app when app's name is longer than NAME_MAX.

## Impact

## Testing
daily test
