### PR TITLE
arch:rv64:add API up_copyfullstate for later FPU support.

### DIFF
--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -186,6 +186,7 @@ void up_ack_irq(int irq);
 
 #ifdef CONFIG_ARCH_RV64GC
 void up_copystate(uint64_t *dest, uint64_t *src);
+void up_copyfullstate(uint64_t *dest, uint64_t *src);
 #else
 void up_copystate(uint32_t *dest, uint32_t *src);
 void up_copyfullstate(uint32_t *dest, uint32_t *src);

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -51,7 +51,7 @@ CMN_CSRCS  += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c
 CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS  += riscv_mdelay.c
+CMN_CSRCS  += riscv_mdelay.c riscv_copyfullstate.c
 
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c

--- a/arch/risc-v/src/rv64gc/riscv_copyfullstate.c
+++ b/arch/risc-v/src/rv64gc/riscv_copyfullstate.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * arch/risc-v/src/rv64gc/riscv_copyfullstate.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <arch/irq.h>
+
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_copyfullstate
+ *
+ * Description:
+ *    Copy the entire register save area (including the floating point
+ *    registers if applicable).  This is a little faster than most memcpy's
+ *    since it does 64-bit transfers.
+ *
+ ****************************************************************************/
+
+void up_copyfullstate(uint64_t *dest, uint64_t *src)
+{
+  int i;
+
+  /* In the RISC-V model, the state is copied from the stack to the TCB,
+   * but only a reference is passed to get the state from the TCB.  So the
+   * following check avoids copying the TCB save area onto itself:
+   */
+
+  if (src != dest)
+    {
+      for (i = 0; i < XCPTCONTEXT_REGS; i++)
+        {
+          *dest++ = *src++;
+        }
+    }
+}

--- a/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
@@ -102,7 +102,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copystate(regs, rtcb->xcp.regs);
+  up_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented


### PR DESCRIPTION
Signed-off-by: hotislandn <hotislandn@hotmail.com>

## Summary
This patch is linked to https://github.com/apache/incubator-nuttx/pull/2918 for rv32im, but for RV64GC.
The purpose is for later FPU support on RV64GC.

## Impact
RV64GC targtes.

## Testing
Pass build for maix-bit.
