### PR TITLE
esp32: Add an option to use the whole region2 memory for imem heap

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -141,6 +141,11 @@ config XTENSA_IMEM_REGION_SIZE
 	depends on XTENSA_IMEM_USE_SEPARATE_HEAP && !XTENSA_IMEM_MAXIMIZE_HEAP_REGION
 	default 0x18000
 
+config XTENSA_IMEM_USE_REGION2_AS_IMEM
+	bool "Use the whole region2 for the imem heap"
+	depends on XTENSA_IMEM_USE_SEPARATE_HEAP
+	default n
+
 source arch/xtensa/src/lx6/Kconfig
 if ARCH_CHIP_ESP32
 source arch/xtensa/src/esp32/Kconfig

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -103,8 +103,10 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 #if CONFIG_MM_REGIONS > 1
 void xtensa_add_region(void)
 {
+#if !defined(CONFIG_XTENSA_IMEM_USE_REGION2_AS_IMEM)
   umm_addregion((FAR void *)HEAP_REGION2_START,
                 (size_t)(uintptr_t)&_eheap - HEAP_REGION2_START);
+#endif
 
 #if defined(CONFIG_ESP32_SPIRAM)
   /* Check for any additional memory regions */

--- a/arch/xtensa/src/esp32/esp32_imm.c
+++ b/arch/xtensa/src/esp32/esp32_imm.c
@@ -77,6 +77,12 @@ void xtensa_imm_initialize(void)
 
   mm_initialize(&g_iheap, start, size);
 
+#if defined(CONFIG_XTENSA_IMEM_USE_REGION2_AS_IMEM)
+  mm_addregion(&g_iheap,
+               (FAR void *)HEAP_REGION2_START,
+               (size_t)(uintptr_t)&_eheap - HEAP_REGION2_START);
+#endif
+
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)
   static struct procfs_meminfo_entry_s g_imm_procfs;
 


### PR DESCRIPTION
## Summary
For some use cases, XTENSA_IMEM_MAXIMIZE_HEAP_REGION does not
provide enough memory for imem heap.

This commit allows to use the entire region2 heap for imem.

## Impact

## Testing
a slight variation was tested with my local app.