### PR TITLE
toos/version.sh: Fix PATCH including extra version

### DIFF
--- a/tools/version.sh
+++ b/tools/version.sh
@@ -112,7 +112,7 @@ if [ "X${MAJOR}.${MINOR}" = "X${VERSION}" ]; then
   echo $ADVICE
   exit 4
 fi
-PATCH=`echo ${VERSION} | cut -d'.' -f3`
+PATCH=`echo ${VERSION} | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" | cut -d'.' -f3`
 
 # Get GIT information (if not provided on the command line)
 


### PR DESCRIPTION
## Summary

VERSION is also used to get MAJOR, MINOR and PATCH configs. The commit
85edf0f added the remaining of the tag as an extra version and this is
being added erroneously to the PATCH variable. This commit excludes the
extra version from PATCH variable keeping only the number.

Fixes: 85edf0f (tools/version.sh: Add the remaining cut to VERSION)
Signed-off-by: Matheus Castello <matheus@castello.eng.br>

## Impact

## Testing

You can `cat .version` to check the `CONFIG_VERSION_*` variables:

![image](https://user-images.githubusercontent.com/2633321/111576317-0b9f6280-878f-11eb-94e7-8a3dec834dab.png)
