### PR TITLE
arch: arm: Add 'select ARM_HAVE_WFE_SEV' to ARCH_CHIP_RP2040

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -231,8 +231,9 @@ config ARCH_CHIP_RP2040
 	select ARCH_HAVE_RAMVECTORS
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_TESTSET
+	select ARM_HAVE_WFE_SEV
 	---help---
-		Raspberry Pi RP2040 architectures (ARM Cortex-M0+).
+		Raspberry Pi RP2040 architectures (ARM dual Cortex-M0+).
 
 config ARCH_CHIP_S32K1XX
 	bool "NXP S32K1XX"


### PR DESCRIPTION
## Summary

- This commit adds 'select ARM_HAVE_WFE_SEV' to ARCH_CHIP_RP2040
- Now NuttX spinlock uses WFE/SEV to reduce power consumption
- Also, modify a comment on rp2040

## Impact

- rp2040 only

## Testing

- Tested with raspberrypi-pico:smp

