### PR TITLE
stm32l5: Enable SPI support and license clearing

### DIFF
--- a/arch/arm/src/stm32l5/Kconfig
+++ b/arch/arm/src/stm32l5/Kconfig
@@ -230,6 +230,10 @@ config STM32L5_HAVE_UART5
 # These "hidden" settings are the OR of individual peripheral selections
 # indicating that the general capability is required.
 
+config STM32L5_SPI
+	bool
+	default n
+
 config STM32L5_USART
 	bool
 	default n
@@ -251,6 +255,18 @@ config STM32L5_PWR
 config STM32L5_RTC
 	bool "RTC"
 	default n
+
+config STM32L5_SPI2
+	bool "SPI2"
+	default n
+	select SPI
+	select STM32L5_SPI
+
+config STM32L5_SPI3
+	bool "SPI3"
+	default n
+	select SPI
+	select STM32L5_SPI
 
 config STM32L5_LPUART1
 	bool "LPUART1"
@@ -292,6 +308,12 @@ comment "APB2 Peripherals"
 config STM32L5_SYSCFG
 	bool "SYSCFG"
 	default y
+
+config STM32L5_SPI1
+	bool "SPI1"
+	default n
+	select SPI
+	select STM32L5_SPI
 
 config STM32L5_USART1
 	bool "USART1"

--- a/arch/arm/src/stm32l5/stm32l5_spi.c
+++ b/arch/arm/src/stm32l5/stm32l5_spi.c
@@ -1,40 +1,20 @@
 /*****************************************************************************
  * arch/arm/src/stm32l5/stm32l5_spi.c
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Michael Jung <mijung@gmx.net>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Based on arm/arm/src/stm32l4/stm32l4_spi.c
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Copyright (C) 2009-2013, 2016 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  *****************************************************************************/
 
@@ -75,6 +55,7 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -236,7 +217,7 @@ static void        spi_setbits(FAR struct spi_dev_s *dev, int nbits);
 static int         spi_hwfeatures(FAR struct spi_dev_s *dev,
                                   spi_hwfeatures_t features);
 #endif
-static uint16_t    spi_send(FAR struct spi_dev_s *dev, uint16_t wd);
+static uint32_t    spi_send(FAR struct spi_dev_s *dev, uint32_t wd);
 static void        spi_exchange(FAR struct spi_dev_s *dev,
                                 FAR const void *txbuffer,
                                 FAR void *rxbuffer, size_t nwords);
@@ -1080,7 +1061,7 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
        * be faster.
        */
 
-      spiinfo("Frequency %d->%d\n", frequency, actual);
+      spiinfo("Frequency %" PRId32 "->%" PRId32 "\n", frequency, actual);
 
       priv->frequency = frequency;
       priv->actual    = actual;
@@ -1306,11 +1287,11 @@ static int spi_hwfeatures(FAR struct spi_dev_s *dev,
  *
  *****************************************************************************/
 
-static uint16_t spi_send(FAR struct spi_dev_s *dev, uint16_t wd)
+static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
 {
   FAR struct stm32l5_spidev_s *priv = (FAR struct stm32l5_spidev_s *)dev;
   uint32_t regval;
-  uint16_t ret;
+  uint32_t ret;
 
   DEBUGASSERT(priv && priv->spibase);
 
@@ -1321,13 +1302,13 @@ static uint16_t spi_send(FAR struct spi_dev_s *dev, uint16_t wd)
 
   if (spi_16bitmode(priv))
     {
-      spi_writeword(priv, wd);
-      ret = spi_readword(priv);
+      spi_writeword(priv, (uint16_t)(wd & 0xffff));
+      ret = (uint32_t)spi_readword(priv);
     }
   else
     {
       spi_writebyte(priv, (uint8_t)(wd & 0xff));
-      ret = (uint16_t)spi_readbyte(priv);
+      ret = (uint32_t)spi_readbyte(priv);
     }
 
   /* Check and clear any error flags (Reading from the SR clears the error
@@ -1338,11 +1319,13 @@ static uint16_t spi_send(FAR struct spi_dev_s *dev, uint16_t wd)
 
   if (spi_16bitmode(priv))
     {
-      spiinfo("Sent: %04x Return: %04x Status: %02x\n", wd, ret, regval);
+      spiinfo("Sent: %04" PRIx32 " Return: %04" PRIx32
+              " Status: %02" PRIx32 "\n", wd, ret, regval);
     }
   else
     {
-      spiinfo("Sent: %02x Return: %02x Status: %02x\n", wd, ret, regval);
+      spiinfo("Sent: %02" PRIx32 " Return: %02" PRIx32
+              " Status: %02" PRIx32 "\n", wd, ret, regval);
     }
 
   UNUSED(regval);

--- a/arch/arm/src/stm32l5/stm32l5_spi.h
+++ b/arch/arm/src/stm32l5/stm32l5_spi.h
@@ -1,40 +1,20 @@
 /*****************************************************************************
  * arch/arm/src/stm32l5/stm32l5_spi.h
  *
- *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
- *   Author: Michael Jung <mijung@gmx.net>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Based on arch/arm/src/stm32l4/stm32l4_spi.h
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *   Copyright (C) 2009, 2015 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  *****************************************************************************/
 


### PR DESCRIPTION
## Summary

Since the original stm32l4 version of this code already has an ASF
license header do that for stm32l5, too.

Apply latest changes to stm32l4_spi.c to stm32l5_spi.c as well.

Update stm32l5/Kconfig to allow selection of SPI1/2/3.

Signed-off-by: Michael Jung <mijung@gmx.net>

## Impact

None, there are no configs yet in NuttX that use stm32l5 with SPI.

## Testing

SPI tested with nucleo-l552ze and an X-NUCLEO-NFC06A1 extension board for the Arduino connector