### PR TITLE
Add CAN FD flags to CAN header

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -811,7 +811,7 @@ static ssize_t can_write(FAR struct file *filep, FAR const char *buffer,
    * shorter than the minimum.
    */
 
-  while ((buflen - nsent) >= CAN_MSGLEN(0))
+  while (((ssize_t)buflen - nsent) >= CAN_MSGLEN(0))
     {
       /* Check if adding this new message would over-run the drivers ability
        * to enqueue xmit data.

--- a/include/nuttx/can/can.h
+++ b/include/nuttx/can/can.h
@@ -455,7 +455,12 @@ begin_packed_struct struct can_hdr_s
   uint8_t      ch_error  : 1; /* 1=ch_id is an error report */
 #endif
   uint8_t      ch_extid  : 1; /* Extended ID indication */
-  uint8_t      ch_unused : 1; /* Unused */
+#ifdef CONFIG_CAN_FD
+  uint8_t      ch_edl    : 1; /* Extended Data Length */
+  uint8_t      ch_brs    : 1; /* Bit Rate Switch */
+  uint8_t      ch_esi    : 1; /* Error State Indicator */
+#endif
+  uint8_t      ch_unused : 1; /* FIXME: This field is useless, kept for backward compatibility */
 } end_packed_struct;
 
 #else
@@ -467,7 +472,12 @@ begin_packed_struct struct can_hdr_s
 #ifdef CONFIG_CAN_ERRORS
   uint8_t      ch_error  : 1; /* 1=ch_id is an error report */
 #endif
-  uint8_t      ch_unused : 2; /* Unused */
+#ifdef CONFIG_CAN_FD
+  uint8_t      ch_edl    : 1; /* Extended Data Length */
+  uint8_t      ch_brs    : 1; /* Bit Rate Switch */
+  uint8_t      ch_esi    : 1; /* Error State Indicator */
+#endif
+  uint8_t      ch_unused : 1; /* FIXME: This field is useless, kept for backward compatibility */
 } end_packed_struct;
 #endif
 


### PR DESCRIPTION
## Summary

The first commit 333345a adds EDL, BRS and ESI bits added to struct can_hdr_s.

The `ch_unused' field is useless (adjacent fields in packed structs are aligned to the next byte), but some
drivers explicitly set this field to zero, so it is kept there for backward compatibility of the API.

When started using DLC > 8 a bug in can_write was revealed. This is fixed (or I would better say work arounded with respect to keeping maximum backward compatibility and not possibly breaking other components) in commit 571dd60.

## Impact

These changes are API backward compatible.

## Testing

Tested on Bosch M_CAN controller on SAMv7 chip (needs additional changes to that driver not included in this pull request).
