### PR TITLE
arch/stm32l4: Fix nxstyle errors

### DIFF
--- a/arch/arm/include/stm32l4/stm32l4x3xx_irq.h
+++ b/arch/arm/include/stm32l4/stm32l4x3xx_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32l4/stm32l4x3xx_irq.h
  *
  *   Copyright (C) 2015 Sebastien Lorquet. All rights reserved.
@@ -33,47 +33,51 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through arch/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_STM32L4X3XX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_STM32L4X3XX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to bits in the
- * NVIC.  This does, however, waste several words of memory in the IRQ to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found in the file
- * nuttx/arch/arm/include/stm32l4/irq.h which includes this file
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in the file nuttx/arch/arm/include/stm32l4/irq.h which includes
+ * this file
  *
  * External interrupts (vectors >= 16)
  *
- * These interrupts vectors was implemented based on RM0394 Table 45 and should work for
- * STM32L431xx, STM32L451xx, STM32L4X2 and STM32L4X3.
+ * These interrupts vectors was implemented based on RM0394 Table 45 and
+ * should work for STM32L431xx, STM32L451xx, STM32L4X2 and STM32L4X3.
  *
  */
 
-#define STM32L4_IRQ_WWDG        (STM32L4_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
-#define STM32L4_IRQ_PVD         (STM32L4_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
-#define STM32L4_IRQ_TAMPER      (STM32L4_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32L4_IRQ_TIMESTAMP   (STM32L4_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32L4_IRQ_RTC_WKUP    (STM32L4_IRQ_FIRST + 3)  /* 3:  RTC global interrupt */
-#define STM32L4_IRQ_FLASH       (STM32L4_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
-#define STM32L4_IRQ_RCC         (STM32L4_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
-#define STM32L4_IRQ_EXTI0       (STM32L4_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
-#define STM32L4_IRQ_EXTI1       (STM32L4_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
-#define STM32L4_IRQ_EXTI2       (STM32L4_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt */
-#define STM32L4_IRQ_EXTI3       (STM32L4_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#define STM32L4_IRQ_WWDG        (STM32L4_IRQ_FIRST + 0)  /*  0: Window Watchdog interrupt */
+#define STM32L4_IRQ_PVD         (STM32L4_IRQ_FIRST + 1)  /*  1: PVD through EXTI Line detection interrupt */
+#define STM32L4_IRQ_TAMPER      (STM32L4_IRQ_FIRST + 2)  /*  2: Tamper and time stamp interrupts */
+#define STM32L4_IRQ_TIMESTAMP   (STM32L4_IRQ_FIRST + 2)  /*  2: Tamper and time stamp interrupts */
+#define STM32L4_IRQ_RTC_WKUP    (STM32L4_IRQ_FIRST + 3)  /*  3: RTC global interrupt */
+#define STM32L4_IRQ_FLASH       (STM32L4_IRQ_FIRST + 4)  /*  4: Flash global interrupt */
+#define STM32L4_IRQ_RCC         (STM32L4_IRQ_FIRST + 5)  /*  5: RCC global interrupt */
+#define STM32L4_IRQ_EXTI0       (STM32L4_IRQ_FIRST + 6)  /*  6: EXTI Line 0 interrupt */
+#define STM32L4_IRQ_EXTI1       (STM32L4_IRQ_FIRST + 7)  /*  7: EXTI Line 1 interrupt */
+#define STM32L4_IRQ_EXTI2       (STM32L4_IRQ_FIRST + 8)  /*  8: EXTI Line 2 interrupt */
+#define STM32L4_IRQ_EXTI3       (STM32L4_IRQ_FIRST + 9)  /*  9: EXTI Line 3 interrupt */
 #define STM32L4_IRQ_EXTI4       (STM32L4_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
 #define STM32L4_IRQ_DMA1CH1     (STM32L4_IRQ_FIRST + 11) /* 11: DMA1 Channel 1 global interrupt */
 #define STM32L4_IRQ_DMA1CH2     (STM32L4_IRQ_FIRST + 12) /* 12: DMA1 Channel 2 global interrupt */
