### PR TITLE
arch/stm32l4: Fix nxstyle errors

### DIFF
--- a/arch/arm/include/stm32l4/chip.h
+++ b/arch/arm/include/stm32l4/chip.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32l4/chip.h
  *
  *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
@@ -33,27 +33,29 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_CHIP_H
 #define __ARCH_ARM_INCLUDE_STM32L4_CHIP_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
+
 /* STM32L475, STM32L476, STM32L486, STM32L496, STM32L4A6
  *
  * Differences between family members:
- *  - L475 has no TSC, no LCD, no AES, no I2C4, no CAN2, No Hash/CRS, no DCMI,
- *    no DMA2D
+ *  - L475 has no TSC, no LCD, no AES, no I2C4, no CAN2, No Hash/CRS, no
+ *    DCMI, no DMA2D
  *  - L486 has AES
- *  - L496, L4A6 has 320 Kib SRAM, 2xCAN and CameraIF. Most (all?) of these have I2C4.
+ *  - L496, L4A6 has 320 Kib SRAM, 2xCAN and CameraIF. Most (all?) of these
+ *    have I2C4.
  *  - L4A6 has AES and HASH
  *
  *   ----------- ---------------- ----- ------ ------ ---- ---- -----
@@ -335,7 +337,8 @@
 #  define STM32L4_NOPAMP                   1   /* Operational Amplifiers */
 #endif /* CONFIG_STM32L4_STM32L412XX || CONFIG_STM32L4_STM32L422XX */
 
-/* NVIC priority levels *************************************************************/
+/* NVIC priority levels *****************************************************/
+
 /* 16 Programmable interrupt levels */
 
 #define NVIC_SYSH_PRIORITY_MIN     0xf0 /* All bits set in minimum priority */

--- a/arch/arm/include/stm32l4/irq.h
+++ b/arch/arm/include/stm32l4/irq.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32l4/irq.h
  *
  *   Copyright (C) 2015 Sebastien Lorquet. All rights reserved.
@@ -31,7 +31,7 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 /* This file should never be included directly but, rather,
  * only indirectly through nuttx/irq.h
@@ -40,41 +40,47 @@
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_IRQ_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  */
 
 /* Processor Exceptions (vectors 0-15) */
 
 #define STM32L4_IRQ_RESERVED       (0) /* Reserved vector (only used with CONFIG_DEBUG_FEATURES) */
-                                     /* Vector  0: Reset stack pointer value */
-                                     /* Vector  1: Reset (not handler as an IRQ) */
+                                       /* Vector  0: Reset stack pointer value */
+                                       /* Vector  1: Reset (not handler as an IRQ) */
 #define STM32L4_IRQ_NMI            (2) /* Vector  2: Non-Maskable Interrupt (NMI) */
 #define STM32L4_IRQ_HARDFAULT      (3) /* Vector  3: Hard fault */
 #define STM32L4_IRQ_MEMFAULT       (4) /* Vector  4: Memory management (MPU) */
 #define STM32L4_IRQ_BUSFAULT       (5) /* Vector  5: Bus fault */
 #define STM32L4_IRQ_USAGEFAULT     (6) /* Vector  6: Usage fault */
-                                     /* Vectors 7-10: Reserved */
+                                       /* Vectors 7-10: Reserved */
 #define STM32L4_IRQ_SVCALL        (11) /* Vector 11: SVC call */
 #define STM32L4_IRQ_DBGMONITOR    (12) /* Vector 12: Debug Monitor */
-                                     /* Vector 13: Reserved */
+                                       /* Vector 13: Reserved */
 #define STM32L4_IRQ_PENDSV        (14) /* Vector 14: Pendable system service request */
 #define STM32L4_IRQ_SYSTICK       (15) /* Vector 15: System tick */
 
-/* External interrupts (vectors >= 16).  These definitions are chip-specific */
+/* External interrupts (vectors >= 16).  These definitions are
+ * chip-specific
+ */
 
 #define STM32L4_IRQ_FIRST         (16) /* Vector number of the first external interrupt */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
 
 #if defined(CONFIG_STM32L4_STM32L4X3)
 #  include <arch/stm32l4/stm32l4x3xx_irq.h>
