### PR TITLE
esp32_ummap: write back spiram cache before calling Cache_Flush

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -1419,6 +1419,9 @@ static void IRAM_ATTR esp32_ummap(FAR struct esp32_spiflash_s *priv,
 #endif
     }
 
+#ifdef CONFIG_ESP32_SPIRAM
+  esp_spiram_writeback_cache();
+#endif
   Cache_Flush(0);
 #ifdef CONFIG_SMP
   Cache_Flush(1);


### PR DESCRIPTION
## Summary

esp32_ummap: write back spiram cache before calling Cache_Flush

This seems to fix esp32_readdata_encrypted() with spiram "buffer".

Note: I'm not sure if this is the right fix or not.
I couldn't find any documentation about Cache_Flush.

## Impact

## Testing
confirmed to fix the data corruption observed on an esp32 board
