### PR TITLE
FlexSPI NOR driver

### DIFF
--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -168,6 +168,10 @@ config IMXRT_LPSPI
 	bool
 	default n
 
+config IMXRT_FLEXSPI
+	bool
+	default n
+
 config IMXRT_ADC
     bool
     default n
@@ -643,6 +647,15 @@ menuconfig IMXRT_LPSPI4
 	select IMXRT_LPSPI
 
 endmenu # LPSPI Peripherals
+
+menu "FLEXSPI Peripherals"
+
+menuconfig IMXRT_FLEXSPI1
+	bool "FLEXSPI1"
+	default n
+	select IMXRT_FLEXSPI
+
+endmenu # FLEXSPI Peripherals
 
 menu "ADC Peripherals"
 

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -138,6 +138,10 @@ ifeq ($(CONFIG_IMXRT_LPSPI),y)
 CHIP_CSRCS += imxrt_lpspi.c
 endif
 
+ifeq ($(CONFIG_IMXRT_FLEXSPI),y)
+CHIP_CSRCS += imxrt_flexspi.c
+endif
+
 ifeq ($(CONFIG_IMXRT_ENC),y)
 CHIP_CSRCS += imxrt_enc.c
 endif

--- a/arch/arm/src/imxrt/hardware/imxrt_flexspi.h
+++ b/arch/arm/src/imxrt/hardware/imxrt_flexspi.h
@@ -1,0 +1,559 @@
+/****************************************************************************
+ * arch/arm/src/imxrt/hardware/imxrt_flexspi.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_IMXRT_HARDWARE_IMXRT_FLEXSPI_H
+#define __ARCH_ARM_SRC_IMXRT_HARDWARE_IMXRT_FLEXSPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "chip.h"
+
+/* FLEXSPI - Register Layout Typedef */
+
+struct flexspi_type_s
+{
+  volatile uint32_t MCR0;                              /* Module Control Register 0, offset: 0x0 */
+  volatile uint32_t MCR1;                              /* Module Control Register 1, offset: 0x4 */
+  volatile uint32_t MCR2;                              /* Module Control Register 2, offset: 0x8 */
+  volatile uint32_t AHBCR;                             /* AHB Bus Control Register, offset: 0xc */
+  volatile uint32_t INTEN;                             /* Interrupt Enable Register, offset: 0x10 */
+  volatile uint32_t INTR;                              /* Interrupt Register, offset: 0x14 */
+  volatile uint32_t LUTKEY;                            /* LUT Key Register, offset: 0x18 */
+  volatile uint32_t LUTCR;                             /* LUT Control Register, offset: 0x1c */
+  volatile uint32_t AHBRXBUFCR0[4];                    /* AHB RX Buffer 0 Control Register 0..AHB RX Buffer 3 Control Register 0, array offset: 0x20, array step: 0x4 */
+       uint8_t RESERVED_0[48];
+  volatile uint32_t FLSHCR0[4];                        /* Flash A1 Control Register 0..Flash B2 Control Register 0, array offset: 0x60, array step: 0x4 */
+  volatile uint32_t FLSHCR1[4];                        /* Flash A1 Control Register 1..Flash B2 Control Register 1, array offset: 0x70, array step: 0x4 */
+  volatile uint32_t FLSHCR2[4];                        /* Flash A1 Control Register 2..Flash B2 Control Register 2, array offset: 0x80, array step: 0x4 */
+       uint8_t RESERVED_1[4];
+  volatile uint32_t FLSHCR4;                           /* Flash Control Register 4, offset: 0x94 */
+       uint8_t RESERVED_2[8];
+  volatile uint32_t IPCR0;                             /* IP Control Register 0, offset: 0xa0 */
+  volatile uint32_t IPCR1;                             /* IP Control Register 1, offset: 0xa4 */
+       uint8_t RESERVED_3[8];
+  volatile uint32_t IPCMD;                             /* IP Command Register, offset: 0xb0 */
+       uint8_t RESERVED_4[4];
+  volatile uint32_t IPRXFCR;                           /* IP RX FIFO Control Register, offset: 0xb8 */
+  volatile uint32_t IPTXFCR;                           /* IP TX FIFO Control Register, offset: 0xbc */
+  volatile uint32_t DLLCR[2];                          /* DLL Control Register 0, array offset: 0xc0, array step: 0x4 */
+       uint8_t RESERVED_5[24];
+  volatile  uint32_t STS0;                              /* Status Register 0, offset: 0xe0 */
+  volatile  uint32_t STS1;                              /* Status Register 1, offset: 0xe4 */
+  volatile  uint32_t STS2;                              /* Status Register 2, offset: 0xe8 */
+  volatile  uint32_t AHBSPNDSTS;                        /* AHB Suspend Status Register, offset: 0xec */
+  volatile  uint32_t IPRXFSTS;                          /* IP RX FIFO Status Register, offset: 0xf0 */
+  volatile  uint32_t IPTXFSTS;                          /* IP TX FIFO Status Register, offset: 0xf4 */
+       uint8_t RESERVED_6[8];
+  volatile  uint32_t RFDR[32];                          /* IP RX FIFO Data Register 0..IP RX FIFO Data Register 31, array offset: 0x100, array step: 0x4 */
+  volatile  uint32_t TFDR[32];                          /* IP TX FIFO Data Register 0..IP TX FIFO Data Register 31, array offset: 0x180, array step: 0x4 */
+  volatile uint32_t LUT[64];                            /* LUT 0..LUT 63, array offset: 0x200, array step: 0x4 */
+};
+
+/* MCR0 - Module Control Register 0 */
+
+#define FLEXSPI_MCR0_SWRESET_MASK                (0x1u)
+#define FLEXSPI_MCR0_SWRESET_SHIFT               (0u)
+
+/* SWRESET - Software Reset */
+
+#define FLEXSPI_MCR0_SWRESET(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_SWRESET_SHIFT)) & FLEXSPI_MCR0_SWRESET_MASK)
+#define FLEXSPI_MCR0_MDIS_MASK                   (0x2u)
+#define FLEXSPI_MCR0_MDIS_SHIFT                  (1u)
+
+/* MDIS - Module Disable */
+
+#define FLEXSPI_MCR0_MDIS(x)                     (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_MDIS_SHIFT)) & FLEXSPI_MCR0_MDIS_MASK)
+#define FLEXSPI_MCR0_RXCLKSRC_MASK               (0x30u)
+#define FLEXSPI_MCR0_RXCLKSRC_SHIFT              (4u)
+
+#define FLEXSPI_MCR0_RXCLKSRC(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_RXCLKSRC_SHIFT)) & FLEXSPI_MCR0_RXCLKSRC_MASK)
+#define FLEXSPI_MCR0_ARDFEN_MASK                 (0x40u)
+#define FLEXSPI_MCR0_ARDFEN_SHIFT                (6u)
+
+#define FLEXSPI_MCR0_ARDFEN(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_ARDFEN_SHIFT)) & FLEXSPI_MCR0_ARDFEN_MASK)
+#define FLEXSPI_MCR0_ATDFEN_MASK                 (0x80u)
+#define FLEXSPI_MCR0_ATDFEN_SHIFT                (7u)
+
+#define FLEXSPI_MCR0_ATDFEN(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_ATDFEN_SHIFT)) & FLEXSPI_MCR0_ATDFEN_MASK)
+#define FLEXSPI_MCR0_HSEN_MASK                   (0x800u)
+#define FLEXSPI_MCR0_HSEN_SHIFT                  (11u)
+
+#define FLEXSPI_MCR0_HSEN(x)                     (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_HSEN_SHIFT)) & FLEXSPI_MCR0_HSEN_MASK)
+#define FLEXSPI_MCR0_DOZEEN_MASK                 (0x1000u)
+#define FLEXSPI_MCR0_DOZEEN_SHIFT                (12u)
+
+#define FLEXSPI_MCR0_DOZEEN(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_DOZEEN_SHIFT)) & FLEXSPI_MCR0_DOZEEN_MASK)
+#define FLEXSPI_MCR0_COMBINATIONEN_MASK          (0x2000u)
+#define FLEXSPI_MCR0_COMBINATIONEN_SHIFT         (13u)
+
+#define FLEXSPI_MCR0_COMBINATIONEN(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_COMBINATIONEN_SHIFT)) & FLEXSPI_MCR0_COMBINATIONEN_MASK)
+#define FLEXSPI_MCR0_SCKFREERUNEN_MASK           (0x4000u)
+#define FLEXSPI_MCR0_SCKFREERUNEN_SHIFT          (14u)
+
+#define FLEXSPI_MCR0_SCKFREERUNEN(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_SCKFREERUNEN_SHIFT)) & FLEXSPI_MCR0_SCKFREERUNEN_MASK)
+#define FLEXSPI_MCR0_IPGRANTWAIT_MASK            (0xff0000u)
+#define FLEXSPI_MCR0_IPGRANTWAIT_SHIFT           (16u)
+
+#define FLEXSPI_MCR0_IPGRANTWAIT(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_IPGRANTWAIT_SHIFT)) & FLEXSPI_MCR0_IPGRANTWAIT_MASK)
+#define FLEXSPI_MCR0_AHBGRANTWAIT_MASK           (0xff000000u)
+#define FLEXSPI_MCR0_AHBGRANTWAIT_SHIFT          (24u)
+
+#define FLEXSPI_MCR0_AHBGRANTWAIT(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR0_AHBGRANTWAIT_SHIFT)) & FLEXSPI_MCR0_AHBGRANTWAIT_MASK)
+
+#define FLEXSPI_MCR1_AHBBUSWAIT_MASK             (0xffffu)
+#define FLEXSPI_MCR1_AHBBUSWAIT_SHIFT            (0u)
+#define FLEXSPI_MCR1_AHBBUSWAIT(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR1_AHBBUSWAIT_SHIFT)) & FLEXSPI_MCR1_AHBBUSWAIT_MASK)
+#define FLEXSPI_MCR1_SEQWAIT_MASK                (0xffff0000u)
+#define FLEXSPI_MCR1_SEQWAIT_SHIFT               (16u)
+#define FLEXSPI_MCR1_SEQWAIT(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR1_SEQWAIT_SHIFT)) & FLEXSPI_MCR1_SEQWAIT_MASK)
+
+#define FLEXSPI_MCR2_CLRAHBBUFOPT_MASK           (0x800u)
+#define FLEXSPI_MCR2_CLRAHBBUFOPT_SHIFT          (11u)
+
+#define FLEXSPI_MCR2_CLRAHBBUFOPT(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR2_CLRAHBBUFOPT_SHIFT)) & FLEXSPI_MCR2_CLRAHBBUFOPT_MASK)
+#define FLEXSPI_MCR2_CLRLEARNPHASE_MASK          (0x4000u)
+#define FLEXSPI_MCR2_CLRLEARNPHASE_SHIFT         (14u)
+
+#define FLEXSPI_MCR2_CLRLEARNPHASE(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR2_CLRLEARNPHASE_SHIFT)) & FLEXSPI_MCR2_CLRLEARNPHASE_MASK)
+#define FLEXSPI_MCR2_SAMEDEVICEEN_MASK           (0x8000u)
+#define FLEXSPI_MCR2_SAMEDEVICEEN_SHIFT          (15u)
+
+#define FLEXSPI_MCR2_SAMEDEVICEEN(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR2_SAMEDEVICEEN_SHIFT)) & FLEXSPI_MCR2_SAMEDEVICEEN_MASK)
+#define FLEXSPI_MCR2_SCKBDIFFOPT_MASK            (0x80000u)
+#define FLEXSPI_MCR2_SCKBDIFFOPT_SHIFT           (19u)
+
+#define FLEXSPI_MCR2_SCKBDIFFOPT(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR2_SCKBDIFFOPT_SHIFT)) & FLEXSPI_MCR2_SCKBDIFFOPT_MASK)
+#define FLEXSPI_MCR2_RESUMEWAIT_MASK             (0xff000000u)
+#define FLEXSPI_MCR2_RESUMEWAIT_SHIFT            (24u)
+
+#define FLEXSPI_MCR2_RESUMEWAIT(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_MCR2_RESUMEWAIT_SHIFT)) & FLEXSPI_MCR2_RESUMEWAIT_MASK)
+
+#define FLEXSPI_AHBCR_APAREN_MASK                (0x1u)
+#define FLEXSPI_AHBCR_APAREN_SHIFT               (0u)
+
+#define FLEXSPI_AHBCR_APAREN(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBCR_APAREN_SHIFT)) & FLEXSPI_AHBCR_APAREN_MASK)
+#define FLEXSPI_AHBCR_CACHABLEEN_MASK            (0x8u)
+#define FLEXSPI_AHBCR_CACHABLEEN_SHIFT           (3u)
+
+#define FLEXSPI_AHBCR_CACHABLEEN(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBCR_CACHABLEEN_SHIFT)) & FLEXSPI_AHBCR_CACHABLEEN_MASK)
+#define FLEXSPI_AHBCR_BUFFERABLEEN_MASK          (0x10u)
+#define FLEXSPI_AHBCR_BUFFERABLEEN_SHIFT         (4u)
+
+#define FLEXSPI_AHBCR_BUFFERABLEEN(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBCR_BUFFERABLEEN_SHIFT)) & FLEXSPI_AHBCR_BUFFERABLEEN_MASK)
+#define FLEXSPI_AHBCR_PREFETCHEN_MASK            (0x20u)
+#define FLEXSPI_AHBCR_PREFETCHEN_SHIFT           (5u)
+
+#define FLEXSPI_AHBCR_PREFETCHEN(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBCR_PREFETCHEN_SHIFT)) & FLEXSPI_AHBCR_PREFETCHEN_MASK)
+#define FLEXSPI_AHBCR_READADDROPT_MASK           (0x40u)
+#define FLEXSPI_AHBCR_READADDROPT_SHIFT          (6u)
+
+#define FLEXSPI_AHBCR_READADDROPT(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBCR_READADDROPT_SHIFT)) & FLEXSPI_AHBCR_READADDROPT_MASK)
+
+#define FLEXSPI_INTEN_IPCMDDONEEN_MASK           (0x1u)
+#define FLEXSPI_INTEN_IPCMDDONEEN_SHIFT          (0u)
+
+#define FLEXSPI_INTEN_IPCMDDONEEN(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_IPCMDDONEEN_SHIFT)) & FLEXSPI_INTEN_IPCMDDONEEN_MASK)
+#define FLEXSPI_INTEN_IPCMDGEEN_MASK             (0x2u)
+#define FLEXSPI_INTEN_IPCMDGEEN_SHIFT            (1u)
+
+#define FLEXSPI_INTEN_IPCMDGEEN(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_IPCMDGEEN_SHIFT)) & FLEXSPI_INTEN_IPCMDGEEN_MASK)
+#define FLEXSPI_INTEN_AHBCMDGEEN_MASK            (0x4u)
+#define FLEXSPI_INTEN_AHBCMDGEEN_SHIFT           (2u)
+
+#define FLEXSPI_INTEN_AHBCMDGEEN(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_AHBCMDGEEN_SHIFT)) & FLEXSPI_INTEN_AHBCMDGEEN_MASK)
+#define FLEXSPI_INTEN_IPCMDERREN_MASK            (0x8u)
+#define FLEXSPI_INTEN_IPCMDERREN_SHIFT           (3u)
+
+#define FLEXSPI_INTEN_IPCMDERREN(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_IPCMDERREN_SHIFT)) & FLEXSPI_INTEN_IPCMDERREN_MASK)
+#define FLEXSPI_INTEN_AHBCMDERREN_MASK           (0x10u)
+#define FLEXSPI_INTEN_AHBCMDERREN_SHIFT          (4u)
+
+#define FLEXSPI_INTEN_AHBCMDERREN(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_AHBCMDERREN_SHIFT)) & FLEXSPI_INTEN_AHBCMDERREN_MASK)
+#define FLEXSPI_INTEN_IPRXWAEN_MASK              (0x20u)
+#define FLEXSPI_INTEN_IPRXWAEN_SHIFT             (5u)
+
+#define FLEXSPI_INTEN_IPRXWAEN(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_IPRXWAEN_SHIFT)) & FLEXSPI_INTEN_IPRXWAEN_MASK)
+#define FLEXSPI_INTEN_IPTXWEEN_MASK              (0x40u)
+#define FLEXSPI_INTEN_IPTXWEEN_SHIFT             (6u)
+
+#define FLEXSPI_INTEN_IPTXWEEN(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_IPTXWEEN_SHIFT)) & FLEXSPI_INTEN_IPTXWEEN_MASK)
+#define FLEXSPI_INTEN_SCKSTOPBYRDEN_MASK         (0x100u)
+#define FLEXSPI_INTEN_SCKSTOPBYRDEN_SHIFT        (8u)
+
+#define FLEXSPI_INTEN_SCKSTOPBYRDEN(x)           (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_SCKSTOPBYRDEN_SHIFT)) & FLEXSPI_INTEN_SCKSTOPBYRDEN_MASK)
+#define FLEXSPI_INTEN_SCKSTOPBYWREN_MASK         (0x200u)
+#define FLEXSPI_INTEN_SCKSTOPBYWREN_SHIFT        (9u)
+
+#define FLEXSPI_INTEN_SCKSTOPBYWREN(x)           (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_SCKSTOPBYWREN_SHIFT)) & FLEXSPI_INTEN_SCKSTOPBYWREN_MASK)
+#define FLEXSPI_INTEN_AHBBUSTIMEOUTEN_MASK       (0x400u)
+#define FLEXSPI_INTEN_AHBBUSTIMEOUTEN_SHIFT      (10u)
+
+#define FLEXSPI_INTEN_AHBBUSTIMEOUTEN(x)         (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_AHBBUSTIMEOUTEN_SHIFT)) & FLEXSPI_INTEN_AHBBUSTIMEOUTEN_MASK)
+#define FLEXSPI_INTEN_SEQTIMEOUTEN_MASK          (0x800u)
+#define FLEXSPI_INTEN_SEQTIMEOUTEN_SHIFT         (11u)
+
+#define FLEXSPI_INTEN_SEQTIMEOUTEN(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTEN_SEQTIMEOUTEN_SHIFT)) & FLEXSPI_INTEN_SEQTIMEOUTEN_MASK)
+
+#define FLEXSPI_INTR_IPCMDDONE_MASK              (0x1u)
+#define FLEXSPI_INTR_IPCMDDONE_SHIFT             (0u)
+
+#define FLEXSPI_INTR_IPCMDDONE(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_IPCMDDONE_SHIFT)) & FLEXSPI_INTR_IPCMDDONE_MASK)
+#define FLEXSPI_INTR_IPCMDGE_MASK                (0x2u)
+#define FLEXSPI_INTR_IPCMDGE_SHIFT               (1u)
+
+#define FLEXSPI_INTR_IPCMDGE(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_IPCMDGE_SHIFT)) & FLEXSPI_INTR_IPCMDGE_MASK)
+#define FLEXSPI_INTR_AHBCMDGE_MASK               (0x4u)
+#define FLEXSPI_INTR_AHBCMDGE_SHIFT              (2u)
+
+#define FLEXSPI_INTR_AHBCMDGE(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_AHBCMDGE_SHIFT)) & FLEXSPI_INTR_AHBCMDGE_MASK)
+#define FLEXSPI_INTR_IPCMDERR_MASK               (0x8u)
+#define FLEXSPI_INTR_IPCMDERR_SHIFT              (3u)
+
+#define FLEXSPI_INTR_IPCMDERR(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_IPCMDERR_SHIFT)) & FLEXSPI_INTR_IPCMDERR_MASK)
+#define FLEXSPI_INTR_AHBCMDERR_MASK              (0x10u)
+#define FLEXSPI_INTR_AHBCMDERR_SHIFT             (4u)
+
+#define FLEXSPI_INTR_AHBCMDERR(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_AHBCMDERR_SHIFT)) & FLEXSPI_INTR_AHBCMDERR_MASK)
+#define FLEXSPI_INTR_IPRXWA_MASK                 (0x20u)
+#define FLEXSPI_INTR_IPRXWA_SHIFT                (5u)
+
+#define FLEXSPI_INTR_IPRXWA(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_IPRXWA_SHIFT)) & FLEXSPI_INTR_IPRXWA_MASK)
+#define FLEXSPI_INTR_IPTXWE_MASK                 (0x40u)
+#define FLEXSPI_INTR_IPTXWE_SHIFT                (6u)
+
+#define FLEXSPI_INTR_IPTXWE(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_IPTXWE_SHIFT)) & FLEXSPI_INTR_IPTXWE_MASK)
+#define FLEXSPI_INTR_SCKSTOPBYRD_MASK            (0x100u)
+#define FLEXSPI_INTR_SCKSTOPBYRD_SHIFT           (8u)
+
+#define FLEXSPI_INTR_SCKSTOPBYRD(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_SCKSTOPBYRD_SHIFT)) & FLEXSPI_INTR_SCKSTOPBYRD_MASK)
+#define FLEXSPI_INTR_SCKSTOPBYWR_MASK            (0x200u)
+#define FLEXSPI_INTR_SCKSTOPBYWR_SHIFT           (9u)
+
+#define FLEXSPI_INTR_SCKSTOPBYWR(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_SCKSTOPBYWR_SHIFT)) & FLEXSPI_INTR_SCKSTOPBYWR_MASK)
+#define FLEXSPI_INTR_AHBBUSTIMEOUT_MASK          (0x400u)
+#define FLEXSPI_INTR_AHBBUSTIMEOUT_SHIFT         (10u)
+
+#define FLEXSPI_INTR_AHBBUSTIMEOUT(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_AHBBUSTIMEOUT_SHIFT)) & FLEXSPI_INTR_AHBBUSTIMEOUT_MASK)
+#define FLEXSPI_INTR_SEQTIMEOUT_MASK             (0x800u)
+#define FLEXSPI_INTR_SEQTIMEOUT_SHIFT            (11u)
+
+#define FLEXSPI_INTR_SEQTIMEOUT(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_INTR_SEQTIMEOUT_SHIFT)) & FLEXSPI_INTR_SEQTIMEOUT_MASK)
+
+#define FLEXSPI_LUTKEY_KEY_MASK                  (0xffffffffu)
+#define FLEXSPI_LUTKEY_KEY_SHIFT                 (0u)
+
+#define FLEXSPI_LUTKEY_KEY(x)                    (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUTKEY_KEY_SHIFT)) & FLEXSPI_LUTKEY_KEY_MASK)
+
+#define FLEXSPI_LUTCR_LOCK_MASK                  (0x1u)
+#define FLEXSPI_LUTCR_LOCK_SHIFT                 (0u)
+
+#define FLEXSPI_LUTCR_LOCK(x)                    (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUTCR_LOCK_SHIFT)) & FLEXSPI_LUTCR_LOCK_MASK)
+#define FLEXSPI_LUTCR_UNLOCK_MASK                (0x2u)
+#define FLEXSPI_LUTCR_UNLOCK_SHIFT               (1u)
+
+#define FLEXSPI_LUTCR_UNLOCK(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUTCR_UNLOCK_SHIFT)) & FLEXSPI_LUTCR_UNLOCK_MASK)
+
+#define FLEXSPI_AHBRXBUFCR0_BUFSZ_MASK           (0xffu)
+#define FLEXSPI_AHBRXBUFCR0_BUFSZ_SHIFT          (0u)
+
+#define FLEXSPI_AHBRXBUFCR0_BUFSZ(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBRXBUFCR0_BUFSZ_SHIFT)) & FLEXSPI_AHBRXBUFCR0_BUFSZ_MASK)
+#define FLEXSPI_AHBRXBUFCR0_MSTRID_MASK          (0xf0000u)
+#define FLEXSPI_AHBRXBUFCR0_MSTRID_SHIFT         (16u)
+
+#define FLEXSPI_AHBRXBUFCR0_MSTRID(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBRXBUFCR0_MSTRID_SHIFT)) & FLEXSPI_AHBRXBUFCR0_MSTRID_MASK)
+#define FLEXSPI_AHBRXBUFCR0_PRIORITY_MASK        (0x3000000u)
+#define FLEXSPI_AHBRXBUFCR0_PRIORITY_SHIFT       (24u)
+
+#define FLEXSPI_AHBRXBUFCR0_PRIORITY(x)          (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBRXBUFCR0_PRIORITY_SHIFT)) & FLEXSPI_AHBRXBUFCR0_PRIORITY_MASK)
+#define FLEXSPI_AHBRXBUFCR0_PREFETCHEN_MASK      (0x80000000u)
+#define FLEXSPI_AHBRXBUFCR0_PREFETCHEN_SHIFT     (31u)
+
+#define FLEXSPI_AHBRXBUFCR0_PREFETCHEN(x)        (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBRXBUFCR0_PREFETCHEN_SHIFT)) & FLEXSPI_AHBRXBUFCR0_PREFETCHEN_MASK)
+
+#define FLEXSPI_AHBRXBUFCR0_COUNT                (4u)
+
+#define FLEXSPI_FLSHCR0_FLSHSZ_MASK              (0x7fffffu)
+#define FLEXSPI_FLSHCR0_FLSHSZ_SHIFT             (0u)
+
+#define FLEXSPI_FLSHCR0_FLSHSZ(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR0_FLSHSZ_SHIFT)) & FLEXSPI_FLSHCR0_FLSHSZ_MASK)
+
+#define FLEXSPI_FLSHCR0_COUNT                    (4u)
+
+#define FLEXSPI_FLSHCR1_TCSS_MASK                (0x1fu)
+#define FLEXSPI_FLSHCR1_TCSS_SHIFT               (0u)
+
+#define FLEXSPI_FLSHCR1_TCSS(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR1_TCSS_SHIFT)) & FLEXSPI_FLSHCR1_TCSS_MASK)
+#define FLEXSPI_FLSHCR1_TCSH_MASK                (0x3e0u)
+#define FLEXSPI_FLSHCR1_TCSH_SHIFT               (5u)
+
+#define FLEXSPI_FLSHCR1_TCSH(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR1_TCSH_SHIFT)) & FLEXSPI_FLSHCR1_TCSH_MASK)
+#define FLEXSPI_FLSHCR1_WA_MASK                  (0x400u)
+#define FLEXSPI_FLSHCR1_WA_SHIFT                 (10u)
+
+#define FLEXSPI_FLSHCR1_WA(x)                    (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR1_WA_SHIFT)) & FLEXSPI_FLSHCR1_WA_MASK)
+#define FLEXSPI_FLSHCR1_CAS_MASK                 (0x7800u)
+#define FLEXSPI_FLSHCR1_CAS_SHIFT                (11u)
+
+#define FLEXSPI_FLSHCR1_CAS(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR1_CAS_SHIFT)) & FLEXSPI_FLSHCR1_CAS_MASK)
+#define FLEXSPI_FLSHCR1_CSINTERVALUNIT_MASK      (0x8000u)
+#define FLEXSPI_FLSHCR1_CSINTERVALUNIT_SHIFT     (15u)
+
+#define FLEXSPI_FLSHCR1_CSINTERVALUNIT(x)        (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR1_CSINTERVALUNIT_SHIFT)) & FLEXSPI_FLSHCR1_CSINTERVALUNIT_MASK)
+#define FLEXSPI_FLSHCR1_CSINTERVAL_MASK          (0xffff0000u)
+#define FLEXSPI_FLSHCR1_CSINTERVAL_SHIFT         (16u)
+
+#define FLEXSPI_FLSHCR1_CSINTERVAL(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR1_CSINTERVAL_SHIFT)) & FLEXSPI_FLSHCR1_CSINTERVAL_MASK)
+
+#define FLEXSPI_FLSHCR1_COUNT                    (4u)
+
+#define FLEXSPI_FLSHCR2_ARDSEQID_MASK            (0xfu)
+#define FLEXSPI_FLSHCR2_ARDSEQID_SHIFT           (0u)
+
+#define FLEXSPI_FLSHCR2_ARDSEQID(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR2_ARDSEQID_SHIFT)) & FLEXSPI_FLSHCR2_ARDSEQID_MASK)
+#define FLEXSPI_FLSHCR2_ARDSEQNUM_MASK           (0xe0u)
+#define FLEXSPI_FLSHCR2_ARDSEQNUM_SHIFT          (5u)
+
+#define FLEXSPI_FLSHCR2_ARDSEQNUM(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR2_ARDSEQNUM_SHIFT)) & FLEXSPI_FLSHCR2_ARDSEQNUM_MASK)
+#define FLEXSPI_FLSHCR2_AWRSEQID_MASK            (0xf00u)
+#define FLEXSPI_FLSHCR2_AWRSEQID_SHIFT           (8u)
+
+#define FLEXSPI_FLSHCR2_AWRSEQID(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR2_AWRSEQID_SHIFT)) & FLEXSPI_FLSHCR2_AWRSEQID_MASK)
+#define FLEXSPI_FLSHCR2_AWRSEQNUM_MASK           (0xe000u)
+#define FLEXSPI_FLSHCR2_AWRSEQNUM_SHIFT          (13u)
+
+#define FLEXSPI_FLSHCR2_AWRSEQNUM(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR2_AWRSEQNUM_SHIFT)) & FLEXSPI_FLSHCR2_AWRSEQNUM_MASK)
+#define FLEXSPI_FLSHCR2_AWRWAIT_MASK             (0xfff0000u)
+#define FLEXSPI_FLSHCR2_AWRWAIT_SHIFT            (16u)
+#define FLEXSPI_FLSHCR2_AWRWAIT(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR2_AWRWAIT_SHIFT)) & FLEXSPI_FLSHCR2_AWRWAIT_MASK)
+#define FLEXSPI_FLSHCR2_AWRWAITUNIT_MASK         (0x70000000u)
+#define FLEXSPI_FLSHCR2_AWRWAITUNIT_SHIFT        (28u)
+
+#define FLEXSPI_FLSHCR2_AWRWAITUNIT(x)           (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR2_AWRWAITUNIT_SHIFT)) & FLEXSPI_FLSHCR2_AWRWAITUNIT_MASK)
+#define FLEXSPI_FLSHCR2_CLRINSTRPTR_MASK         (0x80000000u)
+#define FLEXSPI_FLSHCR2_CLRINSTRPTR_SHIFT        (31u)
+
+#define FLEXSPI_FLSHCR2_CLRINSTRPTR(x)           (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR2_CLRINSTRPTR_SHIFT)) & FLEXSPI_FLSHCR2_CLRINSTRPTR_MASK)
+
+#define FLEXSPI_FLSHCR2_COUNT                    (4u)
+
+#define FLEXSPI_FLSHCR4_WMOPT1_MASK              (0x1u)
+#define FLEXSPI_FLSHCR4_WMOPT1_SHIFT             (0u)
+
+#define FLEXSPI_FLSHCR4_WMOPT1(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR4_WMOPT1_SHIFT)) & FLEXSPI_FLSHCR4_WMOPT1_MASK)
+#define FLEXSPI_FLSHCR4_WMENA_MASK               (0x4u)
+#define FLEXSPI_FLSHCR4_WMENA_SHIFT              (2u)
+
+#define FLEXSPI_FLSHCR4_WMENA(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR4_WMENA_SHIFT)) & FLEXSPI_FLSHCR4_WMENA_MASK)
+#define FLEXSPI_FLSHCR4_WMENB_MASK               (0x8u)
+#define FLEXSPI_FLSHCR4_WMENB_SHIFT              (3u)
+
+#define FLEXSPI_FLSHCR4_WMENB(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_FLSHCR4_WMENB_SHIFT)) & FLEXSPI_FLSHCR4_WMENB_MASK)
+
+#define FLEXSPI_IPCR0_SFAR_MASK                  (0xffffffffu)
+#define FLEXSPI_IPCR0_SFAR_SHIFT                 (0u)
+
+#define FLEXSPI_IPCR0_SFAR(x)                    (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPCR0_SFAR_SHIFT)) & FLEXSPI_IPCR0_SFAR_MASK)
+
+#define FLEXSPI_IPCR1_IDATSZ_MASK                (0xffffu)
+#define FLEXSPI_IPCR1_IDATSZ_SHIFT               (0u)
+
+#define FLEXSPI_IPCR1_IDATSZ(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPCR1_IDATSZ_SHIFT)) & FLEXSPI_IPCR1_IDATSZ_MASK)
+#define FLEXSPI_IPCR1_ISEQID_MASK                (0xf0000u)
+#define FLEXSPI_IPCR1_ISEQID_SHIFT               (16u)
+
+#define FLEXSPI_IPCR1_ISEQID(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPCR1_ISEQID_SHIFT)) & FLEXSPI_IPCR1_ISEQID_MASK)
+#define FLEXSPI_IPCR1_ISEQNUM_MASK               (0x7000000u)
+#define FLEXSPI_IPCR1_ISEQNUM_SHIFT              (24u)
+
+#define FLEXSPI_IPCR1_ISEQNUM(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPCR1_ISEQNUM_SHIFT)) & FLEXSPI_IPCR1_ISEQNUM_MASK)
+#define FLEXSPI_IPCR1_IPAREN_MASK                (0x80000000u)
+#define FLEXSPI_IPCR1_IPAREN_SHIFT               (31u)
+
+#define FLEXSPI_IPCR1_IPAREN(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPCR1_IPAREN_SHIFT)) & FLEXSPI_IPCR1_IPAREN_MASK)
+
+#define FLEXSPI_IPCMD_TRG_MASK                   (0x1u)
+#define FLEXSPI_IPCMD_TRG_SHIFT                  (0u)
+
+#define FLEXSPI_IPCMD_TRG(x)                     (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPCMD_TRG_SHIFT)) & FLEXSPI_IPCMD_TRG_MASK)
+
+#define FLEXSPI_IPRXFCR_CLRIPRXF_MASK            (0x1u)
+#define FLEXSPI_IPRXFCR_CLRIPRXF_SHIFT           (0u)
+
+#define FLEXSPI_IPRXFCR_CLRIPRXF(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPRXFCR_CLRIPRXF_SHIFT)) & FLEXSPI_IPRXFCR_CLRIPRXF_MASK)
+#define FLEXSPI_IPRXFCR_RXDMAEN_MASK             (0x2u)
+#define FLEXSPI_IPRXFCR_RXDMAEN_SHIFT            (1u)
+
+#define FLEXSPI_IPRXFCR_RXDMAEN(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPRXFCR_RXDMAEN_SHIFT)) & FLEXSPI_IPRXFCR_RXDMAEN_MASK)
+#define FLEXSPI_IPRXFCR_RXWMRK_MASK              (0x3cu)
+#define FLEXSPI_IPRXFCR_RXWMRK_SHIFT             (2u)
+
+#define FLEXSPI_IPRXFCR_RXWMRK(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPRXFCR_RXWMRK_SHIFT)) & FLEXSPI_IPRXFCR_RXWMRK_MASK)
+
+#define FLEXSPI_IPTXFCR_CLRIPTXF_MASK            (0x1u)
+#define FLEXSPI_IPTXFCR_CLRIPTXF_SHIFT           (0u)
+
+#define FLEXSPI_IPTXFCR_CLRIPTXF(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPTXFCR_CLRIPTXF_SHIFT)) & FLEXSPI_IPTXFCR_CLRIPTXF_MASK)
+#define FLEXSPI_IPTXFCR_TXDMAEN_MASK             (0x2u)
+#define FLEXSPI_IPTXFCR_TXDMAEN_SHIFT            (1u)
+
+#define FLEXSPI_IPTXFCR_TXDMAEN(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPTXFCR_TXDMAEN_SHIFT)) & FLEXSPI_IPTXFCR_TXDMAEN_MASK)
+#define FLEXSPI_IPTXFCR_TXWMRK_MASK              (0x3cu)
+#define FLEXSPI_IPTXFCR_TXWMRK_SHIFT             (2u)
+
+#define FLEXSPI_IPTXFCR_TXWMRK(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPTXFCR_TXWMRK_SHIFT)) & FLEXSPI_IPTXFCR_TXWMRK_MASK)
+
+#define FLEXSPI_DLLCR_DLLEN_MASK                 (0x1u)
+#define FLEXSPI_DLLCR_DLLEN_SHIFT                (0u)
+
+#define FLEXSPI_DLLCR_DLLEN(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_DLLCR_DLLEN_SHIFT)) & FLEXSPI_DLLCR_DLLEN_MASK)
+#define FLEXSPI_DLLCR_DLLRESET_MASK              (0x2u)
+#define FLEXSPI_DLLCR_DLLRESET_SHIFT             (1u)
+
+#define FLEXSPI_DLLCR_DLLRESET(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_DLLCR_DLLRESET_SHIFT)) & FLEXSPI_DLLCR_DLLRESET_MASK)
+#define FLEXSPI_DLLCR_SLVDLYTARGET_MASK          (0x78u)
+#define FLEXSPI_DLLCR_SLVDLYTARGET_SHIFT         (3u)
+
+#define FLEXSPI_DLLCR_SLVDLYTARGET(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_DLLCR_SLVDLYTARGET_SHIFT)) & FLEXSPI_DLLCR_SLVDLYTARGET_MASK)
+#define FLEXSPI_DLLCR_OVRDEN_MASK                (0x100u)
+#define FLEXSPI_DLLCR_OVRDEN_SHIFT               (8u)
+
+#define FLEXSPI_DLLCR_OVRDEN(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_DLLCR_OVRDEN_SHIFT)) & FLEXSPI_DLLCR_OVRDEN_MASK)
+#define FLEXSPI_DLLCR_OVRDVAL_MASK               (0x7e00u)
+#define FLEXSPI_DLLCR_OVRDVAL_SHIFT              (9u)
+
+#define FLEXSPI_DLLCR_OVRDVAL(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_DLLCR_OVRDVAL_SHIFT)) & FLEXSPI_DLLCR_OVRDVAL_MASK)
+
+#define FLEXSPI_DLLCR_COUNT                      (2u)
+
+#define FLEXSPI_STS0_SEQIDLE_MASK                (0x1u)
+#define FLEXSPI_STS0_SEQIDLE_SHIFT               (0u)
+
+#define FLEXSPI_STS0_SEQIDLE(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS0_SEQIDLE_SHIFT)) & FLEXSPI_STS0_SEQIDLE_MASK)
+#define FLEXSPI_STS0_ARBIDLE_MASK                (0x2u)
+#define FLEXSPI_STS0_ARBIDLE_SHIFT               (1u)
+
+#define FLEXSPI_STS0_ARBIDLE(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS0_ARBIDLE_SHIFT)) & FLEXSPI_STS0_ARBIDLE_MASK)
+#define FLEXSPI_STS0_ARBCMDSRC_MASK              (0xcu)
+#define FLEXSPI_STS0_ARBCMDSRC_SHIFT             (2u)
+
+#define FLEXSPI_STS0_ARBCMDSRC(x)                (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS0_ARBCMDSRC_SHIFT)) & FLEXSPI_STS0_ARBCMDSRC_MASK)
+
+#define FLEXSPI_STS1_AHBCMDERRID_MASK            (0xfu)
+#define FLEXSPI_STS1_AHBCMDERRID_SHIFT           (0u)
+
+#define FLEXSPI_STS1_AHBCMDERRID(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS1_AHBCMDERRID_SHIFT)) & FLEXSPI_STS1_AHBCMDERRID_MASK)
+#define FLEXSPI_STS1_AHBCMDERRCODE_MASK          (0xf00u)
+#define FLEXSPI_STS1_AHBCMDERRCODE_SHIFT         (8u)
+
+#define FLEXSPI_STS1_AHBCMDERRCODE(x)            (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS1_AHBCMDERRCODE_SHIFT)) & FLEXSPI_STS1_AHBCMDERRCODE_MASK)
+#define FLEXSPI_STS1_IPCMDERRID_MASK             (0xf0000u)
+#define FLEXSPI_STS1_IPCMDERRID_SHIFT            (16u)
+
+#define FLEXSPI_STS1_IPCMDERRID(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS1_IPCMDERRID_SHIFT)) & FLEXSPI_STS1_IPCMDERRID_MASK)
+#define FLEXSPI_STS1_IPCMDERRCODE_MASK           (0xf000000u)
+#define FLEXSPI_STS1_IPCMDERRCODE_SHIFT          (24u)
+
+#define FLEXSPI_STS1_IPCMDERRCODE(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS1_IPCMDERRCODE_SHIFT)) & FLEXSPI_STS1_IPCMDERRCODE_MASK)
+
+#define FLEXSPI_STS2_ASLVLOCK_MASK               (0x1u)
+#define FLEXSPI_STS2_ASLVLOCK_SHIFT              (0u)
+
+#define FLEXSPI_STS2_ASLVLOCK(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS2_ASLVLOCK_SHIFT)) & FLEXSPI_STS2_ASLVLOCK_MASK)
+#define FLEXSPI_STS2_AREFLOCK_MASK               (0x2u)
+#define FLEXSPI_STS2_AREFLOCK_SHIFT              (1u)
+
+#define FLEXSPI_STS2_AREFLOCK(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS2_AREFLOCK_SHIFT)) & FLEXSPI_STS2_AREFLOCK_MASK)
+#define FLEXSPI_STS2_ASLVSEL_MASK                (0xfcu)
+#define FLEXSPI_STS2_ASLVSEL_SHIFT               (2u)
+
+#define FLEXSPI_STS2_ASLVSEL(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS2_ASLVSEL_SHIFT)) & FLEXSPI_STS2_ASLVSEL_MASK)
+#define FLEXSPI_STS2_AREFSEL_MASK                (0x3f00u)
+#define FLEXSPI_STS2_AREFSEL_SHIFT               (8u)
+
+#define FLEXSPI_STS2_AREFSEL(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS2_AREFSEL_SHIFT)) & FLEXSPI_STS2_AREFSEL_MASK)
+#define FLEXSPI_STS2_BSLVLOCK_MASK               (0x10000u)
+#define FLEXSPI_STS2_BSLVLOCK_SHIFT              (16u)
+
+#define FLEXSPI_STS2_BSLVLOCK(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS2_BSLVLOCK_SHIFT)) & FLEXSPI_STS2_BSLVLOCK_MASK)
+#define FLEXSPI_STS2_BREFLOCK_MASK               (0x20000u)
+#define FLEXSPI_STS2_BREFLOCK_SHIFT              (17u)
+
+#define FLEXSPI_STS2_BREFLOCK(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS2_BREFLOCK_SHIFT)) & FLEXSPI_STS2_BREFLOCK_MASK)
+#define FLEXSPI_STS2_BSLVSEL_MASK                (0xfc0000u)
+#define FLEXSPI_STS2_BSLVSEL_SHIFT               (18u)
+
+#define FLEXSPI_STS2_BSLVSEL(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS2_BSLVSEL_SHIFT)) & FLEXSPI_STS2_BSLVSEL_MASK)
+#define FLEXSPI_STS2_BREFSEL_MASK                (0x3f000000u)
+#define FLEXSPI_STS2_BREFSEL_SHIFT               (24u)
+
+#define FLEXSPI_STS2_BREFSEL(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_STS2_BREFSEL_SHIFT)) & FLEXSPI_STS2_BREFSEL_MASK)
+
+#define FLEXSPI_AHBSPNDSTS_ACTIVE_MASK           (0x1u)
+#define FLEXSPI_AHBSPNDSTS_ACTIVE_SHIFT          (0u)
+
+#define FLEXSPI_AHBSPNDSTS_ACTIVE(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBSPNDSTS_ACTIVE_SHIFT)) & FLEXSPI_AHBSPNDSTS_ACTIVE_MASK)
+#define FLEXSPI_AHBSPNDSTS_BUFID_MASK            (0xeU)
+#define FLEXSPI_AHBSPNDSTS_BUFID_SHIFT           (1u)
+
+#define FLEXSPI_AHBSPNDSTS_BUFID(x)              (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBSPNDSTS_BUFID_SHIFT)) & FLEXSPI_AHBSPNDSTS_BUFID_MASK)
+#define FLEXSPI_AHBSPNDSTS_DATLFT_MASK           (0xffff0000u)
+#define FLEXSPI_AHBSPNDSTS_DATLFT_SHIFT          (16u)
+
+#define FLEXSPI_AHBSPNDSTS_DATLFT(x)             (((uint32_t)(((uint32_t)(x)) << FLEXSPI_AHBSPNDSTS_DATLFT_SHIFT)) & FLEXSPI_AHBSPNDSTS_DATLFT_MASK)
+
+#define FLEXSPI_IPRXFSTS_FILL_MASK               (0xffu)
+#define FLEXSPI_IPRXFSTS_FILL_SHIFT              (0u)
+
+#define FLEXSPI_IPRXFSTS_FILL(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPRXFSTS_FILL_SHIFT)) & FLEXSPI_IPRXFSTS_FILL_MASK)
+#define FLEXSPI_IPRXFSTS_RDCNTR_MASK             (0xffff0000u)
+#define FLEXSPI_IPRXFSTS_RDCNTR_SHIFT            (16u)
+
+#define FLEXSPI_IPRXFSTS_RDCNTR(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPRXFSTS_RDCNTR_SHIFT)) & FLEXSPI_IPRXFSTS_RDCNTR_MASK)
+
+#define FLEXSPI_IPTXFSTS_FILL_MASK               (0xffu)
+#define FLEXSPI_IPTXFSTS_FILL_SHIFT              (0u)
+
+#define FLEXSPI_IPTXFSTS_FILL(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPTXFSTS_FILL_SHIFT)) & FLEXSPI_IPTXFSTS_FILL_MASK)
+#define FLEXSPI_IPTXFSTS_WRCNTR_MASK             (0xffff0000u)
+#define FLEXSPI_IPTXFSTS_WRCNTR_SHIFT            (16u)
+
+#define FLEXSPI_IPTXFSTS_WRCNTR(x)               (((uint32_t)(((uint32_t)(x)) << FLEXSPI_IPTXFSTS_WRCNTR_SHIFT)) & FLEXSPI_IPTXFSTS_WRCNTR_MASK)
+
+#define FLEXSPI_RFDR_RXDATA_MASK                 (0xffffffffu)
+#define FLEXSPI_RFDR_RXDATA_SHIFT                (0u)
+
+#define FLEXSPI_RFDR_RXDATA(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_RFDR_RXDATA_SHIFT)) & FLEXSPI_RFDR_RXDATA_MASK)
+
+#define FLEXSPI_RFDR_COUNT                       (32u)
+
+#define FLEXSPI_TFDR_TXDATA_MASK                 (0xffffffffu)
+#define FLEXSPI_TFDR_TXDATA_SHIFT                (0u)
+
+#define FLEXSPI_TFDR_TXDATA(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_TFDR_TXDATA_SHIFT)) & FLEXSPI_TFDR_TXDATA_MASK)
+
+#define FLEXSPI_TFDR_COUNT                       (32u)
+
+#define FLEXSPI_LUT_COUNT                        (64u)
+
+#endif /* __ARCH_ARM_SRC_IMXRT_HARDWARE_IMXRT_FLEXSPI_H */

