### PR TITLE
Fix typos (and nxstyle errors)

### DIFF
--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -16586,7 +16586,7 @@ detailed bugfix information):
         script.  From Mateusz Szafoni.
       - Nucleo-F334R8:  Add missing ram_vectors configuration in linker
         script.  From Mateusz Szafoni.
-      - Nucleo-F334R8:  Add Missing ADC trigger configuration tot he highpri
+      - Nucleo-F334R8:  Add Missing ADC trigger configuration to the highpri
         configuration.  From Mateusz Szafoni.
       - STM3240G-EVAL:  The timer frequencies (BOARD_TIMx_FREQUENCY) are
         incorrectly defined in board.h.  Since the APB prescalers are set to

--- a/arch/arm/src/cxd56xx/cxd56_dmac_common.h
+++ b/arch/arm/src/cxd56xx/cxd56_dmac_common.h
@@ -31,8 +31,8 @@
  * Public Types
  ****************************************************************************/
 
-/* DMA_HANDLE provides an opaque are reference that can be used to represent
- * a DMA channel.
+/* DMA_HANDLE provides an opaque reference that can be used to represent a
+ * DMA channel.
  */
 
 typedef FAR void *DMA_HANDLE;
@@ -42,7 +42,7 @@ typedef FAR void *DMA_HANDLE;
  *   completion of the DMA.
  *
  * Input Parameters:
- *   handle - Refers tot he DMA channel or stream
+ *   handle - Refers to the DMA channel or stream
  *   status - A bit encoded value that provides the completion status.
  *            See the DMASTATUS_* definitions above.
  *   arg    - A user-provided value that was provided when cxd56_dmastart()

--- a/arch/arm/src/efm32/efm32_dma.h
+++ b/arch/arm/src/efm32/efm32_dma.h
@@ -89,7 +89,7 @@
  * Public Types
  ************************************************************************************/
 
-/* DMA_HANDLE provides an opaque are reference that can be used to represent a DMA
+/* DMA_HANDLE provides an opaque reference that can be used to represent a DMA
  * channel.
  */
 
@@ -100,11 +100,11 @@ typedef FAR void *DMA_HANDLE;
  *   completion of the DMA.
  *
  * Input Parameters:
- *   handle - Refers tot he DMA channel or stream
- *   status - A bit encoded value that provides the completion status.  See the
- *            DMASTATUS_* definitions above.
- *   arg    - A user-provided value that was provided when efm32_dmastart() was
- *            called.
+ *   handle - Refers to the DMA channel or stream
+ *   status - A bit encoded value that provides the completion status.  See
+ *            the DMASTATUS_* definitions above.
+ *   arg    - A user-provided value that was provided when efm32_dmastart()
+ *            was called.
  */
 
 typedef void (*dma_callback_t)(DMA_HANDLE handle, uint8_t status, void *arg);

--- a/arch/arm/src/lpc54xx/lpc54_lcd.c
+++ b/arch/arm/src/lpc54xx/lpc54_lcd.c
@@ -5,7 +5,7 @@
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * This driver derives from the LPC1788 LCD driver.  The LPC1788 LCD is
- * identical tot he LPC54628 LCD other than some minor clocking differences.
+ * identical to the LPC54628 LCD other than some minor clocking differences.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/arch/arm/src/rp2040/rp2040_dmac.h
+++ b/arch/arm/src/rp2040/rp2040_dmac.h
@@ -99,8 +99,8 @@ extern "C"
  * Public Types
  ****************************************************************************/
 
-/* DMA_HANDLE provides an opaque are reference that can be used to represent
- * a DMA channel.
+/* DMA_HANDLE provides an opaque reference that can be used to represent a
+ * DMA channel.
  */
 
 typedef FAR void *DMA_HANDLE;

--- a/arch/arm/src/stm32/stm32_dma.h
+++ b/arch/arm/src/stm32/stm32_dma.h
@@ -72,8 +72,8 @@
  * Public Types
  ****************************************************************************/
 
