### PR TITLE
Revert "arch: Allocate the space from the beginning in up_stack_frame"

### DIFF
--- a/Documentation/reference/os/arch.rst
+++ b/Documentation/reference/os/arch.rst
@@ -57,8 +57,8 @@ APIs Exported by Architecture-Specific Logic to NuttX
   -  ``adj_stack_size``: Stack size after adjustment for hardware,
      processor, etc. This value is retained only for debug purposes.
   -  ``stack_alloc_ptr``: Pointer to allocated stack
-  -  ``stack_base_ptr``: Adjusted stack base pointer after the TLS Data
-     and Arguments has been removed from the stack allocation.
+  -  ``adj_stack_ptr``: Adjusted ``stack_alloc_ptr`` for HW. The
+     initial value of the stack pointer.
 
   :param tcb: The TCB of new task.
   :param stack_size: The requested stack size. At least this much
@@ -93,8 +93,8 @@ APIs Exported by Architecture-Specific Logic to NuttX
   -  ``adj_stack_size``: Stack size after adjustment for hardware,
      processor, etc. This value is retained only for debug purposes.
   -  ``stack_alloc_ptr``: Pointer to allocated stack
-  -  ``stack_base_ptr``: Adjusted stack base pointer after the TLS Data
-     and Arguments has been removed from the stack allocation.
+  -  ``adj_stack_ptr``: Adjusted ``stack_alloc_ptr`` for HW. The
+     initial value of the stack pointer.
 
   :param tcb: The TCB of new task.
   :param stack_size: The allocated stack size.
@@ -120,24 +120,9 @@ APIs Exported by Architecture-Specific Logic to NuttX
 
   -  ``adj_stack_size``: Stack size after removal of the stack frame
      from the stack.
-  -  ``stack_base_ptr``: Adjusted stack base pointer after the TLS Data
-     and Arguments has been removed from the stack allocation.
-
-  Here is the diagram after some allocation(tls, arg):
-
-                   +-------------+ <-stack_alloc_ptr(lowest)
-                   |  TLS Data   |
-                   +-------------+
-                   |  Arguments  |
-  stack_base_ptr-> +-------------+\
-                   |  Available  | +
-                   |    Stack    | |
-                |  |             | |
-                |  |             | +->adj_stack_size
-                v  |             | |
-                   |             | |
-                   |             | +
-                   +-------------+/
+  -  ``adj_stack_ptr``: Adjusted initial stack pointer after the
+     frame has been removed from the stack. This will still be the
+     initial value of the stack pointer when the task is started.
 
   :param tcb: The TCB of new task.
   :param frame_size: The size of the stack frame to allocate.

--- a/arch/arm/src/arm/arm_assert.c
+++ b/arch/arm/src/arm/arm_assert.c
@@ -171,7 +171,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -240,14 +240,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 
 #ifdef CONFIG_ARCH_USBDUMP

