### PR TITLE
arch:rv64:fix 64bit data type and instruction for FPU handlers.

### DIFF
--- a/arch/risc-v/src/rv64gc/riscv_fpu.S
+++ b/arch/risc-v/src/rv64gc/riscv_fpu.S
@@ -95,7 +95,7 @@ up_fpuconfig:
  *   floating point registers.
  *
  * C Function Prototype:
- *   void riscv_savefpu(uint32_t *regs);
+ *   void riscv_savefpu(uint64_t *regs);
  *
  * Input Parameters:
  *   regs - A pointer to the register save area in which to save the floating point
@@ -109,7 +109,7 @@ up_fpuconfig:
     .type         riscv_savefpu, function
 
 riscv_savefpu:
-    lw            t0, REG_INT_CTX(a0)
+    ld            t0, REG_INT_CTX(a0)
     li            t1, FS_MASK
     and           t2, t0, t1
     li            t1, FS_DIRTY
@@ -118,7 +118,7 @@ riscv_savefpu:
     and           t0, t0, t1
     li            t1, FS_CLEAN
     or            t0, t0, t1
-    sw            t0, REG_INT_CTX(a0)
+    sd            t0, REG_INT_CTX(a0)
 
     /* Store all floating point registers */
 
@@ -156,7 +156,7 @@ riscv_savefpu:
     FSTORE        f31, REG_F31(a0)
 
     frcsr         t0
-    sw            t0, REG_FCSR(a0)
+    sd            t0, REG_FCSR(a0)
 
 1:
     ret
@@ -169,7 +169,7 @@ riscv_savefpu:
  *   floating point registers.
  *
  * C Function Prototype:
- *   void riscv_restorefpu(const uint32_t *regs);
+ *   void riscv_restorefpu(const uint64_t *regs);
  *
  * Input Parameters:
  *   regs - A pointer to the register save area containing the floating point
@@ -184,7 +184,7 @@ riscv_savefpu:
     .type        riscv_restorefpu, function
 
 riscv_restorefpu:
-    lw           t0, REG_INT_CTX(a0)
+    ld           t0, REG_INT_CTX(a0)
     li           t1, FS_MASK
     and          t2, t0, t1
     li           t1, FS_INITIAL
@@ -227,7 +227,7 @@ riscv_restorefpu:
 
     /* Store the floating point control and status register */
 
-    lw           t0, REG_FCSR(a0)
+    ld           t0, REG_FCSR(a0)
     fscsr        t0
 
 1:


### PR DESCRIPTION
Signed-off-by: hotislandn <hotislandn@hotmail.com>

## Summary
This patch uses 64bit data type and instruction for FPU handlers in RV64 port.

## Impact
RV64 targets that have FPU enabled.

## Testing
The FPU tests within "ostest" passed on build: smartl-c906:fpu.