-/* DMA_HANDLE provides an opaque are reference that can be used to represent
- * a DMA channel (F1) or a DMA stream (F4).
+/* DMA_HANDLE provides an opaque reference that can be used to represent a
+ * DMA channel (F1) or a DMA stream (F4).
  */
 
 typedef FAR void *DMA_HANDLE;
@@ -83,7 +83,7 @@ typedef FAR void *DMA_HANDLE;
  *   completion of the DMA.
  *
  * Input Parameters:
- *   handle - Refers tot he DMA channel or stream
+ *   handle - Refers to the DMA channel or stream
  *   status - A bit encoded value that provides the completion status.  See
  *            the DMASTATUS_* definitions above.
  *   arg    - A user-provided value that was provided when stm32_dmastart()

--- a/arch/arm/src/stm32f0l0g0/stm32_dma.h
+++ b/arch/arm/src/stm32f0l0g0/stm32_dma.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32f0l0g0/stm32_dma.h
  *
  *   Copyright (C) 2009, 2011-2013, 2018 Gregory Nutt. All rights reserved.
@@ -31,26 +31,26 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32F0L0G0_STM32_DMA_H
 #define __ARCH_ARM_SRC_STM32F0L0G0_STM32_DMA_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <sys/types.h>
 
 #include "hardware/stm32_dma_v1.h"
 
-/************************************************************************************
+/****************************************************************************
  * Pre-processor Definitions
- ************************************************************************************/
+ ****************************************************************************/
 
-/* These definitions provide the bit encoding of the 'status' parameter passed to the
- * DMA callback function (see dma_callback_t).
+/* These definitions provide the bit encoding of the 'status' parameter
+ * passed to the DMA callback function (see dma_callback_t).
  */
 
 #define DMA_STATUS_TEIF     DMA_CHAN_TEIF_BIT     /* Channel Transfer Error */
@@ -60,12 +60,12 @@
 #define DMA_STATUS_ERROR    (DMA_STATUS_TEIF)
 #define DMA_STATUS_SUCCESS  (DMA_STATUS_TCIF | DMA_STATUS_HTIF)
 
-/************************************************************************************
+/****************************************************************************
  * Public Types
- ************************************************************************************/
+ ****************************************************************************/
 
-/* DMA_HANDLE provides an opaque are reference that can be used to represent a DMA
- * channel (F1) or a DMA stream (F4).
+/* DMA_HANDLE provides an opaque reference that can be used to represent a
+ * DMA channel (F1) or a DMA stream (F4).
  */
 
 typedef FAR void *DMA_HANDLE;
@@ -75,11 +75,11 @@ typedef FAR void *DMA_HANDLE;
  *   completion of the DMA.
  *
  * Input Parameters:
- *   handle - Refers tot he DMA channel or stream
- *   status - A bit encoded value that provides the completion status.  See the
- *            DMASTATUS_* definitions above.
- *   arg    - A user-provided value that was provided when stm32_dmastart() was
- *            called.
+ *   handle - Refers to the DMA channel or stream
+ *   status - A bit encoded value that provides the completion status.  See
+ *            the DMASTATUS_* definitions above.
+ *   arg    - A user-provided value that was provided when stm32_dmastart()
+ *            was called.
  */
 
 typedef void (*dma_callback_t)(DMA_HANDLE handle, uint8_t status, void *arg);
