### PR TITLE
Do some adjustments for epoll

### DIFF
--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -275,7 +275,7 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
           {
             if (eph->poll[i].fd == fd)
               {
-                if (i != eph->occupied - 1)
+                if (i != eph->occupied)
                   {
                     memmove(&eph->data[i], &eph->data[i + 1],
                             sizeof(epoll_data_t) * (eph->occupied - i));

--- a/include/sys/epoll.h
+++ b/include/sys/epoll.h
@@ -41,6 +41,7 @@
  ****************************************************************************/
 
 #include <poll.h>
+#include <fcntl.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -86,7 +87,7 @@ enum EPOLL_EVENTS
 
 enum
 {
-  EPOLL_CLOEXEC = 02000000
+  EPOLL_CLOEXEC = O_CLOEXEC
 #define EPOLL_CLOEXEC EPOLL_CLOEXEC
 };
 


### PR DESCRIPTION
## Summary
1.Fix epoll cannot work under 64-bit operating system by switching to the real file handle.
2.Fix one bug of EPOLL_CTL_DEL.

## Impact
The return value from epoll_create is a real file handle not the raw pointer anymore.

## Testing

