### PR TITLE
arch/stm32: Fix nxstyle errors

### DIFF
--- a/arch/arm/include/stm32/stm32f10xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f10xxx_irq.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32/stm32f10xxx_irq.h
  *
  *   Copyright (C) 2009, 2012, 2018 Gregory Nutt. All rights reserved.
@@ -31,7 +31,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 /* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
@@ -40,28 +40,28 @@
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F10XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F10XXX_IRQ_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found
- * in nuttx/arch/arm/include/stm32/irq.h
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in nuttx/arch/arm/include/stm32/irq.h
  *
  * External interrupts (vectors >= 16)
  */
 
- /* Value line devices */
+/* Value line devices */
 
 #if defined(CONFIG_STM32_VALUELINE)
 #  define STM32_IRQ_WWDG        (16) /* 0:  Window Watchdog interrupt */
@@ -282,13 +282,13 @@
 #  define STM32_IRQ_CAN1RX0     STM32_IRQ_USBLPCANRX0
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Public Types
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Public Data
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -299,9 +299,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/include/stm32/stm32f20xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f20xxx_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32/stm32f20xxx_irq.h
  *
  *   Copyright (C) 2012, 2018 Gregory Nutt. All rights reserved.
@@ -31,135 +31,137 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through nuttx/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F20XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F20XXX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found
- * in nuttx/arch/arm/include/stm32/irq.h
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in nuttx/arch/arm/include/stm32/irq.h
  *
  * External interrupts (vectors >= 16)
  */
 
-#define STM32_IRQ_WWDG        (STM32_IRQ_FIRST+0)  /* 0:  Window Watchdog interrupt */
-#define STM32_IRQ_PVD         (STM32_IRQ_FIRST+1)  /* 1:  PVD through EXTI Line detection interrupt */
-#define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST+2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST+2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST+3)  /* 3:  RTC global interrupt */
-#define STM32_IRQ_FLASH       (STM32_IRQ_FIRST+4)  /* 4:  Flash global interrupt */
-#define STM32_IRQ_RCC         (STM32_IRQ_FIRST+5)  /* 5:  RCC global interrupt */
-#define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST+6)  /* 6:  EXTI Line 0 interrupt */
-#define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST+7)  /* 7:  EXTI Line 1 interrupt */
-#define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST+8)  /* 8:  EXTI Line 2 interrupt */
-#define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST+9)  /* 9:  EXTI Line 3 interrupt */
-#define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST+10) /* 10: EXTI Line 4 interrupt */
-#define STM32_IRQ_DMA1S0      (STM32_IRQ_FIRST+11) /* 11: DMA1 Stream 0 global interrupt */
-#define STM32_IRQ_DMA1S1      (STM32_IRQ_FIRST+12) /* 12: DMA1 Stream 1 global interrupt */
-#define STM32_IRQ_DMA1S2      (STM32_IRQ_FIRST+13) /* 13: DMA1 Stream 2 global interrupt */
-#define STM32_IRQ_DMA1S3      (STM32_IRQ_FIRST+14) /* 14: DMA1 Stream 3 global interrupt */
-#define STM32_IRQ_DMA1S4      (STM32_IRQ_FIRST+15) /* 15: DMA1 Stream 4 global interrupt */
-#define STM32_IRQ_DMA1S5      (STM32_IRQ_FIRST+16) /* 16: DMA1 Stream 5 global interrupt */
-#define STM32_IRQ_DMA1S6      (STM32_IRQ_FIRST+17) /* 17: DMA1 Stream 6 global interrupt */
-#define STM32_IRQ_ADC         (STM32_IRQ_FIRST+18) /* 18: ADC1, ADC2, and ADC3 global interrupt */
-#define STM32_IRQ_CAN1TX      (STM32_IRQ_FIRST+19) /* 19: CAN1 TX interrupts */
-#define STM32_IRQ_CAN1RX0     (STM32_IRQ_FIRST+20) /* 20: CAN1 RX0 interrupts */
-#define STM32_IRQ_CAN1RX1     (STM32_IRQ_FIRST+21) /* 21: CAN1 RX1 interrupt */
-#define STM32_IRQ_CAN1SCE     (STM32_IRQ_FIRST+22) /* 22: CAN1 SCE interrupt */
-#define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST+23) /* 23: EXTI Line[9:5] interrupts */
-#define STM32_IRQ_TIM1BRK     (STM32_IRQ_FIRST+24) /* 24: TIM1 Break interrupt */
-#define STM32_IRQ_TIM9        (STM32_IRQ_FIRST+24) /* 24: TIM9 global interrupt */
-#define STM32_IRQ_TIM1UP      (STM32_IRQ_FIRST+25) /* 25: TIM1 Update interrupt */
-#define STM32_IRQ_TIM10       (STM32_IRQ_FIRST+25) /* 25: TIM10 global interrupt */
-#define STM32_IRQ_TIM1TRGCOM  (STM32_IRQ_FIRST+26) /* 26: TIM1 Trigger and Commutation interrupts */
-#define STM32_IRQ_TIM11       (STM32_IRQ_FIRST+26) /* 26: TIM11 global interrupt */
-#define STM32_IRQ_TIM1CC      (STM32_IRQ_FIRST+27) /* 27: TIM1 Capture Compare interrupt */
-#define STM32_IRQ_TIM2        (STM32_IRQ_FIRST+28) /* 28: TIM2 global interrupt */
-#define STM32_IRQ_TIM3        (STM32_IRQ_FIRST+29) /* 29: TIM3 global interrupt */
-#define STM32_IRQ_TIM4        (STM32_IRQ_FIRST+30) /* 30: TIM4 global interrupt */
-#define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST+31) /* 31: I2C1 event interrupt */
-#define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST+32) /* 32: I2C1 error interrupt */
-#define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST+33) /* 33: I2C2 event interrupt */
-#define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST+34) /* 34: I2C2 error interrupt */
-#define STM32_IRQ_SPI1        (STM32_IRQ_FIRST+35) /* 35: SPI1 global interrupt */
-#define STM32_IRQ_SPI2        (STM32_IRQ_FIRST+36) /* 36: SPI2 global interrupt */
-#define STM32_IRQ_USART1      (STM32_IRQ_FIRST+37) /* 37: USART1 global interrupt */
-#define STM32_IRQ_USART2      (STM32_IRQ_FIRST+38) /* 38: USART2 global interrupt */
-#define STM32_IRQ_USART3      (STM32_IRQ_FIRST+39) /* 39: USART3 global interrupt */
-#define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST+40) /* 40: EXTI Line[15:10] interrupts */
-#define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST+41) /* 41: RTC alarm through EXTI line interrupt */
-#define STM32_IRQ_OTGFSWKUP   (STM32_IRQ_FIRST+42) /* 42: USB On-The-Go FS Wakeup through EXTI line interrupt */
-#define STM32_IRQ_TIM8BRK     (STM32_IRQ_FIRST+43) /* 43: TIM8 Break interrupt */
-#define STM32_IRQ_TIM12       (STM32_IRQ_FIRST+43) /* 43: TIM12 global interrupt */
-#define STM32_IRQ_TIM8UP      (STM32_IRQ_FIRST+44) /* 44: TIM8 Update interrupt */
-#define STM32_IRQ_TIM13       (STM32_IRQ_FIRST+44) /* 44: TIM13 global interrupt */
-#define STM32_IRQ_TIM8TRGCOM  (STM32_IRQ_FIRST+45) /* 45: TIM8 Trigger and Commutation interrupts */
-#define STM32_IRQ_TIM14       (STM32_IRQ_FIRST+45) /* 45: TIM14 global interrupt */
-#define STM32_IRQ_TIM8CC      (STM32_IRQ_FIRST+46) /* 46: TIM8 Capture Compare interrupt */
-#define STM32_IRQ_DMA1S7      (STM32_IRQ_FIRST+47) /* 47: DMA1 Stream 7 global interrupt */
-#define STM32_IRQ_FSMC        (STM32_IRQ_FIRST+48) /* 48: FSMC global interrupt */
-#define STM32_IRQ_SDIO        (STM32_IRQ_FIRST+49) /* 49: SDIO global interrupt */
-#define STM32_IRQ_TIM5        (STM32_IRQ_FIRST+50) /* 50: TIM5 global interrupt */
-#define STM32_IRQ_SPI3        (STM32_IRQ_FIRST+51) /* 51: SPI3 global interrupt */
-#define STM32_IRQ_UART4       (STM32_IRQ_FIRST+52) /* 52: UART4 global interrupt */
-#define STM32_IRQ_UART5       (STM32_IRQ_FIRST+53) /* 53: UART5 global interrupt */
-#define STM32_IRQ_TIM6        (STM32_IRQ_FIRST+54) /* 54: TIM6 global interrupt */
-#define STM32_IRQ_DAC         (STM32_IRQ_FIRST+54) /* 54: DAC1 and DAC2 underrun error interrupts */
-#define STM32_IRQ_TIM7        (STM32_IRQ_FIRST+55) /* 55: TIM7 global interrupt */
-#define STM32_IRQ_DMA2S0      (STM32_IRQ_FIRST+56) /* 56: DMA2 Stream 0 global interrupt */
-#define STM32_IRQ_DMA2S1      (STM32_IRQ_FIRST+57) /* 57: DMA2 Stream 1 global interrupt */
-#define STM32_IRQ_DMA2S2      (STM32_IRQ_FIRST+58) /* 58: DMA2 Stream 2 global interrupt */
-#define STM32_IRQ_DMA2S3      (STM32_IRQ_FIRST+59) /* 59: DMA2 Stream 3 global interrupt */
-#define STM32_IRQ_DMA2S4      (STM32_IRQ_FIRST+60) /* 60: DMA2 Stream 4 global interrupt */
-#define STM32_IRQ_ETH         (STM32_IRQ_FIRST+61) /* 61: Ethernet global interrupt */
-#define STM32_IRQ_ETHWKUP     (STM32_IRQ_FIRST+62) /* 62: Ethernet Wakeup through EXTI line interrupt */
-#define STM32_IRQ_CAN2TX      (STM32_IRQ_FIRST+63) /* 63: CAN2 TX interrupts */
-#define STM32_IRQ_CAN2RX0     (STM32_IRQ_FIRST+64) /* 64: CAN2 RX0 interrupts */
-#define STM32_IRQ_CAN2RX1     (STM32_IRQ_FIRST+65) /* 65: CAN2 RX1 interrupt */
-#define STM32_IRQ_CAN2SCE     (STM32_IRQ_FIRST+66) /* 66: CAN2 SCE interrupt */
-#define STM32_IRQ_OTGFS       (STM32_IRQ_FIRST+67) /* 67: USB On The Go FS global interrupt */
-#define STM32_IRQ_DMA2S5      (STM32_IRQ_FIRST+68) /* 68: DMA2 Stream 5 global interrupt */
-#define STM32_IRQ_DMA2S6      (STM32_IRQ_FIRST+69) /* 69: DMA2 Stream 6 global interrupt */
-#define STM32_IRQ_DMA2S7      (STM32_IRQ_FIRST+70) /* 70: DMA2 Stream 7 global interrupt */
-#define STM32_IRQ_USART6      (STM32_IRQ_FIRST+71) /* 71: USART6 global interrupt */
-#define STM32_IRQ_I2C3EV      (STM32_IRQ_FIRST+72) /* 72: I2C3 event interrupt */
-#define STM32_IRQ_I2C3ER      (STM32_IRQ_FIRST+73) /* 73: I2C3 error interrupt */
-#define STM32_IRQ_OTGHSEP1OUT (STM32_IRQ_FIRST+74) /* 74: USB On The Go HS End Point 1 Out global interrupt */
-#define STM32_IRQ_OTGHSEP1IN  (STM32_IRQ_FIRST+75) /* 75: USB On The Go HS End Point 1 In global interrupt */
-#define STM32_IRQ_OTGHSWKUP   (STM32_IRQ_FIRST+76) /* 76: USB On The Go HS Wakeup through EXTI interrupt */
-#define STM32_IRQ_OTGHS       (STM32_IRQ_FIRST+77) /* 77: USB On The Go HS global interrupt */
-#define STM32_IRQ_DCMI        (STM32_IRQ_FIRST+78) /* 78: DCMI global interrupt */
-#define STM32_IRQ_CRYP        (STM32_IRQ_FIRST+79) /* 79: CRYP crypto global interrupt */
-#define STM32_IRQ_HASH        (STM32_IRQ_FIRST+80) /* 80: Hash and Rng global interrupt */
-#define STM32_IRQ_RNG         (STM32_IRQ_FIRST+80) /* 80: Hash and Rng global interrupt */
+#define STM32_IRQ_WWDG        (STM32_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
+#define STM32_IRQ_PVD         (STM32_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
+#define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
+#define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
+#define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST + 3)  /* 3:  RTC global interrupt */
+#define STM32_IRQ_FLASH       (STM32_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
+#define STM32_IRQ_RCC         (STM32_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
+#define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
+#define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
+#define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt */
+#define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
+#define STM32_IRQ_DMA1S0      (STM32_IRQ_FIRST + 11) /* 11: DMA1 Stream 0 global interrupt */
+#define STM32_IRQ_DMA1S1      (STM32_IRQ_FIRST + 12) /* 12: DMA1 Stream 1 global interrupt */
+#define STM32_IRQ_DMA1S2      (STM32_IRQ_FIRST + 13) /* 13: DMA1 Stream 2 global interrupt */
+#define STM32_IRQ_DMA1S3      (STM32_IRQ_FIRST + 14) /* 14: DMA1 Stream 3 global interrupt */
+#define STM32_IRQ_DMA1S4      (STM32_IRQ_FIRST + 15) /* 15: DMA1 Stream 4 global interrupt */
+#define STM32_IRQ_DMA1S5      (STM32_IRQ_FIRST + 16) /* 16: DMA1 Stream 5 global interrupt */
+#define STM32_IRQ_DMA1S6      (STM32_IRQ_FIRST + 17) /* 17: DMA1 Stream 6 global interrupt */
+#define STM32_IRQ_ADC         (STM32_IRQ_FIRST + 18) /* 18: ADC1, ADC2, and ADC3 global interrupt */
+#define STM32_IRQ_CAN1TX      (STM32_IRQ_FIRST + 19) /* 19: CAN1 TX interrupts */
+#define STM32_IRQ_CAN1RX0     (STM32_IRQ_FIRST + 20) /* 20: CAN1 RX0 interrupts */
+#define STM32_IRQ_CAN1RX1     (STM32_IRQ_FIRST + 21) /* 21: CAN1 RX1 interrupt */
+#define STM32_IRQ_CAN1SCE     (STM32_IRQ_FIRST + 22) /* 22: CAN1 SCE interrupt */
+#define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST + 23) /* 23: EXTI Line[9:5] interrupts */
+#define STM32_IRQ_TIM1BRK     (STM32_IRQ_FIRST + 24) /* 24: TIM1 Break interrupt */
+#define STM32_IRQ_TIM9        (STM32_IRQ_FIRST + 24) /* 24: TIM9 global interrupt */
+#define STM32_IRQ_TIM1UP      (STM32_IRQ_FIRST + 25) /* 25: TIM1 Update interrupt */
+#define STM32_IRQ_TIM10       (STM32_IRQ_FIRST + 25) /* 25: TIM10 global interrupt */
+#define STM32_IRQ_TIM1TRGCOM  (STM32_IRQ_FIRST + 26) /* 26: TIM1 Trigger and Commutation interrupts */
+#define STM32_IRQ_TIM11       (STM32_IRQ_FIRST + 26) /* 26: TIM11 global interrupt */
+#define STM32_IRQ_TIM1CC      (STM32_IRQ_FIRST + 27) /* 27: TIM1 Capture Compare interrupt */
+#define STM32_IRQ_TIM2        (STM32_IRQ_FIRST + 28) /* 28: TIM2 global interrupt */
+#define STM32_IRQ_TIM3        (STM32_IRQ_FIRST + 29) /* 29: TIM3 global interrupt */
+#define STM32_IRQ_TIM4        (STM32_IRQ_FIRST + 30) /* 30: TIM4 global interrupt */
+#define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST + 31) /* 31: I2C1 event interrupt */
+#define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST + 32) /* 32: I2C1 error interrupt */
+#define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST + 33) /* 33: I2C2 event interrupt */
+#define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST + 34) /* 34: I2C2 error interrupt */
+#define STM32_IRQ_SPI1        (STM32_IRQ_FIRST + 35) /* 35: SPI1 global interrupt */
+#define STM32_IRQ_SPI2        (STM32_IRQ_FIRST + 36) /* 36: SPI2 global interrupt */
+#define STM32_IRQ_USART1      (STM32_IRQ_FIRST + 37) /* 37: USART1 global interrupt */
+#define STM32_IRQ_USART2      (STM32_IRQ_FIRST + 38) /* 38: USART2 global interrupt */
+#define STM32_IRQ_USART3      (STM32_IRQ_FIRST + 39) /* 39: USART3 global interrupt */
+#define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST + 40) /* 40: EXTI Line[15:10] interrupts */
+#define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST + 41) /* 41: RTC alarm through EXTI line interrupt */
+#define STM32_IRQ_OTGFSWKUP   (STM32_IRQ_FIRST + 42) /* 42: USB On-The-Go FS Wakeup through EXTI line interrupt */
+#define STM32_IRQ_TIM8BRK     (STM32_IRQ_FIRST + 43) /* 43: TIM8 Break interrupt */
+#define STM32_IRQ_TIM12       (STM32_IRQ_FIRST + 43) /* 43: TIM12 global interrupt */
+#define STM32_IRQ_TIM8UP      (STM32_IRQ_FIRST + 44) /* 44: TIM8 Update interrupt */
+#define STM32_IRQ_TIM13       (STM32_IRQ_FIRST + 44) /* 44: TIM13 global interrupt */
+#define STM32_IRQ_TIM8TRGCOM  (STM32_IRQ_FIRST + 45) /* 45: TIM8 Trigger and Commutation interrupts */
+#define STM32_IRQ_TIM14       (STM32_IRQ_FIRST + 45) /* 45: TIM14 global interrupt */
+#define STM32_IRQ_TIM8CC      (STM32_IRQ_FIRST + 46) /* 46: TIM8 Capture Compare interrupt */
+#define STM32_IRQ_DMA1S7      (STM32_IRQ_FIRST + 47) /* 47: DMA1 Stream 7 global interrupt */
+#define STM32_IRQ_FSMC        (STM32_IRQ_FIRST + 48) /* 48: FSMC global interrupt */
+#define STM32_IRQ_SDIO        (STM32_IRQ_FIRST + 49) /* 49: SDIO global interrupt */
+#define STM32_IRQ_TIM5        (STM32_IRQ_FIRST + 50) /* 50: TIM5 global interrupt */
+#define STM32_IRQ_SPI3        (STM32_IRQ_FIRST + 51) /* 51: SPI3 global interrupt */
+#define STM32_IRQ_UART4       (STM32_IRQ_FIRST + 52) /* 52: UART4 global interrupt */
+#define STM32_IRQ_UART5       (STM32_IRQ_FIRST + 53) /* 53: UART5 global interrupt */
+#define STM32_IRQ_TIM6        (STM32_IRQ_FIRST + 54) /* 54: TIM6 global interrupt */
+#define STM32_IRQ_DAC         (STM32_IRQ_FIRST + 54) /* 54: DAC1 and DAC2 underrun error interrupts */
+#define STM32_IRQ_TIM7        (STM32_IRQ_FIRST + 55) /* 55: TIM7 global interrupt */
+#define STM32_IRQ_DMA2S0      (STM32_IRQ_FIRST + 56) /* 56: DMA2 Stream 0 global interrupt */
+#define STM32_IRQ_DMA2S1      (STM32_IRQ_FIRST + 57) /* 57: DMA2 Stream 1 global interrupt */
+#define STM32_IRQ_DMA2S2      (STM32_IRQ_FIRST + 58) /* 58: DMA2 Stream 2 global interrupt */
+#define STM32_IRQ_DMA2S3      (STM32_IRQ_FIRST + 59) /* 59: DMA2 Stream 3 global interrupt */
+#define STM32_IRQ_DMA2S4      (STM32_IRQ_FIRST + 60) /* 60: DMA2 Stream 4 global interrupt */
+#define STM32_IRQ_ETH         (STM32_IRQ_FIRST + 61) /* 61: Ethernet global interrupt */
+#define STM32_IRQ_ETHWKUP     (STM32_IRQ_FIRST + 62) /* 62: Ethernet Wakeup through EXTI line interrupt */
+#define STM32_IRQ_CAN2TX      (STM32_IRQ_FIRST + 63) /* 63: CAN2 TX interrupts */
+#define STM32_IRQ_CAN2RX0     (STM32_IRQ_FIRST + 64) /* 64: CAN2 RX0 interrupts */
+#define STM32_IRQ_CAN2RX1     (STM32_IRQ_FIRST + 65) /* 65: CAN2 RX1 interrupt */
+#define STM32_IRQ_CAN2SCE     (STM32_IRQ_FIRST + 66) /* 66: CAN2 SCE interrupt */
+#define STM32_IRQ_OTGFS       (STM32_IRQ_FIRST + 67) /* 67: USB On The Go FS global interrupt */
+#define STM32_IRQ_DMA2S5      (STM32_IRQ_FIRST + 68) /* 68: DMA2 Stream 5 global interrupt */
+#define STM32_IRQ_DMA2S6      (STM32_IRQ_FIRST + 69) /* 69: DMA2 Stream 6 global interrupt */
+#define STM32_IRQ_DMA2S7      (STM32_IRQ_FIRST + 70) /* 70: DMA2 Stream 7 global interrupt */
+#define STM32_IRQ_USART6      (STM32_IRQ_FIRST + 71) /* 71: USART6 global interrupt */
+#define STM32_IRQ_I2C3EV      (STM32_IRQ_FIRST + 72) /* 72: I2C3 event interrupt */
+#define STM32_IRQ_I2C3ER      (STM32_IRQ_FIRST + 73) /* 73: I2C3 error interrupt */
+#define STM32_IRQ_OTGHSEP1OUT (STM32_IRQ_FIRST + 74) /* 74: USB On The Go HS End Point 1 Out global interrupt */
+#define STM32_IRQ_OTGHSEP1IN  (STM32_IRQ_FIRST + 75) /* 75: USB On The Go HS End Point 1 In global interrupt */
+#define STM32_IRQ_OTGHSWKUP   (STM32_IRQ_FIRST + 76) /* 76: USB On The Go HS Wakeup through EXTI interrupt */
+#define STM32_IRQ_OTGHS       (STM32_IRQ_FIRST + 77) /* 77: USB On The Go HS global interrupt */
+#define STM32_IRQ_DCMI        (STM32_IRQ_FIRST + 78) /* 78: DCMI global interrupt */
+#define STM32_IRQ_CRYP        (STM32_IRQ_FIRST + 79) /* 79: CRYP crypto global interrupt */
+#define STM32_IRQ_HASH        (STM32_IRQ_FIRST + 80) /* 80: Hash and Rng global interrupt */
+#define STM32_IRQ_RNG         (STM32_IRQ_FIRST + 80) /* 80: Hash and Rng global interrupt */
 
 #define STM32_IRQ_NEXTINT     (81)