--- a/arch/arm/src/arm/arm_initialstate.c
+++ b/arch/arm/src/arm/arm_initialstate.c
@@ -62,7 +62,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -72,8 +72,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/arm/src/arm/vfork.S
+++ b/arch/arm/src/arm/vfork.S
@@ -57,16 +57,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/arm/src/armv6-m/arm_assert.c
+++ b/arch/arm/src/armv6-m/arm_assert.c
@@ -209,7 +209,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -266,14 +266,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp < ustackbase && sp >= ustackbase - ustacksize)
     {
       up_stackdump(sp, ustackbase);
     }
   else
     {
       _alert("ERROR: Stack pointer is not within the allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
 
 #else
@@ -288,14 +288,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 #endif
 

--- a/arch/arm/src/armv6-m/arm_initialstate.c
+++ b/arch/arm/src/armv6-m/arm_initialstate.c
@@ -64,7 +64,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -74,8 +74,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point (stripping off the thumb bit) */
 

--- a/arch/arm/src/armv6-m/vfork.S
+++ b/arch/arm/src/armv6-m/vfork.S
@@ -57,16 +57,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/arm/src/armv7-a/arm_assert.c
+++ b/arch/arm/src/armv7-a/arm_assert.c
@@ -212,7 +212,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   _alert("Current sp: %08x\n", sp);
@@ -291,10 +291,10 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase - ustacksize && sp < ustackbase)
     {
       _alert("User Stack\n", sp);
-      up_stackdump(sp, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
@@ -312,7 +312,7 @@ static void up_dumpstate(void)
   else
     {
       _alert("ERROR: Stack pointer is not within the allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
 #ifdef CONFIG_ARCH_KERNEL_STACK
       up_stackdump(kstackbase, kstackbase + CONFIG_ARCH_KERNEL_STACKSIZE);
 #endif

--- a/arch/arm/src/armv7-a/arm_cpuidlestack.c
+++ b/arch/arm/src/armv7-a/arm_cpuidlestack.c
@@ -94,8 +94,8 @@ static FAR const uint32_t *g_cpu_stackalloc[CONFIG_SMP_NCPUS] =
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is
@@ -111,6 +111,7 @@ int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
 {
 #if CONFIG_SMP_NCPUS > 1
   uintptr_t stack_alloc;
+  uintptr_t top_of_stack;
 
   DEBUGASSERT(cpu > 0 && cpu < CONFIG_SMP_NCPUS && tcb != NULL &&
               stack_size <= SMP_STACK_SIZE);
@@ -119,10 +120,11 @@ int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
 
   stack_alloc          = (uintptr_t)g_cpu_stackalloc[cpu];
   DEBUGASSERT(stack_alloc != 0 && STACK_ISALIGNED(stack_alloc));
+  top_of_stack         = stack_alloc + SMP_STACK_SIZE;
 
   tcb->adj_stack_size  = SMP_STACK_SIZE;
-  tcb->stack_alloc_ptr = (FAR void *)stack_alloc;
-  tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+  tcb->stack_alloc_ptr = (FAR uint32_t *)stack_alloc;
+  tcb->adj_stack_ptr   = (FAR uint32_t *)top_of_stack;
 #endif
 
   return OK;

--- a/arch/arm/src/armv7-a/arm_initialstate.c
+++ b/arch/arm/src/armv7-a/arm_initialstate.c
@@ -62,7 +62,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -72,8 +72,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
-                                tcb->adj_stack_size;
+  xcp->regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/arm/src/armv7-a/vfork.S
+++ b/arch/arm/src/armv7-a/vfork.S
@@ -57,16 +57,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/arm/src/armv7-m/arm_assert.c
+++ b/arch/arm/src/armv7-m/arm_assert.c
@@ -217,7 +217,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
@@ -278,14 +278,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp < ustackbase && sp >= ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
   else
     {
       _alert("ERROR: Stack pointer is not within the allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
 
 #else
@@ -303,14 +303,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within the allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within the allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 
 #endif

--- a/arch/arm/src/armv7-m/arm_initialstate.c
+++ b/arch/arm/src/armv7-m/arm_initialstate.c
@@ -65,7 +65,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -75,8 +75,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
 #ifdef CONFIG_ARMV7M_STACKCHECK
   /* Set the stack limit value */

--- a/arch/arm/src/armv7-m/gnu/vfork.S
+++ b/arch/arm/src/armv7-m/gnu/vfork.S
@@ -59,16 +59,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/arm/src/armv7-m/iar/vfork.S
+++ b/arch/arm/src/armv7-m/iar/vfork.S
@@ -60,16 +60,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/arm/src/armv7-r/arm_assert.c
+++ b/arch/arm/src/armv7-r/arm_assert.c
@@ -209,7 +209,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   _alert("Current sp: %08x\n", sp);
@@ -284,10 +284,10 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase - ustacksize && sp < ustackbase)
     {
       _alert("User Stack\n", sp);
-      up_stackdump(sp, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
@@ -305,7 +305,7 @@ static void up_dumpstate(void)
   else
     {
       _alert("ERROR: Stack pointer is not within the allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
 #ifdef CONFIG_ARCH_KERNEL_STACK
       up_stackdump(kstackbase, kstackbase + CONFIG_ARCH_KERNEL_STACKSIZE);
 #endif

--- a/arch/arm/src/armv7-r/arm_initialstate.c
+++ b/arch/arm/src/armv7-r/arm_initialstate.c
@@ -62,7 +62,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -72,8 +72,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
-                                tcb->adj_stack_size;
+  xcp->regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/arm/src/armv7-r/vfork.S
+++ b/arch/arm/src/armv7-r/vfork.S
@@ -57,16 +57,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -217,7 +217,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
@@ -278,14 +278,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp < ustackbase && sp >= ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
   else
     {
       _alert("ERROR: Stack pointer is not within the allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
 
 #else
@@ -303,14 +303,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within the allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within the allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 
 #endif

--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -65,7 +65,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -75,8 +75,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
 #ifdef CONFIG_ARMV8M_STACKCHECK
   /* Set the stack limit value */

--- a/arch/arm/src/armv8-m/vfork.S
+++ b/arch/arm/src/armv8-m/vfork.S
@@ -59,16 +59,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/tls.h>
 #include <nuttx/board.h>
 
 #include "sched/sched.h"
@@ -206,12 +207,13 @@ void arm_stack_color(FAR void *stackbase, size_t nbytes)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck(tcb->stack_base_ptr, tcb->adj_stack_size);
+  return do_stackcheck((FAR void *)((uintptr_t)tcb->adj_stack_ptr -
+      tcb->adj_stack_size), tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
 {
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
+  return (ssize_t)tcb->adj_stack_size - (ssize_t)up_check_tcbstack(tcb);
 }
 
 size_t up_check_stack(void)

--- a/arch/arm/src/common/arm_stackframe.c
+++ b/arch/arm/src/common/arm_stackframe.c
@@ -79,8 +79,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -95,8 +96,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -108,15 +107,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/arm/src/common/arm_usestack.c
+++ b/arch/arm/src/common/arm_usestack.c
@@ -53,6 +53,12 @@
 #define STACK_ALIGN_DOWN(a) ((a) & ~STACK_ALIGN_MASK)
 #define STACK_ALIGN_UP(a)   (((a) + STACK_ALIGN_MASK) & ~STACK_ALIGN_MASK)
 
+/* 32bit alignment macros */
+
+#define INT32_ALIGN_MASK    (3)
+#define INT32_ALIGN_DOWN(a) ((a) & ~INT32_ALIGN_MASK)
+#define INT32_ALIGN_UP(a)   (((a) + INT32_ALIGN_MASK) & ~INT32_ALIGN_MASK)
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -71,8 +77,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -87,11 +93,15 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
+  size_t tls_size;
+
 #ifdef CONFIG_TLS_ALIGNED
   /* Make certain that the user provided stack is properly aligned */
 
   DEBUGASSERT(((uintptr_t)stack & TLS_STACK_MASK) == 0);
 #endif
+
+  tls_size = INT32_ALIGN_UP(sizeof(struct tls_info_s));
 
   /* Is there already a stack allocated? */
 
@@ -117,9 +127,28 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
-  tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
-  tcb->adj_stack_size  =
-      STACK_ALIGN_DOWN((uintptr_t)stack + stack_size) - (uintptr_t)stack;
+
+  /* Align stack top */
+
+  tcb->adj_stack_ptr =
+      (FAR void *)STACK_ALIGN_DOWN((uintptr_t)stack + stack_size);
+
+  /* Offset by tls_size */
+
+  stack = (FAR void *)((uintptr_t)stack + tls_size);
+
+  /* Is there enough room for at least TLS ? */
+
+  if ((uintptr_t)stack > (uintptr_t)tcb->adj_stack_ptr)
+    {
+      return -ENOMEM;
+    }
+
+  tcb->adj_stack_size = (uintptr_t)tcb->adj_stack_ptr - (uintptr_t)stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, tls_size);
 
 #ifdef CONFIG_STACK_COLORATION
   /* If stack debug is enabled, then fill the stack with a
@@ -127,7 +156,8 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * water marks.
    */
 
-  arm_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+  arm_stack_color((FAR void *)((uintptr_t)tcb->adj_stack_ptr -
+                  tcb->adj_stack_size), tcb->adj_stack_size);
 #endif /* CONFIG_STACK_COLORATION */
 
   return OK;

--- a/arch/arm/src/cxd56xx/cxd56_cpuidlestack.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpuidlestack.c
@@ -67,8 +67,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is

--- a/arch/arm/src/cxd56xx/cxd56_cpustart.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpustart.c
@@ -179,8 +179,7 @@ int up_cpu_start(int cpu)
 
   /* Copy initial stack and reset vector for APP_DSP */
 
-  putreg32((uint32_t)tcb->stack_base_ptr +
-           tcb->adj_stack_size, VECTOR_ISTACK);
+  putreg32((uint32_t)tcb->adj_stack_ptr, VECTOR_ISTACK);
   putreg32((uint32_t)appdsp_boot, VECTOR_RESETV);
 
   spin_lock(&g_appdsp_boot);

--- a/arch/arm/src/lc823450/lc823450_cpuidlestack.c
+++ b/arch/arm/src/lc823450/lc823450_cpuidlestack.c
@@ -63,8 +63,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is

--- a/arch/arm/src/lc823450/lc823450_cpustart.c
+++ b/arch/arm/src/lc823450/lc823450_cpustart.c
@@ -167,8 +167,7 @@ int up_cpu_start(int cpu)
   putreg32(0x1, REMAP); /* remap enable */
   backup[0] = getreg32(CPU1_VECTOR_ISTACK);
   backup[1] = getreg32(CPU1_VECTOR_RESETV);
-  putreg32((uint32_t)tcb->stack_base_ptr +
-           tcb->adj_stack_size, CPU1_VECTOR_ISTACK);
+  putreg32((uint32_t)tcb->adj_stack_ptr, CPU1_VECTOR_ISTACK);
   putreg32((uint32_t)cpu1_boot, CPU1_VECTOR_RESETV);
 
   spin_lock(&g_cpu_wait[0]);

--- a/arch/arm/src/rp2040/rp2040_cpuidlestack.c
+++ b/arch/arm/src/rp2040/rp2040_cpuidlestack.c
@@ -67,8 +67,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is

--- a/arch/arm/src/rp2040/rp2040_cpustart.c
+++ b/arch/arm/src/rp2040/rp2040_cpustart.c
@@ -222,8 +222,7 @@ int up_cpu_start(int cpu)
   core1_boot_msg[0] = 0;
   core1_boot_msg[1] = 1;
   core1_boot_msg[2] = getreg32(ARMV6M_SYSCON_VECTAB);
-  core1_boot_msg[3] = (uint32_t)tcb->stack_base_ptr +
-                                tcb->adj_stack_size;
+  core1_boot_msg[3] = (uint32_t)tcb->adj_stack_ptr;
   core1_boot_msg[4] = (uint32_t)core1_boot;
 
   do

--- a/arch/arm/src/sam34/sam4cm_cpuidlestack.c
+++ b/arch/arm/src/sam34/sam4cm_cpuidlestack.c
@@ -97,8 +97,8 @@ void up_idle(void)
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is

--- a/arch/arm/src/sam34/sam4cm_cpustart.c
+++ b/arch/arm/src/sam34/sam4cm_cpustart.c
@@ -204,8 +204,7 @@ int up_cpu_start(int cpu)
 
   /* Copy initial vectors for CPU1 */
 
-  putreg32((uint32_t)tcb->stack_base_ptr +
-           tcb->adj_stack_size, CPU1_VECTOR_ISTACK);
+  putreg32((uint32_t)tcb->adj_stack_ptr, CPU1_VECTOR_ISTACK);
   putreg32((uint32_t)cpu1_boot, CPU1_VECTOR_RESETV);
 
   spin_lock(&g_cpu1_boot);

--- a/arch/avr/src/avr/up_checkstack.c
+++ b/arch/avr/src/avr/up_checkstack.c
@@ -146,12 +146,12 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
 {
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
+  return (ssize_t)tcb->adj_stack_size - (ssize_t)up_check_tcbstack(tcb);
 }
 
 size_t up_check_stack(void)

--- a/arch/avr/src/avr/up_createstack.c
+++ b/arch/avr/src/avr/up_createstack.c
@@ -64,8 +64,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -86,6 +86,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -125,14 +129,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -141,14 +147,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -166,6 +172,8 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
+      size_t top_of_stack;
+
       /* Yes.. If stack debug is enabled, then fill the stack with a
        * recognizable value that we can use later to test for high
        * water marks.
@@ -175,10 +183,22 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       memset(tcb->stack_alloc_ptr, STACK_COLOR, stack_size);
 #endif
 
+      /* The AVR uses a push-down stack:  the stack grows toward lower
+       * addresses in memory.  The stack pointer register, points to the
+       * lowest, valid work address (the "top" of the stack).  Items on the
+       * stack are referenced as positive word offsets from sp.
+       */
+
+      top_of_stack = (size_t)tcb->stack_alloc_ptr + stack_size;
+
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (FAR void *)top_of_stack;
       tcb->adj_stack_size = stack_size;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
 #if defined(ARCH_HAVE_LEDS)
       board_autoled_on(LED_STACKCREATED);

--- a/arch/avr/src/avr/up_dumpstate.c
+++ b/arch/avr/src/avr/up_dumpstate.c
@@ -139,7 +139,7 @@ void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint16_t)rtcb->stack_base_ptr;
+  ustackbase = (uint16_t)rtcb->adj_stack_ptr;
   ustacksize = (uint16_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -196,14 +196,14 @@ void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp < ustackbase && sp >= ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
   else
     {
       _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
 #else
   _alert("sp:         %04x\n", sp);
@@ -217,14 +217,14 @@ void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 #endif
 }

--- a/arch/avr/src/avr/up_initialstate.c
+++ b/arch/avr/src/avr/up_initialstate.c
@@ -55,7 +55,6 @@
 void up_initial_state(struct tcb_s *tcb)
 {
   struct xcptcontext *xcp = &tcb->xcp;
-  uintptr_t sp;
 
   /* Initialize the idle thread stack */
 
@@ -63,7 +62,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -73,12 +72,10 @@ void up_initial_state(struct tcb_s *tcb)
 
   memset(xcp, 0, sizeof(struct xcptcontext));
 
-  /* Set the initial stack pointer to the top of the allocated stack */
+  /* Set the initial stack pointer to the "base" of the allocated stack */
 
-  sp                   = (uintptr_t)tcb->stack_base_ptr +
-                                    tcb->adj_stack_size;
-  xcp->regs[REG_SPH]   = (uint8_t)(sp >> 8);
-  xcp->regs[REG_SPL]   = (uint8_t)(sp & 0xff);
+  xcp->regs[REG_SPH]   = (uint8_t)((uint16_t)tcb->adj_stack_ptr >> 8);
+  xcp->regs[REG_SPL]   = (uint8_t)((uint16_t)tcb->adj_stack_ptr & 0xff);
 
   /* Save the task entry point */
 

--- a/arch/avr/src/avr/up_stackframe.c
+++ b/arch/avr/src/avr/up_stackframe.c
@@ -77,8 +77,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -93,8 +94,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -106,15 +105,17 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr     = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size   -= frame_size;
+
+  /* Set the initial stack pointer to the "base" of the allocated stack */
+
+  tcb->xcp.regs[REG_SPH] = (uint8_t)((uint16_t)tcb->adj_stack_ptr >> 8);
+  tcb->xcp.regs[REG_SPL] = (uint8_t)((uint16_t)tcb->adj_stack_ptr & 0xff);
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/avr/src/avr/up_usestack.c
+++ b/arch/avr/src/avr/up_usestack.c
@@ -54,8 +54,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -70,6 +70,8 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
+  size_t top_of_stack;
+
 #ifdef CONFIG_TLS_ALIGNED
   /* Make certain that the user provided stack is properly aligned */
 
@@ -103,10 +105,16 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * positive word offsets from sp.
    */
 
+  top_of_stack = (size_t)tcb->stack_alloc_ptr + stack_size;
+
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr  = (FAR void *)top_of_stack;
   tcb->adj_stack_size = stack_size;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/avr/src/avr32/up_createstack.c
+++ b/arch/avr/src/avr32/up_createstack.c
@@ -64,8 +64,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -91,6 +91,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -130,14 +134,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -146,14 +152,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -171,7 +177,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -189,19 +195,23 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * the stack are referenced as positive word offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (size_t)tcb->stack_alloc_ptr + stack_size;
 
       /* The AVR32 stack must be aligned at word (4 byte) boundaries. If
        * necessary top_of_stack must be rounded down to the next boundary
        */
 
       top_of_stack &= ~3;
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (size_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (FAR void *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/avr/src/avr32/up_dumpstate.c
+++ b/arch/avr/src/avr32/up_dumpstate.c
@@ -109,7 +109,7 @@ void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -166,14 +166,14 @@ void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp < ustackbase && sp >= ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
   else
     {
       _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
 #else
   _alert("sp:         %08x\n", sp);
@@ -187,14 +187,14 @@ void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 #endif
 }

--- a/arch/avr/src/avr32/up_initialstate.c
+++ b/arch/avr/src/avr32/up_initialstate.c
@@ -60,7 +60,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -85,8 +85,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Set the initial stack pointer to the top of the allocated stack */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/avr/src/avr32/up_stackframe.c
+++ b/arch/avr/src/avr32/up_stackframe.c
@@ -79,8 +79,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -95,8 +96,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -108,15 +107,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/avr/src/avr32/up_usestack.c
+++ b/arch/avr/src/avr32/up_usestack.c
@@ -53,8 +53,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -69,7 +69,7 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -106,7 +106,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * referenced as positive word offsets from sp.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (size_t)tcb->stack_alloc_ptr + stack_size;
 
   /* The AVR32 stack must be aligned at word (4 byte)
    * boundaries. If necessary top_of_stack must be rounded
@@ -114,12 +114,16 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    */
 
   top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (size_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr  = (FAR void *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/hc/src/common/up_stackframe.c
+++ b/arch/hc/src/common/up_stackframe.c
@@ -79,8 +79,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -95,8 +96,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -108,15 +107,17 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SPH] = (uint16_t)tcb->adj_stack_ptr >> 8;
+  tcb->xcp.regs[REG_SPL] = (uint16_t)tcb->adj_stack_ptr & 0xff;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/hc/src/common/up_usestack.c
+++ b/arch/hc/src/common/up_usestack.c
@@ -52,8 +52,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -66,9 +66,9 @@
  *
  ****************************************************************************/
 
-int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
+int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -105,7 +105,7 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
    * stack address.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (size_t)tcb->stack_alloc_ptr + stack_size;
 
   /* The CPU12 stack should be aligned at half-word (2 byte)
    * boundaries. If necessary top_of_stack must be rounded
@@ -113,12 +113,16 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
    */
 
   top_of_stack &= ~1;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (size_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/hc/src/m9s12/m9s12_assert.c
+++ b/arch/hc/src/m9s12/m9s12_assert.c
@@ -184,7 +184,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint16_t)rtcb->stack_base_ptr;
+  ustackbase = (uint16_t)rtcb->adj_stack_ptr;
   ustacksize = (uint16_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -238,14 +238,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 
 #ifdef CONFIG_ARCH_USBDUMP

--- a/arch/hc/src/m9s12/m9s12_initialstate.c
+++ b/arch/hc/src/m9s12/m9s12_initialstate.c
@@ -52,7 +52,6 @@
 void up_initial_state(struct tcb_s *tcb)
 {
   struct xcptcontext *xcp = &tcb->xcp;
-  uintptr_t sp;
 
   /* Initialize the idle thread stack */
 
@@ -60,7 +59,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -70,10 +69,8 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  sp                      = (uintptr_t)tcb->stack_base_ptr +
-                                       tcb->adj_stack_size;
-  xcp->regs[REG_SPH]      = sp >> 8;
-  xcp->regs[REG_SPL]      = sp & 0xff;
+  xcp->regs[REG_SPH]      = (uint16_t)tcb->adj_stack_ptr >> 8;
+  xcp->regs[REG_SPL]      = (uint16_t)tcb->adj_stack_ptr & 0xff;
 
   /* Save the task entry point */
 

--- a/arch/mips/src/common/mips_createstack.c
+++ b/arch/mips/src/common/mips_createstack.c
@@ -82,8 +82,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -109,6 +109,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -147,14 +151,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -163,14 +169,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -188,7 +194,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -206,7 +212,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * the stack are referenced as positive word offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
       /* The MIPS stack must be aligned at word (4 byte) boundaries; for
        * floating point use, the stack must be aligned to 8-byte addresses.
@@ -222,12 +228,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * The size need not be aligned.
        */
 
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/mips/src/common/mips_stackframe.c
+++ b/arch/mips/src/common/mips_stackframe.c
@@ -82,8 +82,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -98,8 +99,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -111,15 +110,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/mips/src/mips32/mips_dumpstate.c
+++ b/arch/mips/src/mips32/mips_dumpstate.c
@@ -139,7 +139,7 @@ void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -193,14 +193,14 @@ void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 }
 

--- a/arch/mips/src/mips32/mips_initialstate.c
+++ b/arch/mips/src/mips32/mips_initialstate.c
@@ -64,7 +64,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -78,8 +78,7 @@ void up_initial_state(struct tcb_s *tcb)
    * only the start function would do that and we have control over that one.
    */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/mips/src/mips32/mips_vfork.c
+++ b/arch/mips/src/mips32/mips_vfork.c
@@ -69,16 +69,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      this consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()
@@ -102,13 +102,15 @@ pid_t up_vfork(const struct vfork_s *context)
 {
   struct tcb_s *parent = this_task();
   struct task_tcb_s *child;
+  size_t stacksize;
   uint32_t newsp;
 #ifdef CONFIG_MIPS32_FRAMEPOINTER
   uint32_t newfp;
 #endif
-  uint32_t newtop;
-  uint32_t stacktop;
   uint32_t stackutil;
+  size_t argsize;
+  void *argv;
+  int ret;
 
   sinfo("s0:%08" PRIx32 " s1:%08" PRIx32 " s2:%08" PRIx32
         " s3:%08" PRIx32 " s4:%08" PRIx32 "\n",
@@ -139,7 +141,7 @@ pid_t up_vfork(const struct vfork_s *context)
 
   /* Allocate and initialize a TCB for the child task. */
 
-  child = nxtask_setup_vfork((start_t)context->ra);
+  child = nxtask_setup_vfork((start_t)context->ra, &argsize);
   if (!child)
     {
       sinfo("nxtask_setup_vfork failed\n");
@@ -148,18 +150,39 @@ pid_t up_vfork(const struct vfork_s *context)
 
   sinfo("Parent=%p Child=%p\n", parent, child);
 
+  /* Get the size of the parent task's stack.  Due to alignment operations,
+   * the adjusted stack size may be smaller than the stack size originally
+   * requested.
+   */
+
+  stacksize = parent->adj_stack_size + CONFIG_STACK_ALIGNMENT - 1;
+
+  /* Allocate the stack for the TCB */
+
+  ret = up_create_stack((FAR struct tcb_s *)child, stacksize + argsize,
+                        parent->flags & TCB_FLAG_TTYPE_MASK);
+  if (ret != OK)
+    {
+      serr("ERROR: up_create_stack failed: %d\n", ret);
+      nxtask_abort_vfork(child, -ret);
+      return (pid_t)ERROR;
+    }
+
+  /* Allocate the memory and copy argument from parent task */
+
+  argv = up_stack_frame((FAR struct tcb_s *)child, argsize);
+  memcpy(argv, parent->adj_stack_ptr, argsize);
+
   /* How much of the parent's stack was utilized?  The MIPS uses
    * a push-down stack so that the current stack pointer should
    * be lower than the initial, adjusted stack pointer.  The
    * stack usage should be the difference between those two.
    */
 
-  stacktop = (uint32_t)parent->stack_base_ptr +
-                       parent->adj_stack_size;
-  DEBUGASSERT(stacktop > context->sp);
-  stackutil = stacktop - context->sp;
+  DEBUGASSERT((uint32_t)parent->adj_stack_ptr > context->sp);
+  stackutil = (uint32_t)parent->adj_stack_ptr - context->sp;
 
-  sinfo("Parent: stackutil:%" PRIu32 "\n", stackutil);
+  sinfo("stacksize:%zd stackutil:%" PRId32 "\n", stacksize, stackutil);
 
   /* Make some feeble effort to perserve the stack contents.  This is
    * feeble because the stack surely contains invalid pointers and other
@@ -168,33 +191,32 @@ pid_t up_vfork(const struct vfork_s *context)
    * effort is overkill.
    */
 
-  newtop = (uintptr_t)child->cmn.stack_base_ptr +
-                      child->cmn.adj_stack_size;
-  newsp = newtop - stackutil;
+  newsp = (uint32_t)child->cmn.adj_stack_ptr - stackutil;
   memcpy((void *)newsp, (const void *)context->sp, stackutil);
 
   /* Was there a frame pointer in place before? */
 
 #ifdef CONFIG_MIPS32_FRAMEPOINTER
-  if (context->fp >= context->sp && context->fp < stacktop)
+  if (context->fp <= (uint32_t)parent->adj_stack_ptr &&
+      context->fp >= (uint32_t)parent->adj_stack_ptr - stacksize)
     {
-      uint32_t frameutil = stacktop - context->fp;
-      newfp = newtop - frameutil;
+      uint32_t frameutil = (uint32_t)parent->adj_stack_ptr - context->fp;
+      newfp = (uint32_t)child->cmn.adj_stack_ptr - frameutil;
     }
   else
     {
       newfp = context->fp;
     }
 
-  sinfo("Old stack top:%08" PRIx32 " SP:%08" PRIx32 " FP:%08" PRIx32 "\n",
-        stacktop, context->sp, context->fp);
-  sinfo("New stack top:%08" PRIx32 " SP:%08" PRIx32 " FP:%08" PRIx32 "\n",
-        newtop, newsp, newfp);
+  sinfo("Old stack base:%p SP:%08" PRIx32 " FP:%08" PRIx32 "\n",
+        parent->adj_stack_ptr, context->sp, context->fp);
+  sinfo("New stack base:%p SP:%08" PRIx32 " FP:%08" PRIx32 "\n",
+        child->cmn.adj_stack_ptr, newsp, newfp);
 #else
-  sinfo("Old stack top:%08" PRIx32 " SP:%08" PRIx32 "\n",
-        stacktop, context->sp);
-  sinfo("New stack top:%08" PRIx32 " SP:%08" PRIx32 "\n",
-        newtop, newsp);
+  sinfo("Old stack base:%p SP:%08" PRIx32 "\n",
+        parent->adj_stack_ptr, context->sp);
+  sinfo("New stack base:%p SP:%08" PRIx32 "\n",
+        child->cmn.adj_stack_ptr, newsp);
 #endif
 
   /* Update the stack pointer, frame pointer, global pointer and saved

--- a/arch/mips/src/mips32/vfork.S
+++ b/arch/mips/src/mips32/vfork.S
@@ -56,16 +56,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/misoc/src/lm32/lm32_createstack.c
+++ b/arch/misoc/src/lm32/lm32_createstack.c
@@ -97,8 +97,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -124,6 +124,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -162,14 +166,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -178,14 +184,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -203,7 +209,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -221,7 +227,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * the stack are referenced as positive word offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
       /* The LM32 stack must be aligned at word (4 byte) boundaries; for
        * floating point use, the stack must be aligned to 8-byte addresses.
@@ -230,12 +236,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (FAR uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/misoc/src/lm32/lm32_dumpstate.c
+++ b/arch/misoc/src/lm32/lm32_dumpstate.c
@@ -141,7 +141,7 @@ void lm32_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -195,14 +195,14 @@ void lm32_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 }
 

--- a/arch/misoc/src/lm32/lm32_initialstate.c
+++ b/arch/misoc/src/lm32/lm32_initialstate.c
@@ -77,7 +77,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -91,8 +91,7 @@ void up_initial_state(struct tcb_s *tcb)
    * only the start function would do that and we have control over that one
    */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/misoc/src/lm32/lm32_stackframe.c
+++ b/arch/misoc/src/lm32/lm32_stackframe.c
@@ -90,8 +90,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -106,8 +107,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -119,15 +118,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/misoc/src/lm32/lm32_usestack.c
+++ b/arch/misoc/src/lm32/lm32_usestack.c
@@ -51,8 +51,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -67,7 +67,7 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -103,19 +103,23 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * positive word offsets from sp.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
   /* The i486 stack must be aligned at word (4 byte) boundaries. If necessary
    * top_of_stack must be rounded down to the next boundary
    */
 
   top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/misoc/src/minerva/minerva_createstack.c
+++ b/arch/misoc/src/minerva/minerva_createstack.c
@@ -89,8 +89,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -116,6 +116,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -155,14 +159,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -171,14 +177,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -196,7 +202,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -214,7 +220,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * the stack are referenced as positive word offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
       /* The MINERVA stack must be aligned at word (4 byte) boundaries; for
        * floating point use, the stack must be aligned to 8-byte addresses.
@@ -223,12 +229,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr = (FAR uint32_t *) top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/misoc/src/minerva/minerva_dumpstate.c
+++ b/arch/misoc/src/minerva/minerva_dumpstate.c
@@ -148,7 +148,7 @@ void minerva_dumpstate(void)
    * == NULL)
    */
 
-  ustackbase = (uint32_t) rtcb->stack_base_ptr;
+  ustackbase = (uint32_t) rtcb->adj_stack_ptr;
   ustacksize = (uint32_t) rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -200,14 +200,14 @@ void minerva_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 }
 

--- a/arch/misoc/src/minerva/minerva_initialstate.c
+++ b/arch/misoc/src/minerva/minerva_initialstate.c
@@ -81,7 +81,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -95,12 +95,11 @@ void up_initial_state(struct tcb_s *tcb)
    * only the start function would do that and we have control over that one.
    */
 
-  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
-                                tcb->adj_stack_size;
+  xcp->regs[REG_SP] = (uint32_t) tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 
-  xcp->regs[REG_CSR_MEPC] = (uint32_t)tcb->start;
+  xcp->regs[REG_CSR_MEPC] = (uint32_t) tcb->start;
 
   xcp->regs[REG_CSR_MSTATUS] = CSR_MSTATUS_MPIE;
 

--- a/arch/misoc/src/minerva/minerva_stackframe.c
+++ b/arch/misoc/src/minerva/minerva_stackframe.c
@@ -90,8 +90,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -106,8 +107,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -119,15 +118,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->adj_stack_ptr   = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SP] = (uint32_t) tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/misoc/src/minerva/minerva_usestack.c
+++ b/arch/misoc/src/minerva/minerva_usestack.c
@@ -51,8 +51,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -67,7 +67,7 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -103,19 +103,23 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * positive word offsets from sp.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
   /* The i486 stack must be aligned at word (4 byte) boundaries. If necessary
    * top_of_stack must be rounded down to the next boundary
    */
 
   top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/or1k/src/common/up_assert.c
+++ b/arch/or1k/src/common/up_assert.c
@@ -209,7 +209,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -266,14 +266,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp < ustackbase && sp >= ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
   else
     {
       _alert("ERROR: Stack pointer is not within the allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
 
 #else
@@ -288,14 +288,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 #endif
 

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/tls.h>
 #include <nuttx/board.h>
 
 #include "sched/sched.h"
@@ -42,11 +43,13 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size);
+static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack);
 
 /****************************************************************************
- * Private Function
+ * Private Functions
  ****************************************************************************/
+
+static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack);
 
 /****************************************************************************
  * Name: do_stackcheck
@@ -65,7 +68,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size)
+static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 {
   FAR uintptr_t start;
   FAR uintptr_t end;
@@ -79,8 +82,21 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-  start = (alloc + 3) & ~3;
-  end   = (alloc + size) & ~3;
+  if (!int_stack)
+    {
+      /* Skip over the TLS data structure at the bottom of the stack */
+
+#ifdef CONFIG_TLS_ALIGNED
+      DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
+#endif
+      start = alloc + sizeof(struct tls_info_s);
+    }
+  else
+    {
+      start = alloc & ~3;
+    }
+
+  end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */
 
@@ -117,12 +133,13 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size,
+                       false);
 }
 
 ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
 {
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
+  return (ssize_t)tcb->adj_stack_size - (ssize_t)up_check_tcbstack(tcb);
 }
 
 size_t up_check_stack(void)
@@ -139,7 +156,8 @@ ssize_t up_check_stack_remain(void)
 size_t up_check_intstack(void)
 {
   return do_stackcheck((uintptr_t)&g_intstackalloc,
-                       (CONFIG_ARCH_INTERRUPTSTACK & ~3));
+                       (CONFIG_ARCH_INTERRUPTSTACK & ~3),
+                       true);
 }
 
 size_t up_check_intstack_remain(void)

--- a/arch/or1k/src/common/up_createstack.c
+++ b/arch/or1k/src/common/up_createstack.c
@@ -74,8 +74,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -102,6 +102,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -141,14 +145,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -157,14 +163,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -182,17 +188,24 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+#if defined(CONFIG_STACK_COLORATION)
+      uintptr_t stack_base;
+#endif
+      size_t top_of_stack;
       size_t size_of_stack;
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
       top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
 #ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a
@@ -200,7 +213,11 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * water marks.
        */
 
-      up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+      stack_base = (uintptr_t)tcb->stack_alloc_ptr +
+                   sizeof(struct tls_info_s);
+      stack_size = tcb->adj_stack_size -
+                   sizeof(struct tls_info_s);
+      up_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
 

--- a/arch/or1k/src/common/up_initialstate.c
+++ b/arch/or1k/src/common/up_initialstate.c
@@ -79,7 +79,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -87,8 +87,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   memset(xcp, 0, sizeof(struct xcptcontext));
 
-  xcp->regs[REG_R1]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_R1]      = (uint32_t)tcb->adj_stack_ptr;
   xcp->regs[REG_PC]      = (uint32_t)tcb->start;
 
   mfspr(SPR_SYS_SR, sr);

--- a/arch/or1k/src/common/up_stackframe.c
+++ b/arch/or1k/src/common/up_stackframe.c
@@ -71,8 +71,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -87,8 +88,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -100,15 +99,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_R1] = (uint32_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/or1k/src/common/up_usestack.c
+++ b/arch/or1k/src/common/up_usestack.c
@@ -51,8 +51,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -67,7 +67,7 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -103,19 +103,23 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * positive word offsets from sp.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
   /* The i486 stack must be aligned at word (4 byte) boundaries. If necessary
    * top_of_stack must be rounded down to the next boundary
    */
 
   top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/renesas/src/common/up_createstack.c
+++ b/arch/renesas/src/common/up_createstack.c
@@ -61,8 +61,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -88,6 +88,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -127,14 +131,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -143,14 +149,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -168,7 +174,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -187,7 +193,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * referenced as positive word offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
       /* The SH stack must be aligned at word (4 byte)
        * boundaries. If necessary top_of_stack must be rounded
@@ -195,12 +201,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       top_of_stack &= ~3;
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/renesas/src/common/up_stackframe.c
+++ b/arch/renesas/src/common/up_stackframe.c
@@ -78,8 +78,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -94,8 +95,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -107,15 +106,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->adj_stack_ptr   = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size -= frame_size;
+
+  /* Reset the initial state */
+
+  up_initial_state(tcb);
 
   /* And return a pointer to allocated memory */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/renesas/src/common/up_usestack.c
+++ b/arch/renesas/src/common/up_usestack.c
@@ -53,8 +53,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -69,7 +69,7 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -105,19 +105,23 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * stack are referenced as positive word offsets from sp.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
   /* The SH stack must be aligned at word (4 byte) boundaries. If necessary
    * top_of_stack must be rounded down to the next boundary
    */
 
   top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr = (FAR void *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/renesas/src/m16c/m16c_dumpstate.c
+++ b/arch/renesas/src/m16c/m16c_dumpstate.c
@@ -136,7 +136,7 @@ void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint16_t)rtcb->stack_base_ptr;
+  ustackbase = (uint16_t)rtcb->adj_stack_ptr;
   ustacksize = (uint16_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory.
@@ -197,14 +197,14 @@ void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      m16c_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      m16c_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      m16c_stackdump(ustackbase, ustackbase + ustacksize);
+      m16c_stackdump(sp, ustackbase);
     }
 }
 

--- a/arch/renesas/src/m16c/m16c_initialstate.c
+++ b/arch/renesas/src/m16c/m16c_initialstate.c
@@ -54,7 +54,6 @@ void up_initial_state(FAR struct tcb_s *tcb)
 {
   FAR struct xcptcontext *xcp  = &tcb->xcp;
   FAR uint8_t            *regs = xcp->regs;
-  uintptr_t               sp;
 
   /* Initialize the idle thread stack */
 
@@ -62,7 +61,7 @@ void up_initial_state(FAR struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -91,9 +90,7 @@ void up_initial_state(FAR struct tcb_s *tcb)
 
   /* Offset 18-20: User stack pointer */
 
-  sp      = (uintptr_t)tcb->stack_base_ptr +
-                       tcb->adj_stack_size;
   regs    = &xcp->regs[REG_SP];
-  *regs++ = sp >> 8; /* Bits 8-15 of SP */
-  *regs   = sp;      /* Bits 0-7 of SP */
+  *regs++ = (uint32_t)tcb->adj_stack_ptr >> 8;  /* Bits 8-15 of SP */
+  *regs   = (uint32_t)tcb->adj_stack_ptr;       /* Bits 0-7 of SP */
 }

--- a/arch/renesas/src/rx65n/rx65n_dumpstate.c
+++ b/arch/renesas/src/rx65n/rx65n_dumpstate.c
@@ -143,7 +143,7 @@ void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint16_t)rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
@@ -194,14 +194,14 @@ void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      rx65n_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      rx65n_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      rx65n_stackdump(ustackbase, ustackbase + ustacksize);
+      rx65n_stackdump(sp, ustackbase);
     }
 }
 

--- a/arch/renesas/src/rx65n/rx65n_initialstate.c
+++ b/arch/renesas/src/rx65n/rx65n_initialstate.c
@@ -67,7 +67,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -75,8 +75,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   memset(xcp, 0, sizeof(struct xcptcontext));
 
-  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
-                                tcb->adj_stack_size;
+  xcp->regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
   xcp->regs[REG_PC] = (uint32_t)tcb->start;
 
   /* Enable or disable interrupts, based on user configuration */

--- a/arch/renesas/src/sh1/sh1_dumpstate.c
+++ b/arch/renesas/src/sh1/sh1_dumpstate.c
@@ -123,7 +123,7 @@ void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -177,14 +177,14 @@ void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      sh1_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      sh1_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      sh1_stackdump(ustackbase, ustackbase + ustacksize);
+      sh1_stackdump(sp, ustackbase);
     }
 }
 

--- a/arch/renesas/src/sh1/sh1_initialstate.c
+++ b/arch/renesas/src/sh1/sh1_initialstate.c
@@ -79,7 +79,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -89,8 +89,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Set the initial stack pointer to the "top" of the allocated stack */
 
-  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
-                                tcb->adj_stack_size;
+  xcp->regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -83,8 +83,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -110,6 +110,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -149,14 +153,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -165,14 +171,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -190,7 +196,10 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+#if defined(CONFIG_STACK_COLORATION)
+      uintptr_t stack_base;
+#endif
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* RISCV uses a push-down stack:  the stack grows toward lower
@@ -212,8 +221,12 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (FAR uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
 #ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a
@@ -221,7 +234,11 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * water marks.
        */
 
-      riscv_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+      stack_base = (uintptr_t)tcb->stack_alloc_ptr +
+                   sizeof(struct tls_info_s);
+      stack_size = tcb->adj_stack_size -
+                   sizeof(struct tls_info_s);
+      riscv_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
 

--- a/arch/risc-v/src/common/riscv_stackframe.c
+++ b/arch/risc-v/src/common/riscv_stackframe.c
@@ -83,8 +83,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -99,8 +100,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -112,15 +111,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SP] = (uintptr_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/risc-v/src/common/riscv_usestack.c
+++ b/arch/risc-v/src/common/riscv_usestack.c
@@ -74,8 +74,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -88,9 +88,9 @@
  *
  ****************************************************************************/
 
-int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
+int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -130,8 +130,12 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr  = (uintptr_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
 #if defined(CONFIG_STACK_COLORATION)
   /* If stack debug is enabled, then fill the stack with a
@@ -139,7 +143,9 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
    * water marks.
    */
 
-  riscv_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+  riscv_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
+                 sizeof(struct tls_info_s)),
+                 size_of_stack - sizeof(struct tls_info_s));
 #endif
 
   return OK;

--- a/arch/risc-v/src/k210/k210_cpuidlestack.c
+++ b/arch/risc-v/src/k210/k210_cpuidlestack.c
@@ -67,8 +67,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -184,7 +184,7 @@ static void riscv_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -238,14 +238,14 @@ static void riscv_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      riscv_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      riscv_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      riscv_stackdump(ustackbase, ustackbase + ustacksize);
+      riscv_stackdump(sp, ustackbase);
     }
 }
 

--- a/arch/risc-v/src/rv32im/riscv_initialstate.c
+++ b/arch/risc-v/src/rv32im/riscv_initialstate.c
@@ -63,7 +63,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -77,8 +77,7 @@ void up_initial_state(struct tcb_s *tcb)
    * only the start function would do that and we have control over that one
    */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/risc-v/src/rv64gc/riscv_assert.c
+++ b/arch/risc-v/src/rv64gc/riscv_assert.c
@@ -195,7 +195,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uintptr_t)rtcb->stack_base_ptr;
+  ustackbase = (uintptr_t)rtcb->adj_stack_ptr;
   ustacksize = (uintptr_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -247,14 +247,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
       _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 }
 

--- a/arch/risc-v/src/rv64gc/riscv_initialstate.c
+++ b/arch/risc-v/src/rv64gc/riscv_initialstate.c
@@ -63,7 +63,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -77,8 +77,7 @@ void up_initial_state(struct tcb_s *tcb)
    * only the start function would do that and we have control over that one
    */
 
-  xcp->regs[REG_SP]      = (uintptr_t)tcb->stack_base_ptr +
-                                      tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uintptr_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/sim/src/sim/up_checkstack.c
+++ b/arch/sim/src/sim/up_checkstack.c
@@ -46,6 +46,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/tls.h>
 #include <nuttx/board.h>
 
 #include "sched/sched.h"
@@ -55,7 +56,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size);
+static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack);
 
 /****************************************************************************
  * Name: do_stackcheck
@@ -74,7 +75,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size)
+static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
 {
   FAR uintptr_t start;
   FAR uintptr_t end;
@@ -88,8 +89,21 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-  start = (alloc + 3) & ~3;
-  end   = (alloc + size) & ~3;
+  if (!int_stack)
+    {
+      /* Skip over the TLS data structure at the bottom of the stack */
+
+#ifdef CONFIG_TLS_ALIGNED
+      DEBUGASSERT((alloc & TLS_STACK_MASK) == 0);
+#endif
+      start = alloc + sizeof(struct tls_info_s);
+    }
+  else
+    {
+      start = alloc & ~3;
+    }
+
+  end   = (alloc + size + 3) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */
 
@@ -171,12 +185,13 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
+  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr, tcb->adj_stack_size,
+                       false);
 }
 
 ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
 {
-  return tcb->adj_stack_size - up_check_tcbstack(tcb);
+  return (ssize_t)tcb->adj_stack_size - (ssize_t)up_check_tcbstack(tcb);
 }
 
 size_t up_check_stack(void)

