### PR TITLE
limits.h: modify _POSIX_OPEN_MAX to 16

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -120,10 +120,10 @@
 #define _POSIX_MAX_INPUT      255
 #define _POSIX_NAME_MAX       CONFIG_NAME_MAX
 #define _POSIX_NGROUPS_MAX    0
-#define _POSIX_OPEN_MAX       INT_MAX
+#define _POSIX_OPEN_MAX       16
 #define _POSIX_PATH_MAX       CONFIG_PATH_MAX
 #define _POSIX_PIPE_BUF       512
-#define _POSIX_STREAM_MAX     INT_MAX
+#define _POSIX_STREAM_MAX     16
 #define _POSIX_TZNAME_MAX     3
 
 #ifdef CONFIG_SMALL_MEMORY


### PR DESCRIPTION
## Summary
Modify _POSIX_OPEN_MAX to 16 because we may use it to create variable, but INT_MAX is too  bigger  so that stack overflow or compiling break.

example:
mq_open/speculative/26-1.c:46:8: error: size of array 'queue' is negative
  mqd_t queue[_POSIX_OPEN_MAX + _POSIX_MQ_OPEN_MAX + 1];

## Impact

## Testing