-#define NR_IRQS               (STM32_IRQ_FIRST+81)
+#define NR_IRQS               (STM32_IRQ_FIRST + 81)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
-****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -170,9 +172,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/include/stm32/stm32f30xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f30xxx_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32/stm32f30xxx_irq.h
  *
  *   Copyright (C) 2012, 2018 Gregory Nutt. All rights reserved.
@@ -31,146 +31,148 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through nuttx/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F30XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F30XXX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found
- * in nuttx/arch/arm/include/stm32/irq.h
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in nuttx/arch/arm/include/stm32/irq.h
  *
  * External interrupts (vectors >= 16)
  */
 
-#define STM32_IRQ_WWDG        (STM32_IRQ_FIRST+0)  /* 0:  Window Watchdog interrupt */
-#define STM32_IRQ_PVD         (STM32_IRQ_FIRST+1)  /* 1:  PVD through EXTI Line detection interrupt */
-#define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST+2)  /* 2:  Tamper interrupt, or */
-#define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST+2)  /* 2:  Time stamp interrupt */
-#define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST+3)  /* 3:  RTC global interrupt */
-#define STM32_IRQ_FLASH       (STM32_IRQ_FIRST+4)  /* 4:  Flash global interrupt */
-#define STM32_IRQ_RCC         (STM32_IRQ_FIRST+5)  /* 5:  RCC global interrupt */
-#define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST+6)  /* 6:  EXTI Line 0 interrupt */
-#define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST+7)  /* 7:  EXTI Line 1 interrupt */
-#define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST+8)  /* 8:  EXTI Line 2 interrupt, or */
-#define STM32_IRQ_TSC         (STM32_IRQ_FIRST+8)  /* 8:  TSC interrupt */
-#define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST+9)  /* 9:  EXTI Line 3 interrupt */
-#define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST+10) /* 10: EXTI Line 4 interrupt */
-#define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST+11) /* 11: DMA1 channel 1 global interrupt */
-#define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST+12) /* 12: DMA1 channel 2 global interrupt */
-#define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST+13) /* 13: DMA1 channel 3 global interrupt */
-#define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST+14) /* 14: DMA1 channel 4 global interrupt */
-#define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST+15) /* 15: DMA1 channel 5 global interrupt */
-#define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST+16) /* 16: DMA1 channel 6 global interrupt */
-#define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST+17) /* 17: DMA1 channel 7 global interrupt */
-#define STM32_IRQ_ADC12       (STM32_IRQ_FIRST+18) /* 18: ADC1/ADC2 global interrupt */
-#define STM32_IRQ_USBHP_1     (STM32_IRQ_FIRST+19) /* 19: USB High Priority interrupts (not remapped) */
-#define STM32_IRQ_CAN1TX      (STM32_IRQ_FIRST+19) /* 19: CAN1 TX interrupts */
-#define STM32_IRQ_USBLP_1     (STM32_IRQ_FIRST+20) /* 20: USB Low Priority interrupt (not remapped) */
-#define STM32_IRQ_CAN1RX0     (STM32_IRQ_FIRST+20) /* 20: CAN1 RX0 interrupts*/
-#define STM32_IRQ_CAN1RX1     (STM32_IRQ_FIRST+21) /* 21: CAN1 RX1 interrupt */
-#define STM32_IRQ_CAN1SCE     (STM32_IRQ_FIRST+22) /* 22: CAN1 SCE interrupt */
-#define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST+23) /* 23: EXTI Line[9:5] interrupts */
-#define STM32_IRQ_TIM1BRK     (STM32_IRQ_FIRST+24) /* 24: TIM1 Break interrupt, or */
-#define STM32_IRQ_TIM15       (STM32_IRQ_FIRST+24) /* 24: TIM15 global interrupt */
-#define STM32_IRQ_TIM1UP      (STM32_IRQ_FIRST+25) /* 25: TIM1 Update interrupt, or */
-#define STM32_IRQ_TIM16       (STM32_IRQ_FIRST+25) /* 25: TIM16 global interrupt */
-#define STM32_IRQ_TIM1TRGCOM  (STM32_IRQ_FIRST+26) /* 26: TIM1 Trigger and Commutation interrupts, or */
-#define STM32_IRQ_TIM17       (STM32_IRQ_FIRST+26) /* 26: TIM17 global interrupt */
-#define STM32_IRQ_TIM1CC      (STM32_IRQ_FIRST+27) /* 27: TIM1 Capture Compare interrupt */
-#define STM32_IRQ_TIM2        (STM32_IRQ_FIRST+28) /* 28: TIM2 global interrupt */
-#define STM32_IRQ_TIM3        (STM32_IRQ_FIRST+29) /* 29: TIM3 global interrupt */
-#define STM32_IRQ_TIM4        (STM32_IRQ_FIRST+30) /* 30: TIM4 global interrupt */
-#define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST+31) /* 31: I2C1 event interrupt, or */
-#define STM32_IRQ_EXTI23      (STM32_IRQ_FIRST+31) /* 31: EXTI Line23 interrupt */
-#define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST+32) /* 32: I2C1 error interrupt */
-#define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST+33) /* 33: I2C2 event interrupt, or */
-#define STM32_IRQ_EXTI24      (STM32_IRQ_FIRST+33) /* 33: EXTI Line24 interrupt */
-#define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST+34) /* 34: I2C2 error interrupt */
-#define STM32_IRQ_SPI1        (STM32_IRQ_FIRST+35) /* 35: SPI1 global interrupt */
-#define STM32_IRQ_SPI2        (STM32_IRQ_FIRST+36) /* 36: SPI2 global interrupt */
-#define STM32_IRQ_USART1      (STM32_IRQ_FIRST+37) /* 37: USART1 global interrupt, or */
-#define STM32_IRQ_EXTI25      (STM32_IRQ_FIRST+37) /* 37: EXTI Line 25 interrupt */
-#define STM32_IRQ_USART2      (STM32_IRQ_FIRST+38) /* 38: USART2 global interrupt, or */
-#define STM32_IRQ_EXTI26      (STM32_IRQ_FIRST+38) /* 38: EXTI Line 26 interrupt */
-#define STM32_IRQ_USART3      (STM32_IRQ_FIRST+39) /* 39: USART3 global interrupt, or */
-#define STM32_IRQ_EXTI28      (STM32_IRQ_FIRST+39) /* 39: EXTI Line 28 interrupt */
-#define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST+40) /* 40: EXTI Line[15:10] interrupts */
-#define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST+41) /* 41: RTC alarm through EXTI line interrupt */
-#define STM32_IRQ_USBWKUP_1   (STM32_IRQ_FIRST+42) /* 42: USB wakeup from suspend through EXTI line interrupt */
-#define STM32_IRQ_EXT18       (STM32_IRQ_FIRST+42) /* 42: EXTI Line 18 interrupt */
-#define STM32_IRQ_TIM8BRK     (STM32_IRQ_FIRST+43) /* 43: TIM8 Break interrupt */
-#define STM32_IRQ_TIM8UP      (STM32_IRQ_FIRST+44) /* 44: TIM8 Update interrupt */
-#define STM32_IRQ_TIM8TRGCOM  (STM32_IRQ_FIRST+45) /* 45: TIM8 Trigger and Commutation interrupts */
-#define STM32_IRQ_TIM8CC      (STM32_IRQ_FIRST+46) /* 46: TIM8 Capture Compare interrupt */
-#define STM32_IRQ_ADC3        (STM32_IRQ_FIRST+47) /* 47: ADC3 global interrupt */
-#define STM32_IRQ_RESERVED48  (STM32_IRQ_FIRST+48) /* 48: Reserved */
-#define STM32_IRQ_RESERVED49  (STM32_IRQ_FIRST+49) /* 49: Reserved */
-#define STM32_IRQ_RESERVED50  (STM32_IRQ_FIRST+50) /* 50: Reserved */
-#define STM32_IRQ_SPI3        (STM32_IRQ_FIRST+51) /* 51: SPI3 global interrupt */
-#define STM32_IRQ_UART4       (STM32_IRQ_FIRST+52) /* 52: UART4 global interrupt, or */
-#define STM32_IRQ_EXTI34      (STM32_IRQ_FIRST+52) /* 52: EXTI Line 34 interrupt */
-#define STM32_IRQ_UART5       (STM32_IRQ_FIRST+53) /* 53: UART5 global interrupt, or */
-#define STM32_IRQ_EXTI35      (STM32_IRQ_FIRST+53) /* 53: EXTI Line 35 interrupt */
-#define STM32_IRQ_TIM6        (STM32_IRQ_FIRST+54) /* 54: TIM6 global interrupt, or */
-#define STM32_IRQ_DAC         (STM32_IRQ_FIRST+54) /* 54: DAC1 and DAC2 underrun error interrupts */
-#define STM32_IRQ_TIM7        (STM32_IRQ_FIRST+55) /* 55: TIM7 global interrupt */
-#define STM32_IRQ_DMA2CH1     (STM32_IRQ_FIRST+56) /* 56: DMA2 channel 1 global interrupt */
-#define STM32_IRQ_DMA2CH2     (STM32_IRQ_FIRST+57) /* 57: DMA2 channel 2 global interrupt */
-#define STM32_IRQ_DMA2CH3     (STM32_IRQ_FIRST+58) /* 58: DMA2 channel 3 global interrupt */
-#define STM32_IRQ_DMA2CH4     (STM32_IRQ_FIRST+59) /* 59: DMA2 channel 4 global interrupt */
-#define STM32_IRQ_DMA2CH5     (STM32_IRQ_FIRST+60) /* 60: DMA2 channel 5 global interrupt */
-#define STM32_IRQ_ADC4        (STM32_IRQ_FIRST+61) /* 61: ADC4 global interrupt */
-#define STM32_IRQ_RESERVED62  (STM32_IRQ_FIRST+62) /* 62: Reserved */
-#define STM32_IRQ_RESERVED63  (STM32_IRQ_FIRST+63) /* 63: Reserved */
-#define STM32_IRQ_COMP123     (STM32_IRQ_FIRST+64) /* 64: COMP1 & COMP2 & COMP3 interrupts, or */
-#define STM32_IRQ_EXTI2129    (STM32_IRQ_FIRST+64) /* 64: EXTI Lines 21, 22 and 29 interrupts */
-#define STM32_IRQ_COMP456     (STM32_IRQ_FIRST+65) /* 65: COMP4 & COMP5 & COMP6 interrupts, or */
-#define STM32_IRQ_EXTI3012    (STM32_IRQ_FIRST+65) /* 65: EXTI Lines 30, 31 and 32 interrupts */
-#define STM32_IRQ_COMP7       (STM32_IRQ_FIRST+66) /* 66: COMP7 interrupt, or */
-#define STM32_IRQ_EXTI33      (STM32_IRQ_FIRST+66) /* 66: EXTI Line 33 interrupt */
-#define STM32_IRQ_RESERVED67  (STM32_IRQ_FIRST+67) /* 67: Reserved */
-#define STM32_IRQ_RESERVED68  (STM32_IRQ_FIRST+68) /* 68: Reserved */
-#define STM32_IRQ_RESERVED69  (STM32_IRQ_FIRST+69) /* 69: Reserved */
-#define STM32_IRQ_RESERVED70  (STM32_IRQ_FIRST+70) /* 70: Reserved */
-#define STM32_IRQ_RESERVED71  (STM32_IRQ_FIRST+71) /* 71: Reserved */
-#define STM32_IRQ_RESERVED72  (STM32_IRQ_FIRST+72) /* 72: Reserved */
-#define STM32_IRQ_RESERVED73  (STM32_IRQ_FIRST+73) /* 73: Reserved */
-#define STM32_IRQ_USBHP_2     (STM32_IRQ_FIRST+74) /* 74: USB High priority interrupt (remapped) */
-#define STM32_IRQ_USBLP_2     (STM32_IRQ_FIRST+75) /* 75: USB Low priority interrupt remapped) */
-#define STM32_IRQ_USBWKUP_2   (STM32_IRQ_FIRST+76) /* 76: USB wakeup from suspend remapped) */
-#define STM32_IRQ_RESERVED77  (STM32_IRQ_FIRST+77) /* 77: Reserved */
-#define STM32_IRQ_RESERVED78  (STM32_IRQ_FIRST+78) /* 78: Reserved */
-#define STM32_IRQ_RESERVED79  (STM32_IRQ_FIRST+79) /* 79: Reserved */
-#define STM32_IRQ_RESERVED80  (STM32_IRQ_FIRST+80) /* 80: Reserved */
-#define STM32_IRQ_FPU         (STM32_IRQ_FIRST+81) /* 81: FPU global interrupt */
+#define STM32_IRQ_WWDG        (STM32_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
+#define STM32_IRQ_PVD         (STM32_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
+#define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST + 2)  /* 2:  Tamper interrupt, or */
+#define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST + 2)  /* 2:  Time stamp interrupt */
+#define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST + 3)  /* 3:  RTC global interrupt */
+#define STM32_IRQ_FLASH       (STM32_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
+#define STM32_IRQ_RCC         (STM32_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
+#define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
+#define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
+#define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt, or */
+#define STM32_IRQ_TSC         (STM32_IRQ_FIRST + 8)  /* 8:  TSC interrupt */
+#define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
+#define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST + 11) /* 11: DMA1 channel 1 global interrupt */
+#define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST + 12) /* 12: DMA1 channel 2 global interrupt */
+#define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST + 13) /* 13: DMA1 channel 3 global interrupt */
+#define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST + 14) /* 14: DMA1 channel 4 global interrupt */
+#define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST + 15) /* 15: DMA1 channel 5 global interrupt */
+#define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST + 16) /* 16: DMA1 channel 6 global interrupt */
+#define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST + 17) /* 17: DMA1 channel 7 global interrupt */
+#define STM32_IRQ_ADC12       (STM32_IRQ_FIRST + 18) /* 18: ADC1/ADC2 global interrupt */
+#define STM32_IRQ_USBHP_1     (STM32_IRQ_FIRST + 19) /* 19: USB High Priority interrupts (not remapped) */
+#define STM32_IRQ_CAN1TX      (STM32_IRQ_FIRST + 19) /* 19: CAN1 TX interrupts */
+#define STM32_IRQ_USBLP_1     (STM32_IRQ_FIRST + 20) /* 20: USB Low Priority interrupt (not remapped) */
+#define STM32_IRQ_CAN1RX0     (STM32_IRQ_FIRST + 20) /* 20: CAN1 RX0 interrupts*/
+#define STM32_IRQ_CAN1RX1     (STM32_IRQ_FIRST + 21) /* 21: CAN1 RX1 interrupt */
+#define STM32_IRQ_CAN1SCE     (STM32_IRQ_FIRST + 22) /* 22: CAN1 SCE interrupt */
+#define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST + 23) /* 23: EXTI Line[9:5] interrupts */
+#define STM32_IRQ_TIM1BRK     (STM32_IRQ_FIRST + 24) /* 24: TIM1 Break interrupt, or */
+#define STM32_IRQ_TIM15       (STM32_IRQ_FIRST + 24) /* 24: TIM15 global interrupt */
+#define STM32_IRQ_TIM1UP      (STM32_IRQ_FIRST + 25) /* 25: TIM1 Update interrupt, or */
+#define STM32_IRQ_TIM16       (STM32_IRQ_FIRST + 25) /* 25: TIM16 global interrupt */
+#define STM32_IRQ_TIM1TRGCOM  (STM32_IRQ_FIRST + 26) /* 26: TIM1 Trigger and Commutation interrupts, or */
+#define STM32_IRQ_TIM17       (STM32_IRQ_FIRST + 26) /* 26: TIM17 global interrupt */
+#define STM32_IRQ_TIM1CC      (STM32_IRQ_FIRST + 27) /* 27: TIM1 Capture Compare interrupt */
+#define STM32_IRQ_TIM2        (STM32_IRQ_FIRST + 28) /* 28: TIM2 global interrupt */
+#define STM32_IRQ_TIM3        (STM32_IRQ_FIRST + 29) /* 29: TIM3 global interrupt */
+#define STM32_IRQ_TIM4        (STM32_IRQ_FIRST + 30) /* 30: TIM4 global interrupt */
+#define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST + 31) /* 31: I2C1 event interrupt, or */
+#define STM32_IRQ_EXTI23      (STM32_IRQ_FIRST + 31) /* 31: EXTI Line23 interrupt */
+#define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST + 32) /* 32: I2C1 error interrupt */
+#define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST + 33) /* 33: I2C2 event interrupt, or */
+#define STM32_IRQ_EXTI24      (STM32_IRQ_FIRST + 33) /* 33: EXTI Line24 interrupt */
+#define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST + 34) /* 34: I2C2 error interrupt */
+#define STM32_IRQ_SPI1        (STM32_IRQ_FIRST + 35) /* 35: SPI1 global interrupt */
+#define STM32_IRQ_SPI2        (STM32_IRQ_FIRST + 36) /* 36: SPI2 global interrupt */
+#define STM32_IRQ_USART1      (STM32_IRQ_FIRST + 37) /* 37: USART1 global interrupt, or */
+#define STM32_IRQ_EXTI25      (STM32_IRQ_FIRST + 37) /* 37: EXTI Line 25 interrupt */
+#define STM32_IRQ_USART2      (STM32_IRQ_FIRST + 38) /* 38: USART2 global interrupt, or */
+#define STM32_IRQ_EXTI26      (STM32_IRQ_FIRST + 38) /* 38: EXTI Line 26 interrupt */
+#define STM32_IRQ_USART3      (STM32_IRQ_FIRST + 39) /* 39: USART3 global interrupt, or */
+#define STM32_IRQ_EXTI28      (STM32_IRQ_FIRST + 39) /* 39: EXTI Line 28 interrupt */
+#define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST + 40) /* 40: EXTI Line[15:10] interrupts */
+#define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST + 41) /* 41: RTC alarm through EXTI line interrupt */
+#define STM32_IRQ_USBWKUP_1   (STM32_IRQ_FIRST + 42) /* 42: USB wakeup from suspend through EXTI line interrupt */
+#define STM32_IRQ_EXT18       (STM32_IRQ_FIRST + 42) /* 42: EXTI Line 18 interrupt */
+#define STM32_IRQ_TIM8BRK     (STM32_IRQ_FIRST + 43) /* 43: TIM8 Break interrupt */
+#define STM32_IRQ_TIM8UP      (STM32_IRQ_FIRST + 44) /* 44: TIM8 Update interrupt */
+#define STM32_IRQ_TIM8TRGCOM  (STM32_IRQ_FIRST + 45) /* 45: TIM8 Trigger and Commutation interrupts */
+#define STM32_IRQ_TIM8CC      (STM32_IRQ_FIRST + 46) /* 46: TIM8 Capture Compare interrupt */
+#define STM32_IRQ_ADC3        (STM32_IRQ_FIRST + 47) /* 47: ADC3 global interrupt */
+#define STM32_IRQ_RESERVED48  (STM32_IRQ_FIRST + 48) /* 48: Reserved */
+#define STM32_IRQ_RESERVED49  (STM32_IRQ_FIRST + 49) /* 49: Reserved */
+#define STM32_IRQ_RESERVED50  (STM32_IRQ_FIRST + 50) /* 50: Reserved */
+#define STM32_IRQ_SPI3        (STM32_IRQ_FIRST + 51) /* 51: SPI3 global interrupt */
+#define STM32_IRQ_UART4       (STM32_IRQ_FIRST + 52) /* 52: UART4 global interrupt, or */
+#define STM32_IRQ_EXTI34      (STM32_IRQ_FIRST + 52) /* 52: EXTI Line 34 interrupt */
+#define STM32_IRQ_UART5       (STM32_IRQ_FIRST + 53) /* 53: UART5 global interrupt, or */
+#define STM32_IRQ_EXTI35      (STM32_IRQ_FIRST + 53) /* 53: EXTI Line 35 interrupt */
+#define STM32_IRQ_TIM6        (STM32_IRQ_FIRST + 54) /* 54: TIM6 global interrupt, or */
+#define STM32_IRQ_DAC         (STM32_IRQ_FIRST + 54) /* 54: DAC1 and DAC2 underrun error interrupts */
+#define STM32_IRQ_TIM7        (STM32_IRQ_FIRST + 55) /* 55: TIM7 global interrupt */
+#define STM32_IRQ_DMA2CH1     (STM32_IRQ_FIRST + 56) /* 56: DMA2 channel 1 global interrupt */
+#define STM32_IRQ_DMA2CH2     (STM32_IRQ_FIRST + 57) /* 57: DMA2 channel 2 global interrupt */
+#define STM32_IRQ_DMA2CH3     (STM32_IRQ_FIRST + 58) /* 58: DMA2 channel 3 global interrupt */
+#define STM32_IRQ_DMA2CH4     (STM32_IRQ_FIRST + 59) /* 59: DMA2 channel 4 global interrupt */
+#define STM32_IRQ_DMA2CH5     (STM32_IRQ_FIRST + 60) /* 60: DMA2 channel 5 global interrupt */
+#define STM32_IRQ_ADC4        (STM32_IRQ_FIRST + 61) /* 61: ADC4 global interrupt */
+#define STM32_IRQ_RESERVED62  (STM32_IRQ_FIRST + 62) /* 62: Reserved */
+#define STM32_IRQ_RESERVED63  (STM32_IRQ_FIRST + 63) /* 63: Reserved */
+#define STM32_IRQ_COMP123     (STM32_IRQ_FIRST + 64) /* 64: COMP1 & COMP2 & COMP3 interrupts, or */
+#define STM32_IRQ_EXTI2129    (STM32_IRQ_FIRST + 64) /* 64: EXTI Lines 21, 22 and 29 interrupts */
+#define STM32_IRQ_COMP456     (STM32_IRQ_FIRST + 65) /* 65: COMP4 & COMP5 & COMP6 interrupts, or */
+#define STM32_IRQ_EXTI3012    (STM32_IRQ_FIRST + 65) /* 65: EXTI Lines 30, 31 and 32 interrupts */
+#define STM32_IRQ_COMP7       (STM32_IRQ_FIRST + 66) /* 66: COMP7 interrupt, or */
+#define STM32_IRQ_EXTI33      (STM32_IRQ_FIRST + 66) /* 66: EXTI Line 33 interrupt */
+#define STM32_IRQ_RESERVED67  (STM32_IRQ_FIRST + 67) /* 67: Reserved */
+#define STM32_IRQ_RESERVED68  (STM32_IRQ_FIRST + 68) /* 68: Reserved */
+#define STM32_IRQ_RESERVED69  (STM32_IRQ_FIRST + 69) /* 69: Reserved */
+#define STM32_IRQ_RESERVED70  (STM32_IRQ_FIRST + 70) /* 70: Reserved */
+#define STM32_IRQ_RESERVED71  (STM32_IRQ_FIRST + 71) /* 71: Reserved */
+#define STM32_IRQ_RESERVED72  (STM32_IRQ_FIRST + 72) /* 72: Reserved */
+#define STM32_IRQ_RESERVED73  (STM32_IRQ_FIRST + 73) /* 73: Reserved */
+#define STM32_IRQ_USBHP_2     (STM32_IRQ_FIRST + 74) /* 74: USB High priority interrupt (remapped) */
+#define STM32_IRQ_USBLP_2     (STM32_IRQ_FIRST + 75) /* 75: USB Low priority interrupt remapped) */
+#define STM32_IRQ_USBWKUP_2   (STM32_IRQ_FIRST + 76) /* 76: USB wakeup from suspend remapped) */
+#define STM32_IRQ_RESERVED77  (STM32_IRQ_FIRST + 77) /* 77: Reserved */
+#define STM32_IRQ_RESERVED78  (STM32_IRQ_FIRST + 78) /* 78: Reserved */
+#define STM32_IRQ_RESERVED79  (STM32_IRQ_FIRST + 79) /* 79: Reserved */
+#define STM32_IRQ_RESERVED80  (STM32_IRQ_FIRST + 80) /* 80: Reserved */
+#define STM32_IRQ_FPU         (STM32_IRQ_FIRST + 81) /* 81: FPU global interrupt */
 
 #define STM32_IRQ_NEXTINT     (82)