@@ -96,7 +100,7 @@
 #define STM32L4_IRQ_TIM1CC      (STM32L4_IRQ_FIRST + 27) /* 27: TIM1 Capture Compare interrupt */
 #define STM32L4_IRQ_TIM2        (STM32L4_IRQ_FIRST + 28) /* 28: TIM2 global interrupt */
 #define STM32L4_IRQ_TIM3        (STM32L4_IRQ_FIRST + 29) /* 29: TIM3 global interrupt */
-/* Reserved */                                           /* 30: TIM4 global interrupt */
+                                                         /* Reserved 30: TIM4 global interrupt */
 #define STM32L4_IRQ_I2C1EV      (STM32L4_IRQ_FIRST + 31) /* 31: I2C1 event interrupt */
 #define STM32L4_IRQ_I2C1ER      (STM32L4_IRQ_FIRST + 32) /* 32: I2C1 error interrupt */
 #define STM32L4_IRQ_I2C2EV      (STM32L4_IRQ_FIRST + 33) /* 33: I2C2 event interrupt */
@@ -108,12 +112,12 @@
 #define STM32L4_IRQ_USART3      (STM32L4_IRQ_FIRST + 39) /* 39: USART3 global interrupt */
 #define STM32L4_IRQ_EXTI1510    (STM32L4_IRQ_FIRST + 40) /* 40: EXTI Line[15:10] interrupts */
 #define STM32L4_IRQ_RTCALRM     (STM32L4_IRQ_FIRST + 41) /* 41: RTC alarm through EXTI line interrupt */
-/* Reserved */                                           /* 42-48: reserved */
+                                                         /* Reserved 42-48 */
 #define STM32L4_IRQ_SDMMC1      (STM32L4_IRQ_FIRST + 49) /* 49: SDMMC1 global interrupt */
-/* Reserved */                                           /* 50: TIM5 global interrupt */
+                                                         /* Reserved 50: TIM5 global interrupt */
 #define STM32L4_IRQ_SPI3        (STM32L4_IRQ_FIRST + 51) /* 51: SPI3 global interrupt */
 #define STM32L4_IRQ_UART4       (STM32L4_IRQ_FIRST + 52) /* 52: UART4 global interrupt */
-/* Reserved */                                         /* 53: UART5 global interrupt */
+                                                         /* Reserved 53: UART5 global interrupt */
 #define STM32L4_IRQ_TIM6        (STM32L4_IRQ_FIRST + 54) /* 54: TIM6 global interrupt */
 #define STM32L4_IRQ_DAC         (STM32L4_IRQ_FIRST + 54) /* 54: DAC1 underrun error interrupts */
 #define STM32L4_IRQ_TIM7        (STM32L4_IRQ_FIRST + 55) /* 55: TIM7 global interrupt */
@@ -124,7 +128,7 @@
 #define STM32L4_IRQ_DMA2CH5     (STM32L4_IRQ_FIRST + 60) /* 60: DMA2 Channel 5 global interrupt */
 #define STM32L4_IRQ_DFSDM0      (STM32L4_IRQ_FIRST + 61) /* 61: DFSDM0 global interrupt */
 #define STM32L4_IRQ_DFSDM1      (STM32L4_IRQ_FIRST + 62) /* 62: DFSDM1 global interrupt*/
-/* Reserved */                                           /* 63: DFSDM2 global interrupt */
+                                                         /* Reserved 63: DFSDM2 global interrupt */
 #define STM32L4_IRQ_COMP        (STM32L4_IRQ_FIRST + 64) /* 64: COMP1/COMP2 interrupts */
 #define STM32L4_IRQ_LPTIM1      (STM32L4_IRQ_FIRST + 65) /* 65: LPTIM1 global interrupt */
 #define STM32L4_IRQ_LPTIM2      (STM32L4_IRQ_FIRST + 66) /* 66: LPTIM2 global interrupt */
