### PR TITLE
esp32: Extract memory layout definitions to a separate header

### DIFF
--- a/arch/xtensa/include/esp32/memory_layout.h
+++ b/arch/xtensa/include/esp32/memory_layout.h
@@ -1,0 +1,112 @@
+/****************************************************************************
+ * arch/xtensa/include/esp32/memory_layout.h
+ *
+ *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* The heap overview:
+ *
+ * CONFIG_HEAP2_BASE                         eg. 3f80 0000
+ *     :
+ *     : g_mmheap region3 (CONFIG_ESP32_SPIRAM)
+ *     :
+ * CONFIG_HEAP2_BASE + CONFIG_HEAP2_SIZE     eg. 3fc0 0000
+ *
+ * _sheap                                    eg. 3ffc 8c6c
+ *     :
+ *     : g_iheap (CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP)
+ *     :
+ * _sheap + CONFIG_XTENSA_IMEM_REGION_SIZE   eg. 3ffd ebfc
+ *     :
+ *     : g_mmheap region1
+ *     :
+ * HEAP_REGION1_END                              3ffd fff0
+ *     :
+ *     : ROM data
+ *     :
+ * HEAP_REGION2_START                            3ffe 1330 or 3ffe 7e40
+ *     :
+ *     : g_mmheap region2
+ *     :
+ *     : about 123KB
+ *     :
+ * _eheap                                        4000 0000
+ */
+
+/* Region 1 of the heap is the area from the end of the .data section to the
+ * beginning of the ROM data.  The start address is defined from the linker
+ * script as "_sheap".  Then end is defined here, as follows:
+ */
+
+#ifndef HEAP_REGION1_END
+#define HEAP_REGION1_END    0x3ffdfff0
+#endif
+
+/* Region 2 of the heap is the area from the end of the ROM data to the end
+ * of DRAM.  The linker script has already set "_eheap" as the end of DRAM,
+ * the following defines the start of region2.
+ * N.B: That ROM data consists of 2 regions, one per CPU.  If SMP is not
+ * enabled include APP's region with the heap.
+ */
+
+#ifndef CONFIG_SMP
+#  define HEAP_REGION2_START  0x3ffe1330
+#else
+#  define HEAP_REGION2_START  0x3ffe7e40
+#endif
+
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
+#define	XTENSA_IMEM_REGION_SIZE	CONFIG_XTENSA_IMEM_REGION_SIZE
+#else
+#define	XTENSA_IMEM_REGION_SIZE	0
+#endif
+
+/* If CONFIG_XTENSA_IMEM_MAXIMIZE_HEAP_REGION is defined, it means
+ * using maximum separate heap for internal memory, but part of
+ * the available memory is reserved for the Region 1 heap.
+ */
+
+#ifdef CONFIG_XTENSA_IMEM_MAXIMIZE_HEAP_REGION
+#ifndef HEAP_REGION_OFFSET
+#define HEAP_REGION_OFFSET      0x2000
+#endif
+#endif

--- a/arch/xtensa/include/esp32/memory_layout.h
+++ b/arch/xtensa/include/esp32/memory_layout.h
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/xtensa/include/esp32/memory_layout.h
  *
- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -46,80 +46,13 @@
 #include <nuttx/mm/mm.h>
 #include <nuttx/board.h>
 #include <arch/board/board.h>
+#include <arch/esp32/memory_layout.h>
 
 #include "xtensa.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-/* The heap overview:
- *
- * CONFIG_HEAP2_BASE                         eg. 3f80 0000
- *     :
- *     : g_mmheap region3 (CONFIG_ESP32_SPIRAM)
- *     :
- * CONFIG_HEAP2_BASE + CONFIG_HEAP2_SIZE     eg. 3fc0 0000
- *
- * _sheap                                    eg. 3ffc 8c6c
- *     :
- *     : g_iheap (CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP)
- *     :
- * _sheap + CONFIG_XTENSA_IMEM_REGION_SIZE   eg. 3ffd ebfc
- *     :
- *     : g_mmheap region1
- *     :
- * HEAP_REGION1_END                              3ffd fff0
- *     :
- *     : ROM data
- *     :
- * HEAP_REGION2_START                            3ffe 1330 or 3ffe 7e40
- *     :
- *     : g_mmheap region2
- *     :
- *     : about 123KB
- *     :
- * _eheap                                        4000 0000
- */
-
-/* Region 1 of the heap is the area from the end of the .data section to the
- * beginning of the ROM data.  The start address is defined from the linker
- * script as "_sheap".  Then end is defined here, as follows:
- */
-
-#ifndef HEAP_REGION1_END
-#define HEAP_REGION1_END    0x3ffdfff0
-#endif
-
-/* Region 2 of the heap is the area from the end of the ROM data to the end
- * of DRAM.  The linker script has already set "_eheap" as the end of DRAM,
- * the following defines the start of region2.
- * N.B: That ROM data consists of 2 regions, one per CPU.  If SMP is not
- * enabled include APP's region with the heap.
- */
-
-#ifndef CONFIG_SMP
-#  define HEAP_REGION2_START  0x3ffe1330
-#else
-#  define HEAP_REGION2_START  0x3ffe7e40
-#endif
-
-#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
-#define	XTENSA_IMEM_REGION_SIZE	CONFIG_XTENSA_IMEM_REGION_SIZE
-#else
-#define	XTENSA_IMEM_REGION_SIZE	0
-#endif
-
-/* If CONFIG_XTENSA_IMEM_MAXIMIZE_HEAP_REGION is defined, it means
- * using maximum separate heap for internal memory, but part of
- * the available memory is reserved for the Region 1 heap.
- */
-
-#ifdef CONFIG_XTENSA_IMEM_MAXIMIZE_HEAP_REGION
-#ifndef HEAP_REGION_OFFSET
-#define HEAP_REGION_OFFSET      0x2000
-#endif
-#endif
 
 /****************************************************************************
  * Public Functions

--- a/arch/xtensa/src/esp32/esp32_imm.c
+++ b/arch/xtensa/src/esp32/esp32_imm.c
@@ -28,6 +28,7 @@
 #include <nuttx/fs/procfs.h>
 #include <nuttx/mm/mm.h>
 #include <malloc.h>
+#include <arch/esp32/memory_layout.h>
 
 #include "xtensa.h"
 
@@ -36,26 +37,6 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
-
-/* Region 1 of the heap is the area from the end of the .data section to the
- * begining of the ROM data.  The start address is defined from the linker
- * script as "_sheap".  Then end is defined here, as follows:
- */
-
-#ifndef HEAP_REGION1_END
-#define HEAP_REGION1_END    0x3ffdfff0
-#endif
-
-/* If define CONFIG_XTENSA_IMEM_MAXIMIZE_HEAP_REGION, it means
- * using maximum separate heap for internal memory, but part of
- * the available memory is reserved for the Region 1 heap.
- */
-
-#ifdef CONFIG_XTENSA_IMEM_MAXIMIZE_HEAP_REGION
-#ifndef HEAP_REGION_OFFSET
-#define HEAP_REGION_OFFSET  0x2000
-#endif
-#endif
 
 /****************************************************************************
  * Private Data


### PR DESCRIPTION
## Summary
esp32: Extract memory layout definitions to a separate header
## Impact

## Testing
build tested