### PR TITLE
docs and comments: Update stale references to COPYING

### DIFF
--- a/Documentation/contributing/coding_style.rst
+++ b/Documentation/contributing/coding_style.rst
@@ -45,8 +45,8 @@ license such as the BSD or MIT licenses). If the file does not
 follow Apache 2.0 licensing, then the appropriate license
 information should be provided in the header rather than the
 Apache 2.0 licensing information and a NOTE should be included in
-the top-level ``COPYING`` file to indicate any variations from
-Apache 2.0 licensing.
+the top-level ``LICENSE`` and/or ``NOTICE`` file(s), as appropriate,
+to indicate any variations from Apache 2.0 licensing.
 
 **Grouping**. All like components in a C source or header file are
 grouped together. Definitions do not appear arbitrarily through

--- a/Documentation/introduction/about.rst
+++ b/Documentation/introduction/about.rst
@@ -107,7 +107,7 @@ Key features of NuttX include:
     and ``rz``). Intel HEX file conversions.
 
     * FAT long file name support may be subject to certain Microsoft patent restrictions if enabled.
-      See the top-level ``COPYING`` file for details.
+      See the top-level ``NOTICE`` file for details.
 
 * **Device Drivers**
 

--- a/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/README.txt
+++ b/boards/arm/lpc17xx_40xx/olimex-lpc1766stk/README.txt
@@ -725,7 +725,7 @@ Configuration Sub-Directories
 
     1. Support for FAT long file names is built-in but can easily be
        removed if you are concerned about Microsoft patent issues (see the
-       section "FAT Long File Names" in the top-level COPYING file).
+       section "FAT Long File Names" in the top-level NOTICE file).
 
        CONFIG_FS_FAT=y
        CONFIG_FAT_LCNAMES=y <-- Long file name support
@@ -827,7 +827,7 @@ Configuration Sub-Directories
        FAT file system support for FAT long file names is built-in but
        can easily be removed if you are concerned about Microsoft patent
        issues (see the section "FAT Long File Names" in the top-level
-       COPYING file).
+       NOTICE file).
 
        CONFIG_FAT_LFN=y                    : Enables long file name support
 

--- a/boards/arm/sam34/arduino-due/README.txt
+++ b/boards/arm/sam34/arduino-due/README.txt
@@ -788,7 +788,7 @@ Configuration sub-directories
          CONFIG_FAT_MAXFNAME=32            : Maximum supported file name length
 
          There are issues related to patents that Microsoft holds on FAT long
-         file name technologies.  See the top level COPYING file for further
+         file name technologies.  See the top level NOTICE file for further
          details.
 
        Device Drivers

--- a/boards/arm/sam34/sam4l-xplained/README.txt
+++ b/boards/arm/sam34/sam4l-xplained/README.txt
@@ -503,7 +503,7 @@ Configuration sub-directories
          CONFIG_FAT_MAXFNAME=32            : Maximum supported file name length
 
          There are issues related to patents that Microsoft holds on FAT long
-         file name technologies.  See the top level COPYING file for further
+         file name technologies.  See the top level NOTICE file for further
          details.
 
        System Type -> Peripherals:

--- a/boards/arm/sama5/giant-board/README.md
+++ b/boards/arm/sama5/giant-board/README.md
@@ -574,7 +574,7 @@ concise summary of the available Giant Board configurations:
 
        The FAT file system includes long file name support. Please be aware
        that Microsoft claims patents against the long file name support (see
-       more discussion in the top-level COPYING file).
+       more discussion in the top-level NOTICE file).
 
          CONFIG_FS_FAT=y        : Enables the FAT file system
          CONFIG_FAT_LCNAMES=y   : Enable lower case 8.3 file names

--- a/boards/arm/sama5/sama5d2-xult/README.txt
+++ b/boards/arm/sama5/sama5d2-xult/README.txt
@@ -927,7 +927,7 @@ Configurations
 
        The FAT file system includes long file name support.  Please be aware
        that Microsoft claims patents against the long file name support (see
-       more discussion in the top-level COPYING file).
+       more discussion in the top-level NOTICE file).
 
          CONFIG_FS_FAT=y        : Enables the FAT file system
          CONFIG_FAT_LCNAMES=y   : Enable lower case 8.3 file names

--- a/boards/arm/sama5/sama5d4-ek/README.txt
+++ b/boards/arm/sama5/sama5d4-ek/README.txt
@@ -4362,7 +4362,7 @@ Configurations
 
        The FAT file system includes long file name support.  Please be aware
        that Microsoft claims patents against the long file name support (see
-       more discussion in the top-level COPYING file).
+       more discussion in the top-level NOTICE file).
 
          CONFIG_FS_FAT=y        : Enables the FAT file system
          CONFIG_FAT_LCNAMES=y   : Enable lower case 8.3 file names

