### PR TITLE
USBDEV RNDIS: Fix occasional disconnections due to race condition

### DIFF
--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -1366,6 +1366,12 @@ rndis_prepare_response(FAR struct rndis_dev_s *priv, size_t size,
   FAR struct rndis_response_header *hdr =
     (FAR struct rndis_response_header *)buf;
 
+  if (priv->response_queue_bytes + size > RNDIS_RESP_QUEUE_LEN)
+    {
+      uerr("RNDIS response queue full, dropping command %08x", request_hdr->msgtype);
+      return NULL;
+    }
+
   hdr->msgtype = request_hdr->msgtype | RNDIS_MSG_COMPLETE;
   hdr->msglen  = size;
   hdr->reqid   = request_hdr->reqid;
@@ -1439,6 +1445,10 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
           resp = rndis_prepare_response(priv,
                                         sizeof(struct rndis_initialize_cmplt),
                                         cmd_hdr);
+          if (!resp)
+            {
+              return -ENOMEM;
+            }
 
           resp->major      = RNDIS_MAJOR_VERSION;
           resp->minor      = RNDIS_MINOR_VERSION;
@@ -1454,6 +1464,7 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
 
       case RNDIS_HALT_MSG:
         {
+          priv->response_queue_bytes = 0;
           priv->connected = false;
         }
         break;
@@ -1468,6 +1479,10 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
             (FAR struct rndis_query_msg *)dataout;
 
           resp = rndis_prepare_response(priv, max_reply_size, cmd_hdr);
+          if (!resp)
+            {
+              return -ENOMEM;
+            }
 
           resp->hdr.msglen = sizeof(struct rndis_query_cmplt);
           resp->bufoffset  = 0;
@@ -1555,6 +1570,11 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
                                         cmd_hdr);
           req  = (FAR struct rndis_set_msg *)dataout;
 
+          if (!resp)
+            {
+              return -ENOMEM;
+            }
+
           uinfo("RNDIS SET RID=%08x OID=%08x LEN=%d DAT=%08x",
                 (unsigned)req->hdr.reqid, (unsigned)req->objid,
                 (int)req->buflen, (unsigned)req->buffer[0]);
@@ -1591,8 +1611,15 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
         {
           FAR struct rndis_reset_cmplt *resp;
 
+          priv->response_queue_bytes = 0;
           resp = rndis_prepare_response(priv, sizeof(struct rndis_reset_cmplt),
                                         cmd_hdr);
+
+          if (!resp)
+            {
+              return -ENOMEM;
+            }
+
           resp->addreset  = 0;
           priv->connected = false;
           rndis_send_encapsulated_response(priv, resp->hdr.msglen);
@@ -1601,9 +1628,15 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
 
       case RNDIS_KEEPALIVE_MSG:
         {
-          rndis_prepare_response(priv, sizeof(struct rndis_response_header),
-                                 cmd_hdr);
-          rndis_send_encapsulated_response(priv, sizeof(struct rndis_response_header));
+          FAR struct rndis_response_header *resp;
+          resp = rndis_prepare_response(priv, sizeof(struct rndis_response_header),
+                                        cmd_hdr);
+          if (!resp)
+            {
+              return -ENOMEM;
+            }
+
+          rndis_send_encapsulated_response(priv, resp->msglen);
         }
         break;
 

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -97,7 +97,8 @@
 
 #define RNDIS_MXDESCLEN         (128)
 #define RNDIS_MAXSTRLEN         (RNDIS_MXDESCLEN-2)
-#define RNDIS_CTRLREQ_LEN       (512)
+#define RNDIS_CTRLREQ_LEN       (256)
+#define RNDIS_RESP_QUEUE_LEN    (256)
 
 #define RNDIS_BUFFER_SIZE       CONFIG_NET_ETH_PKTSIZE
 #define RNDIS_BUFFER_COUNT      4
@@ -167,12 +168,14 @@ struct rndis_dev_s
   size_t current_rx_msglen;              /* Length of the entire message to be received */
   bool rdreq_submitted;                  /* Indicates if the read request is submitted */
   bool rx_blocked;                       /* Indicates if we can receive packets on bulk in endpoint */
-  bool ctrlreq_has_encap_response;       /* Indicates if ctrlreq buffer holds a response */
   bool connected;                        /* Connection status indicator */
   uint32_t rndis_packet_filter;          /* RNDIS packet filter value */
   uint32_t rndis_host_tx_count;          /* TX packet counter */
   uint32_t rndis_host_rx_count;          /* RX packet counter */
   uint8_t host_mac_address[6];           /* Host side MAC address */
+
+  uint8_t response_queue[RNDIS_RESP_QUEUE_LEN];
+  size_t response_queue_bytes;   /* Count of bytes waiting in response_queue. */
 };
 
 /* The internal version of the class driver */
