### PR TITLE
CI: remove linkcheck when building docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,8 +29,6 @@ jobs:
           pip3 install pipenv
           pipenv install
           pipenv run make html
-          # This step flakes frequently so still annotate errors but dont fail the build
-          pipenv run make linkcheck || true
       - uses: actions/upload-artifact@v2
         with:
           name: sphinx-docs


### PR DESCRIPTION
## Summary

We're running linkcheck and ignoring errors but this still slows CI build
and can even make it fail due to timeout. The linkcheck is useful for local
manual test but not really for CI.

## Impact

CI

## Testing

CI
