### PR TITLE
fs/lfs: Update version to 2.4.0

### DIFF
--- a/arch/arm/src/lpc43xx/lpc43_allocateheap.c
+++ b/arch/arm/src/lpc43xx/lpc43_allocateheap.c
@@ -491,10 +491,10 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
   size_t    usize = CONFIG_RAM_END - ubase;
   int       log2;
 
-  DEBUGASSERT(ubase < (uintptr_t)SRAM1_END);
+  DEBUGASSERT(ubase < (uintptr_t)CONFIG_RAM_END);
 
   /* Adjust that size to account for MPU alignment requirements.
-   * NOTE that there is an implicit assumption that the SRAM1_END
+   * NOTE that there is an implicit assumption that the CONFIG_RAM_END
    * is aligned to the MPU requirement.
    */
 

--- a/arch/arm/src/sama5/sam_ohci.c
+++ b/arch/arm/src/sama5/sam_ohci.c
@@ -2897,9 +2897,7 @@ errout:
 
 static int sam_epfree(struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 {
-#ifdef CONFIG_DEBUG_ASSERTIONS
   struct sam_rhport_s *rhport = (struct sam_rhport_s *)drvr;
-#endif
   struct sam_eplist_s *eplist = (struct sam_eplist_s *)ep;
   struct sam_ed_s *ed;
   int ret;

--- a/arch/arm/src/sama5/sam_ssc.c
+++ b/arch/arm/src/sama5/sam_ssc.c
@@ -445,9 +445,7 @@ struct sam_ssc_s
   uintptr_t base;              /* SSC controller register base address */
   sem_t exclsem;               /* Assures mutually exclusive access to SSC */
   uint8_t datalen;             /* Data width (8, 16, or 32) */
-#ifdef CONFIG_DEBUG_FEATURES
   uint8_t align;               /* Log2 of data width (0, 1, or 3) */
-#endif
   uint8_t pid;                 /* Peripheral ID */
   uint8_t rxfslen;             /* RX frame sync length */
   uint8_t txfslen;             /* TX frame sync length */
@@ -2021,21 +2019,15 @@ static int ssc_checkwidth(struct sam_ssc_s *priv, int bits)
   switch (bits)
     {
     case 8:
-#ifdef CONFIG_DEBUG_FEATURES
       priv->align = 0;
-#endif
       break;
 
     case 16:
-#ifdef CONFIG_DEBUG_FEATURES
       priv->align = 1;
-#endif
       break;
 
     case 32:
-#ifdef CONFIG_DEBUG_FEATURES
       priv->align = 3;
-#endif
       break;
 
     default:
@@ -3216,9 +3208,7 @@ static void ssc0_configure(struct sam_ssc_s *priv)
 
   priv->base    = SAM_SSC0_VBASE;
   priv->datalen = CONFIG_SAMA5_SSC0_DATALEN;
-#ifdef CONFIG_DEBUG_FEATURES
   priv->align   = SAMA5_SSC0_DATAMASK;
-#endif
   priv->pid     = SAM_PID_SSC0;
 }
 #endif
@@ -3357,9 +3347,7 @@ static void ssc1_configure(struct sam_ssc_s *priv)
 
   priv->base    = SAM_SSC1_VBASE;
   priv->datalen = CONFIG_SAMA5_SSC1_DATALEN;
-#ifdef CONFIG_DEBUG_FEATURES
   priv->align   = SAMA5_SSC1_DATAMASK;
-#endif
   priv->pid     = SAM_PID_SSC1;
 }
 #endif

--- a/arch/arm/src/sama5/sam_xdmac.c
+++ b/arch/arm/src/sama5/sam_xdmac.c
@@ -1623,9 +1623,7 @@ static inline int sam_single(struct sam_xdmach_s *xdmach)
 static inline int sam_multiple(struct sam_xdmach_s *xdmach)
 {
   struct sam_xdmac_s *xdmac = sam_controller(xdmach);
-#ifdef CONFIG_DEBUG_ASSERTIONS
   struct chnext_view1_s *llhead = xdmach->llhead;
-#endif
   uintptr_t paddr;
   uint32_t regval;
 
@@ -1666,7 +1664,7 @@ static inline int sam_multiple(struct sam_xdmach_s *xdmach)
    * REVIST:  Using NDAIF=0.  Is that correct?
    */
 
-  paddr = sam_physramaddr((uintptr_t)xdmach->llhead);
+  paddr = sam_physramaddr((uintptr_t)llhead);
   sam_putdmach(xdmach, (uint32_t)paddr, SAM_XDMACH_CNDA_OFFSET);
 
   /* 5. Program the CNDC register:

--- a/arch/arm/src/samv7/sam_ssc.c
+++ b/arch/arm/src/samv7/sam_ssc.c
@@ -419,9 +419,7 @@ struct sam_ssc_s
   uintptr_t base;              /* SSC controller register base address */
   sem_t exclsem;               /* Assures mutually exclusive access to SSC */
   uint8_t datalen;             /* Data width (8, 16, or 32) */
-#ifdef CONFIG_DEBUG_FEATURES
   uint8_t align;               /* Log2 of data width (0, 1, or 3) */
-#endif
   uint8_t pid;                 /* Peripheral ID */
   uint8_t rxfslen;             /* RX frame sync length */
   uint8_t txfslen;             /* TX frame sync length */
@@ -2001,21 +1999,15 @@ static int ssc_checkwidth(struct sam_ssc_s *priv, int bits)
   switch (bits)
     {
     case 8:
-#ifdef CONFIG_DEBUG_FEATURES
       priv->align = 0;
-#endif
       break;
 
     case 16:
-#ifdef CONFIG_DEBUG_FEATURES
       priv->align = 1;
-#endif
       break;
 
     case 32:
-#ifdef CONFIG_DEBUG_FEATURES
       priv->align = 3;
-#endif
       break;
 
     default:
@@ -3198,9 +3190,7 @@ static void ssc0_configure(struct sam_ssc_s *priv)
 
   priv->base    = SAM_SSC0_BASE;
   priv->datalen = CONFIG_SAMV7_SSC0_DATALEN;
-#ifdef CONFIG_DEBUG_FEATURES
   priv->align   = SAMV7_SSC0_DATAMASK;
-#endif
   priv->pid     = SAM_PID_SSC0;
 }
 #endif
@@ -3339,9 +3329,7 @@ static void ssc1_configure(struct sam_ssc_s *priv)
 
   priv->base    = SAM_SSC1_BASE;
   priv->datalen = CONFIG_SAMV7_SSC1_DATALEN;
-#ifdef CONFIG_DEBUG_FEATURES
   priv->align   = SAMV7_SSC1_DATAMASK;
-#endif
   priv->pid     = SAM_PID_SSC1;
 }
 #endif

--- a/arch/arm/src/samv7/sam_xdmac.c
+++ b/arch/arm/src/samv7/sam_xdmac.c
@@ -1317,9 +1317,7 @@ static inline int sam_single(struct sam_xdmach_s *xdmach)
 static inline int sam_multiple(struct sam_xdmach_s *xdmach)
 {
   struct sam_xdmac_s *xdmac = sam_controller(xdmach);
-#ifdef CONFIG_DEBUG_ASSERTIONS
   struct chnext_view1_s *llhead = xdmach->llhead;
-#endif
   uintptr_t paddr;
   uint32_t regval;
 
@@ -1360,7 +1358,7 @@ static inline int sam_multiple(struct sam_xdmach_s *xdmach)
    * REVIST:  Using NDAIF=0.  Is that correct?
    */
 
-  paddr = sam_physramaddr((uintptr_t)xdmach->llhead);
+  paddr = sam_physramaddr((uintptr_t)llhead);
   sam_putdmach(xdmach, (uint32_t)paddr, SAM_XDMACH_CNDA_OFFSET);
 
   /* 5. Program the CNDC register:

--- a/arch/arm/src/stm32/stm32_i2s.c
+++ b/arch/arm/src/stm32/stm32_i2s.c
@@ -296,9 +296,7 @@ struct stm32_i2s_s
   sem_t             exclsem;      /* Assures mutually exclusive access to I2S */
   bool              initialized;  /* Has I2S interface been initialized */
   uint8_t           datalen;      /* Data width (8 or 16) */
-#ifdef CONFIG_DEBUG_FEATURES
   uint8_t           align;        /* Log2 of data width (0 or 1) */
-#endif
   uint8_t           rxenab:1;     /* True: RX transfers enabled */
   uint8_t           txenab:1;     /* True: TX transfers enabled */
   uint8_t           i2sno:6;      /* I2S controller number (0 or 1) */
@@ -1750,15 +1748,11 @@ static int i2s_checkwidth(struct stm32_i2s_s *priv, int bits)
   switch (bits)
     {
     case 8:
-#ifdef CONFIG_DEBUG
       priv->align = 0;
-#endif
       break;
 
     case 16:
-#ifdef CONFIG_DEBUG
       priv->align = 1;
-#endif
       break;
 
     default:

--- a/arch/sim/src/sim/up_oneshot.c
+++ b/arch/sim/src/sim/up_oneshot.c
@@ -210,7 +210,7 @@ static void sim_process_tick(sq_entry_t *entry)
 static int sim_max_delay(FAR struct oneshot_lowerhalf_s *lower,
                          FAR struct timespec *ts)
 {
-  DEBUGASSERT(lower != NULL && ts != NULL);
+  DEBUGASSERT(ts != NULL);
 
   ts->tv_sec  = UINT_MAX;
   ts->tv_nsec = NSEC_PER_SEC - 1;
@@ -316,12 +316,7 @@ static int sim_cancel(FAR struct oneshot_lowerhalf_s *lower,
 static int sim_current(FAR struct oneshot_lowerhalf_s *lower,
                        FAR struct timespec *ts)
 {
-#ifdef CONFIG_DEBUG_ASSERTIONS
-  FAR struct sim_oneshot_lowerhalf_s *priv =
-    (FAR struct sim_oneshot_lowerhalf_s *)lower;
-#endif
-
-  DEBUGASSERT(priv != NULL && ts != NULL);
+  DEBUGASSERT(ts != NULL);
 
   *ts = g_current;
   return OK;

--- a/boards/risc-v/bl602/bl602evb/src/bl602_gpio.c
+++ b/boards/risc-v/bl602/bl602evb/src/bl602_gpio.c
@@ -465,7 +465,7 @@ static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
     (FAR struct bl602_gpint_dev_s *)dev;
 
   DEBUGASSERT(bl602xgpint != NULL && value != NULL);
-  DEBUGASSERT(bl602xgpint->bl602xgpio.id < BOARD_NGPIOINT);
+  DEBUGASSERT(bl602xgpint->bl602gpio.id < BOARD_NGPIOINT);
   gpioinfo("Reading int pin...\n");
 
   *value = bl602_gpioread(g_gpiointinputs[bl602xgpint->bl602gpio.id]);

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -353,7 +353,6 @@ static inline unsigned int noteram_next(unsigned int ndx,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_ASSERTIONS
 static unsigned int noteram_length(void)
 {
   unsigned int head = g_noteram_info.ni_head;
@@ -366,7 +365,6 @@ static unsigned int noteram_length(void)
 
   return head - tail;
 }
-#endif
 
 /****************************************************************************
  * Name: noteram_unread_length

--- a/drivers/sensors/apds9960.c
+++ b/drivers/sensors/apds9960.c
@@ -1228,10 +1228,6 @@ int apds9960_register(FAR const char *devpath,
 {
   int ret;
 
-  /* Sanity check */
-
-  DEBUGASSERT(i2c != NULL);
-
   /* Initialize the APDS9960 device structure */
 
   FAR struct apds9960_dev_s *priv =

--- a/drivers/wireless/ieee802154/xbee/xbee_mac.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_mac.c
@@ -308,9 +308,7 @@ int xbee_req_data(XBEEHANDLE xbee,
   int index;
   uint16_t apiframelen;
   uint8_t frametype;
-#ifdef CONFIG_DEBUG_ASSERTIONS
   int prevoffs = frame->io_offset;
-#endif
 #ifdef CONFIG_XBEE_LOCKUP_WORKAROUND
   int retries = XBEE_LOCKUP_SENDATTEMPTS;
 #endif

--- a/drivers/wireless/ieee802154/xbee/xbee_netdev.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_netdev.c
@@ -1381,8 +1381,6 @@ int xbee_netdev_register(XBEEHANDLE xbee)
 
   nxsem_init(&priv->xd_exclsem, 0, 1);
 
-  DEBUGASSERT(priv->xd_txpoll != NULL);
-
   /* Set the network mask. */
 
   xbeenet_netmask(dev);

--- a/fs/littlefs/Make.defs
+++ b/fs/littlefs/Make.defs
@@ -31,15 +31,13 @@ CSRCS += lfs.c lfs_util.c
 DEPPATH += --dep-path littlefs/littlefs
 VPATH += :littlefs/littlefs
 
-ifneq ($(CONFIG_DEBUG_FS_INFO),y)
-  CFLAGS += -DLFS_NO_DEBUG
-endif
+CFLAGS += -DLFS_TRACE=finfo
+CFLAGS += -DLFS_DEBUG=finfo
+CFLAGS += -DLFS_WARN=fwarn
+CFLAGS += -DLFS_ERROR=ferr
+CFLAGS += -DLFS_ASSERT=DEBUGASSERT
 
-ifneq ($(CONFIG_DEBUG_FS_WARN),y)
-  CFLAGS += -DLFS_NO_WARN
-endif
-
-LITTLEFS_VERSION ?= 2.2.1
+LITTLEFS_VERSION ?= 2.4.0
 LITTLEFS_TARBALL = v$(LITTLEFS_VERSION).tar.gz
 
 $(LITTLEFS_TARBALL):

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1023,9 +1023,8 @@ static int littlefs_bind(FAR struct inode *driver, FAR const void *data,
   fs->cfg.block_count    = fs->geo.neraseblocks;
   fs->cfg.block_cycles   = 500;
   fs->cfg.cache_size     = fs->geo.blocksize;
-  fs->cfg.lookahead_size =
-    lfs_min(lfs_alignup((fs->cfg.block_count + 7) / 8, 8),
-            fs->cfg.read_size);
+  fs->cfg.lookahead_size = lfs_min(lfs_alignup(fs->cfg.block_count, 64) / 8,
+                                   fs->cfg.read_size);
 
   /* Then get information about the littlefs filesystem on the devices
    * managed by this driver.

--- a/include/assert.h
+++ b/include/assert.h
@@ -75,7 +75,7 @@
 #  define DEBUGVERIFY(f) VERIFY(f)
 #else
 #  define DEBUGPANIC()
-#  define DEBUGASSERT(f)
+#  define DEBUGASSERT(f) UNUSED(f)
 #  define DEBUGVERIFY(f) ((void)(f))
 #endif
 
@@ -85,7 +85,7 @@
  */
 
 #ifdef NDEBUG
-#  define assert(f)
+#  define assert(f) UNUSED(f)
 #else
 #  define assert(f) ASSERT(f)
 #endif

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -49,7 +49,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(a))
+#  define UNUSED(a) ((void)(1 || (a)))
 
 /* Built-in functions */
 
@@ -301,7 +301,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(a))
+#  define UNUSED(a) ((void)(1 || (a)))
 
 /* SDCC-specific definitions ************************************************/
 
@@ -394,7 +394,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(a))
+#  define UNUSED(a) ((void)(1 || (a)))
 
 /* It is assumed that the system is build using the small
  * data model with storage defaulting to internal RAM.
@@ -447,7 +447,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(a))
+#  define UNUSED(a) ((void)(1 || (a)))
 
 /* Zilog-specific definitions ***********************************************/
 
@@ -578,7 +578,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(a))
+#  define UNUSED(a) ((void)(1 || (a)))
 
 /* ICCARM-specific definitions **********************************************/
 
@@ -590,7 +590,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(a))
+#  define UNUSED(a) ((void)(1 || (a)))
 
 #  define weak_alias(name, aliasname)
 #  define weak_data            __weak
@@ -686,7 +686,7 @@
 #  undef  CONFIG_HAVE_ANONYMOUS_STRUCT
 #  undef  CONFIG_HAVE_ANONYMOUS_UNION
 
-#  define UNUSED(a) ((void)(a))
+#  define UNUSED(a) ((void)(1 || (a)))
 
 #endif
 

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -48,9 +48,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
 {
   FAR struct mm_heap_impl_s *heap_impl;
   FAR struct mm_allocnode_s *node;
-#ifdef CONFIG_DEBUG_ASSERTIONS
   FAR struct mm_allocnode_s *prev;
-#endif
   size_t mxordblk = 0;
   int    ordblks  = 0;  /* Number of non-inuse chunks */
   size_t uordblks = 0;  /* Total allocated space */
@@ -71,9 +69,8 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
   for (region = 0; region < heap_impl->mm_nregions; region++)
 #endif
     {
-#ifdef CONFIG_DEBUG_ASSERTIONS
       prev = NULL;
-#endif
+
       /* Visit each node in the region
        * Retake the semaphore for each region to reduce latencies
        */
@@ -99,9 +96,8 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
             }
           else
             {
-#ifdef CONFIG_DEBUG_ASSERTIONS
               FAR struct mm_freenode_s *fnode = (FAR void *)node;
-#endif
+
               DEBUGASSERT(node->size >= SIZEOF_MM_FREENODE);
               DEBUGASSERT(fnode->blink->flink == fnode);
               DEBUGASSERT(fnode->blink->size <= fnode->size);
@@ -120,9 +116,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
 
           DEBUGASSERT(prev == NULL ||
                       prev->size == (node->preceding & ~MM_ALLOC_BIT));
-#ifdef CONFIG_DEBUG_ASSERTIONS
           prev = node;
-#endif
         }
 
       minfo("region=%d node=%p heapend=%p\n",

--- a/net/bluetooth/bluetooth_input.c
+++ b/net/bluetooth/bluetooth_input.c
@@ -60,7 +60,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_DEBUG_ASSERTIONS) && CONFIG_NET_BLUETOOTH_BACKLOG > 0
+#if CONFIG_NET_BLUETOOTH_BACKLOG > 0
 static int bluetooth_count_frames(FAR struct bluetooth_conn_s *conn)
 {
   FAR struct bluetooth_container_s *container;

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -82,7 +82,7 @@ struct bluetooth_recvfrom_s
  *
  ****************************************************************************/
 
-#if defined(CONFIG_DEBUG_ASSERTIONS) && CONFIG_NET_BLUETOOTH_BACKLOG > 0
+#if CONFIG_NET_BLUETOOTH_BACKLOG > 0
 static int bluetooth_count_frames(FAR struct bluetooth_conn_s *conn)
 {
   FAR struct bluetooth_container_s *container;

--- a/net/ieee802154/ieee802154_input.c
+++ b/net/ieee802154/ieee802154_input.c
@@ -56,7 +56,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_DEBUG_ASSERTIONS) && CONFIG_NET_IEEE802154_BACKLOG > 0
+#if CONFIG_NET_IEEE802154_BACKLOG > 0
 static int ieee802154_count_frames(FAR struct ieee802154_conn_s *conn)
 {
   FAR struct ieee802154_container_s *container;

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -80,7 +80,7 @@ struct ieee802154_recvfrom_s
  *
  ****************************************************************************/
 
-#if defined(CONFIG_DEBUG_ASSERTIONS) && CONFIG_NET_IEEE802154_BACKLOG > 0
+#if CONFIG_NET_IEEE802154_BACKLOG > 0
 static int ieee802154_count_frames(FAR struct ieee802154_conn_s *conn)
 {
   FAR struct ieee802154_container_s *container;

--- a/wireless/ieee802154/mac802154_netdev.c
+++ b/wireless/ieee802154/mac802154_netdev.c
@@ -1361,8 +1361,6 @@ int mac802154netdev_register(MACHANDLE mac)
 
   nxsem_init(&priv->md_exclsem, 0, 1);
 
-  DEBUGASSERT(priv->md_txpoll != NULL);
-
   /* Set the network mask. */
 
   macnet_netmask(dev);


### PR DESCRIPTION
## Summary
And redirect assert and log to NuttX's version
which is possible after:
```
commit c0cc0a417e727764ccce6f1284e3570898d750e6
Author: Christopher Haster <chaster@utexas.edu>
Date:   Mon Jan 18 14:01:53 2021 -0600

    Enabled overriding of LFS_ASSERT/TRACE/DEBUG/etc

    This is useful for testing the new erroring assert behavior in CI.
    Asserts do not error by default, so this macro needs to be overriden.

    It is possible to test this behavior using the existing option of
    overriding lfs_util.h with a custom file, by using a small sed
    one-line script. But this is much simpler.

    This does raise the question if more of the configuration options in
    lfs_util.h should be opened up for function-like macro overrides.
```

## Impact
Move to the latest official release

## Testing
Pass CI
