### PR TITLE
xtensa/esp32: Fix buffer size word-alignment for DMA transfers

### DIFF
--- a/arch/xtensa/src/esp32/esp32_dma.c
+++ b/arch/xtensa/src/esp32/esp32_dma.c
@@ -36,6 +36,14 @@
 #include "esp32_dma.h"
 
 /****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+#ifndef MIN
+#  define MIN(a,b) (a < b ? a : b)
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -51,7 +59,6 @@
  *   num     - DMA descriptions number
  *   pbuf    - RX/TX buffer pointer
  *   len     - RX/TX buffer length
- *   isrx    - true: RX DMA descriptions. false: TX DMA descriptions
  *
  * Returned Value:
  *   Binded pbuf data bytes
@@ -59,47 +66,38 @@
  ****************************************************************************/
 
 uint32_t esp32_dma_init(struct esp32_dmadesc_s *dmadesc, uint32_t num,
-                        uint8_t *pbuf, uint32_t len, int isrx)
+                        uint8_t *pbuf, uint32_t len)
 {
   int i;
   uint32_t bytes = len;
   uint8_t *pdata = pbuf;
-  uint32_t n;
+  uint32_t data_len;
 
-  DEBUGASSERT(pbuf && len);
-  if (isrx)
-    {
-      DEBUGASSERT((len & 3) == 0);
-    }
+  DEBUGASSERT(dmadesc != NULL);
+  DEBUGASSERT(pbuf != NULL);
+  DEBUGASSERT(len > 0);
 
   for (i = 0; i < num; i++)
     {
-      if (bytes < ESP32_DMA_DATALEN_MAX)
-        {
-          n = bytes;
-        }
-      else
-        {
-          n = ESP32_DMA_DATALEN_MAX;
-        }
+      data_len = MIN(bytes, ESP32_DMA_DATALEN_MAX);
 
-      dmadesc[i].ctrl = (n << DMA_CTRL_DATALEN_S) |
-                        (n << DMA_CTRL_BUFLEN_S) |
+      dmadesc[i].ctrl = (data_len << DMA_CTRL_DATALEN_S) |
+                        (data_len << DMA_CTRL_BUFLEN_S) |
                         DMA_CTRL_OWN;
       dmadesc[i].pbuf = pdata;
       dmadesc[i].next = &dmadesc[i + 1];
 
-      bytes -= n;
-      if (!bytes)
+      bytes -= data_len;
+      if (bytes == 0)
         {
           break;
         }
 
-      pdata += n;
+      pdata += data_len;
     }
 
   dmadesc[i].ctrl |= DMA_CTRL_EOF;
-  dmadesc[i].next = NULL;
+  dmadesc[i].next  = NULL;
 
   return len - bytes;
 }

--- a/arch/xtensa/src/esp32/esp32_dma.c
+++ b/arch/xtensa/src/esp32/esp32_dma.c
@@ -72,6 +72,7 @@ uint32_t esp32_dma_init(struct esp32_dmadesc_s *dmadesc, uint32_t num,
   uint32_t bytes = len;
   uint8_t *pdata = pbuf;
   uint32_t data_len;
+  uint32_t buf_len;
 
   DEBUGASSERT(dmadesc != NULL);
   DEBUGASSERT(pbuf != NULL);
@@ -81,8 +82,14 @@ uint32_t esp32_dma_init(struct esp32_dmadesc_s *dmadesc, uint32_t num,
     {
       data_len = MIN(bytes, ESP32_DMA_DATALEN_MAX);
 
+      /* Round the number of bytes to the nearest word, since the buffer
+       * length must be word-aligned.
+       */
+
+      buf_len = (data_len + sizeof(uintptr_t) - 1) / sizeof(uintptr_t);
+
       dmadesc[i].ctrl = (data_len << DMA_CTRL_DATALEN_S) |
-                        (data_len << DMA_CTRL_BUFLEN_S) |
+                        (buf_len << DMA_CTRL_BUFLEN_S) |
                         DMA_CTRL_OWN;
       dmadesc[i].pbuf = pdata;
       dmadesc[i].next = &dmadesc[i + 1];

--- a/arch/xtensa/src/esp32/esp32_dma.h
+++ b/arch/xtensa/src/esp32/esp32_dma.h
@@ -80,7 +80,6 @@ struct esp32_dmadesc_s
  *   num     - DMA descriptions number
  *   pbuf    - RX/TX buffer pointer
  *   len     - RX/TX buffer length
- *   isrx    - true: RX DMA descriptions. false: TX DMA descriptions
  *
  * Returned Value:
  *   Bind pbuf data bytes
@@ -88,7 +87,7 @@ struct esp32_dmadesc_s
  ****************************************************************************/
 
 uint32_t esp32_dma_init(struct esp32_dmadesc_s *dmadesc, uint32_t num,
-                        uint8_t *pbuf, uint32_t len, int isrx);
+                        uint8_t *pbuf, uint32_t len);
 
 #ifdef __cplusplus
 }

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -917,7 +917,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       esp32_spi_reset_regbits(priv, SPI_DMA_CONF_OFFSET, SPI_DMA_RESET_MASK);
 
       n = esp32_dma_init(s_dma_txdesc[priv->config->dma_chan - 1],
-                         SPI_DMADESC_NUM, tp, bytes, 0);
+                         SPI_DMADESC_NUM, tp, bytes);
 
       regval = (uintptr_t)s_dma_txdesc[priv->config->dma_chan - 1] &
                SPI_OUTLINK_ADDR_V;
