### PR TITLE
Improvements for libdsp and support for fixed16 libdsp implementation

### DIFF
--- a/boards/arm/stm32/stm32f334-disco/src/stm32_smps.c
+++ b/boards/arm/stm32/stm32f334-disco/src/stm32_smps.c
@@ -431,6 +431,10 @@ static int smps_start(FAR struct smps_dev_s *dev)
   /* Set PID controller saturation */
 
   pid_saturation_set(&priv->pid, 0.0, BOOST_VOLT_MAX);
+
+  /* Reset PI integral if saturated */
+
+  pi_ireset_enable(&priv->pid, true);
 #endif
 
   /* Get TIMA period value for given frequency */

--- a/boards/arm/stm32/stm32f334-disco/src/stm32_smps.c
+++ b/boards/arm/stm32/stm32f334-disco/src/stm32_smps.c
@@ -205,14 +205,14 @@ struct smps_lower_dev_s
 
 struct smps_priv_s
 {
-  uint8_t           conv_mode;   /* Converter mode */
-  uint16_t          v_in_raw;    /* Voltage input RAW value */
-  uint16_t          v_out_raw;   /* Voltage output RAW value */
-  float             v_in;        /* Voltage input real value in V */
-  float             v_out;       /* Voltage output real value in V  */
-  bool              running;     /* Running flag */
-  pid_controller_t  pid;         /* PID controller */
-  float            *c_limit_tab; /* Current limit tab */
+  uint8_t               conv_mode;   /* Converter mode */
+  uint16_t              v_in_raw;    /* Voltage input RAW value */
+  uint16_t              v_out_raw;   /* Voltage output RAW value */
+  float                 v_in;        /* Voltage input real value in V */
+  float                 v_out;       /* Voltage output real value in V  */
+  bool                  running;     /* Running flag */
+  pid_controller_f32_t  pid;         /* PID controller */
+  float                *c_limit_tab; /* Current limit tab */
 };
 
 /****************************************************************************

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -360,10 +360,7 @@ struct foc_data_f32_s
 struct motor_phy_params_f32_s
 {
   uint8_t p;                   /* Number of the motor pole pairs */
-
-  float   res;                 /* Phase-to-neutral temperature compensated
-                                * resistance
-                                */
+  float   res;                 /* Phase-to-neutral resistance */
   float   ind;                 /* Average phase-to-neutral inductance */
   float   one_by_ind;          /* Inverse phase-to-neutral inductance */
 };

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -231,8 +231,6 @@ struct svm3_state_f32_s
   float       d_u;             /* Duty cycle for phase U */
   float       d_v;             /* Duty cycle for phase V */
   float       d_w;             /* Duty cycle for phase W */
-  float       d_max;           /* Duty cycle max */
-  float       d_min;           /* Duty cycle min */
 };
 
 /* Motor open-loop control data */
@@ -411,10 +409,10 @@ void phase_angle_update(FAR struct phase_angle_f32_s *angle, float val);
 
 /* 3-phase system space vector modulation */
 
-void svm3_init(FAR struct svm3_state_f32_s *s, float min, float max);
+void svm3_init(FAR struct svm3_state_f32_s *s);
 void svm3(FAR struct svm3_state_f32_s *s, FAR ab_frame_f32_t *ab);
 void svm3_current_correct(FAR struct svm3_state_f32_s *s,
-                          int32_t *c0, int32_t *c1, int32_t *c2);
+                          float *c0, float *c1, float *c2);
 
 /* Field Oriented control */
 

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -56,6 +56,7 @@
 
 /* Phase rotation direction */
 
+#define DIR_NONE (0.0f)
 #define DIR_CW   (1.0f)
 #define DIR_CCW  (-1.0f)
 

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -177,17 +177,24 @@ typedef struct float_sat_f32_s float_sat_f32_t;
 
 struct pid_controller_f32_s
 {
-  float           out;          /* Controller output */
-  float_sat_f32_t sat;          /* Output saturation */
-  float           err;          /* Current error value */
-  float           err_prev;     /* Previous error value */
-  float           KP;           /* Proportional coefficient */
-  float           KI;           /* Integral coefficient */
-  float           KD;           /* Derivative coefficient */
-  float           part[3];      /* 0 - proporitonal part
-                                 * 1 - integral part
-                                 * 2 - derivative part
-                                 */
+  bool            aw_en;       /* Integral part decay if saturated */
+  bool            ireset_en;   /* Intergral part reset if saturated */
+  bool            pisat_en;    /* PI saturation enabled */
+  bool            pidsat_en;   /* PID saturation enabled */
+  bool            _res;        /* Reserved */
+  float           out;         /* Controller output */
+  float_sat_f32_t sat;         /* Output saturation */
+  float           err;         /* Current error value */
+  float           err_prev;    /* Previous error value */
+  float           KP;          /* Proportional coefficient */
+  float           KI;          /* Integral coefficient */
+  float           KD;          /* Derivative coefficient */
+  float           part[3];     /* 0 - proporitonal part
+                                * 1 - integral part
+                                * 2 - derivative part
+                                */
+  float           KC;          /* Integral anti-windup decay coefficient */
+  float           aw;          /* Integral anti-windup decay part */
 };
 
 typedef struct pid_controller_f32_s pid_controller_f32_t;
@@ -390,6 +397,9 @@ void pid_integral_reset(FAR pid_controller_f32_t *pid);
 void pi_integral_reset(FAR pid_controller_f32_t *pid);
 float pi_controller(FAR pid_controller_f32_t *pid, float err);
 float pid_controller(FAR pid_controller_f32_t *pid, float err);
+void pi_antiwindup_enable(FAR pid_controller_f32_t *pid, float KC,
+                          bool enable);
+void pi_ireset_enable(FAR pid_controller_f32_t *pid, bool enable);
 
 /* Transformation functions */
 

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -44,9 +44,10 @@
 #  ifndef CONFIG_DEBUG_ASSERTIONS
 #    warning "Need CONFIG_DEBUG_ASSERTIONS to work properly"
 #  endif
+#  define LIBDSP_DEBUGASSERT(x) DEBUGASSERT(x)
 #else
-#  undef DEBUGASSERT
-#  define DEBUGASSERT(x)
+#  undef LIBDSP_DEBUGASSERT
+#  define LIBDSP_DEBUGASSERT(x)
 #endif
 
 #ifndef CONFIG_LIBDSP_PRECISION

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -237,7 +237,6 @@ struct svm3_state_f32_s
 
 struct openloop_data_f32_s
 {
-  float max;           /* Open-loop max speed */
   float angle;         /* Open-loop current angle normalized to <0.0, 2PI> */
   float per;           /* Open-loop control execution period */
 };
