### PR TITLE
esp32 boards: BUTTON_BOOT should use PULLUP instead PULLDOWN

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c
@@ -56,7 +56,7 @@
 
 uint32_t board_button_initialize(void)
 {
-  esp32_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLDOWN);
+  esp32_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLUP);
   return 1;
 }
 

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c
@@ -56,7 +56,7 @@
 
 uint32_t board_button_initialize(void)
 {
-  esp32_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLDOWN);
+  esp32_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLUP);
   return 1;
 }
 

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c
@@ -56,7 +56,7 @@
 
 uint32_t board_button_initialize(void)
 {
-  esp32_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLDOWN);
+  esp32_configgpio(BUTTON_BOOT, INPUT_FUNCTION_3 | PULLUP);
   return 1;
 }
 


### PR DESCRIPTION
## Summary
esp32 boards: BUTTON_BOOT should use PULLUP instead PULLDOWN
## Impact
Only ESP32 boards
## Testing
ESP32-Devkitc
