### PR TITLE
getopt_common():  Correct handling of unsupported long options.

### DIFF
--- a/libs/libc/unistd/lib_getopt_common.c
+++ b/libs/libc/unistd/lib_getopt_common.c
@@ -384,7 +384,16 @@ int getopt_common(int argc, FAR char * const argv[],
 
               /* And parse the long option */
 
-              return getopt_long_option(go, argv, longopts, longindex);
+              ret = getopt_long_option(go, argv, longopts, longindex);
+              if (ret == '?')
+                {
+                  /* Skip over the unrecognized long option */
+
+                  go->go_optind++;
+                  go->go_optptr = NULL;
+                }
+
+              return ret;
             }
 
           /* The -option form is only valid in getop_long_only() mode and
@@ -401,8 +410,18 @@ int getopt_common(int argc, FAR char * const argv[],
                */
 
               ret = getopt_long_option(go, argv, longopts, longindex);
-              if (ret != '?' ||  *(go->go_optptr + 1) != '\0')
+              if (ret != '?')
                 {
+                  /* Success or ERROR */
+
+                  return ret;
+                }
+              else if (*(go->go_optptr + 1) != '\0')
+                {
+                  /* Skip over the unrecognized long option */
+
+                  go->go_optind++;
+                  go->go_optptr = NULL;
                   return ret;
                 }
             }


### PR DESCRIPTION
## Summary

If an unrecognized long option is encountered, we must skip over that argv[] entry or getopt_long() will seriously misbehave.

## Impact

Affects getopt_long() and getopt_long_only()

## Testing

Problem found and fix verified with an updated version of the OS test.
