### PR TITLE
stm32h7: Add support for IO compensation.

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -764,6 +764,19 @@ config STM32H7_UART8
 endmenu # STM32H7 U[S]ART Selection
 endmenu # STM32H7 Peripheral Selection
 
+config STM32H7_SYSCFG_IOCOMPENSATION
+	bool "SYSCFG I/O Compensation"
+	default n
+	select STM32H7_CSI
+	---help---
+		By default the I/O compensation cell is not used. However when the I/O
+		output buffer speed is configured in 50 MHz or 100 MHz mode, it is
+		recommended to use the compensation cell for slew rate control on I/O
+		tf(IO)out)/tr(IO)out commutation to reduce the I/O noise on power supply.
+
+		The I/O compensation cell can be used only when the supply voltage ranges
+		from 2.4 to 3.6 V
+
 menu "I2C Configuration"
 	depends on STM32H7_I2C
 

--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_syscfg.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_syscfg.h
@@ -44,7 +44,8 @@
 #define STM32_SYSCFG_EXTICR3_OFFSET   0x0010 /* SYSCFG external interrupt configuration register 3 */
 #define STM32_SYSCFG_EXTICR4_OFFSET   0x0014 /* SYSCFG external interrupt configuration register 4 */
 
-#define STM32_SYSCFG_CCSR_OFFSET      0x0020 /* Compensation cell control/status register */
+#define STM32_SYSCFG_CFGR_OFFSET      0x0018 /* SYSCFG configuration register */
+#define STM32_SYSCFG_CCCSR_OFFSET     0x0020 /* Compensation cell control/status register */
 #define STM32_SYSCFG_CCVR_OFFSET      0x0024 /* Compensation cell value register */
 #define STM32_SYSCFG_CCCR_OFFSET      0x0028 /* Compensation cell code register */
 #define STM32_SYSCFG_PWRCR_OFFSET     0x002c /* Power Control register */
@@ -80,7 +81,7 @@
 #define STM32_SYSCFG_EXTICR3          (STM32_SYSCFG_BASE + STM32_SYSCFG_EXTICR3_OFFSET)
 #define STM32_SYSCFG_EXTICR4          (STM32_SYSCFG_BASE + STM32_SYSCFG_EXTICR4_OFFSET)
 
-#define STM32_SYSCFG_CCSR             (STM32_SYSCFG_BASE + STM32_SYSCFG_CCSR_OFFSET)
+#define STM32_SYSCFG_CCCSR            (STM32_SYSCFG_BASE + STM32_SYSCFG_CCCSR_OFFSET)
 #define STM32_SYSCFG_CCVR             (STM32_SYSCFG_BASE + STM32_SYSCFG_CCVR_OFFSET)
 #define STM32_SYSCFG_CCCR             (STM32_SYSCFG_BASE + STM32_SYSCFG_CCCR_OFFSET)
 #define STM32_SYSCFG_PWRCR            (STM32_SYSCFG_BASE + STM32_SYSCFG_PWRCR_OFFSET)
@@ -164,9 +165,10 @@
 
 /* Compensation cell control/status register */
 
-/* REVISIT:  Missing bitfield definitions */
-
-#define SYSCFG_CCSR_
+#define SYSCFG_CCCSR_EN               (1 << 0)  /* Bit 0: Compensation Cell enable */
+#define SYSCFG_CCCSR_CS               (1 << 1)  /* Bit 1: Compensation Cell code selection */
+#define SYSCFG_CCCSR_READY            (1 << 8)  /* Bit 8: Compensation Cell ready flag */
+#define SYSCFG_CCCSR_HSLV             (1 << 16) /* Bit 16: High-speed at low-voltage */
 
 /* Compensation cell value register */
 

--- a/arch/arm/src/stm32h7/stm32_gpio.c
+++ b/arch/arm/src/stm32h7/stm32_gpio.c
@@ -449,4 +449,42 @@ bool stm32_gpioread(uint32_t pinset)
   return 0;
 }
 
