### PR TITLE
arch/risc-v: Internal functions should be prefixed with riscv_ not up_

### DIFF
--- a/arch/risc-v/src/bl602/bl602_allocateheap.c
+++ b/arch/risc-v/src/bl602/bl602_allocateheap.c
@@ -24,6 +24,8 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/arch.h>
+
 #include "chip.h"
 
 /****************************************************************************

--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -82,7 +82,7 @@ void up_irqinitialize(void)
   /* Colorize the interrupt stack for debug purposes */
 
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
-  up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+  riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif
 
@@ -92,7 +92,7 @@ void up_irqinitialize(void)
 
   /* Attach the ecall interrupt handler */
 
-  irq_attach(BL602_IRQ_ECALLM, up_swint, NULL);
+  irq_attach(BL602_IRQ_ECALLM, riscv_swint, NULL);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 
@@ -171,14 +171,14 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: up_get_newintctx
+ * Name: riscv_get_newintctx
  *
  * Description:
  *   Return initial mstatus when a task is created.
  *
  ****************************************************************************/
 
-uint32_t up_get_newintctx(void)
+uint32_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
@@ -192,14 +192,14 @@ uint32_t up_get_newintctx(void)
 }
 
 /****************************************************************************
- * Name: up_ack_irq
+ * Name: riscv_ack_irq
  *
  * Description:
  *   Acknowledge the IRQ
  *
  ****************************************************************************/
 
-void up_ack_irq(int irq)
+void riscv_ack_irq(int irq)
 {
 }
 

--- a/arch/risc-v/src/bl602/bl602_irq_dispatch.c
+++ b/arch/risc-v/src/bl602/bl602_irq_dispatch.c
@@ -72,7 +72,7 @@ void *bl602_dispatch_irq(uint32_t vector, uint32_t *regs)
 
   /* Acknowledge the interrupt */
 
-  up_ack_irq(irq);
+  riscv_ack_irq(irq);
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
@@ -103,7 +103,7 @@ void *bl602_dispatch_irq(uint32_t vector, uint32_t *regs)
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)g_current_regs);
+      riscv_restorefpu((uint32_t *)g_current_regs);
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/risc-v/src/bl602/bl602_lowputc.c
+++ b/arch/risc-v/src/bl602/bl602_lowputc.c
@@ -333,14 +333,14 @@ void bl602_uart_configure(const struct uart_config_s *config)
 }
 
 /****************************************************************************
- * Name: up_lowputc
+ * Name: riscv_lowputc
  *
  * Description:
  *   Output one byte on the serial console
  *
  ****************************************************************************/
 
-void up_lowputc(char ch)
+void riscv_lowputc(char ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
   /* Wait for FIFO */

--- a/arch/risc-v/src/bl602/bl602_serial.c
+++ b/arch/risc-v/src/bl602/bl602_serial.c
@@ -111,7 +111,7 @@
 
 /* Common initialization logic will not not know that the all of the UARTs
  * have been disabled.  So, as a result, we may still have to provide
- * stub implementations of up_earlyserialinit(), up_serialinit(), and
+ * stub implementations of riscv_earlyserialinit(), riscv_serialinit(), and
  * up_putc().
  */
 
@@ -812,18 +812,18 @@ static bool bl602_txempty(struct uart_dev_s *dev)
 #ifdef USE_EARLYSERIALINIT
 
 /****************************************************************************
- * Name: up_earlyserialinit
+ * Name: riscv_earlyserialinit
  *
  * Description:
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
- *   before up_serialinit.  NOTE:  This function depends on GPIO pin
+ *   before riscv_serialinit.  NOTE:  This function depends on GPIO pin
  *   configuration performed in up_consoleinit() and main clock
  *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
 #ifdef HAVE_SERIAL_CONSOLE
   /* Configuration whichever one is the console */
@@ -835,15 +835,15 @@ void up_earlyserialinit(void)
 #endif
 
 /****************************************************************************
- * Name: up_serialinit
+ * Name: riscv_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
- *   that up_earlyserialinit was called previously.
+ *   that riscv_earlyserialinit was called previously.
  *
  ****************************************************************************/
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
   int  i;
   char devname[16];
@@ -900,17 +900,17 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
   leave_critical_section(flags);
 #endif
   return ch;
 }
 
 /****************************************************************************
- * Name: up_earlyserialinit, up_serialinit, and up_putc
+ * Name: riscv_earlyserialinit, riscv_serialinit, and up_putc
  *
  * Description:
  *   stubs that may be needed.  These stubs would be used if all UARTs are
@@ -921,11 +921,11 @@ int up_putc(int ch)
  ****************************************************************************/
 
 #else /* HAVE_UART_DEVICE */
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
 }
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
 }
 
@@ -954,10 +954,10 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
 #endif
   return ch;
 }

--- a/arch/risc-v/src/bl602/bl602_start.c
+++ b/arch/risc-v/src/bl602/bl602_start.c
@@ -42,7 +42,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_FEATURES
-#define showprogress(c) up_lowputc(c)
+#define showprogress(c) riscv_lowputc(c)
 #else
 #define showprogress(c)
 #endif
@@ -118,7 +118,7 @@ void bfl_main(void)
   modifyreg32(BL602_HBN_IRQ_MODE, 0, HBN_IRQ_MODE_REG_AON_PAD_IE_SMT);
 
 #ifdef USE_EARLYSERIALINIT
-  up_earlyserialinit();
+  riscv_earlyserialinit();
 #endif
 
   /* Do board initialization */

--- a/arch/risc-v/src/c906/c906_allocateheap.c
+++ b/arch/risc-v/src/c906/c906_allocateheap.c
@@ -23,9 +23,11 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+
 #include <nuttx/kmalloc.h>
 #include <nuttx/userspace.h>
 
+#include <nuttx/arch.h>
 #include <arch/board/board.h>
 
 #include "c906.h"

--- a/arch/risc-v/src/c906/c906_irq.c
+++ b/arch/risc-v/src/c906/c906_irq.c
@@ -74,7 +74,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 7
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~7);
-  up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+  riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif
 
@@ -97,10 +97,10 @@ void up_irqinitialize(void)
 
   /* Attach the ecall interrupt handler */
 
-  irq_attach(C906_IRQ_ECALLM, up_swint, NULL);
+  irq_attach(C906_IRQ_ECALLM, riscv_swint, NULL);
 
 #ifdef CONFIG_BUILD_PROTECTED
-  irq_attach(C906_IRQ_ECALLU, up_swint, NULL);
+  irq_attach(C906_IRQ_ECALLU, riscv_swint, NULL);
 #endif
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
@@ -198,14 +198,14 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: up_get_newintctx
+ * Name: riscv_get_newintctx
  *
  * Description:
  *   Return initial mstatus when a task is created.
  *
  ****************************************************************************/
 
-uint32_t up_get_newintctx(void)
+uint32_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode. Reegardless of
    * how NuttX is configured and of what kind of thread is being started.
@@ -223,14 +223,14 @@ uint32_t up_get_newintctx(void)
 }
 
 /****************************************************************************
- * Name: up_ack_irq
+ * Name: riscv_ack_irq
  *
  * Description:
  *   Acknowledge the IRQ
  *
  ****************************************************************************/
 
-void up_ack_irq(int irq)
+void riscv_ack_irq(int irq)
 {
 }
 

--- a/arch/risc-v/src/c906/c906_irq_dispatch.c
+++ b/arch/risc-v/src/c906/c906_irq_dispatch.c
@@ -83,7 +83,7 @@ void *c906_dispatch_irq(uint64_t vector, uint64_t *regs)
 
   /* Acknowledge the interrupt */
 
-  up_ack_irq(irq);
+  riscv_ack_irq(irq);
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
@@ -126,7 +126,7 @@ void *c906_dispatch_irq(uint64_t vector, uint64_t *regs)
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint64_t *)CURRENT_REGS);
+      riscv_restorefpu((uint64_t *)CURRENT_REGS);
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/risc-v/src/c906/c906_lowputc.c
+++ b/arch/risc-v/src/c906/c906_lowputc.c
@@ -70,14 +70,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_lowputc
+ * Name: riscv_lowputc
  *
  * Description:
  *   Output one byte on the serial console
  *
  ****************************************************************************/
 
