### PR TITLE
syslog: add option to prefix process name

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -142,20 +142,20 @@ config SYSLOG_TIMESTAMP_BUFFER
 	---help---
 		Buffer size to store syslog formatted timestamps.
 
-config SYSLOG_COLOR_OUTPUT
-	bool "Colored syslog output"
-	default n
-	---help---
-		Enables colored output in syslog, according to message priority.
-
 config SYSLOG_PRIORITY
 	bool "Prepend priority to syslog message"
 	default n
 	---help---
 		Prepend log priority (severity) to syslog message.
 
+config SYSLOG_PROCESS_NAME
+  bool "Prepend process name to syslog message"
+	default n
+	---help---
+		Prepend Process name to syslog message.
+
 config SYSLOG_PROCESSID
-	bool "Prepend Process ID to syslog message"
+	bool "Prepend process ID to syslog message"
 	default n
 	---help---
 		Prepend Process ID to syslog message.
@@ -172,6 +172,12 @@ config SYSLOG_PREFIX_STRING
 	default ""
 	---help---
 		The prefix string to be prepend.
+
+config SYSLOG_COLOR_OUTPUT
+	bool "Colored syslog output"
+	default n
+	---help---
+		Enables colored output in syslog, according to message priority.
 
 choice
 	prompt "System log device"


### PR DESCRIPTION
## Summary

Add support for printing process name as a prefix to syslog message, which is more declarative than PID. Output looks like:

```
[    0.000000] [NOTICE] drive_controller: motors disabled
[    0.000000] [ DEBUG] robot: started
[    0.000000] [ DEBUG] drive_controller: started
```

## Impact

Add feature.

## Testing

Custom config.
