### PR TITLE
fs/epoll: correct the return value of epoll_ctl(2)

### DIFF
--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -283,13 +283,18 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
                             sizeof(struct pollfd) * (eph->occupied - i));
                   }
 
-                eph->occupied--;
                 break;
               }
           }
 
-        set_errno(ENOENT);
-        return -1;
+        if (i > eph->occupied)
+          {
+            set_errno(ENOENT);
+            return -1;
+          }
+
+        eph->occupied--;
+        break;
 
       case EPOLL_CTL_MOD:
         finfo("%08x CTL MOD(%d): fd=%d ev=%08" PRIx32 "\n",
@@ -304,8 +309,13 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
               }
           }
 
-        set_errno(ENOENT);
-        return -1;
+        if (i > eph->occupied)
+          {
+            set_errno(ENOENT);
+            return -1;
+          }
+
+        break;
 
       default:
         set_errno(EINVAL);


### PR DESCRIPTION

## Summary

fs/epoll: correct the return value of epoll_ctl(2)

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

epoll_ctl(2)

## Testing

epoll_ctl(2) return value test