--- a/arch/sim/src/sim/up_cpuidlestack.c
+++ b/arch/sim/src/sim/up_cpuidlestack.c
@@ -63,8 +63,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is
@@ -82,6 +82,6 @@ int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
 
   tcb->adj_stack_size  = 0;
   tcb->stack_alloc_ptr = NULL;
-  tcb->stack_base_ptr   = NULL;
+  tcb->adj_stack_ptr   = NULL;
   return OK;
 }

--- a/arch/sim/src/sim/up_createstack.c
+++ b/arch/sim/src/sim/up_createstack.c
@@ -66,8 +66,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -91,6 +91,10 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
   FAR uint8_t *stack_alloc_ptr;
   int ret = ERROR;
 
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -105,25 +109,43 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   /* Move up to next even word boundary if necessary */
 
-  size_t adj_stack_size = STACK_ALIGN_UP(stack_size);
+  size_t adj_stack_size  = STACK_ALIGN_UP(stack_size);
 
   /* Allocate the memory for the stack */
 
 #ifdef CONFIG_TLS_ALIGNED
-  stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, adj_stack_size);
+  stack_alloc_ptr = (FAR uint8_t *)kumm_memalign(TLS_STACK_ALIGN,
+                                                 adj_stack_size);
 #else
-  stack_alloc_ptr = kumm_malloc(adj_stack_size);
+  stack_alloc_ptr = (FAR uint8_t *)kumm_malloc(adj_stack_size);
 #endif
 
   /* Was the allocation successful? */
 
   if (stack_alloc_ptr)
     {
+#if defined(CONFIG_STACK_COLORATION)
+      uintptr_t stack_base;
+#endif
+
+      /* This is the address of the last aligned word in the allocation.
+       * NOTE that stack_alloc_ptr + adj_stack_size may lie one byte
+       * outside of the stack.  This is okay for an initial state; the
+       * first pushed values will be within the stack allocation.
+       */
+
+      uintptr_t adj_stack_addr =
+        STACK_ALIGN_DOWN((uintptr_t)stack_alloc_ptr + adj_stack_size);
+
       /* Save the values in the TCB */
 
       tcb->adj_stack_size  = adj_stack_size;
       tcb->stack_alloc_ptr = stack_alloc_ptr;
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (FAR void *)adj_stack_addr;
+
+      /* Initialize the TLS data structure */
+
+      memset(stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
 #ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a
@@ -131,7 +153,10 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * water marks.
        */
 
-      up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+      stack_base = (uintptr_t)tcb->stack_alloc_ptr +
+                   sizeof(struct tls_info_s);
+      stack_size = tcb->adj_stack_size - sizeof(struct tls_info_s);
+      up_stack_color((FAR void *)stack_base, stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
 

--- a/arch/sim/src/sim/up_releasestack.c
+++ b/arch/sim/src/sim/up_releasestack.c
@@ -74,5 +74,5 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 
   dtcb->stack_alloc_ptr = NULL;
   dtcb->adj_stack_size  = 0;
-  dtcb->stack_base_ptr   = NULL;
+  dtcb->adj_stack_ptr   = NULL;
 }

--- a/arch/sim/src/sim/up_usestack.c
+++ b/arch/sim/src/sim/up_usestack.c
@@ -67,8 +67,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -83,6 +83,7 @@
 
 int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
 {
+  uintptr_t adj_stack_addr;
   size_t adj_stack_size;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -96,11 +97,23 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
 
   adj_stack_size = STACK_ALIGN_DOWN(stack_size);
 
+  /* This is the address of the last word in the allocation.
+   * NOTE that stack_alloc_ptr + adj_stack_size may lie one byte
+   * outside of the stack.  This is okay for an initial state; the
+   * first pushed values will be within the stack allocation.
+   */
+
+  adj_stack_addr = STACK_ALIGN_DOWN((uintptr_t)stack + adj_stack_size);
+
   /* Save the values in the TCB */
 
   tcb->adj_stack_size  = adj_stack_size;
   tcb->stack_alloc_ptr = stack;
-  tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr   = (FAR void *)adj_stack_addr;
+
+  /* Initialize the TLS data structure */
+
+  memset(stack, 0, sizeof(struct tls_info_s));
 
 #if defined(CONFIG_STACK_COLORATION)
   /* If stack debug is enabled, then fill the stack with a
@@ -108,7 +121,9 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
    * water marks.
    */
 
-  up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+  up_stack_color((FAR void *)((uintptr_t)tcb->stack_alloc_ptr +
+                 sizeof(struct tls_info_s)),
+                 adj_stack_size - sizeof(struct tls_info_s));
 #endif
 
   return OK;

--- a/arch/sim/src/sim/up_vfork.c
+++ b/arch/sim/src/sim/up_vfork.c
@@ -56,16 +56,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.
  *      This consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()
@@ -86,11 +86,13 @@ pid_t up_vfork(const xcpt_reg_t *context)
 {
   struct tcb_s *parent = this_task();
   struct task_tcb_s *child;
+  size_t stacksize;
   xcpt_reg_t newsp;
   xcpt_reg_t newfp;
-  xcpt_reg_t newtop;
-  xcpt_reg_t stacktop;
   xcpt_reg_t stackutil;
+  size_t argsize;
+  void *argv;
+  int ret;
 
   sinfo("vfork context [%p]:\n", context);
   sinfo("  frame pointer:%08" PRIxPTR " sp:%08" PRIxPTR " pc:%08" PRIxPTR ""
@@ -98,7 +100,7 @@ pid_t up_vfork(const xcpt_reg_t *context)
 
   /* Allocate and initialize a TCB for the child task. */
 
-  child = nxtask_setup_vfork((start_t)context[JB_PC]);
+  child = nxtask_setup_vfork((start_t)(context[JB_PC]), &argsize);
   if (!child)
     {
       serr("ERROR: nxtask_setup_vfork failed\n");
@@ -107,18 +109,38 @@ pid_t up_vfork(const xcpt_reg_t *context)
 
   sinfo("TCBs: Parent=%p Child=%p\n", parent, child);
 
+  /* Get the size of the parent task's stack. */
+
+  stacksize = parent->adj_stack_size;
+
+  /* Allocate the stack for the TCB */
+
+  ret = up_create_stack((FAR struct tcb_s *)child, stacksize + argsize,
+                        parent->flags & TCB_FLAG_TTYPE_MASK);
+  if (ret != OK)
+    {
+      serr("ERROR: up_create_stack failed: %d\n", ret);
+      nxtask_abort_vfork(child, -ret);
+      return (pid_t)ERROR;
+    }
+
+  /* Allocate the memory and copy argument from parent task */
+
+  argv = up_stack_frame((FAR struct tcb_s *)child, argsize);
+
+  memcpy(argv, parent->adj_stack_ptr, argsize);
+
   /* How much of the parent's stack was utilized?  The ARM uses
    * a push-down stack so that the current stack pointer should
    * be lower than the initial, adjusted stack pointer.  The
    * stack usage should be the difference between those two.
    */
 
-  stacktop = (xcpt_reg_t)parent->stack_base_ptr +
-                         parent->adj_stack_size;
-  DEBUGASSERT(stacktop > context[JB_SP]);
-  stackutil = stacktop - context[JB_SP];
+  DEBUGASSERT((xcpt_reg_t)parent->adj_stack_ptr > context[JB_SP]);
+  stackutil = (xcpt_reg_t)parent->adj_stack_ptr - context[JB_SP];
 
-  sinfo("Parent: stackutil:%" PRIuPTR "\n", stackutil);
+  sinfo("Parent: stacksize:%zu stackutil:%" PRIdPTR "\n",
+        stacksize, stackutil);
 
   /* Make some feeble effort to preserve the stack contents.  This is
    * feeble because the stack surely contains invalid pointers and other
@@ -127,27 +149,28 @@ pid_t up_vfork(const xcpt_reg_t *context)
    * effort is overkill.
    */
 
-  newtop = (xcpt_reg_t)child->cmn.stack_base_ptr +
-                       child->cmn.adj_stack_size;
-  newsp = newtop - stackutil;
+  newsp = (xcpt_reg_t)child->cmn.adj_stack_ptr - stackutil;
   memcpy((void *)newsp, (const void *)context[JB_SP], stackutil);
 
   /* Was there a frame pointer in place before? */
 
-  if (context[JB_FP] >= context[JB_SP] && context[JB_FP] < stacktop)
+  if (context[JB_FP] <= (xcpt_reg_t)parent->adj_stack_ptr &&
+      context[JB_FP] >= (xcpt_reg_t)parent->adj_stack_ptr -
+                              stacksize)
     {
-      xcpt_reg_t frameutil = stacktop - context[JB_FP];
-      newfp = newtop - frameutil;
+      xcpt_reg_t frameutil = (xcpt_reg_t)parent->adj_stack_ptr -
+                                context[JB_FP];
+      newfp = (xcpt_reg_t)child->cmn.adj_stack_ptr - frameutil;
     }
   else
     {
       newfp = context[JB_FP];
     }
 
-  sinfo("Old stack top:%08" PRIxPTR " SP:%08" PRIxPTR " FP:%08" PRIxPTR "\n",
-        stacktop, context[JB_SP], context[JB_FP]);
-  sinfo("New stack top:%08" PRIxPTR " SP:%08" PRIxPTR " FP:%08" PRIxPTR "\n",
-        newtop, newsp, newfp);
+  sinfo("Parent: stack base:%p SP:%08" PRIxPTR " FP:%08" PRIxPTR "\n",
+        parent->adj_stack_ptr, context[JB_SP], context[JB_FP]);
+  sinfo("Child:  stack base:%p SP:%08" PRIxPTR " FP:%08" PRIxPTR "\n",
+        child->cmn.adj_stack_ptr, newsp, newfp);
 
   /* Update the stack pointer, frame pointer, and volatile registers.  When
    * the child TCB was initialized, all of the values were set to zero.
@@ -156,8 +179,8 @@ pid_t up_vfork(const xcpt_reg_t *context)
    * child thread.
    */
 
-  memcpy(child->cmn.xcp.regs, context,
-         sizeof(xcpt_reg_t) * XCPTCONTEXT_REGS);
+  memcpy(child->cmn.xcp.regs, context, sizeof(xcpt_reg_t) *
+         XCPTCONTEXT_REGS);
   child->cmn.xcp.regs[JB_FP] = newfp; /* Frame pointer */
   child->cmn.xcp.regs[JB_SP] = newsp; /* Stack pointer */
 

--- a/arch/sim/src/sim/up_vfork32.S
+++ b/arch/sim/src/sim/up_vfork32.S
@@ -63,16 +63,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/sim/src/sim/up_vfork64.S
+++ b/arch/sim/src/sim/up_vfork64.S
@@ -63,16 +63,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/sim/src/sim/up_vfork_arm.S
+++ b/arch/sim/src/sim/up_vfork_arm.S
@@ -55,16 +55,16 @@
  *
  *   1) User code calls vfork().  vfork() collects context information and
  *      transfers control up up_vfork().
- *   2) up_vfork() and calls nxtask_setup_vfork().
+ *   2) up_vfork()and calls nxtask_setup_vfork().
  *   3) nxtask_setup_vfork() allocates and configures the child task's TCB.  This
  *      consists of:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()

--- a/arch/x86/src/common/up_assert.c
+++ b/arch/x86/src/common/up_assert.c
@@ -145,7 +145,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -199,14 +199,14 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      up_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 
 #ifdef CONFIG_ARCH_USBDUMP

--- a/arch/x86/src/i486/up_createstack.c
+++ b/arch/x86/src/i486/up_createstack.c
@@ -63,8 +63,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -90,6 +90,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -129,14 +133,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -145,14 +151,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -170,7 +176,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -188,19 +194,23 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * the stack are referenced as positive word offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
       /* The i486 stack must be aligned at word (4 byte) boundaries. If
        * necessary top_of_stack must be rounded down to the next boundary
        */
 
       top_of_stack &= ~3;
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/x86/src/i486/up_initialstate.c
+++ b/arch/x86/src/i486/up_initialstate.c
@@ -60,7 +60,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -73,8 +73,7 @@ void up_initial_state(struct tcb_s *tcb)
    * that depends on if a priority change is required or not.
    */
 
-  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/x86/src/i486/up_stackframe.c
+++ b/arch/x86/src/i486/up_stackframe.c
@@ -80,8 +80,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -96,8 +97,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -109,15 +108,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SP] = (uint32_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/x86/src/i486/up_usestack.c
+++ b/arch/x86/src/i486/up_usestack.c
@@ -53,8 +53,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -69,7 +69,7 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -105,19 +105,23 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * positive word offsets from sp.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
   /* The i486 stack must be aligned at word (4 byte) boundaries. If necessary
    * top_of_stack must be rounded down to the next boundary
    */
 
   top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/x86_64/src/common/up_assert.c
+++ b/arch/x86_64/src/common/up_assert.c
@@ -123,7 +123,7 @@ static void up_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint64_t)rtcb->stack_base_ptr;
+  ustackbase = (uint64_t)rtcb->adj_stack_ptr;
   ustacksize = (uint64_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -172,14 +172,15 @@ static void up_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      up_stackdump(sp, ustackbase + ustacksize);
+#if !defined(CONFIG_ARCH_INTERRUPTSTACK) || CONFIG_ARCH_INTERRUPTSTACK < 4
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+#endif
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      up_stackdump(ustackbase, ustackbase + ustacksize);
+      up_stackdump(sp, ustackbase);
     }
 
   /* Then dump the registers (if available) */

--- a/arch/x86_64/src/intel64/up_createstack.c
+++ b/arch/x86_64/src/intel64/up_createstack.c
@@ -63,8 +63,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -90,6 +90,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -129,14 +133,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -145,14 +151,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -170,7 +176,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -188,7 +194,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * the stack are referenced as positive quad-words offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint64_t)tcb->stack_alloc_ptr + stack_size;
 
       /* The intel64 stack must be aligned at word (16 byte) boundaries. If
        * necessary top_of_stack must be rounded down to the next boundary.
@@ -197,12 +203,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       top_of_stack &= ~0x0f;
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint64_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (uint64_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/x86_64/src/intel64/up_initialstate.c
+++ b/arch/x86_64/src/intel64/up_initialstate.c
@@ -51,9 +51,12 @@
  *
  ****************************************************************************/
 