-void up_lowputc(char ch)
+void riscv_lowputc(char ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
   /* Wait until the TX data register is empty */

--- a/arch/risc-v/src/c906/c906_serial.c
+++ b/arch/risc-v/src/c906/c906_serial.c
@@ -83,7 +83,7 @@
 
 /* Common initialization logic will not not know that the all of the UARTs
  * have been disabled.  So, as a result, we may still have to provide
- * stub implementations of up_earlyserialinit(), up_serialinit(), and
+ * stub implementations of riscv_earlyserialinit(), riscv_serialinit(), and
  * up_putc().
  */
 
@@ -599,18 +599,18 @@ static bool up_txempty(struct uart_dev_s *dev)
 #ifdef USE_EARLYSERIALINIT
 
 /****************************************************************************
- * Name: up_earlyserialinit
+ * Name: riscv_earlyserialinit
  *
  * Description:
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
- *   before up_serialinit.  NOTE:  This function depends on GPIO pin
+ *   before riscv_serialinit.  NOTE:  This function depends on GPIO pin
  *   configuration performed in up_consoleinit() and main clock iniialization
  *   performed in up_clkinitialize().
  *
  ****************************************************************************/
 
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
   /* Disable interrupts from all UARTS.  The console is enabled in
    * c906_consoleinit().
@@ -631,15 +631,15 @@ void up_earlyserialinit(void)
 #endif
 
 /****************************************************************************
- * Name: up_serialinit
+ * Name: riscv_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
- *   that up_earlyserialinit was called previously.
+ *   that riscv_earlyserialinit was called previously.
  *
  ****************************************************************************/
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
   /* Register the console */
 
@@ -677,17 +677,17 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
   return ch;
 }
 
 /****************************************************************************
- * Name: up_earlyserialinit, up_serialinit, and up_putc
+ * Name: riscv_earlyserialinit, riscv_serialinit, and up_putc
  *
  * Description:
  *   stubs that may be needed.  These stubs would be used if all UARTs are
@@ -698,11 +698,11 @@ int up_putc(int ch)
  ****************************************************************************/
 
 #else /* HAVE_UART_DEVICE */
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
 }
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
 }
 
@@ -731,10 +731,10 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
 #endif
   return ch;
 }

--- a/arch/risc-v/src/c906/c906_start.c
+++ b/arch/risc-v/src/c906/c906_start.c
@@ -39,7 +39,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_FEATURES
-#  define showprogress(c) up_lowputc(c)
+#  define showprogress(c) riscv_lowputc(c)
 #else
 #  define showprogress(c)
 #endif
@@ -112,7 +112,7 @@ void __c906_start(uint32_t mhartid)
   showprogress('A');
 
 #ifdef USE_EARLYSERIALINIT
-  up_earlyserialinit();
+  riscv_earlyserialinit();
 #endif
 
   showprogress('B');

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -253,7 +253,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
                    sizeof(struct tls_info_s);
       stack_size = tcb->adj_stack_size -
                    sizeof(struct tls_info_s);
-      up_stack_color((FAR void *)stack_base, stack_size);
+      riscv_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
 
@@ -265,7 +265,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 }
 
 /****************************************************************************
- * Name: up_stack_color
+ * Name: riscv_stack_color
  *
  * Description:
  *   Write a well know value into the stack
@@ -273,7 +273,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes)
+void riscv_stack_color(FAR void *stackbase, size_t nbytes)
 {
   /* Take extra care that we do not write outsize the stack boundaries */
 

--- a/arch/risc-v/src/common/riscv_initialize.c
+++ b/arch/risc-v/src/common/riscv_initialize.c
@@ -123,7 +123,7 @@ void up_initialize(void)
    * with the power management subsystem).
    */
 
-  up_pminitialize();
+  riscv_pminitialize();
 #endif
 
   /* Register devices */
@@ -143,7 +143,7 @@ void up_initialize(void)
   /* Initialize the serial device driver */
 
 #ifdef USE_SERIALDRIVER
-  up_serialinit();
+  riscv_serialinit();
 #endif
 
 #ifdef CONFIG_RPMSG_UART

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -178,8 +178,6 @@ void riscv_addregion(void);
 # define riscv_addregion()
 #endif
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size);
-
 /* IRQ initialization *******************************************************/
 
 void riscv_ack_irq(int irq);

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -166,10 +166,6 @@ EXTERN uint32_t _ebss;            /* End+1 of .bss */
 
 #ifndef __ASSEMBLY__
 
-/* Low level initialization provided by board-level logic *******************/
-
-void up_boot(void);
-
 /* Memory allocation ********************************************************/
 
 #if CONFIG_MM_REGIONS > 1

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -70,11 +70,11 @@
  */
 
 #ifdef CONFIG_ARCH_RV64GC
-#define up_savestate(regs)    up_copystate(regs, (uint64_t*)CURRENT_REGS)
-#define up_restorestate(regs) (CURRENT_REGS = regs)
+#define riscv_savestate(regs)    riscv_copystate(regs, (uint64_t*)CURRENT_REGS)
+#define riscv_restorestate(regs) (CURRENT_REGS = regs)
 #else
-#define up_savestate(regs)    up_copystate(regs, (uint32_t*)g_current_regs)
-#define up_restorestate(regs) (g_current_regs = regs)
+#define riscv_savestate(regs)    riscv_copystate(regs, (uint32_t*)g_current_regs)
+#define riscv_restorestate(regs) (g_current_regs = regs)
 #endif
 
 #define _START_TEXT  &_stext
@@ -182,53 +182,53 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size);
 
 /* IRQ initialization *******************************************************/
 
-void up_ack_irq(int irq);
+void riscv_ack_irq(int irq);
 
 #ifdef CONFIG_ARCH_RV64GC
-void up_copystate(uint64_t *dest, uint64_t *src);
-void up_copyfullstate(uint64_t *dest, uint64_t *src);
+void riscv_copystate(uint64_t *dest, uint64_t *src);
+void riscv_copyfullstate(uint64_t *dest, uint64_t *src);
 #else
-void up_copystate(uint32_t *dest, uint32_t *src);
-void up_copyfullstate(uint32_t *dest, uint32_t *src);
+void riscv_copystate(uint32_t *dest, uint32_t *src);
+void riscv_copyfullstate(uint32_t *dest, uint32_t *src);
 #endif
 
-void up_sigdeliver(void);
-int up_swint(int irq, FAR void *context, FAR void *arg);
-uint32_t up_get_newintctx(void);
+void riscv_sigdeliver(void);
+int riscv_swint(int irq, FAR void *context, FAR void *arg);
+uint32_t riscv_get_newintctx(void);
 
 #ifdef CONFIG_ARCH_FPU
 #ifdef CONFIG_ARCH_RV64GC
-void up_savefpu(uint64_t *regs);
-void up_restorefpu(const uint64_t *regs);
+void riscv_savefpu(uint64_t *regs);
+void riscv_restorefpu(const uint64_t *regs);
 #else /* !CONFIG_ARCH_RV64GC */
-void up_savefpu(uint32_t *regs);
-void up_restorefpu(const uint32_t *regs);
+void riscv_savefpu(uint32_t *regs);
+void riscv_restorefpu(const uint32_t *regs);
 #endif /* CONFIG_ARCH_RV64GC */
 #else
-#  define up_savefpu(regs)
-#  define up_restorefpu(regs)
+#  define riscv_savefpu(regs)
+#  define riscv_restorefpu(regs)
 #endif
 
 /* Power management *********************************************************/
 
 #ifdef CONFIG_PM
-void up_pminitialize(void);
+void riscv_pminitialize(void);
 #else
-#  define up_pminitialize()
+#  define riscv_pminitialize()
 #endif
 
 /* Low level serial output **************************************************/
 
-void up_lowputc(char ch);
-void up_puts(const char *str);
-void up_lowputs(const char *str);
+void riscv_lowputc(char ch);
+void riscv_puts(const char *str);
+void riscv_lowputs(const char *str);
 
 #ifdef USE_SERIALDRIVER
