### PR TITLE
arm/rp2040: Fix LDFLAGS for boot stage2

### DIFF
--- a/arch/arm/src/rp2040/boot2/Make.defs
+++ b/arch/arm/src/rp2040/boot2/Make.defs
@@ -46,6 +46,6 @@ $(BOOT_STAGE2).bin: %.bin: %.elf
 	$(OBJCOPY) -Obinary $< $@
 
 $(BOOT_STAGE2).elf: $(BOOT2SRC)
-	$(CC) $(LDFLAGS) $(BOOT2CFLAGS) -o $@ $<
+	$(CC) -nostartfiles -nodefaultlibs $(ARCHSCRIPT) $(BOOT2CFLAGS) -o $@ $<
 
 EXTRADELFILE = $(BOOT_STAGE2).*


### PR DESCRIPTION
## Summary
Fix LDFLAGS option to create boot stage 2 of Raspberry Pi Pico.

Because `CONFIG_SCHED_INSTRUMENTATION_SYSCALL=y` adds extra `--wrap` options to LDFLAGS, boot stage2 build fails.
This PR fixes the problem.

## Impact
rp2040 only

## Testing
Enable `CONFIG_SCHED_INSTRUMENTATION_SYSCALL=y` and check boot stage2 build.