### PR TITLE
mtd/progmem: Add up_progmem_read callback guarded by ARCH_HAVE_PROGMEM_READ

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -303,6 +303,11 @@ config ARCH_HAVE_PROGMEM
 	bool
 	default n
 
+config ARCH_HAVE_PROGMEM_READ
+	bool
+	default n
+	depends on ARCH_HAVE_PROGMEM
+
 config ARCH_HAVE_RESET
 	bool
 	default n

--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -130,6 +130,7 @@ endif # MTD_READAHEAD
 config MTD_PROGMEM
 	bool "Enable on-chip program FLASH MTD device"
 	default n
+	depends on ARCH_HAVE_PROGMEM
 	---help---
 		Enable to support an MTD device that supports the on-chip FLASH
 		using the interfaces defined in include/nuttx/progmem.  Those

--- a/drivers/mtd/mtd_progmem.c
+++ b/drivers/mtd/mtd_progmem.c
@@ -49,7 +49,7 @@
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/mtd/mtd.h>
 
-#ifdef CONFIG_ARCH_HAVE_PROGMEM
+#ifdef CONFIG_MTD_PROGMEM
 
 /****************************************************************************
  * Private Types
@@ -422,4 +422,4 @@ FAR struct mtd_dev_s *progmem_initialize(void)
   return (FAR struct mtd_dev_s *)priv;
 }
 
-#endif /* CONFIG_ARCH_HAVE_PROGMEM */
+#endif /* CONFIG_MTD_PROGMEM */

--- a/include/nuttx/progmem.h
+++ b/include/nuttx/progmem.h
@@ -216,6 +216,39 @@ ssize_t up_progmem_ispageerased(size_t page);
 
 ssize_t up_progmem_write(size_t addr, FAR const void *buf, size_t count);
 
+/****************************************************************************
+ * Name: up_progmem_read
+ *
+ * Description:
+ *   Read data at given address
+ *
+ *   Note: this function is not limited to single page and nor it requires
+ *   the address be aligned inside the page boundaries.
+ *
+ * Input Parameters:
+ *   addr  - Address with or without flash offset
+ *           (absolute or aligned to page0)
+ *   buf   - Pointer to buffer
+ *   count - Number of bytes to read
+ *
+ * Returned Value:
+ *   Bytes read or negative value on error.  The following errors are
+ *   reported (errno is not set!)
+ *
+ *     EINVAL: If count is not aligned with the flash boundaries (i.e.
+ *             some MCU's require per half-word or even word access)
+ *     EFAULT: On invalid address
+ *     EIO:    On unsuccessful read
+ *     EACCES: Insufficient permissions (read/write protected)
+ *     EPERM:  If operation is not permitted due to some other constraints
+ *             (i.e. some internal block is not running etc.)
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_HAVE_PROGMEM_READ
+ssize_t up_progmem_read(size_t addr, FAR void *buf, size_t count);
+#endif
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary
since sometime platform code need do some special action during memcpy

## Impact
No, since ARCH_HAVE_PROGMEM_READ isn't enabled by default.

## Testing

