### PR TITLE
fix local_sendmsg return length

### DIFF
--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -92,15 +92,6 @@ static ssize_t local_send(FAR struct socket *psock,
           /* Send the packet */
 
           ret = local_send_packet(&peer->lc_outfile, buf, len);
-
-          /* If the send was successful, then the full packet will have been
-           * sent
-           */
-
-          if (ret >= 0)
-            {
-              ret = len;
-            }
         }
         break;
 #endif /* CONFIG_NET_LOCAL_STREAM */

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -120,8 +120,8 @@ static int local_fifo_write(FAR struct file *filep, FAR const uint8_t *buf,
  *   len      Length of data to send
  *
  * Returned Value:
- *   Zero is returned on success; a negated errno value is returned on any
- *   failure.
+ *   Packet length is returned on success; a negated errno value is returned
+ *   on any failure.
  *
  ****************************************************************************/
 
@@ -158,10 +158,10 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
               if (ret < 0)
                 break;
               else
-                len16 += ret;
+                len16 += iov->iov_len;
             }
 
-          if (ret > 0)
+          if (ret == OK)
             ret = len16;
         }
     }


### PR DESCRIPTION
Previous patch for sendmsg left a bug in local socket which returns the wrong length. Fixed here :)