@@ -136,7 +140,7 @@
 #define STM32L4_IRQ_I2C3EV      (STM32L4_IRQ_FIRST + 72) /* 72: I2C3 event interrupt */
 #define STM32L4_IRQ_I2C3ER      (STM32L4_IRQ_FIRST + 73) /* 73: I2C3 error interrupt */
 #define STM32L4_IRQ_SAI1        (STM32L4_IRQ_FIRST + 74) /* 74: SAI1 global interrupt */
-/* Reserved */                                           /* 75: SAI2 global interrupt */
+                                                         /* Reserved 75: SAI2 global interrupt */
 #define STM32L4_IRQ_SWPMI1      (STM32L4_IRQ_FIRST + 76) /* 76: SWPMI1 global interrupt */
 #define STM32L4_IRQ_TSC         (STM32L4_IRQ_FIRST + 77) /* 77: TSC global interrupt */
 #define STM32L4_IRQ_LCD         (STM32L4_IRQ_FIRST + 78) /* 78: LCD global interrupt */
@@ -157,13 +161,13 @@
 
 #define NR_IRQS                 (STM32L4_IRQ_FIRST + STM32L4_IRQ_NEXTINTS)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -174,9 +178,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/include/stm32l4/stm32l4xrxx_irq.h
+++ b/arch/arm/include/stm32l4/stm32l4xrxx_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32l4/stm32l4xrxx_irq.h
  *
  *   Copyright (C) 2015 Sebastien Lorquet. All rights reserved.
@@ -32,43 +32,47 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through arch/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through arch/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32L4_STM32L4XRXX_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32L4_STM32L4XRXX_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to bits in the
- * NVIC.  This does, however, waste several words of memory in the IRQ to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found in the file
- * nuttx/arch/arm/include/stm32l4/irq.h which includes this file.
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in the file nuttx/arch/arm/include/stm32l4/irq.h which includes
+ * this file.
  *
  * External interrupts (vectors >= 16)
  */
 
-#define STM32L4_IRQ_WWDG        (STM32L4_IRQ_FIRST + 0)  /* 0:  Window Watchdog interrupt */
-#define STM32L4_IRQ_PVD         (STM32L4_IRQ_FIRST + 1)  /* 1:  PVD through EXTI Line detection interrupt */
-#define STM32L4_IRQ_TAMPER      (STM32L4_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32L4_IRQ_TIMESTAMP   (STM32L4_IRQ_FIRST + 2)  /* 2:  Tamper and time stamp interrupts */
-#define STM32L4_IRQ_RTC_WKUP    (STM32L4_IRQ_FIRST + 3)  /* 3:  RTC global interrupt */
-#define STM32L4_IRQ_FLASH       (STM32L4_IRQ_FIRST + 4)  /* 4:  Flash global interrupt */
-#define STM32L4_IRQ_RCC         (STM32L4_IRQ_FIRST + 5)  /* 5:  RCC global interrupt */
-#define STM32L4_IRQ_EXTI0       (STM32L4_IRQ_FIRST + 6)  /* 6:  EXTI Line 0 interrupt */
-#define STM32L4_IRQ_EXTI1       (STM32L4_IRQ_FIRST + 7)  /* 7:  EXTI Line 1 interrupt */
-#define STM32L4_IRQ_EXTI2       (STM32L4_IRQ_FIRST + 8)  /* 8:  EXTI Line 2 interrupt */
-#define STM32L4_IRQ_EXTI3       (STM32L4_IRQ_FIRST + 9)  /* 9:  EXTI Line 3 interrupt */
+#define STM32L4_IRQ_WWDG        (STM32L4_IRQ_FIRST + 0)  /*  0: Window Watchdog interrupt */
+#define STM32L4_IRQ_PVD         (STM32L4_IRQ_FIRST + 1)  /*  1: PVD through EXTI Line detection interrupt */
+#define STM32L4_IRQ_TAMPER      (STM32L4_IRQ_FIRST + 2)  /*  2: Tamper and time stamp interrupts */
+#define STM32L4_IRQ_TIMESTAMP   (STM32L4_IRQ_FIRST + 2)  /*  2: Tamper and time stamp interrupts */
+#define STM32L4_IRQ_RTC_WKUP    (STM32L4_IRQ_FIRST + 3)  /*  3: RTC global interrupt */
+#define STM32L4_IRQ_FLASH       (STM32L4_IRQ_FIRST + 4)  /*  4: Flash global interrupt */
+#define STM32L4_IRQ_RCC         (STM32L4_IRQ_FIRST + 5)  /*  5: RCC global interrupt */
+#define STM32L4_IRQ_EXTI0       (STM32L4_IRQ_FIRST + 6)  /*  6: EXTI Line 0 interrupt */
+#define STM32L4_IRQ_EXTI1       (STM32L4_IRQ_FIRST + 7)  /*  7: EXTI Line 1 interrupt */
+#define STM32L4_IRQ_EXTI2       (STM32L4_IRQ_FIRST + 8)  /*  8: EXTI Line 2 interrupt */
+#define STM32L4_IRQ_EXTI3       (STM32L4_IRQ_FIRST + 9)  /*  9: EXTI Line 3 interrupt */
 #define STM32L4_IRQ_EXTI4       (STM32L4_IRQ_FIRST + 10) /* 10: EXTI Line 4 interrupt */
 #define STM32L4_IRQ_DMA1CH1     (STM32L4_IRQ_FIRST + 11) /* 11: DMA1 Channel 1 global interrupt */
 #define STM32L4_IRQ_DMA1CH2     (STM32L4_IRQ_FIRST + 12) /* 12: DMA1 Channel 2 global interrupt */
