### PR TITLE
Revert "net: tcp: Add DEBUGASSERT() in psock_tcp_send()"

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1143,11 +1143,6 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
            */
 
           blresult = net_breaklock(&count);
-
-          /* NOTE: At least IOB needs to hold the packet */
-
-          DEBUGASSERT((CONFIG_IOB_NBUFFERS * CONFIG_IOB_BUFSIZE) > len);
-
           result = TCP_WBCOPYIN(wrb, (FAR uint8_t *)buf, len);
           if (blresult >= 0)
             {


### PR DESCRIPTION
## Summary

- Based on the discussion (https://github.com/apache/incubator-nuttx/pull/2772), let me revert the commit

## Impact

- None

## Testing

- N/A

