### PR TITLE
riscv/esp32c3: Fix heap end address

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_allocateheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_allocateheap.c
@@ -34,6 +34,8 @@
 
 #include "esp32c3.h"
 
+#include "hardware/esp32c3_rom_layout.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -64,12 +66,13 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
    */
 
   extern uint8_t *_sheap;
-  extern uint8_t *_eheap;
+  extern const struct esp32c3_rom_layout_s *ets_rom_layout_p;
 
   board_autoled_on(LED_HEAPALLOCATE);
 
   *heap_start = (FAR void *)&_sheap;
-  *heap_size = (size_t)((uintptr_t)&_eheap - (uintptr_t)&_sheap);
+  *heap_size = (size_t)(ets_rom_layout_p->dram0_rtos_reserved_start -
+                        (uintptr_t)&_sheap);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_rom_layout.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_rom_layout.h
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/hardware/esp32c3_rom_layout.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_ROM_LAYOUT_H
+#define __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_ROM_LAYOUT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Structure and functions for returning ROM global layout
+ *
+ * This is for address symbols defined in the linker script,
+ * which may change during ECOs.
+ */
+
+struct esp32c3_rom_layout_s
+{
+  uintptr_t dram0_stack_shared_mem_start;
+  uintptr_t dram0_rtos_reserved_start;
+  uintptr_t stack_sentry;
+  uintptr_t stack;
+  uintptr_t stack_sentry_app;
+  uintptr_t stack_app;
+
+  /* BTDM data */
+
+  uintptr_t data_start_btdm;
+  uintptr_t data_end_btdm;
+  uintptr_t bss_start_btdm;
+  uintptr_t bss_end_btdm;
+  uintptr_t data_start_btdm_rom;
+  uintptr_t data_end_btdm_rom;
+  uintptr_t data_start_interface_btdm;
+  uintptr_t data_end_interface_btdm;
+  uintptr_t bss_start_interface_btdm;
+  uintptr_t bss_end_interface_btdm;
+
+  /* PHY data */
+
+  uintptr_t dram_start_phyrom;
+  uintptr_t dram_end_phyrom;
+
+  /* Wi-Fi data */
+
+  uintptr_t dram_start_coexist;
+  uintptr_t dram_end_coexist;
+  uintptr_t dram_start_net80211;
+  uintptr_t dram_end_net80211;
+  uintptr_t dram_start_pp;
+  uintptr_t dram_end_pp;
+  uintptr_t data_start_interface_coexist;
+  uintptr_t data_end_interface_coexist;
+  uintptr_t bss_start_interface_coexist;
+  uintptr_t bss_end_interface_coexist;
+  uintptr_t data_start_interface_net80211;
+  uintptr_t data_end_interface_net80211;
+  uintptr_t bss_start_interface_net80211;
+  uintptr_t bss_end_interface_net80211;
+  uintptr_t data_start_interface_pp;
+  uintptr_t data_end_interface_pp;
+  uintptr_t bss_start_interface_pp;
+  uintptr_t bss_end_interface_pp;
+  uintptr_t dram_start_usbdev_rom;
+  uintptr_t dram_end_usbdev_rom;
+  uintptr_t dram_start_uart_rom;
+  uintptr_t dram_end_uart_rom;
+};
+
+#endif /* __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_ROM_LAYOUT_H */
+

--- a/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.template.ld
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.template.ld
@@ -82,10 +82,6 @@ MEMORY
 
 }
 
-/* Heap ends at the start of the static data of the ROM bootloader */
-
-_eheap = 0x3fccae00;
-
 #if CONFIG_ESP32C3_DEVKIT_RUN_IRAM
   REGION_ALIAS("default_rodata_seg", dram0_0_seg);
   REGION_ALIAS("default_code_seg", iram0_0_seg);


### PR DESCRIPTION
## Summary

Fix heap end address.

ESP32C3 has its private ROM layout map: https://github.com/espressif/esp-idf/blob/master/components/esp_rom/include/esp32c3/rom/rom_layout.h.

## Impact

## Testing

