### PR TITLE
arch/stm32, arch/stm32f7: Fix nxstyle errors

### DIFF
--- a/arch/arm/src/stm32/hardware/stm32_dma2d.h
+++ b/arch/arm/src/stm32/hardware/stm32_dma2d.h
@@ -49,52 +49,52 @@
 
 #define STM32_DMA2D_NCLUT           256    /* Number of entries in the CLUT */
 
-/* DMA2D Register Offsets ****************************************************/
+/* DMA2D Register Offsets ***************************************************/
 
 #define STM32_DMA2D_CR_OFFSET       0x0000 /* DMA2D Control Register */
 #define STM32_DMA2D_ISR_OFFSET      0x0004 /* DMA2D Interrupt Status Register */
 #define STM32_DMA2D_IFCR_OFFSET     0x0008 /* DMA2D Interrupt Flag Clear Register */
-#define STM32_DMA2D_FGMAR_OFFSET    0x000C /* DMA2D Foreground Memory Address Register */
+#define STM32_DMA2D_FGMAR_OFFSET    0x000c /* DMA2D Foreground Memory Address Register */
 #define STM32_DMA2D_FGOR_OFFSET     0x0010 /* DMA2D Foreground Offset Register */
 #define STM32_DMA2D_BGMAR_OFFSET    0x0014 /* DMA2D Background Memory Address Register */
 #define STM32_DMA2D_BGOR_OFFSET     0x0018 /* DMA2D Background Offset Register */
-#define STM32_DMA2D_FGPFCCR_OFFSET  0x001C /* DMA2D Foreground PFC Control Register */
+#define STM32_DMA2D_FGPFCCR_OFFSET  0x001c /* DMA2D Foreground PFC Control Register */
 #define STM32_DMA2D_FGCOLR_OFFSET   0x0020 /* DMA2D Foreground Color Register */
 #define STM32_DMA2D_BGPFCCR_OFFSET  0x0024 /* DMA2D Background PFC Control Register */
 #define STM32_DMA2D_BGCOLR_OFFSET   0x0028 /* DMA2D Background Color Register */
-#define STM32_DMA2D_FGCMAR_OFFSET   0x002C /* DMA2D Foreground CLUT Memory Address Register */
+#define STM32_DMA2D_FGCMAR_OFFSET   0x002c /* DMA2D Foreground CLUT Memory Address Register */
 #define STM32_DMA2D_BGCMAR_OFFSET   0x0030 /* DMA2D Background CLUT Memory Address Register */
 #define STM32_DMA2D_OPFCCR_OFFSET   0x0034 /* DMA2D Output PFC Control Register */
 #define STM32_DMA2D_OCOLR_OFFSET    0x0038 /* DMA2D Output Color Register */
-#define STM32_DMA2D_OMAR_OFFSET     0x003C /* DMA2D Output Memory Address Register */
+#define STM32_DMA2D_OMAR_OFFSET     0x003c /* DMA2D Output Memory Address Register */
 #define STM32_DMA2D_OOR_OFFSET      0x0040 /* DMA2D Output Offset Register */
 #define STM32_DMA2D_NLR_OFFSET      0x0044 /* DMA2D Number Of Line Register */
 #define STM32_DMA2D_LWR_OFFSET      0x0048 /* DMA2D Line Watermark Register */
-#define STM32_DMA2D_AMTCR_OFFSET    0x004C /* DMA2D AHB Master Time Configuration Register */
+#define STM32_DMA2D_AMTCR_OFFSET    0x004c /* DMA2D AHB Master Time Configuration Register */
 
-/* DMA2D Register Addresses **************************************************/
+/* DMA2D Register Addresses *************************************************/
 
-#define STM32_DMA2D_CR              (STM32_DMA2D_BASE+STM32_DMA2D_CR_OFFSET)
-#define STM32_DMA2D_ISR             (STM32_DMA2D_BASE+STM32_DMA2D_ISR_OFFSET)
-#define STM32_DMA2D_IFCR            (STM32_DMA2D_BASE+STM32_DMA2D_IFCR_OFFSET)
-#define STM32_DMA2D_FGMAR           (STM32_DMA2D_BASE+STM32_DMA2D_FGMAR_OFFSET)
-#define STM32_DMA2D_FGOR            (STM32_DMA2D_BASE+STM32_DMA2D_FGOR_OFFSET)
-#define STM32_DMA2D_BGMAR           (STM32_DMA2D_BASE+STM32_DMA2D_BGMAR_OFFSET)
-#define STM32_DMA2D_BGOR            (STM32_DMA2D_BASE+STM32_DMA2D_BGOR_OFFSET)
-#define STM32_DMA2D_FGPFCCR         (STM32_DMA2D_BASE+STM32_DMA2D_FGPFCCR_OFFSET)
-#define STM32_DMA2D_FGCOLR          (STM32_DMA2D_BASE+STM32_DMA2D_FGCOLR_OFFSET)
-#define STM32_DMA2D_BGPFCCR         (STM32_DMA2D_BASE+STM32_DMA2D_BGPFCCR_OFFSET)
-#define STM32_DMA2D_BGCOLR          (STM32_DMA2D_BASE+STM32_DMA2D_BGCOLR_OFFSET)
-#define STM32_DMA2D_FGCMAR          (STM32_DMA2D_BASE+STM32_DMA2D_FGCMAR_OFFSET)
-#define STM32_DMA2D_BGCMAR          (STM32_DMA2D_BASE+STM32_DMA2D_BGCMAR_OFFSET)
-#define STM32_DMA2D_OPFCCR          (STM32_DMA2D_BASE+STM32_DMA2D_OPFCCR_OFFSET)
-#define STM32_DMA2D_OCOLR           (STM32_DMA2D_BASE+STM32_DMA2D_OCOLR_OFFSET)
-#define STM32_DMA2D_OMAR            (STM32_DMA2D_BASE+STM32_DMA2D_OMAR_OFFSET)
-#define STM32_DMA2D_OOR             (STM32_DMA2D_BASE+STM32_DMA2D_OOR_OFFSET)
-#define STM32_DMA2D_NLR             (STM32_DMA2D_BASE+STM32_DMA2D_NLR_OFFSET)
-#define STM32_DMA2D_LWR             (STM32_DMA2D_BASE+STM32_DMA2D_LWR_OFFSET)
+#define STM32_DMA2D_CR              (STM32_DMA2D_BASE + STM32_DMA2D_CR_OFFSET)
+#define STM32_DMA2D_ISR             (STM32_DMA2D_BASE + STM32_DMA2D_ISR_OFFSET)
+#define STM32_DMA2D_IFCR            (STM32_DMA2D_BASE + STM32_DMA2D_IFCR_OFFSET)
+#define STM32_DMA2D_FGMAR           (STM32_DMA2D_BASE + STM32_DMA2D_FGMAR_OFFSET)
+#define STM32_DMA2D_FGOR            (STM32_DMA2D_BASE + STM32_DMA2D_FGOR_OFFSET)
+#define STM32_DMA2D_BGMAR           (STM32_DMA2D_BASE + STM32_DMA2D_BGMAR_OFFSET)
+#define STM32_DMA2D_BGOR            (STM32_DMA2D_BASE + STM32_DMA2D_BGOR_OFFSET)
+#define STM32_DMA2D_FGPFCCR         (STM32_DMA2D_BASE + STM32_DMA2D_FGPFCCR_OFFSET)
+#define STM32_DMA2D_FGCOLR          (STM32_DMA2D_BASE + STM32_DMA2D_FGCOLR_OFFSET)
+#define STM32_DMA2D_BGPFCCR         (STM32_DMA2D_BASE + STM32_DMA2D_BGPFCCR_OFFSET)
+#define STM32_DMA2D_BGCOLR          (STM32_DMA2D_BASE + STM32_DMA2D_BGCOLR_OFFSET)
+#define STM32_DMA2D_FGCMAR          (STM32_DMA2D_BASE + STM32_DMA2D_FGCMAR_OFFSET)
+#define STM32_DMA2D_BGCMAR          (STM32_DMA2D_BASE + STM32_DMA2D_BGCMAR_OFFSET)
+#define STM32_DMA2D_OPFCCR          (STM32_DMA2D_BASE + STM32_DMA2D_OPFCCR_OFFSET)
+#define STM32_DMA2D_OCOLR           (STM32_DMA2D_BASE + STM32_DMA2D_OCOLR_OFFSET)
+#define STM32_DMA2D_OMAR            (STM32_DMA2D_BASE + STM32_DMA2D_OMAR_OFFSET)
+#define STM32_DMA2D_OOR             (STM32_DMA2D_BASE + STM32_DMA2D_OOR_OFFSET)
+#define STM32_DMA2D_NLR             (STM32_DMA2D_BASE + STM32_DMA2D_NLR_OFFSET)
+#define STM32_DMA2D_LWR             (STM32_DMA2D_BASE + STM32_DMA2D_LWR_OFFSET)
 
-/* DMA2D Register Bit Definitions ********************************************/
+/* DMA2D Register Bit Definitions *******************************************/
 
 /* DMA2D Control Register */
 
@@ -107,7 +107,7 @@
 #define DMA2D_CR_CAEIE              (1 << 11) /* CLUT Access Error Interrupt Enable Bit */
 #define DMA2D_CR_CTCIE              (1 << 12) /* CLUT Transfer Complete Interrupt Enable Bit */
 #define DMA2D_CR_CEIE               (1 << 13) /* Configuration Error Interrupt Enable Bit */
-#define DMA2D_CR_MODE_SHIFT         (16) /* Bits 16-17 DMA2D mode Bits */
+#define DMA2D_CR_MODE_SHIFT         (16)      /* Bits 16-17 DMA2D mode Bits */
 #define DMA2D_CR_MODE_MASK          (3 << DMA2D_CR_MODE_SHIFT)
 #define DMA2D_CR_MODE(n)            ((uint32_t)(n) << DMA2D_CR_MODE_SHIFT)
 
@@ -135,26 +135,26 @@
 
 /* DMA2D Foreground/Background Offset Register */
 
-#define DMA2D_xGOR_SHIFT            (0)  /* Bits 0-13 Line Offset */
-#define DMA2D_xGOR_MASK             (0x3FFF << DMA2D_xGOR_SHIFT)
-#define DMA2D_xGOR(n)               ((uint32_t)(n) << DMA2D_xGOR_SHIFT)
+#define DMA2D_XGOR_SHIFT            (0)      /* Bits 0-13 Line Offset */
+#define DMA2D_XGOR_MASK             (0x3fff << DMA2D_XGOR_SHIFT)
+#define DMA2D_XGOR(n)               ((uint32_t)(n) << DMA2D_XGOR_SHIFT)
 
 /* DMA2D Foreground/Background PFC Control Register */
 
-#define DMA2D_xGPFCCR_CM_SHIFT      (0)  /* Bits 0-3 Color Mode */
-#define DMA2D_xGPFCCR_CM_MASK       (0xF << DMA2D_xGPFCCR_CM_SHIFT)
-#define DMA2D_xGPFCCR_CM(n)         ((uint32_t)(n) << DMA2D_xGPFCCR_CM_SHIFT)
-#define DMA2D_xGPFCCR_CCM           (1 << 4)  /* CLUT Color Mode */
-#define DMA2D_xGPFCCR_START         (1 << 5)  /* Start */
-#define DMA2D_xGPFCCR_CS_SHIFT      (8)  /* Bits 8-15 CLUT Size */
-#define DMA2D_xGPFCCR_CS_MASK       (0xFF << DMA2D_xGPFCCR_CS_SHIFT)
-#define DMA2D_xGPFCCR_CS(n)         ((uint32_t)(n) << DMA2D_xGPFCCR_CS_SHIFT)
-#define DMA2D_xGPFCCR_AM_SHIFT      (16)  /* Bits 16-17 Alpha Mode */
-#define DMA2D_xGPFCCR_AM_MASK       (3 << DMA2D_xGPFCCR_AM_SHIFT)
-#define DMA2D_xGPFCCR_AM(n)         ((uint32_t)(n) << DMA2D_xGPFCCR_AM_SHIFT)
-#define DMA2D_xGPFCCR_ALPHA_SHIFT   (24)  /* Bits 24-31 Alpha Value */
-#define DMA2D_xGPFCCR_ALPHA_MASK    (0xFF << DMA2D_xGPFCCR_ALPHA_SHIFT)
-#define DMA2D_xGPFCCR_ALPHA(n)      ((uint32_t)(n) << DMA2D_xGPFCCR_ALPHA_SHIFT)
+#define DMA2D_XGPFCCR_CM_SHIFT      (0)      /* Bits 0-3 Color Mode */
+#define DMA2D_XGPFCCR_CM_MASK       (0xf << DMA2D_XGPFCCR_CM_SHIFT)
+#define DMA2D_XGPFCCR_CM(n)         ((uint32_t)(n) << DMA2D_XGPFCCR_CM_SHIFT)
+#define DMA2D_XGPFCCR_CCM           (1 << 4) /* CLUT Color Mode */
+#define DMA2D_XGPFCCR_START         (1 << 5) /* Start */
+#define DMA2D_XGPFCCR_CS_SHIFT      (8)      /* Bits 8-15 CLUT Size */
+#define DMA2D_XGPFCCR_CS_MASK       (0xff << DMA2D_XGPFCCR_CS_SHIFT)
+#define DMA2D_XGPFCCR_CS(n)         ((uint32_t)(n) << DMA2D_XGPFCCR_CS_SHIFT)
+#define DMA2D_XGPFCCR_AM_SHIFT      (16)     /* Bits 16-17 Alpha Mode */
+#define DMA2D_XGPFCCR_AM_MASK       (3 << DMA2D_XGPFCCR_AM_SHIFT)
+#define DMA2D_XGPFCCR_AM(n)         ((uint32_t)(n) << DMA2D_XGPFCCR_AM_SHIFT)
+#define DMA2D_XGPFCCR_ALPHA_SHIFT   (24)     /* Bits 24-31 Alpha Value */
+#define DMA2D_XGPFCCR_ALPHA_MASK    (0xff << DMA2D_XGPFCCR_ALPHA_SHIFT)
+#define DMA2D_XGPFCCR_ALPHA(n)      ((uint32_t)(n) << DMA2D_XGPFCCR_ALPHA_SHIFT)
 
 /* DMA2D PFC alpha mode */
 
@@ -164,15 +164,15 @@
 
 /* DMA2D Foreground/Background Color Register */
 
-#define DMA2D_xGCOLR_BLUE_SHIFT     (0)  /* Bits 0-7 Blue Value */
-#define DMA2D_xGCOLR_BLUE_MASK      (0xFF << DMA2D_xGCOLR_BLUE_SHIFT)
-#define DMA2D_xGCOLR_BLUE(n)        ((uint32_t)(n) << DMA2D_xGCOLR_BLUE_SHIFT)
-#define DMA2D_xGCOLR_GREEN_SHIFT    (8)  /* Bits 8-15 Green Value */
-#define DMA2D_xGCOLR_GREEN_MASK     (0xFF << DMA2D_xGCOLR_GREEN_SHIFT)
-#define DMA2D_xGCOLR_GREEN(n)       ((uint32_t)(n) << DMA2D_xGCOLR_GREEN_SHIFT)
-#define DMA2D_xGCOLR_RED_SHIFT      (16)  /* Bits 16-23 Red Value */
-#define DMA2D_xGCOLR_RED_MASK       (0xFF << DMA2D_xGCOLR_RED_SHIFT)
-#define DMA2D_xGCOLR_RED(n)         ((uint32_t)(n) << DMA2D_xGCOLR_RED_SHIFT)
+#define DMA2D_XGCOLR_BLUE_SHIFT     (0)      /* Bits 0-7 Blue Value */
+#define DMA2D_XGCOLR_BLUE_MASK      (0xff << DMA2D_XGCOLR_BLUE_SHIFT)
+#define DMA2D_XGCOLR_BLUE(n)        ((uint32_t)(n) << DMA2D_XGCOLR_BLUE_SHIFT)
+#define DMA2D_XGCOLR_GREEN_SHIFT    (8)      /* Bits 8-15 Green Value */
+#define DMA2D_XGCOLR_GREEN_MASK     (0xff << DMA2D_XGCOLR_GREEN_SHIFT)
+#define DMA2D_XGCOLR_GREEN(n)       ((uint32_t)(n) << DMA2D_XGCOLR_GREEN_SHIFT)
+#define DMA2D_XGCOLR_RED_SHIFT      (16)     /* Bits 16-23 Red Value */
+#define DMA2D_XGCOLR_RED_MASK       (0xff << DMA2D_XGCOLR_RED_SHIFT)
+#define DMA2D_XGCOLR_RED(n)         ((uint32_t)(n) << DMA2D_XGCOLR_RED_SHIFT)
 
 /* DMA2D Foreground CLUT Memory Address Register */
 
@@ -201,46 +201,46 @@
 /* DMA2D Output Color Register */
 
 #define DMA2D_OCOLR_BLUE_SHIFT      (0)  /* Bits 0-7 Blue Value */
-#define DMA2D_OCOLR_BLUE_MASK       (0xFF << DMA2D_OCOLR_BLUE_SHIFT)
+#define DMA2D_OCOLR_BLUE_MASK       (0xff << DMA2D_OCOLR_BLUE_SHIFT)
 #define DMA2D_OCOLR_BLUE(n)         ((uint32_t)(n) << DMA2D_OCOLR_BLUE_SHIFT)
 #define DMA2D_OCOLR_GREEN_SHIFT     (8)  /* Bits 8-15 Green Value */
-#define DMA2D_OCOLR_GREEN_MASK      (0xFF << DMA2D_OCOLR_GREEN_SHIFT)
+#define DMA2D_OCOLR_GREEN_MASK      (0xff << DMA2D_OCOLR_GREEN_SHIFT)
 #define DMA2D_OCOLR_GREEN(n)        ((uint32_t)(n) << DMA2D_OCOLR_GREEN_SHIFT)
 #define DMA2D_OCOLR_RED_SHIFT       (16)  /* Bits 16-23 Red Value */
-#define DMA2D_OCOLR_RED_MASK        (0xFF << DMA2D_OCOLR_RED_SHIFT)
+#define DMA2D_OCOLR_RED_MASK        (0xff << DMA2D_OCOLR_RED_SHIFT)
 #define DMA2D_OCOLR_RED(n)          ((uint32_t)(n) << DMA2D_OCOLR_RED_SHIFT)
 #define DMA2D_OCOLR_ALPHA_SHIFT     (24)  /* Bits 24-31 Alpha Value */
-#define DMA2D_OCOLR_ALPHA_MASK      (0xFF << DMA2D_OCOLR_ALPHA_SHIFT)
+#define DMA2D_OCOLR_ALPHA_MASK      (0xff << DMA2D_OCOLR_ALPHA_SHIFT)
 #define DMA2D_OCOLR_ALPHA(n)        ((uint32_t)(n) << DMA2D_OCOLR_ALPHA_SHIFT)
 
 /* DMA2D Output Memory Address Register */
 
 /* DMA2D Output Offset Register */
 
-#define DMA2D_OOR_LO_SHIFT          (0)  /* Bits 0-13 Line Offset */
-#define DMA2D_OOR_LO_MASK           (0x3FFF << DMA2D_OOR_LO_SHIFT)
+#define DMA2D_OOR_LO_SHIFT          (0)      /* Bits 0-13 Line Offset */
+#define DMA2D_OOR_LO_MASK           (0x3fff << DMA2D_OOR_LO_SHIFT)
 #define DMA2D_OOR_LO(n)             ((uint32_t)(n) << DMA2D_OOR_LO_SHIFT)
 
 /* DMA2D Number Of Line Register */
 
-#define DMA2D_NLR_NL_SHIFT          (0)  /* Bits 0-15 Number Of Lines */
-#define DMA2D_NLR_NL_MASK           (0xFFFF << DMA2D_NLR_NL_SHIFT)
+#define DMA2D_NLR_NL_SHIFT          (0)      /* Bits 0-15 Number Of Lines */
+#define DMA2D_NLR_NL_MASK           (0xffff << DMA2D_NLR_NL_SHIFT)
 #define DMA2D_NLR_NL(n)             ((uint32_t)(n) << DMA2D_NLR_NL_SHIFT)
-#define DMA2D_NLR_PL_SHIFT          (16) /* Bits 16-29 Pixel per Lines */
-#define DMA2D_NLR_PL_MASK           (0x3FFF << DMA2D_NLR_PL_SHIFT)
+#define DMA2D_NLR_PL_SHIFT          (16)     /* Bits 16-29 Pixel per Lines */
+#define DMA2D_NLR_PL_MASK           (0x3fff << DMA2D_NLR_PL_SHIFT)
 #define DMA2D_NLR_PL(n)             ((uint32_t)(n) << DMA2D_NLR_PL_SHIFT)
 
 /* DMA2D Line Watermark Register */
 
-#define DMA2D_LWR_LW_SHIFT          (0)  /* Bits 0-15 Line Watermark */
-#define DMA2D_LWR_LW_MASK           (0xFFFF << DMA2D_LWR_LW_SHIFT)
+#define DMA2D_LWR_LW_SHIFT          (0)      /* Bits 0-15 Line Watermark */
+#define DMA2D_LWR_LW_MASK           (0xffff << DMA2D_LWR_LW_SHIFT)
 #define DMA2D_LWR_LW(n)             ((uint32_t)(n) << DMA2D_LWR_LW_SHIFT)
 
 /* DMA2D AHB Master Timer Configuration Register */
 
-#define DMA2D_AMTCR_EN              (1 << 0)  /* Enable */
-#define DMA2D_AMTCR_DT_SHIFT        (0)  /* Bits 8-15 Dead Time */
-#define DMA2D_AMTCR_DT_MASK         (0xFF << DMA2D_AMTCR_DT_SHIFT)
+#define DMA2D_AMTCR_EN              (1 << 0) /* Enable */
+#define DMA2D_AMTCR_DT_SHIFT        (0)      /* Bits 8-15 Dead Time */
+#define DMA2D_AMTCR_DT_MASK         (0xff << DMA2D_AMTCR_DT_SHIFT)
 #define DMA2D_AMTCR_DT(n)           ((uint32_t)(n) << DMA2D_AMTCR_DT_SHIFT)
 
 /****************************************************************************

--- a/arch/arm/src/stm32/hardware/stm32_ltdc.h
+++ b/arch/arm/src/stm32/hardware/stm32_ltdc.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32/hardware/stm32_ltdc.h
  *
  *   Copyright (C) 2013 Ken Pettit. All rights reserved.
@@ -31,25 +31,25 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32_HARDWARE_STM32_LTDC_H
 #define __ARCH_ARM_SRC_STM32_HARDWARE_STM32_LTDC_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include "hardware/stm32_memorymap.h"
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
-#define STM32_LTDC_NCLUT              256    /* Number of entries in the CLUTs */
+#define STM32_LTDC_NCLUT            256    /* Number of entries in the CLUTs */
 
-/* LCDC Register Offsets ************************************************************/
+/* LCDC Register Offsets ****************************************************/
 
 #define STM32_LTDC_SSCR_OFFSET      0x0008 /* LTDC Synchronization Size Config Register */
 #define STM32_LTDC_BPCR_OFFSET      0x000c /* LTDC Back Porch Configuration Register */
