### PR TITLE
esp32-devkitc: Add BMP180 sensor support

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -66,6 +66,14 @@
 #  include "esp32_board_wlan.h"
 #endif
 
+#ifdef CONFIG_ESP32_I2C
+#  include "esp32_board_i2c.h"
+#endif
+
+#ifdef CONFIG_SENSORS_BMP180
+#  include "esp32_bmp180.h"
+#endif
+
 #ifdef CONFIG_ESP32_AES_ACCELERATOR
 #  include "esp32_aes.h"
 #endif
@@ -289,6 +297,42 @@ int esp32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize GPIO Driver: %d\n", ret);
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_I2C_DRIVER
+
+#ifdef CONFIG_ESP32_I2C0
+  ret = esp32_i2c_register(0);
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize I2C Driver for I2C0: %d\n", ret);
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_ESP32_I2C1
+  ret = esp32_i2c_register(1);
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize I2C Driver for I2C1: %d\n", ret);
+      return ret;
+    }
+#endif
+
+#endif
+
+#ifdef CONFIG_SENSORS_BMP180
+  /* Try to register BMP180 device in I2C0 */
+
+  ret = board_bmp180_initialize(0, 0);
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize BMP180 driver: %d\n", ret);
       return ret;
     }
 #endif


### PR DESCRIPTION
## Summary
esp32-devkitc: Add BMP180 sensor support
## Impact
Only ESP32-Devkitc
## Testing
ESP32-Devkitc
