### PR TITLE
stm32/stm32_adc: various improvements for ADC

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -8151,6 +8151,17 @@ config STM32_ADC5_RESOLUTION
 	---help---
 		ADC5 resolution. 0 - 12 bit, 1 - 10 bit, 2 - 8 bit, 3 - 6 bit
 
+config STM32_ADC_MAX_SAMPLES
+	int "The maximum number of channels that can be sampled"
+	default 16
+	---help---
+		The maximum number of samples which can be handled without
+		overrun depends on various factors. This is the user's
+		responsibility to correctly select this value.
+		Since the interfece to update the sampling time is available
+		for all supported devices, the user can change the default
+		vaules in the board initialization logic and avoid ADC overrun.
+
 config STM32_ADC_NO_STARTUP_CONV
 	bool "Do not start conversion when opening ADC device"
 	default n

--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -8185,6 +8185,12 @@ config STM32_ADC1_DMA
 		DMA transfer, which is necessary if multiple channels are read
 		or if very high trigger frequencies are used.
 
+config STM32_ADC1_SCAN
+	bool "ADC1 scan mode"
+	depends on STM32_ADC1 && STM32_HAVE_IP_ADC_V1
+	default y if STM32_ADC1_DMA
+	default n
+
 config STM32_ADC1_DMA_CFG
 	int "ADC1 DMA configuration"
 	depends on STM32_ADC1_DMA && !STM32_HAVE_IP_ADC_V1_BASIC
@@ -8202,6 +8208,12 @@ config STM32_ADC2_DMA
 		DMA transfer, which is necessary if multiple channels are read
 		or if very high trigger frequencies are used.
 
+config STM32_ADC2_SCAN
+	bool "ADC2 scan mode"
+	depends on STM32_ADC2 && STM32_HAVE_IP_ADC_V1
+	default y if STM32_ADC2_DMA
+	default n
+
 config STM32_ADC2_DMA_CFG
 	int "ADC2 DMA configuration"
 	depends on STM32_ADC2_DMA && !STM32_HAVE_IP_ADC_V1_BASIC
@@ -8218,6 +8230,12 @@ config STM32_ADC3_DMA
 		If DMA is selected, then the ADC may be configured to support
 		DMA transfer, which is necessary if multiple channels are read
 		or if very high trigger frequencies are used.
+
+config STM32_ADC3_SCAN
+	bool "ADC3 scan mode"
+	depends on STM32_ADC3 && STM32_HAVE_IP_ADC_V1
+	default y if STM32_ADC3_DMA
+	default n
 
 config STM32_ADC3_DMA_CFG
 	int "ADC3 DMA configuration"

--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -8199,6 +8199,16 @@ config STM32_ADC1_DMA_CFG
 	---help---
 		0 - ADC1 DMA in One Shot Mode, 1 - ADC1 DMA in Circular Mode
 
+config STM32_ADC1_ANIOC_TRIGGER
+	int "ADC1 software trigger (ANIOC_TRIGGER) configuration"
+	depends on STM32_ADC1
+	range 1 3
+	default 3
+	---help---
+		1 - ANIOC_TRIGGER only starts regular conversion
+		2 - ANIOC_TRIGGER only starts injected conversion
+		3 - ANIOC_TRIGGER starts both regular and injected conversions
+
 config STM32_ADC2_DMA
 	bool "ADC2 DMA"
 	depends on STM32_ADC2 && STM32_HAVE_ADC2_DMA
@@ -8221,6 +8231,16 @@ config STM32_ADC2_DMA_CFG
 	default 0
 	---help---
 		0 - ADC2 DMA in One Shot Mode, 1 - ADC2 DMA in Circular Mode
+
+config STM32_ADC2_ANIOC_TRIGGER
+	int "ADC2 software trigger (ANIOC_TRIGGER) configuration"
+	depends on STM32_ADC2
+	range 1 3
+	default 3
+	---help---
+		1 - ANIOC_TRIGGER only starts regular conversion
+		2 - ANIOC_TRIGGER only starts injected conversion
+		3 - ANIOC_TRIGGER starts both regular and injected conversions
 
 config STM32_ADC3_DMA
 	bool "ADC3 DMA"
