### PR TITLE
arch/arm: Replace the hardcode syscall number with macro

### DIFF
--- a/arch/arm/src/armv6-m/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv6-m/arm_fullcontextrestore.S
@@ -71,7 +71,7 @@ arm_fullcontextrestore:
 
 	mov		r1, r0				/* R1: regs */
 	mov		r0, #SYS_restore_context	/* R0: restore context */
-	svc		0				/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall			/* Force synchronous SVCall (or Hard Fault) */
 
 	/* This call should not return */
 

--- a/arch/arm/src/armv6-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv6-m/arm_saveusercontext.S
@@ -73,7 +73,7 @@ arm_saveusercontext:
 
 	mov		r1, r0			/* R1: regs */
 	mov		r0, #SYS_save_context	/* R0: save context (also return value) */
-	svc		0			/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall		/* Force synchronous SVCall (or Hard Fault) */
 
 	/* There are two return conditions.  On the first return, R0 (the
 	 * return value will be zero.  On the second return we need to

--- a/arch/arm/src/armv6-m/arm_signal_handler.S
+++ b/arch/arm/src/armv6-m/arm_signal_handler.S
@@ -95,7 +95,7 @@ up_signal_handler:
 	/* Execute the SYS_signal_handler_return SVCall (will not return) */
 
 	mov		r0, #SYS_signal_handler_return
-	svc		0
+	svc		#SYS_syscall
 	nop
 
 	.size	up_signal_handler, .-up_signal_handler

--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -33,10 +33,6 @@
 #include <arch/irq.h>
 #include <nuttx/sched.h>
 
-#ifdef CONFIG_LIB_SYSCALL
-#  include <syscall.h>
-#endif
-
 #include "signal/signal.h"
 #include "svcall.h"
 #include "exc_return.h"

--- a/arch/arm/src/armv6-m/arm_switchcontext.S
+++ b/arch/arm/src/armv6-m/arm_switchcontext.S
@@ -73,7 +73,7 @@ arm_switchcontext:
 	mov		r2, r1					/* R2: restoreregs */
 	mov		r1, r0					/* R1: saveregs */
 	mov		r0, #SYS_switch_context			/* R0: context switch */
-	svc		0					/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall				/* Force synchronous SVCall (or Hard Fault) */
 
 	/* We will get here only after the rerturn from the context switch */
 

--- a/arch/arm/src/armv6-m/svcall.h
+++ b/arch/arm/src/armv6-m/svcall.h
@@ -27,9 +27,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_LIB_SYSCALL
-#  include <syscall.h>
-#endif
+#include <syscall.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/arm/src/armv7-a/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-a/arm_fullcontextrestore.S
@@ -96,11 +96,11 @@ arm_fullcontextrestore:
 	 * to either user or kernel mode.
 	 */
 
-	/* Perform the System call with R0=SYS_context_restore, R1=restoreregs */
+	/* Perform the System call with R0=1 and R1=regs */
 
-	mov		r1, r0				/* R1: restoreregs */
-	mov		r0, #SYS_context_restore	/* R0: SYS_context_restore syscall */
-	svc		#0x900001			/* Perform the system call */
+	mov		r1, r0				/* R1: regs */
+	mov		r0, #SYS_restore_context	/* R0: restore context */
+	svc		#SYS_syscall			/* Force synchronous SVCall (or Hard Fault) */
 
 	/* This call should not return */
 

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -27,7 +27,6 @@
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
-#include <syscall.h>
 #include <assert.h>
 #include <debug.h>
 
@@ -219,19 +218,19 @@ uint32_t *arm_syscall(uint32_t *regs)
         }
         break;
 
-      /* R0=SYS_context_restore:  Restore task context
+      /* R0=SYS_restore_context:  Restore task context
        *
        * void arm_fullcontextrestore(uint32_t *restoreregs)
        *   noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
-       *   R0 = SYS_context_restore
+       *   R0 = SYS_restore_context
        *   R1 = restoreregs
        */
 
 #ifdef CONFIG_BUILD_KERNEL
-      case SYS_context_restore:
+      case SYS_restore_context:
         {
           /* Replace 'regs' with the pointer to the register set in
            * regs[REG_R1].  On return from the system call, that register

--- a/arch/arm/src/armv7-a/crt0.c
+++ b/arch/arm/src/armv7-a/crt0.c
@@ -78,7 +78,8 @@ static void sig_trampoline(void)
     " pop  {r2}\n"       /* Recover LR in R2 */
     " mov  lr, r2\n"     /* Restore LR */
     " mov  r0, #5\n"     /* SYS_signal_handler_return */
-    " svc #0x900001\n"   /* Return from the signal handler */
+    " svc %0\n"          /* Return from the SYSCALL */
+    ::"i"(SYS_syscall)
   );
 }
 

--- a/arch/arm/src/armv7-a/svcall.h
+++ b/arch/arm/src/armv7-a/svcall.h
@@ -27,9 +27,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_LIB_SYSCALL
-#  include <syscall.h>
-#endif
+#include <syscall.h>
 
 #ifdef CONFIG_LIB_SYSCALL
 
