### PR TITLE
modlib: Always use separate allocation for text and data

### DIFF
--- a/include/nuttx/lib/modlib.h
+++ b/include/nuttx/lib/modlib.h
@@ -159,12 +159,8 @@ struct module_s
   mod_initializer_t initializer;       /* Module initializer function */
 #endif
   struct mod_info_s modinfo;           /* Module information */
-#if defined(CONFIG_ARCH_USE_MODULE_TEXT)
   FAR void *textalloc;                 /* Allocated kernel text memory */
   FAR void *dataalloc;                 /* Allocated kernel memory */
-#else
-  FAR void *alloc;                     /* Allocated kernel memory */
-#endif
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
   size_t textsize;                     /* Size of the kernel .text memory allocation */
   size_t datasize;                     /* Size of the kernel .bss/.data memory allocation */

--- a/libs/libc/dlfcn/lib_dlclose.c
+++ b/libs/libc/dlfcn/lib_dlclose.c
@@ -112,17 +112,30 @@ static inline int dlremove(FAR void *handle)
 
   /* Release resources held by the module */
 
-  if (modp->alloc != NULL)
+  if (modp->textalloc != NULL)
     {
       /* Free the module memory */
 
-      lib_free((FAR void *)modp->alloc);
+      lib_free((FAR void *)modp->textalloc);
 
       /* Nullify so that the memory cannot be freed again */
 
-      modp->alloc = NULL;
+      modp->textalloc = NULL;
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
       modp->textsize  = 0;
+#endif
+    }
+
+  if (modp->dataalloc != NULL)
+    {
+      /* Free the module memory */
+
+      lib_free((FAR void *)modp->dataalloc);
+
+      /* Nullify so that the memory cannot be freed again */
+
+      modp->dataalloc = NULL;
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
       modp->datasize  = 0;
 #endif
     }

--- a/libs/libc/dlfcn/lib_dlopen.c
+++ b/libs/libc/dlfcn/lib_dlopen.c
@@ -208,7 +208,8 @@ static inline FAR void *dlinsert(FAR const char *filename)
 
   /* Save the load information */
 
-  modp->alloc       = (FAR void *)loadinfo.textalloc;
+  modp->textalloc       = (FAR void *)loadinfo.textalloc;
+  modp->dataalloc       = (FAR void *)loadinfo.datastart;
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
   modp->textsize    = loadinfo.textsize;
   modp->datasize    = loadinfo.datasize;

--- a/libs/libc/modlib/modlib_unload.c
+++ b/libs/libc/modlib/modlib_unload.c
@@ -58,22 +58,19 @@ int modlib_unload(struct mod_loadinfo_s *loadinfo)
 
   /* Release memory holding the relocated ELF image */
 
-#if defined(CONFIG_ARCH_USE_MODULE_TEXT)
   if (loadinfo->textalloc != 0)
     {
+#if defined(CONFIG_ARCH_USE_MODULE_TEXT)
       up_module_text_free((FAR void *)loadinfo->textalloc);
+#else
+      lib_free((FAR void *)loadinfo->textalloc);
+#endif
     }
 
   if (loadinfo->datastart != 0)
     {
       lib_free((FAR void *)loadinfo->datastart);
     }
-#else
-  if (loadinfo->textalloc != 0)
-    {
-      lib_free((FAR void *)loadinfo->textalloc);
-    }
-#endif
 
   /* Clear out all indications of the allocated address environment */
 

--- a/sched/module/mod_insmod.c
+++ b/sched/module/mod_insmod.c
@@ -224,12 +224,8 @@ FAR void *insmod(FAR const char *filename, FAR const char *modname)
 
   /* Save the load information */
 
-#if defined(CONFIG_ARCH_USE_MODULE_TEXT)
   modp->textalloc   = (FAR void *)loadinfo.textalloc;
   modp->dataalloc   = (FAR void *)loadinfo.datastart;
-#else
-  modp->alloc       = (FAR void *)loadinfo.textalloc;
-#endif
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
   modp->textsize    = loadinfo.textsize;
   modp->datasize    = loadinfo.datasize;

--- a/sched/module/mod_procfs.c
+++ b/sched/module/mod_procfs.c
@@ -138,17 +138,9 @@ static int modprocfs_callback(FAR struct module_s *modp, FAR void *arg)
                       modp->modname, modp->initializer,
                       modp->modinfo.uninitializer, modp->modinfo.arg,
                       modp->modinfo.nexports,
-#if defined(CONFIG_ARCH_USE_MODULE_TEXT)
                       modp->textalloc,
-#else
-                      modp->alloc,
-#endif
                       (unsigned long)modp->textsize,
-#if defined(CONFIG_ARCH_USE_MODULE_TEXT)
                       (FAR uint8_t *)modp->dataalloc,
-#else
-                      (FAR uint8_t *)modp->alloc + modp->textsize,
-#endif
                       (unsigned long)modp->datasize);
   copysize = procfs_memcpy(priv->line, linesize, priv->buffer,
                            priv->remaining, &priv->offset);

--- a/sched/module/mod_rmmod.c
+++ b/sched/module/mod_rmmod.c
@@ -113,11 +113,7 @@ int rmmod(FAR void *handle)
 
   /* Release resources held by the module */
 
-#if defined(CONFIG_ARCH_USE_MODULE_TEXT)
   if (modp->textalloc != NULL || modp->dataalloc != NULL)
-#else
-  if (modp->alloc != NULL)
-#endif
     {
       /* Free the module memory
        * and nullify so that the memory cannot be freed again
@@ -125,13 +121,12 @@ int rmmod(FAR void *handle)
 
 #if defined(CONFIG_ARCH_USE_MODULE_TEXT)
       up_module_text_free((FAR void *)modp->textalloc);
+#else
+      kmm_free((FAR void *)modp->textalloc);
+#endif
       kmm_free((FAR void *)modp->dataalloc);
       modp->textalloc = NULL;
       modp->dataalloc = NULL;
-#else
-      kmm_free((FAR void *)modp->alloc);
-      modp->alloc = NULL;
-#endif
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MODULE)
       modp->textsize  = 0;
       modp->datasize  = 0;


### PR DESCRIPTION
## Summary

modlib: Always use separate allocation for text and data

Pros:

* Reduce code differences
* Smaller allocations for !CONFIG_ARCH_USE_MODULE_TEXT

Cons:

* Likely to use more memory for !CONFIG_ARCH_USE_MODULE_TEXT in total

## Impact

## Testing

Tested with:

* sim:module on macOS
* esp32-devkit:nsh + CONFIG_MODULE on qemu
* lm3s6965-ek:qemu-protected + CONFIG_EXAMPLES_SOTEST on qemu