### PR TITLE
tools/mksymtab: support non-function symbols

### DIFF
--- a/tools/mksymtab.c
+++ b/tools/mksymtab.c
@@ -286,7 +286,7 @@ int main(int argc, char **argv, char **envp)
 
       /* Output the symbol table entry */
 
-      fprintf(outstream, "%s  { \"%s\", (FAR const void *)%s }",
+      fprintf(outstream, "%s  { \"%s\", (FAR const void *)&%s }",
               nextterm, g_parm[NAME_INDEX], g_parm[NAME_INDEX]);
 
       if (cond)


### PR DESCRIPTION
## Summary

Support non-function symbols by using `&` to take the address of the symbol - required for, eg, `optind` and `optarg`.

## Impact

Take a reference to the symbol to be exported rather than the symbol directly. For function arguments this has no effect. For non-function arguments this enabled exporting global variables.

## Testing

Load and relocate `nsh` as an ELF binary on eZ80 architecture; verify symtab file builds for ARM.