### PR TITLE
Added support for multiple syslog channels.

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -17,6 +17,12 @@ config SYSLOG_WRITE
 	bool
 	default n
 
+config SYSLOG_MAX_CHANNELS
+	int "Maximum SYSLOG channels"
+	default 1
+	---help---
+		Maximum number of supported SYSLOG channels.
+
 config RAMLOG
 	bool "RAM log device support"
 	default n

--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -48,7 +48,8 @@ extern "C"
  */
 
 struct syslog_channel_s; /* Forward reference */
-EXTERN FAR const struct syslog_channel_s *g_syslog_channel;
+EXTERN FAR const struct syslog_channel_s *g_syslog_channel
+                                                [CONFIG_SYSLOG_MAX_CHANNELS];
 
 /****************************************************************************
  * Public Function Prototypes
@@ -216,7 +217,6 @@ int syslog_add_intbuffer(int ch);
  *   to the SYSLOG device.
  *
  * Input Parameters:
- *   channel - The syslog channel to use in performing the flush operation.
  *   force   - Use the force() method of the channel vs. the putc() method.
  *
  * Returned Value:
@@ -229,8 +229,7 @@ int syslog_add_intbuffer(int ch);
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_INTBUFFER
-int syslog_flush_intbuffer(FAR const struct syslog_channel_s *channel,
-                           bool force);
+int syslog_flush_intbuffer(bool force);
 #endif
 
 /****************************************************************************

--- a/drivers/syslog/syslog_flush.c
+++ b/drivers/syslog/syslog_flush.c
@@ -64,21 +64,29 @@
 
 int syslog_flush(void)
 {
-  DEBUGASSERT(g_syslog_channel != NULL);
+  int i;
 
 #ifdef CONFIG_SYSLOG_INTBUFFER
   /* Flush any characters that may have been added to the interrupt
    * buffer.
    */
 
-  syslog_flush_intbuffer(g_syslog_channel, true);
+  syslog_flush_intbuffer(true);
 #endif
 
-  /* Then flush all of the buffered output to the SYSLOG device */
-
-  if (g_syslog_channel->sc_flush != NULL)
+  for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
     {
-      return g_syslog_channel->sc_flush();
+      if (g_syslog_channel[i] == NULL)
+        {
+          break;
+        }
+
+      /* Then flush all of the buffered output to the SYSLOG device */
+
+      if (g_syslog_channel[i]->sc_flush != NULL)
+        {
+          g_syslog_channel[i]->sc_flush();
+        }
     }
 
   return OK;

--- a/drivers/syslog/syslog_force.c
+++ b/drivers/syslog/syslog_force.c
@@ -55,18 +55,29 @@
 
 int syslog_force(int ch)
 {
-  DEBUGASSERT(g_syslog_channel != NULL &&
-              g_syslog_channel->sc_force != NULL);
+  int i;
 
 #ifdef CONFIG_SYSLOG_INTBUFFER
   /* Flush any characters that may have been added to the interrupt
    * buffer through the emergency channel
    */
 
-  syslog_flush_intbuffer(g_syslog_channel, true);
+  syslog_flush_intbuffer(true);
 #endif
 
-  /* Then send the character to the emergency channel */
+  for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
+    {
+      if (g_syslog_channel[i] == NULL)
+        {
+          break;
+        }
 
-  return g_syslog_channel->sc_force(ch);
+      DEBUGASSERT(g_syslog_channel[i]->sc_force != NULL);
+
+      /* Then send the character to the emergency channel */
+
+      g_syslog_channel[i]->sc_force(ch);
+    }
+
+  return ch;
 }

--- a/drivers/syslog/syslog_putc.c
+++ b/drivers/syslog/syslog_putc.c
@@ -55,7 +55,7 @@
 
 int syslog_putc(int ch)
 {
-  DEBUGASSERT(g_syslog_channel != NULL);
+  int i;
 
   /* Is this an attempt to do SYSLOG output from an interrupt handler? */
 
@@ -65,8 +65,8 @@ int syslog_putc(int ch)
       if (up_interrupt_context())
         {
           /* Buffer the character in the interrupt buffer.
-           *  The interrupt buffer will be flushed before the next normal,
-           * non-interrupt SYSLOG output.
+           * The interrupt buffer will be flushed before the next
+           * normal,non-interrupt SYSLOG output.
            */
 
           return syslog_add_intbuffer(ch);
@@ -76,27 +76,46 @@ int syslog_putc(int ch)
         {
           /* Force the character to the SYSLOG device immediately
            * (if possible).
-           * This means that the interrupt data may not be in synchronization
-           * with output data that may have been buffered by sc_putc().
+           * This means that the interrupt data may not be in
+           * synchronization with output data that may have been
+           * buffered by sc_putc().
            */
 
-          DEBUGASSERT(g_syslog_channel->sc_force != NULL);
+          for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
+            {
+              if (g_syslog_channel[i] == NULL)
+                {
+                  break;
+                }
 
-          return g_syslog_channel->sc_force(ch);
+              DEBUGASSERT(g_syslog_channel[i]->sc_force != NULL);
+
+              g_syslog_channel[i]->sc_force(ch);
+            }
         }
     }
   else
     {
-      DEBUGASSERT(g_syslog_channel->sc_putc != NULL);
-
 #ifdef CONFIG_SYSLOG_INTBUFFER
       /* Flush any characters that may have been added to the interrupt
        * buffer.
        */
 
-      syslog_flush_intbuffer(g_syslog_channel, false);
+      syslog_flush_intbuffer(false);
 #endif
 
-      return g_syslog_channel->sc_putc(ch);
+      for (i = 0; i < CONFIG_SYSLOG_MAX_CHANNELS; i++)
+        {
+          if (g_syslog_channel[i] == NULL)
+            {
+              break;
+            }
+
+          DEBUGASSERT(g_syslog_channel[i]->sc_putc != NULL);
+
+          g_syslog_channel[i]->sc_putc(ch);
+        }
     }
+
+  return ch;
 }

--- a/include/nuttx/syslog/syslog.h
+++ b/include/nuttx/syslog/syslog.h
@@ -131,12 +131,30 @@ extern "C"
  *   channel - Provides the interface to the channel to be used.
  *
  * Returned Value:
- *   Zero (OK)is returned on  success.  A negated errno value is returned
+ *   Zero (OK) is returned on success.  A negated errno value is returned
  *   on any failure.
  *
  ****************************************************************************/
 
 int syslog_channel(FAR const struct syslog_channel_s *channel);
+
+/****************************************************************************
+ * Name: syslog_channel_remove
+ *
+ * Description:
+ *   Removes an already configured SYSLOG channel from the list of used
+ *   channels.
+ *
+ * Input Parameters:
+ *   channel - Provides the interface to the channel to be removed.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  A negated errno value is returned
+ *   on any failure.
+ *
+ ****************************************************************************/
+
+int syslog_channel_remove(FAR const struct syslog_channel_s *channel);
 
 /****************************************************************************
  * Name: syslog_initialize


### PR DESCRIPTION
## Summary
Adds support for multiple syslog channels, logging simultaneously.

## Impact
None on existing configurations. It defaults to 1 channel, as it was previously.

## Testing
Tested on a custom STM32F4 board, logging simultaneously on serial and in an SD file.

