### PR TITLE
arch:rv32:up_sigdeliver missing fpu contexts.

### DIFF
--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -30,7 +30,7 @@ CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_createstack.c riscv_exit.c
 CMN_CSRCS  += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS  += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mdelay.c
-CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c
+CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -188,6 +188,7 @@ void up_ack_irq(int irq);
 void up_copystate(uint64_t *dest, uint64_t *src);
 #else
 void up_copystate(uint32_t *dest, uint32_t *src);
+void up_copyfullstate(uint32_t *dest, uint32_t *src);
 #endif
 
 void up_sigdeliver(void);

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -35,7 +35,7 @@ CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_allocateheap.c riscv_createstack.c riscv_exit.c riscv_exception.c
 CMN_CSRCS  += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS  += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mdelay.c
-CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c
+CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 

--- a/arch/risc-v/src/fe310/Make.defs
+++ b/arch/risc-v/src/fe310/Make.defs
@@ -46,7 +46,7 @@ CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
 CMN_CSRCS  += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS  += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mdelay.c
-CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c
+CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 

--- a/arch/risc-v/src/gap8/Make.defs
+++ b/arch/risc-v/src/gap8/Make.defs
@@ -59,7 +59,7 @@ CMN_CSRCS  += riscv_createstack.c riscv_exit.c
 CMN_CSRCS  += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS  += riscv_interruptcontext.c riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_sigdeliver.c
-CMN_CSRCS  += riscv_unblocktask.c riscv_usestack.c
+CMN_CSRCS  += riscv_unblocktask.c riscv_usestack.c riscv_copyfullstate.c
 
 ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
 CMN_CSRCS  += riscv_vfork.c

--- a/arch/risc-v/src/litex/Make.defs
+++ b/arch/risc-v/src/litex/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
 CMN_CSRCS  += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS  += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mdelay.c
-CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c
+CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 

--- a/arch/risc-v/src/nr5m100/Make.defs
+++ b/arch/risc-v/src/nr5m100/Make.defs
@@ -61,7 +61,7 @@ CMN_CSRCS  += riscv_allocateheap.c riscv_createstack.c riscv_exit.c riscv_idle.c
 CMN_CSRCS  += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS  += riscv_interruptcontext.c riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c nr5_schedulesigaction.c riscv_sigdeliver.c
-CMN_CSRCS  += riscv_unblocktask.c riscv_usestack.c
+CMN_CSRCS  += riscv_unblocktask.c riscv_usestack.c riscv_copyfullstate.c
 
 ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
 CMN_CSRCS  += riscv_vfork.c

--- a/arch/risc-v/src/rv32im/riscv_copyfullstate.c
+++ b/arch/risc-v/src/rv32im/riscv_copyfullstate.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * arch/risc-v/src/rv32im/riscv_copyfullstate.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <arch/irq.h>
+
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_copyfullstate
+ *
+ * Description:
+ *    Copy the entire register save area (including the floating point
+ *    registers if applicable).  This is a little faster than most memcpy's
+ *    since it does 32-bit transfers.
+ *
+ ****************************************************************************/
+
+void up_copyfullstate(uint32_t *dest, uint32_t *src)
+{
+  int i;
+
+  /* In the RV32 targets, the state is copied from the stack to the TCB,
+   * but only a reference is passed to get the state from the TCB.  So the
+   * following check avoids copying the TCB save area onto itself:
+   */
+
+  if (src != dest)
+    {
+      for (i = 0; i < XCPTCONTEXT_REGS; i++)
+        {
+          *dest++ = *src++;
+        }
+    }
+}

--- a/arch/risc-v/src/rv32im/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv32im/riscv_sigdeliver.c
@@ -93,7 +93,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copystate(regs, rtcb->xcp.regs);
+  up_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always


### PR DESCRIPTION
Signed-off-by: hotislandn <hotislandn@hotmail.com>

## Summary
This is a bug fix that is reported on bl602evb with FPU enabled.
When up_sigdeliver() is called, the up_copystate() will only copy the contents of int regs, since "FS" flag is "clean". Which leads to an invalid value in the stack that will be pop as 'fcsr' later in context restore. From now on, when the CPU encounters the float instruction, it will raise an "invalid instruction" fault.

## Impact
rv32 targets which utils the signal deliver logic.

## Testing
Tested and verified on bl602evb, it runs normally with this patch.
