### PR TITLE
ESP32: Allow a BSS section to reside in external memory

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -131,6 +131,13 @@ config XTENSA_IMEM_REGION_SIZE
 	depends on XTENSA_IMEM_USE_SEPARATE_HEAP
 	default 0x18000
 
+config XTENSA_EXTMEM_BSS
+	bool "Allow BSS section in external memory"
+	default n
+	help
+		Adds a section and an attribute that allows to force variables into
+		the external memory.
+
 source arch/xtensa/src/lx6/Kconfig
 if ARCH_CHIP_ESP32
 source arch/xtensa/src/esp32/Kconfig

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -216,6 +216,8 @@ extern uint32_t _sbss;              /* Start of .bss */
 extern uint32_t _ebss;              /* End+1 of .bss */
 extern uint32_t _sheap;             /* Start of heap */
 extern uint32_t _eheap;             /* End+1 of heap */
+extern uint32_t _sbss_extmem;       /* start of external memory bss */
+extern uint32_t _ebss_extmem;       /* End+1 of external memory bss */
 
 /****************************************************************************
  * Inline Functions

--- a/arch/xtensa/src/common/xtensa_attr.h
+++ b/arch/xtensa/src/common/xtensa_attr.h
@@ -69,10 +69,12 @@
 
 #define RTC_RODATA_ATTR __attribute__((section(".rtc.rodata")))
 
-/* Forces bss variable into external memory. */
+/* Allow bss variables into external memory. */
 
 #ifdef CONFIG_XTENSA_EXTMEM_BSS
 #  define EXT_RAM_ATTR __attribute__((section(".extmem.bss")))
+#else
+#  define EXT_RAM_ATTR
 #endif
 
 #endif /* __ARCH_XTENSA_SRC_COMMON_XTENSA_ATTR_H */

--- a/arch/xtensa/src/common/xtensa_attr.h
+++ b/arch/xtensa/src/common/xtensa_attr.h
@@ -28,6 +28,12 @@
 #define __ARCH_XTENSA_SRC_COMMON_XTENSA_ATTR_H
 
 /****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -62,5 +68,11 @@
  */
 
 #define RTC_RODATA_ATTR __attribute__((section(".rtc.rodata")))
+
+/* Forces bss variable into external memory. */
+
+#ifdef CONFIG_XTENSA_EXTMEM_BSS
+#  define EXT_RAM_ATTR __attribute__((section(".extmem.bss")))
+#endif
 
 #endif /* __ARCH_XTENSA_SRC_COMMON_XTENSA_ATTR_H */

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -148,11 +148,16 @@ void xtensa_add_region(void)
   umm_addregion(start, size);
 #endif
 
-#if defined(CONFIG_ESP32_SPIRAM)
-  /* Check for any additional memory regions */
-
+#ifdef CONFIG_ESP32_SPIRAM
 #  if defined(CONFIG_HEAP2_BASE) && defined(CONFIG_HEAP2_SIZE)
-    umm_addregion((FAR void *)CONFIG_HEAP2_BASE, CONFIG_HEAP2_SIZE);
+#    ifdef CONFIG_XTENSA_EXTMEM_BSS
+      start = (FAR void *)(&_ebss_extmem);
+      size = CONFIG_HEAP2_SIZE - (size_t)(&_ebss_extmem - &_sbss_extmem);
+#    else
+      start = (FAR void *)CONFIG_HEAP2_BASE;
+      size = CONFIG_HEAP2_SIZE;
+#    endif
+    umm_addregion(start, size);
 #  endif
 #endif
 }

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -157,6 +157,14 @@ void IRAM_ATTR __start(void)
       PANIC();
 #  endif
     }
+
+  /* Set external memory bss section to zero */
+
+#  ifdef CONFIG_XTENSA_EXTMEM_BSS
+     memset(&_sbss_extmem, 0,
+            (&_ebss_extmem - &_sbss_extmem) * sizeof(_sbss_extmem));
+#  endif
+
 #endif
 
   /* Initialize onboard resources */

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
@@ -68,6 +68,10 @@ MEMORY
 
   rtc_slow_seg(RW)  :    org = 0x50000000 + CONFIG_ESP32_ULP_COPROC_RESERVE_MEM,
                          len = 0x1000 - CONFIG_ESP32_ULP_COPROC_RESERVE_MEM
+
+  /* External memory, including data and text */
+
+  extmem_seg(RWX)  :  org = 0x3f800000, len = 0x400000
 }
 
 /* Heap ends at top of dram0_0_seg */

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
@@ -123,6 +123,16 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } >dram0_0_seg
 
+  /* External memory bss, from any global variable with EXT_RAM_ATTR attribute */
+
+  .extmem.bss (NOLOAD) :
+  {
+    _sbss_extmem = ABSOLUTE(.);
+    *(.extmem.bss .extmem.bss.*)
+    . = ALIGN(4);
+    _ebss_extmem = ABSOLUTE(.);
+  } > extmem_seg
+
   .flash.rodata :
   {
     _srodata = ABSOLUTE(.);

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
@@ -68,6 +68,10 @@ MEMORY
 
   rtc_slow_seg(RW)  :    org = 0x50000000 + CONFIG_ESP32_ULP_COPROC_RESERVE_MEM,
                          len = 0x1000 - CONFIG_ESP32_ULP_COPROC_RESERVE_MEM
+
+  /* External memory, including data and text */
+
+  extmem_seg(RWX)  :  org = 0x3f800000, len = 0x400000
 }
 
 /* Heap ends at top of dram0_0_seg */

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
@@ -125,6 +125,16 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } >dram0_0_seg
 
+  /* External memory bss, from any global variable with EXT_RAM_ATTR attribute */
+
+  .extmem.bss (NOLOAD) :
+  {
+    _sbss_extmem = ABSOLUTE(.);
+    *(.extmem.bss .extmem.bss.*)
+    . = ALIGN(4);
+    _ebss_extmem = ABSOLUTE(.);
+  } > extmem_seg
+
   .flash.rodata :
   {
     _srodata = ABSOLUTE(.);

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
@@ -68,6 +68,10 @@ MEMORY
 
   rtc_slow_seg(RW)  :    org = 0x50000000 + CONFIG_ESP32_ULP_COPROC_RESERVE_MEM,
                          len = 0x1000 - CONFIG_ESP32_ULP_COPROC_RESERVE_MEM
+
+  /* External memory, including data and text */
+
+  extmem_seg(RWX)  :  org = 0x3f800000, len = 0x400000
 }
 
 /* Heap ends at top of dram0_0_seg */

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
@@ -125,6 +125,16 @@ SECTIONS
     _sheap = ABSOLUTE(.);
   } >dram0_0_seg
 
+  /* External memory bss, from any global variable with EXT_RAM_ATTR attribute */
+
+  .extmem.bss (NOLOAD) :
+  {
+    _sbss_extmem = ABSOLUTE(.);
+    *(.extmem.bss .extmem.bss.*)
+    . = ALIGN(4);
+    _ebss_extmem = ABSOLUTE(.);
+  } > extmem_seg
+
   .flash.rodata :
   {
     _srodata = ABSOLUTE(.);


### PR DESCRIPTION
## Summary
  1. Add a bss section that can be locate in external memory.
  2. Adapt the heap when the external memory bss section exists.
## Impact
New feature for ESP32.  Disabled by default.
## Testing

ESP32 boards with external PSRAM.
