### PR TITLE
boards/nucleo-f446re: register button and fix typo in Kconfig

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -2885,7 +2885,7 @@ endif
 if ARCH_BOARD_NUCLEO_F412ZG
 source "boards/arm/stm32/nucleo-f412zg/Kconfig"
 endif
-if ARCH_BOARD_NUCLEO_F44RE
+if ARCH_BOARD_NUCLEO_F446RE
 source "boards/arm/stm32/nucleo-f446re/Kconfig"
 endif
 if ARCH_BOARD_NUCLEO_F401RE || ARCH_BOARD_NUCLEO_F411RE

--- a/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
@@ -39,11 +39,15 @@
 
 #include <arch/board/board.h>
 
-#include "nucleo-f446re.h"
+#ifdef CONFIG_BUTTONS
+#  include <nuttx/input/buttons.h>
+#endif
 
 #ifdef CONFIG_SENSORS_QENCODER
 #include "board_qencoder.h"
 #endif
+
+#include "nucleo-f446re.h"
 
 /****************************************************************************
  * Public Functions
@@ -66,6 +70,16 @@
 int stm32_bringup(void)
 {
   int ret = OK;
+
+#ifdef CONFIG_BUTTONS
+  /* Register the BUTTON driver */
+
+  ret = btn_lower_initialize("/dev/buttons");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: btn_lower_initialize() failed: %d\n", ret);
+    }
+#endif
 
 #ifdef HAVE_MMCSD
   /* First, get an instance of the SDIO interface */


### PR DESCRIPTION
## Summary

## Impact

## Testing

