### PR TITLE
armv8-m: Fix EXC_RETURN for non-secure usage

### DIFF
--- a/arch/arm/src/armv8-m/exc_return.h
+++ b/arch/arm/src/armv8-m/exc_return.h
@@ -40,13 +40,19 @@
  * a normal branch operation and instead, that the exception is complete.
  * Therefore, it starts the exception return sequence.
  *
- * Bits[4:0] of the EXC_RETURN value indicate the required return stack and eventual
+ * Bits[6:0] of the EXC_RETURN value indicate the required return stack and eventual
  * processor mode.  The remaining bits of the EXC_RETURN value should be set to 1.
  */
 
 /* EXC_RETURN_BASE: Bits that are always set in an EXC_RETURN value. */
 
-#define EXC_RETURN_BASE          0xffffffe1
+#define EXC_RETURN_BASE          0xffffff80
+
+/* EXC_RETURN_EXC_SECURE: Exception Secure.  The security domain the exception
+ * was taken to.  If this bit is clear non-secure, else secure.
+ */
+
+#define EXC_RETURN_EXC_SECURE    (1 << 0)
 
 /* EXC_RETURN_PROCESS_STACK: The exception saved (and will restore) the hardware
  * context using the process stack pointer (if not set, the context was saved
@@ -68,21 +74,40 @@
 
 #define EXC_RETURN_STD_CONTEXT   (1 << 4)
 
+/* EXC_RETURN_DEF_STACKING: Default callee register stacking (DCRS).  Indicates
+ * whether the default stacking rules apply, or whether the callee registers are
+ * already on the stack.  The possible values of this bit are: 0 - Stacking of
+ * the callee saved registers skipped.  1 - Default rules for stacking the
+ * callee registers followed.
+ */
+
+#define EXC_RETURN_DEF_STACKING  (1 << 5)
+
+/* EXC_RETURN_SECURE_STACK: Secure or Non-secure stack.  Indicates whether a
+ * Secure or Non-secure stack is used to restore stack frame on exception
+ * return.  The possible values of this bit are: 0 -  Non-secure stack used.
+ * 1 - Secure stack used.
+ */
+
+#define EXC_RETURN_SECURE_STACK  (1 << 6)
+
 /* EXC_RETURN_HANDLER: Return to handler mode. Exception return gets state from
  * the main stack. Execution uses MSP after return.
  */
 
-#define EXC_RETURN_HANDLER       0xfffffff1
+#define EXC_RETURN_HANDLER       (EXC_RETURN_BASE | EXC_RETURN_DEF_STACKING | \
+                                  EXC_RETURN_STD_CONTEXT)
 
 /* EXC_RETURN_PRIVTHR: Return to privileged thread mode. Exception return gets
  * state from the main stack. Execution uses MSP after return.
  */
 
 #if !defined(CONFIG_ARMV8M_LAZYFPU) && defined(CONFIG_ARCH_FPU)
-#  define EXC_RETURN_PRIVTHR     (EXC_RETURN_BASE | EXC_RETURN_THREAD_MODE)
+#  define EXC_RETURN_PRIVTHR     (EXC_RETURN_BASE | EXC_RETURN_THREAD_MODE | \
+                                  EXC_RETURN_DEF_STACKING)
 #else
 #  define EXC_RETURN_PRIVTHR     (EXC_RETURN_BASE | EXC_RETURN_STD_CONTEXT | \
-                                  EXC_RETURN_THREAD_MODE)
+                                  EXC_RETURN_THREAD_MODE | EXC_RETURN_DEF_STACKING)
 #endif
 
 /* EXC_RETURN_UNPRIVTHR: Return to unprivileged thread mode. Exception return gets
@@ -91,10 +116,11 @@
 
 #if !defined(CONFIG_ARMV8M_LAZYFPU) && defined(CONFIG_ARCH_FPU)
 #  define EXC_RETURN_UNPRIVTHR   (EXC_RETURN_BASE | EXC_RETURN_THREAD_MODE | \
-                                  EXC_RETURN_PROCESS_STACK)
+                                  EXC_RETURN_PROCESS_STACK | EXC_RETURN_DEF_STACKING)
 #else
 #  define EXC_RETURN_UNPRIVTHR   (EXC_RETURN_BASE | EXC_RETURN_STD_CONTEXT | \
-                                  EXC_RETURN_THREAD_MODE | EXC_RETURN_PROCESS_STACK)
+                                  EXC_RETURN_THREAD_MODE | EXC_RETURN_PROCESS_STACK | \
+                                  EXC_RETURN_DEF_STACKING)
 #endif
 
 /************************************************************************************


### PR DESCRIPTION
## Summary

With TrustZone support in armv8-m the bit-fields in EXC_RETURN have been
extended.  Bit 6 ('S') now specifies whether the interrupted program was
running in the Non-Secure (S=0) or Secure (S=1) security state.
Furthermore, Bit 0 ('ES' - Exception Secure) specifies the
security state athe exception is taken to (0: Non-Secure, 1: Secure).

When NuttX is run together with TrustedFirmware-M as the application in
the non-secure world both the S and the ES bits have to be set to '0'.
For armv8-m those are also the correct values if TrustZone is not
implemented on the respective MCU or if it is disabled.

## Impact

Required change to run NuttX in the TrustZone non-secure security state.

Should have no impact if NuttX is run with TrustZone disabled.

I am not aware of any configuration that is running NuttX in the TrustZone secure security state. If there are any then this change will probably break them. In this case we should probably make this configurable.

## Testing

Tested with TrustZone disabled and with running NuttX in the non-secure world of TrustedFirmware-M