### PR TITLE
[FlexCAN] Correct reset state for CTRL1 register

### DIFF
--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -1579,6 +1579,15 @@ static int kinetis_initialize(struct kinetis_driver_s *priv)
       return -1;
     }
 
+  /* Reset CTRL1 register to reset value */
+
+  regval  = getreg32(priv->base + KINETIS_CAN_CTRL1_OFFSET);
+  regval &= ~(CAN_CTRL1_LOM | CAN_CTRL1_LBUF | CAN_CTRL1_TSYN |
+              CAN_CTRL1_BOFFREC | CAN_CTRL1_SMP | CAN_CTRL1_RWRNMSK |
+              CAN_CTRL1_TWRNMSK | CAN_CTRL1_LPB | CAN_CTRL1_ERRMSK |
+              CAN_CTRL1_BOFFMSK);
+  putreg32(regval, priv->base + KINETIS_CAN_CTRL1_OFFSET);
+
 #ifndef CONFIG_NET_CAN_CANFD
   regval  = getreg32(priv->base + KINETIS_CAN_CTRL1_OFFSET);
 

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1582,6 +1582,15 @@ static int s32k1xx_initialize(struct s32k1xx_driver_s *priv)
       return -1;
     }
 
+  /* Reset CTRL1 register to reset value */
+
+  regval  = getreg32(priv->base + S32K1XX_CAN_CTRL1_OFFSET);
+  regval &= ~(CAN_CTRL1_LOM | CAN_CTRL1_LBUF | CAN_CTRL1_TSYN |
+              CAN_CTRL1_BOFFREC | CAN_CTRL1_SMP | CAN_CTRL1_RWRNMSK |
+              CAN_CTRL1_TWRNMSK | CAN_CTRL1_LPB | CAN_CTRL1_ERRMSK |
+              CAN_CTRL1_BOFFMSK);
+  putreg32(regval, priv->base + S32K1XX_CAN_CTRL1_OFFSET);
+
 #ifndef CONFIG_NET_CAN_CANFD
   regval  = getreg32(priv->base + S32K1XX_CAN_CTRL1_OFFSET);
 


### PR DESCRIPTION
## Summary
FlexCAN assumed that CTRL1 was in reset, but is not always the case which could case a bug that the CAN controller stays in listen-only mode.

## Impact
S32K1XX Kinetis

## Testing
Tested on UCANS32K146