-void up_serialinit(void);
+void riscv_serialinit(void);
 #endif
 
 #ifdef USE_EARLYSERIALINIT
-void up_earlyserialinit(void);
+void riscv_earlyserialinit(void);
 #endif
 
 #ifdef CONFIG_RPMSG_UART
@@ -242,7 +242,7 @@ void riscv_exception(uint32_t mcause, uint32_t *regs);
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes);
+void riscv_stack_color(FAR void *stackbase, size_t nbytes);
 #endif
 
 #undef EXTERN

--- a/arch/risc-v/src/common/riscv_puts.c
+++ b/arch/risc-v/src/common/riscv_puts.c
@@ -47,14 +47,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_puts
+ * Name: riscv_puts
  *
  * Description:
  *   This is a low-level helper function used to support debug.
  *
  ****************************************************************************/
 
-void up_puts(const char *str)
+void riscv_puts(const char *str)
 {
   while (*str)
     {

--- a/arch/risc-v/src/common/riscv_usestack.c
+++ b/arch/risc-v/src/common/riscv_usestack.c
@@ -158,7 +158,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * water marks.
    */
 
-  up_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
+  riscv_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
                  sizeof(struct tls_info_s)),
                  size_of_stack - sizeof(struct tls_info_s));
 #endif

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -95,7 +95,7 @@ void up_irqinitialize(void)
 
   /* Attach the ECALL interrupt. */
 
-  irq_attach(ESP32C3_IRQ_ECALL_M, up_swint, NULL);
+  irq_attach(ESP32C3_IRQ_ECALL_M, riscv_swint, NULL);
 
 #ifdef CONFIG_ESP32C3_GPIO_IRQ
   /* Initialize GPIO interrupt support */
@@ -112,14 +112,14 @@ void up_irqinitialize(void)
 }
 
 /****************************************************************************
- * Name: up_get_newintctx
+ * Name: riscv_get_newintctx
  *
  * Description:
  *   Return initial mstatus when a task is created.
  *
  ****************************************************************************/
 
-uint32_t up_get_newintctx(void)
+uint32_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable

--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.c
@@ -632,7 +632,7 @@ void esp32c3_lowputc_restore_pins(const struct esp32c3_uart_s *priv)
 }
 
 /****************************************************************************
- * Name: up_lowputc
+ * Name: riscv_lowputc
  *
  * Description:
  *   Output one byte on the serial console.
@@ -642,7 +642,7 @@ void esp32c3_lowputc_restore_pins(const struct esp32c3_uart_s *priv)
  *
  ****************************************************************************/
 
-void up_lowputc(char ch)
+void riscv_lowputc(char ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
 

--- a/arch/risc-v/src/esp32c3/esp32c3_serial.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_serial.c
@@ -668,12 +668,12 @@ static int esp32c3_ioctl(struct file *filep, int cmd, unsigned long arg)
 #ifdef USE_EARLYSERIALINIT
 
 /****************************************************************************
- * Name: up_earlyserialinit
+ * Name: riscv_earlyserialinit
  *
  * Description:
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
- *   before up_serialinit.  NOTE:  This function depends on GPIO pin
+ *   before riscv_serialinit.  NOTE:  This function depends on GPIO pin
  *   configuration performed in up_consoleinit() and main clock
  *   initialization performed in up_clkinitialize().
  *
@@ -681,7 +681,7 @@ static int esp32c3_ioctl(struct file *filep, int cmd, unsigned long arg)
 
 /* TODO */
 
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
   /* I've been looking at others chips/arches and I noticed
    * that <chips>_lowsetup performs almost the same of this func and it's
@@ -693,15 +693,15 @@ void up_earlyserialinit(void)
 #endif /* USE_EARLYSERIALINIT */
 
 /****************************************************************************
- * Name: up_serialinit
+ * Name: riscv_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
- *   that up_earlyserialinit was called previously.
+ *   that riscv_earlyserialinit was called previously.
  *
  ****************************************************************************/
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
 #ifdef HAVE_SERIAL_CONSOLE
   uart_register("/dev/console", &CONSOLE_DEV);
@@ -737,10 +737,10 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
   esp32c3_lowputc_restore_all_uart_int(CONSOLE_DEV.priv, &int_status);
 #endif
   return ch;
@@ -749,7 +749,7 @@ int up_putc(int ch)
 #else /* HAVE_UART_DEVICE */
 
 /****************************************************************************
- * Name: up_earlyserialinit, up_serialinit, and up_putc
+ * Name: riscv_earlyserialinit, riscv_serialinit, and up_putc
  *
  * Description:
  *   stubs that may be needed.  These stubs will be used if all UARTs are
@@ -759,11 +759,11 @@ int up_putc(int ch)
  *
  ****************************************************************************/
 
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
 }
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
 }
 
@@ -777,7 +777,7 @@ int up_putc(int ch)
 
 /* Common initialization logic will not not know that the all of the UARTs
  * have been disabled.  So, as a result, we may still have to provide
- * stub implementations of up_earlyserialinit(), up_serialinit(), and
+ * stub implementations of riscv_earlyserialinit(), riscv_serialinit(), and
  * up_putc().
  */
 
@@ -802,10 +802,10 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
   esp32c3_lowputc_restore_all_uart_int(CONSOLE_DEV.priv, &int_status);
 #endif
   return ch;

--- a/arch/risc-v/src/esp32c3/esp32c3_start.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_start.c
@@ -40,7 +40,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_FEATURES
-#  define showprogress(c) up_lowputc(c)
+#  define showprogress(c) riscv_lowputc(c)
 #else
 #  define showprogress(c)
 #endif

--- a/arch/risc-v/src/fe310/fe310_allocateheap.c
+++ b/arch/risc-v/src/fe310/fe310_allocateheap.c
@@ -36,6 +36,7 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/arch.h>
 #include <arch/board/board.h>
 
 #include "fe310.h"

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -76,7 +76,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
-  up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+  riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif
 
@@ -99,7 +99,7 @@ void up_irqinitialize(void)
 
   /* Attach the ecall interrupt handler */
 
-  irq_attach(FE310_IRQ_ECALLM, up_swint, NULL);
+  irq_attach(FE310_IRQ_ECALLM, riscv_swint, NULL);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 
@@ -184,14 +184,14 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: up_get_newintctx
+ * Name: riscv_get_newintctx
  *
  * Description:
  *   Return initial mstatus when a task is created.
  *
  ****************************************************************************/
 
-uint32_t up_get_newintctx(void)
+uint32_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
@@ -201,14 +201,14 @@ uint32_t up_get_newintctx(void)
 }
 
 /****************************************************************************
- * Name: up_ack_irq
+ * Name: riscv_ack_irq
  *
  * Description:
  *   Acknowledge the IRQ
  *
  ****************************************************************************/
 
-void up_ack_irq(int irq)
+void riscv_ack_irq(int irq)
 {
   board_autoled_on(LED_CPU);
 }

--- a/arch/risc-v/src/fe310/fe310_irq_dispatch.c
+++ b/arch/risc-v/src/fe310/fe310_irq_dispatch.c
@@ -89,7 +89,7 @@ void *fe310_dispatch_irq(uint32_t vector, uint32_t *regs)
 
   /* Acknowledge the interrupt */
 
-  up_ack_irq(irq);
+  riscv_ack_irq(irq);
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/risc-v/src/fe310/fe310_lowputc.c
+++ b/arch/risc-v/src/fe310/fe310_lowputc.c
@@ -85,14 +85,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_lowputc
+ * Name: riscv_lowputc
  *
  * Description:
  *   Output one byte on the serial console
  *
  ****************************************************************************/
 
