### PR TITLE
stm32h7:DMA BDMA does not auto disabled on completion

### DIFF
--- a/arch/arm/src/stm32h7/stm32_dma.c
+++ b/arch/arm/src/stm32h7/stm32_dma.c
@@ -1841,6 +1841,10 @@ static void stm32_bdma_setup(DMA_HANDLE handle, FAR stm32_dmacfg_t *cfg)
    * for the EN bit to be cleared before starting any stream configuration."
    */
 
+  regval =  dmachan_getreg(dmachan, STM32_BDMACH_CCR_OFFSET);
+  regval &= ~BDMA_CCR_EN;
+  dmachan_putreg(dmachan, STM32_BDMACH_CCR_OFFSET, regval);
+
   while ((dmachan_getreg(dmachan, STM32_BDMACH_CCR_OFFSET) &
           BDMA_CCR_EN) != 0);
 


### PR DESCRIPTION
## Summary

The BDMA differs from the regular DMA in that the EN bit is only cleared on error, not normal completion. 

## Impact

Systems using BDMA will hang on second usage.

## Testing

px4 cuav_nora
