### PR TITLE
fs/mmap: Clarify MAP_PRIVATE dependency on CONFIG_FS_RAMMAP

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -98,13 +98,15 @@
  *     ENOSYS
  *       Returned if any of the unsupported mmap() features are attempted
  *     EBADF
- *      'fd' is not a valid file descriptor.
+ *       'fd' is not a valid file descriptor.
  *     EINVAL
- *      Length is 0. flags contained neither MAP_PRIVATE or MAP_SHARED, or
- *      contained both of these values.
+ *       Length is 0. flags contained neither MAP_PRIVATE or MAP_SHARED, or
+ *       contained both of these values.
  *     ENODEV
- *      The underlying filesystem of the specified file does not support
- *      memory mapping.
+ *       The underlying filesystem of the specified file does not support
+ *       memory mapping.
+ *     ENOMEM
+ *       Insufficient memory is available to map the file.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
This PR intends to fix a misleading reported error when `mmap` is called with the MAP_PRIVATE flag and CONFIG_FS_RAMMAP is not enabled.

A simple refactor on `fs_mmap.c` makes this dependency explicit.

## Impact
No actual control flow change to the `mmap` function. When CONFIG_DEBUG_FEATURES is enabled, it will now report a **ENOSYS** error for `mmap` calls with MAP_PRIVATE flag and CONFIG_FS_RAMMAP not defined.

## Testing
LTP tests on ESP32 and ESP32-C3.