### PR TITLE
tcp_sendfile.c: Remove an unused copy of CONFIG_NET_TCP_SPLIT_SIZE

### DIFF
--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -78,10 +78,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_NET_TCP_SPLIT) && !defined(CONFIG_NET_TCP_SPLIT_SIZE)
-#  define CONFIG_NET_TCP_SPLIT_SIZE 40
-#endif
-
 #define TCPIPv4BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
 #define TCPIPv6BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 


### PR DESCRIPTION
## Summary
tcp_sendfile.c: Remove an unused copy of CONFIG_NET_TCP_SPLIT_SIZE
## Impact

## Testing
build tested
