### PR TITLE
syslog: Fix in syslog_intbuffer flushing.

### DIFF
--- a/drivers/syslog/syslog_intbuffer.c
+++ b/drivers/syslog/syslog_intbuffer.c
@@ -307,8 +307,8 @@ int syslog_flush_intbuffer(bool force)
 
           /* Select which putc function to use for this flush */
 
-          putfunc = force ? g_syslog_channel[i]->sc_ops->sc_putc :
-                    g_syslog_channel[i]->sc_ops->sc_force;
+          putfunc = force ? g_syslog_channel[i]->sc_ops->sc_force :
+                    g_syslog_channel[i]->sc_ops->sc_putc;
 
           putfunc(g_syslog_channel[i], ch);
         }


### PR DESCRIPTION
## Summary
For some reason the `force` flag in `syslog_flush_intbuffer(bool force)` was treated incorrectly.  
The conditional that choses between the putc and force variants was reversed.

With this PR, the correct function is used.

## Impact
Syslog intbuffer should be flushed correctly now.

## Testing
Not much, since I am not aware of how I can make the code to exhibit wrong behavior based on the wrong conditional, but nevertheless the change is very trivial.

