### PR TITLE
STM32 USB OTGFSDEV: Fix handling of SETUP OUT longer than 64 bytes.

### DIFF
--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -481,15 +481,21 @@ struct stm32_usbdev_s
    * ep0data
    *   For OUT SETUP requests, the SETUP data phase must also complete before
    *   the SETUP command can be processed.  The pack receipt logic will save
-   *   the accompanying EP0 IN data in ep0data[] before the SETUP command is
-   *   processed.
+   *   the accompanying EP0 OUT data in ep0data[] before the SETUP command is
+   *   processed. The data length is specified in the SETUP packet payload,
+   *   and can consist of multiple DATA packets.
    *
    *   For IN SETUP requests, the DATA phase will occur AFTER the SETUP
    *   control request is processed.  In that case, ep0data[] may be used as
    *   the response buffer.
    *
    * ep0datlen
-   *   Length of OUT DATA received in ep0data[] (Not used with OUT data)
+   *   Length of data received part of OUT SETUP request. During transfer
+   *   it is the total number of bytes received, which can be more than
+   *   CONFIG_USBDEV_SETUP_MAXDATASIZE. The value is clamped to valid length
+   *   of data in ep0data[] before SETUP OUT handler is called. Bytes that
+   *   exceed the maximum length are discarded, but must be read out of the
+   *   USB peripheral FIFO.
    */
 
   struct usb_ctrlreq_s    ctrlreq;

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -1590,7 +1590,9 @@ static inline void stm32_ep0out_receive(FAR struct stm32_ep_s *privep,
       if (priv->ep0datlen < CONFIG_USBDEV_SETUP_MAXDATASIZE)
         {
           /* Read the data into our special buffer for SETUP data */
-          int readlen = MIN(CONFIG_USBDEV_SETUP_MAXDATASIZE - priv->ep0datlen, bcnt);
+
+          int bufspace = CONFIG_USBDEV_SETUP_MAXDATASIZE - priv->ep0datlen;
+          int readlen = MIN(bufspace, bcnt);
           stm32_rxfifo_read(privep, priv->ep0data, readlen);
           priv->ep0datlen += readlen;
           bcnt -= readlen;
@@ -1612,13 +1614,15 @@ static inline void stm32_ep0out_receive(FAR struct stm32_ep_s *privep,
 
           privep->active  = false;
           priv->ep0state  = EP0STATE_SETUP_READY;
-          priv->ep0datlen = MIN(CONFIG_USBDEV_SETUP_MAXDATASIZE, priv->ep0datlen);
+          priv->ep0datlen = MIN(CONFIG_USBDEV_SETUP_MAXDATASIZE,
+                                priv->ep0datlen);
 
           stm32_ep0out_setup(priv);
         }
       else
         {
           /* More data to come, clear NAKSTS */
+
           uint32_t regval  = stm32_getreg(STM32_OTGFS_DOEPCTL0);
           regval |= OTGFS_DOEPCTL0_CNAK;
           stm32_putreg(regval, STM32_OTGFS_DOEPCTL0);


### PR DESCRIPTION
## Summary

For example Windows RNDIS driver issues SETUP requests that are 76 bytes long. Previously NuttX would read them all, but only if they arrive at the same time. If host transfer scheduling causes a pause between the two DATA packets, `stm32_ep0out_receive()` would proceed with an incomplete transfer. The rest of the data could either be skipped by the error handler branch, or be left in NAK state forever, stopping any further communication on the endpoint.

Example USB trace:

<pre>
13:44:49.290952 | usb_packet-1: SETUP ADDR 1 EP 0
13:44:49.290955 | usb_packet-1: DATA0 [ 21 00 00 00 00 00 4C 00 ]            <--- Request to transfer 76 bytes to device
13:44:49.290963 | usb_packet-1: ACK
13:44:49.290970 | usb_packet-1: IN ADDR 1 EP 1
13:44:49.290974 | usb_packet-1: NAK
                | Previous two lines repeated 150 times
13:44:49.291909 | usb_packet-1: SOF 1251
13:44:49.291942 | usb_packet-1: IN ADDR 1 EP 3
13:44:49.291946 | usb_packet-1: NAK
13:44:49.291960 | usb_packet-1: OUT ADDR 1 EP 0
13:44:49.291963 | usb_packet-1: DATA1 [ 04 00 00 00 4C 00 00 00 FE 02 00 00 01 01 02 00 30 00 00 00 14 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
13:44:49.292009 | usb_packet-1: NAK                           <--- Trying to transfer first 64 bytes, but NuttX is not yet ready
13:44:49.292044 | usb_packet-1: IN ADDR 1 EP 1
                | Previous two lines repeated 139 times
13:44:49.292909 | usb_packet-1: SOF 1252
13:44:49.292943 | usb_packet-1: IN ADDR 1 EP 3
13:44:49.292946 | usb_packet-1: NAK
13:44:49.292961 | usb_packet-1: OUT ADDR 1 EP 0
13:44:49.292964 | usb_packet-1: DATA1 [ 04 00 00 00 4C 00 00 00 FE 02 00 00 01 01 02 00 30 00 00 00 14 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
13:44:49.293010 | usb_packet-1: ACK                           <---- NuttX accepts the first 64 bytes
13:44:49.293046 | usb_packet-1: IN ADDR 1 EP 1
13:44:49.293049 | usb_packet-1: NAK
                | Previous two lines repeated 138 times        <---- Host is slow to send second part of transfer, NuttX IRQ handler executes in meanwhile and setup handler is already executed.
13:44:49.293909 | usb_packet-1: SOF 1253
13:44:49.293943 | usb_packet-1: IN ADDR 1 EP 3
13:44:49.293946 | usb_packet-1: NAK
13:44:49.293961 | usb_packet-1: OUT ADDR 1 EP 0
13:44:49.293964 | usb_packet-1: DATA0 [ 00 00 00 00 00 00 00 00 00 00 00 00 ]
13:44:49.293975 | usb_packet-1: NAK                        <------ NuttX refuses last 12 bytes of transfer
...
13:44:49.296962 | usb_packet-1: OUT ADDR 1 EP 0    <---- Host will keep retrying and communication no longer works
13:44:49.296965 | usb_packet-1: DATA0 [ 00 00 00 00 00 00 00 00 00 00 00 00 ]
13:44:49.296976 | usb_packet-1: NAK
</pre>

This commit changes it so that the whole transfer has to be received before SETUP handler is called. The variable `priv->ep0datlen` is used to track the total amount of received data until it matches the transfer length specified in SETUP packet.

Depending on `CONFIG_USBDEV_SETUP_MAXDATASIZE` any excess bytes will be discarded, but doing this in a controlled way ensures deterministic behavior. In the specific case of RNDIS, the trailing bytes are unused padding bytes and can be safely discarded.

## Impact

Fully backward compatible. The previous behavior was already to drop bytes that
do not fit in buffer, but it only worked if all of the USB packets arrived before IRQ
handler ran. With this patch the logic behaves the same even if the second
USB packet is delayed due to other USB traffic.

## Testing

Tested on custom STM32F4 board with USB RNDIS driver.

The bug can be easiest reproduced by opening the Windows network adapter statistics
window, which causes concurrent RNDIS requests. Note that there is also a separate
RNDIS bug that happens in this situation, fix in separate pull request.