### PR TITLE
sched: Move the default Task Stack size to Stack menu

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -27,13 +27,6 @@ config DEFAULT_SMALL
 		have already been selected in your configuration file.  This applies
 		only to new settings that require a default value.
 
-config DEFAULT_TASK_STACKSIZE
-	int "The default stack size for tasks"
-	default 65536 if ARCH_SIM
-	default 2048
-	---help---
-		The default stack size for tasks.
-
 choice
 	prompt "Build Host Platform"
 	default HOST_LINUX

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1746,6 +1746,13 @@ endmenu # Work Queue Support
 
 menu "Stack and heap information"
 
+config DEFAULT_TASK_STACKSIZE
+	int "The default stack size for tasks"
+	default 65536 if ARCH_SIM
+	default 2048
+	---help---
+		The default stack size for tasks.
+
 config IDLETHREAD_STACKSIZE
 	int "Idle thread stack size"
 	default 1024


### PR DESCRIPTION
## Summary
Move the default Task Stack size to Stack menu
## Impact
It will simplify the process to select the stack size
## Testing
building