@@ -1347,26 +1350,28 @@ static inline int rndis_recvpacket(FAR struct rndis_dev_s *priv,
  * Input Parameters:
  *   priv: pointer to RNDIS device driver structure
  *
+ * Returns:
+ *   pointer to response buffer
+ *
  * Assumptions:
  *   Called from critical section
  *
  ****************************************************************************/
 
-static bool
+static FAR void*
 rndis_prepare_response(FAR struct rndis_dev_s *priv, size_t size,
                        FAR struct rndis_command_header *request_hdr)
 {
+  uint8_t *buf = priv->response_queue + priv->response_queue_bytes;
   FAR struct rndis_response_header *hdr =
-    (FAR struct rndis_response_header *)priv->ctrlreq->buf;
+    (FAR struct rndis_response_header *)buf;
 
   hdr->msgtype = request_hdr->msgtype | RNDIS_MSG_COMPLETE;
   hdr->msglen  = size;
   hdr->reqid   = request_hdr->reqid;
   hdr->status  = RNDIS_STATUS_SUCCESS;
 
-  priv->ctrlreq_has_encap_response = true;
-
-  return true;
+  return hdr;
 }
 
 /****************************************************************************
@@ -1384,11 +1389,16 @@ rndis_prepare_response(FAR struct rndis_dev_s *priv, size_t size,
  *
  ****************************************************************************/
 
-static int rndis_send_encapsulated_response(FAR struct rndis_dev_s *priv)
+static int rndis_send_encapsulated_response(FAR struct rndis_dev_s *priv, size_t size)
 {
   FAR struct rndis_notification *notif =
     (FAR struct rndis_notification *)priv->epintin_req->buf;
 
+  /* Mark the response as available in the queue */
+  priv->response_queue_bytes += size;
+  DEBUGASSERT(priv->response_queue_bytes <= RNDIS_RESP_QUEUE_LEN);
+
+  /* Send notification on IRQ endpoint, to tell host to read the data. */
   notif->notification = RNDIS_NOTIFICATION_RESPONSE_AVAILABLE;
   notif->reserved = 0;
   priv->epintin_req->len = sizeof(struct rndis_notification);
@@ -1426,9 +1436,9 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
         {
           FAR struct rndis_initialize_cmplt *resp;
 
-          rndis_prepare_response(priv, sizeof(struct rndis_initialize_cmplt),
-                                 cmd_hdr);
-          resp = (FAR struct rndis_initialize_cmplt *)priv->ctrlreq->buf;
+          resp = rndis_prepare_response(priv,
+                                        sizeof(struct rndis_initialize_cmplt),
+                                        cmd_hdr);
 
           resp->major      = RNDIS_MAJOR_VERSION;
           resp->minor      = RNDIS_MINOR_VERSION;
@@ -1438,7 +1448,7 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
           resp->xfrsize    = (4 + 44 + 22) + RNDIS_BUFFER_SIZE;
           resp->pktalign   = 2;
 
-          rndis_send_encapsulated_response(priv);
+          rndis_send_encapsulated_response(priv, resp->hdr.msglen);
         }
         break;
 
@@ -1453,11 +1463,11 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
           int i;
           size_t max_reply_size = sizeof(struct rndis_query_cmplt) +
                                   sizeof(g_rndis_supported_oids);
-          rndis_prepare_response(priv, max_reply_size, cmd_hdr);
+          FAR struct rndis_query_cmplt *resp;
           FAR struct rndis_query_msg *req =
             (FAR struct rndis_query_msg *)dataout;
-          FAR struct rndis_query_cmplt *resp =
-            (FAR struct rndis_query_cmplt *)priv->ctrlreq->buf;
+
+          resp = rndis_prepare_response(priv, max_reply_size, cmd_hdr);
 
           resp->hdr.msglen = sizeof(struct rndis_query_cmplt);
           resp->bufoffset  = 0;
@@ -1532,7 +1542,7 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
 
           resp->hdr.msglen += resp->buflen;
 
-          rndis_send_encapsulated_response(priv);
+          rndis_send_encapsulated_response(priv, resp->hdr.msglen);
         }
         break;
 
@@ -1541,10 +1551,9 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
           FAR struct rndis_set_msg *req;
           FAR struct rndis_response_header *resp;
 
-          rndis_prepare_response(priv, sizeof(struct rndis_response_header),
-                                 cmd_hdr);
+          resp = rndis_prepare_response(priv, sizeof(struct rndis_response_header),
+                                        cmd_hdr);
           req  = (FAR struct rndis_set_msg *)dataout;
-          resp = (FAR struct rndis_response_header *)priv->ctrlreq->buf;
 
           uinfo("RNDIS SET RID=%08x OID=%08x LEN=%d DAT=%08x",
                 (unsigned)req->hdr.reqid, (unsigned)req->objid,
@@ -1574,7 +1583,7 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
               resp->status = RNDIS_STATUS_NOT_SUPPORTED;
             }
 
-          rndis_send_encapsulated_response(priv);
+          rndis_send_encapsulated_response(priv, resp->msglen);
         }
         break;
 
