### PR TITLE
drivers: Fix typos reported by codespell

### DIFF
--- a/drivers/analog/max1161x.c
+++ b/drivers/analog/max1161x.c
@@ -111,7 +111,7 @@ struct max1161x_dev_s
 
   /* Current configuration of the ADC. There are two bytes holding
    * the complete configuration - the Setup Byte has Bit 7 always set,
-   * while the command byte has bit 7 alway reset
+   * while the command byte has bit 7 always reset
    */
 
   uint8_t                           setupbyte;

--- a/drivers/audio/Kconfig
+++ b/drivers/audio/Kconfig
@@ -41,12 +41,12 @@ if AUDIO_CXD56
 if AUDIO_DRIVER_SPECIFIC_BUFFERS
 
 config AUDIO_CXD56_SRC
-	bool "CXD56 audio sample rate convertor"
+	bool "CXD56 audio sample rate converter"
 	select AUDIO_SRC
 	default n
 	---help---
 		Enable support for audio playback using the CXD5247 chip on the
-		CXD56 Spresense board with sample rate convertor.
+		CXD56 Spresense board with sample rate converter.
 
 config CXD56_AUDIO_NUM_BUFFERS
 	int "Number of audio buffers to use"
@@ -291,7 +291,7 @@ config WM8994_CLKDEBUG
 	bool "WM8994 clock analysis"
 	default n
 	---help---
-		Enable logic to analyze WM8994 clock configuation.
+		Enable logic to analyze WM8994 clock configuration.
 
 endif # AUDIO_WM8994
 

--- a/drivers/audio/wm8994.c
+++ b/drivers/audio/wm8994.c
@@ -1990,9 +1990,9 @@ FAR struct audio_lowerhalf_s *
       wm8994_writereg(priv, WM8994_SWRST, 0);
       wm8994_dump_registers(&priv->dev, "After reset");
 
-      /* chip revison */
+      /* chip revision */
 
