### PR TITLE
net/tcp/tcp_send_buffered.c: Fix non-blocking I/O

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1259,6 +1259,11 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
       if (chunk_result == 0)
         {
           DEBUGASSERT(nonblock);
+          if (result == 0)
+            {
+              result = -EAGAIN;
+            }
+
           break;
         }
 

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1271,6 +1271,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
         }
 
       DEBUGASSERT(chunk_result <= len);
+      DEBUGASSERT(chunk_result <= chunk_len);
       DEBUGASSERT(result >= 0);
       cp += chunk_result;
       len -= chunk_result;

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1193,9 +1193,11 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
             {
               if (TCP_WBPKTLEN(wrb) > 0)
                 {
-                  ninfo("INFO: Allocated part of the requested data\n");
                   DEBUGASSERT(TCP_WBPKTLEN(wrb) >= off);
                   chunk_result = TCP_WBPKTLEN(wrb) - off;
+                  ninfo("INFO: Allocated part of the requested data "
+                        "%zd/%zu\n",
+                        chunk_result, chunk_len);
 
                   /* Note: chunk_result here can be 0 if we are trying
                    * to coalesce into the existing buffer and we failed

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1287,11 +1287,6 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
       goto errout;
     }
 
-  if (ret < 0)
-    {
-      goto errout;
-    }
-
   /* Return the number of bytes actually sent */
 
   return result;


### PR DESCRIPTION
## Summary
net/tcp/tcp_send_buffered.c: Fix non-blocking I/O

My recent changes to buffered tcp send broke this. [1]

[1]
```
commit 837e1a72a47b4e5a874124e316192b2172301d30
Author: YAMAMOTO Takashi <yamamoto@midokura.com>
Date:   Mon Mar 15 16:19:42 2021 +0900

    tcp_send_buffered.c: improve tcp write buffering
```

## Impact
non-blocking i/o with CONFIG_NET_TCP_WRITE_BUFFERS

## Testing

One of my local apps using non-blocking tcp is working
again with this fix.