-#define NR_IRQS               (STM32_IRQ_FIRST+82)
+#define NR_IRQS               (STM32_IRQ_FIRST + 82)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
-****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -181,9 +183,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/include/stm32/stm32f33xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f33xxx_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32/stm32f33xxx_irq.h
  *
  *   Copyright (C) 2017, 2018 Gregory Nutt. All rights reserved.
@@ -32,136 +32,138 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through nuttx/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F33XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F33XXX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found
- * in nuttx/arch/arm/include/stm32/irq.h
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in nuttx/arch/arm/include/stm32/irq.h
  *
  * External interrupts (vectors >= 16)
  */
 
-#define STM32_IRQ_WWDG        (STM32_IRQ_FIRST+0)  /* 0:  Window Watchdog interrupt */
-#define STM32_IRQ_PVD         (STM32_IRQ_FIRST+1)  /* 1:  PVD through EXTI Line detection interrupt */
-#define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST+2)  /* 2:  Tamper interrupt, or */
-#define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST+2)  /* 2:  Time stamp interrupt */
-#define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST+3)  /* 3:  RTC global interrupt */
-#define STM32_IRQ_FLASH       (STM32_IRQ_FIRST+4)  /* 4:  Flash global interrupt */
-#define STM32_IRQ_RCC         (STM32_IRQ_FIRST+5)  /* 5:  RCC global interrupt */
-#define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST+6)  /* 6:  EXTI Line 0 interrupt */
-#define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST+7)  /* 7:  EXTI Line 1 interrupt */
-#define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST+8)  /* 8:  EXTI Line 2 interrupt, or */
-#define STM32_IRQ_TSC         (STM32_IRQ_FIRST+8)  /* 8:  TSC interrupt */
-#define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST+9)  /* 9:  EXTI Line 3 interrupt */
-#define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST+10) /* 10: EXTI Line 4 interrupt */
-#define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST+11) /* 11: DMA1 channel 1 global interrupt */
-#define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST+12) /* 12: DMA1 channel 2 global interrupt */
-#define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST+13) /* 13: DMA1 channel 3 global interrupt */
-#define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST+14) /* 14: DMA1 channel 4 global interrupt */
-#define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST+15) /* 15: DMA1 channel 5 global interrupt */
-#define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST+16) /* 16: DMA1 channel 6 global interrupt */
-#define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST+17) /* 17: DMA1 channel 7 global interrupt */
-#define STM32_IRQ_ADC12       (STM32_IRQ_FIRST+18) /* 18: ADC1/ADC2 global interrupt */
-#define STM32_IRQ_CAN1TX      (STM32_IRQ_FIRST+19) /* 19: CAN1 TX interrupts */
-#define STM32_IRQ_CAN1RX0     (STM32_IRQ_FIRST+20) /* 20: CAN1 RX0 interrupts*/
-#define STM32_IRQ_CAN1RX1     (STM32_IRQ_FIRST+21) /* 21: CAN1 RX1 interrupt */
-#define STM32_IRQ_CAN1SCE     (STM32_IRQ_FIRST+22) /* 22: CAN1 SCE interrupt */
-#define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST+23) /* 23: EXTI Line[9:5] interrupts */
-#define STM32_IRQ_TIM1BRK     (STM32_IRQ_FIRST+24) /* 24: TIM1 Break interrupt, or */
-#define STM32_IRQ_TIM15       (STM32_IRQ_FIRST+24) /* 24: TIM15 global interrupt */
-#define STM32_IRQ_TIM1UP      (STM32_IRQ_FIRST+25) /* 25: TIM1 Update interrupt, or */
-#define STM32_IRQ_TIM16       (STM32_IRQ_FIRST+25) /* 25: TIM16 global interrupt */
-#define STM32_IRQ_TIM1TRGCOM  (STM32_IRQ_FIRST+26) /* 26: TIM1 Trigger and Commutation interrupts, or */
-#define STM32_IRQ_TIM17       (STM32_IRQ_FIRST+26) /* 26: TIM17 global interrupt */
-#define STM32_IRQ_TIM1CC      (STM32_IRQ_FIRST+27) /* 27: TIM1 Capture Compare interrupt */
-#define STM32_IRQ_TIM2        (STM32_IRQ_FIRST+28) /* 28: TIM2 global interrupt */
-#define STM32_IRQ_TIM3        (STM32_IRQ_FIRST+29) /* 29: TIM3 global interrupt */
-#define STM32_IRQ_RESERVED30  (STM32_IRQ_FIRST+30) /* 30: Reserved */
-#define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST+31) /* 31: I2C1 event interrupt */
-#define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST+32) /* 32: I2C1 error interrupt */
-#define STM32_IRQ_RESERVED33  (STM32_IRQ_FIRST+33) /* 33: Reserved */
-#define STM32_IRQ_RESERVED34  (STM32_IRQ_FIRST+34) /* 34: Reserved */
-#define STM32_IRQ_SPI1        (STM32_IRQ_FIRST+35) /* 35: SPI1 global interrupt */
-#define STM32_IRQ_RESERVED36  (STM32_IRQ_FIRST+36) /* 36: Reserved */
-#define STM32_IRQ_USART1      (STM32_IRQ_FIRST+37) /* 37: USART1 global interrupt */
-#define STM32_IRQ_USART2      (STM32_IRQ_FIRST+38) /* 38: USART2 global interrupt */
-#define STM32_IRQ_USART3      (STM32_IRQ_FIRST+39) /* 39: USART3 global interrupt */
-#define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST+40) /* 40: EXTI Line[15:10] interrupts */
-#define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST+41) /* 41: RTC alarm through EXTI line interrupt */
-#define STM32_IRQ_RESERVED42  (STM32_IRQ_FIRST+42) /* 42: Reserved */
-#define STM32_IRQ_RESERVED43  (STM32_IRQ_FIRST+43) /* 43: Reserved */
-#define STM32_IRQ_RESERVED44  (STM32_IRQ_FIRST+44) /* 44: Reserved */
-#define STM32_IRQ_RESERVED45  (STM32_IRQ_FIRST+45) /* 45: Reserved */
-#define STM32_IRQ_RESERVED46  (STM32_IRQ_FIRST+46) /* 46: Reserved */
-#define STM32_IRQ_RESERVED47  (STM32_IRQ_FIRST+47) /* 47: Reserved */
-#define STM32_IRQ_RESERVED48  (STM32_IRQ_FIRST+48) /* 48: Reserved */
-#define STM32_IRQ_RESERVED49  (STM32_IRQ_FIRST+49) /* 49: Reserved */
-#define STM32_IRQ_RESERVED50  (STM32_IRQ_FIRST+50) /* 50: Reserved */
-#define STM32_IRQ_RESERVED51  (STM32_IRQ_FIRST+51) /* 51: Reserved */
-#define STM32_IRQ_RESERVED52  (STM32_IRQ_FIRST+52) /* 52: Reserved */
-#define STM32_IRQ_RESERVED53  (STM32_IRQ_FIRST+53) /* 53: Reserved */
-#define STM32_IRQ_TIM6        (STM32_IRQ_FIRST+54) /* 54: TIM6 global interrupt, or */
-#define STM32_IRQ_DAC1        (STM32_IRQ_FIRST+54) /* 54: DAC1 underrun error interrupts */
-#define STM32_IRQ_TIM7        (STM32_IRQ_FIRST+55) /* 55: TIM7 global interrupt, or */
-#define STM32_IRQ_DAC2        (STM32_IRQ_FIRST+54) /* 55: DAC2 underrun error interrupts */
-#define STM32_IRQ_RESERVED56  (STM32_IRQ_FIRST+56) /* 56: Reserved */
-#define STM32_IRQ_RESERVED57  (STM32_IRQ_FIRST+57) /* 57: Reserved */
-#define STM32_IRQ_RESERVED58  (STM32_IRQ_FIRST+58) /* 58: Reserved */
-#define STM32_IRQ_RESERVED59  (STM32_IRQ_FIRST+59) /* 59: Reserved */
-#define STM32_IRQ_RESERVED60  (STM32_IRQ_FIRST+60) /* 60: Reserved */
-#define STM32_IRQ_RESERVED61  (STM32_IRQ_FIRST+61) /* 61: Reserved */
-#define STM32_IRQ_RESERVED62  (STM32_IRQ_FIRST+62) /* 62: Reserved */
-#define STM32_IRQ_RESERVED63  (STM32_IRQ_FIRST+63) /* 63: Reserved */
-#define STM32_IRQ_COMP2       (STM32_IRQ_FIRST+64) /* 64: COMP2 interrupts, or */
-#define STM32_IRQ_EXTI2129    (STM32_IRQ_FIRST+64) /* 64: EXTI Lines 21, 22 and 29 interrupts */
-#define STM32_IRQ_COMP46      (STM32_IRQ_FIRST+65) /* 65: COMP4 & COMP6 interrupts, or */
-#define STM32_IRQ_EXTI3012    (STM32_IRQ_FIRST+65) /* 65: EXTI Lines 30, 31 and 32 interrupts */
-#define STM32_IRQ_RESERVED66  (STM32_IRQ_FIRST+66) /* 66: Reserved */
-#define STM32_IRQ_HRTIMTM     (STM32_IRQ_FIRST+67) /* 67: HRTIM master timer interrupt */
-#define STM32_IRQ_HRTIMTA     (STM32_IRQ_FIRST+68) /* 68: HRTIM timer A interrupt */
-#define STM32_IRQ_HRTIMTB     (STM32_IRQ_FIRST+69) /* 69: HRTIM timer B interrupt */
-#define STM32_IRQ_HRTIMTC     (STM32_IRQ_FIRST+70) /* 70: HRTIM timer C interrupt */
-#define STM32_IRQ_HRTIMTD     (STM32_IRQ_FIRST+71) /* 71: HRTIM timer D interrupt */
-#define STM32_IRQ_HRTIMTE     (STM32_IRQ_FIRST+72) /* 72: HRTIM timer E interrupt */
-#define STM32_IRQ_HRTIMFLT    (STM32_IRQ_FIRST+73) /* 73: HRTIM fault interrupt */
-#define STM32_IRQ_RESERVED74  (STM32_IRQ_FIRST+74) /* 74: Reserved */
-#define STM32_IRQ_RESERVED75  (STM32_IRQ_FIRST+75) /* 75: Reserved */
-#define STM32_IRQ_RESERVED76  (STM32_IRQ_FIRST+76) /* 76: Reserved */
-#define STM32_IRQ_RESERVED77  (STM32_IRQ_FIRST+77) /* 77: Reserved */
-#define STM32_IRQ_RESERVED78  (STM32_IRQ_FIRST+78) /* 78: Reserved */
-#define STM32_IRQ_RESERVED79  (STM32_IRQ_FIRST+79) /* 79: Reserved */
-#define STM32_IRQ_RESERVED80  (STM32_IRQ_FIRST+80) /* 80: Reserved */
-#define STM32_IRQ_FPU         (STM32_IRQ_FIRST+81) /* 81: FPU global interrupt */
+#define STM32_IRQ_WWDG        (STM32_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
+#define STM32_IRQ_PVD         (STM32_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
+#define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST + 2)  /* 2:  Tamper interrupt, or */
+#define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST + 2)  /* 2:  Time stamp interrupt */
+#define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST + 3)  /* 3:  RTC global interrupt */
+#define STM32_IRQ_FLASH       (STM32_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
+#define STM32_IRQ_RCC         (STM32_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
+#define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
+#define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
+#define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt, or */
+#define STM32_IRQ_TSC         (STM32_IRQ_FIRST + 8)  /* 8:  TSC interrupt */
+#define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
+#define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST + 11) /* 11: DMA1 channel 1 global interrupt */
+#define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST + 12) /* 12: DMA1 channel 2 global interrupt */
+#define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST + 13) /* 13: DMA1 channel 3 global interrupt */
+#define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST + 14) /* 14: DMA1 channel 4 global interrupt */
+#define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST + 15) /* 15: DMA1 channel 5 global interrupt */
+#define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST + 16) /* 16: DMA1 channel 6 global interrupt */
+#define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST + 17) /* 17: DMA1 channel 7 global interrupt */
+#define STM32_IRQ_ADC12       (STM32_IRQ_FIRST + 18) /* 18: ADC1/ADC2 global interrupt */
+#define STM32_IRQ_CAN1TX      (STM32_IRQ_FIRST + 19) /* 19: CAN1 TX interrupts */
+#define STM32_IRQ_CAN1RX0     (STM32_IRQ_FIRST + 20) /* 20: CAN1 RX0 interrupts*/
+#define STM32_IRQ_CAN1RX1     (STM32_IRQ_FIRST + 21) /* 21: CAN1 RX1 interrupt */
+#define STM32_IRQ_CAN1SCE     (STM32_IRQ_FIRST + 22) /* 22: CAN1 SCE interrupt */
+#define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST + 23) /* 23: EXTI Line[9:5] interrupts */
+#define STM32_IRQ_TIM1BRK     (STM32_IRQ_FIRST + 24) /* 24: TIM1 Break interrupt, or */
+#define STM32_IRQ_TIM15       (STM32_IRQ_FIRST + 24) /* 24: TIM15 global interrupt */
+#define STM32_IRQ_TIM1UP      (STM32_IRQ_FIRST + 25) /* 25: TIM1 Update interrupt, or */
+#define STM32_IRQ_TIM16       (STM32_IRQ_FIRST + 25) /* 25: TIM16 global interrupt */
+#define STM32_IRQ_TIM1TRGCOM  (STM32_IRQ_FIRST + 26) /* 26: TIM1 Trigger and Commutation interrupts, or */
+#define STM32_IRQ_TIM17       (STM32_IRQ_FIRST + 26) /* 26: TIM17 global interrupt */
+#define STM32_IRQ_TIM1CC      (STM32_IRQ_FIRST + 27) /* 27: TIM1 Capture Compare interrupt */
+#define STM32_IRQ_TIM2        (STM32_IRQ_FIRST + 28) /* 28: TIM2 global interrupt */
+#define STM32_IRQ_TIM3        (STM32_IRQ_FIRST + 29) /* 29: TIM3 global interrupt */
+#define STM32_IRQ_RESERVED30  (STM32_IRQ_FIRST + 30) /* 30: Reserved */
+#define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST + 31) /* 31: I2C1 event interrupt */
+#define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST + 32) /* 32: I2C1 error interrupt */
+#define STM32_IRQ_RESERVED33  (STM32_IRQ_FIRST + 33) /* 33: Reserved */
+#define STM32_IRQ_RESERVED34  (STM32_IRQ_FIRST + 34) /* 34: Reserved */
+#define STM32_IRQ_SPI1        (STM32_IRQ_FIRST + 35) /* 35: SPI1 global interrupt */
+#define STM32_IRQ_RESERVED36  (STM32_IRQ_FIRST + 36) /* 36: Reserved */
+#define STM32_IRQ_USART1      (STM32_IRQ_FIRST + 37) /* 37: USART1 global interrupt */
+#define STM32_IRQ_USART2      (STM32_IRQ_FIRST + 38) /* 38: USART2 global interrupt */
+#define STM32_IRQ_USART3      (STM32_IRQ_FIRST + 39) /* 39: USART3 global interrupt */
+#define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST + 40) /* 40: EXTI Line[15:10] interrupts */
+#define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST + 41) /* 41: RTC alarm through EXTI line interrupt */
+#define STM32_IRQ_RESERVED42  (STM32_IRQ_FIRST + 42) /* 42: Reserved */
+#define STM32_IRQ_RESERVED43  (STM32_IRQ_FIRST + 43) /* 43: Reserved */
+#define STM32_IRQ_RESERVED44  (STM32_IRQ_FIRST + 44) /* 44: Reserved */
+#define STM32_IRQ_RESERVED45  (STM32_IRQ_FIRST + 45) /* 45: Reserved */
+#define STM32_IRQ_RESERVED46  (STM32_IRQ_FIRST + 46) /* 46: Reserved */
+#define STM32_IRQ_RESERVED47  (STM32_IRQ_FIRST + 47) /* 47: Reserved */
+#define STM32_IRQ_RESERVED48  (STM32_IRQ_FIRST + 48) /* 48: Reserved */
+#define STM32_IRQ_RESERVED49  (STM32_IRQ_FIRST + 49) /* 49: Reserved */
+#define STM32_IRQ_RESERVED50  (STM32_IRQ_FIRST + 50) /* 50: Reserved */
+#define STM32_IRQ_RESERVED51  (STM32_IRQ_FIRST + 51) /* 51: Reserved */
+#define STM32_IRQ_RESERVED52  (STM32_IRQ_FIRST + 52) /* 52: Reserved */
+#define STM32_IRQ_RESERVED53  (STM32_IRQ_FIRST + 53) /* 53: Reserved */
+#define STM32_IRQ_TIM6        (STM32_IRQ_FIRST + 54) /* 54: TIM6 global interrupt, or */
+#define STM32_IRQ_DAC1        (STM32_IRQ_FIRST + 54) /* 54: DAC1 underrun error interrupts */
+#define STM32_IRQ_TIM7        (STM32_IRQ_FIRST + 55) /* 55: TIM7 global interrupt, or */
+#define STM32_IRQ_DAC2        (STM32_IRQ_FIRST + 54) /* 55: DAC2 underrun error interrupts */
+#define STM32_IRQ_RESERVED56  (STM32_IRQ_FIRST + 56) /* 56: Reserved */
+#define STM32_IRQ_RESERVED57  (STM32_IRQ_FIRST + 57) /* 57: Reserved */
+#define STM32_IRQ_RESERVED58  (STM32_IRQ_FIRST + 58) /* 58: Reserved */
+#define STM32_IRQ_RESERVED59  (STM32_IRQ_FIRST + 59) /* 59: Reserved */
+#define STM32_IRQ_RESERVED60  (STM32_IRQ_FIRST + 60) /* 60: Reserved */
+#define STM32_IRQ_RESERVED61  (STM32_IRQ_FIRST + 61) /* 61: Reserved */
+#define STM32_IRQ_RESERVED62  (STM32_IRQ_FIRST + 62) /* 62: Reserved */
+#define STM32_IRQ_RESERVED63  (STM32_IRQ_FIRST + 63) /* 63: Reserved */
+#define STM32_IRQ_COMP2       (STM32_IRQ_FIRST + 64) /* 64: COMP2 interrupts, or */
+#define STM32_IRQ_EXTI2129    (STM32_IRQ_FIRST + 64) /* 64: EXTI Lines 21, 22 and 29 interrupts */
+#define STM32_IRQ_COMP46      (STM32_IRQ_FIRST + 65) /* 65: COMP4 & COMP6 interrupts, or */
+#define STM32_IRQ_EXTI3012    (STM32_IRQ_FIRST + 65) /* 65: EXTI Lines 30, 31 and 32 interrupts */
+#define STM32_IRQ_RESERVED66  (STM32_IRQ_FIRST + 66) /* 66: Reserved */
+#define STM32_IRQ_HRTIMTM     (STM32_IRQ_FIRST + 67) /* 67: HRTIM master timer interrupt */
+#define STM32_IRQ_HRTIMTA     (STM32_IRQ_FIRST + 68) /* 68: HRTIM timer A interrupt */
+#define STM32_IRQ_HRTIMTB     (STM32_IRQ_FIRST + 69) /* 69: HRTIM timer B interrupt */
+#define STM32_IRQ_HRTIMTC     (STM32_IRQ_FIRST + 70) /* 70: HRTIM timer C interrupt */
+#define STM32_IRQ_HRTIMTD     (STM32_IRQ_FIRST + 71) /* 71: HRTIM timer D interrupt */
+#define STM32_IRQ_HRTIMTE     (STM32_IRQ_FIRST + 72) /* 72: HRTIM timer E interrupt */
+#define STM32_IRQ_HRTIMFLT    (STM32_IRQ_FIRST + 73) /* 73: HRTIM fault interrupt */
+#define STM32_IRQ_RESERVED74  (STM32_IRQ_FIRST + 74) /* 74: Reserved */
+#define STM32_IRQ_RESERVED75  (STM32_IRQ_FIRST + 75) /* 75: Reserved */
+#define STM32_IRQ_RESERVED76  (STM32_IRQ_FIRST + 76) /* 76: Reserved */
+#define STM32_IRQ_RESERVED77  (STM32_IRQ_FIRST + 77) /* 77: Reserved */
+#define STM32_IRQ_RESERVED78  (STM32_IRQ_FIRST + 78) /* 78: Reserved */
+#define STM32_IRQ_RESERVED79  (STM32_IRQ_FIRST + 79) /* 79: Reserved */
+#define STM32_IRQ_RESERVED80  (STM32_IRQ_FIRST + 80) /* 80: Reserved */
+#define STM32_IRQ_FPU         (STM32_IRQ_FIRST + 81) /* 81: FPU global interrupt */
 
 #define STM32_IRQ_NEXTINT     (82)