+/****************************************************************************
+ * Name: stm32_iocompensation
+ *
+ * Description:
+ *   Enable I/O compensation.
+ *
+ *   By default the I/O compensation cell is not used. However when the I/O
+ *   output buffer speed is configured in 50 MHz or 100 MHz mode, it is
+ *   recommended to use the compensation cell for slew rate control on I/O
+ *   tf(IO)out)/tr(IO)out commutation to reduce the I/O noise on power
+ *   supply.
+ *
+ *   The I/O compensation cell can be used only when the supply voltage
+ *   ranges from 2.4 to 3.6 V.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void stm32_iocompensation(void)
+{
+  /* Enable I/O Compensation.  Writing '1' to the CMPCR power-down bit
+   * enables the I/O compensation cell.
+   */
+
+  putreg32(SYSCFG_CCCSR_EN, STM32_SYSCFG_CCCSR);
+
+  /* Wait for compensation cell to become ready */
+
+  while ((getreg32(STM32_SYSCFG_CCCSR) & SYSCFG_CCCSR_READY) == 0)
+    {
+    }
+}
+
 #endif /* CONFIG_STM32H7_STM32H7X3XX || CONFIG_STM32H7_STM32H7X7XX */

--- a/arch/arm/src/stm32h7/stm32_gpio.c
+++ b/arch/arm/src/stm32h7/stm32_gpio.c
@@ -472,6 +472,7 @@ bool stm32_gpioread(uint32_t pinset)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_STM32H7_SYSCFG_IOCOMPENSATION
 void stm32_iocompensation(void)
 {
   /* Enable I/O Compensation.  Writing '1' to the CMPCR power-down bit
@@ -486,5 +487,6 @@ void stm32_iocompensation(void)
     {
     }
 }
+#endif
 
 #endif /* CONFIG_STM32H7_STM32H7X3XX || CONFIG_STM32H7_STM32H7X7XX */

--- a/arch/arm/src/stm32h7/stm32_gpio.h
+++ b/arch/arm/src/stm32h7/stm32_gpio.h
@@ -326,6 +326,31 @@ void stm32_gpiowrite(uint32_t pinset, bool value);
 bool stm32_gpioread(uint32_t pinset);
 
 /****************************************************************************
+ * Name: stm32_iocompensation
+ *
+ * Description:
+ *   Enable I/O compensation.
+ *
+ *   By default the I/O compensation cell is not used. However when the I/O
+ *   output buffer speed is configured in 50 MHz or 100 MHz mode, it is
+ *   recommended to use the compensation cell for slew rate control on I/O
+ *   tf(IO)out)/tr(IO)out commutation to reduce the I/O noise on power
+ *   supply.
+ *
+ *   The I/O compensation cell can be used only when the supply voltage
+ *   ranges from 2.4 to 3.6 V.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void stm32_iocompensation(void);
+
+/****************************************************************************
  * Name: stm32_gpiosetevent
  *
  * Description:

--- a/arch/arm/src/stm32h7/stm32_gpio.h
+++ b/arch/arm/src/stm32h7/stm32_gpio.h
@@ -348,7 +348,9 @@ bool stm32_gpioread(uint32_t pinset);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_STM32H7_SYSCFG_IOCOMPENSATION
 void stm32_iocompensation(void);
+#endif
 
 /****************************************************************************
  * Name: stm32_gpiosetevent

--- a/arch/arm/src/stm32h7/stm32_rcc.c
+++ b/arch/arm/src/stm32h7/stm32_rcc.c
@@ -35,6 +35,7 @@
 #include "arm_arch.h"
 
 #include "hardware/stm32_flash.h"
+#include "stm32_gpio.h"
 #include "stm32_rcc.h"
 #include "stm32_pwr.h"
 
@@ -120,6 +121,12 @@ void stm32_clockconfig(void)
   /* Enable peripheral clocking */
 
   rcc_enableperipherals();
+
+#ifdef CONFIG_STM32H7_SYSCFG_IOCOMPENSATION
+  /* Enable I/O Compensation */
+
+  stm32_iocompensation();
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
stm32h7: Add support for IO compensation.

### Note: This is dependent on #3520. Merge that first.

## Impact
None. Users now have access to enabling the IO compensation cell.

## Testing
Built and ran custom configuration.

