### PR TITLE
libc/unistd: Fix getpriority not handling invalid input value

### DIFF
--- a/libs/libc/unistd/lib_getpriority.c
+++ b/libs/libc/unistd/lib_getpriority.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <sys/resource.h>
 #include <sched.h>
 
 #include <errno.h>
@@ -46,7 +47,13 @@
  * Returned Value:
  *   Upon successful completion, getpriority() shall return an integer in
  *   the range -{NZERO} to {NZERO}-1. Otherwise, -1 shall be returned and
- *   errno set to indicate the error.
+ *   errno set to indicate the error. The following errors may be
+ *   reported:
+ *
+ *   - ESRCH: No process was located using the which and who values
+ *            specified.
+ *   - EINVAL: which was not one of PRIO_PROCESS, PRIO_PGRP, or
+ *             PRIO_USER.
  *
  * Assumptions:
  *
@@ -56,6 +63,12 @@ int getpriority(int which, id_t who)
 {
   struct sched_param param;
   int ret;
+
+  if (which > PRIO_USER || which < PRIO_PROCESS)
+    {
+      set_errno(EINVAL);
+      return ERROR;
+    }
 
   if (who == 0)
     {


### PR DESCRIPTION
## Summary
This PR intends to fix the implementation of `getpriority` function, which is not compliant with the specification from OpenGroup:  
https://pubs.opengroup.org/onlinepubs/009695399/functions/getpriority.html

## Impact
Fix `getpriority01` test from LTP.

## Testing
Running LTP on a `esp32c3-devkit` board.
