### PR TITLE
stm32h7: Initialize CSI and HSI48 clocks as needed based on enabled peripherals

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -410,6 +410,14 @@ config STM32H7_RTC
 	default n
 	select RTC
 
+config STM32H7_CSI
+	bool "CSI Low-speed internal oscillator (4MHz)"
+	default n
+
+config STM32H7_HSI48
+	bool "HSI48 High-speed 48MHz internal oscillator"
+	default n
+
 config STM32H7_PWR
 	bool "PWR"
 	default n
@@ -493,12 +501,14 @@ config STM32H7_OTGFS
 	bool "OTG FS"
 	default n
 	select USBHOST_HAVE_ASYNCH if USBHOST
+	select STM32H7_HSI48
 
 config STM32H7_OTGHS
 	bool "OTG HS"
 	default n
 	depends on EXPERIMENTAL
 	select USBHOST_HAVE_ASYNCH if USBHOST
+	select STM32H7_HSI48
 
 config STM32H7_OTG_SOFOUTPUT
 	bool "OTG SOF output"

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -501,14 +501,12 @@ config STM32H7_OTGFS
 	bool "OTG FS"
 	default n
 	select USBHOST_HAVE_ASYNCH if USBHOST
-	select STM32H7_HSI48
 
 config STM32H7_OTGHS
 	bool "OTG HS"
 	default n
 	depends on EXPERIMENTAL
 	select USBHOST_HAVE_ASYNCH if USBHOST
-	select STM32H7_HSI48
 
 config STM32H7_OTG_SOFOUTPUT
 	bool "OTG SOF output"

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -52,8 +52,10 @@
 #if defined(CONFIG_USBDEV) && (defined(CONFIG_STM32H7_OTGFS) || \
     defined(CONFIG_STM32H7_OTGHS))
 
-#ifdef CONFIG_STM32H7_OTGHS
-#  warning OTG HS not tested for STM32H7 !
+#if (STM32_RCC_D2CCIP2R_USBSRC == RCC_D2CCIP2R_USBSEL_HSI48) && \
+    !defined(CONFIG_STM32H7_HSI48)
+#  error board.h selected HSI48 as USB clock source, but HSI48 is not \
+         enabled. Enable STM32H7_HSI48
 #endif
 
 /****************************************************************************

--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -623,7 +623,6 @@ void stm32_stdclockconfig(void)
     }
 #endif
 
-#define CONFIG_STM32H7_HSI48
 #ifdef CONFIG_STM32H7_HSI48
   /* Enable HSI48 */
 
@@ -634,6 +633,20 @@ void stm32_stdclockconfig(void)
   /* Wait until the HSI48 is ready */
 
   while ((getreg32(STM32_RCC_CR) & RCC_CR_HSI48RDY) == 0)
+    {
+    }
+#endif
+
+#ifdef CONFIG_STM32H7_CSI
+  /* Enable CSI */
+
+  regval  = getreg32(STM32_RCC_CR);
+  regval |= RCC_CR_CSION;
+  putreg32(regval, STM32_RCC_CR);
+
+  /* Wait until the CSI is ready */
+
+  while ((getreg32(STM32_RCC_CR) & RCC_CR_CSIRDY) == 0)
     {
     }
 #endif

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -637,7 +637,6 @@ void stm32_stdclockconfig(void)
     }
 #endif
 
-#define CONFIG_STM32H7_HSI48
 #ifdef CONFIG_STM32H7_HSI48
   /* Enable HSI48 */
 
@@ -648,6 +647,20 @@ void stm32_stdclockconfig(void)
   /* Wait until the HSI48 is ready */
 
   while ((getreg32(STM32_RCC_CR) & RCC_CR_HSI48RDY) == 0)
+    {
+    }
+#endif
+
+#ifdef CONFIG_STM32H7_CSI
+  /* Enable CSI */
+
+  regval  = getreg32(STM32_RCC_CR);
+  regval |= RCC_CR_CSION;
+  putreg32(regval, STM32_RCC_CR);
+
+  /* Wait until the CSI is ready */
+
+  while ((getreg32(STM32_RCC_CR) & RCC_CR_CSIRDY) == 0)
     {
     }
 #endif


### PR DESCRIPTION
## Summary
Prior to this commit, the HSI48 clock was forced on at all times, and the CSI (low-speed internal clock), was never enabled. This change adds configuration options for both of these clocks. In general, the user will not set these. Instead, they will be selected by peripherals that depend on one of these clocks.

## Impact
HSI48 clock will be disabled for any user not using a peripheral that depends on the HSI48 (USB for example)

## Testing
Built and ran configuration.