@@ -95,9 +95,9 @@ struct stm32_dmaregs_s
 };
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Public Data
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 
@@ -110,9 +110,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 /****************************************************************************
  * Name: stm32_dmachannel
@@ -159,11 +159,13 @@ DMA_HANDLE stm32_dmachannel(unsigned int chan);
  * Name: stm32_dmafree
  *
  * Description:
- *   Release a DMA channel.  If another thread is waiting for this DMA channel
- *   in a call to stm32_dmachannel, then this function will re-assign the
- *   DMA channel to that thread and wake it up.  NOTE:  The 'handle' used
- *   in this argument must NEVER be used again until stm32_dmachannel() is
- *   called again to re-gain access to the channel.
+ *   Release a DMA channel.  If another thread is waiting for this DMA
+ *   channel in a call to stm32_dmachannel, then this function will
+ *   re-assign the DMA channel to that thread and wake it up.
+ *
+ *   NOTE:  The 'handle' used in this argument must NEVER be used again
+ *          until stm32_dmachannel() is called again to re-gain access to
+ *          the channel.
  *
  * Returned Value:
  *   None
@@ -207,8 +209,8 @@ void stm32_dmastart(DMA_HANDLE handle, dma_callback_t callback, void *arg,
  *
  * Description:
  *   Cancel the DMA.  After stm32_dmastop() is called, the DMA channel is
- *   reset and stm32_dmasetup() must be called before stm32_dmastart() can be
- *   called again
+ *   reset and stm32_dmasetup() must be called before stm32_dmastart() can
+ *   be called again
  *
  * Assumptions:
  *   - DMA handle allocated by stm32_dmachannel()
@@ -237,8 +239,8 @@ size_t stm32_dmaresidual(DMA_HANDLE handle);
  *   Check if the DMA controller can transfer data to/from given memory
  *   address with the given configuration. This depends on the internal
  *   connections in the ARM bus matrix of the processor. Note that this
- *   only applies to memory addresses, it will return false for any peripheral
- *   address.
+ *   only applies to memory addresses, it will return false for any
+ *   peripheral address.
  *
  * Returned Value:
  *   True, if transfer is possible.

--- a/arch/arm/src/stm32f7/stm32_dma.h
+++ b/arch/arm/src/stm32f7/stm32_dma.h
@@ -62,8 +62,8 @@
  * Public Types
  ****************************************************************************/
 
-/* DMA_HANDLE Provides an opaque are reference that can be used to represent
- * a DMA stream.
+/* DMA_HANDLE Provides an opaque reference that can be used to represent a
+ * DMA stream.
  */
 
 typedef FAR void *DMA_HANDLE;
@@ -75,7 +75,7 @@ typedef FAR void *DMA_HANDLE;
  *   invalidate DMA buffers after completion of the DMA RX operations.
  *
  * Input Parameters:
- *   handle - Refers tot he DMA channel or stream
+ *   handle - Refers to the DMA channel or stream
  *   status - A bit encoded value that provides the completion status.  See
  *            the DMASTATUS_* definitions above.
  *   arg    - A user-provided value that was provided when stm32_dmastart()

--- a/arch/arm/src/stm32h7/stm32_dma.h
+++ b/arch/arm/src/stm32h7/stm32_dma.h
@@ -84,8 +84,8 @@ struct stm32_dma_config_s
 
 typedef struct stm32_dma_config_s stm32_dmacfg_t;
 
-/* DMA_HANDLE Provides an opaque are reference that can be used to represent
- * a DMA stream.
+/* DMA_HANDLE Provides an opaque reference that can be used to represent a
+ * DMA stream.
  */
 
 typedef FAR void *DMA_HANDLE;
@@ -97,7 +97,7 @@ typedef FAR void *DMA_HANDLE;
  *   invalidate DMA buffers after completion of the DMA RX operations.
  *
  * Input Parameters:
- *   handle - Refers tot he DMA channel or stream
+ *   handle - Refers to the DMA channel or stream
  *   status - A bit encoded value that provides the completion status.  See
  *            the DMASTATUS_* definitions above.
  *   arg    - A user-provided value that was provided when stm32_dmastart()

