### PR TITLE
docker: add cmake

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -186,6 +186,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   avr-libc \
   build-essential \
   ccache \
+  cmake \
   curl \
   gcc \
   gcc-avr \


### PR DESCRIPTION
## Summary

Adds CMake to Docker image to start testing CMake based build system.

## Impact

No impact, this tool will be unused for make-based build.

## Testing

None
