### PR TITLE
Fixed __stack_overflow_trap declaration typo.

### DIFF
--- a/arch/arm/src/armv7-m/arm_stackcheck.c
+++ b/arch/arm/src/armv7-m/arm_stackcheck.c
@@ -59,7 +59,7 @@ void __cyg_profile_func_enter(void *func, void *caller)
   __attribute__((naked, no_instrument_function));
 void __cyg_profile_func_exit(void *func, void *caller)
   __attribute__((naked, no_instrument_function));
-void  _stack_overflow_trap(void)
+void __stack_overflow_trap(void)
   __attribute__((naked, no_instrument_function));
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
There is a typo in `__stack_overflow_trap` declaration for armv7-m.
Due to this, although the code builds fine, the `__attribute__((naked, no_instrument_function))` is not applied.

When stack check was enabled, the `__stack_overflow_trap` was instrumented, causing endless recursive calls to itself.

## Impact
Now this function is properly working.

## Testing
Created a stack overflow with the following simply defined in a function:
```c
uint8_t overflow_buffer[4096];  //Much larger than the stack.
```

Before the code was entering an endless recursion of calls to `__stack_overflow_trap`.  
Now the trap is properly executed.



