### PR TITLE
stm32h7: Allow custom clock configuration to use stdclockconfig

### DIFF
--- a/arch/arm/src/stm32h7/stm32_rcc.h
+++ b/arch/arm/src/stm32h7/stm32_rcc.h
@@ -152,6 +152,16 @@ static inline void stm32_mco2config(uint32_t source, uint32_t div)
 void stm32_clockconfig(void);
 
 /****************************************************************************
+ * Name: stm32_stdclockconfig
+ *
+ * Description:
+ *   Setup the system using the "standard" clock configuration
+ *
+ ****************************************************************************/
+
+void stm32_stdclockconfig(void);
+
+/****************************************************************************
  * Name: stm32_board_clockconfig
  *
  * Description:

--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -558,6 +558,26 @@ static inline void rcc_enableapb4(void)
 }
 
 /****************************************************************************
+ * Name: rcc_enableperiphals
+ ****************************************************************************/
+
+static inline void rcc_enableperipherals(void)
+{
+  rcc_enableahb1();
+  rcc_enableahb2();
+  rcc_enableahb3();
+  rcc_enableahb4();
+  rcc_enableapb1();
+  rcc_enableapb2();
+  rcc_enableapb3();
+  rcc_enableapb4();
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
  * Name: stm32_stdclockconfig
  *
  * Description:
@@ -567,8 +587,7 @@ static inline void rcc_enableapb4(void)
  *   power clocking modes!
  ****************************************************************************/
 
-#ifndef CONFIG_STM32H7_CUSTOM_CLOCKCONFIG
-static void stm32_stdclockconfig(void)
+void stm32_stdclockconfig(void)
 {
   uint32_t regval;
   volatile int32_t timeout;
@@ -943,24 +962,3 @@ static void stm32_stdclockconfig(void)
 #endif
     }
 }
-#endif
-
-/****************************************************************************
- * Name: rcc_enableperiphals
- ****************************************************************************/
-
-static inline void rcc_enableperipherals(void)
-{
-  rcc_enableahb1();
-  rcc_enableahb2();
-  rcc_enableahb3();
-  rcc_enableahb4();
-  rcc_enableapb1();
-  rcc_enableapb2();
-  rcc_enableapb3();
-  rcc_enableapb4();
-}
-
-/****************************************************************************
- * Public Functions
- ****************************************************************************/

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+ * arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
  *
  *   Copyright (C) 2018, 2019 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
@@ -560,6 +560,26 @@ static inline void rcc_enableapb4(void)
 }
 
 /****************************************************************************
+ * Name: rcc_enableperiphals
+ ****************************************************************************/
+
+static inline void rcc_enableperipherals(void)
+{
+  rcc_enableahb1();
+  rcc_enableahb2();
+  rcc_enableahb3();
+  rcc_enableahb4();
+  rcc_enableapb1();
+  rcc_enableapb2();
+  rcc_enableapb3();
+  rcc_enableapb4();
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
  * Name: stm32_stdclockconfig
  *
  * Description:
@@ -569,8 +589,7 @@ static inline void rcc_enableapb4(void)
  *   power clocking modes!
  ****************************************************************************/
 
-#ifndef CONFIG_STM32H7_CUSTOM_CLOCKCONFIG
-static void stm32_stdclockconfig(void)
+void stm32_stdclockconfig(void)
 {
   uint32_t regval;
   volatile int32_t timeout;
@@ -933,24 +952,3 @@ static void stm32_stdclockconfig(void)
 #endif
     }
 }
-#endif
-
-/****************************************************************************
- * Name: rcc_enableperiphals
- ****************************************************************************/
-
-static inline void rcc_enableperipherals(void)
-{
-  rcc_enableahb1();
-  rcc_enableahb2();
-  rcc_enableahb3();
-  rcc_enableahb4();
-  rcc_enableapb1();
-  rcc_enableapb2();
-  rcc_enableapb3();
-  rcc_enableapb4();
-}
-
-/****************************************************************************
- * Public Functions
- ****************************************************************************/


### PR DESCRIPTION
## Summary
This change makes it so that stm32_stdclockconfig is included and exposed when STM32H7_CUSTOM_CLOCKCONFIG is enabled allowing for the board to extend the standard clock configuration.

## Impact
No existing code should be effected.

## Testing
Used in Arduino Portenta H7 port that will follow.

