### PR TITLE
sim: fix signal deliver calling error on sim platform

### DIFF
--- a/arch/sim/src/sim/up_blocktask.c
+++ b/arch/sim/src/sim/up_blocktask.c
@@ -134,18 +134,6 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
           rtcb = this_task();
           sinfo("New Active Task TCB=%p\n", rtcb);
 
-          /* The way that we handle signals in the simulation is kind of
-           * a kludge.  This would be unsafe in a truly multi-threaded,
-           * interrupt driven environment.
-           */
-
-          if (rtcb->xcp.sigdeliver)
-            {
-              sinfo("Delivering signals TCB=%p\n", rtcb);
-              ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
-              rtcb->xcp.sigdeliver = NULL;
-            }
-
           /* Reset scheduler parameters */
 
           nxsched_resume_scheduler(rtcb);
@@ -153,6 +141,21 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
           /* Then switch contexts */
 
           up_longjmp(rtcb->xcp.regs, 1);
+        }
+      else
+        {
+          /* The way that we handle signals in the simulation is kind of
+           * a kludge.  This would be unsafe in a truly multi-threaded,
+           * interrupt driven environment.
+           */
+
+          rtcb = this_task();
+          if (rtcb->xcp.sigdeliver)
+            {
+              sinfo("Delivering signals TCB=%p\n", rtcb);
+              ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+              rtcb->xcp.sigdeliver = NULL;
+            }
         }
     }
 }

--- a/arch/sim/src/sim/up_exit.c
+++ b/arch/sim/src/sim/up_exit.c
@@ -92,18 +92,6 @@ void up_exit(int status)
 
   nxsched_resume_scheduler(tcb);
 
-  /* The way that we handle signals in the simulation is kind of
-   * a kludge.  This would be unsafe in a truly multi-threaded, interrupt
-   * driven environment.
-   */
-
-  if (tcb->xcp.sigdeliver)
-    {
-      sinfo("Delivering signals TCB=%p\n", tcb);
-      ((sig_deliver_t)tcb->xcp.sigdeliver)(tcb);
-      tcb->xcp.sigdeliver = NULL;
-    }
-
   /* Then switch contexts */
 
   up_longjmp(tcb->xcp.regs, 1);

--- a/arch/sim/src/sim/up_releasepending.c
+++ b/arch/sim/src/sim/up_releasepending.c
@@ -103,18 +103,6 @@ void up_release_pending(void)
           rtcb = this_task();
           sinfo("New Active Task TCB=%p\n", rtcb);
 
-          /* The way that we handle signals in the simulation is kind of
-           * a kludge.  This would be unsafe in a truly multi-threaded,
-           * interrupt driven environment.
-           */
-
-          if (rtcb->xcp.sigdeliver)
-            {
-              sinfo("Delivering signals TCB=%p\n", rtcb);
-              ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
-              rtcb->xcp.sigdeliver = NULL;
-            }
-
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(rtcb);
@@ -122,6 +110,21 @@ void up_release_pending(void)
           /* Then switch contexts */
 
           up_longjmp(rtcb->xcp.regs, 1);
+        }
+      else
+        {
+          /* The way that we handle signals in the simulation is kind of
+           * a kludge.  This would be unsafe in a truly multi-threaded,
+           * interrupt driven environment.
+           */
+
+          rtcb = this_task();
+          if (rtcb->xcp.sigdeliver)
+            {
+              sinfo("Delivering signals TCB=%p\n", rtcb);
+              ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+              rtcb->xcp.sigdeliver = NULL;
+            }
         }
     }
 }

--- a/arch/sim/src/sim/up_reprioritizertr.c
+++ b/arch/sim/src/sim/up_reprioritizertr.c
@@ -158,18 +158,6 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
               rtcb = this_task();
               sinfo("New Active Task TCB=%p\n", rtcb);
 
-              /* The way that we handle signals in the simulation is kind of
-               * a kludge.  This would be unsafe in a truly multi-threaded,
-               * interrupt driven environment.
-               */
-
-              if (rtcb->xcp.sigdeliver)
-                {
-                  sinfo("Delivering signals TCB=%p\n", rtcb);
-                  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
-                  rtcb->xcp.sigdeliver = NULL;
-                }
-
               /* Update scheduler parameters */
 
               nxsched_resume_scheduler(rtcb);
@@ -177,6 +165,21 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
               /* Then switch contexts */
 
               up_longjmp(rtcb->xcp.regs, 1);
+            }
+          else
+            {
+              /* The way that we handle signals in the simulation is kind of
+               * a kludge.  This would be unsafe in a truly multi-threaded,
+               * interrupt driven environment.
+               */
+
+              rtcb = this_task();
+              if (rtcb->xcp.sigdeliver)
+                {
+                  sinfo("Delivering signals TCB=%p\n", rtcb);
+                  ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+                  rtcb->xcp.sigdeliver = NULL;
+                }
             }
         }
     }

--- a/arch/sim/src/sim/up_unblocktask.c
+++ b/arch/sim/src/sim/up_unblocktask.c
@@ -136,18 +136,6 @@ void up_unblock_task(FAR struct tcb_s *tcb)
           rtcb = this_task();
           sinfo("New Active Task TCB=%p\n", rtcb);
 
-          /* The way that we handle signals in the simulation is kind of
-           * a kludge.  This would be unsafe in a truly multi-threaded,
-           * interrupt driven environment.
-           */
-
-          if (rtcb->xcp.sigdeliver)
-            {
-              sinfo("Delivering signals TCB=%p\n", rtcb);
-              ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
-              rtcb->xcp.sigdeliver = NULL;
-            }
-
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(rtcb);
@@ -155,6 +143,21 @@ void up_unblock_task(FAR struct tcb_s *tcb)
           /* Then switch contexts */
 
           up_longjmp(rtcb->xcp.regs, 1);
+        }
+      else
+        {
+          /* The way that we handle signals in the simulation is kind of
+           * a kludge.  This would be unsafe in a truly multi-threaded,
+           * interrupt driven environment.
+           */
+
+          rtcb = this_task();
+          if (rtcb->xcp.sigdeliver)
+            {
+              sinfo("Delivering signals TCB=%p\n", rtcb);
+              ((sig_deliver_t)rtcb->xcp.sigdeliver)(rtcb);
+              rtcb->xcp.sigdeliver = NULL;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
since the signal deliver handler should be called in signal owner task.

## Impact
signal handler is executed in the target task, not the caller thread.

## Testing
Pass ostest when CONFIG_SIG_DEFAULT=y

