### PR TITLE
stm32h7: Fixes build error in stm32_sdmmc.c without DCACHE 

### DIFF
--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -3034,9 +3034,7 @@ static int stm32_registercallback(FAR struct sdio_dev_s *dev,
 static int stm32_dmapreflight(FAR struct sdio_dev_s *dev,
                               FAR const uint8_t *buffer, size_t buflen)
 {
-#if defined(CONFIG_ARMV7M_DCACHE) && !defined(CONFIG_ARMV7M_DCACHE_WRITETHROUGH)
   struct stm32_dev_s *priv = (struct stm32_dev_s *)dev;
-#endif
   DEBUGASSERT(priv != NULL && buffer != NULL && buflen > 0);
 
   /* IDMA must be possible to the buffer */


### PR DESCRIPTION
## Summary
DCACHE guards were blocking a needed variable, regardless of the configuration.

## Impact
Fixes build errors on stm32h7 platforms using SDMMC without DCACHE enabled.

## Testing
Built a configuration without DCACHE enabled.
