### PR TITLE
arch/stm32f0l0g0: Fix nxstyle errors

### DIFF
--- a/arch/arm/include/stm32f0l0g0/chip.h
+++ b/arch/arm/include/stm32f0l0g0/chip.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32f0l0g0/chip.h
  *
  *   Copyright (C) 2017-2018 Gregory Nutt. All rights reserved.
@@ -33,27 +33,27 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_INCLUDE_STM32F0L0G0_CHIP_H
 #define __ARCH_ARM_INCLUDE_STM32F0L0G0_CHIP_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
 /* Get customizations for each supported chip */
 
 #if defined(CONFIG_ARCH_CHIP_STM32F030RC) || defined(CONFIG_ARCH_CHIP_STM32F030CC)
 
-#  define STM32_FLASH_SIZE      (256*1024) /* 256Kb */
-#  define STM32_SRAM_SIZE       (32*1024)  /*  32Kb */
+#  define STM32_FLASH_SIZE      (256 * 1024) /* 256Kb */
+#  define STM32_SRAM_SIZE       (32 * 1024)  /*  32Kb */
 
 #  define STM32_NSPI            2  /* Two SPI modules (SPI or I2S) */
 #  define STM32_NI2S            0  /* No I2S modules */
@@ -71,8 +71,8 @@
 
 #elif defined(CONFIG_ARCH_CHIP_STM32F051R8)
 
-#  define STM32_FLASH_SIZE      (64*1024) /* 64Kb */
-#  define STM32_SRAM_SIZE       (8*1024)  /*  8Kb */
+#  define STM32_FLASH_SIZE      (64 * 1024) /* 64Kb */
+#  define STM32_SRAM_SIZE       (8 * 1024)  /*  8Kb */
 
 #  define STM32_NSPI            2  /* Two SPI modules (SPI or I2S) */
 #  define STM32_NI2S            2  /* Two I2S modules (SPI or I2S) */
@@ -91,11 +91,11 @@
 #elif defined(CONFIG_ARCH_CHIP_STM32F072C8) || defined(CONFIG_ARCH_CHIP_STM32F072CB)
 
 #  ifdef CONFIG_ARCH_CHIP_STM32F072C8
-#    define STM32_FLASH_SIZE    (64*1024)  /*  64Kb */
+#    define STM32_FLASH_SIZE    (64 * 1024)  /*  64Kb */
 #  else
-#    define STM32_FLASH_SIZE    (128*1024) /* 128Kb */
+#    define STM32_FLASH_SIZE    (128 * 1024) /* 128Kb */
 #  endif
-#  define STM32_SRAM_SIZE       (16*1024)  /*  16Kb */
+#  define STM32_SRAM_SIZE       (16 * 1024)  /*  16Kb */
 
 #  define STM32_NATIM           1  /* One advanced timer TIM1 */
 #  define STM32_NGTIM16         5  /* 16-bit general up/down timers TIM3, TIM14-17 */
@@ -147,11 +147,11 @@
 #elif defined(CONFIG_ARCH_CHIP_STM32F072V8) || defined(CONFIG_ARCH_CHIP_STM32F072VB)
 
 #  ifdef CONFIG_ARCH_CHIP_STM32F072V8
-#    define STM32_FLASH_SIZE    (64*1024)  /*  64Kb */
+#    define STM32_FLASH_SIZE    (64 * 1024)  /*  64Kb */
 #  else
-#    define STM32_FLASH_SIZE    (128*1024) /* 128Kb */
+#    define STM32_FLASH_SIZE    (128 * 1024) /* 128Kb */
 #  endif
-#  define STM32_SRAM_SIZE       (16*1024)  /*  16Kb */
+#  define STM32_SRAM_SIZE       (16 * 1024)  /*  16Kb */
 
 #  define STM32_NATIM           1  /* One advanced timer TIM1 */
 #  define STM32_NGTIM16         5  /* 16-bit general up/down timers TIM3, TIM14-17 */
