### PR TITLE
net/dev: check the available address further

### DIFF
--- a/net/netdev/netdev_findbyaddr.c
+++ b/net/netdev/netdev_findbyaddr.c
@@ -73,7 +73,8 @@ FAR struct net_driver_s *netdev_findby_lipv4addr(in_addr_t lipaddr)
     {
       /* Is the interface in the "up" state? */
 
-      if ((dev->d_flags & IFF_UP) != 0)
+      if ((dev->d_flags & IFF_UP) != 0 &&
+          !net_ipv4addr_cmp(dev->d_ipaddr, INADDR_ANY))
         {
           /* Yes.. check for an address match (under the netmask) */
 
@@ -125,7 +126,8 @@ FAR struct net_driver_s *netdev_findby_lipv6addr(
     {
       /* Is the interface in the "up" state? */
 
-      if ((dev->d_flags & IFF_UP) != 0)
+      if ((dev->d_flags & IFF_UP) != 0 &&
+          !net_ipv6addr_cmp(dev->d_ipv6addr, g_ipv6_unspecaddr))
         {
           /* Yes.. check for an address match (under the netmask) */
 


### PR DESCRIPTION
## Summary

net/dev: check the available address further

check the available address further to avoid obtain unusable device

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

multiple net device, eg:

```
ap> ifconfig
lo      Link encap:Local Loopback at UP
        inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0

wlan0   Link encap:Ethernet HWaddr 8c:de:f9:83:0d:84 at RUNNING
        inet addr:192.168.31.189 DRaddr:192.168.31.1 Mask:255.255.255.0

wlan1   Link encap:Ethernet HWaddr 8c:de:f9:83:0d:85 at DOWN
        inet addr:0.0.0.0 DRaddr:0.0.0.0 Mask:0.0.0.0
```

## Testing

multiple network card test