### PR TITLE
Add experimental support for an eZ80 toolchain using llvm and GNU binutils

### DIFF
--- a/Documentation/introduction/detailed_support.rst
+++ b/Documentation/introduction/detailed_support.rst
@@ -3095,7 +3095,21 @@ All three boards are based on the eZ80F091 part and all use the Zilog
 ZDS-II Windows command line tools. The development environment is either
 Windows native or Cygwin or MSYS2 under Windows.
 
+It is also possible to compile using ``clang`` and the GNU ``binutils``
+toolchain. You must have a variant of ``clang`` that supports the eZ80,
+and an install of ``binutils`` built with Z80 support.
 
+``clang`` with eZ80 support is available as part of the Texas Instruments
+CE 85+ unofficial `toolchain <https://ce-programming.github.io/toolchain/>`
+and requires a further `patch <https://github.com/codebje/ez80-toolchain/tree/master/clang>`
+to support GNU assembler syntax.
+
+GNU ``binutils`` supports the Z80 family. It will require compilation with
+appropriate configuration to enable support.
+
+C intrinsics are also required. Some may be found in the Zilog ZDS-II
+distribution, requiring some modification to build with the GNU assembler.
+Additional intrinsics for 64-bit support must be supplied.
 
 Zilog Z8Encore!
 ===============

--- a/arch/z80/include/ez80/inttypes.h
+++ b/arch/z80/include/ez80/inttypes.h
@@ -199,6 +199,23 @@
 #  define UINT16_C(x) x
 #  define UINT24_C(x) x
 #  define UINT32_C(x) x ## ul
+
+#  ifdef __clang__
+#    define PRId64      "lld"
+#    define PRIi64      "lli"
+#    define PRIo64      "llo"
+#    define PRIu64      "llu"
+#    define PRIx64      "llx"
+#    define PRIX64      "llX"
+#    define SCNd64      "lld"
+#    define SCNi64      "lli"
+#    define SCNo64      "llo"
+#    define SCNu64      "llu"
+#    define SCNx64      "llx"
+#    define INT64_C(x) x ## ll
+#    define UINT64_C(x) x ## ull
+#  endif
+
 #endif
 
 #endif /* __ARCH_Z80_INCLUDE_EZ80_INTTYPES_H */

--- a/arch/z80/include/ez80/limits.h
+++ b/arch/z80/include/ez80/limits.h
@@ -74,4 +74,10 @@
 #define UPTR_MAX    16777215U
 #endif
 
+#ifdef __clang__
+#define LLONG_MIN       (-LLONG_MAX - 1)
+#define LLONG_MAX       9223372036854775807LL
+#define ULLONG_MAX      18446744073709551615ULL
+#endif
+
 #endif /* __ARCH_Z80_INCLUDE_EZ80_LIMITS_H */

--- a/arch/z80/include/ez80/types.h
+++ b/arch/z80/include/ez80/types.h
@@ -54,6 +54,10 @@
  *   long   - 32-bits
  *   char   - 8-bits
  *   float  - 32-bits
+ *
+ * Clang additionally supports:
+ *
+ *   long long - 64-bits
  */
 
 typedef signed char        _int8_t;
@@ -69,8 +73,16 @@ typedef unsigned int       _uint24_t;
 typedef signed long        _int32_t;
 typedef unsigned long      _uint32_t;
 
+#ifdef __clang__
+typedef signed long long   _int64_t;
+typedef unsigned long long _uint64_t;
+#define __INT64_DEFINED
+typedef _int64_t           _intmax_t;
+typedef _uint64_t          _uintmax_t;
+#else
 typedef _int32_t           _intmax_t;
 typedef _uint32_t          _uintmax_t;
