### PR TITLE
syslog: Drop extra carriage return from syslog calls

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -608,7 +608,7 @@ static int imxrt_transmit(FAR struct imxrt_driver_s *priv)
 
   if (mbi == TOTALMBCOUNT)
     {
-      nwarn("No TX MB available mbi %" PRIi32 "\r\n", mbi);
+      nwarn("No TX MB available mbi %" PRIi32 "\n", mbi);
       NETDEV_TXERRORS(&priv->dev);
       return 0;       /* No transmission for you! */
     }
@@ -1590,7 +1590,7 @@ static int imxrt_initialize(struct imxrt_driver_s *priv)
   imxrt_setfreeze(priv->base, 1);
   if (!imxrt_waitfreezeack_change(priv->base, 1))
     {
-      ninfo("FLEXCAN: freeze fail\r\n");
+      ninfo("FLEXCAN: freeze fail\n");
       return -1;
     }
 
@@ -1684,7 +1684,7 @@ static int imxrt_initialize(struct imxrt_driver_s *priv)
   for (i = 0; i < RXMBCOUNT; i++)
     {
       struct mb_s *rx = flexcan_get_mb(priv, i);
-      ninfo("Set MB%" PRIi32 " to receive %p\r\n", i, rx);
+      ninfo("Set MB%" PRIi32 " to receive %p\n", i, rx);
       rx->cs.edl = 0x1;
       rx->cs.brs = 0x1;
       rx->cs.esi = 0x0;
@@ -1702,7 +1702,7 @@ static int imxrt_initialize(struct imxrt_driver_s *priv)
   imxrt_setfreeze(priv->base, 0);
   if (!imxrt_waitfreezeack_change(priv->base, 0))
     {
-      ninfo("FLEXCAN: unfreeze fail\r\n");
+      ninfo("FLEXCAN: unfreeze fail\n");
       return -1;
     }
 
@@ -1749,8 +1749,8 @@ static void imxrt_reset(struct imxrt_driver_s *priv)
   for (i = 0; i < TOTALMBCOUNT; i++)
     {
       struct mb_s *rx = flexcan_get_mb(priv, i);
-      ninfo("MB %" PRIi32 " %p\r\n", i, rx);
-      ninfo("MB %" PRIi32 " %p\r\n", i, &rx->id.w);
+      ninfo("MB %" PRIi32 " %p\n", i, rx);
+      ninfo("MB %" PRIi32 " %p\n", i, &rx->id.w);
       rx->cs.cs = 0x0;
       rx->id.w = 0x0;
       rx->data[0].w00 = 0x0;
@@ -1931,7 +1931,7 @@ int imxrt_caninitialize(int intf)
    * the device and/or calling imxrt_ifdown().
    */
 
-  ninfo("callbacks done\r\n");
+  ninfo("callbacks done\n");
 
   imxrt_ifdown(&priv->dev);
 

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -634,7 +634,7 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
 
   if (mbi == TXMBCOUNT)
     {
-      nwarn("No TX MB available mbi %i\r\n", mbi);
+      nwarn("No TX MB available mbi %i\n", mbi);
       NETDEV_TXERRORS(&priv->dev);
       return 0;       /* No transmission for you! */
     }
@@ -1575,7 +1575,7 @@ static int kinetis_initialize(struct kinetis_driver_s *priv)
   kinetis_setfreeze(priv->base, 1);
   if (!kinetis_waitfreezeack_change(priv->base, 1))
     {
-      ninfo("FLEXCAN: freeze fail\r\n");
+      ninfo("FLEXCAN: freeze fail\n");
       return -1;
     }
 
@@ -1654,7 +1654,7 @@ static int kinetis_initialize(struct kinetis_driver_s *priv)
 
   for (i = 0; i < RXMBCOUNT; i++)
     {
-      ninfo("Set MB%i to receive %p\r\n", i, &priv->rx[i]);
+      ninfo("Set MB%i to receive %p\n", i, &priv->rx[i]);
       priv->rx[i].cs.edl = 0x1;
       priv->rx[i].cs.brs = 0x1;
       priv->rx[i].cs.esi = 0x0;
@@ -1672,7 +1672,7 @@ static int kinetis_initialize(struct kinetis_driver_s *priv)
   kinetis_setfreeze(priv->base, 0);
   if (!kinetis_waitfreezeack_change(priv->base, 0))
     {
-      ninfo("FLEXCAN: unfreeze fail\r\n");
+      ninfo("FLEXCAN: unfreeze fail\n");
       return -1;
     }
 
@@ -1718,8 +1718,8 @@ static void kinetis_reset(struct kinetis_driver_s *priv)
 
   for (i = 0; i < TOTALMBCOUNT; i++)
     {
-      ninfo("MB %i %p\r\n", i, &priv->rx[i]);
-      ninfo("MB %i %p\r\n", i, &priv->rx[i].id.w);
+      ninfo("MB %i %p\n", i, &priv->rx[i]);
+      ninfo("MB %i %p\n", i, &priv->rx[i].id.w);
       priv->rx[i].cs.cs = 0x0;
       priv->rx[i].id.w = 0x0;
       priv->rx[i].data[0].w00 = 0x0;
@@ -1930,7 +1930,7 @@ int kinetis_caninitialize(int intf)
    * the device and/or calling kinetis_ifdown().
    */
 
-  ninfo("callbacks done\r\n");
+  ninfo("callbacks done\n");
 
   kinetis_initialize(priv);
 

--- a/arch/arm/src/lpc43xx/lpc43_rit.c
+++ b/arch/arm/src/lpc43xx/lpc43_rit.c
@@ -202,7 +202,7 @@ void up_timer_initialize(void)
       mask_bits++;
     }
 
-  tmrinfo("mask_bits = %d, mask = %X, ticks_per_int = %d\r\n",
+  tmrinfo("mask_bits = %d, mask = %X, ticks_per_int = %d\n",
           mask_bits, (0xffffffff << (32 - mask_bits)), ticks_per_int);
 
   /* Set the mask and compare value so we get interrupts every

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -636,7 +636,7 @@ static int s32k1xx_transmit(FAR struct s32k1xx_driver_s *priv)
 
   if (mbi == TXMBCOUNT)
     {
-      nwarn("No TX MB available mbi %" PRIi32 "\r\n", mbi);
+      nwarn("No TX MB available mbi %" PRIi32 "\n", mbi);
       NETDEV_TXERRORS(&priv->dev);
       return 0;       /* No transmission for you! */
     }
@@ -1578,7 +1578,7 @@ static int s32k1xx_initialize(struct s32k1xx_driver_s *priv)
   s32k1xx_setfreeze(priv->base, 1);
   if (!s32k1xx_waitfreezeack_change(priv->base, 1))
     {
-      ninfo("FLEXCAN: freeze fail\r\n");
+      ninfo("FLEXCAN: freeze fail\n");
       return -1;
     }
 
@@ -1658,7 +1658,7 @@ static int s32k1xx_initialize(struct s32k1xx_driver_s *priv)
 
   for (i = 0; i < RXMBCOUNT; i++)
     {
-      ninfo("Set MB%" PRIi32 " to receive %p\r\n", i, &priv->rx[i]);
+      ninfo("Set MB%" PRIi32 " to receive %p\n", i, &priv->rx[i]);
       priv->rx[i].cs.edl = 0x1;
       priv->rx[i].cs.brs = 0x1;
       priv->rx[i].cs.esi = 0x0;
@@ -1676,7 +1676,7 @@ static int s32k1xx_initialize(struct s32k1xx_driver_s *priv)
   s32k1xx_setfreeze(priv->base, 0);
   if (!s32k1xx_waitfreezeack_change(priv->base, 0))
     {
-      ninfo("FLEXCAN: unfreeze fail\r\n");
+      ninfo("FLEXCAN: unfreeze fail\n");
       return -1;
     }
 
@@ -1722,8 +1722,8 @@ static void s32k1xx_reset(struct s32k1xx_driver_s *priv)
 
   for (i = 0; i < TOTALMBCOUNT; i++)
     {
-      ninfo("MB %" PRIi32 " %p\r\n", i, &priv->rx[i]);
-      ninfo("MB %" PRIi32 " %p\r\n", i, &priv->rx[i].id.w);
+      ninfo("MB %" PRIi32 " %p\n", i, &priv->rx[i]);
+      ninfo("MB %" PRIi32 " %p\n", i, &priv->rx[i].id.w);
       priv->rx[i].cs.cs = 0x0;
       priv->rx[i].id.w = 0x0;
       priv->rx[i].data[0].w00 = 0x0;
@@ -1927,7 +1927,7 @@ int s32k1xx_caninitialize(int intf)
    * the device and/or calling s32k1xx_ifdown().
    */
 
-  ninfo("callbacks done\r\n");
+  ninfo("callbacks done\n");
 
   s32k1xx_initialize(priv);
 

--- a/arch/renesas/src/rx65n/rx65n_usbhost.c
+++ b/arch/renesas/src/rx65n/rx65n_usbhost.c
@@ -917,7 +917,7 @@ void hw_usb_hmodule_init (void)
     case RX65N_USB_SYSSTS0_LNST_LS_JSTS :
     case RX65N_USB_SYSSTS0_LNST_FS_JSTS : /* USB device already connected */
 
-    syslog (LOG_INFO, "USB Device already connected\n\r");
+    syslog (LOG_INFO, "USB Device already connected\n");
     rx65n_usbhost_setbit (RX65N_USB_DVSTCTR0, RX65N_USB_DVSTCTR0_USBRST);
     up_mdelay(20);                        /* Need to wait greater equal 10ms in USB spec */
     rx65n_usbhost_clearbit (RX65N_USB_DVSTCTR0,
@@ -3049,7 +3049,7 @@ uint16_t usb_hstd_chk_attach (void)
         }
       else if (RX65N_USB_SYSSTS0_LNST_SE0 == (buf[0] & 3))
         {
-          syslog (LOG_INFO, "Debug: Detach device\n\r");
+          syslog (LOG_INFO, "Debug: Detach device\n");
         }
       else
         {
@@ -3058,7 +3058,7 @@ uint16_t usb_hstd_chk_attach (void)
     }
   else
     {
-      syslog (LOG_INFO, "Already device attached\n\r");
+      syslog (LOG_INFO, "Already device attached\n");
       return 0;
     }
 
@@ -4897,7 +4897,7 @@ static void rx65n_usbhost_checkreg(uint32_t addr, uint32_t val, bool iswrite)
             {
               /* No.. More than one. */
 
-              uinfo("[repeats %d more times]\n\r", count);
+              uinfo("[repeats %d more times]\n", count);
             }
         }
 
@@ -5457,7 +5457,7 @@ static inline int rx65n_usbhost_addinted(struct rx65n_usbhost_s *priv,
   interval     = rx65n_usbhost_getinterval(epdesc->interval);
 
   ed->interval = interval;
-  uinfo("interval: %d->%d\n\r", epdesc->interval, interval);
+  uinfo("interval: %d->%d\n", epdesc->interval, interval);
 
   /* Get the offset associated with the ED direction. IN EDs get the even
    * entries, OUT EDs get the odd entries.
@@ -5492,7 +5492,7 @@ static inline int rx65n_usbhost_addinted(struct rx65n_usbhost_s *priv,
         }
     }
 
-  uinfo("min interval: %d offset: %d\n\r", interval, offset);
+  uinfo("min interval: %d offset: %d\n", interval, offset);
 
   /* Get value for Interval Error Detection Interval  */
 
@@ -5556,7 +5556,7 @@ static inline int rx65n_usbhost_addinted(struct rx65n_usbhost_s *priv,
   if (xfrinfo == NULL)
     {
       rx65n_usbhost_free_xfrinfo(xfrinfo);
-      uerr("ERROR: rx65n_usbhost_alloc_xfrinfo failed\n\r");
+      uerr("ERROR: rx65n_usbhost_alloc_xfrinfo failed\n");
       return -ENOMEM;
     }
 
@@ -5592,7 +5592,7 @@ static inline int rx65n_usbhost_addinted(struct rx65n_usbhost_s *priv,
 
   ed->hw.nexted = head;
   rx65n_usbhost_setinttab((uint32_t)ed, interval, offset);
-  uinfo("head: %08x next: %08x\n\r", ed, head);
+  uinfo("head: %08x next: %08x\n", ed, head);
 
   return OK;
 #else
@@ -5645,7 +5645,7 @@ static inline int rx65n_usbhost_addisoced(struct rx65n_usbhost_s *priv,
                                   struct rx65n_usbhost_ed_s *ed)
 {
 #ifndef CONFIG_USBHOST_ISOC_DISABLE
-  printf("Isochronous endpoints not yet supported\n\r");
+  printf("Isochronous endpoints not yet supported\n");
 #endif
   return -ENOSYS;
 }
@@ -5662,7 +5662,7 @@ static inline int rx65n_usbhost_remisoced(struct rx65n_usbhost_s *priv,
                                   struct rx65n_usbhost_ed_s *ed)
 {
 #ifndef CONFIG_USBHOST_ISOC_DISABLE
-  printf("Isochronous endpoints not yet supported\n\r");
+  printf("Isochronous endpoints not yet supported\n");
 #endif
   return -ENOSYS;
 }
@@ -5792,7 +5792,7 @@ static int rx65n_usbhost_ctrltd(struct rx65n_usbhost_s *priv,
   xfrinfo = rx65n_usbhost_alloc_xfrinfo();
   if (xfrinfo == NULL)
     {
-      uerr("ERROR: rx65n_usbhost_alloc_xfrinfo failed\n\r");
+      uerr("ERROR: rx65n_usbhost_alloc_xfrinfo failed\n");
       return -ENOMEM;
     }
 
@@ -5819,7 +5819,7 @@ static int rx65n_usbhost_ctrltd(struct rx65n_usbhost_s *priv,
       ret = rx65n_usbhost_wdhwait(priv, ed);
       if (ret < 0)
         {
-          syslog(LOG_INFO, "ERROR: Device disconnected\n\r");
+          syslog(LOG_INFO, "ERROR: Device disconnected\n");
           goto errout_with_xfrinfo;
         }
     }
@@ -5956,7 +5956,7 @@ static int rx65n_usbhost_ctrltd(struct rx65n_usbhost_s *priv,
         }
       else
         {
-          uerr("ERROR: Bad TD completion status: %d\n\r", xfrinfo->tdstatus);
+          uerr("ERROR: Bad TD completion status: %d\n", xfrinfo->tdstatus);
           ret = xfrinfo->tdstatus == TD_CC_STALL ? -EPERM : -EIO;
         }
     }
@@ -6156,7 +6156,7 @@ static int rx65n_usbhost_usbinterrupt(int irq, void *context, FAR void *arg)
   else
     {
       syslog (LOG_INFO, "Unhandled interrupt. INTENB0 = 0x%x, \
-      INTENB1 = 0x%x, INTSTS0 = 0x%x and INTSTS1 = 0x%x\n\r",
+      INTENB1 = 0x%x, INTSTS0 = 0x%x and INTSTS1 = 0x%x\n",
       intenb0, intenb1, intsts0, intsts1);
     }
 
@@ -8069,7 +8069,7 @@ static int rx65n_usbhost_connect(FAR struct usbhost_driver_s *drvr,
 
   if (ret >= 0)
     {
-      syslog (LOG_INFO, "Hub Port device enumerated\n\r");
+      syslog (LOG_INFO, "Hub Port device enumerated\n");
     }
 
   return OK;
@@ -8135,7 +8135,7 @@ static void rx65n_usbhost_disconnect(struct usbhost_driver_s *drvr,
 
           g_kbdpipe = 0;
           g_hubkbd = false;
-          syslog (LOG_INFO, "KBD Device Disconnected from Hub\n\r");
+          syslog (LOG_INFO, "KBD Device Disconnected from Hub\n");
         }
 
       if (hport->speed == USB_SPEED_FULL)
@@ -8149,7 +8149,7 @@ static void rx65n_usbhost_disconnect(struct usbhost_driver_s *drvr,
                 }
             }
 
-          syslog (LOG_INFO, "MSC Device Disconnected from Hub\n\r");
+          syslog (LOG_INFO, "MSC Device Disconnected from Hub\n");
         }
     }
 
@@ -8536,7 +8536,7 @@ struct usbhost_connection_s *rx65n_usbhost_initialize(int controller)
 
   IEN(PERIB, INTB185) = 1U;
 
-  syslog (LOG_INFO, "Debug:USB host Initialized, Device connected:%s\n\r",
+  syslog (LOG_INFO, "Debug:USB host Initialized, Device connected:%s\n",
           priv->connected ? "YES" : "NO");
 
   return &g_usbconn;

--- a/arch/risc-v/src/bl602/bl602_flash.c
+++ b/arch/risc-v/src/bl602/bl602_flash.c
@@ -69,7 +69,7 @@ int bl602_flash_erase(uint32_t addr, int len)
   irqstate_t flags;
 
   syslog(LOG_INFO,
-    "bl602_flash_erase addr = %08lx, len = %d\r\n", addr, len);
+    "bl602_flash_erase addr = %08lx, len = %d\n", addr, len);
 
   flags = up_irq_save();
   ((bl602_romdrv_erase_fn)(*((uint32_t *)(ROMAPI_SFLASH_EREASE_NEEDLOCK))))
@@ -84,7 +84,7 @@ int bl602_flash_write(uint32_t addr, const uint8_t *src, int len)
   irqstate_t flags;
 
   syslog(LOG_INFO,
-    "bl602_flash_write addr = %08lx, len = %d\r\n", addr, len);
+    "bl602_flash_write addr = %08lx, len = %d\n", addr, len);
 
   flags = up_irq_save();
   ((bl602_romdrv_write_fn)(*((uint32_t *)(ROMAPI_SFLASH_WRITE_NEEDLOCK))))
@@ -99,7 +99,7 @@ int bl602_flash_read(uint32_t addr, uint8_t *dst, int len)
   irqstate_t flags;
 
   syslog(LOG_INFO,
-    "bl602_flash_read addr = %08lx, len = %d\r\n", addr, len);
+    "bl602_flash_read addr = %08lx, len = %d\n", addr, len);
 
   flags = up_irq_save();
   ((bl602_romdrv_read_fn)(*((uint32_t *)(ROMAPI_SFLASH_READ_NEEDLOCK))))

--- a/arch/risc-v/src/bl602/bl602_i2c.c
+++ b/arch/risc-v/src/bl602/bl602_i2c.c
@@ -264,7 +264,7 @@ static void bl602_i2c_clear_status(int i2cx)
     }
   else
     {
-      i2cerr("port error\r\n");
+      i2cerr("port error\n");
     }
 }
 
@@ -684,14 +684,14 @@ static int bl602_i2c_transfer(FAR struct i2c_master_s *dev,
 
   if (count <= 0)
     {
-      i2cerr("count is error\r\n");
+      i2cerr("count is error\n");
       return -1;
     }
 
   ret = nxsem_wait_uninterruptible(&priv->sem_excl);
   if (ret < 0)
     {
-      i2cerr("take sem_excl error\r\n");
+      i2cerr("take sem_excl error\n");
       return ret;
     }
 
@@ -699,7 +699,7 @@ static int bl602_i2c_transfer(FAR struct i2c_master_s *dev,
 
   if (ret < 0)
     {
-      i2cerr("take sem_irq error\r\n");
+      i2cerr("take sem_irq error\n");
       return ret;
     }
 
@@ -742,17 +742,17 @@ static int bl602_i2c_transfer(FAR struct i2c_master_s *dev,
 
       if (ret < 0)
         {
-          i2cerr("transter error\r\n");
+          i2cerr("transter error\n");
           return ret;
         }
 
       if (priv->i2cstate == EV_I2C_END_INT)
         {
-          i2cinfo("i2c transfer success\r\n");
+          i2cinfo("i2c transfer success\n");
         }
       else
         {
-          i2cerr("i2c transfer error, event = %d \r\n", priv->i2cstate);
+          i2cerr("i2c transfer error, event = %d \n", priv->i2cstate);
         }
 
       nxsem_post(&priv->sem_isr);
@@ -936,7 +936,7 @@ static int bl602_i2c_irq(int cpuint, void *context, FAR void *arg)
     }
   else
     {
-      i2cerr("other interrupt \r\n");
+      i2cerr("other interrupt \n");
       priv->i2cstate = EV_I2C_UNKNOW_INT;
       bl602_i2c_callback(priv);
       return -1;

--- a/arch/risc-v/src/bl602/bl602_spiflash.c
+++ b/arch/risc-v/src/bl602/bl602_spiflash.c
@@ -146,7 +146,7 @@ static int bl602_erase(FAR struct mtd_dev_s *dev, off_t startblock,
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
 
-  syslog(LOG_INFO, "bl602_erase dev=%p, addr=0x%lx, size=0x%lx\r\n",
+  syslog(LOG_INFO, "bl602_erase dev=%p, addr=0x%lx, size=0x%lx\n",
       dev, addr, size);
 
   ret = bl602_flash_erase(addr, size);
@@ -184,7 +184,7 @@ static ssize_t bl602_read(FAR struct mtd_dev_s *dev, off_t offset,
   uint32_t addr = priv->config->flash_offset + offset;
   uint32_t size = nbytes;
 
-  syslog(LOG_INFO, "bl602_read dev=%p, addr=0x%lx, size=0x%lx\r\n",
+  syslog(LOG_INFO, "bl602_read dev=%p, addr=0x%lx, size=0x%lx\n",
       dev, addr, size);
 
   if (0 == bl602_flash_read(addr, buffer, size))
@@ -221,7 +221,7 @@ static ssize_t bl602_bread(FAR struct mtd_dev_s *dev, off_t startblock,
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
 
-  syslog(LOG_INFO, "bl602_bread dev=%p, addr=0x%lx, size=0x%lx\r\n",
+  syslog(LOG_INFO, "bl602_bread dev=%p, addr=0x%lx, size=0x%lx\n",
       dev, addr, size);
 
   if (0 == bl602_flash_read(addr, buffer, size))
@@ -259,7 +259,7 @@ static ssize_t bl602_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
 
-  syslog(LOG_INFO, "bl602_bwrite dev=%p, addr=0x%lx, size=0x%lx\r\n",
+  syslog(LOG_INFO, "bl602_bwrite dev=%p, addr=0x%lx, size=0x%lx\n",
       dev, addr, size);
 
   if (0 == bl602_flash_write(addr, buffer, size))
@@ -297,7 +297,7 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
     {
       case MTDIOC_GEOMETRY:
         {
-          syslog(LOG_INFO, "cmd(0x%x) MTDIOC_GEOMETRY.\r\n", cmd);
+          syslog(LOG_INFO, "cmd(0x%x) MTDIOC_GEOMETRY.\n", cmd);
           geo = (FAR struct mtd_geometry_s *)arg;
           if (geo)
             {
@@ -318,7 +318,7 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
           /* Erase the entire partition */
 
           syslog(LOG_INFO,
-            "cmd(0x%x) MTDIOC_BULKERASE not support.\r\n", cmd);
+            "cmd(0x%x) MTDIOC_BULKERASE not support.\n", cmd);
         }
         break;
       case MTDIOC_XIPBASE:
@@ -326,18 +326,18 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
           /* Get the XIP base of the entire FLASH */
 
           syslog(LOG_INFO,
-            "cmd(0x%x) MTDIOC_XIPBASE not support.\r\n", cmd);
+            "cmd(0x%x) MTDIOC_XIPBASE not support.\n", cmd);
         }
         break;
       case BIOC_FLUSH:
         {
-          syslog(LOG_INFO, "cmd(0x%x) BIOC_FLUSH.\r\n", cmd);
+          syslog(LOG_INFO, "cmd(0x%x) BIOC_FLUSH.\n", cmd);
           ret = OK;
         }
         break;
       default:
         {
-          syslog(LOG_INFO, "cmd(0x%x) not support.\r\n", cmd);
+          syslog(LOG_INFO, "cmd(0x%x) not support.\n", cmd);
           ret = -ENOTTY;
         }
         break;

--- a/arch/risc-v/src/bl602/bl602_start.c
+++ b/arch/risc-v/src/bl602/bl602_start.c
@@ -128,13 +128,13 @@ __cyg_profile_func_enter(void *this_fn, void *call_site)
       rtcb = running_task();
 
       syslog(LOG_EMERG,
-             "task %s stack overflow detected! base:0x%x >= sp:0x%x\r\n",
+             "task %s stack overflow detected! base:0x%x >= sp:0x%x\n",
              rtcb->name,
              stack_base,
              sp);
 #else
       syslog(LOG_EMERG,
-             "stack overflow detected! base:0x%x >= sp:0x%x\r\n",
+             "stack overflow detected! base:0x%x >= sp:0x%x\n",
              stack_base,
              sp);
 #endif

--- a/arch/risc-v/src/esp32c3/esp32c3_wlan.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wlan.c
@@ -1425,7 +1425,7 @@ static int esp32c3_net_initialize(unsigned int devno)
 
   memcpy(priv->dev.d_mac.ether.ether_addr_octet, eth_mac, sizeof(eth_mac));
 
-  ninfo("%02X:%02X:%02X:%02X:%02X:%02X \r\n",
+  ninfo("%02X:%02X:%02X:%02X:%02X:%02X \n",
         eth_mac[0], eth_mac[1], eth_mac[2],
         eth_mac[3], eth_mac[4], eth_mac[5]);
 

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -5918,7 +5918,7 @@ int esp_wifi_sta_country(struct iwreq *iwr, bool set)
       country_code = (char *)iwr->u.data.pointer;
       if (strlen(country_code) != 2)
         {
-          wlerr("ERROR: Invalid input arguments\r\n");
+          wlerr("ERROR: Invalid input arguments\n");
           return -EINVAL;
         }
 

--- a/boards/renesas/rx65n/rx65n-grrose/src/rx65n_bringup.c
+++ b/boards/renesas/rx65n/rx65n-grrose/src/rx65n_bringup.c
@@ -113,13 +113,13 @@ static int nsh_waiter(int argc, char *argv[])
 {
   struct usbhost_hubport_s *hport;
 
-  syslog(LOG_INFO, "nsh_waiter: Running\n\r");
+  syslog(LOG_INFO, "nsh_waiter: Running\n");
   for (; ; )
     {
       /* Wait for the device to change state */
 
       DEBUGVERIFY(CONN_WAIT(g_usbconn, &hport));
-      syslog(LOG_INFO, "nsh_waiter: %s\n\r",
+      syslog(LOG_INFO, "nsh_waiter: %s\n",
              hport->connected ? "Host:connected" : "Host:disconnected");
 
       /* Did we just become connected? */
@@ -156,7 +156,7 @@ static int nsh_usbhostinitialize(void)
    * that we care about:
    */
 
-  syslog(LOG_INFO, "Register class drivers\n\r");
+  syslog(LOG_INFO, "Register class drivers\n");
 
 #ifdef CONFIG_USBHOST_HUB
   /* Initialize USB hub class support */
@@ -208,12 +208,12 @@ static int nsh_usbhostinitialize(void)
     {
       /* Start a thread to handle device connection. */
 
-      syslog(LOG_INFO, "Start nsh_waiter\n\r");
+      syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
                            CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
-      syslog(LOG_INFO, "USBHost: Created pid = %d\n\r", pid);
+      syslog(LOG_INFO, "USBHost: Created pid = %d\n", pid);
       return pid < 0 ? -ENOEXEC : OK;
     }
 

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_bringup.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_bringup.c
@@ -112,7 +112,7 @@ static int nsh_waiter(int argc, char *argv[])
 {
   struct usbhost_hubport_s *hport;
 
-  syslog(LOG_INFO, "nsh_waiter: Running\n\r");
+  syslog(LOG_INFO, "nsh_waiter: Running\n");
   for (; ; )
     {
       /* Wait for the device to change state */
@@ -153,12 +153,12 @@ static int nsh_usbhostinitialize(void)
    * that we care about:
    */
 
-  syslog(LOG_INFO, "Register class drivers\n\r");
+  syslog(LOG_INFO, "Register class drivers\n");
 
 #ifdef CONFIG_USBHOST_MSC
   /* Register the USB host Mass Storage Class */
 
-        printf ("USB Host MSC\n\r");
+        printf ("USB Host MSC\n");
   ret = usbhost_msc_initialize();
   if (ret != OK)
     {
@@ -170,7 +170,7 @@ static int nsh_usbhostinitialize(void)
 #ifdef CONFIG_USBHOST_CDCACM
   /* Register the CDC/ACM serial class */
 
-  printf ("USB Host CDCACM \n\r");
+  printf ("USB Host CDCACM \n");
   ret = usbhost_kbdinit();
   if (ret != OK)
     {
@@ -207,12 +207,12 @@ static int nsh_usbhostinitialize(void)
     {
       /* Start a thread to handle device connection. */
 
-      syslog(LOG_INFO, "Start nsh_waiter\n\r");
+      syslog(LOG_INFO, "Start nsh_waiter\n");
 
       pid = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
                            CONFIG_USBHOST_STACKSIZE,
                            (main_t)nsh_waiter, (FAR char * const *)NULL);
-      syslog(LOG_INFO, "USBHost: Created pid = %d\n\r", pid);
+      syslog(LOG_INFO, "USBHost: Created pid = %d\n", pid);
       return pid < 0 ? -ENOEXEC : OK;
     }
 
@@ -393,7 +393,7 @@ int rx65n_bringup(void)
 
 #if defined(CONFIG_USBHOST)
   ret = nsh_usbhostinitialize();
-  printf ("USB Initialization done!!! with return value = %d\n\r", ret);
+  printf ("USB Initialization done!!! with return value = %d\n", ret);
 #endif
 
 #if defined(CONFIG_CDCACM) && !defined(CONFIG_CDCACM_CONSOLE)

--- a/boards/risc-v/bl602/bl602evb/src/bl602_gpio.c
+++ b/boards/risc-v/bl602/bl602evb/src/bl602_gpio.c
@@ -288,7 +288,7 @@ static int bl602_gpio_interrupt(int irq, void *context, void *arg)
       while ((1 == bl602_gpio_get_intstatus(gpio_pin)) && time_out);
       if (!time_out)
         {
-          printf("WARNING: Clear GPIO interrupt status fail.\r\n");
+          gpiowarn("WARNING: Clear GPIO interrupt status fail.\n");
         }
 
       /* if time_out==0, GPIO interrupt status not cleared */
@@ -341,7 +341,7 @@ static int gpio_setpintype(FAR struct gpio_dev_s *dev,
     }
   else
     {
-      printf("pintype error\r\n");
+      gpioerr("pintype error\n");
       return -1;
     }
 

--- a/drivers/sensors/lsm303agr.c
+++ b/drivers/sensors/lsm303agr.c
@@ -394,7 +394,9 @@ static int lsm303agr_sensor_start(FAR struct lsm303agr_dev_s *priv)
 
   sninfo("Starting....");
 
-  /* Accelerometer config registers Turn on the accelerometer: 833Hz, +- 16g */
+  /* Accelerometer config registers:
+   * Turn on the accelerometer: 833Hz, +- 16g
+   */
 
   lsm303agr_writereg8(priv, LSM303AGR_CTRL_REG1_A, 0x77);
   lsm303agr_writereg8(priv, LSM303AGR_CTRL_REG4_A, 0xb0);
@@ -940,7 +942,7 @@ static int lsm303agr_sensor_read(FAR struct lsm303agr_dev_s *priv,
 
 static int lsm303agr_open(FAR struct file *filep)
 {
-  sninfo("Device LSM303AGR opened!!\r\n");
+  sninfo("Device LSM303AGR opened!!\n");
   return OK;
 }
 

--- a/drivers/sensors/lsm6dsl.c
+++ b/drivers/sensors/lsm6dsl.c
@@ -428,7 +428,9 @@ static int lsm6dsl_sensor_start(FAR struct lsm6dsl_dev_s *priv)
 
   sninfo("Starting....");
 
-  /* Accelerometer config registers Turn on the accelerometer: 833Hz, +- 16g */
+  /* Accelerometer config registers:
+   * Turn on the accelerometer: 833Hz, +- 16g
+   */
 
   lsm6dsl_writereg8(priv, LSM6DSL_CTRL1_XL, 0x74);
   g_accelerofactor = 0.488;
@@ -1046,7 +1048,7 @@ static int lsm6dsl_sensor_read(FAR struct lsm6dsl_dev_s *priv,
 
 static int lsm6dsl_open(FAR struct file *filep)
 {
-  sninfo("Device LSM6DSL opened!!\r\n");
+  sninfo("Device LSM6DSL opened!!\n");
   return OK;
 }
 

--- a/drivers/sensors/vl53l1x.c
+++ b/drivers/sensors/vl53l1x.c
@@ -266,7 +266,8 @@ static const struct file_operations g_vl53l1xfops =
  * Name: vl53l1x_SensorInit
  *
  * Description:
- *  This function loads the 135 bytes default values to initialize the sensor.
+ *  This function loads the 135 bytes default values to initialize the
+ *  sensor.
  *
  ****************************************************************************/
 
@@ -842,7 +843,7 @@ static uint16_t vl53l1x_getreg16(FAR struct vl53l1x_dev_s *priv,
 
   /* Register to read */
 
-  sninfo("Reg %02x % \r\n", reg_addr_aux[0], reg_addr_aux[1]);
+  sninfo("Reg %02x % \n", reg_addr_aux[0], reg_addr_aux[1]);
   ret = i2c_write(priv->i2c, &config, (uint8_t *)&reg_addr_aux, 2);
   if (ret < 0)
     {
@@ -967,8 +968,8 @@ static void vl53l1x_putreg8(FAR struct vl53l1x_dev_s *priv, uint16_t regaddr,
  *
  ****************************************************************************/
 
-static void vl53l1x_putreg16(FAR struct vl53l1x_dev_s *priv, uint16_t regaddr,
-                             uint16_t regval)
+static void vl53l1x_putreg16(FAR struct vl53l1x_dev_s *priv,
+                             uint16_t regaddr, uint16_t regval)
 {
   struct i2c_config_s config;
   uint8_t data[4];
@@ -1005,8 +1006,8 @@ static void vl53l1x_putreg16(FAR struct vl53l1x_dev_s *priv, uint16_t regaddr,
  *
  ****************************************************************************/
 
-static void vl53l1x_putreg32(FAR struct vl53l1x_dev_s *priv, uint16_t regaddr,
-                             uint32_t regval)
+static void vl53l1x_putreg32(FAR struct vl53l1x_dev_s *priv,
+                             uint16_t regaddr, uint32_t regval)
 {
   struct i2c_config_s config;
   uint8_t data[7];
@@ -1160,7 +1161,8 @@ int vl53l1x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Initialize the vl53l1x device structure */
 
-  priv = (FAR struct vl53l1x_dev_s *)kmm_malloc(sizeof(struct vl53l1x_dev_s));
+  priv = (FAR struct vl53l1x_dev_s *)kmm_malloc(
+    sizeof(struct vl53l1x_dev_s));
   if (!priv)
     {
       snerr("ERROR: Failed to allocate instance\n");

--- a/drivers/sensors/wtgahrs2.c
+++ b/drivers/sensors/wtgahrs2.c
@@ -201,7 +201,7 @@ static void wtgahrs2_accel_data(FAR struct wtgahrs2_dev_s *rtdata,
   accel.temperature = (short)(buffer[7] << 8 | buffer[6]) / 100.0f;
 
   lower->push_event(lower->priv, &accel, sizeof(accel));
-  sninfo("Accel: %.3fm/s^2 %.3fm/s^2 %.3fm/s^2, t:%.1f\r\n",
+  sninfo("Accel: %.3fm/s^2 %.3fm/s^2 %.3fm/s^2, t:%.1f\n",
          accel.x, accel.y, accel.z, accel.temperature);
 }
 
@@ -227,7 +227,7 @@ static void wtgahrs2_gyro_data(FAR struct wtgahrs2_dev_s *rtdata,
   gyro.temperature = (short)(buffer[7] << 8 | buffer[6]) / 100.0f;
 
   lower->push_event(lower->priv, &gyro, sizeof(gyro));
-  sninfo("Gyro: %.3frad/s %.3frad/s %.3frad/s, t:%.1f\r\n",
+  sninfo("Gyro: %.3frad/s %.3frad/s %.3frad/s, t:%.1f\n",
           gyro.x, gyro.y, gyro.z, gyro.temperature);
 }
 
@@ -253,7 +253,7 @@ static void wtgahrs2_mag_data(FAR struct wtgahrs2_dev_s *rtdata,
   mag.temperature = (short)(buffer[7] << 8 | buffer[6]) / 100.0f;
 
   lower->push_event(lower->priv, &mag, sizeof(mag));
-  sninfo("Mag: %.3fuT %.3fuT %.3fuT, t:%.1f\r\n",
+  sninfo("Mag: %.3fuT %.3fuT %.3fuT, t:%.1f\n",
          mag.x, mag.y, mag.z, mag.temperature);
 }
 
@@ -278,7 +278,7 @@ static void wtgahrs2_baro_data(FAR struct wtgahrs2_dev_s *rtdata,
   baro.temperature = NAN;
 
   lower->push_event(lower->priv, &baro, sizeof(baro));
-  sninfo("Pressure : %.3fhPa\r\n", baro.pressure);
+  sninfo("Pressure : %.3fhPa\n", baro.pressure);
 }
 
 static void wtgahrs2_gps_data(FAR struct wtgahrs2_dev_s *rtdata,
@@ -336,12 +336,12 @@ static void wtgahrs2_gps_data(FAR struct wtgahrs2_dev_s *rtdata,
     {
       rtdata->gps_mask = 0;
       lower->push_event(lower->priv, &rtdata->gps, sizeof(rtdata->gps));
-      sninfo("Time : %d/%d/%d-%d:%d:%d\r\n", rtdata->gps.year,
+      sninfo("Time : %d/%d/%d-%d:%d:%d\n", rtdata->gps.year,
               rtdata->gps.month, rtdata->gps.day, rtdata->gps.hour,
               rtdata->gps.min, rtdata->gps.sec);
-      sninfo("GPS longitude : %fdegree, latitude:%fdegree\r\n",
+      sninfo("GPS longitude : %fdegree, latitude:%fdegree\n",
               rtdata->gps.longitude, rtdata->gps.latitude);
-      sninfo("GPS speed: %fm/s, yaw:%fdegrees, height:%fm \r\n",
+      sninfo("GPS speed: %fm/s, yaw:%fdegrees, height:%fm \n",
               rtdata->gps.speed, rtdata->gps.yaw, rtdata->gps.height);
     }
 }


### PR DESCRIPTION
## Summary
`\r`  was explicitly added to a lot of syslog calls. The use of a carriage return is controlled by the driver itself.

NOTE: While making this change I saw a few cases where we are calling syslog directly or even worse calling printf.  I will handle this in another PR later.

## Impact
Carriage return is controlled by syslog driver as expected.

## Testing
Minimal, but this change is fixing the call convention.
