### PR TITLE
risc-v/esp32-c3: Adds termios support.

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -175,12 +175,14 @@ config ESP32C3_UART0
 	default y
 	select ESP32C3_UART
 	select UART0_SERIALDRIVER
+	select ARCH_HAVE_SERIAL_TERMIOS
 
 config ESP32C3_UART1
 	bool "UART1"
 	default n
 	select ESP32C3_UART
 	select UART1_SERIALDRIVER
+	select ARCH_HAVE_SERIAL_TERMIOS
 
 config ESP32C3_TIMER0
 	bool "54-bit Timer 0 (Group 0 Timer 0)"

--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
@@ -92,9 +92,9 @@ struct esp32c3_uart_s
   uint8_t   id;             /* UART ID */
   uint8_t   irq;            /* IRQ associated with this UART */
   uint32_t  baud;           /* Configured baud rate */
-  uint8_t   bits;
+  uint8_t   bits;           /* Data length (5 to 8 bits). */
   uint8_t   parity;         /* 0=no parity, 1=odd parity, 2=even parity */
-  uint8_t   stop_b2;        /* Use 2 stop bits? 0 no, others yes */
+  uint8_t   stop_b2;        /* Use 2 stop bits? 0 = no (use 1) 1 = yes (use 2) */
   uint8_t   int_pri;        /* UART Interrupt Priority */
   uint8_t   txpin;          /* TX pin */
   uint8_t   txsig;          /* TX signal */


### PR DESCRIPTION
## Summary
This PR adds the termios support for ESP32-C3 according to NuttX support.

Support status:

Termios Interfaces:

1. `cfgetspeed()` and `cfsetspeed()` are implemented by the OS and relies on `tcsetattr` and on `tcgetattr`.

2. `cfmakeraw()` was implemented by the OS.

3. `tcdrain()` - Associated IOCTLS were implementes in `serial.c`

4. `tcflow()` - Pending
Requires TCXONC ioctl to be implemented with the following actions:

       TCOOFF suspends output.

       TCOON  restarts suspended output.

       TCIOFF transmits a STOP character, which stops the terminal
              device from transmitting data to the system.

       TCION  transmits a START character, which starts the terminal
              device transmitting data to the system.
No chip implements it.

3. `tcflush()` - Associated IOCTLS were implementes in `serial.c`

4. `tcgetattr()` - Associated IOCTLS were implemented in `esp32c3-serial.c`.

5. `tcgetsid()` - Interface declared but never defined in NuttX.

6. `tcsendbreak()` - Interface declared but never defined in NuttX.

7. `tcsetattr()` - Associated IOCTLS were implemented in `esp32c3-serial.c`.

-------------------------------------------------------------------------------------------------------------

DEBUG feature: TIOCSERGSTRUCT IOCTL was implemented.

## Impact

All ESP32-C3 users.

## Testing
The tested was perfomed using the `termios` example. (This example will still be submitted to `/apps`)
![image](https://user-images.githubusercontent.com/33546913/110791041-87118900-8250-11eb-8d2f-f053f6bf8b44.png)
![image](https://user-images.githubusercontent.com/33546913/110789881-2170cd00-824f-11eb-889e-228d78793ff2.png)



