### PR TITLE
pthread: Fix pthread_rwlock_init return error

### DIFF
--- a/libs/libc/pthread/pthread_rwlock.c
+++ b/libs/libc/pthread/pthread_rwlock.c
@@ -55,7 +55,7 @@ int pthread_rwlock_init(FAR pthread_rwlock_t *lock,
 
   if (attr != NULL)
     {
-      return -ENOSYS;
+      return ENOSYS;
     }
 
   lock->num_readers       = 0;


### PR DESCRIPTION
## Summary
According to OpenGroup pthread_rwlock_init() should return EINVAL
if attr parameter is invalid.
## Impact
Return the expected error code
## Testing
N/A
