### PR TITLE
boards/xtensa/esp32: Move the WLAN initialisation to the common directory.

### DIFF
--- a/boards/xtensa/esp32/common/include/esp32_board_wlan.h
+++ b/boards/xtensa/esp32/common/include/esp32_board_wlan.h
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/include/esp32_board_wlan.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_WLAN_H
+#define __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_WLAN_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32_WIRELESS
+
+/****************************************************************************
+ * Name: board_wlan_init
+ *
+ * Description:
+ *   Configure the wireless subsystem.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   to indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+int board_wlan_init(void);
+
+#endif /* CONFIG_ESP32_WIRELESS */
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_WLAN_H */

--- a/boards/xtensa/esp32/common/src/Make.defs
+++ b/boards/xtensa/esp32/common/src/Make.defs
@@ -30,6 +30,10 @@ ifeq ($(CONFIG_I2C_DRIVER),y)
   CSRCS += esp32_board_i2c.c
 endif
 
+ifeq ($(CONFIG_ESP32_WIRELESS),y)
+  CSRCS += esp32_board_wlan.c
+endif
+
 ifeq ($(CONFIG_SENSORS_BMP180),y)
   CSRCS += esp32_bmp180.c
 endif

--- a/boards/xtensa/esp32/common/src/esp32_board_wlan.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_wlan.c
@@ -1,0 +1,124 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_board_wlan.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <debug.h>
+
+#include <nuttx/wireless/wireless.h>
+
+#include "esp32_spiflash.h"
+#include "esp32_wlan.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
+static int esp32_init_wifi_storage(void)
+{
+  int ret;
+  const char *path = "/dev/mtdblock1";
+  FAR struct mtd_dev_s *mtd_part;
+
+  mtd_part = esp32_spiflash_alloc_mtdpart();
+  if (!mtd_part)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");
+      return -1;
+    }
+
+  ret = register_mtddriver(path, mtd_part, 0777, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to regitser MTD: %d\n", ret);
+      return -1;
+    }
+
+  ret = nx_mount(path, CONFIG_ESP32_WIFI_FS_MOUNTPT, "spiffs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
+      return ret;
+    }
+
+  return 0;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_wlan_init
+ *
+ * Description:
+ *   Configure the wireless subsystem.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   to indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+int board_wlan_init(void)
+{
+  int ret = OK;
+
+#ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
+  ret = esp32_init_wifi_storage();
+  if (ret)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi storage\n");
+      return ret;
+    }
+#endif
+
+#ifdef ESP32_WLAN_HAS_STA
+  ret = esp32_wlan_sta_initialize();
+  if (ret)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi station\n");
+      return ret;
+    }
+#endif
+
+#ifdef ESP32_WLAN_HAS_SOFTAP
+  ret = esp32_wlan_softap_initialize();
+  if (ret)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi softAP\n");
+      return ret;
+    }
+#endif
+
+  return ret;
+}
+

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -39,7 +39,6 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/himem/himem.h>
 
-#include "esp32_wlan.h"
 #include "esp32_spiflash.h"
 #include "esp32_partition.h"
 
@@ -61,6 +60,10 @@
 
 #ifdef CONFIG_WATCHDOG
 #  include "esp32_board_wdt.h"
+#endif
+
+#ifdef CONFIG_ESP32_WIRELESS
+#  include "esp32_board_wlan.h"
 #endif
 
 #ifdef CONFIG_ESP32_AES_ACCELERATOR
@@ -94,38 +97,6 @@
  *     Called from the NSH library
  *
  ****************************************************************************/
-
-#ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
-static int esp32_init_wifi_storage(void)
-{
-  int ret;
-  const char *path = "/dev/mtdblock1";
-  FAR struct mtd_dev_s *mtd_part;
-
-  mtd_part = esp32_spiflash_alloc_mtdpart();
-  if (!mtd_part)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");
-      return -1;
-    }
-
-  ret = register_mtddriver(path, mtd_part, 0777, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to regitser MTD: %d\n", ret);
-      return -1;
-    }
-
-  ret = nx_mount(path, CONFIG_ESP32_WIFI_FS_MOUNTPT, "spiffs", 0, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
-      return ret;
-    }
-
-  return 0;
-}
-#endif
 
 int esp32_bringup(void)
 {
@@ -212,36 +183,13 @@ int esp32_bringup(void)
 #endif
 
 #ifdef CONFIG_ESP32_WIRELESS
-
-#ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
-  ret = esp32_init_wifi_storage();
-  if (ret)
+  ret = board_wlan_init();
+  if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi storage\n");
+      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+             ret);
       return ret;
     }
-#endif
-
-#ifdef CONFIG_NET
-#ifdef ESP32_WLAN_HAS_STA
-  ret = esp32_wlan_sta_initialize();
-  if (ret)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi station\n");
-      return ret;
-    }
-#endif
-
-#ifdef ESP32_WLAN_HAS_SOFTAP
-  ret = esp32_wlan_softap_initialize();
-  if (ret)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi softAP\n");
-      return ret;
-    }
-#endif
-#endif
-
 #endif
 
 /* First, register the timer drivers and let timer 1 for oneshot

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -77,10 +77,6 @@
 #include "esp32-devkitc.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -195,6 +191,7 @@ int esp32_bringup(void)
 /* First, register the timer drivers and let timer 1 for oneshot
  * if it is enabled.
  */
