### PR TITLE
xtensa/esp32: Fix typos reported by codespell

### DIFF
--- a/arch/xtensa/src/common/xtensa_backtrace.S
+++ b/arch/xtensa/src/common/xtensa_backtrace.S
@@ -91,7 +91,7 @@ xtensa_backtrace_start:
    * Use a5 and a6 as scratch.
    */
 
-  l32e    a5, sp, -16     /* Get i PC, which is ret addres of i+1 */
+  l32e    a5, sp, -16     /* Get i PC, which is ret address of i+1 */
   s32i    a5, a2, 0       /* Store i PC to arg *pc */
   l32e    a6, sp, -12     /* Get i+1 SP. Used to access i BS */
   l32e    a5, a6, -12     /* Get i SP */

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -542,7 +542,7 @@ xtensa_context_restore:
 	 *   a4,a5,a8,a9,a12,a13: preserved
 	 *   a6,a7,a10,a11,a14,a15 clobbered if they were part of window(s)
 	 *      to be spilled, otherwise they are the same as on entry
-	 *   loop registers: Perserved
+	 *   loop registers: Preserved
 	 *   SAR: clobbered
 	 *
 	 * We need to preserve only a2 for _xtensa_context_restore

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -314,7 +314,7 @@ _xtensa_level1_handler:
 	call0	_xtensa_context_save			/* Save full register state */
 
   /* Save current SP before (possibly) overwriting it, it's the register save
-   * area. This value will be used later by dispatch_c_isr to retrive the
+   * area. This value will be used later by dispatch_c_isr to retrieve the
    * register save area.
    */
 

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -120,7 +120,7 @@
  ****************************************************************************/
 
 /* Insert some waypoints for jumping beyond the signed 8-bit range of
- * conditional branch instructions, so the conditional branchces to specific
+ * conditional branch instructions, so the conditional branches to specific
  * exception handlers are not taken in the mainline. Saves some cycles in the
  * mainline.
  */

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -83,7 +83,7 @@
  */
 
 /* Region 1 of the heap is the area from the end of the .data section to the
- * begining of the ROM data.  The start address is defined from the linker
+ * beginning of the ROM data.  The start address is defined from the linker
  * script as "_sheap".  Then end is defined here, as follows:
  */
 

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -688,7 +688,7 @@ static void emac_start(void)
  * Name: emac_init_dma
  *
  * Description:
- *   Initailize DMA of EMAC
+ *   Initialize DMA of EMAC
  *
  * Input Parameters:
  *   priv - Reference to the driver state structure
@@ -738,7 +738,7 @@ static void emac_init_dma(struct esp32_emac_s *priv)
  * Name: emac_deinit_dma
  *
  * Description:
- *   Deinitailize DMA of EMAC by force to free RX & TX buffer
+ *   Deinitialize DMA of EMAC by force to free RX & TX buffer
  *
  * Input Parameters:
  *   priv - Reference to the driver state structure

--- a/arch/xtensa/src/esp32/esp32_himem.c
+++ b/arch/xtensa/src/esp32/esp32_himem.c
@@ -50,7 +50,8 @@
  *
  * It gets even worse when both A and B are written: theoretically, a write
  * to a 32-byte cache line in A can be entirely undone because of a write to
- * a different addres in B that happens to be in the same 32-byte cache line.
+ * a different address in B that happens to be in the same 32-byte cache
+ * line.
  *
  * Because of these reasons, we do not allow double mappings at all. This,
  * however, has other implications that make supporting ranges not really
