### PR TITLE
arch/arm: Use macro defined swi range in dispatch_syscall

### DIFF
--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -100,7 +100,7 @@ static void dispatch_syscall(void)
     " pop {r4, r5}\n"             /* Recover R4 and R5 */
     " mov r2, r0\n"               /* R2=Save return value in R2 */
     " mov r0, #3\n"               /* R0=SYS_syscall_return */
-    " svc 0"                      /* Return from the syscall */
+    " svc %0\n"::"i"(SYS_syscall) /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -98,7 +98,7 @@ static void dispatch_syscall(void)
     " add sp, sp, #16\n"           /* Destroy the stack frame */
     " mov r2, r0\n"                /* R2=Save return value in R2 */
     " mov r0, #0\n"                /* R0=SYS_syscall_return */
-    " svc #0x900001\n"             /* Return from the SYSCALL */
+    " svc %0\n"::"i"(SYS_syscall)  /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -108,7 +108,7 @@ static void dispatch_syscall(void)
       " add sp, sp, r2\n"            /* Restore SP */
       " mov r2, r0\n"                /* R2=Save return value in R2 */
       " mov r0, #3\n"                /* R0=SYS_syscall_return */
-      " svc 0"                       /* Return from the syscall */
+      " svc %0\n"::"i"(SYS_syscall)  /* Return from the SYSCALL */
     );
 }
 #endif

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -95,7 +95,7 @@ static void dispatch_syscall(void)
     " add sp, sp, #16\n"           /* Destroy the stack frame */
     " mov r2, r0\n"                /* R2=Save return value in R2 */
     " mov r0, #0\n"                /* R0=SYS_syscall_return */
-    " svc #0x900001\n"             /* Return from the SYSCALL */
+    " svc %0\n"::"i"(SYS_syscall)  /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -107,7 +107,7 @@ static void dispatch_syscall(void)
       " add sp, sp, r2\n"            /* Restore SP */
       " mov r2, r0\n"                /* R2=Save return value in R2 */
       " mov r0, #3\n"                /* R0=SYS_syscall_return */
-      " svc 0"                       /* Return from the syscall */
+      " svc %0\n"::"i"(SYS_syscall)  /* Return from the SYSCALL */
     );
 }
 #endif


### PR DESCRIPTION
## Summary
This is a follow-up patch(https://github.com/apache/incubator-nuttx/pull/3075) to fix the swi number out of range in THUMB mode.

## Impact
All arm based chips with libsyscall enabled

## Testing
Pass the build