+#endif
 
 /* A pointer is 2 or 3 bytes, depending upon if the ez80 is in z80
  * compatibility mode or not

--- a/arch/z80/src/Makefile
+++ b/arch/z80/src/Makefile
@@ -23,10 +23,14 @@
 include $(TOPDIR)/Make.defs
 -include chip/Make.defs
 
-# Compiler-Dependent Make:  SDCC or ZiLOG ZDS-II
+# Compiler-Dependent Make:  SDCC, Clang, or ZiLOG ZDS-II
 
 COMPILER = ${shell basename "$(CC)"}
-ifeq ($(COMPILER),sdcc)
+ifeq ($(patsubst %-clang,clang,$(COMPILER)),clang)
+
+    include Makefile.clang
+
+else ifeq ($(COMPILER),sdcc)
 
   # Check for SDCC native windows build
 

--- a/arch/z80/src/Makefile.clang
+++ b/arch/z80/src/Makefile.clang
@@ -1,0 +1,135 @@
+############################################################################
+# arch/z80/src/Makefile.clang
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Directories
+
+ARCH_SRCDIR = $(TOPDIR)/arch/$(CONFIG_ARCH)/src
+BOARDDIR = $(TOPDIR)/arch/$(CONFIG_ARCH)/src/board
+
+# Tools
+
+CFLAGS += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)chip}
+CFLAGS += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)common}
+CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)sched}
+CFLAGS += -I.
+
+CPPFLAGS += -D__ASSEMBLY__
+
+############################################################################
+# Files and directories
+
+# There should be one head source (.asm file)
+#
+HEAD_OBJ = $(HEAD_ASRC:$(ASMEXT)=$(OBJEXT))
+STARTUP_OBJS ?= $(HEAD_OBJ)
+
+# Assembly sources and objects
+
+ASRCS = $(CHIP_ASRCS) $(CMN_ASRCS)
+AOBJS = $(ASRCS:$(ASMEXT)=$(OBJEXT))
+
+CSRCS = $(CHIP_CSRCS) $(CMN_CSRCS)
+COBJS = $(CSRCS:.c=$(OBJEXT))
+
+# All sources and objcts
+
+SRCS = $(ASRCS) $(CSRCS)
+OBJS = $(AOBJS) $(COBJS)
+
+# Sources that can have dependencies (no .asm files)
+
+DEPSRCS  = $(CSRCS)
+
+VPATH = chip:common:board
+
+############################################################################
+# Targets
+
+all: $(HEAD_OBJ) libarch$(LIBEXT)
+
+.PHONY: board$(DELIM)libboard$(LIBEXT)
+
+$(AOBJS) $(HEAD_OBJ): %$(OBJEXT): %$(ASMEXT)
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+# TODO will I need the asm_mem.h hack of SDCC?
+
+libarch$(LIBEXT): $(OBJS)
+	$(call ARCHIVE, $@, $(OBJS))
+
+board$(DELIM)libboard$(LIBEXT):
+	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+LIBPATHS += -L"$(TOPDIR)$(DELIM)staging"
+LIBPATHS += -L"$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board"
+
+LDLIBS += $(patsubst %.a,%,$(patsubst lib%,-l%,$(LINKLIBS))) -lboard
+
+NUTTX = "$(TOPDIR)$(DELIM)nuttx$(EXEEXT)"
+
+nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) $(LINKCMD)
+	$(Q) echo "LD: nuttx into $(NUTTX)"
+	$(Q) "$(LD)" -o $(NUTTX) $(HEAD_OBJ) -T $(LINKCMD) --orphan-handling=error --print-memory-usage \
+	    $(LIBPATHS) "-(" $(LDLIBS) "-)" $(LDFLAGS) -Map="$(TOPDIR)$(DELIM)nuttx.map"
+
+.depend: Makefile chip$(DELIM)Make.defs $(DEPSRCS) $(TOPDIR)$(DELIM).config
+	$(Q) if [ -e board$(DELIM)Makefile ]; then \
+		$(MAKE) -C board depend ; \
+	fi
+	$(Q) $(MKDEP) --dep-path chip --dep-path common "$(CC)" -- $(CFLAGS) -- $(DEPSRCS) >Make.dep
+	$(Q) touch $@
+
+# This is part of the top-level export target
+
+export_startup: board$(DELIM)libboard$(LIBEXT) $(STARTUP_OBJS)
+	$(Q) if [ -d "$(EXPORT_DIR)$(DELIM)startup" ]; then \
+		cp -f $(STARTUP_OBJS) "$(EXPORT_DIR)$(DELIM)startup"; \
+	 else \
+		echo "$(EXPORT_DIR)$(DELIM)startup does not exist"; \
+		exit 1; \
+	 fi
+
+# Dependencies
+
+depend: .depend
+
+context::
+
+clean_context::
+
+clean:
+	$(Q) if [ -e board$(DELIM)Makefile ]; then \
+		$(MAKE) -C board clean ; \
+	fi
+	$(call DELFILE, *.map)
+	$(call DELFILE, libarch$(LIBEXT))
+	$(call CLEAN)
+
+distclean: clean
+	$(Q) if [ -e board$(DELIM)Makefile ]; then \
+		$(MAKE) -C board distclean ; \
+	fi
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep

--- a/arch/z80/src/ez80/Kconfig
+++ b/arch/z80/src/ez80/Kconfig
@@ -50,17 +50,24 @@ config ARCH_CHIP_EZ80F93
 
 endchoice
 
-# The ZiLOG ZDS-II Windows toolchain is the only toolchain available for
-# the ez80.
-#
+choice
+    prompt "Toolchain Selection"
+    default EZ80_TOOLCHAIN_ZDSII
 
 config EZ80_TOOLCHAIN_ZDSII
-	bool
-	default y
+	bool "ZDS-II for Windows"
+	depends on TOOLCHAIN_WINDOWS
+
+config EZ80_TOOLCHAIN_CLANG
+	bool "Clang for Linux, macOS, or Cygwin"
+        depends on EXPERIMENTAL
+
+endchoice
 
 choice
 	prompt "ZDS-II Toolchain version"
 	default EZ80_ZDSII_V533
+	depends on EZ80_TOOLCHAIN_ZDSII
 
 config EZ80_ZDSII_V511
 	bool "ZDS-II 5.1.1"

--- a/arch/z80/src/ez80/Make.defs
+++ b/arch/z80/src/ez80/Make.defs
@@ -36,6 +36,7 @@ CHIP_ASRCS += ez80_saveusercontext.asm ez80_restorecontext.asm
 ifeq ($(CONFIG_ARCH_CHIP_EZ80F91),y)
 HEAD_ASRC = ez80_reset.asm
 CHIP_ASRCS += ez80f91_init.asm ez80f91_handlers.asm
+chip/ez80f91_handlers.asm_AFLAGS := -include clang_handlers.inc
 endif
 
 ifeq ($(CONFIG_ARCH_CHIP_EZ80F92),y)
@@ -84,3 +85,5 @@ ifeq ($(CONFIG_EZ80_EMAC),y)
 CHIP_CSRCS += ez80_emac.c
 endif
 endif
+
+AFLAGS += -Ichip

--- a/arch/z80/src/ez80/Toolchain.defs
+++ b/arch/z80/src/ez80/Toolchain.defs
@@ -18,6 +18,74 @@
 #
 ############################################################################
 
+# CPU Identification
+
+ifeq ($(CONFIG_ARCH_CHIP_EZ80F91),y)
+  ARCHCPU    = eZ80F91
+  ARCHCPUDEF = _EZ80F91
+  ARCHFAMILY = _EZ80ACCLAIM
+else ifeq ($(CONFIG_ARCH_CHIP_EZ80F92),y)
+  ARCHCPU    = eZ80F92
+  ARCHCPUDEF = _EZ80F92
+  ARCHFAMILY = _EZ80ACCLAIM
+endif
+
+ifeq ($(CONFIG_EZ80_TOOLCHAIN_CLANG),y)
+
+# Optimization level
+
+ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
+  ARCHASMOPTIMIZATION =
+  ARCHOPTIMIZATION = -g
+else
+  ARCHASMOPTIMIZATION =
+  ARCHOPTIMIZATION =
+endif
+
+ifeq ($(CONFIG_DEBUG_NOOPT),y)
+  ARCHOPTIMIZATION += -O0
+else
+  ARCHOPTIMIZATION += -Oz
+endif
+
+ARCHSTDINCLUDES =
+
+ARCHCPUFLAGS = -Dinterrupt="__attribute__((__interrupt__))" -ffreestanding
+ARCHCPUFLAGS += -ffunction-sections -fdata-sections -Wa,-march=ez80
+ARCHLIST = 
+ARCHWARNINGS = -Wall -Wextra -Wno-incompatible-library-redeclaration
+ARCHWARNINGS += -Wno-main-return-type -Wno-unused-parameter
+ARCHWARNINGS += -Wno-invalid-noreturn -Wimplicit-int-conversion
+ARCHDEFINES = -D$(ARCHCPUDEF) -D"$(ARCHFAMILY)"
+ARCHINCLUDES = $(ARCHSTDINCLUDES)
+
+ARCHASMCPUFLAGS = -Wa,-march=ez80 -xassembler-with-cpp
+ARCHASMINCLUDES = -include chip/clang-compat.asm
+ARCHASMLIST =
+ARCHASMWARNINGS = -W
+
+LDFLAGS += -gc-sections
+
+# Tool names/paths.
+
+CROSSDEV = ez80-none-elf-
+CC = $(CROSSDEV)clang
+CPP = $(CC) -E -P -x c
+STRIP = $(CROSSDEV)strip --strip-unneeded
+LD = $(CROSSDEV)ld
+AS = $(CROSSDEV)as
+AR = $(CROSSDEV)ar -r
+OBJCOPY= $(CROSSDEV)objcopy
+
+# File extensions
+
+ASMEXT = .asm
+OBJEXT = .o
+LIBEXT = .a
+EXEEXT = .bin
+
+else
+
 # These are the default directories where the ZDS-II toolchain is installed.
 # NOTE that short 8.3 path names are used in order to avoid spaces.  On my
 # machine I have:
@@ -76,18 +144,6 @@ else
   EZDSZILOGINCDIR := ${shell echo "$(WZDSZILOGINCDIR)" | sed -e "s/ /%20/g"}
 endif
 
-# CPU Identification
-
-ifeq ($(CONFIG_ARCH_CHIP_EZ80F91),y)
-  ARCHCPU    = eZ80F91
-  ARCHCPUDEF = _EZ80F91
-  ARCHFAMILY = _EZ80ACCLAIM!
-else ifeq ($(CONFIG_ARCH_CHIP_EZ80F92),y)
-  ARCHCPU    = eZ80F92
-  ARCHCPUDEF = _EZ80F92
-  ARCHFAMILY = _EZ80ACCLAIM!
-endif
-
 # Optimization level
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
@@ -104,6 +160,13 @@ else
   ARCHOPTIMIZATION += -promote -NOreduceopt -sdiopt -optsize
 endif
 
+ARCHCPUFLAGS = -chartype:S -promote -cpu:$(ARCHCPU) -NOgenprintf -NOmodsect \
+               -asmsw:" $(ARCHASMCPUFLAGS) $(EARCHASMINCLUDES) $(ARCHASMWARNINGS) $(ARCHASMOPTIMIZATION)"
+ARCHLIST = -keeplst -NOlist -NOlistinc -keepasm
+ARCHWARNINGS = -warn
+ARCHDEFINES = -define:$(ARCHCPUDEF) -define:$(ARCHFAMILY)
+ARCHINCLUDES = $(ARCHSTDINCLUDES)
+
 # Tool names/paths.
 
 CROSSDEV =
@@ -119,3 +182,5 @@ ASMEXT = .asm
 OBJEXT = .obj
 LIBEXT = .lib
 EXEEXT = .lod
+
+endif

--- a/arch/z80/src/ez80/clang-compat.asm
+++ b/arch/z80/src/ez80/clang-compat.asm
@@ -1,0 +1,81 @@
+;**************************************************************************
+; arch/z80/src/ez80/clang-compat.asm
+;
+; Licensed to the Apache Software Foundation (ASF) under one or more
+; contributor license agreements.  See the NOTICE file distributed with
+; this work for additional information regarding copyright ownership.  The
+; ASF licenses this file to you under the Apache License, Version 2.0 (the
+; "License"); you may not use this file except in compliance with the
+; License.  You may obtain a copy of the License at
+;
+;   http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+; License for the specific language governing permissions and limitations
+; under the License.
+;
+;**************************************************************************
+
+; ZDS-II macros end with 'endmac' and the name of the macro. A preprocessor
+; macro substitutes this with the GNU assembler's endm and comments out the
+; macro name.
+#define endmac		endm ;
+
+; The ZDS-II assembler directive DEFINE constructs a segment. This macro
+; doesn't provide a complete implementation of the DEFINE directive, but
+; instead supports the use of DEFINE required for the arch build. This
+; use includes a .RESET section that may be in ROM or RAM, a .STARTUP
+; section that is always in ROM, and an IVECTS section that's initialized
+; data for the eZ80F92 (in ROM or RAM) and uninitialized data for the
+; eZ80F91.
+	.macro	define name space align=0
+	.ifc \name,.STARTUP
+		.section	.startup,"ax",@progbits
+	.else
+	.ifc \name,.RESET
+		.ifc \space,ROM
+			.section	.reset,"ax",@progbits
+		.else
+			.section	.reset,"axw",@progbits
+		.endif
+	.else
+	.ifc \name,.IVECTS
+#		ifdef CONFIG_ARCH_CHIP_EZ80F91
+			.section	.ivects,"wx",@nobits
+#		else
+			.section	.ivects,"awx",@nobits
+#		endif
+	.else
+		error "Unsupported define for \name"
+	.endif
+	.endif
+	.endif
+	.if \align > 0
+		.balign \align
+	.endif
+	.endm
+
+; The segment macro ensures the SEGMENT directive matches the define macro,
+; and includes the CODE segment which should be translated to be the .text
+; section.
+	.macro	segment name
+	.ifc \name,CODE
+		.section	.text
+	.else
+	.ifc \name,.STARTUP
+		.section	.startup
+	.else
+	.ifc \name,.RESET
+		.section	.reset
+	.else
+	.ifc \name,.IVECTS
+		.section	.ivects
+	.else
+		error "Unsupported segment \name"
+	.endif ; .ifc name,.IVECTS
+	.endif ; .ifc name,.RESET
+	.endif ; .ifc name,.STARTUP
+	.endif ; .ifc name,CODE
+	.endm

--- a/arch/z80/src/ez80/clang_handlers.inc
+++ b/arch/z80/src/ez80/clang_handlers.inc
@@ -1,5 +1,5 @@
 ;**************************************************************************
-; arch/z80/src/ez80/ez80_getsp.asm
+; arch/z80/src/ez80/clang_handlers.inc
 ;
 ; Licensed to the Apache Software Foundation (ASF) under one or more
 ; contributor license agreements.  See the NOTICE file distributed with
@@ -18,30 +18,11 @@
 ;
 ;**************************************************************************
 
-;**************************************************************************
-; Global Symbols Exported
-;**************************************************************************
-
-	xdef	_z80_getsp
-
-;**************************************************************************
-; Code
-;**************************************************************************
-
-	segment CODE
-	.assume ADL=1
-
-;**************************************************************************
-;* Name: _z80_getsp
-;*
-;* Description:
-;*   Return the current value of the stack pointer
-;*
-;**************************************************************************
-
-_z80_getsp:
-	ld		hl, 0			; Initialize HL to zero
-	add		hl, sp			; Add the stack pointer to HL
-	ret						; Return stack pointer in HL
-
-	end
+irqhandler:	.macro vectno
+	; Save AF on the stack, set the interrupt number and jump to the
+	; common reset handling logic.
+							; Offset 8: Return PC is already on the stack
+	push	af					; Offset 7: AF (retaining flags)
+	ld		a, \vectno			; A = vector number
+	jp		_ez80_irq_common		; Remaining RST handling is common
+	.endm

--- a/arch/z80/src/ez80/ez80F91.inc
+++ b/arch/z80/src/ez80/ez80F91.inc
@@ -1,0 +1,483 @@
+
+;***********************************************************************************
+; arch/z80/src/ez80/ez80f91.h
+;
+; Licensed to the Apache Software Foundation (ASF) under one or more
+; contributor license agreements.  See the NOTICE file distributed with
+; this work for additional information regarding copyright ownership.  The
+; ASF licenses this file to you under the Apache License, Version 2.0 (the
+; "License"); you may not use this file except in compliance with the
+; License.  You may obtain a copy of the License at
+;
+;   http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+; License for the specific language governing permissions and limitations
+; under the License. *
+;***********************************************************************************
+
+;***********************************************************************************
+; Included Files
+;***********************************************************************************
+
+; Product ID Registers  ************************************************************
+
+ZDI_ID_L		EQU	000h
+ZDI_ID_H		EQU	001h
+ZDI_ID_REV		EQU	002h
+
+; Interrupt Registers  *************************************************************
+
+INT_P0			EQU	010h
+INT_P1			EQU	011h
+INT_P2			EQU	012h
+INT_P3			EQU	013h
+INT_P4			EQU	014h
+INT_P5			EQU	015h
+
+; EMACC Registers  *****************************************************************
+
+EMAC_TEST		EQU	020h  ; EMAC test register *
+EMAC_CFG1		EQU	021h  ; EMAC configuration 1 register *
+EMAC_CFG2		EQU	022h  ; EMAC configuration 2 register *
+EMAC_CFG3		EQU	023h  ; EMAC configuration 3 register *
+EMAC_CFG4		EQU	024h  ; EMAC configuration 4 register *
+EMAC_STAD_0		EQU	025h  ; EMAC station address register 0 *
+EMAC_STAD_1		EQU	026h  ; EMAC station address register 1 *
+EMAC_STAD_2		EQU	027h  ; EMAC station address register 2 *
+EMAC_STAD_3		EQU	028h  ; EMAC station address register 3 *
+EMAC_STAD_4		EQU	029h  ; EMAC station address register 4 *
+EMAC_STAD_5		EQU	02ah  ; EMAC station address register 5 *
+EMAC_TPTV_L		EQU	02bh  ; Transit pause timer value (low) *
+EMAC_TPTV_H		EQU	02ch  ; Transit pause timer value (high) *
+EMAC_IPGT		EQU	02dh  ; EMAC Interpacket gap register *
+EMAC_IPGR1		EQU	02eh  ; Non-back-to-back IPG register 1 *
+EMAC_IPGR2		EQU	02fh  ; Non-back-to-back IPG register 2 *
+EMAC_MAXF_L		EQU	030h  ; EMAC maximum frame length register (low) *
+EMAC_MAXF_H		EQU	031h  ; EMAC maximum frame length register (high) *
+EMAC_AFR		EQU	032h  ; EMAC address filter register *
+EMAC_HTBL_0		EQU	033h  ; EMAC hash table register 0 *
+EMAC_HTBL_1		EQU	034h  ; EMAC hash table register 1 *
+EMAC_HTBL_2		EQU	035h  ; EMAC hash table register 2 *
+EMAC_HTBL_3		EQU	036h  ; EMAC hash table register 3 *
+EMAC_HTBL_4		EQU	037h  ; EMAC hash table register 4 *
+EMAC_HTBL_5		EQU	038h  ; EMAC hash table register 5 *
+EMAC_HTBL_6		EQU	039h  ; EMAC hash table register 6 *
+EMAC_HTBL_7		EQU	03ah  ; EMAC hash table register 7 *
+EMAC_MIIMGT		EQU	03bh  ; EMACS MII management register *
+EMAC_CTLD_L		EQU	03ch  ; PHY configuration data register (low) *
+EMAC_CTLD_H		EQU	03dh  ; PHY configuration data register (high) *
+EMAC_RGAD		EQU	03eh  ; PHY address register *
+EMAC_FIAD		EQU	03fh  ; PHY unit select register *
+EMAC_PTMR		EQU	040h  ; EMAC transmit polling timer register *
+EMAC_RST		EQU	041h  ; EMAC reset control register *
+EMAC_TLBP_L		EQU	042h  ; EMAC transmit lower boundary pointer (low) *
+EMAC_TLBP_H		EQU	043h  ; EMAC transmit lower boundary pointer (high) *
+EMAC_BP_L		EQU	044h  ; EMAC boundary pointer register (low) *
+EMAC_BP_H		EQU	045h  ; EMAC boundary pointer register (high) *
+EMAC_BP_U		EQU	046h  ; EMAC boundary pointer register (upper byte) *
+EMAC_RHBP_L		EQU	047h  ; EMAC receive high boundary pointer register (low) *
+EMAC_RHBP_H		EQU	048h  ; EMAC receive high boundary pointer register (high) *
+EMAC_RRP_L		EQU	049h  ; EMAC receive read pointer (low) *
+EMAC_RRP_H		EQU	04ah  ; EMAC receive read pointer (high) *
+EMAC_BUFSZ		EQU	04bh  ; EMAC buffer size register *
+EMAC_IEN		EQU	04ch  ; EMAC interrupt enable register *
+EMAC_ISTAT		EQU	04dh  ; EMAC interrupt status register *
+EMAC_PRSD_L		EQU	04eh  ; PHY read status data register (low) *
+EMAC_PRSD_H		EQU	04fh  ; PHY read status data register (high) *
+EMAC_MIISTAT		EQU	050h  ; EMAC MII status register *
+EMAC_RWP_L		EQU	051h  ; EMAC receive write pointer (low) *
+EMAC_RWP_H		EQU	052h  ; EMAC receive write pointer (high) *
+EMAC_TRP_L		EQU	053h  ; EMAC transmit read pointer (low) *
+EMAC_TRP_H		EQU	054h  ; EMAC transmit read pointer (high) *
+EMAC_BLKSLFT_L		EQU	055h  ; EMAC receive blocks left register (low) *
+EMAC_BLKSLFT_H		EQU	056h  ; EMAC receive blocks left register (high) *
+EMAC_FDATA_L		EQU	057h  ; EMAC FIFO data register (low) *
+EMAC_FDATA_H		EQU	058h  ; EMAC FIFO data register (high) *
+EMAC_FFLAGS		EQU	059h  ; EMAC FIFO flags register *
+
+; PLL Registers  *******************************************************************
+
+PLL_DIV_L		EQU	05ch
+PLL_DIV_H		EQU	05dh
+PLL_CTL0		EQU	05eh
+PLL_CTL1		EQU	05fh
+
+; Timer Registers  *****************************************************************
+
+TMR0_CTL		EQU	060h        ; RW: Timer 0 control register *
+TMR0_IER		EQU	061h        ; RW: Timer 0 interrupt enable register *
+TMR0_IIR		EQU	062h        ; R : Timer 0 interrupt ID register *
+TMR0_DRL		EQU	063h        ; R : Timer 0 data register (low) *
+TMR0_DRH		EQU	064h        ; R : Timer 0 data register (high) *
+TMR0_RRL		EQU	063h        ;  W: Timer 0 reload register (low) *
+TMR0_RRH		EQU	064h        ;  W: Timer 0 reload register (high) *
+
+TMR1_CTL		EQU	065h        ; RW: Timer 1 control register *
+TMR1_IER		EQU	066h        ; RW: Timer 1 interrupt enable register *
+TMR1_IIR		EQU	067h        ; R : Timer 1 interrupt ID register *
+TMR1_DRL		EQU	068h        ; R : Timer 1 data register (low) *
+TMR1_DRH		EQU	069h        ; R : Timer 1 data register (high) *
+TMR1_RRL		EQU	068h        ;  W: Timer 1 reload register (low) *
+TMR1_RRH		EQU	069h        ;  W: Timer 1 reload register (high) *
+TMR1_CAPCTL		EQU	06ah        ; RW: Timer 1 input capture control register *
+TMR1_CAPAL		EQU	06bh        ; R : Timer 1 capture input value A (low) *
+TMR1_CAPAH		EQU	06ch        ; R : Timer 1 capture input value A (high) *
+TMR1_CAPBL		EQU	06dh        ; R : Timer 1 capture input value B (low) *
+TMR1_CAPBH		EQU	06eh
+
+TMR2_CTL		EQU	06fh        ; RW: Timer 2 control register *
+TMR2_IER		EQU	070h        ; RW: Timer 2 interrupt enable register *
+TMR2_IIR		EQU	071h        ; R : Timer 2 interrupt ID register *
+TMR2_DRL		EQU	072h        ; R : Timer 2 data register (low) *
+TMR2_DRH		EQU	073h        ; R : Timer 2 data register (high) *
+TMR2_RRL		EQU	072h        ;  W: Timer 2 reload register (low) *
+TMR2_RRH		EQU	073h        ;  W: Timer 2 reload register (high) *
+
+TMR3_CTL		EQU	074h        ; RW: Timer 3 control register *
+TMR3_IER		EQU	075h        ; RW: Timer 3 interrupt enable register *
+TMR3_IIR		EQU	076h        ; R : Timer 3 interrupt ID register *
+TMR3_DRL		EQU	077h        ; R : Timer 3 data register (low) *
+TMR3_DRH		EQU	078h        ; R : Timer 3 data register (high) *
+TMR3_RRL		EQU	077h        ;  W: Timer 3 reload register (low) *
+TMR3_RRH		EQU	078h        ;  W: Timer 3 reload register (high) *
+TMR3_CAPCTL		EQU	07bh        ; RW: Timer 3 input capture control register *
+TMR3_CAPAL		EQU	07ch        ; R : Timer 3 capture input value A (low) *
+TMR3_CAPAH		EQU	07dh        ; R : Timer 3 capture input value A (high) *
+TMR3_CAPBL		EQU	07eh        ; R : Timer 3 capture input value B (low) *
+TMR3_CAPBH		EQU	07fh        ; R : Timer 3 capture input value B (high) *
+TMR3_OCCTL1		EQU	080h        ; RW: Timer 3 output compare control register1 *
+TMR3_OCCTL2		EQU	081h        ; RW: Timer 3 output compare control register2 *
+TMR3_OC0L		EQU	082h        ; RW: Timer 3 output compare value 0 (low) *
+TMR3_OC0H		EQU	083h        ; RW: Timer 3 output compare value 0 (high) *
+TMR3_OC1L		EQU	084h        ; RW: Timer 3 output compare value 1 (low) *
+TMR3_OC1H		EQU	085h        ; RW: Timer 3 output compare value 1 (high) *
+TMR3_OC2L		EQU	086h        ; RW: Timer 3 output compare value 2 (low) *
+TMR3_OC2H		EQU	087h        ; RW: Timer 3 output compare value 2 (high) *
+TMR3_OC3L		EQU	088h        ; RW: Timer 3 output compare value 3 (low) *
+TMR3_OC3H		EQU	089h        ; RW: Timer 3 output compare value 3 (high) *
+
+; TMR0/1/2/3 CTL Register Bit Definitions ******************************************
+
+TMRCTL_BRKSTOP		EQU	080h        ; Bit 7: Stop timer for debug operation *
+TMRCTL_CLKSEL		EQU	060h        ; Bits 6-5: Timer source *
+TMRCLKSEL_SYSCLK	EQU	000h       ;   00: System clock divided by prescaler *
+TMRCLKSEL_RTC		EQU	020h        ;   01: Real time clock input *
+TMRCLKSEL_ECF		EQU	040h        ;   10: Event count input, falling edge *
+TMRCLKSEL_ECR		EQU	060h        ;   11: Event count input, rising edge *
+TMRCTL_CLKDIV		EQU	018h        ; Bits 3-4: System clock divider *
+TMRCLKDIV_4		EQU	000h        ;   00:   4 *
+TMRCLKDIV_16		EQU	008h        ;   01:  16 *
+TMRCLKDIV_64		EQU	010h        ;   10:  64 *
+TMRCLKDIV_256		EQU	018h        ;   11: 256 *
+TMRCTL_TIMCONT		EQU	004h        ; Bit 2: Continuous mode *
+TMRCTL_RLD		EQU	002h        ; Bit 1: Force reload *
+TMRCTL_TIMEN		EQU	001h        ; Bit 0: Programmable reload timer enabled *
+
+; TMR0/1/2/3 IER Register Bit Definitions ******************************************
+
+                                           ; Bit 7: Reserved *
+TMRIER_OC3EN		EQU	040h        ; Bit 6: TMR3 OC3 enabled *
+TMRIER_OC2EN		EQU	020h        ; Bit 5: TMR3 OC2 enabled *
+TMRIER_OC1EN		EQU	010h        ; Bit 4: TMR3 OC1 enabled *
+TMRIER_OC0EN		EQU	008h        ; Bit 3: TMR3 OC0 enabled *
+TMRIER_ICBEN		EQU	004h        ; Bit 2: TMR1/3 capture pin enabled *
+TMRIER_ICAEN		EQU	002h        ; Bit 1: TMR1/3 capture pin enabled *
+TMRIER_EOCEN		EQU	001h        ; Bit 0: End of count interrupt enabled *
+
+; TMR0/1/2/3 IER Register Bit Definitions ******************************************
+
+                                           ; Bit 7: Reserved *
+TMRIIR_OC3		EQU	040h        ; Bit 6: TMR3 OC3 *
+TMRIIR_OC2		EQU	020h        ; Bit 5: TMR3 OC2 *
+TMRIIR_OC1		EQU	010h        ; Bit 4: TMR3 OC1 *
+TMRIIR_OC0		EQU	008h        ; Bit 3: TMR3 OC0 *
+TMRIIR_ICB		EQU	004h        ; Bit 2: TMR1/3 capture pin *
+TMRIIR_ICA		EQU	002h        ; Bit 1: TMR1/3 capture pin *
+TMRIIR_EOC		EQU	001h        ; Bit 0: End of count interrupt *
+
+; PWM Registers ********************************************************************
+
+PWM_CTL1		EQU	079h
+PWM_CTL2		EQU	07ah
+PWM_CTL3		EQU	07bh
+PWM0R_L			EQU	07ch
+PWM0R_H			EQU	07dh
+PWM1R_L			EQU	07eh
+PWM1R_H			EQU	07fh
+PWM2R_L			EQU	080h
+PWM2R_H			EQU	081h
+PWM3R_L			EQU	082h
+PWM3R_H			EQU	083h
+PWM0F_L			EQU	084h
+PWM0F_H			EQU	085h
+PWM1F_L			EQU	086h
+PWM1F_H			EQU	087h
+PWM2F_L			EQU	088h
+PWM2F_H			EQU	089h
+PWM3F_L			EQU	08ah
+PWM3F_H			EQU	08bh
+
+; WDT Registers ********************************************************************
+
+WDT_CTL			EQU	093h
+WDT_RR			EQU	094h
+
+; GPIO Registers *******************************************************************
+
+PA_DR			EQU	096h
+PA_DDR			EQU	097h
+PA_ALT0			EQU	0a6h
+PA_ALT1			EQU	098h
+PA_ALT2			EQU	099h
+PB_DR			EQU	09ah
+PB_DDR			EQU	09bh
+PB_ALT0			EQU	0a7h
+PB_ALT1			EQU	09ch
+PB_ALT2			EQU	09dh
+PC_DR			EQU	09eh
+PC_DDR			EQU	09fh
+PC_ALT0			EQU	0ceh
+PC_ALT1			EQU	0a0h
+PC_ALT2			EQU	0a1h
+PD_DR			EQU	0a2h
+PD_DDR			EQU	0a3h
+PD_ALT0			EQU	0cfh
+PD_ALT1			EQU	0a4h
+PD_ALT2			EQU	0a5h
+
+; CS Registers *********************************************************************
+
+CS0_LBR			EQU	0a8h
+CS0_UBR			EQU	0a9h
+CS0_CTL			EQU	0aah
+CS1_LBR			EQU	0abh
+CS1_UBR			EQU	0ach
+CS1_CTL			EQU	0adh
+CS2_LBR			EQU	0aeh
+CS2_UBR			EQU	0afh
+CS2_CTL			EQU	0b0h
+CS3_LBR			EQU	0b1h
+CS3_UBR			EQU	0b2h
+CS3_CTL			EQU	0b3h
+
+; RAMCTL reggisters ****************************************************************
+
+RAM_CTL			EQU	0b4h
+RAM_CTL0		EQU	0b4h
+RAM_ADDR_U		EQU	0b5h
+MBIST_GPR		EQU	0b6h
+MBIST_EMR		EQU	0b7h
+
+; RAMCTL bit definitions ***********************************************************
+
+RAMCTL_ERAMEN		EQU	(1 << 6) ; Bit 7: 1=On chip EMAC SRAM is enabled *
+RAMCTL_GPRAMEN		EQU	(1 << 7) ; Bit 7: 1=On chip GP SRAM is enabled *
+
+; SPI Registers ********************************************************************
+
+SPI_BRG_L		EQU	0b8h
+SPI_BRG_H		EQU	0b9h
+SPI_CTL			EQU	0bah
+SPI_SR			EQU	0bbh
+SPI_RBR			EQU	0bch
+SPI_TSR			EQU	0bch
+
+; UART Register Offsets ************************************************************
+
+                                           ; DLAB=0: *
+UART_THR		EQU	000h        ;    W: UART Transmit holding register *
+UART_RBR		EQU	000h        ;   R : UART Receive buffer register *
+UART_IER		EQU	001h        ;   RW: UART Interrupt enable register *
+                                           ; DLAB=1: *
+UART_BRG		EQU	000h        ;   RW: UART Baud rate generator register *
+UART_BRGL		EQU	000h        ;   RW: UART Baud rate generator register (low) *
+UART_BRGH		EQU	001h        ;   RW: UART Baud rate generator register (high) *
+                                           ; DLAB=N/A: *
+UART_IIR		EQU	002h        ;   R : UART Interrupt identification register *
+UART_FCTL		EQU	002h        ;    W: UART FIFO control register *
+UART_LCTL		EQU	003h        ;   RW: UART Line control register *
+UART_MCTL		EQU	004h        ;   RW: UART Modem control register *
+UART_LSR		EQU	005h        ;   R : UART Line status register *
+UART_MSR		EQU	006h        ;   R : UART Modem status register *
+UART_SPR		EQU	007h        ;   RW: UART Scratchpad register *
+
+; UART0/1 Base Register Addresses **************************************************
+
+UART0_BASE		EQU	0c0h
+UART1_BASE		EQU	0d0h
+
+; UART0/1 Register Addresses *******************************************************
+
+UART0_THR		EQU	UART0_BASE + UART_THR
+UART0_RBR		EQU	UART0_BASE + UART_RBR
+UART0_IER		EQU	UART0_BASE + UART_IER
+UART0_BRG		EQU	UART0_BASE + UART_BRG
+UART0_BRGL		EQU	UART0_BASE + UART_BRGL
+UART0_BRGH		EQU	UART0_BASE + UART_BRGH
+UART0_IIR		EQU	UART0_BASE + UART_IIR
+UART0_FCTL		EQU	UART0_BASE + UART_FCTL
+UART0_LCTL		EQU	UART0_BASE + UART_LCTL
+UART0_MCTL		EQU	UART0_BASE + UART_MCTL
+UART0_LSR		EQU	UART0_BASE + UART_LSR
+UART0_MSR		EQU	UART0_BASE + UART_MSR
+UART0_SPR		EQU	UART0_BASE + UART_SPR
+
+UART1_THR		EQU	UART1_BASE + UART_THR
+UART1_RBR		EQU	UART1_BASE + UART_RBR
+UART1_IER		EQU	UART1_BASE + UART_IER
+UART1_BRG		EQU	UART1_BASE + UART_BRG
+UART1_BRGL		EQU	UART1_BASE + UART_BRGL
+UART1_BRGH		EQU	UART1_BASE + UART_BRGH
+UART1_IIR		EQU	UART1_BASE + UART_IIR
+UART1_FCTL		EQU	UART1_BASE + UART_FCTL
+UART1_LCTL		EQU	UART1_BASE + UART_LCTL
+UART1_MCTL		EQU	UART1_BASE + UART_MCTL
+UART1_LSR		EQU	UART1_BASE + UART_LSR
+UART1_MSR		EQU	UART1_BASE + UART_MSR
+UART1_SPR		EQU	UART1_BASE + UART_SPR
+
+; UART0/1 IER register bits ********************************************************
+
+UARTEIR_INTMASK		EQU	01fh         ; Bits 5-7: Reserved *
+UARTEIR_TCIE		EQU	010h         ; Bit 4: Transmission complete interrupt *
+UARTEIR_MIIE		EQU	008h         ; Bit 3: Modem status input interrupt *
+UARTEIR_LSIE		EQU	004h         ; Bit 2: Line status interrupt *
+UARTEIR_TIE		EQU	002h         ; Bit 1: Transmit interrupt *
+UARTEIR_RIE		EQU	001h         ; Bit 0: Receive interrupt *
+
+; UART0/1 IIR register bits ********************************************************
+
+UARTIIR_FSTS		EQU	080h         ; Bit 7: FIFO enable *
+                                            ; Bits 4-6: Reserved *
+UARTIIR_INSTS		EQU	00eh         ; Bits 1-3: Interrupt status code *
+UARTINSTS_CTO		EQU	00ch         ;   110: Character timeout *
+UARTINSTS_TC		EQU	00ah         ;   101: Transmission complete *
+UARTINSTS_RLS		EQU	006h         ;   011: Receiver line status *
+UARTINSTS_RDR		EQU	004h         ;   010: Receive data ready or trigger level *
+UARTINSTS_TBE		EQU	002h         ;   001: Transmisson buffer empty *
+UARTINSTS_MS		EQU	000h         ;   000: Modem status *
+UARTIIR_INTBIT		EQU	001h         ; Bit 0: Active interrupt source *
+UARTIIR_CAUSEMASK	EQU	00fh
+
+; UART0/1 FCTL register bits *******************************************************
+
+UARTFCTL_TRIG		EQU	0c0h         ; Bits 6-7: UART receive FIFO trigger level *
+UARTTRIG_1		EQU	000h         ;   00: Receive FIFO trigger level=1 *
+UARTTRIG_4		EQU	040h         ;   01: Receive FIFO trigger level=4 *
+UARTTRIG_8		EQU	080h         ;   10: Receive FIFO trigger level=8 *
+UARTTRIG_14		EQU	0c0h         ;   11: Receive FIFO trigger level=14 *
+                                            ; Bit 3-5: Reserved *
+UARTFCTL_CLRTXF		EQU	004h         ; Bit 2: Transmit enable *
+UARTFCTL_CLRRXF		EQU	002h         ; Bit 1: Receive enable *
+UARTFCTL_FIFOEN		EQU	001h         ; Bit 0: Enable receive/transmit FIFOs *
+
+; UART0/1 LCTL register bits *******************************************************
+
+UARTLCTL_DLAB		EQU	080h         ; Bit 7: Enable access to baud rate generator *
+UARTLCTL_SB		EQU	040h         ; Bit 6: Send break *
+UARTLCTL_FPE		EQU	020h         ; Bit 5: Force parity error *
+UARTLCTL_EPS		EQU	010h         ; Bit 4: Even parity select *
+UARTLCTL_PEN		EQU	008h         ; Bit 3: Parity enable *
+UARTLCTL_2STOP		EQU	004h         ; Bit 2: 2 stop bits *
+UARTLCTL_CHAR		EQU	003h         ; Bits 0-2: Number of data bits *
+UARTCHAR_5BITS		EQU	000h         ;   00: 5 data bits *
+UARTCHAR_6BITS		EQU	001h         ;   01: 6 data bits *
+UARTCHAR_7BITS		EQU	002h         ;   10: 7 data bits *
+UARTCHAR_8BITS		EQU	003h         ;   11: 8 data bits *
+
+UARTLCTL_MASK		EQU	03fh
+
+; UART0/1 MCTL register bits *******************************************************
+
+                                            ; Bit 7: Reserved *
+UARTMCTL_POLARITY	EQU	040h         ; Bit 6: Invert polarity of RxD and TxD *
+UARTMCTL_MDM		EQU	020h         ; Bit 5: Multi-drop mode enable *
+UARTMCTL_LOOP		EQU	010h         ; Bit 4: Loopback mode enable *
+UARTMCTL_OUT2		EQU	008h         ; Bit 3: (loopback mode only) *
+UARTMCTL_OUT1		EQU	004h         ; Bit 2: (loopback mode only) *
+UARTMCTL_RTS		EQU	002h         ; Bit 1: Request to send *
+UARTMCTL_DTR		EQU	001h         ; Bit 0: Data termnal read *
+
+; UART0/1 LSR register bits ********************************************************
+
+UARTLSR_ERR		EQU	080h         ; Bit 7: Error detected in FIFO *
+UARTLSR_TEMT		EQU	040h         ; Bit 6: Transmit FIFO empty and idle *
+UARTLSR_THRE		EQU	020h         ; Bit 5: Transmit FIFO empty *
+UARTLSR_BI		EQU	010h         ; Bit 4: Break on input *
+UARTLSR_FE		EQU	008h         ; Bit 3: Framing error *
+UARTLSR_PE		EQU	004h         ; Bit 2: Parity error *
+UARTLSR_OE		EQU	002h         ; Bit 1: Overrun error *
+UARTLSR_DR		EQU	001h         ; Bit 0: Data ready *
+
+; UART0/1 MSR register bits ********************************************************
+
+UARTMSR_DCD		EQU	080h         ; Bit 7: Data carrier detect *
+UARTMSR_RI		EQU	040h         ; Bit 6: Ring indicator *
+UARTMSR_DSR		EQU	020h         ; Bit 5: Data set ready *
+UARTMSR_CTS		EQU	010h         ; Bit 4: Clear to send *
+UARTMSR_DDCD		EQU	008h         ; Bit 3: Delta on DCD input *
+UARTMSR_TERI		EQU	004h         ; Bit 2: Trailing edge change on RI *
+UARTMSR_DDSR		EQU	002h         ; Bit 1: Delta on DSR input *
+UARTMSR_DCTS		EQU	001h         ; Bit 0: Delta on CTS input *
+
+; IR Registers  ********************************************************************
+
+IR_CTL			EQU	0bfh
+
+; I2C Registers  *******************************************************************
+
+I2C_SAR			EQU	0c8h
+I2C_XSAR		EQU	0c9h
+I2C_DR			EQU	0cah
+I2C_CTL			EQU	0cbh
+I2C_SR			EQU	0cch
+I2C_CCR			EQU	0cdh
+I2C_SRR			EQU	0ceh
+
+; CLK Registers  *******************************************************************
+
+CLK_PPD1		EQU	0dbh
+CLK_PPD2		EQU	0dch
+
+; RTC Registers  *******************************************************************
+
+RTC_SEC			EQU	0e0h
+RTC_MIN			EQU	0e1h
+RTC_HRS			EQU	0e2h
+RTC_DOW			EQU	0e3h
+RTC_DOM			EQU	0e4h
+RTC_MON			EQU	0e5h
+RTC_YR			EQU	0e6h
+RTC_CEN			EQU	0e7h
+RTC_ASEC		EQU	0e8h
+RTC_AMIN		EQU	0e9h
+RTC_AHRS		EQU	0eah
+RTC_ADOW		EQU	0ebh
+RTC_ACTRL		EQU	0ech
+RTC_CTRL		EQU	0edh
+
+; CSBMC Registers  *****************************************************************
+
+CS0_BMC			EQU	0f0h
+CS1_BMC			EQU	0f1h
+CS2_BMC			EQU	0f2h
+CS3_BMC			EQU	0f3h
+
+; FLASH Registers  *****************************************************************
+
+FLASH_KEY		EQU	0f5h
+FLASH_DATA		EQU	0f6h
+FLASH_ADDR_U		EQU	0f7h
+FLASH_CTRL		EQU	0f8h
+FLASH_FDIV		EQU	0f9h
+FLASH_PROT		EQU	0fah
+FLASH_INTC		EQU	0fbh
+FLASH_IRQ		EQU	FLASH_INTC	; compat. with ZDS-II
+FLASH_PAGE		EQU	0fch
+FLASH_ROW		EQU	0fdh
+FLASH_COL		EQU	0feh
+FLASH_PGCTL		EQU	0ffh
+

--- a/arch/z80/src/ez80/ez80_io.asm
+++ b/arch/z80/src/ez80/ez80_io.asm
@@ -33,7 +33,7 @@
 ; Global Symbols Expported
 ;**************************************************************************
 
-	CONFIG_EZ80_Z80MODE equ 0
+CONFIG_EZ80_Z80MODE	equ	0
 
 ;**************************************************************************
 ; Code
@@ -54,7 +54,7 @@ _outp:
 	; Create a stack frame
 
 	push	ix
-	ld	ix, #0
+	ld	ix, 0
 	add	ix, sp
 
 	; Get the arguments from the stack
@@ -104,7 +104,7 @@ _inp:
 	; Create a stack frame
 
 	push	ix
-	ld	ix, #0
+	ld	ix, 0
 	add	ix, sp
 
 	; Get the arguments from the stack

--- a/arch/z80/src/ez80/ez80_irqcommon.asm
+++ b/arch/z80/src/ez80/ez80_irqcommon.asm
@@ -26,7 +26,7 @@
 
 EZ80_C_FLAG		EQU	01h		; Bit 0: Carry flag
 EZ80_N_FLAG		EQU	02h		; Bit 1: Add/Subtract flag
-EZ80_PV_FLAG	EQU	04h		; Bit 2: Parity/Overflow flag
+EZ80_PV_FLAG		EQU	04h		; Bit 2: Parity/Overflow flag
 EZ80_H_FLAG		EQU	10h		; Bit 4: Half carry flag
 EZ80_Z_FLAG		EQU	40h		; Bit 5: Zero flag
 EZ80_S_FLAG		EQU	80h		; Bit 7: Sign flag
@@ -62,7 +62,7 @@ _ez80_irq_common:
 	; IRQ number is in A
 
 	push	hl					; Offset 6: HL
-	ld		hl, #(3*3)			;    HL is the value of the stack pointer before
+	ld		hl, 3*3				;    HL is the value of the stack pointer before
 	add		hl, sp				;    the interrupt occurred (3 for PC, AF, HL)
 	push	hl					; Offset 5: Stack pointer
 	push	iy					; Offset 4: IY
@@ -74,16 +74,16 @@ _ez80_irq_common:
 	; so we can save a fake indication that will cause interrupts to restored when
 	; this context is restored
 
-	ld		bc, #EZ80_PV_FLAG	; Parity bit.  1=parity odd, IEF2=1
+	ld		bc, EZ80_PV_FLAG	; Parity bit.  1=parity odd, IEF2=1
 	push	bc					; Offset 0: I with interrupt state in parity
 	di							; (not necessary)
 
 	; Call the interrupt decode logic. SP points to the beginning of the reg structure
 
-	ld		hl, #0				; Argument #2 is the beginning of the reg structure
+	ld		hl, 0				; Argument #2 is the beginning of the reg structure
 	add		hl, sp				;
 	push	hl					; Place argument #2 at the top of stack
-	ld		bc, #0				; BC = reset number
+	ld		bc, 0				; BC = reset number
 	ld		c, a				;   Save the reset number in C
 	push	bc					; Argument #1 is the Reset number
 	call	_z80_doirq			; Decode the IRQ

--- a/arch/z80/src/ez80/ez80_reset.asm
+++ b/arch/z80/src/ez80/ez80_reset.asm
@@ -69,7 +69,7 @@ _rst30:
 	rstvector
 _rst38:
 	rstvector
-	ds %26
+	ds 026h
 _nmi:
 	retn
 	end

--- a/arch/z80/src/ez80/ez80_rtc.c
+++ b/arch/z80/src/ez80/ez80_rtc.c
@@ -95,11 +95,6 @@ struct alm_cbinfo_s
  * Private Data
  ****************************************************************************/
 