@@ -8245,6 +8265,16 @@ config STM32_ADC3_DMA_CFG
 	---help---
 		0 - ADC3 DMA in One Shot Mode, 1 - ADC3 DMA in Circular Mode
 
+config STM32_ADC3_ANIOC_TRIGGER
+	int "ADC3 software trigger (ANIOC_TRIGGER) configuration"
+	depends on STM32_ADC3
+	range 1 3
+	default 3
+	---help---
+		1 - ANIOC_TRIGGER only starts regular conversion
+		2 - ANIOC_TRIGGER only starts injected conversion
+		3 - ANIOC_TRIGGER starts both regular and injected conversions
+
 config STM32_ADC4_DMA
 	bool "ADC4 DMA"
 	depends on STM32_ADC4 && STM32_HAVE_ADC4_DMA
@@ -8261,6 +8291,16 @@ config STM32_ADC4_DMA_CFG
 	default 0
 	---help---
 		0 - ADC4 DMA in One Shot Mode, 1 - ADC4 DMA in Circular Mode
+
+config STM32_ADC4_ANIOC_TRIGGER
+	int "ADC4 software trigger (ANIOC_TRIGGER) configuration"
+	depends on STM32_ADC4
+	range 1 3
+	default 3
+	---help---
+		1 - ANIOC_TRIGGER only starts regular conversion
+		2 - ANIOC_TRIGGER only starts injected conversion
+		3 - ANIOC_TRIGGER starts both regular and injected conversions
 
 config STM32_ADC5_DMA
 	bool "ADC5 DMA"

--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -2498,7 +2498,7 @@ static void adc_sampletime_cfg(FAR struct adc_dev_s *dev)
    */
 
 #ifdef CONFIG_STM32_ADC_CHANGE_SAMPLETIME
-  adc_sampletime_write((FAR struct stm32_adc_dev_s *)dev);
+  adc_sampletime_write((FAR struct stm32_adc_dev_s *)dev->ad_priv);
 #else
   FAR struct stm32_dev_s *priv = (FAR struct stm32_dev_s *)dev->ad_priv;
 

--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -350,6 +350,23 @@
 #  undef ADC_HAVE_DMACFG
 #endif
 
+/* ADC scan mode support - only for ADCv1 */
+
+#ifdef CONFIG_STM32_HAVE_IP_ADC_V1
+#  define ADC_HAVE_SCAN 1
+#  ifndef CONFIG_STM32_ADC1_SCAN
+#    define CONFIG_STM32_ADC1_SCAN 0
+#  endif
+#  ifndef CONFIG_STM32_ADC2_SCAN
+#    define CONFIG_STM32_ADC2_SCAN 0
+#  endif
+#  ifndef CONFIG_STM32_ADC3_SCAN
+#    define CONFIG_STM32_ADC3_SCAN 0
+#  endif
+#else
+#  undef ADC_HAVE_SCAN
+#endif
+
 /* We have to support ADC callbacks if default ADC interrupts or
  * DMA transfer are enabled
  */
@@ -408,6 +425,9 @@ struct stm32_dev_s
   uint8_t dmacfg;            /* DMA channel configuration, only for ADC IPv2 */
 #  endif
   bool    hasdma;            /* True: This channel supports DMA */
