### PR TITLE
ESP32-C3: Fix GPIO pin function configuration

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_gpio.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_gpio.c
@@ -159,8 +159,8 @@ int esp32c3_configgpio(int pin, gpio_pinattr_t attr)
 
   func |= (uint32_t)(2ul << FUN_DRV_S);
 
-  /* Select the pad's function.  If no function was given, consider it a
-   * normal input or output (i.e. function3).
+  /* Select the pad's function. If no function was given, consider it a
+   * normal input or output (i.e. function1).
    */
 
   if ((attr & FUNCTION_MASK) != 0)
@@ -169,12 +169,12 @@ int esp32c3_configgpio(int pin, gpio_pinattr_t attr)
     }
   else
     {
-      func |= (uint32_t)((2 >> FUNCTION_SHIFT) << MCU_SEL_S);
+      func |= (uint32_t)(PIN_FUNC_GPIO << MCU_SEL_S);
     }
 
   if ((attr & OPEN_DRAIN) != 0)
     {
-      cntrl = (1 << GPIO_PIN_PAD_DRIVER_S);
+      cntrl |= (1 << GPIO_PIN_PAD_DRIVER_S);
     }
 
   /* Set the pin function to its register */

--- a/arch/risc-v/src/esp32c3/esp32c3_gpio.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_gpio.c
@@ -134,11 +134,15 @@ int esp32c3_configgpio(int pin, gpio_pinattr_t attr)
     {
       putreg32((1ul << pin), GPIO_ENABLE_W1TC_REG);
 
+      /* Input enable */
+
+      func |= FUN_IE;
+
       if ((attr & PULLUP) != 0)
         {
           func |= FUN_PU;
         }
-      else if (attr & PULLDOWN)
+      else if ((attr & PULLDOWN) != 0)
         {
           func |= FUN_PD;
         }
@@ -146,7 +150,7 @@ int esp32c3_configgpio(int pin, gpio_pinattr_t attr)
 
   /* Handle output pins */
 
-  else if ((attr & OUTPUT) != 0)
+  if ((attr & OUTPUT) != 0)
     {
       putreg32((1ul << pin), GPIO_ENABLE_W1TS_REG);
     }
@@ -154,10 +158,6 @@ int esp32c3_configgpio(int pin, gpio_pinattr_t attr)
   /* Add drivers */
 
   func |= (uint32_t)(2ul << FUN_DRV_S);
-
-  /* Input enable... Required for output as well? */
-
-  func |= FUN_IE;
 
   /* Select the pad's function.  If no function was given, consider it a
    * normal input or output (i.e. function3).


### PR DESCRIPTION
## Summary
This PR intends to address two issue on the GPIO driver for ESP32-C3:
- Allow a pin to be configured as Input and Output simultaneously
- Fix default GPIO function when no option is provided

## Impact
Current implementation unconditionally enabled the INPUT function and this behavior has been changed.
In case any device was relying on this wrong behavior, it now must explicitly configure the GPIO as INPUT.

## Testing
Tested with a customized `esp32c3-devkit` configuration.