-/* Interrupt handlers attached to the ALARM EXTI */
-
-static xcpt_t g_alarm_callback;
-static void  *g_callback_arg;
-
 #ifdef CONFIG_RTC_ALARM
 /* Callback to use when an EXTI is activated  */
 
@@ -289,7 +284,7 @@ static void set_raw_time(FAR const struct rtc_timeregs_s *rtcregs)
   outp(EZ80_RTC_MON, rtcregs->mon);
   outp(EZ80_RTC_YR,  rtcregs->yr);
   outp(EZ80_RTC_CEN, rtcregs->cen);
-  rtc_unlock();
+  rtc_lock();
 }
 
 /****************************************************************************
@@ -306,6 +301,7 @@ static void set_raw_time(FAR const struct rtc_timeregs_s *rtcregs)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_RTC_ALARM
 static void get_raw_alarm(FAR struct rtc_almregs_s *almregs)
 {
   almregs->sec = inp(EZ80_RTC_ASEC);
@@ -313,6 +309,7 @@ static void get_raw_alarm(FAR struct rtc_almregs_s *almregs)
   almregs->hrs = inp(EZ80_RTC_AHRS);
   almregs->dow = inp(EZ80_RTC_ADOW);
 }
+#endif
 
 /****************************************************************************
  * Name: set_raw_alarm
@@ -328,6 +325,7 @@ static void get_raw_alarm(FAR struct rtc_almregs_s *almregs)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_RTC_ALARM
 static void set_raw_alarm(FAR const struct rtc_almregs_s *almregs)
 {
   rtc_unlock();
@@ -335,8 +333,9 @@ static void set_raw_alarm(FAR const struct rtc_almregs_s *almregs)
   outp(EZ80_RTC_AMIN, almregs->min);
   outp(EZ80_RTC_AHRS, almregs->hrs);
   outp(EZ80_RTC_ADOW, almregs->dow);
-  rtc_unlock();
+  rtc_lock();
 }
+#endif
 
 /****************************************************************************
  * Name: ez80_alarm_interrupt

--- a/arch/z80/src/ez80/ez80_saveusercontext.asm
+++ b/arch/z80/src/ez80/ez80_saveusercontext.asm
@@ -32,50 +32,50 @@
 ; Constants
 ;*************************************************************************
 
-	CONFIG_EZ80_Z80MODE equ 0
+CONFIG_EZ80_Z80MODE	equ	0
 
 	.if CONFIG_EZ80_Z80MODE
 	; Register save area layout
 
-	XCPT_I		equ	2*0	; Offset 0: Saved I w/interrupt state in parity
-	XCPT_BC		equ	2*1	; Offset 1: Saved BC register
-	XCPT_DE		equ	2*2	; Offset 2: Saved DE register
-	XCPT_IX		equ	2*3	; Offset 3: Saved IX register
-	XCPT_IY		equ	2*4	; Offset 4: Saved IY register
-	XCPT_SP		equ	2*5	; Offset 5: Offset to SP at time of interrupt
-	XCPT_HL		equ	2*6	; Offset 6: Saved HL register
-	XCPT_AF		equ	2*7	; Offset 7: Saved AF register
-	XCPT_PC		equ	2*8	; Offset 8: Offset to PC at time of interrupt
+XCPT_I		equ	2*0	; Offset 0: Saved I w/interrupt state in parity
+XCPT_BC		equ	2*1	; Offset 1: Saved BC register
+XCPT_DE		equ	2*2	; Offset 2: Saved DE register
+XCPT_IX		equ	2*3	; Offset 3: Saved IX register
+XCPT_IY		equ	2*4	; Offset 4: Saved IY register
+XCPT_SP		equ	2*5	; Offset 5: Offset to SP at time of interrupt
+XCPT_HL		equ	2*6	; Offset 6: Saved HL register
+XCPT_AF		equ	2*7	; Offset 7: Saved AF register
+XCPT_PC		equ	2*8	; Offset 8: Offset to PC at time of interrupt
 
 	; Stack frame
 
-	FRAME_IY	equ	2*0	; Location of IY on the stack
-	FRAME_IX	equ	2*1	; Location of IX on the stack
-	FRAME_RET	equ	2*2	; Location of return address on the stack
-	FRAME_REGS	equ	2*3	; Location of reg save area on stack
+FRAME_IY	equ	2*0	; Location of IY on the stack
+FRAME_IX	equ	2*1	; Location of IX on the stack
+FRAME_RET	equ	2*2	; Location of return address on the stack
+FRAME_REGS	equ	2*3	; Location of reg save area on stack
 
-	SP_OFFSET	equ	2*3
+SP_OFFSET	equ	2*3
 	.else
 	; Register save area layout
 
-	XCPT_I		equ	3*0	; Offset 0: Saved I w/interrupt state in parity
-	XCPT_BC		equ	3*1	; Offset 1: Saved BC register
-	XCPT_DE		equ	3*2	; Offset 2: Saved DE register
-	XCPT_IX		equ	3*3	; Offset 3: Saved IX register
-	XCPT_IY		equ	3*4	; Offset 4: Saved IY register
-	XCPT_SP		equ	3*5	; Offset 5: Offset to SP at time of interrupt
-	XCPT_HL		equ	3*6	; Offset 6: Saved HL register
-	XCPT_AF		equ	3*7	; Offset 7: Saved AF register
-	XCPT_PC		equ	3*8	; Offset 8: Offset to PC at time of interrupt	.endif
+XCPT_I		equ	3*0	; Offset 0: Saved I w/interrupt state in parity
+XCPT_BC		equ	3*1	; Offset 1: Saved BC register
+XCPT_DE		equ	3*2	; Offset 2: Saved DE register
+XCPT_IX		equ	3*3	; Offset 3: Saved IX register
+XCPT_IY		equ	3*4	; Offset 4: Saved IY register
+XCPT_SP		equ	3*5	; Offset 5: Offset to SP at time of interrupt
+XCPT_HL		equ	3*6	; Offset 6: Saved HL register
+XCPT_AF		equ	3*7	; Offset 7: Saved AF register
+XCPT_PC		equ	3*8	; Offset 8: Offset to PC at time of interrupt	.endif
 
 	; Stack frame
 
-	FRAME_IY	equ	3*0	; Location of IY on the stack
-	FRAME_IX	equ	3*1	; Location of IX on the stack
-	FRAME_RET	equ	3*2	; Location of return address on the stack
-	FRAME_REGS	equ	3*3	; Location of reg save area on stack
+FRAME_IY	equ	3*0	; Location of IY on the stack
+FRAME_IX	equ	3*1	; Location of IX on the stack
+FRAME_RET	equ	3*2	; Location of return address on the stack
+FRAME_REGS	equ	3*3	; Location of reg save area on stack
 
-	SP_OFFSET	equ	3*3
+SP_OFFSET	equ	3*3
 	.endif
 
 ;**************************************************************************
@@ -94,13 +94,13 @@ _ez80_saveusercontext:
 
 	push	ix			; Save IX and IY
 	push	iy
-	ld	ix, #0
+	ld	ix, 0
 	add	ix, sp			; IX = stack frame
 
 	; Fetch the address of the save area
 
 	ld	de, (ix + FRAME_REGS)	; DE = save area address
-	ld	iy, #0
+	ld	iy, 0
 	add	iy, de			; IY = save area address
 
 	; Then save the registers
@@ -130,13 +130,13 @@ _ez80_saveusercontext:
 
 	; Save that stack pointer as it would be upon return in offset 5
 
-	ld	hl, #SP_OFFSET		; Value of stack pointer on return
+	ld	hl, SP_OFFSET		; Value of stack pointer on return
 	add	hl, sp
 	ld	(iy + XCPT_SP), hl	; Index 5 SP
 
 	; HL is saved as the value 1 at offset 6
 
-	ld	hl, #1
+	ld	hl, 1
 	ld	(iy + XCPT_HL), hl	; Index 2: HL on return (=1)
 
 	; AF is not preserved (offset 7)
@@ -148,7 +148,7 @@ _ez80_saveusercontext:
 
 	; Return the value 0
 
-	ld	hl, #0
+	ld	hl, 0
 
 	pop	iy
 	pop	ix

--- a/arch/z80/src/ez80/ez80_schedulesigaction.c
+++ b/arch/z80/src/ez80/ez80_schedulesigaction.c
@@ -102,7 +102,7 @@ static void ez80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
 
 void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
+  sinfo("tcb=0x%p sigdeliver=0x%06" PRIx32 "\n", tcb, (uint32_t)sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -137,7 +137,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
                * disabled.
                */
 
