### PR TITLE
vfs: adjust the error code of write to be consistent with read

### DIFF
--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -73,7 +73,7 @@ ssize_t file_write(FAR struct file *filep, FAR const void *buf,
 
   if ((filep->f_oflags & O_WROK) == 0)
     {
-      return -EBADF;
+      return -EACCES;
     }
 
   /* Is a driver registered? Does it support the write method? */


### PR DESCRIPTION
According to POSIX, the EACCES will be set when file can not be
written access. Just like fs_read

## Summary

## Impact

## Testing

