### PR TITLE
drivers: wireless: Fix to receive a UDP packet partially in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -650,7 +650,7 @@ static bool _copy_data_from_pkt(FAR struct gs2200m_dev_s *dev,
 
   pkt_dat->remain -= len;
 
-  if (0 == pkt_dat->remain)
+  if (0 == pkt_dat->remain || TYPE_BULK_DATA_UDP == pkt_dat->type)
     {
       _remove_and_free_pkt(dev, c);
     }


### PR DESCRIPTION
## Summary

- When receiving a UDP packet partially, the rest of the packet
  must be discarded.

## Impact

- None

## Testing

- Tested with a UDP sample program

