### PR TITLE
arch/arm: Fix syscall number out of swi range in thumb mode

### DIFF
--- a/arch/arm/include/arm/syscall.h
+++ b/arch/arm/include/arm/syscall.h
@@ -54,7 +54,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define SYS_syscall 0x900001
+#define SYS_syscall 0x00
 
 #if defined(__thumb__) || defined(__thumb2__)
 #  define SYS_smhcall 0xab

--- a/arch/arm/include/armv7-a/syscall.h
+++ b/arch/arm/include/armv7-a/syscall.h
@@ -54,7 +54,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define SYS_syscall 0x900001
+#define SYS_syscall 0x00
 
 #if defined(__thumb__) || defined(__thumb2__)
 #  define SYS_smhcall 0xab

--- a/arch/arm/include/armv7-r/syscall.h
+++ b/arch/arm/include/armv7-r/syscall.h
@@ -54,7 +54,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define SYS_syscall 0x900001
+#define SYS_syscall 0x00
 
 #if defined(__thumb__) || defined(__thumb2__)
 #  define SYS_smhcall 0xab


### PR DESCRIPTION
## Summary
The immediate number is 8bits in thumb mode:
```
+---------------------+---------------+
|15 14 13 12 11 10 9 8|7 6 5 4 3 2 1 0|
+---------------------+---------------+
| 1  1  0  1  1  1 1 1|      imm8     |
+---------------------+---------------+
```
The immediate number is 24bits in arm mode:
```
+-----------+-------------------------------------------------------------------------+
|31 30 29 28|27 26 25 24|23 22 21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0|
+-----------+-----------+-------------------------------------------------------------+
|   cond    | 1  1  1  1|                                imm24                        |
+-----------+-----------+-------------------------------------------------------------+
```

## Impact
Fix the build error in thumb mode when syscall is enabled

## Testing