@@ -59,11 +59,11 @@
                                            /* 0x0020 Reserved */
 #define STM32_LTDC_SRCR_OFFSET      0x0024 /* LTDC Shadow Reload Configuration Register */
                                            /* 0x0028 Reserved */
-#define STM32_LTDC_BCCR_OFFSET      0x002C /* LTDC Background Color Configuration Register */
+#define STM32_LTDC_BCCR_OFFSET      0x002c /* LTDC Background Color Configuration Register */
                                            /* 0x0030 Reserved */
 #define STM32_LTDC_IER_OFFSET       0x0034 /* LTDC Interrupt Enable Register */
 #define STM32_LTDC_ISR_OFFSET       0x0038 /* LTDC Interrupt Status Register */
-#define STM32_LTDC_ICR_OFFSET       0x003C /* LTDC Interrupt Clear Register */
+#define STM32_LTDC_ICR_OFFSET       0x003c /* LTDC Interrupt Clear Register */
 #define STM32_LTDC_LIPCR_OFFSET     0x0040 /* LTDC Line Interrupt Position Config Register */
 #define STM32_LTDC_CPSR_OFFSET      0x0044 /* LTDC Current Position Status Register */
 #define STM32_LTDC_CDSR_OFFSET      0x0048 /* LTDC Current Display Status Register */
@@ -71,78 +71,78 @@
 
 #define STM32_LTDC_L1CR_OFFSET      0x0084 /* LTDC Layer 1 Control Register */
 #define STM32_LTDC_L1WHPCR_OFFSET   0x0088 /* LTDC Layer 1 Window Horiz Pos Config Register */
-#define STM32_LTDC_L1WVPCR_OFFSET   0x008C /* LTDC Layer 1 Window Vert Pos Config Register */
+#define STM32_LTDC_L1WVPCR_OFFSET   0x008c /* LTDC Layer 1 Window Vert Pos Config Register */
 #define STM32_LTDC_L1CKCR_OFFSET    0x0090 /* LTDC Layer 1 Color Keying Config Register */
 #define STM32_LTDC_L1PFCR_OFFSET    0x0094 /* LTDC Layer 1 Pixel Format Configuration Register */
 #define STM32_LTDC_L1CACR_OFFSET    0x0098 /* LTDC Layer 1 Constant Alpha Config Register */
-#define STM32_LTDC_L1DCCR_OFFSET    0x009C /* LTDC Layer 1 Default Color Config Register */
-#define STM32_LTDC_L1BFCR_OFFSET    0x00A0 /* LTDC Layer 1 Blending Factors Config Register */
+#define STM32_LTDC_L1DCCR_OFFSET    0x009c /* LTDC Layer 1 Default Color Config Register */
+#define STM32_LTDC_L1BFCR_OFFSET    0x00a0 /* LTDC Layer 1 Blending Factors Config Register */
                                            /* 0x00A4-0x00A8 Reserved */
-#define STM32_LTDC_L1CFBAR_OFFSET   0x00AC /* LTDC Layer 1 Color Frame Buffer Address Register */
-#define STM32_LTDC_L1CFBLR_OFFSET   0x00B0 /* LTDC Layer 1 Color Frame Buffer Length Register */
-#define STM32_LTDC_L1CFBLNR_OFFSET  0x00B4 /* LTDC Layer 1 Color Frame Buffer Line Number Register */
+#define STM32_LTDC_L1CFBAR_OFFSET   0x00ac /* LTDC Layer 1 Color Frame Buffer Address Register */
+#define STM32_LTDC_L1CFBLR_OFFSET   0x00b0 /* LTDC Layer 1 Color Frame Buffer Length Register */
+#define STM32_LTDC_L1CFBLNR_OFFSET  0x00b4 /* LTDC Layer 1 Color Frame Buffer Line Number Register */
                                            /* 0x00B8-0x00C0 Reserved */
-#define STM32_LTDC_L1CLUTWR_OFFSET  0x00C4 /* LTDC Layer 1 CLUT Write Register */
+#define STM32_LTDC_L1CLUTWR_OFFSET  0x00c4 /* LTDC Layer 1 CLUT Write Register */
                                            /* 0x00C8-0x0100 Reserved */
 #define STM32_LTDC_L2CR_OFFSET      0x0104 /* LTDC Layer 2 Control Register */
 #define STM32_LTDC_L2WHPCR_OFFSET   0x0108 /* LTDC Layer 2 Window Horiz Pos Config Register */
-#define STM32_LTDC_L2WVPCR_OFFSET   0x010C /* LTDC Layer 2 Window Vert Pos Config Register */
+#define STM32_LTDC_L2WVPCR_OFFSET   0x010c /* LTDC Layer 2 Window Vert Pos Config Register */
 #define STM32_LTDC_L2CKCR_OFFSET    0x0110 /* LTDC Layer 2 Color Keying Config Register */
 #define STM32_LTDC_L2PFCR_OFFSET    0x0114 /* LTDC Layer 2 Pixel Format Configuration Register */
 #define STM32_LTDC_L2CACR_OFFSET    0x0118 /* LTDC Layer 2 Constant Alpha Config Register */
-#define STM32_LTDC_L2DCCR_OFFSET    0x011C /* LTDC Layer 2 Default Color Config Register */
+#define STM32_LTDC_L2DCCR_OFFSET    0x011c /* LTDC Layer 2 Default Color Config Register */
 #define STM32_LTDC_L2BFCR_OFFSET    0x0120 /* LTDC Layer 2 Blending Factors Config Register */
                                            /* 0x0124-0x0128 Reserved */
-#define STM32_LTDC_L2CFBAR_OFFSET   0x012C /* LTDC Layer 2 Color Frame Buffer Address Register */
+#define STM32_LTDC_L2CFBAR_OFFSET   0x012c /* LTDC Layer 2 Color Frame Buffer Address Register */
 #define STM32_LTDC_L2CFBLR_OFFSET   0x0130 /* LTDC Layer 2 Color Frame Buffer Length Register */
 #define STM32_LTDC_L2CFBLNR_OFFSET  0x0134 /* LTDC Layer 2 Color Frame Buffer Line Number Register */
                                            /* 0x0138-0x0130 Reserved */
 #define STM32_LTDC_L2CLUTWR_OFFSET  0x0144 /* LTDC Layer 2 CLUT Write Register */
                                            /* 0x0148-0x03ff Reserved */
 
-/* LTDC Register Addresses *********************************************************/
+/* LTDC Register Addresses **************************************************/
 
-#define STM32_LTDC_SSCR             (STM32_LTDC_BASE+STM32_LTDC_SSCR_OFFSET)
-#define STM32_LTDC_BPCR             (STM32_LTDC_BASE+STM32_LTDC_BPCR_OFFSET)
-#define STM32_LTDC_AWCR             (STM32_LTDC_BASE+STM32_LTDC_AWCR_OFFSET)
-#define STM32_LTDC_TWCR             (STM32_LTDC_BASE+STM32_LTDC_TWCR_OFFSET)
-#define STM32_LTDC_GCR              (STM32_LTDC_BASE+STM32_LTDC_GCR_OFFSET)
-#define STM32_LTDC_SRCR             (STM32_LTDC_BASE+STM32_LTDC_SRCR_OFFSET)
-#define STM32_LTDC_BCCR             (STM32_LTDC_BASE+STM32_LTDC_BCCR_OFFSET)
-#define STM32_LTDC_IER              (STM32_LTDC_BASE+STM32_LTDC_IER_OFFSET)
-#define STM32_LTDC_ISR              (STM32_LTDC_BASE+STM32_LTDC_ISR_OFFSET)
-#define STM32_LTDC_ICR              (STM32_LTDC_BASE+STM32_LTDC_ICR_OFFSET)
-#define STM32_LTDC_LIPCR            (STM32_LTDC_BASE+STM32_LTDC_LIPCR_OFFSET)
-#define STM32_LTDC_CPSR             (STM32_LTDC_BASE+STM32_LTDC_CPSR_OFFSET)
-#define STM32_LTDC_CDSR             (STM32_LTDC_BASE+STM32_LTDC_CDSR_OFFSET)
+#define STM32_LTDC_SSCR             (STM32_LTDC_BASE + STM32_LTDC_SSCR_OFFSET)
+#define STM32_LTDC_BPCR             (STM32_LTDC_BASE + STM32_LTDC_BPCR_OFFSET)
+#define STM32_LTDC_AWCR             (STM32_LTDC_BASE + STM32_LTDC_AWCR_OFFSET)
+#define STM32_LTDC_TWCR             (STM32_LTDC_BASE + STM32_LTDC_TWCR_OFFSET)
+#define STM32_LTDC_GCR              (STM32_LTDC_BASE + STM32_LTDC_GCR_OFFSET)
+#define STM32_LTDC_SRCR             (STM32_LTDC_BASE + STM32_LTDC_SRCR_OFFSET)
+#define STM32_LTDC_BCCR             (STM32_LTDC_BASE + STM32_LTDC_BCCR_OFFSET)
+#define STM32_LTDC_IER              (STM32_LTDC_BASE + STM32_LTDC_IER_OFFSET)
+#define STM32_LTDC_ISR              (STM32_LTDC_BASE + STM32_LTDC_ISR_OFFSET)
+#define STM32_LTDC_ICR              (STM32_LTDC_BASE + STM32_LTDC_ICR_OFFSET)
+#define STM32_LTDC_LIPCR            (STM32_LTDC_BASE + STM32_LTDC_LIPCR_OFFSET)
+#define STM32_LTDC_CPSR             (STM32_LTDC_BASE + STM32_LTDC_CPSR_OFFSET)
+#define STM32_LTDC_CDSR             (STM32_LTDC_BASE + STM32_LTDC_CDSR_OFFSET)
 
-#define STM32_LTDC_L1CR             (STM32_LTDC_BASE+STM32_LTDC_L1CR_OFFSET)
-#define STM32_LTDC_L1WHPCR          (STM32_LTDC_BASE+STM32_LTDC_L1WHPCR_OFFSET)
-#define STM32_LTDC_L1WVPCR          (STM32_LTDC_BASE+STM32_LTDC_L1WVPCR_OFFSET)
-#define STM32_LTDC_L1CKCR           (STM32_LTDC_BASE+STM32_LTDC_L1CKCR_OFFSET)
-#define STM32_LTDC_L1PFCR           (STM32_LTDC_BASE+STM32_LTDC_L1PFCR_OFFSET)
-#define STM32_LTDC_L1CACR           (STM32_LTDC_BASE+STM32_LTDC_L1CACR_OFFSET)
-#define STM32_LTDC_L1DCCR           (STM32_LTDC_BASE+STM32_LTDC_L1DCCR_OFFSET)
-#define STM32_LTDC_L1BFCR           (STM32_LTDC_BASE+STM32_LTDC_L1BFCR_OFFSET)
-#define STM32_LTDC_L1CFBAR          (STM32_LTDC_BASE+STM32_LTDC_L1CFBAR_OFFSET)
-#define STM32_LTDC_L1CFBLR          (STM32_LTDC_BASE+STM32_LTDC_L1CFBLR_OFFSET)
-#define STM32_LTDC_L1CFBLNR         (STM32_LTDC_BASE+STM32_LTDC_L1CFBLNR_OFFSET)
-#define STM32_LTDC_L1CLUTWR         (STM32_LTDC_BASE+STM32_LTDC_L1CLUTWR_OFFSET)
+#define STM32_LTDC_L1CR             (STM32_LTDC_BASE + STM32_LTDC_L1CR_OFFSET)
+#define STM32_LTDC_L1WHPCR          (STM32_LTDC_BASE + STM32_LTDC_L1WHPCR_OFFSET)
+#define STM32_LTDC_L1WVPCR          (STM32_LTDC_BASE + STM32_LTDC_L1WVPCR_OFFSET)
+#define STM32_LTDC_L1CKCR           (STM32_LTDC_BASE + STM32_LTDC_L1CKCR_OFFSET)
+#define STM32_LTDC_L1PFCR           (STM32_LTDC_BASE + STM32_LTDC_L1PFCR_OFFSET)
+#define STM32_LTDC_L1CACR           (STM32_LTDC_BASE + STM32_LTDC_L1CACR_OFFSET)
+#define STM32_LTDC_L1DCCR           (STM32_LTDC_BASE + STM32_LTDC_L1DCCR_OFFSET)
+#define STM32_LTDC_L1BFCR           (STM32_LTDC_BASE + STM32_LTDC_L1BFCR_OFFSET)
+#define STM32_LTDC_L1CFBAR          (STM32_LTDC_BASE + STM32_LTDC_L1CFBAR_OFFSET)
+#define STM32_LTDC_L1CFBLR          (STM32_LTDC_BASE + STM32_LTDC_L1CFBLR_OFFSET)
+#define STM32_LTDC_L1CFBLNR         (STM32_LTDC_BASE + STM32_LTDC_L1CFBLNR_OFFSET)
+#define STM32_LTDC_L1CLUTWR         (STM32_LTDC_BASE + STM32_LTDC_L1CLUTWR_OFFSET)
 
-#define STM32_LTDC_L2CR             (STM32_LTDC_BASE+STM32_LTDC_L2CR_OFFSET)
-#define STM32_LTDC_L2WHPCR          (STM32_LTDC_BASE+STM32_LTDC_L2WHPCR_OFFSET)
-#define STM32_LTDC_L2WVPCR          (STM32_LTDC_BASE+STM32_LTDC_L2WVPCR_OFFSET)
-#define STM32_LTDC_L2CKCR           (STM32_LTDC_BASE+STM32_LTDC_L2CKCR_OFFSET)
-#define STM32_LTDC_L2PFCR           (STM32_LTDC_BASE+STM32_LTDC_L2PFCR_OFFSET)
-#define STM32_LTDC_L2CACR           (STM32_LTDC_BASE+STM32_LTDC_L2CACR_OFFSET)
-#define STM32_LTDC_L2DCCR           (STM32_LTDC_BASE+STM32_LTDC_L2DCCR_OFFSET)
-#define STM32_LTDC_L2BFCR           (STM32_LTDC_BASE+STM32_LTDC_L2BFCR_OFFSET)
-#define STM32_LTDC_L2CFBAR          (STM32_LTDC_BASE+STM32_LTDC_L2CFBAR_OFFSET)
-#define STM32_LTDC_L2CFBLR          (STM32_LTDC_BASE+STM32_LTDC_L2CFBLR_OFFSET)
-#define STM32_LTDC_L2CFBLNR         (STM32_LTDC_BASE+STM32_LTDC_L2CFBLNR_OFFSET)
-#define STM32_LTDC_L2CLUTWR         (STM32_LTDC_BASE+STM32_LTDC_L2CLUTWR_OFFSET)
+#define STM32_LTDC_L2CR             (STM32_LTDC_BASE + STM32_LTDC_L2CR_OFFSET)
+#define STM32_LTDC_L2WHPCR          (STM32_LTDC_BASE + STM32_LTDC_L2WHPCR_OFFSET)
+#define STM32_LTDC_L2WVPCR          (STM32_LTDC_BASE + STM32_LTDC_L2WVPCR_OFFSET)
+#define STM32_LTDC_L2CKCR           (STM32_LTDC_BASE + STM32_LTDC_L2CKCR_OFFSET)
+#define STM32_LTDC_L2PFCR           (STM32_LTDC_BASE + STM32_LTDC_L2PFCR_OFFSET)
+#define STM32_LTDC_L2CACR           (STM32_LTDC_BASE + STM32_LTDC_L2CACR_OFFSET)
+#define STM32_LTDC_L2DCCR           (STM32_LTDC_BASE + STM32_LTDC_L2DCCR_OFFSET)
+#define STM32_LTDC_L2BFCR           (STM32_LTDC_BASE + STM32_LTDC_L2BFCR_OFFSET)
+#define STM32_LTDC_L2CFBAR          (STM32_LTDC_BASE + STM32_LTDC_L2CFBAR_OFFSET)
+#define STM32_LTDC_L2CFBLR          (STM32_LTDC_BASE + STM32_LTDC_L2CFBLR_OFFSET)
+#define STM32_LTDC_L2CFBLNR         (STM32_LTDC_BASE + STM32_LTDC_L2CFBLNR_OFFSET)
+#define STM32_LTDC_L2CLUTWR         (STM32_LTDC_BASE + STM32_LTDC_L2CLUTWR_OFFSET)
 
-/* LTDC Register Bit Definitions ***************************************************/
+/* LTDC Register Bit Definitions ********************************************/
 
 /* LTDC Synchronization Size Configuration Register */
 
@@ -206,13 +206,13 @@
 /* LTDC Background Color Configuration Register */
 
 #define LTDC_BCCR_BCBLUE_SHIFT      (0)       /* Bits 0-7: Background Color Blue Value */
-#define LTDC_BCCR_BCBLUE_MASK       (0xFF << LTDC_BCCR_BCBLUE_SHIFT)
+#define LTDC_BCCR_BCBLUE_MASK       (0xff << LTDC_BCCR_BCBLUE_SHIFT)
 #  define LTDC_BCCR_BCBLUE(n)       ((uint32_t)(n) << LTDC_BCCR_BCBLUE_SHIFT)
 #define LTDC_BCCR_BCGREEN_SHIFT     (8)       /* Bits 8-15: Background Color Green Value */
-#define LTDC_BCCR_BCGREEN_MASK      (0xFF << LTDC_BCCR_BCGREEN_SHIFT)
+#define LTDC_BCCR_BCGREEN_MASK      (0xff << LTDC_BCCR_BCGREEN_SHIFT)
 #  define LTDC_BCCR_BCGREEN(n)      ((uint32_t)(n) << LTDC_BCCR_BCGREEN_SHIFT)
 #define LTDC_BCCR_BCRED_SHIFT       (16)       /* Bits 16-23: Background Color Red Value */
-#define LTDC_BCCR_BCRED_MASK        (0xFF << LTDC_BCCR_BCRED_SHIFT)
+#define LTDC_BCCR_BCRED_MASK        (0xff << LTDC_BCCR_BCRED_SHIFT)
 #  define LTDC_BCCR_BCRED(n)        ((uint32_t)(n) << LTDC_BCCR_BCRED_SHIFT)
 
 /* LTDC Interrupt Enable Register */
@@ -239,16 +239,16 @@
 /* LTDC Line Interrupt Posittion Configuration Register */
 
 #define LTDC_LIPCR_LIPOS_SHIFT      (0)       /* Bits 0-10: Line Interrupt Position */
-#define LTDC_LIPCR_LIPOS_MASK       (0x7FF << LTDC_LIPCR_LIPOS_SHIFT)
+#define LTDC_LIPCR_LIPOS_MASK       (0x7ff << LTDC_LIPCR_LIPOS_SHIFT)
 #  define LTDC_LIPCR_LIPOS(n)       ((uint32_t)(n) << LTDC_LIPCR_LIPOS_SHIFT)
 
 /* LTDC Current Position Status Register */
 
 #define LTDC_CPSR_CYPOS_SHIFT       (0)       /* Bits 0-15: Current Y Position */
-#define LTDC_CPSR_CYPOS_MASK        (0xFFFF << LTDC_CPSR_CYPOS_SHIFT)
+#define LTDC_CPSR_CYPOS_MASK        (0xffff << LTDC_CPSR_CYPOS_SHIFT)
 #  define LTDC_CPSR_CYPOS(n)        ((uint32_t)(n) << LTDC_CPSR_CYPOS_SHIFT)
 #define LTDC_CPSR_CXPOS_SHIFT       (16)      /* Bits 15-31: Current X Position */
-#define LTDC_CPSR_CXPOS_MASK        (0xFFFF << LTDC_CPSR_CXPOS_SHIFT)
+#define LTDC_CPSR_CXPOS_MASK        (0xffff << LTDC_CPSR_CXPOS_SHIFT)
 #  define LTDC_CPSR_CXPOS(n)        ((uint32_t)(n) << LTDC_CPSR_CXPOS_SHIFT)
 
 /* LTDC Current Display Status Register */
@@ -260,45 +260,45 @@
 
 /* LTDC Layer x Control Register */
 
-#define LTDC_LxCR_LEN               (1 << 0)  /* Bit 0:  Layer Enable */
-#define LTDC_LxCR_COLKEN            (1 << 1)  /* Bit 1:  Color Keying Enable */
-#define LTDC_LxCR_CLUTEN            (1 << 4)  /* Bit 4:  Color Look-Up Table Enable */
+#define LTDC_LXCR_LEN               (1 << 0)  /* Bit 0:  Layer Enable */
+#define LTDC_LXCR_COLKEN            (1 << 1)  /* Bit 1:  Color Keying Enable */
+#define LTDC_LXCR_CLUTEN            (1 << 4)  /* Bit 4:  Color Look-Up Table Enable */
 
 /* LTDC Layer x Window Horizontal Position Configuration Register */
 
-#define LTDC_LxWHPCR_WHSTPOS_SHIFT  (0)       /* Bits 0-11: Window Horizontal Start Position */
-#define LTDC_LxWHPCR_WHSTPOS_MASK   (0xFFF << LTDC_LxWHPCR_WHSTPOS_SHIFT)
-#  define LTDC_LxWHPCR_WHSTPOS(n)   ((uint32_t)(n) << LTDC_LxWHPCR_WHSTPOS_SHIFT)
-#define LTDC_LxWHPCR_WHSPPOS_SHIFT  (16)      /* Bits 16-27: Window Horizontal Stop Position */
-#define LTDC_LxWHPCR_WHSPPOS_MASK   (0xFFF << LTDC_LxWHPCR_WHSPPOS_SHIFT)
-#  define LTDC_LxWHPCR_WHSPPOS(n)   ((uint32_t)(n) << LTDC_LxWHPCR_WHSPPOS_SHIFT)
+#define LTDC_LXWHPCR_WHSTPOS_SHIFT  (0)       /* Bits 0-11: Window Horizontal Start Position */
+#define LTDC_LXWHPCR_WHSTPOS_MASK   (0xFFF << LTDC_LXWHPCR_WHSTPOS_SHIFT)
+#  define LTDC_LXWHPCR_WHSTPOS(n)   ((uint32_t)(n) << LTDC_LXWHPCR_WHSTPOS_SHIFT)
+#define LTDC_LXWHPCR_WHSPPOS_SHIFT  (16)      /* Bits 16-27: Window Horizontal Stop Position */
+#define LTDC_LXWHPCR_WHSPPOS_MASK   (0xFFF << LTDC_LXWHPCR_WHSPPOS_SHIFT)
+#  define LTDC_LXWHPCR_WHSPPOS(n)   ((uint32_t)(n) << LTDC_LXWHPCR_WHSPPOS_SHIFT)
 
 /* LTDC Layer x Window Vertical Position Configuration Register */
 
