### PR TITLE
ESP32: Mount TMPFS on board bring up

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -174,6 +174,17 @@ int esp32_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmpfs file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at %s: %d\n",
+             CONFIG_LIBC_TMPDIR, ret);
+    }
+#endif
+
 #ifdef CONFIG_MMCSD
   ret = esp32_mmcsd_initialize(0);
   if (ret < 0)

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
@@ -134,6 +134,17 @@ int esp32_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmpfs file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at %s: %d\n",
+             CONFIG_LIBC_TMPDIR, ret);
+    }
+#endif
+
 #ifdef CONFIG_MMCSD
   ret = esp32_mmcsd_initialize(0);
   if (ret < 0)

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -143,6 +143,17 @@ int esp32_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_FS_TMPFS
+  /* Mount the tmpfs file system */
+
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at %s: %d\n",
+             CONFIG_LIBC_TMPDIR, ret);
+    }
+#endif
+
 #ifdef CONFIG_MMCSD
   ret = esp32_mmcsd_initialize(0);
   if (ret < 0)


### PR DESCRIPTION
## Summary
This PR intends to add the functionality of mounting a TMPFS directory on board bring up when CONFIG_FS_TMPFS is enabled.

## Impact
New feature, will only take effect when CONFIG_FS_TMPFS is enabled.

## Testing
`esp32-wrover-kit:nsh` with `CONFIG_FS_TMPFS=y`
```shell
NuttShell (NSH) NuttX-10.0.1
nsh> mount
  /proc type procfs
  /tmp type tmpfs
nsh> 
```
