### PR TITLE
esp32-wrover-kit: Don't use User GPIO Subsystem to control LED

### DIFF
--- a/boards/xtensa/esp32/esp32-wrover-kit/include/board.h
+++ b/boards/xtensa/esp32/esp32-wrover-kit/include/board.h
@@ -107,7 +107,8 @@
 
 /* GPIO pins used by the GPIO Subsystem */
 
-#define BOARD_NGPIOOUT    3 /* Amount of GPIO Output pins */
+#define BOARD_NGPIOIN     1 /* Amount of GPIO Input pins */
+#define BOARD_NGPIOOUT    1 /* Amount of GPIO Output pins */
 #define BOARD_NGPIOINT    1 /* Amount of GPIO Input w/ Interruption pins */
 
 #endif /* __BOARDS_XTENSA_ESP32_ESP32_WROVER_KIT_INCLUDE_BOARD_H */


### PR DESCRIPTION
## Summary
The GPIO_LEDx are already used by esp32_userleds.c, they shouldn't
be used by esp32_gpio.c. This patch also includes the GPIO Input
example (GPIN) that was missing.
## Impact
Only esp32-wrover-kit
## Testing
ESP32-Wrover-Kit
