### PR TITLE
boards/esp32c3-devkit: Use nx_mount to avoid overriding errno

### DIFF
--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
@@ -78,7 +78,7 @@ int esp32c3_bringup(void)
 #ifdef CONFIG_FS_TMPFS
   /* Mount the tmpfs file system */
 
-  ret = mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
+  ret = nx_mount(NULL, CONFIG_LIBC_TMPDIR, "tmpfs", 0, NULL);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to mount tmpfs at %s: %d\n",


### PR DESCRIPTION
## Summary
Change `mount` call to `nx_mount` to not mess with the `errno` value in driver code.

## Impact
No impact.

## Testing
`esp32c3-devkit:nsh` with CONFIG_FS_TMPFS correctly mounting /tmp