-              ez80_sigsetup(tcb, sigdeliver, IRQ_STATE());
+              ez80_sigsetup(tcb, sigdeliver, (chipreg_t *)IRQ_STATE());
 
               /* And make sure that the saved context in the TCB
                * is the same as the interrupt return context.

--- a/arch/z80/src/ez80/ez80_serial.c
+++ b/arch/z80/src/ez80/ez80_serial.c
@@ -154,7 +154,7 @@ static uart_dev_t g_uart0port =
   },
   &g_uart_ops,              /* ops */
   &g_uart0priv,             /* priv */
-  NULL,                     /* pollfds */
+  { },                      /* pollfds: all zero */
 };
 #endif
 
@@ -201,7 +201,7 @@ static uart_dev_t g_uart1port =
   },
   &g_uart_ops,              /* ops */
   &g_uart1priv,             /* priv */
-  NULL,                     /* pollfds */
+  { },                      /* pollfds */
 };
 #endif
 

--- a/arch/z80/src/ez80/ez80_spi.c
+++ b/arch/z80/src/ez80/ez80_spi.c
@@ -417,7 +417,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
       return (uint32_t)0xff;
     }
 
-  spiinfo("cmd: %04x resp: %02x\n", wd, response);
+  spiinfo("cmd: %04" PRIx32 " resp: %02x\n", wd, response);
   return (uint32_t)response;
 }
 
