### PR TITLE
Fix indexing for stm32h7 usbhost tracing

### DIFF
--- a/arch/arm/src/stm32h7/stm32_usbhost.c
+++ b/arch/arm/src/stm32h7/stm32_usbhost.c
@@ -56,68 +56,35 @@ struct stm32_usbhost_trace_s
 
 static const struct stm32_usbhost_trace_s g_trace1[TRACE1_NSTRINGS] =
 {
-#ifdef CONFIG_STM32H7_OTGFS
+#ifdef HAVE_USBHOST_TRACE
 
-  TRENTRY(OTGFS_TRACE1_DEVDISCONN,         TR_FMT1, "OTGFS ERROR: Host Port %d. Device disconnected\n"),
-  TRENTRY(OTGFS_TRACE1_IRQATTACH,          TR_FMT1, "OTGFS ERROR: Failed to attach IRQ\n"),
-  TRENTRY(OTGFS_TRACE1_TRNSFRFAILED,       TR_FMT1, "OTGFS  ERROR: Transfer Failed. ret=%d\n"),
-  TRENTRY(OTGFS_TRACE1_SENDSETUP,          TR_FMT1, "OTGFS  ERROR: ctrl_sendsetup() failed with: %d\n"),
-  TRENTRY(OTGFS_TRACE1_SENDDATA,           TR_FMT1, "OTGFS  ERROR: ctrl_senddata() failed with: %d\n"),
-  TRENTRY(OTGFS_TRACE1_RECVDATA,           TR_FMT1, "OTGFS  ERROR: ctrl_recvdata() failed with: %d\n"),
-
-#  ifdef HAVE_USBHOST_TRACE_VERBOSE
-
-  TRENTRY(OTGFS_VTRACE1_CONNECTED,         TR_FMT1, "OTGFS Host Port %d connected.\n"),
-  TRENTRY(OTGFS_VTRACE1_DISCONNECTED,      TR_FMT1, "OTGFS Host Port %d disconnected.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT,              TR_FMT1, "OTGFS Handling Interrupt. Entry Point.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_SOF,          TR_FMT1, "OTGFS Handle the start of frame interrupt.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_RXFLVL,       TR_FMT1, "OTGFS Handle the RxFIFO non-empty interrupt.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_NPTXFE,       TR_FMT1, "OTGFS Handle the non-periodic TxFIFO empty interrupt.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_PTXFE,        TR_FMT1, "OTGFS Handle the periodic TxFIFO empty interrupt.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HC,           TR_FMT1, "OTGFS Handle the host channels interrupt.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HPRT,         TR_FMT1, "OTGFS Handle the host port interrupt.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_POCCHNG, TR_FMT1, "OTGFS  HPRT: Port Over-Current Change.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_PCDET,   TR_FMT1, "OTGFS  HPRT: Port Connect Detect.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_PENCHNG, TR_FMT1, "OTGFS  HPRT: Port Enable Changed.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_LSDEV,   TR_FMT1, "OTGFS  HPRT: Low Speed Device Connected.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_FSDEV,   TR_FMT1, "OTGFS  HPRT: Full Speed Device Connected.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_LSFSSW,  TR_FMT1, "OTGFS  HPRT: Host Switch: LS -> FS.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_HPRT_FSLSSW,  TR_FMT1, "OTGFS  HPRT: Host Switch: FS -> LS.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_DISC,         TR_FMT1, "OTGFS Handle the disconnect detected interrupt.\n"),
-  TRENTRY(OTGFS_VTRACE1_GINT_IPXFR,        TR_FMT1, "OTGFS Handle the incomplete periodic transfer.\n"),
-
-#  endif
-#endif
-
-#ifdef CONFIG_STM32H7_OTGFS
-
-  TRENTRY(OTGHS_TRACE1_DEVDISCONN,         TR_FMT1, "OTGHS ERROR: Host Port %d. Device disconnected\n"),
-  TRENTRY(OTGHS_TRACE1_IRQATTACH,          TR_FMT1, "OTGHS ERROR: Failed to attach IRQ\n"),
-  TRENTRY(OTGHS_TRACE1_TRNSFRFAILED,       TR_FMT1, "OTGHS  ERROR: Transfer Failed. ret=%d\n"),
-  TRENTRY(OTGHS_TRACE1_SENDSETUP,          TR_FMT1, "OTGHS  ERROR: ctrl_sendsetup() failed with: %d\n"),
-  TRENTRY(OTGHS_TRACE1_SENDDATA,           TR_FMT1, "OTGHS  ERROR: ctrl_senddata() failed with: %d\n"),
-  TRENTRY(OTGHS_TRACE1_RECVDATA,           TR_FMT1, "OTGHS  ERROR: ctrl_recvdata() failed with: %d\n"),
+  TRENTRY(OTG_TRACE1_DEVDISCONN,         TR_FMT1, "OTG ERROR: Host Port %d. Device disconnected\n"),
+  TRENTRY(OTG_TRACE1_IRQATTACH,          TR_FMT1, "OTG ERROR: Failed to attach IRQ\n"),
+  TRENTRY(OTG_TRACE1_TRNSFRFAILED,       TR_FMT1, "OTG ERROR: Transfer Failed. ret=%d\n"),
+  TRENTRY(OTG_TRACE1_SENDSETUP,          TR_FMT1, "OTG ERROR: ctrl_sendsetup() failed with: %d\n"),
+  TRENTRY(OTG_TRACE1_SENDDATA,           TR_FMT1, "OTG ERROR: ctrl_senddata() failed with: %d\n"),
+  TRENTRY(OTG_TRACE1_RECVDATA,           TR_FMT1, "OTG ERROR: ctrl_recvdata() failed with: %d\n"),
 
 #  ifdef HAVE_USBHOST_TRACE_VERBOSE
 
-  TRENTRY(OTGHS_VTRACE1_CONNECTED,         TR_FMT1, "OTGHS Host Port %d connected.\n"),
-  TRENTRY(OTGHS_VTRACE1_DISCONNECTED,      TR_FMT1, "OTGHS Host Port %d disconnected.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT,              TR_FMT1, "OTGHS Handling Interrupt. Entry Point.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_SOF,          TR_FMT1, "OTGHS Handle the start of frame interrupt.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_RXFLVL,       TR_FMT1, "OTGHS Handle the RxFIFO non-empty interrupt.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_NPTXFE,       TR_FMT1, "OTGHS Handle the non-periodic TxFIFO empty interrupt.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_PTXFE,        TR_FMT1, "OTGHS Handle the periodic TxFIFO empty interrupt.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HC,           TR_FMT1, "OTGHS Handle the host channels interrupt.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HPRT,         TR_FMT1, "OTGHS Handle the host port interrupt.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_POCCHNG, TR_FMT1, "OTGHS  HPRT: Port Over-Current Change.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_PCDET,   TR_FMT1, "OTGHS  HPRT: Port Connect Detect.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_PENCHNG, TR_FMT1, "OTGHS  HPRT: Port Enable Changed.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_LSDEV,   TR_FMT1, "OTGHS  HPRT: Low Speed Device Connected.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_HSDEV,   TR_FMT1, "OTGHS  HPRT: Full Speed Device Connected.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_LSHSSW,  TR_FMT1, "OTGHS  HPRT: Host Switch: LS -> HS.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_HPRT_HSLSSW,  TR_FMT1, "OTGHS  HPRT: Host Switch: HS -> LS.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_DISC,         TR_FMT1, "OTGHS Handle the disconnect detected interrupt.\n"),
-  TRENTRY(OTGHS_VTRACE1_GINT_IPXFR,        TR_FMT1, "OTGHS Handle the incomplete periodic transfer.\n"),
+  TRENTRY(OTG_VTRACE1_CONNECTED,         TR_FMT1, "OTG Host Port %d connected.\n"),
+  TRENTRY(OTG_VTRACE1_DISCONNECTED,      TR_FMT1, "OTG Host Port %d disconnected.\n"),
+  TRENTRY(OTG_VTRACE1_GINT,              TR_FMT1, "OTG Handling Interrupt. Entry Point.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_SOF,          TR_FMT1, "OTG Handle the start of frame interrupt.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_RXFLVL,       TR_FMT1, "OTG Handle the RxFIFO non-empty interrupt.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_NPTXFE,       TR_FMT1, "OTG Handle the non-periodic TxFIFO empty interrupt.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_PTXFE,        TR_FMT1, "OTG Handle the periodic TxFIFO empty interrupt.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HC,           TR_FMT1, "OTG Handle the host channels interrupt.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HPRT,         TR_FMT1, "OTG Handle the host port interrupt.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HPRT_POCCHNG, TR_FMT1, "OTG  HPRT: Port Over-Current Change.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HPRT_PCDET,   TR_FMT1, "OTG  HPRT: Port Connect Detect.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HPRT_PENCHNG, TR_FMT1, "OTG  HPRT: Port Enable Changed.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HPRT_LSDEV,   TR_FMT1, "OTG  HPRT: Low Speed Device Connected.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HPRT_FSDEV,   TR_FMT1, "OTG  HPRT: Full Speed Device Connected.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HPRT_LSFSSW,  TR_FMT1, "OTG  HPRT: Host Switch: LS -> FS.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_HPRT_FSLSSW,  TR_FMT1, "OTG  HPRT: Host Switch: FS -> LS.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_DISC,         TR_FMT1, "OTG Handle the disconnect detected interrupt.\n"),
+  TRENTRY(OTG_VTRACE1_GINT_IPXFR,        TR_FMT1, "OTG Handle the incomplete periodic transfer.\n"),
 
 #  endif
 #endif
@@ -125,61 +92,32 @@ static const struct stm32_usbhost_trace_s g_trace1[TRACE1_NSTRINGS] =
 
 static const struct stm32_usbhost_trace_s g_trace2[TRACE2_NSTRINGS] =
 {
-#ifdef CONFIG_STM32H7_OTGFS
+#ifdef HAVE_USBHOST_TRACE
 
-  TRENTRY(OTGFS_TRACE2_CLIP,                TR_FMT2, "OTGFS CLIP: chidx: %d buflen: %d\n"),
-
-#  ifdef HAVE_USBHOST_TRACE_VERBOSE
-
-  TRENTRY(OTGFS_VTRACE2_CHANWAKEUP_IN,      TR_FMT2, "OTGFS  EP%d(IN)  wake up with result: %d\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANWAKEUP_OUT,     TR_FMT2, "OTGFS  EP%d(OUT) wake up with result: %d\n"),
-  TRENTRY(OTGFS_VTRACE2_CTRLIN,             TR_FMT2, "OTGFS CTRL_IN  type: %02x req: %02x\n"),
-  TRENTRY(OTGFS_VTRACE2_CTRLOUT,            TR_FMT2, "OTGFS CTRL_OUT type: %02x req: %02x\n"),
-  TRENTRY(OTGFS_VTRACE2_INTRIN,             TR_FMT2, "OTGFS INTR_IN  chidx: %02x len: %02x\n"),
-  TRENTRY(OTGFS_VTRACE2_INTROUT,            TR_FMT2, "OTGFS INTR_OUT chidx: %02x len: %02x\n"),
-  TRENTRY(OTGFS_VTRACE2_BULKIN,             TR_FMT2, "OTGFS BULK_IN  chidx: %02x len: %02x\n"),
-  TRENTRY(OTGFS_VTRACE2_BULKOUT,            TR_FMT2, "OTGFS BULK_OUT chidx: %02x len: %02x\n"),
-  TRENTRY(OTGFS_VTRACE2_ISOCIN,             TR_FMT2, "OTGFS ISOC_IN  chidx: %02x len: %04d\n"),
-  TRENTRY(OTGFS_VTRACE2_ISOCOUT,            TR_FMT2, "OTGFS ISOC_OUT chidx: %02x req: %02x\n"),
-  TRENTRY(OTGFS_VTRACE2_STARTTRANSFER,      TR_FMT2, "OTGFS  Transfer chidx: %d buflen: %d\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANCONF_CTRL_IN,   TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,IN ,CTRL)\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANCONF_CTRL_OUT,  TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,OUT,CTRL)\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANCONF_INTR_IN,   TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,IN ,INTR)\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANCONF_INTR_OUT,  TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,OUT,INTR)\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANCONF_BULK_IN,   TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,IN ,BULK)\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANCONF_BULK_OUT,  TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,OUT,BULK)\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANCONF_ISOC_IN,   TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,IN ,ISOC)\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANCONF_ISOC_OUT,  TR_FMT2, "OTGFS Channel configured. chidx: %d: (EP%d,OUT,ISOC)\n"),
-  TRENTRY(OTGFS_VTRACE2_CHANHALT,           TR_FMT2, "OTGFS Channel halted. chidx: %d, reason: %d\n"),
-
-#  endif
-#endif
-#ifdef CONFIG_STM32H7_OTGHS
-
-  TRENTRY(OTGHS_TRACE2_CLIP,                TR_FMT2, "OTGHS CLIP: chidx: %d buflen: %d\n"),
+  TRENTRY(OTG_TRACE2_CLIP,                TR_FMT2, "OTG CLIP: chidx: %d buflen: %d\n"),
 
 #  ifdef HAVE_USBHOST_TRACE_VERBOSE
 
-  TRENTRY(OTGHS_VTRACE2_CHANWAKEUP_IN,      TR_FMT2, "OTGHS  EP%d(IN)  wake up with result: %d\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANWAKEUP_OUT,     TR_FMT2, "OTGHS  EP%d(OUT) wake up with result: %d\n"),
-  TRENTRY(OTGHS_VTRACE2_CTRLIN,             TR_FMT2, "OTGHS CTRL_IN  type: %02x req: %02x\n"),
-  TRENTRY(OTGHS_VTRACE2_CTRLOUT,            TR_FMT2, "OTGHS CTRL_OUT type: %02x req: %02x\n"),
-  TRENTRY(OTGHS_VTRACE2_INTRIN,             TR_FMT2, "OTGHS INTR_IN  chidx: %02x len: %02x\n"),
-  TRENTRY(OTGHS_VTRACE2_INTROUT,            TR_FMT2, "OTGHS INTR_OUT chidx: %02x len: %02x\n"),
-  TRENTRY(OTGHS_VTRACE2_BULKIN,             TR_FMT2, "OTGHS BULK_IN  chidx: %02x len: %02x\n"),
-  TRENTRY(OTGHS_VTRACE2_BULKOUT,            TR_FMT2, "OTGHS BULK_OUT chidx: %02x len: %02x\n"),
-  TRENTRY(OTGHS_VTRACE2_ISOCIN,             TR_FMT2, "OTGHS ISOC_IN  chidx: %02x len: %04d\n"),
-  TRENTRY(OTGHS_VTRACE2_ISOCOUT,            TR_FMT2, "OTGHS ISOC_OUT chidx: %02x req: %02x\n"),
-  TRENTRY(OTGHS_VTRACE2_STARTTRANSFER,      TR_FMT2, "OTGHS  Transfer chidx: %d buflen: %d\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANCONF_CTRL_IN,   TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,IN ,CTRL)\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANCONF_CTRL_OUT,  TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,OUT,CTRL)\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANCONF_INTR_IN,   TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,IN ,INTR)\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANCONF_INTR_OUT,  TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,OUT,INTR)\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANCONF_BULK_IN,   TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,IN ,BULK)\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANCONF_BULK_OUT,  TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,OUT,BULK)\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANCONF_ISOC_IN,   TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,IN ,ISOC)\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANCONF_ISOC_OUT,  TR_FMT2, "OTGHS Channel configured. chidx: %d: (EP%d,OUT,ISOC)\n"),
-  TRENTRY(OTGHS_VTRACE2_CHANHALT,           TR_FMT2, "OTGHS Channel halted. chidx: %d, reason: %d\n"),
+  TRENTRY(OTG_VTRACE2_CHANWAKEUP_IN,      TR_FMT2, "OTG  EP%d(IN)  wake up with result: %d\n"),
+  TRENTRY(OTG_VTRACE2_CHANWAKEUP_OUT,     TR_FMT2, "OTG  EP%d(OUT) wake up with result: %d\n"),
+  TRENTRY(OTG_VTRACE2_CTRLIN,             TR_FMT2, "OTG CTRL_IN  type: %02x req: %02x\n"),
+  TRENTRY(OTG_VTRACE2_CTRLOUT,            TR_FMT2, "OTG CTRL_OUT type: %02x req: %02x\n"),
+  TRENTRY(OTG_VTRACE2_INTRIN,             TR_FMT2, "OTG INTR_IN  chidx: %02x len: %02x\n"),
+  TRENTRY(OTG_VTRACE2_INTROUT,            TR_FMT2, "OTG INTR_OUT chidx: %02x len: %02x\n"),
+  TRENTRY(OTG_VTRACE2_BULKIN,             TR_FMT2, "OTG BULK_IN  chidx: %02x len: %02x\n"),
+  TRENTRY(OTG_VTRACE2_BULKOUT,            TR_FMT2, "OTG BULK_OUT chidx: %02x len: %02x\n"),
+  TRENTRY(OTG_VTRACE2_ISOCIN,             TR_FMT2, "OTG ISOC_IN  chidx: %02x len: %04d\n"),
+  TRENTRY(OTG_VTRACE2_ISOCOUT,            TR_FMT2, "OTG ISOC_OUT chidx: %02x req: %02x\n"),
+  TRENTRY(OTG_VTRACE2_STARTTRANSFER,      TR_FMT2, "OTG  Transfer chidx: %d buflen: %d\n"),
+  TRENTRY(OTG_VTRACE2_CHANCONF_CTRL_IN,   TR_FMT2, "OTG Channel configured. chidx: %d: (EP%d,IN ,CTRL)\n"),
+  TRENTRY(OTG_VTRACE2_CHANCONF_CTRL_OUT,  TR_FMT2, "OTG Channel configured. chidx: %d: (EP%d,OUT,CTRL)\n"),
+  TRENTRY(OTG_VTRACE2_CHANCONF_INTR_IN,   TR_FMT2, "OTG Channel configured. chidx: %d: (EP%d,IN ,INTR)\n"),
+  TRENTRY(OTG_VTRACE2_CHANCONF_INTR_OUT,  TR_FMT2, "OTG Channel configured. chidx: %d: (EP%d,OUT,INTR)\n"),
+  TRENTRY(OTG_VTRACE2_CHANCONF_BULK_IN,   TR_FMT2, "OTG Channel configured. chidx: %d: (EP%d,IN ,BULK)\n"),
+  TRENTRY(OTG_VTRACE2_CHANCONF_BULK_OUT,  TR_FMT2, "OTG Channel configured. chidx: %d: (EP%d,OUT,BULK)\n"),
+  TRENTRY(OTG_VTRACE2_CHANCONF_ISOC_IN,   TR_FMT2, "OTG Channel configured. chidx: %d: (EP%d,IN ,ISOC)\n"),
+  TRENTRY(OTG_VTRACE2_CHANCONF_ISOC_OUT,  TR_FMT2, "OTG Channel configured. chidx: %d: (EP%d,OUT,ISOC)\n"),
+  TRENTRY(OTG_VTRACE2_CHANHALT,           TR_FMT2, "OTG Channel halted. chidx: %d, reason: %d\n"),
 
 #  endif
 #endif

--- a/arch/arm/src/stm32h7/stm32_usbhost.h
+++ b/arch/arm/src/stm32h7/stm32_usbhost.h
@@ -143,7 +143,7 @@ enum usbhost_trace1codes_e
 
 #  define TRACE1_FIRST     ((int)__TRACE1_BASEVALUE + 1)
 #  define TRACE1_INDEX(id) ((int)(id) - TRACE1_FIRST)
-#  define TRACE1_NSTRINGS  TRACE1_INDEX(__TRACE1_NSTRINGS)
+#  define TRACE1_NSTRINGS  TRACE1_INDEX(__TRACE1_NSTRINGS + 1)
 
 #  define TRACE2_FIRST     ((int)__TRACE1_NSTRINGS + 1)
 #  define TRACE2_INDEX(id) ((int)(id) - TRACE2_FIRST)


### PR DESCRIPTION
## Summary
The USB Host tracing is not split between hs and fs for the stm32h7 port so trace messages were defined out of index range.  The two related PRs passed CI, but together they cause the issue to appear as a compile warning.  This fixes that.

## Impact
Compile warning is resolved that is failing the build.

## Testing
Local testing and CI
