### PR TITLE
arch/risc-v: Internal functions should be prefixed with "riscv_"

### DIFF
--- a/arch/risc-v/include/rv32im/syscall.h
+++ b/arch/risc-v/include/rv32im/syscall.h
@@ -65,7 +65,7 @@
 
 /* SYS call 0:
  *
- * int up_saveusercontext(uint32_t *saveregs);
+ * int riscv_saveusercontext(uint32_t *saveregs);
  *
  * Return:
  * 0: Normal Return
@@ -73,35 +73,35 @@
  */
 
 #define SYS_save_context (0)
-#define up_saveusercontext(saveregs) \
+#define riscv_saveusercontext(saveregs) \
   (int)sys_call1(SYS_save_context, (uintptr_t)saveregs)
 
 /* SYS call 1:
  *
- * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ * void riscv_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_restore_context (1)
-#define up_fullcontextrestore(restoreregs) \
+#define riscv_fullcontextrestore(restoreregs) \
   sys_call1(SYS_restore_context, (uintptr_t)restoreregs)
 
 /* SYS call 2:
  *
- * void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ * void riscv_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  */
 
 #define SYS_switch_context (2)
-#define up_switchcontext(saveregs, restoreregs) \
+#define riscv_switchcontext(saveregs, restoreregs) \
   sys_call2(SYS_switch_context, (uintptr_t)saveregs, (uintptr_t)restoreregs)
 
 #ifdef CONFIG_BUILD_KERNEL
 /* SYS call 3:
  *
- * void up_syscall_return(void);
+ * void riscv_syscall_return(void);
  */
 
 #define SYS_syscall_return (3)
-#define up_syscall_return() (void)sys_call0(SYS_syscall_return)
+#define riscv_syscall_return() (void)sys_call0(SYS_syscall_return)
 
 #endif
 #endif /* __ASSEMBLY__ */

--- a/arch/risc-v/include/rv32im/syscall.h
+++ b/arch/risc-v/include/rv32im/syscall.h
@@ -133,7 +133,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: up_syscall0
+ * Name: sys_call0
  *
  * Description:
  *   System call SYS_ argument and no additional parameters.
@@ -143,7 +143,7 @@ extern "C"
 uintptr_t sys_call0(unsigned int nbr);
 
 /****************************************************************************
- * Name: up_syscall1
+ * Name: sys_call1
  *
  * Description:
  *   System call SYS_ argument and one additional parameter.
@@ -153,7 +153,7 @@ uintptr_t sys_call0(unsigned int nbr);
 uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1);
 
 /****************************************************************************
- * Name: up_syscall2
+ * Name: sys_call2
  *
  * Description:
  *   System call SYS_ argument and two additional parameters.
@@ -163,7 +163,7 @@ uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1);
 uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1, uintptr_t parm2);
 
 /****************************************************************************
- * Name: up_syscall3
+ * Name: sys_call3
  *
  * Description:
  *   System call SYS_ argument and three additional parameters.
@@ -174,7 +174,7 @@ uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1, uintptr_t parm2,
                     uintptr_t parm3);
 
 /****************************************************************************
- * Name: up_syscall4
+ * Name: sys_call4
  *
  * Description:
  *   System call SYS_ argument and four additional parameters.
@@ -185,7 +185,7 @@ uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1, uintptr_t parm2,
                     uintptr_t parm3, uintptr_t parm4);
 
 /****************************************************************************
- * Name: up_syscall5
+ * Name: sys_call5
  *
  * Description:
  *   System call SYS_ argument and five additional parameters.

--- a/arch/risc-v/include/rv64gc/syscall.h
+++ b/arch/risc-v/include/rv64gc/syscall.h
@@ -158,7 +158,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: up_syscall0
+ * Name: sys_call0
  *
  * Description:
  *   System call SYS_ argument and no additional parameters.
@@ -181,7 +181,7 @@ static inline uintptr_t sys_call0(unsigned int nbr)
 }
 
 /****************************************************************************
- * Name: up_syscall1
+ * Name: sys_call1
  *
  * Description:
  *   System call SYS_ argument and one additional parameter.
@@ -205,7 +205,7 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
 }
 
 /****************************************************************************
- * Name: up_syscall2
+ * Name: sys_call2
  *
  * Description:
  *   System call SYS_ argument and two additional parameters.
@@ -231,7 +231,7 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
 }
 
 /****************************************************************************
- * Name: up_syscall3
+ * Name: sys_call3
  *
  * Description:
  *   System call SYS_ argument and three additional parameters.
@@ -258,7 +258,7 @@ static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
 }
 
 /****************************************************************************
- * Name: up_syscall4
+ * Name: sys_call4
  *
  * Description:
  *   System call SYS_ argument and four additional parameters.
@@ -287,7 +287,7 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
 }
 
 /****************************************************************************
- * Name: up_syscall5
+ * Name: sys_call5
  *
  * Description:
  *   System call SYS_ argument and five additional parameters.
@@ -317,7 +317,7 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
 }
 
 /****************************************************************************
- * Name: up_syscall6
+ * Name: sys_call6
  *
  * Description:
  *   System call SYS_ argument and six additional parameters.

--- a/arch/risc-v/include/rv64gc/syscall.h
+++ b/arch/risc-v/include/rv64gc/syscall.h
@@ -90,7 +90,7 @@
 
 /* SYS call 0:
  *
- * int up_saveusercontext(uint64_t *saveregs);
+ * int riscv_saveusercontext(uint64_t *saveregs);
  *
  * Return:
  * 0: Normal Return
@@ -98,35 +98,35 @@
  */
 
 #define SYS_save_context (0)