-      audinfo("wm8994 chip revison: %d\n",
+      audinfo("wm8994 chip revision: %d\n",
                 wm8994_readreg(priv, WM8994_CHIP_REV));
 
       /* Reset and reconfigure the WM8994 hardwaqre */

--- a/drivers/audio/wm8994.h
+++ b/drivers/audio/wm8994.h
@@ -55,12 +55,12 @@
 #define WM8994_SWRST                                    0x00                                  /* SW Reset and ID */
 #define WM8994_ID                                       0x00                                  /* SW Reset and ID */
 
-#define WM8994_PM1                                      0x01                                  /* Power Mangement */
-#define WM8994_PM2                                      0x02                                  /* Power Mangement */
-#define WM8994_PM3                                      0x03                                  /* Power Mangement */
-#define WM8994_PM4                                      0x04                                  /* Power Mangement */
-#define WM8994_PM5                                      0x05                                  /* Power Mangement */
-#define WM8994_PM6                                      0x06                                  /* Power Mangement */
+#define WM8994_PM1                                      0x01                                  /* Power Management */
+#define WM8994_PM2                                      0x02                                  /* Power Management */
+#define WM8994_PM3                                      0x03                                  /* Power Management */
+#define WM8994_PM4                                      0x04                                  /* Power Management */
+#define WM8994_PM5                                      0x05                                  /* Power Management */
+#define WM8994_PM6                                      0x06                                  /* Power Management */
 
 #define WM8994_INPUT_MIXER1                             0x15                                  /* Input Mixer (1) */
 
@@ -361,7 +361,7 @@
  */
 
 #define WM8994_BIAS_ENA                           (1 << 0)                                    /* Bit 0: Enables the Normal bias current generator (for all analogue functions */
-#define   WM8994_BIAS_ENA_DISABLE                 (0)                                         /* Diabled */
+#define   WM8994_BIAS_ENA_DISABLE                 (0)                                         /* Disabled */
 #define   WM8994_BIAS_ENA_ENABLE                  WM8994_BIAS_ENA                             /* Enabled */
 #define WM8994_VMID_SEL_SHITF                     (1)                                         /* Bits 1-2: VMID Divider Enable and Select */
 #define   WM8994_VMID_SEL_DISABLE                 (0 << WM8994_VMID_SEL_SHIFT)                /* VMID disabled (for OFF mode) */
@@ -564,7 +564,7 @@
 #define   WM8994_IN1L_VOL_DEFAULT                (11 << 0)                                    /* -16.5dB to +30dB in 1.5dB steps */
 #define   WM8994_IN1L_VOL_MAX                    (31 << 0)                                    /* +30dB */
                                                                                               /* Bit 5: Reserved */
-#define WM8994_IN1L_ZC                           (1 << 6)                                     /* Bit 6: IN1L PGA Zero Cross Dectector */ 
+#define WM8994_IN1L_ZC                           (1 << 6)                                     /* Bit 6: IN1L PGA Zero Cross Detector */ 
 #define   WM8994_IN1L_ZC_NO                      (0)                                          /* Change gain immediately */
 #define   WM8994_IN1L_ZC_YES                     (WM8994_IN1L_ZC)                             /* Change gain on zero cross only */
 #define WM8994_IN1L_MUTE                         (1 << 7)                                     /* Bit 7: IN1L PGA Mute */
@@ -582,7 +582,7 @@
 #define   WM8994_IN2L_VOL_DEFAULT                (11 << WM8994_IN2L_VOL_SHIFT)                /* -16.5dB to +30dB in 1.5dB steps */
 #define   WM8994_IN2L_VOL_MAX                    (31 << WM8994_IN2L_VOL_SHIFT)                /* +30dB */
                                                                                               /* Bit 5: Reserved */
-#define WM8994_IN2L_ZC                           (1 << 6)                                     /* Bit 6: IN2L PGA Zero Cross Dectector */ 
+#define WM8994_IN2L_ZC                           (1 << 6)                                     /* Bit 6: IN2L PGA Zero Cross Detector */ 
 #define   WM8994_IN2L_ZC_NO                      (0)                                          /* Change gain immediately */
 #define   WM8994_IN2L_ZC_YES                     (WM8994_IN2L_ZC)                             /* Change gain on zero cross only */
 #define WM8994_IN2L_MUTE                         (1 << 7)                                     /* Bit 7: IN2L PGA Mute */
@@ -600,7 +600,7 @@
 #define   WM8994_IN1R_VOL_DEFAULT                (11 << WM8994_IN1R_VOL_SHIFT)                /* -16.5dB to +30dB in 1.5dB steps */
 #define   WM8994_IN1R_VOL_MAX                    (31 << WM8994_IN1R_VOL_SHIFT)                /* +30dB */
                                                                                               /* Bit 5: Reserved */
-#define WM8994_IN1R_ZC_SHIFT                     (6)                                          /* Bit 6: IN1R PGA Zero Cross Dectector */ 
+#define WM8994_IN1R_ZC_SHIFT                     (6)                                          /* Bit 6: IN1R PGA Zero Cross Detector */ 
 #define   WM8994_IN1R_ZC_NO                      (0)                                          /* Change gain immediately */
 #define   WM8994_IN1R_ZC_YES                     (1 << WM8994_IN1R_ZC_SHIFT)                  /* Change gain on zero cross only */
 #define WM8994_IN1R_MUTE_SHIFT                   (7)                                          /* Bit 7: IN1R PGA Mute */
@@ -619,7 +619,7 @@
 #define   WM8994_IN2R_VOL_DEFAULT                (11 << WM8994_IN2R_VOL_SHIFT)                /* -16.5dB to +30dB in 1.5dB steps */
 #define   WM8994_IN2R_VOL_MAX                    (31 << WM8994_IN2R_VOL_SHIFT)                /* +30dB */
                                                                                               /* Bit 5: Reserved */
-#define WM8994_IN2R_ZC_SHIFT                     (6)                                          /* Bit 6: IN2R PGA Zero Cross Dectector */ 
+#define WM8994_IN2R_ZC_SHIFT                     (6)                                          /* Bit 6: IN2R PGA Zero Cross Detector */ 
 #define   WM8994_IN2R_ZC_NO                      (0)                                          /* Change gain immediately */
 #define   WM8994_IN2R_ZC_YES                     (1 << WM8994_IN2R_ZC_SHIFT)                  /* Change gain on zero cross only */
 #define WM8994_IN2R_MUTE_SHIFT                         (7)                                    /* Bit 7: IN2R PGA Mute */

--- a/drivers/i2s/i2schar.c
+++ b/drivers/i2s/i2schar.c
@@ -61,6 +61,7 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
 /* Configuration ************************************************************/
 
 #ifndef CONFIG_AUDIO_I2SCHAR_RXTIMEOUT
@@ -88,22 +89,25 @@ struct i2schar_dev_s
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
+
 /* I2S callback function */
 
-static void    i2schar_rxcallback(FAR struct i2s_dev_s *dev,
-                 FAR struct ap_buffer_s *apb, FAR void *arg, int result);
-static void    i2schar_txcallback(FAR struct i2s_dev_s *dev,
-                 FAR struct ap_buffer_s *apb, FAR void *arg,
-                 int result);
+static void i2schar_rxcallback(FAR struct i2s_dev_s *dev,
+                               FAR struct ap_buffer_s *apb,
+                               FAR void *arg,
+                               int result);
+static void i2schar_txcallback(FAR struct i2s_dev_s *dev,
+                               FAR struct ap_buffer_s *apb,
+                               FAR void *arg,
+                               int result);
 
 /* Character driver methods */
 
 static ssize_t i2schar_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                            size_t buflen);
 static ssize_t i2schar_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