-#define NR_IRQS               (STM32_IRQ_FIRST+82)
+#define NR_IRQS               (STM32_IRQ_FIRST + 82)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
-****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -172,9 +174,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/include/stm32/stm32f37xxx_irq.h
+++ b/arch/arm/include/stm32/stm32f37xxx_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32/stm32f37xxx_irq.h
  *
  *   Copyright (C) 2012, 2018 Gregory Nutt. All rights reserved.
@@ -32,131 +32,133 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through nuttx/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32F37XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32F37XXX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found
- * in nuttx/arch/arm/include/stm32/irq.h
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in nuttx/arch/arm/include/stm32/irq.h
  *
  * External interrupts (vectors >= 16)
  */
 
-#define STM32_IRQ_WWDG        (STM32_IRQ_FIRST+0)  /* 0:  Window Watchdog interrupt */
-#define STM32_IRQ_PVD         (STM32_IRQ_FIRST+1)  /* 1:  PVD through EXTI Line detection interrupt */
-#define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST+2)  /* 2:  Tamper interrupt, or */
-#define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST+2)  /* 2:  Time stamp interrupt */
-#define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST+3)  /* 3:  RTC global interrupt */
-#define STM32_IRQ_FLASH       (STM32_IRQ_FIRST+4)  /* 4:  Flash global interrupt */
-#define STM32_IRQ_RCC         (STM32_IRQ_FIRST+5)  /* 5:  RCC global interrupt */
-#define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST+6)  /* 6:  EXTI Line 0 interrupt */
-#define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST+7)  /* 7:  EXTI Line 1 interrupt */
-#define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST+8)  /* 8:  EXTI Line 2 interrupt, or */
-#define STM32_IRQ_TSC         (STM32_IRQ_FIRST+8)  /* 8:  TSC interrupt */
-#define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST+9)  /* 9:  EXTI Line 3 interrupt */
-#define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST+10) /* 10: EXTI Line 4 interrupt */
-#define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST+11) /* 11: DMA1 channel 1 global interrupt */
-#define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST+12) /* 12: DMA1 channel 2 global interrupt */
-#define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST+13) /* 13: DMA1 channel 3 global interrupt */
-#define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST+14) /* 14: DMA1 channel 4 global interrupt */
-#define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST+15) /* 15: DMA1 channel 5 global interrupt */
-#define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST+16) /* 16: DMA1 channel 6 global interrupt */
-#define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST+17) /* 17: DMA1 channel 7 global interrupt */
-#define STM32_IRQ_ADC1        (STM32_IRQ_FIRST+18) /* 18: ADC1 global interrupt */
-#define STM32_IRQ_CAN1TX      (STM32_IRQ_FIRST+19) /* 19: CAN1 TX interrupts */
-#define STM32_IRQ_CAN1RX0     (STM32_IRQ_FIRST+20) /* 20: CAN1 RX0 interrupts*/
-#define STM32_IRQ_CAN1RX1     (STM32_IRQ_FIRST+21) /* 21: CAN1 RX1 interrupt */
-#define STM32_IRQ_CAN1SCE     (STM32_IRQ_FIRST+22) /* 22: CAN1 SCE interrupt */
-#define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST+23) /* 23: EXTI Line[9:5] interrupts */
-#define STM32_IRQ_TIM15       (STM32_IRQ_FIRST+24) /* 24: TIM15 global interrupt */
-#define STM32_IRQ_TIM16       (STM32_IRQ_FIRST+25) /* 25: TIM16 global interrupt */
-#define STM32_IRQ_TIM17       (STM32_IRQ_FIRST+26) /* 26: TIM17 global interrupt */
-#define STM32_IRQ_TIM18       (STM32_IRQ_FIRST+27) /* 27: TIM18 global interrupt, or */
-#define STM32_IRQ_DAC2        (STM32_IRQ_FIRST+27) /* 27: DAC2 global interrupt */
-#define STM32_IRQ_TIM2        (STM32_IRQ_FIRST+28) /* 28: TIM2 global interrupt */
-#define STM32_IRQ_TIM3        (STM32_IRQ_FIRST+29) /* 29: TIM3 global interrupt */
-#define STM32_IRQ_TIM4        (STM32_IRQ_FIRST+30) /* 30: TIM4 global interrupt */
-#define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST+31) /* 31: I2C1 event interrupt */
-#define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST+32) /* 32: I2C1 error interrupt */
-#define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST+33) /* 33: I2C2 event interrupt */
-#define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST+34) /* 34: I2C2 error interrupt */
-#define STM32_IRQ_SPI1        (STM32_IRQ_FIRST+35) /* 35: SPI1 global interrupt */
-#define STM32_IRQ_SPI2        (STM32_IRQ_FIRST+36) /* 36: SPI2 global interrupt */
-#define STM32_IRQ_USART1      (STM32_IRQ_FIRST+37) /* 37: USART1 global interrupt */
-#define STM32_IRQ_USART2      (STM32_IRQ_FIRST+38) /* 38: USART2 global interrupt */
-#define STM32_IRQ_USART3      (STM32_IRQ_FIRST+39) /* 39: USART3 global interrupt */
-#define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST+40) /* 40: EXTI Line[15:10] interrupts */
-#define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST+41) /* 41: RTC alarm through EXTI line interrupt */
-#define STM32_IRQ_CEC         (STM32_IRQ_FIRST+42) /* 42: CEC Interrupt */
-#define STM32_IRQ_TIM12       (STM32_IRQ_FIRST+43) /* 43: TIM12 global interrupt */
-#define STM32_IRQ_TIM13       (STM32_IRQ_FIRST+44) /* 44: TIM13 global interrupt */
-#define STM32_IRQ_TIM14       (STM32_IRQ_FIRST+45) /* 45: TIM14 global interrupt */
-#define STM32_IRQ_RESERVED46  (STM32_IRQ_FIRST+46) /* 46: Reserved */
-#define STM32_IRQ_RESERVED47  (STM32_IRQ_FIRST+47) /* 47: Reserved */
-#define STM32_IRQ_RESERVED48  (STM32_IRQ_FIRST+48) /* 48: Reserved */
-#define STM32_IRQ_RESERVED49  (STM32_IRQ_FIRST+49) /* 49: Reserved */
-#define STM32_IRQ_RESERVED50  (STM32_IRQ_FIRST+50) /* 50: Reserved */
-#define STM32_IRQ_SPI3        (STM32_IRQ_FIRST+51) /* 51: SPI3 global interrupt */
-#define STM32_IRQ_RESERVED52  (STM32_IRQ_FIRST+52) /* 52: Reserved */
-#define STM32_IRQ_RESERVED53  (STM32_IRQ_FIRST+53) /* 53: Reserved */
-#define STM32_IRQ_TIM6        (STM32_IRQ_FIRST+54) /* 54: TIM6 global interrupt, or */
-#define STM32_IRQ_DAC1        (STM32_IRQ_FIRST+54) /* 54: DAC1 underrun error interrupts */
-#define STM32_IRQ_TIM7        (STM32_IRQ_FIRST+55) /* 55: TIM7 global interrupt */
-#define STM32_IRQ_DMA2CH1     (STM32_IRQ_FIRST+56) /* 56: DMA2 channel 1 global interrupt */
-#define STM32_IRQ_DMA2CH2     (STM32_IRQ_FIRST+57) /* 57: DMA2 channel 2 global interrupt */
-#define STM32_IRQ_DMA2CH3     (STM32_IRQ_FIRST+58) /* 58: DMA2 channel 3 global interrupt */
-#define STM32_IRQ_DMA2CH4     (STM32_IRQ_FIRST+59) /* 59: DMA2 channel 4 global interrupt */
-#define STM32_IRQ_DMA2CH5     (STM32_IRQ_FIRST+60) /* 60: DMA2 channel 5 global interrupt */
-#define STM32_IRQ_SDADC1      (STM32_IRQ_FIRST+61) /* 61: ADC Sigma Delta 1 global interrupt */
-#define STM32_IRQ_SDADC2      (STM32_IRQ_FIRST+62) /* 62: ADC Sigma Delta 2 global interrupt */
-#define STM32_IRQ_SDADC3      (STM32_IRQ_FIRST+63) /* 63: ADC Sigma Delta 3 global interrupt */
-#define STM32_IRQ_COMP12      (STM32_IRQ_FIRST+64) /* 64: COMP1 & COMP2 interrupts*/
-#define STM32_IRQ_RESERVED65  (STM32_IRQ_FIRST+65) /* 65: Reserved */
-#define STM32_IRQ_RESERVED66  (STM32_IRQ_FIRST+66) /* 66: Reserved */
-#define STM32_IRQ_RESERVED67  (STM32_IRQ_FIRST+67) /* 67: Reserved */
-#define STM32_IRQ_RESERVED68  (STM32_IRQ_FIRST+68) /* 68: Reserved */
-#define STM32_IRQ_RESERVED69  (STM32_IRQ_FIRST+69) /* 69: Reserved */
-#define STM32_IRQ_RESERVED70  (STM32_IRQ_FIRST+70) /* 70: Reserved */
-#define STM32_IRQ_RESERVED71  (STM32_IRQ_FIRST+71) /* 71: Reserved */
-#define STM32_IRQ_RESERVED72  (STM32_IRQ_FIRST+72) /* 72: Reserved */
-#define STM32_IRQ_RESERVED73  (STM32_IRQ_FIRST+73) /* 73: Reserved */
-#define STM32_IRQ_USBHP       (STM32_IRQ_FIRST+74) /* 74: USB High priority interrupt */
-#define STM32_IRQ_USBLP       (STM32_IRQ_FIRST+75) /* 75: USB Low priority interrupt */
-#define STM32_IRQ_USBWKUP     (STM32_IRQ_FIRST+76) /* 76: USB wakeup from suspend */
-#define STM32_IRQ_RESERVED77  (STM32_IRQ_FIRST+77) /* 77: Reserved */
-#define STM32_IRQ_RESERVED78  (STM32_IRQ_FIRST+78) /* 78: Reserved */
-#define STM32_IRQ_RESERVED79  (STM32_IRQ_FIRST+79) /* 79: Reserved */
-#define STM32_IRQ_RESERVED80  (STM32_IRQ_FIRST+80) /* 80: Reserved */
-#define STM32_IRQ_FPU         (STM32_IRQ_FIRST+81) /* 81: FPU global interrupt */
+#define STM32_IRQ_WWDG        (STM32_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
+#define STM32_IRQ_PVD         (STM32_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
+#define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST + 2)  /* 2:  Tamper interrupt, or */
+#define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST + 2)  /* 2:  Time stamp interrupt */
+#define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST + 3)  /* 3:  RTC global interrupt */
+#define STM32_IRQ_FLASH       (STM32_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
+#define STM32_IRQ_RCC         (STM32_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
+#define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
+#define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
+#define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt, or */
+#define STM32_IRQ_TSC         (STM32_IRQ_FIRST + 8)  /* 8:  TSC interrupt */
+#define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
+#define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST + 11) /* 11: DMA1 channel 1 global interrupt */
+#define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST + 12) /* 12: DMA1 channel 2 global interrupt */
+#define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST + 13) /* 13: DMA1 channel 3 global interrupt */
+#define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST + 14) /* 14: DMA1 channel 4 global interrupt */
+#define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST + 15) /* 15: DMA1 channel 5 global interrupt */
+#define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST + 16) /* 16: DMA1 channel 6 global interrupt */
+#define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST + 17) /* 17: DMA1 channel 7 global interrupt */
+#define STM32_IRQ_ADC1        (STM32_IRQ_FIRST + 18) /* 18: ADC1 global interrupt */
+#define STM32_IRQ_CAN1TX      (STM32_IRQ_FIRST + 19) /* 19: CAN1 TX interrupts */
+#define STM32_IRQ_CAN1RX0     (STM32_IRQ_FIRST + 20) /* 20: CAN1 RX0 interrupts*/
+#define STM32_IRQ_CAN1RX1     (STM32_IRQ_FIRST + 21) /* 21: CAN1 RX1 interrupt */
+#define STM32_IRQ_CAN1SCE     (STM32_IRQ_FIRST + 22) /* 22: CAN1 SCE interrupt */
+#define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST + 23) /* 23: EXTI Line[9:5] interrupts */
+#define STM32_IRQ_TIM15       (STM32_IRQ_FIRST + 24) /* 24: TIM15 global interrupt */
+#define STM32_IRQ_TIM16       (STM32_IRQ_FIRST + 25) /* 25: TIM16 global interrupt */
+#define STM32_IRQ_TIM17       (STM32_IRQ_FIRST + 26) /* 26: TIM17 global interrupt */
+#define STM32_IRQ_TIM18       (STM32_IRQ_FIRST + 27) /* 27: TIM18 global interrupt, or */
+#define STM32_IRQ_DAC2        (STM32_IRQ_FIRST + 27) /* 27: DAC2 global interrupt */
+#define STM32_IRQ_TIM2        (STM32_IRQ_FIRST + 28) /* 28: TIM2 global interrupt */
+#define STM32_IRQ_TIM3        (STM32_IRQ_FIRST + 29) /* 29: TIM3 global interrupt */
+#define STM32_IRQ_TIM4        (STM32_IRQ_FIRST + 30) /* 30: TIM4 global interrupt */
+#define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST + 31) /* 31: I2C1 event interrupt */
+#define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST + 32) /* 32: I2C1 error interrupt */
+#define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST + 33) /* 33: I2C2 event interrupt */
+#define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST + 34) /* 34: I2C2 error interrupt */
+#define STM32_IRQ_SPI1        (STM32_IRQ_FIRST + 35) /* 35: SPI1 global interrupt */
+#define STM32_IRQ_SPI2        (STM32_IRQ_FIRST + 36) /* 36: SPI2 global interrupt */
+#define STM32_IRQ_USART1      (STM32_IRQ_FIRST + 37) /* 37: USART1 global interrupt */
+#define STM32_IRQ_USART2      (STM32_IRQ_FIRST + 38) /* 38: USART2 global interrupt */
+#define STM32_IRQ_USART3      (STM32_IRQ_FIRST + 39) /* 39: USART3 global interrupt */
+#define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST + 40) /* 40: EXTI Line[15:10] interrupts */
+#define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST + 41) /* 41: RTC alarm through EXTI line interrupt */
+#define STM32_IRQ_CEC         (STM32_IRQ_FIRST + 42) /* 42: CEC Interrupt */
+#define STM32_IRQ_TIM12       (STM32_IRQ_FIRST + 43) /* 43: TIM12 global interrupt */
+#define STM32_IRQ_TIM13       (STM32_IRQ_FIRST + 44) /* 44: TIM13 global interrupt */
+#define STM32_IRQ_TIM14       (STM32_IRQ_FIRST + 45) /* 45: TIM14 global interrupt */
+#define STM32_IRQ_RESERVED46  (STM32_IRQ_FIRST + 46) /* 46: Reserved */
+#define STM32_IRQ_RESERVED47  (STM32_IRQ_FIRST + 47) /* 47: Reserved */
+#define STM32_IRQ_RESERVED48  (STM32_IRQ_FIRST + 48) /* 48: Reserved */
+#define STM32_IRQ_RESERVED49  (STM32_IRQ_FIRST + 49) /* 49: Reserved */
+#define STM32_IRQ_RESERVED50  (STM32_IRQ_FIRST + 50) /* 50: Reserved */
+#define STM32_IRQ_SPI3        (STM32_IRQ_FIRST + 51) /* 51: SPI3 global interrupt */
+#define STM32_IRQ_RESERVED52  (STM32_IRQ_FIRST + 52) /* 52: Reserved */
+#define STM32_IRQ_RESERVED53  (STM32_IRQ_FIRST + 53) /* 53: Reserved */
+#define STM32_IRQ_TIM6        (STM32_IRQ_FIRST + 54) /* 54: TIM6 global interrupt, or */
+#define STM32_IRQ_DAC1        (STM32_IRQ_FIRST + 54) /* 54: DAC1 underrun error interrupts */
+#define STM32_IRQ_TIM7        (STM32_IRQ_FIRST + 55) /* 55: TIM7 global interrupt */
+#define STM32_IRQ_DMA2CH1     (STM32_IRQ_FIRST + 56) /* 56: DMA2 channel 1 global interrupt */
+#define STM32_IRQ_DMA2CH2     (STM32_IRQ_FIRST + 57) /* 57: DMA2 channel 2 global interrupt */
+#define STM32_IRQ_DMA2CH3     (STM32_IRQ_FIRST + 58) /* 58: DMA2 channel 3 global interrupt */
+#define STM32_IRQ_DMA2CH4     (STM32_IRQ_FIRST + 59) /* 59: DMA2 channel 4 global interrupt */
+#define STM32_IRQ_DMA2CH5     (STM32_IRQ_FIRST + 60) /* 60: DMA2 channel 5 global interrupt */
+#define STM32_IRQ_SDADC1      (STM32_IRQ_FIRST + 61) /* 61: ADC Sigma Delta 1 global interrupt */
+#define STM32_IRQ_SDADC2      (STM32_IRQ_FIRST + 62) /* 62: ADC Sigma Delta 2 global interrupt */
+#define STM32_IRQ_SDADC3      (STM32_IRQ_FIRST + 63) /* 63: ADC Sigma Delta 3 global interrupt */
+#define STM32_IRQ_COMP12      (STM32_IRQ_FIRST + 64) /* 64: COMP1 & COMP2 interrupts*/
+#define STM32_IRQ_RESERVED65  (STM32_IRQ_FIRST + 65) /* 65: Reserved */
+#define STM32_IRQ_RESERVED66  (STM32_IRQ_FIRST + 66) /* 66: Reserved */
+#define STM32_IRQ_RESERVED67  (STM32_IRQ_FIRST + 67) /* 67: Reserved */
+#define STM32_IRQ_RESERVED68  (STM32_IRQ_FIRST + 68) /* 68: Reserved */
+#define STM32_IRQ_RESERVED69  (STM32_IRQ_FIRST + 69) /* 69: Reserved */
+#define STM32_IRQ_RESERVED70  (STM32_IRQ_FIRST + 70) /* 70: Reserved */
+#define STM32_IRQ_RESERVED71  (STM32_IRQ_FIRST + 71) /* 71: Reserved */
+#define STM32_IRQ_RESERVED72  (STM32_IRQ_FIRST + 72) /* 72: Reserved */
+#define STM32_IRQ_RESERVED73  (STM32_IRQ_FIRST + 73) /* 73: Reserved */
+#define STM32_IRQ_USBHP       (STM32_IRQ_FIRST + 74) /* 74: USB High priority interrupt */
+#define STM32_IRQ_USBLP       (STM32_IRQ_FIRST + 75) /* 75: USB Low priority interrupt */
+#define STM32_IRQ_USBWKUP     (STM32_IRQ_FIRST + 76) /* 76: USB wakeup from suspend */
+#define STM32_IRQ_RESERVED77  (STM32_IRQ_FIRST + 77) /* 77: Reserved */
+#define STM32_IRQ_RESERVED78  (STM32_IRQ_FIRST + 78) /* 78: Reserved */
+#define STM32_IRQ_RESERVED79  (STM32_IRQ_FIRST + 79) /* 79: Reserved */
+#define STM32_IRQ_RESERVED80  (STM32_IRQ_FIRST + 80) /* 80: Reserved */
+#define STM32_IRQ_FPU         (STM32_IRQ_FIRST + 81) /* 81: FPU global interrupt */
 
 #define STM32_IRQ_NEXTINT     (82)