--- a/arch/arm/src/stm32l4/stm32l4_dma.h
+++ b/arch/arm/src/stm32l4/stm32l4_dma.h
@@ -1,4 +1,4 @@
-/************************************************************************************
+/****************************************************************************
  * arch/arm/src/stm32l4/stm32l4_dma.h
  *
  *   Copyright (C) 2009, 2011-2013 Gregory Nutt. All rights reserved.
@@ -33,14 +33,14 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ARCH_ARM_SRC_STM32L4_STM32L4_DMA_H
 #define __ARCH_ARM_SRC_STM32L4_STM32L4_DMA_H
 
-/************************************************************************************
+/****************************************************************************
  * Included Files
- ************************************************************************************/
+ ****************************************************************************/
 
 #include <nuttx/config.h>
 #include <sys/types.h>
@@ -62,8 +62,8 @@
 #  error "Unsupported STM32L4 chip"
 #endif
 
-/* These definitions provide the bit encoding of the 'status' parameter passed to the
- * DMA callback function (see dma_callback_t).
+/* These definitions provide the bit encoding of the 'status' parameter
+ * passed to the DMA callback function (see dma_callback_t).
  */
 
 #  define DMA_STATUS_TEIF         DMA_CHAN_TEIF_BIT     /* Channel Transfer Error */
@@ -73,12 +73,12 @@
 #define DMA_STATUS_ERROR          (DMA_STATUS_TEIF)
 #define DMA_STATUS_SUCCESS        (DMA_STATUS_TCIF|DMA_STATUS_HTIF)
 
-/************************************************************************************
+/****************************************************************************
  * Public Types
- ************************************************************************************/
+ ****************************************************************************/
 
-/* DMA_HANDLE provides an opaque are reference that can be used to represent a DMA
- * channel.
+/* DMA_HANDLE provides an opaque reference that can be used to represent a
+ * DMA channel.
  */
 
 typedef FAR void *DMA_HANDLE;
@@ -89,10 +89,10 @@ typedef FAR void *DMA_HANDLE;
  *
  * Input Parameters:
  *   handle - Refers to the DMA channel
- *   status - A bit encoded value that provides the completion status.  See the
- *            DMASTATUS_* definitions above.
- *   arg    - A user-provided value that was provided when stm32l4_dmastart() was
- *            called.
+ *   status - A bit encoded value that provides the completion status.  See
+ *            the DMASTATUS_* definitions above.
+ *   arg    - A user-provided value that was provided when
+ *            stm32l4_dmastart() was called.
  */
 
 typedef void (*dma_callback_t)(DMA_HANDLE handle, uint8_t status, void *arg);
@@ -122,9 +122,9 @@ struct stm32l4_dmaregs_s
 };
 #endif
 
-/************************************************************************************
+/****************************************************************************
  * Public Data
- ************************************************************************************/
+ ****************************************************************************/
 
 #ifndef __ASSEMBLY__
 
@@ -137,9 +137,9 @@ extern "C"
 #define EXTERN extern
 #endif
 
-/************************************************************************************
- * Public Functions
- ************************************************************************************/
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
 
 #if defined(CONFIG_STM32L4_STM32L4X3) || defined(CONFIG_STM32L4_STM32L4X5) || \
     defined(CONFIG_STM32L4_STM32L4X6)
@@ -154,12 +154,12 @@ extern "C"
  *   channel cannot do DMA concurrently!  See the DMACHAN_* definitions in
  *   stm32l4_dma.h.
  *
- *   If the DMA channel is not available, then stm32l4_dmachannel() will wait
- *   until the holder of the channel relinquishes the channel by calling
- *   stm32l4_dmafree().  WARNING: If you have two devices sharing a DMA
- *   channel and the code never releases the channel, the stm32l4_dmachannel
- *   call for the other will hang forever in this function!  Don't let your
- *   design do that!
+ *   If the DMA channel is not available, then stm32l4_dmachannel() will
+ *   wait until the holder of the channel relinquishes the channel by
+ *   calling stm32l4_dmafree().  WARNING: If you have two devices sharing a
+ *   DMA channel and the code never releases the channel, the
+ *   stm32l4_dmachannel call for the other will hang forever in this
+ *   function!  Don't let your design do that!
  *
  *   Hmm.. I suppose this interface could be extended to make a non-blocking
  *   version.  Feel free to do that if that is what you need.
