### PR TITLE
arch/stm32h7: Fix syntax error

### DIFF
--- a/arch/arm/src/stm32h7/stm32_dma.c
+++ b/arch/arm/src/stm32h7/stm32_dma.c
@@ -1969,7 +1969,7 @@ static void stm32_bdma_start(DMA_HANDLE handle, dma_callback_t callback,
 static size_t stm32_bdma_residual(DMA_HANDLE handle)
 {
   DMA_CHANNEL dmachan    = (DMA_CHANNEL)handle;
-  uint32_t    residual   = 0
+  uint32_t    residual   = 0;
 
   DEBUGASSERT(handle != NULL);
   DEBUGASSERT(dmachan->ctrl == BDMA);


### PR DESCRIPTION
## Summary

Fix syntax error (missing semicolon) in stm32_bdma_residual() in arch/arm/src/stm32h7/stm32_dma.c.

## Impact

Removes syntax error, encountered if `CONFIG_STM32H7_BDMA`.

## Testing

- Build testing
- nxstyle