-#define NR_IRQS               (STM32_IRQ_FIRST+82)
+#define NR_IRQS               (STM32_IRQ_FIRST + 82)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
-****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -167,9 +169,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/include/stm32/stm32l15xxx_irq.h
+++ b/arch/arm/include/stm32/stm32l15xxx_irq.h
@@ -1,6 +1,7 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32/stm32l15xxx_irq.h
- * For STM32L100xx, STM32L151xx, STM32L152xx and STM32L162xx advanced ARM-based 32-bit MCUs
+ * For STM32L100xx, STM32L151xx, STM32L152xx and STM32L162xx advanced
+ * ARM-based 32-bit MCUs
  *
  *   Copyright (C) 2013, 2018 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
@@ -32,224 +33,226 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through nuttx/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32_STM32FL15XXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32_STM32FL15XXX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/*  IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found
- * in nuttx/arch/arm/include/stm32/irq.h
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in nuttx/arch/arm/include/stm32/irq.h
  *
  * External interrupts (vectors >= 16) for low and medium density devices
  */
 
 #if defined(CONFIG_STM32_LOWDENSITY) || defined(CONFIG_STM32_MEDIUMDENSITY)
-#  define STM32_IRQ_WWDG        (STM32_IRQ_FIRST+0)  /* 0:  Window Watchdog interrupt */
-#  define STM32_IRQ_PVD         (STM32_IRQ_FIRST+1)  /* 1:  PVD through EXTI Line detection interrupt */
-#  define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST+2)  /* 2:  Tamper through EXTI line interrupt, or */
-#  define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST+2)  /* 2:  Time stamp through EXTI line interrupt */
-#  define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST+3)  /* 3:  RTC Wakeup through EXTI line interrupt */
-#  define STM32_IRQ_FLASH       (STM32_IRQ_FIRST+4)  /* 4:  Flash global interrupt */
-#  define STM32_IRQ_RCC         (STM32_IRQ_FIRST+5)  /* 5:  RCC global interrupt */
-#  define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST+6)  /* 6:  EXTI Line 0 interrupt */
-#  define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST+7)  /* 7:  EXTI Line 1 interrupt */
-#  define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST+8)  /* 8:  EXTI Line 2 interrupt */
-#  define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST+9)  /* 9:  EXTI Line 3 interrupt */
-#  define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST+10) /* 10: EXTI Line 4 interrupt */
-#  define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST+11) /* 11: DMA1 channel 1 global interrupt */
-#  define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST+12) /* 12: DMA1 channel 2 global interrupt */
-#  define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST+13) /* 13: DMA1 channel 3 global interrupt */
-#  define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST+14) /* 14: DMA1 channel 4 global interrupt */
-#  define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST+15) /* 15: DMA1 channel 5 global interrupt */
-#  define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST+16) /* 16: DMA1 channel 6 global interrupt */
-#  define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST+17) /* 17: DMA1 channel 7 global interrupt */
-#  define STM32_IRQ_ADC1        (STM32_IRQ_FIRST+18) /* 18: ADC1 global interrupt */
-#  define STM32_IRQ_USBHP       (STM32_IRQ_FIRST+19) /* 19: USB High Priority interrupts */
-#  define STM32_IRQ_USBLP       (STM32_IRQ_FIRST+20) /* 20: USB Low Priority interrupt */
-#  define STM32_IRQ_DAC         (STM32_IRQ_FIRST+21) /* 21: DAC interrupt */
-#  define STM32_IRQ_COMP        (STM32_IRQ_FIRST+22) /* 22: Comparator wakeup through EXTI interrupt */
-#  define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST+23) /* 23: EXTI Line[9:5] interrupts */
-#  define STM32_IRQ_LDC         (STM32_IRQ_FIRST+24) /* 24: LCD global interrupt */
-#  define STM32_IRQ_TIM9        (STM32_IRQ_FIRST+25) /* 25: TIM9 global interrupt */
-#  define STM32_IRQ_TIM10       (STM32_IRQ_FIRST+26) /* 26: TIM10 global interrupt */
-#  define STM32_IRQ_TIM11       (STM32_IRQ_FIRST+27) /* 27: TIM11 global interrupt */
-#  define STM32_IRQ_TIM2        (STM32_IRQ_FIRST+28) /* 28: TIM2 global interrupt */
-#  define STM32_IRQ_TIM3        (STM32_IRQ_FIRST+29) /* 29: TIM3 global interrupt */
-#  define STM32_IRQ_TIM4        (STM32_IRQ_FIRST+30) /* 30: TIM4 global interrupt */
-#  define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST+31) /* 31: I2C1 event interrupt */
-#  define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST+32) /* 32: I2C1 error interrupt */
-#  define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST+33) /* 33: I2C2 event interrupt */
-#  define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST+34) /* 34: I2C2 error interrupt */
-#  define STM32_IRQ_SPI1        (STM32_IRQ_FIRST+35) /* 35: SPI1 global interrupt */
-#  define STM32_IRQ_SPI2        (STM32_IRQ_FIRST+36) /* 36: SPI2 global interrupt */
-#  define STM32_IRQ_USART1      (STM32_IRQ_FIRST+37) /* 37: USART1 global interrupt */
-#  define STM32_IRQ_USART2      (STM32_IRQ_FIRST+38) /* 38: USART2 global interrupt */
-#  define STM32_IRQ_USART3      (STM32_IRQ_FIRST+39) /* 39: USART3 global interrupt */
-#  define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST+40) /* 40: EXTI Line[15:10] interrupts */
-#  define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST+41) /* 41: RTC alarm through EXTI line interrupt */
-#  define STM32_IRQ_USBWKUP     (STM32_IRQ_FIRST+42) /* 42: USB wakeup from suspend through EXTI line interrupt */
-#  define STM32_IRQ_TIM6        (STM32_IRQ_FIRST+43) /* 43: TIM6 global interrupt */
-#  define STM32_IRQ_TIM7        (STM32_IRQ_FIRST+44) /* 44: TIM7 global interrupt */
+#  define STM32_IRQ_WWDG        (STM32_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
+#  define STM32_IRQ_PVD         (STM32_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
+#  define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST + 2)  /* 2:  Tamper through EXTI line interrupt, or */
+#  define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST + 2)  /* 2:  Time stamp through EXTI line interrupt */
+#  define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST + 3)  /* 3:  RTC Wakeup through EXTI line interrupt */
+#  define STM32_IRQ_FLASH       (STM32_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
+#  define STM32_IRQ_RCC         (STM32_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
+#  define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
+#  define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
+#  define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt */
+#  define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#  define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
+#  define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST + 11) /* 11: DMA1 channel 1 global interrupt */
+#  define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST + 12) /* 12: DMA1 channel 2 global interrupt */
+#  define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST + 13) /* 13: DMA1 channel 3 global interrupt */
+#  define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST + 14) /* 14: DMA1 channel 4 global interrupt */
+#  define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST + 15) /* 15: DMA1 channel 5 global interrupt */
+#  define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST + 16) /* 16: DMA1 channel 6 global interrupt */
+#  define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST + 17) /* 17: DMA1 channel 7 global interrupt */
+#  define STM32_IRQ_ADC1        (STM32_IRQ_FIRST + 18) /* 18: ADC1 global interrupt */
+#  define STM32_IRQ_USBHP       (STM32_IRQ_FIRST + 19) /* 19: USB High Priority interrupts */
+#  define STM32_IRQ_USBLP       (STM32_IRQ_FIRST + 20) /* 20: USB Low Priority interrupt */
+#  define STM32_IRQ_DAC         (STM32_IRQ_FIRST + 21) /* 21: DAC interrupt */
+#  define STM32_IRQ_COMP        (STM32_IRQ_FIRST + 22) /* 22: Comparator wakeup through EXTI interrupt */
+#  define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST + 23) /* 23: EXTI Line[9:5] interrupts */
+#  define STM32_IRQ_LDC         (STM32_IRQ_FIRST + 24) /* 24: LCD global interrupt */
+#  define STM32_IRQ_TIM9        (STM32_IRQ_FIRST + 25) /* 25: TIM9 global interrupt */
+#  define STM32_IRQ_TIM10       (STM32_IRQ_FIRST + 26) /* 26: TIM10 global interrupt */
+#  define STM32_IRQ_TIM11       (STM32_IRQ_FIRST + 27) /* 27: TIM11 global interrupt */
+#  define STM32_IRQ_TIM2        (STM32_IRQ_FIRST + 28) /* 28: TIM2 global interrupt */
+#  define STM32_IRQ_TIM3        (STM32_IRQ_FIRST + 29) /* 29: TIM3 global interrupt */
+#  define STM32_IRQ_TIM4        (STM32_IRQ_FIRST + 30) /* 30: TIM4 global interrupt */
+#  define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST + 31) /* 31: I2C1 event interrupt */
+#  define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST + 32) /* 32: I2C1 error interrupt */
+#  define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST + 33) /* 33: I2C2 event interrupt */
+#  define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST + 34) /* 34: I2C2 error interrupt */
+#  define STM32_IRQ_SPI1        (STM32_IRQ_FIRST + 35) /* 35: SPI1 global interrupt */
+#  define STM32_IRQ_SPI2        (STM32_IRQ_FIRST + 36) /* 36: SPI2 global interrupt */
+#  define STM32_IRQ_USART1      (STM32_IRQ_FIRST + 37) /* 37: USART1 global interrupt */
+#  define STM32_IRQ_USART2      (STM32_IRQ_FIRST + 38) /* 38: USART2 global interrupt */
+#  define STM32_IRQ_USART3      (STM32_IRQ_FIRST + 39) /* 39: USART3 global interrupt */
+#  define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST + 40) /* 40: EXTI Line[15:10] interrupts */
+#  define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST + 41) /* 41: RTC alarm through EXTI line interrupt */
+#  define STM32_IRQ_USBWKUP     (STM32_IRQ_FIRST + 42) /* 42: USB wakeup from suspend through EXTI line interrupt */
+#  define STM32_IRQ_TIM6        (STM32_IRQ_FIRST + 43) /* 43: TIM6 global interrupt */
+#  define STM32_IRQ_TIM7        (STM32_IRQ_FIRST + 44) /* 44: TIM7 global interrupt */
 
 #  define STM32_IRQ_NEXTINT     (45)
