### PR TITLE
xtensa/esp32: Add WPA2 Enterprise and WPA3 support

### DIFF
--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -194,7 +194,7 @@ endif
 
 ifeq ($(CONFIG_ESP32_WIRELESS),y)
 WIRELESS_DRV_UNPACK  = esp-wireless-drivers-3rdparty
-WIRELESS_DRV_ID      = 4a352be
+WIRELESS_DRV_ID      = e766ea3
 WIRELESS_DRV_ZIP     = $(WIRELESS_DRV_ID).zip
 WIRELESS_DRV_URL     = https://github.com/espressif/esp-wireless-drivers-3rdparty/archive
 
@@ -215,9 +215,10 @@ clean_context::
 	$(call DELDIR, chip/$(WIRELESS_DRV_UNPACK))
 
 INCLUDES += $(shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)chip$(DELIM)esp-wireless-drivers-3rdparty$(DELIM)include)
+INCLUDES += $(shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)chip$(DELIM)esp-wireless-drivers-3rdparty$(DELIM)include$(DELIM)esp32)
 CHIP_CSRCS += esp32_wlan.c esp32_wifi_adapter.c
 
-EXTRA_LIBPATHS += -L $(ARCH_SRCDIR)$(DELIM)chip$(DELIM)esp-wireless-drivers-3rdparty$(DELIM)libs
+EXTRA_LIBPATHS += -L $(ARCH_SRCDIR)$(DELIM)chip$(DELIM)esp-wireless-drivers-3rdparty$(DELIM)libs$(DELIM)esp32
 EXTRA_LIBS += -lcore -lrtc -lnet80211 -lpp -lsmartconfig -lcoexist -lespnow -lphy -lwpa_supplicant
 
 # Due to some Wi-Fi related libraries, the option is need to avoid linking too much

--- a/arch/xtensa/src/esp32/esp32_rt_timer.c
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.c
@@ -93,7 +93,7 @@ static struct esp32_tim_dev_s *s_esp32_tim_dev;
  ****************************************************************************/
 
 static void start_rt_timer(FAR struct rt_timer_s *timer,
-                           uint32_t timeout,
+                           uint64_t timeout,
                            bool repeat)
 {
   irqstate_t flags;
@@ -507,7 +507,7 @@ int rt_timer_create(FAR const struct rt_timer_args_s *args,
  ****************************************************************************/
 
 void rt_timer_start(FAR struct rt_timer_s *timer,
-                    uint32_t timeout,
+                    uint64_t timeout,
                     bool repeat)
 {
   stop_rt_timer(timer);

--- a/arch/xtensa/src/esp32/esp32_rt_timer.h
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.h
@@ -52,7 +52,7 @@ enum rt_timer_state_e
 
 struct rt_timer_s
 {
-  uint32_t timeout;             /* Timeout value */
+  uint64_t timeout;             /* Timeout value */
   uint64_t alarm;               /* Timeout period */
   void (*callback)(void *arg);  /* Callback function */
   void *arg;                    /* Private data */
@@ -115,7 +115,7 @@ int rt_timer_create(FAR const struct rt_timer_args_s *args,
  ****************************************************************************/
 
 void rt_timer_start(FAR struct rt_timer_s *timer,
-                    uint32_t timeout,
+                    uint64_t timeout,
                     bool repeat);
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -480,7 +480,7 @@ wifi_osi_funcs_t g_wifi_osi_funcs =
 
 /* WiFi feature capacity data */
 
-uint64_t g_wifi_feature_caps;
+uint64_t g_wifi_feature_caps = CONFIG_FEATURE_WPA3_SAE_BIT;
 
 /* WiFi TAG string data */
 
@@ -4175,8 +4175,6 @@ int32_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
 
-  DEBUGASSERT(timeout_us <= UINT32_MAX);
-
   rt_timer_start(rt_timer, timeout_us, false);
 
   return 0;
@@ -4200,8 +4198,6 @@ int32_t esp_timer_start_once(esp_timer_handle_t timer, uint64_t timeout_us)
 int32_t esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period)
 {
   struct rt_timer_s *rt_timer = (struct rt_timer_s *)timer;
-
-  DEBUGASSERT(period <= UINT32_MAX);
 
   rt_timer_start(rt_timer, period, true);
 
@@ -4709,6 +4705,8 @@ int esp_wifi_connect_internal(void)
   memset(&wifi_cfg, 0, sizeof(wifi_config_t));
   memcpy((char *)wifi_cfg.sta.ssid, g_ssid, g_ssid_len);
   memcpy((char *)wifi_cfg.sta.password, g_password, g_password_len);
+
+  wifi_cfg.sta.pmf_cfg.capable = true;
 
   ret = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_cfg);
   if (ret)


### PR DESCRIPTION
## Summary

Add WPA2 Enterprise and WPA3 support.

## Impact

## Testing

