### PR TITLE
esp32 & esp32c3: Update Wi-Fi BT and Wi-Fi libraries to fix some issues

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -423,6 +423,13 @@ config ESP32C3_WIFI_FS_MOUNTPT
 	help
 		Mount point of Wi-Fi storage file system.
 
+config ESP32C3_WIFI_STA_DISCONNECT_PM
+	bool "Power Management for station when disconnected"
+	default n
+	---help---
+		Select this option to enable power management for station when disconnected.
+		Chip will do modem-sleep when RF module is not in use anymore.
+
 endmenu # ESP32C3_WIRELESS
 
 menu "SPI Flash configuration"

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -95,7 +95,7 @@ endif
 
 ifeq ($(CONFIG_ESP32C3_WIRELESS),y)
 WIRELESS_DRV_UNPACK  = esp-wireless-drivers-3rdparty
-WIRELESS_DRV_ID      = 3cc7f67
+WIRELESS_DRV_ID      = 2b53111
 WIRELESS_DRV_ZIP     = $(WIRELESS_DRV_ID).zip
 WIRELESS_DRV_URL     = https://github.com/espressif/esp-wireless-drivers-3rdparty/archive
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -4820,6 +4820,12 @@ int esp_wifi_adapter_init(void)
   wifi_cfg.ampdu_rx_enable = 0;
 #endif
 
+#ifdef CONFIG_ESP32C3_WIFI_STA_DISCONNECT_PM
+  wifi_cfg.sta_disconnected_pm = true;
+#else
+  wifi_cfg.sta_disconnected_pm = false;
+#endif
+
   wifi_cfg.rx_ba_win          = CONFIG_ESP32C3_WIFI_RXBA_AMPDU_WZ;
   wifi_cfg.static_rx_buf_num  = CONFIG_ESP32C3_WIFI_STATIC_RXBUF_NUM;
   wifi_cfg.dynamic_rx_buf_num = CONFIG_ESP32C3_WIFI_DYNAMIC_RXBUF_NUM;

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -957,6 +957,13 @@ config ESP32_WIFI_FS_MOUNTPT
 	help
 		Mount point of WiFi storage file system.
 
+config ESP32_WIFI_STA_DISCONNECT_PM
+	bool "Power Management for station when disconnected"
+	default n
+	---help---
+		Select this option to enable power management for station when disconnected.
+		Chip will do modem-sleep when RF module is not in use anymore.
+
 endmenu # ESP32_WIRELESS
 
 menu "Real-Time Timer"

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -186,7 +186,7 @@ endif
 
 ifeq ($(CONFIG_ESP32_WIRELESS),y)
 WIRELESS_DRV_UNPACK  = esp-wireless-drivers-3rdparty
-WIRELESS_DRV_ID      = e766ea3
+WIRELESS_DRV_ID      = 2b53111
 WIRELESS_DRV_ZIP     = $(WIRELESS_DRV_ID).zip
 WIRELESS_DRV_URL     = https://github.com/espressif/esp-wireless-drivers-3rdparty/archive
 

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -4895,6 +4895,12 @@ int esp_wifi_adapter_init(void)
   wifi_cfg.ampdu_rx_enable = 0;
 #endif
 
+#ifdef CONFIG_ESP32_WIFI_STA_DISCONNECT_PM
+  wifi_cfg.sta_disconnected_pm = true;
+#else
+  wifi_cfg.sta_disconnected_pm = false;
+#endif
+
   wifi_cfg.rx_ba_win          = CONFIG_ESP32_WIFI_RXBA_AMPDU_WZ;
   wifi_cfg.static_rx_buf_num  = CONFIG_ESP32_WIFI_STATIC_RXBUF_NUM;
   wifi_cfg.dynamic_rx_buf_num = CONFIG_ESP32_WIFI_DYNAMIC_RXBUF_NUM;

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
@@ -58,6 +58,9 @@ SECTIONS
     *libarch.a:esp32_spiflash.*(.literal .text .literal.* .text.*)
     *(.wifirxiram .wifirxiram.*)
     *(.wifi0iram  .wifi0iram.*)
+    *(.wifislpiram .wifislpiram.*)
+    *(.wifislprxiram .wifislprxiram.*)
+    *(.phyiram .phyiram.*)
     _iram_text_end = ABSOLUTE(.);
 
     /* Module text area starts at the end of iram0_0_seg */

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
@@ -61,6 +61,9 @@ SECTIONS
     *libarch.a:esp32_spiflash.*(.literal .text .literal.* .text.*)
     *(.wifirxiram .wifirxiram.*)
     *(.wifirxiram .wifi0iram.*)
+    *(.wifislpiram .wifislpiram.*)
+    *(.wifislprxiram .wifislprxiram.*)
+    *(.phyiram .phyiram.*)
     _iram_text_end = ABSOLUTE(.);
 
     /* Module text area starts at the end of iram0_0_seg */

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
@@ -61,6 +61,9 @@ SECTIONS
     *libarch.a:esp32_spiflash.*(.literal .text .literal.* .text.*)
     *(.wifirxiram .wifirxiram.*)
     *(.wifirxiram .wifi0iram.*)
+    *(.wifislpiram .wifislpiram.*)
+    *(.wifislprxiram .wifislprxiram.*)
+    *(.phyiram .phyiram.*)
     _iram_text_end = ABSOLUTE(.);
 
     /* Module text area starts at the end of iram0_0_seg */


### PR DESCRIPTION
## Summary

Update Wi-Fi BT and Wi-Fi libraries to fix some issue.

Especial fix crash for ESP32-C3 ECO3 chips.

## Impact

## Testing