-#  define NR_IRQS               (STM32_IRQ_FIRST+45)
+#  define NR_IRQS               (STM32_IRQ_FIRST + 45)
 
 /* External interrupts (vectors >= 16) medium+ density devices */
 
 #elif defined(CONFIG_STM32_MEDIUMPLUSDENSITY)
-#  define STM32_IRQ_WWDG        (STM32_IRQ_FIRST+0)  /* 0:  Window Watchdog interrupt */
-#  define STM32_IRQ_PVD         (STM32_IRQ_FIRST+1)  /* 1:  PVD through EXTI Line detection interrupt */
-#  define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST+2)  /* 2:  Tamper through EXTI line interrupt, or */
-#  define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST+2)  /* 2:  Time stamp through EXTI line interrupt */
-#  define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST+3)  /* 3:  RTC Wakeup through EXTI line interrupt */
-#  define STM32_IRQ_FLASH       (STM32_IRQ_FIRST+4)  /* 4:  Flash global interrupt */
-#  define STM32_IRQ_RCC         (STM32_IRQ_FIRST+5)  /* 5:  RCC global interrupt */
-#  define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST+6)  /* 6:  EXTI Line 0 interrupt */
-#  define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST+7)  /* 7:  EXTI Line 1 interrupt */
-#  define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST+8)  /* 8:  EXTI Line 2 interrupt */
-#  define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST+9)  /* 9:  EXTI Line 3 interrupt */
-#  define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST+10) /* 10: EXTI Line 4 interrupt */
-#  define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST+11) /* 11: DMA1 channel 1 global interrupt */
-#  define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST+12) /* 12: DMA1 channel 2 global interrupt */
-#  define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST+13) /* 13: DMA1 channel 3 global interrupt */
-#  define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST+14) /* 14: DMA1 channel 4 global interrupt */
-#  define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST+15) /* 15: DMA1 channel 5 global interrupt */
-#  define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST+16) /* 16: DMA1 channel 6 global interrupt */
-#  define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST+17) /* 17: DMA1 channel 7 global interrupt */
-#  define STM32_IRQ_ADC1        (STM32_IRQ_FIRST+18) /* 18: ADC1 global interrupt */
-#  define STM32_IRQ_USBHP       (STM32_IRQ_FIRST+19) /* 19: USB High Priority interrupts */
-#  define STM32_IRQ_USBLP       (STM32_IRQ_FIRST+20) /* 20: USB Low Priority interrupt */
-#  define STM32_IRQ_DAC         (STM32_IRQ_FIRST+21) /* 21: DAC interrupt */
-#  define STM32_IRQ_COMP        (STM32_IRQ_FIRST+22) /* 22: Comparator wakeup through EXTI interrupt, or */
-#  define STM32_IRQ_CA          (STM32_IRQ_FIRST+22) /* 22: Channel acquisition interrupt */
-#  define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST+23) /* 23: EXTI Line[9:5] interrupts */
-#  define STM32_IRQ_LDC         (STM32_IRQ_FIRST+24) /* 24: LCD global interrupt */
-#  define STM32_IRQ_TIM9        (STM32_IRQ_FIRST+25) /* 25: TIM9 global interrupt */
-#  define STM32_IRQ_TIM10       (STM32_IRQ_FIRST+26) /* 26: TIM10 global interrupt */
-#  define STM32_IRQ_TIM11       (STM32_IRQ_FIRST+27) /* 27: TIM11 global interrupt */
-#  define STM32_IRQ_TIM2        (STM32_IRQ_FIRST+28) /* 28: TIM2 global interrupt */
-#  define STM32_IRQ_TIM3        (STM32_IRQ_FIRST+29) /* 29: TIM3 global interrupt */
-#  define STM32_IRQ_TIM4        (STM32_IRQ_FIRST+30) /* 30: TIM4 global interrupt */
-#  define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST+31) /* 31: I2C1 event interrupt */
-#  define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST+32) /* 32: I2C1 error interrupt */
-#  define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST+33) /* 33: I2C2 event interrupt */
-#  define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST+34) /* 34: I2C2 error interrupt */
-#  define STM32_IRQ_SPI1        (STM32_IRQ_FIRST+35) /* 35: SPI1 global interrupt */
-#  define STM32_IRQ_SPI2        (STM32_IRQ_FIRST+36) /* 36: SPI2 global interrupt */
-#  define STM32_IRQ_USART1      (STM32_IRQ_FIRST+37) /* 37: USART1 global interrupt */
-#  define STM32_IRQ_USART2      (STM32_IRQ_FIRST+38) /* 38: USART2 global interrupt */
-#  define STM32_IRQ_USART3      (STM32_IRQ_FIRST+39) /* 39: USART3 global interrupt */
-#  define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST+40) /* 40: EXTI Line[15:10] interrupts */
-#  define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST+41) /* 41: RTC alarm through EXTI line interrupt */
-#  define STM32_IRQ_USBWKUP     (STM32_IRQ_FIRST+42) /* 42: USB wakeup from suspend through EXTI line interrupt */
-#  define STM32_IRQ_TIM6        (STM32_IRQ_FIRST+43) /* 43: TIM6 global interrupt */
-#  define STM32_IRQ_TIM7        (STM32_IRQ_FIRST+44) /* 44: TIM7 global interrupt */
-#  define STM32_IRQ_TIM5        (STM32_IRQ_FIRST+45) /* 45: TIM5 global interrupt */
-#  define STM32_IRQ_SPI3        (STM32_IRQ_FIRST+46) /* 46: SPI3 global interrupt */
-#  define STM32_IRQ_DMA2CH1     (STM32_IRQ_FIRST+47) /* 47: DMA2 channel 1 global interrupt */
-#  define STM32_IRQ_DMA2CH2     (STM32_IRQ_FIRST+48) /* 48: DMA2 channel 2 global interrupt */
-#  define STM32_IRQ_DMA2CH3     (STM32_IRQ_FIRST+49) /* 49: DMA2 channel 3 global interrupt */
-#  define STM32_IRQ_DMA2CH4     (STM32_IRQ_FIRST+50) /* 50: DMA2 channel 4 global interrupt */
-#  define STM32_IRQ_DMA2CH5     (STM32_IRQ_FIRST+51) /* 51: DMA2 channel 5 global interrupt */
-#  define STM32_IRQ_AES         (STM32_IRQ_FIRST+52) /* 52: AES global interrupt */
-#  define STM32_IRQ_COMPACQ     (STM32_IRQ_FIRST+53) /* 53: Comparator Channel Acquisition Interrupt */
+#  define STM32_IRQ_WWDG        (STM32_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
+#  define STM32_IRQ_PVD         (STM32_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
+#  define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST + 2)  /* 2:  Tamper through EXTI line interrupt, or */
+#  define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST + 2)  /* 2:  Time stamp through EXTI line interrupt */
+#  define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST + 3)  /* 3:  RTC Wakeup through EXTI line interrupt */
+#  define STM32_IRQ_FLASH       (STM32_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
+#  define STM32_IRQ_RCC         (STM32_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
+#  define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
+#  define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
+#  define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt */
+#  define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#  define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
+#  define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST + 11) /* 11: DMA1 channel 1 global interrupt */
+#  define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST + 12) /* 12: DMA1 channel 2 global interrupt */
+#  define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST + 13) /* 13: DMA1 channel 3 global interrupt */
+#  define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST + 14) /* 14: DMA1 channel 4 global interrupt */
+#  define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST + 15) /* 15: DMA1 channel 5 global interrupt */
+#  define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST + 16) /* 16: DMA1 channel 6 global interrupt */
+#  define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST + 17) /* 17: DMA1 channel 7 global interrupt */
+#  define STM32_IRQ_ADC1        (STM32_IRQ_FIRST + 18) /* 18: ADC1 global interrupt */
+#  define STM32_IRQ_USBHP       (STM32_IRQ_FIRST + 19) /* 19: USB High Priority interrupts */
+#  define STM32_IRQ_USBLP       (STM32_IRQ_FIRST + 20) /* 20: USB Low Priority interrupt */
+#  define STM32_IRQ_DAC         (STM32_IRQ_FIRST + 21) /* 21: DAC interrupt */
+#  define STM32_IRQ_COMP        (STM32_IRQ_FIRST + 22) /* 22: Comparator wakeup through EXTI interrupt, or */
+#  define STM32_IRQ_CA          (STM32_IRQ_FIRST + 22) /* 22: Channel acquisition interrupt */
+#  define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST + 23) /* 23: EXTI Line[9:5] interrupts */
+#  define STM32_IRQ_LDC         (STM32_IRQ_FIRST + 24) /* 24: LCD global interrupt */
+#  define STM32_IRQ_TIM9        (STM32_IRQ_FIRST + 25) /* 25: TIM9 global interrupt */
+#  define STM32_IRQ_TIM10       (STM32_IRQ_FIRST + 26) /* 26: TIM10 global interrupt */
+#  define STM32_IRQ_TIM11       (STM32_IRQ_FIRST + 27) /* 27: TIM11 global interrupt */
+#  define STM32_IRQ_TIM2        (STM32_IRQ_FIRST + 28) /* 28: TIM2 global interrupt */
+#  define STM32_IRQ_TIM3        (STM32_IRQ_FIRST + 29) /* 29: TIM3 global interrupt */
+#  define STM32_IRQ_TIM4        (STM32_IRQ_FIRST + 30) /* 30: TIM4 global interrupt */
+#  define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST + 31) /* 31: I2C1 event interrupt */
+#  define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST + 32) /* 32: I2C1 error interrupt */
+#  define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST + 33) /* 33: I2C2 event interrupt */
+#  define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST + 34) /* 34: I2C2 error interrupt */
+#  define STM32_IRQ_SPI1        (STM32_IRQ_FIRST + 35) /* 35: SPI1 global interrupt */
+#  define STM32_IRQ_SPI2        (STM32_IRQ_FIRST + 36) /* 36: SPI2 global interrupt */
+#  define STM32_IRQ_USART1      (STM32_IRQ_FIRST + 37) /* 37: USART1 global interrupt */
+#  define STM32_IRQ_USART2      (STM32_IRQ_FIRST + 38) /* 38: USART2 global interrupt */
+#  define STM32_IRQ_USART3      (STM32_IRQ_FIRST + 39) /* 39: USART3 global interrupt */
+#  define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST + 40) /* 40: EXTI Line[15:10] interrupts */
+#  define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST + 41) /* 41: RTC alarm through EXTI line interrupt */
+#  define STM32_IRQ_USBWKUP     (STM32_IRQ_FIRST + 42) /* 42: USB wakeup from suspend through EXTI line interrupt */
+#  define STM32_IRQ_TIM6        (STM32_IRQ_FIRST + 43) /* 43: TIM6 global interrupt */
+#  define STM32_IRQ_TIM7        (STM32_IRQ_FIRST + 44) /* 44: TIM7 global interrupt */
+#  define STM32_IRQ_TIM5        (STM32_IRQ_FIRST + 45) /* 45: TIM5 global interrupt */
+#  define STM32_IRQ_SPI3        (STM32_IRQ_FIRST + 46) /* 46: SPI3 global interrupt */
+#  define STM32_IRQ_DMA2CH1     (STM32_IRQ_FIRST + 47) /* 47: DMA2 channel 1 global interrupt */
+#  define STM32_IRQ_DMA2CH2     (STM32_IRQ_FIRST + 48) /* 48: DMA2 channel 2 global interrupt */
+#  define STM32_IRQ_DMA2CH3     (STM32_IRQ_FIRST + 49) /* 49: DMA2 channel 3 global interrupt */
+#  define STM32_IRQ_DMA2CH4     (STM32_IRQ_FIRST + 50) /* 50: DMA2 channel 4 global interrupt */
+#  define STM32_IRQ_DMA2CH5     (STM32_IRQ_FIRST + 51) /* 51: DMA2 channel 5 global interrupt */
+#  define STM32_IRQ_AES         (STM32_IRQ_FIRST + 52) /* 52: AES global interrupt */
+#  define STM32_IRQ_COMPACQ     (STM32_IRQ_FIRST + 53) /* 53: Comparator Channel Acquisition Interrupt */
 
 #  define STM32_IRQ_NEXTINT     (54)
