### PR TITLE
board/arm/lpc17xx_40xx/mbed: Add userleds driver support

### DIFF
--- a/boards/arm/lpc17xx_40xx/mbed/README.txt
+++ b/boards/arm/lpc17xx_40xx/mbed/README.txt
@@ -70,8 +70,6 @@ mbed Configuration Options
 
     CONFIG_ARCH_STACKDUMP - Do stack dumps after assertions
 
-    CONFIG_ARCH_LEDS -  Use LEDs to show state. Unique to board architecture.
-
     Individual subsystems can be enabled:
       CONFIG_LPC17_40_MAINOSC=y
       CONFIG_LPC17_40_PLL0=y
@@ -195,6 +193,11 @@ mbed Configuration Options
       Size of one end-user I/O buffer.  This can be zero if the
       application can guarantee that all end-user I/O buffers
       reside in AHB SRAM.
+
+    CONFIG_USERLED
+    CONFIG_USERLED_LOWER
+      Setup the generic driver to support the board leds, and so creates the
+device into /dev/userleds
 
 USB Host Configuration
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/boards/arm/lpc17xx_40xx/mbed/src/Makefile
+++ b/boards/arm/lpc17xx_40xx/mbed/src/Makefile
@@ -20,7 +20,11 @@
 
 include $(TOPDIR)/Make.defs
 
-CSRCS = lpc17_40_boot.c lpc17_40_leds.c lpc17_40_dac.c
+CSRCS = lpc17_40_boot.c lpc17_40_dac.c
+
+ifeq ($(CONFIG_ARCH_LEDS),y)
+CSRCS += lpc17_40_leds.c
+endif
 
 ifeq ($(CONFIG_LIB_BOARDCTL),y)
 CSRCS += lpc17_40_appinit.c
@@ -36,6 +40,10 @@ endif
 
 ifeq ($(CONFIG_ADC),y)
 CSRCS += lpc17_40_adc.c
+endif
+
+ifeq ($(CONFIG_USERLED),y)
+CSRCS += lpc17_40_userleds.c
 endif
 
 include $(TOPDIR)/boards/Board.mk

--- a/boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_appinit.c
+++ b/boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_appinit.c
@@ -34,6 +34,10 @@
 
 #include "mbed.h"
 
+#ifdef CONFIG_USERLED
+#include <nuttx/leds/userled.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -103,6 +107,16 @@ int board_app_initialize(uintptr_t arg)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: mbed_adc_setup failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_USERLED
+  /* Register the LED driver */
+
+  ret = userled_lower_initialize("/dev/userleds");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_leds.c
+++ b/boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_leds.c
@@ -79,7 +79,7 @@
  */
 
 static bool g_initialized;
