### PR TITLE
1wire: Removes duplicate device information

### DIFF
--- a/drivers/sensors/ds18b20.c
+++ b/drivers/sensors/ds18b20.c
@@ -286,7 +286,7 @@ static int ds18b20_isalarm(FAR struct onewire_master_s *master,
   alarm.romcode = config->romcode;
   alarm.isalarm = false;
 
-  ret = onewire_search(master, config->family, true, ds18b20_alarm_cb,
+  ret = onewire_search(master, DS18B20_DEVICE_FAMILY, true, ds18b20_alarm_cb,
                        &alarm);
   if (ret > 0)
     {
@@ -935,7 +935,6 @@ int ds18b20_register(int devno, FAR struct onewire_master_s *onewire,
 
   priv->master           = onewire;
   priv->config.romcode   = romcode;
-  priv->config.family    = DS18B20_DEVICE_FAMILY;
   priv->reg.res          = DS18B20_RES_CONV(DS18B20_RESMAX);
   priv->reg.alarm.thigh  = DS18B20_TALARM_MAX;
   priv->reg.alarm.tlow   = DS18B20_TALARM_MIN;

--- a/include/nuttx/1wire/1wire_master.h
+++ b/include/nuttx/1wire/1wire_master.h
@@ -39,7 +39,6 @@ struct onewire_master_s;
 
 struct onewire_config_s
 {
-  uint8_t  family;                  /* Device family identifier */
   uint64_t romcode;                 /* Unique device identifier */
 };
 


### PR DESCRIPTION
## Summary
Removes the family identifier from the device configuration, since the device
family is already part of the rom code and the underlying logic does know how
to extract this information.

## Impact
include/nuttx/1wire drivers/sensors

## Testing
stm32f103-minimum

Signed-off-by: Marco Krahl <ocram.lhark@gmail.com>