### PR TITLE
esp32/mcp2515: Enable irq after attaching to the pin irq

### DIFF
--- a/boards/xtensa/esp32/common/src/esp32_mcp2515.c
+++ b/boards/xtensa/esp32/common/src/esp32_mcp2515.c
@@ -163,6 +163,8 @@ static int mcp2515_attach(FAR struct mcp2515_config_s *state,
       return ret;
     }
 
+  esp32_gpioirqenable(irq, FALLING);
+
   leave_critical_section(flags);
 
   return OK;


### PR DESCRIPTION
## Summary
esp32/mcp2515: Enable irq after attaching to the pin irq
## Impact
MCP2515 will work to receive data
## Testing
ESP32-Devkitc