+
 #ifdef CONFIG_TIMER
 
 #ifdef CONFIG_ESP32_TIMER0
@@ -208,7 +205,7 @@ int esp32_bringup(void)
     }
 #endif
 
-#if defined(CONFIG_ESP32_TIMER1) && !defined(CONFIG_ONESHOT) 
+#if defined(CONFIG_ESP32_TIMER1) && !defined(CONFIG_ONESHOT)
   ret = esp32_timer_initialize("/dev/timer1", TIMER1);
   if (ret < 0)
     {
@@ -230,7 +227,7 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESP32_TIMER3 
+#ifdef CONFIG_ESP32_TIMER3
   ret = esp32_timer_initialize("/dev/timer3", TIMER3);
   if (ret < 0)
     {

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
@@ -39,7 +39,6 @@
 #include <nuttx/fs/fs.h>
 #include <nuttx/himem/himem.h>
 
-#include "esp32_wlan.h"
 #include "esp32_spiflash.h"
 #include "esp32_partition.h"
 
@@ -57,6 +56,10 @@
 
 #ifdef CONFIG_WATCHDOG
 #  include "esp32_board_wdt.h"
+#endif
+
+#ifdef CONFIG_ESP32_WIRELESS
+#  include "esp32_board_wlan.h"
 #endif
 
 #ifdef CONFIG_BUTTONS
@@ -86,38 +89,6 @@
  *     Called from the NSH library
  *
  ****************************************************************************/
-
-#ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
-static int esp32_init_wifi_storage(void)
-{
-  int ret;
-  const char *path = "/dev/mtdblock1";
-  FAR struct mtd_dev_s *mtd_part;
-
-  mtd_part = esp32_spiflash_alloc_mtdpart();
-  if (!mtd_part)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");
-      return -1;
-    }
-
-  ret = register_mtddriver(path, mtd_part, 0777, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to regitser MTD: %d\n", ret);
-      return -1;
-    }
-
-  ret = nx_mount(path, CONFIG_ESP32_WIFI_FS_MOUNTPT, "spiffs", 0, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
-      return ret;
-    }
-
-  return 0;
-}
-#endif
 
 int esp32_bringup(void)
 {
@@ -187,36 +158,13 @@ int esp32_bringup(void)
 #endif
 
 #ifdef CONFIG_ESP32_WIRELESS
-
-#ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
-  ret = esp32_init_wifi_storage();
-  if (ret)
+  ret = board_wlan_init();
+  if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi storage\n");
+      syslog(LOG_ERR, "ERROR: Failed to initialize wireless subsystem=%d\n",
+             ret);
       return ret;
     }
-#endif
-
-#ifdef CONFIG_NET
-#ifdef ESP32_WLAN_HAS_STA
-  ret = esp32_wlan_sta_initialize();
-  if (ret)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi station\n");
-      return ret;
-    }
-#endif
-
-#ifdef ESP32_WLAN_HAS_SOFTAP
-  ret = esp32_wlan_softap_initialize();
-  if (ret)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi softAP\n");
-      return ret;
-    }
-#endif
-#endif
-
 #endif
 
 /* First, register the timer drivers and let timer 1 for oneshot

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
@@ -69,10 +69,6 @@
 #include "esp32-ethernet-kit.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -170,6 +166,7 @@ int esp32_bringup(void)
 /* First, register the timer drivers and let timer 1 for oneshot
  * if it is enabled.
  */
+
 #ifdef CONFIG_TIMER
 
 #ifdef CONFIG_ESP32_TIMER0
@@ -183,7 +180,7 @@ int esp32_bringup(void)
     }
 #endif
 
-#if defined(CONFIG_ESP32_TIMER1) && !defined(CONFIG_ONESHOT) 
+#if defined(CONFIG_ESP32_TIMER1) && !defined(CONFIG_ONESHOT)
   ret = esp32_timer_initialize("/dev/timer1", TIMER1);
   if (ret < 0)
     {
@@ -205,7 +202,7 @@ int esp32_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESP32_TIMER3 
+#ifdef CONFIG_ESP32_TIMER3
   ret = esp32_timer_initialize("/dev/timer3", TIMER3);
   if (ret < 0)
     {

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -78,10 +78,6 @@
 #include "esp32-wrover-kit.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -179,6 +175,7 @@ int esp32_bringup(void)
 /* First, register the timer drivers and let timer 1 for oneshot
  * if it is enabled.
  */
+
 #ifdef CONFIG_TIMER
 
 #ifdef CONFIG_ESP32_TIMER0


### PR DESCRIPTION
## Summary
Move the WLAN initialisation to the common directory.  Since the initialisation part is the same for all the boards.
## Impact
Shouldn't have any impact.  The same code was just refactored.
## Testing
esp32-devkitc:wapi
esp32-wrover-kit:wapi