--- a/arch/arm/src/imxrt/hardware/imxrt_iomuxc.h
+++ b/arch/arm/src/imxrt/hardware/imxrt_iomuxc.h
@@ -175,4 +175,7 @@
 
 #define IOMUX_ADC_DEFAULT                     (0)
 
+#define IOMUX_FLEXSPI_DEFAULT                 (IOMUX_SLEW_FAST | IOMUX_DRIVE_40OHM | IOMUX_SPEED_MAX | \
+                                               IOMUX_PULL_DOWN_100K | IOMUX_PULL_KEEP | GPIO_SION_ENABLE )
+
 #endif /* __ARCH_ARM_SRC_IMXRT_HARDWARE_IMXRT_IOMUXC_H */

--- a/arch/arm/src/imxrt/imxrt_flexspi.c
+++ b/arch/arm/src/imxrt/imxrt_flexspi.c
@@ -1,0 +1,1307 @@
+/****************************************************************************
+ * arch/arm/src/imxrt/imxrt_flexspi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <arch/board/board.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/wdog.h>
+#include <nuttx/clock.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/spi/flexspi.h>
+
+#include "arm_internal.h"
+#include "arm_arch.h"
+#include "barriers.h"
+
+#include "imxrt_gpio.h"
+#include "imxrt_periphclks.h"
+#include "imxrt_flexspi.h"
+#include "hardware/imxrt_pinmux.h"
+#include "hardware/imxrt_flexspi.h"
+
+#ifdef CONFIG_IMXRT_FLEXSPI
+
+/*  There is AHBBUSERROREN bit in INTEN register */
+#define FLEXSPI_HAS_INTEN_AHBBUSERROREN (0)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* The state of the FlexSPI controller.
+ *
+ */
+
+struct imxrt_flexspidev_s
+{
+  struct flexspi_dev_s flexspi; /* Externally visible part of the FlexSPI
+                                 * interface */
+
+  struct flexspi_type_s *base; /* FlexSPI controller register base address */
+
+  bool initialized;            /* TRUE: Controller has been initialized */
+
+  sem_t exclsem;               /* Assures mutually exclusive access to
+                                * FlexSPI */
+};
+
+/* FlexSPI methods */
+
+static int imxrt_flexspi_lock(struct flexspi_dev_s *dev, bool lock);
+static int imxrt_flexspi_transfer_blocking(struct flexspi_dev_s *dev,
+                                      FAR struct flexspi_transfer_s *xfer);
+static void imxrt_flexspi_software_reset(struct flexspi_dev_s *dev);
+static void imxrt_flexspi_update_lut(struct flexspi_dev_s *dev,
+                                     uint32_t index,
+                                     const uint32_t *cmd,
+                                     uint32_t count);
+static void imxrt_flexspi_set_device_config(struct flexspi_dev_s *dev,
+                                      struct flexspi_device_config_s *config,
+                                      enum flexspi_port_e port);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* FlexSPI0 driver operations */
+
+static const struct flexspi_ops_s g_flexspi0ops =
+{
+  .lock              = imxrt_flexspi_lock,
+  .transfer_blocking = imxrt_flexspi_transfer_blocking,
+  .software_reset    = imxrt_flexspi_software_reset,
+  .update_lut        = imxrt_flexspi_update_lut,
+  .set_device_config  = imxrt_flexspi_set_device_config,
+};
+
+/* This is the overall state of the FlexSPI0 controller */
+
+static struct imxrt_flexspidev_s g_flexspi0dev =
+{
+  .flexspi =
+  {
+    .ops = &g_flexspi0ops,
+  },
+  .base = (struct flexspi_type_s *) IMXRT_FLEXSPIC_BASE,
+};
+
+#define FREQ_1MHz             (1000000ul)
+#define FLEXSPI_DLLCR_DEFAULT (0x100ul)
+#define FLEXSPI_LUT_KEY_VAL   (0x5af05af0ul)
+
+enum
+{
+  FLEXSPI_DELAY_CELL_UNIT_MIN = 75,  /* 75ps */
+
+  FLEXSPI_DELAY_CELL_UNIT_MAX = 225, /* 225ps */
+};
+
+enum
+{
+  FLEXSPI_FLASH_A_SAMPLE_CLOCK_SLAVE_DELAY_LOCKED =
+      FLEXSPI_STS2_ASLVLOCK_MASK, /* Flash A sample clock slave delay line locked */
+
+  FLEXSPI_FLASH_A_SAMPLE_CLOCK_REF_DELAY_LOCKED =
+      FLEXSPI_STS2_AREFLOCK_MASK, /* Flash A sample clock reference delay line locked */
+
+  FLEXSPI_FLASH_B_SAMPLE_CLOCK_SLAVE_DELAY_LOCKED =
+      FLEXSPI_STS2_BSLVLOCK_MASK, /* Flash B sample clock slave delay line locked */
+
+  FLEXSPI_FLASH_B_SAMPLE_CLOCK_REF_DELAY_LOCKED =
+      FLEXSPI_STS2_BREFLOCK_MASK, /* Flash B sample clock reference delay line locked */
+};
+
+/* FLEXSPI interrupt status flags */
+
+enum flexspi_flags_e
+{
+  FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT_FLAG = FLEXSPI_INTEN_SEQTIMEOUTEN_MASK, /* Sequence execution timeout */
+#if defined(FLEXSPI_HAS_INTEN_AHBBUSERROREN) && FLEXSPI_HAS_INTEN_AHBBUSERROREN
+  FLEXSPI_AHB_BUS_ERROR_FLAG = FLEXSPI_INTEN_AHBBUSERROREN_MASK, /* AHB Bus error flag */
+#else
+  FLEXSPI_AHB_BUS_TIMEOUT_FLAG = FLEXSPI_INTEN_AHBBUSTIMEOUTEN_MASK, /* AHB Bus timeout */
+#endif
+  FLEXSPI_SCK_STOPPED_BECAUSE_TX_EMPTY_FLAG =
+      FLEXSPI_INTEN_SCKSTOPBYWREN_MASK, /* SCK is stopped during command
+                                         * sequence because Async TX FIFO empty */
+
+  FLEXSPI_SCK_STOPPED_BECAUSE_RX_FULL_FLAG =
+      FLEXSPI_INTEN_SCKSTOPBYRDEN_MASK, /* SCK is stopped during command
+                                         * sequence because Async RX FIFO full */
+
+  FLEXSPI_IP_TX_FIFO_WATERMARK_EMPTY_FLAG     = FLEXSPI_INTEN_IPTXWEEN_MASK, /* IP TX FIFO WaterMark empty */
+
+  FLEXSPI_IP_RX_FIFO_WATERMARK_AVAILABLE_FLAG = FLEXSPI_INTEN_IPRXWAEN_MASK, /* IP RX FIFO WaterMark available */
+
+  FLEXSPI_AHB_COMMAND_SEQUENCE_ERROR_FLAG =
+      FLEXSPI_INTEN_AHBCMDERREN_MASK,                                  /* AHB triggered Command Sequences Error */
+
+  FLEXSPI_IP_COMMAND_SEQUENCE_ERROR_FLAG = FLEXSPI_INTEN_IPCMDERREN_MASK, /* IP triggered Command Sequences Error */
+
+  FLEXSPI_AHB_COMMAND_GRANT_TIMEOUT_FLAG =
+      FLEXSPI_INTEN_AHBCMDGEEN_MASK, /* AHB triggered Command Sequences Grant Timeout */
+
+  FLEXSPI_IP_COMMAND_GRANT_TIMEOUT_FLAG =
+      FLEXSPI_INTEN_IPCMDGEEN_MASK, /* IP triggered Command Sequences Grant Timeout */
+
+  FLEXSPI_IP_COMMAND_EXECUTION_DONE_FLAG =
+      FLEXSPI_INTEN_IPCMDDONEEN_MASK,  /* IP triggered Command Sequences Execution finished */
+
+  FLEXSPI_ALL_INTERRUPT_FLAGS = 0xfffu, /* All flags */
+};
+
+/* Common sets of flags used by the driver */
+
+enum flexspi_flag_constants_e
+{
+  /*  Errors to check for */
+
+  ERROR_FLAGS = FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT_FLAG |
+                FLEXSPI_IP_COMMAND_SEQUENCE_ERROR_FLAG |
+                FLEXSPI_IP_COMMAND_GRANT_TIMEOUT_FLAG,
+};
+
+#define FLEXSPI_AHB_BUFFER_COUNT (4)
+
+/* FLEXSPI sample clock source selection for Flash Reading */
+
+enum flexspi_read_sample_clock_e
+{
+  FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY =         0x0u,      /* Dummy Read strobe generated by FlexSPI Controller
+                                                                    * and loopback internally */
+
+  FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD =       0x1u,      /* Dummy Read strobe generated by FlexSPI Controller
+                                                                    * and loopback from DQS pad */
+
+  FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD =       0x2u, /* SCK output clock and loopback from SCK pad */
+
+  FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD = 0x3u, /* Flash provided Read strobe and input from DQS pad */
+};
+
+struct flexspi_ahb_buffer_config_s
+{
+  uint8_t priority;    /* This priority for AHB Master Read which this AHB RX Buffer is assigned */
+
+  uint8_t master_index; /* AHB Master ID the AHB RX Buffer is assigned */
+
+  uint16_t buffer_size; /* AHB buffer size in byte */
+
+  bool enable_prefetch; /* AHB Read Prefetch Enable for current AHB RX Buffer corresponding Master, allows
+                         * prefetch disable/enable separately for each master */
+};
+
+/*   FLEXSPI configuration structure */
+
+struct flexspi_config_s
+{
+  enum flexspi_read_sample_clock_e rx_sample_clock; /* Sample Clock source selection for Flash Reading */
+
+  bool enable_sck_free_running;                 /* Enable/disable SCK output free-running */
+
+  bool enable_combination;                    /* Enable/disable combining PORT A and B Data Pins
+                                               * (SIOA[3:0] and SIOB[3:0]) to support Flash Octal mode */
+
+  bool enable_doze;                           /* Enable/disable doze mode support */
+
+  bool enable_half_speed_access;                /* Enable/disable divide by 2 of the clock for half
+                                                 * speed commands */
+
+  bool enable_sckb_diff_opt;                    /* Enable/disable SCKB pad use as SCKA differential clock
+                                                 * output, when enable, Port B flash access is not available */
+
+  bool enable_same_config_for_all;               /* Enable/disable same configuration for all connected devices
+                                                  * when enabled, same configuration in FLASHA1CRx is applied to all */
+
+  uint16_t seq_timeout_cycle;                  /* Timeout wait cycle for command sequence execution,
+                                                * timeout after ahb_grant_timeout_cyle*1024 serial root clock cycles */
+
+  uint8_t ip_grant_timeout_cycle;               /* Timeout wait cycle for IP command grant, timeout after
+                                                 * ip_grant_timeout_cycle*1024 AHB clock cycles */
+
+  uint8_t tx_watermark;                       /* FLEXSPI IP transmit watermark value */
+
+  uint8_t rx_watermark;                       /* FLEXSPI receive watermark value */
+
+  struct
+  {
+#if !(defined(FLEXSPI_HAS_NO_MCR0_ATDFEN) && FLEXSPI_HAS_NO_MCR0_ATDFEN)
+    bool enable_ahb_write_ip_tx_fifo; /* Enable AHB bus write access to IP TX FIFO */
+#endif
+#if !(defined(FLEXSPI_HAS_NO_MCR0_ARDFEN) && FLEXSPI_HAS_NO_MCR0_ARDFEN)
+    bool enable_ahb_write_ip_rx_fifo; /* Enable AHB bus write access to IP RX FIFO */
+#endif
+    uint8_t ahb_grant_timeout_cycle; /* Timeout wait cycle for AHB command grant,
+                                      * timeout after ahb_grant_timeout_cyle*1024 AHB clock cycles */
+
+    uint16_t ahb_bus_timeout_cycle;  /* Timeout wait cycle for AHB read/write access,
+                                      * timeout after ahb_bus_timeout_cycle*1024 AHB clock cycles */
+
+    uint8_t resume_wait_cycle;      /* Wait cycle for idle state before suspended command sequence
+                                     * resume, timeout after ahb_bus_timeout_cycle AHB clock cycles */
+
+    struct flexspi_ahb_buffer_config_s buffer[FLEXSPI_AHB_BUFFER_COUNT]; /* AHB buffer size */
+
+    bool enable_clear_ahb_buffer_opt; /* Enable/disable automatically clean AHB RX Buffer and TX Buffer
+                                       * when FLEXSPI returns STOP mode ACK */
+
+    bool enable_read_address_opt;    /* Enable/disable remove AHB read burst start address alignment limitation.
+                                      * when enable, there is no AHB read burst start address alignment limitation */
+
+    bool enable_ahb_prefetch;       /* Enable/disable AHB read prefetch feature, when enabled, FLEXSPI
+                                     * will fetch more data than current AHB burst */
+
+    bool enable_ahb_bufferable;     /* Enable/disable AHB bufferable write access support, when enabled,
+                                     * FLEXSPI return before waiting for command execution finished */
+
+    bool enable_ahb_cachable;       /* Enable AHB bus cachable read access support */
+  } ahb_config;
+};
+
+/****************************************************************************
+ * Prototypes
+ ****************************************************************************/
+
+/* Check and clear IP command execution errors.
+ *
+ * @param base FLEXSPI base pointer.
+ * @param status interrupt status.
+ */
+
+static int imxrt_flexspi_check_and_clear_error(struct flexspi_type_s *base,
+                                               uint32_t status);
+
+/****************************************************************************
+ * Variables
+ ****************************************************************************/
+
+/****************************************************************************
+ * Code
+ ****************************************************************************/
+
+/* Software reset for the FLEXSPI logic.
+ *
+ * This function sets the software reset flags for both AHB and buffer domain
+ * and resets both AHB buffer and also IP FIFOs.
+ *
+ * @param base FLEXSPI peripheral base address.
+ */
+
+static inline void imxrt_flexspi_software_reset_private(
+                        struct flexspi_type_s *base)
+{
+  base->MCR0 |= FLEXSPI_MCR0_SWRESET_MASK;
+  while (0u != (base->MCR0 & FLEXSPI_MCR0_SWRESET_MASK))
+    {
+    }
+}
+
+/* Returns whether the bus is idle.
+ *
+ * @param base FLEXSPI peripheral base address.
+ * @retval true Bus is idle.
+ * @retval false Bus is busy.
+ */
+
+static inline bool imxrt_flexspi_get_bus_idle_status(
+                        struct flexspi_type_s *base)
+{
+  return (0u != (base->STS0 & FLEXSPI_STS0_ARBIDLE_MASK)) &&
+          (0u != (base->STS0 & FLEXSPI_STS0_SEQIDLE_MASK));
+}
+
+static uint32_t imxrt_flexspi_configure_dll(struct flexspi_type_s *base,
+                                  struct flexspi_device_config_s *config)
+{
+  bool is_unified_config = true;
+  uint32_t flexspi_dll_value;
+  uint32_t dll_value;
+  uint32_t temp;
+
+  uint32_t rx_sample_clock = (base->MCR0 & FLEXSPI_MCR0_RXCLKSRC_MASK) >>
+                              FLEXSPI_MCR0_RXCLKSRC_SHIFT;
+  switch (rx_sample_clock)
+    {
+      case (uint32_t)FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_INTERNALLY:
+      case (uint32_t)FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD:
+      case (uint32_t)FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_SCK_PAD:
+        is_unified_config = true;
+        break;
+      case (uint32_t)FLEXSPI_READ_SAMPLE_CLK_EXTERNAL_INPUT_FROM_DQS_PAD:
+        if (config->is_sck2_enabled)
+          {
+            is_unified_config = true;
+          }
+        else
+          {
+            is_unified_config = false;
+          }
+        break;
+      default:
+          assert(false);
+          break;
+  }
+
+  if (is_unified_config)
+    {
+      flexspi_dll_value = FLEXSPI_DLLCR_DEFAULT; /* 1 fixed delay cells in DLL delay chain */
+    }
+  else
+    {
+      if (config->flexspi_root_clk >= 100u * FREQ_1MHz)
+        {
+          /* DLLEN = 1, SLVDLYTARGET = 0xF, */
+
+          flexspi_dll_value = FLEXSPI_DLLCR_DLLEN(1) |
+                              FLEXSPI_DLLCR_SLVDLYTARGET(0x0f);
+        }
+      else
+        {
+          temp     = (uint32_t)config->data_valid_time * 1000u; /* Convert data valid time in ns to ps */
+
+          dll_value = temp / (uint32_t)FLEXSPI_DELAY_CELL_UNIT_MIN;
+          if (dll_value * (uint32_t)FLEXSPI_DELAY_CELL_UNIT_MIN < temp)
+            {
+              dll_value++;
+            }
+          flexspi_dll_value = FLEXSPI_DLLCR_OVRDEN(1) |
+                              FLEXSPI_DLLCR_OVRDVAL(dll_value);
+        }
+    }
+  return flexspi_dll_value;
+}
+
+static int imxrt_flexspi_check_and_clear_error(struct flexspi_type_s *base,
+                                               uint32_t status)
+{
+  int result = 0;
+
+  /* Check for error */
+
+  status &= (uint32_t)ERROR_FLAGS;
+  if (0u != status)
+    {
+      /* Select the correct error code */
+
+      if (0u != (status & (uint32_t)FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT_FLAG))
+        {
+          result = STATUS_FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT;
+        }
+      else if (0u != (status &
+                      (uint32_t)FLEXSPI_IP_COMMAND_SEQUENCE_ERROR_FLAG))
+        {
+          result = STATUS_FLEXSPI_IP_COMMAND_SEQUENCE_ERROR;
+        }
+      else if (0u != (status &
+                      (uint32_t)FLEXSPI_IP_COMMAND_GRANT_TIMEOUT_FLAG))
+        {
+          result = STATUS_FLEXSPI_IP_COMMAND_GRANT_TIMEOUT;
+        }
+      else
+        {
+          assert(false);
+        }
+
+      /* Clear the flags */
+
+      base->INTR |= status;
+
+      /* Reset fifos. These flags clear automatically */
+
+      base->IPTXFCR |= FLEXSPI_IPTXFCR_CLRIPTXF_MASK;
+      base->IPRXFCR |= FLEXSPI_IPRXFCR_CLRIPRXF_MASK;
+  }
+
+  return result;
+}
+
+/* Initializes the FLEXSPI module and internal state.
+ *
+ * This function enables the clock for FLEXSPI and also configures the
+ * FLEXSPI with the input configure parameters. Users should call this
+ * function before any FLEXSPI operations.
+ *
+ * param base FLEXSPI peripheral base address.
+ * param config FLEXSPI configure structure.
+ */
+
+void imxrt_flexspi_init(struct flexspi_type_s *base,
+                        const struct flexspi_config_s *config)
+{
+  uint32_t config_value = 0;
+  uint8_t i            = 0;
+
+  /* Reset peripheral before configuring it */
+
+  base->MCR0 &= ~FLEXSPI_MCR0_MDIS_MASK;
+  imxrt_flexspi_software_reset_private(base);
+
+  /* Configure MCR0 configuration items */
+
+  config_value = FLEXSPI_MCR0_RXCLKSRC(config->rx_sample_clock) |
+                 FLEXSPI_MCR0_DOZEEN(config->enable_doze) |
+                 FLEXSPI_MCR0_IPGRANTWAIT(config->ip_grant_timeout_cycle) |
+                 FLEXSPI_MCR0_AHBGRANTWAIT(
+                   config->ahb_config.ahb_grant_timeout_cycle) |
+                 FLEXSPI_MCR0_SCKFREERUNEN(config->enable_sck_free_running) |
+                 FLEXSPI_MCR0_HSEN(config->enable_half_speed_access) |
+                 FLEXSPI_MCR0_COMBINATIONEN(config->enable_combination) |
+#if !(defined(FLEXSPI_HAS_NO_MCR0_ATDFEN) && FLEXSPI_HAS_NO_MCR0_ATDFEN)
+                 FLEXSPI_MCR0_ATDFEN(
+                   config->ahb_config.enable_ahb_write_ip_tx_fifo) |
+#endif
+#if !(defined(FLEXSPI_HAS_NO_MCR0_ARDFEN) && FLEXSPI_HAS_NO_MCR0_ARDFEN)
+                 FLEXSPI_MCR0_ARDFEN(
+                   config->ahb_config.enable_ahb_write_ip_rx_fifo) |
+#endif
+                 FLEXSPI_MCR0_MDIS_MASK;
+  base->MCR0 = config_value;
+
+  /* Configure MCR1 configurations */
+
+  config_value =
+      FLEXSPI_MCR1_SEQWAIT(config->seq_timeout_cycle) |
+      FLEXSPI_MCR1_AHBBUSWAIT(config->ahb_config.ahb_bus_timeout_cycle);
+
+  base->MCR1 = config_value;
+
+  /* Configure MCR2 configurations */
+
+  config_value = base->MCR2;
+  config_value &= ~(FLEXSPI_MCR2_RESUMEWAIT_MASK |
+                    FLEXSPI_MCR2_SCKBDIFFOPT_MASK |
+                    FLEXSPI_MCR2_SAMEDEVICEEN_MASK |
+                    FLEXSPI_MCR2_CLRAHBBUFOPT_MASK);
+
+  config_value |= FLEXSPI_MCR2_RESUMEWAIT(
+                    config->ahb_config.resume_wait_cycle) |
+                  FLEXSPI_MCR2_SCKBDIFFOPT(
+                    config->enable_sckb_diff_opt) |
+                  FLEXSPI_MCR2_SAMEDEVICEEN(
+                    config->enable_same_config_for_all) |
+                  FLEXSPI_MCR2_CLRAHBBUFOPT(
+                    config->ahb_config.enable_clear_ahb_buffer_opt);
+
+  base->MCR2 = config_value;
+
+  /* Configure AHB control items */
+
+  config_value = base->AHBCR;
+  config_value &= ~(FLEXSPI_AHBCR_READADDROPT_MASK |
+                    FLEXSPI_AHBCR_PREFETCHEN_MASK |
+                    FLEXSPI_AHBCR_BUFFERABLEEN_MASK |
+                    FLEXSPI_AHBCR_CACHABLEEN_MASK);
+
+  config_value |= FLEXSPI_AHBCR_READADDROPT(
+                    config->ahb_config.enable_read_address_opt) |
+                  FLEXSPI_AHBCR_PREFETCHEN(
+                    config->ahb_config.enable_ahb_prefetch) |
+                  FLEXSPI_AHBCR_BUFFERABLEEN(
+                    config->ahb_config.enable_ahb_bufferable) |
+                  FLEXSPI_AHBCR_CACHABLEEN(
+                    config->ahb_config.enable_ahb_cachable);
+
+  base->AHBCR = config_value;
+
+  /* Configure AHB rx buffers */
+
+  for (i = 0; i < (uint32_t)FLEXSPI_AHB_BUFFER_COUNT; i++)
+    {
+      config_value = base->AHBRXBUFCR0[i];
+
+      config_value &= ~(FLEXSPI_AHBRXBUFCR0_PREFETCHEN_MASK |
+                        FLEXSPI_AHBRXBUFCR0_PRIORITY_MASK |
+                        FLEXSPI_AHBRXBUFCR0_MSTRID_MASK |
+                        FLEXSPI_AHBRXBUFCR0_BUFSZ_MASK);
+
+      config_value |= FLEXSPI_AHBRXBUFCR0_PREFETCHEN(
+                        config->ahb_config.buffer[i].enable_prefetch) |
+                      FLEXSPI_AHBRXBUFCR0_PRIORITY(
+                        config->ahb_config.buffer[i].priority) |
+                      FLEXSPI_AHBRXBUFCR0_MSTRID(
+                        config->ahb_config.buffer[i].master_index) |
+                      FLEXSPI_AHBRXBUFCR0_BUFSZ((uint32_t)
+                        config->ahb_config.buffer[i].buffer_size / 8u);
+
+      base->AHBRXBUFCR0[i] = config_value;
+    }
+
+  /* Configure IP FIFO watermarks */
+
+  base->IPRXFCR &= ~FLEXSPI_IPRXFCR_RXWMRK_MASK;
+  base->IPRXFCR |=
+        FLEXSPI_IPRXFCR_RXWMRK((uint32_t)config->rx_watermark / 8u - 1u);
+  base->IPTXFCR &= ~FLEXSPI_IPTXFCR_TXWMRK_MASK;
+  base->IPTXFCR |=
+        FLEXSPI_IPTXFCR_TXWMRK((uint32_t)config->tx_watermark / 8u - 1u);
+
+  /* Reset flash size on all ports */
+
+  for (i = 0; i < (uint32_t)FLEXSPI_PORT_COUNT; i++)
+    {
+      base->FLSHCR0[i] = 0;
+    }
+}
+
+/* Gets default settings for FLEXSPI.
+ *
+ * param config FLEXSPI configuration structure.
+ */
+
+void imxrt_flexspi_get_default_config(struct flexspi_config_s *config)
+{
+  /* Initializes the configure structure to zero */
+
+  (void)memset(config, 0, sizeof(*config));
+
+  config->rx_sample_clock = FLEXSPI_READ_SAMPLE_CLK_LOOPBACK_FROM_DQS_PAD;
+  config->enable_sck_free_running     = false;
+  config->enable_combination          = false;
+  config->enable_doze                 = true;
+  config->enable_half_speed_access    = false;
+  config->enable_sckb_diff_opt        = false;
+  config->enable_same_config_for_all  = false;
+  config->seq_timeout_cycle           = 0xffff;
+  config->ip_grant_timeout_cycle      = 0xff;
+  config->tx_watermark                = 8;
+  config->rx_watermark                = 8;
+
+#if !(defined(FLEXSPI_HAS_NO_MCR0_ATDFEN) && FLEXSPI_HAS_NO_MCR0_ATDFEN)
+  config->ahb_config.enable_ahb_write_ip_tx_fifo = false;
+#endif
+
+#if !(defined(FLEXSPI_HAS_NO_MCR0_ARDFEN) && FLEXSPI_HAS_NO_MCR0_ARDFEN)
+  config->ahb_config.enable_ahb_write_ip_rx_fifo = false;
+#endif
+
+  config->ahb_config.ahb_grant_timeout_cycle  = 0xff;
+  config->ahb_config.ahb_bus_timeout_cycle    = 0xffff;
+  config->ahb_config.resume_wait_cycle        = 0x20;
+  (void)memset(config->ahb_config.buffer, 0,
+               sizeof(config->ahb_config.buffer));
+
+  /* Use invalid master ID 0xF and buffer size 0 for the first several
+   * buffers.
+   */
+
+  for (uint8_t i = 0; i < ((uint8_t)FLEXSPI_AHB_BUFFER_COUNT - 2u); i++)
+    {
+      /* Default enable AHB prefetch */
+
+      config->ahb_config.buffer[i].enable_prefetch = true;
+
+      /* Invalid master index which is no used, so will never hit */
+
+      config->ahb_config.buffer[i].master_index = 0xf;
+
+      /* Default buffer size 0 for buffer0 to
+       * buffer(FLEXSPI_AHB_BUFFER_COUNT - 3)
+       */
+
+      config->ahb_config.buffer[i].buffer_size = 0;
+    }
+
+  for (uint8_t i = ((uint8_t)FLEXSPI_AHB_BUFFER_COUNT - 2);
+       i < (uint8_t)FLEXSPI_AHB_BUFFER_COUNT; i++)
+    {
+      config->ahb_config.buffer[i].enable_prefetch = true; /* Default enable
+                                                            * AHB prefetch.
+                                                            */
+
+      config->ahb_config.buffer[i].buffer_size     = 256u; /* Default buffer
+                                                            * size 256 bytes.
+                                                            */
+    }
+
+  config->ahb_config.enable_clear_ahb_buffer_opt  = false;
+  config->ahb_config.enable_read_address_opt      = false;
+  config->ahb_config.enable_ahb_prefetch          = false;
+  config->ahb_config.enable_ahb_bufferable        = false;
+  config->ahb_config.enable_ahb_cachable          = false;
+}
+
+/* Configures the connected device parameter.
+ *
+ * This function configures the connected device relevant parameters, such
+ * as the size, command, and so on. The flash configuration value cannot have
+ * a default value. The user needs to configure it according to the connected
+ * device.
+ *
+ * param base   FLEXSPI peripheral base address.
+ * param config Device configuration parameters.
+ * param port   FLEXSPI Operation port.
+ */
+
+void imxrt_flexspi_set_device_config_private(struct flexspi_type_s *base,
+                                    struct flexspi_device_config_s *config,
+                                    enum flexspi_port_e port)
+{
+  uint32_t config_value = 0;
+  uint32_t status_value = 0;
+  uint8_t index        = (uint8_t)port >> 1u; /* PortA with index 0, PortB with index 1 */
+
+  /* Wait for bus idle before change flash configuration */
+
+  while (!imxrt_flexspi_get_bus_idle_status(base))
+    {
+    }
+
+  /* Configure flash size */
+
+  base->FLSHCR0[port] = config->flash_size;
+
+  /* Configure flash parameters */
+
+  base->FLSHCR1[port] =
+        FLEXSPI_FLSHCR1_CSINTERVAL(config->cs_interval) |
+        FLEXSPI_FLSHCR1_CSINTERVALUNIT(config->cs_interval_unit) |
+        FLEXSPI_FLSHCR1_TCSH(config->cs_hold_time) |
+        FLEXSPI_FLSHCR1_TCSS(config->cs_setup_time) |
+        FLEXSPI_FLSHCR1_CAS(config->columnspace) |
+        FLEXSPI_FLSHCR1_WA(config->enable_word_address);
+
+  /* Configure AHB operation items */
+
+  config_value = base->FLSHCR2[port];
+
+  config_value &= ~(FLEXSPI_FLSHCR2_AWRWAITUNIT_MASK |
+                    FLEXSPI_FLSHCR2_AWRWAIT_MASK |
+                    FLEXSPI_FLSHCR2_AWRSEQNUM_MASK |
+                    FLEXSPI_FLSHCR2_AWRSEQID_MASK |
+                    FLEXSPI_FLSHCR2_ARDSEQNUM_MASK |
+                    FLEXSPI_FLSHCR2_ARDSEQID_MASK);
+
+  config_value |=
+      FLEXSPI_FLSHCR2_AWRWAITUNIT(config->ahb_write_wait_unit) |
+      FLEXSPI_FLSHCR2_AWRWAIT(config->ahb_write_wait_interval);
+
+  if (config->awr_seq_number > 0u)
+    {
+      config_value |= FLEXSPI_FLSHCR2_AWRSEQID(
+                       (uint32_t)config->awr_seq_index) |
+                      FLEXSPI_FLSHCR2_AWRSEQNUM(
+                       (uint32_t)config->awr_seq_number - 1u);
+    }
+
+  if (config->ard_seq_number > 0u)
+    {
+      config_value |= FLEXSPI_FLSHCR2_ARDSEQID(
+                       (uint32_t)config->ard_seq_index) |
+                      FLEXSPI_FLSHCR2_ARDSEQNUM(
+                       (uint32_t)config->ard_seq_number - 1u);
+    }
+
+  base->FLSHCR2[port] = config_value;
+
+  /* Configure DLL */
+
+  config_value        = imxrt_flexspi_configure_dll(base, config);
+  base->DLLCR[index] = config_value;
+
+  /* Configure write mask */
+
+  if (config->enable_write_mask)
+    {
+      base->FLSHCR4 &= ~FLEXSPI_FLSHCR4_WMOPT1_MASK;
+    }
+  else
+    {
+      base->FLSHCR4 |= FLEXSPI_FLSHCR4_WMOPT1_MASK;
+    }
+
+  if (index == 0u) /* Port A */
+    {
+      base->FLSHCR4 &= ~FLEXSPI_FLSHCR4_WMENA_MASK;
+      base->FLSHCR4 |= FLEXSPI_FLSHCR4_WMENA(config->enable_write_mask);
+    }
+  else
+    {
+      base->FLSHCR4 &= ~FLEXSPI_FLSHCR4_WMENB_MASK;
+      base->FLSHCR4 |= FLEXSPI_FLSHCR4_WMENB(config->enable_write_mask);
+    }
+
+  /* Exit stop mode */
+
+  base->MCR0 &= ~FLEXSPI_MCR0_MDIS_MASK;
+
+  /* According to ERR011377, need to delay at least 100 NOPs to ensure the
+   * DLL is locked.
+   */
+
+  status_value =
+      (index == 0u) ?
+          ((uint32_t)FLEXSPI_FLASH_A_SAMPLE_CLOCK_SLAVE_DELAY_LOCKED |
+           (uint32_t)FLEXSPI_FLASH_A_SAMPLE_CLOCK_REF_DELAY_LOCKED) :
+          ((uint32_t)FLEXSPI_FLASH_B_SAMPLE_CLOCK_SLAVE_DELAY_LOCKED |
+           (uint32_t)FLEXSPI_FLASH_B_SAMPLE_CLOCK_REF_DELAY_LOCKED);
+
+  if (0u != (config_value & FLEXSPI_DLLCR_DLLEN_MASK))
+    {
+      /* Wait slave delay line locked and slave reference delay line locked */
+
+      while ((base->STS2 & status_value) != status_value)
+        {
+        }
+
+      /* Wait at least 100 NOPs */
+
+      for (uint8_t delay = 100u; delay > 0u; delay--)
+        {
+          asm("NOP");
+        }
+    }
+}
+
+/* Updates the LUT table.
+ *
+ * param base  FLEXSPI peripheral base address.
+ * param index From which index start to update.
+ *             It could be any index of the LUT table, which also allows
+ *             user to update command content inside a command. Each command
+ *             consists of up to 8 instructions and occupy 4*32-bit memory.
+ * param cmd   Command sequence array.
+ * param count Number of sequences.
+ */
+
+void imxrt_flexspi_update_lut_private(struct flexspi_type_s *base,
+                                      uint32_t index,
+                                      const uint32_t *cmd,
+                                      uint32_t count)
+{
+  assert(index < 64u);
+
+  uint32_t i = 0;
+  volatile uint32_t *lut_base;
+
+  /* Wait for bus idle before change flash configuration */
+
+  while (!imxrt_flexspi_get_bus_idle_status(base))
+    {
+    }
+
+  /* Unlock LUT for update */
+
+  base->LUTKEY = FLEXSPI_LUT_KEY_VAL;
+  base->LUTCR  = 0x02;
+
+  lut_base = &base->LUT[index];
+  for (i = 0; i < count; i++)
+    {
+      *lut_base++ = *cmd++;
+    }
+
+  /* Lock LUT */
+
+  base->LUTKEY = FLEXSPI_LUT_KEY_VAL;
+  base->LUTCR  = 0x01;
+}
+
+/* Sends a buffer of data bytes using blocking method.
+ * note This function blocks via polling until all bytes have been sent.
+ * param base FLEXSPI peripheral base address
+ * param buffer The data bytes to send
+ * param size The number of data bytes to send
+ * retval 0 write success without error
+ * STATUS_FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT sequence execution timeout
+ * STATUS_FLEXSPI_IP_COMMAND_SEQUENCE_ERROR IP command sequence error
+ * detected
+ * STATUS_FLEXSPI_IP_COMMAND_GRANT_TIMEOUT IP command grant
+ * timeout detected.
+ */
+
+static int imxrt_flexspi_write_blocking(struct flexspi_type_s *base,
+                                        uint32_t *buffer, size_t size)
+{
+  uint32_t tx_watermark = ((base->IPTXFCR & FLEXSPI_IPTXFCR_TXWMRK_MASK) >>
+                           FLEXSPI_IPTXFCR_TXWMRK_SHIFT) + 1u;
+  uint32_t status;
+  int result = 0;
+  uint32_t i      = 0;
+
+  /* Send data buffer */
+
+  while (0u != size)
+    {
+      /* Wait until there is room in the fifo. This also checks for errors */
+
+      while (0u == ((status = base->INTR) &
+             (uint32_t)FLEXSPI_IP_TX_FIFO_WATERMARK_EMPTY_FLAG))
+        {
+        }
+
+      result = imxrt_flexspi_check_and_clear_error(base, status);
+
+      if (0 != result)
+        {
+          return result;
+        }
+
+      /* Write watermark level data into tx fifo  */
+
+      if (size >= 8u * tx_watermark)
+        {
+          for (i = 0u; i < 2u * tx_watermark; i++)
+            {
+              base->TFDR[i] = *buffer++;
+            }
+
+          size = size - 8u * tx_watermark;
+        }
+      else
+        {
+          for (i = 0u; i < (size / 4u + 1u); i++)
+            {
+              base->TFDR[i] = *buffer++;
+            }
+          size = 0u;
+        }
+
+      /* Push a watermark level data into IP TX FIFO */
+
+      base->INTR |= (uint32_t)FLEXSPI_IP_TX_FIFO_WATERMARK_EMPTY_FLAG;
+    }
+
+  return result;
+}
+
+/* Receives a buffer of data bytes using a blocking method.
+ * note This function blocks via polling until all bytes have been sent.
+ * param base FLEXSPI peripheral base address
+ * param buffer The data bytes to send
+ * param size The number of data bytes to receive
+ * retval 0 read success without error
+ * retval STATUS_FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT sequence execution
+ * timeout retval STATUS_FLEXSPI_IP_COMMAND_SEQUENCE_ERROR IP command
+ * sequence error detected retval STATUS_FLEXSPI_IP_COMMAND_GRANT_TIMEOUT
+ * IP command grant timeout detected.
+ */
+
+static int imxrt_flexspi_read_blocking(struct flexspi_type_s *base,
+                                       uint32_t *buffer, size_t size)
+{
+  uint32_t rx_watermark = ((base->IPRXFCR & FLEXSPI_IPRXFCR_RXWMRK_MASK) >>
+                          FLEXSPI_IPRXFCR_RXWMRK_SHIFT) + 1u;
+  uint32_t status;
+  int result = 0;
+  uint32_t i      = 0;
+  bool is_return   = false;
+
+  /* Send data buffer */
+
+  while (0u != size)
+    {
+      if (size >= 8u * rx_watermark)
+        {
+          /* Wait until there is room in the fifo. This also checks for
+           * errors.
+           */
+
+          while (0u == ((status = base->INTR) &
+                 (uint32_t)FLEXSPI_IP_RX_FIFO_WATERMARK_AVAILABLE_FLAG))
+            {
+              result = imxrt_flexspi_check_and_clear_error(base, status);
+
+              if (0 != result)
+                {
+                  is_return = true;
+                  break;
+                }
+            }
+        }
+      else
+        {
+          /* Wait fill level. This also checks for errors */
+
+          while (size > ((((base->IPRXFSTS) & FLEXSPI_IPRXFSTS_FILL_MASK) >>
+                 FLEXSPI_IPRXFSTS_FILL_SHIFT) * 8u))
+            {
+              result = imxrt_flexspi_check_and_clear_error(base, base->INTR);
+
+              if (0 != result)
+                {
+                  is_return = true;
+                  break;
+                }
+            }
+        }
+
+      if (is_return)
+        {
+          break;
+        }
+
+      result = imxrt_flexspi_check_and_clear_error(base, base->INTR);
+
+      if (0 != result)
+        {
+          break;
+        }
+
+      /* Read watermark level data from rx fifo  */
+
+      if (size >= 8u * rx_watermark)
+        {
+          for (i = 0u; i < 2u * rx_watermark; i++)
+            {
+              *buffer++ = base->RFDR[i];
+            }
+
+          size = size - 8u * rx_watermark;
+        }
+      else
+        {
+          for (i = 0u; i < ((size + 3u) / 4u); i++)
+            {
+              *buffer++ = base->RFDR[i];
+            }
+          size = 0;
+        }
+
+      /* Pop out a watermark level datas from IP RX FIFO */
+
+      base->INTR |= (uint32_t)FLEXSPI_IP_RX_FIFO_WATERMARK_AVAILABLE_FLAG;
+    }
+
+  return result;
+}
+
+/* Brief Execute command to transfer a buffer data bytes using a blocking
+ * method. param base FLEXSPI peripheral base address param xfer pointer to
+ * the transfer structure. retval 0 command transfer success without error
+ * retval STATUS_FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT sequence execution
+ * timeout retval STATUS_FLEXSPI_IP_COMMAND_SEQUENCE_ERROR IP command
+ * sequence error detected retval STATUS_FLEXSPI_IP_COMMAND_GRANT_TIMEOUT
+ * IP command grant timeout detected.
+ */
+
+int imxrt_flexspi_transfer_blocking_private(struct flexspi_type_s *base,
+                                            struct flexspi_transfer_s *xfer)
+{
+  uint32_t config_value = 0;
+  int result      = 0;
+
+  /* Clear sequence pointer before sending data to external devices */
+
+  base->FLSHCR2[xfer->port] |= FLEXSPI_FLSHCR2_CLRINSTRPTR_MASK;
+
+  /* Clear former pending status before start this transfer */
+
+  base->INTR |= FLEXSPI_INTR_AHBCMDERR_MASK |
+                FLEXSPI_INTR_IPCMDERR_MASK |
+                FLEXSPI_INTR_AHBCMDGE_MASK |
+                FLEXSPI_INTR_IPCMDGE_MASK;
+
+  /* Configure base address */
+
+  base->IPCR0 = xfer->device_address;
+
+  /* Reset fifos */
+
+  base->IPTXFCR |= FLEXSPI_IPTXFCR_CLRIPTXF_MASK;
+  base->IPRXFCR |= FLEXSPI_IPRXFCR_CLRIPRXF_MASK;
+
+  /* Configure data size */
+
+  if ((xfer->cmd_type == FLEXSPI_READ)  ||
+      (xfer->cmd_type == FLEXSPI_WRITE) ||
+      (xfer->cmd_type == FLEXSPI_CONFIG))
+    {
+      config_value = FLEXSPI_IPCR1_IDATSZ(xfer->data_size);
+    }
+
+  /* Configure sequence ID */
+
+  config_value |=
+      FLEXSPI_IPCR1_ISEQID((uint32_t)xfer->seq_index) | \
+      FLEXSPI_IPCR1_ISEQNUM((uint32_t)xfer->seq_number - 1u);
+  base->IPCR1 = config_value;
+
+  /* Start Transfer */
+
+  base->IPCMD |= FLEXSPI_IPCMD_TRG_MASK;
+
+  if ((xfer->cmd_type == FLEXSPI_WRITE) ||
+      (xfer->cmd_type == FLEXSPI_CONFIG))
+    {
+      result = imxrt_flexspi_write_blocking(base, xfer->data,
+                                            xfer->data_size);
+    }
+  else if (xfer->cmd_type == FLEXSPI_READ)
+    {
+      result = imxrt_flexspi_read_blocking(base, xfer->data,
+                                           xfer->data_size);
+    }
+  else
+    {
+      /* Empty else */
+    }
+
+  /* Wait for bus idle */
+
+  while (!imxrt_flexspi_get_bus_idle_status(base))
+    {
+    }
+
+  if (xfer->cmd_type == FLEXSPI_COMMAND)
+    {
+      result = imxrt_flexspi_check_and_clear_error(base, base->INTR);
+    }
+
+  return result;
+}
+
+/****************************************************************************
+ * Name: imxrt_flexspi_lock
+ *
+ * Description:
+ *   On FlexSPI buses where there are multiple devices, it will be necessary
+ *   to lock FlexSPI to have exclusive access to the buses for a sequence of
+ *   transfers.  The bus should be locked before the chip is selected.
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *   lock - true: Lock FlexSPI bus, false: unlock FlexSPI bus
+ *
+ * Returned Value:
+ *   Semaphore status
+ *
+ ****************************************************************************/
+
+static int imxrt_flexspi_lock(struct flexspi_dev_s *dev, bool lock)
+{
+  struct imxrt_flexspidev_s *priv = (struct imxrt_flexspidev_s *)dev;
+  int ret;
+
+  spiinfo("lock=%d\n", lock);
+  if (lock)
+    {
+      ret = nxsem_wait_uninterruptible(&priv->exclsem);
+    }
+  else
+    {
+      ret = nxsem_post(&priv->exclsem);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: imxrt_flexspi_transfer_blocking
+ *
+ * Description:
+ *   Perform one FlexSPI transfer
+ *
+ * Input Parameters:
+ *   dev     - Device-specific state data
+ *   xfer    - Describes the transfer to be performed.
+ *
+ * Returned Value:
+ *   0 on SUCCESS, STATUS_FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT,
+ *   STATUS_FLEXSPI_IP_COMMAND_SEQUENCE_ERROR or
+ *   STATUS_FLEXSPI_IP_COMMAND_GRANT_TIMEOUT otherwise
+ *
+ ****************************************************************************/
+
+static int imxrt_flexspi_transfer_blocking(struct flexspi_dev_s *dev,
+                                           struct flexspi_transfer_s *xfer)
+{
+  struct imxrt_flexspidev_s *priv = (struct imxrt_flexspidev_s *)dev;
+
+  return (int)imxrt_flexspi_transfer_blocking_private(priv->base, xfer);
+}
+
+/****************************************************************************
+ * Name: imxrt_flexspi_software_reset
+ *
+ * Description:
+ *   Performs a software reset of FlexSPI
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void imxrt_flexspi_software_reset(struct flexspi_dev_s *dev)
+{
+  struct imxrt_flexspidev_s *priv = (struct imxrt_flexspidev_s *)dev;
+
+  imxrt_flexspi_software_reset_private(priv->base);
+}
+
+/****************************************************************************
+ * Name: imxrt_flexspi_update_lut
+ *
+ * Description:
+ *   Perform FlexSPI LUT table update
+ *
+ * Input Parameters:
+ *   dev     - Device-specific state data
+ *   index   - Index start to update
+ *   cmd     - Command array
+ *   count   - Size of the array
+ *
+ * Returned Value:
+ *   none
+ *
+ ****************************************************************************/
+
+static void imxrt_flexspi_update_lut(struct flexspi_dev_s *dev,
+                                     uint32_t index,
+                                     const uint32_t *cmd,
+                                     uint32_t count)
+{
+  struct imxrt_flexspidev_s *priv = (struct imxrt_flexspidev_s *)dev;
+
+  imxrt_flexspi_update_lut_private(priv->base, index, cmd, count);
+}
+
+/****************************************************************************
+ * Name: imxrt_flexspi_set_device_config
+ *
+ * Description:
+ *   Perform FlexSPI device config
+ *
+ * Input Parameters:
+ *   dev     - Device-specific state data
+ *   config  - Config data for external device
+ *   port    - Port
+ *
+ * Returned Value:
+ *   none
+ *
+ ****************************************************************************/
+
+static void imxrt_flexspi_set_device_config(struct flexspi_dev_s *dev,
+                                    struct flexspi_device_config_s *config,
+                                    enum flexspi_port_e port)
+{
+  struct imxrt_flexspidev_s *priv = (struct imxrt_flexspidev_s *)dev;
+
+  imxrt_flexspi_set_device_config_private(priv->base, config, port);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imxrt_flexspi_initialize
+ *
+ * Description:
+ *   Initialize the selected FlexSPI port in master mode
+ *
+ * Input Parameters:
+ *   intf - Interface number(must be zero)
+ *
+ * Returned Value:
+ *   Valid FlexSPI device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+struct flexspi_dev_s *imxrt_flexspi_initialize(int intf)
+{
+  struct imxrt_flexspidev_s *priv;
+  struct flexspi_config_s flexspi_config;
+
+  /* The supported i.MXRT parts have only a single FlexSPI port. Other
+   * is reserved for code XIP
+   */
+
+  spiinfo("intf: %d\n", intf);
+  DEBUGASSERT(intf >= 0 && intf < 1);
+
+  /* Select the FlexSPI interface */
+
+  if (intf == 0)
+    {
+      /* If this function is called multiple times, the following operations
+       * will be performed multiple times.
+       */
+
+      /* Select FlexSPI */
+
+      priv = &g_flexspi0dev;
+
+      /* Enable clocking to the FlexSPI peripheral */
+
+      imxrt_clockrun_flexspi();
+
+      /* Configure multiplexed pins as connected on the board */
+
+      imxrt_config_gpio(GPIO_FLEXSPI_DQS);
+      imxrt_config_gpio(GPIO_FLEXSPI_CS);
+      imxrt_config_gpio(GPIO_FLEXSPI_IO0);
+      imxrt_config_gpio(GPIO_FLEXSPI_IO1);
+      imxrt_config_gpio(GPIO_FLEXSPI_IO2);
+      imxrt_config_gpio(GPIO_FLEXSPI_IO3);
+      imxrt_config_gpio(GPIO_FLEXSPI_SCK);
+    }
+  else
+    {
+      spierr("ERROR: FlexSPI%d not supported\n", intf);
+      return NULL;
+    }
+
+  /* Has the FlexSPI hardware been initialized? */
+
+  if (!priv->initialized)
+    {
+      /* No perform one time initialization */
+
+      /* Initialize the FlexSPI semaphore that enforces mutually exclusive
+       * access to the FlexSPI registers.
+       */
+
+      nxsem_init(&priv->exclsem, 0, 1);
+
+      /* Perform hardware initialization. Puts the FlexSPI into an active
+       * state.
+       */
+
+      imxrt_flexspi_get_default_config(&flexspi_config);
+      imxrt_flexspi_init(priv->base, &flexspi_config);
+
+      /* Enable interrupts at the NVIC */
+
+      priv->initialized = true;
+    }
+
+  return &priv->flexspi;
+}
+
+#endif /* CONFIG_IMXRT_FLEXSPI */

--- a/arch/arm/src/imxrt/imxrt_flexspi.h
+++ b/arch/arm/src/imxrt/imxrt_flexspi.h
@@ -1,0 +1,93 @@
+/****************************************************************************
+ * arch/arm/src/imxrt/imxrt_flexspi.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_IMXRT_IMXRT_FLEXSPI_H
+#define __ARCH_ARM_SRC_IMXRT_IMXRT_FLEXSPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "chip.h"
+#include "imxrt_config.h"
+
+#ifdef CONFIG_IMXRT_FLEXSPI
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imxrt_flexspi_initialize
+ *
+ * Description:
+ *   Initialize the selected FlexSPI port in master mode
+ *
+ * Input Parameters:
+ *   intf - Interface number(must be zero)
+ *
+ * Returned Value:
+ *   Valid FlexSPI device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+struct flexspi_dev_s;
+FAR struct flexspi_dev_s *imxrt_flexspi_initialize(int intf);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* CONFIG_IMXRT_FLEXSPI */
+#endif /* __ARCH_ARM_SRC_IMXRT_IMXRT_FLEXSPI_H */

--- a/boards/arm/imxrt/imxrt1064-evk/src/imxrt_flexspi_nor.c
+++ b/boards/arm/imxrt/imxrt1064-evk/src/imxrt_flexspi_nor.c
@@ -1,0 +1,701 @@
+/****************************************************************************
+ * boards/arm/imxrt/imxrt1064-evk/src/imxrt_flexspi_nor.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/signal.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/mtd/mtd.h>
+
+#include "imxrt_flexspi.h"
+#include "imxrt1064-evk.h"
+#include "hardware/imxrt_pinmux.h"
+
+#ifdef CONFIG_IMXRT_FLEXSPI
+
+#define NOR_PAGE_SIZE   0x0100U
+#define NOR_SECTOR_SIZE 0x1000U
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+enum
+{
+  /* SPI instructions */
+
+  READ_ID,
+  READ_STATUS_REG,
+  WRITE_STATUS_REG,
+  WRITE_ENABLE,
+  ERASE_SECTOR,
+  ERASE_CHIP,
+
+  /* Quad SPI instructions */
+
+  READ_FAST_QUAD_OUTPUT,
+  PAGE_PROGRAM_QUAD_INPUT,
+  ENTER_QPI,
+};
+
+static const uint32_t g_flexspi_nor_lut[][4] =
+{
+  [READ_ID] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x9f,
+        FLEXSPI_COMMAND_READ_SDR,  FLEXSPI_1PAD, 0x04),
+  },
+
+  [READ_STATUS_REG] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x05,
+        FLEXSPI_COMMAND_READ_SDR,  FLEXSPI_1PAD, 0x04),
+  },
+
+  [WRITE_STATUS_REG] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x01,
+        FLEXSPI_COMMAND_WRITE_SDR, FLEXSPI_1PAD, 0x04),
+  },
+
+  [WRITE_ENABLE] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x06,
+        FLEXSPI_COMMAND_STOP,      FLEXSPI_1PAD, 0),
+  },
+
+  [ERASE_SECTOR] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x20,
+        FLEXSPI_COMMAND_RADDR_SDR, FLEXSPI_1PAD, 0x18),
+  },
+
+  [ERASE_CHIP] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0xc7,
+        FLEXSPI_COMMAND_STOP,      FLEXSPI_1PAD, 0),
+  },
+
+  [READ_FAST_QUAD_OUTPUT] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x6b,
+        FLEXSPI_COMMAND_RADDR_SDR, FLEXSPI_1PAD, 0x18),
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_DUMMY_SDR, FLEXSPI_4PAD, 0x08,
+        FLEXSPI_COMMAND_READ_SDR,  FLEXSPI_4PAD, 0x04),
+  },
+
+  [PAGE_PROGRAM_QUAD_INPUT] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x32,
+        FLEXSPI_COMMAND_RADDR_SDR, FLEXSPI_1PAD, 0x18),
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_WRITE_SDR, FLEXSPI_4PAD, 0x04,
+        FLEXSPI_COMMAND_STOP,      FLEXSPI_1PAD, 0),
+  },
+
+  [ENTER_QPI] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x35,
+        FLEXSPI_COMMAND_STOP,      FLEXSPI_1PAD, 0),
+  },
+};
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* FlexSPI NOR device private data */
+
+struct imxrt_flexspi_nor_dev_s
+{
+  struct mtd_dev_s mtd;
+  struct flexspi_dev_s *flexspi;   /* Saved FlexSPI interface instance */
+  uint8_t *ahb_base;
+  enum flexspi_port_e port;
+  struct flexspi_device_config_s *config;
+};
+
+/****************************************************************************
+ * Private Functions Prototypes
+ ****************************************************************************/
+
+/* MTD driver methods */
+
+static int imxrt_flexspi_nor_erase(FAR struct mtd_dev_s *dev,
+                                   off_t startblock,
+                                   size_t nblocks);
+static ssize_t imxrt_flexspi_nor_read(FAR struct mtd_dev_s *dev,
+                                      off_t offset,
+                                      size_t nbytes,
+                                      FAR uint8_t *buffer);
+static ssize_t imxrt_flexspi_nor_bread(FAR struct mtd_dev_s *dev,
+                                       off_t startblock,
+                                       size_t nblocks,
+                                       FAR uint8_t *buffer);
+static ssize_t imxrt_flexspi_nor_bwrite(FAR struct mtd_dev_s *dev,
+                                        off_t startblock,
+                                        size_t nblocks,
+                                        FAR const uint8_t *buffer);
+static int imxrt_flexspi_nor_ioctl(FAR struct mtd_dev_s *dev,
+                                   int cmd,
+                                   unsigned long arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct flexspi_device_config_s g_flexspi_device_config =
+{
+  .flexspi_root_clk = 120000000,
+  .flash_size = 8192,
+  .cs_interval_unit = FLEXSPI_CS_INTERVAL_UNIT1_SCK_CYCLE,
+  .cs_interval = 0,
+  .cs_hold_time = 3,
+  .cs_setup_time = 3,
+  .data_valid_time = 0,
+  .columnspace = 0,
+  .enable_word_address = 0,
+  .awr_seq_index = 0,
+  .awr_seq_number = 0,
+  .ard_seq_index = READ_FAST_QUAD_OUTPUT,
+  .ard_seq_number = 1,
+  .ahb_write_wait_unit = FLEXSPI_AHB_WRITE_WAIT_UNIT2_AHB_CYCLE,
+  .ahb_write_wait_interval = 0
+};
+
+static struct imxrt_flexspi_nor_dev_s g_flexspi_nor =
+{
+  .mtd =
+          {
+            .erase  = imxrt_flexspi_nor_erase,
+            .bread  = imxrt_flexspi_nor_bread,
+            .bwrite = imxrt_flexspi_nor_bwrite,
+            .read   = imxrt_flexspi_nor_read,
+            .ioctl  = imxrt_flexspi_nor_ioctl,
+#ifdef CONFIG_MTD_BYTE_WRITE
+            .write  = NULL,
+#endif
+            .name   = "imxrt_flexspi_nor"
+          },
+  .flexspi = (void *)0,
+  .ahb_base = (uint8_t *) 0x60000000,
+  .port = FLEXSPI_PORT_A1,
+  .config = &g_flexspi_device_config
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int imxrt_flexspi_nor_get_vendor_id(
+                const struct imxrt_flexspi_nor_dev_s *dev,
+    uint8_t *vendor_id)
+{
+  uint32_t buffer = 0;
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_READ,
+    .seq_number = 1,
+    .seq_index = READ_ID,
+    .data = &buffer,
+    .data_size = 1,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  *vendor_id = buffer;
+
+  return 0;
+}
+
+static int imxrt_flexspi_nor_read_status(
+                const struct imxrt_flexspi_nor_dev_s *dev,
+                uint32_t *status)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_READ,
+    .seq_number = 1,
+    .seq_index = READ_STATUS_REG,
+    .data = status,
+    .data_size = 1,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int imxrt_flexspi_nor_write_status(
+                const struct imxrt_flexspi_nor_dev_s *dev,
+    uint32_t *status)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_WRITE,
+    .seq_number = 1,
+    .seq_index = WRITE_STATUS_REG,
+    .data = status,
+    .data_size = 1,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int imxrt_flexspi_nor_write_enable(
+                const struct imxrt_flexspi_nor_dev_s *dev)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_COMMAND,
+    .seq_number = 1,
+    .seq_index = WRITE_ENABLE,
+    .data = NULL,
+    .data_size = 0,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int imxrt_flexspi_nor_erase_sector(
+                const struct imxrt_flexspi_nor_dev_s *dev,
+  off_t offset)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = offset,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_COMMAND,
+    .seq_number = 1,
+    .seq_index = ERASE_SECTOR,
+    .data = NULL,
+    .data_size = 0,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int imxrt_flexspi_nor_erase_chip(
+                const struct imxrt_flexspi_nor_dev_s *dev)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_COMMAND,
+    .seq_number = 1,
+    .seq_index = ERASE_CHIP,
+    .data = NULL,
+    .data_size = 0,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int imxrt_flexspi_nor_page_program(
+                      const struct imxrt_flexspi_nor_dev_s *dev,
+                      off_t offset,
+                      const void *buffer,
+                      size_t len)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = offset,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_WRITE,
+    .seq_number = 1,
+    .seq_index = PAGE_PROGRAM_QUAD_INPUT,
+    .data = (uint32_t *) buffer,
+    .data_size = len,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int imxrt_flexspi_nor_wait_bus_busy(
+                const struct imxrt_flexspi_nor_dev_s *dev)
+{
+  uint32_t status = 0;
+  int ret;
+
+  do
+    {
+      ret = imxrt_flexspi_nor_read_status(dev, &status);
+      if (ret)
+        {
+          return ret;
+        }
+    }
+  while (status & 1);
+
+  return 0;
+}
+
+static int imxrt_flexspi_nor_enable_quad_mode(
+                const struct imxrt_flexspi_nor_dev_s *dev)
+{
+  uint32_t status = 0x40;
+
+  imxrt_flexspi_nor_write_status(dev, &status);
+  imxrt_flexspi_nor_wait_bus_busy(dev);
+  FLEXSPI_SOFTWARE_RESET(dev->flexspi);
+
+  return 0;
+}
+
+static ssize_t imxrt_flexspi_nor_read(FAR struct mtd_dev_s *dev,
+                                      off_t offset,
+                                      size_t nbytes,
+                                      FAR uint8_t *buffer)
+{
+  FAR struct imxrt_flexspi_nor_dev_s *priv =
+                  (FAR struct imxrt_flexspi_nor_dev_s *)dev;
+  uint8_t *src;
+
+  finfo("offset: %08lx nbytes: %d\n", (long)offset, (int)nbytes);
+
+  if (priv->port >= FLEXSPI_PORT_COUNT)
+    {
+      return -EIO;
+    }
+
+  src = priv->ahb_base + offset;
+
+  memcpy(buffer, src, nbytes);
+
+  finfo("return nbytes: %d\n", (int)nbytes);
+  return (ssize_t)nbytes;
+}
+
+static ssize_t imxrt_flexspi_nor_bread(FAR struct mtd_dev_s *dev,
+                                       off_t startblock,
+                                       size_t nblocks,
+                                       FAR uint8_t *buffer)
+{
+  ssize_t nbytes;
+
+  finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+
+  /* On this device, we can handle the block read just like the byte-oriented
+   * read
+   */
+
+  nbytes = imxrt_flexspi_nor_read(dev, startblock * NOR_PAGE_SIZE,
+                                  nblocks * NOR_PAGE_SIZE, buffer);
+  if (nbytes > 0)
+    {
+      nbytes /= NOR_PAGE_SIZE;
+    }
+
+  return nbytes;
+}
+
+static ssize_t imxrt_flexspi_nor_bwrite(FAR struct mtd_dev_s *dev,
+                                        off_t startblock,
+                                        size_t nblocks,
+                                        FAR const uint8_t *buffer)
+{
+  FAR struct imxrt_flexspi_nor_dev_s *priv =
+                  (FAR struct imxrt_flexspi_nor_dev_s *)dev;
+  size_t len = nblocks * NOR_PAGE_SIZE;
+  off_t offset = startblock * NOR_PAGE_SIZE;
+  uint8_t *src = (uint8_t *) buffer;
+  uint8_t *dst = priv->ahb_base + startblock * NOR_PAGE_SIZE;
+  int i;
+
+  finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+
+  while (len)
+    {
+      i = MIN(NOR_PAGE_SIZE, len);
+      imxrt_flexspi_nor_write_enable(priv);
+      imxrt_flexspi_nor_page_program(priv, offset, src, i);
+      imxrt_flexspi_nor_wait_bus_busy(priv);
+      FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+      offset += i;
+      len -= i;
+    }
+
+#ifdef CONFIG_ARMV7M_DCACHE
+  up_invalidate_dcache((uintptr_t)dst,
+                       (uintptr_t)dst + nblocks * NOR_PAGE_SIZE);
+#endif
+
+  return nblocks;
+}
+
+static int imxrt_flexspi_nor_erase(FAR struct mtd_dev_s *dev,
+                                   off_t startblock,
+                                   size_t nblocks)
+{
+  FAR struct imxrt_flexspi_nor_dev_s *priv =
+                  (FAR struct imxrt_flexspi_nor_dev_s *)dev;
+  size_t blocksleft = nblocks;
+  uint8_t *dst = priv->ahb_base + startblock * NOR_SECTOR_SIZE;
+
+  finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+
+  while (blocksleft-- > 0)
+    {
+      /* Erase each sector */
+
+      imxrt_flexspi_nor_write_enable(priv);
+      imxrt_flexspi_nor_erase_sector(priv, startblock * NOR_SECTOR_SIZE);
+      imxrt_flexspi_nor_wait_bus_busy(priv);
+      FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+      startblock++;
+    }
+
+#ifdef CONFIG_ARMV7M_DCACHE
+  up_invalidate_dcache((uintptr_t)dst,
+                       (uintptr_t)dst + nblocks * NOR_SECTOR_SIZE);
+#endif
+
+  return (int)nblocks;
+}
+
+static int imxrt_flexspi_nor_ioctl(FAR struct mtd_dev_s *dev,
+                                   int cmd,
+                                   unsigned long arg)
+{
+  FAR struct imxrt_flexspi_nor_dev_s *priv =
+                  (FAR struct imxrt_flexspi_nor_dev_s *)dev;
+  int ret = -EINVAL; /* Assume good command with bad parameters */
+
+  finfo("cmd: %d \n", cmd);
+
+  switch (cmd)
+    {
+      case MTDIOC_GEOMETRY:
+        {
+          FAR struct mtd_geometry_s *geo =
+            (FAR struct mtd_geometry_s *)((uintptr_t)arg);
+
+          if (geo)
+            {
+              /* Populate the geometry structure with information need to
+               * know the capacity and how to access the device.
+               *
+               * NOTE:
+               * that the device is treated as though it where just an array
+               * of fixed size blocks.  That is most likely not true, but the
+               * client will expect the device logic to do whatever is
+               * necessary to make it appear so.
+               */
+
+              geo->blocksize    = (NOR_PAGE_SIZE);
+              geo->erasesize    = (NOR_SECTOR_SIZE);
+              geo->neraseblocks = 2048; /* 8MB only */
+
+              ret               = OK;
+
+              finfo("blocksize: %lu erasesize: %lu neraseblocks: %lu\n",
+                    geo->blocksize, geo->erasesize, geo->neraseblocks);
+            }
+        }
+        break;
+
+      case MTDIOC_BULKERASE:
+        {
+          /* Erase the entire device */
+
+          imxrt_flexspi_nor_write_enable(priv);
+          imxrt_flexspi_nor_erase_chip(priv);
+          imxrt_flexspi_nor_wait_bus_busy(priv);
+          FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+        }
+        break;
+
+      case MTDIOC_PROTECT:
+
+        /* TODO */
+
+        break;
+
+      case MTDIOC_UNPROTECT:
+
+        /* TODO */
+
+        break;
+
+      default:
+        ret = -ENOTTY; /* Bad/unsupported command */
+        break;
+    }
+
+  finfo("return %d\n", ret);
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imxrt_flexspi_nor_initialize
+ *
+ * Description:
+ *  This function is called by board-bringup logic to configure the
+ *  flash device.
+ *
+ * Returned Value:
+ *   Zero is returned on success.  Otherwise, a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+int imxrt_flexspi_nor_initialize(void)
+{
+  uint8_t vendor_id;
+#ifdef CONFIG_FS_LITTLEFS
+  FAR struct mtd_dev_s *mtd_dev = &g_flexspi_nor.mtd;
+  int ret = -1;
+#endif
+  /* Configure multiplexed pins as connected on the board */
+
+  imxrt_config_gpio(GPIO_FLEXSPI_DQS);
+  imxrt_config_gpio(GPIO_FLEXSPI_CS);
+  imxrt_config_gpio(GPIO_FLEXSPI_IO0);
+  imxrt_config_gpio(GPIO_FLEXSPI_IO1);
+  imxrt_config_gpio(GPIO_FLEXSPI_IO2);
+  imxrt_config_gpio(GPIO_FLEXSPI_IO3);
+  imxrt_config_gpio(GPIO_FLEXSPI_SCK);
+
+  g_flexspi_nor.flexspi = imxrt_flexspi_initialize(0);
+  if (!g_flexspi_nor.flexspi)
+    {
+      return -1;
+    }
+
+  FLEXSPI_SET_DEVICE_CONFIG(g_flexspi_nor.flexspi,
+                            g_flexspi_nor.config,
+                            g_flexspi_nor.port);
+  FLEXSPI_UPDATE_LUT(g_flexspi_nor.flexspi,
+                     0,
+                     (const uint32_t *)g_flexspi_nor_lut,
+                     sizeof(g_flexspi_nor_lut) / 4);
+  FLEXSPI_SOFTWARE_RESET(g_flexspi_nor.flexspi);
+
+  if (imxrt_flexspi_nor_get_vendor_id(&g_flexspi_nor, &vendor_id))
+    {
+      return -EIO;
+    }
+
+  if (imxrt_flexspi_nor_enable_quad_mode(&g_flexspi_nor))
+    {
+      return -EIO;
+    }
+
+#ifdef CONFIG_FS_LITTLEFS
+  /* Register the MTD driver so that it can be accessed from the
+   * VFS.
+   */
+
+  ret = register_mtddriver("/dev/nor", mtd_dev, 0755, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to register MTD driver: %d\n",
+             ret);
+    }
+
+  /* mtd_dev->ioctl(mtd_dev, MTDIOC_BULKERASE, 0); */
+
+  /* Mount the LittleFS file system */
+
+  ret = nx_mount("/dev/nor", "/mnt/lfs", "littlefs", 0,
+                 "autoformat");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to mount LittleFS at /mnt/lfs: %d\n",
+             ret);
+    }
+#endif
+
+  return 0;
+}
+
+#endif /* CONFIG_IMXRT_FLEXSPI */

