### PR TITLE
Documentation: Minor fixes

### DIFF
--- a/Documentation/guides/drivers.rst
+++ b/Documentation/guides/drivers.rst
@@ -149,7 +149,7 @@ NuttX Drivers as a Reference
 
 If you're not porting a NuttX driver from another architecture, it still helps to look at other similar NuttX
 drivers, if there are any. For instance, when implementing an Ethernet driver, look at other NuttX Ethernet drivers;
-for an SD Card driver, look at other NuttX Ethernet drivers. Even if the chip-specific code won't be the same, the
+for an SD Card driver, look at other NuttX SD Card drivers. Even if the chip-specific code won't be the same, the
 structure to interface with NuttX can be used.
 
 Using Chip Datasheets

--- a/Documentation/platforms/arm/imxrt/index.rst
+++ b/Documentation/platforms/arm/imxrt/index.rst
@@ -5,7 +5,7 @@ i.MX RT
 The i.MX RT series of chips from NXP Semiconductors is based around an ARM Cortex-M7 core running
 at 500 MHz, 600 MHz or 1 GHz based on particular MCUs
 
-Suported MCUs
+Supported MCUs
 =============
 
 The following list includes MCUs from i.MX RT series and indicates whether they are supported in NuttX

--- a/Documentation/platforms/xtensa/esp32/index.rst
+++ b/Documentation/platforms/xtensa/esp32/index.rst
@@ -699,9 +699,8 @@ Things to Do
 2. Currently the Xtensa port copies register state save information from
    the stack into the TCB.  A more efficient alternative would be to just
    save a pointer to a register state save area in the TCB.  This would
-   add some complexity to signal handling and also also the
-   up_initialstate().  But the performance improvement might be worth
-   the effort.
+   add some complexity to signal handling and also to up_initialstate().
+   But the performance improvement might be worth the effort.
 
 3. See SMP-related issues above
 

--- a/Documentation/reference/os/index.rst
+++ b/Documentation/reference/os/index.rst
@@ -5,7 +5,7 @@ Architecture APIs
 The file ``include/nuttx/arch.h`` identifies by prototype all of
 the APIs that must be provided by the architecture specific logic.
 The internal OS APIs that architecture-specific logic must
-interface with also also identified in ``include/nuttx/arch.h`` or
+interface with are also identified in ``include/nuttx/arch.h`` or
 in other header files.
 
 .. toctree::


### PR DESCRIPTION
## Summary

Documentation/guides/drivers.rst:

- Replace wrong "Ethernet" with "SD Card"

Documentation/platforms/arm/imxrt/index.rst:

- Fix misspelled "Supported"

Documentation/platforms/xtensa/esp32/index.rst:

- Fix doubled "also"
- Fix "the" -> "to"

Documentation/reference/os/index.rst:

- Fix doubled "also"
- Fix "also" -> "are"

## Impact

No functional difference. Improves documentation only.

## Testing

Manual proofreading.