### PR TITLE
cxd56_gnss: Add missing include header for cxd56_gnss.c

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fixedmath.h>
+#include <fcntl.h>
 #include <poll.h>
 #include <errno.h>
 #include <debug.h>


### PR DESCRIPTION
## Summary

cxd56_gnss.c uses file descriptor operation from next change.
 0536953 Kernel module should prefer functions with nx/kmm prefix

But this change need to add fcntl.h in include header.
So, add missing header.

## Impact

## Testing

Tested by spresense board
