### PR TITLE
Replace wrong inclusion of sys/errno.h (toolchain provided) with errno.h

### DIFF
--- a/arch/risc-v/src/bl602/bl602_spiflash.c
+++ b/arch/risc-v/src/bl602/bl602_spiflash.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <syslog.h>
 
 #ifdef CONFIG_BL602_SPIFLASH

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#include <sys/errno.h>
+#include <errno.h>
 #include <debug.h>
 
 #include <nuttx/irq.h>

--- a/arch/risc-v/src/esp32c3/esp32c3_partition.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_partition.c
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <debug.h>
 #include <stdio.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include <nuttx/kmalloc.h>
 

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/init.h>

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -31,7 +31,7 @@
 #include <debug.h>
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include <arpa/inet.h>
 #include <net/if.h>

--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <debug.h>
 #include <stdio.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include <nuttx/kmalloc.h>
 

--- a/arch/xtensa/src/esp32/esp32_spicache.c
+++ b/arch/xtensa/src/esp32/esp32_spicache.c
@@ -31,7 +31,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include "xtensa.h"
 #include "xtensa_attr.h"

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -31,7 +31,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/init.h>

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -35,7 +35,7 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <sys/errno.h>
+#include <errno.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/himem/himem.h>
 

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
@@ -35,7 +35,7 @@
 #include <debug.h>
 #include <stdio.h>
 
-#include <sys/errno.h>
+#include <errno.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/himem/himem.h>
 

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 
 #include <syslog.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/himem/himem.h>
 


### PR DESCRIPTION
## Summary

Found many files including `sys/errno.h` which is actually provided by system. The correct path should be just `errno.h`
which is provided by NuttX.

## Impact

Probably nothing was broken, as only very basic standard definitions where used from that file.

## Testing

Build esp32 configs successfully, others should behave the same
