### PR TITLE
telnet: fix crash about telnet client connect

### DIFF
--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -1070,9 +1070,9 @@ static int telnet_session(FAR struct telnet_session_s *session)
       goto errout_with_semaphore;
     }
 
-  /* Close the original psoock (keeping the clone) */
+  /* Close the original psock (keeping the clone) */
 
-  psock_close(psock);
+  nx_close(session->ts_sd);
 
 #ifdef CONFIG_TELNET_SUPPORT_NAWS
   telnet_sendopt(priv, TELNET_DO, TELNET_NAWS);


### PR DESCRIPTION
## Summary
telnet: fix crash about telnet client connect. this path associated with PR:https://github.com/apache/incubator-nuttx/pull/2899

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
normal using telnet.
## Testing

