### PR TITLE
ESP32XX: Add more flash options to esptool

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -52,6 +52,11 @@ config ESP32C3_DUAL_CPU
 	bool
 	default n
 
+config ESP32C3_ESP32C3XXX
+	bool
+	default n
+	select ESP32C3_SINGLE_CPU
+
 config ESP32C3_FLASH_2M
 	bool
 	default n
@@ -68,10 +73,46 @@ config ESP32C3_FLASH_16M
 	bool
 	default n
 
-config ESP32C3_ESP32C3XXX
-	bool
+config ESP32C3_FLASH_DETECT
+	bool "Auto-detect FLASH size (to be used with master esptool)"
 	default n
-	select ESP32C3_SINGLE_CPU
+	help
+		Auto detect flash size when flashing.
+		Current released version of esptool doesn't support auto-detecting flash size.
+		Use latest master from https://github.com/espressif/esptool.
+
+choice ESP32C3_FLASH_MODE
+	prompt "SPI FLASH mode"
+	default ESP32C3_FLASH_MODE_DIO
+	help
+		These options control how many I/O pins are used for communication with the attached SPI flash chip.
+		The option selected here is then used by esptool when flashing.
+
+	config ESP32C3_FLASH_MODE_DIO
+		bool "Dual IO (DIO)"
+	config ESP32C3_FLASH_MODE_DOUT
+		bool "Dual Output (DOUT)"
+	config ESP32C3_FLASH_MODE_QIO
+		bool "Quad IO (QIO)"
+	config ESP32C3_FLASH_MODE_QOUT
+		bool "Quad Output (QOUT)"
+endchoice # ESP32C3_FLASH_MODE
+
+choice ESP32C3_FLASH_FREQ
+	prompt "SPI FLASH frequency"
+	default ESP32C3_FLASH_FREQ_40M
+	help
+		SPI FLASH frequency
+		
+	config ESP32C3_FLASH_FREQ_80M
+		bool "80 MHz"
+	config ESP32C3_FLASH_FREQ_40M
+		bool "40 MHz"
+	config ESP32C3_FLASH_FREQ_26M
+		bool "26 MHz"
+	config ESP32C3_FLASH_FREQ_20M
+		bool "20 MHz"
+endchoice # ESP32C3_FLASH_FREQ
 
 choice ESP32C3_CPU_FREQ
 	prompt "CPU frequency"

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -111,6 +111,12 @@ config ESP32_FLASH_16M
 	bool
 	default n
 
+config ESP32_FLASH_DETECT
+	bool "Auto-detect FLASH size"
+	default y
+	help
+		Auto detect flash size when flashing.
+
 config ESP32_PSRAM_8M
 	bool
 	default n
@@ -129,6 +135,39 @@ config ESP32_ESP32DXWDXX
 	bool
 	default n
 	select ESP32_DUAL_CPU
+
+choice ESP32_FLASH_MODE
+	prompt "SPI FLASH mode"
+	default ESP32_FLASH_MODE_DIO
+	help
+		These options control how many I/O pins are used for communication with the attached SPI flash chip.
+		The option selected here is then used by esptool when flashing.
+
+	config ESP32_FLASH_MODE_DIO
+		bool "Dual IO (DIO)"
+	config ESP32_FLASH_MODE_DOUT
+		bool "Dual Output (DOUT)"
+	config ESP32_FLASH_MODE_QIO
+		bool "Quad IO (QIO)"
+	config ESP32_FLASH_MODE_QOUT
+		bool "Quad Output (QOUT)"
+endchoice # ESP32_FLASH_MODE
+
+choice ESP32_FLASH_FREQ
+	prompt "SPI FLASH frequency"
+	default ESP32_FLASH_FREQ_40M
+	help
+		SPI FLASH frequency
+		
+	config ESP32_FLASH_FREQ_80M
+		bool "80 MHz"
+	config ESP32_FLASH_FREQ_40M
+		bool "40 MHz"
+	config ESP32_FLASH_FREQ_26M
+		bool "26 MHz"
+	config ESP32_FLASH_FREQ_20M
+		bool "20 MHz"
+endchoice # ESP32_FLASH_FREQ
 
 choice ESP32_DEFAULT_CPU_FREQ
 	prompt "CPU frequency"

--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -22,6 +22,46 @@
 # and assemble source files and to insert the resulting object files into an
 # archive.  These replace the default definitions at tools/Config.mk
 
