### PR TITLE
CI: restrict linting to .github, tools and Documentation dirs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,4 @@ jobs:
         env:
           VALIDATE_YAML: true
           VALIDATE_PYTHON_BLACK: true
+          FILTER_REGEX_INCLUDE: .*(\.github|tools|Documentation)/.*


### PR DESCRIPTION
## Summary

Restrict linter directories to where there are actually python/YAML files. 

## Impact

CI

## Testing

CI