### PR TITLE
boards: Remove useless comment from Kconfig

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3198,7 +3198,6 @@ config BOARD_INITRNGSEED
 		board_init_rndseed() upon initialization. This function
 		can then provide early entropy seed to the pool through
 		entropy injection APIs provided at 'nuttx/random.h'.
-#endif
 
 config LIB_BOARDCTL
 	bool "Enable boardctl() interface"


### PR DESCRIPTION
## Summary
Remove a commented line from Kconfig that seems to had been committed by accident.

## Impact
No impact.

## Testing
Not applicable.