@@ -175,11 +175,11 @@
 #elif defined(CONFIG_ARCH_CHIP_STM32F091CB) || defined(CONFIG_ARCH_CHIP_STM32F091CC)
 
 #  ifdef CONFIG_ARCH_CHIP_STM32F091CB
-#    define STM32_FLASH_SIZE    (128*1024) /* 128Kb */
+#    define STM32_FLASH_SIZE    (128 * 1024) /* 128Kb */
 #  else
-#    define STM32_FLASH_SIZE    (256*1024) /* 256Kb */
+#    define STM32_FLASH_SIZE    (256 * 1024) /* 256Kb */
 #  endif
-#  define STM32_SRAM_SIZE       (32*1024)  /*  32Kb */
+#  define STM32_SRAM_SIZE       (32 * 1024)  /*  32Kb */
 
 #  define STM32_NATIM           1  /* One advanced timer TIM1 */
 #  define STM32_NGTIM16         5  /* 16-bit general up/down timers TIM3, TIM14-17 */
@@ -204,11 +204,11 @@
       defined(CONFIG_ARCH_CHIP_STM32F091VB) || defined(CONFIG_ARCH_CHIP_STM32F091VC)
 
 #  if defined(CONFIG_ARCH_CHIP_STM32F091RB) || defined(CONFIG_ARCH_CHIP_STM32F091VB)
-#    define STM32_FLASH_SIZE    (128*1024) /* 128Kb */
+#    define STM32_FLASH_SIZE    (128 * 1024) /* 128Kb */
 #  else
-#    define STM32_FLASH_SIZE    (256*1024) /* 256Kb */
+#    define STM32_FLASH_SIZE    (256 * 1024) /* 256Kb */
 #  endif
-#  define STM32_SRAM_SIZE       (32*1024)  /*  32Kb */
+#  define STM32_SRAM_SIZE       (32 * 1024)  /*  32Kb */
 
 #  define STM32_NATIM           1  /* One advanced timer TIM1 */
 #  define STM32_NGTIM16         5  /* 16-bit general up/down timers TIM3, TIM14-17 */
@@ -236,8 +236,8 @@
 #elif defined(CONFIG_ARCH_CHIP_STM32G070KB) || defined(CONFIG_ARCH_CHIP_STM32G070CB) || \
       defined(CONFIG_ARCH_CHIP_STM32G070RB)
 
-#  define STM32_FLASH_SIZE     (128*1024) /* 128Kb */
-#  define STM32_SRAM_SIZE      (32*1024)  /* 32Kb */
+#  define STM32_FLASH_SIZE     (128 * 1024) /* 128Kb */
+#  define STM32_SRAM_SIZE      (32 * 1024)  /* 32Kb */
 
 #  define STM32_NATIM           1  /* One advanced timer TIM1 */
 #  define STM32_NGTIM16         5  /* 16-bit general up/down timers TIM3,
@@ -287,7 +287,7 @@
 #  define STM32_NUSBDEV         0  /* No USB full-speed device controller */
 #  define STM32_NUSBOTG         0  /* No USB OTG */
 #  define STM32_NCEC            1  /* One HDMI-CEC controller */
-#  define STM32_NADC            1   /* (1) ADC1, 12-channels */
+#  define STM32_NADC            1  /* (1) ADC1, 12-channels */
 
 #  define STM32_NDAC            2  /* Two DAC channels */
 #  define STM32_NCOMP           2  /* Two Analog Comparators */
@@ -296,7 +296,7 @@
 #  define STM32_NCAP            0  /* No Capacitive sensing channels */
 #  define STM32_NPORTS          6  /* Six GPIO ports, GPIOA-E, H */
 
