### PR TITLE
risc-v/esp32c3: Fix CPU interrupts freeing on WDT driver

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.c
@@ -668,6 +668,7 @@ static int32_t esp32c3_wdt_setisr(struct esp32c3_wdt_dev_s *dev,
           up_disable_irq(wdt->cpuint);
           irq_detach(wdt->irq);
           esp32c3_free_cpuint(wdt->periph);
+          wdt->cpuint = -ENOMEM;
         }
     }
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.c
@@ -678,7 +678,7 @@ static int32_t esp32c3_wdt_setisr(struct esp32c3_wdt_dev_s *dev,
     {
       if (wdt->cpuint != -ENOMEM)
         {
-          /* Disable the provided CPU Interrupt to configure it. */
+          /* Disable the provided CPU interrupt to configure it. */
 
           up_disable_irq(wdt->cpuint);
         }
@@ -695,12 +695,18 @@ static int32_t esp32c3_wdt_setisr(struct esp32c3_wdt_dev_s *dev,
       /* Attach and enable the IRQ. */
 
       ret = irq_attach(wdt->irq, handler, arg);
-      if (ret == OK)
+      if (ret != OK)
         {
-          /* Enable the CPU Interrupt that is linked to the WDT. */
+          /* Failed to attach IRQ, so CPU interrupt must be freed. */
 
-          up_enable_irq(wdt->cpuint);
+          esp32c3_free_cpuint(wdt->periph);
+          wdt->cpuint = -ENOMEM;
+          return ret;
         }
+
+      /* Enable the CPU interrupt that is linked to the WDT. */
+
+      up_enable_irq(wdt->cpuint);
     }
 
   return ret;


### PR DESCRIPTION
## Summary
NuttX watchdog API allows the application to unregister a previously allocated interrupt handler for the watchdog timer.

This PR intends to fix two issues that would occur in case the application tries to register an interrupt handler from a WDT device that had already performed the unregister operation.

## Impact
Fix for a WDT issue on a specific scenario.

## Testing
`esp32c3-devkit:watcher`
