### PR TITLE
net/arp: add timeout to avoid infinite send wait

### DIFF
--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -337,7 +337,12 @@ int arp_send(in_addr_t ipaddr)
 
       do
         {
-          net_lockedwait(&state.snd_sem);
+          ret = net_timedwait_uninterruptible(&state.snd_sem,
+                                              CONFIG_ARP_SEND_DELAYMSEC);
+          if (ret == -ETIMEDOUT)
+            {
+              goto timeout;
+            }
         }
       while (!state.snd_sent);
 
@@ -366,6 +371,8 @@ int arp_send(in_addr_t ipaddr)
 
           break;
         }
+
+timeout:
 
       /* Increment the retry count */
 


### PR DESCRIPTION

## Summary

net/arp: add timeout to avoid infinite send wait

add timeout to avoid infinite send wait if the network device is unreachable

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

arp send

## Testing

arp send if the network device is unreachable