-void up_lowputc(char ch)
+void riscv_lowputc(char ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
   /* Wait until the TX data register is empty */

--- a/arch/risc-v/src/fe310/fe310_serial.c
+++ b/arch/risc-v/src/fe310/fe310_serial.c
@@ -98,7 +98,7 @@
 
 /* Common initialization logic will not not know that the all of the UARTs
  * have been disabled.  So, as a result, we may still have to provide
- * stub implementations of up_earlyserialinit(), up_serialinit(), and
+ * stub implementations of riscv_earlyserialinit(), riscv_serialinit(), and
  * up_putc().
  */
 
@@ -604,18 +604,18 @@ static bool up_txempty(struct uart_dev_s *dev)
 #ifdef USE_EARLYSERIALINIT
 
 /****************************************************************************
- * Name: up_earlyserialinit
+ * Name: riscv_earlyserialinit
  *
  * Description:
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
- *   before up_serialinit.  NOTE:  This function depends on GPIO pin
+ *   before riscv_serialinit.  NOTE:  This function depends on GPIO pin
  *   configuration performed in up_consoleinit() and main clock
  *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
   /* Disable interrupts from all UARTS.  The console is enabled in
    * fe310_consoleinit().
@@ -636,15 +636,15 @@ void up_earlyserialinit(void)
 #endif
 
 /****************************************************************************
- * Name: up_serialinit
+ * Name: riscv_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
- *   that up_earlyserialinit was called previously.
+ *   that riscv_earlyserialinit was called previously.
  *
  ****************************************************************************/
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
   /* Register the console */
 
@@ -682,17 +682,17 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
   return ch;
 }
 
 /****************************************************************************
- * Name: up_earlyserialinit, up_serialinit, and up_putc
+ * Name: riscv_earlyserialinit, riscv_serialinit, and up_putc
  *
  * Description:
  *   stubs that may be needed.  These stubs would be used if all UARTs are
@@ -703,11 +703,11 @@ int up_putc(int ch)
  ****************************************************************************/
 
 #else /* HAVE_UART_DEVICE */
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
 }
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
 }
 
@@ -736,10 +736,10 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
 #endif
   return ch;
 }

--- a/arch/risc-v/src/fe310/fe310_start.c
+++ b/arch/risc-v/src/fe310/fe310_start.c
@@ -50,7 +50,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_FEATURES
-#  define showprogress(c) up_lowputc(c)
+#  define showprogress(c) riscv_lowputc(c)
 #else
 #  define showprogress(c)
 #endif
@@ -115,7 +115,7 @@ void __fe310_start(void)
   showprogress('A');
 
 #ifdef USE_EARLYSERIALINIT
-  up_earlyserialinit();
+  riscv_earlyserialinit();
 #endif
 
   showprogress('B');

--- a/arch/risc-v/src/k210/k210_allocateheap.c
+++ b/arch/risc-v/src/k210/k210_allocateheap.c
@@ -35,9 +35,11 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+
 #include <nuttx/kmalloc.h>
 #include <nuttx/userspace.h>
 
+#include <nuttx/arch.h>
 #include <arch/board/board.h>
 
 #include "k210.h"

--- a/arch/risc-v/src/k210/k210_cpupause.c
+++ b/arch/risc-v/src/k210/k210_cpupause.c
@@ -154,7 +154,7 @@ int up_cpu_paused(int cpu)
    * of the assigned task list for this CPU.
    */
 
-  up_savestate(tcb->xcp.regs);
+  riscv_savestate(tcb->xcp.regs);
 
   /* Wait for the spinlock to be released */
 
@@ -181,7 +181,7 @@ int up_cpu_paused(int cpu)
    * will be made when the interrupt returns.
    */
 
-  up_restorestate(tcb->xcp.regs);
+  riscv_restorestate(tcb->xcp.regs);
 
   spin_unlock(&g_cpu_wait[cpu]);
 

--- a/arch/risc-v/src/k210/k210_cpustart.c
+++ b/arch/risc-v/src/k210/k210_cpustart.c
@@ -69,7 +69,7 @@
 #endif
 
 #ifdef CONFIG_DEBUG_FEATURES
-#  define showprogress(c) up_lowputc(c)
+#  define showprogress(c) riscv_lowputc(c)
 #else
 #  define showprogress(c)
 #endif

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -97,7 +97,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 7
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~7);
-  up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+  riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif
 
@@ -120,10 +120,10 @@ void up_irqinitialize(void)
 
   /* Attach the ecall interrupt handler */
 
-  irq_attach(K210_IRQ_ECALLM, up_swint, NULL);
+  irq_attach(K210_IRQ_ECALLM, riscv_swint, NULL);
 
 #ifdef CONFIG_BUILD_PROTECTED
-  irq_attach(K210_IRQ_ECALLU, up_swint, NULL);
+  irq_attach(K210_IRQ_ECALLU, riscv_swint, NULL);
 #endif
 
 #ifdef CONFIG_SMP
@@ -232,14 +232,14 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: up_get_newintctx
+ * Name: riscv_get_newintctx
  *
  * Description:
  *   Return initial mstatus when a task is created.
  *
  ****************************************************************************/
 
-uint32_t up_get_newintctx(void)
+uint32_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode. Reegardless of
    * how NuttX is configured and of what kind of thread is being started.
@@ -253,14 +253,14 @@ uint32_t up_get_newintctx(void)
 }
 
 /****************************************************************************
- * Name: up_ack_irq
+ * Name: riscv_ack_irq
  *
  * Description:
  *   Acknowledge the IRQ
  *
  ****************************************************************************/
 
-void up_ack_irq(int irq)
+void riscv_ack_irq(int irq)
 {
 }
 

--- a/arch/risc-v/src/k210/k210_irq_dispatch.c
+++ b/arch/risc-v/src/k210/k210_irq_dispatch.c
@@ -95,7 +95,7 @@ void *k210_dispatch_irq(uint64_t vector, uint64_t *regs)
 
   /* Acknowledge the interrupt */
 
-  up_ack_irq(irq);
+  riscv_ack_irq(irq);
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/risc-v/src/k210/k210_lowputc.c
+++ b/arch/risc-v/src/k210/k210_lowputc.c
@@ -85,14 +85,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_lowputc
+ * Name: riscv_lowputc
  *
  * Description:
  *   Output one byte on the serial console
  *
  ****************************************************************************/
 
-void up_lowputc(char ch)
+void riscv_lowputc(char ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
   /* Wait until the TX data register is empty */

--- a/arch/risc-v/src/k210/k210_serial.c
+++ b/arch/risc-v/src/k210/k210_serial.c
@@ -98,7 +98,7 @@
 
 /* Common initialization logic will not not know that the all of the UARTs
  * have been disabled.  So, as a result, we may still have to provide
- * stub implementations of up_earlyserialinit(), up_serialinit(), and
+ * stub implementations of riscv_earlyserialinit(), riscv_serialinit(), and
  * up_putc().
  */
 
@@ -604,18 +604,18 @@ static bool up_txempty(struct uart_dev_s *dev)
 #ifdef USE_EARLYSERIALINIT
 
 /****************************************************************************
- * Name: up_earlyserialinit
+ * Name: riscv_earlyserialinit
  *
  * Description:
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
- *   before up_serialinit.  NOTE:  This function depends on GPIO pin
+ *   before riscv_serialinit.  NOTE:  This function depends on GPIO pin
  *   configuration performed in up_consoleinit() and main clock
  *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
   /* Disable interrupts from all UARTS.  The console is enabled in
    * k210_consoleinit().
@@ -636,15 +636,15 @@ void up_earlyserialinit(void)
 #endif
 
 /****************************************************************************
- * Name: up_serialinit
+ * Name: riscv_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
- *   that up_earlyserialinit was called previously.
+ *   that riscv_earlyserialinit was called previously.
  *
  ****************************************************************************/
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
   /* Register the console */
 
@@ -682,17 +682,17 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
   return ch;
 }
 
 /****************************************************************************
- * Name: up_earlyserialinit, up_serialinit, and up_putc
+ * Name: riscv_earlyserialinit, riscv_serialinit, and up_putc
  *
  * Description:
  *   stubs that may be needed.  These stubs would be used if all UARTs are
@@ -703,11 +703,11 @@ int up_putc(int ch)
  ****************************************************************************/
 
 #else /* HAVE_UART_DEVICE */
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
 }
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
 }
 
