### PR TITLE
arch/stm32f7: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/stm32f7/stm32_ltdc.h
+++ b/arch/arm/src/stm32f7/stm32_ltdc.h
@@ -49,7 +49,7 @@
 #include <nuttx/nx/nxglib.h>
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
@@ -62,7 +62,7 @@
 
 void stm32_ltdcreset(void);
 
-/*****************************************************************************
+/****************************************************************************
  * Name: stm32_ltdcinitialize
  *
  * Description:
@@ -75,7 +75,7 @@ void stm32_ltdcreset(void);
 
 int stm32_ltdcinitialize(void);
 
-/*****************************************************************************
+/****************************************************************************
  * Name: stm32_ltdcuninitialize
  *
  * Description:
@@ -85,7 +85,7 @@ int stm32_ltdcinitialize(void);
 
 void stm32_ltdcuninitialize(void);
 
-/*****************************************************************************
+/****************************************************************************
  * Name: stm32_ltdcgetvplane
  *
  * Description:
@@ -105,8 +105,8 @@ FAR struct fb_vtable_s *stm32_ltdcgetvplane(int vplane);
  * Name: stm32_lcd_backlight
  *
  * Description:
- *   If CONFIG_STM32F7_LCD_BACKLIGHT is defined, then the board-specific logic
- *   must provide this interface to turn the backlight on and off.
+ *   If CONFIG_STM32F7_LCD_BACKLIGHT is defined, then the board-specific
+ *   logic must provide this interface to turn the backlight on and off.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/stm32f7/stm32_pm.h
+++ b/arch/arm/src/stm32f7/stm32_pm.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32f7/stm32_pm.h
  *
  *   Copyright (C) 2018 Haltian Ltd. All rights reserved.
@@ -31,7 +31,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32F7_STM32_PM_H
 #define __ARCH_ARM_SRC_STM32F7_STM32_PM_H
@@ -68,8 +68,8 @@ extern "C"
  *
  * Input Parameters:
  *   lpds - true: To further reduce power consumption in Stop mode, put the
- *          internal voltage regulator in low-power under-drive mode using the
- *          LPDS and LPUDS bits of the Power control register (PWR_CR1).
+ *          internal voltage regulator in low-power under-drive mode using
+ *          the LPDS and LPUDS bits of the Power control register (PWR_CR1).
  *
  * Returned Value:
  *   None
@@ -104,8 +104,9 @@ void stm32_pmstandby(void);
  *   sleeponexit - true:  SLEEPONEXIT bit is set when the WFI instruction is
  *                        executed, the MCU enters Sleep mode as soon as it
  *                        exits the lowest priority ISR.
- *               - false: SLEEPONEXIT bit is cleared, the MCU enters Sleep mode
- *                        as soon as WFI or WFE instruction is executed.
+ *               - false: SLEEPONEXIT bit is cleared, the MCU enters Sleep
+ *                        mode as soon as WFI or WFE instruction is
+ *                        executed.
  * Returned Value:
  *   None
  *

--- a/arch/arm/src/stm32f7/stm32_pmsleep.c
+++ b/arch/arm/src/stm32f7/stm32_pmsleep.c
@@ -61,8 +61,9 @@
  *   sleeponexit - true:  SLEEPONEXIT bit is set when the WFI instruction is
  *                        executed, the MCU enters Sleep mode as soon as it
  *                        exits the lowest priority ISR.
- *               - false: SLEEPONEXIT bit is cleared, the MCU enters Sleep mode
- *                        as soon as WFI or WFE instruction is executed.
+ *               - false: SLEEPONEXIT bit is cleared, the MCU enters Sleep
+ *                        mode as soon as WFI or WFE instruction is
+ *                        executed.
  * Returned Value:
  *   None
  *

--- a/arch/arm/src/stm32f7/stm32_pmstandby.c
+++ b/arch/arm/src/stm32f7/stm32_pmstandby.c
@@ -80,7 +80,9 @@ void stm32_pmstandby(void)
 
   modifyreg32(STM32_RCC_CSR, 0, RCC_CSR_RMVF);
 
-  /* Set the Power Down Deep Sleep (PDDS) bit in the power control register. */
+  /* Set the Power Down Deep Sleep (PDDS) bit in the power control
+   * register.
+   */
 
   modifyreg32(STM32_PWR_CR1, 0, PWR_CR1_PDDS);
 

