### PR TITLE
stm32h7: Adds stm32_dbgmcu.h to match stm32f7 port.

### DIFF
--- a/arch/arm/src/stm32h7/stm32_dbgmcu.h
+++ b/arch/arm/src/stm32h7/stm32_dbgmcu.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+ * arch/arm/src/stm32h7/stm32_dbgmcu.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32H7_STM32_DBGMCU_H
+#define __ARCH_ARM_SRC_STM32H7_STM32_DBGMCU_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "hardware/stm32h7xxx_dbgmcu.h"
+
+#endif /* __ARCH_ARM_SRC_STM32H7_STM32_DBGMCU_H */

--- a/arch/arm/src/stm32h7/stm32_lse.c
+++ b/arch/arm/src/stm32h7/stm32_lse.c
@@ -28,7 +28,7 @@
 
 #include "stm32_rcc.h"
 #include "stm32_pwr.h"
-#include "hardware/stm32h7xxx_dbgmcu.h"
+#include "stm32_dbgmcu.h"
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary
stm32_dbgmcu.h is included by some code. To match the stm32 and stm32f7 ports the location and linking between the hardware/ folder was matched.

## Impact
Additional header available to use.

## Testing
Built configuration