### PR TITLE
ESP32: Bugfixes and Improvements for SPI DMA Exchange function

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <assert.h>
 #include <errno.h>
 #include <debug.h>
 #include <time.h>
@@ -855,6 +856,8 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
   uint8_t *allocrp;
 #endif
 
+  DEBUGASSERT((txbuffer != NULL) || (rxbuffer != NULL));
+
   /* If the buffer comes from PSRAM, allocate a new one from DRAM */
 
 #ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
@@ -911,14 +914,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       esp32_spi_set_reg(priv, SPI_DMA_OUT_LINK_OFFSET,
                         regval | SPI_OUTLINK_START_M);
       esp32_spi_set_reg(priv, SPI_MOSI_DLEN_OFFSET, bytes * 8 - 1);
-      if (tp)
-        {
-          esp32_spi_set_regbits(priv, SPI_USER_OFFSET, SPI_USR_MOSI_M);
-        }
-      else
-        {
-          esp32_spi_reset_regbits(priv, SPI_USER_OFFSET, SPI_USR_MOSI_M);
-        }
+      esp32_spi_set_regbits(priv, SPI_USER_OFFSET, SPI_USR_MOSI_M);
 
       if (rp)
         {

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -916,6 +916,8 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       esp32_spi_set_reg(priv, SPI_MOSI_DLEN_OFFSET, bytes * 8 - 1);
       esp32_spi_set_regbits(priv, SPI_USER_OFFSET, SPI_USR_MOSI_M);
 
+      tp += n;
+
       if (rp)
         {
           esp32_dma_init(s_dma_rxdesc[priv->config->dma_chan - 1],
@@ -927,6 +929,8 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
                             regval | SPI_INLINK_START_M);
           esp32_spi_set_reg(priv, SPI_MISO_DLEN_OFFSET, bytes * 8 - 1);
           esp32_spi_set_regbits(priv, SPI_USER_OFFSET, SPI_USR_MISO_M);
+
+          rp += n;
         }
       else
         {
@@ -938,8 +942,6 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       esp32_spi_sem_waitdone(priv);
 
       bytes -= n;
-      tp += n;
-      rp += n;
     }
 
   esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_INT_EN_M);

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -908,7 +908,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
                SPI_OUTLINK_ADDR_V;
       esp32_spi_set_reg(priv, SPI_DMA_OUT_LINK_OFFSET,
                         regval | SPI_OUTLINK_START_M);
-      esp32_spi_set_reg(priv, SPI_MOSI_DLEN_OFFSET, bytes * 8 - 1);
+      esp32_spi_set_reg(priv, SPI_MOSI_DLEN_OFFSET, n * 8 - 1);
       esp32_spi_set_regbits(priv, SPI_USER_OFFSET, SPI_USR_MOSI_M);
 
       tp += n;
@@ -922,7 +922,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
                    SPI_INLINK_ADDR_V;
           esp32_spi_set_reg(priv, SPI_DMA_IN_LINK_OFFSET,
                             regval | SPI_INLINK_START_M);
-          esp32_spi_set_reg(priv, SPI_MISO_DLEN_OFFSET, bytes * 8 - 1);
+          esp32_spi_set_reg(priv, SPI_MISO_DLEN_OFFSET, n * 8 - 1);
           esp32_spi_set_regbits(priv, SPI_USER_OFFSET, SPI_USR_MISO_M);
 
           rp += n;

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -882,7 +882,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
       rp = (uint8_t *)rxbuffer;
     }
 
-  if (!tp)
+  if (tp == NULL)
     {
       tp = rp;
     }
@@ -890,7 +890,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
   esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_TRANS_DONE_M);
   esp32_spi_set_regbits(priv, SPI_SLAVE_OFFSET, SPI_INT_EN_M);
 
-  while (bytes)
+  while (bytes != 0)
     {
       esp32_spi_set_reg(priv, SPI_DMA_IN_LINK_OFFSET, 0);
       esp32_spi_set_reg(priv, SPI_DMA_OUT_LINK_OFFSET, 0);
@@ -913,7 +913,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
 
       tp += n;
 
-      if (rp)
+      if (rp != NULL)
         {
           esp32_dma_init(s_dma_rxdesc[priv->config->dma_chan - 1],
                          SPI_DMADESC_NUM, rp, bytes);
@@ -1053,7 +1053,7 @@ static void esp32_spi_poll_exchange(FAR struct esp32_spi_priv_s *priv,
       uint32_t w_wd = 0xffff;
       uint32_t r_wd;
 
-      if (txbuffer)
+      if (txbuffer != NULL)
         {
           if (priv->nbits == 8)
             {
@@ -1067,7 +1067,7 @@ static void esp32_spi_poll_exchange(FAR struct esp32_spi_priv_s *priv,
 
       r_wd = esp32_spi_poll_send(priv, w_wd);
 
-      if (rxbuffer)
+      if (rxbuffer != NULL)
         {
           if (priv->nbits == 8)
             {
@@ -1474,7 +1474,7 @@ int esp32_spibus_uninitialize(FAR struct spi_dev_s *dev)
 
   flags = enter_critical_section();
 
-  if (--priv->refs)
+  if (--priv->refs != 0)
     {
       leave_critical_section(flags);
       return OK;

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -786,11 +786,6 @@ static void esp32_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
   spiinfo("nbits=%d\n", nbits);
 
   priv->nbits = nbits;
-
-  esp32_spi_set_reg(priv, SPI_MISO_DLEN_OFFSET,
-                    (priv->nbits - 1) << SPI_USR_MISO_DBITLEN_S);
-  esp32_spi_set_reg(priv, SPI_MOSI_DLEN_OFFSET,
-                    (priv->nbits - 1) << SPI_USR_MOSI_DBITLEN_S);
 }
 
 /****************************************************************************
@@ -982,6 +977,9 @@ static uint32_t esp32_spi_poll_send(FAR struct esp32_spi_priv_s *priv,
                                     uint32_t wd)
 {
   uint32_t val;
+
+  esp32_spi_set_reg(priv, SPI_MISO_DLEN_OFFSET, (priv->nbits - 1));
+  esp32_spi_set_reg(priv, SPI_MOSI_DLEN_OFFSET, (priv->nbits - 1));
 
   esp32_spi_set_reg(priv, SPI_W0_OFFSET, wd);
 


### PR DESCRIPTION
## Summary
This PR intends to address two issues and bring three small improvements to the ESP32 SPI driver:

**Bugfixes**:
1) For SPI SNDBLOCK operations, RX Buffer will be `NULL`. Currently, every loop unconditionally increments the RX buffer pointer by 4, even when it is `NULL`. So for transfers larger than 4092 bytes, an exception would be raised during the second loop iteration.
2) On `esp32_spi_dma_exchange`, MISO/MOSI data length fields were being configured with the total number of remaining bytes instead of the number of bytes actually bound to DMA descriptors. While it didn't cause any issue, this could induce a wrong operation of the DMA engine.

**Improvements**:
1) Remove the check for a pointer that is guaranteed to be valid, assuming that the TX buffer of a SPI DMA exchange will always be non-NULL.
2) In order to avoid consistency issues during Mixed mode, the `esp32_spi_setbits` configuration will be committed before the transaction operation.
3) Use essential boolean expressions on condition statements.

## Impact
Impact to SPI peripherals on ESP32.

## Testing
Tested with `ESP-WROVER-KIT` board.
