### PR TITLE
boards/xtensa/esp32: Delete the QEMU generated image on distclean.

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-devkitc/src/Make.defs
@@ -61,6 +61,7 @@ context:: $(SCRIPTOUT)
 
 distclean::
 	$(call DELFILE, $(SCRIPTOUT))
+	$(call DELFILE, $(TOPDIR)/esp32_qemu_img.bin)
 
 DEPPATH += --dep-path board
 VPATH += :board

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/Make.defs
@@ -57,6 +57,7 @@ context:: $(SCRIPTOUT)
 
 distclean::
 	$(call DELFILE, $(SCRIPTOUT))
+	$(call DELFILE, $(TOPDIR)/esp32_qemu_img.bin)
 
 DEPPATH += --dep-path board
 VPATH += :board

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/Make.defs
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/Make.defs
@@ -67,6 +67,7 @@ context:: $(SCRIPTOUT)
 
 distclean::
 	$(call DELFILE, $(SCRIPTOUT))
+	$(call DELFILE, $(TOPDIR)/esp32_qemu_img.bin)
 
 DEPPATH += --dep-path board
 VPATH += :board


### PR DESCRIPTION
## Summary
Delete the QEMU generated image on distclean.
## Impact
N/A
## Testing
N/A
