### PR TITLE
esp32/esp32-c3: Timer conflict refactoring

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
@@ -57,6 +57,7 @@
 #define RT_TIMER_TASK_STACK_SIZE  CONFIG_ESP32C3_RT_TIMER_TASK_STACK_SIZE
 
 #define ESP32C3_TIMER_PRESCALER     (APB_CLK_FREQ / (1000 * 1000))
+#define ESP32C3_RT_TIMER            0 /* Timer 0 */
 
 /****************************************************************************
  * Private Data
@@ -597,7 +598,7 @@ int esp32c3_rt_timer_init(void)
   irqstate_t flags;
   struct esp32c3_tim_dev_s *tim;
 
-  tim = esp32c3_tim0_init();
+  tim = esp32c3_tim_init(ESP32C3_RT_TIMER);
   if (!tim)
     {
       tmrerr("ERROR: Failed to initialize ESP32 timer0\n");
@@ -669,6 +670,7 @@ void esp32c3_rt_timer_deinit(void)
   flags = enter_critical_section();
 
   ESP32C3_TIM_STOP(s_esp32c3_tim_dev);
+  esp32c3_tim_deinit(s_esp32c3_tim_dev);
   s_esp32c3_tim_dev = NULL;
 
   leave_critical_section(flags);

--- a/arch/risc-v/src/esp32c3/esp32c3_tim.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.c
@@ -662,9 +662,7 @@ static void esp32c3_tim_ackint(FAR struct esp32c3_tim_dev_s *dev)
  * Name: esp32c3_tim_init
  *
  * Description:
- *   Initialize TIMER device, if software real-time timer
- *   (CONFIG_ESP32C3_RT_TIMER) is enabled, then timer0 can't
- *   be initialized by this function directly.
+ *   Initialize TIMER device.
  *
  * Parameters:
  *   timer           - Timer instance to be initialized.
@@ -681,11 +679,11 @@ FAR struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer)
 {
   FAR struct esp32c3_tim_priv_s *tim = NULL;
 
-  /* Get timer instance */
+  /* First, take the data structure associated with the timer instance */
 
   switch (timer)
     {
-#if defined(CONFIG_ESP32C3_TIMER0) && !defined(CONFIG_ESP32C3_RT_TIMER)
+#ifdef CONFIG_ESP32C3_TIMER0
       case 0:
         {
           tim = &g_esp32c3_tim0_priv;
@@ -708,7 +706,13 @@ FAR struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer)
         }
     }
 
-  if (tim->inuse == true)
+  /* Verify if it is in use */
+
+  if (tim->inuse == false)
+    {
+      tim->inuse = true;  /* If it was not, now it is */
+    }
+  else
     {
       tmrerr("ERROR: TIMER %d is already in use\n", timer);
       tim = NULL;
@@ -738,37 +742,3 @@ void esp32c3_tim_deinit(FAR struct esp32c3_tim_dev_s *dev)
   tim = (FAR struct esp32c3_tim_priv_s *)dev;
   tim->inuse = false;
 }
-
-/****************************************************************************
- * Name: esp32c3_tim0_init
- *
- * Description:
- *   Initialize TIMER0 device, if software real-time timer
- *   (CONFIG_ESP32C3_RT_TIMER) is enabled.
- *
- * Parameters:
- *   None
- *
- * Returned Values:
- *   If the initialization is successful, return a pointer to the timer
- *   driver struct associated to that timer instance.
- *   In case it fails, return NULL.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_ESP32C3_RT_TIMER
-
-FAR struct esp32c3_tim_dev_s *esp32c3_tim0_init(void)
-{
-  FAR struct esp32c3_tim_priv_s *tim = &g_esp32c3_tim0_priv;
-
-  if (tim->inuse == true)
-    {
-      tmrerr("ERROR: TIMER0 is already in use\n");
-      tim = NULL;
-    }
-
-  return (FAR struct esp32c3_tim_dev_s *)tim;
-}
-
-#endif

--- a/arch/risc-v/src/esp32c3/esp32c3_tim.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.h
@@ -135,12 +135,4 @@ struct esp32c3_tim_ops_s
 FAR struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer);
 void esp32c3_tim_deinit(FAR struct esp32c3_tim_dev_s *dev);
 
-/****************************************************************************
- * The Timer0 is used by RT-Timer of wireless driver, so please don't use it
- * in any other components.
- ****************************************************************************/
-#ifdef CONFIG_ESP32C3_RT_TIMER
-FAR struct esp32c3_tim_dev_s *esp32c3_tim0_init(void);
-#endif
-
 #endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_TIM_H */

--- a/arch/xtensa/src/esp32/esp32_rt_timer.c
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.c
@@ -57,6 +57,7 @@
 #define RT_TIMER_TASK_STACK_SIZE  CONFIG_ESP32_RT_TIMER_TASK_STACK_SIZE
 
 #define ESP32_TIMER_PRESCALER     (APB_CLK_FREQ / (1000 * 1000))