@@ -736,10 +736,10 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
 #endif
   return ch;
 }

--- a/arch/risc-v/src/k210/k210_start.c
+++ b/arch/risc-v/src/k210/k210_start.c
@@ -51,7 +51,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_FEATURES
-#  define showprogress(c) up_lowputc(c)
+#  define showprogress(c) riscv_lowputc(c)
 #else
 #  define showprogress(c)
 #endif
@@ -124,7 +124,7 @@ void __k210_start(uint32_t mhartid)
   showprogress('A');
 
 #ifdef USE_EARLYSERIALINIT
-  up_earlyserialinit();
+  riscv_earlyserialinit();
 #endif
 
   showprogress('B');

--- a/arch/risc-v/src/litex/litex_allocateheap.c
+++ b/arch/risc-v/src/litex/litex_allocateheap.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <nuttx/arch.h>
 #include <arch/board/board.h>
 
 #include "litex.h"

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -60,7 +60,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
-  up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+  riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif
 
@@ -72,7 +72,7 @@ void up_irqinitialize(void)
 
   /* Attach the ecall interrupt handler */
 
-  irq_attach(LITEX_IRQ_ECALLM, up_swint, NULL);
+  irq_attach(LITEX_IRQ_ECALLM, riscv_swint, NULL);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 
@@ -175,14 +175,14 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: up_get_newintctx
+ * Name: riscv_get_newintctx
  *
  * Description:
  *   Return initial mstatus when a task is created.
  *
  ****************************************************************************/
 
-uint32_t up_get_newintctx(void)
+uint32_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
@@ -192,14 +192,14 @@ uint32_t up_get_newintctx(void)
 }
 
 /****************************************************************************
- * Name: up_ack_irq
+ * Name: riscv_ack_irq
  *
  * Description:
  *   Acknowledge the IRQ
  *
  ****************************************************************************/
 
-void up_ack_irq(int irq)
+void riscv_ack_irq(int irq)
 {
 }
 

--- a/arch/risc-v/src/litex/litex_irq_dispatch.c
+++ b/arch/risc-v/src/litex/litex_irq_dispatch.c
@@ -93,7 +93,7 @@ void *litex_dispatch_irq(uint32_t vector, uint32_t *regs)
 
   /* Acknowledge the interrupt */
 
-  up_ack_irq(irq);
+  riscv_ack_irq(irq);
 
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();

--- a/arch/risc-v/src/litex/litex_lowputc.c
+++ b/arch/risc-v/src/litex/litex_lowputc.c
@@ -70,14 +70,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_lowputc
+ * Name: riscv_lowputc
  *
  * Description:
  *   Output one byte on the serial console
  *
  ****************************************************************************/
 
-void up_lowputc(char ch)
+void riscv_lowputc(char ch)
 {
 #ifdef HAVE_SERIAL_CONSOLE
   /* Wait until the TX data register is empty */

--- a/arch/risc-v/src/litex/litex_serial.c
+++ b/arch/risc-v/src/litex/litex_serial.c
@@ -107,7 +107,7 @@
 
 /* Common initialization logic will not not know that the all of the UARTs
  * have been disabled.  So, as a result, we may still have to provide
- * stub implementations of up_earlyserialinit(), up_serialinit(), and
+ * stub implementations of riscv_earlyserialinit(), riscv_serialinit(), and
  * up_putc().
  */
 
@@ -621,18 +621,18 @@ static bool up_txempty(struct uart_dev_s *dev)
 #ifdef USE_EARLYSERIALINIT
 
 /****************************************************************************
- * Name: up_earlyserialinit
+ * Name: riscv_earlyserialinit
  *
  * Description:
  *   Performs the low level UART initialization early in debug so that the
  *   serial console will be available during bootup.  This must be called
- *   before up_serialinit.  NOTE:  This function depends on GPIO pin
+ *   before riscv_serialinit.  NOTE:  This function depends on GPIO pin
  *   configuration performed in up_consoleinit() and main clock
  *   initialization performed in up_clkinitialize().
  *
  ****************************************************************************/
 
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
   /* Disable interrupts from all UARTS.  The console is enabled in
    * litex_consoleinit().
@@ -653,15 +653,15 @@ void up_earlyserialinit(void)
 #endif
 
 /****************************************************************************
- * Name: up_serialinit
+ * Name: riscv_serialinit
  *
  * Description:
  *   Register serial console and serial ports.  This assumes
- *   that up_earlyserialinit was called previously.
+ *   that riscv_earlyserialinit was called previously.
  *
  ****************************************************************************/
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
   /* Register the console */
 
@@ -699,17 +699,17 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
   up_restoreuartint(priv, imr);
 #endif
   return ch;
 }
 
 /****************************************************************************
- * Name: up_earlyserialinit, up_serialinit, and up_putc
+ * Name: riscv_earlyserialinit, riscv_serialinit, and up_putc
  *
  * Description:
  *   stubs that may be needed.  These stubs would be used if all UARTs are
@@ -720,11 +720,11 @@ int up_putc(int ch)
  ****************************************************************************/
 
 #else /* HAVE_UART_DEVICE */
-void up_earlyserialinit(void)
+void riscv_earlyserialinit(void)
 {
 }
 
-void up_serialinit(void)
+void riscv_serialinit(void)
 {
 }
 
@@ -753,10 +753,10 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      up_lowputc('\r');
+      riscv_lowputc('\r');
     }
 
-  up_lowputc(ch);
+  riscv_lowputc(ch);
 #endif
   return ch;
 }

--- a/arch/risc-v/src/litex/litex_start.c
+++ b/arch/risc-v/src/litex/litex_start.c
@@ -38,7 +38,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_FEATURES
-#  define showprogress(c) up_lowputc(c)
+#  define showprogress(c) riscv_lowputc(c)
 #else
 #  define showprogress(c)
 #endif
@@ -105,7 +105,7 @@ void __litex_start(void)
   showprogress('A');
 
 #ifdef USE_EARLYSERIALINIT
-  up_earlyserialinit();
+  riscv_earlyserialinit();
 #endif
 
   showprogress('B');

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -81,10 +81,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_stackdump
+ * Name: riscv_stackdump
  ****************************************************************************/
 
-static void up_stackdump(uint32_t sp, uint32_t stack_base)
+static void riscv_stackdump(uint32_t sp, uint32_t stack_base)
 {
   uint32_t stack ;
 
@@ -98,11 +98,11 @@ static void up_stackdump(uint32_t sp, uint32_t stack_base)
 }
 
 /****************************************************************************
- * Name: up_taskdump
+ * Name: riscv_taskdump
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void riscv_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 {
   /* Dump interesting properties of this task */
 
@@ -119,25 +119,25 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 #endif
 
 /****************************************************************************
- * Name: up_showtasks
+ * Name: riscv_showtasks
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-static inline void up_showtasks(void)
+static inline void riscv_showtasks(void)
 {
   /* Dump interesting properties of each task in the crash environment */
 
-  nxsched_foreach(up_taskdump, NULL);
+  nxsched_foreach(riscv_taskdump, NULL);
 }
 #else
-#  define up_showtasks()
+#  define riscv_showtasks()
 #endif
 
 /****************************************************************************
- * Name: up_registerdump
+ * Name: riscv_registerdump
  ****************************************************************************/
 
-static inline void up_registerdump(void)
+static inline void riscv_registerdump(void)
 {
   /* Are user registers available from interrupt processing? */
 
@@ -179,10 +179,10 @@ static inline void up_registerdump(void)
 }
 
 /****************************************************************************
- * Name: up_dumpstate
+ * Name: riscv_dumpstate
  ****************************************************************************/
 