-/* STM32L EnergyLite Line ***********************************************************/
+/* STM32L EnergyLite Line ***************************************************/
 
 /* STM32L073XX  - With LCD
  * STM32L072XX  - No LCD
@@ -491,7 +491,7 @@
 #  define STM32_NADC            1  /* One 12-bit module */
 #  define STM32_NDAC            2  /* Two DAC channels */
 #  define STM32_NCOMP           2  /* Two Analog Comparators */
-#  define STM32_NCRC            1   /* One CRC module */
+#  define STM32_NCRC            1  /* One CRC module */
 #  define STM32_NRNG            1  /* One Random number generator (RNG) */
 #  define STM32_NCAP            24 /* Twenty-four Capacitive sensing channels */
 #  define STM32_NPORTS          6  /* Six GPIO ports, GPIOA-E, H */
@@ -544,7 +544,7 @@
 #  define STM32_NADC            1  /* One 12-bit module */
 #  define STM32_NDAC            2  /* Two DAC channels */
 #  define STM32_NCOMP           2  /* Two Analog Comparators */
-#  define STM32_NCRC            1   /* One CRC module */
+#  define STM32_NCRC            1  /* One CRC module */
 #  define STM32_NRNG            1  /* One Random number generator (RNG) */
 #  define STM32_NCAP            17 /* Seventeen Capacitive sensing channels */
 #  define STM32_NPORTS          6  /* Six GPIO ports, GPIOA-E, H */
@@ -579,10 +579,12 @@
 #  error "Unsupported STM32F0xx chip"
 #endif
 
-/* NVIC priority levels *************************************************************/
-/* Each priority field holds a priority value, 0-31. The lower the value, the greater
- * the priority of the corresponding interrupt. The processor implements only
- * bits[7:6] of each field, bits[5:0] read as zero and ignore writes.
+/* NVIC priority levels *****************************************************/
+
+/* Each priority field holds a priority value, 0-31. The lower the value,
+ * the greater the priority of the corresponding interrupt.  The processor
+ * implements only bits[7:6] of each field, bits[5:0] read as zero and
+ * ignore writes.
  */
 
 #define NVIC_SYSH_PRIORITY_MIN     0xc0 /* All bits[7:6] set is minimum priority */
@@ -590,16 +592,16 @@
 #define NVIC_SYSH_PRIORITY_MAX     0x00 /* Zero is maximum priority */
 #define NVIC_SYSH_PRIORITY_STEP    0x40 /* Two bits of interrupt priority used */
 
-/************************************************************************************
+/****************************************************************************
  * Public Types
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
+/****************************************************************************
  * Public Data
- ************************************************************************************/
+ ****************************************************************************/
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #endif /* __ARCH_ARM_INCLUDE_STM32F0L0G0_CHIP_H */

--- a/arch/arm/include/stm32f0l0g0/irq.h
+++ b/arch/arm/include/stm32f0l0g0/irq.h
@@ -76,6 +76,10 @@
 
 #define STM32_IRQ_EXTINT        (16) /* Vector number of the first external interrupt */
 
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
 /* Include MCU-specific external interrupt definitions */
 
 #if defined(CONFIG_ARCH_CHIP_STM32F0)

--- a/arch/arm/include/stm32f0l0g0/stm32f0_irq.h
+++ b/arch/arm/include/stm32f0l0g0/stm32f0_irq.h
@@ -53,12 +53,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found
- * in nuttx/arch/arm/include/stm32f0l0g0/irq.h
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in nuttx/arch/arm/include/stm32f0l0g0/irq.h
  */
 
 #define STM32_IRQ_WWDG          (STM32_IRQ_EXTINT + 0)  /* 0: WWDG */

--- a/arch/arm/include/stm32f0l0g0/stm32g0_irq.h
+++ b/arch/arm/include/stm32f0l0g0/stm32g0_irq.h
@@ -1,4 +1,4 @@
-/****************************************************************************************************
+/****************************************************************************
  * arch/arm/include/stm32f0l0g0/stm32g0_irq.h
  *
  *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
@@ -32,31 +32,33 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* This file should never be included directly but, rather, only indirectly through nuttx/irq.h */
+/* This file should never be included directly but, rather, only indirectly
+ * through nuttx/irq.h
+ */
 
 #ifndef __ARCH_ARM_INCLUDE_STM32F0L0G0_STM32G0_IRQ_H
 #define __ARCH_ARM_INCLUDE_STM32F0L0G0_STM32G0_IRQ_H
 