+#endif
+#ifdef ADC_HAVE_SCAN
+  bool    scan;              /* True: Scan mode */
 #endif
 #ifdef CONFIG_STM32_ADC_CHANGE_SAMPLETIME
   /* Sample time selection. These bits must be written only when ADON=0.
@@ -769,6 +789,9 @@ static struct stm32_dev_s g_adcpriv1 =
 #  endif
   .hasdma      = true,
 #endif
+#ifdef ADC_HAVE_SCAN
+  .scan        = CONFIG_STM32_ADC1_SCAN,
+#endif
 };
 
 static struct adc_dev_s g_adcdev1 =
@@ -825,6 +848,9 @@ static struct stm32_dev_s g_adcpriv2 =
 #  endif
   .hasdma      = true,
 #endif
+#ifdef ADC_HAVE_SCAN
+  .scan        = CONFIG_STM32_ADC2_SCAN,
+#endif
 };
 
 static struct adc_dev_s g_adcdev2 =
@@ -880,6 +906,9 @@ static struct stm32_dev_s g_adcpriv3 =
   .dmacfg      = CONFIG_STM32_ADC3_DMA_CFG,
 #  endif
   .hasdma      = true,
+#endif
+#ifdef ADC_HAVE_SCAN
+  .scan        = CONFIG_STM32_ADC3_SCAN,
 #endif
 };
 
@@ -2401,8 +2430,8 @@ static void adc_mode_cfg(FAR struct stm32_dev_s *priv)
   setbits |= ADC_CR1_IND;
 #endif
 
-#ifdef ADC_HAVE_DMA
-  if (priv->hasdma)
+#ifdef ADC_HAVE_SCAN
+  if (priv->scan == true)
     {
       setbits |= ADC_CR1_SCAN;
     }

--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -377,6 +377,11 @@
 #  undef ADC_HAVE_CB
 #endif
 
+/* ADC software trigger configuration */
+
+#define ANIOC_TRIGGER_REGULAR  (1 << 0)
+#define ANIOC_TRIGGER_INJECTED (1 << 1)
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -416,6 +421,7 @@ struct stm32_dev_s
   uint8_t intf;              /* ADC interface number */
   uint8_t initialized;       /* ADC interface initialization counter */
   uint8_t current;           /* Current ADC channel being converted */
+  uint8_t anioc_trg;         /* ANIOC_TRIGGER configuration */
 #ifdef HAVE_ADC_RESOLUTION
   uint8_t resolution;        /* ADC resolution (0-3) */
 #endif
@@ -766,6 +772,7 @@ static struct stm32_dev_s g_adcpriv1 =
 #endif
   .intf        = 1,
   .initialized = 0,
+  .anioc_trg   = CONFIG_STM32_ADC1_ANIOC_TRIGGER,
 #ifdef HAVE_ADC_RESOLUTION
   .resolution  = CONFIG_STM32_ADC1_RESOLUTION,
 #endif
@@ -825,6 +832,7 @@ static struct stm32_dev_s g_adcpriv2 =
 #endif
   .intf        = 2,
   .initialized = 0,
+  .anioc_trg   = CONFIG_STM32_ADC2_ANIOC_TRIGGER,
 #ifdef HAVE_ADC_RESOLUTION
   .resolution  = CONFIG_STM32_ADC2_RESOLUTION,
 #endif
@@ -884,6 +892,7 @@ static struct stm32_dev_s g_adcpriv3 =
 #endif
   .intf        = 3,
   .initialized = 0,
+  .anioc_trg   = CONFIG_STM32_ADC3_ANIOC_TRIGGER,
 #ifdef HAVE_ADC_RESOLUTION
   .resolution  = CONFIG_STM32_ADC3_RESOLUTION,
 #endif
@@ -936,6 +945,7 @@ static struct stm32_dev_s g_adcpriv4 =
 #endif
   .intf        = 4,
   .initialized = 0,
+  .anioc_trg   = CONFIG_STM32_ADC4_ANIOC_TRIGGER,
 #ifdef HAVE_ADC_RESOLUTION
   .resolution  = CONFIG_STM32_ADC4_RESOLUTION,
 #endif
