### PR TITLE
Correct a comment

### DIFF
--- a/libs/libc/tls/tls_getinfo.c
+++ b/libs/libc/tls/tls_getinfo.c
@@ -63,8 +63,8 @@ FAR struct tls_info_s *tls_get_info(void)
   ret = nxsched_get_stackinfo(0, &stackinfo);
   if (ret >= 0)
     {
-      /* This currently assumes a push-down stack.  The TLS data lies at the
-       * lowest address of the stack allocation.
+      /* The TLS data lies at the lowest address of the stack allocation.
+       * This is true for both push-up and push-down stacks.
        */
 
       info = (FAR struct tls_info_s *)stackinfo.stack_alloc_ptr;


### PR DESCRIPTION
## Summary

Fix comment in libs/libc/tls/tls_getinfo.c:  The TLS data must lie at the beginning of the allocated stack memory for both push-up and push-down stacks.

## Impact

None

## Testing

N/A