@@ -445,8 +444,7 @@ void motor_sobserver_div(FAR struct motor_observer_f32_s *o,
 
 /* Motor openloop control */
 
-void motor_openloop_init(FAR struct openloop_data_f32_s *op,
-                         float max, float per);
+void motor_openloop_init(FAR struct openloop_data_f32_s *op, float per);
 void motor_openloop(FAR struct openloop_data_f32_s *op, float speed,
                     float dir);
 float motor_openloop_angle_get(FAR struct openloop_data_f32_s *op);

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -252,11 +252,11 @@ struct openloop_data_f32_s
 
 struct motor_observer_f32_s
 {
-  float angle;               /* Estimated observer angle */
-  float speed;               /* Estimated observer speed */
-  float per;                 /* Observer execution period */
+  float angle;             /* Estimated observer angle */
+  float speed;             /* Estimated observer speed */
+  float per;               /* Observer execution period */
 
-  float angle_err;           /* Observer angle error.
+  float angle_err;         /* Observer angle error.
                               * This can be used to gradually eliminate
                               * error between openloop angle and observer
                               * angle
@@ -274,13 +274,13 @@ struct motor_observer_f32_s
 
 struct motor_sobserver_div_f32_s
 {
-  float angle_diff;             /* Mechanical angle difference */
-  float angle_acc;              /* Accumulated mechanical angle */
-  float angle_prev;             /* Previous mechanical angle */
-  float one_by_dt;              /* Frequency of observer execution */
-  float cntr;                   /* Sample counter */
-  float samples;                /* Number of samples for observer */
-  float filter;                 /* Low-pass filter for final omega */
+  float angle_diff;           /* Mechanical angle difference */
+  float angle_acc;            /* Accumulated mechanical angle */
+  float angle_prev;           /* Previous mechanical angle */
+  float one_by_dt;            /* Frequency of observer execution */
+  float cntr;                 /* Sample counter */
+  float samples;              /* Number of samples for observer */
+  float filter;               /* Low-pass filter for final omega */
 };
 
 /* Speed observer PLL method data */
@@ -297,6 +297,7 @@ struct motor_observer_smo_f32_s
 {
   float k_slide;        /* Bang-bang controller gain */
   float err_max;        /* Linear mode threshold */
+  float one_by_err_max; /* One by err_max */
   float F;              /* Current observer F gain (1-Ts*R/L) */
   float G;              /* Current observer G gain (Ts/L) */
   float emf_lp_filter1; /* Adaptive first low pass EMF filter */

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -131,14 +131,14 @@
  * Besides angle value it also stores sine and cosine values for given angle.
  */
 
-struct phase_angle_s
+struct phase_angle_f32_s
 {
   float   angle;               /* Phase angle in radians <0, 2PI> */
   float   sin;                 /* Phase angle sine */
   float   cos;                 /* Phase angle cosine */
 };
 
-typedef struct phase_angle_s phase_angle_t;
+typedef struct phase_angle_f32_s phase_angle_f32_t;
 
 /* This structure stores motor angles and corresponding sin and cos values
  *
@@ -153,78 +153,78 @@ typedef struct phase_angle_s phase_angle_t;
  *  NOTE: pole_pairs = poles_total/2
  */
 
-struct motor_angle_s
+struct motor_angle_f32_s
 {
-  phase_angle_t angle_el;      /* Electrical angle */
-  float         anglem;        /* Mechanical angle in radians <0, 2PI> */
-  float         one_by_p;      /* Aux variable */
-  uint8_t       p;             /* Number of the motor pole pairs */
-  int8_t        i;             /* Pole counter */
+  phase_angle_f32_t angle_el;  /* Electrical angle */
+  float             anglem;    /* Mechanical angle in radians <0, 2PI> */
+  float             one_by_p;  /* Aux variable */
+  uint8_t           p;         /* Number of the motor pole pairs */
+  int8_t            i;         /* Pole counter */
 };
 
 /* Float number saturaton */
 
-struct float_sat_s
+struct float_sat_f32_s
 {
   float min;                    /* Lower limit */
   float max;                    /* Upper limit */
 };
 
-typedef struct float_sat_s float_sat_t;
+typedef struct float_sat_f32_s float_sat_f32_t;
 
 /* PI/PID controller state structure */
 
-struct pid_controller_s
+struct pid_controller_f32_s
 {
-  float       out;              /* Controller output */
-  float_sat_t sat;              /* Output saturation */
-  float       err;              /* Current error value */
-  float       err_prev;         /* Previous error value */
-  float       KP;               /* Proportional coefficient */
-  float       KI;               /* Integral coefficient */
-  float       KD;               /* Derivative coefficient */
-  float       part[3];          /* 0 - proporitonal part
+  float           out;          /* Controller output */
+  float_sat_f32_t sat;          /* Output saturation */
+  float           err;          /* Current error value */
+  float           err_prev;     /* Previous error value */
+  float           KP;           /* Proportional coefficient */
+  float           KI;           /* Integral coefficient */
+  float           KD;           /* Derivative coefficient */
+  float           part[3];      /* 0 - proporitonal part
                                  * 1 - integral part
                                  * 2 - derivative part
                                  */
 };
 
-typedef struct pid_controller_s pid_controller_t;
+typedef struct pid_controller_f32_s pid_controller_f32_t;
 
 /* This structure represents the ABC frame (3 phase vector) */
 
-struct abc_frame_s
+struct abc_frame_f32_s
 {
   float a;                     /* A component */
   float b;                     /* B component */
   float c;                     /* C component */
 };
 
-typedef struct abc_frame_s abc_frame_t;
+typedef struct abc_frame_f32_s abc_frame_f32_t;
 
 /* This structure represents the alpha-beta frame (2 phase vector) */
 
-struct ab_frame_s
+struct ab_frame_f32_s
 {
   float a;                     /* Alpha component */
   float b;                     /* Beta component */
 };
 
-typedef struct ab_frame_s ab_frame_t;
+typedef struct ab_frame_f32_s ab_frame_f32_t;
 
 /* This structure represent the direct-quadrature frame */
 
-struct dq_frame_s
+struct dq_frame_f32_s
 {
   float d;                     /* Driect component */
   float q;                     /* Quadrature component */
 };
 
-typedef struct dq_frame_s dq_frame_t;
+typedef struct dq_frame_f32_s dq_frame_f32_t;
 
 /* Space Vector Modulation data for 3-phase system */
 
-struct svm3_state_s
+struct svm3_state_f32_s
 {
   uint8_t     sector;          /* Current space vector sector */
   float       d_u;             /* Duty cycle for phase U */
@@ -236,7 +236,7 @@ struct svm3_state_s
 
 /* Motor open-loop control data */
 
-struct openloop_data_s
+struct openloop_data_f32_s
 {
   float max;           /* Open-loop max speed */
   float angle;         /* Open-loop current angle normalized to <0.0, 2PI> */
@@ -245,7 +245,7 @@ struct openloop_data_s
 
 /* Common motor observer structure */
 
-struct motor_observer_s
+struct motor_observer_f32_s
 {
   float angle;               /* Estimated observer angle */
   float speed;               /* Estimated observer speed */
@@ -267,7 +267,7 @@ struct motor_observer_s
 
 /* Speed observer division method data */
 
-struct motor_sobserver_div_s
+struct motor_sobserver_div_f32_s
 {
   float angle_diff;             /* Mechanical angle difference */
   float angle_acc;              /* Accumulated mechanical angle */
@@ -280,7 +280,7 @@ struct motor_sobserver_div_s
 
 /* Speed observer PLL method data */
 #if 0
-struct motor_sobserver_pll_s
+struct motor_sobserver_pll_f32_s
 {
   /* TODO */
 };
@@ -288,7 +288,7 @@ struct motor_sobserver_pll_s
 
 /* Motor Sliding Mode Observer private data */
 
-struct motor_observer_smo_s
+struct motor_observer_smo_f32_s
 {
   float k_slide;        /* Bang-bang controller gain */
   float err_max;        /* Linear mode threshold */
@@ -296,13 +296,13 @@ struct motor_observer_smo_s
   float G;              /* Current observer G gain (Ts/L) */
   float emf_lp_filter1; /* Adaptive first low pass EMF filter */
   float emf_lp_filter2; /* Adaptive second low pass EMF filter */
-  ab_frame_t emf;       /* Estimated back-EMF */
-  ab_frame_t emf_f;     /* Fitlered estimated back-EMF */
-  ab_frame_t z;         /* Correction factor */
-  ab_frame_t i_est;     /* Estimated idq current */
-  ab_frame_t v_err;     /* v_err = v_ab - emf */
-  ab_frame_t i_err;     /* i_err = i_est - i_dq */
-  ab_frame_t sign;      /* Bang-bang controller sign */
+  ab_frame_f32_t emf;   /* Estimated back-EMF */
+  ab_frame_f32_t emf_f; /* Fitlered estimated back-EMF */
+  ab_frame_f32_t z;     /* Correction factor */
+  ab_frame_f32_t i_est; /* Estimated idq current */
+  ab_frame_f32_t v_err; /* v_err = v_ab - emf */
+  ab_frame_f32_t i_err; /* i_err = i_est - i_dq */
+  ab_frame_f32_t sign;  /* Bang-bang controller sign */
 };
 
 /* Motor physical parameters.
@@ -310,7 +310,7 @@ struct motor_observer_smo_s
  * but probably can be used to describe different types of motors.
  */
 
-struct motor_phy_params_s
+struct motor_phy_params_f32_s
 {
   uint8_t p;                   /* Number of the motor pole pairs */
 
@@ -328,23 +328,24 @@ struct motor_phy_params_s
  * REVISIT:
  */
 
-struct foc_data_s
+struct foc_data_f32_s
 {
-  abc_frame_t      v_abc;    /* Voltage in ABC frame */
-  ab_frame_t       v_ab;     /* Voltage in alpha-beta frame */
-  dq_frame_t       v_dq;     /* Voltage in dq frame */
-  ab_frame_t       v_ab_mod; /* Modulation voltage normalized to
+  abc_frame_f32_t  v_abc;    /* Voltage in ABC frame */
+  ab_frame_f32_t   v_ab;     /* Voltage in alpha-beta frame */
+  dq_frame_f32_t   v_dq;     /* Voltage in dq frame */
+  ab_frame_f32_t   v_ab_mod; /* Modulation voltage normalized to
                               * magnitude (0.0, 1.0)
                               */
 
-  abc_frame_t      i_abc;    /* Current in ABC frame */
-  ab_frame_t       i_ab;     /* Current in apha-beta frame */
-  dq_frame_t       i_dq;     /* Current in dq frame */
-  dq_frame_t       i_dq_err; /* DQ current error */
+  abc_frame_f32_t  i_abc;    /* Current in ABC frame */
+  ab_frame_f32_t   i_ab;     /* Current in apha-beta frame */
+  dq_frame_f32_t   i_dq;     /* Current in dq frame */
+  dq_frame_f32_t   i_dq_err; /* DQ current error */
 
-  dq_frame_t       i_dq_ref; /* Current dq reference frame */
-  pid_controller_t id_pid;   /* Current d-axis component PI controller */
-  pid_controller_t iq_pid;   /* Current q-axis component PI controller */
+  dq_frame_f32_t   i_dq_ref; /* Current dq reference frame */
+
+  pid_controller_f32_t id_pid;   /* Current d-axis component PI controller */
+  pid_controller_f32_t iq_pid;   /* Current q-axis component PI controller */
 
   float vdq_mag_max;         /* Maximum dq voltage magnitude */
   float vab_mod_scale;       /* Voltage alpha-beta modulation scale */
@@ -376,95 +377,96 @@ void f_saturate(FAR float *val, float min, float max);
 float vector2d_mag(float x, float y);
 void vector2d_saturate(FAR float *x, FAR float *y, float max);
 
-void dq_saturate(FAR dq_frame_t *dq, float max);
-float dq_mag(FAR dq_frame_t *dq);
+void dq_saturate(FAR dq_frame_f32_t *dq, float max);
+float dq_mag(FAR dq_frame_f32_t *dq);
 
 /* PID controller functions */
 
-void pid_controller_init(FAR pid_controller_t *pid,
+void pid_controller_init(FAR pid_controller_f32_t *pid,
                          float KP, float KI, float KD);
-void pi_controller_init(FAR pid_controller_t *pid,
+void pi_controller_init(FAR pid_controller_f32_t *pid,
                         float KP, float KI);
-void pid_saturation_set(FAR pid_controller_t *pid, float min, float max);
-void pi_saturation_set(FAR pid_controller_t *pid, float min, float max);
-void pid_integral_reset(FAR pid_controller_t *pid);
-void pi_integral_reset(FAR pid_controller_t *pid);
-float pi_controller(FAR pid_controller_t *pid, float err);
-float pid_controller(FAR pid_controller_t *pid, float err);
+void pid_saturation_set(FAR pid_controller_f32_t *pid, float min, float max);
+void pi_saturation_set(FAR pid_controller_f32_t *pid, float min, float max);
+void pid_integral_reset(FAR pid_controller_f32_t *pid);
+void pi_integral_reset(FAR pid_controller_f32_t *pid);
+float pi_controller(FAR pid_controller_f32_t *pid, float err);
+float pid_controller(FAR pid_controller_f32_t *pid, float err);
 
 /* Transformation functions */
 
-void clarke_transform(FAR abc_frame_t *abc, FAR ab_frame_t *ab);
-void inv_clarke_transform(FAR ab_frame_t *ab, FAR abc_frame_t *abc);
-void park_transform(FAR phase_angle_t *angle, FAR ab_frame_t *ab,
-                    FAR dq_frame_t *dq);
-void inv_park_transform(FAR phase_angle_t *angle, FAR dq_frame_t *dq,
-                        FAR ab_frame_t *ab);
+void clarke_transform(FAR abc_frame_f32_t *abc, FAR ab_frame_f32_t *ab);
+void inv_clarke_transform(FAR ab_frame_f32_t *ab, FAR abc_frame_f32_t *abc);
+void park_transform(FAR phase_angle_f32_t *angle, FAR ab_frame_f32_t *ab,
+                    FAR dq_frame_f32_t *dq);
+void inv_park_transform(FAR phase_angle_f32_t *angle, FAR dq_frame_f32_t *dq,
+                        FAR ab_frame_f32_t *ab);
 
 /* Phase angle related functions */
 
 void angle_norm(FAR float *angle, float per, float bottom, float top);
 void angle_norm_2pi(FAR float *angle, float bottom, float top);
-void phase_angle_update(FAR struct phase_angle_s *angle, float val);
+void phase_angle_update(FAR struct phase_angle_f32_s *angle, float val);
 
 /* 3-phase system space vector modulation */
 
-void svm3_init(FAR struct svm3_state_s *s, float min, float max);
-void svm3(FAR struct svm3_state_s *s, FAR ab_frame_t *ab);
-void svm3_current_correct(FAR struct svm3_state_s *s,
+void svm3_init(FAR struct svm3_state_f32_s *s, float min, float max);
+void svm3(FAR struct svm3_state_f32_s *s, FAR ab_frame_f32_t *ab);
+void svm3_current_correct(FAR struct svm3_state_f32_s *s,
                           int32_t *c0, int32_t *c1, int32_t *c2);
 
 /* Field Oriented control */
 
-void foc_vbase_update(FAR struct foc_data_s *foc, float vbase);
-void foc_idq_ref_set(FAR struct foc_data_s *data, float d, float q);
+void foc_vbase_update(FAR struct foc_data_f32_s *foc, float vbase);
+void foc_idq_ref_set(FAR struct foc_data_f32_s *data, float d, float q);
 
-void foc_init(FAR struct foc_data_s *data,
+void foc_init(FAR struct foc_data_f32_s *data,
               float id_kp, float id_ki, float iq_kp, float iq_ki);
-void foc_process(FAR struct foc_data_s *foc,
-                 FAR abc_frame_t *i_abc,
-                 FAR phase_angle_t *angle);
+void foc_process(FAR struct foc_data_f32_s *foc,
+                 FAR abc_frame_f32_t *i_abc,
+                 FAR phase_angle_f32_t *angle);
 
 /* BLDC/PMSM motor observers */
 
-void motor_observer_init(FAR struct motor_observer_s *observer,
+void motor_observer_init(FAR struct motor_observer_f32_s *observer,
                          FAR void *ao, FAR void *so, float per);
-float motor_observer_speed_get(FAR struct motor_observer_s *o);
-float motor_observer_angle_get(FAR struct motor_observer_s *o);
+float motor_observer_speed_get(FAR struct motor_observer_f32_s *o);
+float motor_observer_angle_get(FAR struct motor_observer_f32_s *o);
 
-void motor_observer_smo_init(FAR struct motor_observer_smo_s *smo,
+void motor_observer_smo_init(FAR struct motor_observer_smo_f32_s *smo,
                              float kslide, float err_max);
-void motor_observer_smo(FAR struct motor_observer_s *o,
-                        FAR ab_frame_t *i_ab, FAR ab_frame_t *v_ab,
-                        FAR struct motor_phy_params_s *phy, float dir);
+void motor_observer_smo(FAR struct motor_observer_f32_s *o,
+                        FAR ab_frame_f32_t *i_ab, FAR ab_frame_f32_t *v_ab,
+                        FAR struct motor_phy_params_f32_s *phy, float dir);
 
-void motor_sobserver_div_init(FAR struct motor_sobserver_div_s *so,
+void motor_sobserver_div_init(FAR struct motor_sobserver_div_f32_s *so,
                               uint8_t samples, float filer, float per);
-void motor_sobserver_div(FAR struct motor_observer_s *o,
+void motor_sobserver_div(FAR struct motor_observer_f32_s *o,
                          float angle, float dir);
 
 /* Motor openloop control */
 
-void motor_openloop_init(FAR struct openloop_data_s *op,
+void motor_openloop_init(FAR struct openloop_data_f32_s *op,
                          float max, float per);
-void motor_openloop(FAR struct openloop_data_s *op, float speed, float dir);
-float motor_openloop_angle_get(FAR struct openloop_data_s *op);
+void motor_openloop(FAR struct openloop_data_f32_s *op, float speed,
+                    float dir);
+float motor_openloop_angle_get(FAR struct openloop_data_f32_s *op);
 
 /* Motor angle */
 
-void motor_angle_init(FAR struct motor_angle_s *angle, uint8_t p);
-void motor_angle_e_update(FAR struct motor_angle_s *angle,
+void motor_angle_init(FAR struct motor_angle_f32_s *angle, uint8_t p);
+void motor_angle_e_update(FAR struct motor_angle_f32_s *angle,
                           float angle_new, float dir);
-void motor_angle_m_update(FAR struct motor_angle_s *angle,
+void motor_angle_m_update(FAR struct motor_angle_f32_s *angle,
                           float angle_new, float dir);
-float motor_angle_m_get(FAR struct motor_angle_s *angle);
-float motor_angle_e_get(FAR struct motor_angle_s *angle);
+float motor_angle_m_get(FAR struct motor_angle_f32_s *angle);
+float motor_angle_e_get(FAR struct motor_angle_f32_s *angle);
 
 /* Motor physical parameters functions */
 
-void motor_phy_params_init(FAR struct motor_phy_params_s *phy, uint8_t poles,
-                            float res, float ind);
-void motor_phy_params_temp_set(FAR struct motor_phy_params_s *phy,
+void motor_phy_params_init(FAR struct motor_phy_params_f32_s *phy,
+                           uint8_t poles, float res, float ind);
+void motor_phy_params_temp_set(FAR struct motor_phy_params_f32_s *phy,
                                float res_alpha, float res_temp_ref);
 
 #undef EXTERN

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -324,9 +324,6 @@ struct motor_phy_params_f32_s
   float   res;                 /* Phase-to-neutral temperature compensated
                                 * resistance
                                 */
-  float   res_base;            /* Phase-to-neutral base resistance */
-  float   res_alpha;           /* Temperature coefficient of resistance */
-  float   res_temp_ref;        /* Reference temperature of alpha */
   float   ind;                 /* Average phase-to-neutral inductance */
   float   one_by_ind;          /* Inverse phase-to-neutral inductance */
 };

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -113,7 +113,7 @@
  *  Get maximum voltage for SVM3 without overmodulation
  *
  *  Notes:
- *   max possible phase voltage for 3-phase power inwerter:
+ *   max possible phase voltage for 3-phase power inverter:
  *     Vd = (2/3)*Vdc
  *   max phase reference voltage according to SVM modulation diagram:
  *     Vrefmax = Vd * cos(30*) = SQRT3_BY_2 * Vd

--- a/include/dspb16.h
+++ b/include/dspb16.h
@@ -1,0 +1,480 @@
+/****************************************************************************
+ * include/dspb16.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_DSPB16_H
+#define __INCLUDE_DSPB16_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/compiler.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <fixedmath.h>
+
+#include <assert.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Disable DEBUGASSERT macro if LIBDSP debug is not enabled */
+
+#ifdef CONFIG_LIBDSP_DEBUG
+#  ifndef CONFIG_DEBUG_ASSERTIONS
+#    warning "Need CONFIG_DEBUG_ASSERTIONS to work properly"
+#  endif
+#  define LIBDSP_DEBUGASSERT(x) DEBUGASSERT(x)
+#else
+#  undef LIBDSP_DEBUGASSERT
+#  define LIBDSP_DEBUGASSERT(x)
+#endif
+
+#ifndef CONFIG_LIBDSP_PRECISION
+#  define CONFIG_LIBDSP_PRECISION 0
+#endif
+
+/* Phase rotation direction */
+
+#define DIR_NONE_B16 ftob16(0.0f)
+#define DIR_CW_B16   ftob16(1.0f)
+#define DIR_CCW_B16  ftob16(-1.0f)
+
+/* Some math constants ******************************************************/
+
+#define SQRT3_BY_TWO_B16     ftob16(0.866025f)
+#define SQRT3_BY_THREE_B16   ftob16(0.57735f)
+#define ONE_BY_SQRT3_B16     ftob16(0.57735f)
+#define TWO_BY_SQRT3_B16     ftob16(1.15470f)
+
+/* Some lib constants *******************************************************/
+
+/* Motor electrical angle is in range 0.0 to 2*PI */
+
+#define MOTOR_ANGLE_E_MAX_B16    (b16TWOPI)
+#define MOTOR_ANGLE_E_MIN_B16    (0)
+#define MOTOR_ANGLE_E_RANGE_B16  (MOTOR_ANGLE_E_MAX_B16 - MOTOR_ANGLE_E_MIN_B16)
+
+/* Motor mechanical angle is in range 0.0 to 2*PI */
+
+#define MOTOR_ANGLE_M_MAX_B16    (b16TWOPI)
+#define MOTOR_ANGLE_M_MIN_B16    (0)
+#define MOTOR_ANGLE_M_RANGE_B16  (MOTOR_ANGLE_M_MAX_B16 - MOTOR_ANGLE_M_MIN_B16)
+
+/* Some useful macros *******************************************************/
+
+/****************************************************************************
+ * Name: LP_FILTER_B16
+ *
+ * Description:
+ *   Simple single-pole digital low pass filter:
+ *     Y(n) = (1-beta)*Y(n-1) + beta*X(n) = (beta * (Y(n-1) - X(n)))
+ *
+ *     filter - (0.0 - 1.0) where 1.0 gives unfiltered values
+ *     filter = T * (2*PI) * f_c
+ *
+ *     phase shift = -arctan(f_in/f_c)
+ *
+ *     T    - period at which the digital filter is being calculated
+ *     f_in - input frequency of the filter
+ *     f_c  - cutoff frequency of the filter
+ *
+ * REFERENCE: https://www.embeddedrelated.com/showarticle/779.php
+ *
+ ****************************************************************************/
+
+#define LP_FILTER_B16(val, sample, filter) val -= (b16mulb16(filter, (val - sample)))
+
+/****************************************************************************
+ * Name: SVM3_BASE_VOLTAGE_GET_B16
+ *
+ * Description:
+ *  Get maximum voltage for SVM3 without overmodulation
+ *
+ *  Notes:
+ *   max possible phase voltage for 3-phase power inwerter:
+ *     Vd = (2/3)*Vdc
+ *   max phase reference voltage according to SVM modulation diagram:
+ *     Vrefmax = Vd * cos(30*) = SQRT3_BY_2 * Vd
+ *   which give us:
+ *     Vrefmax = SQRT3_BY_3 * Vdc
+ *
+ *   Vdc - bus voltage
+ *
+ ****************************************************************************/
+
+#define SVM3_BASE_VOLTAGE_GET_B16(vbus) (b16mulb16(vbus, SQRT3_BY_THREE_B16))
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* This structure represents phase angle.
+ * Besides angle value it also stores sine and cosine values for given angle.
+ */
+
+struct phase_angle_b16_s
+{
+  b16_t   angle;               /* Phase angle in radians <0, 2PI> */
+  b16_t   sin;                 /* Phase angle sine */
+  b16_t   cos;                 /* Phase angle cosine */
+};
+
+typedef struct phase_angle_b16_s phase_angle_b16_t;
+
+/* This structure stores motor angles and corresponding sin and cos values
+ *
+ * th_el = th_m * pole_pairs
+ * th_m = th_el/pole_pairs
+ *
+ * where:
+ *   th_el      - motor electrical angle
+ *   th_m       - motor mechanical angle
+ *   pole_pairs - motor pole pairs
+ *
+ *  NOTE: pole_pairs = poles_total/2
+ */
+
+struct motor_angle_b16_s
+{
+  phase_angle_b16_t angle_el;  /* Electrical angle */
+  b16_t             anglem;    /* Mechanical angle in radians <0, 2PI> */
+  b16_t             one_by_p;  /* Aux variable */
+  uint8_t           p;         /* Number of the motor pole pairs */
+  int8_t            i;         /* Pole counter */
+};
+
+/* Float number saturaton */
+
+struct float_sat_b16_s
+{
+  b16_t min;                    /* Lower limit */
+  b16_t max;                    /* Upper limit */
+};
+
+typedef struct float_sat_b16_s float_sat_b16_t;
+
+/* PI/PID controller state structure */
+
+struct pid_controller_b16_s
+{
+  bool            aw_en;       /* Integral part decay if saturated */
+  bool            ireset_en;   /* Intergral part reset if saturated */
+  bool            pisat_en;    /* PI saturation enabled */
+  bool            pidsat_en;   /* PID saturation enabled */
+  bool            _res;        /* Reserved */
+  b16_t           out;         /* Controller output */
+  float_sat_b16_t sat;         /* Output saturation */
+  b16_t           err;         /* Current error value */
+  b16_t           err_prev;    /* Previous error value */
+  b16_t           KP;          /* Proportional coefficient */
+  b16_t           KI;          /* Integral coefficient */
+  b16_t           KD;          /* Derivative coefficient */
+  b16_t           part[3];     /* 0 - proporitonal part
+                                * 1 - integral part
+                                * 2 - derivative part
+                                */
+  b16_t           KC;          /* Integral anti-windup decay coefficient */
+  b16_t           aw;          /* Integral anti-windup decay part */
+};
+
+typedef struct pid_controller_b16_s pid_controller_b16_t;
+
+/* This structure represents the ABC frame (3 phase vector) */
+
+struct abc_frame_b16_s
+{
+  b16_t  a;                       /* A component */
+  b16_t  b;                       /* B component */
+  b16_t  c;                       /* C component */
+};
+
+typedef struct abc_frame_b16_s abc_frame_b16_t;
+
+/* This structure represents the alpha-beta frame (2 phase vector) */
+
+struct ab_frame_b16_s
+{
+  b16_t  a;                       /* Alpha component */
+  b16_t  b;                       /* Beta component */
+};
+
+typedef struct ab_frame_b16_s ab_frame_b16_t;
+
+/* This structure represent the direct-quadrature frame */
+
+struct dq_frame_b16_s
+{
+  b16_t  d;                       /* Driect component */
+  b16_t  q;                       /* Quadrature component */
+};
+
+typedef struct dq_frame_b16_s dq_frame_b16_t;
+
+/* Space Vector Modulation data for 3-phase system */
+
+struct svm3_state_b16_s
+{
+  uint8_t   sector;          /* Current space vector sector */
+  b16_t     d_u;             /* Duty cycle for phase U */
+  b16_t     d_v;             /* Duty cycle for phase V */
+  b16_t     d_w;             /* Duty cycle for phase W */
+};
+
+/* FOC initialize data */
+
+struct foc_initdata_b16_s
+{
+  b16_t id_kp;                  /* KP for d current */
+  b16_t id_ki;                  /* KI for d current */
+  b16_t iq_kp;                  /* KP for q current */
+  b16_t iq_ki;                  /* KI for q current */
+};
+
+/* Field Oriented Control (FOC) data */
+
+struct foc_data_b16_s
+{
+  abc_frame_b16_t  v_abc;    /* Voltage in ABC frame */
+  ab_frame_b16_t   v_ab;     /* Voltage in alpha-beta frame */
+  dq_frame_b16_t   v_dq;     /* Requested voltage in dq frame */
+  ab_frame_b16_t   v_ab_mod; /* Modulation voltage normalized to
+                              * magnitude (0.0, 1.0)
+                              */
+
+  abc_frame_b16_t  i_abc;    /* Current in ABC frame */
+  ab_frame_b16_t   i_ab;     /* Current in alpha-beta frame */
+  dq_frame_b16_t   i_dq;     /* Current in dq frame */
+  dq_frame_b16_t   i_dq_err; /* DQ current error */
+
+  dq_frame_b16_t   i_dq_ref; /* Requested current for the FOC
+                              * current controler
+                              */
+
+  pid_controller_b16_t id_pid; /* Current d-axis component PI controller */
+  pid_controller_b16_t iq_pid; /* Current q-axis component PI controller */
+
+  b16_t vdq_mag_max;         /* Maximum dq voltage magnitude */
+  b16_t vab_mod_scale;       /* Voltage alpha-beta modulation scale */
+
+  phase_angle_b16_t   angle; /* Phase angle */
+};
+
+/* Motor physical parameters.
+ * This data structure was designed to work with BLDC/PMSM motors,
+ * but probably can be used to describe different types of motors.
+ */
+
+struct motor_phy_params_b16_s
+{
+  uint8_t p;                   /* Number of the motor pole pairs */
+  b16_t   res;                 /* Phase-to-neutral temperature compensated
+                                * resistance
+                                */
+  b16_t   ind;                 /* Average phase-to-neutral inductance */
+  b16_t   one_by_ind;          /* Inverse phase-to-neutral inductance */
+};
+
+/* PMSM motor physcial parameters */
+
+struct pmsm_phy_params_b16_s
+{
+  struct motor_phy_params_b16_s motor;       /* Motor common PHY */
+  b16_t                         iner;        /* Rotor inertia */
+  b16_t                         flux_link;   /* Flux linkage */
+  b16_t                         ind_d;       /* d-inductance */
+  b16_t                         ind_q;       /* q-inductance */
+  b16_t                         one_by_iner; /* One by J */
+  b16_t                         one_by_indd; /* One by Ld */
+  b16_t                         one_by_indq; /* One by Lq */
+};
+
+/* PMSM motor model state */
+
+struct pmsm_model_state_b16_s
+{
+  /* Motor model phase current */
+
+  abc_frame_b16_t i_abc;
+  ab_frame_b16_t  i_ab;
+  dq_frame_b16_t  i_dq;
+
+  /* Motor model phase voltage */
+
+  abc_frame_b16_t v_abc;
+  ab_frame_b16_t  v_ab;
+  dq_frame_b16_t  v_dq;
+
+  /* Motor model angle */
+
+  struct motor_angle_b16_s angle;
+
+  /* Angular speed */
+
+  b16_t omega_e;
+  b16_t omega_m;
+};
+
+/* PMSM motor model external conditions */
+
+struct pmsm_model_ext_b16_s
+{
+  b16_t load;                /* Motor model load torque */
+};
+
+/* PMSM motor model */
+
+struct pmsm_model_b16_s
+{
+  struct pmsm_phy_params_b16_s  phy;    /* Motor model physical parameters */
+  struct pmsm_model_state_b16_s state;  /* Motor model state */
+  struct pmsm_model_ext_b16_s   ext;    /* Motor model external conditions */
+  b16_t                         per;    /* Control period */
+  b16_t                         id_int; /* Id integral part */
+  b16_t                         iq_int; /* Iq integral part */
+};
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/* Math functions */
+
+b16_t fast_sin_b16(b16_t angle);
+b16_t fast_sin2_b16(b16_t angle);
+b16_t fast_cos_b16(b16_t angle);
+b16_t fast_cos2_b16(b16_t angle);
+b16_t fast_atan2_b16(b16_t y, b16_t x);
+void  f_saturate_b16(FAR b16_t *val, b16_t min, b16_t max);
+b16_t vector2d_mag_b16(b16_t x, b16_t y);
+void  vector2d_saturate_b16(FAR b16_t *x, FAR b16_t *y, b16_t max);
+void  dq_saturate_b16(FAR dq_frame_b16_t *dq, b16_t max);
+b16_t dq_mag_b16(FAR dq_frame_b16_t *dq);
+
+/* PID controller functions */
+
+void pid_controller_init_b16(FAR pid_controller_b16_t *pid,
+                             b16_t KP, b16_t KI, b16_t KD);
+void pi_controller_init_b16(FAR pid_controller_b16_t *pid,
+                            b16_t KP, b16_t KI);
+void pid_saturation_set_b16(FAR pid_controller_b16_t *pid, b16_t min,
+                            b16_t max);
+void pi_saturation_set_b16(FAR pid_controller_b16_t *pid, b16_t min,
+                           b16_t max);
+void pid_integral_reset_b16(FAR pid_controller_b16_t *pid);
+void pi_integral_reset_b16(FAR pid_controller_b16_t *pid);
+b16_t pi_controller_b16(FAR pid_controller_b16_t *pid, b16_t err);
+b16_t pid_controller_b16(FAR pid_controller_b16_t *pid, b16_t err);
+void pi_antiwindup_enable_b16(FAR pid_controller_b16_t *pid, b16_t KC,
+                              bool enable);
+void pi_ireset_enable_b16(FAR pid_controller_b16_t *pid, bool enable);
+
+/* Transformation functions */
+
+void clarke_transform_b16(FAR abc_frame_b16_t *abc, FAR ab_frame_b16_t *ab);
+void inv_clarke_transform_b16(FAR ab_frame_b16_t *ab,
+                              FAR abc_frame_b16_t *abc);
+void park_transform_b16(FAR phase_angle_b16_t *angle, FAR ab_frame_b16_t *ab,
+                        FAR dq_frame_b16_t *dq);
+void inv_park_transform_b16(FAR phase_angle_b16_t *angle,
+                            FAR dq_frame_b16_t *dq, FAR ab_frame_b16_t *ab);
+
+/* Phase angle related functions */
+
+void angle_norm_b16(FAR b16_t *angle, b16_t per, b16_t bottom, b16_t top);
+void angle_norm_2pi_b16(FAR b16_t *angle, b16_t bottom, b16_t top);
+void phase_angle_update_b16(FAR struct phase_angle_b16_s *angle, b16_t val);
+
+/* 3-phase system space vector modulation */
+
+void svm3_init_b16(FAR struct svm3_state_b16_s *s);
+void svm3_b16(FAR struct svm3_state_b16_s *s, FAR ab_frame_b16_t *ab);
+void svm3_current_correct_b16(FAR struct svm3_state_b16_s *s,
+                              b16_t *c0, b16_t *c1, b16_t *c2);
+
+/* Field Oriented Control */
+
+void foc_init_b16(FAR struct foc_data_b16_s *foc,
+                  FAR struct foc_initdata_b16_s *init);
+void foc_vbase_update_b16(FAR struct foc_data_b16_s *foc, b16_t vbase);
+void foc_angle_update_b16(FAR struct foc_data_b16_s *foc,
+                          FAR phase_angle_b16_t *angle);
+void foc_iabc_update_b16(FAR struct foc_data_b16_s *foc,
+                         FAR abc_frame_b16_t *i_abc);
+void foc_voltage_control_b16(FAR struct foc_data_b16_s *foc,
+                             FAR dq_frame_b16_t *vdq_ref);
+void foc_current_control_b16(FAR struct foc_data_b16_s *foc,
+                             FAR dq_frame_b16_t *idq_ref,
+                             FAR dq_frame_b16_t *vdq_comp,
+                             FAR dq_frame_b16_t *v_dq_ref);
+void foc_vabmod_get_b16(FAR struct foc_data_b16_s *foc,
+                        FAR ab_frame_b16_t *v_ab_mod);
+void foc_vdq_mag_max_get_b16(FAR struct foc_data_b16_s *foc, FAR b16_t *max);
+
+/* Motor angle */
+
+void motor_angle_init_b16(FAR struct motor_angle_b16_s *angle, uint8_t p);
+void motor_angle_e_update_b16(FAR struct motor_angle_b16_s *angle,
+                              b16_t angle_new, b16_t dir);
+void motor_angle_m_update_b16(FAR struct motor_angle_b16_s *angle,
+                              b16_t angle_new, b16_t dir);
+b16_t motor_angle_m_get_b16(FAR struct motor_angle_b16_s *angle);
+b16_t motor_angle_e_get_b16(FAR struct motor_angle_b16_s *angle);
+
+/* Motor physical parameters */
+
+void motor_phy_params_init_b16(FAR struct motor_phy_params_b16_s *phy,
+                               uint8_t poles, b16_t res, b16_t ind);
+
+/* PMSM physical parameters functions */
+
+void pmsm_phy_params_init_b16(FAR struct pmsm_phy_params_b16_s *phy,
+                              uint8_t poles, b16_t res, b16_t ind,
+                              b16_t iner, b16_t flux,
+                              b16_t ind_d, b16_t ind_q);
+
+/* PMSM motor model */
+
+int pmsm_model_initialize_b16(FAR struct pmsm_model_b16_s *model,
+                              FAR struct pmsm_phy_params_b16_s *phy,
+                              b16_t per);
+int pmsm_model_elec_b16(FAR struct pmsm_model_b16_s *model,
+                        FAR ab_frame_b16_t *vab);
+int pmsm_model_mech_b16(FAR struct pmsm_model_b16_s *model, b16_t load);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __INCLUDE_DSPB16_H */

--- a/include/dspb16.h
+++ b/include/dspb16.h
@@ -113,7 +113,7 @@
  *  Get maximum voltage for SVM3 without overmodulation
  *
  *  Notes:
- *   max possible phase voltage for 3-phase power inwerter:
+ *   max possible phase voltage for 3-phase power inverter:
  *     Vd = (2/3)*Vdc
  *   max phase reference voltage according to SVM modulation diagram:
  *     Vrefmax = Vd * cos(30*) = SQRT3_BY_2 * Vd

--- a/libs/libdsp/Kconfig
+++ b/libs/libdsp/Kconfig
@@ -3,7 +3,7 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config LIBDSP
+menuconfig LIBDSP
 	bool "Digital Signal Processing Library"
 	default n
 	---help---
@@ -29,5 +29,8 @@ config LIBDSP_PRECISION
 		0 - the fastest calculation but the lowest precision
 		1 - a little better precision than above, but slowest
 		2 - the most accuracte but the slowest one, use standard math functions.
+
+config LIBDSP_FOC_VABC
+	bool "Libdsp FOC includes voltage abc frame"
 
 endif # LIBDSP

--- a/libs/libdsp/Kconfig
+++ b/libs/libdsp/Kconfig
@@ -26,8 +26,9 @@ config LIBDSP_PRECISION
 	---help---
 		With this option we can select libdsp precision for
 		some of calculations. There are 3 available options:
-		0 - the fastest calculation but the lowest precision
-		1 - a little better precision than above, but slowest
+		0 - the fastest calculation but the lowest precision,
+		1 - increased precision than for option 0 at the expense
+		    of a longer execution time,
 		2 - the most accuracte but the slowest one, use standard math functions.
 
 config LIBDSP_FOC_VABC

--- a/libs/libdsp/Makefile
+++ b/libs/libdsp/Makefile
@@ -29,6 +29,14 @@ CSRCS += lib_foc.c
 CSRCS += lib_misc.c
 CSRCS += lib_motor.c
 CSRCS += lib_pmsm_model.c
+
+CSRCS += lib_pid_b16.c
+CSRCS += lib_svm_b16.c
+CSRCS += lib_transform_b16.c
+CSRCS += lib_foc_b16.c
+CSRCS += lib_misc_b16.c
+CSRCS += lib_motor_b16.c
+CSRCS += lib_pmsm_model_b16.c
 endif
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))

--- a/libs/libdsp/Makefile
+++ b/libs/libdsp/Makefile
@@ -28,6 +28,7 @@ CSRCS += lib_observer.c
 CSRCS += lib_foc.c
 CSRCS += lib_misc.c
 CSRCS += lib_motor.c
+CSRCS += lib_pmsm_model.c
 endif
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))

--- a/libs/libdsp/lib_foc.c
+++ b/libs/libdsp/lib_foc.c
@@ -45,11 +45,11 @@
  *
  ****************************************************************************/
 
-static void foc_current_control(FAR struct foc_data_s *foc)
+static void foc_current_control(FAR struct foc_data_f32_s *foc)
 {
-  FAR pid_controller_t *id_pid = &foc->id_pid;
-  FAR pid_controller_t *iq_pid = &foc->iq_pid;
-  FAR dq_frame_t       *v_dq  = &foc->v_dq;
+  FAR pid_controller_f32_t *id_pid = &foc->id_pid;
+  FAR pid_controller_f32_t *iq_pid = &foc->iq_pid;
+  FAR dq_frame_f32_t       *v_dq   = &foc->v_dq;
 
   /* Get dq current error */
 
@@ -88,7 +88,8 @@ static void foc_current_control(FAR struct foc_data_s *foc)
  *
  ****************************************************************************/
 
-static void foc_vab_mod_scale_set(FAR struct foc_data_s *foc, float scale)
+static void foc_vab_mod_scale_set(FAR struct foc_data_f32_s *foc,
+                                  float scale)
 {
   foc->vab_mod_scale = scale;
 }
@@ -108,7 +109,7 @@ static void foc_vab_mod_scale_set(FAR struct foc_data_s *foc, float scale)
  *
  ****************************************************************************/
 
-static void foc_vdq_mag_max_set(FAR struct foc_data_s *foc, float max)
+static void foc_vdq_mag_max_set(FAR struct foc_data_f32_s *foc, float max)
 {
   foc->vdq_mag_max = max;
 
@@ -140,12 +141,12 @@ static void foc_vdq_mag_max_set(FAR struct foc_data_s *foc, float max)
  *
  ****************************************************************************/
 
-void foc_init(FAR struct foc_data_s *foc,
+void foc_init(FAR struct foc_data_f32_s *foc,
               float id_kp, float id_ki, float iq_kp, float iq_ki)
 {
   /* Reset data */
 
-  memset(foc, 0, sizeof(struct foc_data_s));
+  memset(foc, 0, sizeof(struct foc_data_f32_s));
 
   /* Initialize PI current d component */
 
@@ -172,7 +173,7 @@ void foc_init(FAR struct foc_data_s *foc,
  *
  ****************************************************************************/
 
-void foc_idq_ref_set(FAR struct foc_data_s *foc, float d, float q)
+void foc_idq_ref_set(FAR struct foc_data_f32_s *foc, float d, float q)
 {
   foc->i_dq_ref.d = d;
   foc->i_dq_ref.q = q;
@@ -228,9 +229,9 @@ void foc_vbase_update(FAR struct foc_data_s *foc, float vbase)
  *
  ****************************************************************************/
 
-void foc_process(FAR struct foc_data_s *foc,
-                 FAR abc_frame_t *i_abc,
-                 FAR phase_angle_t *angle)
+void foc_process(FAR struct foc_data_f32_s *foc,
+                 FAR abc_frame_f32_t *i_abc,
+                 FAR phase_angle_f32_t *angle)
 {
   DEBUGASSERT(foc != NULL);
   DEBUGASSERT(i_abc != NULL);

--- a/libs/libdsp/lib_foc.c
+++ b/libs/libdsp/lib_foc.c
@@ -233,9 +233,9 @@ void foc_process(FAR struct foc_data_f32_s *foc,
                  FAR abc_frame_f32_t *i_abc,
                  FAR phase_angle_f32_t *angle)
 {
-  DEBUGASSERT(foc != NULL);
-  DEBUGASSERT(i_abc != NULL);
-  DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(foc != NULL);
+  LIBDSP_DEBUGASSERT(i_abc != NULL);
+  LIBDSP_DEBUGASSERT(angle != NULL);
 
   /* Copy ABC current to foc data */
 

--- a/libs/libdsp/lib_foc_b16.c
+++ b/libs/libdsp/lib_foc_b16.c
@@ -1,0 +1,464 @@
+/****************************************************************************
+ * libs/libdsp/lib_foc_b16.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+#include <stdbool.h>
+
+#include <dspb16.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: foc_current_controler_b16
+ *
+ * Description:
+ *   This function implements FOC current controler algorithm.
+ *
+ * Input Parameters:
+ *   foc      - (in/out) pointer to the FOC data
+ *   v_dq_req - (in) pointer to the voltage DQ request frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void foc_current_controler_b16(FAR struct foc_data_b16_s *foc,
+                                      FAR dq_frame_b16_t *v_dq_req)
+{
+  FAR pid_controller_b16_t *id_pid = &foc->id_pid;
+  FAR pid_controller_b16_t *iq_pid = &foc->iq_pid;
+
+  LIBDSP_DEBUGASSERT(foc != NULL);
+  LIBDSP_DEBUGASSERT(v_dq_req != NULL);
+
+  /* Get dq current error */
+
+  foc->i_dq_err.d = foc->i_dq_ref.d - foc->i_dq.d;
+  foc->i_dq_err.q = foc->i_dq_ref.q - foc->i_dq.q;
+
+  /* NOTE: PI controllers saturation is updated in foc_vdq_mag_max_set() */
+
+  /* PI controller for d-current (flux loop) */
+
+  v_dq_req->d = pi_controller_b16(id_pid, foc->i_dq_err.d);
+
+  /* PI controller for q-current (torque loop) */
+
+  v_dq_req->q = pi_controller_b16(iq_pid, foc->i_dq_err.q);
+}
+
+/****************************************************************************
+ * Name: foc_vab_mod_scale_set_b16
+ *
+ * Description:
+ *
+ * Input Parameters:
+ *   foc   - (in/out) pointer to the FOC data
+ *   scale - (in) scaling factor for alpha-beta voltage
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void foc_vab_mod_scale_set_b16(FAR struct foc_data_b16_s *foc,
+                                      b16_t scale)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+
+  foc->vab_mod_scale = scale;
+}
+
+/****************************************************************************
+ * Name: foc_vdq_mag_max_set_b16
+ *
+ * Description:
+ *   Set maximum dq voltage vector magnitude
+ *
+ * Input Parameters:
+ *   foc - (in/out) pointer to the FOC data
+ *   max - (in) maximum dq voltage magnitude
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void foc_vdq_mag_max_set_b16(FAR struct foc_data_b16_s *foc,
+                                    b16_t max)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+
+  foc->vdq_mag_max = max;
+
+  /* Update regulators saturation */
+
+  pi_saturation_set_b16(&foc->id_pid, -foc->vdq_mag_max, foc->vdq_mag_max);
+  pi_saturation_set_b16(&foc->iq_pid, -foc->vdq_mag_max, foc->vdq_mag_max);
+}
+
+/****************************************************************************
+ * Name: foc_vdq_ref_set_b16
+ *
+ * Description:
+ *   Set dq requested voltage vector
+ *
+ * Input Parameters:
+ *   foc     - (in/out) pointer to the FOC data
+ *   vdq_ref - (in) pointer to the requested idq voltage
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void foc_vdq_ref_set_b16(FAR struct foc_data_b16_s *foc,
+                                FAR dq_frame_b16_t *vdq_ref)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+  LIBDSP_DEBUGASSERT(vdq_ref != NULL);
+
+  foc->v_dq.d = vdq_ref->d;
+  foc->v_dq.q = vdq_ref->q;
+}
+
+/****************************************************************************
+ * Name: foc_idq_ref_set_b16
+ *
+ * Description:
+ *   Set dq reference current vector
+ *
+ * Input Parameters:
+ *   foc     - (in/out) pointer to the FOC data
+ *   idq_ref - (in) pointer to the reference idq current
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void foc_idq_ref_set_b16(FAR struct foc_data_b16_s *foc,
+                                FAR dq_frame_b16_t *idq_ref)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+  LIBDSP_DEBUGASSERT(idq_ref != NULL);
+
+  foc->i_dq_ref.d = idq_ref->d;
+  foc->i_dq_ref.q = idq_ref->q;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: foc_init_b16
+ *
+ * Description:
+ *   Initialize FOC controller
+ *
+ * Input Parameters:
+ *   foc  - (in/out) pointer to the FOC data
+ *   init - (in) pointer to the FOC initialization data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void foc_init_b16(FAR struct foc_data_b16_s *foc,
+                  FAR struct foc_initdata_b16_s *init)
+{
+  /* Reset data */
+
+  memset(foc, 0, sizeof(struct foc_data_b16_s));
+
+  /* Initialize PI current d component */
+
+  pi_controller_init_b16(&foc->id_pid, init->id_kp, init->id_ki);
+
+  /* Initialize PI current q component */
+
+  pi_controller_init_b16(&foc->iq_pid, init->iq_kp, init->iq_ki);
+
+  /* Disable PI intergral part reset when saturated */
+
+  pi_ireset_enable_b16(&foc->iq_pid, false);
+  pi_ireset_enable_b16(&foc->id_pid, false);
+
+  /* Enable PI anti-windup protection */
+
+  pi_antiwindup_enable_b16(&foc->iq_pid, ftob16(0.99f), true);
+  pi_antiwindup_enable_b16(&foc->id_pid, ftob16(0.99f), true);
+}
+
+/****************************************************************************
+ * Name: foc_vbase_update_b16
+ *
+ * Description:
+ *   Update base voltage for FOC controller
+ *
+ * Input Parameters:
+ *   foc   - (in/out) pointer to the FOC data
+ *   vbase - (in) base voltage for FOC
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void foc_vbase_update_b16(FAR struct foc_data_b16_s *foc, b16_t vbase)
+{
+  b16_t scale   = 0;
+  b16_t mag_max = 0;
+
+  /* Prevent division by zero */
+
+  if (vbase < 1)
+    {
+      vbase = 1;
+    }
+
+  /* NOTE: this is base voltage for FOC, not bus voltage! */
+
+  scale = b16divb16(b16ONE, vbase);
+  mag_max = vbase;
+
+  /* Update */
+
+  foc_vab_mod_scale_set_b16(foc, scale);
+  foc_vdq_mag_max_set_b16(foc, mag_max);
+}
+
+/****************************************************************************
+ * Name: foc_angle_update_b16
+ *
+ * Description:
+ *   Update FOC data with new motor phase angle.
+ *
+ * Input Parameters:
+ *   foc   - (in/out) pointer to the FOC data
+ *   angle - (in) pointer to the phase angle data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void foc_angle_update_b16(FAR struct foc_data_b16_s *foc,
+                          FAR phase_angle_b16_t *angle)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+  LIBDSP_DEBUGASSERT(angle != NULL);
+
+  /* Copy angle to foc data */
+
+  foc->angle.angle = angle->angle;
+  foc->angle.sin   = angle->sin;
+  foc->angle.cos   = angle->cos;
+}
+
+/****************************************************************************
+ * Name: foc_iabc_update_b16
+ *
+ * Description:
+ *   Update FOC data with new iabc frame.
+ *
+ *   To work properly this function requires some additional steps:
+ *     1. phase angle must be set with foc_angle_update()
+ *
+ * Input Parameters:
+ *   foc   - (in/out) pointer to the FOC data
+ *   i_abc - (in) pointer to the ABC current frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void foc_iabc_update_b16(FAR struct foc_data_b16_s *foc,
+                         FAR abc_frame_b16_t *i_abc)
+{
+  dq_frame_b16_t i_dq;
+
+  LIBDSP_DEBUGASSERT(foc != NULL);
+  LIBDSP_DEBUGASSERT(i_abc != NULL);
+
+  /* Reset data */
+
+  i_dq.d = 0;
+  i_dq.q = 0;
+
+  /* Copy ABC current to foc data */
+
+  foc->i_abc.a = i_abc->a;
+  foc->i_abc.b = i_abc->b;
+  foc->i_abc.c = i_abc->c;
+
+  /* Convert abc current to alpha-beta current */
+
+  clarke_transform_b16(&foc->i_abc, &foc->i_ab);
+
+  /* Convert alpha-beta current to dq current */
+
+  park_transform_b16(&foc->angle, &foc->i_ab, &i_dq);
+
+  /* Store dq current */
+
+  foc->i_dq.d = i_dq.d;
+  foc->i_dq.q = i_dq.q;
+}
+
+/****************************************************************************
+ * Name: foc_voltage_control_b16
+ *
+ * Description:
+ *   Process FOC voltage control.
+ *
+ * Input Parameters:
+ *   foc     - (in/out) pointer to the FOC data
+ *   vdq_ref - (in) voltage dq reference frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void foc_voltage_control_b16(FAR struct foc_data_b16_s *foc,
+                             FAR dq_frame_b16_t *vdq_ref)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+
+  /* Update VDQ request */
+
+  foc_vdq_ref_set_b16(foc, vdq_ref);
+
+  /* Inverse Park transform (voltage dq -> voltage alpha-beta) */
+
+  inv_park_transform_b16(&foc->angle, &foc->v_dq, &foc->v_ab);
+
+#ifdef CONFIG_LIBDSP_FOC_VABC
+  /* Inverse Clarke transform (voltage alpha-beta -> voltage abc) */
+
+  inv_clarke_transform_b16(&foc->v_ab, &foc->v_abc);
+#endif
+
+  /* Normalize the alpha-beta voltage to get the alpha-beta modulation
+   * voltage
+   */
+
+  foc->v_ab_mod.a = b16mulb16(foc->v_ab.a, foc->vab_mod_scale);
+  foc->v_ab_mod.b = b16mulb16(foc->v_ab.b, foc->vab_mod_scale);
+}
+
+/****************************************************************************
+ * Name: foc_current_control_b16
+ *
+ * Description:
+ *   Process FOC current control.
+ *
+ * Input Parameters:
+ *   foc      - (in/out) pointer to the FOC data
+ *   idq_ref  - (in) current dq reference frame
+ *   vdq_comp - (in) voltage dq compensation frame
+ *   vdq_ref  - (out) voltage dq reference frame
+ *
+ * Returned Value:
+ *   None
+ *
+ * TODO: add some reference and a brief description of the FOC
+ *
+ ****************************************************************************/
+
+void foc_current_control_b16(FAR struct foc_data_b16_s *foc,
+                             FAR dq_frame_b16_t *idq_ref,
+                             FAR dq_frame_b16_t *vdq_comp,
+                             FAR dq_frame_b16_t *vdq_ref)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+
+  /* Update IDQ reference */
+
+  foc_idq_ref_set_b16(foc, idq_ref);
+
+  /* Run FOC current controler (current dq -> voltage dq) */
+
+  foc_current_controler_b16(foc, vdq_ref);
+
+  /* DQ voltage compensation */
+
+  vdq_ref->d = vdq_ref->d - vdq_comp->d;
+  vdq_ref->q = vdq_ref->q - vdq_comp->q;
+}
+
+/****************************************************************************
+ * Name: foc_vabmod_get_b16
+ *
+ * Description:
+ *   Get result from the FOC controler (foc_current_control or
+ *   foc_voltage_control)
+ *
+ * Input Parameters:
+ *   foc      - (in/out) pointer to the FOC data
+ *   v_ab_mod - (out) pointer to the voltage alpha-beta modulation frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void foc_vabmod_get_b16(FAR struct foc_data_b16_s *foc,
+                        FAR ab_frame_b16_t *v_ab_mod)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+  LIBDSP_DEBUGASSERT(v_ab_mod != NULL);
+
+  v_ab_mod->a = foc->v_ab_mod.a;
+  v_ab_mod->b = foc->v_ab_mod.b;
+}
+
+/****************************************************************************
+ * Name: foc_vdq_mag_max_get_b16
+ *
+ * Description:
+ *   Get maximum dq voltage vector magnitude
+ *
+ * Input Parameters:
+ *   foc - (in/out) pointer to the FOC data
+ *   max - (out) maximum dq voltage magnitude
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void foc_vdq_mag_max_get_b16(FAR struct foc_data_b16_s *foc, FAR b16_t *max)
+{
+  LIBDSP_DEBUGASSERT(foc != NULL);
+
+  *max = foc->vdq_mag_max;
+}

--- a/libs/libdsp/lib_misc.c
+++ b/libs/libdsp/lib_misc.c
@@ -435,7 +435,7 @@ void angle_norm_2pi(FAR float *angle, float bottom, float top)
 
 void phase_angle_update(FAR struct phase_angle_f32_s *angle, float val)
 {
-  DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(angle != NULL);
 
   /* Normalize angle to <0.0, 2PI> */
 

--- a/libs/libdsp/lib_misc.c
+++ b/libs/libdsp/lib_misc.c
@@ -138,7 +138,7 @@ void vector2d_saturate(FAR float *x, FAR float *y, float max)
  *
  ****************************************************************************/
 
-float dq_mag(FAR dq_frame_t *dq)
+float dq_mag(FAR dq_frame_f32_t *dq)
 {
   return vector2d_mag(dq->d, dq->q);
 }
@@ -158,7 +158,7 @@ float dq_mag(FAR dq_frame_t *dq)
  *
  ****************************************************************************/
 
-void dq_saturate(FAR dq_frame_t *dq, float max)
+void dq_saturate(FAR dq_frame_f32_t *dq, float max)
 {
   vector2d_saturate(&dq->d, &dq->q, max);
 }
@@ -433,7 +433,7 @@ void angle_norm_2pi(FAR float *angle, float bottom, float top)
  *
  ****************************************************************************/
 
-void phase_angle_update(FAR struct phase_angle_s *angle, float val)
+void phase_angle_update(FAR struct phase_angle_f32_s *angle, float val)
 {
   DEBUGASSERT(angle != NULL);
 

--- a/libs/libdsp/lib_misc.c
+++ b/libs/libdsp/lib_misc.c
@@ -169,8 +169,6 @@ void dq_saturate(FAR dq_frame_f32_t *dq, float max)
  * Description:
  *   Fast sin calculation
  *
- *   Reference: http://lab.polygonal.de/?p=205
- *
  * Input Parameters:
  *   angle - (in)
  *
@@ -228,12 +226,11 @@ float fast_cos(float angle)
  * Name: fast_sin2
  *
  * Description:
- *   Fast sin calculation with better accuracy
- *
- *   Reference: http://lab.polygonal.de/?p=205
+ *   Fast sin calculation with better accuracy (quadratic curve
+ *   approximation)
  *
  * Input Parameters:
- *   angle
+ *   angle - (in)
  *
  * Returned Value:
  *   Return estimated sine value
@@ -287,7 +284,8 @@ float fast_sin2(float angle)
  * Name:fast_cos2
  *
  * Description:
- *   Fast cos calculation with better accuracy
+ *   Fast cos calculation with better accuracy (quadratic curve
+ *   approximation)
  *
  * Input Parameters:
  *   angle - (in)

--- a/libs/libdsp/lib_misc_b16.c
+++ b/libs/libdsp/lib_misc_b16.c
@@ -1,0 +1,457 @@
+/****************************************************************************
+ * libs/libdsp/lib_misc_b16.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <dspb16.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define VECTOR2D_SATURATE_MAG_MIN (1)
+#define FAST_ATAN2_SMALLNUM       (1)
+
+#ifndef ABS
+#  define ABS(a)   (a < 0 ? -a : a)
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: f_saturate_b16
+ *
+ * Description:
+ *   Saturate b16_t number
+ *
+ * Input Parameters:
+ *   val - pointer to b16_t number
+ *   min - lower limit
+ *   max - upper limit
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void f_saturate_b16(FAR b16_t *val, b16_t min, b16_t max)
+{
+  if (*val < min)
+    {
+      *val = min;
+    }
+
+  else if (*val > max)
+    {
+      *val = max;
+    }
+}
+
+/****************************************************************************
+ * Name: vector2d_mag_b16
+ *
+ * Description:
+ *   Get 2D vector magnitude.
+ *
+ * Input Parameters:
+ *   x   - (in) vector x component
+ *   y   - (in) vector y component
+ *
+ * Returned Value:
+ *   Return 2D vector magnitude
+ *
+ ****************************************************************************/
+
+b16_t vector2d_mag_b16(b16_t x, b16_t y)
+{
+  b16_t t0 = 0;
+  b16_t t1 = 0;
+  b16_t t3 = 0;
+
+  t0 = b16sqr(x);
+  t1 = b16sqr(y);
+  t3 = t0 + t1;
+
+  /* TODO: move to fixedmath sqrt */
+
+  if (t3 == 0)
+    {
+      return 0;
+    }
+
+#if CONFIG_LIBDSP_PRECISION == 0
+  /* Use ub8 sqrt */
+
+  return ub8toub16(ub16sqrtub8(t3));
+#else
+  /* Too slow ! */
+
+  return ub16sqrtub16(t3);
+#endif
+}
+
+/****************************************************************************
+ * Name: vector2d_saturate_b16
+ *
+ * Description:
+ *   Saturate 2D vector magnitude.
+ *
+ * Input Parameters:
+ *   x   - (in/out) pointer to the vector x component
+ *   y   - (in/out) pointer to the vector y component
+ *   max - (in) maximum vector magnitude
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void vector2d_saturate_b16(FAR b16_t *x, FAR b16_t *y, b16_t max)
+{
+  b16_t mag = 0;
+  b16_t tmp = 0;
+
+  /* Get vector magnitude */
+
+  mag = vector2d_mag_b16(*x, *y);
+
+  if (mag < VECTOR2D_SATURATE_MAG_MIN)
+    {
+      mag = VECTOR2D_SATURATE_MAG_MIN;
+    }
+
+  if (mag > max)
+    {
+      /* Saturate vector */
+
+      tmp = b16divb16(max, mag);
+      *x  = b16mulb16(*x, tmp);
+      *y  = b16mulb16(*x, tmp);
+    }
+}
+
+/****************************************************************************
+ * Name: dq_mag_b16
+ *
+ * Description:
+ *   Get DQ vector magnitude.
+ *
+ * Input Parameters:
+ *   dq  - (in/out) dq frame vector
+ *
+ * Returned Value:
+ *  Return dq vector magnitude
+ *
+ ****************************************************************************/
+
+b16_t dq_mag_b16(FAR dq_frame_b16_t *dq)
+{
+  return vector2d_mag_b16(dq->d, dq->q);
+}
+
+/****************************************************************************
+ * Name: dq_saturate_b16
+ *
+ * Description:
+ *   Saturate dq frame vector magnitude.
+ *
+ * Input Parameters:
+ *   dq  - (in/out) dq frame vector
+ *   max - (in) maximum vector magnitude
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void dq_saturate_b16(FAR dq_frame_b16_t *dq, b16_t max)
+{
+  vector2d_saturate_b16(&dq->d, &dq->q, max);
+}
+
+/****************************************************************************
+ * Name: fast_sin_b16
+ *
+ * Description:
+ *   Fast sin calculation
+ *
+ *   Reference: http://lab.polygonal.de/?p=205
+ *
+ * Input Parameters:
+ *   angle - (in)
+ *
+ * Returned Value:
+ *   Return estimated sine value
+ *
+ ****************************************************************************/
+
+b16_t fast_sin_b16(b16_t angle)
+{
+  b16_t sin  = 0;
+  b16_t n1   = ftob16(1.27323954f);
+  b16_t n2   = ftob16(0.405284735f);
+  b16_t tmp1 = 0;
+  b16_t tmp2 = 0;
+
+  /* Normalize angle */
+
+  angle_norm_2pi_b16(&angle, -b16PI, b16PI);
+
+  /* Get estiamte sine value from quadratic equation */
+
+  if (angle < 0)
+    {
+      tmp1 = b16mulb16(n1, angle);
+      tmp2 = b16mulb16(n2, b16sqr(angle));
+      sin  = tmp1 + tmp2;
+    }
+  else
+    {
+      tmp1 = b16mulb16(n1, angle);
+      tmp2 = b16mulb16(n2, b16sqr(angle));
+      sin  = tmp1 - tmp2;
+    }
+
+  return sin;
+}
+
+/****************************************************************************
+ * Name:fast_cos_b16
+ *
+ * Description:
+ *   Fast cos calculation
+ *
+ * Input Parameters:
+ *   angle - (in)
+ *
+ * Returned Value:
+ *   Return estimated cosine value
+ *
+ ****************************************************************************/
+
+b16_t fast_cos_b16(b16_t angle)
+{
+  /* Get cosine value from sine sin(x + PI/2) = cos(x)  */
+
+  return fast_sin_b16(angle + b16HALFPI);
+}
+
+/****************************************************************************
+ * Name: fast_sin2_b16
+ *
+ * Description:
+ *   Fast sin calculation with better accuracy
+ *
+ *   Reference: http://lab.polygonal.de/?p=205
+ *
+ * Input Parameters:
+ *   angle
+ *
+ * Returned Value:
+ *   Return estimated sine value
+ *
+ ****************************************************************************/
+
+b16_t fast_sin2_b16(b16_t angle)
+{
+  return b16sin(angle);
+}
+
+/****************************************************************************
+ * Name:fast_cos2_b16
+ *
+ * Description:
+ *   Fast cos calculation with better accuracy
+ *
+ * Input Parameters:
+ *   angle - (in)
+ *
+ * Returned Value:
+ *   Return estimated cosine value
+ *
+ ****************************************************************************/
+
+b16_t fast_cos2_b16(b16_t angle)
+{
+  return b16cos(angle);
+}
+
+/****************************************************************************
+ * Name: fast_atan2_b16
+ *
+ * Description:
+ *   Fast atan2 calculation
+ *
+ * REFERENCE:
+ * https://dspguru.com/dsp/tricks/fixed-point-atan2-with-self-normalization/
+ *
+ * Input Parameters:
+ *   x - (in)
+ *   y - (in)
+ *
+ * Returned Value:
+ *   Return estimated angle
+ *
+ ****************************************************************************/
+
+b16_t fast_atan2_b16(b16_t y, b16_t x)
+{
+  b16_t angle = 0;
+  b16_t abs_y = 0;
+  b16_t rsq   = 0;
+  b16_t r     = 0;
+  b16_t n1    = ftob16(0.1963f);
+  b16_t n2    = ftob16(0.9817f);
+  b16_t tmp1 = 0;
+  b16_t tmp2 = 0;
+  b16_t tmp3 = 0;
+
+  /* Get absolute value of y and add some small number to prevent 0/0 */
+
+  abs_y = ABS(y) + FAST_ATAN2_SMALLNUM;
+
+  /* Calculate angle */
+
+  if (x >= 0)
+    {
+      r     = b16divb16((x - abs_y), (x + abs_y));
+      rsq   = b16mulb16(r, r);
+      tmp1  = b16mulb16(n1, rsq);
+      tmp2  = b16mulb16((tmp1 - n2), r);
+      tmp3  = b16mulb16(b16PI, ftob16(0.25f));
+      angle = tmp2 + tmp3;
+    }
+  else
+    {
+      r     = b16divb16((x + abs_y), (abs_y - x));
+      rsq   = b16mulb16(r, r);
+      tmp1  = b16mulb16(n1, rsq);
+      tmp2  = b16mulb16((tmp1 - n2), r);
+      tmp3  = b16mulb16(b16PI, ftob16(0.75f));
+      angle = tmp2 + tmp3;
+    }
+
+  /* Get angle sign */
+
+  if (y < 0)
+    {
+      angle = -angle;
+    }
+
+  return angle;
+}
+
+/****************************************************************************
+ * Name: angle_norm_b16
+ *
+ * Description:
+ *   Normalize radians angle to a given boundary and a given period.
+ *
+ * Input Parameters:
+ *   angle  - (in/out) pointer to the angle data
+ *   per    - (in) angle period
+ *   bottom - (in) lower limit
+ *   top    - (in) upper limit
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void angle_norm_b16(FAR b16_t *angle, b16_t per, b16_t bottom, b16_t top)
+{
+  while (*angle > top)
+    {
+      /* Move the angle backwards by given period */
+
+      *angle = *angle - per;
+    }
+
+  while (*angle < bottom)
+    {
+      /* Move the angle forwards by given period */
+
+      *angle = *angle + per;
+    }
+}
+
+/****************************************************************************
+ * Name: angle_norm_2pi_b16
+ *
+ * Description:
+ *   Normalize radians angle with period 2*PI to a given boundary.
+ *
+ * Input Parameters:
+ *   angle  - (in/out) pointer to the angle data
+ *   bottom - (in) lower limit
+ *   top    - (in) upper limit
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void angle_norm_2pi_b16(FAR b16_t *angle, b16_t bottom, b16_t top)
+{
+  angle_norm_b16(angle, b16TWOPI, bottom, top);
+}
+
+/****************************************************************************
+ * Name: phase_angle_update_b16
+ *
+ * Description:
+ *   Update phase_angle_s structure:
+ *     1. normalize angle value to <0.0, 2PI> range
+ *     2. update angle value
+ *     3. update sin/cos value for given angle
+ *
+ * Input Parameters:
+ *   angle - (in/out) pointer to the angle data
+ *   val   - (in) angle radian value
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void phase_angle_update_b16(FAR struct phase_angle_b16_s *angle, b16_t val)
+{
+  LIBDSP_DEBUGASSERT(angle != NULL);
+
+  /* Normalize angle to <0.0, 2PI> */
+
+  angle_norm_2pi_b16(&val, 0, b16TWOPI);
+
+  /* Update structure */
+
+  angle->angle = val;
+
+#if CONFIG_LIBDSP_PRECISION == 0
+  angle->sin = fast_sin_b16(val);
+  angle->cos = fast_cos_b16(val);
+#else
+  angle->sin = fast_sin2_b16(val);
+  angle->cos = fast_cos2_b16(val);
+#endif
+}

--- a/libs/libdsp/lib_misc_b16.c
+++ b/libs/libdsp/lib_misc_b16.c
@@ -196,8 +196,6 @@ void dq_saturate_b16(FAR dq_frame_b16_t *dq, b16_t max)
  * Description:
  *   Fast sin calculation
  *
- *   Reference: http://lab.polygonal.de/?p=205
- *
  * Input Parameters:
  *   angle - (in)
  *
@@ -261,12 +259,11 @@ b16_t fast_cos_b16(b16_t angle)
  * Name: fast_sin2_b16
  *
  * Description:
- *   Fast sin calculation with better accuracy
- *
- *   Reference: http://lab.polygonal.de/?p=205
+ *   Fast sin calculation with better accuracy (quadratic curve
+ *   approximation)
  *
  * Input Parameters:
- *   angle
+ *   angle - (in)
  *
  * Returned Value:
  *   Return estimated sine value
@@ -282,7 +279,8 @@ b16_t fast_sin2_b16(b16_t angle)
  * Name:fast_cos2_b16
  *
  * Description:
- *   Fast cos calculation with better accuracy
+ *   Fast cos calculation with better accuracy (quadratic curve
+ *   approximation)
  *
  * Input Parameters:
  *   angle - (in)

--- a/libs/libdsp/lib_motor.c
+++ b/libs/libdsp/lib_motor.c
@@ -42,7 +42,6 @@
  *
  * Input Parameters:
  *   op  - (in/out) pointer to the openloop data structure
- *   max - (in) maximum openloop speed
  *   per - (in) period of the open-loop control
  *
  * Returned Value:
@@ -50,11 +49,9 @@
  *
  ****************************************************************************/
 
-void motor_openloop_init(FAR struct openloop_data_f32_s *op, float max,
-                         float per)
+void motor_openloop_init(FAR struct openloop_data_f32_s *op, float per)
 {
   LIBDSP_DEBUGASSERT(op != NULL);
-  LIBDSP_DEBUGASSERT(max > 0.0f);
   LIBDSP_DEBUGASSERT(per > 0.0f);
 
   /* Reset openloop structure */
@@ -63,7 +60,6 @@ void motor_openloop_init(FAR struct openloop_data_f32_s *op, float max,
 
   /* Initialize data */
 
-  op->max = max;
   op->per = per;
 }
 
@@ -91,15 +87,6 @@ void motor_openloop(FAR struct openloop_data_f32_s *op, float speed,
   LIBDSP_DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
 
   float phase_step = 0.0f;
-
-  /* REVISIT: what should we do if speed is greater than max open-loop speed?
-   *          Saturate speed or stop motor ?
-   */
-
-  if (speed > op->max)
-    {
-      speed = op->max;
-    }
 
   /* Get phase step */
 

--- a/libs/libdsp/lib_motor.c
+++ b/libs/libdsp/lib_motor.c
@@ -53,9 +53,9 @@
 void motor_openloop_init(FAR struct openloop_data_f32_s *op, float max,
                          float per)
 {
-  DEBUGASSERT(op != NULL);
-  DEBUGASSERT(max > 0.0f);
-  DEBUGASSERT(per > 0.0f);
+  LIBDSP_DEBUGASSERT(op != NULL);
+  LIBDSP_DEBUGASSERT(max > 0.0f);
+  LIBDSP_DEBUGASSERT(per > 0.0f);
 
   /* Reset openloop structure */
 
@@ -86,9 +86,9 @@ void motor_openloop_init(FAR struct openloop_data_f32_s *op, float max,
 void motor_openloop(FAR struct openloop_data_f32_s *op, float speed,
                     float dir)
 {
-  DEBUGASSERT(op != NULL);
-  DEBUGASSERT(speed >= 0.0f);
-  DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
+  LIBDSP_DEBUGASSERT(op != NULL);
+  LIBDSP_DEBUGASSERT(speed >= 0.0f);
+  LIBDSP_DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
 
   float phase_step = 0.0f;
 
@@ -130,7 +130,7 @@ void motor_openloop(FAR struct openloop_data_f32_s *op, float speed,
 
 float motor_openloop_angle_get(FAR struct openloop_data_f32_s *op)
 {
-  DEBUGASSERT(op != NULL);
+  LIBDSP_DEBUGASSERT(op != NULL);
 
   return op->angle;
 }
@@ -182,8 +182,8 @@ float motor_openloop_angle_get(FAR struct openloop_data_f32_s *op)
 
 void motor_angle_init(FAR struct motor_angle_f32_s *angle, uint8_t p)
 {
-  DEBUGASSERT(angle != NULL);
-  DEBUGASSERT(p > 0);
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(p > 0);
 
   /* Reset structure */
 
@@ -217,9 +217,9 @@ void motor_angle_init(FAR struct motor_angle_f32_s *angle, uint8_t p)
 void motor_angle_e_update(FAR struct motor_angle_f32_s *angle,
                           float angle_new, float dir)
 {
-  DEBUGASSERT(angle != NULL);
-  DEBUGASSERT(angle_new >= 0.0f && angle_new <= MOTOR_ANGLE_E_MAX);
-  DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(angle_new >= 0.0f && angle_new <= MOTOR_ANGLE_E_MAX);
+  LIBDSP_DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
 
   /* Check if we crossed electrical angle boundaries */
 
@@ -286,9 +286,9 @@ void motor_angle_e_update(FAR struct motor_angle_f32_s *angle,
 void motor_angle_m_update(FAR struct motor_angle_f32_s *angle,
                           float angle_new, float dir)
 {
-  DEBUGASSERT(angle != NULL);
-  DEBUGASSERT(angle_new >= 0.0f && angle_new <= MOTOR_ANGLE_E_MAX);
-  DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(angle_new >= 0.0f && angle_new <= MOTOR_ANGLE_E_MAX);
+  LIBDSP_DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
 
   float angle_el = 0.0f;
 
@@ -325,7 +325,7 @@ void motor_angle_m_update(FAR struct motor_angle_f32_s *angle,
 
 float motor_angle_m_get(FAR struct motor_angle_f32_s *angle)
 {
-  DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(angle != NULL);
 
   return angle->anglem;
 }
@@ -346,7 +346,7 @@ float motor_angle_m_get(FAR struct motor_angle_f32_s *angle)
 
 float motor_angle_e_get(FAR struct motor_angle_f32_s *angle)
 {
-  DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(angle != NULL);
 
   return angle->angle_el.angle;
 }
@@ -372,7 +372,7 @@ float motor_angle_e_get(FAR struct motor_angle_f32_s *angle)
 void motor_phy_params_init(FAR struct motor_phy_params_f32_s *phy,
                            uint8_t poles, float res, float ind)
 {
-  DEBUGASSERT(phy != NULL);
+  LIBDSP_DEBUGASSERT(phy != NULL);
 
   phy->p          = poles;
   phy->res_base   = res;
@@ -404,7 +404,7 @@ void motor_phy_params_init(FAR struct motor_phy_params_f32_s *phy,
 void motor_phy_params_temp_set(FAR struct motor_phy_params_f32_s *phy,
                                float res_alpha, float res_temp_ref)
 {
-  DEBUGASSERT(phy != NULL);
+  LIBDSP_DEBUGASSERT(phy != NULL);
 
   phy->res_alpha    = res_alpha;
   phy->res_temp_ref = res_temp_ref;

--- a/libs/libdsp/lib_motor.c
+++ b/libs/libdsp/lib_motor.c
@@ -210,20 +210,24 @@ void motor_angle_e_update(FAR struct motor_angle_f32_s *angle,
 
   /* Check if we crossed electrical angle boundaries */
 
-  if (dir == DIR_CW &&
-      angle_new - angle->angle_el.angle < -POLE_CNTR_THR)
+  if (dir == DIR_CW)
     {
       /* For CW direction - previous angle is greater than current angle */
 
-      angle->i += 1;
+      if (angle_new - angle->angle_el.angle < -POLE_CNTR_THR)
+        {
+          angle->i += 1;
+        }
     }
 
-  else if (dir == DIR_CCW &&
-           angle_new - angle->angle_el.angle > POLE_CNTR_THR)
+  else if (dir == DIR_CCW)
     {
       /* For CCW direction - previous angle is lower than current angle */
 
-      angle->i -= 1;
+      if (angle_new - angle->angle_el.angle > POLE_CNTR_THR)
+        {
+          angle->i -= 1;
+        }
     }
 
   /* Reset pole counter if needed */

--- a/libs/libdsp/lib_motor.c
+++ b/libs/libdsp/lib_motor.c
@@ -372,3 +372,47 @@ void motor_phy_params_init(FAR struct motor_phy_params_f32_s *phy,
   phy->ind        = ind;
   phy->one_by_ind = (1.0f / ind);
 }
+
+/****************************************************************************
+ * Name: pmsm_phy_params_init
+ *
+ * Description:
+ *   Initialize PMSM physical parameters
+ *
+ * Input Parameters:
+ *   phy   - (in/out) pointer to the PMSM physical parameters
+ *   poles - (in) number of the motor pole pairs
+ *   res   - (in) average phase-to-neutral base motor resistance
+ *                    (without temperature compensation)
+ *   ind   - (in) average phase-to-neutral motor inductance
+ *   iner  - (in) rotor inertia (J)
+ *   flux  - (in) flux linkage
+ *   ind_d - (in) d-inductance
+ *   ind_q - (in) q-inductance
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void pmsm_phy_params_init(FAR struct pmsm_phy_params_f32_s *phy,
+                          uint8_t poles, float res, float ind,
+                          float iner, float flux,
+                          float ind_d, float ind_q)
+{
+  LIBDSP_DEBUGASSERT(phy != NULL);
+
+  /* Initialize motor phy */
+
+  motor_phy_params_init(&phy->motor, poles, res, ind);
+
+  /* Iniitalize PMSM specific data */
+
+  phy->iner        = iner;
+  phy->flux_link   = flux;
+  phy->ind_d       = ind_d;
+  phy->ind_q       = ind_q;
+  phy->one_by_iner = (1.0f / iner);
+  phy->one_by_indd = (1.0f / ind_d);
+  phy->one_by_indq = (1.0f / ind_q);
+}

--- a/libs/libdsp/lib_motor.c
+++ b/libs/libdsp/lib_motor.c
@@ -50,7 +50,7 @@
  *
  ****************************************************************************/
 
-void motor_openloop_init(FAR struct openloop_data_s *op, float max,
+void motor_openloop_init(FAR struct openloop_data_f32_s *op, float max,
                          float per)
 {
   DEBUGASSERT(op != NULL);
@@ -59,7 +59,7 @@ void motor_openloop_init(FAR struct openloop_data_s *op, float max,
 
   /* Reset openloop structure */
 
-  memset(op, 0, sizeof(struct openloop_data_s));
+  memset(op, 0, sizeof(struct openloop_data_f32_s));
 
   /* Initialize data */
 
@@ -83,7 +83,8 @@ void motor_openloop_init(FAR struct openloop_data_s *op, float max,
  *
  ****************************************************************************/
 
-void motor_openloop(FAR struct openloop_data_s *op, float speed, float dir)
+void motor_openloop(FAR struct openloop_data_f32_s *op, float speed,
+                    float dir)
 {
   DEBUGASSERT(op != NULL);
   DEBUGASSERT(speed >= 0.0f);
@@ -127,7 +128,7 @@ void motor_openloop(FAR struct openloop_data_s *op, float speed, float dir)
  *
  ****************************************************************************/
 
-float motor_openloop_angle_get(FAR struct openloop_data_s *op)
+float motor_openloop_angle_get(FAR struct openloop_data_f32_s *op)
 {
   DEBUGASSERT(op != NULL);
 
@@ -179,14 +180,14 @@ float motor_openloop_angle_get(FAR struct openloop_data_s *op)
  *
  ****************************************************************************/
 
-void motor_angle_init(FAR struct motor_angle_s *angle, uint8_t p)
+void motor_angle_init(FAR struct motor_angle_f32_s *angle, uint8_t p)
 {
   DEBUGASSERT(angle != NULL);
   DEBUGASSERT(p > 0);
 
   /* Reset structure */
 
-  memset(angle, 0, sizeof(struct motor_angle_s));
+  memset(angle, 0, sizeof(struct motor_angle_f32_s));
 
   /* Store pole pairs */
 
@@ -213,8 +214,8 @@ void motor_angle_init(FAR struct motor_angle_s *angle, uint8_t p)
  *
  ****************************************************************************/
 
-void motor_angle_e_update(FAR struct motor_angle_s *angle, float angle_new,
-                          float dir)
+void motor_angle_e_update(FAR struct motor_angle_f32_s *angle,
+                          float angle_new, float dir)
 {
   DEBUGASSERT(angle != NULL);
   DEBUGASSERT(angle_new >= 0.0f && angle_new <= MOTOR_ANGLE_E_MAX);
@@ -282,8 +283,8 @@ void motor_angle_e_update(FAR struct motor_angle_s *angle, float angle_new,
  *
  ****************************************************************************/
 
-void motor_angle_m_update(FAR struct motor_angle_s *angle, float angle_new,
-                          float dir)
+void motor_angle_m_update(FAR struct motor_angle_f32_s *angle,
+                          float angle_new, float dir)
 {
   DEBUGASSERT(angle != NULL);
   DEBUGASSERT(angle_new >= 0.0f && angle_new <= MOTOR_ANGLE_E_MAX);
@@ -322,7 +323,7 @@ void motor_angle_m_update(FAR struct motor_angle_s *angle, float angle_new,
  *
  ****************************************************************************/
 
-float motor_angle_m_get(FAR struct motor_angle_s *angle)
+float motor_angle_m_get(FAR struct motor_angle_f32_s *angle)
 {
   DEBUGASSERT(angle != NULL);
 
@@ -343,7 +344,7 @@ float motor_angle_m_get(FAR struct motor_angle_s *angle)
  *
  ****************************************************************************/
 
-float motor_angle_e_get(FAR struct motor_angle_s *angle)
+float motor_angle_e_get(FAR struct motor_angle_f32_s *angle)
 {
   DEBUGASSERT(angle != NULL);
 
@@ -368,8 +369,8 @@ float motor_angle_e_get(FAR struct motor_angle_s *angle)
  *
  ****************************************************************************/
 
-void motor_phy_params_init(FAR struct motor_phy_params_s *phy, uint8_t poles,
-                            float res, float ind)
+void motor_phy_params_init(FAR struct motor_phy_params_f32_s *phy,
+                           uint8_t poles, float res, float ind)
 {
   DEBUGASSERT(phy != NULL);
 
@@ -400,7 +401,7 @@ void motor_phy_params_init(FAR struct motor_phy_params_s *phy, uint8_t poles,
  *
  ****************************************************************************/
 
-void motor_phy_params_temp_set(FAR struct motor_phy_params_s *phy,
+void motor_phy_params_temp_set(FAR struct motor_phy_params_f32_s *phy,
                                float res_alpha, float res_temp_ref)
 {
   DEBUGASSERT(phy != NULL);

--- a/libs/libdsp/lib_motor.c
+++ b/libs/libdsp/lib_motor.c
@@ -365,38 +365,10 @@ void motor_phy_params_init(FAR struct motor_phy_params_f32_s *phy,
 {
   LIBDSP_DEBUGASSERT(phy != NULL);
 
+  memset(phy, 0, sizeof(struct motor_phy_params_f32_s));
+
   phy->p          = poles;
-  phy->res_base   = res;
+  phy->res        = res;
   phy->ind        = ind;
-  phy->one_by_ind = 1.0f / ind;
-
-  /* Initialize with zeros */
-
-  phy->res          = 0.0f;
-  phy->res_alpha    = 0.0f;
-  phy->res_temp_ref = 0.0f;
-}
-
-/****************************************************************************
- * Name: motor_phy_params_temp_set
- * Description:
- *   Initialize motor physical temperature parameters
- *
- * Input Parameters:
- *   phy          - (in/out) pointer to the motor physical parameters
- *   res_alpha    - (in) temperature coefficient of the winding resistance
- *   res_temp_ref - (in) reference temperature for alpha
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-void motor_phy_params_temp_set(FAR struct motor_phy_params_f32_s *phy,
-                               float res_alpha, float res_temp_ref)
-{
-  LIBDSP_DEBUGASSERT(phy != NULL);
-
-  phy->res_alpha    = res_alpha;
-  phy->res_temp_ref = res_temp_ref;
+  phy->one_by_ind = (1.0f / ind);
 }

--- a/libs/libdsp/lib_motor_b16.c
+++ b/libs/libdsp/lib_motor_b16.c
@@ -1,0 +1,279 @@
+/****************************************************************************
+ * control/lib_motor_b16.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <dspb16.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define POLE_CNTR_THR (0)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: motor_angle_e_update_b16
+ *
+ * Description:
+ *   Update motor angle structure using electrical motor angle.
+ *
+ * Input Parameters:
+ *   angle     - (in/out) pointer to the motor angle structure
+ *   angle_new - (in) new motor electrical angle in range <0.0, 2PI>
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void motor_angle_e_update_b16(FAR struct motor_angle_b16_s *angle,
+                              b16_t angle_new, b16_t dir)
+{
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(angle_new >= 0 && angle_new <= MOTOR_ANGLE_E_MAX_B16);
+  LIBDSP_DEBUGASSERT(dir == DIR_CW_B16 || dir == DIR_CCW_B16);
+
+  b16_t tmp1 = 0;
+  b16_t tmp2 = 0;
+
+  /* Check if we crossed electrical angle boundaries */
+
+  if (dir == DIR_CW_B16)
+    {
+      /* For CW direction - previous angle is greater than current angle */
+
+      if (angle_new - angle->angle_el.angle < -POLE_CNTR_THR)
+        {
+          angle->i += 1;
+        }
+    }
+
+  else if (dir == DIR_CCW_B16)
+    {
+      /* For CCW direction - previous angle is lower than current angle */
+
+      if (angle_new - angle->angle_el.angle > POLE_CNTR_THR)
+        {
+          angle->i -= 1;
+        }
+    }
+
+  /* Reset pole counter if needed */
+
+  if (angle->i >= angle->p)
+    {
+      angle->i = 0;
+    }
+
+  else if (angle->i < 0)
+    {
+      angle->i = angle->p - 1;
+    }
+
+  /* Update electrical angle structure */
+
+  phase_angle_update_b16(&angle->angle_el, angle_new);
+
+  /* Calculate mechanical angle.
+   * One electrical angle rotation is equal to one mechanical rotation
+   * divided by number of motor pole pairs.
+   */
+
+  tmp1 = b16mulb16(MOTOR_ANGLE_E_RANGE_B16, itob16(angle->i));
+  tmp2 = tmp1 + angle->angle_el.angle;
+
+  angle->anglem = b16mulb16(tmp2, angle->one_by_p);
+
+  /* Normalize mechanical angle to <0, 2PI> and store */
+
+  angle_norm_2pi_b16(&angle->anglem, MOTOR_ANGLE_M_MIN_B16,
+                     MOTOR_ANGLE_M_MAX_B16);
+}
+
+/****************************************************************************
+ * Name: motor_angle_m_update_b16
+ *
+ * Description:
+ *   Update motor angle structure using mechanical motor angle
+ *
+ * Input Parameters:
+ *   angle     - (in/out) pointer to the motor angle structure
+ *   angle_new - (in) new motor mechanical angle in range <0.0, 2PI>
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void motor_angle_m_update_b16(FAR struct motor_angle_b16_s *angle,
+                              b16_t angle_new, b16_t dir)
+{
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(angle_new >= 0 && angle_new <= MOTOR_ANGLE_E_MAX_B16);
+  LIBDSP_DEBUGASSERT(dir == DIR_CW_B16 || dir == DIR_CCW_B16);
+
+  b16_t angle_el = 0;
+  b16_t tmp1     = 0;
+  b16_t tmp2     = 0;
+
+  /* Store new mechanical angle */
+
+  angle->anglem = angle_new;
+
+  /* Update pole counter */
+
+  tmp1 = b16mulb16(angle->anglem, itob16(angle->p));
+
+  angle->i = (uint8_t) b16toi(b16divb16(tmp1, MOTOR_ANGLE_M_MAX_B16));
+
+  /* Get electrical angle */
+
+  tmp1 = b16mulb16(angle->anglem, itob16(angle->p));
+  tmp2 = b16mulb16(MOTOR_ANGLE_E_MAX_B16, itob16(angle->i));
+
+  angle_el = (tmp1 - tmp2);
+
+  /* Update electrical angle structure */
+
+  phase_angle_update_b16(&angle->angle_el, angle_el);
+}
+
+/****************************************************************************
+ * Name: motor_angle_m_get_b16
+ *
+ * Description:
+ *   Get motor mechanical angle
+ *
+ * Input Parameters:
+ *   angle - (in/out) pointer to the motor angle structure
+ *
+ * Returned Value:
+ *   Return motor mechanical angle
+ *
+ ****************************************************************************/
+
+b16_t motor_angle_m_get_b16(FAR struct motor_angle_b16_s *angle)
+{
+  LIBDSP_DEBUGASSERT(angle != NULL);
+
+  return angle->anglem;
+}
+
+/****************************************************************************
+ * Name: motor_angle_e_get_b16
+ *
+ * Description:
+ *   Get motor electrical angle
+ *
+ * Input Parameters:
+ *   angle - (in/out) pointer to the motor angle structure
+ *
+ * Returned Value:
+ *   Return motor electrical angle
+ *
+ ****************************************************************************/
+
+b16_t motor_angle_e_get_b16(FAR struct motor_angle_b16_s *angle)
+{
+  LIBDSP_DEBUGASSERT(angle != NULL);
+
+  return angle->angle_el.angle;
+}
+
+/****************************************************************************
+ * Name: motor_phy_params_init_b16
+ *
+ * Description:
+ *   Initialize motor physical parameters
+ *
+ * Input Parameters:
+ *   phy   - (in/out) pointer to the motor physical parameters
+ *   poles - (in) number of the motor pole pairs
+ *   res   - (in) average phase-to-neutral base motor resistance
+ *                (without temperature compensation)
+ *   ind   - (in) average phase-to-neutral motor inductance
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void motor_phy_params_init_b16(FAR struct motor_phy_params_b16_s *phy,
+                               uint8_t poles, b16_t res, b16_t ind)
+{
+  LIBDSP_DEBUGASSERT(phy != NULL);
+
+  memset(phy, 0, sizeof(struct motor_phy_params_b16_s));
+
+  phy->p          = poles;
+  phy->res        = res;
+  phy->ind        = ind;
+  phy->one_by_ind = b16divb16(b16ONE, ind);
+}
+
+/****************************************************************************
+ * Name: pmsm_phy_params_init_b16
+ *
+ * Description:
+ *   Initialize PMSM physical parameters
+ *
+ * Input Parameters:
+ *   phy   - (in/out) pointer to the PMSM physical parameters
+ *   poles - (in) number of the motor pole pairs
+ *   res   - (in) average phase-to-neutral base motor resistance
+ *                (without temperature compensation)
+ *   ind   - (in) average phase-to-neutral motor inductance
+ *   iner  - (in) rotor inertia (J)
+ *   flux  - (in) flux linkage
+ *   ind_d - (in) d-inductance
+ *   ind_q - (in) q-inductance
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void pmsm_phy_params_init_b16(FAR struct pmsm_phy_params_b16_s *phy,
+                              uint8_t poles, b16_t res, b16_t ind,
+                              b16_t iner, b16_t flux,
+                              b16_t ind_d, b16_t ind_q)
+{
+  LIBDSP_DEBUGASSERT(phy != NULL);
+
+  /* Initialize motor phy */
+
+  motor_phy_params_init_b16(&phy->motor, poles, res, ind);
+
+  /* Iniitalize PMSM specific data */
+
+  phy->iner        = iner;
+  phy->flux_link   = flux;
+  phy->ind_d       = ind_d;
+  phy->ind_q       = ind_q;
+  phy->one_by_iner = b16divb16(b16ONE, iner);
+  phy->one_by_indd = b16divb16(b16ONE, ind_d);
+  phy->one_by_indq = b16divb16(b16ONE, ind_q);
+}

--- a/libs/libdsp/lib_motor_b16.c
+++ b/libs/libdsp/lib_motor_b16.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * control/lib_motor_b16.c
+ * libs/libdsp/lib_motor_b16.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/libs/libdsp/lib_observer.c
+++ b/libs/libdsp/lib_observer.c
@@ -54,10 +54,10 @@
 void motor_observer_init(FAR struct motor_observer_f32_s *observer,
                          FAR void *ao, FAR void *so, float per)
 {
-  DEBUGASSERT(observer != NULL);
-  DEBUGASSERT(ao != NULL);
-  DEBUGASSERT(so != NULL);
-  DEBUGASSERT(per > 0.0f);
+  LIBDSP_DEBUGASSERT(observer != NULL);
+  LIBDSP_DEBUGASSERT(ao != NULL);
+  LIBDSP_DEBUGASSERT(so != NULL);
+  LIBDSP_DEBUGASSERT(per > 0.0f);
 
   /* Reset observer data */
 
@@ -95,9 +95,9 @@ void motor_observer_init(FAR struct motor_observer_f32_s *observer,
 void motor_observer_smo_init(FAR struct motor_observer_smo_f32_s *smo,
                              float kslide, float err_max)
 {
-  DEBUGASSERT(smo != NULL);
-  DEBUGASSERT(kslide > 0.0f);
-  DEBUGASSERT(err_max > 0.0f);
+  LIBDSP_DEBUGASSERT(smo != NULL);
+  LIBDSP_DEBUGASSERT(kslide > 0.0f);
+  LIBDSP_DEBUGASSERT(err_max > 0.0f);
 
   /* Reset structure */
 
@@ -170,10 +170,10 @@ void motor_observer_smo(FAR struct motor_observer_f32_s *o,
                         FAR ab_frame_f32_t *i_ab, FAR ab_frame_f32_t *v_ab,
                         FAR struct motor_phy_params_f32_s *phy, float dir)
 {
-  DEBUGASSERT(o != NULL);
-  DEBUGASSERT(i_ab != NULL);
-  DEBUGASSERT(v_ab != NULL);
-  DEBUGASSERT(phy != NULL);
+  LIBDSP_DEBUGASSERT(o != NULL);
+  LIBDSP_DEBUGASSERT(i_ab != NULL);
+  LIBDSP_DEBUGASSERT(v_ab != NULL);
+  LIBDSP_DEBUGASSERT(phy != NULL);
 
   FAR struct motor_observer_smo_f32_s *smo =
     (FAR struct motor_observer_smo_f32_s *)o->ao;
@@ -382,9 +382,9 @@ void motor_observer_smo(FAR struct motor_observer_f32_s *o,
 void motor_sobserver_div_init(FAR struct motor_sobserver_div_f32_s *so,
                               uint8_t samples, float filter, float per)
 {
-  DEBUGASSERT(so != NULL);
-  DEBUGASSERT(samples > 0);
-  DEBUGASSERT(filter > 0.0f);
+  LIBDSP_DEBUGASSERT(so != NULL);
+  LIBDSP_DEBUGASSERT(samples > 0);
+  LIBDSP_DEBUGASSERT(filter > 0.0f);
 
   /* Reset observer data */
 
@@ -421,9 +421,9 @@ void motor_sobserver_div_init(FAR struct motor_sobserver_div_f32_s *so,
 void motor_sobserver_div(FAR struct motor_observer_f32_s *o,
                          float angle, float dir)
 {
-  DEBUGASSERT(o != NULL);
-  DEBUGASSERT(angle >= 0.0f && angle <= 2*M_PI_F);
-  DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
+  LIBDSP_DEBUGASSERT(o != NULL);
+  LIBDSP_DEBUGASSERT(angle >= 0.0f && angle <= 2*M_PI_F);
+  LIBDSP_DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
 
   FAR struct motor_sobserver_div_f32_s *so =
     (FAR struct motor_sobserver_div_f32_s *)o->so;
@@ -515,7 +515,7 @@ void motor_sobserver_div(FAR struct motor_observer_f32_s *o,
 
 float motor_observer_speed_get(FAR struct motor_observer_f32_s *o)
 {
-  DEBUGASSERT(o != NULL);
+  LIBDSP_DEBUGASSERT(o != NULL);
 
   return o->speed;
 }
@@ -536,7 +536,7 @@ float motor_observer_speed_get(FAR struct motor_observer_f32_s *o)
 
 float motor_observer_angle_get(FAR struct motor_observer_f32_s *o)
 {
-  DEBUGASSERT(o != NULL);
+  LIBDSP_DEBUGASSERT(o != NULL);
 
   return o->angle;
 }

--- a/libs/libdsp/lib_observer.c
+++ b/libs/libdsp/lib_observer.c
@@ -51,7 +51,7 @@
  *
  ****************************************************************************/
 
-void motor_observer_init(FAR struct motor_observer_s *observer,
+void motor_observer_init(FAR struct motor_observer_f32_s *observer,
                          FAR void *ao, FAR void *so, float per)
 {
   DEBUGASSERT(observer != NULL);
@@ -61,7 +61,7 @@ void motor_observer_init(FAR struct motor_observer_s *observer,
 
   /* Reset observer data */
 
-  memset(observer, 0, sizeof(struct motor_observer_s));
+  memset(observer, 0, sizeof(struct motor_observer_f32_s));
 
   /* Set observer period */
 
@@ -92,9 +92,8 @@ void motor_observer_init(FAR struct motor_observer_s *observer,
  *
  ****************************************************************************/
 
-void motor_observer_smo_init(FAR struct motor_observer_smo_s *smo,
-                             float kslide,
-                             float err_max)
+void motor_observer_smo_init(FAR struct motor_observer_smo_f32_s *smo,
+                             float kslide, float err_max)
 {
   DEBUGASSERT(smo != NULL);
   DEBUGASSERT(kslide > 0.0f);
@@ -102,7 +101,7 @@ void motor_observer_smo_init(FAR struct motor_observer_smo_s *smo,
 
   /* Reset structure */
 
-  memset(smo, 0, sizeof(struct motor_observer_smo_s));
+  memset(smo, 0, sizeof(struct motor_observer_smo_f32_s));
 
   /* Initialize structure */
 
@@ -167,24 +166,24 @@ void motor_observer_smo_init(FAR struct motor_observer_smo_s *smo,
  *
  ****************************************************************************/
 
-void motor_observer_smo(FAR struct motor_observer_s *o, FAR ab_frame_t *i_ab,
-                        FAR ab_frame_t *v_ab,
-                        FAR struct motor_phy_params_s *phy, float dir)
+void motor_observer_smo(FAR struct motor_observer_f32_s *o,
+                        FAR ab_frame_f32_t *i_ab, FAR ab_frame_f32_t *v_ab,
+                        FAR struct motor_phy_params_f32_s *phy, float dir)
 {
   DEBUGASSERT(o != NULL);
   DEBUGASSERT(i_ab != NULL);
   DEBUGASSERT(v_ab != NULL);
   DEBUGASSERT(phy != NULL);
 
-  FAR struct motor_observer_smo_s *smo =
-    (FAR struct motor_observer_smo_s *)o->ao;
-  FAR ab_frame_t *emf    = &smo->emf;
-  FAR ab_frame_t *emf_f  = &smo->emf_f;
-  FAR ab_frame_t *z      = &smo->z;
-  FAR ab_frame_t *i_est  = &smo->i_est;
-  FAR ab_frame_t *v_err  = &smo->v_err;
-  FAR ab_frame_t *i_err  = &smo->i_err;
-  FAR ab_frame_t *sign   = &smo->sign;
+  FAR struct motor_observer_smo_f32_s *smo =
+    (FAR struct motor_observer_smo_f32_s *)o->ao;
+  FAR ab_frame_f32_t *emf    = &smo->emf;
+  FAR ab_frame_f32_t *emf_f  = &smo->emf_f;
+  FAR ab_frame_f32_t *z      = &smo->z;
+  FAR ab_frame_f32_t *i_est  = &smo->i_est;
+  FAR ab_frame_f32_t *v_err  = &smo->v_err;
+  FAR ab_frame_f32_t *i_err  = &smo->i_err;
+  FAR ab_frame_f32_t *sign   = &smo->sign;
   float i_err_a_abs  = 0.0f;
   float i_err_b_abs  = 0.0f;
   float angle        = 0.0f;
@@ -380,10 +379,8 @@ void motor_observer_smo(FAR struct motor_observer_s *o, FAR ab_frame_t *i_ab,
  *
  ****************************************************************************/
 
-void motor_sobserver_div_init(FAR struct motor_sobserver_div_s *so,
-                              uint8_t samples,
-                              float filter,
-                              float per)
+void motor_sobserver_div_init(FAR struct motor_sobserver_div_f32_s *so,
+                              uint8_t samples, float filter, float per)
 {
   DEBUGASSERT(so != NULL);
   DEBUGASSERT(samples > 0);
@@ -391,7 +388,7 @@ void motor_sobserver_div_init(FAR struct motor_sobserver_div_s *so,
 
   /* Reset observer data */
 
-  memset(so, 0, sizeof(struct motor_sobserver_div_s));
+  memset(so, 0, sizeof(struct motor_sobserver_div_f32_s));
 
   /* Store number of samples for DIV observer */
 
@@ -421,15 +418,15 @@ void motor_sobserver_div_init(FAR struct motor_sobserver_div_s *so,
  *
  ****************************************************************************/
 
-void motor_sobserver_div(FAR struct motor_observer_s *o,
-                          float angle, float dir)
+void motor_sobserver_div(FAR struct motor_observer_f32_s *o,
+                         float angle, float dir)
 {
   DEBUGASSERT(o != NULL);
   DEBUGASSERT(angle >= 0.0f && angle <= 2*M_PI_F);
   DEBUGASSERT(dir == DIR_CW || dir == DIR_CCW);
 
-  FAR struct motor_sobserver_div_s *so =
-    (FAR struct motor_sobserver_div_s *)o->so;
+  FAR struct motor_sobserver_div_f32_s *so =
+    (FAR struct motor_sobserver_div_f32_s *)o->so;
   volatile float omega = 0.0f;
 
   /* Get angle diff */
@@ -516,7 +513,7 @@ void motor_sobserver_div(FAR struct motor_observer_s *o,
  *
  ****************************************************************************/
 
-float motor_observer_speed_get(FAR struct motor_observer_s *o)
+float motor_observer_speed_get(FAR struct motor_observer_f32_s *o)
 {
   DEBUGASSERT(o != NULL);
 
@@ -537,7 +534,7 @@ float motor_observer_speed_get(FAR struct motor_observer_s *o)
  *
  ****************************************************************************/
 
-float motor_observer_angle_get(FAR struct motor_observer_s *o)
+float motor_observer_angle_get(FAR struct motor_observer_f32_s *o)
 {
   DEBUGASSERT(o != NULL);
 

--- a/libs/libdsp/lib_observer.c
+++ b/libs/libdsp/lib_observer.c
@@ -110,7 +110,7 @@ void motor_observer_smo_init(FAR struct motor_observer_smo_f32_s *smo,
 
   /* Store inverted err_max to avoid division */
 
-  smo->one_by_err_max = (1.0f/err_max);
+  smo->one_by_err_max = (1.0f / err_max);
 }
 
 /****************************************************************************

--- a/libs/libdsp/lib_observer.c
+++ b/libs/libdsp/lib_observer.c
@@ -107,6 +107,10 @@ void motor_observer_smo_init(FAR struct motor_observer_smo_f32_s *smo,
 
   smo->k_slide = kslide;
   smo->err_max = err_max;
+
+  /* Store inverted err_max to avoid division */
+
+  smo->one_by_err_max = (1.0f/err_max);
 }
 
 /****************************************************************************
@@ -159,7 +163,8 @@ void motor_observer_smo_init(FAR struct motor_observer_smo_f32_s *smo,
  *   i_ab   - (in) inverter alpha-beta current
  *   v_ab   - (in) inverter alpha-beta voltage
  *   phy    - (in) pointer to the motor physical parameters
- *   dir    - (in) rotation direction (1.0 for CW, -1.0 for CCW)
+ *   dir    - (in) rotation direction (1.0 for CCW, -1.0 for CW)
+ *            NOTE: (mechanical dir) = -(electrical dir)
  *
  * Returned Value:
  *   None
@@ -189,7 +194,9 @@ void motor_observer_smo(FAR struct motor_observer_f32_s *o,
   float angle        = 0.0f;
   float filter       = 0.0f;
 
-  /* REVISIT: observer works only when IQ current is high enough */
+  /* REVISIT: observer works only when IQ current is high enough
+   * Lower IQ current -> lower K_SLIDE
+   */
 
   /* Calculate observer gains */
 
@@ -289,7 +296,7 @@ void motor_observer_smo(FAR struct motor_observer_f32_s *o,
     {
       /* Enter linear region if error is small enough */
 
-      z->a = i_err->a * smo->k_slide / smo->err_max;
+      z->a = i_err->a * smo->k_slide * smo->one_by_err_max;
     }
   else
     {
@@ -302,7 +309,7 @@ void motor_observer_smo(FAR struct motor_observer_f32_s *o,
     {
       /* Enter linear region if error is small enough */
 
-      z->b = i_err->b * smo->k_slide / smo->err_max;
+      z->b = i_err->b * smo->k_slide * smo->one_by_err_max;
     }
   else
     {
@@ -325,23 +332,11 @@ void motor_observer_smo(FAR struct motor_observer_f32_s *o,
    *   emf_a = -|emf| * sin(th)
    *   emf_b =  |emf| * cos(th)
    *   th = atan2(-emf_a, emf->b)
+   *
+   * NOTE: bottleneck but we can't do much more to optimise this
    */
 
   angle = fast_atan2(-emf->a, emf->b);
-
-#if 1
-  /* Some assertions
-   * TODO: simplify
-   */
-
-  if (angle != angle) angle = 0.0f;
-  if (emf->a != emf->a) emf->a = 0.0f;
-  if (emf->b != emf->b) emf->b = 0.0f;
-  if (z->a != z->a) z->a = 0.0f;
-  if (z->b != z->b) z->b = 0.0f;
-  if (i_est->a != i_est->a) i_est->a = 0.0f;
-  if (i_est->b != i_est->b) i_est->b = 0.0f;
-#endif
 
   /* Angle compensation.
    * Due to low pass filtering we have some delay in estimated phase angle.
@@ -398,7 +393,7 @@ void motor_sobserver_div_init(FAR struct motor_sobserver_div_f32_s *so,
 
   so->filter  = filter;
 
-  /*  */
+  /* Store inverted sampling period */
 
   so->one_by_dt = 1.0f / (so->samples * per);
 }

--- a/libs/libdsp/lib_pid.c
+++ b/libs/libdsp/lib_pid.c
@@ -60,6 +60,7 @@ void pid_controller_init(FAR pid_controller_f32_t *pid, float KP, float KI,
   pid->KP = KP;
   pid->KI = KI;
   pid->KD = KD;
+  pid->KC = 0.0;
 }
 
 /****************************************************************************
@@ -92,6 +93,12 @@ void pi_controller_init(FAR pid_controller_f32_t *pid, float KP, float KI)
   pid->KP = KP;
   pid->KI = KI;
   pid->KD = 0.0f;
+  pid->KC = 0.0f;
+
+  /* No windup-protection at default */
+
+  pid->aw_en     = false;
+  pid->ireset_en = false;
 }
 
 /****************************************************************************
@@ -119,6 +126,10 @@ void pid_saturation_set(FAR pid_controller_f32_t *pid, float min, float max)
 
   pid->sat.max = max;
   pid->sat.min = min;
+
+  /* Enable saturation in PID controller */
+
+  pid->pidsat_en = true;
 }
 
 /****************************************************************************
@@ -141,7 +152,32 @@ void pi_saturation_set(FAR pid_controller_f32_t *pid, float min, float max)
   LIBDSP_DEBUGASSERT(pid != NULL);
   LIBDSP_DEBUGASSERT(min < max);
 
-  pid_saturation_set(pid, min, max);
+  pid->sat.max = max;
+  pid->sat.min = min;
+
+  /* Enable saturation in PI controller */
+
+  pid->pisat_en = true;
+}
+
+/****************************************************************************
+ * Name: pid_antiwindup_enable
+ ****************************************************************************/
+
+void pi_antiwindup_enable(FAR pid_controller_f32_t *pid, float KC,
+                          bool enable)
+{
+  pid->aw_en = enable;
+  pid->KC    = KC;
+}
+
+/****************************************************************************
+ * Name: pid_ireset_enable
+ ****************************************************************************/
+
+void pi_ireset_enable(FAR pid_controller_f32_t *pid, bool enable)
+{
+  pid->ireset_en = enable;
 }
 
 /****************************************************************************
@@ -151,6 +187,7 @@ void pi_saturation_set(FAR pid_controller_f32_t *pid, float min, float max)
 void pid_integral_reset(FAR pid_controller_f32_t *pid)
 {
   pid->part[1] = 0.0f;
+  pid->aw      = 0.0f;
 }
 
 /****************************************************************************
@@ -181,6 +218,8 @@ float pi_controller(FAR pid_controller_f32_t *pid, float err)
 {
   LIBDSP_DEBUGASSERT(pid != NULL);
 
+  float tmp = 0.0f;
+
   /* Store error in controller structure */
 
   pid->err = err;
@@ -191,45 +230,59 @@ float pi_controller(FAR pid_controller_f32_t *pid, float err)
 
   /* Get intergral part */
 
-  pid->part[1] += pid->KI * err;
+  pid->part[1] += pid->KI * (err - pid->aw);
 
   /* Add proportional, integral */
 
   pid->out = pid->part[0] + pid->part[1];
 
-  /* Saturate output only if we are not in a PID calculation and only
-   * if some limits are set. Saturation for a PID controller are done later
-   * in PID routine.
-   */
+  /* Store not saturated output */
 
-  if (pid->sat.max != pid->sat.min && pid->KD == 0.0f)
+  tmp = pid->out;
+
+  /* Saturate output if enabled */
+
+  if (pid->pisat_en == true)
     {
       if (pid->out > pid->sat.max)
         {
+          if (pid->ireset_en == true)
+            {
+              /* Reset I part */
+
+              if (err > 0.0f)
+                {
+                  pi_integral_reset(pid);
+                }
+            }
+
           /* Limit output to the upper limit */
 
           pid->out = pid->sat.max;
-
-          /* Integral anti-windup - reset integral part */
-
-          if (err > 0.0f)
-            {
-              pi_integral_reset(pid);
-            }
         }
       else if (pid->out < pid->sat.min)
         {
+          if (pid->ireset_en == true)
+            {
+              /* Reset I part */
+
+              if (err < 0.0f)
+                {
+                  pi_integral_reset(pid);
+                }
+            }
+
           /* Limit output to the lower limit */
 
           pid->out = pid->sat.min;
-
-          /* Integral anti-windup - reset integral part */
-
-          if (err < 0.0f)
-            {
-              pi_integral_reset(pid);
-            }
         }
+    }
+
+  /* Anti-windup I-part decay if enabled */
+
+  if (pid->aw_en == true)
+    {
+      pid->aw = pid->KC * (tmp - pid->out);
     }
 
   /* Return regulator output */
@@ -272,9 +325,9 @@ float pid_controller(FAR pid_controller_f32_t *pid, float err)
 
   pid->err_prev = err;
 
-  /* Saturate output if limits are set */
+  /* Saturate output if enabled */
 
-  if (pid->sat.max != pid->sat.min)
+  if (pid->pidsat_en == true)
     {
       if (pid->out > pid->sat.max)
         {

--- a/libs/libdsp/lib_pid.c
+++ b/libs/libdsp/lib_pid.c
@@ -49,7 +49,7 @@
 void pid_controller_init(FAR pid_controller_f32_t *pid, float KP, float KI,
                          float KD)
 {
-  DEBUGASSERT(pid != NULL);
+  LIBDSP_DEBUGASSERT(pid != NULL);
 
   /* Reset controller data */
 
@@ -81,7 +81,7 @@ void pid_controller_init(FAR pid_controller_f32_t *pid, float KP, float KI,
 
 void pi_controller_init(FAR pid_controller_f32_t *pid, float KP, float KI)
 {
-  DEBUGASSERT(pid != NULL);
+  LIBDSP_DEBUGASSERT(pid != NULL);
 
   /* Reset controller data */
 
@@ -114,8 +114,8 @@ void pi_controller_init(FAR pid_controller_f32_t *pid, float KP, float KI)
 
 void pid_saturation_set(FAR pid_controller_f32_t *pid, float min, float max)
 {
-  DEBUGASSERT(pid != NULL);
-  DEBUGASSERT(min < max);
+  LIBDSP_DEBUGASSERT(pid != NULL);
+  LIBDSP_DEBUGASSERT(min < max);
 
   pid->sat.max = max;
   pid->sat.min = min;
@@ -138,8 +138,8 @@ void pid_saturation_set(FAR pid_controller_f32_t *pid, float min, float max)
 
 void pi_saturation_set(FAR pid_controller_f32_t *pid, float min, float max)
 {
-  DEBUGASSERT(pid != NULL);
-  DEBUGASSERT(min < max);
+  LIBDSP_DEBUGASSERT(pid != NULL);
+  LIBDSP_DEBUGASSERT(min < max);
 
   pid_saturation_set(pid, min, max);
 }
@@ -179,7 +179,7 @@ void pi_integral_reset(FAR pid_controller_f32_t *pid)
 
 float pi_controller(FAR pid_controller_f32_t *pid, float err)
 {
-  DEBUGASSERT(pid != NULL);
+  LIBDSP_DEBUGASSERT(pid != NULL);
 
   /* Store error in controller structure */
 
@@ -254,7 +254,7 @@ float pi_controller(FAR pid_controller_f32_t *pid, float err)
 
 float pid_controller(FAR pid_controller_f32_t *pid, float err)
 {
-  DEBUGASSERT(pid != NULL);
+  LIBDSP_DEBUGASSERT(pid != NULL);
 
   /* Get PI output */
 

--- a/libs/libdsp/lib_pid.c
+++ b/libs/libdsp/lib_pid.c
@@ -46,14 +46,14 @@
  *
  ****************************************************************************/
 
-void pid_controller_init(FAR pid_controller_t *pid, float KP, float KI,
+void pid_controller_init(FAR pid_controller_f32_t *pid, float KP, float KI,
                          float KD)
 {
   DEBUGASSERT(pid != NULL);
 
   /* Reset controller data */
 
-  memset(pid, 0, sizeof(pid_controller_t));
+  memset(pid, 0, sizeof(pid_controller_f32_t));
 
   /* Copy controller parameters */
 
@@ -79,13 +79,13 @@ void pid_controller_init(FAR pid_controller_t *pid, float KP, float KI,
  *
  ****************************************************************************/
 
-void pi_controller_init(FAR pid_controller_t *pid, float KP, float KI)
+void pi_controller_init(FAR pid_controller_f32_t *pid, float KP, float KI)
 {
   DEBUGASSERT(pid != NULL);
 
   /* Reset controller data */
 
-  memset(pid, 0, sizeof(pid_controller_t));
+  memset(pid, 0, sizeof(pid_controller_f32_t));
 
   /* Copy controller parameters */
 
@@ -112,7 +112,7 @@ void pi_controller_init(FAR pid_controller_t *pid, float KP, float KI)
  *
  ****************************************************************************/
 
-void pid_saturation_set(FAR pid_controller_t *pid, float min, float max)
+void pid_saturation_set(FAR pid_controller_f32_t *pid, float min, float max)
 {
   DEBUGASSERT(pid != NULL);
   DEBUGASSERT(min < max);
@@ -136,7 +136,7 @@ void pid_saturation_set(FAR pid_controller_t *pid, float min, float max)
  *
  ****************************************************************************/
 
-void pi_saturation_set(FAR pid_controller_t *pid, float min, float max)
+void pi_saturation_set(FAR pid_controller_f32_t *pid, float min, float max)
 {
   DEBUGASSERT(pid != NULL);
   DEBUGASSERT(min < max);
@@ -148,7 +148,7 @@ void pi_saturation_set(FAR pid_controller_t *pid, float min, float max)
  * Name: pid_integral_reset
  ****************************************************************************/
 
-void pid_integral_reset(FAR pid_controller_t *pid)
+void pid_integral_reset(FAR pid_controller_f32_t *pid)
 {
   pid->part[1] = 0.0f;
 }
@@ -157,7 +157,7 @@ void pid_integral_reset(FAR pid_controller_t *pid)
  * Name: pi_integral_reset
  ****************************************************************************/
 
-void pi_integral_reset(FAR pid_controller_t *pid)
+void pi_integral_reset(FAR pid_controller_f32_t *pid)
 {
   pid_integral_reset(pid);
 }
@@ -177,7 +177,7 @@ void pi_integral_reset(FAR pid_controller_t *pid)
  *
  ****************************************************************************/
 
-float pi_controller(FAR pid_controller_t *pid, float err)
+float pi_controller(FAR pid_controller_f32_t *pid, float err)
 {
   DEBUGASSERT(pid != NULL);
 
@@ -252,7 +252,7 @@ float pi_controller(FAR pid_controller_t *pid, float err)
  *
  ****************************************************************************/
 
-float pid_controller(FAR pid_controller_t *pid, float err)
+float pid_controller(FAR pid_controller_f32_t *pid, float err)
 {
   DEBUGASSERT(pid != NULL);
 

--- a/libs/libdsp/lib_pid_b16.c
+++ b/libs/libdsp/lib_pid_b16.c
@@ -1,0 +1,352 @@
+/****************************************************************************
+ * libs/libdsp/lib_pid_b16.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <dspb16.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pid_controller_init_b16
+ *
+ * Description:
+ *   Initialize PID controller. This function does not initialize saturation
+ *   limits.
+ *
+ * Input Parameters:
+ *   pid - (out) pointer to the PID controller data
+ *   KP  - (in) proportional gain
+ *   KI  - (in) integral gain
+ *   KD  - (in) derivative gain
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void pid_controller_init_b16(FAR pid_controller_b16_t *pid, b16_t KP,
+                             b16_t KI, b16_t KD)
+{
+  LIBDSP_DEBUGASSERT(pid != NULL);
+
+  /* Reset controller data */
+
+  memset(pid, 0, sizeof(pid_controller_b16_t));
+
+  /* Copy controller parameters */
+
+  pid->KP = KP;
+  pid->KI = KI;
+  pid->KD = KD;
+  pid->KC = 0;
+}
+
+/****************************************************************************
+ * Name: pi_controller_init_b16
+ *
+ * Description:
+ *   Initialize PI controller. This function does not initialize saturation
+ *   limits.
+ *
+ * Input Parameters:
+ *   pid - (out) pointer to the PID controller data
+ *   KP  - (in) proportional gain
+ *   KI  - (in) integral gain
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void pi_controller_init_b16(FAR pid_controller_b16_t *pid, b16_t KP,
+                            b16_t KI)
+{
+  LIBDSP_DEBUGASSERT(pid != NULL);
+
+  /* Reset controller data */
+
+  memset(pid, 0, sizeof(pid_controller_b16_t));
+
+  /* Copy controller parameters */
+
+  pid->KP = KP;
+  pid->KI = KI;
+  pid->KD = 0;
+  pid->KC = 0;
+
+  /* No windup-protection at default */
+
+  pid->aw_en     = false;
+  pid->ireset_en = false;
+}
+
+/****************************************************************************
+ * Name: pid_saturation_set_b16
+ *
+ * Description:
+ *   Set controller saturation limits. Sometimes we need change saturation
+ *   configuration in the run-time, so this function is separate from
+ *   pid_controller_init().
+ *
+ * Input Parameters:
+ *   pid - (out) pointer to the PID controller data
+ *   min - (in) lower limit
+ *   max - (in) upper limit
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void pid_saturation_set_b16(FAR pid_controller_b16_t *pid, b16_t min,
+                            b16_t max)
+{
+  LIBDSP_DEBUGASSERT(pid != NULL);
+  LIBDSP_DEBUGASSERT(min < max);
+
+  pid->sat.max = max;
+  pid->sat.min = min;
+
+  /* Enable saturation in PID controller */
+
+  pid->pidsat_en = true;
+}
+
+/****************************************************************************
+ * Name: pi_saturation_set_b16
+ *
+ * Description:
+ *
+ * Input Parameters:
+ *   pid - (out) pointer to the PID controller data
+ *   min - (in) lower limit
+ *   max - (in) upper limit
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void pi_saturation_set_b16(FAR pid_controller_b16_t *pid, b16_t min,
+                           b16_t max)
+{
+  LIBDSP_DEBUGASSERT(pid != NULL);
+  LIBDSP_DEBUGASSERT(min < max);
+
+  pid->sat.max = max;
+  pid->sat.min = min;
+
+  /* Enable saturation in PI controller */
+
+  pid->pisat_en = true;
+}
+
+/****************************************************************************
+ * Name: pid_antiwindup_enable_b16
+ ****************************************************************************/
+
+void pi_antiwindup_enable_b16(FAR pid_controller_b16_t *pid, b16_t KC,
+                              bool enable)
+{
+  pid->aw_en = enable;
+  pid->KC    = KC;
+}
+
+/****************************************************************************
+ * Name: pid_ireset_enable_b16
+ ****************************************************************************/
+
+void pi_ireset_enable_b16(FAR pid_controller_b16_t *pid, bool enable)
+{
+  pid->ireset_en = enable;
+}
+
+/****************************************************************************
+ * Name: pid_integral_reset_b16
+ ****************************************************************************/
+
+void pid_integral_reset_b16(FAR pid_controller_b16_t *pid)
+{
+  pid->part[1] = 0;
+  pid->aw      = 0;
+}
+
+/****************************************************************************
+ * Name: pi_integral_reset_b16
+ ****************************************************************************/
+
+void pi_integral_reset_b16(FAR pid_controller_b16_t *pid)
+{
+  pid_integral_reset_b16(pid);
+}
+
+/****************************************************************************
+ * Name: pi_controller_b16
+ *
+ * Description:
+ *   PI controller with output saturation and windup protection
+ *
+ * Input Parameters:
+ *   pid - (in/out) pointer to the PI controller data
+ *   err - (in) current controller error
+ *
+ * Returned Value:
+ *   Return controller output.
+ *
+ ****************************************************************************/
+
+b16_t pi_controller_b16(FAR pid_controller_b16_t *pid, b16_t err)
+{
+  LIBDSP_DEBUGASSERT(pid != NULL);
+
+  b16_t tmp = 0;
+
+  /* Store error in controller structure */
+
+  pid->err = err;
+
+  /* Get proportional part */
+
+  pid->part[0] = b16mulb16(pid->KP, err);
+
+  /* Get intergral part */
+
+  pid->part[1] += b16mulb16(pid->KI, (err - pid->aw));
+
+  /* Add proportional, integral */
+
+  pid->out = pid->part[0] + pid->part[1];
+
+  /* Store not saturated output */
+
+  tmp = pid->out;
+
+  /* Saturate output if enabled */
+
+  if (pid->pisat_en == true)
+    {
+      if (pid->out > pid->sat.max)
+        {
+          if (pid->ireset_en == true)
+            {
+              /* Reset I part */
+
+              if (err > 0)
+                {
+                  pi_integral_reset_b16(pid);
+                }
+            }
+
+          /* Limit output to the upper limit */
+
+          pid->out = pid->sat.max;
+        }
+      else if (pid->out < pid->sat.min)
+        {
+          if (pid->ireset_en == true)
+            {
+              /* Reset I part */
+
+              if (err < 0)
+                {
+                  pi_integral_reset_b16(pid);
+                }
+            }
+
+          /* Limit output to the lower limit */
+
+          pid->out = pid->sat.min;
+        }
+    }
+
+  /* Anti-windup I-part decay if enabled */
+
+  if (pid->aw_en == true)
+    {
+      pid->aw = b16mulb16(pid->KC, (tmp - pid->out));
+    }
+
+  /* Return regulator output */
+
+  return pid->out;
+}
+
+/****************************************************************************
+ * Name: pid_controller_b16
+ *
+ * Description:
+ *   PID controller with output saturation and windup protection
+ *
+ * Input Parameters:
+ *   pid - (in/out) pointer to the PID controller data
+ *   err - (in) current controller error
+ *
+ * Returned Value:
+ *   Return controller output.
+ *
+ ****************************************************************************/
+
+b16_t pid_controller_b16(FAR pid_controller_b16_t *pid, b16_t err)
+{
+  LIBDSP_DEBUGASSERT(pid != NULL);
+
+  /* Get PI output */
+
+  pi_controller_b16(pid, err);
+
+  /* Get derivative part */
+
+  pid->part[2] = b16mulb16(pid->KD, (err - pid->err_prev));
+
+  /* Add derivative part to the PI part */
+
+  pid->out += pid->part[2];
+
+  /* Store current error */
+
+  pid->err_prev = err;
+
+  /* Saturate output if enabled */
+
+  if (pid->pidsat_en == true)
+    {
+      if (pid->out > pid->sat.max)
+        {
+          /* Limit output to the upper limit */
+
+          pid->out = pid->sat.max;
+        }
+      else if (pid->out < pid->sat.min)
+        {
+          /* Limit output to the lower limit */
+
+          pid->out = pid->sat.min;
+        }
+    }
+
+  /* Return regulator output */
+
+  return pid->out;
+}

--- a/libs/libdsp/lib_pmsm_model.c
+++ b/libs/libdsp/lib_pmsm_model.c
@@ -1,0 +1,283 @@
+/****************************************************************************
+ * libs/libdsp/lib_pmsm_model.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Permanent magnet synchronous motor model (PMSM)
+ *
+ * 1) Flux equation:
+ *
+ *   lambda_q = L_q * i_q
+ *   lambda_d = L_d * i_d + lampda_m
+ *
+ * 2) Voltage equation:
+ *
+ *   a) D-part:
+ *
+ *       id    Rs          Ld
+ *    o-->----/\/\/\/\----mmmmmm----+
+ *    ^                             |
+ *    .                             |
+ *    .                          .-----.
+ *    .                          |  ^  |
+ * vd .                          |  |  |
+ *    .                          .-----.
+ *    .                             | ed
+ *    .                             |
+ *    o-----------------------------+
+ *
+ *   ed = -we * lamda_q
+ *   ed = -we * (Lq * iq)
+ *
+ *   vd = (Rs * id) + (d/dt * (Ld * id)) - (Lq * we * iq)
+ *   Ld * (d/dt * id) = vd - (Rs * id) + (we * Lq * iq)
+ *   (d/dt * id) = (vd - (Rs * id) + (we * Lq * iq)) / Ld
+ *
+ *   b) Q-part:
+ *
+ *       iq    Rs          Lq
+ *    o-->----/\/\/\/\----mmmmmm----+
+ *    ^                             |
+ *    .                             |
+ *    .                          .-----.
+ *    .                          |  ^  |
+ * vq .                          |  |  |
+ *    .                          .-----.
+ *    .                             | eq
+ *    .                             |
+ *    o-----------------------------+
+ *
+ *   eq = we * lamda_d
+ *   eq = we * (Lq * iq + lamda_m)
+ *
+ *   vq = (Rs * iq) + (d/dt * (Lq * iq)) + (we * (Ld * id + lambda_m))
+ *   Lq * (d/dt * iq) = vq - (Rs * iq) - (we * (Ld * id + lambda_m))
+ *   (d/dt * iq) = (vq - (Rs * iq) - (we * (Ld * id + lambda_m))) / Lq
+ *
+ * 3) Torque equation:
+ *
+ *   Te = (3/2) * p * (lambda_d * i_q - lambda_q * i_d)
+ *   Te = (3/2) * p * (lambda_m * i_q + (L_d - L_q) * i_q * i_d)
+ *   Te = (3/2) * p * i_q * (lambda_m  + (L_d - L_q) * i_d)
+ *
+ * 4) Electromechanical power equation:
+ *
+ *   Pem = wm * Te
+ *   Pem = (3/2) * wm * (lamda_d * i_q - lamda_q * i_d)
+ *
+ * 5) The general mechanical equation for the motor:
+ *
+ *   Te = Tl + Td + B * wm + J * (d/dt) * wm
+ *   we = p * wm = (P/2) * wm
+ *   p  = (P/2)
+ *
+ *   assume no friction:
+ *
+ *     Te = Tl + J * (d/dt) * wm
+ *     (d/dt) * wm = (Te - Tl) / J
+ *
+ *  where:
+ *   B        - viscous frictions coefficient
+ *   J        - interia of the shaft and the load system
+ *   Td       - dry friction
+ *   Tl       - load torque
+ *   Te       - electromagnetic torque
+ *   Pe       - electromagnetical power
+ *   we       - electrical velociti of the motor
+ *   wm       - mechanical velocity of the rotor
+ *   lambda_m - flux linkage
+ *   P        - Number of poles
+ *   p        - pole pairs
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <dsp.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pmsm_model_initialize
+ *
+ * Description:
+ *   Initialzie FOC model
+ *
+ ****************************************************************************/
+
+int pmsm_model_initialize(FAR struct pmsm_model_f32_s *model,
+                          FAR struct pmsm_phy_params_f32_s *phy,
+                          float per)
+{
+  DEBUGASSERT(model);
+  DEBUGASSERT(phy);
+  DEBUGASSERT(per > 0.0f);
+
+  /* Copy motor model parameters */
+
+  memcpy(&model->phy, phy, sizeof(struct pmsm_phy_params_f32_s));
+
+  /* Initialize controller period */
+
+  model->per = per;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: pmsm_model_elec
+ *
+ * Description:
+ *  Update motor model electrical state
+ *
+ ****************************************************************************/
+
+int pmsm_model_elec(FAR struct pmsm_model_f32_s *model,
+                    FAR ab_frame_f32_t *vab)
+{
+  float tmp1 = 0.0f;
+  float tmp2 = 0.0f;
+  float tmp3 = 0.0f;
+  float tmp4 = 0.0f;
+  float tmp5 = 0.0f;
+  float tmp6 = 0.0f;
+
+  DEBUGASSERT(model);
+  DEBUGASSERT(vab);
+
+  /* Copy alpha-beta voltage */
+
+  model->state.v_ab.a = vab->a;
+  model->state.v_ab.b = vab->b;
+
+  /* Inverse Clarke transform - get abc voltage */
+
+  inv_clarke_transform(&model->state.v_ab,
+                       &model->state.v_abc);
+
+  /* Park transform - get DQ voltage */
+
+  park_transform(&model->state.angle.angle_el,
+                 &model->state.v_ab,
+                 &model->state.v_dq);
+
+  /* q current */
+
+  tmp1 = model->phy.motor.res * model->state.i_dq.q;
+  tmp2 = model->phy.ind_d * model->state.i_dq.d;
+  tmp3 = tmp2 + model->phy.flux_link;
+  tmp4 = model->state.omega_e * tmp3;
+  tmp5 = model->state.v_dq.q - tmp1 - tmp4;
+  tmp6 = model->per * tmp5;
+
+  model->iq_int += (tmp6 * model->phy.one_by_indq);
+
+  /* d current */
+
+  tmp1 = model->phy.motor.res * model->state.i_dq.d;
+  tmp2 = model->phy.ind_q * model->state.i_dq.q;
+  tmp3 = tmp2 * model->state.omega_e;
+  tmp4 = model->state.v_dq.d - tmp1 + tmp3;
+  tmp5 = model->per * tmp4;
+
+  model->id_int += (tmp5 * model->phy.one_by_indd);
+
+  /* Store currents */
+
+  model->state.i_dq.q = model->iq_int;
+  model->state.i_dq.d = model->id_int;
+
+  /* Inverse Park transform - get alpha-beta current */
+
+  inv_park_transform(&model->state.angle.angle_el,
+                     &model->state.i_dq,
+                     &model->state.i_ab);
+
+  /* Inverse Clarke transform - get abc current */
+
+  inv_clarke_transform(&model->state.i_ab,
+                       &model->state.i_abc);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: pmsm_model_mech
+ *
+ * Description:
+ *  Update motor model mechanical state
+ *
+ ****************************************************************************/
+
+int pmsm_model_mech(FAR struct pmsm_model_f32_s *model, float load)
+{
+  float angle = 0.0f;
+  float dir   = 0.0f;
+  float te    = 0.0f;
+  float tmp1  = 0.0f;
+  float tmp2  = 0.0f;
+  float tmp3  = 0.0f;
+  float tmp4  = 0.0f;
+  float tmp5  = 0.0f;
+
+  DEBUGASSERT(model);
+
+  /* Get electrical torque developed by the motor */
+
+  tmp1 = model->phy.ind_d - model->phy.ind_q;
+  tmp2 = tmp1 * model->state.i_dq.d;
+  tmp3 = model->phy.flux_link - tmp2;
+  tmp4 = 1.5f * model->phy.motor.p;
+  tmp5 = tmp4 * model->state.i_dq.q;
+
+  te =  tmp5 * tmp3;
+
+  /* Get new mechanical velocity */
+
+  tmp1 = te - load;
+  tmp2 = model->per * tmp1 ;
+  tmp3 = tmp2 * model->phy.one_by_iner;
+
+  model->state.omega_m = (model->state.omega_m + tmp3);
+
+  /* Get new electrical velocity */
+
+  model->state.omega_e = model->state.omega_m * model->phy.motor.p;
+
+  /* Get rotation direction */
+
+  dir = (model->state.omega_e > 0 ? DIR_CW : DIR_CCW);
+
+  /* Update electrical angle */
+
+  tmp1 = model->state.omega_e * model->per;
+
+  angle = model->state.angle.angle_el.angle + tmp1;
+
+  /* Update with mechanical angel */
+
+  motor_angle_e_update(&model->state.angle, angle, dir);
+
+  return OK;
+}

--- a/libs/libdsp/lib_pmsm_model_b16.c
+++ b/libs/libdsp/lib_pmsm_model_b16.c
@@ -1,0 +1,197 @@
+/****************************************************************************
+ * libs/libdsp/lib_pmsm_model_b16.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <dspb16.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pmsm_model_initialize_b16
+ *
+ * Description:
+ *   Initialzie FOC model
+ *
+ ****************************************************************************/
+
+int pmsm_model_initialize_b16(FAR struct pmsm_model_b16_s *model,
+                              FAR struct pmsm_phy_params_b16_s *phy,
+                              b16_t per)
+{
+  DEBUGASSERT(model);
+  DEBUGASSERT(phy);
+  DEBUGASSERT(per > 0);
+
+  /* Copy motor model parameters */
+
+  memcpy(&model->phy, phy, sizeof(struct pmsm_phy_params_b16_s));
+
+  /* Initialize controller period */
+
+  model->per = per;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: pmsm_model_elec_b16
+ *
+ * Description:
+ *  Update motor model electrical state
+ *
+ ****************************************************************************/
+
+int pmsm_model_elec_b16(FAR struct pmsm_model_b16_s *model,
+                        FAR ab_frame_b16_t *vab)
+{
+  b16_t        tmp1   = 0;
+  b16_t        tmp2   = 0;
+  b16_t        tmp3   = 0;
+  b16_t        tmp4   = 0;
+  b16_t        tmp5   = 0;
+  b16_t        tmp6   = 0;
+
+  DEBUGASSERT(model);
+  DEBUGASSERT(vab);
+
+  /* Copy alpha-beta voltage */
+
+  model->state.v_ab.a = vab->a;
+  model->state.v_ab.b = vab->b;
+
+  /* Inverse Clarke transform - get abc voltage */
+
+  inv_clarke_transform_b16(&model->state.v_ab,
+                           &model->state.v_abc);
+
+  /* Park transform - get DQ voltage */
+
+  park_transform_b16(&model->state.angle.angle_el,
+                     &model->state.v_ab,
+                     &model->state.v_dq);
+
+  /* q current */
+
+  tmp1 = b16mulb16(model->phy.motor.res, model->state.i_dq.q);
+  tmp2 = b16mulb16(model->phy.ind_d, model->state.i_dq.d);
+  tmp3 = tmp2 + model->phy.flux_link;
+  tmp4 = b16mulb16(model->state.omega_e, tmp3);
+  tmp5 = model->state.v_dq.q - tmp1 - tmp4;
+  tmp6 = b16mulb16(model->per, tmp5);
+
+  model->iq_int += b16mulb16(tmp6, model->phy.one_by_indq);
+
+  /* d current */
+
+  tmp1 = b16mulb16(model->phy.motor.res, model->state.i_dq.d);
+  tmp2 = b16mulb16(model->phy.ind_q, model->state.i_dq.q);
+  tmp3 = b16mulb16(tmp2, model->state.omega_e);
+  tmp4 = model->state.v_dq.d - tmp1 + tmp3;
+  tmp5 = b16mulb16(model->per, tmp4);
+
+  model->id_int += b16mulb16(tmp5, model->phy.one_by_indd);
+
+  /* Store currents */
+
+  model->state.i_dq.q = model->iq_int;
+  model->state.i_dq.d = model->id_int;
+
+  /* Inverse Park transform - get alpha-beta current */
+
+  inv_park_transform_b16(&model->state.angle.angle_el,
+                         &model->state.i_dq,
+                         &model->state.i_ab);
+
+  /* Inverse Clarke transform - get abc current */
+
+  inv_clarke_transform_b16(&model->state.i_ab,
+                           &model->state.i_abc);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: pmsm_model_mech_b16
+ *
+ * Description:
+ *  Update motor model mechanical state
+ *
+ ****************************************************************************/
+
+int pmsm_model_mech_b16(FAR struct pmsm_model_b16_s *model, b16_t load)
+{
+  b16_t angle = 0;
+  b16_t dir   = 0;
+  b16_t te    = 0;
+  b16_t tmp1  = 0;
+  b16_t tmp2  = 0;
+  b16_t tmp3  = 0;
+  b16_t tmp4  = 0;
+  b16_t tmp5  = 0;
+
+  DEBUGASSERT(model);
+
+  /* Get electrical torque developed by the motor */
+
+  tmp1 = model->phy.ind_d - model->phy.ind_q;
+  tmp2 = b16mulb16(tmp1, model->state.i_dq.d);
+  tmp3 = model->phy.flux_link - tmp2;
+  tmp4 = b16mulb16((b16ONE + b16HALF), itob16(model->phy.motor.p));
+  tmp5 = b16mulb16(tmp4, model->state.i_dq.q);
+
+  te = b16mulb16(tmp5, tmp3);
+
+  /* Get new mechanical velocity */
+
+  tmp1 = te - load;
+  tmp2 = b16mulb16(model->per, tmp1);
+  tmp3 = b16mulb16(tmp2, model->phy.one_by_iner);
+
+  model->state.omega_m = model->state.omega_m + tmp3;
+
+  /* Get new electrical velocity */
+
+  model->state.omega_e = b16mulb16(model->state.omega_m,
+                                   itob16(model->phy.motor.p));
+
+  /* Get rotation direction */
+
+  dir = (model->state.omega_e > 0 ? DIR_CW_B16 : DIR_CCW_B16);
+
+  /* Update electrical angle */
+
+  tmp1 = b16mulb16(model->state.omega_e, model->per);
+
+  angle = model->state.angle.angle_el.angle + tmp1;
+
+  /* Update with mechanical angel */
+
+  motor_angle_e_update_b16(&model->state.angle, angle, dir);
+
+  return OK;
+}

--- a/libs/libdsp/lib_svm.c
+++ b/libs/libdsp/lib_svm.c
@@ -44,7 +44,7 @@
  *
  ****************************************************************************/
 
-static uint8_t svm3_sector_get(FAR abc_frame_t *ijk)
+static uint8_t svm3_sector_get(FAR abc_frame_f32_t *ijk)
 {
   uint8_t sector = 0;
   float i = ijk->a;
@@ -135,7 +135,8 @@ static uint8_t svm3_sector_get(FAR abc_frame_t *ijk)
  *
  ****************************************************************************/
 
-static void svm3_duty_calc(FAR struct svm3_state_s *s, FAR abc_frame_t *ijk)
+static void svm3_duty_calc(FAR struct svm3_state_f32_s *s,
+                           FAR abc_frame_f32_t *ijk)
 {
   float i = ijk->a;
   float j = ijk->b;
@@ -320,12 +321,12 @@ static void svm3_duty_calc(FAR struct svm3_state_s *s, FAR abc_frame_t *ijk)
  *
  ****************************************************************************/
 
-void svm3(FAR struct svm3_state_s *s, FAR ab_frame_t *v_ab)
+void svm3(FAR struct svm3_state_f32_s *s, FAR ab_frame_f32_t *v_ab)
 {
   DEBUGASSERT(s != NULL);
   DEBUGASSERT(v_ab != NULL);
 
-  abc_frame_t ijk;
+  abc_frame_f32_t ijk;
 
   /* Perform modified inverse Clarke-transformation (alpha,beta) -> (i,j,k)
    * to obtain auxiliary frame which will be used in further calculations.
@@ -359,8 +360,8 @@ void svm3(FAR struct svm3_state_s *s, FAR ab_frame_t *v_ab)
  *
  ****************************************************************************/
 
-void svm3_current_correct(FAR struct svm3_state_s *s,
-                              int32_t *c0, int32_t *c1, int32_t *c2)
+void svm3_current_correct(FAR struct svm3_state_f32_s *s,
+                          int32_t *c0, int32_t *c1, int32_t *c2)
 {
   /* Get best ADC samples according to SVM sector.
    *
@@ -432,12 +433,12 @@ void svm3_current_correct(FAR struct svm3_state_s *s,
  *
  ****************************************************************************/
 
-void svm3_init(FAR struct svm3_state_s *s, float min, float max)
+void svm3_init(FAR struct svm3_state_f32_s *s, float min, float max)
 {
   DEBUGASSERT(s != NULL);
   DEBUGASSERT(max > min);
 
-  memset(s, 0, sizeof(struct svm3_state_s));
+  memset(s, 0, sizeof(struct svm3_state_f32_s));
 
   s->d_max = max;
   s->d_min = min;

--- a/libs/libdsp/lib_svm.c
+++ b/libs/libdsp/lib_svm.c
@@ -195,7 +195,7 @@ static void svm3_duty_calc(FAR struct svm3_state_f32_s *s,
         {
           /* We should not get here */
 
-          DEBUGASSERT(0);
+          LIBDSP_DEBUGASSERT(0);
           break;
         }
     }
@@ -260,7 +260,7 @@ static void svm3_duty_calc(FAR struct svm3_state_f32_s *s,
         {
           /* We should not get here */
 
-          DEBUGASSERT(0);
+          LIBDSP_DEBUGASSERT(0);
           break;
         }
     }
@@ -323,8 +323,8 @@ static void svm3_duty_calc(FAR struct svm3_state_f32_s *s,
 
 void svm3(FAR struct svm3_state_f32_s *s, FAR ab_frame_f32_t *v_ab)
 {
-  DEBUGASSERT(s != NULL);
-  DEBUGASSERT(v_ab != NULL);
+  LIBDSP_DEBUGASSERT(s != NULL);
+  LIBDSP_DEBUGASSERT(v_ab != NULL);
 
   abc_frame_f32_t ijk;
 
@@ -435,8 +435,8 @@ void svm3_current_correct(FAR struct svm3_state_f32_s *s,
 
 void svm3_init(FAR struct svm3_state_f32_s *s, float min, float max)
 {
-  DEBUGASSERT(s != NULL);
-  DEBUGASSERT(max > min);
+  LIBDSP_DEBUGASSERT(s != NULL);
+  LIBDSP_DEBUGASSERT(max > min);
 
   memset(s, 0, sizeof(struct svm3_state_f32_s));
 

--- a/libs/libdsp/lib_svm_b16.c
+++ b/libs/libdsp/lib_svm_b16.c
@@ -1,0 +1,437 @@
+/****************************************************************************
+ * libs/libdsp/lib_svm_b16.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+
+#include <dspb16.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: svm3_sector_get_b16
+ *
+ * Description:
+ *   Get current sector for space vector modulation.
+ *
+ * Input Parameters:
+ *   ijk - (in) pointer to the auxiliary ABC frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static uint8_t svm3_sector_get_b16(FAR abc_frame_b16_t *ijk)
+{
+  uint8_t sector = 0;
+  b16_t   i      = ijk->a;
+  b16_t   j      = ijk->b;
+  b16_t   k      = ijk->c;
+
+  /* Identify the correct sector based on i,j,k frame:
+   * 1. sector 1:
+   *              i > 0.0
+   *              j > 0.0
+   *              k <= 0.0
+   * 2. sector 2:
+   *              i <= 0.0
+   *              j >  0.0
+   *              k <= 0.0
+   * 3. sector 3:
+   *              i <= 0.0
+   *              j >  0.0
+   *              k >  0.0
+   * 4. sector 4:
+   *              i <= 0.0
+   *              j <= 0.0
+   *              k >  0.0
+   * 5. sector 5:
+   *              i >  0.0
+   *              j <= 0.0
+   *              k >  0.0
+   * 6. sector 6:
+   *              i >  0.0
+   *              j <=  0.0
+   *              k <=  0.0
+   */
+
+  if (k <= 0)
+    {
+      if (i <= 0)
+        {
+          sector = 2;
+        }
+      else
+        {
+          if (j <= 0)
+            {
+              sector = 6;
+            }
+          else
+            {
+              sector = 1;
+            }
+        }
+    }
+  else
+    {
+      if (i <= 0)
+        {
+          if (j <= 0)
+            {
+              sector = 4;
+            }
+          else
+            {
+              sector = 3;
+            }
+        }
+      else
+        {
+          sector = 5;
+        }
+    }
+
+  /* Return SVM sector */
+
+  return sector;
+}
+
+/****************************************************************************
+ * Name: svm3_duty_calc_b16
+ *
+ * Description:
+ *   Calculate duty cycles for space vector modulation.
+ *
+ * Input Parameters:
+ *   s   - (in/out) pointer to the SVM state data
+ *   ijk - (in) pointer to the auxiliary ABC frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void svm3_duty_calc_b16(FAR struct svm3_state_b16_s *s,
+                               FAR abc_frame_b16_t *ijk)
+{
+  b16_t i  = ijk->a;
+  b16_t j  = ijk->b;
+  b16_t k  = ijk->c;
+  b16_t T0 = 0;
+  b16_t T1 = 0;
+  b16_t T2 = 0;
+
+  /* Determine T1, T2 and T0 based on the sector */
+
+  switch (s->sector)
+    {
+      case 1:
+        {
+          T1 = i;
+          T2 = j;
+          break;
+        }
+
+      case 2:
+        {
+          T1 = -k;
+          T2 = -i;
+          break;
+        }
+
+      case 3:
+        {
+          T1 = j;
+          T2 = k;
+          break;
+        }
+
+      case 4:
+        {
+          T1 = -i;
+          T2 = -j;
+          break;
+        }
+
+      case 5:
+        {
+          T1 = k;
+          T2 = i;
+          break;
+        }
+
+      case 6:
+        {
+          T1 = -j;
+          T2 = -k;
+          break;
+        }
+
+      default:
+        {
+          /* We should not get here */
+
+          LIBDSP_DEBUGASSERT(0);
+          break;
+        }
+    }
+
+  /* Get null vector time */
+
+  T0 = b16ONE - T1 - T2;
+
+  /* Calculate duty cycle for 3 phase */
+
+  switch (s->sector)
+    {
+      case 1:
+        {
+          s->d_u = T1 + T2 + b16mulb16(T0, b16HALF);
+          s->d_v = T2 + b16mulb16(T0, b16HALF);
+          s->d_w = b16mulb16(T0, b16HALF);
+          break;
+        }
+
+      case 2:
+        {
+          s->d_u = T1 + b16mulb16(T0, b16HALF);
+          s->d_v = T1 + T2 + b16mulb16(T0, b16HALF);
+          s->d_w = b16mulb16(T0, b16HALF);
+          break;
+        }
+
+      case 3:
+        {
+          s->d_u = b16mulb16(T0, b16HALF);
+          s->d_v = T1 + T2 + b16mulb16(T0, b16HALF);
+          s->d_w = T2 + b16mulb16(T0, b16HALF);
+          break;
+        }
+
+      case 4:
+        {
+          s->d_u = b16mulb16(T0, b16HALF);
+          s->d_v = T1 + b16mulb16(T0, b16HALF);
+          s->d_w = T1 + T2 + b16mulb16(T0, b16HALF);
+          break;
+        }
+
+      case 5:
+        {
+          s->d_u = T2 + b16mulb16(T0, b16HALF);
+          s->d_v = b16mulb16(T0, b16HALF);
+          s->d_w = T1 + T2 + b16mulb16(T0, b16HALF);
+          break;
+        }
+
+      case 6:
+        {
+          s->d_u = T1 + T2 + b16mulb16(T0, b16HALF);
+          s->d_v = b16mulb16(T0, b16HALF);
+          s->d_w = T1 + b16mulb16(T0, b16HALF);
+          break;
+        }
+
+      default:
+        {
+          /* We should not get here */
+
+          LIBDSP_DEBUGASSERT(0);
+          break;
+        }
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: svm3_b16
+ *
+ * Description:
+ *   One step of the space vector modulation.
+ *   This is most common of SVM with alternate-reverse null vector.
+ *
+ *   Voltage vector definitions in 3-phase SVM:
+ *
+ *  |---------|-----------|--------------------|-----------------|
+ *  | Voltage | swithcing | Line to neutral    | Line to line    |
+ *  | vector  | vectors   | voltage            | voltage         |
+ *  |         |-----------|--------------------|-----------------|
+ *  |         | a | b | c | Van  | Vbn  | Vcn  | Vab | Vbe | Vca |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *  | V0      | 0 | 0 | 0 |  0   |  0   |  0   |  0  |  0  |  0  |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *  | V1      | 1 | 0 | 0 |  2/3 | -1/3 | -1/3 |  1  |  0  | -1  |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *  | V2      | 1 | 1 | 0 |  1/3 |  1/3 | -2/3 |  0  |  1  | -1  |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *  | V3      | 0 | 1 | 0 | -1/3 |  2/3 | -1/3 | -1  |  1  |  0  |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *  | V4      | 0 | 1 | 1 | -2/3 |  1/3 |  1/3 | -1  |  0  |  1  |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *  | V5      | 0 | 0 | 1 | -1/3 | -1/3 |  2/3 |  0  | -1  |  1  |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *  | V6      | 1 | 0 | 1 |  1/3 | -2/3 |  1/3 |  1  | -1  |  0  |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *  | V7      | 1 | 1 | 1 |  0   |  0   |  0   |  0  |  0  |  0  |
+ *  |---------|---|---|---|------|------|------|-----|-----|-----|
+ *
+ *   Voltage values given in relation to the bus voltage (Vbus)/
+ *
+ * Input Parameters:
+ *   s    - (out) pointer to the SVM data
+ *   v_ab - (in) pointer to the modulation voltage vector in alpha-beta
+ *          frame, normalized to magnitude (0.0 - 1.0)
+ *
+ * NOTE: v_ab vector magnitude must be in range <0.0, 1.0> to get correct
+ *       SVM3 results.
+ *
+ * REFERENCE:
+ *   https://e2e.ti.com/group/motor/m/pdf_presentations/665547/download
+ *     pages 32-34
+ *
+ ****************************************************************************/
+
+void svm3_b16(FAR struct svm3_state_b16_s *s, FAR ab_frame_b16_t *v_ab)
+{
+  LIBDSP_DEBUGASSERT(s != NULL);
+  LIBDSP_DEBUGASSERT(v_ab != NULL);
+
+  abc_frame_b16_t ijk;
+
+  /* Perform modified inverse Clarke-transformation (alpha,beta) -> (i,j,k)
+   * to obtain auxiliary frame which will be used in further calculations.
+   */
+
+  ijk.a = b16mulb16(-b16HALF, v_ab->b) + b16mulb16(SQRT3_BY_TWO_B16,
+                                                   v_ab->a);
+  ijk.b = v_ab->b;
+  ijk.c = -ijk.b - ijk.a;
+
+  /* Get vector sector */
+
+  s->sector = svm3_sector_get_b16(&ijk);
+
+  /* Get duty cycle */
+
+  svm3_duty_calc_b16(s, &ijk);
+
+  /* NOTE: we return not-saturated output. Duty-cycle saturation is
+   *       board-specific characteristic and we have not access to this
+   *       information here.
+   */
+}
+
+/****************************************************************************
+ * Name: svm3_current_correct_b16
+ *
+ * Description:
+ *   Correct ADC samples (int32) according to SVM3 state.
+ *   NOTE: This works only with 3 shunt resistors configuration.
+ *
+ ****************************************************************************/
+
+void svm3_current_correct_b16(FAR struct svm3_state_b16_s *s,
+                              b16_t *c0, b16_t *c1, b16_t *c2)
+{
+  /* Get best ADC samples according to SVM sector.
+   *
+   * In SVM phase current can be sampled only in v0 vector state, when lower
+   * bridge transistors are turned on.
+   *
+   * We ignore sample from phase which has the shortest V0 state and
+   * estimate its value with KCL for motor phases:
+   *    i_a + i_b + i_c = 0
+   */
+
+  switch (s->sector)
+    {
+      case 1:
+      case 6:
+        {
+          /* Sector 1-6: ignore phase 1 */
+
+          *c0 = -(*c1 + *c2);
+
+          break;
+        }
+
+      case 2:
+      case 3:
+        {
+          /* Sector 2-3: ignore phase 2 */
+
+          *c1 = -(*c0 + *c2);
+
+          break;
+        }
+
+      case 4:
+      case 5:
+        {
+          /* Sector 4-5: ignore phase 3 */
+
+          *c2 = -(*c0 + *c1);
+
+          break;
+        }
+
+      default:
+        {
+          /* We should not get here. */
+
+          *c0 = 0;
+          *c1 = 0;
+          *c2 = 0;
+
+          break;
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: svm3_init_b16
+ *
+ * Description:
+ *   Initialize 3-phase SVM data.
+ *
+ * Input Parameters:
+ *   s - (in/out) pointer to the SVM state data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void svm3_init_b16(FAR struct svm3_state_b16_s *s)
+{
+  LIBDSP_DEBUGASSERT(s != NULL);
+
+  memset(s, 0, sizeof(struct svm3_state_b16_s));
+}

--- a/libs/libdsp/lib_transform.c
+++ b/libs/libdsp/lib_transform.c
@@ -53,8 +53,8 @@
 void clarke_transform(FAR abc_frame_f32_t *abc,
                       FAR ab_frame_f32_t *ab)
 {
-  DEBUGASSERT(abc != NULL);
-  DEBUGASSERT(ab != NULL);
+  LIBDSP_DEBUGASSERT(abc != NULL);
+  LIBDSP_DEBUGASSERT(ab != NULL);
 
   ab->a = abc->a;
   ab->b = ONE_BY_SQRT3_F*abc->a + TWO_BY_SQRT3_F*abc->b;
@@ -78,8 +78,8 @@ void clarke_transform(FAR abc_frame_f32_t *abc,
 void inv_clarke_transform(FAR ab_frame_f32_t *ab,
                           FAR abc_frame_f32_t *abc)
 {
-  DEBUGASSERT(ab != NULL);
-  DEBUGASSERT(abc != NULL);
+  LIBDSP_DEBUGASSERT(ab != NULL);
+  LIBDSP_DEBUGASSERT(abc != NULL);
 
   /* Assume non-power-invariant transform and balanced system */
 
@@ -108,9 +108,9 @@ void park_transform(FAR phase_angle_f32_t *angle,
                     FAR ab_frame_f32_t *ab,
                     FAR dq_frame_f32_t *dq)
 {
-  DEBUGASSERT(angle != NULL);
-  DEBUGASSERT(ab != NULL);
-  DEBUGASSERT(dq != NULL);
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(ab != NULL);
+  LIBDSP_DEBUGASSERT(dq != NULL);
 
   dq->d = angle->cos * ab->a + angle->sin * ab->b;
   dq->q = angle->cos * ab->b - angle->sin * ab->a;
@@ -136,9 +136,9 @@ void inv_park_transform(FAR phase_angle_f32_t *angle,
                         FAR dq_frame_f32_t *dq,
                         FAR ab_frame_f32_t *ab)
 {
-  DEBUGASSERT(angle != NULL);
-  DEBUGASSERT(dq != NULL);
-  DEBUGASSERT(ab != NULL);
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(dq != NULL);
+  LIBDSP_DEBUGASSERT(ab != NULL);
 
   ab->a = angle->cos * dq->d - angle->sin * dq->q;
   ab->b = angle->cos * dq->q + angle->sin * dq->d;

--- a/libs/libdsp/lib_transform.c
+++ b/libs/libdsp/lib_transform.c
@@ -29,9 +29,10 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: Clarke transform (abc frame -> ab frame)
+ * Name: clarke_transform
  *
  * Description:
+ *   Clarke transform (abc frame -> ab frame).
  *   Transform the abc frame to the alpha-beta frame.
  *
  *   i_alpha = k*(i_a - 0.5*i_b - 0.5*i_c)
@@ -61,9 +62,10 @@ void clarke_transform(FAR abc_frame_f32_t *abc,
 }
 
 /****************************************************************************
- * Name: Inverse Clarke transform (ab frame -> abc frame)
+ * Name: inv_clarke_transform
  *
  * Description:
+ *   Inverse Clarke transform (ab frame -> abc frame).
  *   Transform the alpha-beta frame to the abc frame.
  *
  * Input Parameters:
@@ -89,9 +91,10 @@ void inv_clarke_transform(FAR ab_frame_f32_t *ab,
 }
 
 /****************************************************************************
- * Name: Park transform (ab frame -> dq frame)
+ * Name: park_transform
  *
  * Description:
+ *   Park transform (ab frame -> dq frame).
  *   Transform the alpha-beta frame to the direct-quadrature frame.
  *
  * Input Parameters:
@@ -117,9 +120,10 @@ void park_transform(FAR phase_angle_f32_t *angle,
 }
 
 /****************************************************************************
- * Name: Inverse Park transform (dq frame -> ab frame)
+ * Name: inv_park_transform
  *
  * Description:
+ *   Inverse Park transform (dq frame -> ab frame).
  *   Transform direct-quadrature frame to alpha-beta frame.
  *
  * Input Parameters:

--- a/libs/libdsp/lib_transform.c
+++ b/libs/libdsp/lib_transform.c
@@ -50,8 +50,8 @@
  *
  ****************************************************************************/
 
-void clarke_transform(FAR abc_frame_t *abc,
-                      FAR ab_frame_t *ab)
+void clarke_transform(FAR abc_frame_f32_t *abc,
+                      FAR ab_frame_f32_t *ab)
 {
   DEBUGASSERT(abc != NULL);
   DEBUGASSERT(ab != NULL);
@@ -75,8 +75,8 @@ void clarke_transform(FAR abc_frame_t *abc,
  *
  ****************************************************************************/
 
-void inv_clarke_transform(FAR ab_frame_t *ab,
-                          FAR abc_frame_t *abc)
+void inv_clarke_transform(FAR ab_frame_f32_t *ab,
+                          FAR abc_frame_f32_t *abc)
 {
   DEBUGASSERT(ab != NULL);
   DEBUGASSERT(abc != NULL);
@@ -104,9 +104,9 @@ void inv_clarke_transform(FAR ab_frame_t *ab,
  *
  ****************************************************************************/
 
-void park_transform(FAR phase_angle_t *angle,
-                    FAR ab_frame_t *ab,
-                    FAR dq_frame_t *dq)
+void park_transform(FAR phase_angle_f32_t *angle,
+                    FAR ab_frame_f32_t *ab,
+                    FAR dq_frame_f32_t *dq)
 {
   DEBUGASSERT(angle != NULL);
   DEBUGASSERT(ab != NULL);
@@ -132,9 +132,9 @@ void park_transform(FAR phase_angle_t *angle,
  *
  ****************************************************************************/
 
-void inv_park_transform(FAR phase_angle_t *angle,
-                        FAR dq_frame_t *dq,
-                        FAR ab_frame_t *ab)
+void inv_park_transform(FAR phase_angle_f32_t *angle,
+                        FAR dq_frame_f32_t *dq,
+                        FAR ab_frame_f32_t *ab)
 {
   DEBUGASSERT(angle != NULL);
   DEBUGASSERT(dq != NULL);

--- a/libs/libdsp/lib_transform_b16.c
+++ b/libs/libdsp/lib_transform_b16.c
@@ -1,0 +1,151 @@
+/****************************************************************************
+ * libs/libdsp/lib_transform_b16.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <dspb16.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: clarke_transform_b16
+ *
+ * Description:
+ *   Clarke transform (abc frame -> ab frame).
+ *   Transform the abc frame to the alpha-beta frame.
+ *
+ *   i_alpha = k*(i_a - 0.5*i_b - 0.5*i_c)
+ *   i_beta  = k*sqrt(3)*0.5*(i_b - i_c)
+ *
+ *   We assume that:
+ *     1) k = 2/3 for the non-power-invariant transformation
+ *     2) balanced system: a + b + c = 0
+ *
+ * Input Parameters:
+ *   abc - (in) pointer to the abc frame
+ *   ab  - (out) pointer to the alpha-beta frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void clarke_transform_b16(FAR abc_frame_b16_t *abc,
+                          FAR ab_frame_b16_t *ab)
+{
+  LIBDSP_DEBUGASSERT(abc != NULL);
+  LIBDSP_DEBUGASSERT(ab != NULL);
+
+  ab->a = abc->a;
+  ab->b = (b16mulb16(ONE_BY_SQRT3_B16, abc->a) +
+           b16mulb16(TWO_BY_SQRT3_B16, abc->b));
+}
+
+/****************************************************************************
+ * Name: inv_clarke_transform_b16
+ *
+ * Description:
+ *   Inverse Clarke transform (ab frame -> abc frame).
+ *   Transform the alpha-beta frame to the abc frame.
+ *
+ * Input Parameters:
+ *   ab  - (in) pointer to the alpha-beta frame
+ *   abc - (out) pointer to the abc frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void inv_clarke_transform_b16(FAR ab_frame_b16_t *ab,
+                              FAR abc_frame_b16_t *abc)
+{
+  LIBDSP_DEBUGASSERT(ab != NULL);
+  LIBDSP_DEBUGASSERT(abc != NULL);
+
+  /* Assume non-power-invariant transform and balanced system */
+
+  abc->a = ab->a;
+  abc->b = (b16mulb16(-b16HALF, ab->a) +
+            b16mulb16(SQRT3_BY_TWO_B16, ab->b));
+  abc->c = (-abc->a - abc->b);
+}
+
+/****************************************************************************
+ * Name: park_transform_b16
+ *
+ * Description:
+ *   Park transform (ab frame -> dq frame).
+ *   Transform the alpha-beta frame to the direct-quadrature frame.
+ *
+ * Input Parameters:
+ *   angle - (in) pointer to the phase angle data
+ *   ab    - (in) pointer to the alpha-beta frame
+ *   dq    - (out) pointer to the direct-quadrature frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void park_transform_b16(FAR phase_angle_b16_t *angle,
+                        FAR ab_frame_b16_t *ab,
+                        FAR dq_frame_b16_t *dq)
+{
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(ab != NULL);
+  LIBDSP_DEBUGASSERT(dq != NULL);
+
+  dq->d = b16mulb16(angle->cos, ab->a) + b16mulb16(angle->sin, ab->b);
+  dq->q = b16mulb16(angle->cos, ab->b) - b16mulb16(angle->sin, ab->a);
+}
+
+/****************************************************************************
+ * Name: inv_park_transform_b16
+ *
+ * Description:
+ *   Inverse Park transform (dq frame -> ab frame).
+ *   Transform direct-quadrature frame to alpha-beta frame.
+ *
+ * Input Parameters:
+ *   angle - (in) pointer to the phase angle data
+ *   dq    - (in) pointer to the direct-quadrature frame
+ *   ab    - (out) pointer to the alpha-beta frame
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void inv_park_transform_b16(FAR phase_angle_b16_t *angle,
+                            FAR dq_frame_b16_t *dq,
+                            FAR ab_frame_b16_t *ab)
+{
+  LIBDSP_DEBUGASSERT(angle != NULL);
+  LIBDSP_DEBUGASSERT(dq != NULL);
+  LIBDSP_DEBUGASSERT(ab != NULL);
+
+  ab->a = b16mulb16(angle->cos, dq->d) - b16mulb16(angle->sin, dq->q);
+  ab->b = b16mulb16(angle->cos, dq->q) + b16mulb16(angle->sin, dq->d);
+}


### PR DESCRIPTION
## Summary

- libdsp: add _f32_ suffix to all libdsp data structures tht use float as a numerical type
- libdsp: introduce libdsp-specific debug assertion (LIBDSP_DEBUGASSERT)
- libs/libdsp/lib_transform.c: update descriptions
- libdsp/lib_svm.c: return not saturated output from modulator, the current corection now takes float as an arguments
- libdsp/lib_motor.c: remove maximum openloop speed limiter
- libs/libdsp/lib_motor.c: refactor
- libdsp/lib_pid.c: add anti-windup protection with decay coefficient and add interface to select anti-windup mechanism
- boards/arm/stm32/stm32f334-disco/src/stm32_smps.c: update according to the previous change in the PI controller
- libdsp/lib_foc.c: use better PI wind-up protection; add interface to run voltage controller without current controller; add separate interfaces to update base voltage and phase angle
- libdsp/lib_observer.c: optimize and add some comments
- include/dsp.h: add DIR_NONE definition
- libdsp/lib_motor.c: remove reference to some unused data
- libdsp: add Permanent Magnet Synchronous Motor (PMSM) model
- libdsp/Kconfig: move configuration to menuconfig, add option to include vabc in FOC data
- libdsp: add support for fixed16 libdsp

## Impact

## Testing

