### PR TITLE
risc-v: Fix typos reported by codespell

### DIFF
--- a/arch/risc-v/src/bl602/bl602_spiflash.c
+++ b/arch/risc-v/src/bl602/bl602_spiflash.c
@@ -246,7 +246,7 @@ static ssize_t bl602_bread(FAR struct mtd_dev_s *dev, off_t startblock,
  *   buffer     - data buffer pointer
  *
  * Returned Value:
- *   Writen block number if success or a negative value if fail.
+ *   Written block number if success or a negative value if fail.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/bl602/bl602_tim.c
+++ b/arch/risc-v/src/bl602/bl602_tim.c
@@ -57,7 +57,7 @@ static void bl602_wdt_access(void)
  *   cmp_no    - TIMER comparator ID type.
  *
  * Returned Value:
- *   Match comapre register value
+ *   Match compare register value
  *
  ****************************************************************************/
 
@@ -76,7 +76,7 @@ uint32_t bl602_timer_getcompvalue(uint8_t timer_ch, uint8_t cmp_no)
  * Input Parameters:
  *   timer_ch - TIMER channel type.
  *   cmp_no   - TIMER comparator ID type.
- *   val     - TIMER match comapre register value.
+ *   val     - TIMER match compare register value.
  *
  * Returned Value:
  *   None
@@ -375,7 +375,7 @@ void bl602_timer_disable(uint8_t timer_ch)
  * Input Parameters:
  *   timer_ch - TIMER channel type.
  *   int_type - TIMER interrupt type.
- *   int_mask - TIMER interrupt mask value:1:disbale interrupt.0:enable
+ *   int_mask - TIMER interrupt mask value:1:disable interrupt.0:enable
  *              interrupt.
  *
  * Returned Value:
@@ -499,7 +499,7 @@ void bl602_wdt_set_clock(uint8_t clk_src, uint8_t div)
  *   None.
  *
  * Returned Value:
- *   Watchdog match comapre register value.
+ *   Watchdog match compare register value.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/bl602/bl602_tim.h
+++ b/arch/risc-v/src/bl602/bl602_tim.h
@@ -130,7 +130,7 @@ extern "C"
  *   cmp_no    - TIMER comparator ID type.
  *
  * Returned Value:
- *   Match comapre register value
+ *   Match compare register value
  *
  ****************************************************************************/
 
@@ -145,7 +145,7 @@ uint32_t bl602_timer_getcompvalue(uint8_t timer_ch, uint8_t cmp_no);
  * Input Parameters:
  *   timer_ch - TIMER channel type.
  *   cmp_no   - TIMER comparator ID type.
- *   val     - TIMER match comapre register value.
+ *   val     - TIMER match compare register value.
  *
  * Returned Value:
  *   None
@@ -330,7 +330,7 @@ void bl602_timer_disable(uint8_t timer_ch);
  * Input Parameters:
  *   timer_ch - TIMER channel type.
  *   int_type - TIMER interrupt type.
- *   int_mask - TIMER interrupt mask value:1:disbale interrupt.0:enable
+ *   int_mask - TIMER interrupt mask value:1:disable interrupt.0:enable
  *              interrupt.
  *
  * Returned Value:
@@ -368,7 +368,7 @@ void bl602_wdt_set_clock(uint8_t clk_src, uint8_t div);
  *   None.
  *
  * Returned Value:
- *   Watchdog match comapre register value.
+ *   Watchdog match compare register value.
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/bl602/bl602_tim_lowerhalf.c
+++ b/arch/risc-v/src/bl602/bl602_tim_lowerhalf.c
@@ -417,7 +417,7 @@ int bl602_timer_initialize(FAR const char *devpath, int timer)
                                  slelect */
 
   timstr.count_mode     = TIMER_COUNT_PRELOAD; /* Timer count mode */
-  timstr.clock_division = TIMER_CLK_DIV;       /* Timer clock divison value */
+  timstr.clock_division = TIMER_CLK_DIV;       /* Timer clock division value */
   timstr.match_val0     = TIMER_MAX_VALUE;     /* Timer match 0 value 0 */
   timstr.match_val1     = TIMER_MAX_VALUE;     /* Timer match 1 value 0 */
   timstr.match_val2     = TIMER_MAX_VALUE;     /* Timer match 2 value 0 */

--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.c
@@ -432,7 +432,7 @@ static void esp32c3_wdt_stop(struct esp32c3_wdt_dev_s *dev)
  *   TRM recommends to change any WDT register through this sequence:
  *   - Disable WP
  *   - Do the op
- *   - Reenable WP
+ *   - Re-enable WP
  *
  * Parameters:
  *   dev           - Pointer to the driver state structure.
@@ -461,7 +461,7 @@ static void esp32c3_wdt_enablewp(struct esp32c3_wdt_dev_s *dev)
  *   TRM recommends to change any WDT register through this sequence:
  *   - Disable WP
  *   - Do the op
- *   - Reenable WP
+ *   - Re-enable WP
  *
  * Parameters:
  *   dev           - Pointer to the driver state structure.

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_rtccntl.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_rtccntl.h
@@ -31,7 +31,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Offset relative to each wathdog timer instance memory base */
+/* Offset relative to each watchdog timer instance memory base */
 
 #define RWDT_CONFIG0_OFFSET         0x0090
 
@@ -833,7 +833,7 @@
 
 /* RTC_CNTL_GLITCH_DET_INT_ENA : R/W ;bitpos:[19] ;default: 1'b0 ; */
 
-/* Description: enbale gitch det interrupt */
+/* Description: enable gitch det interrupt */
 
 #define RTC_CNTL_GLITCH_DET_INT_ENA  (BIT(19))
 #define RTC_CNTL_GLITCH_DET_INT_ENA_M  (BIT(19))
@@ -3030,7 +3030,7 @@
 
 /* RTC_CNTL_XTAL32K_RETURN_WAIT : R/W ;bitpos:[3:0] ;default: 4'h0 ; */
 
-/* Description: cycles to wait to return noral xtal 32k */
+/* Description: cycles to wait to return normal xtal 32k */
 
 #define RTC_CNTL_XTAL32K_RETURN_WAIT  0x0000000F
 #define RTC_CNTL_XTAL32K_RETURN_WAIT_M  ((RTC_CNTL_XTAL32K_RETURN_WAIT_V)<<(RTC_CNTL_XTAL32K_RETURN_WAIT_S))
@@ -3099,7 +3099,7 @@
 
 /* RTC_CNTL_GLITCH_DET_INT_ENA_W1TS : WO ;bitpos:[19] ;default: 1'b0 ; */
 
-/* Description: enbale gitch det interrupt */
+/* Description: enable gitch det interrupt */
 
 #define RTC_CNTL_GLITCH_DET_INT_ENA_W1TS  (BIT(19))
 #define RTC_CNTL_GLITCH_DET_INT_ENA_W1TS_M  (BIT(19))
@@ -3180,7 +3180,7 @@
 
 /* RTC_CNTL_GLITCH_DET_INT_ENA_W1TC : WO ;bitpos:[19] ;default: 1'b0 ; */
 
-/* Description: enbale gitch det interrupt */
+/* Description: enable gitch det interrupt */
 
 #define RTC_CNTL_GLITCH_DET_INT_ENA_W1TC  (BIT(19))
 #define RTC_CNTL_GLITCH_DET_INT_ENA_W1TC_M  (BIT(19))

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_uart.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_uart.h
@@ -233,7 +233,7 @@
 #define UART_RXFIFO_TOUT_INT_RAW_S  8
 
 /* UART_SW_XON_INT_RAW : R/WTC/SS; bitpos: [9]; default: 0;
- * This interrupt raw bit turns to high level when receiver recevies Xon
+ * This interrupt raw bit turns to high level when receiver receives Xon
  * char when uart_sw_flow_con_en is set to
  * 1.
  */
@@ -1118,7 +1118,7 @@
 #define UART_SW_DTR_S  7
 
 /* UART_TXD_BRK : R/W; bitpos: [8]; default: 0;
- * Set this bit to enbale transmitter to  send NULL when the process of
+ * Set this bit to enable transmitter to  send NULL when the process of
  * sending data is
  * done.
  */
@@ -1391,7 +1391,7 @@
 #define UART_RX_FLOW_EN_S  20
 
 /* UART_RX_TOUT_EN : R/W; bitpos: [21]; default: 0;
- * This is the enble bit for uart receiver's timeout
+ * This is the enable bit for uart receiver's timeout
  * function.
  */
 
@@ -1975,7 +1975,7 @@
 #define UART_HIGHPULSE_REG(i) (REG_UART_BASE(i) + 0x2c)
 
 /* UART_HIGHPULSE_MIN_CNT : RO; bitpos: [12:0]; default: 4095;
- * This register stores  the value of the maxinum duration time for the
+ * This register stores  the value of the maximum duration time for the
  * high level pulse. It is used in baud rate-detect
  * process.
  */

--- a/arch/risc-v/src/nr5m100/hardware/nr5m1xx_timer.h
+++ b/arch/risc-v/src/nr5m100/hardware/nr5m1xx_timer.h
@@ -44,7 +44,7 @@
  * licensed RTL code from the OpenMSP430 project on opencores.org.
  */
 
-/* TimerA offet definitions */
+/* TimerA offset definitions */
 
 #define NR5_TIMERA_TACTL_OFFSET           0x00
 #define NR5_TIMERA_TAR_OFFSET             0x04

--- a/arch/risc-v/src/rv32im/riscv_vfork.c
+++ b/arch/risc-v/src/rv32im/riscv_vfork.c
@@ -199,7 +199,7 @@ pid_t up_vfork(const struct vfork_s *context)
 
   sinfo("stacksize:%d stackutil:%d\n", stacksize, stackutil);
 
-  /* Make some feeble effort to perserve the stack contents.  This is
+  /* Make some feeble effort to preserve the stack contents.  This is
    * feeble because the stack surely contains invalid pointers and other
    * content that will not work in the child context.  However, if the
    * user follows all of the caveats of vfork() usage, even this feeble

--- a/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.ld
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.ld
@@ -214,7 +214,7 @@ SECTIONS
   } >rtc_iram_seg
 
   /* This section is required to skip rtc.text area because the text and
-   * data segements reflect the same address space on different buses.
+   * data segments reflect the same address space on different buses.
    */
 
   .rtc.dummy :


### PR DESCRIPTION
## Summary
Just fixing some misspelled words in RISC-V CPUs and boards implementation.

## Impact
No impact, most of the fixes are in comments.

## Testing
Not applicable.