### PR TITLE
xtensa/esp32: Fix SPI polling mode when DMA is also enabled.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -889,6 +889,9 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       tp = rp;
     }
 
+  esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_TRANS_DONE_M);
+  esp32_spi_set_regbits(priv, SPI_SLAVE_OFFSET, SPI_INT_EN_M);
+
   while (bytes)
     {
       esp32_spi_set_reg(priv, SPI_DMA_IN_LINK_OFFSET, 0);
@@ -942,6 +945,8 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       tp += n;
       rp += n;
     }
+
+  esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_INT_EN_M);
 
 #ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
   if (esp32_ptr_extram(rxbuffer))
@@ -1303,8 +1308,6 @@ static void esp32_spi_init(FAR struct spi_dev_s *dev)
       esp32_spi_set_reg(priv, SPI_DMA_CONF_OFFSET, SPI_OUT_DATA_BURST_EN_M |
                                                    SPI_INDSCR_BURST_EN_M |
                                                    SPI_OUTDSCR_BURST_EN_M);
-
-      esp32_spi_set_regbits(priv, SPI_SLAVE_OFFSET, SPI_INT_EN_M);
     }
 
   esp32_spi_setfrequency(dev, config->clk_freq);

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -784,28 +784,12 @@ static void esp32_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
 
   spiinfo("nbits=%d\n", nbits);
 
-  /* Has the number of bits changed? */
+  priv->nbits = nbits;
 
-  if (nbits != priv->nbits)
-    {
-      /* Save the selection so that subsequent re-configurations
-       * will be faster.
-       */
-
-      priv->nbits = nbits;
-
-      /* Each DMA transmission will set these value according to
-       * calculated buffer length.
-       */
-
-      if (!priv->config->use_dma)
-        {
-          esp32_spi_set_reg(priv, SPI_MISO_DLEN_OFFSET,
-                            (priv->nbits - 1) << SPI_USR_MISO_DBITLEN_S);
-          esp32_spi_set_reg(priv, SPI_MOSI_DLEN_OFFSET,
-                            (priv->nbits - 1) << SPI_USR_MOSI_DBITLEN_S);
-        }
-    }
+  esp32_spi_set_reg(priv, SPI_MISO_DLEN_OFFSET,
+                    (priv->nbits - 1) << SPI_USR_MISO_DBITLEN_S);
+  esp32_spi_set_reg(priv, SPI_MOSI_DLEN_OFFSET,
+                    (priv->nbits - 1) << SPI_USR_MOSI_DBITLEN_S);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
This PR intends to address a regression caused by PR #3117 when SPI is configured to work in Mixed mode, i.e. transfers via both polling and interrupts (with DMA).
There are two issues being addressed:
1) Failure to set the length in bits of polling operations when DMA was also enabled due to a wrong checking. Now `esp32_spi_setbits` will always modify the register SPI_MOSI_DLEN and SPI_MISO_DLEN registers, regardless of the transfer mode. In case of a DMA transfer, both fields will be overridden anyway in `esp32_spi_dma_exchange` based on the configured length.
2) Previously SPI interrupts were enabled on DMA initialization. But since the addition of SPI Mixed mode it created a side-effect, breaking polling transfers. So now interrupts are enabled before the DMA transactions and disabled once they are finished. Furthermore, the transaction done flag is also cleared before a new transaction starts.

## Impact
In case a peripheral using SPI interface only relied on Polling, it wouldn't suffer any effect.
This fix is related for SPI with DMA.

## Testing
Custom configuration based on `esp32-wrover-kit`.
