### PR TITLE
tools/testbuild.sh: Quote the parameter expansion pattern by "

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -340,7 +340,7 @@ for line in $testlist; do
     dir=`echo $line | cut -d',' -f1`
     list=`find boards$dir -name defconfig | cut -d'/' -f4,6`
     for i in ${list}; do
-      dotest $i${line/$dir/}
+      dotest $i${line/"$dir"/}
     done
   else
     dotest $line


### PR DESCRIPTION
## Summary
to enable the exact match(disable glob match)

## Impact
work correctly with the special character(e.g. /sim/*/*/*/[a-n]*)

## Testing
Pass CI
