### PR TITLE
Stm32h7 fix heap clobber

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1690,6 +1690,13 @@ config STM32H7_CUSTOM_CLOCKCONFIG
 	---help---
 		Enables special, board-specific STM32 clock configuration.
 
+config STM32H7_SRAM4EXCLUDE
+	bool "Exclude SRAM4 from the heap"
+	default n
+	---help---
+		Exclude SRAM4 from the HEAP in order to use this 64 KB region
+		for other uses, such as DMA buffers, etc.
+
 config STM32H7_DTCMEXCLUDE
 	bool "Exclude DTCM SRAM from the heap"
 	default y if LIBC_ARCH_ELF

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
@@ -170,10 +170,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
     /* Stabs debugging sections. */

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
@@ -79,10 +79,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > ksram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
     /* Stabs debugging sections */

--- a/boards/arm/stm32h7/nucleo-h743zi2/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi2/scripts/flash.ld
@@ -170,10 +170,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
     /* Stabs debugging sections. */

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
@@ -168,10 +168,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
     /* Stabs debugging sections. */

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
@@ -79,10 +79,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > ksram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
 


### PR DESCRIPTION
## Summary

arch/stm32h7:
- Ensure HEAP and static data in SRAM4 do not overlap each other (heap will start after any static data)
- New Kconfig option `CONFIG_STM32H7_SRAM4EXCLUDE` allows to completely exclude SRAM4 from heap

See commit log for (excruciating) detail.

References:

[1] See the dev@nuttx.a.o mailing list discussion started 2021/03/25: "How to ensure HEAP will not overlap static DMA buffer?" [https://lists.apache.org/thread.html/recf2bb9043f8c9f53c10917e2adb2ec64fe35dc5e6f9a695a7ac6ecc%40%3Cdev.nuttx.apache.org%3E](https://lists.apache.org/thread.html/recf2bb9043f8c9f53c10917e2adb2ec64fe35dc5e6f9a695a7ac6ecc%40%3Cdev.nuttx.apache.org%3E)

[2] See arm_addregion() in arch/arm/src/stm32h7/stm32_allocateheap.c

Thanks to Gregory Nutt and David Sidrane for suggestions and reviews.

## Impact

- Prevents serious problem where HEAP-allocated objects and statically-allocated objects placed in SRAM4 may clobber each other, leading to all sorts of undefined behavior. In particular, if configured to use SPI6 with DMA, the SPI6 BDMA Tx and Rx buffers will have this problem. There may be other such statically allocated buffers.

- Requires change to all board linker scripts (this PR makes the change for all in-tree boards):

Every STM32H7 linker script must replace this:

```
    .sram4 :
    {
    } > sram4
```

with this:

```
    .sram4_reserve (NOLOAD) :
    {
        *(.sram4)
        . = ALIGN(4);
        _sram4_heap_start = ABSOLUTE(.);
    } > sram4
```

or link will fail with: `undefined reference to '_sram4_heap_start'`.

The Release Notes should document this for users with out-of-tree boards.

## Testing

- Successfully built all of the following configurations:

```
      nucleo-h743zi2:jumbo
      nucleo-h743zi2:nsh
      nucleo-h743zi:nxlines_oled
      nucleo-h743zi:elf
      nucleo-h743zi:otg_fs_host
      nucleo-h743zi:nsh
      nucleo-h743zi:netnsh
      nucleo-h743zi:pwm
      stm32h747i-disco:nsh
```
- Tested with custom board.

- nxstyle.
