### PR TITLE
Fix stm32f7 protected build

### DIFF
--- a/arch/arm/src/stm32/stm32_allocateheap.c
+++ b/arch/arm/src/stm32/stm32_allocateheap.c
@@ -677,7 +677,6 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
    */
 
   log2  = (int)mpu_log2regionfloor(usize);
-  DEBUGASSERT((SRAM1_END & ((1 << log2) - 1)) == 0);
 
   usize = (1 << log2);
   ubase = SRAM1_END - usize;
@@ -740,7 +739,6 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    */
 
   log2  = (int)mpu_log2regionfloor(usize);
-  DEBUGASSERT((SRAM1_END & ((1 << log2) - 1)) == 0);
 
   usize = (1 << log2);
   ubase = SRAM1_END - usize;

--- a/arch/arm/src/stm32f7/stm32_allocateheap.c
+++ b/arch/arm/src/stm32f7/stm32_allocateheap.c
@@ -273,20 +273,29 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
   uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
                     CONFIG_MM_KERNEL_HEAPSIZE;
   size_t    usize = SRAM1_END - ubase;
+  size_t    subreg_mask;
   int       log2;
-
-  DEBUGASSERT(ubase < (uintptr_t)SRAM1_END);
 
   /* Adjust that size to account for MPU alignment requirements.
    * NOTE that there is an implicit assumption that the SRAM1_END
    * is aligned to the MPU requirement.
    */
 
-  log2  = (int)mpu_log2regionfloor(usize);
-  DEBUGASSERT((SRAM1_END & ((1 << log2) - 1)) == 0);
+  /* align the ubase initially to a suitable mpu subregion start */
 
-  usize = (1 << log2);
-  ubase = SRAM1_END - usize;
+  log2  = (int)mpu_log2regionceil(usize);
+  subreg_mask = (1 << log2) / 8 - 1;
+  if (ubase & subreg_mask)
+    {
+      ubase = (ubase | subreg_mask) + 1;
+    }
+
+  DEBUGASSERT(ubase < (uintptr_t)SRAM1_END);
+
+  /* reset the size to fit in SRAM and align down to subregion size */
+
+  usize = SRAM1_END - ubase;
+  usize &= ~subreg_mask;
 
   /* Return the user-space heap settings */
 
@@ -328,35 +337,19 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
 void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
 {
-  /* Get the unaligned size and position of the user-space heap.
-   * This heap begins after the user-space .bss section at an offset
-   * of CONFIG_MM_KERNEL_HEAPSIZE (subject to alignment).
+  /* User heap was just initialized, with proper MPU alignment, in nx_start,
+   * store the user heap start address
    */
 
-  uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
-                    CONFIG_MM_KERNEL_HEAPSIZE;
-  size_t    usize = SRAM1_END - ubase;
-  int       log2;
-
+  uintptr_t ubase = (uintptr_t)*heap_start;
   DEBUGASSERT(ubase < (uintptr_t)SRAM1_END);
-
-  /* Adjust that size to account for MPU alignment requirements.
-   * NOTE that there is an implicit assumption that the SRAM1_END
-   * is aligned to the MPU requirement.
-   */
-
-  log2  = (int)mpu_log2regionfloor(usize);
-  DEBUGASSERT((SRAM1_END & ((1 << log2) - 1)) == 0);
-
-  usize = (1 << log2);
-  ubase = SRAM1_END - usize;
 
   /* Return the kernel heap settings (i.e., the part of the heap region
    * that was not dedicated to the user heap).
    */
 
   *heap_start = (FAR void *)USERSPACE->us_bssend;
-  *heap_size  = ubase - (uintptr_t)USERSPACE->us_bssend;
+  *heap_size  = ubase - USERSPACE->us_bssend;
 }
 #endif
 

--- a/arch/arm/src/stm32f7/stm32_mpuinit.c
+++ b/arch/arm/src/stm32f7/stm32_mpuinit.c
@@ -70,12 +70,25 @@ void stm32_mpuinitialize(void)
 
   mpu_showtype();
 
-  /* Configure user flash and SRAM space */
+  /* Configure user flash space */
 
   mpu_user_flash(USERSPACE->us_textstart,
                  USERSPACE->us_textend - USERSPACE->us_textstart);
 
-  mpu_user_intsram(datastart, dataend - datastart);
+  /* Configure user SRAM space
+   * Ordered
+   * Cacheable
+   * Not Bufferable
+   * Not Shareable
+   * P:RW   U:RW
+   * Instruction access
+   */
+
+  mpu_configure_region(datastart, dataend - datastart,
+                       MPU_RASR_TEX_SO   |
+                       MPU_RASR_C        |
+                       MPU_RASR_AP_RWRW
+                       );
 
   /* Then enable the MPU */
 
@@ -94,7 +107,20 @@ void stm32_mpuinitialize(void)
 
 void stm32_mpu_uheap(uintptr_t start, size_t size)
 {
-  mpu_user_intsram(start, size);
+  /* Configure the user SRAM space
+   * Ordered
+   * Cacheable
+   * Not Bufferable
+   * Not Shareable
+   * P:RW   U:RW
+   * Instruction access
+   */
+
+  mpu_configure_region(start, size,
+                       MPU_RASR_TEX_SO   |
+                       MPU_RASR_C        |
+                       MPU_RASR_AP_RWRW
+                       );
 }
 
 #endif /* CONFIG_BUILD_PROTECTED && CONFIG_ARM_MPU */


### PR DESCRIPTION
## Summary

The protected build on stm32f7 didn't work for me mainly for two reasons:
- For some reason (which I didn't fully understand), setting the MPU_RASR_S makes SRAM not writable. Not setting this bit solves the problem; My thinking here is that since this is a single core chip anyhow, it is fine to leave the bit out.

- The allocateheap logic makes assumption that the SRAM1_END is aligned to MPU - friendly address. This is not the case, especially if one needs to use larger user-side memory chunks. The solution for this is to use MPU subregions to map the memory with higher granularity. This code has been tested with the following memory setup (but only with this, and only with stm32f7):

  kflash (rx) : ORIGIN = 0x08008000, LENGTH = 512K-32K
  uflash (rx) : ORIGIN = 0x08080000, LENGTH = 1536K

  ksram (rwx) : ORIGIN = 0x20020000, LENGTH = 128K
  usram (rwx) : ORIGIN = 0x20040000, LENGTH = 368K-128K
