### PR TITLE
CI: ensure docker is rebuilt on corresponding workflow changes

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -19,11 +19,13 @@ on:
       - master
     paths:
       - 'tools/ci/docker/linux/**'
+      - '.github/workflows/docker_linux.yml'
 
   # Run builds for any PRs.
   pull_request:
     paths:
       - 'tools/ci/docker/linux/**'
+      - '.github/workflows/docker_linux.yml'
 
 env:
   IMAGE_NAME: apache-nuttx-ci-linux


### PR DESCRIPTION
## Summary

Docker images was only being built on changes to docker definition itself, not the docker workflow. This PR fixes that.

## Impact

Docker build

## Testing

None