@@ -735,7 +736,7 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-      /* Allocate the maping range */
+      /* Allocate the mapping range */
 
       case HIMEMIOC_ALLOC_MAP_RANGE:
         {
@@ -755,7 +756,7 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-      /* Free the maping range */
+      /* Free the mapping range */
 
       case HIMEMIOC_FREE_MAP_RANGE:
         {

--- a/arch/xtensa/src/esp32/esp32_himem.h
+++ b/arch/xtensa/src/esp32/esp32_himem.h
@@ -47,7 +47,7 @@ extern "C"
  *   [out] handle_out Handle to be returned
  *
  * returns:
- *   - ESP_OK if succesful
+ *   - ESP_OK if successful
  *   - ESP_ERR_NO_MEM if out of memory
  *   - ESP_ERR_INVALID_SIZE if size is not a multiple of 32K
  */
@@ -65,7 +65,7 @@ int esp_himem_alloc(size_t size, esp_himem_handle_t *handle_out);
  *   [out] handle_out Handle to be returned
  *
  * returns:
- *   - ESP_OK if succesful
+ *   - ESP_OK if successful
  *   - ESP_ERR_NO_MEM if out of memory or address space
  *   - ESP_ERR_INVALID_SIZE if size is not a multiple of 32K
  */
@@ -121,7 +121,7 @@ int esp_himem_map(esp_himem_handle_t handle,
  *   handle Handle to the block of memory, as given by esp_himem_alloc
  *
  * returns:
- *   - ESP_OK if the memory is succesfully freed
+ *   - ESP_OK if the memory is successfully freed
  *   - ESP_ERR_INVALID_ARG if the handle still is (partially) mapped
  */
 
@@ -138,7 +138,7 @@ int esp_himem_free(esp_himem_handle_t handle);
  *   handle Handle to the range block, as given by esp_himem_alloc_map_range
  *
  * returns:
- *   - ESP_OK if the memory is succesfully freed
+ *   - ESP_OK if the memory is successfully freed
  *   - ESP_ERR_INVALID_ARG if the handle still is (partially) mapped to
  */
 
@@ -152,7 +152,7 @@ int esp_himem_free_map_range(esp_himem_rangehandle_t handle);
  *   len   Length of the block to be unmapped. Must be aligned to the SPI RAM
  *         MMU blocksize (32K)
  * returns:
- *   - ESP_OK if the memory is succesfully unmapped,
+ *   - ESP_OK if the memory is successfully unmapped,
  *   - ESP_ERR_INVALID_ARG if ptr or len are invalid.
  */
 

--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -433,7 +433,7 @@ static ssize_t esp32_part_bread(FAR struct mtd_dev_s *dev, off_t startblock,
  *   buffer - data buffer pointer
  *
  * Returned Value:
- *   Writen bytes if success or a negative value if fail.
+ *   Written bytes if success or a negative value if fail.
  *
  ****************************************************************************/
 
@@ -459,7 +459,7 @@ static ssize_t esp32_part_write(FAR struct mtd_dev_s *dev, off_t offset,
  *   buffer     - data buffer pointer
  *
  * Returned Value:
- *   Writen block number if success or a negative value if fail.
+ *   Written block number if success or a negative value if fail.
  *
  ****************************************************************************/
 
@@ -567,7 +567,7 @@ int esp32_partition_init(void)
   int ret = 0;
   const int num = PARTITION_MAX_SIZE / sizeof(struct partition_info_priv);
   const char path_base[] = ESP32_PARTITION_MOUNT;
-  char lable[PARTITION_LABEL_LEN + 1];
+  char label[PARTITION_LABEL_LEN + 1];
   char path[PARTITION_LABEL_LEN + sizeof(path_base)];
 
   pbuf = kmm_malloc(PARTITION_MAX_SIZE);
@@ -611,11 +611,11 @@ int esp32_partition_init(void)
           break;
         }
 
-      strncpy(lable, (char *)info->label, PARTITION_LABEL_LEN);
-      lable[PARTITION_LABEL_LEN] = 0;
-      sprintf(path, "%s%s", path_base, lable);
+      strncpy(label, (char *)info->label, PARTITION_LABEL_LEN);
+      label[PARTITION_LABEL_LEN] = 0;
+      sprintf(path, "%s%s", path_base, label);
 
-      finfo("INFO: [label]:   %s\n", lable);
+      finfo("INFO: [label]:   %s\n", label);
       finfo("INFO: [type]:    %d\n", info->type);
       finfo("INFO: [subtype]: %d\n", info->subtype);
       finfo("INFO: [offset]:  0x%08x\n", info->offset);
@@ -639,7 +639,7 @@ int esp32_partition_init(void)
       mtd_priv->mtd.ioctl  = esp32_part_ioctl;
       mtd_priv->mtd.read   = esp32_part_read;
       mtd_priv->mtd.write  = esp32_part_write;
-      mtd_priv->mtd.name   = lable;
+      mtd_priv->mtd.name   = label;
 
       mtd_part = mtd_partition(&mtd_priv->mtd,
                                info->offset / geo.blocksize,

--- a/arch/xtensa/src/esp32/esp32_pm.c
+++ b/arch/xtensa/src/esp32/esp32_pm.c
@@ -583,7 +583,7 @@ static int IRAM_ATTR esp32_sleep_start(uint32_t pd_flags)
 
   if (esp32_configure_cpu_freq(cur_freq) != OK)
     {
-      pwrwarn("WARNING: Faile to restore CPU frequency"
+      pwrwarn("WARNING: Failed to restore CPU frequency"
               "Configure cpu frequency %d.\n", cur_freq);
     }
 

--- a/arch/xtensa/src/esp32/esp32_psram.c
+++ b/arch/xtensa/src/esp32/esp32_psram.c
@@ -243,8 +243,8 @@ typedef struct
   uint16_t addr_bit_len;       /* Address byte length */
   uint32_t *tx_data;           /* Point to send data buffer */
   uint16_t tx_data_bit_len;    /* Send data byte length. */
-  uint32_t *rx_data;           /* Point to recevie data buffer */
-  uint16_t rx_data_bit_len;    /* Recevie Data byte length. */
+  uint32_t *rx_data;           /* Point to receive data buffer */
+  uint16_t rx_data_bit_len;    /* Receive Data byte length. */
   uint32_t dummy_bit_len;
 } psram_cmd_t;
 
@@ -929,7 +929,7 @@ psram_2t_mode_enable(psram_spi_num_t spi_num)
 
   /* setp3: keep cs as high level
    *        send 128 cycles clock
-   *        send 1 bit high levle in ninth clock from the back to PSRAM SIO1
+   *        send 1 bit high level in ninth clock from the back to PSRAM SIO1
    */
 
   GPIO_OUTPUT_SET(CONFIG_D0WD_PSRAM_CS_IO, 1);
@@ -1751,7 +1751,7 @@ psram_cache_init(int psram_cache_mode, int vaddrmode)
    * 0 -->32k,(accord with the settings in cache_sram_mmu_set)
    */
 
-  /* get into unknow exception if not comment */
+  /* get into unknown exception if not comment */
 
   regval  = getreg32(DPORT_PRO_CACHE_CTRL1_REG);
   regval &= ~(DPORT_PRO_CMMU_SRAM_PAGE_MODE <<

--- a/arch/xtensa/src/esp32/esp32_rng.c
+++ b/arch/xtensa/src/esp32/esp32_rng.c
@@ -103,7 +103,7 @@ uint32_t IRAM_ATTR esp_random(void)
    * actually wait a bit longer due to extra time spent in arithmetic and
    * branch statements.
    *
-   * As a (probably unncessary) precaution to avoid returning the
+   * As a (probably unnecessary) precaution to avoid returning the
    * RNG state as-is, the result is XORed with additional
    * WDEV_RND_REG reads while waiting.
    */

--- a/arch/xtensa/src/esp32/esp32_rt_timer.c
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.c
@@ -347,7 +347,7 @@ static int rt_timer_thread(int argc, FAR char *argv[])
               kmm_free(timer);
             }
 
-          /* Enter critical for next scaning list */
+          /* Enter critical for next scanning list */
 
           flags = enter_critical_section();
 

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -630,7 +630,7 @@ static int esp32_io_interrupt(int irq, void *context, FAR void *arg)
  * Description:
  *   Process SPI slave TX.
  *
- *   DMA mode    : Initliaze register to prepare for TX
+ *   DMA mode    : Initialize register to prepare for TX
  *   Non-DMA mode: Fill data to TX register
  *
  * Input Parameters:
@@ -678,7 +678,7 @@ static void esp32_spislv_tx(struct esp32_spislv_priv_s *priv)
  *   Process SPI slave RX. Process SPI slave device receive callback by
  *   calling SPI_SDEV_RECEIVE and prepare for next RX.
  *
- *   DMA mode : Initliaze register to prepare for RX
+ *   DMA mode : Initialize register to prepare for RX
  *
  * Input Parameters:
  *   priv   - Private SPI device structure

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -1396,7 +1396,7 @@ static int IRAM_ATTR esp32_mmap(FAR struct esp32_spiflash_s *priv,
  *
  * Input Parameters:
  *   spi - ESP32 SPI Flash chip data
- *   req - SPI Flash mapping requesting paramters
+ *   req - SPI Flash mapping requesting parameters
  *
  * Returned Value:
  *   None.
@@ -1738,7 +1738,7 @@ static ssize_t esp32_bread_decrypt(FAR struct mtd_dev_s *dev,
  *   buffer - data buffer pointer
  *
  * Returned Value:
- *   Writen bytes if success or a negative value if fail.
+ *   Written bytes if success or a negative value if fail.
  *
  ****************************************************************************/
 
@@ -1799,7 +1799,7 @@ error_with_buffer:
  *   buffer     - data buffer pointer
  *
  * Returned Value:
- *   Writen block number if success or a negative value if fail.
+ *   Written block number if success or a negative value if fail.
  *
  ****************************************************************************/
 
@@ -1843,7 +1843,7 @@ static ssize_t esp32_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
  *   buffer     - data buffer pointer
  *
  * Returned Value:
- *   Writen block number if success or a negative value if fail.
+ *   Written block number if success or a negative value if fail.
  *
  ****************************************************************************/
 

--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -416,10 +416,10 @@ static int esp32_wdt_stop(FAR struct esp32_wdt_dev_s *dev)
  *
  * Description:
  *   Enables write protection (WP) on registers against accidental writing.
- *   TRM recommends to change any WDT register thorugh this sequence:
+ *   TRM recommends to change any WDT register through this sequence:
  *   - Disable WP
  *   - Do the op
- *   - Reenable WP
+ *   - Re-enable WP
  *
  ****************************************************************************/
 
@@ -449,10 +449,10 @@ static int esp32_wdt_enablewp(FAR struct esp32_wdt_dev_s *dev)
  *
  * Description:
  *   Disables write protection (WP) on registers against accidental writing.
- *   TRM recommends to change any WDT register thorugh this sequence:
+ *   TRM recommends to change any WDT register through this sequence:
  *   - Disable WP
  *   - Do the op
- *   - Reenable WP
+ *   - Re-enable WP
  *
  ****************************************************************************/
 

--- a/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
@@ -608,7 +608,7 @@ static int    esp32_wdt_handler(int irq, FAR void *context, FAR void *arg)
  *
  * Description:
  *   Initialize the WDT watchdog timer.  The watchdog timer is initialized
- *   and registerd as 'devpath'.
+ *   and registered as 'devpath'.
  *
  * Input Parameters:
  *   devpath                 - The full path to the watchdog.  This should

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -540,7 +540,7 @@ static int esp_int_adpt_cb(int irq, void *context, FAR void *arg)
  *   Delete thread self's semaphore
  *
  * Input Parameters:
- *   semphr - Semphore data pointer
+ *   semphr - Semaphore data pointer
  *
  * Returned Value:
  *   None
@@ -881,7 +881,7 @@ static void IRAM_ATTR esp_task_yield_from_isr(void)
  *   init - semaphore initialization value
  *
  * Returned Value:
- *   Semphore data pointer
+ *   Semaphore data pointer
  *
  ****************************************************************************/
 
@@ -917,7 +917,7 @@ static void *esp_semphr_create(uint32_t max, uint32_t init)
  *   Delete semaphore
  *
  * Input Parameters:
- *   semphr - Semphore data pointer
+ *   semphr - Semaphore data pointer
  *
  * Returned Value:
  *   None
@@ -939,7 +939,7 @@ static void esp_semphr_delete(void *semphr)
  *   Wait semaphore within a certain period of time
  *
  * Input Parameters:
- *   semphr - Semphore data pointer
+ *   semphr - Semaphore data pointer
  *   ticks  - Wait system ticks
  *
  * Returned Value:
@@ -992,7 +992,7 @@ static int32_t esp_semphr_take(void *semphr, uint32_t ticks)
  *   Post semaphore
  *
  * Input Parameters:
- *   semphr - Semphore data pointer
+ *   semphr - Semaphore data pointer
  *
  * Returned Value:
  *   True if success or false if fail
@@ -1023,7 +1023,7 @@ static int32_t esp_semphr_give(void *semphr)
  *   None
  *
  * Returned Value:
- *   Semphore data pointer
+ *   Semaphore data pointer
  *
  ****************************************************************************/
 
@@ -1810,13 +1810,13 @@ static void *esp_task_get_current_task(void)
  * Name: esp_task_get_max_priority
  *
  * Description:
- *   Get OS task maxium priority
+ *   Get OS task maximum priority
  *
  * Input Parameters:
  *   None
  *
  * Returned Value:
- *   Task maxium priority
+ *   Task maximum priority
  *
  ****************************************************************************/
 
@@ -2195,7 +2195,7 @@ static void wifi_apb80m_release(void)
  *   Update WiFi mac timer.
  *
  * Input Parameters:
- *   en_clock_stopped - Check if clock is stoppped
+ *   en_clock_stopped - Check if clock is stopped
  *   now              - time now
  *
  * Returned Value:
@@ -2251,7 +2251,7 @@ static void wifi_phy_disable(void)
 
       phy_close_rf();
 
-      /* Update WiFi MAC time before disalbe
+      /* Update WiFi MAC time before disabling it.
        * WiFi/BT common peripheral clock.
        */
 
@@ -4158,7 +4158,7 @@ int32_t esp_timer_stop(esp_timer_handle_t timer)
  * Name: esp_timer_delete
  *
  * Description:
- *   Delete timer and free recource
+ *   Delete timer and free resource
  *
  * Input Parameters:
  *   timer  - Timer handle pointer
@@ -4181,7 +4181,7 @@ int32_t esp_timer_delete(esp_timer_handle_t timer)
  * Name: __assert_func
  *
  * Description:
- *   Delete timer and free recource
+ *   Delete timer and free resource
  *
  * Input Parameters:
  *   file  - assert file
@@ -4220,7 +4220,7 @@ void __assert_func(const char *file, int line,
  *   ticks_to_wait   - Waiting system ticks
  *
  * Returned Value:
- *   Task maxium priority
+ *   Task maximum priority
  *
  ****************************************************************************/
 

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -465,7 +465,7 @@ static void wlan_tx_done(uint8_t ifidx, uint8_t *data,
  * Function: wlan_rx_done
  *
  * Description:
- *   WiFi RX done callback function. If this is called, it means receiveing
+ *   WiFi RX done callback function. If this is called, it means receiving
  *   packet.
  *
  * Input Parameters:

--- a/arch/xtensa/src/esp32/hardware/efuse_reg.h
+++ b/arch/xtensa/src/esp32/hardware/efuse_reg.h
@@ -314,7 +314,7 @@
 #define EFUSE_RD_FLASH_CRYPT_CONFIG_S  28
 
 /* EFUSE_RD_DIG_VOL_L6: RO; bitpos:[27:24];
- * Descritpion: This field stores the difference between the digital
+ * Description: This field stores the difference between the digital
  * regulator voltage at level6 and 1.2 V. (RO)
  * BIT[27] is the sign bit, 0: + , 1: -
  * BIT[26:24] is the difference value, unit: 0.017V
@@ -748,7 +748,7 @@
 #define EFUSE_FLASH_CRYPT_CONFIG_S     28
 
 /* EFUSE_DIG_VOL_L6: R/W; bitpos:[27:24];
- * Descritpion: This field stores the difference between the digital
+ * Description: This field stores the difference between the digital
  * regulator voltage at level6 and 1.2 V. (R/W)
  * BIT[27] is the sign bit, 0: + , 1: -
  * BIT[26:24] is the difference value, unit: 0.017V

--- a/arch/xtensa/src/esp32/hardware/esp32_emac.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_emac.h
@@ -108,7 +108,7 @@
 
 #define EMAC_EOCCR_OFFSET     (0x804)
 
-/* Clock resource selection and enbale */
+/* Clock resource selection and enable */
 
 #define EMAC_ECCR_OFFSET      (0x808)
 
@@ -364,8 +364,8 @@
 #define EMAC_RA_E             (BIT(31)) /* Receive all frame */
 #define EMAC_SAF_E            (BIT(9))  /* Src address filter */
 #define EMAC_SARF_E           (BIT(8))  /* Src address reverse filter */
-#define EMAC_PCF_S            (6)       /* Proccess control frame shift */
-#define EMAC_PCF_V            (0x3)     /* Proccess control frame max value */
+#define EMAC_PCF_S            (6)       /* Process control frame shift */
+#define EMAC_PCF_V            (0x3)     /* Process control frame max value */
 #define EMAC_BF_D             (BIT(5))  /* Disable pass broadcast frame */
 #define EMAC_PMF_E            (BIT(4))  /* Pass multicast frame */
 #define EMAC_DAIF_E           (BIT(3))  /* multicast and unicast reverse filter */
@@ -441,8 +441,8 @@
 #define EMAC_RXDMA_SRI        (BIT(31)) /* Stop RI interrupt */
 #define EMAC_RXDMA_RER        (BIT(15)) /* Receive end of ring */
 #define EMAC_RXDMA_RCH        (BIT(14)) /* Second address chained */
-#define EMAC_RXDMA_RBS_S      (0)       /* Receive bufer size shift */
-#define EMAC_RXDMA_RBS_V      (0x1fff)  /* Receive bufer size max value */
+#define EMAC_RXDMA_RBS_S      (0)       /* Receive buffer size shift */
+#define EMAC_RXDMA_RBS_V      (0x1fff)  /* Receive buffer size max value */
 
 /* TX DMA description TDES0 register ****************************************/
 

--- a/arch/xtensa/src/esp32/hardware/esp32_i2c.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_i2c.h
@@ -71,7 +71,7 @@
 /* I2C_RX_LSB_FIRST : R/W ;bitpos:[7] ;default: 1'h0 ; */
 
 /* Description: This bit is used to control the storage mode for received
- * datas.
+ * data.
  * 1: receive data from most significant bit
  * 0: receive data from least significant bit
  */
@@ -128,7 +128,7 @@
 /* I2C_SCL_FORCE_OUT : R/W ;bitpos:[1] ;default: 1'b1 ; */
 
 /* Description:
- * 1: normally ouput scl clock
+ * 1: normally output scl clock
  * 0: exchange the function of scl_o and scl_oe (scl_o is the original
  * internal output scl signal scl_oe is the enable bit for the internal
  * output scl signal)
@@ -142,7 +142,7 @@
 /* I2C_SDA_FORCE_OUT : R/W ;bitpos:[0] ;default: 1'b1 ; */
 
 /* Description:
- * 1: normally ouput sda data
+ * 1: normally output sda data
  * 0: exchange the function of sda_o and sda_oe (sda_o is the original
  * internal output sda signal sda_oe is the enable bit for the internal
  * output sda signal)
@@ -429,7 +429,7 @@
 
 /* I2C_NONFIFO_EN : R/W ;bitpos:[10] ;default: 1'b0 ; */
 
-/* Description: Set this bit to enble apb nonfifo access. */
+/* Description: Set this bit to enable apb nonfifo access. */
 
 #define I2C_NONFIFO_EN          (BIT(10))
 #define I2C_NONFIFO_EN_M        (BIT(10))

--- a/arch/xtensa/src/esp32/hardware/esp32_rtccntl.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_rtccntl.h
@@ -39,7 +39,7 @@
 
 /* WDT defines */
 
-/* Offset relative to each wathdog timer instance memory base */
+/* Offset relative to each watchdog timer instance memory base */
 
 /* RWDT */
 #define RWDT_CONFIG0_OFFSET         0x008c

--- a/arch/xtensa/src/esp32/hardware/esp32_soc.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_soc.h
@@ -789,7 +789,7 @@ extern int rom_i2c_writeReg(int block, int block_id, int reg_add,
 #define IROM0_PAGES_START           64
 #define IROM0_PAGES_END             256
 
-/* MMU invaild value */
+/* MMU invalid value */
 
 #define INVALID_MMU_VAL             0x100
 

--- a/arch/xtensa/src/esp32/hardware/esp32_uart.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_uart.h
@@ -1695,7 +1695,7 @@
 
 /* UART_TX_MEM_EMPTY_THRHD : R/W ;bitpos:[30:28] ;default: 3'h0 ; */
 
-/* Description: refer to txfifo_empty_thrhd 's describtion. */
+/* Description: refer to txfifo_empty_thrhd 's description. */
 
 #define UART_TX_MEM_EMPTY_THRHD         0x00000007
 #define UART_TX_MEM_EMPTY_THRHD_M       ((UART_TX_MEM_EMPTY_THRHD_V) << (UART_TX_MEM_EMPTY_THRHD_S))
@@ -1704,7 +1704,7 @@
 
 /* UART_RX_MEM_FULL_THRHD : R/W ;bitpos:[27:25] ;default: 3'h0 ; */
 
-/* Description: refer to the rxfifo_full_thrhd's describtion. */
+/* Description: refer to the rxfifo_full_thrhd's description. */
 
 #define UART_RX_MEM_FULL_THRHD          0x00000007
 #define UART_RX_MEM_FULL_THRHD_M        ((UART_RX_MEM_FULL_THRHD_V) << (UART_RX_MEM_FULL_THRHD_S))
@@ -1713,7 +1713,7 @@
 
 /* UART_XOFF_THRESHOLD_H2 : R/W ;bitpos:[24:23] ;default: 2'h0 ; */
 
-/* Description: refer to the uart_xoff_threshold's describtion. */
+/* Description: refer to the uart_xoff_threshold's description. */
 
 #define UART_XOFF_THRESHOLD_H2          0x00000003
 #define UART_XOFF_THRESHOLD_H2_M        ((UART_XOFF_THRESHOLD_H2_V) << (UART_XOFF_THRESHOLD_H2_S))
@@ -1722,7 +1722,7 @@
 
 /* UART_XON_THRESHOLD_H2 : R/W ;bitpos:[22:21] ;default: 2'h0 ; */
 
-/* Description: refer to the uart_xon_threshold's describtion. */
+/* Description: refer to the uart_xon_threshold's description. */
 
 #define UART_XON_THRESHOLD_H2           0x00000003
 #define UART_XON_THRESHOLD_H2_M         ((UART_XON_THRESHOLD_H2_V) << (UART_XON_THRESHOLD_H2_S))
@@ -1731,7 +1731,7 @@
 
 /* UART_RX_TOUT_THRHD_H3 : R/W ;bitpos:[20:18] ;default: 3'h0 ; */
 
-/* Description: refer to the rx_tout_thrhd's describtion. */
+/* Description: refer to the rx_tout_thrhd's description. */
 
 #define UART_RX_TOUT_THRHD_H3           0x00000007
 #define UART_RX_TOUT_THRHD_H3_M         ((UART_RX_TOUT_THRHD_H3_V) << (UART_RX_TOUT_THRHD_H3_S))
@@ -1740,7 +1740,7 @@
 
 /* UART_RX_FLOW_THRHD_H3 : R/W ;bitpos:[17:15] ;default: 3'h0 ; */
 
-/* Description: refer to the rx_flow_thrhd's describtion. */
+/* Description: refer to the rx_flow_thrhd's description. */
 
 #define UART_RX_FLOW_THRHD_H3           0x00000007
 #define UART_RX_FLOW_THRHD_H3_M         ((UART_RX_FLOW_THRHD_H3_V) << (UART_RX_FLOW_THRHD_H3_S))
@@ -1809,7 +1809,7 @@
 
 /* UART_TX_MEM_CNT : RO ;bitpos:[5:3] ;default: 3'b0 ; */
 
-/* Description: refer to the txfifo_cnt's describtion. */
+/* Description: refer to the txfifo_cnt's description. */
 
 #define UART_TX_MEM_CNT                 0x00000007
 #define UART_TX_MEM_CNT_M               ((UART_TX_MEM_CNT_V) << (UART_TX_MEM_CNT_S))
@@ -1818,7 +1818,7 @@
 
 /* UART_RX_MEM_CNT : RO ;bitpos:[2:0] ;default: 3'b0 ; */
 
-/* Description: refer to the rxfifo_cnt's describtion. */
+/* Description: refer to the rxfifo_cnt's description. */
 
 #define UART_RX_MEM_CNT                 0x00000007
 #define UART_RX_MEM_CNT_M               ((UART_RX_MEM_CNT_V) << (UART_RX_MEM_CNT_S))

--- a/arch/xtensa/src/esp32/rom/esp32_spiflash.h
+++ b/arch/xtensa/src/esp32/rom/esp32_spiflash.h
@@ -454,7 +454,7 @@ esp_rom_spiflash_config_clk(uint8_t freqdiv,
  *
  *   Please do not call this function in SDK.
  *
- * Input Paramater:
+ * Input Parameter:
  *   esp_rom_spiflash_common_cmd_t *cmd : A struct to show the action of a
  *                                        command.
  *

--- a/boards/xtensa/esp32/esp32-devkitc/Kconfig
+++ b/boards/xtensa/esp32/esp32-devkitc/Kconfig
@@ -134,7 +134,7 @@ config ESP32_SPIRAM_SPIWP_SD3_PIN
 	default 7
 	help
 	    This value is ignored unless flash mode is set to DIO or DOUT and
-	    the SPI flash pins have been overriden by setting the eFuses
+	    the SPI flash pins have been overridden by setting the eFuses
 	    SPI_PAD_CONFIG_xxx.
 
 	    When this is the case, the eFuse config only defines 3 of the 4

--- a/boards/xtensa/esp32/esp32-devkitc/README.txt
+++ b/boards/xtensa/esp32/esp32-devkitc/README.txt
@@ -237,7 +237,7 @@ Ethernet
       ESP32 GPIO          PHY Chip GPIO
         IO5        <-->      Reset_N
 
-Espressif has an offcial Ethernet development board:
+Espressif has an official Ethernet development board:
 
   https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit.html
 
@@ -250,7 +250,7 @@ causes failing to bring the ESP32 chip up.
 =============
 
   ESP32 has 4 generic timers of 64 bits (2 from Group 0 and 2 from Group 1). They're
-  acessible as character drivers, the configuration along with a guidance on how
+  accessible as character drivers, the configuration along with a guidance on how
   to run the example and the description of the application level interface can be found here:
 
   https://nuttx.apache.org/docs/latest/components/drivers/character/timer.html
@@ -259,7 +259,7 @@ Watchdog Timers
 ===============
 
   ESP32 has 3 WDTs. 2 MWDTS from the Timers Module and 1 RWDT from the RTC Module
-  (Currently not supported yet). They're acessible as character drivers,
+  (Currently not supported yet). They're accessible as character drivers,
   The configuration along with a guidance on how to run the example and the description
   of the application level interface can be found here:
 

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_spiflash.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_spiflash.c
@@ -70,7 +70,7 @@ int esp32_spiflash_init(void)
           return ret;
         }
 
-      finfo("Erase successed, initializaing again\n");
+      finfo("Erase successful, initializing again\n");
       ret = smart_initialize(0, mtd, NULL);
       if (ret < 0)
         {

--- a/boards/xtensa/esp32/esp32-ethernet-kit/README.txt
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/README.txt
@@ -63,7 +63,7 @@ Ethernet
       ESP32 GPIO          PHY Chip GPIO
         IO5        <-->      Reset_N
 
-Espressif has an offcial Ethernet development board:
+Espressif has an official Ethernet development board:
 
   https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit.html
 

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_spiflash.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_spiflash.c
@@ -70,7 +70,7 @@ int esp32_spiflash_init(void)
           return ret;
         }
 
-      finfo("Erase successed, initializaing again\n");
+      finfo("Erase successful, initializing again\n");
       ret = smart_initialize(0, mtd, NULL);
       if (ret < 0)
         {

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_spiflash.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_spiflash.c
@@ -70,7 +70,7 @@ int esp32_spiflash_init(void)
           return ret;
         }
 
-      finfo("Erase successed, initializaing again\n");
+      finfo("Erase successful, initializing again\n");
       ret = smart_initialize(0, mtd, NULL);
       if (ret < 0)
         {


### PR DESCRIPTION
## Summary
Just fixing some misspelled words in the esp32 implementation.

## Impact
No impact, most of the fixes are in comments.

## Testing
Not applicable.
