### PR TITLE
ESP32: Fix GPIO pin function configuration

### DIFF
--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -196,7 +196,7 @@ int esp32_configgpio(int pin, gpio_pinattr_t attr)
 
   /* Handle output pins */
 
-  else if ((attr & OUTPUT) != 0)
+  if ((attr & OUTPUT) != 0)
     {
       if (pin < 32)
         {

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -180,6 +180,10 @@ int esp32_configgpio(int pin, gpio_pinattr_t attr)
           putreg32((1ul << (pin - 32)), GPIO_ENABLE1_W1TC_REG);
         }
 
+      /* Input enable */
+
+      func |= FUN_IE;
+
       if ((attr & PULLUP) != 0)
         {
           func |= FUN_PU;
@@ -207,10 +211,6 @@ int esp32_configgpio(int pin, gpio_pinattr_t attr)
   /* Add drivers */
 
   func |= (uint32_t)(2ul << FUN_DRV_S);
-
-  /* Input enable... Required for output as well? */
-
-  func |= FUN_IE;
 
   /* Select the pad's function.  If no function was given, consider it a
    * normal input or output (i.e. function3).

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -222,7 +222,7 @@ int esp32_configgpio(int pin, gpio_pinattr_t attr)
     }
   else
     {
-      func |= (uint32_t)((2 >> FUNCTION_SHIFT) << MCU_SEL_S);
+      func |= (uint32_t)(PIN_FUNC_GPIO << MCU_SEL_S);
     }
 
   if ((attr & OPEN_DRAIN) != 0)

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -227,7 +227,7 @@ int esp32_configgpio(int pin, gpio_pinattr_t attr)
 
   if ((attr & OPEN_DRAIN) != 0)
     {
-      cntrl = (1 << GPIO_PIN_PAD_DRIVER_S);
+      cntrl |= (1 << GPIO_PIN_PAD_DRIVER_S);
     }
 
   regaddr = DR_REG_IO_MUX_BASE + g_pin2func[pin];

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -503,7 +503,10 @@ static void esp32_i2c_init(FAR struct esp32_i2c_priv_s *priv)
   esp32_gpiowrite(config->scl_pin, 1);
   esp32_gpiowrite(config->sda_pin, 1);
 
-  esp32_configgpio(config->scl_pin, OUTPUT | OPEN_DRAIN | FUNCTION_3);
+  esp32_configgpio(config->scl_pin, INPUT |
+                                    OUTPUT |
+                                    OPEN_DRAIN |
+                                    FUNCTION_3);
   esp32_gpio_matrix_out(config->scl_pin, config->scl_outsig, 0, 0);
   esp32_gpio_matrix_in(config->scl_pin, config->scl_insig, 0);
 


### PR DESCRIPTION
## Summary
This PR intends to address two issuea on the GPIO driver for ESP32:
- Allow a pin to be configured as Input and Output simultaneously
- Fix default GPIO function when no option is provided

This PR is porting the same fix from #2972

## Impact
Current implementation unconditionally enabled the INPUT function and this behavior has been changed.
In case any device was relying on this wrong behavior, it now must explicitly configure the GPIO as INPUT.
The affected I2C driver has been updated in this PR.

## Testing
`esp32-wrover-kit:bmp180`
