### PR TITLE
usbhost: Add usb host tracing strings to stm32h7

### DIFF
--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -181,6 +181,14 @@ ifeq ($(CONFIG_USBHOST),y)
 CHIP_CSRCS += stm32_otghost.c
 endif
 
+ifeq ($(CONFIG_USBHOST_TRACE),y)
+CHIP_CSRCS += stm32_usbhost.c
+else
+ifeq ($(CONFIG_DEBUG_USB),y)
+CHIP_CSRCS += stm32_usbhost.c
+endif
+endif
+
 ifeq ($(CONFIG_STM32H7_TIM),y)
 CHIP_CSRCS += stm32_tim.c
 endif

--- a/arch/arm/src/stm32h7/stm32_otghost.c
+++ b/arch/arm/src/stm32h7/stm32_otghost.c
@@ -5545,33 +5545,4 @@ FAR struct usbhost_connection_s *stm32_otgfshost_initialize(int controller)
   return &g_usbconn;
 }
 
-#if defined(CONFIG_USBHOST_TRACE) || defined(CONFIG_DEBUG_USB)
-/****************************************************************************
- * Name: usbhost_trformat1 and usbhost_trformat2
- *
- * Description:
- *   This interface must be provided by platform specific logic that knows
- *   the HCDs encoding of USB trace data.
- *
- *   Given an 9-bit index, return a format string suitable for use with, say,
- *   printf.  The returned format is expected to handle two unsigned integer
- *   values.
- *
- ****************************************************************************/
-
-FAR const char *usbhost_trformat1(uint16_t id)
-{
-  /* TODO: */
-
-  return NULL;
-}
-
-FAR const char *usbhost_trformat2(uint16_t id)
-{
-  /* TODO: */
-
-  return NULL;
-}
-#endif /* CONFIG_USBHOST_TRACE && CONFIG_DEBUG_USB */
-
 #endif /* CONFIG_USBHOST && CONFIG_STM32H7_OTGFS */