-
-static int     i2schar_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+                             size_t buflen);
+static int i2schar_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -348,14 +352,13 @@ errout_with_reference:
   return ret;
 }
 
-
-/************************************************************************************
+/****************************************************************************
  * Name: i2char_ioctl
  *
  * Description:
  *   Perform I2S device ioctl if exists
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 static int i2schar_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
@@ -420,7 +423,8 @@ int i2schar_register(FAR struct i2s_dev_s *i2s, int minor)
 
   /* Allocate a I2S character device structure */
 
-  priv = (FAR struct i2schar_dev_s *)kmm_zalloc(sizeof(struct i2schar_dev_s));
+  size_t dev_size = sizeof(struct i2schar_dev_s);
+  priv = (FAR struct i2schar_dev_s *)kmm_zalloc(dev_size);
   if (priv)
     {
       /* Initialize the I2S character device structure */
@@ -446,7 +450,6 @@ int i2schar_register(FAR struct i2s_dev_s *i2s, int minor)
 
       return OK;
     }
-
 
   return -ENOMEM;
 }

--- a/drivers/i2s/i2schar.c
+++ b/drivers/i2s/i2schar.c
@@ -136,7 +136,7 @@ static const struct file_operations i2schar_fops =
  *
  *   Also, the test buffer is simply freed.  This will work if this driver
  *   has the sole reference to buffer; in that case the buffer will be freed.
- *   Otherwise -- memory leak!  A more efficient design would recyle the
+ *   Otherwise -- memory leak!  A more efficient design would recycle the
  *   audio buffers.
  *
  ****************************************************************************/