@@ -448,7 +448,7 @@ static void spi_exchange(FAR struct spi_dev_s *dev,
                          size_t nwords)
 {
   FAR const uint8_t *inptr = (FAR const uint8_t *)txbuffer;
-  FAR uint8_t *outptr = (FAR const uint8_t *)rxbuffer;
+  FAR uint8_t *outptr = (FAR uint8_t *)rxbuffer;
 
   spiinfo("txbuffer: %p rxbuffer: %p nwords: %lu\n",
           txbuffer, rxbuffer, (unsigned long)nwords);

--- a/arch/z80/src/ez80/ez80_startup.asm
+++ b/arch/z80/src/ez80/ez80_startup.asm
@@ -22,11 +22,11 @@
 ; Constants
 ;**************************************************************************
 
-EZ80_RAM_CTL      EQU %b4
-EZ80_RAM_ADDR_U   EQU %b5
+EZ80_RAM_CTL      EQU 0b4h
+EZ80_RAM_ADDR_U   EQU 0b5h
 
-EZ80_FLASH_ADDR_U EQU %f7
-EZ80_FLASH_CTRL   EQU %f8
+EZ80_FLASH_ADDR_U EQU 0f7h
+EZ80_FLASH_CTRL   EQU 0f8h
 
 ;**************************************************************************
 ; Imported Symbols
@@ -82,10 +82,13 @@ _ez80_startup:
 	out0	(EZ80_RAM_CTL), a
 
 	; Position the IDLE task stack point at an offset of 1Kb in on-chip SRAM
-	; On-chip SRAM resides at an offset of %00e000 from the RAM base address.
+	; On-chip SRAM resides at an offset of 000e000h from the RAM base address.
 	; REVISIT:  CONFIG_IDLETHREAD_STACKSIZE is not used!
 
-	ld		sp, __RAM_ADDR_U_INIT_PARAM << 16 + %00e400
+	; The GNU assembler (2.36.1) cannot produce this relocation, although the
+	; Z80 ELF format supports it. The instruction is instead hand assembled.
+	;ld		sp, __RAM_ADDR_U_INIT_PARAM << 16 + 000e400h
+	db		031h, 000h, 0e4h, __RAM_ADDR_U_INIT_PARAM
 
 	; Perform chip-specific initialization
 

--- a/arch/z80/src/ez80/ez80f91_handlers.asm
+++ b/arch/z80/src/ez80/ez80f91_handlers.asm
@@ -43,14 +43,17 @@ EZ80_UNUSED	EQU	64		; Denotes an unused vector
 
 ; Define one interrupt handler
 
+ifdef irqhandler
+else
 irqhandler: macro vectno
 	; Save AF on the stack, set the interrupt number and jump to the
 	; common reset handling logic.
-								; Offset 8: Return PC is already on the stack
+							; Offset 8: Return PC is already on the stack
 	push	af					; Offset 7: AF (retaining flags)
 	ld		a, #vectno			; A = vector number
-	jp		_ez80_irq_common	; Remaining RST handling is common
+	jp		_ez80_irq_common		; Remaining RST handling is common
 	endmac	irqhandler
+endif
 
 ;**************************************************************************
 ; Interrupt Vector Handlers
@@ -64,7 +67,7 @@ irqhandler: macro vectno
 						;----------------- --- ----- -----
 _ez80_handlers:
 	irqhandler	 0		; EZ80_EMACRX_IRQ   0    0   0x040
-	_handlersize equ $-_ez80_handlers
+_handlersize equ $-_ez80_handlers
 	irqhandler	 1		; EZ80_EMACTX_IRQ   1    1   0x044
 	irqhandler	 2		; EZ80_EMACSYS_IRQ  2    2   0x048
 	irqhandler	 3		; EZ80_PLL_IRQ      3    3   0x04c
@@ -159,23 +162,29 @@ _ez80_initvectors:
 	;  (24 bits) are required.  A fourth byte is implemented for both
 	;  programmability and expansion purposes."
 
-$1:
+L1:
 	ld		(iy), hl			; Store IRQ handler
 	ld		(iy+3), a			; Pad with zero to 4 bytes
 	add		hl, de				; Point to next handler
-	push	de
+	push		de
 	ld		de, 4
 	add		iy, de				; Point to next entry in vector table
 	pop		de
-	djnz	$1					; Loop until all vectors have been written
+	djnz		L1				; Loop until all vectors have been written
 
 	; Select interrupt mode 2
 
-	im		2					; Interrupt mode 2
+	im		2				; Interrupt mode 2
 
 	; Write the address of the vector table into the interrupt vector base
 
-	ld		hl, _ez80_vectable >> 8
+	; The GNU assembler (2.36.1) cannot produce this relocation, although the
+	; Z80 ELF format supports it. The instruction is instead hand assembled.
+	;ld		hl, _ez80_vectable >> 8
+	db		021h
+	db		_ez80_vectable >> 8
+	db		_ez80_vectable >> 16
+	db		0
 	ld		i, hl
 	ret
 

--- a/arch/z80/src/ez80/ez80f91_init.asm
+++ b/arch/z80/src/ez80/ez80f91_init.asm
@@ -28,35 +28,35 @@
 ; Constants
 ;**************************************************************************
 
-;PLL_DIV_L    EQU %5C
-;PLL_DIV_H    EQU %5D
-;PLL_CTL0     EQU %5E
-;PLL_CTL1     EQU %5F
+;PLL_DIV_L    EQU 05Ch
+;PLL_DIV_H    EQU 05Dh
+;PLL_CTL0     EQU 05Eh
+;PLL_CTL1     EQU 05Fh
 
 OSC           EQU 0
 PLL           EQU 1
 RTC           EQU 2
 
-CLK_MUX_OSC   EQU %00
-CLK_MUX_PLL   EQU %01
-CLK_MUX_RTC   EQU %02
+CLK_MUX_OSC   EQU 000h
+CLK_MUX_PLL   EQU 001h
+CLK_MUX_RTC   EQU 002h
 
-CHRP_CTL_0    EQU %00
-CHRP_CTL_1    EQU %40
-CHRP_CTL_2    EQU %80
-CHRP_CTL_3    EQU %C0
+CHRP_CTL_0    EQU 000h
+CHRP_CTL_1    EQU 040h
+CHRP_CTL_2    EQU 080h
+CHRP_CTL_3    EQU 0C0h
 
-LDS_CTL_0     EQU %00
-LDS_CTL_1     EQU %04
-LDS_CTL_2     EQU %08
-LDS_CTL_3     EQU %0C
+LDS_CTL_0     EQU 000h
+LDS_CTL_1     EQU 004h
+LDS_CTL_2     EQU 008h
+LDS_CTL_3     EQU 00Ch
 
-LCK_STATUS    EQU %20
-INT_LOCK      EQU %10
-INT_UNLOCK    EQU %08
-INT_LOCK_EN   EQU %04
-INT_UNLOCK_EN EQU %02
-PLL_ENABLE    EQU %01
+LCK_STATUS    EQU 020h
+INT_LOCK      EQU 010h
+INT_UNLOCK    EQU 008h
+INT_LOCK_EN   EQU 004h
+INT_UNLOCK_EN EQU 002h
+PLL_ENABLE    EQU 001h
 
 ;**************************************************************************
 ; Global symbols used
@@ -105,12 +105,12 @@ PLL_ENABLE    EQU %01
 _ez80_init:
 	; Disable internal peripheral interrupt sources
 
-	ld		a, %ff
+	ld		a, 0ffh
 	out0	(PA_DDR), a			; GPIO
 	out0	(PB_DDR), a
 	out0	(PC_DDR), a
 	out0	(PD_DDR), a
-	ld		a, %00
+	ld		a, 000h
 	out0	(PA_ALT1), a
 	out0	(PB_ALT1), a
 	out0	(PC_ALT1), a
@@ -129,10 +129,10 @@ _ez80_init:
 	out0	(I2C_CTL), a		; I2C
 	out0	(EMAC_IEN), a		; EMAC
 	out0	(FLASH_IRQ), a		; Flash
-	ld		a, %04
+	ld		a, 004h
 	out0	(SPI_CTL), a		; SPI
 	in0		a, (RTC_CTRL)		; RTC,
-	and		a, %be
+	and		a, 0beh
 	out0	(RTC_CTRL), a
 
 	; Configure external memory/io
@@ -196,7 +196,7 @@ _ez80_initsysclk:
 	; Set charge pump and lock criteria
 
 	ld		a, __PLL_CTL0_INIT_PARAM
-	and		a, %CC  ; mask off reserved and clock source bits
+	and		a, 0CCh  ; mask off reserved and clock source bits
 	out0	(PLL_CTL0), a
 
 	; Enable PLL

--- a/arch/z80/src/ez80/ez80f92_init.asm
+++ b/arch/z80/src/ez80/ez80f92_init.asm
@@ -67,12 +67,12 @@
 _ez80_init:
 	; Disable internal peripheral interrupt sources
 
-	ld		a, %ff
+	ld		a, 0ffh
 	out0	(PB_DDR), a			; GPIO
 	out0	(PC_DDR), a
 	out0	(PD_DDR), a
 
-	ld		a, %00
+	ld		a, 000h
 	out0	(PB_ALT1), a
 	out0	(PC_ALT1), a
 	out0	(PD_ALT1), a
@@ -95,11 +95,11 @@ _ez80_init:
 
 	out0	(FLASH_IRQ), a		; Flash
 
-	ld		a, %04
+	ld		a, 004h
 	out0	(SPI_CTL), a		; SPI
 
 	in0		a, (RTC_CTRL)		; RTC,
-	and		a, %be
+	and		a, 0beh
 	out0	(RTC_CTRL), a
 
 	; Configure external memory/io

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -164,6 +164,13 @@
 #  define DSEG
 #  define CODE
 
+/* Define these here and allow specific architectures to override as needed */
+
+#  define CONFIG_HAVE_LONG_LONG 1
+#  define CONFIG_HAVE_FLOAT 1
+#  define CONFIG_HAVE_DOUBLE 1
+#  define CONFIG_HAVE_LONG_DOUBLE 1
+
 /* Handle cases where sizeof(int) is 16-bits, sizeof(long) is 32-bits, and
  * pointers are 16-bits.
  */
@@ -252,6 +259,30 @@
 #   define CONFIG_PTR_IS_NOT_INT 1
 # endif
 
+#elif defined(_EZ80ACCLAIM)
+
+/* No I-space access qualifiers */
+
+#  define IOBJ
+#  define IPTR
+
+/* Select the large, 24-bit addressing model */
+
+#  undef  CONFIG_SMALL_MEMORY
+
+/* int is 24-bits, long is 32-bits */
+
+#  define CONFIG_LONG_IS_NOT_INT 1
+
+/* pointers are 24-bits too */
+
+#  undef  CONFIG_PTR_IS_NOT_INT
+
+/* the ez80 stdlib doesn't support doubles */
+
+#  undef  CONFIG_HAVE_DOUBLE
+#  undef  CONFIG_HAVE_LONG_DOUBLE
+
 #else
 
 /* No I-space access qualifiers */
@@ -270,6 +301,7 @@
 /* Pointers and int are the same size (32-bits) */
 
 #  undef  CONFIG_PTR_IS_NOT_INT
+
 #endif
 
 /* ISO C11 supports anonymous (unnamed) structures and unions, added in
@@ -293,11 +325,6 @@
 #    define CONFIG_HAVE_ANONYMOUS_STRUCT 1
 #    define CONFIG_HAVE_ANONYMOUS_UNION 1
 #  endif
-
-#  define CONFIG_HAVE_LONG_LONG 1
-#  define CONFIG_HAVE_FLOAT 1
-#  define CONFIG_HAVE_DOUBLE 1
-#  define CONFIG_HAVE_LONG_DOUBLE 1
 
 /* Indicate that a local variable is not used */
 

--- a/libs/libc/libc.csv
+++ b/libs/libc/libc.csv
@@ -194,7 +194,7 @@
 "strrchr","string.h","","FAR char *","FAR const char *","int"
 "strspn","string.h","","size_t","FAR const char *","FAR const char *"
 "strstr","string.h","","FAR char","FAR const char *","FAR const char *"
-"strtod","stdlib.h","","double","FAR const char *","FAR char **"
+"strtod","stdlib.h","defined(CONFIG_HAVE_DOUBLE)","double","FAR const char *","FAR char **"
 "strtok","string.h","","FAR char *","FAR char *","FAR const char *"
 "strtok_r","string.h","","FAR char *","FAR char *","FAR const char *","FAR char **"
 "strtol","stdlib.h","","long","FAR const char *","FAR char **","int"


### PR DESCRIPTION
## Summary

Add experimental support for an eZ80 toolchain using llvm and GNU binutils.

An additional fix for the RTC driver to lock the RTC after setting values instead of unlocking it is included.

## Impact

Allows a non-supported fork of llvm with Z80 support to be used to build ELF objects, and GNU binutils compiled with Z80 support enabled to be used as a linker. There are modifications to support 64-bit integers, and further modifications to allow a toolchain to support LONG LONG without supporting DOUBLE.

The assembly code for the eZ80 has been modified to support compilation using both ZDS-II and GNU assembler. This is partially accomplished with macros for the GNU assembler to partially implement the ZDS-II assembler directives.

## Testing

I am using this toolchain to regularly build for the eZ80, with an additional (forthcoming) patch to add ELF support for the architecture. I have compiled the modified assembly using ZDS-II on a Linux VM using Wine, but not executed the result. I have validated boot code, interrupt handling, and drivers for SPI, Ethernet, and UART.

There is an error somewhere in the Ethernet driver that will occasionally lock the driver up if the receive buffer overflows. The error is not introduced by this patch.