### PR TITLE
arch/arm: Replace "b lr" or "mov pc, lr" with "bx lr"

### DIFF
--- a/arch/arm/src/arm/vfork.S
+++ b/arch/arm/src/arm/vfork.S
@@ -119,6 +119,6 @@ vfork:
 
 	ldr		lr, [sp, #VFORK_LR_OFFSET]
 	add		sp, sp, #VFORK_SIZEOF
-	mov		pc, lr
+	bx		lr
 	.size	vfork, .-vfork
 	.end

--- a/arch/arm/src/armv7-a/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-a/arm_saveusercontext.S
@@ -120,14 +120,14 @@ arm_saveusercontext:
 	/* Return 0 now indicating that this return is not a context switch */
 
 	mov		r0, #0			/* Return value == 0 */
-	mov		pc, lr			/* Return */
+	bx		lr			/* Return */
 
 1:
 
 	/* Return 1 now indicating that this return is a context switch */
 
 	mov		r0, #1			/* Return value == 1 */
-	mov		pc, lr			/* Return */
+	bx		lr			/* Return */
 
 	.size	arm_saveusercontext, .-arm_saveusercontext
 	.end

--- a/arch/arm/src/armv7-a/vfork.S
+++ b/arch/arm/src/armv7-a/vfork.S
@@ -119,6 +119,6 @@ vfork:
 
 	ldr		lr, [sp, #VFORK_LR_OFFSET]
 	add		sp, sp, #VFORK_SIZEOF
-	mov		pc, lr
+	bx		lr
 	.size	vfork, .-vfork
 	.end

--- a/arch/arm/src/armv7-r/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-r/arm_saveusercontext.S
@@ -119,6 +119,6 @@ arm_saveusercontext:
 	/* Return 0 now indicating that this return is not a context switch */
 
 	mov		r0, #0			/* Return value == 0 */
-	mov		pc, lr			/* Return */
+	bx		lr			/* Return */
 	.size	arm_saveusercontext, .-arm_saveusercontext
 	.end

--- a/arch/arm/src/armv7-r/vfork.S
+++ b/arch/arm/src/armv7-r/vfork.S
@@ -119,6 +119,6 @@ vfork:
 
 	ldr		lr, [sp, #VFORK_LR_OFFSET]
 	add		sp, sp, #VFORK_SIZEOF
-	mov		pc, lr
+	bx		lr
 	.size	vfork, .-vfork
 	.end

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_setjmp.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_setjmp.S
@@ -136,7 +136,7 @@ longjmp:
 #endif /* CONFIG_ARCH_FPU */
 
 	mov		r0, r1				/* return val */
-	b		lr
+	bx		lr
 
 	.size	longjmp, .-longjmp
 	.end


### PR DESCRIPTION
## Summary
to unify the return method

## Impact
No real change

## Testing
Pass CI and ostest
