### PR TITLE
arch:rv64:keep the stack to be 16bytes aligned.

### DIFF
--- a/arch/risc-v/src/rv64gc/riscv_signal_handler.S
+++ b/arch/risc-v/src/rv64gc/riscv_signal_handler.S
@@ -69,8 +69,8 @@ up_signal_handler:
 
   /* Save ra on the stack */
 
-  addi sp, sp, -8
-  sd   ra, (sp)
+  addi sp, sp, -16
+  sd   ra, 8(sp)
 
   /* Call the signal handler */
 
@@ -82,8 +82,8 @@ up_signal_handler:
 
   /* Restore the register */
 
-  ld   ra, (sp)  /* Restore ra in sp */
-  addi sp, sp, 8
+  ld   ra, 8(sp)  /* Restore ra in sp */
+  addi sp, sp, 16
 
   /* Execute the SYS_signal_handler_return SVCall (will not return) */
 


### PR DESCRIPTION
Signed-off-by: hotislandn <hotislandn@hotmail.com>

## Summary
This patch makes the stack 16bytes aligned for RV64.

## Impact
RV64 targets.

## Testing
"ostest" passed for smartl-c906:knsh build.
