### PR TITLE
lib_fgets: don't check for printability

### DIFF
--- a/libs/libc/stdio/lib_libfgets.c
+++ b/libs/libc/stdio/lib_libfgets.c
@@ -216,11 +216,9 @@ FAR char *lib_fgets(FAR char *buf, size_t buflen, FILE *stream,
             }
         }
 
-      /* Otherwise, check if the character is printable and, if so, put the
-       * character in the line buffer
-       */
+      /* Otherwise, put the character in the line buffer */
 
-      else if (isprint(ch))
+      else
         {
           buf[nch++] = ch;
 


### PR DESCRIPTION

## Summary

fgets should care only about newline character and end-of-line condition. It shouldn't check for printability of character. isprint checks only for ASCII characters and  doesn't allow to work with extended ASCII files.



