### PR TITLE
arch: imx6: Fix an error message in imx_enet.c

### DIFF
--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -103,7 +103,7 @@
 #endif
 
 #if !defined (CONFIG_NET_TCP_WRITE_BUFFERS) && (CONFIG_IMX_ENET_NTXBUFFERS != 1)
-#  error "CONFIG_IMX_ENET_NTXBUFFERS must be 1 without TCP_WRITE_BUFFERS"
+#  error "TCP_WRITE_BUFFERS are disabled. CONFIG_IMX_ENET_NTXBUFFERS must be set to 1"
 #endif
 
 #if CONFIG_IMX_ENET_NRXBUFFERS < 1


### PR DESCRIPTION
## Summary

- This commit fixes an error message in imx_enet.c
- See https://github.com/apache/incubator-nuttx/pull/2772

## Impact

- None

## Testing

- Build only
