### PR TITLE
ESP32: Fix math for DMA buffer length rounding

### DIFF
--- a/arch/xtensa/src/esp32/esp32_dma.c
+++ b/arch/xtensa/src/esp32/esp32_dma.c
@@ -24,13 +24,8 @@
 
 #include <nuttx/config.h>
 
-#include <string.h>
-#include <debug.h>
-#include <errno.h>
 #include <assert.h>
 #include <sys/types.h>
-#include <nuttx/kmalloc.h>
-#include <nuttx/irq.h>
 
 #include "hardware/esp32_dma.h"
 #include "esp32_dma.h"

--- a/arch/xtensa/src/esp32/esp32_dma.c
+++ b/arch/xtensa/src/esp32/esp32_dma.c
@@ -43,6 +43,10 @@
 #  define MIN(a,b) (a < b ? a : b)
 #endif
 
+#ifndef ALIGN_UP
+#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -82,11 +86,9 @@ uint32_t esp32_dma_init(struct esp32_dmadesc_s *dmadesc, uint32_t num,
     {
       data_len = MIN(bytes, ESP32_DMA_DATALEN_MAX);
 
-      /* Round the number of bytes to the nearest word, since the buffer
-       * length must be word-aligned.
-       */
+      /* Buffer length must be rounded to next 32-bit boundary. */
 
-      buf_len = (data_len + sizeof(uintptr_t) - 1) / sizeof(uintptr_t);
+      buf_len = ALIGN_UP(data_len, sizeof(uintptr_t));
 
       dmadesc[i].ctrl = (data_len << DMA_CTRL_DATALEN_S) |
                         (buf_len << DMA_CTRL_BUFLEN_S) |


### PR DESCRIPTION
## Summary
This PR intends to fix the math operation used for rounding the DMA buffer length.
It was incorrectly performing a division operation.

## Impact
DMA engine buffer length was shorter than the number of valid bytes, it could induce the DMA engine to make shorter transfers, but I haven't actually noticed any performance drawback.

## Testing
Using SPI DMA for successfully controlling an LCD display.