+extern uintptr_t tux_mm_new_pd1(void);
+
 void up_initial_state(struct tcb_s *tcb)
 {
   struct xcptcontext *xcp = &tcb->xcp;
+  struct tcb_s *rtcb;
 
   /* Initialize the idle thread stack */
 
@@ -61,7 +64,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       tcb->stack_alloc_ptr = (void *)(g_idle_topstack -
                                       CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)g_idle_topstack;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -77,14 +80,17 @@ void up_initial_state(struct tcb_s *tcb)
 
   xcp->regs[3]      = (uint64_t)0x0000000000001f80;
 
+  /* set page table to share space with current process */
+
+  rtcb = this_task();
+  UNUSED(rtcb);
+
   /* Save the initial stack pointer... the value of the stackpointer before
    * the "interrupt occurs."
    */
 
-  xcp->regs[REG_RSP]      = (uint64_t)tcb->stack_base_ptr +
-                                      tcb->adj_stack_size;
-  xcp->regs[REG_RBP]      = (uint64_t)tcb->stack_base_ptr +
-                                      tcb->adj_stack_size;
+  xcp->regs[REG_RSP]      = (uint64_t)tcb->adj_stack_ptr;
+  xcp->regs[REG_RBP]      = (uint64_t)tcb->adj_stack_ptr;
 
   /* Save the task entry point */
 

--- a/arch/x86_64/src/intel64/up_stackframe.c
+++ b/arch/x86_64/src/intel64/up_stackframe.c
@@ -80,8 +80,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -96,8 +97,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -109,15 +108,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, tcb->adj_stack_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_RSP] = (uint64_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -71,8 +71,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -102,6 +102,10 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
   struct xcptcontext *xcp;
   uintptr_t cpstart;
 #endif
+
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
 
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
@@ -152,14 +156,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = UMM_MEMALIGN(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)UMM_MEMALIGN(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -168,14 +174,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = UMM_MALLOC(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)UMM_MALLOC(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -237,12 +243,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       top_of_stack  = STACK_ALIGN_DOWN(top_of_stack);
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (FAR uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
 #ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a
@@ -250,7 +260,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * water marks.
        */
 
-      up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+      up_stack_color((FAR void *)tcb->stack_alloc_ptr +
+                     sizeof(struct tls_info_s),
+                     tcb->adj_stack_size - sizeof(struct tls_info_s));
 #endif
 
       board_autoled_on(LED_STACKCREATED);

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -291,7 +291,7 @@ void xtensa_dumpstate(void)
 
   /* Get the limits on the user stack memory */
 
-  ustackbase = (uint32_t)rtcb->stack_base_ptr;
+  ustackbase = (uint32_t)rtcb->adj_stack_ptr;
   ustacksize = (uint32_t)rtcb->adj_stack_size;
 
   /* Get the limits on the interrupt stack memory */
@@ -362,14 +362,14 @@ void xtensa_dumpstate(void)
    * stack memory.
    */
 
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
+  if (sp >= ustackbase || sp < ustackbase - ustacksize)
     {
-      xtensa_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      xtensa_stackdump(ustackbase - ustacksize, ustackbase);
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      xtensa_stackdump(ustackbase, ustackbase + ustacksize);
+      xtensa_stackdump(sp, ustackbase);
     }
 
   /* Dump the state of all tasks (if available) */

--- a/arch/xtensa/src/common/xtensa_initialstate.c
+++ b/arch/xtensa/src/common/xtensa_initialstate.c
@@ -63,7 +63,8 @@ void up_initial_state(struct tcb_s *tcb)
   if (tcb->pid == 0)
     {
       tcb->stack_alloc_ptr = g_idlestack;
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (char *)g_idlestack +
+                             CONFIG_IDLETHREAD_STACKSIZE;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -73,10 +74,9 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Set initial values of registers */
 
-  xcp->regs[REG_PC]   = (uint32_t)tcb->start;           /* Task entrypoint                */
-  xcp->regs[REG_A0]   = 0;                              /* To terminate GDB backtrace     */
-  xcp->regs[REG_A1]   = (uint32_t)tcb->stack_base_ptr + /* Physical top of stack frame    */
-                                  tcb->adj_stack_size;
+  xcp->regs[REG_PC]   = (uint32_t)tcb->start;         /* Task entrypoint                */
+  xcp->regs[REG_A0]   = 0;                            /* To terminate GDB backtrace     */
+  xcp->regs[REG_A1]   = (uint32_t)tcb->adj_stack_ptr; /* Physical top of stack frame    */
 
   /* Set initial PS to int level 0, EXCM disabled ('rfe' will enable), user
    * mode.

--- a/arch/xtensa/src/common/xtensa_stackframe.c
+++ b/arch/xtensa/src/common/xtensa_stackframe.c
@@ -68,8 +68,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -84,8 +85,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -97,15 +96,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr    = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size  -= frame_size;
+
+  /* Reset the initial stack pointer (A1) */
+
+  tcb->xcp.regs[REG_A1] = (uint32_t)tcb->adj_stack_ptr;
 
   /* And return the pointer to the allocated region */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/xtensa/src/esp32/esp32_cpuidlestack.c
+++ b/arch/xtensa/src/esp32/esp32_cpuidlestack.c
@@ -73,8 +73,8 @@ uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS]
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is
@@ -88,6 +88,8 @@ uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS]
 
 int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
 {
+  uintptr_t topofstack;
+
   /* XTENSA uses a push-down stack:  the stack grows toward lower* addresses
    * in memory.  The stack pointer register points to the lowest, valid
    * working address (the "top" of the stack).  Items on the stack are
@@ -98,7 +100,9 @@ int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
 
   tcb->stack_alloc_ptr = g_cpu1_idlestack;
   tcb->adj_stack_size  = CPU1_IDLETHREAD_STACKSIZE;
-  tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+  topofstack           = (uintptr_t)g_cpu1_idlestack +
+                         CPU1_IDLETHREAD_STACKSIZE;
+  tcb->adj_stack_ptr   = (uint32_t *)topofstack;
 
 #if XCHAL_CP_NUM > 0
   /* REVISIT: Does it make since to have co-processors enabled on the IDLE

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -158,7 +158,7 @@ void xtensa_appcpu_start(void)
    * is to switch to a well-known IDLE thread stack.
    */
 
-  sp = (uint32_t)tcb->stack_base_ptr + tcb->adj_stack_size;
+  sp = (uint32_t)tcb->adj_stack_ptr;
   __asm__ __volatile__("mov sp, %0\n" : : "r"(sp));
 
   sinfo("CPU%d Started\n", up_cpu_index());

--- a/arch/z16/src/common/z16_createstack.c
+++ b/arch/z16/src/common/z16_createstack.c
@@ -62,8 +62,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -84,6 +84,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -123,14 +127,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -139,14 +145,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -164,7 +170,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -182,19 +188,23 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * the stack are referenced as positive word offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
       /* Align the stack to word (4 byte) boundaries.  This is probably
        * a greater alignment than is required.
        */
 
       top_of_stack &= ~3;
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/z16/src/common/z16_initialstate.c
+++ b/arch/z16/src/common/z16_initialstate.c
@@ -59,7 +59,6 @@ void up_initial_state(struct tcb_s *tcb)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   tcb->xcp.regs[REG_FLAGS] = (uint16_t)Z16F_CNTRL_FLAGS_IRQE; /* IRQE flag will enable interrupts */
 #endif
-  reg32[REG_SP / 2]        = (uint32_t)tcb->stack_base_ptr +
-                                       tcb->adj_stack_size;
+  reg32[REG_SP / 2]        = (uint32_t)tcb->adj_stack_ptr;
   reg32[REG_PC / 2]        = (uint32_t)tcb->start;
 }

--- a/arch/z16/src/common/z16_stackdump.c
+++ b/arch/z16/src/common/z16_stackdump.c
@@ -50,7 +50,7 @@ static void z16_stackdump(void)
 {
   struct tcb_s *rtcb = this_task();
   chipreg_t sp = z16_getsp();
-  chipreg_t stack_base = (chipreg_t)rtcb->stack_base_ptr;
+  chipreg_t stack_base = (chipreg_t)rtcb->adj_stack_ptr;
   chipreg_t stack_size = (chipreg_t)rtcb->adj_stack_size;
   chipreg_t stack;
 
@@ -58,18 +58,18 @@ static void z16_stackdump(void)
   _alert("stack_size: %08x\n", stack_size);
   _alert("sp:         %08x\n", sp);
 
-  if (sp >= stack_base && sp < stack_base + stack_size)
+  if (sp >= stack_base || sp < stack_base - stack_size)
     {
-      stack = sp;
+      _err("ERROR: Stack pointer is not within allocated stack\n");
+      stack = stack_base - stack_size;
     }
   else
     {
-      _err("ERROR: Stack pointer is not within allocated stack\n");
-      stack = stack_base;
+      stack = sp;
     }
 
   for (stack = stack & ~0x0f;
-       stack < stack_base + stack_size;
+       stack < stack_base;
        stack += 8 * sizeof(chipreg_t))
     {
       chipreg_t *ptr = (chipreg_t *)stack;

--- a/arch/z16/src/common/z16_stackframe.c
+++ b/arch/z16/src/common/z16_stackframe.c
@@ -71,8 +71,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -87,8 +88,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -100,15 +99,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
-  tcb->adj_stack_size -= frame_size;
+  tcb->adj_stack_ptr      = (uint8_t *)tcb->adj_stack_ptr - frame_size;
+  tcb->adj_stack_size    -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[REG_SP / 2] = (uint32_t)tcb->adj_stack_ptr;
 
   /* And return a pointer to the allocated memory */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/z16/src/common/z16_usestack.c
+++ b/arch/z16/src/common/z16_usestack.c
@@ -53,8 +53,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -67,9 +67,9 @@
  *
  ****************************************************************************/
 
-int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
+int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -105,19 +105,23 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
    * the stack are referenced as positive word offsets from sp.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
   /* Align the stack to word (4 byte) boundaries.  This is probably
    * a greater alignment than is required.
    */
 
   top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_size = top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/z80/src/common/z80_createstack.c
+++ b/arch/z80/src/common/z80_createstack.c
@@ -61,8 +61,8 @@
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -88,6 +88,10 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
+  /* Add the size of the TLS information structure */
+
+  stack_size += sizeof(struct tls_info_s);
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -127,14 +131,16 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kmm_memalign(TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_memalign(TLS_STACK_ALIGN, stack_size);
+          tcb->stack_alloc_ptr =
+            (uint32_t *)kumm_memalign(TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS_ALIGNED */
@@ -143,14 +149,14 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          tcb->stack_alloc_ptr = kmm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kmm_malloc(stack_size);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          tcb->stack_alloc_ptr = kumm_malloc(stack_size);
+          tcb->stack_alloc_ptr = (uint32_t *)kumm_malloc(stack_size);
         }
 #endif /* CONFIG_TLS_ALIGNED */
 
@@ -168,7 +174,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
   if (tcb->stack_alloc_ptr)
     {
-      uintptr_t top_of_stack;
+      size_t top_of_stack;
       size_t size_of_stack;
 
       /* Yes.. If stack debug is enabled, then fill the stack with a
@@ -187,19 +193,23 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * referenced as positive word offsets from sp.
        */
 
-      top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+      top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
       /* The Z80 stack does not need to be aligned.  Here is is aligned at
        * word (4 byte) boundary.
        */
 
       top_of_stack &= ~3;
-      size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+      size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr  = (FAR uint32_t *)top_of_stack;
       tcb->adj_stack_size = size_of_stack;
+
+      /* Initialize the TLS data structure */
+
+      memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/z80/src/common/z80_stackdump.c
+++ b/arch/z80/src/common/z80_stackdump.c
@@ -45,7 +45,7 @@ void up_stackdump(void)
 {
   FAR struct tcb_s *rtcb = this_task();
   uintptr_t sp = z80_getsp();
-  uintptr_t stack_base = (uintptr_t)rtcb->stack_base_ptr;
+  uintptr_t stack_base = (uintptr_t)rtcb->adj_stack_ptr;
   uintptr_t stack_size = (uintptr_t)rtcb->adj_stack_size;
   uintptr_t stack;
 
@@ -53,17 +53,17 @@ void up_stackdump(void)
   _alert("stack_size: %06x\n", stack_size);
   _alert("sp:         %06x\n", sp);
 
-  if (sp >= stack_base && sp < stack_base + stack_size)
+  if (sp >= stack_base || sp < stack_base - stack_size)
     {
-      stack = sp;
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      stack = stack_base - stack_size;
     }
   else
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      stack = stack_base;
+      stack = sp;
     }
 
-  for (stack = stack & ~0x0f; stack < stack_base + stack_size; stack += 16)
+  for (stack = stack & ~0x0f; stack < stack_base; stack += 16)
     {
       FAR uint8_t *ptr = (FAR uint8_t *)stack;
 

--- a/arch/z80/src/common/z80_stackframe.c
+++ b/arch/z80/src/common/z80_stackframe.c
@@ -70,8 +70,9 @@
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -86,8 +87,6 @@
 
 FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
-
   /* Align the frame_size */
 
   frame_size = STACK_ALIGN_UP(frame_size);
@@ -99,15 +98,16 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
       return NULL;
     }
 
-  ret = tcb->stack_base_ptr;
-  memset(ret, 0, frame_size);
-
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->adj_stack_ptr   = (uint8_t *)tcb->adj_stack_ptr - frame_size;
   tcb->adj_stack_size -= frame_size;
+
+  /* Reset the initial stack pointer */
+
+  tcb->xcp.regs[XCPT_SP] = (chipreg_t)tcb->adj_stack_ptr;
 
   /* And return a pointer to the allocated memory */
 
-  return ret;
+  return tcb->adj_stack_ptr;
 }

--- a/arch/z80/src/common/z80_usestack.c
+++ b/arch/z80/src/common/z80_usestack.c
@@ -52,8 +52,8 @@
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -68,7 +68,7 @@
 
 int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
-  uintptr_t top_of_stack;
+  size_t top_of_stack;
   size_t size_of_stack;
 
 #ifdef CONFIG_TLS_ALIGNED
@@ -104,19 +104,23 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * the stack are* referenced as positive word offsets from sp.
    */
 
-  top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
+  top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size;
 
   /* The Z80 stack does not need to be aligned.  Here is is aligned at
    * word (4 byte) boundary.
    */
 
   top_of_stack &= ~3;
-  size_of_stack = top_of_stack - (uintptr_t)tcb->stack_alloc_ptr;
+  size_of_stack = top_of_stack - (uint32_t)tcb->stack_alloc_ptr;
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->adj_stack_size = top_of_stack;
   tcb->adj_stack_size = size_of_stack;
+
+  /* Initialize the TLS data structure */
+
+  memset(tcb->stack_alloc_ptr, 0, sizeof(struct tls_info_s));
 
   return OK;
 }

--- a/arch/z80/src/ez80/ez80_initialstate.c
+++ b/arch/z80/src/ez80/ez80_initialstate.c
@@ -52,7 +52,7 @@
 
 void up_initial_state(FAR struct tcb_s *tcb)
 {
-  FAR struct xcptcontext *xcp = &tcb->xcp;
+  struct xcptcontext *xcp = &tcb->xcp;
 
   /* Initialize the initial exception register context structure */
 
@@ -61,10 +61,9 @@ void up_initial_state(FAR struct tcb_s *tcb)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   /* Parity/Overflow flag will enable interrupts */
 
-  ((FAR uint8_t *)xcp->regs)[XCPT_IF_OFFSET] = EZ80_PV_FLAG;
+  ((FAR uint8_t *)xcp->regs)[XCPT_IF_OFFSET]  = EZ80_PV_FLAG;
 #endif
 
-  xcp->regs[XCPT_SP] = (chipreg_t)tcb->stack_base_ptr +
-                                  tcb->adj_stack_size;
+  xcp->regs[XCPT_SP] = (chipreg_t)tcb->adj_stack_ptr;
   xcp->regs[XCPT_PC] = (chipreg_t)tcb->start;
 }

--- a/arch/z80/src/z180/z180_initialstate.c
+++ b/arch/z80/src/z180/z180_initialstate.c
@@ -58,7 +58,8 @@ void up_initial_state(struct tcb_s *tcb)
   if (tcb->pid == 0)
     {
       tcb->stack_alloc_ptr = (void *)CONFIG_STACK_BASE;
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->adj_stack_ptr   = (void *)(CONFIG_STACK_BASE +
+                                      CONFIG_IDLETHREAD_STACKSIZE);
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
     }
 
@@ -68,7 +69,6 @@ void up_initial_state(struct tcb_s *tcb)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   xcp->regs[XCPT_I]  = Z180_PV_FLAG; /* Parity flag will enable interrupts */
 #endif
-  xcp->regs[XCPT_SP] = (chipreg_t)tcb->stack_base_ptr +
-                                  tcb->adj_stack_size;
+  xcp->regs[XCPT_SP] = (chipreg_t)tcb->adj_stack_ptr;
   xcp->regs[XCPT_PC] = (chipreg_t)tcb->start;
 }

--- a/arch/z80/src/z8/z8_initialstate.c
+++ b/arch/z80/src/z8/z8_initialstate.c
@@ -74,7 +74,6 @@ void up_initial_state(FAR struct tcb_s *tcb)
   xcp->regs[XCPT_IRQCTL]  = 0x0080; /* IRQE bit will enable interrupts */
 #endif
   xcp->regs[XCPT_RPFLAGS] = 0xe000; /* RP=%e0 */
-  xcp->regs[XCPT_SP]      = (chipreg_t)tcb->stack_base_ptr +
-                                       tcb->adj_stack_size;
+  xcp->regs[XCPT_SP]      = (chipreg_t)tcb->adj_stack_ptr;
   xcp->regs[XCPT_PC]      = (chipreg_t)tcb->start;
 }

--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -181,8 +181,7 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
       pdump->info.stacks.user.sp = currentsp;
     }
 
-  pdump->info.stacks.user.top = (uint32_t)rtcb->stack_base_ptr +
-                                          rtcb->adj_stack_size;
+  pdump->info.stacks.user.top = (uint32_t)rtcb->adj_stack_ptr;
   pdump->info.stacks.user.size = (uint32_t)rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -449,9 +449,8 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
       pdump->info.stacks.user.sp = currentsp;
     }
 
-  pdump->info.stacks.user.top = (uint32_t)rtcb->stack_base_ptr +
-                                          rtcb->adj_stack_size;
-  pdump->info.stacks.user.size = (uint32_t)rtcb->adj_stack_size;
+  pdump->info.stacks.user.top = (uint32_t) rtcb->adj_stack_ptr;
+  pdump->info.stacks.user.size = (uint32_t) rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
   /* Get the limits on the interrupt stack memory */

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
@@ -449,9 +449,8 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
       pdump->info.stacks.user.sp = currentsp;
     }
 
