### PR TITLE
BMP180 sensor support to RP2040

### DIFF
--- a/boards/arm/rp2040/common/include/rp2040_bmp180.h
+++ b/boards/arm/rp2040/common/include/rp2040_bmp180.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * boards/arm/rp2040/common/include/rp2040_bmp180.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_BMP180_H
+#define __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_BMP180_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_bmp180_initialize
+ *
+ * Description:
+ *   Initialize and register the BMP180 Pressure Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/pressN
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_bmp180_initialize(int busno);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_BMP180_H */

--- a/boards/arm/rp2040/common/src/Make.defs
+++ b/boards/arm/rp2040/common/src/Make.defs
@@ -34,6 +34,10 @@ ifeq ($(CONFIG_RP2040_SPISD),y)
   CSRCS += rp2040_spisd.c
 endif
 
+ifeq ($(CONFIG_SENSORS_BMP180),y)
+  CSRCS += rp2040_bmp180.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)

--- a/boards/arm/rp2040/common/src/rp2040_bmp180.c
+++ b/boards/arm/rp2040/common/src/rp2040_bmp180.c
@@ -1,0 +1,109 @@
+/****************************************************************************
+ * boards/arm/rp2040/common/src/rp2040_bmp180.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/sensors/bmp180.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#include "rp2040_i2c.h"
+#include "rp2040_bmp180.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_bmp180_initialize
+ *
+ * Description:
+ *   Initialize and register the BMP180 Pressure Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/pressN
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_bmp180_initialize(int busno)
+{
+  struct i2c_master_s *i2c;
+  char devpath[12];
+  int ret;
+  const int devno = 0;
+
+  sninfo("Initializing BMP180!\n");
+
+  /* Initialize BMP180 */
+
+  i2c = rp2040_i2cbus_initialize(busno);
+  if (i2c)
+    {
+      /* Then try to register the barometer sensor in I2C0 */
+
+      snprintf(devpath, 12, "/dev/press%d", devno);
+      ret = bmp180_register(devpath, i2c);
+      if (ret < 0)
+        {
+          snerr("ERROR: Error registering BMP180 in I2C%d\n", busno);
+        }
+    }
+  else
+    {
+      ret = -ENODEV;
+    }
+
+  return ret;
+}
+

--- a/boards/arm/rp2040/raspberrypi-pico/README.txt
+++ b/boards/arm/rp2040/raspberrypi-pico/README.txt
@@ -17,6 +17,7 @@ Currently only the following devices are suppored.
   - SRAM Boot
     - If Pico SDK is available, nuttx.uf2 file which can be used in
       BOOTSEL mode will be created.
+  - BMP180 sensor at I2C0 (don't forget to define I2C0 GPIOs at "I2C0 GPIO pin assign" in Board Selection menu)
 
   Not supported:
   - All other devices

--- a/boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c
+++ b/boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c
@@ -102,5 +102,15 @@ int rp2040_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_SENSORS_BMP180
+  /* Try to register BMP180 device in I2C0 */
+
+  ret = board_bmp180_initialize(0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize BMP180 driver: %d\n", ret);
+    }
+#endif
+
   return ret;
 }


### PR DESCRIPTION
## Summary
This commit adds BMP180 sensor support to RP2040 (at this moment: Raspberry Pi Pico board).
BMP180 sensor should be wired to I2C0 (there's no support for it in I2C1).

## Impact
None, once it only adds BMP180 sensor support in RP2040 boards.

## Testing
Successfully tested in a Raspberry Pi Pico Board, as seen in figure below:

![image](https://user-images.githubusercontent.com/16869652/110515564-e5b6f580-80de-11eb-98e9-97547a07c9b6.png)

