### PR TITLE
esp32_allocateheap.c: Don't allocate ROM regions when running in QEMU.

### DIFF
--- a/arch/xtensa/include/esp32/memory_layout.h
+++ b/arch/xtensa/include/esp32/memory_layout.h
@@ -114,18 +114,18 @@
  * the size of the internal heap.
  *
  * The QEMU bootloader image is slightly different than the chip's one.
- * The ROM on PRO and APP uses different regions for static data. In QEMU,
- * however, we load only one ROM binary, taken from the PRO CPU, and it is
- * used by both CPUs.  So, in QEMU, if we allocate this part early, it will
- * be clobbered once the APP CPU starts.
+ * The ROM on PRO and APP CPUs uses different regions for static data.
+ * In QEMU, however, we load only one ROM binary, taken from the PRO CPU,
+ * and it is used by both CPUs.  So, in QEMU, if we allocate PRO CPUs region
+ * early, it will be clobbered once the APP CPU starts.
  * We can delay the allocation to when everything has started through the
  * board_late_initiliaze hook, as is done for the APP data, however this
  * should be fixed from QEMU side.  The following macros, then, just skip
- * PRO CPU's data when a QEMU image generation is enabled with SMP.
+ * PRO CPU's regions when a QEMU image generation is enabled with SMP.
  */
 
 #if defined(CONFIG_ESP32_QEMU_IMAGE) && defined(CONFIG_SMP)
-#  define HEAP_REGION2_START  0x3ffe1330
+#  define HEAP_REGION2_START  0x3ffe7e40
 #else
 #  define HEAP_REGION2_START  0x3ffe0450
 #endif

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -127,6 +127,11 @@ void xtensa_add_region(void)
   umm_addregion(start, size);
 
 #else
+#ifdef CONFIG_ESP32_QEMU_IMAGE
+  start = (FAR void *)HEAP_REGION2_START;
+  size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
+  umm_addregion(start, size);
+#else
   start = (FAR void *)HEAP_REGION2_START;
   size  = (size_t)(HEAP_REGION2_END - HEAP_REGION2_START);
   umm_addregion(start, size);
@@ -135,10 +140,13 @@ void xtensa_add_region(void)
   size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
   umm_addregion(start, size);
 #endif
+#endif
 
+#ifndef CONFIG_ESP32_QEMU_IMAGE
   start = (FAR void *)HEAP_REGION0_START;
   size  = (size_t)(HEAP_REGION0_END - HEAP_REGION0_START);
   umm_addregion(start, size);
+#endif
 
 #if defined(CONFIG_ESP32_SPIRAM)
   /* Check for any additional memory regions */


### PR DESCRIPTION
## Summary
This PR fixes instabilities found when running ostest in QEMU with SMP.
## Impact
ESP32/QEMU/SMP
## Testing
esp32-devkitc:smp + ostest