-#define LTDC_LxWVPCR_WVSTPOS_SHIFT  (0)       /* Bits 0-10: Window Vertical Start Position */
-#define LTDC_LxWVPCR_WVSTPOS_MASK   (0x7FF << LTDC_LxWVPCR_WVSTPOS_SHIFT)
-#  define LTDC_LxWVPCR_WVSTPOS(n)   ((uint32_t)(n) << LTDC_LxWVPCR_WVSTPOS_SHIFT)
-#define LTDC_LxWVPCR_WVSPPOS_SHIFT  (16)      /* Bits 16-26: Window Vertical Stop Position */
-#define LTDC_LxWVPCR_WVSPPOS_MASK   (0x7FF << LTDC_LxWVPCR_WVSPPOS_SHIFT)
-#  define LTDC_LxWVPCR_WVSPPOS(n)   ((uint32_t)(n) << LTDC_LxWVPCR_WVSPPOS_SHIFT)
+#define LTDC_LXWVPCR_WVSTPOS_SHIFT  (0)       /* Bits 0-10: Window Vertical Start Position */
+#define LTDC_LXWVPCR_WVSTPOS_MASK   (0x7ff << LTDC_LXWVPCR_WVSTPOS_SHIFT)
+#  define LTDC_LXWVPCR_WVSTPOS(n)   ((uint32_t)(n) << LTDC_LXWVPCR_WVSTPOS_SHIFT)
+#define LTDC_LXWVPCR_WVSPPOS_SHIFT  (16)      /* Bits 16-26: Window Vertical Stop Position */
+#define LTDC_LXWVPCR_WVSPPOS_MASK   (0x7ff << LTDC_LXWVPCR_WVSPPOS_SHIFT)
+#  define LTDC_LXWVPCR_WVSPPOS(n)   ((uint32_t)(n) << LTDC_LXWVPCR_WVSPPOS_SHIFT)
 
 /* LTDC Layer x Color Keying Configuration Register */
 
-#define LTDC_LxCKCR_CKBLUE_SHIFT    (0)       /* Bits 0-7: Color Key Blue Value */
-#define LTDC_LxCKCR_CKBLUE_MASK     (0xFF << LTDC_LxCKCR_CKBLUE_SHIFT)
-#  define LTDC_LxCKCR_CKBLUE(n)     ((uint32_t)(n) << LTDC_LxCKCR_CKBLUE_SHIFT)
-#define LTDC_LxCKCR_CKGREEN_SHIFT   (8)       /* Bits 8-15: Color Key Green Value */
-#define LTDC_LxCKCR_CKGREEN_MASK    (0xFF << LTDC_LxCKCR_CKGREEN_SHIFT)
-#  define LTDC_LxCKCR_CKGREEN(n)    ((uint32_t)(n) << LTDC_LxCKCR_CKGREEN_SHIFT)
-#define LTDC_LxCKCR_CKRED_SHIFT     (16)       /* Bits 16-23: Color Key Red Value */
-#define LTDC_LxCKCR_CKRED_MASK      (0xFF << LTDC_LxCKCR_CKRED_SHIFT)
-#  define LTDC_LxCKCR_CKRED(n)      ((uint32_t)(n) << LTDC_LxCKCR_CKRED_SHIFT)
+#define LTDC_LXCKCR_CKBLUE_SHIFT    (0)       /* Bits 0-7: Color Key Blue Value */
+#define LTDC_LXCKCR_CKBLUE_MASK     (0xff << LTDC_LXCKCR_CKBLUE_SHIFT)
+#  define LTDC_LXCKCR_CKBLUE(n)     ((uint32_t)(n) << LTDC_LXCKCR_CKBLUE_SHIFT)
+#define LTDC_LXCKCR_CKGREEN_SHIFT   (8)       /* Bits 8-15: Color Key Green Value */
+#define LTDC_LXCKCR_CKGREEN_MASK    (0xff << LTDC_LXCKCR_CKGREEN_SHIFT)
+#  define LTDC_LXCKCR_CKGREEN(n)    ((uint32_t)(n) << LTDC_LXCKCR_CKGREEN_SHIFT)
+#define LTDC_LXCKCR_CKRED_SHIFT     (16)       /* Bits 16-23: Color Key Red Value */
+#define LTDC_LXCKCR_CKRED_MASK      (0xff << LTDC_LXCKCR_CKRED_SHIFT)
+#  define LTDC_LXCKCR_CKRED(n)      ((uint32_t)(n) << LTDC_LXCKCR_CKRED_SHIFT)
 
 /* LTDC Layer x Pixel Format Configuration Register */
 
-#define LTDC_LxPFCR_PF_SHIFT        (0)       /* Bits 0-2: Pixel Format */
-#define LTDC_LxPFCR_PF_MASK         (0x7 << LTDC_LxPFCR_PF_SHIFT)
-#  define LTDC_LxPFCR_PF(n)         ((uint32_t)(n) << LTDC_LxPFCR_PF_SHIFT)
+#define LTDC_LXPFCR_PF_SHIFT        (0)       /* Bits 0-2: Pixel Format */
+#define LTDC_LXPFCR_PF_MASK         (0x7 << LTDC_LXPFCR_PF_SHIFT)
+#  define LTDC_LXPFCR_PF(n)         ((uint32_t)(n) << LTDC_LXPFCR_PF_SHIFT)
 
 #define LTDC_PF_ARGB8888            0
 #define LTDC_PF_RGB888              1
@@ -311,33 +311,33 @@
 
 /* LTDC Layer x Constant Alpha Configuration Register */
 
-#define LTDC_LxCACR_CONSTA_SHIFT    (0)       /* Bits 0-7: Constant Alpha */
-#define LTDC_LxCACR_CONSTA_MASK     (0x7 << LTDC_LxCACR_CONSTA_SHIFT)
-#  define LTDC_LxCACR_CONSTA(n)     ((uint32_t)(n) << LTDC_LxCACR_CONSTA_SHIFT)
+#define LTDC_LXCACR_CONSTA_SHIFT    (0)       /* Bits 0-7: Constant Alpha */
+#define LTDC_LXCACR_CONSTA_MASK     (0x7 << LTDC_LXCACR_CONSTA_SHIFT)
+#  define LTDC_LXCACR_CONSTA(n)     ((uint32_t)(n) << LTDC_LXCACR_CONSTA_SHIFT)
 
 /* LTDC Layer x Default Color Configuration Register */
 
-#define LTDC_LxDCCR_DCBLUE_SHIFT    (0)       /* Bits 0-7: Default Color Blue Value */
-#define LTDC_LxDCCR_DCBLUE_MASK     (0xFF << LTDC_LxDCCR_DCBLUE_SHIFT)
-#  define LTDC_LxDCCR_DCBLUE(n)     ((uint32_t)(n) << LTDC_LxDCCR_DCBLUE_SHIFT)
-#define LTDC_LxDCCR_DCGREEN_SHIFT   (8)       /* Bits 8-15: Default Color Green Value */
-#define LTDC_LxDCCR_DCGREEN_MASK    (0xFF << LTDC_LxDCCR_DCGREEN_SHIFT)
-#  define LTDC_LxDCCR_DCGREEN(n)    ((uint32_t)(n) << LTDC_LxDCCR_DCGREEN_SHIFT)
-#define LTDC_LxDCCR_DCRED_SHIFT     (16)       /* Bits 16-23: Default Color Red Value */
-#define LTDC_LxDCCR_DCRED_MASK      (0xFF << LTDC_LxDCCR_DCRED_SHIFT)
-#  define LTDC_LxDCCR_DCRED(n)      ((uint32_t)(n) << LTDC_LxDCCR_DCRED_SHIFT)
-#define LTDC_LxDCCR_DCALPHA_SHIFT   (24)       /* Bits 24-31: Default Color Alpha Value */
-#define LTDC_LxDCCR_DCALPHA_MASK    (0xFF << LTDC_LxDCCR_DCALPHA_SHIFT)
-#  define LTDC_LxDCCR_DCALPHA(n)    ((uint32_t)(n) << LTDC_LxDCCR_DCALPHA_SHIFT)
+#define LTDC_LXDCCR_DCBLUE_SHIFT    (0)       /* Bits 0-7: Default Color Blue Value */
+#define LTDC_LXDCCR_DCBLUE_MASK     (0xff << LTDC_LXDCCR_DCBLUE_SHIFT)
+#  define LTDC_LXDCCR_DCBLUE(n)     ((uint32_t)(n) << LTDC_LXDCCR_DCBLUE_SHIFT)
+#define LTDC_LXDCCR_DCGREEN_SHIFT   (8)       /* Bits 8-15: Default Color Green Value */
+#define LTDC_LXDCCR_DCGREEN_MASK    (0xff << LTDC_LXDCCR_DCGREEN_SHIFT)
+#  define LTDC_LXDCCR_DCGREEN(n)    ((uint32_t)(n) << LTDC_LXDCCR_DCGREEN_SHIFT)
+#define LTDC_LXDCCR_DCRED_SHIFT     (16)       /* Bits 16-23: Default Color Red Value */
+#define LTDC_LXDCCR_DCRED_MASK      (0xff << LTDC_LXDCCR_DCRED_SHIFT)
+#  define LTDC_LXDCCR_DCRED(n)      ((uint32_t)(n) << LTDC_LXDCCR_DCRED_SHIFT)
+#define LTDC_LXDCCR_DCALPHA_SHIFT   (24)       /* Bits 24-31: Default Color Alpha Value */
+#define LTDC_LXDCCR_DCALPHA_MASK    (0xff << LTDC_LXDCCR_DCALPHA_SHIFT)
+#  define LTDC_LXDCCR_DCALPHA(n)    ((uint32_t)(n) << LTDC_LXDCCR_DCALPHA_SHIFT)
 
 /* LTDC Layer x Blending Factors Configuration Register */
 
-#define LTDC_LxBFCR_BF2_SHIFT       (0)       /* Bits 0-2: Blending Factor 2 */
-#define LTDC_LxBFCR_BF2_MASK        (0x7 << LTDC_LxBFCR_BF2_SHIFT)
-#  define LTDC_LxBFCR_BF2(n)        ((uint32_t)(n) << LTDC_LxBFCR_BF2_SHIFT)
-#define LTDC_LxBFCR_BF1_SHIFT       (8)       /* Bits 8-10: Blending Factor 1 */
-#define LTDC_LxBFCR_BF1_MASK        (0x7 << LTDC_LxBFCR_BF1_SHIFT)
-#  define LTDC_LxBFCR_BF1(n)        ((uint32_t)(n) << LTDC_LxBFCR_BF1_SHIFT)
+#define LTDC_LXBFCR_BF2_SHIFT       (0)       /* Bits 0-2: Blending Factor 2 */
+#define LTDC_LXBFCR_BF2_MASK        (0x7 << LTDC_LXBFCR_BF2_SHIFT)
+#  define LTDC_LXBFCR_BF2(n)        ((uint32_t)(n) << LTDC_LXBFCR_BF2_SHIFT)
+#define LTDC_LXBFCR_BF1_SHIFT       (8)       /* Bits 8-10: Blending Factor 1 */
+#define LTDC_LXBFCR_BF1_MASK        (0x7 << LTDC_LXBFCR_BF1_SHIFT)
+#  define LTDC_LXBFCR_BF1(n)        ((uint32_t)(n) << LTDC_LXBFCR_BF1_SHIFT)
 
 #define LTDC_BF1_CONST_ALPHA        0x04      /* Constant Alpha */
 #define LTDC_BF1_PIXEL_ALPHA        0x06      /* Pixel Alpha x Constant Alpha */
@@ -346,36 +346,36 @@
 
 /* LTDC Layer x Color Frame Buffer Length Configuration Register */
 
-#define LTDC_LxCFBLR_CFBLL_SHIFT    (0)       /* Bits 0-12: Color Frame Buffer Line Length */
-#define LTDC_LxCFBLR_CFBLL_MASK     (0x1FFF << LTDC_LxCFBLR_CFBLL_SHIFT)
-#  define LTDC_LxCFBLR_CFBLL(n)     ((uint32_t)(n) << LTDC_LxCFBLR_CFBLL_SHIFT)
-#define LTDC_LxCFBLR_CFBP_SHIFT     (16)       /* Bits 16-28: Color Frame Buffer Pitch */
-#define LTDC_LxCFBLR_CFBP_MASK      (0x1FFF << LTDC_LxCFBLR_CFBP_SHIFT)
-#  define LTDC_LxCFBLR_CFBP(n)      ((uint32_t)(n) << LTDC_LxCFBLR_CFBP_SHIFT)
+#define LTDC_LXCFBLR_CFBLL_SHIFT    (0)       /* Bits 0-12: Color Frame Buffer Line Length */
+#define LTDC_LXCFBLR_CFBLL_MASK     (0x1fff << LTDC_LXCFBLR_CFBLL_SHIFT)
+#  define LTDC_LXCFBLR_CFBLL(n)     ((uint32_t)(n) << LTDC_LXCFBLR_CFBLL_SHIFT)
+#define LTDC_LXCFBLR_CFBP_SHIFT     (16)       /* Bits 16-28: Color Frame Buffer Pitch */
+#define LTDC_LXCFBLR_CFBP_MASK      (0x1fff << LTDC_LXCFBLR_CFBP_SHIFT)
+#  define LTDC_LXCFBLR_CFBP(n)      ((uint32_t)(n) << LTDC_LXCFBLR_CFBP_SHIFT)
 
 /* LTDC Layer x Color Frame Buffer Line Number Register */
 
-#define LTDC_LxCFBLNR_LN_SHIFT      (0)       /* Bits 0-10: Color Frame Buffer Line Number */
-#define LTDC_LxCFBLNR_LN_MASK       (0x7FF << LTDC_LxCFBLNR_LN_SHIFT)
-#  define LTDC_LxCFBLNR_LN(n)       ((uint32_t)(n) << LTDC_LxCFBLNR_LN_SHIFT)
+#define LTDC_LXCFBLNR_LN_SHIFT      (0)       /* Bits 0-10: Color Frame Buffer Line Number */
+#define LTDC_LXCFBLNR_LN_MASK       (0x7ff << LTDC_LXCFBLNR_LN_SHIFT)
+#  define LTDC_LXCFBLNR_LN(n)       ((uint32_t)(n) << LTDC_LXCFBLNR_LN_SHIFT)
 
 /* LTDC Layer x CLUT Write Register */
 
-#define LTDC_LxCLUTWR_BLUE_SHIFT    (0)       /* Bits 0-7: Default Color Blue Value */
-#define LTDC_LxCLUTWR_BLUE_MASK     (0xFF << LTDC_LxCLUTWR_BLUE_SHIFT)
-#  define LTDC_LxCLUTWR_BLUE(n)     ((uint32_t)(n) << LTDC_LxCLUTWR_BLUE_SHIFT)
-#define LTDC_LxCLUTWR_GREEN_SHIFT   (8)       /* Bits 8-15: Default Color Green Value */
-#define LTDC_LxCLUTWR_GREEN_MASK    (0xFF << LTDC_LxCLUTWR_GREEN_SHIFT)
-#  define LTDC_LxCLUTWR_GREEN(n)    ((uint32_t)(n) << LTDC_LxCLUTWR_GREEN_SHIFT)
-#define LTDC_LxCLUTWR_RED_SHIFT     (16)       /* Bits 16-23: Default Color Red Value */
-#define LTDC_LxCLUTWR_RED_MASK      (0xFF << LTDC_LxCLUTWR_RED_SHIFT)
-#  define LTDC_LxCLUTWR_RED(n)      ((uint32_t)(n) << LTDC_LxCLUTWR_RED_SHIFT)
-#define LTDC_LxCLUTWR_CLUTADD_SHIFT (24)       /* Bits 24-31: CLUT Address */
-#define LTDC_LxCLUTWR_CLUTADD_MASK  (0xFF << LTDC_LxCLUTWR_CLUTADD_SHIFT)
-#  define LTDC_LxCLUTWR_CLUTADD(n)  ((uint32_t)(n) << LTDC_LxCLUTWR_CLUTADD_SHIFT)
+#define LTDC_LXCLUTWR_BLUE_SHIFT    (0)       /* Bits 0-7: Default Color Blue Value */
+#define LTDC_LXCLUTWR_BLUE_MASK     (0xff << LTDC_LXCLUTWR_BLUE_SHIFT)
+#  define LTDC_LXCLUTWR_BLUE(n)     ((uint32_t)(n) << LTDC_LXCLUTWR_BLUE_SHIFT)
+#define LTDC_LXCLUTWR_GREEN_SHIFT   (8)       /* Bits 8-15: Default Color Green Value */
+#define LTDC_LXCLUTWR_GREEN_MASK    (0xff << LTDC_LXCLUTWR_GREEN_SHIFT)
+#  define LTDC_LXCLUTWR_GREEN(n)    ((uint32_t)(n) << LTDC_LXCLUTWR_GREEN_SHIFT)
+#define LTDC_LXCLUTWR_RED_SHIFT     (16)       /* Bits 16-23: Default Color Red Value */
+#define LTDC_LXCLUTWR_RED_MASK      (0xff << LTDC_LXCLUTWR_RED_SHIFT)
+#  define LTDC_LXCLUTWR_RED(n)      ((uint32_t)(n) << LTDC_LXCLUTWR_RED_SHIFT)
+#define LTDC_LXCLUTWR_CLUTADD_SHIFT (24)       /* Bits 24-31: CLUT Address */
+#define LTDC_LXCLUTWR_CLUTADD_MASK  (0xff << LTDC_LXCLUTWR_CLUTADD_SHIFT)
+#  define LTDC_LXCLUTWR_CLUTADD(n)  ((uint32_t)(n) << LTDC_LXCLUTWR_CLUTADD_SHIFT)
 
-/************************************************************************************
+/****************************************************************************
  * Public Types
- ************************************************************************************/
+ ****************************************************************************/
 
 #endif /* __ARCH_ARM_SRC_STM32_HARDWARE_STM32_LTDC_H */

--- a/arch/arm/src/stm32/stm32_dma2d.c
+++ b/arch/arm/src/stm32/stm32_dma2d.c
@@ -483,7 +483,7 @@ static int stm32_dma2d_loadclut(uintptr_t pfcreg)
   /* Start clut loading */
 
   regval  = getreg32(pfcreg);
-  regval |= DMA2D_xGPFCCR_START;
+  regval |= DMA2D_XGPFCCR_START;
   reginfo("set regval=%08x\n", regval);
   putreg32(regval, pfcreg);
   reginfo("configured regval=%08x\n", getreg32(pfcreg));
