### PR TITLE
sched/task: fix pthread call exit() failed

### DIFF
--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -175,6 +175,7 @@ static inline void nxtask_exitstatus(FAR struct task_group_s *group,
                                      int status)
 {
   FAR struct child_status_s *child;
+  FAR struct tcb_s *rtcb = this_task();
 
   /* Check if the parent task group has suppressed retention of
    * child exit status information.
@@ -184,7 +185,11 @@ static inline void nxtask_exitstatus(FAR struct task_group_s *group,
     {
       /* No.. Find the exit status entry for this task in the parent TCB */
 
+#ifdef CONFIG_DISABLE_PTHREAD
       child = group_find_child(group, getpid());
+#else
+      child = group_find_child(group, rtcb->group->tg_task);
+#endif
       if (child)
         {
           /* Save the exit status..  For the case of HAVE_GROUP_MEMBERS,
@@ -214,6 +219,7 @@ static inline void nxtask_exitstatus(FAR struct task_group_s *group,
 static inline void nxtask_groupexit(FAR struct task_group_s *group)
 {
   FAR struct child_status_s *child;
+  FAR struct tcb_s *rtcb = this_task();
 
   /* Check if the parent task group has suppressed retention of child exit
    * status information.
@@ -223,7 +229,11 @@ static inline void nxtask_groupexit(FAR struct task_group_s *group)
     {
       /* No.. Find the exit status entry for this task in the parent TCB */
 
+#ifdef CONFIG_DISABLE_PTHREAD
       child = group_find_child(group, getpid());
+#else
+      child = group_find_child(group, rtcb->group->tg_task);
+#endif
       if (child)
         {
           /* Mark that all members of the child task group has exited */


### PR DESCRIPTION

## Summary
sched/task: fix pthread call exit() failed

## Impact
pthread call pthread_exit()  => current pthread exit
pthread call exit()                => current task exit

## Testing

