### PR TITLE
ESP32: Fix multiple inclusion of the common Kconfig

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3116,6 +3116,9 @@ endif
 if ARCH_BOARD_RX65N_GRROSE
 source "boards/renesas/rx65n/rx65n-grrose/Kconfig"
 endif
+if ARCH_CHIP_ESP32 && !ARCH_BOARD_CUSTOM
+source "boards/xtensa/esp32/common/Kconfig"
+endif
 if ARCH_BOARD_ESP32_DEVKITC
 source "boards/xtensa/esp32/esp32-devkitc/Kconfig"
 endif

--- a/boards/xtensa/esp32/common/Kconfig
+++ b/boards/xtensa/esp32/common/Kconfig
@@ -2,7 +2,6 @@
 # For a description of the syntax of this configuration file,
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
-
 config ESP32_QEMU_IMAGE
 	bool "ESP32 binary image for QEMU"
 	default n
@@ -10,22 +9,26 @@ config ESP32_QEMU_IMAGE
 		Create a binary flash image used for QEMU.
 
 choice ESP32_SPIFLASH_FS
-  prompt "SPIFLASH File System"
-  default ESP32_SPIFLASH_SMARTFS
-  depends on ESP32_SPIFLASH
+	prompt "SPIFLASH File System"
+	default ESP32_SPIFLASH_SMARTFS
+	depends on ESP32_SPIFLASH
 
-  config ESP32_SPIFLASH_SMARTFS
-        bool "SmartFS"
-        depends on FS_SMARTFS
-  config ESP32_SPIFLASH_NXFFS
-        bool "NXFFS"
-        depends on FS_NXFFS
-  config ESP32_SPIFLASH_SPIFFS
-        bool "SPIFFS"
-        depends on FS_SPIFFS
-  config ESP32_SPIFLASH_LITTLEFS
-        bool "LittleFS"
-        depends on FS_LITTLEFS
+	config ESP32_SPIFLASH_SMARTFS
+		bool "SmartFS"
+		depends on FS_SMARTFS
+
+	config ESP32_SPIFLASH_NXFFS
+		bool "NXFFS"
+		depends on FS_NXFFS
+
+	config ESP32_SPIFLASH_SPIFFS
+		bool "SPIFFS"
+		depends on FS_SPIFFS
+
+	config ESP32_SPIFLASH_LITTLEFS
+		bool "LittleFS"
+		depends on FS_LITTLEFS
+
 endchoice
 
 config ESP32_SPIFLASH_ENCRYPTION_TEST
@@ -33,7 +36,7 @@ config ESP32_SPIFLASH_ENCRYPTION_TEST
 	default n
 	depends on ESP32_SPIFLASH
 	select DEBUG_ASSERTIONS
-	help
+	---help---
 		Enable SPI Flash encryption test. This option will also select
 		DEBUG_ASSERTIONS to enable kernel assert macro.
 
@@ -41,5 +44,5 @@ config ESP32_SPIFLASH_TEST_ADDRESS
 	hex "SPI Flash test address"
 	default 0x180000
 	depends on ESP32_SPIFLASH_ENCRYPTION_TEST
-	help
+	---help---
 		SPI Flash encryption test read/write address.

--- a/boards/xtensa/esp32/esp32-devkitc/Kconfig
+++ b/boards/xtensa/esp32/esp32-devkitc/Kconfig
@@ -5,8 +5,6 @@
 
 if ARCH_BOARD_ESP32_DEVKITC
 
-source boards/xtensa/esp32/common/Kconfig
-
 if PM
 
 config PM_ALARM_SEC

--- a/boards/xtensa/esp32/esp32-ethernet-kit/Kconfig
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/Kconfig
@@ -5,6 +5,4 @@
 
 if ARCH_BOARD_ESP32_ETHERNETKIT
 
-source boards/xtensa/esp32/common/Kconfig
-
 endif # ARCH_BOARD_ESP32_ETHERNETKIT

--- a/boards/xtensa/esp32/esp32-wrover-kit/Kconfig
+++ b/boards/xtensa/esp32/esp32-wrover-kit/Kconfig
@@ -5,6 +5,4 @@
 
 if ARCH_BOARD_ESP32_WROVERKIT
 
-source boards/xtensa/esp32/common/Kconfig
-
 endif # ARCH_BOARD_ESP32_WROVERKIT


### PR DESCRIPTION
## Summary
This PR intends to provide a fix for the multiple definition of config that are common to every ESP32-based board.

### Bug 
![image](https://user-images.githubusercontent.com/38959758/114223989-ded20b80-9946-11eb-9a9d-8d15eb505c2b.png)

### Fix 
![image](https://user-images.githubusercontent.com/38959758/114224008-e5f91980-9946-11eb-8462-2b090b11d14b.png)

## Impact
No impact, just reorganization of current configuration.

## Testing
CI build pass.