--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -655,6 +655,25 @@ config W25QXXXJV_SECTOR512
 
 endif # MTD_W25QXXXJV
 
+config MTD_FLEXSPI_NOR
+	bool "FlexSPI-based NOR FLASH"
+	default n
+	---help---
+		Support the W25Q064JV, WIS25WP064
+
+if MTD_FLEXSPI_NOR
+
+config FLEXSPI_NOR_FREQUENCY
+	int "FlexSPI NOR Frequency"
+	default 133000000
+	---help---
+		Per data sheet:
+		– 133MHz Single, Dual/Quad SPI clocks
+		– 266/532MHz equivalent Dual/Quad SPI
+		– 66MB/S continuous data transfer rate
+
+endif # MTD_FLEXSPI_NOR
+
 config MTD_MX25RXX
 	bool "QuadSPI-based Macronix MX25RXX family FLASH"
 	default n

--- a/drivers/mtd/Make.defs
+++ b/drivers/mtd/Make.defs
@@ -140,6 +140,10 @@ ifeq ($(CONFIG_MTD_IS25XP),y)
 CSRCS += is25xp.c
 endif
 
+ifeq ($(CONFIG_MTD_FLEXSPI_NOR),y)
+CSRCS += flexspi_nor.c
+endif
+
 ifeq ($(CONFIG_MTD_SMART),y)
 ifeq ($(CONFIG_FS_SMARTFS),y)
 CSRCS += smart.c

