### PR TITLE
fs/inode: correct the return value 

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -369,7 +369,7 @@ int fs_getfilep(int fd, FAR struct file **filep)
       _files_semgive(list);
     }
 
-  return OK;
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

fs/inode: correct the return value 

correct the return value of fs_getfilep() since the
semaphore take may probably fail if the thread canceled


## Impact

N/A

## Testing

nuttx daily test