### PR TITLE
serial: Don't comment out ws_[x|y]pixel field from winsize struct

### DIFF
--- a/include/nuttx/serial/tioctl.h
+++ b/include/nuttx/serial/tioctl.h
@@ -208,9 +208,8 @@ struct winsize
   uint16_t ws_row;
   uint16_t ws_col;
 
-  /* uint16_t ws_xpixel;    unused */
-
-  /* uint16_t ws_ypixel;    unused */
+  uint16_t ws_xpixel; /* unused */
+  uint16_t ws_ypixel; /* unused */
 };
 
 /* Structure used with TIOCSRS485 and TIOCGRS485 (Linux compatible) */


### PR DESCRIPTION
## Summary
Make it more compatible with Unix
 
## Impact
Add two unused fields.

## Testing
Pass CI.
