### PR TITLE
net/if: remove the macro expansion of the public structure

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -195,9 +195,7 @@ struct lifconf
 struct ifreq
 {
   char                        ifr_name[IFNAMSIZ];       /* Network device name (e.g. "eth0") */
-#ifdef CONFIG_NETDEV_IFINDEX
   int16_t                     ifr_ifindex;              /* Interface index */
-#endif
   union
   {
     struct sockaddr           ifru_addr;                /* IP Address */


### PR DESCRIPTION

## Summary

net/if: remove the macro expansion of the public structure

This is a compatibility issue if different structures included
in the usrsock server/client scene, usrsock client has no habit
of actively choosing of config CONFIG_NETDEV_IFINDEX at most of the time

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

usrsock client or server without compile config "CONFIG_NETDEV_IFINDEX"

## Testing

usrsock client/server test