### PR TITLE
risc-v/esp32c3: Support Wi-Fi scan to reconnect

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -412,6 +412,10 @@ config ESP32C3_WIFI_SCAN_RESULT_SIZE
 	help
 		Maximum scan result buffer size.
 
+config ESP32C3_SCAN_TO_RECONNECT
+	bool "Wi-Fi scan to reconnet"
+	default n
+
 config ESP32C3_WIFI_SAVE_PARAM
 	bool "Save Wi-Fi Parameters"
 	default n

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -2056,6 +2056,7 @@ static void esp_evt_work_cb(FAR void *arg)
         {
           case WIFI_ADPT_EVT_SCAN_DONE:
             esp_wifi_scan_event_parse();
+
             break;
 
 #ifdef ESP32C3_WLAN_HAS_STA
@@ -2079,7 +2080,11 @@ static void esp_evt_work_cb(FAR void *arg)
             g_sta_connected = false;
             if (g_sta_reconnect)
               {
+#ifdef CONFIG_ESP32C3_SCAN_TO_RECONNECT
+                ret = esp_wifi_scan_to_reconnect();
+#else
                 ret = esp_wifi_connect();
+#endif
                 if (ret)
                   {
                     wlerr("ERROR: Failed to connect AP error=%d\n", ret);

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.h
@@ -111,6 +111,23 @@ void esp_wifi_scan_event_parse(void);
 
 int esp_wifi_scan_init(void);
 
+/****************************************************************************
+ * Name: esp_wifi_scan_to_reconnect
+ *
+ * Description:
+ *   Reconnect AP(Access Point) according to the scan results.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   OK on success (positive non-zero values are cmd-specific)
+ *   Negated errno returned on failure.
+ *
+ ****************************************************************************/
+
+int esp_wifi_scan_to_reconnect(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

Reconnect AP(Access Point) according to the scan results.

## Impact

Make Wi-Fi reconnect more effective.

## Testing

After the  AP(Access Point) is powered off, the device will disconnect from the AP and then make AP(Access Point)  power on
, the device will reconnect according to the scan results.