@@ -88,13 +94,13 @@
 #  error "Unsupported STM32 L4 chip"
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Public Types
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Public Data
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -105,9 +111,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/include/stm32l4/stm32l4x5xx_irq.h
+++ b/arch/arm/include/stm32l4/stm32l4x5xx_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32l4/stm32l4x5xx_irq.h
  *
  *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
@@ -34,43 +34,47 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through arch/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_STM32L4X5XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_STM32L4X5XX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to bits in the
- * NVIC.  This does, however, waste several words of memory in the IRQ to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found in the file
- * nuttx/arch/arm/include/stm32l4/irq.h which includes this file.
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in the file nuttx/arch/arm/include/stm32l4/irq.h which includes
+ * this file.
  *
  * External interrupts (vectors >= 16)
  */
 
-#define STM32L4_IRQ_WWDG        (STM32L4_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
-#define STM32L4_IRQ_PVD         (STM32L4_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
-#define STM32L4_IRQ_TAMPER      (STM32L4_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32L4_IRQ_TIMESTAMP   (STM32L4_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32L4_IRQ_RTC_WKUP    (STM32L4_IRQ_FIRST + 3)  /* 3:  RTC global interrupt */
-#define STM32L4_IRQ_FLASH       (STM32L4_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
-#define STM32L4_IRQ_RCC         (STM32L4_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
-#define STM32L4_IRQ_EXTI0       (STM32L4_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
-#define STM32L4_IRQ_EXTI1       (STM32L4_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
-#define STM32L4_IRQ_EXTI2       (STM32L4_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt */
-#define STM32L4_IRQ_EXTI3       (STM32L4_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#define STM32L4_IRQ_WWDG        (STM32L4_IRQ_FIRST + 0)  /*  0: Window Watchdog interrupt */
+#define STM32L4_IRQ_PVD         (STM32L4_IRQ_FIRST + 1)  /*  1: PVD through EXTI Line detection interrupt */
+#define STM32L4_IRQ_TAMPER      (STM32L4_IRQ_FIRST + 2)  /*  2: Tamper and time stamp interrupts */
+#define STM32L4_IRQ_TIMESTAMP   (STM32L4_IRQ_FIRST + 2)  /*  2: Tamper and time stamp interrupts */
+#define STM32L4_IRQ_RTC_WKUP    (STM32L4_IRQ_FIRST + 3)  /*  3: RTC global interrupt */
+#define STM32L4_IRQ_FLASH       (STM32L4_IRQ_FIRST + 4)  /*  4: Flash global interrupt */
+#define STM32L4_IRQ_RCC         (STM32L4_IRQ_FIRST + 5)  /*  5: RCC global interrupt */
+#define STM32L4_IRQ_EXTI0       (STM32L4_IRQ_FIRST + 6)  /*  6: EXTI Line 0 interrupt */
+#define STM32L4_IRQ_EXTI1       (STM32L4_IRQ_FIRST + 7)  /*  7: EXTI Line 1 interrupt */
+#define STM32L4_IRQ_EXTI2       (STM32L4_IRQ_FIRST + 8)  /*  8: EXTI Line 2 interrupt */
+#define STM32L4_IRQ_EXTI3       (STM32L4_IRQ_FIRST + 9)  /*  9: EXTI Line 3 interrupt */
 #define STM32L4_IRQ_EXTI4       (STM32L4_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
 #define STM32L4_IRQ_DMA1CH1     (STM32L4_IRQ_FIRST + 11) /* 11: DMA1 Channel 1 global interrupt */
 #define STM32L4_IRQ_DMA1CH2     (STM32L4_IRQ_FIRST + 12) /* 12: DMA1 Channel 2 global interrupt */
@@ -154,13 +158,13 @@
 
 #define NR_IRQS                 (STM32L4_IRQ_FIRST + STM32L4_IRQ_NEXTINTS)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -171,9 +175,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/include/stm32l4/stm32l4x6xx_irq.h