@@ -195,8 +195,8 @@ DMA_HANDLE stm32l4_dmachannel(unsigned int chan);
  *
  * Input Parameters:
  *   dmamap - Identifies the stream/channel resource. For the STM32L4+, this
- *     is a bit-encoded value as provided by the DMAMAP_* definitions
- *     in hardware/stm32l4xrxx_dmamux.h
+ *     is a bit-encoded value as provided by the DMAMAP_* definitions in
+ *     hardware/stm32l4xrxx_dmamux.h
  *
  * Returned Value:
  *   One success, this function returns a non-NULL, void* DMA channel
@@ -218,11 +218,13 @@ DMA_HANDLE stm32l4_dmachannel(unsigned int dmamap);
  * Name: stm32l4_dmafree
  *
  * Description:
- *   Release a DMA channel.  If another thread is waiting for this DMA channel
- *   in a call to stm32l4_dmachannel, then this function will re-assign the
- *   DMA channel to that thread and wake it up.  NOTE:  The 'handle' used
- *   in this argument must NEVER be used again until stm32l4_dmachannel() is
- *   called again to re-gain access to the channel.
+ *   Release a DMA channel.  If another thread is waiting for this DMA
+ *   channel in a call to stm32l4_dmachannel, then this function will
+ *   re-assign the DMA channel to that thread and wake it up.
+ *
+ *   NOTE:  The 'handle' used in this argument must NEVER be used again
+ *          until stm32l4_dmachannel() is called again to re-gain access to
+ *          the channel.
  *
  * Returned Value:
  *   None
@@ -266,8 +268,8 @@ void stm32l4_dmastart(DMA_HANDLE handle, dma_callback_t callback, void *arg,
  *
  * Description:
  *   Cancel the DMA.  After stm32l4_dmastop() is called, the DMA channel is
- *   reset and stm32l4_dmasetup() must be called before stm32l4_dmastart() can be
- *   called again
+ *   reset and stm32l4_dmasetup() must be called before stm32l4_dmastart()
+ *   can be called again
  *
  * Assumptions:
  *   - DMA handle allocated by stm32l4_dmachannel()
@@ -296,8 +298,8 @@ size_t stm32l4_dmaresidual(DMA_HANDLE handle);
  *   Check if the DMA controller can transfer data to/from given memory
  *   address with the given configuration. This depends on the internal
  *   connections in the ARM bus matrix of the processor. Note that this
- *   only applies to memory addresses, it will return false for any peripheral
- *   address.
+ *   only applies to memory addresses, it will return false for any
+ *   peripheral address.
  *
  * Returned Value:
  *   True, if transfer is possible.

--- a/arch/renesas/src/rx65n/rx65n_dtc.h
+++ b/arch/renesas/src/rx65n/rx65n_dtc.h
@@ -38,8 +38,8 @@
  * Public Types
  ****************************************************************************/
 
-/* DTC_HANDLE provides an opaque are reference that can be used to represent
- * a DTC channel.
+/* DTC_HANDLE provides an opaque reference that can be used to represent a
+ * DTC channel.
  */
 
 typedef FAR void *DTC_HANDLE;

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -1016,7 +1016,7 @@ static int spiffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       return ret;
     }
 