+ifeq ($(CONFIG_ESP32_FLASH_2M),y)
+	FLASH_SIZE := 2MB
+else ifeq ($(CONFIG_ESP32_FLASH_4M),y)
+	FLASH_SIZE := 4MB
+else ifeq ($(CONFIG_ESP32_FLASH_8M),y)
+	FLASH_SIZE := 8MB
+else ifeq ($(CONFIG_ESP32_FLASH_16M),y)
+	FLASH_SIZE := 16MB
+endif
+
+ifeq ($(CONFIG_ESP32_FLASH_MODE_DIO),y)
+	FLASH_MODE := dio
+else ifeq ($(CONFIG_ESP32_FLASH_MODE_DOUT),y)
+	FLASH_MODE := dout
+else ifeq ($(CONFIG_ESP32_FLASH_MODE_QIO),y)
+	FLASH_MODE := qio
+else ifeq ($(CONFIG_ESP32_FLASH_MODE_QOUT),y)
+	FLASH_MODE := qout
+endif
+
+ifeq ($(CONFIG_ESP32_FLASH_FREQ_80M),y)
+	FLASH_FREQ := 80m
+else ifeq ($(CONFIG_ESP32_FLASH_FREQ_40M),y)
+	FLASH_FREQ := 40m
+else ifeq ($(CONFIG_ESP32_FLASH_FREQ_26M),y)
+	FLASH_FREQ := 26m
+else ifeq ($(CONFIG_ESP32_FLASH_FREQ_20M),y)
+	FLASH_FREQ := 20m
+endif
+
+ESPTOOL_FLASH_OPTS := -fs $(FLASH_SIZE) -fm $(FLASH_MODE) -ff $(FLASH_FREQ)
+ESPTOOL_ELF2IMG_OPTS := $(ESPTOOL_FLASH_OPTS)
+
+ifeq ($(CONFIG_ESP32_FLASH_DETECT),y)
+	ESPTOOL_WRITEFLASH_OPTS := -fs detect -fm $(FLASH_MODE) -ff $(FLASH_FREQ)
+else
+	ESPTOOL_WRITEFLASH_OPTS := $(ESPTOOL_FLASH_OPTS)
+endif
+
+
 ifdef ESPTOOL_BINDIR
 	BL_OFFSET=0x1000
 	PT_OFFSET=0x8000
@@ -29,16 +69,6 @@ ifdef ESPTOOL_BINDIR
 	PARTITION_TABLE=$(ESPTOOL_BINDIR)/partition-table-esp32.bin
 	FLASH_BL=$(BL_OFFSET) $(BOOTLOADER)
 	FLASH_PT=$(PT_OFFSET) $(PARTITION_TABLE)
-endif
-
-ifeq ($(CONFIG_ESP32_FLASH_2M),y)
-	FLASH_SIZE="2MB"
-else ifeq ($(CONFIG_ESP32_FLASH_4M),y)
-	FLASH_SIZE="4MB"
-else ifeq ($(CONFIG_ESP32_FLASH_8M),y)
-	FLASH_SIZE="8MB"
-else ifeq ($(CONFIG_ESP32_FLASH_16M),y)
-	FLASH_SIZE="16MB"
 endif
 
 ifeq ($(CONFIG_ESP32_QEMU_IMAGE),y)
@@ -63,7 +93,7 @@ define POSTBUILD
 		echo "Missing Flash memory size configuration for the ESP32 chip."; \
 		exit 1; \
 	fi
-	esptool.py --chip esp32 elf2image --flash_mode dio --flash_size $(FLASH_SIZE) -o nuttx.bin nuttx
+	esptool.py -c esp32 elf2image $(ESPTOOL_ELF2IMG_OPTS) -o nuttx.bin nuttx
 	$(Q) echo "Generated: nuttx.bin (ESP32 compatible)"
 	$(Q) $(MK_QEMU_IMG)
 endef
@@ -75,10 +105,13 @@ ESPTOOL_BAUD ?= 921600
 # DOWNLOAD -- Download binary image via esptool.py
 
 define DOWNLOAD
+
+	$(eval ESPTOOL_BINS := $(FLASH_BL) $(FLASH_PT) 0x10000 $(1).bin)
+
 	$(Q) if [ -z $(ESPTOOL_PORT) ]; then \
 		echo "DOWNLOAD error: Missing serial port device argument."; \
 		echo "USAGE: make download ESPTOOL_PORT=<port> [ ESPTOOL_BAUD=<baud> ] [ ESPTOOL_BINDIR=<dir> ]"; \
 		exit 1; \
 	fi
-	esptool.py --chip esp32 --port $(ESPTOOL_PORT) --baud $(ESPTOOL_BAUD) write_flash $(FLASH_BL) $(FLASH_PT) 0x10000 $(1).bin
+	esptool.py -c esp32 -p $(ESPTOOL_PORT) -b $(ESPTOOL_BAUD) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS)
 endef


### PR DESCRIPTION
## Summary
Adds more flash options to `esptool` for both ESP32 and ESP32-C3.
## Impact
None on any other chips.
## Testing
Building and flashing ESP32 and ESP32-C3 boards.
Autodetecting flash size in ESP32-C3 is disabled by default, next released version of `esptool` will fix this.