+++ b/arch/arm/include/stm32l4/stm32l4x6xx_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32l4/stm32l4x6xx_irq.h
  *
  *   Copyright (C) 2015 Sebastien Lorquet. All rights reserved.
@@ -32,43 +32,47 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through arch/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_STM32L4X6XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_STM32L4X6XX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to bits in the
- * NVIC.  This does, however, waste several words of memory in the IRQ to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found in the file
- * nuttx/arch/arm/include/stm32l4/irq.h which includes this file.
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in the file nuttx/arch/arm/include/stm32l4/irq.h which includes
+ * this file.
  *
  * External interrupts (vectors >= 16)
  */
 
-#define STM32L4_IRQ_WWDG        (STM32L4_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
-#define STM32L4_IRQ_PVD         (STM32L4_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
-#define STM32L4_IRQ_TAMPER      (STM32L4_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32L4_IRQ_TIMESTAMP   (STM32L4_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32L4_IRQ_RTC_WKUP    (STM32L4_IRQ_FIRST + 3)  /* 3:  RTC global interrupt */
-#define STM32L4_IRQ_FLASH       (STM32L4_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
-#define STM32L4_IRQ_RCC         (STM32L4_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
-#define STM32L4_IRQ_EXTI0       (STM32L4_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
-#define STM32L4_IRQ_EXTI1       (STM32L4_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
-#define STM32L4_IRQ_EXTI2       (STM32L4_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt */
-#define STM32L4_IRQ_EXTI3       (STM32L4_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#define STM32L4_IRQ_WWDG        (STM32L4_IRQ_FIRST + 0)  /*  0: Window Watchdog interrupt */
+#define STM32L4_IRQ_PVD         (STM32L4_IRQ_FIRST + 1)  /*  1: PVD through EXTI Line detection interrupt */
+#define STM32L4_IRQ_TAMPER      (STM32L4_IRQ_FIRST + 2)  /*  2: Tamper and time stamp interrupts */
+#define STM32L4_IRQ_TIMESTAMP   (STM32L4_IRQ_FIRST + 2)  /*  2: Tamper and time stamp interrupts */
+#define STM32L4_IRQ_RTC_WKUP    (STM32L4_IRQ_FIRST + 3)  /*  3: RTC global interrupt */
+#define STM32L4_IRQ_FLASH       (STM32L4_IRQ_FIRST + 4)  /*  4: Flash global interrupt */
+#define STM32L4_IRQ_RCC         (STM32L4_IRQ_FIRST + 5)  /*  5: RCC global interrupt */
+#define STM32L4_IRQ_EXTI0       (STM32L4_IRQ_FIRST + 6)  /*  6: EXTI Line 0 interrupt */
+#define STM32L4_IRQ_EXTI1       (STM32L4_IRQ_FIRST + 7)  /*  7: EXTI Line 1 interrupt */
+#define STM32L4_IRQ_EXTI2       (STM32L4_IRQ_FIRST + 8)  /*  8: EXTI Line 2 interrupt */
+#define STM32L4_IRQ_EXTI3       (STM32L4_IRQ_FIRST + 9)  /*  9: EXTI Line 3 interrupt */
 #define STM32L4_IRQ_EXTI4       (STM32L4_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
 #define STM32L4_IRQ_DMA1CH1     (STM32L4_IRQ_FIRST + 11) /* 11: DMA1 Channel 1 global interrupt */
 #define STM32L4_IRQ_DMA1CH2     (STM32L4_IRQ_FIRST + 12) /* 12: DMA1 Channel 2 global interrupt */
@@ -170,13 +174,13 @@
 
 #define NR_IRQS                 (STM32L4_IRQ_FIRST + STM32L4_IRQ_NEXTINTS)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -187,9 +191,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Fix nxstyle errors in:

- arch/arm/include/stm32l4/chip.h
- arch/arm/include/stm32l4/irq.h
- arch/arm/include/stm32l4/stm32l4x5xx_irq.h
- arch/arm/include/stm32l4/stm32l4x6xx_irq.h

## Impact

Removes nxstyle errors.

## Testing

nxstyle