### PR TITLE
drivers/sensors/qencoder.c - Remove bad sninfo() format string

### DIFF
--- a/drivers/sensors/qencoder.c
+++ b/drivers/sensors/qencoder.c
@@ -222,7 +222,7 @@ static int qe_close(FAR struct file *filep)
       /* Disable the QEncoder device */
 
       DEBUGASSERT(lower->ops->shutdown != NULL);
-      sninfo("calling shutdown: %d\n");
+      sninfo("calling shutdown\n");
 
       lower->ops->shutdown(lower);
     }


### PR DESCRIPTION
## Summary

drivers/sensors/qencoder.c: qe_close(): Call to sninfo() contained extraneous "%d" format specifier. Removing it, as it appears there was never a matching argument.

## Impact

Removes compiler warning.

## Testing

- build testing
- nxstyle