-#define up_saveusercontext(saveregs) \
+#define riscv_saveusercontext(saveregs) \
   (int)sys_call1(SYS_save_context, (uintptr_t)saveregs)
 
 /* SYS call 1:
  *
- * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ * void riscv_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_restore_context (1)
-#define up_fullcontextrestore(restoreregs) \
+#define riscv_fullcontextrestore(restoreregs) \
   sys_call1(SYS_restore_context, (uintptr_t)restoreregs)
 
 /* SYS call 2:
  *
- * void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ * void riscv_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  */
 
 #define SYS_switch_context (2)
-#define up_switchcontext(saveregs, restoreregs) \
+#define riscv_switchcontext(saveregs, restoreregs) \
   sys_call2(SYS_switch_context, (uintptr_t)saveregs, (uintptr_t)restoreregs)
 
 #ifdef CONFIG_BUILD_KERNEL
 /* SYS call 3:
  *
- * void up_syscall_return(void);
+ * void riscv_syscall_return(void);
  */
 
 #define SYS_syscall_return (3)
-#define up_syscall_return() sys_call0(SYS_syscall_return)
+#define riscv_syscall_return() sys_call0(SYS_syscall_return)
 
 #endif
 #endif /* __ASSEMBLY__ */

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -190,9 +190,9 @@ void up_exit(int status)
 
   /* Then switch contexts */
 
-  up_fullcontextrestore(tcb->xcp.regs);
+  riscv_fullcontextrestore(tcb->xcp.regs);
 
-  /* up_fullcontextrestore() should not return but could if the software
+  /* riscv_fullcontextrestore() should not return but could if the software
    * interrupts are disabled.
    */
 

--- a/arch/risc-v/src/rv32im/riscv_blocktask.c
+++ b/arch/risc-v/src/rv32im/riscv_blocktask.c
@@ -165,9 +165,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          riscv_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* riscv_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/risc-v/src/rv32im/riscv_releasepending.c
+++ b/arch/risc-v/src/rv32im/riscv_releasepending.c
@@ -137,9 +137,9 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          riscv_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* riscv_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/risc-v/src/rv32im/riscv_reprioritizertr.c
+++ b/arch/risc-v/src/rv32im/riscv_reprioritizertr.c
@@ -190,12 +190,13 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
-              up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+              riscv_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-              /* up_switchcontext forces a context switch to the task at the
-               * head of the ready-to-run list.  It does not 'return' in the
-               * normal sense. When it does return, it is because the blocked
-               * task is again ready to run and has execution priority.
+              /* riscv_switchcontext forces a context switch to the task at
+               * the head of the ready-to-run list.  It does not 'return' in
+               * the normal sense. When it does return, it is because the
+               * blocked task is again ready to run and has execution
+               * priority.
                */
             }
         }

--- a/arch/risc-v/src/rv32im/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv32im/riscv_sigdeliver.c
@@ -137,9 +137,9 @@ void riscv_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
-  up_fullcontextrestore(regs);
+  riscv_fullcontextrestore(regs);
 
-  /* up_fullcontextrestore() should not return but could if the software
+  /* riscv_fullcontextrestore() should not return but could if the software
    * interrupts are disabled.
    */
 

