### PR TITLE
Remove unused 'running' field from freerun lower half drivers.

### DIFF
--- a/arch/arm/src/sam34/sam4cm_freerun.c
+++ b/arch/arm/src/sam34/sam4cm_freerun.c
@@ -183,7 +183,6 @@ int sam_freerun_initialize(struct sam_freerun_s *freerun, int chan,
    */
 
   freerun->chan     = chan;
-  freerun->running  = false;
   freerun->overflow = 0;
 
   /* Set up to receive the callback when the counter overflow occurs */

--- a/arch/arm/src/sam34/sam4cm_freerun.h
+++ b/arch/arm/src/sam34/sam4cm_freerun.h
@@ -53,7 +53,6 @@
 struct sam_freerun_s
 {
   uint8_t chan;              /* The timer/counter in use */
-  bool running;              /* True: the timer is running */
   uint32_t overflow;         /* Timer counter overflow */
   TC_HANDLE tch;             /* Handle returned by sam_tc_initialize() */
 };

--- a/arch/arm/src/sama5/sam_freerun.c
+++ b/arch/arm/src/sama5/sam_freerun.c
@@ -184,7 +184,6 @@ int sam_freerun_initialize(struct sam_freerun_s *freerun, int chan,
    */
 
   freerun->chan     = chan;
-  freerun->running  = false;
   freerun->overflow = 0;
 
   /* Set up to receive the callback when the counter overflow occurs */

--- a/arch/arm/src/sama5/sam_freerun.h
+++ b/arch/arm/src/sama5/sam_freerun.h
@@ -53,7 +53,6 @@
 struct sam_freerun_s
 {
   uint8_t chan;              /* The timer/counter in use */
-  bool running;              /* True: the timer is running */
   uint16_t overflow;         /* Timer counter overflow */
   TC_HANDLE tch;             /* Handle returned by sam_tc_initialize() */
 };

--- a/arch/arm/src/samd5e5/sam_freerun.c
+++ b/arch/arm/src/samd5e5/sam_freerun.c
@@ -121,7 +121,6 @@ int sam_freerun_initialize(struct sam_freerun_s *freerun, int chan,
    */
 
   freerun->chan     = chan;
-  freerun->running  = false;
   freerun->overflow = 0;
 
   /* Set up to receive the callback when the counter overflow occurs */

--- a/arch/arm/src/samd5e5/sam_freerun.h
+++ b/arch/arm/src/samd5e5/sam_freerun.h
@@ -57,7 +57,6 @@
 struct sam_freerun_s
 {
   uint8_t chan;              /* The timer/counter in use */
-  bool running;              /* True: the timer is running */
   uint32_t overflow;         /* Timer counter overflow */
   TC_HANDLE tch;             /* Handle returned by sam_tc_initialize() */
 };

--- a/arch/arm/src/samv7/sam_freerun.c
+++ b/arch/arm/src/samv7/sam_freerun.c
@@ -185,7 +185,6 @@ int sam_freerun_initialize(struct sam_freerun_s *freerun, int chan,
    */
 
   freerun->chan     = chan;
-  freerun->running  = false;
   freerun->overflow = 0;
 
   /* Set up to receive the callback when the counter overflow occurs */

--- a/arch/arm/src/samv7/sam_freerun.h
+++ b/arch/arm/src/samv7/sam_freerun.h
@@ -53,7 +53,6 @@
 struct sam_freerun_s
 {
   uint8_t chan;              /* The timer/counter in use */
-  bool running;              /* True: the timer is running */
   uint32_t overflow;         /* Timer counter overflow */
   TC_HANDLE tch;             /* Handle returned by sam_tc_initialize() */
 };

--- a/arch/arm/src/stm32/stm32_freerun.c
+++ b/arch/arm/src/stm32/stm32_freerun.c
@@ -124,7 +124,6 @@ int stm32_freerun_initialize(struct stm32_freerun_s *freerun, int chan,
 
   freerun->chan         = chan;
   freerun->width        = STM32_TIM_GETWIDTH(freerun->tch);
-  freerun->running      = false;
 
 #ifdef CONFIG_CLOCK_TIMEKEEPING
   freerun->counter_mask = 0xffffffffull;

--- a/arch/arm/src/stm32/stm32_freerun.h
+++ b/arch/arm/src/stm32/stm32_freerun.h
@@ -49,7 +49,6 @@ struct stm32_freerun_s
 {
   uint8_t chan;                    /* The timer/counter in use */
   uint8_t width;                   /* Width of timer (16- or 32-bits) */
-  bool running;                    /* True: the timer is running */
   FAR struct stm32_tim_dev_s *tch; /* Handle returned by stm32_tim_init() */
   uint32_t frequency;
 

--- a/arch/arm/src/stm32l4/stm32l4_freerun.c
+++ b/arch/arm/src/stm32l4/stm32l4_freerun.c
@@ -138,7 +138,6 @@ int stm32l4_freerun_initialize(FAR struct stm32l4_freerun_s *freerun,
    */
 
   freerun->chan     = chan;
-  freerun->running  = false;
   freerun->overflow = 0;
 
   /* Set up to receive the callback when the counter overflow occurs */

--- a/arch/arm/src/stm32l4/stm32l4_freerun.h
+++ b/arch/arm/src/stm32l4/stm32l4_freerun.h
@@ -64,7 +64,6 @@
 struct stm32l4_freerun_s
 {
   uint8_t chan;                      /* The timer/counter in use */
-  bool running;                      /* True: the timer is running */
   uint32_t overflow;                 /* Timer counter overflow */
   FAR struct stm32l4_tim_dev_s *tch; /* Handle returned by stm32l4_tim_init() */
   uint32_t frequency;

--- a/arch/mips/src/pic32mz/pic32mz_freerun.c
+++ b/arch/mips/src/pic32mz/pic32mz_freerun.c
@@ -139,7 +139,6 @@ int pic32mz_freerun_initialize(struct pic32mz_freerun_s *freerun, int chan,
   freerun->freq    = PIC32MZ_TIMER_GETFREQ(freerun->timer);
   freerun->width   = PIC32MZ_TIMER_GETWIDTH(freerun->timer);
   freerun->chan    = chan;
-  freerun->running = false;
 
 #ifdef CONFIG_CLOCK_TIMEKEEPING
   if (freerun->width == 32)
@@ -169,7 +168,6 @@ int pic32mz_freerun_initialize(struct pic32mz_freerun_s *freerun, int chan,
   /* Start the timer */
 
   PIC32MZ_TIMER_START(freerun->timer);
-  freerun->running = true;
 
   return OK;
 }
@@ -307,7 +305,6 @@ int pic32mz_freerun_uninitialize(struct pic32mz_freerun_s *freerun)
 
   pic32mz_timer_deinit(freerun->timer);
 
-  freerun->running = false;
   freerun->timer = NULL;
 
   return OK;

--- a/arch/mips/src/pic32mz/pic32mz_freerun.h
+++ b/arch/mips/src/pic32mz/pic32mz_freerun.h
@@ -49,7 +49,6 @@ struct pic32mz_freerun_s
 {
   uint8_t chan;                            /* The timer in use            */
   uint8_t width;                           /* Width of timer (16- or 32)  */
-  bool running;                            /* True: the timer is running  */
   FAR struct pic32mz_timer_dev_s *timer;   /* PIC32MZ timer driver        */
   uint32_t freq;                           /* Timer's frequency (Hz)      */
 


### PR DESCRIPTION
## Summary

That field is never used and, in most cases, is never initialized correctly.

## Impact

This should have no impact to anything with the possible exception of free-running drivers.

## Testing

Verified using CI builds only.


