### PR TITLE
include: Add iso646.h for alternative spellings

### DIFF
--- a/include/iso646.h
+++ b/include/iso646.h
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * include/iso646.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_ISO646_H
+#define __INCLUDE_ISO646_H
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* The <iso646.h> header shall define the following eleven macros
+ * (on the left) that expand to the corresponding tokens (on the right):
+ *
+ * and          &&
+ * and_eq       &=
+ * bitand       &
+ * bitor        |
+ * compl        ~
+ * not          !
+ * not_eq       !=
+ * or           ||
+ * or_eq        |=
+ * xor          ^
+ * xor_eq       ^=
+ *
+ * Reference: Opengroup.org
+ */
+
+#define and         &&
+#define and_eq      &=
+#define bitand      &
+#define bitor       |
+#define compl       ~
+#define not         !
+#define not_eq      !=
+#define or          ||
+#define or_eq       |=
+#define xor         ^
+#define xor_eq      ^=
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_ISO646_H */


### PR DESCRIPTION
## Summary
Add `<iso646.h>` header for supporting alternative spellings as defined in the ISO C Standard:

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/iso646.h.html

## Impact
No impact, new feature.

## Testing
Tested locally using a simple example:
```c
#define STR_BOOL(OP)  ((OP) ? "TRUE" : "FALSE")

int main(int argc, char *argv[])
{
  int a = 1;
  int b = 3;
  int x = 5;
  int y = 7;

  printf("a = %d\n", a);
  printf("b = %d\n", b);
  printf("x = %d\n", x);
  printf("y = %d\n", y);

  printf("\n");

  printf("(a < b) = %s\n", STR_BOOL(a < b));
  printf("not (a < b) = %s\n", STR_BOOL(not (a < b)));
  printf("(a < b) or (x > y) = %s\n", STR_BOOL((a < b) or (x > y)));
  printf("(a < b) and (x < y) = %s\n", STR_BOOL((a < b) and (x < y)));

  printf("\n");

  printf("x bitand y = %d\n", x bitand y);
  printf("b bitor x = %d\n", b bitor x);
  printf("x xor b = %d\n", x xor b);

  printf("\n");

  printf("compl a = %d (%x)\n", compl a, compl a);

  return 0;
}
```
The result is:
```shell
nsh> iso646
a = 1
b = 3
x = 5
y = 7

(a < b) = TRUE
not (a < b) = FALSE
(a < b) or (x > y) = TRUE
(a < b) and (x < y) = TRUE

x bitand y = 5
b bitor x = 7
x xor b = 6

compl a = -2 (fffffffe)
```