### PR TITLE
esp32: move common XTAL and RUN_IRAM configs to ESP32 KConfig

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -200,6 +200,18 @@ config ESP32_DEFAULT_CPU_FREQ_MHZ
 	default 160 if ESP32_DEFAULT_CPU_FREQ_160
 	default 240 if ESP32_DEFAULT_CPU_FREQ_240
 
+choice
+	prompt "On-board Crystal Frequency"
+	default ESP32_XTAL_40MZ
+
+config ESP32_XTAL_40MZ
+	bool "40MHz"
+
+config ESP32_XTAL_26MHz
+	bool "26MHz"
+
+endchoice # On-board Crystal Frequency
+
 config ESP32_RT_TIMER
 	bool "Real-time Timer"
 	default n
@@ -211,6 +223,13 @@ config ESP32_PARTITION
 	---help---
 		Decode esp-idf's partition file and initialize
 		partition by nuttx MTD.
+
+config ESP32_RUN_IRAM
+	bool "Run from IRAM"
+	default n
+	---help---
+		This loads all of NuttX inside IRAM.  Used to test somewhat small
+		images that can fit entirely in IRAM.
 
 menu "ESP32 Peripheral Selection"
 

--- a/boards/xtensa/esp32/esp32-devkitc/Kconfig
+++ b/boards/xtensa/esp32/esp32-devkitc/Kconfig
@@ -5,25 +5,6 @@
 
 if ARCH_BOARD_ESP32_DEVKITC
 
-choice
-	prompt "On-board Crystal Frequency"
-	default ESP32_DEVKITC_XTAL_40MZ
-
-config ESP32_DEVKITC_XTAL_40MZ
-	bool "40MHz"
-
-config ESP32_DEVKITC_XTAL_26MHz
-	bool "26MHz"
-
-endchoice # On-board Crystal Frequency
-
-config ESP32_DEVKITC_RUN_IRAM
-	bool "Run from IRAM"
-	default n
-	---help---
-		This loads all of NuttX inside IRAM.  Used to test somewhat small
-		images that can fit entirely in IRAM.
-
 source boards/xtensa/esp32/common/Kconfig
 
 if PM

--- a/boards/xtensa/esp32/esp32-devkitc/include/board.h
+++ b/boards/xtensa/esp32/esp32-devkitc/include/board.h
@@ -29,7 +29,7 @@
 
 /* The ESP32 Core board V2 is fitted with either a 26 a 40MHz crystal */
 
-#ifdef CONFIG_ESP32_DEVKITC_XTAL_26MHz
+#ifdef CONFIG_ESP32_XTAL_26MHz
 #  define BOARD_XTAL_FREQUENCY  26000000
 #else
 #  define BOARD_XTAL_FREQUENCY  40000000
@@ -60,7 +60,7 @@
  *           /bootloader_support/src/bootloader_clock.c#L38-L62
  */
 
-#ifdef CONFIG_ESP32_DEVKITC_RUN_IRAM
+#ifdef CONFIG_ESP32_RUN_IRAM
 #  define BOARD_CLOCK_FREQUENCY (2 * BOARD_XTAL_FREQUENCY)
 #else
 #ifdef CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/Make.defs
@@ -27,7 +27,7 @@ LDSCRIPT1 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_out.ld
 LDSCRIPT3 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_rom.ld
 LDSCRIPT4 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_peripherals.ld
 
-ifeq ($(CONFIG_ESP32_DEVKITC_RUN_IRAM),y)
+ifeq ($(CONFIG_ESP32_RUN_IRAM),y)
   LDSCRIPT2 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_iram.ld
 else
   LDSCRIPT2 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_flash.ld

--- a/boards/xtensa/esp32/esp32-ethernet-kit/Kconfig
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/Kconfig
@@ -5,25 +5,6 @@
 
 if ARCH_BOARD_ESP32_ETHERNETKIT
 
-choice
-	prompt "On-board Crystal Frequency"
-	default ESP32_ETHERNETKIT_XTAL_40MZ
-
-config ESP32_ETHERNETKIT_XTAL_40MZ
-	bool "40MHz"
-
-config ESP32_ETHERNETKIT_XTAL_26MHz
-	bool "26MHz"
-
-endchoice # On-board Crystal Frequency
-
-config ESP32_ETHERNETKIT_RUN_IRAM
-	bool "Run from IRAM"
-	default n
-	---help---
-		This loads all of NuttX inside IRAM.  Used to test somewhat small
-		images that can fit entirely in IRAM.
-
 source boards/xtensa/esp32/common/Kconfig
 
 endif # ARCH_BOARD_ESP32_ETHERNETKIT