-  pdump->info.stacks.user.top = (uint32_t)rtcb->stack_base_ptr +
-                                          rtcb->adj_stack_size;
-  pdump->info.stacks.user.size = (uint32_t)rtcb->adj_stack_size;
+  pdump->info.stacks.user.top = (uint32_t) rtcb->adj_stack_ptr;
+  pdump->info.stacks.user.size = (uint32_t) rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
   /* Get the limits on the interrupt stack memory */

--- a/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-grrose/src/rx65n_sbram.c
@@ -403,9 +403,8 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
       pdump->info.stacks.user.sp = currentsp;
     }
 
-  pdump->info.stacks.user.top = (uint32_t)rtcb->stack_base_ptr +
-                                          rtcb->adj_stack_size;
-  pdump->info.stacks.user.size = (uint32_t)rtcb->adj_stack_size;
+  pdump->info.stacks.user.top = (uint32_t) rtcb->adj_stack_ptr;
+  pdump->info.stacks.user.size = (uint32_t) rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
   /* Get the limits on the interrupt stack memory */

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_sbram.c
@@ -401,9 +401,8 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
       pdump->info.stacks.user.sp = currentsp;
     }
 
-  pdump->info.stacks.user.top = (uint32_t)rtcb->stack_base_ptr +
-                                          rtcb->adj_stack_size;
-  pdump->info.stacks.user.size = (uint32_t)rtcb->adj_stack_size;
+  pdump->info.stacks.user.top = (uint32_t) rtcb->adj_stack_ptr;
+  pdump->info.stacks.user.size = (uint32_t) rtcb->adj_stack_size;
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
   /* Get the limits on the interrupt stack memory */

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -857,7 +857,7 @@ static ssize_t proc_stack(FAR struct proc_file_s *procfile,
   /* Show the stack base address */
 
   linesize   = snprintf(procfile->line, STATUS_LINELEN, "%-12s0x%p\n",
-                        "StackBase:", tcb->stack_base_ptr);
+                        "StackBase:", tcb->adj_stack_ptr);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                              &offset);
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -232,8 +232,8 @@ void up_initial_state(FAR struct tcb_s *tcb);
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task
@@ -274,8 +274,8 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype);
  *     processor, etc.  This value is retained only for debug
  *     purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The