-static void up_dumpstate(void)
+static void riscv_dumpstate(void)
 {
   struct tcb_s *rtcb = running_task();
   uint32_t sp = riscv_getsp();
@@ -195,7 +195,7 @@ static void up_dumpstate(void)
 
   /* Dump the registers (if available) */
 
-  up_registerdump();
+  riscv_registerdump();
 
   /* Get the limits on the user stack memory */
 
@@ -223,7 +223,7 @@ static void up_dumpstate(void)
     {
       /* Yes.. dump the interrupt stack */
 
-      up_stackdump(sp, istackbase);
+      riscv_stackdump(sp, istackbase);
 
       /* Extract the user stack pointer which should lie
        * at the base of the interrupt stack.
@@ -235,7 +235,7 @@ static void up_dumpstate(void)
   else if (g_current_regs)
     {
       _alert("ERROR: Stack pointer is not within the interrupt stack\n");
-      up_stackdump(istackbase - istacksize, istackbase);
+      riscv_stackdump(istackbase - istacksize, istackbase);
     }
 
   /* Show user stack info */
@@ -256,21 +256,21 @@ static void up_dumpstate(void)
   if (sp > ustackbase || sp <= ustackbase - ustacksize)
     {
       _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase - ustacksize, ustackbase);
+      riscv_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      up_stackdump(sp, ustackbase);
+      riscv_stackdump(sp, ustackbase);
     }
 }
 
 #endif /* CONFIG_ARCH_STACKDUMP */
 
 /****************************************************************************
- * Name: _up_assert
+ * Name: riscv_assert
  ****************************************************************************/
 
-static void _up_assert(void)
+static void riscv_assert(void)
 {
   /* Flush any buffered SYSLOG data */
 
@@ -354,11 +354,11 @@ void up_assert(const char *filename, int lineno)
         filename, lineno);
 #endif
 
-  up_dumpstate();
+  riscv_dumpstate();
 
   /* Dump the state of all tasks (if available) */
 
-  up_showtasks();
+  riscv_showtasks();
 
 #ifdef CONFIG_ARCH_USBDUMP
   /* Dump USB trace data */
@@ -374,5 +374,5 @@ void up_assert(const char *filename, int lineno)
   board_crashdump(riscv_getsp(), running_task(), filename, lineno);
 #endif
 
-  _up_assert();
+  riscv_assert();
 }

--- a/arch/risc-v/src/rv32im/riscv_blocktask.c
+++ b/arch/risc-v/src/rv32im/riscv_blocktask.c
@@ -121,7 +121,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the g_current_regs into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          riscv_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -137,7 +137,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          riscv_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/risc-v/src/rv32im/riscv_copyfullstate.c
+++ b/arch/risc-v/src/rv32im/riscv_copyfullstate.c
@@ -34,7 +34,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyfullstate
+ * Name: riscv_copyfullstate
  *
  * Description:
  *    Copy the entire register save area (including the floating point
@@ -43,7 +43,7 @@
  *
  ****************************************************************************/
 
-void up_copyfullstate(uint32_t *dest, uint32_t *src)
+void riscv_copyfullstate(uint32_t *dest, uint32_t *src)
 {
   int i;
 

--- a/arch/risc-v/src/rv32im/riscv_copystate.c
+++ b/arch/risc-v/src/rv32im/riscv_copystate.c
@@ -61,12 +61,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copystate
+ * Name: riscv_copystate
  ****************************************************************************/
 
 /* A little faster than most memcpy's */
 
-void up_copystate(uint32_t *dest, uint32_t *src)
+void riscv_copystate(uint32_t *dest, uint32_t *src)
 {
   int i;
 
@@ -94,7 +94,7 @@ void up_copystate(uint32_t *dest, uint32_t *src)
        */
 
 #ifdef CONFIG_ARCH_FPU
-      up_savefpu(regs);
+      riscv_savefpu(regs);
 #endif
     }
 }

--- a/arch/risc-v/src/rv32im/riscv_doirq.c
+++ b/arch/risc-v/src/rv32im/riscv_doirq.c
@@ -110,7 +110,7 @@ uint32_t *up_doirq(int irq, uint32_t *regs)
 #ifdef CONFIG_ARCH_FPU
       /* Restore floating point registers */
 
-      up_restorefpu((uint32_t *)g_current_regs);
+      riscv_restorefpu((uint32_t *)g_current_regs);
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/risc-v/src/rv32im/riscv_fpu.S
+++ b/arch/risc-v/src/rv32im/riscv_fpu.S
@@ -36,8 +36,8 @@
  ************************************************************************************/
 
 	.globl		up_fpuconfig
-	.globl		up_savefpu
-	.globl		up_restorefpu
+	.globl		riscv_savefpu
+	.globl		riscv_restorefpu
 
 	.file		"up_fpu.S"
 
@@ -88,14 +88,14 @@ up_fpuconfig:
 	ret
 
 /************************************************************************************
- * Name: up_savefpu
+ * Name: riscv_savefpu
  *
  * Description:
  *   Given the pointer to a register save area (in A0), save the state of the
  *   floating point registers.
  *
  * C Function Prototype:
- *   void up_savefpu(uint32_t *regs);
+ *   void riscv_savefpu(uint32_t *regs);
  *
  * Input Parameters:
  *   regs - A pointer to the register save area in which to save the floating point
@@ -106,9 +106,9 @@ up_fpuconfig:
  *
  ************************************************************************************/
 
-	.type		up_savefpu, function
+	.type		riscv_savefpu, function
 
-up_savefpu:
+riscv_savefpu:
 	lw		t0, REG_INT_CTX(a0)
 	li		t1, FS_MASK
 	and		t2, t0, t1
@@ -162,14 +162,14 @@ up_savefpu:
 	ret
 
 /************************************************************************************
- * Name: up_restorefpu
+ * Name: riscv_restorefpu
  *
  * Description:
  *   Given the pointer to a register save area (in A0), restore the state of the
  *   floating point registers.
  *
  * C Function Prototype:
- *   void up_restorefpu(const uint32_t *regs);
+ *   void riscv_restorefpu(const uint32_t *regs);
  *
  * Input Parameters:
  *   regs - A pointer to the register save area containing the floating point
@@ -181,9 +181,9 @@ up_savefpu:
  *
  ************************************************************************************/
 
-	.type		up_restorefpu, function
+	.type		riscv_restorefpu, function
 
-up_restorefpu:
+riscv_restorefpu:
 	lw		t0, REG_INT_CTX(a0)
 	li		t1, FS_MASK
 	and		t2, t0, t1

--- a/arch/risc-v/src/rv32im/riscv_initialstate.c
+++ b/arch/risc-v/src/rv32im/riscv_initialstate.c
@@ -125,6 +125,6 @@ void up_initial_state(struct tcb_s *tcb)
    *
    */
 
-  regval = up_get_newintctx();
+  regval = riscv_get_newintctx();
   xcp->regs[REG_INT_CTX] = regval;
 }

--- a/arch/risc-v/src/rv32im/riscv_releasepending.c
+++ b/arch/risc-v/src/rv32im/riscv_releasepending.c
@@ -93,7 +93,7 @@ void up_release_pending(void)
            * Just copy the g_current_regs into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+           riscv_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -109,7 +109,7 @@ void up_release_pending(void)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          riscv_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/risc-v/src/rv32im/riscv_reprioritizertr.c
+++ b/arch/risc-v/src/rv32im/riscv_reprioritizertr.c
@@ -146,7 +146,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the g_current_regs into the OLD rtcb.
                */
 
-               up_savestate(rtcb->xcp.regs);
+               riscv_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -162,7 +162,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * changes will be made when the interrupt returns.
                */
 
-              up_restorestate(rtcb->xcp.regs);
+              riscv_restorestate(rtcb->xcp.regs);
             }
 
           /* No, then we will need to perform the user context switch */

--- a/arch/risc-v/src/rv32im/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/rv32im/riscv_schedulesigaction.c
@@ -133,7 +133,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * disabled
                */
 
-              g_current_regs[REG_EPC]     = (uint32_t)up_sigdeliver;
+              g_current_regs[REG_EPC]     = (uint32_t)riscv_sigdeliver;
 
               int_ctx                     = g_current_regs[REG_INT_CTX];
               int_ctx                    &= ~MSTATUS_MPIE;
@@ -144,7 +144,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * is the same as the interrupt return context.
                */
 
-              up_savestate(tcb->xcp.regs);
+              riscv_savestate(tcb->xcp.regs);
 
               sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32
                     " New: %08" PRIx32 "/%08" PRIx32 "\n",