-#  define NR_IRQS               (STM32_IRQ_FIRST+54)
+#  define NR_IRQS               (STM32_IRQ_FIRST + 54)
 
 /* External interrupts (vectors >= 16) high density devices */
 
 #elif defined(CONFIG_STM32_HIGHDENSITY)
-#  define STM32_IRQ_WWDG        (STM32_IRQ_FIRST+0)  /* 0:  Window Watchdog interrupt */
-#  define STM32_IRQ_PVD         (STM32_IRQ_FIRST+1)  /* 1:  PVD through EXTI Line detection interrupt */
-#  define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST+2)  /* 2:  Tamper through EXTI line interrupt, or */
-#  define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST+2)  /* 2:  Time stamp through EXTI line interrupt */
-#  define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST+3)  /* 3:  RTC Wakeup through EXTI line interrupt */
-#  define STM32_IRQ_FLASH       (STM32_IRQ_FIRST+4)  /* 4:  Flash global interrupt */
-#  define STM32_IRQ_RCC         (STM32_IRQ_FIRST+5)  /* 5:  RCC global interrupt */
-#  define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST+6)  /* 6:  EXTI Line 0 interrupt */
-#  define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST+7)  /* 7:  EXTI Line 1 interrupt */
-#  define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST+8)  /* 8:  EXTI Line 2 interrupt */
-#  define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST+9)  /* 9:  EXTI Line 3 interrupt */
-#  define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST+10) /* 10: EXTI Line 4 interrupt */
-#  define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST+11) /* 11: DMA1 channel 1 global interrupt */
-#  define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST+12) /* 12: DMA1 channel 2 global interrupt */
-#  define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST+13) /* 13: DMA1 channel 3 global interrupt */
-#  define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST+14) /* 14: DMA1 channel 4 global interrupt */
-#  define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST+15) /* 15: DMA1 channel 5 global interrupt */
-#  define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST+16) /* 16: DMA1 channel 6 global interrupt */
-#  define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST+17) /* 17: DMA1 channel 7 global interrupt */
-#  define STM32_IRQ_ADC1        (STM32_IRQ_FIRST+18) /* 18: ADC1 global interrupt */
-#  define STM32_IRQ_USBHP       (STM32_IRQ_FIRST+19) /* 19: USB High Priority interrupts */
-#  define STM32_IRQ_USBLP       (STM32_IRQ_FIRST+20) /* 20: USB Low Priority interrupt */
-#  define STM32_IRQ_DAC         (STM32_IRQ_FIRST+21) /* 21: DAC interrupt */
-#  define STM32_IRQ_COMP        (STM32_IRQ_FIRST+22) /* 22: Comparator wakeup through EXTI interrupt, or */
-#  define STM32_IRQ_CA          (STM32_IRQ_FIRST+22) /* 22: Channel acquisition interrupt */
-#  define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST+23) /* 23: EXTI Line[9:5] interrupts */
-#  define STM32_IRQ_LDC         (STM32_IRQ_FIRST+24) /* 24: LCD global interrupt */
-#  define STM32_IRQ_TIM9        (STM32_IRQ_FIRST+25) /* 25: TIM9 global interrupt */
-#  define STM32_IRQ_TIM10       (STM32_IRQ_FIRST+26) /* 26: TIM10 global interrupt */
-#  define STM32_IRQ_TIM11       (STM32_IRQ_FIRST+27) /* 27: TIM11 global interrupt */
-#  define STM32_IRQ_TIM2        (STM32_IRQ_FIRST+28) /* 28: TIM2 global interrupt */
-#  define STM32_IRQ_TIM3        (STM32_IRQ_FIRST+29) /* 29: TIM3 global interrupt */
-#  define STM32_IRQ_TIM4        (STM32_IRQ_FIRST+30) /* 30: TIM4 global interrupt */
-#  define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST+31) /* 31: I2C1 event interrupt */
-#  define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST+32) /* 32: I2C1 error interrupt */
-#  define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST+33) /* 33: I2C2 event interrupt */
-#  define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST+34) /* 34: I2C2 error interrupt */
-#  define STM32_IRQ_SPI1        (STM32_IRQ_FIRST+35) /* 35: SPI1 global interrupt */
-#  define STM32_IRQ_SPI2        (STM32_IRQ_FIRST+36) /* 36: SPI2 global interrupt */
-#  define STM32_IRQ_USART1      (STM32_IRQ_FIRST+37) /* 37: USART1 global interrupt */
-#  define STM32_IRQ_USART2      (STM32_IRQ_FIRST+38) /* 38: USART2 global interrupt */
-#  define STM32_IRQ_USART3      (STM32_IRQ_FIRST+39) /* 39: USART3 global interrupt */
-#  define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST+40) /* 40: EXTI Line[15:10] interrupts */
-#  define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST+41) /* 41: RTC alarm through EXTI line interrupt */
-#  define STM32_IRQ_USBWKUP     (STM32_IRQ_FIRST+42) /* 42: USB wakeup from suspend through EXTI line interrupt */
-#  define STM32_IRQ_TIM6        (STM32_IRQ_FIRST+43) /* 43: TIM6 global interrupt */
-#  define STM32_IRQ_TIM7        (STM32_IRQ_FIRST+44) /* 44: TIM7 global interrupt */
-#  define STM32_IRQ_SDIO        (STM32_IRQ_FIRST+45) /* 45: SDIO Global interrupt */
-#  define STM32_IRQ_TIM5        (STM32_IRQ_FIRST+46) /* 46: TIM5 global interrupt */
-#  define STM32_IRQ_SPI3        (STM32_IRQ_FIRST+47) /* 47: SPI3 global interrupt */
-#  define STM32_IRQ_UART4       (STM32_IRQ_FIRST+48) /* 48: UART4 global interrupt */
-#  define STM32_IRQ_UART5       (STM32_IRQ_FIRST+49) /* 49: UART5 global interrupt */
-#  define STM32_IRQ_DMA2CH1     (STM32_IRQ_FIRST+50) /* 50: DMA2 channel 1 global interrupt */
-#  define STM32_IRQ_DMA2CH2     (STM32_IRQ_FIRST+51) /* 51: DMA2 channel 2 global interrupt */
-#  define STM32_IRQ_DMA2CH3     (STM32_IRQ_FIRST+52) /* 52: DMA2 channel 3 global interrupt */
-#  define STM32_IRQ_DMA2CH4     (STM32_IRQ_FIRST+53) /* 53: DMA2 channel 4 global interrupt */
-#  define STM32_IRQ_DMA2CH5     (STM32_IRQ_FIRST+54) /* 54: DMA2 channel 5 global interrupt */
-#  define STM32_IRQ_AES         (STM32_IRQ_FIRST+55) /* 55: AES global interrupt */
-#  define STM32_IRQ_COMPACQ     (STM32_IRQ_FIRST+56) /* 56: Comparator Channel Acquisition Interrupt */
+#  define STM32_IRQ_WWDG        (STM32_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
+#  define STM32_IRQ_PVD         (STM32_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
+#  define STM32_IRQ_TAMPER      (STM32_IRQ_FIRST + 2)  /* 2:  Tamper through EXTI line interrupt, or */
+#  define STM32_IRQ_TIMESTAMP   (STM32_IRQ_FIRST + 2)  /* 2:  Time stamp through EXTI line interrupt */
+#  define STM32_IRQ_RTC_WKUP    (STM32_IRQ_FIRST + 3)  /* 3:  RTC Wakeup through EXTI line interrupt */
+#  define STM32_IRQ_FLASH       (STM32_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
+#  define STM32_IRQ_RCC         (STM32_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
+#  define STM32_IRQ_EXTI0       (STM32_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
+#  define STM32_IRQ_EXTI1       (STM32_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
+#  define STM32_IRQ_EXTI2       (STM32_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt */
+#  define STM32_IRQ_EXTI3       (STM32_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#  define STM32_IRQ_EXTI4       (STM32_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
+#  define STM32_IRQ_DMA1CH1     (STM32_IRQ_FIRST + 11) /* 11: DMA1 channel 1 global interrupt */
+#  define STM32_IRQ_DMA1CH2     (STM32_IRQ_FIRST + 12) /* 12: DMA1 channel 2 global interrupt */
+#  define STM32_IRQ_DMA1CH3     (STM32_IRQ_FIRST + 13) /* 13: DMA1 channel 3 global interrupt */
+#  define STM32_IRQ_DMA1CH4     (STM32_IRQ_FIRST + 14) /* 14: DMA1 channel 4 global interrupt */
+#  define STM32_IRQ_DMA1CH5     (STM32_IRQ_FIRST + 15) /* 15: DMA1 channel 5 global interrupt */
+#  define STM32_IRQ_DMA1CH6     (STM32_IRQ_FIRST + 16) /* 16: DMA1 channel 6 global interrupt */
+#  define STM32_IRQ_DMA1CH7     (STM32_IRQ_FIRST + 17) /* 17: DMA1 channel 7 global interrupt */
+#  define STM32_IRQ_ADC1        (STM32_IRQ_FIRST + 18) /* 18: ADC1 global interrupt */
+#  define STM32_IRQ_USBHP       (STM32_IRQ_FIRST + 19) /* 19: USB High Priority interrupts */
+#  define STM32_IRQ_USBLP       (STM32_IRQ_FIRST + 20) /* 20: USB Low Priority interrupt */
+#  define STM32_IRQ_DAC         (STM32_IRQ_FIRST + 21) /* 21: DAC interrupt */
+#  define STM32_IRQ_COMP        (STM32_IRQ_FIRST + 22) /* 22: Comparator wakeup through EXTI interrupt, or */
+#  define STM32_IRQ_CA          (STM32_IRQ_FIRST + 22) /* 22: Channel acquisition interrupt */
+#  define STM32_IRQ_EXTI95      (STM32_IRQ_FIRST + 23) /* 23: EXTI Line[9:5] interrupts */
+#  define STM32_IRQ_LDC         (STM32_IRQ_FIRST + 24) /* 24: LCD global interrupt */
+#  define STM32_IRQ_TIM9        (STM32_IRQ_FIRST + 25) /* 25: TIM9 global interrupt */
+#  define STM32_IRQ_TIM10       (STM32_IRQ_FIRST + 26) /* 26: TIM10 global interrupt */
+#  define STM32_IRQ_TIM11       (STM32_IRQ_FIRST + 27) /* 27: TIM11 global interrupt */
+#  define STM32_IRQ_TIM2        (STM32_IRQ_FIRST + 28) /* 28: TIM2 global interrupt */
+#  define STM32_IRQ_TIM3        (STM32_IRQ_FIRST + 29) /* 29: TIM3 global interrupt */
+#  define STM32_IRQ_TIM4        (STM32_IRQ_FIRST + 30) /* 30: TIM4 global interrupt */
+#  define STM32_IRQ_I2C1EV      (STM32_IRQ_FIRST + 31) /* 31: I2C1 event interrupt */
+#  define STM32_IRQ_I2C1ER      (STM32_IRQ_FIRST + 32) /* 32: I2C1 error interrupt */
+#  define STM32_IRQ_I2C2EV      (STM32_IRQ_FIRST + 33) /* 33: I2C2 event interrupt */
+#  define STM32_IRQ_I2C2ER      (STM32_IRQ_FIRST + 34) /* 34: I2C2 error interrupt */
+#  define STM32_IRQ_SPI1        (STM32_IRQ_FIRST + 35) /* 35: SPI1 global interrupt */
+#  define STM32_IRQ_SPI2        (STM32_IRQ_FIRST + 36) /* 36: SPI2 global interrupt */
+#  define STM32_IRQ_USART1      (STM32_IRQ_FIRST + 37) /* 37: USART1 global interrupt */
+#  define STM32_IRQ_USART2      (STM32_IRQ_FIRST + 38) /* 38: USART2 global interrupt */
+#  define STM32_IRQ_USART3      (STM32_IRQ_FIRST + 39) /* 39: USART3 global interrupt */
+#  define STM32_IRQ_EXTI1510    (STM32_IRQ_FIRST + 40) /* 40: EXTI Line[15:10] interrupts */
+#  define STM32_IRQ_RTCALRM     (STM32_IRQ_FIRST + 41) /* 41: RTC alarm through EXTI line interrupt */
+#  define STM32_IRQ_USBWKUP     (STM32_IRQ_FIRST + 42) /* 42: USB wakeup from suspend through EXTI line interrupt */
+#  define STM32_IRQ_TIM6        (STM32_IRQ_FIRST + 43) /* 43: TIM6 global interrupt */
+#  define STM32_IRQ_TIM7        (STM32_IRQ_FIRST + 44) /* 44: TIM7 global interrupt */
+#  define STM32_IRQ_SDIO        (STM32_IRQ_FIRST + 45) /* 45: SDIO Global interrupt */
+#  define STM32_IRQ_TIM5        (STM32_IRQ_FIRST + 46) /* 46: TIM5 global interrupt */
+#  define STM32_IRQ_SPI3        (STM32_IRQ_FIRST + 47) /* 47: SPI3 global interrupt */
+#  define STM32_IRQ_UART4       (STM32_IRQ_FIRST + 48) /* 48: UART4 global interrupt */
+#  define STM32_IRQ_UART5       (STM32_IRQ_FIRST + 49) /* 49: UART5 global interrupt */
+#  define STM32_IRQ_DMA2CH1     (STM32_IRQ_FIRST + 50) /* 50: DMA2 channel 1 global interrupt */
+#  define STM32_IRQ_DMA2CH2     (STM32_IRQ_FIRST + 51) /* 51: DMA2 channel 2 global interrupt */
+#  define STM32_IRQ_DMA2CH3     (STM32_IRQ_FIRST + 52) /* 52: DMA2 channel 3 global interrupt */
+#  define STM32_IRQ_DMA2CH4     (STM32_IRQ_FIRST + 53) /* 53: DMA2 channel 4 global interrupt */
+#  define STM32_IRQ_DMA2CH5     (STM32_IRQ_FIRST + 54) /* 54: DMA2 channel 5 global interrupt */
+#  define STM32_IRQ_AES         (STM32_IRQ_FIRST + 55) /* 55: AES global interrupt */
+#  define STM32_IRQ_COMPACQ     (STM32_IRQ_FIRST + 56) /* 56: Comparator Channel Acquisition Interrupt */
 
 #  define STM32_IRQ_NEXTINT     (57)
-#  define NR_IRQS               (STM32_IRQ_FIRST+57)
+#  define NR_IRQS               (STM32_IRQ_FIRST + 57)
 #else
 #  error "Unknown STM32L density"
 #endif
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
-****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -260,9 +263,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Fix nxstyle errors in:

- arch/arm/include/stm32/stm32f10xxx_irq.h
- arch/arm/include/stm32/stm32f20xxx_irq.h
- arch/arm/include/stm32/stm32f30xxx_irq.h
- arch/arm/include/stm32/stm32f33xxx_irq.h
- arch/arm/include/stm32/stm32f37xxx_irq.h
- arch/arm/include/stm32/stm32l15xxx_irq.h

## Impact

Removes nxstyle errors.

## Testing

nxstyle