### PR TITLE
arch/sim/src/sim/up_hostmemory.c: build fix for older macOS versions

### DIFF
--- a/arch/sim/src/sim/up_hostmemory.c
+++ b/arch/sim/src/sim/up_hostmemory.c
@@ -140,5 +140,14 @@ void *host_calloc(size_t n, size_t elem_size)
 
 void *host_memalign(size_t alignment, size_t size)
 {
-  return aligned_alloc(alignment, size);
+  void *p;
+  int error;
+
+  error = posix_memalign(&p, alignment, size);
+  if (error != 0)
+    {
+      return NULL;
+    }
+
+  return p;
 }

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -195,6 +195,7 @@ endif
 
 ifeq ($(CONFIG_SIM_SANITIZE),y)
   CCLINKFLAGS += -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer
+  HOSTLDFLAGS += -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer
 endif
 
 HOSTCFLAGS = $(ARCHWARNINGS) $(ARCHOPTIMIZATION) \


### PR DESCRIPTION
## Summary
arch/sim/src/sim/up_hostmemory.c: build fix for older macOS versions

I'm still using 10.14 (Mojave) for nuttx related things.

Note: the CI is using 10.15. (Catalina)

## Impact

## Testing
tested on mojave.