### PR TITLE
arch/stm32f7: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/stm32f7/stm32_tim.h
+++ b/arch/arm/src/stm32f7/stm32_tim.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32f7/stm32_tim.h
  *
  *   Copyright (C) 2011 Uros Platise. All rights reserved.
@@ -36,24 +36,25 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32F7_STM32_TIM_H
 #define __ARCH_ARM_SRC_STM32F7_STM32_TIM_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
 #include "chip.h"
 #include "hardware/stm32_tim.h"
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
-/* Helpers **************************************************************************/
+ ****************************************************************************/
+
+/* Helpers ******************************************************************/
 
 #define STM32_TIM_SETMODE(d,mode)       ((d)->ops->setmode(d,mode))
 #define STM32_TIM_SETCLOCK(d,freq)      ((d)->ops->setclock(d,freq))
@@ -70,9 +71,9 @@
 #define STM32_TIM_ACKINT(d,s)           ((d)->ops->ackint(d,s))
 #define STM32_TIM_CHECKINT(d,s)         ((d)->ops->checkint(d,s))
 
-/************************************************************************************
+/****************************************************************************
  * Public Types
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 
@@ -110,20 +111,22 @@ typedef enum
   /* One of the following */
 
   STM32_TIM_MODE_CK_INT       = 0x0000,
-//STM32_TIM_MODE_CK_INT_TRIG  = 0x0400,
-//STM32_TIM_MODE_CK_EXT       = 0x0800,
-//STM32_TIM_MODE_CK_EXT_TRIG  = 0x0c00,
+#if 0
+  STM32_TIM_MODE_CK_INT_TRIG  = 0x0400,   /* TODO: Not supported */
+  STM32_TIM_MODE_CK_EXT       = 0x0800,   /* TODO: Not supported */
+  STM32_TIM_MODE_CK_EXT_TRIG  = 0x0c00,   /* TODO: Not supported */
+#endif
 
   /* Clock sources, OR'ed with CK_EXT */
+#if 0
+  STM32_TIM_MODE_CK_CHINVALID = 0x0000,   /* TODO: Not supported */
+  STM32_TIM_MODE_CK_CH1       = 0x0001,   /* TODO: Not supported */
+  STM32_TIM_MODE_CK_CH2       = 0x0002,   /* TODO: Not supported */
+  STM32_TIM_MODE_CK_CH3       = 0x0003,   /* TODO: Not supported */
+  STM32_TIM_MODE_CK_CH4       = 0x0004    /* TODO: Not supported */
+#endif
 
-//STM32_TIM_MODE_CK_CHINVALID = 0x0000,
-//STM32_TIM_MODE_CK_CH1       = 0x0001,
-//STM32_TIM_MODE_CK_CH2       = 0x0002,
-//STM32_TIM_MODE_CK_CH3       = 0x0003,
-//STM32_TIM_MODE_CK_CH4       = 0x0004
-
-  /* Todo: external trigger block */
-
+  /* TODO: external trigger block */
 } stm32_tim_mode_t;
 
 /* TIM Channel Modes */
@@ -144,15 +147,18 @@ typedef enum
   /* Output Compare Modes */
 
   STM32_TIM_CH_OUTPWM         = 0x04,     /* Enable standard PWM mode, active high when counter < compare */
-//STM32_TIM_CH_OUTCOMPARE     = 0x06,
+#if 0
+  STM32_TIM_CH_OUTCOMPARE     = 0x06,     /* TODO: Not supported */
+#endif
   STM32_TIM_CH_OUTTOGGLE      = 0x08,
 
+#if 0
+  /* TODO other modes ... as PWM capture, ENCODER and Hall Sensor */
 
-  // TODO other modes ... as PWM capture, ENCODER and Hall Sensor
-//STM32_TIM_CH_INCAPTURE      = 0x10,
-//STM32_TIM_CH_INPWM          = 0x20
-//STM32_TIM_CH_DRIVE_OC   -- open collector mode
-
+  STM32_TIM_CH_INCAPTURE      = 0x10,
+  STM32_TIM_CH_INPWM          = 0x20
+  STM32_TIM_CH_DRIVE_OC -- open collector mode
+#endif
 } stm32_tim_channel_t;
 
 /* TIM Operations */
@@ -178,16 +184,17 @@ struct stm32_tim_ops_s
 
   /* Timer interrupts */
 
-  int  (*setisr)(FAR struct stm32_tim_dev_s *dev, xcpt_t handler, void * arg, int source);
+  int  (*setisr)(FAR struct stm32_tim_dev_s *dev, xcpt_t handler,
+                 void * arg, int source);
   void (*enableint)(FAR struct stm32_tim_dev_s *dev, int source);
   void (*disableint)(FAR struct stm32_tim_dev_s *dev, int source);
   void (*ackint)(FAR struct stm32_tim_dev_s *dev, int source);
   int  (*checkint)(FAR struct stm32_tim_dev_s *dev, int source);
 };
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 /* Power-up timer and get its structure */
 
@@ -216,7 +223,7 @@ int stm32_tim_deinit(FAR struct stm32_tim_dev_s *dev);
  ****************************************************************************/
 
 #ifdef CONFIG_TIMER
-FAR struct timer_lowerhalf_s* stm32_timer_initialize(FAR const char *devpath,
+FAR struct timer_lowerhalf_s *stm32_timer_initialize(FAR const char *devpath,
                                                      int timer);
 #endif
 


### PR DESCRIPTION
## Summary

Fix nxstyle errors in arch/arm/src/stm32f7/stm32_tim.h.

In particular, please review how I eliminated the C++ style comments that nxstyle was complaining about. Rather than comment out code, I placed `#if 0 ... #endif` around it.

## Impact

Removes nxstyle errors.

## Testing

nxstyle.