--- a/boards/arm/samd2l2/samd20-xplained/README.txt
+++ b/boards/arm/samd2l2/samd20-xplained/README.txt
@@ -737,7 +737,7 @@ Configuration sub-directories
          CONFIG_FAT_MAXFNAME=32            : Maximum supported file name length
 
          There are issues related to patents that Microsoft holds on FAT long
-         file name technologies.  See the top level COPYING file for further
+         file name technologies.  See the top level NOTICE file for further
          details.
 
        System Type -> Peripherals:

--- a/boards/arm/samd2l2/samd21-xplained/README.txt
+++ b/boards/arm/samd2l2/samd21-xplained/README.txt
@@ -608,7 +608,7 @@ Configuration sub-directories
          CONFIG_FAT_MAXFNAME=32            : Maximum supported file name length
 
          There are issues related to patents that Microsoft holds on FAT long
-         file name technologies.  See the top level COPYING file for further
+         file name technologies.  See the top level NOTICE file for further
          details.
 
        System Type -> Peripherals:

--- a/boards/arm/samd2l2/saml21-xplained/README.txt
+++ b/boards/arm/samd2l2/saml21-xplained/README.txt
@@ -769,7 +769,7 @@ Configuration sub-directories
          CONFIG_FAT_MAXFNAME=32            : Maximum supported file name length
 
          There are issues related to patents that Microsoft holds on FAT long
-         file name technologies.  See the top level COPYING file for further
+         file name technologies.  See the top level NOTICE file for further
          details.
 
        System Type -> Peripherals:

--- a/boards/arm/stm32/hymini-stm32v/README.txt
+++ b/boards/arm/stm32/hymini-stm32v/README.txt
@@ -400,7 +400,7 @@ Where <subdir> is one of the following:
         you will have to turn local echo on.
     (3) Microsoft holds several patents related to the design of
         long file names in the FAT file system.  Please refer to the
-        details in the top-level COPYING file.  Please do not use FAT
+        details in the top-level NOTICE file.  Please do not use FAT
         long file name unless you are familiar with these patent issues.
     (4) When built as an NSH add-on command (CONFIG_NSH_BUILTIN_APPS=y),
         Caution should be used to assure that the SD drive is not in use when

--- a/boards/arm/stm32/stm3210e-eval/README.txt
+++ b/boards/arm/stm32/stm3210e-eval/README.txt
@@ -558,7 +558,7 @@ Where <subdir> is one of the following:
         you will have to turn local echo on.
     (4) Microsoft holds several patents related to the design of
         long file names in the FAT file system.  Please refer to the
-        details in the top-level COPYING file.  Please do not use FAT
+        details in the top-level NOTICE file.  Please do not use FAT
         long file name unless you are familiar with these patent issues.
     (5) When built as an NSH add-on command (CONFIG_NSH_BUILTIN_APPS=y),
         Caution should be used to assure that the SD drive is not in use when

--- a/fs/fat/Kconfig
+++ b/fs/fat/Kconfig
@@ -25,7 +25,7 @@ config FAT_LFN
 	---help---
 		Enable FAT long file names.  NOTE:  Microsoft claims
 		patents on FAT long file name technology.  Please read the
-		disclaimer in the top-level COPYING file and only enable this
+		disclaimer in the top-level NOTICE file and only enable this
 		feature if you understand these issues.
 
 config FAT_MAXFNAME

--- a/libs/libc/string/Kconfig
+++ b/libs/libc/string/Kconfig
@@ -47,7 +47,7 @@ config MEMCPY_VIK
 	---help---
 		Select this option to use the optimized memcpy() function by Daniel Vik.
 		Select this option for improved performance at the expense of increased
-		size. See licensing information in the top-level COPYING file.
+		size. See licensing information in the top-level LICENSE file.
 
 if MEMCPY_VIK
 


### PR DESCRIPTION
## Summary

Since 7a046358d95228349ecedcb5df0edb5fea12d006 the top-level COPYING file has been deleted and replaced by DISCLAIMER, LICENSE, and NOTICE files. However, some references to the old COPYING file remained in Kconfig help text and documentation.

This commit updates stale references to the old top-level COPYING file to either LICENSE or NOTICE (or both), as appropriate in each instance in the following files:

- Documentation/contributing/coding_style.rst
- Documentation/introduction/about.rst
- boards/arm/lpc17xx_40xx/olimex-lpc1766stk/README.txt
- boards/arm/sam34/arduino-due/README.txt
- boards/arm/sam34/sam4l-xplained/README.txt
- boards/arm/sama5/giant-board/README.md
- boards/arm/sama5/sama5d2-xult/README.txt
- boards/arm/sama5/sama5d4-ek/README.txt
- boards/arm/samd2l2/samd20-xplained/README.txt
- boards/arm/samd2l2/samd21-xplained/README.txt
- boards/arm/samd2l2/saml21-xplained/README.txt
- boards/arm/stm32/hymini-stm32v/README.txt
- boards/arm/stm32/stm3210e-eval/README.txt
- fs/fat/Kconfig
- libs/libc/string/Kconfig

## Impact

No functional impact; makes documentation more accurate.

## Testing

None.