### PR TITLE
esp32: remove extra initial newline on syslog call

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -5360,7 +5360,7 @@ int esp_wifi_sta_essid(struct iwreq *iwr, bool set)
 #ifdef CONFIG_DEBUG_WIRELESS_INFO
   memcpy(buf, pdata, len);
   buf[len] = 0;
-  wlinfo("\nINFO: WiFi station ssid=%s len=%d\n", buf, len);
+  wlinfo("WiFi station ssid=%s len=%d\n", buf, len);
 #endif
 
   return OK;


### PR DESCRIPTION
## Summary

Remove unneeded leading newline on syslog call

## Impact

syslog output

## Testing

esp32-devkitc:wapi
