### PR TITLE
NuttX: Falker Atomacao Agrícola Ltda: update licenses to Apache

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,94 @@
+This is a list of all the contributors tha have submitted ICLA, SGA
+If you are not on this list and believe you should be, please inform us.
+
+ICLA
+====
+Abdelatif Guettouche
+Adam Porter
+Alan Carvalho de Assis
+Alin Jerpelea
+Anthony Merlino
+Beat Kung
+Chao An
+David S. Alessio
+David Sidrane
+Dong Heng
+Goden Freemans
+Guiding Li
+Gwenhael Goavec
+Haitao Liu
+Henry Adam Feuer (Adam Feuer)
+Herman A Glenn (Hal Glenn)
+Ivan Petrov Ucherdzhiev (Ivan Ucherdzhiev)
+Jacob A Dahl (Jacob Dahl)
+Jaehyuk Cho
+Janne Rosberg
+Johannes Schock
+Jose Pablo Carballo
+Jukka Laitinen
+Junmin Kim
+Ken Pettit
+Laurent Latil
+Manuel Stuhn
+Marc Rechte
+Marc Rosen
+Marco Krahl
+Mark Schulte
+Martin Lederhilger
+Masatoshi Ueno
+Masayuki Ishikawa
+Mateusz Tomasz Szafoni (Mateusz Szafoni)
+Matias Nitsche
+Matous Pokorny
+Matthew Trescott
+Mattias Edlund
+Michael Jung
+Michal Lyszczek
+Miguel Ángel Herranz Trillo (Miguel Herranz)
+Mihai Serban
+Neil Hancock
+Nicholas Elliot Chin (Nicholas Chin)
+Oki Minabe
+Paul Alexander Patience (Paul A. Patience)
+Petro Karashchenko
+Pierre-Noel Bouteville
+Pierre-Olivier Vauboin (PO Vauboin)
+Richard Cochran
+Robert A. Feretich (Bob Feretich)
+Sakari Matias Kapanen (Sakari Kapanen)
+Sara da Cunha Monteiro de Souza (Sara Monteiro)
+Sebastian Ene
+Sebastien Lorquet
+Sergey Nikitenko
+Takashi Yamamoto (Yamamoto Takashi)
+Thomas Axelsson
+Uros Platise
+Vasilijev Alexand Anatoljevich (Alexander Vasiliev)
+Wolfgang Gerd Reißnegger (Wolfgang Reißnegger)
+Xiang Xiao
+Yuuichi Nakamura
+
+CCLA
+====
+Starcat LLC (Adam Feuer)
+
+SGA
+===
+2G Engineering
+Actia Nordic AB
+Beijing Xiaomi Mobile Software Co., Ltd
+Bouffalo Lab (Nanjing) Co., Ltd.
+Datavision S.R.O.
+DS Automotion GmbH
+Espressif Systems (Shanghai) Co. Ltd.
+Falker Atomação Agrícola Ltda
+Gregory Ellis Nutt
+Max Holtzberg
+RAF Research LLC
+Software Grant from Uniquix Technologia Ltda
+Sony
+Zhu Yan Lin
+
+NOTE:
+To avoid spam the email addresses can be retrieved from git history
+

--- a/arch/arm/src/samd5e5/hardware/sam_tc.h
+++ b/arch/arm/src/samd5e5/hardware/sam_tc.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/hardware/sam_tc.h
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/hardware/sam_wdt.h
+++ b/arch/arm/src/samd5e5/hardware/sam_wdt.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/hardware/sam_wdt.h
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_freerun.c
+++ b/arch/arm/src/samd5e5/sam_freerun.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_freerun.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_freerun.h
+++ b/arch/arm/src/samd5e5/sam_freerun.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_freerun.h
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_i2c_master.h
+++ b/arch/arm/src/samd5e5/sam_i2c_master.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_i2c_master.h
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_oneshot.c
+++ b/arch/arm/src/samd5e5/sam_oneshot.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_oneshot.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_oneshot.h
+++ b/arch/arm/src/samd5e5/sam_oneshot.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_oneshot.h
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_oneshot_lowerhalf.c
+++ b/arch/arm/src/samd5e5/sam_oneshot_lowerhalf.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_oneshot_lowerhalf.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_tc.c
+++ b/arch/arm/src/samd5e5/sam_tc.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_tc.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_tc.h
+++ b/arch/arm/src/samd5e5/sam_tc.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_tc.h
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_tickless.c
+++ b/arch/arm/src/samd5e5/sam_tickless.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_tickless.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_usbhost.c
+++ b/arch/arm/src/samd5e5/sam_usbhost.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_usbhost.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_usbhost.h
+++ b/arch/arm/src/samd5e5/sam_usbhost.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_usbhost.h
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_wdt.c
+++ b/arch/arm/src/samd5e5/sam_wdt.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_wdt.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/arm/src/samd5e5/sam_wdt.h
+++ b/arch/arm/src/samd5e5/sam_wdt.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/arm/src/samd5e5/sam_wdt.h
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/boards/arm/samd5e5/metro-m4/src/sam_automount.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_automount.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * boards/arm/samd5e5/metro-m4/src/sam_automount.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/boards/arm/samd5e5/metro-m4/src/sam_composite.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_composite.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * boards/arm/samd5e5/metro-m4/src/sam_composite.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/boards/arm/samd5e5/metro-m4/src/sam_gpio.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_gpio.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * boards/arm/samd5e5/metro-m4/src/sam_gpio.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/boards/arm/samd5e5/metro-m4/src/sam_i2c.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_i2c.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * boards/arm/samd5e5/metro-m4/src/sam_i2c.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/boards/arm/samd5e5/metro-m4/src/sam_usbdev.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_usbdev.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * boards/arm/samd5e5/metro-m4/src/sam_usbdev.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/boards/arm/samd5e5/metro-m4/src/sam_usbhost.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_usbhost.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * boards/arm/samd5e5/metro-m4/src/sam_usbhost.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/boards/arm/samd5e5/metro-m4/src/sam_usbmsc.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_usbmsc.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * boards/arm/samd5e5/metro-m4/src/sam_usbmsc.c
  *
- *   Copyright 2020 Falker Automacao Agricola LTDA.
- *   Author: Leomar Mateus Radke <leomar@falker.com.br>
- *   Author: Ricardo Wartchow <wartchow@gmail.com>
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
Falker Atomacao Agrícola Ltda has submitted the SGA and we can migrate the licenses
 to Apache.

## Impact
NONE

## Testing
NONE