+#define ESP32_RT_TIMER            0 /* Timer 0 */
 
 /****************************************************************************
  * Private Data
@@ -597,7 +598,7 @@ int esp32_rt_timer_init(void)
   irqstate_t flags;
   struct esp32_tim_dev_s *tim;
 
-  tim = esp32_tim0_init();
+  tim = esp32_tim_init(ESP32_RT_TIMER);
   if (!tim)
     {
       tmrerr("ERROR: Failed to initialize ESP32 timer0\n");
@@ -669,6 +670,7 @@ void esp32_rt_timer_deinit(void)
   flags = enter_critical_section();
 
   ESP32_TIM_STOP(s_esp32_tim_dev);
+  esp32_tim_deinit(s_esp32_tim_dev);
   s_esp32_tim_dev = NULL;
 
   leave_critical_section(flags);

--- a/arch/xtensa/src/esp32/esp32_tim.c
+++ b/arch/xtensa/src/esp32/esp32_tim.c
@@ -732,9 +732,7 @@ static int esp32_tim_checkint(FAR struct esp32_tim_dev_s *dev)
  * Name: esp32_tim_init
  *
  * Description:
- *   Initialize TIMER device, if software real-time timer
- *   (CONFIG_ESP32_RT_TIMER) is enabled, then timer0 can't
- *   be initialized by this function directly.
+ *   Initialize TIMER device.
  *
  ****************************************************************************/
 
@@ -746,7 +744,7 @@ FAR struct esp32_tim_dev_s *esp32_tim_init(int timer)
 
   switch (timer)
     {
-#if defined(CONFIG_ESP32_TIMER0) && !defined(CONFIG_ESP32_RT_TIMER)
+#ifdef CONFIG_ESP32_TIMER0
       case 0:
         {
           tim = &g_esp32_tim0_priv;
@@ -819,29 +817,3 @@ void esp32_tim_deinit(FAR struct esp32_tim_dev_s *dev)
 
   tim->inuse = false;
 }
-
-/****************************************************************************
- * Name: esp32_tim0_init
- *
- * Description:
- *   Initialize TIMER0 device, this function is only used by software
- *   real-time timer(esp32_rt_timer.c).
- *
- ****************************************************************************/
-
-#ifdef CONFIG_ESP32_RT_TIMER
-
-FAR struct esp32_tim_dev_s *esp32_tim0_init(void)
-{
-  FAR struct esp32_tim_priv_s *tim = &g_esp32_tim0_priv;
-
-  if (tim->inuse == true)
-    {
-      tmrerr("ERROR: Timer0 is already in use\n");
-      tim = NULL;
-    }
-
-  return (FAR struct esp32_tim_dev_s *)tim;
-}
-
-#endif /* CONFIG_ESP32_RT_TIMER */

--- a/arch/xtensa/src/esp32/esp32_tim.h
+++ b/arch/xtensa/src/esp32/esp32_tim.h
@@ -116,6 +116,5 @@ struct esp32_tim_ops_s
 
 FAR struct esp32_tim_dev_s *esp32_tim_init(int timer);
 void esp32_tim_deinit(FAR struct esp32_tim_dev_s *dev);
-FAR struct esp32_tim_dev_s *esp32_tim0_init(void);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_TIM_H */

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -202,7 +202,7 @@ int esp32_bringup(void)
 
 #ifdef CONFIG_TIMER
 
-#ifdef CONFIG_ESP32_TIMER0
+#if defined(CONFIG_ESP32_TIMER0) && !defined(CONFIG_ESP32_RT_TIMER)
   ret = esp32_timer_initialize("/dev/timer0", TIMER0);
   if (ret < 0)
     {

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
@@ -169,7 +169,7 @@ int esp32_bringup(void)
 
 #ifdef CONFIG_TIMER
 
-#ifdef CONFIG_ESP32_TIMER0
+#if defined(CONFIG_ESP32_TIMER0) && !defined(CONFIG_ESP32_RT_TIMER)
   ret = esp32_timer_initialize("/dev/timer0", TIMER0);
   if (ret < 0)
     {

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -189,7 +189,7 @@ int esp32_bringup(void)
 
 #ifdef CONFIG_TIMER
 
-#ifdef CONFIG_ESP32_TIMER0
+#if defined(CONFIG_ESP32_TIMER0) && !defined(CONFIG_ESP32_RT_TIMER)
   ret = esp32_timer_initialize("/dev/timer0", TIMER0);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
This PR removes the "duplicated" timer init function to initialize the timer ​used by the WLAN driver.
It also reorganizes  it and move the  conflict solving to the boards level instead of the driver level.

## Impact
WLAN driver users from both chips.

## Testing

ESP32:
Devkit: mqtt
Ethernet and Wrover: wapi

ESP32-C3:
Inconclusive test since the wapi seems to be facing an issue before this PR.