-  /* Handle the IOCTL according tot he command */
+  /* Handle the IOCTL according to the command */
 
   switch (cmd)
     {

--- a/net/route/cacheroute.h
+++ b/net/route/cacheroute.h
@@ -85,7 +85,7 @@ int net_addcache_ipv6(FAR struct net_route_ipv6_s *route);
  *
  * Input Parameters:
  *   handler - Will be called for each route in the routing table cache.
- *   arg     - An arbitrary value that will be passed tot he handler.
+ *   arg     - An arbitrary value that will be passed to the handler.
  *
  * Returned Value:
  *   Zero (OK) returned if the entire table was searched.  A negated errno

--- a/net/route/net_cacheroute.c
+++ b/net/route/net_cacheroute.c
@@ -678,7 +678,7 @@ int net_addcache_ipv6(FAR struct net_route_ipv6_s *route)
  *
  * Input Parameters:
  *   handler - Will be called for each route in the routing table cache.
- *   arg     - An arbitrary value that will be passed tot he handler.
+ *   arg     - An arbitrary value that will be passed to the handler.
  *
  * Returned Value:
  *   Zero (OK) returned if the entire table was searched.  A negated errno

--- a/net/route/net_foreach_fileroute.c
+++ b/net/route/net_foreach_fileroute.c
@@ -48,7 +48,7 @@
  *
  * Input Parameters:
  *   handler - Will be called for each route in the routing table.
- *   arg     - An arbitrary value that will be passed tot he handler.
+ *   arg     - An arbitrary value that will be passed to the handler.
  *
  * Returned Value:
  *   Zero (OK) returned if the entire table was search.  A negated errno

--- a/net/route/net_foreach_ramroute.c
+++ b/net/route/net_foreach_ramroute.c
@@ -48,7 +48,7 @@
  *
  * Input Parameters:
  *   handler - Will be called for each route in the routing table.
- *   arg     - An arbitrary value that will be passed tot he handler.
+ *   arg     - An arbitrary value that will be passed to the handler.
  *
  * Returned Value:
  *   Zero (OK) returned if the entire table was search.  A negated errno

--- a/net/route/net_foreach_romroute.c
+++ b/net/route/net_foreach_romroute.c
@@ -43,7 +43,7 @@
  *
  * Input Parameters:
  *   handler - Will be called for each route in the routing table.
- *   arg     - An arbitrary value that will be passed tot he handler.
+ *   arg     - An arbitrary value that will be passed to the handler.
  *
  * Returned Value:
  *   Zero (OK) returned if the entire table was search.  A negated errno

--- a/net/route/route.h
+++ b/net/route/route.h
@@ -256,7 +256,7 @@ void netdev_ipv6_router(FAR struct net_driver_s *dev,
  *
  * Input Parameters:
  *   handler - Will be called for each route in the routing table.
- *   arg     - An arbitrary value that will be passed tot he handler.
+ *   arg     - An arbitrary value that will be passed to the handler.
  *
  * Returned Value:
  *   Zero (OK) returned if the entire table was searched.  A negated errno


### PR DESCRIPTION
## Summary

Fix the following typos in comments:
- remove spurious "are"
- "tot he" -> "to the"

In the following files:
- ReleaseNotes,
- arch/arm/src/cxd56xx/cxd56_dmac_common.h,
- arch/arm/src/efm32/efm32_dma.h,
- arch/arm/src/lpc54xx/lpc54_lcd.c,
- arch/arm/src/rp2040/rp2040_dmac.h,
- arch/arm/src/stm32/stm32_dma.h,
- arch/arm/src/stm32f0l0g0/stm32_dma.h,
- arch/arm/src/stm32f7/stm32_dma.h,
- arch/arm/src/stm32h7/stm32_dma.h,
- arch/arm/src/stm32l4/stm32l4_dma.h,
- arch/renesas/src/rx65n/rx65n_dtc.h,
- fs/spiffs/src/spiffs_vfs.c,
- net/route/cacheroute.h,
- net/route/net_cacheroute.c,
- net/route/net_foreach_fileroute.c,
- net/route/net_foreach_ramroute.c,
- net/route/net_foreach_romroute.c, and
- net/route/route.h.

Also fix nxstyle errors in these affected files:

- arch/arm/src/stm32f0l0g0/stm32_dma.h and
- arch/arm/src/stm32l4/stm32l4_dma.h.

## Impact

Improves readability of affected comments and removes nxstyle errors.

## Testing

nxstyle