--- a/arch/risc-v/src/rv32im/riscv_swint.c
+++ b/arch/risc-v/src/rv32im/riscv_swint.c
@@ -147,7 +147,7 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
     {
       /* A0=SYS_save_context:  This is a save context command:
        *
-       *  int up_saveusercontext(uint32_t *saveregs);
+       *  int riscv_saveusercontext(uint32_t *saveregs);
        *
        * At this point, the following values are saved in context:
        *
@@ -172,7 +172,8 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
 
       /* A0=SYS_restore_context: This a restore context command:
        *
-       * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+       * void
+       *   riscv_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -195,7 +196,7 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
 
       /* A0=SYS_switch_context: This a switch context command:
        *
-       *   void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+       * void riscv_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/risc-v/src/rv32im/riscv_unblocktask.c
+++ b/arch/risc-v/src/rv32im/riscv_unblocktask.c
@@ -151,9 +151,9 @@ void up_unblock_task(struct tcb_s *tcb)
 
           /* Then switch contexts */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          riscv_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* riscv_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/risc-v/src/rv64gc/riscv_blocktask.c
+++ b/arch/risc-v/src/rv64gc/riscv_blocktask.c
@@ -165,9 +165,9 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           /* Then switch contexts */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          riscv_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* riscv_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/risc-v/src/rv64gc/riscv_releasepending.c
+++ b/arch/risc-v/src/rv64gc/riscv_releasepending.c
@@ -137,9 +137,9 @@ void up_release_pending(void)
 
           /* Then switch contexts */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          riscv_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* riscv_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/risc-v/src/rv64gc/riscv_reprioritizertr.c
+++ b/arch/risc-v/src/rv64gc/riscv_reprioritizertr.c
@@ -190,12 +190,13 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               /* Then switch contexts */
 
-              up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+              riscv_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-              /* up_switchcontext forces a context switch to the task at the
-               * head of the ready-to-run list.  It does not 'return' in the
-               * normal sense. When it does return, it is because the blocked
-               * task is again ready to run and has execution priority.
+              /* riscv_switchcontext forces a context switch to the task at
+               * the head of the ready-to-run list.  It does not 'return' in
+               * the normal sense. When it does return, it is because the
+               * blocked task is again ready to run and has execution
+               * priority.
                */
             }
         }

--- a/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
@@ -183,5 +183,5 @@ void riscv_sigdeliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
-  up_fullcontextrestore(regs);
+  riscv_fullcontextrestore(regs);
 }

--- a/arch/risc-v/src/rv64gc/riscv_swint.c
+++ b/arch/risc-v/src/rv64gc/riscv_swint.c
@@ -170,7 +170,8 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
     {
       /* A0=SYS_restore_context: This a restore context command:
        *
-       * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+       * void
+       *   riscv_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -192,7 +193,7 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
 
       /* A0=SYS_switch_context: This a switch context command:
        *
-       *   void up_switchcontext(uint64_t *saveregs, uint64_t *restoreregs);
+       * void riscv_switchcontext(uint64_t *saveregs, uint64_t *restoreregs);
        *
        * At this point, the following values are saved in context:
        *

--- a/arch/risc-v/src/rv64gc/riscv_unblocktask.c
+++ b/arch/risc-v/src/rv64gc/riscv_unblocktask.c
@@ -151,9 +151,9 @@ void up_unblock_task(struct tcb_s *tcb)
 
           /* Then switch contexts */
 
-          up_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
+          riscv_switchcontext(rtcb->xcp.regs, nexttcb->xcp.regs);
 
-          /* up_switchcontext forces a context switch to the task at the
+          /* riscv_switchcontext forces a context switch to the task at the
            * head of the ready-to-run list.  It does not 'return' in the
            * normal sense.  When it does return, it is because the blocked
            * task is again ready to run and has execution priority.

--- a/arch/risc-v/src/rv64gc/svcall.h
+++ b/arch/risc-v/src/rv64gc/svcall.h
@@ -63,21 +63,21 @@
 
 /* SYS call 0:
  *
- * int up_saveusercontext(uint32_t *saveregs);
+ * int riscv_saveusercontext(uint32_t *saveregs);
  */
 
 #define SYS_save_context          (0)
 
 /* SYS call 1:
  *
- * void up_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
+ * void riscv_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_restore_context       (1)
 
 /* SYS call 2:
  *
- * void up_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
+ * void riscv_switchcontext(uint32_t *saveregs, uint32_t *restoreregs);
  */
 
 #define SYS_switch_context        (2)
@@ -85,7 +85,7 @@
 #ifdef CONFIG_LIB_SYSCALL
 /* SYS call 3:
  *
- * void up_syscall_return(void);
+ * void riscv_syscall_return(void);
  */
 
 #define SYS_syscall_return        (3)

--- a/boards/risc-v/bl602/bl602evb/src/bl602_ostest.c
+++ b/boards/risc-v/bl602/bl602evb/src/bl602_ostest.c
@@ -72,7 +72,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  riscv_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 

--- a/boards/risc-v/c906/smartl-c906/src/c906_ostest.c
+++ b/boards/risc-v/c906/smartl-c906/src/c906_ostest.c
@@ -72,7 +72,7 @@ void arch_getfpu(FAR uint32_t *fpusave)
   /* Take a snapshot of the thread context right now */
 
   flags = enter_critical_section();
-  up_saveusercontext(g_saveregs);
+  riscv_saveusercontext(g_saveregs);
 
   /* Return only the floating register values */
 


### PR DESCRIPTION
## Summary
1. Internal functions should be prefixed with "riscv_" instead of "up"
2. Fix syscall names in comments.
## Impact
N/A
## Testing
N/A