### PR TITLE
arch:rv64:add memory clobber to inline asm for syscall.

### DIFF
--- a/arch/risc-v/include/rv64gc/syscall.h
+++ b/arch/risc-v/include/rv64gc/syscall.h
@@ -158,6 +158,7 @@ static inline uintptr_t sys_call0(unsigned int nbr)
     (
      "ecall"
      :: "r"(r0)
+     : "memory"
      );
 
   asm volatile("nop" : "=r"(r0));
@@ -182,6 +183,7 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
     (
      "ecall"
      :: "r"(r0), "r"(r1)
+     : "memory"
      );
 
   asm volatile("nop" : "=r"(r0));
@@ -208,6 +210,7 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
     (
      "ecall"
      :: "r"(r0), "r"(r1), "r"(r2)
+     : "memory"
      );
 
   asm volatile("nop" : "=r"(r0));
@@ -235,6 +238,7 @@ static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
     (
      "ecall"
      :: "r"(r0), "r"(r1), "r"(r2), "r"(r3)
+     : "memory"
      );
 
   asm volatile("nop" : "=r"(r0));
@@ -264,6 +268,7 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
     (
      "ecall"
      :: "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4)
+     : "memory"
      );
 
   asm volatile("nop" : "=r"(r0));
@@ -294,6 +299,7 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
     (
      "ecall"
      :: "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5)
+     : "memory"
      );
 
   asm volatile("nop" : "=r"(r0));
@@ -326,6 +332,7 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
     (
      "ecall"
      :: "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5), "r"(r6)
+     : "memory"
      );
 
   asm volatile("nop" : "=r"(r0));


### PR DESCRIPTION
Signed-off-by: hotislandn <hotislandn@hotmail.com>

## Summary
This patch adds "memory" for the inlined asm syscalls for RV64GC.
Without this, the compiler will remove some of the memory operations before syscall APIs under high optimization.

## Impact
All RV64GC targets.

## Testing
1. Chech the compiler output to ensure memory accesses are not eliminated.
2. All configurations for C906 have been built and verified with QEMU.
