### PR TITLE
pthread_mutexattr_setprotocol.c: Return EINVAL instead of ENOSYS.

### DIFF
--- a/libs/libc/pthread/pthread_mutexattr_setprotocol.c
+++ b/libs/libc/pthread/pthread_mutexattr_setprotocol.c
@@ -69,6 +69,6 @@ int pthread_mutexattr_setprotocol(FAR pthread_mutexattr_t *attr,
       return OK;
     }
 
-  return ENOSYS;
+  return EINVAL;
 #endif
 }


### PR DESCRIPTION
## Summary
The ENOSYS return [1] has been removed [2].

1. https://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_mutexattr_setprotocol.html
2. https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutexattr_setprotocol.html
## Impact

## Testing