@@ -73,7 +71,7 @@
  * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
-#define SYS_context_restore       (1)
+#define SYS_restore_context       (1)
 
 /* SYS call 2:
  *

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -34,10 +34,6 @@
 #include <nuttx/sched.h>
 #include <nuttx/userspace.h>
 
-#ifdef CONFIG_LIB_SYSCALL
-#  include <syscall.h>
-#endif
-
 #include "signal/signal.h"
 #include "svcall.h"
 #include "exc_return.h"

--- a/arch/arm/src/armv7-m/gnu/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-m/gnu/arm_fullcontextrestore.S
@@ -70,7 +70,7 @@ arm_fullcontextrestore:
 
 	mov		r1, r0				/* R1: regs */
 	mov		r0, #SYS_restore_context	/* R0: restore context */
-	svc		0				/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall			/* Force synchronous SVCall (or Hard Fault) */
 
 	/* This call should not return */
 

--- a/arch/arm/src/armv7-m/gnu/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-m/gnu/arm_saveusercontext.S
@@ -72,7 +72,7 @@ arm_saveusercontext:
 
 	mov		r1, r0			/* R1: regs */
 	mov		r0, #SYS_save_context	/* R0: save context (also return value) */
-	svc		0			/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall		/* Force synchronous SVCall (or Hard Fault) */
 
 	/* There are two return conditions.  On the first return, R0 (the
 	 * return value will be zero.  On the second return we need to

--- a/arch/arm/src/armv7-m/gnu/arm_signal_handler.S
+++ b/arch/arm/src/armv7-m/gnu/arm_signal_handler.S
@@ -94,7 +94,7 @@ up_signal_handler:
 	/* Execute the SYS_signal_handler_return SVCall (will not return) */
 
 	mov		r0, #SYS_signal_handler_return
-	svc		0
+	svc		#SYS_syscall
 	nop
 
 	.size	up_signal_handler, .-up_signal_handler

--- a/arch/arm/src/armv7-m/gnu/arm_switchcontext.S
+++ b/arch/arm/src/armv7-m/gnu/arm_switchcontext.S
@@ -72,7 +72,7 @@ arm_switchcontext:
 	mov		r2, r1					/* R2: restoreregs */
 	mov		r1, r0					/* R1: saveregs */
 	mov		r0, #SYS_switch_context			/* R0: context switch */
-	svc		0					/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall				/* Force synchronous SVCall (or Hard Fault) */
 
 	/* We will get here only after the rerturn from the context switch */
 

--- a/arch/arm/src/armv7-m/iar/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-m/iar/arm_fullcontextrestore.S
@@ -70,7 +70,7 @@ arm_fullcontextrestore:
 
 	mov		r1, r0				/* R1: regs */
 	mov		r0, #SYS_restore_context	/* R0: restore context */
-	svc		0				/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall			/* Force synchronous SVCall (or Hard Fault) */
 
 	/* This call should not return */
 

--- a/arch/arm/src/armv7-m/iar/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-m/iar/arm_saveusercontext.S
@@ -71,7 +71,7 @@ arm_saveusercontext:
 
 	mov		r1, r0			/* R1: regs */
 	mov		r0, #SYS_save_context	/* R0: save context (also return value) */
-	svc		0			/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall		/* Force synchronous SVCall (or Hard Fault) */
 
 	/* There are two return conditions.  On the first return, R0 (the
 	 * return value will be zero.  On the second return we need to

--- a/arch/arm/src/armv7-m/iar/arm_switchcontext.S
+++ b/arch/arm/src/armv7-m/iar/arm_switchcontext.S
@@ -72,7 +72,7 @@ arm_switchcontext:
 	mov		r2, r1					/* R2: restoreregs */
 	mov		r1, r0					/* R1: saveregs */
 	mov		r0, #SYS_switch_context			/* R0: context switch */
-	svc		0					/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall				/* Force synchronous SVCall (or Hard Fault) */
 
 	/* We will get here only after the rerturn from the context switch */
 

--- a/arch/arm/src/armv7-m/svcall.h
+++ b/arch/arm/src/armv7-m/svcall.h
@@ -27,9 +27,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_LIB_SYSCALL
-#  include <syscall.h>
-#endif
+#include <syscall.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/arm/src/armv7-r/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-r/arm_fullcontextrestore.S
@@ -100,11 +100,11 @@ arm_fullcontextrestore:
 	 * to either user or kernel mode.
 	 */
 
-	/* Perform the System call with R0=SYS_context_restore, R1=restoreregs */
+	/* Perform the System call with R0=1 and R1=regs */
 
-	mov		r1, r0				/* R1: restoreregs */
-	mov		r0, #SYS_context_restore	/* R0: SYS_context_restore syscall */
-	svc		#0x900001			/* Perform the system call */
+	mov		r1, r0				/* R1: regs */
+	mov		r0, #SYS_restore_context	/* R0: restore context */
+	svc		#SYS_syscall			/* Force synchronous SVCall (or Hard Fault) */
 
 	/* This call should not return */
 

