### PR TITLE
Remove a redundant critical section in nxsem

### DIFF
--- a/sched/semaphore/sem_clockwait.c
+++ b/sched/semaphore/sem_clockwait.c
@@ -91,7 +91,6 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
                     FAR const struct timespec *abstime)
 {
   FAR struct tcb_s *rtcb = this_task();
-  irqstate_t flags;
   sclock_t ticks;
   int status;
   int ret = ERROR;
@@ -109,15 +108,10 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
     }
 #endif
 
-  /* We will disable interrupts until we have completed the semaphore
-   * wait.  We need to do this (as opposed to just disabling pre-emption)
-   * because there could be interrupt handlers that are asynchronously
-   * posting semaphores and to prevent race conditions with watchdog
-   * timeout.  This is not too bad because interrupts will be re-
-   * enabled while we are blocked waiting for the semaphore.
+  /* NOTE: We do not need a critical section here, because
+   * nxsem_wait() and nxsem_timeout() use a critical section
+   * in the functions.
    */
-
-  flags = enter_critical_section();
 
   /* Try to take the semaphore without waiting. */
 
@@ -126,7 +120,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
     {
       /* We got it! */
 
-      goto success_with_irqdisabled;
+      goto out;
     }
 
   /* We will have to wait for the semaphore.  Make sure that we were provided
@@ -136,7 +130,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
   if (abstime->tv_nsec < 0 || abstime->tv_nsec >= 1000000000)
     {
       ret = -EINVAL;
-      goto errout_with_irqdisabled;
+      goto out;
     }
 
   /* Convert the timespec to clock ticks.  We must have interrupts
@@ -153,7 +147,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
   if (status == OK && ticks <= 0)
     {
       ret = -ETIMEDOUT;
-      goto errout_with_irqdisabled;
+      goto out;
     }
 
   /* Handle any time-related errors */
@@ -161,7 +155,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
   if (status != OK)
     {
       ret = -status;
-      goto errout_with_irqdisabled;
+      goto out;
     }
 
   /* Start the watchdog */
@@ -178,11 +172,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
 
   wd_cancel(&rtcb->waitdog);
 
-  /* We can now restore interrupts and delete the watchdog */
-
-success_with_irqdisabled:
-errout_with_irqdisabled:
-  leave_critical_section(flags);
+out:
   return ret;
 }
 

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -70,21 +70,15 @@
 int nxsem_tickwait(FAR sem_t *sem, clock_t start, uint32_t delay)
 {
   FAR struct tcb_s *rtcb = this_task();
-  irqstate_t flags;
   clock_t elapsed;
   int ret;
 
   DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
 
-  /* We will disable interrupts until we have completed the semaphore
-   * wait.  We need to do this (as opposed to just disabling pre-emption)
-   * because there could be interrupt handlers that are asynchronously
-   * posting semaphores and to prevent race conditions with watchdog
-   * timeout.  This is not too bad because interrupts will be re-
-   * enabled while we are blocked waiting for the semaphore.
+  /* NOTE: We do not need a critical section here, because
+   * nxsem_wait() and nxsem_timeout() use a critical section
+   * in the functions.
    */
-
-  flags = enter_critical_section();
 
   /* Try to take the semaphore without waiting. */
 
@@ -93,7 +87,7 @@ int nxsem_tickwait(FAR sem_t *sem, clock_t start, uint32_t delay)
     {
       /* We got it! */
 
-      goto success_with_irqdisabled;
+      goto out;
     }
 
   /* We will have to wait for the semaphore.  Make sure that we were provided
@@ -104,7 +98,7 @@ int nxsem_tickwait(FAR sem_t *sem, clock_t start, uint32_t delay)
     {
       /* Return the errno from nxsem_trywait() */
 
-      goto errout_with_irqdisabled;
+      goto out;
     }
 
   /* Adjust the delay for any time since the delay was calculated */
@@ -113,7 +107,7 @@ int nxsem_tickwait(FAR sem_t *sem, clock_t start, uint32_t delay)
   if (/* elapsed >= (UINT32_MAX / 2) || */ elapsed >= delay)
     {
       ret = -ETIMEDOUT;
-      goto errout_with_irqdisabled;
+      goto out;
     }
 
   delay -= elapsed;
@@ -130,21 +124,8 @@ int nxsem_tickwait(FAR sem_t *sem, clock_t start, uint32_t delay)
 
   wd_cancel(&rtcb->waitdog);
 
-  if (ret < 0)
-    {
-      goto errout_with_irqdisabled;
-    }
+out:
 
-  /* We can now restore interrupts */
-
-  /* Success exits */
-
-success_with_irqdisabled:
-
-  /* Error exits */
-
-errout_with_irqdisabled:
-  leave_critical_section(flags);
   return ret;
 }
 


### PR DESCRIPTION
## Summary

- This PR removes a redundant critical section in nxsem_clockwait() and nxsem_tickwait()

## Impact

- None

## Testing

- Tested with ostest with the following configurations
   - maix-bit:smp (QEMU), sim:smp, esp32-devkitc:smp
   - sabre-6quad:smp (QEMU), spresense:smp
   - maix-bit:nsh (QEMU), sim:ostest, esp32-devkitc:ostest
   - sabre-6quad:nsh (QEMU), spresense:wifi
- Tested with ping with the following configs
   - spresense:rndis, spresense:rndis_smp
   - 