### PR TITLE
Revert a change that accepted UDP packets not destined for us.

### DIFF
--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -297,7 +297,6 @@ int ipv4_input(FAR struct net_driver_s *dev)
             }
           else
 #endif
-          if (ipv4->proto != IP_PROTO_UDP)
             {
               /* Not destined for us and not forwardable... Drop the
                * packet.

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -433,7 +433,6 @@ int ipv6_input(FAR struct net_driver_s *dev)
             }
           else
 #endif
-          if (nxthdr != IP_PROTO_UDP)
             {
               /* Not destined for us and not forwardable...
                * drop the packet.


### PR DESCRIPTION
## Summary
Reverts a change introduced in ab148bc69fe that allowed specifically UDP packets that aren't destined for the interface to pass through. 

Perhaps there is a need for extended support for bypassing address checks if needed, but I strongly disagree with changing the default behavior to blindly accept traffic not destined for us. I can tell you first hand the havic it can wreak when packets that aren't destined for an endpoint start being accepted as valid data.

## Impact
@anchao Can you better explain why this was needed so that we can find a more appropriate solution? To me, this is a hack and should never have been accepted.

## Testing
Built.

