### PR TITLE
sched: task: Fix to initialize the task-specific data

### DIFF
--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -137,6 +137,10 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
   group->tg_libvars = up_stack_frame(&tcb->cmn, sizeof(struct libvars_s));
   DEBUGASSERT(group->tg_libvars != NULL);
 
+  /* Initialize the task-specific data */
+
+  memset(group->tg_libvars, 0, sizeof(struct libvars_s));
+
   /* Save the allocated task data in TLS */
 
   tls_set_taskdata(&tcb->cmn);


### PR DESCRIPTION
## Summary

- I noticed that getopt() test in ostest wailed with
  esp32-devkitc:smp and spresense:smp
- Finally, I found that the task-specific data is not
  initialized.
- This commit fixes this issue

## Impact

- None

## Testing

- Tested with ostest esp32-devkitc:smp and spresense:smp
