### PR TITLE
arch: fe310: Add coloration for the idle stack

### DIFF
--- a/arch/risc-v/src/fe310/fe310_head.S
+++ b/arch/risc-v/src/fe310/fe310_head.S
@@ -26,6 +26,8 @@
 #include <arch/rv32im/irq.h>
 
 #include "chip.h"
+#include "fe310_memorymap.h"
+#include "riscv_internal.h"
 
 /****************************************************************************
  * Public Symbols
@@ -44,8 +46,7 @@ __start:
 
   /* Set stack pointer to the idle thread stack */
 
-  lui  sp, %hi(FE310_IDLESTACK_TOP)
-  addi sp, sp, %lo(FE310_IDLESTACK_TOP)
+  la   sp, FE310_IDLESTACK_TOP
 
   /* Disable all interrupts (i.e. timer, external) in mie */
 
@@ -53,9 +54,21 @@ __start:
 
   /* Initialize the Machine Trap Vector */
 
-  lui  t0, %hi(__trap_vec)
-  addi t0, t0, %lo(__trap_vec)
-  csrw  mtvec, t0
+  la   t0, __trap_vec
+  csrw mtvec, t0
+
+#ifdef CONFIG_STACK_COLORATION
+  /* t0 = start of IDLE stack; t1 = top of the stack; t2 = coloration */
+
+  la   t0, FE310_IDLESTACK_BASE
+  la   t1, FE310_IDLESTACK_TOP
+  li   t2, STACK_COLOR
+
+1:
+  sw   t2, 0(t0)
+  addi t0, t0, 4
+  bne  t0, t1, 1b
+#endif
 
   /* Jump to __fe310_start */
 

--- a/arch/risc-v/src/fe310/fe310_memorymap.h
+++ b/arch/risc-v/src/fe310/fe310_memorymap.h
@@ -36,12 +36,13 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Idle thread stack starts from _ebss */
+/* Idle thread stack starts from _default_stack_limit */
 
 #ifndef __ASSEMBLY__
-#define FE310_IDLESTACK_BASE  (uint32_t)&_ebss
+extern uintptr_t *_default_stack_limit;
+#define FE310_IDLESTACK_BASE  (uintptr_t)&_default_stack_limit
 #else
-#define FE310_IDLESTACK_BASE  _ebss
+#define FE310_IDLESTACK_BASE  _default_stack_limit
 #endif
 
 #define FE310_IDLESTACK_TOP  (FE310_IDLESTACK_BASE + CONFIG_IDLETHREAD_STACKSIZE)

--- a/boards/risc-v/fe310/hifive1-revb/scripts/ld-qemu.script
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/ld-qemu.script
@@ -74,6 +74,8 @@ SECTIONS
         *(COMMON)
         . = ALIGN(4);
         _ebss = ABSOLUTE(.);
+        . = ALIGN(32);
+        _default_stack_limit = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/fe310/hifive1-revb/scripts/ld.script
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/ld.script
@@ -74,6 +74,8 @@ SECTIONS
         *(COMMON)
         . = ALIGN(4);
         _ebss = ABSOLUTE(.);
+        . = ALIGN(32);
+        _default_stack_limit = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */


### PR DESCRIPTION
## Summary

- This commit adds coloration for the idle stack
- Also, apply la pseudo-instruction instead of lui and addi

## Impact

- fe310 only

## Testing

- Tested with nsh with QEMU and dev board

