### PR TITLE
arch/sim: Don't remove OPOST in the raw mode

### DIFF
--- a/arch/sim/src/sim/up_simuart.c
+++ b/arch/sim/src/sim/up_simuart.c
@@ -70,7 +70,6 @@ static void setrawmode(int fd)
 
   raw.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR |
                    ICRNL | IXON);
-  raw.c_oflag &= ~OPOST;
   raw.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
   raw.c_cflag &= ~(CSIZE | PARENB);
   raw.c_cflag |= CS8;


### PR DESCRIPTION
## Summary
to ensure '\n' from host library output correctly(translate to '\r\n')

## Impact
ALSA log change from:
```
[    0.000000] [ 0] NuttX RTOS Initializtion Entry
ALSA lib conf.c:3722:(snd_config_hooks_call) Cannot open shared library libasound_module_conf_pulse.so (/usr/lib/i386-linux-gnu/alsa-lib/libasound_module_conf_pulse.so: libasound_module_conf_pulse.so: cannot open shared object file: No such file or directory)
                                                                                                                                 ALSA lib control.c:1379:(snd_ctl_open_noupdate) Invalid CTL default
                                                                  [    0.000000] [ 0] Starting init thread
[    0.000000] [ 3] nsh: main entry
[    0.000000] [ 3] NuttX  9.1.1 b8a4d9c043-dirty Mar  7 2021 23:10:16 sim sim

```
to:
```
[    0.000000] [ 0] NuttX RTOS Initializtion Entry
ALSA lib conf.c:3722:(snd_config_hooks_call) Cannot open shared library libasound_module_conf_pulse.so (/usr/lib/i386-linux-gnu/alsa-lib/libasound_module_conf_pulse.so: libasound_module_conf_pulse.so: cannot open shared object file: No such file or directory)
ALSA lib control.c:1379:(snd_ctl_open_noupdate) Invalid CTL default
[    0.000000] [ 0] Starting init thread
[    0.000000] [ 3] nsh: main entry
[    0.000000] [ 3] NuttX  9.1.1 b8a4d9c043-dirty Mar  7 2021 23:10:16 sim sim
```

## Testing