--- a/drivers/mtd/flexspi_nor.c
+++ b/drivers/mtd/flexspi_nor.c
@@ -1,0 +1,647 @@
+/****************************************************************************
+ * drivers/mtd/flexspi_nor.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/signal.h>
+#include <nuttx/fs/ioctl.h>
+#include <nuttx/spi/flexspi.h>
+#include <nuttx/mtd/mtd.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+/* Configuration ************************************************************/
+
+#define NOR_PAGE_SIZE   0x0100U
+#define NOR_SECTOR_SIZE 0x1000U
+
+/* This type represents the state of the MTD device. The struct mtd_dev_s
+ * must appear at the beginning of the definition so that you can freely
+ * cast between pointers to struct mtd_dev_s and struct flexspi_nor_dev_s.
+ */
+
+struct flexspi_nor_dev_s
+{
+  struct mtd_dev_s mtd;
+  FAR struct flexspi_dev_s *flexspi;   /* Saved FlexSPI interface instance */
+  uint8_t *ahb_base;
+  enum flexspi_port_e port;
+  struct flexspi_device_config_s config;
+};
+
+enum
+{
+  /* SPI instructions */
+
+  READ_ID,
+  READ_STATUS_REG,
+  WRITE_STATUS_REG,
+  WRITE_ENABLE,
+  ERASE_SECTOR,
+  ERASE_CHIP,
+
+  /* Quad SPI instructions */
+
+  READ_FAST_QUAD_OUTPUT,
+  PAGE_PROGRAM_QUAD_INPUT,
+  ENTER_QPI,
+};
+
+static const uint32_t flexspi_nor_lut[][4] =
+{
+  [READ_ID] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x9f,
+        FLEXSPI_COMMAND_READ_SDR,  FLEXSPI_1PAD, 0x04),
+  },
+
+  [READ_STATUS_REG] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x05,
+        FLEXSPI_COMMAND_READ_SDR,  FLEXSPI_1PAD, 0x04),
+  },
+
+  [WRITE_STATUS_REG] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x01,
+        FLEXSPI_COMMAND_WRITE_SDR, FLEXSPI_1PAD, 0x04),
+  },
+
+  [WRITE_ENABLE] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x06,
+        FLEXSPI_COMMAND_STOP,      FLEXSPI_1PAD, 0),
+  },
+
+  [ERASE_SECTOR] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x20,
+        FLEXSPI_COMMAND_RADDR_SDR, FLEXSPI_1PAD, 0x18),
+  },
+
+  [ERASE_CHIP] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0xc7,
+        FLEXSPI_COMMAND_STOP,      FLEXSPI_1PAD, 0),
+  },
+
+  [READ_FAST_QUAD_OUTPUT] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x6b,
+        FLEXSPI_COMMAND_RADDR_SDR, FLEXSPI_1PAD, 0x18),
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_DUMMY_SDR, FLEXSPI_4PAD, 0x08,
+        FLEXSPI_COMMAND_READ_SDR,  FLEXSPI_4PAD, 0x04),
+  },
+
+  [PAGE_PROGRAM_QUAD_INPUT] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x32,
+        FLEXSPI_COMMAND_RADDR_SDR, FLEXSPI_1PAD, 0x18),
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_WRITE_SDR, FLEXSPI_4PAD, 0x04,
+        FLEXSPI_COMMAND_STOP,      FLEXSPI_1PAD, 0),
+  },
+
+  [ENTER_QPI] =
+  {
+    FLEXSPI_LUT_SEQ(FLEXSPI_COMMAND_SDR,       FLEXSPI_1PAD, 0x35,
+        FLEXSPI_COMMAND_STOP,      FLEXSPI_1PAD, 0),
+  },
+};
+
+static int flexspi_nor_get_vendor_id(const struct flexspi_nor_dev_s *dev,
+    uint8_t *vendor_id)
+{
+  uint32_t buffer = 0;
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_READ,
+    .seq_number = 1,
+    .seq_index = READ_ID,
+    .data = &buffer,
+    .data_size = 1,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  *vendor_id = buffer;
+
+  return 0;
+}
+
+static int flexspi_nor_read_status(const struct flexspi_nor_dev_s *dev,
+    uint32_t *status)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_READ,
+    .seq_number = 1,
+    .seq_index = READ_STATUS_REG,
+    .data = status,
+    .data_size = 1,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int flexspi_nor_write_status(const struct flexspi_nor_dev_s *dev,
+    uint32_t *status)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_WRITE,
+    .seq_number = 1,
+    .seq_index = WRITE_STATUS_REG,
+    .data = status,
+    .data_size = 1,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int flexspi_nor_write_enable(const struct flexspi_nor_dev_s *dev)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_COMMAND,
+    .seq_number = 1,
+    .seq_index = WRITE_ENABLE,
+    .data = NULL,
+    .data_size = 0,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int flexspi_nor_erase_sector(const struct flexspi_nor_dev_s *dev,
+  off_t offset)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = offset,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_COMMAND,
+    .seq_number = 1,
+    .seq_index = ERASE_SECTOR,
+    .data = NULL,
+    .data_size = 0,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int flexspi_nor_erase_chip(const struct flexspi_nor_dev_s *dev)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = 0,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_COMMAND,
+    .seq_number = 1,
+    .seq_index = ERASE_CHIP,
+    .data = NULL,
+    .data_size = 0,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int flexspi_nor_page_program(const struct flexspi_nor_dev_s *dev,
+    off_t offset, const void *buffer, size_t len)
+{
+  int stat;
+
+  struct flexspi_transfer_s transfer =
+  {
+    .device_address = offset,
+    .port = dev->port,
+    .cmd_type = FLEXSPI_WRITE,
+    .seq_number = 1,
+    .seq_index = PAGE_PROGRAM_QUAD_INPUT,
+    .data = (uint32_t *) buffer,
+    .data_size = len,
+  };
+
+  stat = FLEXSPI_TRANSFER(dev->flexspi, &transfer);
+  if (stat != 0)
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+static int flexspi_nor_wait_bus_busy(const struct flexspi_nor_dev_s *dev)
+{
+  uint32_t status = 0;
+  int ret;
+
+  do
+    {
+      ret = flexspi_nor_read_status(dev, &status);
+      if (ret)
+        {
+          return ret;
+        }
+    }
+  while (status & 1);
+
+  return 0;
+}
+
+static int flexspi_nor_enable_quad_mode(const struct flexspi_nor_dev_s *dev)
+{
+  uint32_t status = 0x40;
+
+  flexspi_nor_write_status(dev, &status);
+  flexspi_nor_wait_bus_busy(dev);
+  FLEXSPI_SOFTWARE_RESET(dev->flexspi);
+
+  return 0;
+}
+
+static ssize_t flexspi_nor_read(FAR struct mtd_dev_s *dev,
+                              off_t offset,
+                              size_t nbytes,
+                              FAR uint8_t *buffer)
+{
+  FAR struct flexspi_nor_dev_s *priv = (FAR struct flexspi_nor_dev_s *)dev;
+  uint8_t *src;
+
+  finfo("offset: %08lx nbytes: %d\n", (long)offset, (int)nbytes);
+
+  if (priv->port >= FLEXSPI_PORT_COUNT)
+    {
+      return -EIO;
+    }
+
+  src = priv->ahb_base + offset;
+
+  memcpy(buffer, src, nbytes);
+
+  finfo("return nbytes: %d\n", (int)nbytes);
+  return (ssize_t)nbytes;
+}
+
+static ssize_t flexspi_nor_bread(FAR struct mtd_dev_s *dev, off_t startblock,
+                               size_t nblocks, FAR uint8_t *buffer)
+{
+  ssize_t nbytes;
+
+  finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+
+  /* On this device, we can handle the block read just like the byte-oriented
+   * read
+   */
+
+  nbytes = flexspi_nor_read(dev, startblock * NOR_PAGE_SIZE,
+                       nblocks * NOR_PAGE_SIZE, buffer);
+  if (nbytes > 0)
+    {
+      nbytes /= NOR_PAGE_SIZE;
+    }
+
+  return nbytes;
+}
+
+static ssize_t flexspi_nor_bwrite(FAR struct mtd_dev_s *dev,
+                                  off_t startblock, size_t nblocks,
+                                  FAR const uint8_t *buffer)
+{
+  FAR struct flexspi_nor_dev_s *priv = (FAR struct flexspi_nor_dev_s *)dev;
+  size_t len = nblocks * NOR_PAGE_SIZE;
+  off_t offset = startblock * NOR_PAGE_SIZE;
+  uint8_t *src = (uint8_t *) buffer;
+  uint8_t *dst = priv->ahb_base + startblock * NOR_PAGE_SIZE;
+  int i;
+
+  finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+
+  while (len)
+    {
+      i = MIN(NOR_PAGE_SIZE, len);
+      flexspi_nor_write_enable(priv);
+      flexspi_nor_page_program(priv, offset, src, i);
+      flexspi_nor_wait_bus_busy(priv);
+      FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+      offset += i;
+      len -= i;
+    }
+
+#ifdef CONFIG_ARMV7M_DCACHE
+  up_invalidate_dcache((uintptr_t)dst,
+                       (uintptr_t)dst + nblocks * NOR_PAGE_SIZE);
+#endif
+
+  return nblocks;
+}
+
+static int flexspi_nor_erase(FAR struct mtd_dev_s *dev, off_t startblock,
+                           size_t nblocks)
+{
+  FAR struct flexspi_nor_dev_s *priv = (FAR struct flexspi_nor_dev_s *)dev;
+  size_t blocksleft = nblocks;
+  uint8_t *dst = priv->ahb_base + startblock * NOR_SECTOR_SIZE;
+
+  finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+
+  while (blocksleft-- > 0)
+    {
+      /* Erase each sector */
+
+      flexspi_nor_write_enable(priv);
+      flexspi_nor_erase_sector(priv, startblock * NOR_SECTOR_SIZE);
+      flexspi_nor_wait_bus_busy(priv);
+      FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+      startblock++;
+    }
+
+#ifdef CONFIG_ARMV7M_DCACHE
+  up_invalidate_dcache((uintptr_t)dst,
+                       (uintptr_t)dst + nblocks * NOR_SECTOR_SIZE);
+#endif
+
+  return (int)nblocks;
+}
+
+static int flexspi_nor_ioctl(FAR struct mtd_dev_s *dev,
+                           int cmd,
+                           unsigned long arg)
+{
+  FAR struct flexspi_nor_dev_s *priv = (FAR struct flexspi_nor_dev_s *)dev;
+  int ret = -EINVAL; /* Assume good command with bad parameters */
+
+  finfo("cmd: %d \n", cmd);
+
+  switch (cmd)
+    {
+      case MTDIOC_GEOMETRY:
+        {
+          FAR struct mtd_geometry_s *geo =
+            (FAR struct mtd_geometry_s *)((uintptr_t)arg);
+
+          if (geo)
+            {
+              /* Populate the geometry structure with information need to
+               * know the capacity and how to access the device.
+               *
+               * NOTE:
+               * that the device is treated as though it where just an array
+               * of fixed size blocks.  That is most likely not true, but the
+               * client will expect the device logic to do whatever is
+               * necessary to make it appear so.
+               */
+
+              geo->blocksize    = (NOR_PAGE_SIZE);
+              geo->erasesize    = (NOR_SECTOR_SIZE);
+              geo->neraseblocks = 2048; /* 8MB only */
+
+              ret               = OK;
+
+              finfo("blocksize: %lu erasesize: %lu neraseblocks: %lu\n",
+                    geo->blocksize, geo->erasesize, geo->neraseblocks);
+            }
+        }
+        break;
+
+      case MTDIOC_BULKERASE:
+        {
+          /* Erase the entire device */
+
+          flexspi_nor_write_enable(priv);
+          flexspi_nor_erase_chip(priv);
+          flexspi_nor_wait_bus_busy(priv);
+          FLEXSPI_SOFTWARE_RESET(priv->flexspi);
+        }
+        break;
+
+      case MTDIOC_PROTECT:
+
+        /* TODO */
+
+        break;
+
+      case MTDIOC_UNPROTECT:
+
+        /* TODO */
+
+        break;
+
+      default:
+        ret = -ENOTTY; /* Bad/unsupported command */
+        break;
+    }
+
+  finfo("return %d\n", ret);
+  return ret;
+}
+
+static int flexspi_nor_init(const struct flexspi_nor_dev_s *dev)
+{
+  uint8_t vendor_id;
+  struct flexspi_device_config_s device_config;
+
+  if (dev->port >= FLEXSPI_PORT_COUNT)
+    {
+      return -EINVAL;
+    }
+
+  device_config.flexspi_root_clk = 120000000;
+  device_config.flash_size = 8192;
+  device_config.cs_interval_unit = FLEXSPI_CS_INTERVAL_UNIT1_SCK_CYCLE;
+  device_config.cs_interval = 0;
+  device_config.cs_hold_time = 3;
+  device_config.cs_setup_time = 3;
+  device_config.data_valid_time = 0;
+  device_config.columnspace = 0;
+  device_config.enable_word_address = 0;
+  device_config.awr_seq_index = 0;
+  device_config.awr_seq_number = 0;
+  device_config.ard_seq_index = READ_FAST_QUAD_OUTPUT;
+  device_config.ard_seq_number = 1;
+  device_config.ahb_write_wait_unit = FLEXSPI_AHB_WRITE_WAIT_UNIT2_AHB_CYCLE;
+  device_config.ahb_write_wait_interval = 0;
+
+  FLEXSPI_SET_DEVICE_CONFIG(dev->flexspi,
+                          (struct flexspi_device_config_s *) &device_config,
+                            dev->port);
+  FLEXSPI_UPDATE_LUT(dev->flexspi, 0, (const uint32_t *)flexspi_nor_lut,
+                     sizeof(flexspi_nor_lut) / 4);
+  FLEXSPI_SOFTWARE_RESET(dev->flexspi);
+
+  if (flexspi_nor_get_vendor_id(dev, &vendor_id))
+    {
+      return -EIO;
+    }
+
+  if (flexspi_nor_enable_quad_mode(dev))
+    {
+      return -EIO;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: flexspi_nor_initialize
+ *
+ * Description:
+ *   Create an initialize MTD device instance for the FlexSPI-based NOR
+ *   FLASH part.
+ *
+ *   MTD devices are not registered in the file system, but are created as
+ *   instances that can be bound to other functions (such as a block or
+ *   character driver front end).
+ *
+ ****************************************************************************/
+
+FAR struct mtd_dev_s *flexspi_nor_initialize(struct flexspi_dev_s *flexspi,
+                                             bool unprotect)
+{
+  FAR struct flexspi_nor_dev_s *priv;
+  int ret;
+
+  finfo("flexspi: %p\n", flexspi);
+  DEBUGASSERT(flexspi != NULL);
+
+  /* Allocate a state structure (we allocate the structure instead of using
+   * a fixed, static allocation so that we can handle multiple FLASH devices.
+   * The current implementation would handle only one FLASH part per FlexSPI
+   * device (only because of the FLEXSPI_DEV_FLASH(0) definition) and so
+   * would have to be extended to handle multiple FLASH parts on the same
+   * FlexSPI bus.
+   */
+
+  priv = (FAR struct flexspi_nor_dev_s *)
+         kmm_zalloc(sizeof(struct flexspi_nor_dev_s));
+  if (priv)
+    {
+      /* Initialize the allocated structure (unsupported methods were
+       * nullified by kmm_zalloc).
+       */
+
+      priv->mtd.erase  = flexspi_nor_erase;
+      priv->mtd.bread  = flexspi_nor_bread;
+      priv->mtd.bwrite = flexspi_nor_bwrite;
+      priv->mtd.read   = flexspi_nor_read;
+      priv->mtd.ioctl  = flexspi_nor_ioctl;
+      priv->mtd.name   = "flexspi_nor";
+      priv->flexspi    = flexspi;
+      priv->ahb_base = (uint8_t *) 0x60000000;
+      priv->port = FLEXSPI_PORT_A1;
+
+      ret = flexspi_nor_init(priv);
+      if (ret != OK)
+        {
+          /* Unrecognized! Discard all of that work we just did and
+           * return NULL
+           */
+
+          ferr("ERROR Unrecognized FlexSPI NOR device\n");
+          goto errout_with_priv;
+        }
+    }
+
+  /* Return the implementation-specific state structure as the MTD device */
+
+  finfo("Return %p\n", priv);
+  return (FAR struct mtd_dev_s *)priv;
+
+errout_with_priv:
+  kmm_free(priv);
+  return NULL;
+}

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -90,7 +90,8 @@
  * Public Types
  ****************************************************************************/
 
-struct qspi_dev_s; /* Forward reference */
+struct qspi_dev_s;    /* Forward reference */
+struct flexspi_dev_s; /* Forward reference */
 
 /* The following defines the geometry for the device.  It treats the device
  * as though it were just an array of fixed size blocks.  That is most likely
@@ -593,6 +594,18 @@ FAR struct mtd_dev_s *n25qxxx_initialize(FAR struct qspi_dev_s *qspi,
 
 FAR struct mtd_dev_s *w25qxxxjv_initialize(FAR struct qspi_dev_s *qspi,
                                          bool unprotect);
+
+/****************************************************************************
+ * Name: flexspi_nor_initialize
+ *
+ * Description:
+ *   Create an initialized MTD device instance for the FlexSPI-based
+ *   FLASH part.
+ *
+ ****************************************************************************/
+
+FAR struct mtd_dev_s *flexspi_nor_initialize(FAR struct flexspi_dev_s
+                                             *flexspi, bool unprotect);
 
 /****************************************************************************
  * Name: blockmtd_initialize

--- a/include/nuttx/spi/flexspi.h
+++ b/include/nuttx/spi/flexspi.h
@@ -1,0 +1,521 @@
+/****************************************************************************
+ * include/nuttx/spi/flexspi.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_SPI_FLEXSPI_H
+#define __INCLUDE_NUTTX_SPI_FLEXSPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Configuration ************************************************************/
+
+/* LUT - LUT 0..LUT 63 */
+
+#define FLEXSPI_LUT_OPERAND0_MASK                (0xffU)
+#define FLEXSPI_LUT_OPERAND0_SHIFT               (0U)
+
+/* OPERAND0 */
+
+#define FLEXSPI_LUT_OPERAND0(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUT_OPERAND0_SHIFT)) & FLEXSPI_LUT_OPERAND0_MASK)
+#define FLEXSPI_LUT_NUM_PADS0_MASK               (0x300U)
+#define FLEXSPI_LUT_NUM_PADS0_SHIFT              (8U)
+
+/* NUM_PADS0 */
+
+#define FLEXSPI_LUT_NUM_PADS0(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUT_NUM_PADS0_SHIFT)) & FLEXSPI_LUT_NUM_PADS0_MASK)
+#define FLEXSPI_LUT_OPCODE0_MASK                 (0xfc00U)
+#define FLEXSPI_LUT_OPCODE0_SHIFT                (10U)
+
+/* OPCODE0 */
+
+#define FLEXSPI_LUT_OPCODE0(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUT_OPCODE0_SHIFT)) & FLEXSPI_LUT_OPCODE0_MASK)
+#define FLEXSPI_LUT_OPERAND1_MASK                (0xff0000U)
+#define FLEXSPI_LUT_OPERAND1_SHIFT               (16U)
+
+/* OPERAND1 */
+
+#define FLEXSPI_LUT_OPERAND1(x)                  (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUT_OPERAND1_SHIFT)) & FLEXSPI_LUT_OPERAND1_MASK)
+#define FLEXSPI_LUT_NUM_PADS1_MASK               (0x3000000U)
+#define FLEXSPI_LUT_NUM_PADS1_SHIFT              (24U)
+
+/* NUM_PADS1 - NUM_PADS1 */
+
+#define FLEXSPI_LUT_NUM_PADS1(x)                 (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUT_NUM_PADS1_SHIFT)) & FLEXSPI_LUT_NUM_PADS1_MASK)
+#define FLEXSPI_LUT_OPCODE1_MASK                 (0xfc000000U)
+#define FLEXSPI_LUT_OPCODE1_SHIFT                (26U)
+
+/* OPCODE1 */
+
+#define FLEXSPI_LUT_OPCODE1(x)                   (((uint32_t)(((uint32_t)(x)) << FLEXSPI_LUT_OPCODE1_SHIFT)) & FLEXSPI_LUT_OPCODE1_MASK)
+
+/* Formula to form FLEXSPI instructions in LUT table */
+
+#define FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1) \
+    (FLEXSPI_LUT_OPERAND0(op0) | FLEXSPI_LUT_NUM_PADS0(pad0) | \
+     FLEXSPI_LUT_OPCODE0(cmd0) | FLEXSPI_LUT_OPERAND1(op1) | \
+     FLEXSPI_LUT_NUM_PADS1(pad1) | FLEXSPI_LUT_OPCODE1(cmd1))
+
+/* Access macros ************************************************************/
+
+/****************************************************************************
+ * Name: FLEXSPI_LOCK
+ *
+ * Description:
+ *   On FlexSPI buses where there are multiple devices, it will be necessary
+ *   to lock FlexSPI to have exclusive access to the buses for a sequence of
+ *   transfers.  The bus should be locked before the chip is selected.
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *   lock - true: Lock FlexSPI bus, false: unlock FlexSPI bus
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#define FLEXSPI_LOCK(d,l) (d)->ops->lock(d,l)
+
+/****************************************************************************
+ * Name: FLEXSPI_TRANSFER
+ *
+ * Description:
+ *   Perform one FlexSPI transfer
+ *
+ * Input Parameters:
+ *   dev     - Device-specific state data
+ *   xfer    - Describes the transfer to be performed.
+ *
+ * Returned Value:
+ *   0 on SUCCESS, STATUS_FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT,
+ *   STATUS_FLEXSPI_IP_COMMAND_SEQUENCE_ERROR or
+ *   STATUS_FLEXSPI_IP_COMMAND_GRANT_TIMEOUT otherwise
+ *
+ ****************************************************************************/
+
+#define FLEXSPI_TRANSFER(d,x) (d)->ops->transfer_blocking(d,x)
+
+/****************************************************************************
+ * Name: FLEXSPI_SOFTWARE_RESET
+ *
+ * Description:
+ *   Perform FlexSPI software reset
+ *
+ * Input Parameters:
+ *   dev     - Device-specific state data
+ *
+ * Returned Value:
+ *   none
+ *
+ ****************************************************************************/
+
+#define FLEXSPI_SOFTWARE_RESET(d) (d)->ops->software_reset(d)
+
+/****************************************************************************
+ * Name: FLEXSPI_UPDATE_LUT
+ *
+ * Description:
+ *   Perform FlexSPI LUT table update
+ *
+ * Input Parameters:
+ *   dev     - Device-specific state data
+ *   index   - Index start to update
+ *   cmd     - Command array
+ *   count   - Size of the array
+ *
+ * Returned Value:
+ *   none
+ *
+ ****************************************************************************/
+
+#define FLEXSPI_UPDATE_LUT(d,i,c,n) (d)->ops->update_lut(d,i,c,n)
+
+/****************************************************************************
+ * Name: FLEXSPI_SET_DEVICE_CONFIG
+ *
+ * Description:
+ *   Perform FlexSPI device config
+ *
+ * Input Parameters:
+ *   dev     - Device-specific state data
+ *   config  - Config data for external device
+ *   port    - Port
+ *
+ * Returned Value:
+ *   none
+ *
+ ****************************************************************************/
+
+#define FLEXSPI_SET_DEVICE_CONFIG(d,c,p) (d)->ops->set_device_config(d,c,p)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* CMD definition of FLEXSPI, use to form LUT instruction, flexspi_command */
+
+enum
+{
+  FLEXSPI_COMMAND_STOP           = 0x00,  /* Stop execution, deassert CS */
+  FLEXSPI_COMMAND_SDR            = 0x01,  /* Transmit Command code to Flash,
+                                           * using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_RADDR_SDR      = 0x02,  /* Transmit Row Address to Flash,
+                                           * using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_CADDR_SDR      = 0x03,  /* Transmit Column Address to
+                                           * Flash, using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_MODE1_SDR      = 0x04,  /* Transmit 1-bit Mode bits to
+                                           * Flash, using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_MODE2_SDR      = 0x05,  /* Transmit 2-bit Mode bits to
+                                           * Flash, using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_MODE4_SDR      = 0x06,  /* Transmit 4-bit Mode bits to
+                                           * Flash, using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_MODE8_SDR      = 0x07,  /* Transmit 8-bit Mode bits to
+                                           * Flash, using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_WRITE_SDR      = 0x08,  /* Transmit Programming Data to
+                                           * Flash, using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_READ_SDR       = 0x09,  /* Receive Read Data from Flash,
+                                           * using SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_LEARN_SDR      = 0x0a,  /* Receive Read Data or Preamble
+                                           * bit from Flash, SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_DATSZ_SDR      = 0x0b,  /* Transmit Read/Program Data size
+                                           * (byte) to Flash, SDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_DUMMY_SDR      = 0x0c,  /* Leave data lines undriven by
+                                           * FlexSPI controller.
+                                           */
+
+  FLEXSPI_COMMAND_DUMMY_RWDS_SDR = 0x0d,  /* Leave data lines undriven by
+                                           * FlexSPI controller, dummy cycles
+                                           * decided by RWDS.
+                                           */
+
+  FLEXSPI_COMMAND_DDR            = 0x21,  /* Transmit Command code to Flash,
+                                           * using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_RADDR_DDR      = 0x22,  /* Transmit Row Address to Flash,
+                                           * using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_CADDR_DDR      = 0x23,  /* Transmit Column Address to
+                                           * Flash, using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_MODE1_DDR      = 0x24,  /* Transmit 1-bit Mode bits to
+                                           * Flash, using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_MODE2_DDR      = 0x25,  /* Transmit 2-bit Mode bits to
+                                           * Flash, using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_MODE4_DDR      = 0x26,  /* Transmit 4-bit Mode bits to
+                                           * Flash, using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_MODE8_DDR      = 0x27,  /* Transmit 8-bit Mode bits to
+                                           * Flash, using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_WRITE_DDR      = 0x28,  /* Transmit Programming Data to
+                                           * Flash, using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_READ_DDR       = 0x29,  /* Receive Read Data from Flash,
+                                           * using DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_LEARN_DDR      = 0x2a,  /* Receive Read Data or Preamble
+                                           * bit from Flash, DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_DATSZ_DDR      = 0x2b,  /* Transmit Read/Program Data size
+                                           * (byte) to Flash, DDR mode.
+                                           */
+
+  FLEXSPI_COMMAND_DUMMY_DDR      = 0x2c,  /* Leave data lines undriven by
+                                           * FlexSPI controller.
+                                           */
+
+  FLEXSPI_COMMAND_DUMMY_RWDS_DDR = 0x2d,  /* Leave data lines undriven by
+                                           * FlexSPI controller, dummy cycles
+                                           * decided by RWDS.
+                                           */
+
+  FLEXSPI_COMMAND_JUMP_ON_CS     = 0x1f,  /* Stop execution, deassert CS and
+                                           * save operand[7:0] as the
+                                           * instruction start pointer for
+                                           * next sequence
+                                           */
+};
+
+/* Pad definition of FLEXSPI, use to form LUT instruction */
+
+enum flexspi_pad_e
+{
+  FLEXSPI_1PAD = 0x00,  /* Transmit command/address and transmit/receive data
+                         * only through DATA0/DATA1.
+                         */
+
+  FLEXSPI_2PAD = 0x01,  /* Transmit command/address and transmit/receive data
+                         * only through DATA[1:0].
+                         */
+
+  FLEXSPI_4PAD = 0x02,  /* Transmit command/address and transmit/receive data
+                         * only through DATA[3:0].
+                         */
+
+  FLEXSPI_8PAD = 0x03,  /* Transmit command/address and transmit/receive data
+                         * only through DATA[7:0].
+                         */
+};
+
+/* FLEXSPI operation port select */
+
+enum flexspi_port_e
+{
+  FLEXSPI_PORT_A1 = 0x0,  /* Access flash on A1 port */
+  FLEXSPI_PORT_A2,        /* Access flash on A2 port */
+  FLEXSPI_PORT_B1,        /* Access flash on B1 port */
+  FLEXSPI_PORT_B2,        /* Access flash on B2 port */
+  FLEXSPI_PORT_COUNT
+};
+
+/* Command type */
+
+enum flexspi_command_type_e
+{
+  FLEXSPI_COMMAND, /* FlexSPI operation: Only command, both TX and Rx buffer
+                    * are ignored.
+                    */
+
+  FLEXSPI_CONFIG,  /* FlexSPI operation: Configure device mode, the TX fifo
+                    * size is fixed in LUT.
+                    */
+
+  FLEXSPI_READ,    /* FlexSPI operation: Read, only Rx Buffer is
+                    * effective.
+                    */
+
+  FLEXSPI_WRITE,   /* FlexSPI operation: Read, only Tx Buffer is
+                    * effective.
+                    */
+};
+
+/* Status structure of FLEXSPI */
+
+enum
+{
+  STATUS_FLEXSPI_BUSY = 0,                        /* FLEXSPI is busy */
+
+  STATUS_FLEXSPI_SEQUENCE_EXECUTION_TIMEOUT = 1,  /* Sequence execution
+                                                   * timeout error occurred
+                                                   * during FLEXSPI transfer.
+                                                   */
+
+  STATUS_FLEXSPI_IP_COMMAND_SEQUENCE_ERROR = 2,   /* IP command Sequence
+                                                   * execution timeout error
+                                                   * occurred during FLEXSPI
+                                                   * transfer.
+                                                   */
+
+  STATUS_FLEXSPI_IP_COMMAND_GRANT_TIMEOUT = 3,    /* IP command grant timeout
+                                                   * error occurred during
+                                                   * FLEXSPI transfer.
+                                                   */
+};
+
+/* Transfer structure for FLEXSPI */
+
+struct flexspi_transfer_s
+{
+  uint32_t device_address;              /* Operation device address */
+  enum flexspi_port_e port;             /* Operation port */
+  enum flexspi_command_type_e cmd_type; /* Execution command type */
+  uint8_t seq_index;                    /* Sequence ID for command */
+  uint8_t seq_number;                   /* Sequence number for command */
+  uint32_t *data;                       /* Data buffer */
+  size_t data_size;                     /* Data size in bytes */
+};
+
+/* FLEXSPI interval unit for flash device select */
+
+enum flexspi_cs_interval_cycle_unit_e
+{
+  FLEXSPI_CS_INTERVAL_UNIT1_SCK_CYCLE   = 0x0,  /* Chip selection interval:
+                                                 * CSINTERVAL * 1 serial
+                                                 * clock cycle.
+                                                 */
+
+  FLEXSPI_CS_INTERVAL_UNIT256_SCK_CYCLE = 0x1,  /* Chip selection interval:
+                                                 * CSINTERVAL * 256 serial
+                                                 * clock cycle.
+                                                 */
+};
+
+/* FLEXSPI AHB wait interval unit for writing */
+
+enum flexspi_ahb_write_wait_unit_e
+{
+  FLEXSPI_AHB_WRITE_WAIT_UNIT2_AHB_CYCLE     = 0x0,  /* AWRWAIT unit is 2
+                                                      * ahb clock cycle.
+                                                      */
+
+  FLEXSPI_AHB_WRITE_WAIT_UNIT8_AHB_CYCLE     = 0x1,  /* AWRWAIT unit is 8
+                                                      * ahb clock cycle.
+                                                      */
+
+  FLEXSPI_AHB_WRITE_WAIT_UNIT32_AHB_CYCLE    = 0x2,  /* AWRWAIT unit is 32
+                                                      * ahb clock cycle.
+                                                      */
+
+  FLEXSPI_AHB_WRITE_WAIT_UNIT128_AHB_CYCLE   = 0x3,  /* AWRWAIT unit is 128
+                                                      * ahb clock cycle.
+                                                      */
+
+  FLEXSPI_AHB_WRITE_WAIT_UNIT512_AHB_CYCLE   = 0x4,  /* AWRWAIT unit is 512
+                                                      * ahb clock cycle.
+                                                      */
+
+  FLEXSPI_AHB_WRITE_WAIT_UNIT2048_AHB_CYCLE  = 0x5,  /* AWRWAIT unit is 2048
+                                                      * ahb clock cycle.
+                                                      */
+
+  FLEXSPI_AHB_WRITE_WAIT_UNIT8192_AHB_CYCLE  = 0x6,  /* AWRWAIT unit is 8192
+                                                      * ahb clock cycle.
+                                                      */
+
+  FLEXSPI_AHB_WRITE_WAIT_UNIT32768_AHB_CYCLE = 0x7,  /* AWRWAIT unit is 32768
+                                                      * ahb clock cycle.
+                                                      */
+};
+
+/* External device configuration items */
+
+struct flexspi_device_config_s
+{
+  uint32_t flexspi_root_clk; /* FLEXSPI serial root clock */
+  bool is_sck2_enabled;      /* FLEXSPI use SCK2 */
+  uint32_t flash_size;       /* Flash size in KByte */
+
+  enum flexspi_cs_interval_cycle_unit_e cs_interval_unit; /* CS interval unit, 1
+                                                      * or 256 cycle.
+                                                      */
+
+  uint16_t cs_interval;     /* CS line assert interval, multiply CS
+                             * interval unit to get the CS line assert
+                             * interval cycles.
+                             */
+
+  uint8_t cs_hold_time;     /* CS line hold time */
+  uint8_t cs_setup_time;    /* CS line setup time */
+  uint8_t data_valid_time;  /* Data valid time for external device */
+  uint8_t columnspace;      /* Column space size */
+  bool enable_word_address; /* If enable word address */
+  uint8_t awr_seq_index;    /* Sequence ID for AHB write command */
+  uint8_t awr_seq_number;   /* Sequence number for AHB write command */
+  uint8_t ard_seq_index;    /* Sequence ID for AHB read command */
+  uint8_t ard_seq_number;   /* Sequence number for AHB read command */
+
+  enum flexspi_ahb_write_wait_unit_e ahb_write_wait_unit;  /* AHB write wait unit */
+
+  uint16_t ahb_write_wait_interval;  /* AHB write wait interval, multiply AHB
+                                      * write interval unit to get the AHB
+                                      * write wait cycles.
+                                      */
+
+  bool enable_write_mask;   /* Enable/Disable FLEXSPI drive DQS pin as write mask
+                             * when writing to external device.
+                             */
+};
+
+/* The FlexSPI vtable */
+
+struct flexspi_dev_s;
+struct flexspi_ops_s
+{
+  CODE int (*lock)(FAR struct flexspi_dev_s *dev, bool lock);
+  CODE int (*transfer_blocking)(FAR struct flexspi_dev_s *dev,
+                                FAR struct flexspi_transfer_s *xfer);
+  CODE void (*software_reset)(FAR struct flexspi_dev_s *dev);
+  CODE void (*update_lut)(FAR struct flexspi_dev_s *dev,
+                          uint32_t index, const uint32_t *cmd,
+                          uint32_t count);
+  CODE void (*set_device_config)(FAR struct flexspi_dev_s *dev,
+                                 FAR struct flexspi_device_config_s *config,
+                                 enum flexspi_port_e port);
+};
+
+/* FlexSPI private data.  This structure only defines the initial fields of
+ * the structure visible to the FlexSPI client.  The specific implementation
+ * may add additional, device specific fields
+ */
+
+struct flexspi_dev_s
+{
+  FAR const struct flexspi_ops_s *ops;
+};
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+#endif /* __INCLUDE_NUTTX_SPI_FLEXSPI_H */


### PR DESCRIPTION
## Summary

i.MXRT FlexSPI architecture driver and mtd  driver to control various NOR devices. 

## Impact

## Testing

Built and tested on MIMXRT1064-EVK board with imxrt_flexspi_nor.c:

#include <nuttx/config.h>

#include <stdbool.h>
#include <errno.h>
#include <debug.h>

#include <nuttx/fs/fs.h>
#include <nuttx/mtd/mtd.h>
#include <nuttx/spi/flexspi.h>

#include "imxrt_flexspi.h"
#include "imxrt1064-evk.h"

int imxrt_flexspi_nor_setup(void)
{
  FAR struct flexspi_dev_s *flexspi_dev ;
  FAR struct mtd_dev_s *mtd_dev;
  int ret = -1;

  flexspi_dev = imxrt_flexspi_initialize(0);
  if (!flexspi_dev)
    {
      _err("ERROR: Failed to initialize FlexSPI minor %d: %d\n",
           0, ret);
      return -1;
    }

  mtd_dev = flexspi_nor_initialize(flexspi_dev, false);
  if (!mtd_dev)
    {
      _err("ERROR: flexspi_nor_initialize() failed!\n");
      return -1;
    }

  ret = register_mtddriver("/dev/nor", mtd_dev, 0755, NULL);
  if (ret < 0)
    {
      syslog(LOG_ERR, "ERROR: Failed to register MTD driver: %d\n",
             ret);
    }

  ret = nx_mount("/dev/nor", "/mnt/lfs", "littlefs", 0,
                 "autoformat");
  if (ret < 0)
    {
      syslog(LOG_ERR,
             "ERROR: Failed to mount LittleFS at /mnt/lfs: %d\n",
             ret);
    }

  return 0;
}

