### PR TITLE
ci: lint only changed files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: YAML Lint
         uses: github/super-linter@v3
         env:
+          VALIDATE_ALL_CODEBASE: false
           VALIDATE_YAML: true
           VALIDATE_PYTHON_BLACK: true


### PR DESCRIPTION
## Summary
Only run the linter against files that changed in the pull request.

## Impact
Faster checking and less risk of blaming a PR for lint issues on files that were not touched.

## Testing
CI
