### PR TITLE
tiva:cc13x0_adi3_refsys fix typo

### DIFF
--- a/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi3_refsys.h
+++ b/arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi3_refsys.h
@@ -184,7 +184,7 @@
 #  define ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_DEFAULT              (0 << ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_SHIFT)  /* Default, about 1.63V */
 #  define ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_TYPICAL              (5 << ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_SHIFT)  /* Typical voltage after trim voltage 1.71V */
 #  define ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_MAX                  (21 << ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_SHIFT) /* Max voltage 1.96V */
-#  define ADI3_REFS */YS_DCDCCTL0_VDDR_TRIM_MIN               (22 << ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_SHIFT) /* Min voltage 1.47V */
+#  define ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_MIN                  (22 << ADI3_REFSYS_DCDCCTL0_VDDR_TRIM_SHIFT) /* Min voltage 1.47V */
 
 #define ADI3_REFSYS_DCDCCTL0_GLDO_ISRC_SHIFT                  (5)       /* Bits 5-7:  Set charge and re-charge current level */
                                                                         /*            2's complement encoding */


### PR DESCRIPTION
## Summary

Fixed typo

## Impact

None it was never referenced in a build

## Testing

CI