### PR TITLE
Fix up STM32H7  lse help text

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1502,8 +1502,8 @@ config STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 		the OSC running. See app note AN2867
 
 			0 = Low drive capability (default)
-			1 = Medium high drive capability
-			2 = Medium low drive capability
+			1 = Medium low drive capability
+			2 = Medium high drive capability
 			3 = High drive capability
 
 		*It will take into account the rev of the silicon and use
@@ -1518,8 +1518,8 @@ config STM32H7_RTC_LSECLOCK_START_DRV_CAPABILITY
 	depends on !STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 	---help---
 		0 = Low drive capability (default)
-		1 = Medium high drive capability
-		2 = Medium low drive capability
+		1 = Medium low drive capability
+		2 = Medium high drive capability
 		3 = High drive capability
 
 		It will take into account the rev of the silicon and use
@@ -1534,8 +1534,8 @@ config STM32H7_RTC_LSECLOCK_RUN_DRV_CAPABILITY
 	depends on !STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 	---help---
 		0 = Low drive capability (default)
-		1 = Medium high drive capability
-		2 = Medium low drive capability
+		1 = Medium low drive capability
+		2 = Medium high drive capability
 		3 = High drive capability
 
 		It will take into account the rev of the silicon and use


### PR DESCRIPTION
## Summary

See  https://github.com/apache/incubator-nuttx/pull/2943#issuecomment-789754798 as reported by @juniskane
## Impact

The values selected for static have to be qualified by the version silicon. So what is right on Ver V silicon will be wrong on Ver Y.
The change here to the text always provides ordinal values that select low to high. the driver will used the correct value for the silicon at run time. 

		0 = Low drive capability (default)
		1 = Medium low drive capability
		2 = Medium high drive capability
		3 = High drive capability

## Testing

Build testing.
