### PR TITLE
syslog_rpmsg: fix system crash when open CONFIG_SCHED_HAVE_PARENT

### DIFF
--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -186,7 +186,8 @@ static void syslog_rpmsg_putchar(FAR struct syslog_rpmsg_s *priv, int ch,
         }
     }
 
-  if (last && !priv->suspend && !priv->transfer)
+  if (last && !priv->suspend && !priv->transfer &&
+          is_rpmsg_ept_ready(&priv->ept))
     {
       clock_t delay = SYSLOG_RPMSG_WORK_DELAY;
       size_t space = SYSLOG_RPMSG_SPACE(priv->head, priv->tail, priv->size);


### PR DESCRIPTION

## Summary
syslog_rpmsg: fix system crash when open CONFIG_SCHED_HAVE_PARENT

## Impact
Reason:

nx_start use syslog at every early time event the idle thread not
full setup, then syslog_rpmsg -> work_queue -> work_signal ->
nxsig_kill -> rtcb is NULL -> crash

Fix:
sched work_queue after is_rpmsg_ept_ready() is true
## Testing