+ *     initial value of the stack pointer.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -308,24 +308,9 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size);
  *
  *   - adj_stack_size: Stack size after removal of the stack frame from
  *     the stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
- *
- *   Here is the diagram after some allocation(tls, arg):
- *
- *                   +-------------+ <-stack_alloc_ptr(lowest)
- *                   |  TLS Data   |
- *                   +-------------+
- *                   |  Arguments  |
- *  stack_base_ptr-> +-------------+\
- *                   |  Available  | +
- *                   |    Stack    | |
- *                |  |             | |
- *                |  |             | +->adj_stack_size
- *                v  |             | |
- *                   |             | |
- *                   |             | +
- *                   +-------------+/
+ *   - adj_stack_ptr: Adjusted initial stack pointer after the frame has
+ *     been removed from the stack.  This will still be the initial value
+ *     of the stack pointer when the task is started.
  *
  * Input Parameters:
  *   - tcb:  The TCB of new task
@@ -1862,8 +1847,8 @@ int up_cpu_index(void);
  *   - adj_stack_size: Stack size after adjustment for hardware, processor,
  *     etc.  This value is retained only for debug purposes.
  *   - stack_alloc_ptr: Pointer to allocated stack
- *   - stack_base_ptr: Adjusted stack base pointer after the TLS Data and
- *     Arguments has been removed from the stack allocation.
+ *   - adj_stack_ptr: Adjusted stack_alloc_ptr for HW.  The initial value of
+ *     the stack pointer.
  *
  * Input Parameters:
  *   - cpu:         CPU index that indicates which CPU the IDLE task is

--- a/include/nuttx/lib/libvars.h
+++ b/include/nuttx/lib/libvars.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/z80/src/z80/z80_initialstate.c
+ * include/nuttx/lib/libvars.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,57 +18,59 @@
  *
  ****************************************************************************/
 
+#ifndef __INCLUDE_NUTTX_LIB_LIBVARS_H
+#define __INCLUDE_NUTTX_LIB_LIBVARS_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#include <string.h>
-#include <nuttx/arch.h>
+#include <stdbool.h>
 
-#include "chip.h"
-#include "z80_internal.h"
-#include "z80_arch.h"
+#include <nuttx/lib/getopt.h>
 
 /****************************************************************************
- * Public Functions
+ * Public Types
  ****************************************************************************/
 
-/****************************************************************************
- * Name: up_initial_state
+#ifndef CONFIG_BUILD_KERNEL
+/* This structure encapsulates all task-specific variables needed by the C
+ * Library.  This structure is retained at the beginning of the main thread
+ * of and is accessed via a reference stored in the TLS of all threads in
+ * the task group.
  *
- * Description:
- *   A new thread is being started and a new TCB
- *   has been created. This function is called to initialize
- *   the processor specific portions of the new TCB.
- *
- *   This function must setup the initial architecture registers
- *   and/or  stack so that execution will begin at tcb->start
- *   on the next context switch.
- *
- ****************************************************************************/
+ * NOTE: task-specific variables are not needed in the KERNEL build.  In
+ * that build mode, all global variables are inherently process-specific.
+ */
 
