### PR TITLE
xtensa/esp32: Fix DMA burst mode being unintendedly disabled

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -900,7 +900,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       esp32_spi_set_regbits(priv, SPI_SLAVE_OFFSET, SPI_SYNC_RESET_M);
       esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_SYNC_RESET_M);
 
-      esp32_spi_set_reg(priv, SPI_DMA_CONF_OFFSET, SPI_DMA_RESET_MASK);
+      esp32_spi_set_regbits(priv, SPI_DMA_CONF_OFFSET, SPI_DMA_RESET_MASK);
       esp32_spi_reset_regbits(priv, SPI_DMA_CONF_OFFSET, SPI_DMA_RESET_MASK);
 
       n = esp32_dma_init(s_dma_txdesc[priv->config->dma_chan - 1],

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -763,9 +763,8 @@ static int esp32_spislv_interrupt(int irq, void *context, FAR void *arg)
 
   if (priv->dma_chan)
     {
-      esp32_spi_set_reg(priv, SPI_DMA_CONF_OFFSET, SPI_DMA_RESET_MASK);
-      esp32_spi_reset_regbits(priv, SPI_DMA_CONF_OFFSET,
-                              SPI_DMA_RESET_MASK);
+      esp32_spi_set_regbits(priv, SPI_DMA_CONF_OFFSET, SPI_DMA_RESET_MASK);
+      esp32_spi_reset_regbits(priv, SPI_DMA_CONF_OFFSET, SPI_DMA_RESET_MASK);
     }
 
   if (priv->process == false)


### PR DESCRIPTION
## Summary
This PR intends to fix an unintended disable of the SPI DMA Burst mode due to a wrong override of the DMA_CONF register bits during the setup of the SPI exchange.

## Impact
This scenario was identified in both SPI Master and SPI Slave drivers.

## Testing
SPI Driver working as expected.