@@ -174,7 +174,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * disabled
            */
 
-          tcb->xcp.regs[REG_EPC]     = (uint32_t)up_sigdeliver;
+          tcb->xcp.regs[REG_EPC]     = (uint32_t)riscv_sigdeliver;
 
           int_ctx                    = tcb->xcp.regs[REG_INT_CTX];
           int_ctx                   &= ~MSTATUS_MPIE;

--- a/arch/risc-v/src/rv32im/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv32im/riscv_sigdeliver.c
@@ -64,7 +64,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_sigdeliver
+ * Name: riscv_sigdeliver
  *
  * Description:
  *   This is the a signal handling trampoline.  When a signal action was
@@ -73,7 +73,7 @@
  *
  ****************************************************************************/
 
-void up_sigdeliver(void)
+void riscv_sigdeliver(void)
 {
   struct tcb_s *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
@@ -93,7 +93,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copyfullstate(regs, rtcb->xcp.regs);
+  riscv_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Then make sure that interrupts are enabled.  Signal handlers must always

--- a/arch/risc-v/src/rv32im/riscv_swint.c
+++ b/arch/risc-v/src/rv32im/riscv_swint.c
@@ -43,11 +43,11 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_registerdump
+ * Name: riscv_registerdump
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-static void up_registerdump(const uint32_t *regs)
+static void riscv_registerdump(const uint32_t *regs)
 {
   svcinfo("EPC:%08x\n",
           regs[REG_EPC]);
@@ -74,7 +74,7 @@ static void up_registerdump(const uint32_t *regs)
 #endif
 }
 #else
-#  define up_registerdump(regs)
+#  define riscv_registerdump(regs)
 #endif
 
 /****************************************************************************
@@ -113,7 +113,7 @@ static void dispatch_syscall(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_swint
+ * Name: riscv_swint
  *
  * Description:
  *   This is software interrupt exception handler that performs context
@@ -121,7 +121,7 @@ static void dispatch_syscall(void)
  *
  ****************************************************************************/
 
-int up_swint(int irq, FAR void *context, FAR void *arg)
+int riscv_swint(int irq, FAR void *context, FAR void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
 
@@ -134,7 +134,7 @@ int up_swint(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
   svcinfo("Entry: regs: %p cmd: %d\n", regs, regs[REG_A0]);
-  up_registerdump(regs);
+  riscv_registerdump(regs);
 #endif
 
   /* Skip ECALL instruction */
@@ -165,7 +165,7 @@ int up_swint(int irq, FAR void *context, FAR void *arg)
       case SYS_save_context:
         {
           DEBUGASSERT(regs[REG_A1] != 0);
-          up_copystate((uint32_t *)regs[REG_A1], regs);
+          riscv_copystate((uint32_t *)regs[REG_A1], regs);
           ((uint32_t *)regs[REG_A1])[REG_A0] = 1;
         }
       break;
@@ -212,7 +212,7 @@ int up_swint(int irq, FAR void *context, FAR void *arg)
       case SYS_switch_context:
         {
           DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
-          up_copystate((uint32_t *)regs[REG_A1], regs);
+          riscv_copystate((uint32_t *)regs[REG_A1], regs);
           g_current_regs = (uint32_t *)regs[REG_A2];
         }
         break;
@@ -309,7 +309,7 @@ int up_swint(int irq, FAR void *context, FAR void *arg)
   if (regs != g_current_regs)
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_registerdump((const uint32_t *)g_current_regs);
+      riscv_registerdump((const uint32_t *)g_current_regs);
     }
   else
     {

--- a/arch/risc-v/src/rv32im/riscv_unblocktask.c
+++ b/arch/risc-v/src/rv32im/riscv_unblocktask.c
@@ -106,7 +106,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the g_current_regs into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          riscv_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -122,7 +122,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          riscv_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/risc-v/src/rv64gc/riscv_blocktask.c
+++ b/arch/risc-v/src/rv64gc/riscv_blocktask.c
@@ -121,7 +121,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          riscv_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -137,7 +137,7 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          riscv_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/risc-v/src/rv64gc/riscv_copyfullstate.c
+++ b/arch/risc-v/src/rv64gc/riscv_copyfullstate.c
@@ -34,7 +34,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copyfullstate
+ * Name: riscv_copyfullstate
  *
  * Description:
  *    Copy the entire register save area (including the floating point
@@ -43,7 +43,7 @@
  *
  ****************************************************************************/
 
-void up_copyfullstate(uint64_t *dest, uint64_t *src)
+void riscv_copyfullstate(uint64_t *dest, uint64_t *src)
 {
   int i;
 

--- a/arch/risc-v/src/rv64gc/riscv_copystate.c
+++ b/arch/risc-v/src/rv64gc/riscv_copystate.c
@@ -61,12 +61,12 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_copystate
+ * Name: riscv_copystate
  ****************************************************************************/
 
 /* A little faster than most memcpy's */
 
-void up_copystate(uint64_t *dest, uint64_t *src)
+void riscv_copystate(uint64_t *dest, uint64_t *src)
 {
   int i;
 
@@ -94,7 +94,7 @@ void up_copystate(uint64_t *dest, uint64_t *src)
        */
 
 #ifdef CONFIG_ARCH_FPU
-      up_savefpu(regs);
+      riscv_savefpu(regs);
 #endif
     }
 }

--- a/arch/risc-v/src/rv64gc/riscv_fpu.S
+++ b/arch/risc-v/src/rv64gc/riscv_fpu.S
@@ -36,8 +36,8 @@
  ************************************************************************************/
 
     .globl        up_fpuconfig
-    .globl        up_savefpu
-    .globl        up_restorefpu
+    .globl        riscv_savefpu
+    .globl        riscv_restorefpu
 
     .file         "riscv_fpu.S"
 
@@ -88,14 +88,14 @@ up_fpuconfig:
     ret
 
 /************************************************************************************
- * Name: up_savefpu
+ * Name: riscv_savefpu
  *
  * Description:
  *   Given the pointer to a register save area (in A0), save the state of the
  *   floating point registers.
  *
  * C Function Prototype:
- *   void up_savefpu(uint32_t *regs);
+ *   void riscv_savefpu(uint32_t *regs);
  *
  * Input Parameters:
  *   regs - A pointer to the register save area in which to save the floating point
@@ -106,9 +106,9 @@ up_fpuconfig:
  *
  ************************************************************************************/
 
-    .type         up_savefpu, function
+    .type         riscv_savefpu, function
 
-up_savefpu:
+riscv_savefpu:
     lw            t0, REG_INT_CTX(a0)
     li            t1, FS_MASK
     and           t2, t0, t1
@@ -162,14 +162,14 @@ up_savefpu:
     ret
 
 /************************************************************************************
- * Name: up_restorefpu
+ * Name: riscv_restorefpu
  *
  * Description:
  *   Given the pointer to a register save area (in A0), restore the state of the
  *   floating point registers.
  *
  * C Function Prototype:
- *   void up_restorefpu(const uint32_t *regs);
+ *   void riscv_restorefpu(const uint32_t *regs);
  *
  * Input Parameters:
  *   regs - A pointer to the register save area containing the floating point
@@ -181,9 +181,9 @@ up_savefpu:
  *
  ************************************************************************************/
 
-    .type        up_restorefpu, function
+    .type        riscv_restorefpu, function
 
-up_restorefpu:
+riscv_restorefpu:
     lw           t0, REG_INT_CTX(a0)
     li           t1, FS_MASK
     and          t2, t0, t1

--- a/arch/risc-v/src/rv64gc/riscv_initialstate.c
+++ b/arch/risc-v/src/rv64gc/riscv_initialstate.c
@@ -106,6 +106,6 @@ void up_initial_state(struct tcb_s *tcb)
    *
    */
 
-  regval = up_get_newintctx();
+  regval = riscv_get_newintctx();
   xcp->regs[REG_INT_CTX] = regval;
 }

--- a/arch/risc-v/src/rv64gc/riscv_releasepending.c
+++ b/arch/risc-v/src/rv64gc/riscv_releasepending.c
@@ -93,7 +93,7 @@ void up_release_pending(void)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-           up_savestate(rtcb->xcp.regs);
+           riscv_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -109,7 +109,7 @@ void up_release_pending(void)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          riscv_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */

--- a/arch/risc-v/src/rv64gc/riscv_reprioritizertr.c
+++ b/arch/risc-v/src/rv64gc/riscv_reprioritizertr.c
@@ -146,7 +146,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * Just copy the CURRENT_REGS into the OLD rtcb.
                */
 
-               up_savestate(rtcb->xcp.regs);
+               riscv_savestate(rtcb->xcp.regs);
 
               /* Restore the exception context of the rtcb at the (new) head
                * of the ready-to-run task list.
@@ -162,7 +162,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
                * changes will be made when the interrupt returns.
                */
 
-              up_restorestate(rtcb->xcp.regs);
+              riscv_restorestate(rtcb->xcp.regs);
             }
 
           /* No, then we will need to perform the user context switch */

--- a/arch/risc-v/src/rv64gc/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/rv64gc/riscv_schedulesigaction.c
@@ -150,7 +150,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * privileged thread mode.
                */
 
-              CURRENT_REGS[REG_EPC]     = (uintptr_t)up_sigdeliver;
+              CURRENT_REGS[REG_EPC]     = (uintptr_t)riscv_sigdeliver;
 
               int_ctx                     = CURRENT_REGS[REG_INT_CTX];
               int_ctx                    &= ~MSTATUS_MPIE;
@@ -164,7 +164,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * is the same as the interrupt return context.
                */
 
-              up_savestate(tcb->xcp.regs);
+              riscv_savestate(tcb->xcp.regs);
 
               sinfo("PC/STATUS Saved: %016" PRIx64 "/%016" PRIx64
                     " New: %016" PRIx64 "/%016" PRIx64 "\n",
@@ -195,7 +195,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * here.
            */
 
-          tcb->xcp.regs[REG_EPC]      = (uintptr_t)up_sigdeliver;
+          tcb->xcp.regs[REG_EPC]      = (uintptr_t)riscv_sigdeliver;
 
           int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
           int_ctx                    &= ~MSTATUS_MPIE;
@@ -290,7 +290,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * to be here.
                    */
 
-                  tcb->xcp.regs[REG_EPC]      = (uintptr_t)up_sigdeliver;
+                  tcb->xcp.regs[REG_EPC]      = (uintptr_t)riscv_sigdeliver;
 
                   int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
                   int_ctx                    &= ~MSTATUS_MPIE;
@@ -315,7 +315,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * privileged thread mode.
                    */
 
-                  CURRENT_REGS[REG_EPC]     = (uintptr_t)up_sigdeliver;
+                  CURRENT_REGS[REG_EPC]     = (uintptr_t)riscv_sigdeliver;
 
                   int_ctx                   = CURRENT_REGS[REG_INT_CTX];
                   int_ctx                   &= ~MSTATUS_MPIE;
@@ -329,7 +329,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * same as the interrupt return context.
                    */
 
-                  up_savestate(tcb->xcp.regs);
+                  riscv_savestate(tcb->xcp.regs);
                 }
 
               /* Increment the IRQ lock count so that when the task is
@@ -382,7 +382,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * here.
            */
 
-          tcb->xcp.regs[REG_EPC]      = (uintptr_t)up_sigdeliver;
+          tcb->xcp.regs[REG_EPC]      = (uintptr_t)riscv_sigdeliver;
 
           int_ctx                     = tcb->xcp.regs[REG_INT_CTX];
           int_ctx                    &= ~MSTATUS_MPIE;

--- a/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
@@ -64,7 +64,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_sigdeliver
+ * Name: riscv_sigdeliver
  *
  * Description:
  *   This is the a signal handling trampoline.  When a signal action was
@@ -73,7 +73,7 @@
  *
  ****************************************************************************/
 
-void up_sigdeliver(void)
+void riscv_sigdeliver(void)
 {
   struct tcb_s *rtcb = this_task();
   uint64_t regs[XCPTCONTEXT_REGS];
@@ -102,7 +102,7 @@ void up_sigdeliver(void)
 
   /* Save the return state on the stack. */
 
-  up_copyfullstate(regs, rtcb->xcp.regs);
+  riscv_copyfullstate(regs, rtcb->xcp.regs);
 
 #ifdef CONFIG_SMP
   /* In the SMP case, up_schedule_sigaction(0) will have incremented

--- a/arch/risc-v/src/rv64gc/riscv_swint.c
+++ b/arch/risc-v/src/rv64gc/riscv_swint.c
@@ -62,11 +62,11 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_registerdump
+ * Name: riscv_registerdump
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
-static void up_registerdump(const uint64_t *regs)
+static void riscv_registerdump(const uint64_t *regs)
 {
   svcinfo("EPC:%08x\n",
           regs[REG_EPC]);
@@ -93,7 +93,7 @@ static void up_registerdump(const uint64_t *regs)
 #endif
 }
 #else
-#  define up_registerdump(regs)
+#  define riscv_registerdump(regs)
 #endif
 
 /****************************************************************************
@@ -140,7 +140,7 @@ static void dispatch_syscall(void)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_swint
+ * Name: riscv_swint
  *
  * Description:
  *   This is software interrupt exception handler that performs context
@@ -148,7 +148,7 @@ static void dispatch_syscall(void)
  *
  ****************************************************************************/
 
-int up_swint(int irq, FAR void *context, FAR void *arg)
+int riscv_swint(int irq, FAR void *context, FAR void *arg)
 {
   uint64_t *regs = (uint64_t *)context;
 
@@ -161,7 +161,7 @@ int up_swint(int irq, FAR void *context, FAR void *arg)
 
 #ifdef CONFIG_DEBUG_SYSCALL_INFO
   svcinfo("Entry: regs: %p cmd: %d\n", regs, regs[REG_A0]);
-  up_registerdump(regs);
+  riscv_registerdump(regs);
 #endif
 
   /* Handle the SWInt according to the command in $a0 */
@@ -209,7 +209,7 @@ int up_swint(int irq, FAR void *context, FAR void *arg)
       case SYS_switch_context:
         {
           DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
-          up_copystate((uint64_t *)regs[REG_A1], regs);
+          riscv_copystate((uint64_t *)regs[REG_A1], regs);
           CURRENT_REGS = (uint64_t *)regs[REG_A2];
         }
         break;
@@ -454,7 +454,7 @@ int up_swint(int irq, FAR void *context, FAR void *arg)
   if (regs != CURRENT_REGS)
     {
       svcinfo("SWInt Return: Context switch!\n");
-      up_registerdump((const uint32_t *)CURRENT_REGS);
+      riscv_registerdump((const uint32_t *)CURRENT_REGS);
     }
   else
     {

--- a/arch/risc-v/src/rv64gc/riscv_unblocktask.c
+++ b/arch/risc-v/src/rv64gc/riscv_unblocktask.c
@@ -106,7 +106,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * Just copy the CURRENT_REGS into the OLD rtcb.
            */
 
-          up_savestate(rtcb->xcp.regs);
+          riscv_savestate(rtcb->xcp.regs);
 
           /* Restore the exception context of the rtcb at the (new) head
            * of the ready-to-run task list.
@@ -122,7 +122,7 @@ void up_unblock_task(struct tcb_s *tcb)
            * changes will be made when the interrupt returns.
            */
 
-          up_restorestate(rtcb->xcp.regs);
+          riscv_restorestate(rtcb->xcp.regs);
         }
 
       /* No, then we will need to perform the user context switch */


### PR DESCRIPTION
## Summary
1. Rename functions internal to the RISC-V directory to start with `riscv_` instead of `up_` which is reserved for functions exported outside the arch directory.
2. `up_alloacte_heap` is already declared in `arch.h` remove it from `riscv_internal.h`
3. Remove a declaration of a function `up_boot` that's not used anywhere.
## Impact
Just renaming.
## Testing
Built a few RISC-V boards.
