### PR TITLE
risc-v/esp32-c3: Refactors and fixes issues on serial driver.

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -307,11 +307,11 @@ if ESP32C3_UART1
 
 config ESP32C3_UART1_TXPIN
 	int "UART1 TX Pin"
-	default 18
+	default 6
 
 config ESP32C3_UART1_RXPIN
 	int "UART1 RX Pin"
-	default 19
+	default 7
 
 endif # ESP32C3_UART1
 

--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
@@ -81,6 +81,11 @@ enum uart_stop_length
 #define UART_TX_FIFO_SIZE 128
 #define UART_RX_FIFO_SIZE 128
 
+/* Maximum serial clock divisor for integer part */
+
+#define MAX_UART_CLKDIV (BIT(12) - 1)
+#define DIV_UP(a, b)    (((a) + (b) - 1) / (b))
+
 /* Struct used to store uart driver information and to
  * manipulate uart driver
  */
@@ -101,6 +106,9 @@ struct esp32c3_uart_s
   uint8_t   rxpin;          /* RX pin */
   uint8_t   rxsig;          /* RX signal */
 };
+
+extern struct esp32c3_uart_s g_uart0_config;
+extern struct esp32c3_uart_s g_uart1_config;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/risc-v/src/esp32c3/esp32c3_start.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_start.c
@@ -75,6 +75,12 @@ void __esp32c3_start(void)
 
   esp32c3_lowsetup();
 
+#ifdef USE_EARLYSERIALINIT
+  /* Perform early serial initialization */
+
+  riscv_earlyserialinit();
+#endif
+
   showprogress('A');
 
   /* Clear .bss.  We'll do this inline (vs. calling memset) just to be


### PR DESCRIPTION
## Summary

This PR:

- [x] Fixes gargabe UART issue in non console serial.
- [x] Refactors serial driver, improving its organization.
- [x] Changes default pins of UART 1
- [x]  Fixes low baud rate issue.

## Impact

All serial driver users on ESP32-C3.
Now we shouldn't have gargabe in the beginning of a transmission from a serial that is not console.
We are also able to configure low baud rates.

## Testing

- [x] I performed several tests sending data from a non console serial (UART 0 and 1) and checked using both linux terminal and Logic Analyzer.
- [x] I tested both serials working from 4800 bps up to 115200.
- [x] All these previous tests were using the new default pins.