@@ -3820,17 +3830,23 @@ static int adc_ioctl(FAR struct adc_dev_s *dev, int cmd, unsigned long arg)
         {
           /* Start regular conversion if regular channels configured */
 
-          if (priv->cr_channels > 0)
+          if (priv->anioc_trg & ANIOC_TRIGGER_REGULAR)
             {
-              adc_reg_startconv(priv, true);
+              if (priv->cr_channels > 0)
+                {
+                  adc_reg_startconv(priv, true);
+                }
             }
 
 #ifdef ADC_HAVE_INJECTED
           /* Start injected conversion if injected channels configured */
 
-          if (priv->cj_channels > 0)
+          if (priv->anioc_trg & ANIOC_TRIGGER_INJECTED)
             {
-              adc_inj_startconv(priv, true);
+              if (priv->cj_channels > 0)
+                {
+                  adc_inj_startconv(priv, true);
+                }
             }
 #endif
 

--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -148,26 +148,6 @@
 
 /* ADC Channels/DMA *********************************************************/
 
-/* The maximum number of channels that can be sampled.  If DMA support is
- * not enabled, then only a single channel can be sampled.  Otherwise,
- * data overruns would occur.
- */
-
-#define ADC_MAX_CHANNELS_DMA   16
-#define ADC_MAX_CHANNELS_NODMA 1
-
-#ifdef ADC_HAVE_DMA
-#  define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_DMA
-#else
-#  if defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX)
-#    define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_DMA /* Works without DMA should sampling frequency be reduced */
-#  elif defined(CONFIG_STM32_STM32L15XX)
-#    define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_DMA /* Works without DMA as IO_START_CONV can switch channels on the fly */
-#  else
-#    define ADC_MAX_SAMPLES ADC_MAX_CHANNELS_NODMA
-#  endif
-#endif
-
 /* DMA values differs according to STM32 DMA IP core version */
 
 #if defined(HAVE_IP_DMA_V2)
@@ -210,7 +190,7 @@
                                (ADC_SMPR_DEFAULT << ADC_SMPR2_SMP8_SHIFT) | \
                                (ADC_SMPR_DEFAULT << ADC_SMPR2_SMP9_SHIFT))
 #elif defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX)
-#  if defined(ADC_HAVE_DMA) || (ADC_MAX_SAMPLES == 1)
+#  if defined(ADC_HAVE_DMA) || (CONFIG_STM32_ADC_MAX_SAMPLES == 1)
 #    define ADC_SMPR_DEFAULT    ADC_SMPR_61p5
 #  else /* Slow down sampling frequency */
 #    define ADC_SMPR_DEFAULT    ADC_SMPR_601p5
@@ -466,12 +446,12 @@ struct stm32_dev_s
 
   /* DMA transfer buffer */
 
-  uint16_t r_dmabuffer[ADC_MAX_SAMPLES];
+  uint16_t r_dmabuffer[CONFIG_STM32_ADC_MAX_SAMPLES];
 #endif
 
   /* List of selected ADC channels to sample */
 
-  uint8_t  r_chanlist[ADC_MAX_SAMPLES];
+  uint8_t  r_chanlist[CONFIG_STM32_ADC_MAX_SAMPLES];
 
 #ifdef ADC_HAVE_INJECTED
   /* List of selected ADC injected channels to sample */
@@ -4760,7 +4740,7 @@ struct adc_dev_s *stm32_adcinitialize(int intf, FAR const uint8_t *chanlist,
 
   /* Configure regular channels */
 
-  DEBUGASSERT(cr_channels <= ADC_MAX_SAMPLES);
+  DEBUGASSERT(cr_channels <= CONFIG_STM32_ADC_MAX_SAMPLES);
 
   priv->cr_channels = cr_channels;
   memcpy(priv->r_chanlist, chanlist, cr_channels);


### PR DESCRIPTION
## Summary

- stm32/stm32_adc.c: fix initial sample time write
- stm32/stm32_adc.c: add an option to configure SCAN mode for ADC IPv1
- stm32/stm32_adc.c: add an option to configure ANIOC_TRIGGER behavior
- stm32/stm32_adc.c: fix enable/disable interrupts logic for coupled ADC
- stm32/stm32_adc.c: move maximum number of samples cfg to Kconfig

## Impact
This PR fixes some problems that I found when implementing the lower-half part of the FOC device for STM32. 

## Testing

Tested on STM32F302 and STM32F446