### PR TITLE
net/ip: bypass UDP input only when the device address is invalid 

### DIFF
--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -297,7 +297,17 @@ int ipv4_input(FAR struct net_driver_s *dev)
             }
           else
 #endif
-          if (ipv4->proto != IP_PROTO_UDP)
+#ifdef NET_UDP_HAVE_STACK
+          if (ipv4->proto == IP_PROTO_UDP &&
+              net_ipv4addr_cmp(dev->d_ipaddr, INADDR_ANY))
+            {
+              /* Accecpt the UDP packet if the devices has not obtained
+               * the IP address to solve the compatibility issue of DHCP
+               * BOOTP working on unicast mode.
+               */
+            }
+          else
+#endif
             {
               /* Not destined for us and not forwardable... Drop the
                * packet.

--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -433,7 +433,6 @@ int ipv6_input(FAR struct net_driver_s *dev)
             }
           else
 #endif
-          if (nxthdr != IP_PROTO_UDP)
             {
               /* Not destined for us and not forwardable...
                * drop the packet.


### PR DESCRIPTION
## Summary

net/ip: bypass UDP input only when the device address is invalid 

Accecpt the UDP packet if the devices has not obtained
the IP address to solve the compatibility issue of DHCP
BOOTP working on unicast mode.

Reference:
https://tools.ietf.org/html/rfc1542

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

DHCP unicast

## Testing

```
NUTTX(DHCPC)              ->  HOSTAP(DHCPD)
0.0.0.0                   ->  255.255.255.255   DISCOVER
192.168.31.1              ->  192.168.31.166    OFFER
0.0.0.0                   ->  255.255.255.255   REQUEST
192.168.31.1              ->  192.168.31.166    ACK
```

## linked issue:
https://github.com/apache/incubator-nuttx/pull/3586
https://github.com/apache/incubator-nuttx/pull/3593