### PR TITLE
arch: k210: Fix interrupt stack corruption in SMP mode

### DIFF
--- a/arch/risc-v/src/k210/k210_head.S
+++ b/arch/risc-v/src/k210/k210_head.S
@@ -223,8 +223,16 @@ normal_irq:
   .type   g_intstackalloc, object
   .type   g_intstackbase, object
 g_intstackalloc:
+#ifndef CONFIG_SMP
   .skip  ((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+#else
+  .skip  (((CONFIG_ARCH_INTERRUPTSTACK * CONFIG_SMP_NCPUS) + 4) & ~7)
+#endif
 g_intstackbase:
   .size  g_intstackbase, 0
+#ifndef CONFIG_SMP
   .size  g_intstackalloc, (CONFIG_ARCH_INTERRUPTSTACK & ~7)
+#else
+  .size  g_intstackalloc, ((CONFIG_ARCH_INTERRUPTSTACK * CONFIG_SMP_NCPUS) & ~7)
+#endif
 #endif


### PR DESCRIPTION
## Summary

- I noticed that stack corruption happens due to recent refactoring
- This commit fixes this issue

## Impact

- SMP only

## Testing

- Tested with maix-bit:smp (QMU and dev board)
