### PR TITLE
stm32h7: Actually use the AXI SRAM as the main heap as the documentation describes in PROTECTED mode.

### DIFF
--- a/arch/arm/src/stm32h7/stm32_allocateheap.c
+++ b/arch/arm/src/stm32h7/stm32_allocateheap.c
@@ -210,10 +210,10 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 
   uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
     CONFIG_MM_KERNEL_HEAPSIZE;
-  size_t    usize = SRAM123_END - ubase;
+  size_t    usize = SRAM_END - ubase;
   int       log2;
 
-  DEBUGASSERT(ubase < (uintptr_t)SRAM123_END);
+  DEBUGASSERT(ubase < (uintptr_t)SRAM_END);
 
   /* Adjust that size to account for MPU alignment requirements.
    * NOTE that there is an implicit assumption that the SRAM123_END
@@ -221,7 +221,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
    */
 
   log2  = (int)mpu_log2regionfloor(usize);
-  DEBUGASSERT((SRAM123_END & ((1 << log2) - 1)) == 0);
+  DEBUGASSERT((SRAM_END & ((1 << log2) - 1)) == 0);
 
   usize = (1 << log2);
   ubase = SRAM123_END - usize;
@@ -277,10 +277,10 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
 
   uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
     CONFIG_MM_KERNEL_HEAPSIZE;
-  size_t    usize = SRAM123_END - ubase;
+  size_t    usize = SRAM_END - ubase;
   int       log2;
 
-  DEBUGASSERT(ubase < (uintptr_t)SRAM123_END);
+  DEBUGASSERT(ubase < (uintptr_t)SRAM_END);
 
   /* Adjust that size to account for MPU alignment requirements.
    * NOTE that there is an implicit assumption that the SRAM123_END
@@ -288,10 +288,10 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    */
 
   log2  = (int)mpu_log2regionfloor(usize);
-  DEBUGASSERT((SRAM123_END & ((1 << log2) - 1)) == 0);
+  DEBUGASSERT((SRAM_END & ((1 << log2) - 1)) == 0);
 
   usize = (1 << log2);
-  ubase = SRAM123_END - usize;
+  ubase = SRAM_END - usize;
 
   /* Return the kernel heap settings (i.e., the part of the heap region
    * that was not dedicated to the user heap).


### PR DESCRIPTION
## Summary

stm32h7: Actually use the AXI SRAM as the main heap as the documentation describes in PROTECTED mode.

The comments at the top of the file say this:
```
 * - AXI SRAM is a 512kb memory area. This will be automatically registered
 *      with the system heap in up_allocate_heap, all the other memory
 *      regions will be registered in arm_addregion().
 *      So, CONFIG_MM_REGIONS must be at least 1 to use AXI SRAM.
 *
 * - Internal SRAM is available in all members of the STM32 family.
 *      This is always registered with system heap.
 *      There are two contiguous regions of internal SRAM:
 *      SRAM1+SRAM2+SRAM3 and SRAM4 at a separate address.
 *      So, add 2 more to CONFIG_MM_REGIONS.
 *
 * - Tightly Coupled Memory (TCM RAM), we can use Data TCM (DTCM) for system
 *      heap. Note that DTCM has a number of limitations, for example DMA
 *      transfers to/from DTCM are limited.
 *      Define CONFIG_STM32H7_DTCMEXCLUDE to exclude the DTCM from heap.
 *      +1 to CONFIG_MM_REGIONS if you want to use DTCM.
 *
 * - External SDRAM can be connected to the FMC peripherial. Initialization
 *      of FMC is done as arm_addregion() will invoke stm32_fmc_init().
 *      Please read the comment in stm32_fmc.c how to initialize FMC
 *      correctly.
 *
```
but the implementation was using SRAM123 instead. Furthermore, arm_addregion then re-adds SRAM123 again.

## Impact
The location of all heap memories for H7's will change. SRAM123 will no longer be used as the kernel heap and will not be added twice.

## Testing
Single board testing. Would be good to have other's test this with their configurations.