-/****************************************************************************************************
+/****************************************************************************
  * Included Files
- ****************************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
 #include <arch/stm32f0l0g0/chip.h>
 
-/****************************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/* IRQ numbers.  The IRQ number corresponds vector number and hence map directly to
- * bits in the NVIC.  This does, however, waste several words of memory in the IRQ
- * to handle mapping tables.
+/* IRQ numbers.  The IRQ number corresponds vector number and hence map
+ * directly to bits in the NVIC.  This does, however, waste several words of
+ * memory in the IRQ to handle mapping tables.
  *
- * Processor Exceptions (vectors 0-15).  These common definitions can be found
- * in nuttx/arch/arm/include/stm32f0l0g0/irq.h
+ * Processor Exceptions (vectors 0-15).  These common definitions can be
+ * found in nuttx/arch/arm/include/stm32f0l0g0/irq.h
  */
 
 #define STM32_IRQ_WWDG         (STM32_IRQ_EXTINT + 0)  /* 0: Window Watchdog interrupt */
@@ -97,6 +99,7 @@
 #if defined(CONFIG_ARCH_CHIP_STM32G070KB) || defined(CONFIG_ARCH_CHIP_STM32G070CB) || \
     defined(CONFIG_ARCH_CHIP_STM32G070RB)
 /* No STM32_IRQ_COMP */
+
 #else
 #  define STM32_IRQ_COMP       (STM32_IRQ_EXTINT + 12) /* 12: COMP */
 #endif
@@ -117,7 +120,9 @@
 #if defined(CONFIG_ARCH_CHIP_STM32G070KB) || defined(CONFIG_ARCH_CHIP_STM32G070CB) || \
     defined(CONFIG_ARCH_CHIP_STM32G070RB)
 /* No STM32_IRQ_DAC */
+
 /* No STM32_IRQ_LPTIM1 */
+
 #else
 #  define STM32_IRQ_DAC        (STM32_IRQ_EXTINT + 17) /* 17: DAC */
 #  define STM32_IRQ_LPTIM1     (STM32_IRQ_EXTINT + 17) /* 17: LPTIM1 */
@@ -128,6 +133,7 @@
 #if defined(CONFIG_ARCH_CHIP_STM32G070KB) || defined(CONFIG_ARCH_CHIP_STM32G070CB) || \
     defined(CONFIG_ARCH_CHIP_STM32G070RB)
 /* No STM32_IRQ_LPTIM2 */
+
 #else
 #  define STM32_IRQ_LPTIM2     (STM32_IRQ_EXTINT + 18) /* 18: LPTIM2 */
 #endif
@@ -161,16 +167,15 @@
 #  define STM32_IRQ_RNG        (STM32_IRQ_EXTINT + 31) /* 31: RNG */
 #endif
 
-
 #define STM32_IRQ_NEXTINT      (32)
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Types
- ****************************************************************************************************/
+ ****************************************************************************/
 
-/****************************************************************************************************
+/****************************************************************************
  * Public Data
-****************************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 #ifdef __cplusplus
@@ -181,9 +186,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/****************************************************************************************************
- * Public Functions
- ****************************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #undef EXTERN
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Fix nxstyle errors in:

- arch/arm/include/stm32f0l0g0/chip.h
- arch/arm/include/stm32f0l0g0/irq.h
- arch/arm/include/stm32f0l0g0/stm32f0_irq.h
- arch/arm/include/stm32f0l0g0/stm32g0_irq.h

## Impact

Removes nxstyle errors.

## Testing

nxstyle