@@ -1582,12 +1591,11 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
         {
           FAR struct rndis_reset_cmplt *resp;
 
-          rndis_prepare_response(priv, sizeof(struct rndis_reset_cmplt),
-                                 cmd_hdr);
-          resp = (FAR struct rndis_reset_cmplt *)priv->ctrlreq->buf;
+          resp = rndis_prepare_response(priv, sizeof(struct rndis_reset_cmplt),
+                                        cmd_hdr);
           resp->addreset  = 0;
           priv->connected = false;
-          rndis_send_encapsulated_response(priv);
+          rndis_send_encapsulated_response(priv, resp->hdr.msglen);
         }
         break;
 
@@ -1595,7 +1603,7 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
         {
           rndis_prepare_response(priv, sizeof(struct rndis_response_header),
                                  cmd_hdr);
-          rndis_send_encapsulated_response(priv);
+          rndis_send_encapsulated_response(priv, sizeof(struct rndis_response_header));
         }
         break;
 
@@ -1738,15 +1746,27 @@ static void rndis_wrcomplete(FAR struct usbdev_ep_s *ep,
 static void usbclass_ep0incomplete(FAR struct usbdev_ep_s *ep,
                                    FAR struct usbdev_req_s *req)
 {
+  struct rndis_dev_s *priv = (FAR struct rndis_dev_s *)ep->priv;
   if (req->result || req->xfrd != req->len)
     {
       usbtrace(TRACE_CLSERROR(USBSER_TRACEERR_REQRESULT),
                (uint16_t)-req->result);
     }
-  else if (req->len > 0)
+  else if (req->len > 0 && req->priv == priv->response_queue)
     {
-      struct rndis_dev_s *priv = (FAR struct rndis_dev_s *)ep->priv;
-      priv->ctrlreq_has_encap_response = false;
+      /* This transfer was from the response queue, subtract remaining byte count. */
+      req->priv = 0;
+      if (req->len >= priv->response_queue_bytes)
+      {
+        /* Queue now empty */
+        priv->response_queue_bytes = 0;
+      }
+      else
+      {
+        /* Copy the remaining responses to beginning of buffer. */
+        priv->response_queue_bytes -= req->len;
+        memcpy(priv->response_queue, priv->response_queue + req->len, priv->response_queue_bytes);
+      }
     }
 }
 
@@ -2194,6 +2214,9 @@ static int usbclass_bind(FAR struct usbdevclass_driver_s *driver,
       leave_critical_section(flags);
     }
 
+  /* Initialize response queue to empty */
+  priv->response_queue_bytes = 0;
+
   /* Report if we are selfpowered */
 
 #ifndef CONFIG_RNDIS_COMPOSITE
@@ -2372,6 +2395,7 @@ static int usbclass_setup(FAR struct usbdevclass_driver_s *driver,
     }
 #endif
   ctrlreq = priv->ctrlreq;
+  ctrlreq->priv = 0;
 
   /* Extract the little-endian 16-bit values to host order */
 
@@ -2474,20 +2498,19 @@ static int usbclass_setup(FAR struct usbdevclass_driver_s *driver,
               }
             else if (ctrl->req == RNDIS_GET_ENCAPSULATED_RESPONSE)
               {
-                if (!priv->ctrlreq_has_encap_response)
+                if (priv->response_queue_bytes == 0)
                   {
+                    /* No reply available is indicated with a single 0x00 byte. */
                     ret = 1;
                     ctrlreq->buf[0] = 0;
                   }
                 else
                   {
-                    /* There is data prepared in the ctrlreq buffer.
-                     * Just assign the length.
-                     */
-
+                    /* Retrieve a single reply from the response queue to control request buffer. */
                     FAR struct rndis_response_header *hdr =
-                      (struct rndis_response_header *)ctrlreq->buf;
-
+                      (struct rndis_response_header *)priv->response_queue;
+                    memcpy(ctrlreq->buf, hdr, hdr->msglen);
+                    ctrlreq->priv = priv->response_queue;
                     ret = hdr->msglen;
                   }
               }

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -1358,7 +1358,7 @@ static inline int rndis_recvpacket(FAR struct rndis_dev_s *priv,
  *
  ****************************************************************************/
 
-static FAR void*
+static FAR void *
 rndis_prepare_response(FAR struct rndis_dev_s *priv, size_t size,
                        FAR struct rndis_command_header *request_hdr)
 {
@@ -1368,7 +1368,8 @@ rndis_prepare_response(FAR struct rndis_dev_s *priv, size_t size,
 
   if (priv->response_queue_bytes + size > RNDIS_RESP_QUEUE_LEN)
     {
-      uerr("RNDIS response queue full, dropping command %08x", request_hdr->msgtype);
+      uerr("RNDIS response queue full, dropping command %08x",
+           (unsigned int)request_hdr->msgtype);
       return NULL;
     }
 
@@ -1395,16 +1396,19 @@ rndis_prepare_response(FAR struct rndis_dev_s *priv, size_t size,
  *
  ****************************************************************************/
 
-static int rndis_send_encapsulated_response(FAR struct rndis_dev_s *priv, size_t size)
+static int rndis_send_encapsulated_response(FAR struct rndis_dev_s *priv,
+                                            size_t size)
 {
   FAR struct rndis_notification *notif =
     (FAR struct rndis_notification *)priv->epintin_req->buf;
 
   /* Mark the response as available in the queue */
+
   priv->response_queue_bytes += size;
   DEBUGASSERT(priv->response_queue_bytes <= RNDIS_RESP_QUEUE_LEN);
 
   /* Send notification on IRQ endpoint, to tell host to read the data. */
+
   notif->notification = RNDIS_NOTIFICATION_RESPONSE_AVAILABLE;
   notif->reserved = 0;
   priv->epintin_req->len = sizeof(struct rndis_notification);
@@ -1441,10 +1445,9 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
       case RNDIS_INITIALIZE_MSG:
         {
           FAR struct rndis_initialize_cmplt *resp;
+          size_t respsize = sizeof(struct rndis_initialize_cmplt);
 
-          resp = rndis_prepare_response(priv,
-                                        sizeof(struct rndis_initialize_cmplt),
-                                        cmd_hdr);
+          resp = rndis_prepare_response(priv, respsize, cmd_hdr);
           if (!resp)
             {
               return -ENOMEM;
@@ -1458,7 +1461,7 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
           resp->xfrsize    = (4 + 44 + 22) + RNDIS_BUFFER_SIZE;
           resp->pktalign   = 2;
 
-          rndis_send_encapsulated_response(priv, resp->hdr.msglen);
+          rndis_send_encapsulated_response(priv, respsize);
         }
         break;
 
@@ -1565,9 +1568,9 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
         {
           FAR struct rndis_set_msg *req;
           FAR struct rndis_response_header *resp;
+          size_t respsize = sizeof(struct rndis_response_header);
 
-          resp = rndis_prepare_response(priv, sizeof(struct rndis_response_header),
-                                        cmd_hdr);
+          resp = rndis_prepare_response(priv, respsize, cmd_hdr);
           req  = (FAR struct rndis_set_msg *)dataout;
 
           if (!resp)
@@ -1603,17 +1606,17 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
               resp->status = RNDIS_STATUS_NOT_SUPPORTED;
             }
 
-          rndis_send_encapsulated_response(priv, resp->msglen);
+          rndis_send_encapsulated_response(priv, respsize);
         }
         break;
 
       case RNDIS_RESET_MSG:
         {
           FAR struct rndis_reset_cmplt *resp;
+          size_t respsize = sizeof(struct rndis_reset_cmplt);
 
           priv->response_queue_bytes = 0;
-          resp = rndis_prepare_response(priv, sizeof(struct rndis_reset_cmplt),
-                                        cmd_hdr);
+          resp = rndis_prepare_response(priv, respsize, cmd_hdr);
 
           if (!resp)
             {
@@ -1622,21 +1625,21 @@ static int rndis_handle_control_message(FAR struct rndis_dev_s *priv,
 
           resp->addreset  = 0;
           priv->connected = false;
-          rndis_send_encapsulated_response(priv, resp->hdr.msglen);
+          rndis_send_encapsulated_response(priv, respsize);
         }
         break;
 
       case RNDIS_KEEPALIVE_MSG:
         {
           FAR struct rndis_response_header *resp;
-          resp = rndis_prepare_response(priv, sizeof(struct rndis_response_header),
-                                        cmd_hdr);
+          size_t respsize = sizeof(struct rndis_response_header);
+          resp = rndis_prepare_response(priv, respsize, cmd_hdr);
           if (!resp)
             {
               return -ENOMEM;
             }
 
-          rndis_send_encapsulated_response(priv, resp->msglen);
+          rndis_send_encapsulated_response(priv, respsize);
         }
         break;
 
@@ -1787,18 +1790,24 @@ static void usbclass_ep0incomplete(FAR struct usbdev_ep_s *ep,
     }
   else if (req->len > 0 && req->priv == priv->response_queue)
     {
-      /* This transfer was from the response queue, subtract remaining byte count. */
+      /* This transfer was from the response queue,
+       * subtract remaining byte count.
+       */
+
       req->priv = 0;
       if (req->len >= priv->response_queue_bytes)
       {
         /* Queue now empty */
+
         priv->response_queue_bytes = 0;
       }
       else
       {
         /* Copy the remaining responses to beginning of buffer. */
+
         priv->response_queue_bytes -= req->len;
-        memcpy(priv->response_queue, priv->response_queue + req->len, priv->response_queue_bytes);
+        memcpy(priv->response_queue, priv->response_queue + req->len,
+               priv->response_queue_bytes);
       }
     }
 }
@@ -2248,6 +2257,7 @@ static int usbclass_bind(FAR struct usbdevclass_driver_s *driver,
     }
 
   /* Initialize response queue to empty */
+
   priv->response_queue_bytes = 0;
 
   /* Report if we are selfpowered */
@@ -2533,13 +2543,19 @@ static int usbclass_setup(FAR struct usbdevclass_driver_s *driver,
               {
                 if (priv->response_queue_bytes == 0)
                   {
-                    /* No reply available is indicated with a single 0x00 byte. */
+                    /* No reply available is indicated with a single
+                     * 0x00 byte.
+                     */
+
                     ret = 1;
                     ctrlreq->buf[0] = 0;
                   }
                 else
                   {
-                    /* Retrieve a single reply from the response queue to control request buffer. */
+                    /* Retrieve a single reply from the response queue to
+                     * control request buffer.
+                     */
+
                     FAR struct rndis_response_header *hdr =
                       (struct rndis_response_header *)priv->response_queue;
                     memcpy(ctrlreq->buf, hdr, hdr->msglen);


### PR DESCRIPTION
## Summary

Sometimes Windows would send RNDIS_KEEPALIVE_MSG and RNDIS_QUERY_MSG close to each other. This would cause the latter command to overwrite the reply for the prior command. This in turn will cause Windows to drop the connection after a 20 second timeout.
    
Easy way to reproduce the issue is to open the Windows "Adapter Status" dialog that shows the realtime TX/RX byte counts. This causes multiple RNDIS_QUERY_MSGs per second, and the connection will drop in less than an hour.
    
This commit fixes this issue, and other potential race conditions (such as USB descriptor read in middle on RNDIS query) by using a separate queue for the reply packets.

Example USB trace:

<pre>
13:21:14.104859 | usb_packet-1: SETUP ADDR 1 EP 0                     <---- Host starts 04 RNDIS_QUERY_MSG request
13:21:14.104862 | usb_packet-1: DATA0 [ 21 00 00 00 00 00 4C 00 ]
13:21:14.104871 | usb_packet-1: ACK
13:21:14.104878 | usb_packet-1: IN ADDR 1 EP 1
13:21:14.104881 | usb_packet-1: NAK
                | Previous two lines repeated 170 times
13:21:14.105847 | usb_packet-1: SOF 750
13:21:14.105850 | usb_packet-1: IN ADDR 1 EP 3
13:21:14.105853 | usb_packet-1: NAK
13:21:14.105859 | usb_packet-1: OUT ADDR 1 EP 0
13:21:14.105863 | usb_packet-1: DATA1 [ 04 00 00 00 4C 00 00 00 BC 03 00 00 02 01 02 00 30 00 00 00 14 00 00 00 00 00 00 00 AB 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
13:21:14.105908 | usb_packet-1: NAK
13:21:14.105916 | usb_packet-1: IN ADDR 1 EP 1
                | Previous two lines repeated 163 times
13:21:14.106847 | usb_packet-1: SOF 751
13:21:14.106850 | usb_packet-1: IN ADDR 1 EP 3
13:21:14.106853 | usb_packet-1: NAK
13:21:14.106860 | usb_packet-1: OUT ADDR 1 EP 0
13:21:14.106863 | usb_packet-1: DATA1 [ 04 00 00 00 4C 00 00 00 BC 03 00 00 02 01 02 00 30 00 00 00 14 00 00 00 00 00 00 00 AB 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
13:21:14.106909 | usb_packet-1: ACK           <---------- 04 RNDIS_QUERY_MSG first packet received
13:21:14.106916 | usb_packet-1: IN ADDR 1 EP 1
13:21:14.106919 | usb_packet-1: NAK
                | Previous two lines repeated 162 times
13:21:14.107847 | usb_packet-1: SOF 752
13:21:14.107850 | usb_packet-1: IN ADDR 1 EP 3
13:21:14.107854 | usb_packet-1: DATA0 [ 01 00 00 00 00 00 00 00 ]
13:21:14.107863 | usb_packet-1: ACK                               <------- Interrupt endpoint notification that command result is available.
13:21:14.107868 | usb_packet-1: OUT ADDR 1 EP 0
13:21:14.107871 | usb_packet-1: DATA0 [ 00 00 00 00 00 00 00 00 00 00 00 00 ]
13:21:14.107883 | usb_packet-1: ACK                             <---- Delayed last 12 bytes (separate bug #3162)
13:21:14.107890 | usb_packet-1: IN ADDR 1 EP 1
13:21:14.107893 | usb_packet-1: NAK
                | Previous two lines repeated 168 times
....
13:21:14.109848 | usb_packet-1: SOF 754
13:21:14.109851 | usb_packet-1: IN ADDR 1 EP 3
13:21:14.109854 | usb_packet-1: NAK
13:21:14.109860 | usb_packet-1: SETUP ADDR 1 EP 0          <---- Host starts 08 RNDIS_KEEPALIVE_MSG
13:21:14.109863 | usb_packet-1: DATA0 [ 21 00 00 00 00 00 0C 00 ]
13:21:14.109872 | usb_packet-1: ACK
13:21:14.109879 | usb_packet-1: IN ADDR 1 EP 1
13:21:14.109883 | usb_packet-1: NAK
                | Previous two lines repeated 170 times
13:21:14.110848 | usb_packet-1: SOF 755
13:21:14.110851 | usb_packet-1: IN ADDR 1 EP 3
13:21:14.110855 | usb_packet-1: NAK
13:21:14.110861 | usb_packet-1: OUT ADDR 1 EP 0
13:21:14.110864 | usb_packet-1: DATA1 [ 08 00 00 00 0C 00 00 00 BD 03 00 00 ]
13:21:14.110875 | usb_packet-1: NAK
13:21:14.110882 | usb_packet-1: IN ADDR 1 EP 1
                | Previous two lines repeated 171 times
13:21:14.111848 | usb_packet-1: SOF 756
13:21:14.111852 | usb_packet-1: IN ADDR 1 EP 3
13:21:14.111855 | usb_packet-1: NAK
13:21:14.111861 | usb_packet-1: OUT ADDR 1 EP 0
13:21:14.111864 | usb_packet-1: DATA1 [ 08 00 00 00 0C 00 00 00 BD 03 00 00 ]
13:21:14.111876 | usb_packet-1: ACK                              <--- RNDIS_KEEPALIVE_MSG complete
13:21:14.111883 | usb_packet-1: IN ADDR 1 EP 1
13:21:14.111886 | usb_packet-1: NAK
                | Previous two lines repeated 170 times
13:21:14.112849 | usb_packet-1: SOF 757
13:21:14.112852 | usb_packet-1: IN ADDR 1 EP 3
13:21:14.112855 | usb_packet-1: DATA1 [ 01 00 00 00 00 00 00 00 ]
13:21:14.112864 | usb_packet-1: ACK                            <--- Notification of command result available
13:21:14.112869 | usb_packet-1: IN ADDR 1 EP 0
13:21:14.112872 | usb_packet-1: DATA1 [ ]
13:21:14.112875 | usb_packet-1: ACK
13:21:14.112882 | usb_packet-1: IN ADDR 1 EP 1
13:21:14.112885 | usb_packet-1: NAK
...
13:21:14.116861 | usb_packet-1: IN ADDR 1 EP 0
13:21:14.116865 | usb_packet-1: DATA1 [ 08 00 00 80 10 00 00 00 BD 03 00 00 00 00 00 00 ]
13:21:14.116879 | usb_packet-1: ACK                          <---- Got 08 RNDIS_KEEPALIVE_MSG response, the earlier 04 has been overwritten.
</pre>

## Impact

This improves reliability of RNDIS communications. In our use case, the problem only occurred once in several days unless the Network Adapter Status dialog was open. So the race condition is quite rare in normal usage.

## Testing

Tested on custom STM32F4 board with USB RNDIS driver.

The bug can be easiest reproduced by opening the Windows network adapter statistics
window, which causes concurrent RNDIS requests. Note that on STM32 #3162 also occurs
in this situation.