### PR TITLE
fs/mount: fix mount cmd break out when meet stat error

### DIFF
--- a/fs/mount/fs_foreachmountpoint.c
+++ b/fs/mount/fs_foreachmountpoint.c
@@ -91,7 +91,7 @@ static int mountpoint_filter(FAR struct inode *node,
 
       if (pathlen + namlen > PATH_MAX)
         {
-          return -ENAMETOOLONG;
+          return OK;
         }
 
       /* Append the inode name to the directory path */
@@ -100,8 +100,7 @@ static int mountpoint_filter(FAR struct inode *node,
 
       /* Get the status of the file system */
 
-      ret = node->u.i_mops->statfs(node, &statbuf);
-      if (ret == OK)
+      if (node->u.i_mops->statfs(node, &statbuf) == OK)
         {
           /* And pass the full path and file system status to the handler */
 


### PR DESCRIPTION

## Summary
fs/mount: fix mount cmd break out when meet stat error

## Impact
when mount cmd meet some mountpoint statfs error, then continue.
still return info->handler error to user

## Testing

