### PR TITLE
sim: Restore stack alignemnt

### DIFF
--- a/arch/sim/src/sim/up_initialstate.c
+++ b/arch/sim/src/sim/up_initialstate.c
@@ -60,7 +60,18 @@ void up_initial_state(struct tcb_s *tcb)
     }
 
   memset(&tcb->xcp, 0, sizeof(struct xcptcontext));
+
+  /* Note: The amd64 ABI requires 16-bytes alignment _before_ a function
+   * call.
+   * On the other hand, our way to set up and switch to a new context
+   * is basically a JUMP.
+   * Thus, we need to emulate the effect of a CALL here, by subtracting
+   * sizeof(xcpt_reg_t), which is the amount a CALL would move RSP to store
+   * the return address.
+   */
+
   tcb->xcp.regs[JB_SP] = (xcpt_reg_t)tcb->stack_base_ptr +
-                                     tcb->adj_stack_size;
+                                     tcb->adj_stack_size -
+                                     sizeof(xcpt_reg_t);
   tcb->xcp.regs[JB_PC] = (xcpt_reg_t)tcb->start;
 }


### PR DESCRIPTION
## Summary

Reapply the following commit [1], which has been reverted by
the recent change [2] with no obvious reasons.

Also, add a comment block to explain the calculation.

[1]
```
commit 298c2e5e4fb46f5ffa7de7bbc5a32a9da0663768
Author: YAMAMOTO Takashi <yamamoto@midokura.com>
Date:   Wed Jan 29 03:26:43 2020 +0900

    sim: Fix stack alignment

    The recent x86-64 convention requires 16-byte alignment before
    (not after) calling a function.

    This fixes snprintf crash I observed on macOS while saving XMM registers.
```

[2]
```
commit 2335b69120a3e36f1aa0cecc19c95208806cae54
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Mon Apr 12 23:44:08 2021 +0800

    arch: Allocate the space from the beginning in up_stack_frame

    arch: Allocate the space from the beginning in up_stack_frame

    and modify the affected portion:
    1.Correct the stack dump and check
    2.Allocate tls_info_s by up_stack_frame too
    3.Move the stack fork allocation from arch to sched

    Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
```

## Impact

## Testing

sim:ostest on macOS
(I stopped it in the middle of it because i had no time to run it to the end.
I guess it's enough testing because It was crashing immediately before this change.)
