### PR TITLE
esp32_part_ioctl: Return -ENOTTY for unknown commands

### DIFF
--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -497,8 +497,8 @@ static int esp32_part_ioctl(FAR struct mtd_dev_s *dev, int cmd,
 
   if (!_MTDIOCVALID(cmd))
     {
-      ferr("ERROR: cmd=%d(%x) is error\n", cmd, cmd);
-      return -EINVAL;
+      finfo("INFO: cmd=%d(%x) is error\n", cmd, cmd);
+      return -ENOTTY;
     }
 
   switch (_IOC_NR(cmd))


### PR DESCRIPTION
## Summary
It's traditional to use ENOTTY for this purpose.
Littlefs seems to rely on this behavior for BIOC_FLUSH.

Also, drop the log level.

## Impact

## Testing
tested tested on esp32