### PR TITLE
tools/version.sh: If the version is not available, use 0.0.0

### DIFF
--- a/tools/version.sh
+++ b/tools/version.sh
@@ -84,10 +84,8 @@ fi
 # Make sure we know what is going on
 
 if [ -z ${VERSION} ] ; then
-  echo "Missing versioning information"
-  echo $USAGE
-  echo $ADVICE
-  exit 1
+  echo "Missing versioning information. Using the dummy value. (0.0.0)"
+  VERSION="0.0.0"
 fi
 
 if [ -z ${OUTFILE} ] ; then


### PR DESCRIPTION
## Summary
It's useful when you only have shallow git history handy.
(eg. to save some network bandwidth)

The default value here was chosen to mirror the default of
tools/Makefile.win.

## Impact

## Testing
build tested locally with a -depth=1 tree.