@@ -936,7 +936,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       if (rp)
         {
           esp32_dma_init(s_dma_rxdesc[priv->config->dma_chan - 1],
-                         SPI_DMADESC_NUM, rp, bytes, 1);
+                         SPI_DMADESC_NUM, rp, bytes);
 
           regval = (uintptr_t)s_dma_rxdesc[priv->config->dma_chan - 1] &
                    SPI_INLINK_ADDR_V;

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -649,7 +649,7 @@ static void esp32_spislv_tx(struct esp32_spislv_priv_s *priv)
   if (priv->dma_chan)
     {
       esp32_dma_init(s_tx_desc[priv->dma_chan - 1], SPI_DMADESC_NUM,
-                     priv->txbuffer, priv->txlen, 0);
+                     priv->txbuffer, priv->txlen);
 
       regval = (uint32_t)s_tx_desc[priv->dma_chan - 1] & SPI_OUTLINK_ADDR_V;
       esp32_spi_set_reg(priv, SPI_DMA_OUT_LINK_OFFSET,
@@ -725,7 +725,7 @@ static void esp32_spislv_rx(struct esp32_spislv_priv_s *priv)
           /* Start to receive next block of data */
 
           esp32_dma_init(s_rx_desc[priv->dma_chan - 1], SPI_DMADESC_NUM,
-                        priv->rxbuffer + priv->rxlen, tmp, 1);
+                        priv->rxbuffer + priv->rxlen, tmp);
 
           regval = (uint32_t)s_rx_desc[priv->dma_chan - 1] &
                    SPI_INLINK_ADDR_V;
@@ -911,7 +911,7 @@ static void esp32_spislv_initialize(FAR struct spi_sctrlr_s *dev)
                                                    SPI_OUTDSCR_BURST_EN_M);
 
       esp32_dma_init(s_rx_desc[priv->dma_chan - 1], SPI_DMADESC_NUM,
-                     priv->rxbuffer, SPI_SLAVE_BUFSIZE, 1);
+                     priv->rxbuffer, SPI_SLAVE_BUFSIZE);
 
       regval = (uint32_t)s_rx_desc[priv->dma_chan - 1] & SPI_INLINK_ADDR_V;
       esp32_spi_set_reg(priv, SPI_DMA_IN_LINK_OFFSET,


### PR DESCRIPTION
## Summary
This PR intends to fix the required buffer length word-alignment for DMA transfers.

Currently, the DMA driver contains a DEBUGASSERT macro to prevent the data transfer whose length is not a multiple of 4.

But, according to the ESP32 Technical Reference Manual, there is no alignment restriction to the **amount of valid data** to be transferred, only to the **length of the buffer** that holds the valid data.

![image](https://user-images.githubusercontent.com/38959758/111838900-bcfddf80-88d8-11eb-946f-18a4c720edf1.png)

## Impact
Previously, DMA RX transfers whose size in bytes were not multiple of 4 would fail on an assertion on DEBUG builds.
Now, the DEBUGASSERT is removed and there is a new logic for calculating the correct buffer length in a given transfer, be it either a TX or RX transfer, according to the required word-alignment.

## Testing
`esp32-devkic:nsh` with a custom SPI device attached on SPI2.