--- a/arch/arm/src/stm32h7/stm32_usbhost.c
+++ b/arch/arm/src/stm32h7/stm32_usbhost.c
@@ -1,0 +1,233 @@
+/********************************************************************************************************************
+ * arch/arm/src/stm32h7/stm32_usbhost.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ********************************************************************************************************************/
+
+/********************************************************************************************************************
+ * Included Files
+ ********************************************************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+#include "stm32_usbhost.h"
+
+#ifdef HAVE_USBHOST_TRACE
+
+/********************************************************************************************************************
+ * Pre-processor Definitions
+ ********************************************************************************************************************/
+
+#define TR_FMT1 false
+#define TR_FMT2 true
+
+#define TRENTRY(id,fmt1,string) {string}
+
+/********************************************************************************************************************
+ * Private Types
+ ********************************************************************************************************************/
+
+struct stm32_usbhost_trace_s
+{
+  FAR const char *string;
+};
+
+/********************************************************************************************************************
+ * Private Data
+ ********************************************************************************************************************/
+
+static const struct stm32_usbhost_trace_s g_trace1[TRACE1_NSTRINGS] =
+{
+#ifdef CONFIG_STM32H7_OTGFS
+
+  TRENTRY(OTGFS_TRACE1_DEVDISCONN,         TR_FMT1, "OTGFS ERROR: Host Port %d. Device disconnected\n"),
+  TRENTRY(OTGFS_TRACE1_IRQATTACH,          TR_FMT1, "OTGFS ERROR: Failed to attach IRQ\n"),
+  TRENTRY(OTGFS_TRACE1_TRNSFRFAILED,       TR_FMT1, "OTGFS  ERROR: Transfer Failed. ret=%d\n"),
+  TRENTRY(OTGFS_TRACE1_SENDSETUP,          TR_FMT1, "OTGFS  ERROR: ctrl_sendsetup() failed with: %d\n"),
+  TRENTRY(OTGFS_TRACE1_SENDDATA,           TR_FMT1, "OTGFS  ERROR: ctrl_senddata() failed with: %d\n"),
+  TRENTRY(OTGFS_TRACE1_RECVDATA,           TR_FMT1, "OTGFS  ERROR: ctrl_recvdata() failed with: %d\n"),
+
+#  ifdef HAVE_USBHOST_TRACE_VERBOSE
+
+  TRENTRY(OTGFS_VTRACE1_CONNECTED,         TR_FMT1, "OTGFS Host Port %d connected.\n"),
+  TRENTRY(OTGFS_VTRACE1_DISCONNECTED,      TR_FMT1, "OTGFS Host Port %d disconnected.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT,              TR_FMT1, "OTGFS Handling Interrupt. Entry Point.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_SOF,          TR_FMT1, "OTGFS Handle the start of frame interrupt.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_RXFLVL,       TR_FMT1, "OTGFS Handle the RxFIFO non-empty interrupt.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_NPTXFE,       TR_FMT1, "OTGFS Handle the non-periodic TxFIFO empty interrupt.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_PTXFE,        TR_FMT1, "OTGFS Handle the periodic TxFIFO empty interrupt.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HC,           TR_FMT1, "OTGFS Handle the host channels interrupt.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HPRT,         TR_FMT1, "OTGFS Handle the host port interrupt.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_POCCHNG, TR_FMT1, "OTGFS  HPRT: Port Over-Current Change.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_PCDET,   TR_FMT1, "OTGFS  HPRT: Port Connect Detect.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_PENCHNG, TR_FMT1, "OTGFS  HPRT: Port Enable Changed.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_LSDEV,   TR_FMT1, "OTGFS  HPRT: Low Speed Device Connected.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_FSDEV,   TR_FMT1, "OTGFS  HPRT: Full Speed Device Connected.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_LSFSSW,  TR_FMT1, "OTGFS  HPRT: Host Switch: LS -> FS.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_FSLSSW,  TR_FMT1, "OTGFS  HPRT: Host Switch: FS -> LS.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_DISC,         TR_FMT1, "OTGFS Handle the disconnect detected interrupt.\n"),
+  TRENTRY(OTGFS_VTRACE1_GINT_IPXFR,        TR_FMT1, "OTGFS Handle the incomplete periodic transfer.\n"),
+
+#  endif
+#endif
+
+#ifdef CONFIG_STM32H7_OTGFS
+
+  TRENTRY(OTGHS_TRACE1_DEVDISCONN,         TR_FMT1, "OTGHS ERROR: Host Port %d. Device disconnected\n"),
+  TRENTRY(OTGHS_TRACE1_IRQATTACH,          TR_FMT1, "OTGHS ERROR: Failed to attach IRQ\n"),
+  TRENTRY(OTGHS_TRACE1_TRNSFRFAILED,       TR_FMT1, "OTGHS  ERROR: Transfer Failed. ret=%d\n"),
+  TRENTRY(OTGHS_TRACE1_SENDSETUP,          TR_FMT1, "OTGHS  ERROR: ctrl_sendsetup() failed with: %d\n"),
+  TRENTRY(OTGHS_TRACE1_SENDDATA,           TR_FMT1, "OTGHS  ERROR: ctrl_senddata() failed with: %d\n"),
+  TRENTRY(OTGHS_TRACE1_RECVDATA,           TR_FMT1, "OTGHS  ERROR: ctrl_recvdata() failed with: %d\n"),
+
+#  ifdef HAVE_USBHOST_TRACE_VERBOSE
+
+  TRENTRY(OTGHS_VTRACE1_CONNECTED,         TR_FMT1, "OTGHS Host Port %d connected.\n"),
+  TRENTRY(OTGHS_VTRACE1_DISCONNECTED,      TR_FMT1, "OTGHS Host Port %d disconnected.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT,              TR_FMT1, "OTGHS Handling Interrupt. Entry Point.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_SOF,          TR_FMT1, "OTGHS Handle the start of frame interrupt.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_RXFLVL,       TR_FMT1, "OTGHS Handle the RxFIFO non-empty interrupt.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_NPTXFE,       TR_FMT1, "OTGHS Handle the non-periodic TxFIFO empty interrupt.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_PTXFE,        TR_FMT1, "OTGHS Handle the periodic TxFIFO empty interrupt.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HC,           TR_FMT1, "OTGHS Handle the host channels interrupt.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HPRT,         TR_FMT1, "OTGHS Handle the host port interrupt.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_POCCHNG, TR_FMT1, "OTGHS  HPRT: Port Over-Current Change.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_PCDET,   TR_FMT1, "OTGHS  HPRT: Port Connect Detect.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_PENCHNG, TR_FMT1, "OTGHS  HPRT: Port Enable Changed.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_LSDEV,   TR_FMT1, "OTGHS  HPRT: Low Speed Device Connected.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_HSDEV,   TR_FMT1, "OTGHS  HPRT: Full Speed Device Connected.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_LSHSSW,  TR_FMT1, "OTGHS  HPRT: Host Switch: LS -> HS.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_HSLSSW,  TR_FMT1, "OTGHS  HPRT: Host Switch: HS -> LS.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_DISC,         TR_FMT1, "OTGHS Handle the disconnect detected interrupt.\n"),
+  TRENTRY(OTGHS_VTRACE1_GINT_IPXFR,        TR_FMT1, "OTGHS Handle the incomplete periodic transfer.\n"),
+
+#  endif
+#endif
+};
+
+static const struct stm32_usbhost_trace_s g_trace2[TRACE2_NSTRINGS] =
+{
+#ifdef CONFIG_STM32H7_OTGFS
+
+  TRENTRY(OTGFS_TRACE2_CLIP,                TR_FMT2, "OTGFS CLIP: chidx: %d buflen: %d\n"),
+
+#  ifdef HAVE_USBHOST_TRACE_VERBOSE
+
+  TRENTRY(OTGFS_VTRACE2_CHANWAKEUP_IN,      TR_FMT2, "OTGFS  EP%d(IN)  wake up with result: %d\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANWAKEUP_OUT,     TR_FMT2, "OTGFS  EP%d(OUT) wake up with result: %d\n"),
+  TRENTRY(OTGFS_VTRACE2_CTRLIN,             TR_FMT2, "OTGFS CTRL_IN  type: %02x req: %02x\n"),
+  TRENTRY(OTGFS_VTRACE2_CTRLOUT,            TR_FMT2, "OTGFS CTRL_OUT type: %02x req: %02x\n"),
+  TRENTRY(OTGFS_VTRACE2_INTRIN,             TR_FMT2, "OTGFS INTR_IN  chidx: %02x len: %02x\n"),
+  TRENTRY(OTGFS_VTRACE2_INTROUT,            TR_FMT2, "OTGFS INTR_OUT chidx: %02x len: %02x\n"),
+  TRENTRY(OTGFS_VTRACE2_BULKIN,             TR_FMT2, "OTGFS BULK_IN  chidx: %02x len: %02x\n"),
+  TRENTRY(OTGFS_VTRACE2_BULKOUT,            TR_FMT2, "OTGFS BULK_OUT chidx: %02x len: %02x\n"),
+  TRENTRY(OTGFS_VTRACE2_ISOCIN,             TR_FMT2, "OTGFS ISOC_IN  chidx: %02x len: %04d\n"),
+  TRENTRY(OTGFS_VTRACE2_ISOCOUT,            TR_FMT2, "OTGFS ISOC_OUT chidx: %02x req: %02x\n"),
+  TRENTRY(OTGFS_VTRACE2_STARTTRANSFER,      TR_FMT2, "OTGFS  Transfer chidx: %d buflen: %d\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANCONF_CTRL_IN,   TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,IN ,CTRL)\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANCONF_CTRL_OUT,  TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,OUT,CTRL)\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANCONF_INTR_IN,   TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,IN ,INTR)\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANCONF_INTR_OUT,  TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,OUT,INTR)\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANCONF_BULK_IN,   TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,IN ,BULK)\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANCONF_BULK_OUT,  TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,OUT,BULK)\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANCONF_ISOC_IN,   TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,IN ,ISOC)\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANCONF_ISOC_OUT,  TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,OUT,ISOC)\n"),
+  TRENTRY(OTGFS_VTRACE2_CHANHALT,           TR_FMT2, "OTGFS Channel halted. chidx: %d, reason: %d\n"),
+
+#  endif
+#endif
+#ifdef CONFIG_STM32H7_OTGHS
+
+  TRENTRY(OTGHS_TRACE2_CLIP,                TR_FMT2, "OTGHS CLIP: chidx: %d buflen: %d\n"),
+
+#  ifdef HAVE_USBHOST_TRACE_VERBOSE
+
+  TRENTRY(OTGHS_VTRACE2_CHANWAKEUP_IN,      TR_FMT2, "OTGHS  EP%d(IN)  wake up with result: %d\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANWAKEUP_OUT,     TR_FMT2, "OTGHS  EP%d(OUT) wake up with result: %d\n"),
+  TRENTRY(OTGHS_VTRACE2_CTRLIN,             TR_FMT2, "OTGHS CTRL_IN  type: %02x req: %02x\n"),
+  TRENTRY(OTGHS_VTRACE2_CTRLOUT,            TR_FMT2, "OTGHS CTRL_OUT type: %02x req: %02x\n"),
+  TRENTRY(OTGHS_VTRACE2_INTRIN,             TR_FMT2, "OTGHS INTR_IN  chidx: %02x len: %02x\n"),
+  TRENTRY(OTGHS_VTRACE2_INTROUT,            TR_FMT2, "OTGHS INTR_OUT chidx: %02x len: %02x\n"),
+  TRENTRY(OTGHS_VTRACE2_BULKIN,             TR_FMT2, "OTGHS BULK_IN  chidx: %02x len: %02x\n"),
+  TRENTRY(OTGHS_VTRACE2_BULKOUT,            TR_FMT2, "OTGHS BULK_OUT chidx: %02x len: %02x\n"),
+  TRENTRY(OTGHS_VTRACE2_ISOCIN,             TR_FMT2, "OTGHS ISOC_IN  chidx: %02x len: %04d\n"),
+  TRENTRY(OTGHS_VTRACE2_ISOCOUT,            TR_FMT2, "OTGHS ISOC_OUT chidx: %02x req: %02x\n"),
+  TRENTRY(OTGHS_VTRACE2_STARTTRANSFER,      TR_FMT2, "OTGHS  Transfer chidx: %d buflen: %d\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANCONF_CTRL_IN,   TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,IN ,CTRL)\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANCONF_CTRL_OUT,  TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,OUT,CTRL)\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANCONF_INTR_IN,   TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,IN ,INTR)\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANCONF_INTR_OUT,  TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,OUT,INTR)\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANCONF_BULK_IN,   TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,IN ,BULK)\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANCONF_BULK_OUT,  TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,OUT,BULK)\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANCONF_ISOC_IN,   TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,IN ,ISOC)\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANCONF_ISOC_OUT,  TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,OUT,ISOC)\n"),
+  TRENTRY(OTGHS_VTRACE2_CHANHALT,           TR_FMT2, "OTGHS Channel halted. chidx: %d, reason: %d\n"),
+
+#  endif
+#endif
+};
+
+/********************************************************************************************************************
+ * Private Function Prototypes
+ ********************************************************************************************************************/
+
+/********************************************************************************************************************
+ * Public Functions
+ ********************************************************************************************************************/
+
+/********************************************************************************************************************
+ * Name: usbhost_trformat1 and usbhost_trformat2
+ *
+ * Description:
+ *   This interface must be provided by platform specific logic that knows
+ *   the HCDs encoding of USB trace data.
+ *
+ *   Given an 9-bit index, return a format string suitable for use with, say,
+ *   printf.  The returned format is expected to handle two unsigned integer
+ *   values.
+ *
+ ********************************************************************************************************************/
+
+FAR const char *usbhost_trformat1(uint16_t id)
+{
+  int ndx = TRACE1_INDEX(id);
+
+  if (ndx < TRACE1_NSTRINGS)
+    {
+      return g_trace1[ndx].string;
+    }
+
+  return NULL;
+}
+
+FAR const char *usbhost_trformat2(uint16_t id)
+{
+  int ndx = TRACE2_INDEX(id);
+
+  if (ndx < TRACE2_NSTRINGS)
+    {
+      return g_trace2[ndx].string;
+    }
+
+  return NULL;
+}
+
+#endif /* HAVE_USBHOST_TRACE */

--- a/arch/arm/src/stm32h7/stm32_usbhost.h
+++ b/arch/arm/src/stm32h7/stm32_usbhost.h
@@ -66,6 +66,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/usb/usbhost.h>
+#include <nuttx/usb/usbhost_trace.h>
+#include <stdint.h>
 #include <stdbool.h>
 
 #if (defined(CONFIG_STM32H7_OTGFS) || defined(CONFIG_STM32H7_OTGHS)) && \


### PR DESCRIPTION
## Summary
This adds support for using the usb host tracing on the stm32h7 architecture.

NOTE: This patch will fail nxstyle because of long lines.  I do not think that we should change it unless someone feels very strongly.  This is consistent with how this is defined for other architectures and breaking the lines would make it much harder to read this.

## Impact
Improved debugging for the usb host driver on this architecture.

## Testing
I have a board configuration that I will be pushing later once I have fixed some issues.  But you can see this feature working:
```
[  104.020000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.030000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.040000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.040000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.050000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.050000] [  INFO] OTGFS Handle the RxFIFO non-empty interrupt.
[  104.060000] [  INFO] OTGFS Handle the RxFIFO non-empty interrupt.
[  104.060000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.070000] [  INFO] OTGFS Channel halted. chidx: 3, reason: 2
[  104.080000] [  INFO] OTGFS Handle the RxFIFO non-empty interrupt.
[  104.080000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.090000] [  INFO] OTGFS  EP0(IN)  wake up with result: 0
[  104.090000] [  INFO] OTGFS  Transfer chidx: 2 buflen: 0
[  104.100000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.100000] [  INFO] OTGFS Channel halted. chidx: 2, reason: 2
[  104.110000] [  INFO] OTGFS Handle the RxFIFO non-empty interrupt.
[  104.120000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.120000] [  INFO] OTGFS  EP0(OUT) wake up with result: 0
[  104.130000] [  INFO] OTGFS CTRL_OUT type: 23 req: 03
[  104.130000] [  INFO] OTGFS  Transfer chidx: 2 buflen: 8
[  104.140000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.140000] [  INFO] OTGFS Channel halted. chidx: 2, reason: 2
[  104.150000] [  INFO] OTGFS Handle the RxFIFO non-empty interrupt.
[  104.160000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.160000] [  INFO] OTGFS  EP0(OUT) wake up with result: 0
[  104.170000] [  INFO] OTGFS  Transfer chidx: 3 buflen: 0
[  104.170000] [  INFO] OTGFS Handle the RxFIFO non-empty interrupt.
[  104.180000] [  INFO] OTGFS Handle the RxFIFO non-empty interrupt.
[  104.180000] [  INFO] OTGFS Handle the host channels interrupt.
[  104.190000] [  INFO] OTGFS Channel halted. chidx: 3, reason: 2
[  104.200000] [  INFO] OTGFS Handle the RxFIFO non-empty interrupt.
[  104.200000] [  INFO] OTGFS[  104.210000] [ ERROR] usbhost_hub_event: ERROR: Failed to enable port 4
```

