### PR TITLE
modlib: Implement sh_addralign handling

### DIFF
--- a/arch/xtensa/src/esp32/esp32_modtext.c
+++ b/arch/xtensa/src/esp32/esp32_modtext.c
@@ -70,16 +70,16 @@ void up_module_text_init()
 }
 
 /****************************************************************************
- * Name: up_module_text_alloc
+ * Name: up_module_text_memalign
  *
  * Description:
- *   Allocate memory for module text.
+ *   Allocate memory for module text with the specified alignment.
  *
  ****************************************************************************/
 
-FAR void *up_module_text_alloc(size_t size)
+FAR void *up_module_text_memalign(size_t align, size_t size)
 {
-  return mm_malloc(&g_module_text, size);
+  return mm_memalign(&g_module_text, align, size);
 }
 
 /****************************************************************************

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -730,15 +730,15 @@ void up_module_text_init(void);
 #endif
 
 /****************************************************************************
- * Name: up_module_text_alloc
+ * Name: up_module_text_memalign
  *
  * Description:
- *   Allocate memory for module text.
+ *   Allocate memory for module text with the specified alignment.
  *
  ****************************************************************************/
 
 #if defined(CONFIG_ARCH_USE_MODULE_TEXT)
-FAR void *up_module_text_alloc(size_t size);
+FAR void *up_module_text_memalign(size_t align, size_t size);
 #endif
 
 /****************************************************************************

--- a/include/nuttx/lib/modlib.h
+++ b/include/nuttx/lib/modlib.h
@@ -198,6 +198,8 @@ struct mod_loadinfo_s
   uintptr_t         datastart;   /* Start of.bss/.data memory in .text allocation */
   size_t            textsize;    /* Size of the module .text memory allocation */
   size_t            datasize;    /* Size of the module .bss/.data memory allocation */
+  size_t            textalign;   /* Necessary alignment of .text */
+  size_t            dataalign;   /* Necessary alignment of .bss/.text */
   off_t             filelen;     /* Length of the entire module file */
   Elf_Ehdr          ehdr;        /* Buffered module file header */
   FAR Elf_Shdr     *shdr;        /* Buffered module section headers */

--- a/sched/module/mod_insmod.c
+++ b/sched/module/mod_insmod.c
@@ -64,6 +64,8 @@ static void mod_dumploadinfo(FAR struct mod_loadinfo_s *loadinfo)
   binfo("  datastart:    %08lx\n", (long)loadinfo->datastart);
   binfo("  textsize:     %ld\n",   (long)loadinfo->textsize);
   binfo("  datasize:     %ld\n",   (long)loadinfo->datasize);
+  binfo("  textalign:    %zu\n",   loadinfo->textalign);
+  binfo("  dataalign:    %zu\n",   loadinfo->dataalign);
   binfo("  filelen:      %ld\n",   (long)loadinfo->filelen);
   binfo("  filfd:        %d\n",    loadinfo->filfd);
   binfo("  symtabidx:    %d\n",    loadinfo->symtabidx);


### PR DESCRIPTION
## Summary
I've seen a module with 16 bytes .rodata alignment for xmm operations.
It was getting SEGV on sim/Linux because of the alignment issue.

## Impact
CONFIG_MODULE

## Testing
The same module binary seems working fine after applying this patch.

Also, tested on sim/macOS and esp32 on qemu,
using a module with an artificially large alignment. (64 bytes)

