### PR TITLE
build: Replace sim with sim01 and sim02

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
 
     strategy:
       matrix:
-        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v, sim, xtensa]
+        boards: [arm-01, arm-02, arm-03, arm-04, arm-05, arm-06, arm-07, arm-08, arm-09, arm-10, arm-11, arm-12, arm-13, other, risc-v, sim01, sim02, xtensa]
 
     steps:
       - name: Download Source Artifact
@@ -169,7 +169,7 @@ jobs:
     needs: Fetch-Source
     strategy:
       matrix:
-        boards: [macos, sim]
+        boards: [macos, sim01, sim02]
     steps:
       - name: Download Source Artifact
         uses: actions/download-artifact@v1


### PR DESCRIPTION
## Summary
follow up nuttx-testing repo change:
```
commit 08d766faef84e43112b70a08f6f0c54654482024
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Sun Apr 4 04:21:57 2021 +0800

    Split sim.dat to sim00.dat and sim01.dat

    to speed up the macOS build
```

## Impact
Speed up the build check

## Testing
Pass CI