-void up_initial_state(struct tcb_s *tcb)
+struct libvars_s
 {
-  struct xcptcontext *xcp = &tcb->xcp;
-
-  /* Initialize the idle thread stack */
-
-  if (tcb->pid == 0)
-    {
-      tcb->stack_alloc_ptr = (void *)CONFIG_STACK_BASE;
-      tcb->adj_stack_ptr   = (void *)(CONFIG_STACK_BASE +
-                                      CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
-    }
-
-  /* Initialize the initial exception register context structure */
-
-  memset(xcp, 0, sizeof(struct xcptcontext));
-#ifndef CONFIG_SUPPRESS_INTERRUPTS
-  xcp->regs[XCPT_I]  = Z80_PV_FLAG; /* Parity flag will enable interrupts */
+  struct getopt_s lv_getopt; /* Globals used by getopt() */
+};
 #endif
-  xcp->regs[XCPT_SP] = (chipreg_t)tcb->adj_stack_ptr;
-  xcp->regs[XCPT_PC] = (chipreg_t)tcb->start;
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
 }
+#endif
+
+#endif /* __INCLUDE_NUTTX_LIB_LIBVARS_H */

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -27,7 +27,7 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/lib/getopt.h>
+#include <sys/types.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -71,26 +71,6 @@
  *
  * The stack memory is fully accessible to user mode threads.  TLS is not
  * available from interrupt handlers (nor from the IDLE thread).
- *
- * The following diagram represent the typic stack layout:
- *
- *      Push Down             Push Up
- *   +-------------+      +-------------+ <- Stack memory allocation
- *   |  TLS Data   |      |  TLS Data   |
- *   +-------------+      +-------------+
- *   | Task Data*  |      | Task Data*  |
- *   +-------------+      +-------------+
- *   |  Arguments  |      |  Arguments  |
- *   +-------------+      +-------------+ |
- *   |             |      |             | v
- *   | Available   |      | Available   |
- *   |   Stack     |      |   Stack     |
- *   |             |      |             |
- *   |             |      |             |
- *   |             | ^    |             |
- *   +-------------+ |    +-------------+
- *
- *  Task data is allocated in the main's thread's stack only
  */
 
 struct tls_info_s
@@ -98,15 +78,8 @@ struct tls_info_s
 #if CONFIG_TLS_NELEM > 0
   uintptr_t tl_elem[CONFIG_TLS_NELEM]; /* TLS elements */
 #endif
+  FAR struct libvars_s *tl_libvars;    /* Task-specific C library data */
   int tl_errno;                        /* Per-thread error number */
-};
-
-struct task_info_s
-{
-  struct tls_info_s ta_tls;    /* Must be first field */
-#ifndef CONFIG_BUILD_KERNEL
-  struct getopt_s   ta_getopt; /* Globals used by getopt() */
-#endif
 };
 
 /****************************************************************************
@@ -215,22 +188,5 @@ int tls_set_value(int tlsindex, uintptr_t tlsvalue);
 #ifndef CONFIG_TLS_ALIGNED
 FAR struct tls_info_s *tls_get_info(void);
 #endif
-
-/****************************************************************************
- * Name: task_get_info
- *
- * Description:
- *   Return a reference to the task_info_s structure.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   A reference to the task-specific task_info_s structure is return on
- *   success.  NULL would be returned in the event of any failure.
- *
- ****************************************************************************/
-
-FAR struct task_info_s *task_get_info(void);
 
 #endif /* __INCLUDE_NUTTX_TLS_H */

--- a/libs/libc/pthread/pthread_get_stackaddr_np.c
+++ b/libs/libc/pthread/pthread_get_stackaddr_np.c
@@ -74,5 +74,5 @@ FAR void *pthread_get_stackaddr_np(pthread_t thread)
       return NULL;
     }
 
-  return stackinfo.stack_base_ptr;
+  return stackinfo.adj_stack_ptr;
 }

--- a/libs/libc/tls/Make.defs
+++ b/libs/libc/tls/Make.defs
@@ -18,8 +18,6 @@
 #
 ############################################################################
 
-CSRCS += task_getinfo.c
-
 ifneq ($(CONFIG_TLS_NELEM),0)
 CSRCS += tls_setvalue.c tls_getvalue.c
 endif

--- a/libs/libc/tls/tls.h
+++ b/libs/libc/tls/tls.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/sim/src/sim/up_initialstate.c
+ * libs/libc/tls/tls.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,48 +18,17 @@
  *
  ****************************************************************************/
 
+#ifndef __SCHED_TLS_TLS_H
+#define __SCHED_TLS_TLS_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#include <stdint.h>
-#include <string.h>
-
-#include <nuttx/arch.h>
-
-#include "up_internal.h"
-
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
-/****************************************************************************
- * Name: up_initial_state
- *
- * Description:
- *   A new thread is being started and a new TCB
- *   has been created. This function is called to initialize
- *   the processor specific portions of the new TCB.
- *
- *   This function must setup the initial architecture registers
- *   and/or  stack so that execution will begin at tcb->start
- *   on the next context switch.
- *
- ****************************************************************************/
-
-void up_initial_state(struct tcb_s *tcb)
-{
-  if (tcb->pid == 0)
-    {
-      tcb->stack_alloc_ptr = (void *)(sim_getsp() -
-                                      CONFIG_IDLETHREAD_STACKSIZE);
-      tcb->adj_stack_ptr   = (void *)sim_getsp();
-      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
-    }
-
-  memset(&tcb->xcp, 0, sizeof(struct xcptcontext));
-  tcb->xcp.regs[JB_SP] = (xcpt_reg_t)tcb->adj_stack_ptr - sizeof(xcpt_reg_t);
-  tcb->xcp.regs[JB_PC] = (xcpt_reg_t)tcb->start;
-}
+#endif /* __SCHED_TLS_TLS_H */

--- a/libs/libc/unistd/lib_getoptvars.c
+++ b/libs/libc/unistd/lib_getoptvars.c
@@ -24,11 +24,16 @@
 
 #include <nuttx/config.h>
 
+#include <unistd.h>
 #include <assert.h>
 
 #include <nuttx/tls.h>
+#include <nuttx/lib/libvars.h>
+
+#include <arch/tls.h>
 
 #include "unistd.h"
+#include "libc.h"
 
 /****************************************************************************
  * Private Data
@@ -65,13 +70,13 @@ FAR struct getopt_s g_getopt_vars =
 FAR struct getopt_s *getoptvars(void)
 {
 #ifndef CONFIG_BUILD_KERNEL
-  FAR struct task_info_s *info;
+  FAR struct tls_info_s *tlsinfo;
 
   /* Get the structure of getopt() variables using the key. */
 
-  info = task_get_info();
-  DEBUGASSERT(info != NULL);
-  return &info->ta_getopt;
+  tlsinfo = up_tls_info();
+  DEBUGASSERT(tlsinfo != NULL && tlsinfo->tl_libvars != NULL);
+  return &tlsinfo->tl_libvars->lv_getopt;
 #else
   return &g_getopt_vars;
 #endif

--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -57,6 +57,10 @@ ifneq ($(CONFIG_TLS_NELEM),0)
 CSRCS += group_tlsalloc.c group_tlsfree.c
 endif
 
+ifndef CONFIG_BUILD_KERNEL
+CSRCS += group_taskdata.c
+endif
+
 # Include group build support
 
 DEPPATH += --dep-path group

--- a/sched/group/group.h
+++ b/sched/group/group.h
@@ -140,4 +140,10 @@ int  group_setuptaskfiles(FAR struct task_tcb_s *tcb);
 int  group_setupstreams(FAR struct task_tcb_s *tcb);
 #endif
 