--- a/arch/arm/src/armv7-r/arm_signal_handler.S
+++ b/arch/arm/src/armv7-r/arm_signal_handler.S
@@ -95,7 +95,7 @@ up_signal_handler:
 	/* Execute the SYS_signal_handler_return SVCall (will not return) */
 
 	mov		r0, #SYS_signal_handler_return
-	svc		0
+	svc		#SYS_syscall
 	nop
 
 	.size	up_signal_handler, .-up_signal_handler

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -26,7 +26,6 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <syscall.h>
 #include <assert.h>
 #include <debug.h>
 
@@ -214,19 +213,19 @@ uint32_t *arm_syscall(uint32_t *regs)
         }
         break;
 
-      /* R0=SYS_context_restore:  Restore task context
+      /* R0=SYS_restore_context:  Restore task context
        *
        * void arm_fullcontextrestore(uint32_t *restoreregs)
        *   noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
-       *   R0 = SYS_context_restore
+       *   R0 = SYS_restore_context
        *   R1 = restoreregs
        */
 
 #ifdef CONFIG_BUILD_PROTECTED
-      case SYS_context_restore:
+      case SYS_restore_context:
         {
           /* Replace 'regs' with the pointer to the register set in
            * regs[REG_R1].  On return from the system call, that register

--- a/arch/arm/src/armv7-r/svcall.h
+++ b/arch/arm/src/armv7-r/svcall.h
@@ -27,9 +27,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_LIB_SYSCALL
-#  include <syscall.h>
-#endif
+#include <syscall.h>
 
 #ifdef CONFIG_LIB_SYSCALL
 
@@ -74,7 +72,7 @@
  * void arm_fullcontextrestore(uint32_t *restoreregs) noreturn_function;
  */
 
-#define SYS_context_restore       (1)
+#define SYS_restore_context       (1)
 
 /* SYS call 2:
  *

--- a/arch/arm/src/armv8-m/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv8-m/arm_fullcontextrestore.S
@@ -70,7 +70,7 @@ arm_fullcontextrestore:
 
 	mov		r1, r0				/* R1: regs */
 	mov		r0, #SYS_restore_context	/* R0: restore context */
-	svc		0				/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall			/* Force synchronous SVCall (or Hard Fault) */
 
 	/* This call should not return */
 

--- a/arch/arm/src/armv8-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv8-m/arm_saveusercontext.S
@@ -72,7 +72,7 @@ arm_saveusercontext:
 
 	mov		r1, r0			/* R1: regs */
 	mov		r0, #SYS_save_context	/* R0: save context (also return value) */
-	svc		0			/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall		/* Force synchronous SVCall (or Hard Fault) */
 
 	/* There are two return conditions.  On the first return, R0 (the
 	 * return value will be zero.  On the second return we need to

--- a/arch/arm/src/armv8-m/arm_signal_handler.S
+++ b/arch/arm/src/armv8-m/arm_signal_handler.S
@@ -94,7 +94,7 @@ up_signal_handler:
 	/* Execute the SYS_signal_handler_return SVCall (will not return) */
 
 	mov		r0, #SYS_signal_handler_return
-	svc		0
+	svc		#SYS_syscall
 	nop
 
 	.size	up_signal_handler, .-up_signal_handler

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -33,10 +33,6 @@
 #include <nuttx/sched.h>
 #include <nuttx/userspace.h>
 
-#ifdef CONFIG_LIB_SYSCALL
-#  include <syscall.h>
-#endif
-
 #include "signal/signal.h"
 #include "svcall.h"
 #include "exc_return.h"

--- a/arch/arm/src/armv8-m/arm_switchcontext.S
+++ b/arch/arm/src/armv8-m/arm_switchcontext.S
@@ -72,7 +72,7 @@ arm_switchcontext:
 	mov		r2, r1					/* R2: restoreregs */
 	mov		r1, r0					/* R1: saveregs */
 	mov		r0, #SYS_switch_context			/* R0: context switch */
-	svc		0					/* Force synchronous SVCall (or Hard Fault) */
+	svc		#SYS_syscall				/* Force synchronous SVCall (or Hard Fault) */
 
 	/* We will get here only after the rerturn from the context switch */
 

--- a/arch/arm/src/armv8-m/svcall.h
+++ b/arch/arm/src/armv8-m/svcall.h
@@ -27,9 +27,7 @@
 
 #include <nuttx/config.h>
 
-#ifdef CONFIG_LIB_SYSCALL
-#  include <syscall.h>
-#endif
+#include <syscall.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary
and rename SYS_context_[save|restore] to SYS_[save|restore]_context
This change finaly finish the previous work: https://github.com/apache/incubator-nuttx/pull/3075 https://github.com/apache/incubator-nuttx/pull/3174

## Impact
Fix the mismatch between the macro and implementation

## Testing
Pass CI and ostest
