### PR TITLE
stdio/lib_clearerr: Did not clear stream buffer flags in clearerr

### DIFF
--- a/libs/libc/stdio/lib_clearerr.c
+++ b/libs/libc/stdio/lib_clearerr.c
@@ -48,6 +48,6 @@
 
 void clearerr(FAR FILE *stream)
 {
-  stream->fs_flags = 0;
+  stream->fs_flags &= (__FS_FLAG_LBF | __FS_FLAG_UBF);
 }
 #endif /* CONFIG_FILE_STREAM */


### PR DESCRIPTION
## Summary

Stream buffer flags has a dependency with allocated buffer,
and it cannot clear without buffer operation.

Change clearerr to keep buffer flags to prevent unexpected
buffer operation.

## Impact

File system

## Testing

Tested by spresense:audio with next code.
<pre>
  FILE *fptr = NULL;

  fptr = fopen("/mnt/spif/test.txt", "w");
  if (!fptr)
    {
      printf("File open failed.\n");
      return -1;
    }

  clearerr(fptr);

  fclose(fptr);
</pre>
