### PR TITLE
fs/romfs: fix open zero-byte file fail issue

### DIFF
--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -982,7 +982,7 @@ int romfs_datastart(struct romfs_mountpt_s *rm, uint32_t offset,
       /* Get the offset to the next chunk */
 
       offset += 16;
-      if (offset >= rm->rm_volsize)
+      if (offset > rm->rm_volsize)
         {
           return -EIO;
         }


### PR DESCRIPTION
## Summary
Fix zero-byte file open failure issue, error log as below:
romfs_open: ERROR: Failed to locate start of file data: -5

## Impact

## Testing
Verifed in sim and local m33 boards
