### PR TITLE
arm/rp2040: Fix SPI halfword DMA transfer

### DIFF
--- a/arch/arm/src/rp2040/rp2040_dmac.c
+++ b/arch/arm/src/rp2040/rp2040_dmac.c
@@ -357,7 +357,7 @@ void rp2040_rxdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
           RP2040_DMA_CTRL_TRIG_TREQ_SEL_MASK) |
          ((ch << RP2040_DMA_CTRL_TRIG_CHAIN_TO_SHIFT) &
           RP2040_DMA_CTRL_TRIG_CHAIN_TO_MASK) |
-         config.size;
+         (config.size << RP2040_DMA_CTRL_TRIG_DATA_SIZE_SHIFT);
 
   if (!config.noincr)
     {
@@ -418,7 +418,7 @@ void rp2040_txdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
           RP2040_DMA_CTRL_TRIG_TREQ_SEL_MASK) |
          ((ch << RP2040_DMA_CTRL_TRIG_CHAIN_TO_SHIFT) &
           RP2040_DMA_CTRL_TRIG_CHAIN_TO_MASK) |
-         config.size;
+         (config.size << RP2040_DMA_CTRL_TRIG_DATA_SIZE_SHIFT);
 
   if (!config.noincr)
     {

--- a/arch/arm/src/rp2040/rp2040_spi.c
+++ b/arch/arm/src/rp2040/rp2040_spi.c
@@ -1070,7 +1070,7 @@ static void spi_dmatxsetup(FAR struct rp2040_spidev_s *priv,
     }
 
   rp2040_txdmasetup(priv->txdmach, (uintptr_t)dst, (uintptr_t)txbuffer,
-                   nwords, priv->txconfig);
+                   nwords << priv->txconfig.size, priv->txconfig);
 }
 
 /****************************************************************************
@@ -1110,7 +1110,7 @@ static void spi_dmarxsetup(FAR struct rp2040_spidev_s *priv,
     }
 
   rp2040_rxdmasetup(priv->rxdmach, (uintptr_t)src, (uintptr_t)rxbuffer,
-                   nwords, priv->rxconfig);
+                   nwords << priv->rxconfig.size, priv->rxconfig);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
BUGFIX: Raspberry Pi Pico SPI harfword DMA transfer doesn't work.
DMA_CTRL register setting and the transfer length was wrong.

## Impact
rp2040 only

## Testing
Tested with under-development "Pico Display Pack" driver which use half word SPI transfer.