@@ -173,7 +173,7 @@ static void i2schar_rxcallback(FAR struct i2s_dev_s *dev,
  *
  *   NOTE: The test buffer is simply freed.  This will work if this driver
  *   has the sole reference to buffer; in that case the buffer will be freed.
- *   Otherwise -- memory leak!  A more efficient design would recyle the
+ *   Otherwise -- memory leak!  A more efficient design would recycle the
  *   audio buffers.
  *
  ****************************************************************************/

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -1008,7 +1008,7 @@ int spq10kbd_register(FAR struct i2c_master_s *i2c,
   priv->config    = config;  /* Save the board configuration */
   priv->tailndx   = 0;       /* Reset keypress buffer state */
   priv->headndx   = 0;
-  priv->crefs     = 0;       /* Reset referece count to 0 */
+  priv->crefs     = 0;       /* Reset reference count to 0 */
   priv->waiting   = false;
 
 #ifdef CONFIG_SPQ10KBD_DJOY

--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -235,7 +235,7 @@ static ssize_t gpio_write(FAR struct file *filep, FAR const char *buffer,
       return -EACCES;
     }
 
-  /* Verfy that a buffer containing data was provided */
+  /* Verify that a buffer containing data was provided */
 
   DEBUGASSERT(buffer != NULL);
   if (buflen != 0)
@@ -333,7 +333,7 @@ static int gpio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
     {
       /* Command:     GPIOC_WRITE
        * Description: Set the value of an output GPIO
-       * Argument:    0=output a low value; 1=outut a high value
+       * Argument:    0=output a low value; 1=output a high value
        */
 
       case GPIOC_WRITE:

--- a/drivers/ioexpander/skeleton.c
+++ b/drivers/ioexpander/skeleton.c
@@ -762,7 +762,7 @@ static void skel_interrupt(FAR void *arg)
  * 1) A reference to an I2C or SPI interface used to interactive with the
  *    device, and
  * 2) A read-only configuration structure that provides things like:  I2C
- *    or SPI characteristics and callbacks to attache, enable, and disable
+ *    or SPI characteristics and callbacks to attach, enable, and disable
  *    interrupts.
  *
  ****************************************************************************/

--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -573,7 +573,7 @@ if LCD_ST7735
 		bool "132x162 Display Resolution"
 		default n
 		---help---
-			Two resolutions are availabe, either the 132x162 or
+			Two resolutions are available, either the 132x162 or
 			the 128x160
 
 	config LCD_ST7735_BPP

--- a/drivers/lcd/st7735.c
+++ b/drivers/lcd/st7735.c
@@ -331,7 +331,7 @@ static void st7735_display(FAR struct st7735_dev_s *dev, bool on)
  * Name: st7735_setarea
  *
  * Description:
- *   Set the rectangular area for an upcomming read or write from RAM.
+ *   Set the rectangular area for an upcoming read or write from RAM.
  *
  ****************************************************************************/
 

--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -322,7 +322,7 @@ static void st7789_display(FAR struct st7789_dev_s *dev, bool on)
  * Name: st7789_setarea
  *
  * Description:
- *   Set the rectangular area for an upcomming read or write from RAM.
+ *   Set the rectangular area for an upcoming read or write from RAM.
  *
  ****************************************************************************/
 

--- a/drivers/mtd/mtd_nandecc.c
+++ b/drivers/mtd/mtd_nandecc.c
@@ -115,7 +115,7 @@ int nandecc_readpage(FAR struct nand_dev_s *nand, off_t block,
   sparesize = nandmodel_getsparesize(model);
 
   /* Store code in spare buffer, either the buffer provided by the caller or
-   * the scatch buffer in the raw NAND structure.
+   * the scratch buffer in the raw NAND structure.
    */
 
   if (!spare)
@@ -224,7 +224,7 @@ int nandecc_writepage(FAR struct nand_dev_s *nand, off_t block,
     }
 
   /* Store code in spare buffer, either the buffer provided by the caller or
-   * the scatch buffer in the raw NAND structure.
+   * the scratch buffer in the raw NAND structure.
    */
 
   if (!spare)

--- a/drivers/mtd/mx25lx.c
+++ b/drivers/mtd/mx25lx.c
@@ -145,7 +145,7 @@
 #define MX25L_WRDI          0x04  /* Write Disable             0   0  0     */
 #define MX25L_RDSR          0x05  /* Read status register      0   0  >=1   */
 #define MX25L_RDCR          0x15  /* Read config register      0   0  >=1   */
-#define MX25L_WRSR          0x01  /* Write stat/conf registe   0   0  2     */
+#define MX25L_WRSR          0x01  /* Write stat/conf register  0   0  2     */
 #define MX25L_4PP           0x38  /* Quad page program         3/4 0  1-256 */
 #define MX25L_SE            0x20  /* 4Kb Sector erase          3/4 0  0     */
 #define MX25L_BE32          0x52  /* 32Kbit block Erase        3/4 0  0     */

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -644,7 +644,7 @@ ssize_t pipecommon_write(FAR struct file *filep, FAR const char *buffer,
               return nwritten;
             }
 
-          /* There is more to be written.. wait for data to be removed fro
+          /* There is more to be written.. wait for data to be removed from
            * the pipe
            */
 

--- a/drivers/power/Make.defs
+++ b/drivers/power/Make.defs
@@ -152,7 +152,7 @@ ifeq ($(CONFIG_I2C_MAX1704X),y)
 CSRCS += max1704x.c
 endif
 
-# Add the bq27426 I2C-based battery guage driver
+# Add the bq27426 I2C-based battery gauge driver
 
 ifeq ($(CONFIG_BQ27426),y)
 CSRCS += bq27426.c
@@ -186,7 +186,7 @@ endif
 
 endif
 
-# Include battery suport in the build
+# Include battery support in the build
 
 POWER_DEPPATH := --dep-path power
 POWER_VPATH := :power

--- a/drivers/power/bq27426.c
+++ b/drivers/power/bq27426.c
@@ -45,7 +45,7 @@
  *
  * CONFIG_BATTERY - Upper half battery driver support
  * CONFIG_I2C - I2C support
- * CONFIG_BQ27426 - And the driver must be explictly selected.
+ * CONFIG_BQ27426 - And the driver must be explicitly selected.
  */
 
 #if defined(CONFIG_BATTERY_GAUGE) && defined(CONFIG_I2C) && \
@@ -416,7 +416,7 @@ static int bq27426_online(struct battery_gauge_dev_s *dev, bool *status)
  *
  *   CONFIG_BATTERY - Upper half battery driver support
  *   CONFIG_I2C - I2C support
- *   CONFIG_BQ27426 - And the driver must be explictly selected.
+ *   CONFIG_BQ27426 - And the driver must be explicitly selected.
  *
  * Input Parameters:
  *   i2c - An instance of the I2C interface to use to communicate with the bq

--- a/drivers/power/bq769x0.c
+++ b/drivers/power/bq769x0.c
@@ -2055,7 +2055,7 @@ static int bq769x0_operate(struct battery_monitor_dev_s *dev,
  *
  *   CONFIG_BATTERY_MONITOR - Upper half battery driver support
  *   CONFIG_I2C - I2C support
- *   CONFIG_I2C_BQ769X0 - And the driver must be explictly selected.
+ *   CONFIG_I2C_BQ769X0 - And the driver must be explicitly selected.
  *
  * Input Parameters:
  *   i2c       - An instance of the I2C interface to use to communicate with

--- a/drivers/rf/dat-31r5-sp.c
+++ b/drivers/rf/dat-31r5-sp.c
@@ -168,7 +168,7 @@ static int dat31r5sp_close(FAR struct file *filep)
  * Name: dat31r5sp_write
  *
  * Description:
- *   Write is not permited, only IOCTLs.
+ *   Write is not permitted, only IOCTLs.
  ****************************************************************************/
 
 static ssize_t dat31r5sp_write(FAR struct file *filep,

--- a/drivers/rwbuffer.c
+++ b/drivers/rwbuffer.c
@@ -311,7 +311,7 @@ static ssize_t rwb_writebuffer(FAR struct rwbuffer_s *rwb,
           nblocks = 0;
         }
 
-      /* 4. We upate a portion at the end of the write buffer */
+      /* 4. We update a portion at the end of the write buffer */
 
       else if (wrbend >= startblock && wrbend <= newend)
         {

--- a/drivers/sensors/README.txt
+++ b/drivers/sensors/README.txt
@@ -15,7 +15,7 @@ ADXL372 (Bob Feretich)
 
 The ADXL372 is a 200g tri-axis accelerometer that is capable of detecting
 and recording shock impact impact events. Recording trigger
-characteristics are programed into the sensor via multiple threshold and
+characteristics are programmed into the sensor via multiple threshold and
 duration registers.  The ADXL372 is a SPI only device that can transfer
 data at 10 MHz.  The data transfer performance of this part permits the
 sensor to be sampled "on demand" rather than periodically sampled by a
@@ -312,7 +312,7 @@ Its goal is to change the sequence of events detailed above to...
  5) NuttX restores the context for the driver's worker task and starts it
     running.
  6) The cluster driver's worker task starts the i/o to collect the sample.
-    There are two choices here. Programed I/O (PIO) or DMA. If PIO is
+    There are two choices here. Programmed I/O (PIO) or DMA. If PIO is
     fastest for a small sample size, but it will lock up the processor for
     the full duration of the transfer; it can only transfer from one
     sensor at a time; and the worker task should manually yield control
@@ -443,7 +443,7 @@ driver_suspend() and driver_resume(): Optional. Set to NULL if not
 
 Note that all drivers are encouraged to extend their entry-point vectors
 beyond this common segment. For example it may be beneficial for the
-worker task  to select between programed i/o and DMA data transfer
+worker task  to select between programmed i/o and DMA data transfer
 routines. Unregulated extensions to the Entry-Point Vector should be
 encouraged to maximize the benefits of a sensor's features.
 

--- a/drivers/sensors/dhtxx.c
+++ b/drivers/sensors/dhtxx.c
@@ -348,7 +348,7 @@ static int dht_parse_data(FAR struct dhtxx_dev_s *priv,
       data->temp = priv->raw_data[2];
 
       /* if data is not within sensor's measurement range,
-       * an error must have accured.
+       * an error must have occurred.
        */
 
       if (!dht_check_data(data, DHT11_MIN_HUM, DHT11_MAX_HUM,

--- a/drivers/sensors/hdc1008.c
+++ b/drivers/sensors/hdc1008.c
@@ -85,7 +85,7 @@
 #  define HDC1008_CONFIGURATION_TRES_14BIT    (CONFIGURATION_RES_14BIT << HDC1008_CONFIGURATION_TRES_SHIFT)
 #  define HDC1008_CONFIGURATION_TRES_11BIT    (CONFIGURATION_RES_11BIT << HDC1008_CONFIGURATION_TRES_SHIFT)
 #define HDC1008_CONFIGURATION_BTST            (1 << 11) /* Bit 11: Battery status */
-#define HDC1008_CONFIGURATION_MODE            (1 << 12) /* Bit 12: Mode of aquisition */
+#define HDC1008_CONFIGURATION_MODE            (1 << 12) /* Bit 12: Mode of acquisition */
 #define HDC1008_CONFIGURATION_HEAT_SHIFT      (13)      /* Bit 13: Heater */
 #define HDC1008_CONFIGURATION_HEAT_MASK       (0x01 << HDC1008_CONFIGURATION_HEAT_SHIFT)
 #  define HDC1008_CONFIGURATION_HEAT_DISABLE  (0x00 << HDC1008_CONFIGURATION_HEAT_SHIFT)
@@ -104,7 +104,7 @@ struct hdc1008_dev_s
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   bool unlinked;                /* True, driver has been unlinked */
 #endif
-  uint8_t mode;                 /* Aquisition mode */
+  uint8_t mode;                 /* Acquisition mode */
   uint16_t configuration;       /* Configuration shadow register */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   int16_t crefs;                /* Number of open references */

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -284,7 +284,7 @@ static ssize_t sensor_read(FAR struct file *filep, FAR char *buffer,
   else
     {
       /* We must make sure that when the semaphore is equal to 1, there must
-       * be events avaliable in the buffer, so we use a while statement to
+       * be events available in the buffer, so we use a while statement to
        * synchronize this case that other read operations consume events
        * that have just entered the buffer.
        */
@@ -316,7 +316,7 @@ static ssize_t sensor_read(FAR struct file *filep, FAR char *buffer,
       ret = circbuf_read(&upper->buffer, buffer, len);
 
       /* Release some buffer space when current mode isn't batch mode
-       * and last mode is batch mode, and the number of bytes avaliable
+       * and last mode is batch mode, and the number of bytes available
        * in buffer is less than the number of bytes origin.
        */
 

--- a/drivers/sensors/wtgahrs2.c
+++ b/drivers/sensors/wtgahrs2.c
@@ -446,7 +446,7 @@ int wtgahrs2_initialize(FAR const char *path, int devno)
 
   if (!path)
     {
-      snerr("Invaild path for serial interface\n");
+      snerr("Invalid path for serial interface\n");
       return -EINVAL;
     }
 

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -136,12 +136,12 @@ static const struct spi_ops_s g_spiops =
  * Name: spi_lock
  *
  * Description:
- *   On SPI busses where there are multiple devices, it will be necessary to
- *   lock SPI to have exclusive access to the busses for a sequence of
+ *   On SPI buses where there are multiple devices, it will be necessary to
+ *   lock SPI to have exclusive access to the buses for a sequence of
  *   transfers.  The bus should be locked before the chip is selected. After
  *   locking the SPI bus, the caller should then also call the setfrequency,
  *   setbits, and setmode methods to make sure that the SPI is properly
- *   configured for the device.  If the SPI buss is being shared, then it
+ *   configured for the device.  If the SPI bus is being shared, then it
  *   may have been left in an incompatible state.
  *
  * Input Parameters:

--- a/drivers/spi/spi_driver.c
+++ b/drivers/spi/spi_driver.c
@@ -325,7 +325,7 @@ static int spidrvr_unlink(FAR struct inode *inode)
       return OK;
     }
 
-  /* No... just mark the driver as unlinked and free the resouces when the
+  /* No... just mark the driver as unlinked and free the resources when the
    * last client closes their reference to the driver.
    */
 

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -1294,7 +1294,7 @@ static int usbclass_setup(FAR struct usbdevclass_driver_s *driver,
         }
     }
 #else
-  /* Composite should send only one resquest for USB_REQ_SETCONFIGURATION.
+  /* Composite should send only one request for USB_REQ_SETCONFIGURATION.
    * Hence ADB driver cannot submit to ep0; composite has to handle it.
    */
 

--- a/drivers/usbdev/pl2303.c
+++ b/drivers/usbdev/pl2303.c
@@ -566,7 +566,7 @@ static uint16_t usbclass_fillrequest(FAR struct pl2303_dev_s *priv, uint8_t *req
  *
  * Description:
  *   This function obtains write requests, transfers the TX data into the request,
- *   and submits the requests to the USB controller.  This continues untils either
+ *   and submits the requests to the USB controller.  This continues until either
  *   (1) there are no further packets available, or (2) there is not further data
  *   to send.
  *

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -1669,7 +1669,7 @@ static inline int usbhost_devinit(FAR struct usbhost_cdcmbim_s *priv)
 
   /* Check if we successfully initialized. We now have to be concerned
    * about asynchronous modification of crefs because the character
-   * driver has been registerd.
+   * driver has been registered.
    */
 
   if (ret >= 0)

--- a/drivers/usbmonitor/usbmonitor.c
+++ b/drivers/usbmonitor/usbmonitor.c
@@ -192,7 +192,7 @@ static int usbmonitor_daemon(int argc, char **argv)
 /****************************************************************************
  * Name: usbmonitor_start
  *
- *   Start the USB monitor kernal daemon.
+ *   Start the USB monitor kernel daemon.
  *
  * Input Parameters:
  *   None

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -46,7 +46,8 @@
  *     ISM Region 2 (Complete America)
  *
  * Todo:
- *   - Extend max packet length up to 255 bytes or rather infinite < 4096 bytes
+ *   - Extend max packet length up to 255 bytes or rather
+ *     infinite < 4096 bytes
  *   - Power up/down modes
  *   - Sequencing between states or add protection for correct termination of
  *     various different state (so that CC1101 does not block in case of
@@ -83,7 +84,8 @@
  * how RSSI and LQI work:
  *
  *  1. A weak signal in the presence of noise may give low RSSI and low LQI.
- *  2. A weak signal in "total" absence of noise may give low RSSI and high LQI.
+ *  2. A weak signal in "total" absence of noise may give low RSSI and high
+ *     LQI.
  *  3. Strong noise (usually coming from an interferer) may give high RSSI
  *     and low LQI.
  *  4. A strong signal without much noise may give high RSSI and high LQI.
@@ -299,7 +301,8 @@ static int cc1101_file_open(FAR struct file *filep);
 static int cc1101_file_close(FAR struct file *filep);
 static ssize_t cc1101_file_read(FAR struct file *filep, FAR char *buffer,
                                 size_t buflen);
-static ssize_t cc1101_file_write(FAR struct file *filep, FAR const char *buffer,
+static ssize_t cc1101_file_write(FAR struct file *filep,
+                                 FAR const char *buffer,
                                  size_t buflen);
 static int cc1101_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
                             bool setup);
@@ -1130,7 +1133,8 @@ int cc1101_powerdown(FAR struct cc1101_dev_s *dev)
  *
  ****************************************************************************/
 
-int cc1101_setgdo(FAR struct cc1101_dev_s *dev, uint8_t pin, uint8_t function)
+int cc1101_setgdo(FAR struct cc1101_dev_s *dev, uint8_t pin,
+                  uint8_t function)
 {
   DEBUGASSERT(dev);
   DEBUGASSERT(pin <= CC1101_IOCFG0);
@@ -1174,30 +1178,36 @@ int cc1101_setgdo(FAR struct cc1101_dev_s *dev, uint8_t pin, uint8_t function)
 int cc1101_setrf(FAR struct cc1101_dev_s *dev,
                  FAR const struct c1101_rfsettings_s *settings)
 {
+  int ret;
+
   DEBUGASSERT(dev);
   DEBUGASSERT(settings);
 
-  if (cc1101_access(
-          dev, CC1101_FSCTRL1, (FAR uint8_t *)&settings->FSCTRL1, -11) < 0)
+  ret = cc1101_access(dev, CC1101_FSCTRL1,
+                      (FAR uint8_t *)&settings->FSCTRL1, -11);
+  if (ret < 0)
     {
       return -EIO;
     }
 
-  if (cc1101_access(dev, CC1101_FOCCFG, (FAR uint8_t *)&settings->FOCCFG, -5) <
-      0)
+  ret = cc1101_access(dev, CC1101_FOCCFG,
+                      (FAR uint8_t *)&settings->FOCCFG, -5);
+  if (ret < 0)
     {
       return -EIO;
     }
 
-  if (cc1101_access(dev, CC1101_FREND1, (FAR uint8_t *)&settings->FREND1, -6) <
-      0)
+  ret = cc1101_access(dev, CC1101_FREND1,
+                      (FAR uint8_t *)&settings->FREND1, -6);
+  if (ret < 0)
     {
       return -EIO;
     }
 
   /* Load Power Table */
 
-  if (cc1101_access(dev, CC1101_PATABLE, (FAR uint8_t *)settings->PA, -8) < 0)
+  ret = cc1101_access(dev, CC1101_PATABLE, (FAR uint8_t *)settings->PA, -8);
+  if (ret < 0)
     {
       return -EIO;
     }
@@ -1351,7 +1361,8 @@ int cc1101_read(FAR struct cc1101_dev_s *dev, FAR uint8_t *buf, size_t size)
 
   nbytes += 2; /* RSSI and LQI */
   buf[0] = nbytes;
-  cc1101_access(dev, CC1101_RXFIFO, buf + 1, (nbytes > size) ? size : nbytes);
+  cc1101_access(dev, CC1101_RXFIFO, buf + 1,
+                (nbytes > size) ? size : nbytes);
 
   /* Flush remaining bytes, if there is no room to receive or if there is a
    * BAD CRC

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -191,8 +191,8 @@
 #define CC1101_VCO_VC_DAC       (0x39 | 0xc0)   /* Current setting from PLL cal module */
 #define CC1101_TXBYTES          (0x3a | 0xc0)   /* Underflow and # of bytes in TXFIFO */
 #define CC1101_RXBYTES          (0x3b | 0xc0)   /* Overflow and # of bytes in RXFIFO */
-#define CC1101_RCCTRL1_STATUS   (0x3c | 0xc0)   /* Last RC oscilator calibration results */
-#define CC1101_RCCTRL0_STATUS   (0x3d | 0xc0)   /* Last RC oscilator calibration results */
+#define CC1101_RCCTRL1_STATUS   (0x3c | 0xc0)   /* Last RC oscillator calibration results */
+#define CC1101_RCCTRL0_STATUS   (0x3d | 0xc0)   /* Last RC oscillator calibration results */
 
 /* Multi byte memory locations */
 

--- a/drivers/wireless/lpwan/sx127x/sx127x.h
+++ b/drivers/wireless/lpwan/sx127x/sx127x.h
@@ -478,7 +478,7 @@
 #  define SX127X_FOM_OSC_CLKOUT_FXOSCd32  (5 << SX127X_FOM_OSC_CLKOUT_SHIFT)
 #  define SX127X_FOM_OSC_CLKOUT_RC        (6 << SX127X_FOM_OSC_CLKOUT_SHIFT)
 #  define SX127X_FOM_OSC_CLKOUT_OFF       (7 << SX127X_FOM_OSC_CLKOUT_SHIFT)
-#define SX127X_FOM_OSC_CLKOUT_RCCALSTART  (3 << 1) /* Bit 3: Trigger the RC oscilator calibration */
+#define SX127X_FOM_OSC_CLKOUT_RCCALSTART  (3 << 1) /* Bit 3: Trigger the RC oscillator calibration */
 
 /* FSK/OOK: Preamble length MSB */
 


### PR DESCRIPTION
## Summary
Just fixing some misspelled words in the drivers folder.

## Impact
No impact.

## Testing
Not applicable.
