### PR TITLE
net/tcp: reset the connection ref count before tcp_free() 

### DIFF
--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -270,6 +270,7 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
 
                   /* Finally, we must free this TCP connection structure */
 
+                  conn->crefs = 0;
                   tcp_free(conn);
                   goto done;
                 }


### PR DESCRIPTION

## Summary

net/tcp: reset the connection ref count before tcp_free() 

reset the connection refcount if SYN retry count has elapsed

Assertion:

up_assert: Assertion failed at file:tcp/tcp_conn.c line: 764 task: netdev_wq

N/A

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

TCP disconnect from remote

## Testing

TCP connect/disconnect stress test