### PR TITLE
risc-v/bl602: fix _heap_start not word aligned

### DIFF
--- a/boards/risc-v/bl602/bl602evb/scripts/ld.script
+++ b/boards/risc-v/bl602/bl602evb/scripts/ld.script
@@ -168,6 +168,8 @@ SECTIONS
     *(COMMON)
   } > ram_tcm
 
+  . = ALIGN(4);
+
   PROVIDE( _heap_start = . );
   PROVIDE( _heap_size = ADDR(.stack) - _heap_start );
 


### PR DESCRIPTION
## Summary
fix _heap_start not word aligned in ld.script
## Impact
risc-v/bl602
## Testing
BL602 boards
