### PR TITLE
sim: do not exit simulator on up_assert (just let the task exit)

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -61,7 +61,7 @@ CSRCS  = up_initialize.c up_idle.c up_interruptcontext.c up_initialstate.c
 CSRCS += up_createstack.c up_usestack.c up_releasestack.c up_stackframe.c
 CSRCS += up_unblocktask.c up_blocktask.c up_releasepending.c
 CSRCS += up_reprioritizertr.c up_exit.c up_schedulesigaction.c
-CSRCS += up_heap.c up_uart.c
+CSRCS += up_heap.c up_uart.c up_assert.c
 CSRCS += up_copyfullstate.c
 
 ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)

--- a/arch/sim/src/sim/up_assert.c
+++ b/arch/sim/src/sim/up_assert.c
@@ -1,0 +1,92 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_assert.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sched/sched.h>
+#include <stdlib.h>
+#include <nuttx/board.h>
+#include "up_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_assert
+ *
+ * Description:
+ *   Called to terminate the simulation abnormally in the event of a failed
+ *   assertion.
+ *
+ ****************************************************************************/
+
+void up_assert(const char *filename, int line)
+{
+  /* Show the location of the failed assertion */
+
+#ifdef CONFIG_SMP
+  syslog(LOG_ERR, "CPU%d: Assertion failed at file:%s line: %d\n",
+          up_cpu_index(), filename, line);
+#else
+  syslog(LOG_ERR, "Assertion failed at file:%s line: %d\n",
+          filename, line);
+#endif
+
+  /* Allow for any board/configuration specific crash information */
+
+#ifdef CONFIG_BOARD_CRASHDUMP
+  board_crashdump(sim_getsp(), this_task(), filename, line);
+#endif
+
+  if (CURRENT_REGS || (running_task())->flink == NULL)
+    {
+      /* Exit the simulation */
+
+      host_abort(EXIT_FAILURE);
+    }
+}

--- a/arch/sim/src/sim/up_head.c
+++ b/arch/sim/src/sim/up_head.c
@@ -100,35 +100,20 @@ int main(int argc, char **argv, char **envp)
 }
 
 /****************************************************************************
- * Name: up_assert
+ * Name: host_abort
  *
  * Description:
- *   Called to terminate the simulation abnormally in the event of a failed
- *   assertion.
+ *   Abort the simulation
  *
+ * Input Parameters:
+ *   status - Exit status to set
  ****************************************************************************/
 
-void up_assert(const char *filename, int line)
+void host_abort(int status)
 {
-  /* Show the location of the failed assertion */
+  /* Save the return code and exit the simulation */
 
-#ifdef CONFIG_SMP
-  syslog(LOG_ERR, "CPU%d: Assertion failed at file:%s line: %d\n",
-          up_cpu_index(), filename, line);
-#else
-  syslog(LOG_ERR, "Assertion failed at file:%s line: %d\n",
-          filename, line);
-#endif
-
-  /* Allow for any board/configuration specific crash information */
-
-#ifdef CONFIG_BOARD_CRASHDUMP
-  board_crashdump(sim_getsp(), this_task(), filename, line);
-#endif
-
-  /* Exit the simulation */
-
-  g_exitcode = EXIT_FAILURE;
+  g_exitcode = status;
   longjmp(g_simabort, 1);
 }
 
@@ -152,9 +137,12 @@ void up_assert(const char *filename, int line)
 #ifdef CONFIG_BOARDCTL_POWEROFF
 int board_power_off(int status)
 {
-  /* Save the return code and exit the simulation */
+  /* Abort simulator */
 
-  g_exitcode = status;
-  longjmp(g_simabort, 1);
+  host_abort(status);
+
+  /* Does not really return */
+
+  return 0;
 }
 #endif

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -214,6 +214,10 @@ void up_copyfullstate(uint32_t *dest, uint32_t *src);
 
 void *up_doirq(int irq, void *regs);
 
+/* up_head.c ****************************************************************/
+
+void host_abort(int status);
+
 /* up_setjmp32.S ************************************************************/
 
 int  up_setjmp(void *jb);


### PR DESCRIPTION
## Summary

`up_assert` was exiting simulator which means that using `assert` from an application would never print the error and just exit the task (as it should).

## Impact

Fix assert() on sim

## Testing

Custom config based on sim:nsh. I can see the assert message now and only the app exits
