### PR TITLE
CI: add action to cancel redundant jobs

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,17 @@
+name: Cancelling Duplicates
+on:
+  workflow_run:
+    workflows: ["Build", "Check", "Build Documentation", "❄️ Lint"]
+    types: ['requested']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel duplicate workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: apache/airflow-cancel-workflow-runs@master
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Summary

This uses the following action: https://github.com/apache/airflow-cancel-workflow-runs
It allows to cancel redundant workflow runs. 

## Impact

CI

## Testing

I don't we ca really test it other than merge this and see how it goes.
