### PR TITLE
Seperate CLOCK_TIMEKEEPING and SCHED_TICKLESS.

### DIFF
--- a/arch/arm/src/stm32/stm32_tickless.c
+++ b/arch/arm/src/stm32/stm32_tickless.c
@@ -126,9 +126,8 @@ struct stm32_tickless_s
   uint32_t frequency;
 #ifdef CONFIG_CLOCK_TIMEKEEPING
   uint64_t counter_mask;
-#else
-  uint32_t overflow;               /* Timer counter overflow */
 #endif
+  uint32_t overflow;               /* Timer counter overflow */
   volatile bool pending;           /* True: pending task */
   uint32_t period;                 /* Interval period */
   uint32_t base;
@@ -339,14 +338,12 @@ static void stm32_interval_handler(void)
  *
  ****************************************************************************/
 
-#ifndef CONFIG_CLOCK_TIMEKEEPING
 static void stm32_timing_handler(void)
 {
   g_tickless.overflow++;
 
   STM32_TIM_ACKINT(g_tickless.tch, GTIM_SR_UIF);
 }
-#endif /* CONFIG_CLOCK_TIMEKEEPING */
 
 /****************************************************************************
  * Name: stm32_tickless_handler
@@ -367,12 +364,10 @@ static int stm32_tickless_handler(int irq, void *context, void *arg)
 {
   int interrupt_flags = stm32_tickless_getint();
 
-#ifndef CONFIG_CLOCK_TIMEKEEPING
   if (interrupt_flags & ATIM_SR_UIF)
     {
       stm32_timing_handler();
     }
-#endif /* CONFIG_CLOCK_TIMEKEEPING */
 
   if (interrupt_flags & (1 << g_tickless.channel))
     {
@@ -529,6 +524,7 @@ void up_timer_initialize(void)
   g_tickless.channel   = CONFIG_STM32_TICKLESS_CHANNEL;
   g_tickless.pending   = false;
   g_tickless.period    = 0;
+  g_tickless.overflow  = 0;
 
   tmrinfo("timer=%d channel=%d frequency=%d Hz\n",
            g_tickless.timer, g_tickless.channel, g_tickless.frequency);
@@ -547,13 +543,11 @@ void up_timer_initialize(void)
   /* Should this be changed to 0xffff because we use 16 bit timers? */
 
   g_tickless.counter_mask = 0xffffffffull;
-#else
-  g_tickless.overflow     = 0;
+#endif
 
   /* Set up to receive the callback when the counter overflow occurs */
 
   STM32_TIM_SETISR(g_tickless.tch, stm32_tickless_handler, NULL, 0);
-#endif
 
   /* Initialize interval to zero */
 
@@ -619,8 +613,6 @@ void up_timer_initialize(void)
  *   operations.
  *
  ****************************************************************************/
-
-#ifndef CONFIG_CLOCK_TIMEKEEPING
 
 int up_timer_gettime(FAR struct timespec *ts)
 {
@@ -700,15 +692,27 @@ int up_timer_gettime(FAR struct timespec *ts)
   return OK;
 }
 
-#else
+#ifdef CONFIG_CLOCK_TIMEKEEPING
+
+/****************************************************************************
+ * Name: up_timer_getcounter
+ *
+ * Description:
+ *   To be provided
+ *
+ * Input Parameters:
+ *   cycles - 64-bit return value
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
 
 int up_timer_getcounter(FAR uint64_t *cycles)
 {
   *cycles = (uint64_t)STM32_TIM_GETCOUNTER(g_tickless.tch);
   return OK;
 }
-
-#endif /* CONFIG_CLOCK_TIMEKEEPING */
 
 /****************************************************************************
  * Name: up_timer_getmask
@@ -724,12 +728,12 @@ int up_timer_getcounter(FAR uint64_t *cycles)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_CLOCK_TIMEKEEPING
 void up_timer_getmask(FAR uint64_t *mask)
 {
   DEBUGASSERT(mask != NULL);
   *mask = g_tickless.counter_mask;
 }
+
 #endif /* CONFIG_CLOCK_TIMEKEEPING */
 
 /****************************************************************************

--- a/arch/arm/src/stm32f7/stm32_tickless.c
+++ b/arch/arm/src/stm32f7/stm32_tickless.c
@@ -134,9 +134,8 @@ struct stm32_tickless_s
   uint32_t frequency;
 #ifdef CONFIG_CLOCK_TIMEKEEPING
   uint64_t counter_mask;
-#else
-  uint32_t overflow;               /* Timer counter overflow */
 #endif
+  uint32_t overflow;               /* Timer counter overflow */
   volatile bool pending;           /* True: pending task */
   uint32_t period;                 /* Interval period */
   uint32_t base;
@@ -351,14 +350,12 @@ static void stm32_interval_handler(void)
  *
  ****************************************************************************/
 
-#ifndef CONFIG_CLOCK_TIMEKEEPING
 static void stm32_timing_handler(void)
 {
   g_tickless.overflow++;
 
   STM32_TIM_ACKINT(g_tickless.tch, 0);
 }
-#endif /* CONFIG_CLOCK_TIMEKEEPING */
 
 /****************************************************************************
  * Name: stm32_tickless_handler
@@ -379,12 +376,10 @@ static int stm32_tickless_handler(int irq, void *context, void *arg)
 {
   int interrupt_flags = stm32_tickless_getint();
 
-#ifndef CONFIG_CLOCK_TIMEKEEPING
   if (interrupt_flags & ATIM_SR_UIF)
     {
       stm32_timing_handler();
     }
-#endif /* CONFIG_CLOCK_TIMEKEEPING */
 
   if (interrupt_flags & (1 << g_tickless.channel))
     {
@@ -573,6 +568,7 @@ void up_timer_initialize(void)
   g_tickless.channel   = CONFIG_STM32F7_TICKLESS_CHANNEL;
   g_tickless.pending   = false;
   g_tickless.period    = 0;
+  g_tickless.overflow  = 0;
 
   tmrinfo("timer=%d channel=%d frequency=%d Hz\n",
            g_tickless.timer, g_tickless.channel, g_tickless.frequency);
@@ -591,13 +587,11 @@ void up_timer_initialize(void)
   /* Should this be changed to 0xffff because we use 16 bit timers? */
 
   g_tickless.counter_mask = 0xffffffffull;
-#else
-  g_tickless.overflow     = 0;
+#endif
 
   /* Set up to receive the callback when the counter overflow occurs */
 
   STM32_TIM_SETISR(g_tickless.tch, stm32_tickless_handler, NULL, 0);
-#endif
 
   /* Initialize interval to zero */
 
@@ -664,7 +658,6 @@ void up_timer_initialize(void)
  *
  ****************************************************************************/
 
-#ifndef CONFIG_CLOCK_TIMEKEEPING
 int up_timer_gettime(FAR struct timespec *ts)
 {
   uint64_t usec;
@@ -752,15 +745,27 @@ int up_timer_gettime(FAR struct timespec *ts)
   return OK;
 }
 
-#else
+#ifdef CONFIG_CLOCK_TIMEKEEPING
+
+/****************************************************************************
+ * Name: up_timer_getcounter
+ *
+ * Description:
+ *   To be provided
+ *
+ * Input Parameters:
+ *   cycles - 64-bit return value
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
 
 int up_timer_getcounter(FAR uint64_t *cycles)
 {
   *cycles = (uint64_t)STM32_TIM_GETCOUNTER(g_tickless.tch);
   return OK;
 }
-
-#endif /* CONFIG_CLOCK_TIMEKEEPING */
 
 /****************************************************************************
  * Name: up_timer_getmask
@@ -776,12 +781,12 @@ int up_timer_getcounter(FAR uint64_t *cycles)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_CLOCK_TIMEKEEPING
 void up_timer_getmask(FAR uint64_t *mask)
 {
   DEBUGASSERT(mask != NULL);
   *mask = g_tickless.counter_mask;
 }
+
 #endif /* CONFIG_CLOCK_TIMEKEEPING */
 
 /****************************************************************************

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -246,7 +246,9 @@ void up_timer_getmask(FAR uint64_t *mask)
         }
     }
 }
-#elif defined(CONFIG_SCHED_TICKLESS)
+#endif
+
+#if defined(CONFIG_SCHED_TICKLESS)
 int up_timer_gettime(FAR struct timespec *ts)
 {
   int ret = -EAGAIN;

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -301,8 +301,9 @@ void up_timer_getmask(FAR uint64_t *mask)
       *mask = next;
     }
 }
+#endif
 
-#elif defined(CONFIG_SCHED_TICKLESS)
+#if defined(CONFIG_SCHED_TICKLESS)
 int up_timer_gettime(FAR struct timespec *ts)
 {
   int ret = -EAGAIN;

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1539,7 +1539,7 @@ void up_timer_initialize(void);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_CLOCK_TIMEKEEPING)
+#if defined(CONFIG_SCHED_TICKLESS)
 int up_timer_gettime(FAR struct timespec *ts);
 #endif
 

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -52,8 +52,10 @@
 
 int clock_gettime(clockid_t clock_id, struct timespec *tp)
 {
+#ifndef CONFIG_CLOCK_TIMEKEEPING
   struct timespec ts;
   uint32_t carry;
+#endif
   int ret = OK;
 
   sinfo("clock_id=%d\n", clock_id);

--- a/sched/clock/clock_settime.c
+++ b/sched/clock/clock_settime.c
@@ -51,8 +51,10 @@
 
 int clock_settime(clockid_t clock_id, FAR const struct timespec *tp)
 {
+#ifndef CONFIG_CLOCK_TIMEKEEPING
   struct timespec bias;
   irqstate_t flags;
+#endif
   int ret = OK;
 
   sinfo("clock_id=%d\n", clock_id);


### PR DESCRIPTION
## Summary
There is a lot of coupling that seems both wrong and unnecessary between CONFIG_CLOCK_TIMEKEEPING and CONFIG_SCHED_TICKLESS. 

Please correct me if there is a valid reason for this coupling, but I don't see it. 

There is still some coupling here that I don't like. In particular, I don't understand why we need up_timer_getcounter() and up_timer_getmask() - couldn't the timekeeping driver just use the typical up_timer_gettime() and keep the interface simpler?

This at least starts the decoupling and fixes build issues.

## Impact

## Testing

