### PR TITLE
mtd/ftl: Don't call ferr if return value equals -ENOTTY

### DIFF
--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -497,7 +497,7 @@ static int ftl_geometry(FAR struct inode *inode,
 
 static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 {
-  struct ftl_struct_s *dev ;
+  FAR struct ftl_struct_s *dev;
   int ret;
 
   finfo("Entry\n");
@@ -542,7 +542,7 @@ static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
    */
 
   ret = MTD_IOCTL(dev->mtd, cmd, arg);
-  if (ret < 0)
+  if (ret < 0 && ret != -ENOTTY)
     {
       ferr("ERROR: MTD ioctl(%04x) failed: %d\n", cmd, ret);
     }


### PR DESCRIPTION
## Summary
since -ENOTTY is an expected code to indicate IOCTL isn't supported

## Impact
don't log ENOTTY message

## Testing
Pass CI
