### PR TITLE
getopt():  Update comments about missing functionality

### DIFF
--- a/libs/libc/unistd/lib_getopt.c
+++ b/libs/libc/unistd/lib_getopt.c
@@ -64,7 +64,10 @@
  *      -1 is returned.  As a result, your command line parsing loops
  *      must call getopt() repeatedly and continue to parse if other
  *      errors are returned ('?' or ':') until getopt() finally returns -1.
- *     (You can also set optind to -1 to force a reset).
+ *      (You can also set optind to -1 to force a reset).
+ *   4. Standard getopt() permutes the contents of argv as it scans, so that
+ *      eventually all the nonoptions are at the end.  This implementation
+ *      does not do this.
  *
  * Returned Value:
  *   If an option was successfully found, then getopt() returns the option

--- a/libs/libc/unistd/lib_getopt_common.c
+++ b/libs/libc/unistd/lib_getopt_common.c
@@ -327,6 +327,9 @@ errout:
  *      must call getopt() repeatedly and continue to parse if other
  *      errors are returned ('?' or ':') until getopt() finally returns -1.
  *     (You can also set optind to -1 to force a reset).
+ *   4. Standard getopt() permutes the contents of argv as it scans, so that
+ *      eventually all the nonoptions are at the end.  This implementation
+ *      does not do this.
  *
  * Returned Value:
  *   If an option was successfully found, then getopt() returns the option


### PR DESCRIPTION
## Summary

Per the Linux man page, "By default, getopt() permutes the contents of argv as it scans, so that eventually all the nonoptions are at the end."  This behavior, however, is not implemented in the NuttX getopt() logic.

## Impact

None, comments only.

## Testing

N/A, comments only


