### PR TITLE
find_blockdriver: Don't ferr() on MTDs

### DIFF
--- a/fs/driver/fs_findblockdriver.c
+++ b/fs/driver/fs_findblockdriver.c
@@ -94,7 +94,17 @@ int find_blockdriver(FAR const char *pathname, int mountflags,
 
   if (!INODE_IS_BLOCK(inode))
     {
-      ferr("ERROR: %s is not a block driver\n", pathname);
+#ifdef CONFIG_MTD
+      if (INODE_IS_MTD(inode))
+        {
+          finfo("%s is a MTD\n", pathname);
+        }
+      else
+#endif
+        {
+          ferr("ERROR: %s is not a block driver\n", pathname);
+        }
+
       ret = -ENOTBLK;
       goto errout_with_inode;
     }


### PR DESCRIPTION
## Summary
find_blockdriver: Don't ferr() on MTDs
It's the normal path when you open a MTD. ferr() is too strong.
## Impact
change the syslog message
## Testing
w/ CONFIG_MTD, tested on a board. (esp32)
w/o CONFIG_MTD, build-tested. (sim:vpnkit)
