### PR TITLE
stm32h7: Allow OTGHS to use internal FS PHY

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -777,6 +777,29 @@ config STM32H7_SYSCFG_IOCOMPENSATION
 		The I/O compensation cell can be used only when the supply voltage ranges
 		from 2.4 to 3.6 V
 
+menu "OTG_HS Configuration"
+	depends on STM32H7_OTGHS
+
+choice
+	prompt "ULPI Selection"
+	default STM32H7_OTGHS_NO_ULPI
+
+config STM32H7_OTGHS_NO_ULPI
+	bool "No External ULPI on board."
+	---help---
+	Select to indicate that there is no external ULPI PHY. This means the OTG_HS
+	peripheral must use the internal full-speed PHY and will be limited to
+	full-speed mode.
+
+config STM32H7_OTGHS_EXTERNAL_ULPI
+	bool "External ULPI"
+	---help---
+		Select to indicate the presence of an external ULPI PHY and use it.
+
+endchoice #"ULPI Selection"
+
+endmenu # OTG_HS Config
+
 menu "I2C Configuration"
 	depends on STM32H7_I2C
 

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -5248,7 +5248,7 @@ static void stm32_hwinitialize(FAR struct stm32_usbdev_s *priv)
 
   stm32_putreg(OTG_GAHBCFG_TXFELVL, STM32_OTG_GAHBCFG);
 
-#if defined(CONFIG_STM32H7_OTGFS)
+#if defined(CONFIG_STM32H7_OTGFS) || defined (CONFIG_STM32H7_OTGHS_NO_ULPI)
   /* Full speed serial transceiver select */
 
   regval  = stm32_getreg(STM32_OTG_GUSBCFG);
@@ -5469,7 +5469,7 @@ static void stm32_hwinitialize(FAR struct stm32_usbdev_s *priv)
   regval &=  OTG_GINT_RESERVED;
   stm32_putreg(regval | OTG_GINT_RC_W1, STM32_OTG_GINTSTS);
 
-#if defined(CONFIG_STM32H7_OTGHS) && !defined(BOARD_ENABLE_USBOTG_HSULPI)
+#if defined(CONFIG_STM32H7_OTGHS) && defined(CONFIG_STM32H7_OTGHS_NO_ULPI)
   /* Disable the ULPI Clock enable in RCC AHB1 Register.  This must
    * be done because if both the ULPI and the FS PHY clock enable bits
    * are set at the same time, the ARM never awakens from WFI due to

--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -207,7 +207,7 @@ static inline void rcc_enableahb1(void)
 #endif
 
 #ifdef CONFIG_STM32H7_OTGHS
-#ifdef BOARD_ENABLE_USBOTG_HSULPI
+#  if defined(CONFIG_STM32H7_OTGHS_EXTERNAL_ULPI)
   /* Enable clocking for USB OTG HS and external PHY */
 
   regval |= (RCC_AHB1ENR_OTGHSEN | RCC_AHB1ENR_OTGHSULPIEN);

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -207,7 +207,7 @@ static inline void rcc_enableahb1(void)
 #endif
 
 #ifdef CONFIG_STM32H7_OTGHS
-#ifdef BOARD_ENABLE_USBOTG_HSULPI
+#  if defined(CONFIG_STM32H7_OTGHS_EXTERNAL_ULPI)
   /* Enable clocking for USB OTG HS and external PHY */
 
   regval |= (RCC_AHB1ENR_OTGHSEN | RCC_AHB1ENR_OTGHSULPIEN);


### PR DESCRIPTION
## Summary
Prior to this change, the OTGHS peripheral's PHYSEL bit was always left in it's default state of 0 (External ULPI). This change adds a Kconfig option to switch between having an External ULPI, or using the built-in Full-Speed PHY. 

## Impact
Users who were using the OTGHS with an external ULPI, probably no one, will have to select the STM32H7_OTGHS_EXTERNAL_ULPI option.

## Testing
Ran OTGHS CDCACM console using the OTGHS peripheral with the built-in FS PHY.