--- a/boards/xtensa/esp32/esp32-ethernet-kit/include/board.h
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/include/board.h
@@ -31,7 +31,7 @@
  * crystal
  */
 
-#ifdef CONFIG_ESP32_ETHERNETKIT_XTAL_26MHz
+#ifdef CONFIG_ESP32_XTAL_26MHz
 #  define BOARD_XTAL_FREQUENCY  26000000
 #else
 #  define BOARD_XTAL_FREQUENCY  40000000
@@ -62,7 +62,7 @@
  *           /bootloader_support/src/bootloader_clock.c#L38-L62
  */
 
-#ifdef CONFIG_ESP32_ETHERNETKIT_RUN_IRAM
+#ifdef CONFIG_ESP32_RUN_IRAM
 #  define BOARD_CLOCK_FREQUENCY (2 * BOARD_XTAL_FREQUENCY)
 #else
 #ifdef CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/Make.defs
@@ -27,7 +27,7 @@ LDSCRIPT1 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_out.ld
 LDSCRIPT3 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_rom.ld
 LDSCRIPT4 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_peripherals.ld
 
-ifeq ($(CONFIG_ESP32_ETHERNETKIT_RUN_IRAM),y)
+ifeq ($(CONFIG_ESP32_RUN_IRAM),y)
   LDSCRIPT2 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_iram.ld
 else
   LDSCRIPT2 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_flash.ld

--- a/boards/xtensa/esp32/esp32-wrover-kit/Kconfig
+++ b/boards/xtensa/esp32/esp32-wrover-kit/Kconfig
@@ -5,25 +5,6 @@
 
 if ARCH_BOARD_ESP32_WROVERKIT
 
-choice
-	prompt "On-board Crystal Frequency"
-	default ESP32_WROVERKIT_XTAL_40MZ
-
-config ESP32_WROVERKIT_XTAL_40MZ
-	bool "40MHz"
-
-config ESP32_WROVERKIT_XTAL_26MHz
-	bool "26MHz"
-
-endchoice # On-board Crystal Frequency
-
-config ESP32_WROVERKIT_RUN_IRAM
-	bool "Run from IRAM"
-	default n
-	---help---
-		This loads all of NuttX inside IRAM.  Used to test somewhat small
-		images that can fit entirely in IRAM.
-
 source boards/xtensa/esp32/common/Kconfig
 
 endif # ARCH_BOARD_ESP32_WROVERKIT

--- a/boards/xtensa/esp32/esp32-wrover-kit/include/board.h
+++ b/boards/xtensa/esp32/esp32-wrover-kit/include/board.h
@@ -31,7 +31,7 @@
  * crystal
  */
 
-#ifdef CONFIG_ESP32_WROVERKIT_XTAL_26MHz
+#ifdef CONFIG_ESP32_XTAL_26MHz
 #  define BOARD_XTAL_FREQUENCY  26000000
 #else
 #  define BOARD_XTAL_FREQUENCY  40000000
@@ -62,7 +62,7 @@
  *           /bootloader_support/src/bootloader_clock.c#L38-L62
  */
 
-#ifdef CONFIG_ESP32_WROVERKIT_RUN_IRAM
+#ifdef CONFIG_ESP32_RUN_IRAM
 #  define BOARD_CLOCK_FREQUENCY (2 * BOARD_XTAL_FREQUENCY)
 #else
 #ifdef CONFIG_ESP32_DEFAULT_CPU_FREQ_MHZ

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/Make.defs
@@ -27,7 +27,7 @@ LDSCRIPT1 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_out.ld
 LDSCRIPT3 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_rom.ld
 LDSCRIPT4 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_peripherals.ld
 
-ifeq ($(CONFIG_ESP32_WROVERKIT_RUN_IRAM),y)
+ifeq ($(CONFIG_ESP32_RUN_IRAM),y)
   LDSCRIPT2 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_iram.ld
 else
   LDSCRIPT2 = $(BOARD_DIR)$(DELIM)scripts$(DELIM)esp32_flash.ld


### PR DESCRIPTION
## Summary

This moves some repeated functionality at board level for ESP32, moving the relevant Kconfig choices
to ESP32 common Kconfig

There's quite a bit of repeitition at board level (we should really avoid growing this problem for new boards),
so this is just a starting point.

## Impact

No functional impact

## Testing

none, just reorganization of configs
