### PR TITLE
Add INA219 support.

### DIFF
--- a/boards/arm/rp2040/common/include/rp2040_ina219.h
+++ b/boards/arm/rp2040/common/include/rp2040_ina219.h
@@ -1,0 +1,78 @@
+/****************************************************************************
+ * boards/arm/rp2040/common/include/rp2040_ina219.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_INA219_H
+#define __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_INA219_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_ina219_initialize
+ *
+ * Description:
+ *   Initialize and register the INA219 voltage/current sensor.
+ *
+ * Input parameters:
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_ina219_initialize(int busno);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_INA219_H

--- a/boards/arm/rp2040/common/src/Make.defs
+++ b/boards/arm/rp2040/common/src/Make.defs
@@ -38,6 +38,10 @@ ifeq ($(CONFIG_SENSORS_BMP180),y)
   CSRCS += rp2040_bmp180.c
 endif
 
+ifeq ($(CONFIG_SENSORS_INA219),y)
+  CSRCS += rp2040_ina219.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)

--- a/boards/arm/rp2040/common/src/rp2040_ina219.c
+++ b/boards/arm/rp2040/common/src/rp2040_ina219.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ * boards/arm/rp2040/common/src/rp2040_ina219.c
+ *
+ *   Copyright (C) 2018 Erle Robotics (Juan Flores Muñoz). All rights
+ *     reserved.
+ *   Author: Erle Robotics (Juan Flores Muñoz) <juan@erlerobotics.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <syslog.h>
+#include <debug.h>
+#include <stdio.h>
+
+#include <nuttx/spi/spi.h>
+#include <nuttx/sensors/ina219.h>
+
+#include "rp2040_i2c.h"
+#include "rp2040_ina219.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_ina219_initialize
+ *
+ * Description:
+ *   Initialize and register the INA219 voltage/current sensor.
+ *
+ * Input parameters:
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_ina219_initialize(int busno)
+{
+  FAR struct i2c_master_s *i2c;
+  char devpath[14];
+  int ret;
+  const int devno = 0;
+
+  sninfo("Initializing INA219!\n");
+
+  /* Initialize I2C */
+
+  i2c = rp2040_i2cbus_initialize(busno);
+  if (!i2c)
+    {
+      return -ENODEV;
+    }
+
+  /* Then register the sensor */
+
+  snprintf(devpath, 14, "/dev/voltamp%d", devno);
+  ret = ina219_register(devpath, i2c, 0x40, 100000, 0x00);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Error registering ina219\n");
+    }
+
+  return ret;
+}

--- a/boards/arm/rp2040/raspberrypi-pico/README.txt
+++ b/boards/arm/rp2040/raspberrypi-pico/README.txt
@@ -18,6 +18,7 @@ Currently only the following devices are suppored.
     - If Pico SDK is available, nuttx.uf2 file which can be used in
       BOOTSEL mode will be created.
   - BMP180 sensor at I2C0 (don't forget to define I2C0 GPIOs at "I2C0 GPIO pin assign" in Board Selection menu)
+  - INA219 sensor / module (don't forget to define I2C0 GPIOs at "I2C0 GPIO pin assign" in Board Selection menu)
 
   Not supported:
   - All other devices

--- a/boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c
+++ b/boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c
@@ -112,5 +112,15 @@ int rp2040_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_SENSORS_INA219
+  /* Configure and initialize the INA219 sensor in I2C0 */
+
+  ret = board_ina219_initialize(0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: rp2040_ina219_initialize() failed: %d\n", ret);
+    }
+#endif
+
   return ret;
 }


### PR DESCRIPTION
## Summary

This commit adds INA219 support in boards for RP2040 (Raspberry Pi Pico)

## Impact

None, once it only adds support to INA219.

## Testing

It works fine, as shown in figure below.
**Obs:** INA219 example considers **/dev/ina219** as corresponding INA219 device (see: https://github.com/apache/incubator-nuttx-apps/blob/master/examples/ina219/ina219_main.c#L61). However, it doesn't seem to be in device naming standards. For this reason, this commit registers INA219 as **/dev/voltamp0** device. To make this example work, I had to modify https://github.com/apache/incubator-nuttx-apps/blob/master/examples/ina219/ina219_main.c#L61 to get data from **/dev/voltamp0**

![ina219_working_nuttx](https://user-images.githubusercontent.com/16869652/110719901-0fa61000-81e4-11eb-9795-3ac4f81e1d8c.png)