@@ -692,7 +692,7 @@ static void stm32_dma2d_lpfc(int lid, uint32_t blendmode, uint8_t alpha,
 
   /* Set color format */
 
-  pfccrreg = DMA2D_xGPFCCR_CM(fmt);
+  pfccrreg = DMA2D_XGPFCCR_CM(fmt);
 
 #ifdef CONFIG_STM32_FB_CMAP
   if (fmt == DMA2D_PF_L8)
@@ -701,17 +701,17 @@ static void stm32_dma2d_lpfc(int lid, uint32_t blendmode, uint8_t alpha,
 
       /* Load CLUT automatically */
 
-      pfccrreg |= DMA2D_xGPFCCR_START;
+      pfccrreg |= DMA2D_XGPFCCR_START;
 
       /* Set the CLUT color mode */
 
 #  ifndef CONFIG_STM32_FB_TRANSPARENCY
-      pfccrreg |= DMA2D_xGPFCCR_CCM;
+      pfccrreg |= DMA2D_XGPFCCR_CCM;
 #  endif
 
       /* Set CLUT size */
 
-      pfccrreg |= DMA2D_xGPFCCR_CS(DMA2D_CLUT_SIZE);
+      pfccrreg |= DMA2D_XGPFCCR_CS(DMA2D_CLUT_SIZE);
 
       /* Set the CLUT memory address */
 
@@ -725,14 +725,14 @@ static void stm32_dma2d_lpfc(int lid, uint32_t blendmode, uint8_t alpha,
 
   /* Set alpha blend mode */
 
-  pfccrreg |= DMA2D_xGPFCCR_AM(blendmode);
+  pfccrreg |= DMA2D_XGPFCCR_AM(blendmode);
 
   if (blendmode == STM32_DMA2D_PFCCR_AM_CONST ||
         blendmode == STM32_DMA2D_PFCCR_AM_PIXEL)
     {
       /* Set alpha value */
 
-      pfccrreg |= DMA2D_xGPFCCR_ALPHA(alpha);
+      pfccrreg |= DMA2D_XGPFCCR_ALPHA(alpha);
     }
 
   putreg32(pfccrreg, stm32_pfccr_layer_t[lid]);

--- a/arch/arm/src/stm32/stm32_ltdc.c
+++ b/arch/arm/src/stm32/stm32_ltdc.c
@@ -85,13 +85,13 @@
 
 /* LTDC_LxWHPCR register */
 
-#define STM32_LTDC_LxWHPCR_WHSTPOS  (BOARD_LTDC_HSYNC + BOARD_LTDC_HBP - 1)
+#define STM32_LTDC_LXWHPCR_WHSTPOS  (BOARD_LTDC_HSYNC + BOARD_LTDC_HBP - 1)
 #define STM32_LTDC_LxWHPCR_WHSPPOS  (BOARD_LTDC_HSYNC + BOARD_LTDC_HBP + \
                                     STM32_LTDC_WIDTH - 1)
 
 /* LTDC_LxWVPCR register */
 
-#define STM32_LTDC_LxWVPCR_WVSTPOS  (BOARD_LTDC_VSYNC + BOARD_LTDC_VBP - 1)
+#define STM32_LTDC_LXWVPCR_WVSTPOS  (BOARD_LTDC_VSYNC + BOARD_LTDC_VBP - 1)
 #define STM32_LTDC_LxWVPCR_WVSPPOS  (BOARD_LTDC_VSYNC + BOARD_LTDC_VBP + \
                                     STM32_LTDC_HEIGHT - 1)
 
@@ -102,8 +102,8 @@
 
 /* LTDC_BPCR register */
 
-#define STM32_LTDC_BPCR_AVBP        LTDC_BPCR_AVBP(STM32_LTDC_LxWVPCR_WVSTPOS)
-#define STM32_LTDC_BPCR_AHBP        LTDC_BPCR_AHBP(STM32_LTDC_LxWHPCR_WHSTPOS)
+#define STM32_LTDC_BPCR_AVBP        LTDC_BPCR_AVBP(STM32_LTDC_LXWVPCR_WVSTPOS)
+#define STM32_LTDC_BPCR_AHBP        LTDC_BPCR_AHBP(STM32_LTDC_LXWHPCR_WHSTPOS)
 
 /* LTDC_AWCR register */
 
@@ -153,23 +153,23 @@
 #if defined(CONFIG_STM32_LTDC_L1_L8)
 #  define STM32_LTDC_L1_BPP         8
 #  define STM32_LTDC_L1_COLOR_FMT   FB_FMT_RGB8
-#  define STM32_LTDC_L1PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_L8)
+#  define STM32_LTDC_L1PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_L8)
 #  define STM32_LTDC_L1_DMA2D_PF    DMA2D_PF_L8
 #  define STM32_LTDC_L1CMAP
 #elif defined(CONFIG_STM32_LTDC_L1_RGB565)
 #  define STM32_LTDC_L1_BPP         16
 #  define STM32_LTDC_L1_COLOR_FMT   FB_FMT_RGB16_565
-#  define STM32_LTDC_L1PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_RGB565)
+#  define STM32_LTDC_L1PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_RGB565)
 #  define STM32_LTDC_L1_DMA2D_PF    DMA2D_PF_RGB565
 #elif defined(CONFIG_STM32_LTDC_L1_RGB888)
 #  define STM32_LTDC_L1_BPP         24
 #  define STM32_LTDC_L1_COLOR_FMT   FB_FMT_RGB24
-#  define STM32_LTDC_L1PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_RGB888)
+#  define STM32_LTDC_L1PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_RGB888)
 #  define STM32_LTDC_L1_DMA2D_PF    DMA2D_PF_RGB888
 #elif defined(CONFIG_STM32_LTDC_L1_ARGB8888)
 #  define STM32_LTDC_L1_BPP         32
 #  define STM32_LTDC_L1_COLOR_FMT   FB_FMT_RGB32
-#  define STM32_LTDC_L1PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_ARGB8888)
+#  define STM32_LTDC_L1PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_ARGB8888)
 #  define STM32_LTDC_L1_DMA2D_PF    DMA2D_PF_ARGB8888
 #else
 #  error "LTDC pixel format not supported"
@@ -181,23 +181,23 @@
 #  if defined(CONFIG_STM32_LTDC_L2_L8)
 #   define STM32_LTDC_L2_BPP         8
 #   define STM32_LTDC_L2_COLOR_FMT   FB_FMT_RGB8
-#   define STM32_LTDC_L2PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_L8)
+#   define STM32_LTDC_L2PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_L8)
 #   define STM32_LTDC_L2_DMA2D_PF    DMA2D_PF_L8
 #   define STM32_LTDC_L2CMAP
 #  elif defined(CONFIG_STM32_LTDC_L2_RGB565)
 #   define STM32_LTDC_L2_BPP         16
 #   define STM32_LTDC_L2_COLOR_FMT   FB_FMT_RGB16_565
-#   define STM32_LTDC_L2PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_RGB565)
+#   define STM32_LTDC_L2PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_RGB565)
 #   define STM32_LTDC_L2_DMA2D_PF    DMA2D_PF_RGB565
 #  elif defined(CONFIG_STM32_LTDC_L2_RGB888)
 #   define STM32_LTDC_L2_BPP         24
 #   define STM32_LTDC_L2_COLOR_FMT   FB_FMT_RGB24
-#   define STM32_LTDC_L2PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_RGB888)
+#   define STM32_LTDC_L2PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_RGB888)
 #   define STM32_LTDC_L2_DMA2D_PF    DMA2D_PF_RGB888
 #  elif defined(CONFIG_STM32_LTDC_L2_ARGB8888)
 #   define STM32_LTDC_L2_BPP         32
 #   define STM32_LTDC_L2_COLOR_FMT   FB_FMT_RGB32
-#   define STM32_LTDC_L2PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_ARGB8888)
+#   define STM32_LTDC_L2PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_ARGB8888)
 #   define STM32_LTDC_L2_DMA2D_PF    DMA2D_PF_ARGB8888
 #  else
 #   error "LTDC pixel format not supported"
@@ -220,7 +220,7 @@
 
 /* LTDC only supports 8 bit per pixel overal */
 
-#define STM32_LTDC_Lx_BYPP(n)       ((n) / 8)
+#define STM32_LTDC_LX_BYPP(n)       ((n) / 8)
 
 #define STM32_LTDC_L1_FBSIZE        (STM32_LTDC_L1_STRIDE * STM32_LTDC_HEIGHT)
 
@@ -1772,18 +1772,18 @@ static void stm32_ltdc_lframebuffer(FAR struct stm32_ltdc_s *layer)
 
   /* Calculate register position */
 
-  rxpos = STM32_LTDC_LxWHPCR_WHSTPOS + 1;
-  rypos = STM32_LTDC_LxWVPCR_WVSTPOS + 1;
+  rxpos = STM32_LTDC_LXWHPCR_WHSTPOS + 1;
+  rypos = STM32_LTDC_LXWVPCR_WVSTPOS + 1;
 
   /* Accumulate horizontal position */
 
-  whpcr =  LTDC_LxWHPCR_WHSTPOS(rxpos);
-  whpcr |= LTDC_LxWHPCR_WHSPPOS(rxpos + stm32_width_layer_t[layerno] - 1);
+  whpcr =  LTDC_LXWHPCR_WHSTPOS(rxpos);
+  whpcr |= LTDC_LXWHPCR_WHSPPOS(rxpos + stm32_width_layer_t[layerno] - 1);
 
   /* Accumulate vertical position */
 
-  wvpcr =  LTDC_LxWVPCR_WVSTPOS(rypos);
-  wvpcr |= LTDC_LxWVPCR_WVSPPOS(rypos + stm32_height_layer_t[layerno] - 1);
+  wvpcr =  LTDC_LXWVPCR_WVSTPOS(rypos);
+  wvpcr |= LTDC_LXWVPCR_WVSPPOS(rypos + stm32_height_layer_t[layerno] - 1);
 
   /* Configure LxWHPCR / LxWVPCR register */
 
@@ -1802,9 +1802,9 @@ static void stm32_ltdc_lframebuffer(FAR struct stm32_ltdc_s *layer)
 
   /* Calculate line length */
 
-  cfblr = LTDC_LxCFBLR_CFBP(stm32_stride_layer_t[layerno]) |
-          LTDC_LxCFBLR_CFBLL(stm32_width_layer_t[layerno] *
-          STM32_LTDC_Lx_BYPP(stm32_bpp_layer_t[layerno]) + 3);
+  cfblr = LTDC_LXCFBLR_CFBP(stm32_stride_layer_t[layerno]) |
+          LTDC_LXCFBLR_CFBLL(stm32_width_layer_t[layerno] *
+          STM32_LTDC_LX_BYPP(stm32_bpp_layer_t[layerno]) + 3);
 
   reginfo("set LTDC_L%dCFBLR=%08x\n", layerno + 1, cfblr);
   putreg32(cfblr, stm32_cfblr_layer_t[layerno]);
@@ -1843,11 +1843,11 @@ static void stm32_ltdc_lenable(FAR struct stm32_ltdc_s *layer, bool enable)
 
   if (enable == true)
     {
-      regval |= LTDC_LxCR_LEN;
+      regval |= LTDC_LXCR_LEN;
     }
   else
     {
-      regval &= ~LTDC_LxCR_LEN;
+      regval &= ~LTDC_LXCR_LEN;
     }
 
   /* Enable/Disable layer */
@@ -1901,11 +1901,11 @@ static void stm32_ltdc_ltransp(FAR struct stm32_ltdc_s *layer,
 #endif
 
   reginfo("set LTDC_L%dBFCR=%08x\n", layer->layerno + 1,
-          (LTDC_LxBFCR_BF1(bf1) | LTDC_LxBFCR_BF2(bf2)));
+          (LTDC_LXBFCR_BF1(bf1) | LTDC_LXBFCR_BF2(bf2)));
 
   /* Set blendmode */
 
-  putreg32((LTDC_LxBFCR_BF1(bf1) | LTDC_LxBFCR_BF2(bf2)),
+  putreg32((LTDC_LXBFCR_BF1(bf1) | LTDC_LXBFCR_BF2(bf2)),
             stm32_bfcr_layer_t[layer->layerno]);
 
   /* Set alpha */
@@ -1985,11 +1985,11 @@ static void stm32_ltdc_lchromakeyenable(FAR struct stm32_ltdc_s *layer,
 
   if (enable == true)
     {
-      regval |= LTDC_LxCR_COLKEN;
+      regval |= LTDC_LXCR_COLKEN;
     }
   else
     {
-      regval &= ~LTDC_LxCR_COLKEN;
+      regval &= ~LTDC_LXCR_COLKEN;
     }
 
   reginfo("set LTDC_L%dCR=%08x\n", layer->layerno + 1, regval);
@@ -2025,11 +2025,11 @@ static void stm32_ltdc_lclutenable(FAR struct stm32_ltdc_s *layer,
 
   if (enable == true)
     {
-      regval |= LTDC_LxCR_CLUTEN;
+      regval |= LTDC_LXCR_CLUTEN;
     }
   else
     {
-      regval &= ~LTDC_LxCR_CLUTEN;
+      regval &= ~LTDC_LXCR_CLUTEN;
     }
 
   reginfo("set LTDC_L%dCR=%08x\n", layer->oinfo.overlay, regval);

--- a/arch/arm/src/stm32f7/hardware/stm32_dma2d.h
+++ b/arch/arm/src/stm32f7/hardware/stm32_dma2d.h
@@ -49,7 +49,7 @@
 
 #define STM32_DMA2D_NCLUT           256    /* Number of entries in the CLUT */
 
-/* DMA2D Register Offsets ****************************************************/
+/* DMA2D Register Offsets ***************************************************/
 
 #define STM32_DMA2D_CR_OFFSET       0x0000 /* DMA2D Control Register */
 #define STM32_DMA2D_ISR_OFFSET      0x0004 /* DMA2D Interrupt Status Register */
@@ -72,7 +72,7 @@
 #define STM32_DMA2D_LWR_OFFSET      0x0048 /* DMA2D Line Watermark Register */
 #define STM32_DMA2D_AMTCR_OFFSET    0x004c /* DMA2D AHB Master Time Configuration Register */
 
-/* DMA2D Register Addresses **************************************************/
+/* DMA2D Register Addresses *************************************************/
 
 #define STM32_DMA2D_CR              (STM32_DMA2D_BASE + STM32_DMA2D_CR_OFFSET)
 #define STM32_DMA2D_ISR             (STM32_DMA2D_BASE + STM32_DMA2D_ISR_OFFSET)
@@ -94,7 +94,7 @@
 #define STM32_DMA2D_NLR             (STM32_DMA2D_BASE + STM32_DMA2D_NLR_OFFSET)
 #define STM32_DMA2D_LWR             (STM32_DMA2D_BASE + STM32_DMA2D_LWR_OFFSET)
 
-/* DMA2D Register Bit Definitions ********************************************/
+/* DMA2D Register Bit Definitions *******************************************/
 
 /* DMA2D Control Register */
 
@@ -107,7 +107,7 @@
 #define DMA2D_CR_CAEIE              (1 << 11) /* CLUT Access Error Interrupt Enable Bit */
 #define DMA2D_CR_CTCIE              (1 << 12) /* CLUT Transfer Complete Interrupt Enable Bit */
 #define DMA2D_CR_CEIE               (1 << 13) /* Configuration Error Interrupt Enable Bit */
-#define DMA2D_CR_MODE_SHIFT         (16) /* Bits 16-17 DMA2D mode Bits */
+#define DMA2D_CR_MODE_SHIFT         (16)      /* Bits 16-17 DMA2D mode Bits */
 #define DMA2D_CR_MODE_MASK          (3 << DMA2D_CR_MODE_SHIFT)
 #define DMA2D_CR_MODE(n)            ((uint32_t)(n) << DMA2D_CR_MODE_SHIFT)
 
@@ -135,26 +135,26 @@
 
 /* DMA2D Foreground/Background Offset Register */
 
-#define DMA2D_xGOR_SHIFT            (0)  /* Bits 0-13 Line Offset */
-#define DMA2D_xGOR_MASK             (0x3FFF << DMA2D_xGOR_SHIFT)
-#define DMA2D_xGOR(n)               ((uint32_t)(n) << DMA2D_xGOR_SHIFT)
+#define DMA2D_XGOR_SHIFT            (0)       /* Bits 0-13 Line Offset */
+#define DMA2D_XGOR_MASK             (0x3fff << DMA2D_XGOR_SHIFT)
+#define DMA2D_XGOR(n)               ((uint32_t)(n) << DMA2D_XGOR_SHIFT)
 
 /* DMA2D Foreground/Background PFC Control Register */
 
-#define DMA2D_xGPFCCR_CM_SHIFT      (0)  /* Bits 0-3 Color Mode */
-#define DMA2D_xGPFCCR_CM_MASK       (0xF << DMA2D_xGPFCCR_CM_SHIFT)
-#define DMA2D_xGPFCCR_CM(n)         ((uint32_t)(n) << DMA2D_xGPFCCR_CM_SHIFT)
-#define DMA2D_xGPFCCR_CCM           (1 << 4)  /* CLUT Color Mode */
-#define DMA2D_xGPFCCR_START         (1 << 5)  /* Start */
-#define DMA2D_xGPFCCR_CS_SHIFT      (8)  /* Bits 8-15 CLUT Size */
-#define DMA2D_xGPFCCR_CS_MASK       (0xFF << DMA2D_xGPFCCR_CS_SHIFT)
-#define DMA2D_xGPFCCR_CS(n)         ((uint32_t)(n) << DMA2D_xGPFCCR_CS_SHIFT)
-#define DMA2D_xGPFCCR_AM_SHIFT      (16)  /* Bits 16-17 Alpha Mode */
-#define DMA2D_xGPFCCR_AM_MASK       (3 << DMA2D_xGPFCCR_AM_SHIFT)
-#define DMA2D_xGPFCCR_AM(n)         ((uint32_t)(n) << DMA2D_xGPFCCR_AM_SHIFT)
-#define DMA2D_xGPFCCR_ALPHA_SHIFT   (24)  /* Bits 24-31 Alpha Value */
-#define DMA2D_xGPFCCR_ALPHA_MASK    (0xFF << DMA2D_xGPFCCR_ALPHA_SHIFT)
-#define DMA2D_xGPFCCR_ALPHA(n)      ((uint32_t)(n) << DMA2D_xGPFCCR_ALPHA_SHIFT)
+#define DMA2D_XGPFCCR_CM_SHIFT      (0)       /* Bits 0-3 Color Mode */
+#define DMA2D_XGPFCCR_CM_MASK       (0xf << DMA2D_XGPFCCR_CM_SHIFT)
+#define DMA2D_XGPFCCR_CM(n)         ((uint32_t)(n) << DMA2D_XGPFCCR_CM_SHIFT)
+#define DMA2D_XGPFCCR_CCM           (1 << 4)  /* CLUT Color Mode */
+#define DMA2D_XGPFCCR_START         (1 << 5)  /* Start */
+#define DMA2D_XGPFCCR_CS_SHIFT      (8)       /* Bits 8-15 CLUT Size */
+#define DMA2D_XGPFCCR_CS_MASK       (0xff << DMA2D_XGPFCCR_CS_SHIFT)
+#define DMA2D_XGPFCCR_CS(n)         ((uint32_t)(n) << DMA2D_XGPFCCR_CS_SHIFT)
+#define DMA2D_XGPFCCR_AM_SHIFT      (16)      /* Bits 16-17 Alpha Mode */
+#define DMA2D_XGPFCCR_AM_MASK       (3 << DMA2D_XGPFCCR_AM_SHIFT)
+#define DMA2D_XGPFCCR_AM(n)         ((uint32_t)(n) << DMA2D_XGPFCCR_AM_SHIFT)
+#define DMA2D_XGPFCCR_ALPHA_SHIFT   (24)      /* Bits 24-31 Alpha Value */
+#define DMA2D_XGPFCCR_ALPHA_MASK    (0xff << DMA2D_XGPFCCR_ALPHA_SHIFT)
+#define DMA2D_XGPFCCR_ALPHA(n)      ((uint32_t)(n) << DMA2D_XGPFCCR_ALPHA_SHIFT)
 
 /* DMA2D PFC alpha mode */
 
@@ -164,15 +164,15 @@
 
 /* DMA2D Foreground/Background Color Register */
 
-#define DMA2D_xGCOLR_BLUE_SHIFT     (0)  /* Bits 0-7 Blue Value */
-#define DMA2D_xGCOLR_BLUE_MASK      (0xFF << DMA2D_xGCOLR_BLUE_SHIFT)
-#define DMA2D_xGCOLR_BLUE(n)        ((uint32_t)(n) << DMA2D_xGCOLR_BLUE_SHIFT)
-#define DMA2D_xGCOLR_GREEN_SHIFT    (8)  /* Bits 8-15 Green Value */
-#define DMA2D_xGCOLR_GREEN_MASK     (0xFF << DMA2D_xGCOLR_GREEN_SHIFT)
-#define DMA2D_xGCOLR_GREEN(n)       ((uint32_t)(n) << DMA2D_xGCOLR_GREEN_SHIFT)
-#define DMA2D_xGCOLR_RED_SHIFT      (16)  /* Bits 16-23 Red Value */
-#define DMA2D_xGCOLR_RED_MASK       (0xFF << DMA2D_xGCOLR_RED_SHIFT)
-#define DMA2D_xGCOLR_RED(n)         ((uint32_t)(n) << DMA2D_xGCOLR_RED_SHIFT)
+#define DMA2D_XGCOLR_BLUE_SHIFT     (0)       /* Bits 0-7 Blue Value */
+#define DMA2D_XGCOLR_BLUE_MASK      (0xff << DMA2D_XGCOLR_BLUE_SHIFT)
+#define DMA2D_XGCOLR_BLUE(n)        ((uint32_t)(n) << DMA2D_XGCOLR_BLUE_SHIFT)
+#define DMA2D_XGCOLR_GREEN_SHIFT    (8)       /* Bits 8-15 Green Value */
+#define DMA2D_XGCOLR_GREEN_MASK     (0xff << DMA2D_XGCOLR_GREEN_SHIFT)
+#define DMA2D_XGCOLR_GREEN(n)       ((uint32_t)(n) << DMA2D_XGCOLR_GREEN_SHIFT)
+#define DMA2D_XGCOLR_RED_SHIFT      (16)      /* Bits 16-23 Red Value */
+#define DMA2D_XGCOLR_RED_MASK       (0xff << DMA2D_XGCOLR_RED_SHIFT)
+#define DMA2D_XGCOLR_RED(n)         ((uint32_t)(n) << DMA2D_XGCOLR_RED_SHIFT)
 
 /* DMA2D Foreground CLUT Memory Address Register */
 
@@ -180,7 +180,7 @@
 
 /* DMA2D Output PFC Control Register */
 
-#define DMA2D_OPFCCR_CM_SHIFT       (0)  /* Bits 0-2 Color Mode */
+#define DMA2D_OPFCCR_CM_SHIFT       (0)       /* Bits 0-2 Color Mode */
 #define DMA2D_OPFCCR_CM_MASK        (7 << DMA2D_OPFCCR_CM_SHIFT)
 #define DMA2D_OPFCCR_CM(n)          ((uint32_t)(n) << DMA2D_OPFCCR_CM_SHIFT)
 
@@ -200,47 +200,47 @@
 
 /* DMA2D Output Color Register */
 
-#define DMA2D_OCOLR_BLUE_SHIFT      (0)  /* Bits 0-7 Blue Value */
-#define DMA2D_OCOLR_BLUE_MASK       (0xFF << DMA2D_OCOLR_BLUE_SHIFT)
+#define DMA2D_OCOLR_BLUE_SHIFT      (0)       /* Bits 0-7 Blue Value */
+#define DMA2D_OCOLR_BLUE_MASK       (0xff << DMA2D_OCOLR_BLUE_SHIFT)
 #define DMA2D_OCOLR_BLUE(n)         ((uint32_t)(n) << DMA2D_OCOLR_BLUE_SHIFT)
-#define DMA2D_OCOLR_GREEN_SHIFT     (8)  /* Bits 8-15 Green Value */
-#define DMA2D_OCOLR_GREEN_MASK      (0xFF << DMA2D_OCOLR_GREEN_SHIFT)
+#define DMA2D_OCOLR_GREEN_SHIFT     (8)       /* Bits 8-15 Green Value */
+#define DMA2D_OCOLR_GREEN_MASK      (0xff << DMA2D_OCOLR_GREEN_SHIFT)
 #define DMA2D_OCOLR_GREEN(n)        ((uint32_t)(n) << DMA2D_OCOLR_GREEN_SHIFT)
-#define DMA2D_OCOLR_RED_SHIFT       (16)  /* Bits 16-23 Red Value */
-#define DMA2D_OCOLR_RED_MASK        (0xFF << DMA2D_OCOLR_RED_SHIFT)
+#define DMA2D_OCOLR_RED_SHIFT       (16)      /* Bits 16-23 Red Value */
+#define DMA2D_OCOLR_RED_MASK        (0xff << DMA2D_OCOLR_RED_SHIFT)
 #define DMA2D_OCOLR_RED(n)          ((uint32_t)(n) << DMA2D_OCOLR_RED_SHIFT)
-#define DMA2D_OCOLR_ALPHA_SHIFT     (24)  /* Bits 24-31 Alpha Value */
-#define DMA2D_OCOLR_ALPHA_MASK      (0xFF << DMA2D_OCOLR_ALPHA_SHIFT)
+#define DMA2D_OCOLR_ALPHA_SHIFT     (24)      /* Bits 24-31 Alpha Value */
+#define DMA2D_OCOLR_ALPHA_MASK      (0xff << DMA2D_OCOLR_ALPHA_SHIFT)
 #define DMA2D_OCOLR_ALPHA(n)        ((uint32_t)(n) << DMA2D_OCOLR_ALPHA_SHIFT)
 
 /* DMA2D Output Memory Address Register */
 
 /* DMA2D Output Offset Register */
 
-#define DMA2D_OOR_LO_SHIFT          (0)  /* Bits 0-13 Line Offset */
-#define DMA2D_OOR_LO_MASK           (0x3FFF << DMA2D_OOR_LO_SHIFT)
+#define DMA2D_OOR_LO_SHIFT          (0)       /* Bits 0-13 Line Offset */
+#define DMA2D_OOR_LO_MASK           (0x3fff << DMA2D_OOR_LO_SHIFT)
 #define DMA2D_OOR_LO(n)             ((uint32_t)(n) << DMA2D_OOR_LO_SHIFT)
 
 /* DMA2D Number Of Line Register */
 
-#define DMA2D_NLR_NL_SHIFT          (0)  /* Bits 0-15 Number Of Lines */
-#define DMA2D_NLR_NL_MASK           (0xFFFF << DMA2D_NLR_NL_SHIFT)
+#define DMA2D_NLR_NL_SHIFT          (0)       /* Bits 0-15 Number Of Lines */
+#define DMA2D_NLR_NL_MASK           (0xffff << DMA2D_NLR_NL_SHIFT)
 #define DMA2D_NLR_NL(n)             ((uint32_t)(n) << DMA2D_NLR_NL_SHIFT)
-#define DMA2D_NLR_PL_SHIFT          (16) /* Bits 16-29 Pixel per Lines */
-#define DMA2D_NLR_PL_MASK           (0x3FFF << DMA2D_NLR_PL_SHIFT)
+#define DMA2D_NLR_PL_SHIFT          (16)      /* Bits 16-29 Pixel per Lines */
+#define DMA2D_NLR_PL_MASK           (0x3fff << DMA2D_NLR_PL_SHIFT)
 #define DMA2D_NLR_PL(n)             ((uint32_t)(n) << DMA2D_NLR_PL_SHIFT)
 
 /* DMA2D Line Watermark Register */
 
-#define DMA2D_LWR_LW_SHIFT          (0)  /* Bits 0-15 Line Watermark */
-#define DMA2D_LWR_LW_MASK           (0xFFFF << DMA2D_LWR_LW_SHIFT)
+#define DMA2D_LWR_LW_SHIFT          (0)       /* Bits 0-15 Line Watermark */
+#define DMA2D_LWR_LW_MASK           (0xffff << DMA2D_LWR_LW_SHIFT)
 #define DMA2D_LWR_LW(n)             ((uint32_t)(n) << DMA2D_LWR_LW_SHIFT)
 
 /* DMA2D AHB Master Timer Configuration Register */
 
 #define DMA2D_AMTCR_EN              (1 << 0)  /* Enable */
-#define DMA2D_AMTCR_DT_SHIFT        (0)  /* Bits 8-15 Dead Time */
-#define DMA2D_AMTCR_DT_MASK         (0xFF << DMA2D_AMTCR_DT_SHIFT)
+#define DMA2D_AMTCR_DT_SHIFT        (0)       /* Bits 8-15 Dead Time */
+#define DMA2D_AMTCR_DT_MASK         (0xff << DMA2D_AMTCR_DT_SHIFT)
 #define DMA2D_AMTCR_DT(n)           ((uint32_t)(n) << DMA2D_AMTCR_DT_SHIFT)
 
 /****************************************************************************

--- a/arch/arm/src/stm32f7/hardware/stm32_ltdc.h
+++ b/arch/arm/src/stm32f7/hardware/stm32_ltdc.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32f7/hardware/stm32_ltdc.h
  *
  *   Copyright (C) 2013 Ken Pettit. All rights reserved.
@@ -31,25 +31,25 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32_LTDC_H
 #define __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32_LTDC_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include "hardware/stm32_memorymap.h"
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
-#define STM32_LTDC_NCLUT              256    /* Number of entries in the CLUTs */
+#define STM32_LTDC_NCLUT            256    /* Number of entries in the CLUTs */
 
-/* LCDC Register Offsets ************************************************************/
+/* LCDC Register Offsets ****************************************************/
 
 #define STM32_LTDC_SSCR_OFFSET      0x0008 /* LTDC Synchronization Size Config Register */
 #define STM32_LTDC_BPCR_OFFSET      0x000c /* LTDC Back Porch Configuration Register */
@@ -59,11 +59,11 @@
                                            /* 0x0020 Reserved */
 #define STM32_LTDC_SRCR_OFFSET      0x0024 /* LTDC Shadow Reload Configuration Register */
                                            /* 0x0028 Reserved */
-#define STM32_LTDC_BCCR_OFFSET      0x002C /* LTDC Background Color Configuration Register */
+#define STM32_LTDC_BCCR_OFFSET      0x002c /* LTDC Background Color Configuration Register */
                                            /* 0x0030 Reserved */
 #define STM32_LTDC_IER_OFFSET       0x0034 /* LTDC Interrupt Enable Register */
 #define STM32_LTDC_ISR_OFFSET       0x0038 /* LTDC Interrupt Status Register */
-#define STM32_LTDC_ICR_OFFSET       0x003C /* LTDC Interrupt Clear Register */
+#define STM32_LTDC_ICR_OFFSET       0x003c /* LTDC Interrupt Clear Register */
 #define STM32_LTDC_LIPCR_OFFSET     0x0040 /* LTDC Line Interrupt Position Config Register */
 #define STM32_LTDC_CPSR_OFFSET      0x0044 /* LTDC Current Position Status Register */
 #define STM32_LTDC_CDSR_OFFSET      0x0048 /* LTDC Current Display Status Register */
@@ -71,78 +71,78 @@
 
 #define STM32_LTDC_L1CR_OFFSET      0x0084 /* LTDC Layer 1 Control Register */
 #define STM32_LTDC_L1WHPCR_OFFSET   0x0088 /* LTDC Layer 1 Window Horiz Pos Config Register */
-#define STM32_LTDC_L1WVPCR_OFFSET   0x008C /* LTDC Layer 1 Window Vert Pos Config Register */
+#define STM32_LTDC_L1WVPCR_OFFSET   0x008c /* LTDC Layer 1 Window Vert Pos Config Register */
 #define STM32_LTDC_L1CKCR_OFFSET    0x0090 /* LTDC Layer 1 Color Keying Config Register */
 #define STM32_LTDC_L1PFCR_OFFSET    0x0094 /* LTDC Layer 1 Pixel Format Configuration Register */
 #define STM32_LTDC_L1CACR_OFFSET    0x0098 /* LTDC Layer 1 Constant Alpha Config Register */
-#define STM32_LTDC_L1DCCR_OFFSET    0x009C /* LTDC Layer 1 Default Color Config Register */
-#define STM32_LTDC_L1BFCR_OFFSET    0x00A0 /* LTDC Layer 1 Blending Factors Config Register */
+#define STM32_LTDC_L1DCCR_OFFSET    0x009c /* LTDC Layer 1 Default Color Config Register */
+#define STM32_LTDC_L1BFCR_OFFSET    0x00a0 /* LTDC Layer 1 Blending Factors Config Register */
                                            /* 0x00A4-0x00A8 Reserved */
-#define STM32_LTDC_L1CFBAR_OFFSET   0x00AC /* LTDC Layer 1 Color Frame Buffer Address Register */
-#define STM32_LTDC_L1CFBLR_OFFSET   0x00B0 /* LTDC Layer 1 Color Frame Buffer Length Register */
-#define STM32_LTDC_L1CFBLNR_OFFSET  0x00B4 /* LTDC Layer 1 Color Frame Buffer Line Number Register */
+#define STM32_LTDC_L1CFBAR_OFFSET   0x00ac /* LTDC Layer 1 Color Frame Buffer Address Register */
+#define STM32_LTDC_L1CFBLR_OFFSET   0x00b0 /* LTDC Layer 1 Color Frame Buffer Length Register */
+#define STM32_LTDC_L1CFBLNR_OFFSET  0x00b4 /* LTDC Layer 1 Color Frame Buffer Line Number Register */
                                            /* 0x00B8-0x00C0 Reserved */
-#define STM32_LTDC_L1CLUTWR_OFFSET  0x00C4 /* LTDC Layer 1 CLUT Write Register */
+#define STM32_LTDC_L1CLUTWR_OFFSET  0x00c4 /* LTDC Layer 1 CLUT Write Register */
                                            /* 0x00C8-0x0100 Reserved */
 #define STM32_LTDC_L2CR_OFFSET      0x0104 /* LTDC Layer 2 Control Register */
 #define STM32_LTDC_L2WHPCR_OFFSET   0x0108 /* LTDC Layer 2 Window Horiz Pos Config Register */
-#define STM32_LTDC_L2WVPCR_OFFSET   0x010C /* LTDC Layer 2 Window Vert Pos Config Register */
+#define STM32_LTDC_L2WVPCR_OFFSET   0x010c /* LTDC Layer 2 Window Vert Pos Config Register */
 #define STM32_LTDC_L2CKCR_OFFSET    0x0110 /* LTDC Layer 2 Color Keying Config Register */
 #define STM32_LTDC_L2PFCR_OFFSET    0x0114 /* LTDC Layer 2 Pixel Format Configuration Register */
 #define STM32_LTDC_L2CACR_OFFSET    0x0118 /* LTDC Layer 2 Constant Alpha Config Register */
-#define STM32_LTDC_L2DCCR_OFFSET    0x011C /* LTDC Layer 2 Default Color Config Register */
+#define STM32_LTDC_L2DCCR_OFFSET    0x011c /* LTDC Layer 2 Default Color Config Register */
 #define STM32_LTDC_L2BFCR_OFFSET    0x0120 /* LTDC Layer 2 Blending Factors Config Register */
                                            /* 0x0124-0x0128 Reserved */
-#define STM32_LTDC_L2CFBAR_OFFSET   0x012C /* LTDC Layer 2 Color Frame Buffer Address Register */
+#define STM32_LTDC_L2CFBAR_OFFSET   0x012c /* LTDC Layer 2 Color Frame Buffer Address Register */
 #define STM32_LTDC_L2CFBLR_OFFSET   0x0130 /* LTDC Layer 2 Color Frame Buffer Length Register */
 #define STM32_LTDC_L2CFBLNR_OFFSET  0x0134 /* LTDC Layer 2 Color Frame Buffer Line Number Register */
                                            /* 0x0138-0x0130 Reserved */
 #define STM32_LTDC_L2CLUTWR_OFFSET  0x0144 /* LTDC Layer 2 CLUT Write Register */
                                            /* 0x0148-0x03ff Reserved */
 
-/* LTDC Register Addresses *********************************************************/
+/* LTDC Register Addresses **************************************************/
 
-#define STM32_LTDC_SSCR             (STM32_LTDC_BASE+STM32_LTDC_SSCR_OFFSET)
-#define STM32_LTDC_BPCR             (STM32_LTDC_BASE+STM32_LTDC_BPCR_OFFSET)
-#define STM32_LTDC_AWCR             (STM32_LTDC_BASE+STM32_LTDC_AWCR_OFFSET)
-#define STM32_LTDC_TWCR             (STM32_LTDC_BASE+STM32_LTDC_TWCR_OFFSET)
-#define STM32_LTDC_GCR              (STM32_LTDC_BASE+STM32_LTDC_GCR_OFFSET)
-#define STM32_LTDC_SRCR             (STM32_LTDC_BASE+STM32_LTDC_SRCR_OFFSET)
-#define STM32_LTDC_BCCR             (STM32_LTDC_BASE+STM32_LTDC_BCCR_OFFSET)
-#define STM32_LTDC_IER              (STM32_LTDC_BASE+STM32_LTDC_IER_OFFSET)
-#define STM32_LTDC_ISR              (STM32_LTDC_BASE+STM32_LTDC_ISR_OFFSET)
-#define STM32_LTDC_ICR              (STM32_LTDC_BASE+STM32_LTDC_ICR_OFFSET)
-#define STM32_LTDC_LIPCR            (STM32_LTDC_BASE+STM32_LTDC_LIPCR_OFFSET)
-#define STM32_LTDC_CPSR             (STM32_LTDC_BASE+STM32_LTDC_CPSR_OFFSET)
-#define STM32_LTDC_CDSR             (STM32_LTDC_BASE+STM32_LTDC_CDSR_OFFSET)
+#define STM32_LTDC_SSCR             (STM32_LTDC_BASE + STM32_LTDC_SSCR_OFFSET)
+#define STM32_LTDC_BPCR             (STM32_LTDC_BASE + STM32_LTDC_BPCR_OFFSET)
+#define STM32_LTDC_AWCR             (STM32_LTDC_BASE + STM32_LTDC_AWCR_OFFSET)
+#define STM32_LTDC_TWCR             (STM32_LTDC_BASE + STM32_LTDC_TWCR_OFFSET)
+#define STM32_LTDC_GCR              (STM32_LTDC_BASE + STM32_LTDC_GCR_OFFSET)
+#define STM32_LTDC_SRCR             (STM32_LTDC_BASE + STM32_LTDC_SRCR_OFFSET)
+#define STM32_LTDC_BCCR             (STM32_LTDC_BASE + STM32_LTDC_BCCR_OFFSET)
+#define STM32_LTDC_IER              (STM32_LTDC_BASE + STM32_LTDC_IER_OFFSET)
+#define STM32_LTDC_ISR              (STM32_LTDC_BASE + STM32_LTDC_ISR_OFFSET)
+#define STM32_LTDC_ICR              (STM32_LTDC_BASE + STM32_LTDC_ICR_OFFSET)
+#define STM32_LTDC_LIPCR            (STM32_LTDC_BASE + STM32_LTDC_LIPCR_OFFSET)
+#define STM32_LTDC_CPSR             (STM32_LTDC_BASE + STM32_LTDC_CPSR_OFFSET)
+#define STM32_LTDC_CDSR             (STM32_LTDC_BASE + STM32_LTDC_CDSR_OFFSET)
 
-#define STM32_LTDC_L1CR             (STM32_LTDC_BASE+STM32_LTDC_L1CR_OFFSET)
-#define STM32_LTDC_L1WHPCR          (STM32_LTDC_BASE+STM32_LTDC_L1WHPCR_OFFSET)
-#define STM32_LTDC_L1WVPCR          (STM32_LTDC_BASE+STM32_LTDC_L1WVPCR_OFFSET)
-#define STM32_LTDC_L1CKCR           (STM32_LTDC_BASE+STM32_LTDC_L1CKCR_OFFSET)
-#define STM32_LTDC_L1PFCR           (STM32_LTDC_BASE+STM32_LTDC_L1PFCR_OFFSET)
-#define STM32_LTDC_L1CACR           (STM32_LTDC_BASE+STM32_LTDC_L1CACR_OFFSET)
-#define STM32_LTDC_L1DCCR           (STM32_LTDC_BASE+STM32_LTDC_L1DCCR_OFFSET)
-#define STM32_LTDC_L1BFCR           (STM32_LTDC_BASE+STM32_LTDC_L1BFCR_OFFSET)
-#define STM32_LTDC_L1CFBAR          (STM32_LTDC_BASE+STM32_LTDC_L1CFBAR_OFFSET)
-#define STM32_LTDC_L1CFBLR          (STM32_LTDC_BASE+STM32_LTDC_L1CFBLR_OFFSET)
-#define STM32_LTDC_L1CFBLNR         (STM32_LTDC_BASE+STM32_LTDC_L1CFBLNR_OFFSET)
-#define STM32_LTDC_L1CLUTWR         (STM32_LTDC_BASE+STM32_LTDC_L1CLUTWR_OFFSET)
+#define STM32_LTDC_L1CR             (STM32_LTDC_BASE + STM32_LTDC_L1CR_OFFSET)
+#define STM32_LTDC_L1WHPCR          (STM32_LTDC_BASE + STM32_LTDC_L1WHPCR_OFFSET)
+#define STM32_LTDC_L1WVPCR          (STM32_LTDC_BASE + STM32_LTDC_L1WVPCR_OFFSET)
+#define STM32_LTDC_L1CKCR           (STM32_LTDC_BASE + STM32_LTDC_L1CKCR_OFFSET)
+#define STM32_LTDC_L1PFCR           (STM32_LTDC_BASE + STM32_LTDC_L1PFCR_OFFSET)
+#define STM32_LTDC_L1CACR           (STM32_LTDC_BASE + STM32_LTDC_L1CACR_OFFSET)
+#define STM32_LTDC_L1DCCR           (STM32_LTDC_BASE + STM32_LTDC_L1DCCR_OFFSET)
+#define STM32_LTDC_L1BFCR           (STM32_LTDC_BASE + STM32_LTDC_L1BFCR_OFFSET)
+#define STM32_LTDC_L1CFBAR          (STM32_LTDC_BASE + STM32_LTDC_L1CFBAR_OFFSET)
+#define STM32_LTDC_L1CFBLR          (STM32_LTDC_BASE + STM32_LTDC_L1CFBLR_OFFSET)
+#define STM32_LTDC_L1CFBLNR         (STM32_LTDC_BASE + STM32_LTDC_L1CFBLNR_OFFSET)
+#define STM32_LTDC_L1CLUTWR         (STM32_LTDC_BASE + STM32_LTDC_L1CLUTWR_OFFSET)
 
-#define STM32_LTDC_L2CR             (STM32_LTDC_BASE+STM32_LTDC_L2CR_OFFSET)
-#define STM32_LTDC_L2WHPCR          (STM32_LTDC_BASE+STM32_LTDC_L2WHPCR_OFFSET)
-#define STM32_LTDC_L2WVPCR          (STM32_LTDC_BASE+STM32_LTDC_L2WVPCR_OFFSET)
-#define STM32_LTDC_L2CKCR           (STM32_LTDC_BASE+STM32_LTDC_L2CKCR_OFFSET)
-#define STM32_LTDC_L2PFCR           (STM32_LTDC_BASE+STM32_LTDC_L2PFCR_OFFSET)
-#define STM32_LTDC_L2CACR           (STM32_LTDC_BASE+STM32_LTDC_L2CACR_OFFSET)
-#define STM32_LTDC_L2DCCR           (STM32_LTDC_BASE+STM32_LTDC_L2DCCR_OFFSET)
-#define STM32_LTDC_L2BFCR           (STM32_LTDC_BASE+STM32_LTDC_L2BFCR_OFFSET)
-#define STM32_LTDC_L2CFBAR          (STM32_LTDC_BASE+STM32_LTDC_L2CFBAR_OFFSET)
-#define STM32_LTDC_L2CFBLR          (STM32_LTDC_BASE+STM32_LTDC_L2CFBLR_OFFSET)
-#define STM32_LTDC_L2CFBLNR         (STM32_LTDC_BASE+STM32_LTDC_L2CFBLNR_OFFSET)
-#define STM32_LTDC_L2CLUTWR         (STM32_LTDC_BASE+STM32_LTDC_L2CLUTWR_OFFSET)
+#define STM32_LTDC_L2CR             (STM32_LTDC_BASE + STM32_LTDC_L2CR_OFFSET)
+#define STM32_LTDC_L2WHPCR          (STM32_LTDC_BASE + STM32_LTDC_L2WHPCR_OFFSET)
+#define STM32_LTDC_L2WVPCR          (STM32_LTDC_BASE + STM32_LTDC_L2WVPCR_OFFSET)
+#define STM32_LTDC_L2CKCR           (STM32_LTDC_BASE + STM32_LTDC_L2CKCR_OFFSET)
+#define STM32_LTDC_L2PFCR           (STM32_LTDC_BASE + STM32_LTDC_L2PFCR_OFFSET)
+#define STM32_LTDC_L2CACR           (STM32_LTDC_BASE + STM32_LTDC_L2CACR_OFFSET)
+#define STM32_LTDC_L2DCCR           (STM32_LTDC_BASE + STM32_LTDC_L2DCCR_OFFSET)
+#define STM32_LTDC_L2BFCR           (STM32_LTDC_BASE + STM32_LTDC_L2BFCR_OFFSET)
+#define STM32_LTDC_L2CFBAR          (STM32_LTDC_BASE + STM32_LTDC_L2CFBAR_OFFSET)
+#define STM32_LTDC_L2CFBLR          (STM32_LTDC_BASE + STM32_LTDC_L2CFBLR_OFFSET)
+#define STM32_LTDC_L2CFBLNR         (STM32_LTDC_BASE + STM32_LTDC_L2CFBLNR_OFFSET)
+#define STM32_LTDC_L2CLUTWR         (STM32_LTDC_BASE + STM32_LTDC_L2CLUTWR_OFFSET)
 
-/* LTDC Register Bit Definitions ***************************************************/
+/* LTDC Register Bit Definitions ********************************************/
 
 /* LTDC Synchronization Size Configuration Register */
 
@@ -206,13 +206,13 @@
 /* LTDC Background Color Configuration Register */
 
 #define LTDC_BCCR_BCBLUE_SHIFT      (0)       /* Bits 0-7: Background Color Blue Value */
-#define LTDC_BCCR_BCBLUE_MASK       (0xFF << LTDC_BCCR_BCBLUE_SHIFT)
+#define LTDC_BCCR_BCBLUE_MASK       (0xff << LTDC_BCCR_BCBLUE_SHIFT)
 #  define LTDC_BCCR_BCBLUE(n)       ((uint32_t)(n) << LTDC_BCCR_BCBLUE_SHIFT)
 #define LTDC_BCCR_BCGREEN_SHIFT     (8)       /* Bits 8-15: Background Color Green Value */
-#define LTDC_BCCR_BCGREEN_MASK      (0xFF << LTDC_BCCR_BCGREEN_SHIFT)
+#define LTDC_BCCR_BCGREEN_MASK      (0xff << LTDC_BCCR_BCGREEN_SHIFT)
 #  define LTDC_BCCR_BCGREEN(n)      ((uint32_t)(n) << LTDC_BCCR_BCGREEN_SHIFT)
 #define LTDC_BCCR_BCRED_SHIFT       (16)       /* Bits 16-23: Background Color Red Value */
-#define LTDC_BCCR_BCRED_MASK        (0xFF << LTDC_BCCR_BCRED_SHIFT)
+#define LTDC_BCCR_BCRED_MASK        (0xff << LTDC_BCCR_BCRED_SHIFT)
 #  define LTDC_BCCR_BCRED(n)        ((uint32_t)(n) << LTDC_BCCR_BCRED_SHIFT)
 
 /* LTDC Interrupt Enable Register */
@@ -239,7 +239,7 @@
 /* LTDC Line Interrupt Posittion Configuration Register */
 
 #define LTDC_LIPCR_LIPOS_SHIFT      (0)       /* Bits 0-10: Line Interrupt Position */
-#define LTDC_LIPCR_LIPOS_MASK       (0x7FF << LTDC_LIPCR_LIPOS_SHIFT)
+#define LTDC_LIPCR_LIPOS_MASK       (0x7ff << LTDC_LIPCR_LIPOS_SHIFT)
 #  define LTDC_LIPCR_LIPOS(n)       ((uint32_t)(n) << LTDC_LIPCR_LIPOS_SHIFT)
 
 /* LTDC Current Position Status Register */
@@ -260,45 +260,45 @@
 
 /* LTDC Layer x Control Register */
 
-#define LTDC_LxCR_LEN               (1 << 0)  /* Bit 0:  Layer Enable */
-#define LTDC_LxCR_COLKEN            (1 << 1)  /* Bit 1:  Color Keying Enable */
-#define LTDC_LxCR_CLUTEN            (1 << 4)  /* Bit 4:  Color Look-Up Table Enable */
+#define LTDC_LXCR_LEN               (1 << 0)  /* Bit 0:  Layer Enable */
+#define LTDC_LXCR_COLKEN            (1 << 1)  /* Bit 1:  Color Keying Enable */
+#define LTDC_LXCR_CLUTEN            (1 << 4)  /* Bit 4:  Color Look-Up Table Enable */
 
 /* LTDC Layer x Window Horizontal Position Configuration Register */
 
-#define LTDC_LxWHPCR_WHSTPOS_SHIFT  (0)       /* Bits 0-11: Window Horizontal Start Position */
-#define LTDC_LxWHPCR_WHSTPOS_MASK   (0xFFF << LTDC_LxWHPCR_WHSTPOS_SHIFT)
-#  define LTDC_LxWHPCR_WHSTPOS(n)   ((uint32_t)(n) << LTDC_LxWHPCR_WHSTPOS_SHIFT)
-#define LTDC_LxWHPCR_WHSPPOS_SHIFT  (16)      /* Bits 16-27: Window Horizontal Stop Position */
-#define LTDC_LxWHPCR_WHSPPOS_MASK   (0xFFF << LTDC_LxWHPCR_WHSPPOS_SHIFT)
-#  define LTDC_LxWHPCR_WHSPPOS(n)   ((uint32_t)(n) << LTDC_LxWHPCR_WHSPPOS_SHIFT)
+#define LTDC_LXWHPCR_WHSTPOS_SHIFT  (0)       /* Bits 0-11: Window Horizontal Start Position */
+#define LTDC_LXWHPCR_WHSTPOS_MASK   (0xfff << LTDC_LXWHPCR_WHSTPOS_SHIFT)
+#  define LTDC_LXWHPCR_WHSTPOS(n)   ((uint32_t)(n) << LTDC_LXWHPCR_WHSTPOS_SHIFT)
+#define LTDC_LXWHPCR_WHSPPOS_SHIFT  (16)      /* Bits 16-27: Window Horizontal Stop Position */
+#define LTDC_LXWHPCR_WHSPPOS_MASK   (0xfff << LTDC_LXWHPCR_WHSPPOS_SHIFT)
+#  define LTDC_LXWHPCR_WHSPPOS(n)   ((uint32_t)(n) << LTDC_LXWHPCR_WHSPPOS_SHIFT)
 
 /* LTDC Layer x Window Vertical Position Configuration Register */
 
-#define LTDC_LxWVPCR_WVSTPOS_SHIFT  (0)       /* Bits 0-10: Window Vertical Start Position */
-#define LTDC_LxWVPCR_WVSTPOS_MASK   (0x7FF << LTDC_LxWVPCR_WVSTPOS_SHIFT)
-#  define LTDC_LxWVPCR_WVSTPOS(n)   ((uint32_t)(n) << LTDC_LxWVPCR_WVSTPOS_SHIFT)
-#define LTDC_LxWVPCR_WVSPPOS_SHIFT  (16)      /* Bits 16-26: Window Vertical Stop Position */
-#define LTDC_LxWVPCR_WVSPPOS_MASK   (0x7FF << LTDC_LxWVPCR_WVSPPOS_SHIFT)
-#  define LTDC_LxWVPCR_WVSPPOS(n)   ((uint32_t)(n) << LTDC_LxWVPCR_WVSPPOS_SHIFT)
+#define LTDC_LXWVPCR_WVSTPOS_SHIFT  (0)       /* Bits 0-10: Window Vertical Start Position */
+#define LTDC_LXWVPCR_WVSTPOS_MASK   (0x7ff << LTDC_LXWVPCR_WVSTPOS_SHIFT)
+#  define LTDC_LXWVPCR_WVSTPOS(n)   ((uint32_t)(n) << LTDC_LXWVPCR_WVSTPOS_SHIFT)
+#define LTDC_LXWVPCR_WVSPPOS_SHIFT  (16)      /* Bits 16-26: Window Vertical Stop Position */
+#define LTDC_LXWVPCR_WVSPPOS_MASK   (0x7ff << LTDC_LXWVPCR_WVSPPOS_SHIFT)
+#  define LTDC_LXWVPCR_WVSPPOS(n)   ((uint32_t)(n) << LTDC_LXWVPCR_WVSPPOS_SHIFT)
 
 /* LTDC Layer x Color Keying Configuration Register */
 
-#define LTDC_LxCKCR_CKBLUE_SHIFT    (0)       /* Bits 0-7: Color Key Blue Value */
-#define LTDC_LxCKCR_CKBLUE_MASK     (0xFF << LTDC_LxCKCR_CKBLUE_SHIFT)
-#  define LTDC_LxCKCR_CKBLUE(n)     ((uint32_t)(n) << LTDC_LxCKCR_CKBLUE_SHIFT)
-#define LTDC_LxCKCR_CKGREEN_SHIFT   (8)       /* Bits 8-15: Color Key Green Value */
-#define LTDC_LxCKCR_CKGREEN_MASK    (0xFF << LTDC_LxCKCR_CKGREEN_SHIFT)
-#  define LTDC_LxCKCR_CKGREEN(n)    ((uint32_t)(n) << LTDC_LxCKCR_CKGREEN_SHIFT)
-#define LTDC_LxCKCR_CKRED_SHIFT     (16)       /* Bits 16-23: Color Key Red Value */
-#define LTDC_LxCKCR_CKRED_MASK      (0xFF << LTDC_LxCKCR_CKRED_SHIFT)
-#  define LTDC_LxCKCR_CKRED(n)      ((uint32_t)(n) << LTDC_LxCKCR_CKRED_SHIFT)
+#define LTDC_LXCKCR_CKBLUE_SHIFT    (0)       /* Bits 0-7: Color Key Blue Value */
+#define LTDC_LXCKCR_CKBLUE_MASK     (0xff << LTDC_LXCKCR_CKBLUE_SHIFT)
+#  define LTDC_LXCKCR_CKBLUE(n)     ((uint32_t)(n) << LTDC_LXCKCR_CKBLUE_SHIFT)
+#define LTDC_LXCKCR_CKGREEN_SHIFT   (8)       /* Bits 8-15: Color Key Green Value */
+#define LTDC_LXCKCR_CKGREEN_MASK    (0xff << LTDC_LXCKCR_CKGREEN_SHIFT)
+#  define LTDC_LXCKCR_CKGREEN(n)    ((uint32_t)(n) << LTDC_LXCKCR_CKGREEN_SHIFT)
+#define LTDC_LXCKCR_CKRED_SHIFT     (16)       /* Bits 16-23: Color Key Red Value */
+#define LTDC_LXCKCR_CKRED_MASK      (0xff << LTDC_LXCKCR_CKRED_SHIFT)
+#  define LTDC_LXCKCR_CKRED(n)      ((uint32_t)(n) << LTDC_LXCKCR_CKRED_SHIFT)
 
 /* LTDC Layer x Pixel Format Configuration Register */
 
-#define LTDC_LxPFCR_PF_SHIFT        (0)       /* Bits 0-2: Pixel Format */
-#define LTDC_LxPFCR_PF_MASK         (0x7 << LTDC_LxPFCR_PF_SHIFT)
-#  define LTDC_LxPFCR_PF(n)         ((uint32_t)(n) << LTDC_LxPFCR_PF_SHIFT)
+#define LTDC_LXPFCR_PF_SHIFT        (0)       /* Bits 0-2: Pixel Format */
+#define LTDC_LXPFCR_PF_MASK         (0x7 << LTDC_LXPFCR_PF_SHIFT)
+#  define LTDC_LXPFCR_PF(n)         ((uint32_t)(n) << LTDC_LXPFCR_PF_SHIFT)
 
 #define LTDC_PF_ARGB8888            0
 #define LTDC_PF_RGB888              1
@@ -311,33 +311,33 @@
 
 /* LTDC Layer x Constant Alpha Configuration Register */
 
-#define LTDC_LxCACR_CONSTA_SHIFT    (0)       /* Bits 0-7: Constant Alpha */
-#define LTDC_LxCACR_CONSTA_MASK     (0x7 << LTDC_LxCACR_CONSTA_SHIFT)
-#  define LTDC_LxCACR_CONSTA(n)     ((uint32_t)(n) << LTDC_LxCACR_CONSTA_SHIFT)
+#define LTDC_LXCACR_CONSTA_SHIFT    (0)       /* Bits 0-7: Constant Alpha */
+#define LTDC_LXCACR_CONSTA_MASK     (0x7 << LTDC_LXCACR_CONSTA_SHIFT)
+#  define LTDC_LXCACR_CONSTA(n)     ((uint32_t)(n) << LTDC_LXCACR_CONSTA_SHIFT)
 
 /* LTDC Layer x Default Color Configuration Register */
 
-#define LTDC_LxDCCR_DCBLUE_SHIFT    (0)       /* Bits 0-7: Default Color Blue Value */
-#define LTDC_LxDCCR_DCBLUE_MASK     (0xFF << LTDC_LxDCCR_DCBLUE_SHIFT)
-#  define LTDC_LxDCCR_DCBLUE(n)     ((uint32_t)(n) << LTDC_LxDCCR_DCBLUE_SHIFT)
-#define LTDC_LxDCCR_DCGREEN_SHIFT   (8)       /* Bits 8-15: Default Color Green Value */
-#define LTDC_LxDCCR_DCGREEN_MASK    (0xFF << LTDC_LxDCCR_DCGREEN_SHIFT)
-#  define LTDC_LxDCCR_DCGREEN(n)    ((uint32_t)(n) << LTDC_LxDCCR_DCGREEN_SHIFT)
-#define LTDC_LxDCCR_DCRED_SHIFT     (16)       /* Bits 16-23: Default Color Red Value */
-#define LTDC_LxDCCR_DCRED_MASK      (0xFF << LTDC_LxDCCR_DCRED_SHIFT)
-#  define LTDC_LxDCCR_DCRED(n)      ((uint32_t)(n) << LTDC_LxDCCR_DCRED_SHIFT)
-#define LTDC_LxDCCR_DCALPHA_SHIFT   (24)       /* Bits 24-31: Default Color Alpha Value */
-#define LTDC_LxDCCR_DCALPHA_MASK    (0xFF << LTDC_LxDCCR_DCALPHA_SHIFT)
-#  define LTDC_LxDCCR_DCALPHA(n)    ((uint32_t)(n) << LTDC_LxDCCR_DCALPHA_SHIFT)
+#define LTDC_LXDCCR_DCBLUE_SHIFT    (0)       /* Bits 0-7: Default Color Blue Value */
+#define LTDC_LXDCCR_DCBLUE_MASK     (0xff << LTDC_LXDCCR_DCBLUE_SHIFT)
+#  define LTDC_LXDCCR_DCBLUE(n)     ((uint32_t)(n) << LTDC_LXDCCR_DCBLUE_SHIFT)
+#define LTDC_LXDCCR_DCGREEN_SHIFT   (8)       /* Bits 8-15: Default Color Green Value */
+#define LTDC_LXDCCR_DCGREEN_MASK    (0xff << LTDC_LXDCCR_DCGREEN_SHIFT)
+#  define LTDC_LXDCCR_DCGREEN(n)    ((uint32_t)(n) << LTDC_LXDCCR_DCGREEN_SHIFT)
+#define LTDC_LXDCCR_DCRED_SHIFT     (16)       /* Bits 16-23: Default Color Red Value */
+#define LTDC_LXDCCR_DCRED_MASK      (0xff << LTDC_LXDCCR_DCRED_SHIFT)
+#  define LTDC_LXDCCR_DCRED(n)      ((uint32_t)(n) << LTDC_LXDCCR_DCRED_SHIFT)
+#define LTDC_LXDCCR_DCALPHA_SHIFT   (24)       /* Bits 24-31: Default Color Alpha Value */
+#define LTDC_LXDCCR_DCALPHA_MASK    (0xff << LTDC_LXDCCR_DCALPHA_SHIFT)
+#  define LTDC_LXDCCR_DCALPHA(n)    ((uint32_t)(n) << LTDC_LXDCCR_DCALPHA_SHIFT)
 
 /* LTDC Layer x Blending Factors Configuration Register */
 
-#define LTDC_LxBFCR_BF2_SHIFT       (0)       /* Bits 0-2: Blending Factor 2 */
-#define LTDC_LxBFCR_BF2_MASK        (0x7 << LTDC_LxBFCR_BF2_SHIFT)
-#  define LTDC_LxBFCR_BF2(n)        ((uint32_t)(n) << LTDC_LxBFCR_BF2_SHIFT)
-#define LTDC_LxBFCR_BF1_SHIFT       (8)       /* Bits 8-10: Blending Factor 1 */
-#define LTDC_LxBFCR_BF1_MASK        (0x7 << LTDC_LxBFCR_BF1_SHIFT)
-#  define LTDC_LxBFCR_BF1(n)        ((uint32_t)(n) << LTDC_LxBFCR_BF1_SHIFT)
+#define LTDC_LXBFCR_BF2_SHIFT       (0)       /* Bits 0-2: Blending Factor 2 */
+#define LTDC_LXBFCR_BF2_MASK        (0x7 << LTDC_LXBFCR_BF2_SHIFT)
+#  define LTDC_LXBFCR_BF2(n)        ((uint32_t)(n) << LTDC_LXBFCR_BF2_SHIFT)
+#define LTDC_LXBFCR_BF1_SHIFT       (8)       /* Bits 8-10: Blending Factor 1 */
+#define LTDC_LXBFCR_BF1_MASK        (0x7 << LTDC_LXBFCR_BF1_SHIFT)
+#  define LTDC_LXBFCR_BF1(n)        ((uint32_t)(n) << LTDC_LXBFCR_BF1_SHIFT)
 
 #define LTDC_BF1_CONST_ALPHA        0x04      /* Constant Alpha */
 #define LTDC_BF1_PIXEL_ALPHA        0x06      /* Pixel Alpha x Constant Alpha */
@@ -346,36 +346,36 @@
 
 /* LTDC Layer x Color Frame Buffer Length Configuration Register */
 
-#define LTDC_LxCFBLR_CFBLL_SHIFT    (0)       /* Bits 0-12: Color Frame Buffer Line Length */
-#define LTDC_LxCFBLR_CFBLL_MASK     (0x1FFF << LTDC_LxCFBLR_CFBLL_SHIFT)
-#  define LTDC_LxCFBLR_CFBLL(n)     ((uint32_t)(n) << LTDC_LxCFBLR_CFBLL_SHIFT)
-#define LTDC_LxCFBLR_CFBP_SHIFT     (16)       /* Bits 16-28: Color Frame Buffer Pitch */
-#define LTDC_LxCFBLR_CFBP_MASK      (0x1FFF << LTDC_LxCFBLR_CFBP_SHIFT)
-#  define LTDC_LxCFBLR_CFBP(n)      ((uint32_t)(n) << LTDC_LxCFBLR_CFBP_SHIFT)
+#define LTDC_LXCFBLR_CFBLL_SHIFT    (0)       /* Bits 0-12: Color Frame Buffer Line Length */
+#define LTDC_LXCFBLR_CFBLL_MASK     (0x1fff << LTDC_LXCFBLR_CFBLL_SHIFT)
+#  define LTDC_LXCFBLR_CFBLL(n)     ((uint32_t)(n) << LTDC_LXCFBLR_CFBLL_SHIFT)
+#define LTDC_LXCFBLR_CFBP_SHIFT     (16)       /* Bits 16-28: Color Frame Buffer Pitch */
+#define LTDC_LXCFBLR_CFBP_MASK      (0x1fff << LTDC_LXCFBLR_CFBP_SHIFT)
+#  define LTDC_LXCFBLR_CFBP(n)      ((uint32_t)(n) << LTDC_LXCFBLR_CFBP_SHIFT)
 
 /* LTDC Layer x Color Frame Buffer Line Number Register */
 
-#define LTDC_LxCFBLNR_LN_SHIFT      (0)       /* Bits 0-10: Color Frame Buffer Line Number */
-#define LTDC_LxCFBLNR_LN_MASK       (0x7FF << LTDC_LxCFBLNR_LN_SHIFT)
-#  define LTDC_LxCFBLNR_LN(n)       ((uint32_t)(n) << LTDC_LxCFBLNR_LN_SHIFT)
+#define LTDC_LXCFBLNR_LN_SHIFT      (0)       /* Bits 0-10: Color Frame Buffer Line Number */
+#define LTDC_LXCFBLNR_LN_MASK       (0x7ff << LTDC_LXCFBLNR_LN_SHIFT)
+#  define LTDC_LXCFBLNR_LN(n)       ((uint32_t)(n) << LTDC_LXCFBLNR_LN_SHIFT)
 
 /* LTDC Layer x CLUT Write Register */
 
-#define LTDC_LxCLUTWR_BLUE_SHIFT    (0)       /* Bits 0-7: Default Color Blue Value */
-#define LTDC_LxCLUTWR_BLUE_MASK     (0xFF << LTDC_LxCLUTWR_BLUE_SHIFT)
-#  define LTDC_LxCLUTWR_BLUE(n)     ((uint32_t)(n) << LTDC_LxCLUTWR_BLUE_SHIFT)
-#define LTDC_LxCLUTWR_GREEN_SHIFT   (8)       /* Bits 8-15: Default Color Green Value */
-#define LTDC_LxCLUTWR_GREEN_MASK    (0xFF << LTDC_LxCLUTWR_GREEN_SHIFT)
-#  define LTDC_LxCLUTWR_GREEN(n)    ((uint32_t)(n) << LTDC_LxCLUTWR_GREEN_SHIFT)
-#define LTDC_LxCLUTWR_RED_SHIFT     (16)       /* Bits 16-23: Default Color Red Value */
-#define LTDC_LxCLUTWR_RED_MASK      (0xFF << LTDC_LxCLUTWR_RED_SHIFT)
-#  define LTDC_LxCLUTWR_RED(n)      ((uint32_t)(n) << LTDC_LxCLUTWR_RED_SHIFT)
-#define LTDC_LxCLUTWR_CLUTADD_SHIFT (24)       /* Bits 24-31: CLUT Address */
-#define LTDC_LxCLUTWR_CLUTADD_MASK  (0xFF << LTDC_LxCLUTWR_CLUTADD_SHIFT)
-#  define LTDC_LxCLUTWR_CLUTADD(n)  ((uint32_t)(n) << LTDC_LxCLUTWR_CLUTADD_SHIFT)
+#define LTDC_LXCLUTWR_BLUE_SHIFT    (0)       /* Bits 0-7: Default Color Blue Value */
+#define LTDC_LXCLUTWR_BLUE_MASK     (0xff << LTDC_LXCLUTWR_BLUE_SHIFT)
+#  define LTDC_LXCLUTWR_BLUE(n)     ((uint32_t)(n) << LTDC_LXCLUTWR_BLUE_SHIFT)
+#define LTDC_LXCLUTWR_GREEN_SHIFT   (8)       /* Bits 8-15: Default Color Green Value */
+#define LTDC_LXCLUTWR_GREEN_MASK    (0xff << LTDC_LXCLUTWR_GREEN_SHIFT)
+#  define LTDC_LXCLUTWR_GREEN(n)    ((uint32_t)(n) << LTDC_LXCLUTWR_GREEN_SHIFT)
+#define LTDC_LXCLUTWR_RED_SHIFT     (16)       /* Bits 16-23: Default Color Red Value */
+#define LTDC_LXCLUTWR_RED_MASK      (0xff << LTDC_LXCLUTWR_RED_SHIFT)
+#  define LTDC_LXCLUTWR_RED(n)      ((uint32_t)(n) << LTDC_LXCLUTWR_RED_SHIFT)
+#define LTDC_LXCLUTWR_CLUTADD_SHIFT (24)       /* Bits 24-31: CLUT Address */
+#define LTDC_LXCLUTWR_CLUTADD_MASK  (0xff << LTDC_LXCLUTWR_CLUTADD_SHIFT)
+#  define LTDC_LXCLUTWR_CLUTADD(n)  ((uint32_t)(n) << LTDC_LXCLUTWR_CLUTADD_SHIFT)
 
-/************************************************************************************
+/****************************************************************************
  * Public Types
- ************************************************************************************/
+ ****************************************************************************/
 
 #endif /* __ARCH_ARM_SRC_STM32F7_HARDWARE_STM32_LTDC_H */

--- a/arch/arm/src/stm32f7/stm32_dma2d.c
+++ b/arch/arm/src/stm32f7/stm32_dma2d.c
@@ -207,12 +207,14 @@ static int stm32_dma2d_start(void);
 #ifdef CONFIG_STM32F7_FB_CMAP
 static int stm32_dma2d_loadclut(uintptr_t reg);
 #endif
-static uint32_t stm32_dma2d_memaddress(FAR struct stm32_dma2d_overlay_s *oinfo,
-                                       uint32_t xpos, uint32_t ypos);
-static uint32_t stm32_dma2d_lineoffset(FAR struct stm32_dma2d_overlay_s *oinfo,
-                                       FAR const struct fb_area_s *area);
-static void stm32_dma2d_lfifo(FAR struct stm32_dma2d_overlay_s *oinfo, int lid,
-                              uint32_t xpos, uint32_t ypos,
+static uint32_t
+stm32_dma2d_memaddress(FAR struct stm32_dma2d_overlay_s *oinfo,
+                       uint32_t xpos, uint32_t ypos);
+static uint32_t
+stm32_dma2d_lineoffset(FAR struct stm32_dma2d_overlay_s *oinfo,
+                       FAR const struct fb_area_s *area);
+static void stm32_dma2d_lfifo(FAR struct stm32_dma2d_overlay_s *oinfo,
+                              int lid, uint32_t xpos, uint32_t ypos,
                               FAR const struct fb_area_s *area);
 static void stm32_dma2d_lcolor(int lid, uint32_t argb);
 static void stm32_dma2d_llnr(FAR const struct fb_area_s *area);
@@ -256,7 +258,7 @@ static uint32_t g_clut[STM32_DMA2D_NCLUT *
 #  else
                       3
 #  endif
-                      / 4 ];
+                      / 4];
 #endif /* CONFIG_STM32F7_FB_CMAP */
 
 /* The DMA2D semaphore that enforces mutually exclusive access */
@@ -479,7 +481,7 @@ static int stm32_dma2d_loadclut(uintptr_t pfcreg)
   /* Start clut loading */
 
   regval  = getreg32(pfcreg);
-  regval |= DMA2D_xGPFCCR_START;
+  regval |= DMA2D_XGPFCCR_START;
   reginfo("set regval=%08x\n", regval);
   putreg32(regval, pfcreg);
   reginfo("configured regval=%08x\n", getreg32(pfcreg));
@@ -536,8 +538,9 @@ static int stm32_dma2d_start(void)
  *
  ****************************************************************************/
 
-static uint32_t stm32_dma2d_memaddress(FAR struct stm32_dma2d_overlay_s *oinfo,
-                                       uint32_t xpos, uint32_t ypos)
+static uint32_t
+stm32_dma2d_memaddress(FAR struct stm32_dma2d_overlay_s *oinfo,
+                       uint32_t xpos, uint32_t ypos)
 {
   uint32_t offset;
   FAR struct fb_overlayinfo_s *poverlay = oinfo->oinfo;
@@ -562,8 +565,9 @@ static uint32_t stm32_dma2d_memaddress(FAR struct stm32_dma2d_overlay_s *oinfo,
  *
  ****************************************************************************/
 
-static uint32_t stm32_dma2d_lineoffset(FAR struct stm32_dma2d_overlay_s *oinfo,
-                                       FAR const struct fb_area_s *area)
+static uint32_t
+stm32_dma2d_lineoffset(FAR struct stm32_dma2d_overlay_s *oinfo,
+                       FAR const struct fb_area_s *area)
 {
   uint32_t loffset;
 
@@ -595,8 +599,10 @@ static void stm32_dma2d_lfifo(FAR struct stm32_dma2d_overlay_s *oinfo,
   lcdinfo("oinfo=%p, lid=%d, xpos=%d, ypos=%d, area=%p\n",
            oinfo, lid, xpos, ypos, area);
 
-  putreg32(stm32_dma2d_memaddress(oinfo, xpos, ypos), stm32_mar_layer_t[lid]);
-  putreg32(stm32_dma2d_lineoffset(oinfo, area), stm32_or_layer_t[lid]);
+  putreg32(stm32_dma2d_memaddress(oinfo, xpos, ypos),
+           stm32_mar_layer_t[lid]);
+  putreg32(stm32_dma2d_lineoffset(oinfo, area),
+           stm32_or_layer_t[lid]);
 }
 
 /****************************************************************************
@@ -679,12 +685,12 @@ static void stm32_dma2d_lpfc(int lid, uint32_t blendmode, uint8_t alpha,
 {
   uint32_t   pfccrreg;
 
-  lcdinfo("lid=%d, blendmode=%08x, alpha=%02x, fmt=%d\n", lid, blendmode, alpha,
-          fmt);
+  lcdinfo("lid=%d, blendmode=%08x, alpha=%02x, fmt=%d\n", lid, blendmode,
+          alpha, fmt);
 
   /* Set color format */
 
-  pfccrreg = DMA2D_xGPFCCR_CM(fmt);
+  pfccrreg = DMA2D_XGPFCCR_CM(fmt);
 
 #ifdef CONFIG_STM32F7_FB_CMAP
   if (fmt == DMA2D_PF_L8)
@@ -693,17 +699,17 @@ static void stm32_dma2d_lpfc(int lid, uint32_t blendmode, uint8_t alpha,
 
       /* Load CLUT automatically */
 
-      pfccrreg |= DMA2D_xGPFCCR_START;
+      pfccrreg |= DMA2D_XGPFCCR_START;
 
       /* Set the CLUT color mode */
 
 #  ifndef CONFIG_STM32F7_FB_TRANSPARENCY
-      pfccrreg |= DMA2D_xGPFCCR_CCM;
+      pfccrreg |= DMA2D_XGPFCCR_CCM;
 #  endif
 
       /* Set CLUT size */
 
-      pfccrreg |= DMA2D_xGPFCCR_CS(DMA2D_CLUT_SIZE);
+      pfccrreg |= DMA2D_XGPFCCR_CS(DMA2D_CLUT_SIZE);
 
       /* Set the CLUT memory address */
 
@@ -717,15 +723,14 @@ static void stm32_dma2d_lpfc(int lid, uint32_t blendmode, uint8_t alpha,
 
   /* Set alpha blend mode */
 
-  pfccrreg |= DMA2D_xGPFCCR_AM(blendmode);
+  pfccrreg |= DMA2D_XGPFCCR_AM(blendmode);
 
   if (blendmode == STM32_DMA2D_PFCCR_AM_CONST ||
         blendmode == STM32_DMA2D_PFCCR_AM_PIXEL)
     {
       /* Set alpha value */
 
-      pfccrreg |= DMA2D_xGPFCCR_ALPHA(alpha);
-
+      pfccrreg |= DMA2D_XGPFCCR_ALPHA(alpha);
     }
 
   putreg32(pfccrreg, stm32_pfccr_layer_t[lid]);
@@ -808,12 +813,13 @@ static int stm32_dma2d_setclut(FAR const struct fb_cmap_s *cmap)
  * Input Parameters:
  *   oinfo - Overlay to fill
  *   area  - Reference to the valid area structure select the area
- *   argb  - Color to fill the selected area. Color must be argb8888 formatted.
+ *   argb  - Color to fill the selected area. Color must be argb8888
+ *           formatted.
  *
  * Returned Value:
  *    OK        - On success
- *   -EINVAL    - If one of the parameter invalid or if the size of the selected
- *                area outside the visible area of the layer.
+ *   -EINVAL    - If one of the parameter invalid or if the size of the
+ *                selected area outside the visible area of the layer.
  *   -ECANCELED - Operation cancelled, something goes wrong.
  *
  ****************************************************************************/
@@ -891,9 +897,10 @@ static int stm32_dma2d_fillcolor(FAR struct stm32_dma2d_overlay_s *oinfo,
  *
  * Returned Value:
  *    OK        - On success
- *   -EINVAL    - If one of the parameter invalid or if the size of the selected
- *                source area outside the visible area of the destination layer.
- *                (The visible area usually represents the display size)
+ *   -EINVAL    - If one of the parameter invalid or if the size of the
+ *                selected source area outside the visible area of the
+ *                destination layer.  (The visible area usually represents
+ *                the display size)
  *   -ECANCELED - Operation cancelled, something goes wrong.
  *
  ****************************************************************************/
@@ -970,9 +977,9 @@ static int stm32_dma2d_blit(FAR struct stm32_dma2d_overlay_s *doverlay,
  * Description:
  *   Blends the selected area from a background layer with selected position
  *   of the foreground layer. Copies the result to the selected position of
- *   the destination layer. Note! The content of the foreground and background
- *   layer keeps unchanged as long destination layer is unequal to the
- *   foreground and background layer.
+ *   the destination layer. Note! The content of the foreground and
+ *   background layer keeps unchanged as long destination layer is unequal
+ *   to the foreground and background layer.
  *
  * Input Parameters:
  *   doverlay - Destination overlay
@@ -982,14 +989,15 @@ static int stm32_dma2d_blit(FAR struct stm32_dma2d_overlay_s *doverlay,
  *   forexpos - x-Offset foreground overlay
  *   foreypos - y-Offset foreground overlay
  *   boverlay - Background overlay
- *   barea    - x-Offset, y-Offset, x-resolution and y-resolution of background
- *              overlay
+ *   barea    - x-Offset, y-Offset, x-resolution and y-resolution of
+ *              background overlay
  *
  * Returned Value:
  *    OK        - On success
- *   -EINVAL    - If one of the parameter invalid or if the size of the selected
- *                source area outside the visible area of the destination layer.
- *                (The visible area usually represents the display size)
+ *   -EINVAL    - If one of the parameter invalid or if the size of the
+ *                selected source area outside the visible area of the
+ *                destination layer.  (The visible area usually represents
+ *                the display size)
  *   -ECANCELED - Operation cancelled, something goes wrong.
  *
  ****************************************************************************/
@@ -1099,8 +1107,8 @@ int stm32_dma2dinitialize(void)
        * arch/arm/src/stm32f7/stm32f7xxxx_rcc.c
        */
 
-      /* Initialize the DMA2D semaphore that enforces mutually exclusive access
-       * to the driver
+      /* Initialize the DMA2D semaphore that enforces mutually exclusive
+       * access to the driver
        */
 
       nxsem_init(&g_lock, 0, 1);
@@ -1126,7 +1134,8 @@ int stm32_dma2dinitialize(void)
 #endif
 
       stm32_dma2d_control(DMA2D_CR_TCIE | DMA2D_CR_CTCIE | DMA2D_CR_TEIE |
-                          DMA2D_CR_CAEIE | DMA2D_CR_CTCIE | DMA2D_CR_CEIE, 0);
+                          DMA2D_CR_CAEIE | DMA2D_CR_CTCIE | DMA2D_CR_CEIE,
+                          0);
 
       /* Attach DMA2D interrupt vector */
 

--- a/arch/arm/src/stm32f7/stm32_ltdc.c
+++ b/arch/arm/src/stm32f7/stm32_ltdc.c
@@ -85,13 +85,13 @@
 
 /* LTDC_LxWHPCR register */
 
-#define STM32_LTDC_LxWHPCR_WHSTPOS  (BOARD_LTDC_HSYNC + BOARD_LTDC_HBP - 1)
+#define STM32_LTDC_LXWHPCR_WHSTPOS  (BOARD_LTDC_HSYNC + BOARD_LTDC_HBP - 1)
 #define STM32_LTDC_LxWHPCR_WHSPPOS  (BOARD_LTDC_HSYNC + BOARD_LTDC_HBP + \
                                     STM32_LTDC_WIDTH - 1)
 
 /* LTDC_LxWVPCR register */
 
-#define STM32_LTDC_LxWVPCR_WVSTPOS  (BOARD_LTDC_VSYNC + BOARD_LTDC_VBP - 1)
+#define STM32_LTDC_LXWVPCR_WVSTPOS  (BOARD_LTDC_VSYNC + BOARD_LTDC_VBP - 1)
 #define STM32_LTDC_LxWVPCR_WVSPPOS  (BOARD_LTDC_VSYNC + BOARD_LTDC_VBP + \
                                     STM32_LTDC_HEIGHT - 1)
 
@@ -102,8 +102,8 @@
 
 /* LTDC_BPCR register */
 
-#define STM32_LTDC_BPCR_AVBP        LTDC_BPCR_AVBP(STM32_LTDC_LxWVPCR_WVSTPOS)
-#define STM32_LTDC_BPCR_AHBP        LTDC_BPCR_AHBP(STM32_LTDC_LxWHPCR_WHSTPOS)
+#define STM32_LTDC_BPCR_AVBP        LTDC_BPCR_AVBP(STM32_LTDC_LXWVPCR_WVSTPOS)
+#define STM32_LTDC_BPCR_AHBP        LTDC_BPCR_AHBP(STM32_LTDC_LXWHPCR_WHSTPOS)
 
 /* LTDC_AWCR register */
 
@@ -153,23 +153,23 @@
 #if defined(CONFIG_STM32F7_LTDC_L1_L8)
 #  define STM32_LTDC_L1_BPP         8
 #  define STM32_LTDC_L1_COLOR_FMT   FB_FMT_RGB8
-#  define STM32_LTDC_L1PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_L8)
+#  define STM32_LTDC_L1PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_L8)
 #  define STM32_LTDC_L1_DMA2D_PF    DMA2D_PF_L8
 #  define STM32_LTDC_L1CMAP
 #elif defined(CONFIG_STM32F7_LTDC_L1_RGB565)
 #  define STM32_LTDC_L1_BPP         16
 #  define STM32_LTDC_L1_COLOR_FMT   FB_FMT_RGB16_565
-#  define STM32_LTDC_L1PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_RGB565)
+#  define STM32_LTDC_L1PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_RGB565)
 #  define STM32_LTDC_L1_DMA2D_PF    DMA2D_PF_RGB565
 #elif defined(CONFIG_STM32F7_LTDC_L1_RGB888)
 #  define STM32_LTDC_L1_BPP         24
 #  define STM32_LTDC_L1_COLOR_FMT   FB_FMT_RGB24
-#  define STM32_LTDC_L1PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_RGB888)
+#  define STM32_LTDC_L1PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_RGB888)
 #  define STM32_LTDC_L1_DMA2D_PF    DMA2D_PF_RGB888
 #elif defined(CONFIG_STM32F7_LTDC_L1_ARGB8888)
 #  define STM32_LTDC_L1_BPP         32
 #  define STM32_LTDC_L1_COLOR_FMT   FB_FMT_RGB32
-#  define STM32_LTDC_L1PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_ARGB8888)
+#  define STM32_LTDC_L1PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_ARGB8888)
 #  define STM32_LTDC_L1_DMA2D_PF    DMA2D_PF_ARGB8888
 #else
 #  error "LTDC pixel format not supported"
@@ -181,23 +181,23 @@
 #  if defined(CONFIG_STM32F7_LTDC_L2_L8)
 #   define STM32_LTDC_L2_BPP         8
 #   define STM32_LTDC_L2_COLOR_FMT   FB_FMT_RGB8
-#   define STM32_LTDC_L2PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_L8)
+#   define STM32_LTDC_L2PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_L8)
 #   define STM32_LTDC_L2_DMA2D_PF    DMA2D_PF_L8
 #   define STM32_LTDC_L2CMAP
 #  elif defined(CONFIG_STM32F7_LTDC_L2_RGB565)
 #   define STM32_LTDC_L2_BPP         16
 #   define STM32_LTDC_L2_COLOR_FMT   FB_FMT_RGB16_565
-#   define STM32_LTDC_L2PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_RGB565)
+#   define STM32_LTDC_L2PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_RGB565)
 #   define STM32_LTDC_L2_DMA2D_PF    DMA2D_PF_RGB565
 #  elif defined(CONFIG_STM32F7_LTDC_L2_RGB888)
 #   define STM32_LTDC_L2_BPP         24
 #   define STM32_LTDC_L2_COLOR_FMT   FB_FMT_RGB24
-#   define STM32_LTDC_L2PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_RGB888)
+#   define STM32_LTDC_L2PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_RGB888)
 #   define STM32_LTDC_L2_DMA2D_PF    DMA2D_PF_RGB888
 #  elif defined(CONFIG_STM32F7_LTDC_L2_ARGB8888)
 #   define STM32_LTDC_L2_BPP         32
 #   define STM32_LTDC_L2_COLOR_FMT   FB_FMT_RGB32
-#   define STM32_LTDC_L2PFCR_PF      LTDC_LxPFCR_PF(LTDC_PF_ARGB8888)
+#   define STM32_LTDC_L2PFCR_PF      LTDC_LXPFCR_PF(LTDC_PF_ARGB8888)
 #   define STM32_LTDC_L2_DMA2D_PF    DMA2D_PF_ARGB8888
 #  else
 #   error "LTDC pixel format not supported"
@@ -220,7 +220,7 @@
 
 /* LTDC only supports 8 bit per pixel overal */
 
-#define STM32_LTDC_Lx_BYPP(n)       ((n) / 8)
+#define STM32_LTDC_LX_BYPP(n)       ((n) / 8)
 
 #define STM32_LTDC_L1_FBSIZE        (STM32_LTDC_L1_STRIDE * STM32_LTDC_HEIGHT)
 
@@ -278,9 +278,9 @@
 
 /* Preallocated LTDC framebuffers */
 
-/* Position the framebuffer memory in the center of the memory set aside.  We
- * will use any skirts before or after the framebuffer memory as a guard against
- * wild framebuffer writes.
+/* Position the framebuffer memory in the center of the memory set aside.
+ * We will use any skirts before or after the framebuffer memory as a guard
+ * against wild framebuffer writes.
  */
 
 #define STM32_LTDC_BUFFER_SIZE      CONFIG_STM32F7_LTDC_FB_SIZE
@@ -344,7 +344,6 @@
 #  else
 #    error "DMA2D pixel format not supported"
 #  endif
-
 
 #  ifdef CONFIG_STM32F7_DMA2D_LAYER_SHARED
 #    define STM32_DMA2D_FBSIZE      CONFIG_STM32F7_DMA2D_FB_SIZE
@@ -701,7 +700,8 @@ static void stm32_ltdc_lframebuffer(FAR struct stm32_ltdc_s *layer);
 static void stm32_ltdc_lenable(FAR struct stm32_ltdc_s *layer, bool enable);
 static void stm32_ltdc_ldefaultcolor(FAR struct stm32_ltdc_s * layer,
                                      uint32_t rgb);
-static void stm32_ltdc_ltransp(FAR struct stm32_ltdc_s *layer, uint8_t transp,
+static void stm32_ltdc_ltransp(FAR struct stm32_ltdc_s *layer,
+                               uint8_t transp,
                                uint32_t mode);
 static void stm32_ltdc_lchromakey(FAR struct stm32_ltdc_s *layer,
                                   uint32_t chromakey);
@@ -773,8 +773,8 @@ static int stm32_setblank(FAR struct fb_vtable_s *vtable,
 static int stm32_setarea(FAR struct fb_vtable_s *vtable,
                          FAR const struct fb_overlayinfo_s *oinfo);
 
-/* The following is provided only if the video hardware supports blit and blend
- * operation
+/* The following is provided only if the video hardware supports blit and
+ * blend operation
  */
 
 #  ifdef CONFIG_FB_OVERLAY_BLIT
@@ -1736,7 +1736,8 @@ static void stm32_ltdc_lpixelformat(FAR struct stm32_ltdc_s *layer)
 
   /* Configure PFCR register */
 
-  reginfo("set LTDC_L%dPFCR=%08x\n", overlay + 1, stm32_fmt_layer_t[overlay]);
+  reginfo("set LTDC_L%dPFCR=%08x\n", overlay + 1,
+          stm32_fmt_layer_t[overlay]);
   putreg32(stm32_fmt_layer_t[overlay], stm32_pfcr_layer_t[overlay]);
 
   /* Reload shadow register */
@@ -1772,18 +1773,18 @@ static void stm32_ltdc_lframebuffer(FAR struct stm32_ltdc_s *layer)
 
   /* Calculate register position */
 
-  rxpos = STM32_LTDC_LxWHPCR_WHSTPOS + 1;
-  rypos = STM32_LTDC_LxWVPCR_WVSTPOS + 1;
+  rxpos = STM32_LTDC_LXWHPCR_WHSTPOS + 1;
+  rypos = STM32_LTDC_LXWVPCR_WVSTPOS + 1;
 
   /* Accumulate horizontal position */
 
-  whpcr =  LTDC_LxWHPCR_WHSTPOS(rxpos);
-  whpcr |= LTDC_LxWHPCR_WHSPPOS(rxpos + stm32_width_layer_t[layerno] - 1);
+  whpcr =  LTDC_LXWHPCR_WHSTPOS(rxpos);
+  whpcr |= LTDC_LXWHPCR_WHSPPOS(rxpos + stm32_width_layer_t[layerno] - 1);
 
   /* Accumulate vertical position */
 
-  wvpcr =  LTDC_LxWVPCR_WVSTPOS(rypos);
-  wvpcr |= LTDC_LxWVPCR_WVSPPOS(rypos + stm32_height_layer_t[layerno] - 1);
+  wvpcr =  LTDC_LXWVPCR_WVSTPOS(rypos);
+  wvpcr |= LTDC_LXWVPCR_WVSPPOS(rypos + stm32_height_layer_t[layerno] - 1);
 
   /* Configure LxWHPCR / LxWVPCR register */
 
@@ -1802,16 +1803,17 @@ static void stm32_ltdc_lframebuffer(FAR struct stm32_ltdc_s *layer)
 
   /* Calculate line length */
 
-  cfblr = LTDC_LxCFBLR_CFBP(stm32_stride_layer_t[layerno]) |
-          LTDC_LxCFBLR_CFBLL(stm32_width_layer_t[layerno] *
-          STM32_LTDC_Lx_BYPP(stm32_bpp_layer_t[layerno]) + 3);
+  cfblr = LTDC_LXCFBLR_CFBP(stm32_stride_layer_t[layerno]) |
+          LTDC_LXCFBLR_CFBLL(stm32_width_layer_t[layerno] *
+          STM32_LTDC_LX_BYPP(stm32_bpp_layer_t[layerno]) + 3);
 
   reginfo("set LTDC_L%dCFBLR=%08x\n", layerno + 1, cfblr);
   putreg32(cfblr, stm32_cfblr_layer_t[layerno]);
 
   /* Configure LxCFBLNR register */
 
-  reginfo("set LTDC_L%dCFBLNR=%08x\n", layerno + 1, stm32_height_layer_t[layerno]);
+  reginfo("set LTDC_L%dCFBLNR=%08x\n", layerno + 1,
+          stm32_height_layer_t[layerno]);
   putreg32(stm32_height_layer_t[layerno], stm32_cfblnr_layer_t[layerno]);
 
   /* Reload shadow register */
@@ -1842,11 +1844,11 @@ static void stm32_ltdc_lenable(FAR struct stm32_ltdc_s *layer, bool enable)
 
   if (enable == true)
     {
-      regval |= LTDC_LxCR_LEN;
+      regval |= LTDC_LXCR_LEN;
     }
   else
     {
-      regval &= ~LTDC_LxCR_LEN;
+      regval &= ~LTDC_LXCR_LEN;
     }
 
   /* Enable/Disable layer */
@@ -1874,8 +1876,8 @@ static void stm32_ltdc_lenable(FAR struct stm32_ltdc_s *layer, bool enable)
  *
  ****************************************************************************/
 
-static void stm32_ltdc_ltransp(FAR struct stm32_ltdc_s *layer, uint8_t transp,
-                               uint32_t mode)
+static void stm32_ltdc_ltransp(FAR struct stm32_ltdc_s *layer,
+                               uint8_t transp, uint32_t mode)
 {
   uint32_t bf1;
   uint32_t bf2;
@@ -1899,11 +1901,11 @@ static void stm32_ltdc_ltransp(FAR struct stm32_ltdc_s *layer, uint8_t transp,
 #endif
 
   reginfo("set LTDC_L%dBFCR=%08x\n", layer->layerno + 1,
-          (LTDC_LxBFCR_BF1(bf1) | LTDC_LxBFCR_BF2(bf2)));
+          (LTDC_LXBFCR_BF1(bf1) | LTDC_LXBFCR_BF2(bf2)));
 
   /* Set blendmode */
 
-  putreg32((LTDC_LxBFCR_BF1(bf1) | LTDC_LxBFCR_BF2(bf2)),
+  putreg32((LTDC_LXBFCR_BF1(bf1) | LTDC_LXBFCR_BF2(bf2)),
             stm32_bfcr_layer_t[layer->layerno]);
 
   /* Set alpha */
@@ -1944,7 +1946,7 @@ static void stm32_ltdc_lchromakey(FAR struct stm32_ltdc_s *layer,
   uint8_t r = g_vtable.cmap.red[chroma];
   uint8_t g = g_vtable.cmap.green[chroma];
   uint8_t b = g_vtable.cmap.blue[chroma];
-  rgb = ((r << 16)|(g << 8)|b);
+  rgb = ((r << 16) | (g << 8) | b);
 #else
   rgb = ARGB8888(chroma);
 #endif
@@ -1983,11 +1985,11 @@ static void stm32_ltdc_lchromakeyenable(FAR struct stm32_ltdc_s *layer,
 
   if (enable == true)
     {
-      regval |= LTDC_LxCR_COLKEN;
+      regval |= LTDC_LXCR_COLKEN;
     }
   else
     {
-      regval &= ~LTDC_LxCR_COLKEN;
+      regval &= ~LTDC_LXCR_COLKEN;
     }
 
   reginfo("set LTDC_L%dCR=%08x\n", layer->layerno + 1, regval);
@@ -2011,7 +2013,8 @@ static void stm32_ltdc_lchromakeyenable(FAR struct stm32_ltdc_s *layer,
  ****************************************************************************/
 
 #ifdef CONFIG_STM32F7_FB_CMAP
-static void stm32_ltdc_lclutenable(FAR struct stm32_ltdc_s *layer, bool enable)
+static void stm32_ltdc_lclutenable(FAR struct stm32_ltdc_s *layer,
+                                   bool enable)
 {
   uint32_t    regval;
 
@@ -2022,11 +2025,11 @@ static void stm32_ltdc_lclutenable(FAR struct stm32_ltdc_s *layer, bool enable)
 
   if (enable == true)
     {
-      regval |= LTDC_LxCR_CLUTEN;
+      regval |= LTDC_LXCR_CLUTEN;
     }
   else
     {
-      regval &= ~LTDC_LxCR_CLUTEN;
+      regval &= ~LTDC_LXCR_CLUTEN;
     }
 
   reginfo("set LTDC_L%dCR=%08x\n", layer->oinfo.overlay, regval);
@@ -2113,7 +2116,6 @@ static void stm32_ltdc_lgetclut(FAR struct stm32_ltdc_s * layer,
 
   for (n = cmap->first; n < cmap->len && n < STM32_LTDC_NCLUT; n++)
     {
-
 #  ifdef CONFIG_STM32F7_FB_TRANSPARENCY
       cmap->transp[n] = priv_cmap->transp[n];
 #  endif
@@ -2121,7 +2123,8 @@ static void stm32_ltdc_lgetclut(FAR struct stm32_ltdc_s * layer,
       cmap->green[n]  = priv_cmap->green[n];
       cmap->blue[n]   = priv_cmap->blue[n];
 
-      reginfo("color = %d, transp=%02x, red=%02x, green=%02x, blue=%02x\n", n,
+      reginfo("color = %d, transp=%02x, red=%02x, green=%02x, blue=%02x\n",
+              n,
 #  ifdef CONFIG_STM32F7_FB_TRANSPARENCY
               cmap->transp[n],
 #  endif
@@ -2145,7 +2148,7 @@ static void stm32_ltdc_lgetclut(FAR struct stm32_ltdc_s * layer,
 
 static void stm32_ltdc_lclear(uint8_t overlayno)
 {
-  memset((uint8_t*)stm32_fbmem_layer_t[overlayno], 0,
+  memset((uint8_t *)stm32_fbmem_layer_t[overlayno], 0,
         stm32_fblen_layer_t[overlayno]);
 }
 
@@ -2168,8 +2171,8 @@ static bool stm32_ltdc_lvalidate(FAR const struct stm32_ltdc_s *layer,
 {
   uint32_t offset;
 
-  offset = (area->y + area->h - 1) * layer->oinfo.stride + (area->x + area->w) *
-      layer->oinfo.bpp / 8;
+  offset = (area->y + area->h - 1) * layer->oinfo.stride +
+           (area->x + area->w) * layer->oinfo.bpp / 8;
 
   return (offset <= layer->oinfo.fblen && area->w > 0 && area->h > 0);
 }
@@ -2205,7 +2208,7 @@ static void stm32_ltdc_linit(uint8_t overlay)
 
   stm32_ltdc_lenable(layer, false);
 
-    /* Clear the layer framebuffer */
+  /* Clear the layer framebuffer */
 
   stm32_ltdc_lclear(overlay);
 
@@ -2515,6 +2518,7 @@ static int stm32_putcmap(struct fb_vtable_s *vtable,
           FAR struct stm32_ltdc_s * layer = &priv->layer[n];
           stm32_ltdc_lputclut(layer, priv_cmap);
         }
+
 #  ifdef CONFIG_STM32F7_DMA2D
       /* Update dma2d cmap */
 
@@ -2529,11 +2533,11 @@ static int stm32_putcmap(struct fb_vtable_s *vtable,
 }
 #endif /* CONFIG_STM32F7_FB_CMAP */
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_ioctl_waitforvsync
  * Description:
  *   Entrypoint ioctl FBIO_WAITFORSYNC
- ***************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_FB_SYNC
 static int stm32_waitforvsync(FAR struct fb_vtable_s *vtable)
@@ -2550,18 +2554,18 @@ static int stm32_waitforvsync(FAR struct fb_vtable_s *vtable)
 }
 #endif /* CONFIG_FB_SYNC */
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_getoverlayinfo
  * Description:
  *   Entrypoint ioctl FBIOGET_OVERLAYINFO
- ***************************************************************************/
+ ****************************************************************************/
 
 #ifdef CONFIG_FB_OVERLAY
 static int stm32_getoverlayinfo(FAR struct fb_vtable_s *vtable,
                                 int overlayno,
                                 FAR struct fb_overlayinfo_s *oinfo)
 {
-  FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s*)vtable;
+  FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s *)vtable;
 
   lcdinfo("vtable=%p overlay=%d oinfo=%p\n", vtable, overlayno, oinfo);
   DEBUGASSERT(vtable != NULL && priv == &g_vtable);
@@ -2577,16 +2581,16 @@ static int stm32_getoverlayinfo(FAR struct fb_vtable_s *vtable,
   return -EINVAL;
 }
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_settransp
  * Description:
  *   Entrypoint ioctl FBIOSET_TRANSP
- ***************************************************************************/
+ ****************************************************************************/
 
 static int stm32_settransp(FAR struct fb_vtable_s *vtable,
                            FAR const struct fb_overlayinfo_s *oinfo)
 {
-  FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s*)vtable;
+  FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s *)vtable;
 
   DEBUGASSERT(vtable != NULL && priv == &g_vtable);
   lcdinfo("vtable=%p, overlay=%d, transp=%02x, transp_mode=%02x\n", vtable,
@@ -2633,11 +2637,11 @@ static int stm32_settransp(FAR struct fb_vtable_s *vtable,
   return -EINVAL;
 }
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_setchromakey
  * Description:
  *   Entrypoint ioctl FBIOSET_CHROMAKEY
- ***************************************************************************/
+ ****************************************************************************/
 
 static int stm32_setchromakey(FAR struct fb_vtable_s *vtable,
                               FAR const struct fb_overlayinfo_s *oinfo)
@@ -2659,6 +2663,7 @@ static int stm32_setchromakey(FAR struct fb_vtable_s *vtable,
           return -ENOSYS;
         }
 #  endif
+
 #  ifndef CONFIG_STM32F7_LTDC_L2_CHROMAKEY
       if (oinfo->overlay == LTDC_LAYER_L2)
         {
@@ -2700,11 +2705,11 @@ static int stm32_setchromakey(FAR struct fb_vtable_s *vtable,
   return -EINVAL;
 }
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_setcolor
  * Description:
  *   Entrypoint ioctl FBIOSET_COLOR
- ***************************************************************************/
+ ****************************************************************************/
 
 static int stm32_setcolor(FAR struct fb_vtable_s *vtable,
                           FAR const struct fb_overlayinfo_s *oinfo)
@@ -2721,7 +2726,8 @@ static int stm32_setcolor(FAR struct fb_vtable_s *vtable,
        */
 
       int ret;
-      FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s*)vtable;
+      FAR struct stm32_ltdcdev_s *priv =
+        (FAR struct stm32_ltdcdev_s *)vtable;
       FAR struct stm32_ltdc_s * layer = &priv->layer[oinfo->overlay];
       FAR struct fb_overlayinfo_s * poverlay = layer->dma2dinfo.oinfo;
 
@@ -2745,16 +2751,16 @@ static int stm32_setcolor(FAR struct fb_vtable_s *vtable,
   return -EINVAL;
 }
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_setblank
  * Description:
  *   Entrypoint ioctl FBIOSET_BLANK
- ***************************************************************************/
+ ****************************************************************************/
 
 static int stm32_setblank(FAR struct fb_vtable_s *vtable,
                           FAR const struct fb_overlayinfo_s *oinfo)
 {
-  FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s*)vtable;
+  FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s *)vtable;
 
   DEBUGASSERT(vtable != NULL && priv == &g_vtable && oinfo != NULL);
   lcdinfo("vtable=%p, overlay=%d, blank=%02x\n", vtable, oinfo->blank);
@@ -2786,11 +2792,11 @@ static int stm32_setblank(FAR struct fb_vtable_s *vtable,
   return -EINVAL;
 }
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_setarea
  * Description:
  *   Entrypoint ioctl FBIOSET_AREA
- ***************************************************************************/
+ ****************************************************************************/
 
 static int stm32_setarea(FAR struct fb_vtable_s *vtable,
                          FAR const struct fb_overlayinfo_s *oinfo)
@@ -2806,11 +2812,14 @@ static int stm32_setarea(FAR struct fb_vtable_s *vtable,
 
       return -ENOSYS;
     }
+
 #  ifdef CONFIG_STM32F7_DMA2D
   if (oinfo->overlay < LTDC_NOVERLAYS)
     {
-      FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s*)vtable;
-      FAR struct stm32_ltdc_s * layer  = &priv->layer[oinfo->overlay];
+      FAR struct stm32_ltdcdev_s *priv =
+        (FAR struct stm32_ltdcdev_s *)vtable;
+      FAR struct stm32_ltdc_s * layer =
+        &priv->layer[oinfo->overlay];
 
       nxsem_wait(layer->lock);
       memcpy(&layer->oinfo.sarea, &oinfo->sarea, sizeof(struct fb_area_s));
@@ -2824,11 +2833,11 @@ static int stm32_setarea(FAR struct fb_vtable_s *vtable,
   return -EINVAL;
 }
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_blit
  * Description:
  *   Entrypoint ioctl FBIOSET_BLIT
- ***************************************************************************/
+ ****************************************************************************/
 
 #  ifdef CONFIG_FB_OVERLAY_BLIT
 static int stm32_blit(FAR struct fb_vtable_s *vtable,
@@ -2837,15 +2846,19 @@ static int stm32_blit(FAR struct fb_vtable_s *vtable,
   DEBUGASSERT(vtable != NULL && vtable == &g_vtable.vtable && blit != NULL);
   lcdinfo("vtable = %p, blit = %p\n", vtable, blit);
 
-  if (blit->dest.overlay < LTDC_NOVERLAYS && blit->src.overlay < LTDC_NOVERLAYS)
+  if (blit->dest.overlay < LTDC_NOVERLAYS &&
+      blit->src.overlay < LTDC_NOVERLAYS)
     {
 #    ifdef CONFIG_STM32F7_DMA2D
       int ret;
       struct fb_area_s sarea;
       FAR const struct fb_area_s *darea = &blit->dest.area;
-      FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s*)vtable;
-      FAR struct stm32_ltdc_s *dlayer = &priv->layer[blit->dest.overlay];
-      FAR struct stm32_ltdc_s *slayer = &priv->layer[blit->src.overlay];
+      FAR struct stm32_ltdcdev_s *priv =
+        (FAR struct stm32_ltdcdev_s *)vtable;
+      FAR struct stm32_ltdc_s *dlayer =
+        &priv->layer[blit->dest.overlay];
+      FAR struct stm32_ltdc_s *slayer =
+        &priv->layer[blit->src.overlay];
 
       DEBUGASSERT(&dlayer->oinfo == dlayer->dma2dinfo.oinfo &&
                   &slayer->oinfo == slayer->dma2dinfo.oinfo);
@@ -2859,7 +2872,7 @@ static int stm32_blit(FAR struct fb_vtable_s *vtable,
       if (!stm32_ltdc_lvalidate(dlayer, darea) ||
           !stm32_ltdc_lvalidate(slayer, &sarea))
         {
-            return -EINVAL;
+          return -EINVAL;
         }
 
       sarea.w = MIN(darea->w, sarea.w);
@@ -2882,11 +2895,11 @@ static int stm32_blit(FAR struct fb_vtable_s *vtable,
   return -EINVAL;
 }
 
-/***************************************************************************
+/****************************************************************************
  * Name: stm32_blend
  * Description:
  *   Entrypoint ioctl FBIOSET_BLEND
- ***************************************************************************/
+ ****************************************************************************/
 
 static int stm32_blend(FAR struct fb_vtable_s *vtable,
                        FAR const struct fb_overlayblend_s *blend)
@@ -2903,10 +2916,13 @@ static int stm32_blend(FAR struct fb_vtable_s *vtable,
       struct fb_area_s barea;
       FAR const struct fb_area_s *darea = &blend->dest.area;
       FAR const struct fb_area_s *farea = &blend->foreground.area;
-      FAR struct stm32_ltdcdev_s *priv = (FAR struct stm32_ltdcdev_s*)vtable;
+      FAR struct stm32_ltdcdev_s *priv =
+        (FAR struct stm32_ltdcdev_s *)vtable;
       FAR struct stm32_ltdc_s *dlayer = &priv->layer[blend->dest.overlay];
-      FAR struct stm32_ltdc_s *flayer = &priv->layer[blend->foreground.overlay];
-      FAR struct stm32_ltdc_s *blayer = &priv->layer[blend->background.overlay];
+      FAR struct stm32_ltdc_s *flayer =
+        &priv->layer[blend->foreground.overlay];
+      FAR struct stm32_ltdc_s *blayer =
+        &priv->layer[blend->background.overlay];
 
       DEBUGASSERT(&dlayer->oinfo == dlayer->dma2dinfo.oinfo &&
                   &flayer->oinfo == flayer->dma2dinfo.oinfo &&
@@ -2922,8 +2938,8 @@ static int stm32_blend(FAR struct fb_vtable_s *vtable,
           !stm32_ltdc_lvalidate(flayer, farea) ||
           !stm32_ltdc_lvalidate(blayer, &barea))
         {
-            lcderr("ERROR: Returning EINVAL\n");
-            return -EINVAL;
+          lcderr("ERROR: Returning EINVAL\n");
+          return -EINVAL;
         }
 
       barea.w = MIN(darea->w, barea.w);


### PR DESCRIPTION
## Summary

Fix nxstyle errors in the following files:

- arch/arm/src/stm32/hardware/stm32_dma2d.h
- arch/arm/src/stm32/hardware/stm32_ltdc.h
- arch/arm/src/stm32/stm32_dma2d.c
- arch/arm/src/stm32/stm32_ltdc.c
- arch/arm/src/stm32f7/hardware/stm32_dma2d.h
- arch/arm/src/stm32f7/hardware/stm32_ltdc.h
- arch/arm/src/stm32f7/stm32_dma2d.c
- arch/arm/src/stm32f7/stm32_ltdc.c

Fix nxstyle "mixed case identifier" errors for the following identifiers:

```
      DMA2D_xGPFCCR_ALPHA         -> DMA2D_XGPFCCR_ALPHA
      DMA2D_xGPFCCR_AM            -> DMA2D_XGPFCCR_AM
      DMA2D_xGPFCCR_CCM           -> DMA2D_XGPFCCR_CCM
      DMA2D_xGPFCCR_CM            -> DMA2D_XGPFCCR_CM
      DMA2D_xGPFCCR_CS            -> DMA2D_XGPFCCR_CS
      DMA2D_xGPFCCR_START         -> DMA2D_XGPFCCR_START
      LTDC_LxBFCR_BF1             -> LTDC_LXBFCR_BF1
      LTDC_LxBFCR_BF2             -> LTDC_LXBFCR_BF2
      LTDC_LxCFBLR_CFBLL          -> LTDC_LXCFBLR_CFBLL
      LTDC_LxCFBLR_CFBP           -> LTDC_LXCFBLR_CFBP
      LTDC_LxCR_CLUTEN            -> LTDC_LXCR_CLUTEN
      LTDC_LxCR_COLKEN            -> LTDC_LXCR_COLKEN
      LTDC_LxCR_LEN               -> LTDC_LXCR_LEN
      LTDC_LxWHPCR_WHSPPOS        -> LTDC_LXWHPCR_WHSPPOS
      LTDC_LxWHPCR_WHSTPOS        -> LTDC_LXWHPCR_WHSTPOS
      LTDC_LxWVPCR_WVSPPOS        -> LTDC_LXWVPCR_WVSPPOS
      LTDC_LxWVPCR_WVSTPOS        -> LTDC_LXWVPCR_WVSTPOS
      STM32_LTDC_LxWHPCR_WHSTPOS  -> STM32_LTDC_LXWHPCR_WHSTPOS
      STM32_LTDC_LxWVPCR_WVSTPOS  -> STM32_LTDC_LXWVPCR_WVSTPOS
      STM32_LTDC_Lx_BYPP          -> STM32_LTDC_LX_BYPP
      DMA2D_xGCOLR_BLUE           -> DMA2D_XGCOLR_BLUE
      DMA2D_xGCOLR_BLUE_MASK      -> DMA2D_XGCOLR_BLUE_MASK
      DMA2D_xGCOLR_BLUE_SHIFT     -> DMA2D_XGCOLR_BLUE_SHIFT
      DMA2D_xGCOLR_GREEN          -> DMA2D_XGCOLR_GREEN
      DMA2D_xGCOLR_GREEN_MASK     -> DMA2D_XGCOLR_GREEN_MASK
      DMA2D_xGCOLR_GREEN_SHIFT    -> DMA2D_XGCOLR_GREEN_SHIFT
      DMA2D_xGCOLR_RED            -> DMA2D_XGCOLR_RED
      DMA2D_xGCOLR_RED_MASK       -> DMA2D_XGCOLR_RED_MASK
      DMA2D_xGCOLR_RED_SHIFT      -> DMA2D_XGCOLR_RED_SHIFT
      DMA2D_xGOR                  -> DMA2D_XGOR
      DMA2D_xGOR_MASK             -> DMA2D_XGOR_MASK
      DMA2D_xGOR_SHIFT            -> DMA2D_XGOR_SHIFT
      DMA2D_xGPFCCR_ALPHA_MASK    -> DMA2D_XGPFCCR_ALPHA_MASK
      DMA2D_xGPFCCR_ALPHA_SHIFT   -> DMA2D_XGPFCCR_ALPHA_SHIFT
      DMA2D_xGPFCCR_AM_MASK       -> DMA2D_XGPFCCR_AM_MASK
      DMA2D_xGPFCCR_AM_SHIFT      -> DMA2D_XGPFCCR_AM_SHIFT
      DMA2D_xGPFCCR_CM_MASK       -> DMA2D_XGPFCCR_CM_MASK
      DMA2D_xGPFCCR_CM_SHIFT      -> DMA2D_XGPFCCR_CM_SHIFT
      DMA2D_xGPFCCR_CS_MASK       -> DMA2D_XGPFCCR_CS_MASK
      DMA2D_xGPFCCR_CS_SHIFT      -> DMA2D_XGPFCCR_CS_SHIFT
      LTDC_LxBFCR_BF1_MASK        -> LTDC_LXBFCR_BF1_MASK
      LTDC_LxBFCR_BF1_SHIFT       -> LTDC_LXBFCR_BF1_SHIFT
      LTDC_LxBFCR_BF2_MASK        -> LTDC_LXBFCR_BF2_MASK
      LTDC_LxBFCR_BF2_SHIFT       -> LTDC_LXBFCR_BF2_SHIFT
      LTDC_LxCACR_CONSTA          -> LTDC_LXCACR_CONSTA
      LTDC_LxCACR_CONSTA          -> LTDC_LXCACR_CONSTA
      LTDC_LxCACR_CONSTA_MASK     -> LTDC_LXCACR_CONSTA_MASK
      LTDC_LxCACR_CONSTA_SHIFT    -> LTDC_LXCACR_CONSTA_SHIFT
      LTDC_LxCFBLNR_LN            -> LTDC_LXCFBLNR_LN
      LTDC_LxCFBLNR_LN            -> LTDC_LXCFBLNR_LN
      LTDC_LxCFBLNR_LN_MASK       -> LTDC_LXCFBLNR_LN_MASK
      LTDC_LxCFBLNR_LN_SHIFT      -> LTDC_LXCFBLNR_LN_SHIFT
      LTDC_LxCFBLR_CFBLL_MASK     -> LTDC_LXCFBLR_CFBLL_MASK
      LTDC_LxCFBLR_CFBLL_SHIFT    -> LTDC_LXCFBLR_CFBLL_SHIFT
      LTDC_LxCFBLR_CFBP_MASK      -> LTDC_LXCFBLR_CFBP_MASK
      LTDC_LxCFBLR_CFBP_SHIFT     -> LTDC_LXCFBLR_CFBP_SHIFT
      LTDC_LxCKCR_CKBLUE          -> LTDC_LXCKCR_CKBLUE
      LTDC_LxCKCR_CKBLUE          -> LTDC_LXCKCR_CKBLUE
      LTDC_LxCKCR_CKBLUE_MASK     -> LTDC_LXCKCR_CKBLUE_MASK
      LTDC_LxCKCR_CKBLUE_SHIFT    -> LTDC_LXCKCR_CKBLUE_SHIFT
      LTDC_LxCKCR_CKGREEN         -> LTDC_LXCKCR_CKGREEN
      LTDC_LxCKCR_CKGREEN         -> LTDC_LXCKCR_CKGREEN
      LTDC_LxCKCR_CKGREEN_MASK    -> LTDC_LXCKCR_CKGREEN_MASK
      LTDC_LxCKCR_CKGREEN_SHIFT   -> LTDC_LXCKCR_CKGREEN_SHIFT
      LTDC_LxCKCR_CKRED           -> LTDC_LXCKCR_CKRED
      LTDC_LxCKCR_CKRED           -> LTDC_LXCKCR_CKRED
      LTDC_LxCKCR_CKRED_MASK      -> LTDC_LXCKCR_CKRED_MASK
      LTDC_LxCKCR_CKRED_SHIFT     -> LTDC_LXCKCR_CKRED_SHIFT
      LTDC_LxCLUTWR_BLUE          -> LTDC_LXCLUTWR_BLUE
      LTDC_LxCLUTWR_BLUE          -> LTDC_LXCLUTWR_BLUE
      LTDC_LxCLUTWR_BLUE_MASK     -> LTDC_LXCLUTWR_BLUE_MASK
      LTDC_LxCLUTWR_BLUE_SHIFT    -> LTDC_LXCLUTWR_BLUE_SHIFT
      LTDC_LxCLUTWR_CLUTADD       -> LTDC_LXCLUTWR_CLUTADD
      LTDC_LxCLUTWR_CLUTADD       -> LTDC_LXCLUTWR_CLUTADD
      LTDC_LxCLUTWR_CLUTADD_MASK  -> LTDC_LXCLUTWR_CLUTADD_MASK
      LTDC_LxCLUTWR_CLUTADD_SHIFT -> LTDC_LXCLUTWR_CLUTADD_SHIFT
      LTDC_LxCLUTWR_GREEN         -> LTDC_LXCLUTWR_GREEN
      LTDC_LxCLUTWR_GREEN         -> LTDC_LXCLUTWR_GREEN
      LTDC_LxCLUTWR_GREEN_MASK    -> LTDC_LXCLUTWR_GREEN_MASK
      LTDC_LxCLUTWR_GREEN_SHIFT   -> LTDC_LXCLUTWR_GREEN_SHIFT
      LTDC_LxCLUTWR_RED           -> LTDC_LXCLUTWR_RED
      LTDC_LxCLUTWR_RED           -> LTDC_LXCLUTWR_RED
      LTDC_LxCLUTWR_RED_MASK      -> LTDC_LXCLUTWR_RED_MASK
      LTDC_LxCLUTWR_RED_SHIFT     -> LTDC_LXCLUTWR_RED_SHIFT
      LTDC_LxDCCR_DCALPHA         -> LTDC_LXDCCR_DCALPHA
      LTDC_LxDCCR_DCALPHA         -> LTDC_LXDCCR_DCALPHA
      LTDC_LxDCCR_DCALPHA_MASK    -> LTDC_LXDCCR_DCALPHA_MASK
      LTDC_LxDCCR_DCALPHA_SHIFT   -> LTDC_LXDCCR_DCALPHA_SHIFT
      LTDC_LxDCCR_DCBLUE          -> LTDC_LXDCCR_DCBLUE
      LTDC_LxDCCR_DCBLUE          -> LTDC_LXDCCR_DCBLUE
      LTDC_LxDCCR_DCBLUE_MASK     -> LTDC_LXDCCR_DCBLUE_MASK
      LTDC_LxDCCR_DCBLUE_SHIFT    -> LTDC_LXDCCR_DCBLUE_SHIFT
      LTDC_LxDCCR_DCGREEN         -> LTDC_LXDCCR_DCGREEN
      LTDC_LxDCCR_DCGREEN         -> LTDC_LXDCCR_DCGREEN
      LTDC_LxDCCR_DCGREEN_MASK    -> LTDC_LXDCCR_DCGREEN_MASK
      LTDC_LxDCCR_DCGREEN_SHIFT   -> LTDC_LXDCCR_DCGREEN_SHIFT
      LTDC_LxDCCR_DCRED           -> LTDC_LXDCCR_DCRED
      LTDC_LxDCCR_DCRED           -> LTDC_LXDCCR_DCRED
      LTDC_LxDCCR_DCRED_MASK      -> LTDC_LXDCCR_DCRED_MASK
      LTDC_LxDCCR_DCRED_SHIFT     -> LTDC_LXDCCR_DCRED_SHIFT
      LTDC_LxPFCR_PF              -> LTDC_LXPFCR_PF
      LTDC_LxPFCR_PF              -> LTDC_LXPFCR_PF
      LTDC_LxPFCR_PF_MASK         -> LTDC_LXPFCR_PF_MASK
      LTDC_LxPFCR_PF_SHIFT        -> LTDC_LXPFCR_PF_SHIFT
      LTDC_LxWHPCR_WHSPPOS_MASK   -> LTDC_LXWHPCR_WHSPPOS_MASK
      LTDC_LxWHPCR_WHSPPOS_SHIFT  -> LTDC_LXWHPCR_WHSPPOS_SHIFT
      LTDC_LxWHPCR_WHSTPOS_MASK   -> LTDC_LXWHPCR_WHSTPOS_MASK
      LTDC_LxWHPCR_WHSTPOS_SHIFT  -> LTDC_LXWHPCR_WHSTPOS_SHIFT
      LTDC_LxWVPCR_WVSPPOS_MASK   -> LTDC_LXWVPCR_WVSPPOS_MASK
      LTDC_LxWVPCR_WVSPPOS_SHIFT  -> LTDC_LXWVPCR_WVSPPOS_SHIFT
      LTDC_LxWVPCR_WVSTPOS_MASK   -> LTDC_LXWVPCR_WVSTPOS_MASK
      LTDC_LxWVPCR_WVSTPOS_SHIFT  -> LTDC_LXWVPCR_WVSTPOS_SHIFT
```

Also, fix all other nxstyle errors in the affected files.

## Impact

Removes numerous nxstyle errors.

## Testing

nxstyle