+#ifndef CONFIG_BUILD_KERNEL
+/* Task specific data */
+
+void tls_set_taskdata(FAR struct tcb_s *tcb);
+#endif
+
 #endif /* __SCHED_GROUP_GROUP_H */

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -40,7 +40,6 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/pthread.h>
-#include <nuttx/tls.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -219,7 +218,6 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
                    pthread_startroutine_t start_routine, pthread_addr_t arg)
 {
   FAR struct pthread_tcb_s *ptcb;
-  FAR struct tls_info_s *info;
   FAR struct join_s *pjoin;
   struct sched_param param;
   int policy;
@@ -293,8 +291,7 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
     {
       /* Allocate the stack for the TCB */
 
-      ret = up_create_stack((FAR struct tcb_s *)ptcb,
-                            sizeof(struct tls_info_s) + attr->stacksize,
+      ret = up_create_stack((FAR struct tcb_s *)ptcb, attr->stacksize,
                             TCB_FLAG_TTYPE_PTHREAD);
     }
 
@@ -304,16 +301,11 @@ int pthread_create(FAR pthread_t *thread, FAR const pthread_attr_t *attr,
       goto errout_with_join;
     }
 
-  /* Initialize thread local storage */
+#ifndef CONFIG_BUILD_KERNEL
+  /* Save the allocated task data in TLS */
 
-  info = up_stack_frame(&ptcb->cmn, sizeof(struct tls_info_s));
-  if (info == NULL)
-    {
-      errcode = ENOMEM;
-      goto errout_with_join;
-    }
-
-  DEBUGASSERT(info == ptcb->cmn.stack_alloc_ptr);
+  tls_set_taskdata(&ptcb->cmn);
+#endif
 
   /* Should we use the priority and scheduler specified in the pthread
    * attributes?  Or should we use the current thread's priority and

--- a/sched/sched/sched_get_stackinfo.c
+++ b/sched/sched/sched_get_stackinfo.c
@@ -42,7 +42,7 @@
  *
  * Input Parameters:
  *   pid       - Identifies the thread to query.  Zero is interpreted as the
- *               the calling thread, -1 is interpreted as the calling task.
+ *               the calling thread
  *   stackinfo - User-provided location to return the stack information.
  *
  * Returned Value:
@@ -68,16 +68,6 @@ int nxsched_get_stackinfo(pid_t pid, FAR struct stackinfo_s *stackinfo)
       /* We can always query ourself */
 
       qtcb = rtcb;
-    }
-  else if (pid == -1)
-    {
-      /* We can always query our main thread */
-
-      qtcb = nxsched_get_tcb(rtcb->group->tg_pid);
-      if (qtcb == NULL)
-        {
-          return -ENOENT;
-        }
     }
   else
     {
@@ -110,7 +100,6 @@ int nxsched_get_stackinfo(pid_t pid, FAR struct stackinfo_s *stackinfo)
 
   stackinfo->adj_stack_size  = qtcb->adj_stack_size;
   stackinfo->stack_alloc_ptr = qtcb->stack_alloc_ptr;
-  stackinfo->stack_base_ptr   = qtcb->stack_base_ptr;
-
+  stackinfo->adj_stack_ptr   = qtcb->adj_stack_ptr;
   return OK;
 }

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -32,7 +32,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
-#include <nuttx/tls.h>
+#include <nuttx/lib/libvars.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -85,7 +85,9 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 main_t entry, FAR char * const argv[])
 {
   uint8_t ttype = tcb->cmn.flags & TCB_FLAG_TTYPE_MASK;
-  FAR struct task_info_s *info;
+#ifndef CONFIG_BUILD_KERNEL
+  FAR struct task_group_s *group;
+#endif
   int ret;
 
 #ifndef CONFIG_DISABLE_PTHREAD
@@ -120,9 +122,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
     {
       /* Allocate the stack for the TCB */
 
-      ret = up_create_stack(&tcb->cmn,
-                            sizeof(struct task_info_s) + stack_size,
-                            ttype);
+      ret = up_create_stack(&tcb->cmn, stack_size, ttype);
     }
 
   if (ret < OK)
@@ -130,16 +130,21 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
       goto errout_with_group;
     }
 
-  /* Initialize thread local storage */
+#ifndef CONFIG_BUILD_KERNEL
+  /* Allocate a stack frame to hold task-specific data */
 
-  info = up_stack_frame(&tcb->cmn, sizeof(struct task_info_s));
-  if (info == NULL)
-    {
-      ret = -ENOMEM;
-      goto errout_with_group;
-    }
+  group = tcb->cmn.group;
+  group->tg_libvars = up_stack_frame(&tcb->cmn, sizeof(struct libvars_s));
+  DEBUGASSERT(group->tg_libvars != NULL);
 
-  DEBUGASSERT(info == tcb->cmn.stack_alloc_ptr);
+  /* Initialize the task-specific data */
+
+  memset(group->tg_libvars, 0, sizeof(struct libvars_s));
+
+  /* Save the allocated task data in TLS */
+
+  tls_set_taskdata(&tcb->cmn);
+#endif
 
   /* Initialize the task control block */
 

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -34,15 +34,190 @@
 #include <debug.h>
 
 #include <nuttx/sched.h>
-#include <nuttx/tls.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
 #include "task/task.h"
 
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
 /* vfork() requires architecture-specific support as well as waipid(). */
 
 #if defined(CONFIG_ARCH_HAVE_VFORK) && defined(CONFIG_SCHED_WAITPID)
+
+/* This is an artificial limit to detect error conditions where an argv[]
+ * list is not properly terminated.
+ */
+
+#define MAX_VFORK_ARGS 256
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxvfork_setup_name
+ *
+ * Description:
+ *   Copy the task name.
+ *
+ * Input Parameters:
+ *   tcb        - Address of the new task's TCB
+ *   name       - Name of the new task
+ *
+ * Returned Value:
+ *  None
+ *
+ ****************************************************************************/
+
+#if CONFIG_TASK_NAME_SIZE > 0
+static inline void nxvfork_setup_name(FAR struct tcb_s *parent,
+                                      FAR struct task_tcb_s *child)
+{
+  /* Copy the name from the parent into the child TCB */
+
+  strncpy(child->cmn.name, parent->name, CONFIG_TASK_NAME_SIZE);
+}
+#else
+#  define nxvfork_setup_name(p,c)
+#endif /* CONFIG_TASK_NAME_SIZE */
+
+/****************************************************************************
+ * Name: nxvfork_setup_stackargs
+ *
+ * Description:
+ *   Clone the task arguments in the same relative positions on the child's
+ *   stack.
+ *
+ * Input Parameters:
+ *   parent - Address of the parent task's TCB
+ *   child  - Address of the child task's TCB
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno on failure.
+ *
+ ****************************************************************************/
+
+static inline int nxvfork_setup_stackargs(FAR struct tcb_s *parent,
+                                          FAR struct task_tcb_s *child)
+{
+  /* Is the parent a task? or a pthread?  Only tasks (and kernel threads)
+   * have command line arguments.
+   */
+
+  child->argv = NULL;
+  if ((parent->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_PTHREAD)
+    {
+      FAR struct task_tcb_s *ptcb = (FAR struct task_tcb_s *)parent;
+      uintptr_t offset;
+      int argc;
+
+      /* Get the address correction */
+
+      offset = (uintptr_t)child->cmn.adj_stack_ptr -
+               (uintptr_t)parent->adj_stack_ptr;
+
+      /* Change the child argv[] to point into its stack (instead of its
+       * parent's stack).
+       */
+
+      child->argv = (FAR char **)((uintptr_t)ptcb->argv + offset);
+
+      /* Copy the adjusted address for each argument */
+
+      argc = 0;
+      while (ptcb->argv[argc])
+        {
+          uintptr_t newaddr = (uintptr_t)ptcb->argv[argc] + offset;
+          child->argv[argc] = (FAR char *)newaddr;
+
+          /* Increment the number of args.  Here is a sanity check to
+           * prevent running away with an unterminated argv[] list.
+           * MAX_VFORK_ARGS should be sufficiently large that this never
+           * happens in normal usage.
+           */
+
+          if (++argc > MAX_VFORK_ARGS)
+            {
+              return -E2BIG;
+            }
+        }
+
+      /* Put a terminator entry at the end of the child argv[] array. */
+
+      child->argv[argc] = NULL;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: nxvfork_setup_arguments
+ *
+ * Description:
+ *   Clone the argument list from the parent to the child.
+ *
+ * Input Parameters:
+ *   parent - Address of the parent task's TCB
+ *   child  - Address of the child task's TCB
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno on failure.
+ *
+ ****************************************************************************/
+
+static inline int nxvfork_setup_arguments(FAR struct tcb_s *parent,
+                                          FAR struct task_tcb_s *child)
+{
+  /* Clone the task name */
+
+  nxvfork_setup_name(parent, child);
+
+  /* Adjust and copy the argv[] array. */
+
+  return nxvfork_setup_stackargs(parent, child);
+}
+
+/****************************************************************************
+ * Name: nxvfork_sizeof_arguments
+ *
+ * Description:
+ *   Get the parent's argument size.
+ *
+ * Input Parameters:
+ *   parent - Address of the parent task's TCB
+ *
+ * Return Value:
+ *   The parent's argument size.
+ *
+ ****************************************************************************/
+
+static inline size_t nxvfork_sizeof_arguments(FAR struct tcb_s *parent)
+{
+  if ((parent->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_PTHREAD)
+    {
+      FAR struct task_tcb_s *ptcb = (FAR struct task_tcb_s *)parent;
+      size_t strtablen = 0;
+      int argc = 0;
+
+      while (ptcb->argv[argc])
+        {
+          /* Add the size of this argument (with NUL terminator) */
+
+          strtablen += strlen(ptcb->argv[argc++]) + 1;
+        }
+
+      /* Return the size to hold argv[] array and the strings. */
+
+      return (argc + 1) * sizeof(FAR char *) + strtablen;
+    }
+  else
+    {
+      return 0;
+    }
+}
 
 /****************************************************************************
  * Public Functions
@@ -71,10 +246,10 @@
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) up_vfork() provides any additional operating context. up_vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) up_vfork() then calls nxtask_start_vfork()
@@ -91,48 +266,29 @@
  *
  ****************************************************************************/
 
-FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
+FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr, size_t *argsize)
 {
-  FAR struct tcb_s *ptcb = this_task();
-  FAR struct task_tcb_s *parent;
+  FAR struct tcb_s *parent = this_task();
   FAR struct task_tcb_s *child;
-  FAR struct task_info_s *info;
-  FAR const char *name = NULL;
-  size_t stack_size;
   uint8_t ttype;
   int priority;
   int ret;
 
-  DEBUGASSERT(retaddr != NULL);
+  DEBUGASSERT(retaddr != NULL && argsize != NULL);
 
   /* Get the type of the fork'ed task (kernel or user) */
 
-  if ((ptcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
+  if ((parent->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
     {
       /* Fork'ed from a kernel thread */
 
       ttype = TCB_FLAG_TTYPE_KERNEL;
-      parent = (FAR struct task_tcb_s *)ptcb;
     }
   else
     {
       /* Fork'ed from a user task or pthread */
 
       ttype = TCB_FLAG_TTYPE_TASK;
-      if ((ptcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_TASK)
-        {
-          parent = (FAR struct task_tcb_s *)ptcb;
-        }
-      else
-        {
-          parent = (FAR struct task_tcb_s *)
-              nxsched_get_tcb(ptcb->group->tg_pid);
-          if (parent == NULL)
-            {
-              ret = -ENOENT;
-              goto errout;
-            }
-        }
     }
 
   /* Allocate a TCB for the child task. */
@@ -141,13 +297,13 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
   if (!child)
     {
       serr("ERROR: Failed to allocate TCB\n");
-      ret = -ENOMEM;
-      goto errout;
+      set_errno(ENOMEM);
+      return NULL;
     }
 
   /* Allocate a new task group with the same privileges as the parent */
 
-  ret = group_allocate(child, ttype);
+  ret = group_allocate(child, parent->flags);
   if (ret < 0)
     {
       goto errout_with_tcb;
@@ -161,71 +317,33 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
       goto errout_with_tcb;
     }
 
-  /* Allocate the stack for the TCB */
-
-  stack_size = (uintptr_t)ptcb->stack_base_ptr -
-      (uintptr_t)ptcb->stack_alloc_ptr + ptcb->adj_stack_size;
-
-  ret = up_create_stack(&child->cmn, stack_size, ttype);
-  if (ret < OK)
-    {
-      goto errout_with_tcb;
-    }
-
-  /* Setup thread local storage */
-
-  info = up_stack_frame(&child->cmn, sizeof(struct task_info_s));
-  if (info == NULL)
-    {
-      ret = -ENOMEM;
-      goto errout_with_tcb;
-    }
-
-  DEBUGASSERT(info == child->cmn.stack_alloc_ptr);
-  memcpy(info, parent->cmn.stack_alloc_ptr, sizeof(struct task_info_s));
-
   /* Get the priority of the parent task */
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-  priority = ptcb->base_priority;   /* "Normal," unboosted priority */
+  priority = parent->base_priority;   /* "Normal," unboosted priority */
 #else
-  priority = ptcb->sched_priority;  /* Current priority */
+  priority = parent->sched_priority;  /* Current priority */
 #endif
 
   /* Initialize the task control block.  This calls up_initial_state() */
 
   sinfo("Child priority=%d start=%p\n", priority, retaddr);
-  ret = nxtask_setup_scheduler(child, priority, retaddr,
-                               ptcb->entry.main, ttype);
+  ret = nxtask_setup_scheduler(child, priority, retaddr, parent->entry.main,
+                          ttype);
   if (ret < OK)
     {
       goto errout_with_tcb;
     }
 
-  /* Setup to pass parameters to the new task */
+  /* Return the argument size */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  name = parent->cmn.name;
-#endif
-
-  nxtask_setup_arguments(child, name, parent->argv);
-
-  /* Now we have enough in place that we can join the group */
-
-  ret = group_initialize(child);
-  if (ret < OK)
-    {
-      goto errout_with_list;
-    }
+  *argsize = nxvfork_sizeof_arguments(parent);
 
   sinfo("parent=%p, returning child=%p\n", parent, child);
   return child;
 
-errout_with_list:
-  dq_rem((FAR dq_entry_t *)child, (FAR dq_queue_t *)&g_inactivetasks);
 errout_with_tcb:
   nxsched_release_tcb((FAR struct tcb_s *)child, ttype);
-errout:
   set_errno(-ret);
   return NULL;
 }
@@ -253,10 +371,10 @@ errout:
  *      - Allocation of the child task's TCB.
  *      - Initialization of file descriptors and streams
  *      - Configuration of environment variables
- *      - Allocate and initialize the stack
  *      - Setup the input parameters for the task.
- *      - Initialization of the TCB (including call to up_initial_state())
+ *      - Initialization of the TCB (including call to up_initial_state()
  *   4) vfork() provides any additional operating context. vfork must:
+ *      - Allocate and initialize the stack
  *      - Initialize special values in any CPU registers that were not
  *        already configured by up_initial_state()
  *   5) vfork() then calls nxtask_start_vfork()
@@ -276,12 +394,31 @@ errout:
 
 pid_t nxtask_start_vfork(FAR struct task_tcb_s *child)
 {
+  FAR struct tcb_s *parent = this_task();
   pid_t pid;
-  int rc = 0;
+  int rc;
   int ret;
 
-  sinfo("Starting Child TCB=%p\n", child);
+  sinfo("Starting Child TCB=%p, parent=%p\n", child, this_task());
   DEBUGASSERT(child);
+
+  /* Duplicate the original argument list in the forked child TCB */
+
+  ret = nxvfork_setup_arguments(parent, child);
+  if (ret < 0)
+    {
+      nxtask_abort_vfork(child, -ret);
+      return ERROR;
+    }
+
+  /* Now we have enough in place that we can join the group */
+
+  ret = group_initialize(child);
+  if (ret < 0)
+    {
+      nxtask_abort_vfork(child, -ret);
+      return ERROR;
+    }
 
   /* Get the assigned pid before we start the task */
 
@@ -316,11 +453,17 @@ pid_t nxtask_start_vfork(FAR struct task_tcb_s *child)
    * opportunity to run.
    */
 
+  rc = 0;
+
+#ifdef CONFIG_DEBUG_FEATURES
   ret = waitpid(pid, &rc, 0);
   if (ret < 0)
     {
       serr("ERROR: waitpid failed: %d\n", get_errno());
     }
+#else
+  waitpid(pid, &rc, 0);
+#endif
 
   sched_unlock();
   return pid;
@@ -346,7 +489,7 @@ void nxtask_abort_vfork(FAR struct task_tcb_s *child, int errcode)
   /* Release the TCB */
 
   nxsched_release_tcb((FAR struct tcb_s *)child,
-                      child->cmn.flags & TCB_FLAG_TTYPE_MASK);
+                   child->cmn.flags & TCB_FLAG_TTYPE_MASK);
   set_errno(errcode);
 }
 


### PR DESCRIPTION
## Summary

This reverts commit 2335b69120a3e36f1aa0cecc19c95208806cae54.

It seems that the commit is question broke sim/Linux and sim/macOS.
Both of the following crashes are fixed by this revert.

My app running with sim/Linux started crashing with the commit.

```
Program received signal SIGSEGV, Segmentation fault.
0x00000000004583ad in snprintf (buf=0x7f6260682b30 "\020", size=140060500962096, format=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at stdio/lib_snprintf.c:41
41      stdio/lib_snprintf.c: No such file or directory.
rax            0x0                 0
rbx            0x0                 0
rcx            0x1                 1
rdx            0x5515d0            5576144
rsi            0x10                16
rdi            0x7f6260682858      140060500961368
rbp            0x7f6260682808      0x7f6260682808
rsp            0x7f6260682628      0x7f6260682628
r8             0x7f62606825e0      140060500960736
r9             0x0                 0
r10            0x8                 8
r11            0x246               582
r12            0x0                 0
r13            0x0                 0
r14            0x0                 0
r15            0x0                 0
rip            0x4583ad            0x4583ad <snprintf+13>
eflags         0x10246             [ PF ZF IF RF ]
cs             0x33                51
ss             0x2b                43
ds             0x0                 0
es             0x0                 0
fs             0x0                 0
gs             0x0                 0
```

sim:ostest on macOS crashes like the following.

```
spacetanuki% lldb ./nuttx
(lldb) target create "./nuttx"
Current executable set to './nuttx' (x86_64).
(lldb) run
Process 67434 launched: '/Users/yamamoto/git/nuttx/nuttx/nuttx' (x86_64)
Process 67434 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=EXC_I386_GPFLT)
    frame #0: 0x00007fff6f1633a6 libdyld.dylib`stack_not_16_byte_aligned_error
libdyld.dylib`stack_not_16_byte_aligned_error:
->  0x7fff6f1633a6 <+0>: movdqa %xmm0, (%rsp)
    0x7fff6f1633ab <+5>: int3

libdyld.dylib`_dyld_fast_stub_entry:
    0x7fff6f1633ac <+0>: pushq  %rbp
    0x7fff6f1633ad <+1>: movq   %rsp, %rbp
Target 0: (nuttx) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=EXC_I386_GPFLT)
  * frame #0: 0x00007fff6f1633a6 libdyld.dylib`stack_not_16_byte_aligned_error
    frame #1: 0x0000000101002048
    frame #2: 0x000000010001682d nuttx`tty_send(dev=0x000000010002f370, ch=115) at up_uart.c:447:3
    frame #3: 0x000000010000d7df nuttx`uart_xmitchars(dev=0x000000010002f370) at serial_io.c:68:7
    frame #4: 0x0000000100016a95 nuttx`tty_txint(dev=0x000000010002f370, enable='\x01') at up_uart.c:462:7
    frame #5: 0x000000010000ce48 nuttx`uart_write(filep=0x00000001010011e8, buffer="", buflen=0) at serial.c:1260:7
    frame #6: 0x0000000100024ef3 nuttx`file_write(filep=0x00000001010011e8, buf=0x0000000100027a30, nbytes=23) at fs_write.c:89:10
    frame #7: 0x0000000100024f6a nuttx`nx_write(fd=1, buf=0x0000000100027a30, nbytes=23) at fs_write.c:138:13
    frame #8: 0x0000000100024fab nuttx`file_write(filep=0x0000000100027a30, buf=0x0000000000000017, nbytes=0) at fs_write.c:76:7
    frame #9: 0x000000010002215e nuttx`stdio_test at ostest_main.c:574:3
    frame #10: 0x0000000100021f1b nuttx`ostest_main(argc=1, argv=0x0000000101001300) at ostest_main.c:602:3
    frame #11: 0x000000010000ff05 nuttx`nxtask_startup(entrypt=(nuttx`ostest_main at ostest_main.c:592), argc=1, argv=0x0000000101001300) at task_startup.c:150:8
    frame #12: 0x000000010000a580 nuttx`nxtask_start at task_start.c:129:7
(lldb)
```

## Impact

## Testing

