### PR TITLE
libc: correct zoneinfo genromfs source directory

### DIFF
--- a/libs/libc/zoneinfo/Makefile
+++ b/libs/libc/zoneinfo/Makefile
@@ -61,7 +61,7 @@ checkgenromfs:
 	}
 
 romfs_zoneinfo.img : checkgenromfs .tzbuilt
-	@genromfs -f $@ -d $(TZBIN_PATH)/etc/zoneinfo -V "TZDatbase" || { echo "genromfs failed" ; exit 1 ; }
+	@genromfs -f $@ -d $(TZBIN_PATH)/usr/share/zoneinfo -V "TZDatbase" || { echo "genromfs failed" ; exit 1 ; }
 
 romfs_zoneinfo.h : romfs_zoneinfo.img
 	@xxd -i $< >$@ || { echo "xxd of $< failed" ; exit 1 ; }


### PR DESCRIPTION


## Summary
Correct zoneinfo genromfs source directory. Or genromfs failed to generate the right romfs.img

## Impact

## Testing
Verified under sim:nsh in which enable:
--- a/boards/sim/sim/sim/configs/nsh/defconfig
+++ b/boards/sim/sim/sim/configs/nsh/defconfig
@@ -30,7 +30,10 @@ CONFIG_FS_PROCFS=y
 CONFIG_FS_ROMFS=y
 CONFIG_IDLETHREAD_STACKSIZE=4096
 CONFIG_LIBC_EXECFUNCS=y
+CONFIG_LIBC_LOCALTIME=y
 CONFIG_LIB_ENVPATH=y
+CONFIG_LIB_ZONEINFO=y
+CONFIG_LIB_ZONEINFO_ROMFS=y
 CONFIG_MAX_TASKS=64
 CONFIG_NSH_ARCHINIT=y
 CONFIG_NSH_ARCHROMFS=y