--- a/arch/arm/src/stm32f7/stm32_pmstop.c
+++ b/arch/arm/src/stm32f7/stm32_pmstop.c
@@ -58,8 +58,8 @@
  *
  * Input Parameters:
  *   lpds - true: To further reduce power consumption in Stop mode, put the
- *          internal voltage regulator in low-power under-drive mode using the
- *          LPDS and LPUDS bits of the Power control register (PWR_CR1).
+ *          internal voltage regulator in low-power under-drive mode using
+ *          the LPDS and LPUDS bits of the Power control register (PWR_CR1).
  *
  * Returned Value:
  *   None
@@ -71,9 +71,9 @@ void stm32_pmstop(bool lpds)
   uint32_t regval;
 
   /* Clear the Power Down Deep Sleep (PDDS), the Low Power Deep Sleep
-   * (LPDS), Under-Drive Enable in Stop Mode (UDEN), Flash Power Down in Stop
-   * Mode (FPDS), Main Regulator in Deepsleep Under-Drive Mode (MRUDS), and
-   * Low-power Regulator in Deepsleep Under-Drive Mode (LPUDS) bits in
+   * (LPDS), Under-Drive Enable in Stop Mode (UDEN), Flash Power Down in
+   * Stop Mode (FPDS), Main Regulator in Deepsleep Under-Drive Mode (MRUDS),
+   * and Low-power Regulator in Deepsleep Under-Drive Mode (LPUDS) bits in
    * the power control register.
    */
 
@@ -108,12 +108,14 @@ void stm32_pmstop(bool lpds)
   asm volatile ("wfi");
 #endif
 
-  /* Clear deep sleep bits, so that MCU does not go into deep sleep in idle. */
+  /* Clear deep sleep bits, so that MCU does not go into deep sleep in
+   * idle.
+   */
 
   /* Clear the Power Down Deep Sleep (PDDS), the Low Power Deep Sleep
-   * (LPDS) bits, Under-Drive Enable in Stop Mode (UDEN), Main Regulator in
-   * Deepsleep Under-Drive Mode (MRUDS), and Low-power Regulator in Deepsleep
-   * Under-Drive Mode (LPUDS) in the power control register.
+   * (LPDS) bits, Under-Drive Enable in Stop Mode (UDEN), Main Regulator
+   * in Deepsleep Under-Drive Mode (MRUDS), and Low-power Regulator in
+   * Deepsleep Under-Drive Mode (LPUDS) in the power control register.
    */
 
   regval  = getreg32(STM32_PWR_CR1);

--- a/arch/arm/src/stm32f7/stm32_pwm.h
+++ b/arch/arm/src/stm32f7/stm32_pwm.h
@@ -111,7 +111,9 @@
 #  undef CONFIG_STM32F7_TIM17_PWM
 #endif
 
-/* The basic timers (timer 6 and 7) are not capable of generating output pulses */
+/* The basic timers (timer 6 and 7) are not capable of generating output
+ * pulses
+ */
 
 #undef CONFIG_STM32F7_TIM6_PWM
 #undef CONFIG_STM32F7_TIM7_PWM
@@ -127,8 +129,16 @@
     defined(CONFIG_STM32F7_TIM15_PWM) || defined(CONFIG_STM32F7_TIM16_PWM) || \
     defined(CONFIG_STM32F7_TIM17_PWM)
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
 #include <arch/board/board.h>
 #include "hardware/stm32_tim.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
 
 #ifdef CONFIG_PWM_MULTICHAN
 
@@ -1079,7 +1089,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Fix nxstyle errors in:

- arch/arm/src/stm32f7/stm32_ltdc.h,
- arch/arm/src/stm32f7/stm32_pm.h,
- arch/arm/src/stm32f7/stm32_pmsleep.c,
- arch/arm/src/stm32f7/stm32_pmstandby.c,
- arch/arm/src/stm32f7/stm32_pmstop.c, and
- arch/arm/src/stm32f7/stm32_pwm.h.

## Impact

Removes nxstyle errors.

## Testing

nxstyle