### PR TITLE
xtensa/esp32: Change I2C SCL default pin to a valid one

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -529,7 +529,7 @@ if ESP32_I2C0
 
 config ESP32_I2C0_SCLPIN
 	int "I2C0 SCL Pin"
-	default 24
+	default 22
 	range 0 39
 
 config ESP32_I2C0_SDAPIN


### PR DESCRIPTION
## Summary
Current default pin for I2C SCL is not available for mapping with IOMUX
peripheral.

## Impact
No impact to existing configuration.

## Testing
Custom `esp32-wrover-kit` configuration with BMP180 sensor.