### PR TITLE
risc-v/esp32-c3: free cpu in case it was preallocated in wdt driver

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.c
@@ -681,6 +681,12 @@ static int32_t esp32c3_wdt_setisr(struct esp32c3_wdt_dev_s *dev,
           /* Disable the provided CPU interrupt to configure it. */
 
           up_disable_irq(wdt->cpuint);
+
+          /* Free CPU interrupt that is attached to this peripheral
+           * because we will get another from esp32c3_request_irq()
+           */
+
+          esp32c3_free_cpuint(wdt->periph);
         }
 
       wdt->cpuint = esp32c3_request_irq(wdt->periph,


### PR DESCRIPTION
## Summary
This PR fixes a minor issue the wdt driver for ESP32-C3.
This PR prevents the driver to allocate another CPU interrupt without freeing the previous allocated one.
It could cause unpredictable behavior or make unused CPU interrupts busy for other peripherals. 

## Impact
All ESP32-C3 users.

## Testing
N/A