-static int  g_nestcount;
+static int  g_nestcount = 0;
 
 /****************************************************************************
  * Private Functions

--- a/boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_userleds.c
+++ b/boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_userleds.c
@@ -1,0 +1,231 @@
+/****************************************************************************
+ * boards/arm/lpc17xx_40xx/mbed/src/lpc17_40_userleds.c
+ *
+ *   Copyright (C) 2011, 2015-2016 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <debug.h>
+
+#include <nuttx/board.h>
+#include <nuttx/power/pm.h>
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include "arm_arch.h"
+#include "arm_internal.h"
+
+#include "lpc17_40_gpio.h"
+#include "mbed.h"
+
+#ifndef CONFIG_ARCH_LEDS
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* This array maps an LED number to GPIO pin configuration */
+
+static uint32_t g_ledcfg[MBED_NLEDS] =
+{
+  MBED_LED1, MBED_LED2, MBED_LED3, MBED_LED4
+};
+
+/****************************************************************************
+ * Private Function Protototypes
+ ****************************************************************************/
+
+/* LED Power Management */
+
+#ifdef CONFIG_PM
+static void led_pm_notify(struct pm_callback_s *cb, int domain,
+                          enum pm_state_e pmstate);
+static int led_pm_prepare(struct pm_callback_s *cb, int domain,
+                          enum pm_state_e pmstate);
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static struct pm_callback_s g_ledscb =
+{
+  .notify  = led_pm_notify,
+  .prepare = led_pm_prepare,
+};
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: led_pm_notify
+ *
+ * Description:
+ *   Notify the driver of new power state. This callback is called after
+ *   all drivers have had the opportunity to prepare for the new power state.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static void led_pm_notify(struct pm_callback_s *cb, int domain,
+                          enum pm_state_e pmstate)
+{
+  switch (pmstate)
+    {
+      case(PM_NORMAL):
+        {
+          /* Restore normal LEDs operation */
+        }
+        break;
+
+      case(PM_IDLE):
+        {
+          /* Entering IDLE mode - Turn leds off */
+        }
+        break;
+
+      case(PM_STANDBY):
+        {
+          /* Entering STANDBY mode - Logic for PM_STANDBY goes here */
+        }
+        break;
+
+      case(PM_SLEEP):
+        {
+          /* Entering SLEEP mode - Logic for PM_SLEEP goes here */
+        }
+        break;
+
+      default:
+        {
+          /* Should not get here */
+        }
+        break;
+    }
+}
+#endif
+
+/****************************************************************************
+ * Name: led_pm_prepare
+ *
+ * Description:
+ *   Request the driver to prepare for a new power state. This is a warning
+ *   that the system is about to enter into a new power state. The driver
+ *   should begin whatever operations that may be required to enter power
+ *   state. The driver may abort the state change mode by returning a
+ *   non-zero value from the callback function.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+static int led_pm_prepare(struct pm_callback_s *cb, int domain,
+                          enum pm_state_e pmstate)
+{
+  /* No preparation to change power modes is required by the LEDs driver.
+   * We always accept the state change by returning OK.
+   */
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_userled_initialize
+ ****************************************************************************/
+
+uint32_t board_userled_initialize(void)
+{
+  /* Configure LED1-4 GPIOs for output */
+
+  lpc17_40_configgpio(MBED_LED1);
+  lpc17_40_configgpio(MBED_LED2);
+  lpc17_40_configgpio(MBED_LED3);
+  lpc17_40_configgpio(MBED_LED4);
+  return MBED_NLEDS;
+}
+
+/****************************************************************************
+ * Name: board_userled
+ ****************************************************************************/
+
+void board_userled(int led, bool ledon)
+{
+  if ((unsigned)led < MBED_NLEDS)
+    {
+      lpc17_40_gpiowrite(g_ledcfg[led], ledon);
+    }
+}
+
+/****************************************************************************
+ * Name: board_userled_all
+ ****************************************************************************/
+
+void board_userled_all(uint32_t ledset)
+{
+  lpc17_40_gpiowrite(MBED_LED1, (ledset & MBED_LED1_BIT) == 0);
+  lpc17_40_gpiowrite(MBED_LED2, (ledset & MBED_LED2_BIT) == 0);
+  lpc17_40_gpiowrite(MBED_LED3, (ledset & MBED_LED3_BIT) == 0);
+  lpc17_40_gpiowrite(MBED_LED4, (ledset & MBED_LED4_BIT) == 0);
+}
+
+/****************************************************************************
+ * Name: lpc17_40_led_pminitialize
+ ****************************************************************************/
+
+#ifdef CONFIG_PM
+void lpc17_40_led_pminitialize(void)
+{
+  /* Register to receive power management callbacks */
+
+  int ret = pm_register(&g_ledscb);
+  if (ret != OK)
+    {
+      board_autoled_on(LED_ASSERTION);
+    }
+}
+#endif /* CONFIG_PM */
+
+#endif /* !CONFIG_ARCH_LEDS */

--- a/boards/arm/lpc17xx_40xx/mbed/src/mbed.h
+++ b/boards/arm/lpc17xx_40xx/mbed/src/mbed.h
@@ -34,20 +34,19 @@
 
 /* MBED GPIO Pin Definitions ************************************************/
 
-#define MBED_LED1             (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN18)
-#define MBED_LED1_OFF          MBED_LED1
-#define MBED_LED1_ON          (MBED_LED1 | GPIO_VALUE_ONE)
-#define MBED_LED2             (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN20)
-#define MBED_LED2_OFF          MBED_LED2
-#define MBED_LED2_ON          (MBED_LED2 | GPIO_VALUE_ONE)
-#define MBED_LED3             (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN21)
-#define MBED_LED3_OFF          MBED_LED3
-#define MBED_LED3_ON          (MBED_LED3 | GPIO_VALUE_ONE)
-#define MBED_LED4             (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN23)
-#define MBED_LED4_OFF         MBED_LED4
-#define MBED_LED4_ON          (MBED_LED 4| GPIO_VALUE_ONE)
+#define MBED_LED1        (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN18)
+#define MBED_LED2        (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN20)
+#define MBED_LED3        (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN21)
+#define MBED_LED4        (GPIO_OUTPUT | GPIO_PORT1 | GPIO_PIN23)
+#define MBED_HEARTBEAT   MBED_LED4
 
-#define MBED_HEARTBEAT        MBED_LED4
+/* LED bits for use with board_userled_all() */
+#define MBED_NLEDS      4
+
+#define MBED_LED1_BIT    (1 << 0)
+#define MBED_LED2_BIT    (1 << 1)
+#define MBED_LED3_BIT    (1 << 2)
+#define MBED_LED4_BIT    (1 << 3)
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
lpc17_40_userleds.c: Adds the support of Userleds driver which
provides a device to manipulate the 4 leds of the board through the
/dev/userleds.

lpc17_40_leds.c: Removes not used definitions, eg. MBED_LED3_ON.

Board LED Status support(CONFIG_ARCH_LED=y) and Device Drivers/Led
Support(CONFIG_ARCH_USERLED=y) can not be enable together.

Signed-off-by: Gustavo L F Walbon <gwalbon@linux.ibm.com>

## Summary

## Impact

## Testing