@@ -109,7 +113,7 @@
 #define STM32L4_IRQ_TIM8UP      (STM32L4_IRQ_FIRST + 44) /* 44: TIM8 Update interrupt */
 #define STM32L4_IRQ_TIM8TRGCOM  (STM32L4_IRQ_FIRST + 45) /* 45: TIM8 Trigger and Commutation interrupts */
 #define STM32L4_IRQ_TIM8CC      (STM32L4_IRQ_FIRST + 46) /* 46: TIM8 Capture Compare interrupt */
-/* Reserved */                                           /* 47: ADC3 global interrupt */
+                                                         /* Reserved 47: ADC3 global interrupt */
 #define STM32L4_IRQ_FSMC        (STM32L4_IRQ_FIRST + 48) /* 48: FSMC global interrupt */
 #define STM32L4_IRQ_SDMMC1      (STM32L4_IRQ_FIRST + 49) /* 49: SDMMC1 global interrupt */
 #define STM32L4_IRQ_TIM5        (STM32L4_IRQ_FIRST + 50) /* 50: TIM5 global interrupt */
@@ -149,7 +153,7 @@
 #define STM32L4_IRQ_I2C4EV      (STM32L4_IRQ_FIRST + 83) /* 83: I2C4 event interrupt */
 #define STM32L4_IRQ_I2C4ER      (STM32L4_IRQ_FIRST + 84) /* 84: I2C4 error interrupt */
 #define STM32L4_IRQ_DCMI        (STM32L4_IRQ_FIRST + 85) /* 85: DCMI global interrupt */
-/* Reserved */                                           /* 86-89: CAN2 */
+                                                         /* Reserved 86-89: CAN2 */
 #define STM32L4_IRQ_DMA2D       (STM32L4_IRQ_FIRST + 90) /* 90: DMA2D global interrupt */
 #define STM32L4_IRQ_LCD_TFT     (STM32L4_IRQ_FIRST + 91) /* 91: LTDC global interrupt */
 #define STM32L4_IRQ_LCD_TFT_ER  (STM32L4_IRQ_FIRST + 92) /* 92: LTDC global error interrupt */
@@ -162,13 +166,13 @@
 
 #define NR_IRQS                 (STM32L4_IRQ_FIRST + STM32L4_IRQ_NEXTINTS)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -179,9 +183,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Fix (most) nxstyle errors in:
- arch/arm/include/stm32l4/stm32l4x3xx_irq.h
- arch/arm/include/stm32l4/stm32l4xrxx_irq.h

## Impact

Removes nxstyle errors.

## Testing

nxstyle