### PR TITLE
esp32: Fix small typo that will trigger an error when IPv6 is enabled

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -1207,7 +1207,7 @@ static int wlan_ifup(FAR struct net_driver_s *dev)
         (dev->d_ipaddr >> 16) & 0xff, dev->d_ipaddr >> 24);
 #endif
 #ifdef CONFIG_NET_IPv6
-  winfo("Bringing up: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
+  ninfo("Bringing up: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
         dev->d_ipv6addr[0], dev->d_ipv6addr[1], dev->d_ipv6addr[2],
         dev->d_ipv6addr[3], dev->d_ipv6addr[4], dev->d_ipv6addr[5],
         dev->d_ipv6addr[6], dev->d_ipv6addr[7]);


### PR DESCRIPTION
## Summary
esp32: Fix small typo that will trigger an error when IPv6 is enabled
This issue was found by Ron J.: https://eadalabs.com/ipv6-from-day-1/
## Impact
Only ESP32
## Testing
ESP32-Devkit
