### PR TITLE
Fix arp

### DIFF
--- a/net/arp/arp_notify.c
+++ b/net/arp/arp_notify.c
@@ -188,6 +188,9 @@ int arp_wait(FAR struct arp_notify_s *notify, unsigned int timeout)
 void arp_notify(in_addr_t ipaddr)
 {
   FAR struct arp_notify_s *curr;
+  irqstate_t flags;
+
+  flags = enter_critical_section();
 
   /* Find an entry with the matching IP address in the list of waiters */
 
@@ -207,6 +210,8 @@ void arp_notify(in_addr_t ipaddr)
           break;
         }
     }
+
+  leave_critical_section(flags);
 }
 
 #endif /* CONFIG_NET_ARP_SEND */

--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -341,6 +341,7 @@ int arp_send(in_addr_t ipaddr)
                                               CONFIG_ARP_SEND_DELAYMSEC);
           if (ret == -ETIMEDOUT)
             {
+              arp_wait_cancel(&notify);
               goto timeout;
             }
         }
@@ -354,6 +355,7 @@ int arp_send(in_addr_t ipaddr)
           /* Break out on a send failure */
 
           nerr("ERROR: Send failed: %d\n", ret);
+          arp_wait_cancel(&notify);
           break;
         }
 


### PR DESCRIPTION
## Summary

- This PR consists of the following 2 commits
- commit 1: net: arp: Fix memory corruption in arp_send()
   - In arp_send(), arp_wait_setup() adds a notify object to g_arp_waiters
      which is removed in arp_wait() in normal case.
   - However, in timeout and error cases, the object was not removed and
     caused memory corruption.
   - This commit fixes this issue.
- commit 2: Fix a potential bug in arp_notify()
   - In arp_wait_setup() and arp_wait_cancel(), g_arp_waiters
      is protected by a critical section.
   - However, I noticed that arp_notify() does not protect the
      g_arp_waiters that would cause memory corruption
   - This commit fixes the issue.

## Impact

- None

## Testing

- Tested with spresense:rndis and spresense:rndis_smp
