### PR TITLE
ESP32-C3: Add driver for the general purpose SPI peripheral in master mode

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -178,8 +178,13 @@ config ESP32C3_WDT
 	bool
 	default n
 
+config ESP32C3_SPI
+	bool
+	default n
+
 config ESP32C3_GPIO_IRQ
 	bool "GPIO pin interrupts"
+	default n
 	---help---
 		Enable support for interrupting GPIO pins
 
@@ -229,6 +234,12 @@ config ESP32C3_SPIFLASH
 	select MTD
 	select MTD_BYTE_WRITE
 	select MTD_PARTITION
+
+config ESP32C3_SPI2
+	bool "SPI 2"
+	default n
+	select ESP32C3_SPI
+	select SPI
 
 config ESP32C3_MWDT0
 	bool "Main System Watchdog Timer (Group 0)"
@@ -287,6 +298,48 @@ config ESP32C3_I2C0_SDAPIN
 endif # ESP32C3_I2C0
 
 endmenu # I2C configuration
+
+menu "SPI configuration"
+	depends on ESP32C3_SPI
+
+config ESP32C3_SPI_SWCS
+	bool "SPI software CS"
+	default n
+	---help---
+		Use SPI software CS.
+
+config ESP32C3_SPI_UDCS
+	bool "User defined CS"
+	default n
+	depends on ESP32C3_SPI_SWCS
+	---help---
+		Use user-defined CS.
+
+if ESP32C3_SPI2
+
+config ESP32C3_SPI2_CSPIN
+	int "SPI2 CS Pin"
+	default 10
+	range 0 21
+
+config ESP32C3_SPI2_CLKPIN
+	int "SPI2 CLK Pin"
+	default 6
+	range 0 21
+
+config ESP32C3_SPI2_MOSIPIN
+	int "SPI2 MOSI Pin"
+	default 7
+	range 0 21
+
+config ESP32C3_SPI2_MISOPIN
+	int "SPI2 MISO Pin"
+	default 2
+	range 0 21
+
+endif # ESP32C3_SPI2
+
+endmenu # SPI configuration
 
 menu "UART configuration"
 	depends on ESP32C3_UART

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -63,6 +63,10 @@ ifeq ($(CONFIG_ESP32C3_I2C),y)
 CHIP_CSRCS += esp32c3_i2c.c
 endif
 
+ifeq ($(CONFIG_ESP32C3_SPI),y)
+CHIP_CSRCS += esp32c3_spi.c
+endif
+
 ifeq ($(CONFIG_ESP32C3_SPIFLASH),y)
 CHIP_CSRCS += esp32c3_spiflash.c
 endif

--- a/arch/risc-v/src/esp32c3/esp32c3_spi.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi.c
@@ -1,0 +1,1144 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/esp32c3_spi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_ESP32C3_SPI
+
+#include <assert.h>
+#include <sys/types.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/spi/spi.h>
+
+#include <arch/board/board.h>
+
+#include "esp32c3_spi.h"
+#include "esp32c3_gpio.h"
+
+#include "riscv_arch.h"
+#include "hardware/esp32c3_gpio_sigmap.h"
+#include "hardware/esp32c3_pinmap.h"
+#include "hardware/esp32c3_spi.h"
+#include "hardware/esp32c3_soc.h"
+#include "hardware/esp32c3_system.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Check if Chip-Select pin will be controlled via software */
+
+#ifdef CONFIG_ESP32C3_SPI_SWCS
+#  define SPI_HAVE_SWCS TRUE
+#else
+#  define SPI_HAVE_SWCS FALSE
+#endif
+
+/* Verify whether SPI has been assigned IOMUX pins.
+ * Otherwise, SPI signals will be routed via GPIO Matrix.
+ */
+
+#define SPI_IS_CS_IOMUX   (CONFIG_ESP32C3_SPI2_CSPIN == SPI2_IOMUX_CSPIN)
+#define SPI_IS_CLK_IOMUX  (CONFIG_ESP32C3_SPI2_CLKPIN == SPI2_IOMUX_CLKPIN)
+#define SPI_IS_MOSI_IOMUX (CONFIG_ESP32C3_SPI2_MOSIPIN == SPI2_IOMUX_MOSIPIN)
+#define SPI_IS_MISO_IOMUX (CONFIG_ESP32C3_SPI2_MISOPIN == SPI2_IOMUX_MISOPIN)
+
+#define SPI_VIA_IOMUX     (SPI_IS_CS_IOMUX || SPI_HAVE_SWCS) && \
+                          (SPI_IS_CLK_IOMUX) && \
+                          (SPI_IS_MOSI_IOMUX) && \
+                          (SPI_IS_MISO_IOMUX)
+
+/* SPI default frequency (limited by clock divider) */
+
+#define SPI_DEFAULT_FREQ  (400000)
+
+/* SPI default width */
+
+#define SPI_DEFAULT_WIDTH (8)
+
+/* SPI default mode */
+
+#define SPI_DEFAULT_MODE  (SPIDEV_MODE0)
+
+/* Helper for applying the mask for a given register field.
+ * Mask is determined by the macros suffixed with _V and _S from the
+ * peripheral register description.
+ */
+
+#define VALUE_MASK(_val, _field) ((_val & (_field##_V)) << (_field##_S))
+
+/* SPI Maximum buffer size in bytes */
+
+#define SPI_MAX_BUF_SIZE (64)
+
+#ifndef MIN
+#  define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* SPI Device hardware configuration */
+
+struct esp32c3_spi_config_s
+{
+  uint32_t clk_freq;          /* SPI default clock frequency */
+  uint32_t width;             /* SPI default width */
+  enum spi_mode_e mode;       /* SPI default mode */
+
+  uint8_t cs_pin;             /* GPIO configuration for CS */
+  uint8_t mosi_pin;           /* GPIO configuration for MOSI */
+  uint8_t miso_pin;           /* GPIO configuration for MISO */
+  uint8_t clk_pin;            /* GPIO configuration for CLK */
+  uint32_t clk_bit;           /* Clock enable bit */
+  uint32_t rst_bit;           /* SPI reset bit */
+  uint32_t cs_insig;          /* SPI CS input signal index */
+  uint32_t cs_outsig;         /* SPI CS output signal index */
+  uint32_t mosi_insig;        /* SPI MOSI input signal index */
+  uint32_t mosi_outsig;       /* SPI MOSI output signal index */
+  uint32_t miso_insig;        /* SPI MISO input signal index */
+  uint32_t miso_outsig;       /* SPI MISO output signal index */
+  uint32_t clk_insig;         /* SPI CLK input signal index */
+  uint32_t clk_outsig;        /* SPI CLK output signal index */
+};
+
+struct esp32c3_spi_priv_s
+{
+  /* Externally visible part of the SPI interface */
+
+  struct spi_dev_s spi_dev;
+
+  /* Port configuration */
+
+  const struct esp32c3_spi_config_s *config;
+  int refs;             /* Reference count */
+  sem_t exclsem;        /* Held while chip is selected for mutual exclusion */
+  uint32_t frequency;   /* Requested clock frequency */
+  uint32_t actual;      /* Actual clock frequency */
+  enum spi_mode_e mode; /* Actual SPI hardware mode */
+  uint8_t nbits;        /* Actual SPI send/receive bits once transmission */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int esp32c3_spi_lock(FAR struct spi_dev_s *dev, bool lock);
+#ifndef CONFIG_ESP32C3_SPI_UDCS
+static void esp32c3_spi_select(FAR struct spi_dev_s *dev,
+                               uint32_t devid, bool selected);
+#endif
+static uint32_t esp32c3_spi_setfrequency(FAR struct spi_dev_s *dev,
+                                         uint32_t frequency);
+static void esp32c3_spi_setmode(FAR struct spi_dev_s *dev,
+                                enum spi_mode_e mode);
+static void esp32c3_spi_setbits(FAR struct spi_dev_s *dev, int nbits);
+#ifdef CONFIG_SPI_HWFEATURES
+static int esp32c3_spi_hwfeatures(FAR struct spi_dev_s *dev,
+                                  spi_hwfeatures_t features);
+#endif
+static uint32_t esp32c3_spi_send(FAR struct spi_dev_s *dev, uint32_t wd);
+static void esp32c3_spi_exchange(FAR struct spi_dev_s *dev,
+                                 FAR const void *txbuffer,
+                                 FAR void *rxbuffer, size_t nwords);
+#ifndef CONFIG_SPI_EXCHANGE
+static void esp32c3_spi_sndblock(FAR struct spi_dev_s *dev,
+                                 FAR const void *txbuffer,
+                                 size_t nwords);
+static void esp32c3_spi_recvblock(FAR struct spi_dev_s *dev,
+                                  FAR void *rxbuffer,
+                                  size_t nwords);
+#endif
+#ifdef CONFIG_SPI_TRIGGER
+static int esp32c3_spi_trigger(FAR struct spi_dev_s *dev);
+#endif
+static void esp32c3_spi_init(FAR struct spi_dev_s *dev);
+static void esp32c3_spi_deinit(FAR struct spi_dev_s *dev);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32C3_SPI2
+static const struct esp32c3_spi_config_s esp32c3_spi2_config =
+{
+  .clk_freq     = SPI_DEFAULT_FREQ,
+  .width        = SPI_DEFAULT_WIDTH,
+  .mode         = SPI_DEFAULT_MODE,
+  .cs_pin       = CONFIG_ESP32C3_SPI2_CSPIN,
+  .mosi_pin     = CONFIG_ESP32C3_SPI2_MOSIPIN,
+  .miso_pin     = CONFIG_ESP32C3_SPI2_MISOPIN,
+  .clk_pin      = CONFIG_ESP32C3_SPI2_CLKPIN,
+  .clk_bit      = SYSTEM_SPI2_CLK_EN,
+  .rst_bit      = SYSTEM_SPI2_RST,
+  .cs_insig     = FSPICS0_IN_IDX,
+  .cs_outsig    = FSPICS0_OUT_IDX,
+  .mosi_insig   = FSPID_IN_IDX,
+  .mosi_outsig  = FSPID_OUT_IDX,
+  .miso_insig   = FSPIQ_IN_IDX,
+  .miso_outsig  = FSPIQ_OUT_IDX,
+  .clk_insig    = FSPICLK_IN_IDX,
+  .clk_outsig   = FSPICLK_OUT_IDX
+};
+
+static const struct spi_ops_s esp32c3_spi2_ops =
+{
+  .lock              = esp32c3_spi_lock,
+#ifdef CONFIG_ESP32C3_SPI_UDCS
+  .select            = esp32c3_spi2_select,
+#else
+  .select            = esp32c3_spi_select,
+#endif
+  .setfrequency      = esp32c3_spi_setfrequency,
+  .setmode           = esp32c3_spi_setmode,
+  .setbits           = esp32c3_spi_setbits,
+#ifdef CONFIG_SPI_HWFEATURES
+  .hwfeatures        = esp32c3_spi_hwfeatures,
+#endif
+  .status            = esp32c3_spi2_status,
+#ifdef CONFIG_SPI_CMDDATA
+  .cmddata           = esp32c3_spi2_cmddata,
+#endif
+  .send              = esp32c3_spi_send,
+#ifdef CONFIG_SPI_EXCHANGE
+  .exchange          = esp32c3_spi_exchange,
+#else
+  .sndblock          = esp32c3_spi_sndblock,
+  .recvblock         = esp32c3_spi_recvblock,
+#endif
+#ifdef CONFIG_SPI_TRIGGER
+  .trigger           = esp32c3_spi_trigger,
+#endif
+  .registercallback  = NULL,
+};
+
+static struct esp32c3_spi_priv_s esp32c3_spi2_priv =
+{
+  .spi_dev   =
+              {
+                .ops = &esp32c3_spi2_ops
+              },
+  .config    = &esp32c3_spi2_config,
+  .refs      = 0,
+  .exclsem   = SEM_INITIALIZER(0),
+  .frequency = 0,
+  .actual    = 0,
+  .mode      = 0,
+  .nbits     = 0
+};
+#endif /* CONFIG_ESP32C3_SPI2 */
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_spi_set_regbits
+ *
+ * Description:
+ *   Set the bits of the SPI register.
+ *
+ * Input Parameters:
+ *   addr   - Address of the register of interest
+ *   bits   - Bits to be set
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static inline void esp32c3_spi_set_regbits(uint32_t addr, uint32_t bits)
+{
+  uint32_t tmp = getreg32(addr);
+
+  putreg32(tmp | bits, addr);
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_clr_regbits
+ *
+ * Description:
+ *   Clear the bits of the SPI register.
+ *
+ * Input Parameters:
+ *   addr   - Address of the register of interest
+ *   bits   - Bits to be cleared
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static inline void esp32c3_spi_clr_regbits(uint32_t addr, uint32_t bits)
+{
+  uint32_t tmp = getreg32(addr);
+
+  putreg32(tmp & (~bits), addr);
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_lock
+ *
+ * Description:
+ *   Lock or unlock the SPI device.
+ *
+ * Input Parameters:
+ *   dev    - Device-specific state data
+ *   lock   - true: Lock spi bus, false: unlock SPI bus
+ *
+ * Returned Value:
+ *   The result of lock or unlock the SPI device
+ *
+ ****************************************************************************/
+
+static int esp32c3_spi_lock(FAR struct spi_dev_s *dev, bool lock)
+{
+  int ret;
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+
+  if (lock)
+    {
+      ret = nxsem_wait_uninterruptible(&priv->exclsem);
+    }
+  else
+    {
+      ret = nxsem_post(&priv->exclsem);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_select
+ *
+ * Description:
+ *   Enable/disable the SPI chip select. The implementation of this method
+ *   must include handshaking: If a device is selected, it must hold off
+ *   all other attempts to select the device until the device is deselected.
+ *
+ *   If ESP32C3_SPI_SWCS is disabled, the driver will use hardware CS so that
+ *   once transmission is started the hardware selects the device and when
+ *   this transmission is done hardware deselects the device automatically.
+ *   So, this function will do nothing.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *   devid    - Identifies the device to select
+ *   selected - true: slave selected, false: slave de-selected
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifndef CONFIG_ESP32C3_SPI_UDCS
+static void esp32c3_spi_select(FAR struct spi_dev_s *dev,
+                               uint32_t devid, bool selected)
+{
+#if SPI_HAVE_SWCS
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  bool value = selected ? false : true;
+
+  esp32c3_gpiowrite(priv->config->cs_pin, value);
+#endif
+
+  spiinfo("devid: %08" PRIx32 " CS: %s\n",
+          devid, selected ? "select" : "free");
+}
+#endif
+
+/****************************************************************************
+ * Name: esp32c3_spi_setfrequency
+ *
+ * Description:
+ *   Set the SPI frequency.
+ *
+ * Input Parameters:
+ *   dev       - Device-specific state data
+ *   frequency - The requested SPI frequency
+ *
+ * Returned Value:
+ *   Returns the current selected frequency.
+ *
+ ****************************************************************************/
+
+static uint32_t esp32c3_spi_setfrequency(FAR struct spi_dev_s *dev,
+                                         uint32_t frequency)
+{
+  uint32_t reg_val;
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  const uint32_t duty_cycle = 128;
+
+  if (priv->frequency == frequency)
+    {
+      /* Requested frequency is the same as the current frequency. */
+
+      return priv->actual;
+    }
+
+  /* In HW, n, h and l fields range from 1 to 64, pre ranges from 1 to 8K.
+   * The value written to register is one lower than the used value.
+   */
+
+  if (frequency > ((APB_CLK_FREQ / 4) * 3))
+    {
+      /* Using APB frequency directly will give us the best result here. */
+
+      reg_val = SPI_CLK_EQU_SYSCLK_M;
+      priv->actual = APB_CLK_FREQ;
+    }
+  else
+    {
+      /* For best duty cycle resolution, we want n to be as close to 32 as
+       * possible, but we also need a pre/n combo that gets us as close as
+       * possible to the intended frequency. To do this, we bruteforce n and
+       * calculate the best pre to go along with that. If there's a choice
+       * between pre/n combos that give the same result, use the one with the
+       * higher n.
+       */
+
+      int32_t pre;
+      int32_t n;
+      int32_t h;
+      int32_t l;
+      int32_t bestn = -1;
+      int32_t bestpre = -1;
+      int32_t besterr = 0;
+      int32_t errval;
+
+      /* Start at n = 2. We need to be able to set h/l so we have at least
+       * one high and one low pulse.
+       */
+
+      for (n = 2; n <= 64; n++)
+        {
+          /* Effectively, this does:
+           *   pre = round((APB_CLK_FREQ / n) / frequency)
+           */
+
+          pre = ((APB_CLK_FREQ / n) + (frequency / 2)) / frequency;
+
+          if (pre <= 0)
+            {
+              pre = 1;
+            }
+
+          if (pre > 16)
+            {
+              pre = 16;
+            }
+
+          errval = abs(APB_CLK_FREQ / (pre * n) - frequency);
+          if (bestn == -1 || errval <= besterr)
+            {
+              besterr = errval;
+              bestn = n;
+              bestpre = pre;
+            }
+        }
+
+      n = bestn;
+      pre = bestpre;
+      l = n;
+
+      /* Effectively, this does:
+       *   h = round((duty_cycle * n) / 256)
+       */
+
+      h = (duty_cycle * n + 127) / 256;
+      if (h <= 0)
+        {
+          h = 1;
+        }
+
+      reg_val = ((l - 1) << SPI_CLKCNT_L_S) |
+                ((h - 1) << SPI_CLKCNT_H_S) |
+                ((n - 1) << SPI_CLKCNT_N_S) |
+                ((pre - 1) << SPI_CLKDIV_PRE_S);
+
+      priv->actual = APB_CLK_FREQ / (n * pre);
+    }
+
+  priv->frequency = frequency;
+
+  putreg32(reg_val, SPI_CLOCK_REG);
+
+  spiinfo("frequency=%" PRIu32 ", actual=%" PRIu32 "\n",
+          priv->frequency, priv->actual);
+
+  return priv->actual;
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_setmode
+ *
+ * Description:
+ *   Set the SPI mode.
+ *
+ * Input Parameters:
+ *   dev  - Device-specific state data
+ *   mode - The requested SPI mode
+ *
+ * Returned Value:
+ *   none
+ *
+ ****************************************************************************/
+
+static void esp32c3_spi_setmode(FAR struct spi_dev_s *dev,
+                                enum spi_mode_e mode)
+{
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+
+  spiinfo("mode=%d\n", mode);
+
+  /* Has the mode changed? */
+
+  if (mode != priv->mode)
+    {
+      uint32_t ck_idle_edge;
+      uint32_t ck_out_edge;
+
+      switch (mode)
+        {
+          case SPIDEV_MODE0: /* CPOL=0; CPHA=0 */
+            ck_idle_edge = 0;
+            ck_out_edge = 0;
+            break;
+
+          case SPIDEV_MODE1: /* CPOL=0; CPHA=1 */
+            ck_idle_edge = 0;
+            ck_out_edge = 1;
+            break;
+
+          case SPIDEV_MODE2: /* CPOL=1; CPHA=0 */
+            ck_idle_edge = 1;
+            ck_out_edge = 1;
+            break;
+
+          case SPIDEV_MODE3: /* CPOL=1; CPHA=1 */
+            ck_idle_edge = 1;
+            ck_out_edge = 0;
+            break;
+
+          default:
+            spierr("Invalid mode: %d\n", mode);
+            DEBUGASSERT(false);
+            return;
+        }
+
+      esp32c3_spi_clr_regbits(SPI_MISC_REG, SPI_CK_IDLE_EDGE_M);
+      esp32c3_spi_set_regbits(SPI_MISC_REG,
+                              VALUE_MASK(ck_idle_edge, SPI_CK_IDLE_EDGE));
+
+      esp32c3_spi_clr_regbits(SPI_USER_REG, SPI_CK_OUT_EDGE_M);
+      esp32c3_spi_set_regbits(SPI_USER_REG,
+                              VALUE_MASK(ck_out_edge, SPI_CK_OUT_EDGE));
+
+      priv->mode = mode;
+    }
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_setbits
+ *
+ * Description:
+ *   Set the number of bits per word.
+ *
+ * Input Parameters:
+ *   dev   - Device-specific state data
+ *   nbits - The number of bits in an SPI word.
+ *
+ * Returned Value:
+ *   none
+ *
+ ****************************************************************************/
+
+static void esp32c3_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
+{
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+
+  spiinfo("nbits=%d\n", nbits);
+
+  priv->nbits = nbits;
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_hwfeatures
+ *
+ * Description:
+ *   Set hardware-specific feature flags.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *   features - H/W feature flags
+ *
+ * Returned Value:
+ *   Zero (OK) if the selected H/W features are enabled; A negated errno
+ *   value if any H/W feature is not supportable.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_HWFEATURES
+static int esp32c3_spi_hwfeatures(FAR struct spi_dev_s *dev,
+                                  spi_hwfeatures_t features)
+{
+  /* Other H/W features are not supported */
+
+  return (features == 0) ? OK : -ENOSYS;
+}
+#endif
+
+/****************************************************************************
+ * Name: esp32c3_spi_poll_send
+ *
+ * Description:
+ *   Send one word on SPI by polling mode.
+ *
+ * Input Parameters:
+ *   priv - SPI private state data
+ *   wd   - The word to send. The size of the data is determined by the
+ *          number of bits selected for the SPI interface.
+ *
+ * Returned Value:
+ *   Received value
+ *
+ ****************************************************************************/
+
+static uint32_t esp32c3_spi_poll_send(FAR struct esp32c3_spi_priv_s *priv,
+                                      uint32_t wd)
+{
+  uint32_t val;
+
+  putreg32((priv->nbits - 1), SPI_MS_DLEN_REG);
+
+  putreg32(wd, SPI_W0_REG);
+
+  /* Trigger start of user-defined transaction for master. */
+
+  esp32c3_spi_set_regbits(SPI_CMD_REG, SPI_UPDATE_M);
+
+  while ((getreg32(SPI_CMD_REG) & SPI_UPDATE_M) != 0)
+    {
+      ;
+    }
+
+  esp32c3_spi_set_regbits(SPI_CMD_REG, SPI_USR_M);
+
+  /* Wait for the user-defined transaction to finish. */
+
+  while ((getreg32(SPI_CMD_REG) & SPI_USR_M) != 0)
+    {
+      ;
+    }
+
+  val = getreg32(SPI_W0_REG);
+
+  spiinfo("send=0x%" PRIx32 " and recv=0x%" PRIx32 "\n", wd, val);
+
+  return val;
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_send
+ *
+ * Description:
+ *   Send one word on SPI.
+ *
+ * Input Parameters:
+ *   dev - Device-specific state data
+ *   wd  - The word to send. The size of the data is determined by the
+ *         number of bits selected for the SPI interface.
+ *
+ * Returned Value:
+ *   Received value
+ *
+ ****************************************************************************/
+
+static uint32_t esp32c3_spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
+{
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+
+  return esp32c3_spi_poll_send(priv, wd);
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_poll_exchange
+ *
+ * Description:
+ *   Exchange a block of data from SPI.
+ *
+ * Input Parameters:
+ *   priv     - SPI private state data
+ *   txbuffer - A pointer to the buffer of data to be sent
+ *   rxbuffer - A pointer to the buffer in which to receive data
+ *   nwords   - The length of data that to be exchanged in units of words.
+ *              The wordsize is determined by the number of bits-per-word
+ *              selected for the SPI interface. If nbits <= 8, the data is
+ *              packed into uint8_t's; if nbits >8, the data is packed into
+ *              uint16_t's
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32c3_spi_poll_exchange(FAR struct esp32c3_spi_priv_s *priv,
+                                      FAR const void *txbuffer,
+                                      FAR void *rxbuffer,
+                                      size_t nwords)
+{
+  const uint32_t total_bytes = nwords * (priv->nbits / 8);
+  uintptr_t bytes_remaining = total_bytes;
+  uint8_t *tp = (uint8_t *)txbuffer;
+  uint8_t *rp = (uint8_t *)rxbuffer;
+
+  while (bytes_remaining != 0)
+    {
+      /* Initialize data_buf_reg with the address of the first data buffer
+       * register (W0).
+       */
+
+      uintptr_t data_buf_reg = SPI_W0_REG;
+      uint32_t transfer_size = MIN(SPI_MAX_BUF_SIZE, bytes_remaining);
+
+      /* Write data words to data buffer registers.
+       * SPI peripheral contains 16 registers (W0 - W15).
+       */
+
+      for (int i = 0 ; i < transfer_size; i += sizeof(uint32_t))
+        {
+          uint32_t w_wd = UINT32_MAX;
+
+          if (tp != NULL)
+            {
+              memcpy(&w_wd, tp, sizeof(uint32_t));
+
+              tp += sizeof(uintptr_t);
+            }
+
+          putreg32(w_wd, data_buf_reg);
+
+          spiinfo("send=0x%" PRIx32 " data_reg=0x%" PRIxPTR "\n",
+                  w_wd, data_buf_reg);
+
+          /* Update data_buf_reg to point to the next data buffer register. */
+
+          data_buf_reg += sizeof(uintptr_t);
+        }
+
+      esp32c3_spi_set_regbits(SPI_USER_REG, SPI_USR_MOSI_M);
+
+      if (rp == NULL)
+        {
+          esp32c3_spi_clr_regbits(SPI_USER_REG, SPI_USR_MISO_M);
+        }
+      else
+        {
+          esp32c3_spi_set_regbits(SPI_USER_REG, SPI_USR_MISO_M);
+        }
+
+      putreg32((transfer_size * 8) - 1, SPI_MS_DLEN_REG);
+
+      /* Trigger start of user-defined transaction for master. */
+
+      esp32c3_spi_set_regbits(SPI_CMD_REG, SPI_UPDATE_M);
+
+      while ((getreg32(SPI_CMD_REG) & SPI_UPDATE_M) != 0)
+        {
+          ;
+        }
+
+      esp32c3_spi_set_regbits(SPI_CMD_REG, SPI_USR_M);
+
+      /* Wait for the user-defined transaction to finish. */
+
+      while ((getreg32(SPI_CMD_REG) & SPI_USR_M) != 0)
+        {
+          ;
+        }
+
+      if (rp != NULL)
+        {
+          /* Set data_buf_reg with the address of the first data buffer
+           * register (W0).
+           */
+
+          data_buf_reg = SPI_W0_REG;
+
+          /* Read received data words from SPI data buffer registers. */
+
+          for (int i = 0 ; i < transfer_size; i += sizeof(uint32_t))
+            {
+              uint32_t r_wd = getreg32(data_buf_reg);
+
+              spiinfo("recv=0x%" PRIx32 " data_reg=0x%" PRIxPTR "\n",
+                      r_wd, data_buf_reg);
+
+              memcpy(rp, &r_wd, sizeof(uint32_t));
+
+              rp += sizeof(uintptr_t);
+
+              /* Update data_buf_reg to point to the next data buffer
+               * register.
+               */
+
+              data_buf_reg += sizeof(uintptr_t);
+            }
+        }
+
+      bytes_remaining -= transfer_size;
+    }
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_exchange
+ *
+ * Description:
+ *   Exchange a block of data from SPI.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *   txbuffer - A pointer to the buffer of data to be sent
+ *   rxbuffer - A pointer to the buffer in which to receive data
+ *   nwords   - The length of data that to be exchanged in units of words.
+ *              The wordsize is determined by the number of bits-per-word
+ *              selected for the SPI interface. If nbits <= 8, the data is
+ *              packed into uint8_t's; if nbits >8, the data is packed into
+ *              uint16_t's
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32c3_spi_exchange(FAR struct spi_dev_s *dev,
+                                 FAR const void *txbuffer,
+                                 FAR void *rxbuffer,
+                                 size_t nwords)
+{
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+
+  esp32c3_spi_poll_exchange(priv, txbuffer, rxbuffer, nwords);
+}
+
+#ifndef CONFIG_SPI_EXCHANGE
+
+/****************************************************************************
+ * Name: esp32c3_spi_sndblock
+ *
+ * Description:
+ *   Send a block of data on SPI.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *   txbuffer - A pointer to the buffer of data to be sent
+ *   nwords   - The length of data to send from the buffer in number of
+ *              words. The wordsize is determined by the number of
+ *              bits-per-word selected for the SPI interface. If nbits <= 8,
+ *              the data is packed into uint8_t's; if nbits >8, the data is
+ *              packed into uint16_t's
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32c3_spi_sndblock(FAR struct spi_dev_s *dev,
+                                 FAR const void *txbuffer,
+                                 size_t nwords)
+{
+  spiinfo("txbuffer=%p nwords=%d\n", txbuffer, nwords);
+
+  esp32c3_spi_exchange(dev, txbuffer, NULL, nwords);
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_recvblock
+ *
+ * Description:
+ *   Receive a block of data from SPI.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *   rxbuffer - A pointer to the buffer in which to receive data
+ *   nwords   - The length of data that can be received in the buffer in
+ *              number of words. The wordsize is determined by the number of
+ *              bits-per-word selected for the SPI interface. If nbits <= 8,
+ *              the data is packed into uint8_t's; if nbits >8, the data is
+ *              packed into uint16_t's
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32c3_spi_recvblock(FAR struct spi_dev_s *dev,
+                                  FAR void *rxbuffer,
+                                  size_t nwords)
+{
+  spiinfo("rxbuffer=%p nwords=%d\n", rxbuffer, nwords);
+
+  esp32c3_spi_exchange(dev, NULL, rxbuffer, nwords);
+}
+#endif
+
+/****************************************************************************
+ * Name: esp32c3_spi_trigger
+ *
+ * Description:
+ *   Trigger a previously configured DMA transfer.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *
+ * Returned Value:
+ *   OK       - Trigger was fired
+ *   -ENOSYS  - Trigger not fired due to lack of DMA or low level support
+ *   -EIO     - Trigger not fired because not previously primed
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_TRIGGER
+static int esp32c3_spi_trigger(FAR struct spi_dev_s *dev)
+{
+  return -ENOSYS;
+}
+#endif
+
+/****************************************************************************
+ * Name: esp32c3_spi_init
+ *
+ * Description:
+ *   Initialize ESP32-C3 SPI hardware interface.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32c3_spi_init(FAR struct spi_dev_s *dev)
+{
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  const struct esp32c3_spi_config_s *config = priv->config;
+  uint32_t regval;
+
+  /* Initialize the SPI semaphore that enforces mutually exclusive access */
+
+  nxsem_init(&priv->exclsem, 0, 1);
+
+  esp32c3_gpiowrite(config->cs_pin, true);
+  esp32c3_gpiowrite(config->mosi_pin, true);
+  esp32c3_gpiowrite(config->miso_pin, true);
+  esp32c3_gpiowrite(config->clk_pin, true);
+
+#if SPI_HAVE_SWCS
+  esp32c3_configgpio(config->cs_pin, OUTPUT_FUNCTION_1);
+  esp32c3_gpio_matrix_out(config->cs_pin, SIG_GPIO_OUT_IDX, 0, 0);
+#endif
+
+#if SPI_VIA_IOMUX
+#if !SPI_HAVE_SWCS
+  esp32c3_configgpio(config->cs_pin, OUTPUT_FUNCTION_2);
+  esp32c3_gpio_matrix_out(config->cs_pin, SIG_GPIO_OUT_IDX, 0, 0);
+#endif
+  esp32c3_configgpio(config->mosi_pin, OUTPUT_FUNCTION_2);
+  esp32c3_gpio_matrix_out(config->mosi_pin, SIG_GPIO_OUT_IDX, 0, 0);
+
+  esp32c3_configgpio(config->miso_pin, INPUT_FUNCTION_2 | PULLUP);
+  esp32c3_gpio_matrix_out(config->miso_pin, SIG_GPIO_OUT_IDX, 0, 0);
+
+  esp32c3_configgpio(config->clk_pin, OUTPUT_FUNCTION_2);
+  esp32c3_gpio_matrix_out(config->clk_pin, SIG_GPIO_OUT_IDX, 0, 0);
+#else
+#if !SPI_HAVE_SWCS
+  esp32c3_configgpio(config->cs_pin, OUTPUT_FUNCTION_1);
+  esp32c3_gpio_matrix_out(config->cs_pin, config->cs_outsig, 0, 0);
+#endif
+  esp32c3_configgpio(config->mosi_pin, OUTPUT_FUNCTION_1);
+  esp32c3_gpio_matrix_out(config->mosi_pin, config->mosi_outsig, 0, 0);
+
+  esp32c3_configgpio(config->miso_pin, INPUT_FUNCTION_1 | PULLUP);
+  esp32c3_gpio_matrix_in(config->miso_pin, config->miso_insig, 0);
+
+  esp32c3_configgpio(config->clk_pin, OUTPUT_FUNCTION_1);
+  esp32c3_gpio_matrix_out(config->clk_pin, config->clk_outsig, 0, 0);
+#endif
+
+  modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0, config->clk_bit);
+  modifyreg32(SYSTEM_PERIP_RST_EN0_REG, config->rst_bit, 0);
+
+  regval = SPI_DOUTDIN_M | SPI_USR_MISO_M | SPI_USR_MOSI_M | SPI_CS_HOLD_M;
+  putreg32(regval, SPI_USER_REG);
+  putreg32(0, SPI_USER1_REG);
+  putreg32(0, SPI_SLAVE_REG);
+  putreg32(SPI_CS1_DIS_M | SPI_CS2_DIS_M, SPI_MISC_REG);
+
+  regval = SPI_CLK_EN_M | SPI_MST_CLK_ACTIVE_M | SPI_MST_CLK_SEL_M;
+  putreg32(regval, SPI_CLK_GATE_REG);
+
+#if SPI_HAVE_SWCS
+  esp32c3_spi_set_regbits(SPI_MISC_REG, SPI_CS0_DIS_M);
+#endif
+
+  putreg32(0, SPI_CTRL_REG);
+  putreg32(VALUE_MASK(0, SPI_CS_HOLD_TIME), SPI_USER1_REG);
+
+  esp32c3_spi_setfrequency(dev, config->clk_freq);
+  esp32c3_spi_setbits(dev, config->width);
+  esp32c3_spi_setmode(dev, config->mode);
+}
+
+/****************************************************************************
+ * Name: esp32c3_spi_deinit
+ *
+ * Description:
+ *   Deinitialize ESP32-C3 SPI hardware interface.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void esp32c3_spi_deinit(FAR struct spi_dev_s *dev)
+{
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+
+  modifyreg32(SYSTEM_PERIP_RST_EN0_REG, 0, priv->config->clk_bit);
+  modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, priv->config->clk_bit, 0);
+
+  priv->frequency = 0;
+  priv->actual    = 0;
+  priv->mode      = SPIDEV_MODE0;
+  priv->nbits     = 0;
+}
+
+/****************************************************************************
+ * Name: esp32c3_spibus_initialize
+ *
+ * Description:
+ *   Initialize the selected SPI bus.
+ *
+ * Input Parameters:
+ *   port     - Port number (for hardware that has multiple SPI interfaces)
+ *
+ * Returned Value:
+ *   Valid SPI device structure reference on success; NULL on failure
+ *
+ ****************************************************************************/
+
+FAR struct spi_dev_s *esp32c3_spibus_initialize(int port)
+{
+  FAR struct spi_dev_s *spi_dev;
+  FAR struct esp32c3_spi_priv_s *priv;
+  irqstate_t flags;
+
+  switch (port)
+    {
+#ifdef CONFIG_ESP32C3_SPI2
+      case ESP32C3_SPI2:
+        priv = &esp32c3_spi2_priv;
+        break;
+#endif
+      default:
+        return NULL;
+    }
+
+  spi_dev = (FAR struct spi_dev_s *)priv;
+
+  flags = enter_critical_section();
+
+  if ((volatile int)priv->refs != 0)
+    {
+      leave_critical_section(flags);
+
+      return spi_dev;
+    }
+
+  esp32c3_spi_init(spi_dev);
+
+  priv->refs++;
+
+  leave_critical_section(flags);
+
+  return spi_dev;
+}
+
+/****************************************************************************
+ * Name: esp32c3_spibus_uninitialize
+ *
+ * Description:
+ *   Uninitialize an SPI bus.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise -1 (ERROR).
+ *
+ ****************************************************************************/
+
+int esp32c3_spibus_uninitialize(FAR struct spi_dev_s *dev)
+{
+  irqstate_t flags;
+  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+
+  DEBUGASSERT(dev);
+
+  if (priv->refs == 0)
+    {
+      return ERROR;
+    }
+
+  flags = enter_critical_section();
+
+  if (--priv->refs != 0)
+    {
+      leave_critical_section(flags);
+      return OK;
+    }
+
+  leave_critical_section(flags);
+
+  esp32c3_spi_deinit(dev);
+
+  nxsem_destroy(&priv->exclsem);
+
+  return OK;
+}
+
+#endif /* CONFIG_ESP32C3_SPI */

--- a/arch/risc-v/src/esp32c3/esp32c3_spi.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi.h
@@ -1,0 +1,137 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/esp32c3_spi.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_ESP32C3_ESP32C3_SPI_H
+#define __ARCH_RISCV_SRC_ESP32C3_ESP32C3_SPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+#ifdef CONFIG_ESP32C3_SPI
+
+#include <nuttx/spi/spi.h>
+
+#ifdef CONFIG_ESP32C3_SPI2
+#  define ESP32C3_SPI2 2
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_spibus_initialize
+ *
+ * Description:
+ *   Initialize the selected SPI bus.
+ *
+ * Input Parameters:
+ *   port     - Port number (for hardware that has multiple SPI interfaces)
+ *
+ * Returned Value:
+ *   Valid SPI device structure reference on success; NULL on failure
+ *
+ ****************************************************************************/
+
+FAR struct spi_dev_s *esp32c3_spibus_initialize(int port);
+
+/****************************************************************************
+ * Name:  esp32c3_spi[0|1]_select and esp32c3_spi[0|1]_status
+ *
+ * Description:
+ *   The external functions, esp32c3_spi[0|1]_select,
+ *   esp32c3_spi[0|1]_status, and esp32c3_spi[0|1]_cmddata must be provided
+ *   by board-specific logic.
+ *   These are implementations of the select, status, and cmddata methods of
+ *   the SPI interface defined by struct spi_ops_s (include/nuttx/spi/spi.h).
+ *   All other methods (including esp32c3_spibus_initialize()) are provided
+ *   by common ESP32-C3 logic. To use this common SPI logic on your board:
+ *
+ *   1. Provide logic in esp32c3_board_initialize() to configure SPI chip
+ *      select pins.
+ *   2. Provide esp32c3_spi[0|1]_select() and esp32c3_spi[0|1]_status()
+ *      functions in your board-specific logic. These functions will perform
+ *      chip selection and status operations using GPIOs in the way your
+ *      board is configured.
+ *   3. If CONFIG_SPI_CMDDATA is defined in your NuttX configuration file,
+ *      then provide esp32c3_spi[0|1]_cmddata() functions in your
+ *      board-specific logic. These functions will perform cmd/data selection
+ *      operations using GPIOs in the way your board is configured.
+ *   4. Add a call to esp32c3_spibus_initialize() in your low level
+ *      application initialization logic.
+ *   5. The handle returned by esp32c3_spibus_initialize() may then be used
+ *      to bind the SPI driver to higher level logic (e.g., calling
+ *      mmcsd_spislotinitialize(), for example, will bind the SPI driver to
+ *      the SPI MMC/SD driver).
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32C3_SPI2
+void esp32c3_spi2_select(FAR struct spi_dev_s *dev, uint32_t devid,
+                         bool selected);
+uint8_t esp32c3_spi2_status(FAR struct spi_dev_s *dev, uint32_t devid);
+int esp32c3_spi2_cmddata(FAR struct spi_dev_s *dev,
+                         uint32_t devid,
+                         bool cmd);
+#endif
+
+/****************************************************************************
+ * Name: esp32c3_spibus_uninitialize
+ *
+ * Description:
+ *   Uninitialize an SPI bus.
+ *
+ * Input Parameters:
+ *   dev      - Device-specific state data
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise -1 (ERROR).
+ *
+ ****************************************************************************/
+
+int esp32c3_spibus_uninitialize(FAR struct spi_dev_s *dev);
+
+#endif /* CONFIG_ESP32C3_SPI */
+
+#ifdef __cplusplus
+}
+#endif
+#undef EXTERN
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_SPI_H */

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_pinmap.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_pinmap.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/hardware/esp32c3_pinmap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_PINMAP_H
+#define __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_PINMAP_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Peripheral's fixed mapped pins by IOMUX, these GPIO pins can have better
+ * speed performance.
+ */
+
+/* SPI2 */
+
+#define SPI2_IOMUX_MISOPIN      (2)
+#define SPI2_IOMUX_MOSIPIN      (7)
+#define SPI2_IOMUX_CLKPIN       (6)
+#define SPI2_IOMUX_CSPIN        (10)
+#define SPI2_IOMUX_WPPIN        (5)
+#define SPI2_IOMUX_HDPIN        (4)
+
+#endif /* __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_PINMAP_H */

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_soc.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_soc.h
@@ -76,17 +76,18 @@
 /* Registers Operation */
 
 #define REG_UHCI_BASE(i)      (DR_REG_UHCI0_BASE - (i) * 0x8000)
-#define REG_UART_BASE( i )    (DR_REG_UART_BASE + (i) * 0x10000 + \
+#define REG_UART_BASE(i)      (DR_REG_UART_BASE + (i) * 0x10000 + \
                                ( (i) > 1 ? 0xe000 : 0 ) )
 #define REG_UART_AHB_BASE(i)  (0x60000000 + (i) * 0x10000 + \
                                ( (i) > 1 ? 0xe000 : 0 ) )
 #define UART_FIFO_AHB_REG(i)  (REG_UART_AHB_BASE(i) + 0x0)
-#define REG_I2S_BASE( i )     (DR_REG_I2S_BASE + (i) * 0x1E000)
+#define REG_I2S_BASE(i)       (DR_REG_I2S_BASE + (i) * 0x1E000)
 #define REG_TIMG_BASE(i)      (DR_REG_TIMERGROUP0_BASE + (i)*0x1000)
 #define REG_SPI_MEM_BASE(i)   (DR_REG_SPI0_BASE - (i) * 0x1000)
+#define REG_SPI_BASE(i)       (DR_REG_SPI2_BASE)
 #define REG_I2C_BASE(i)       (DR_REG_I2C_EXT_BASE + (i) * 0x14000)
 
-/* Periheral Clock */
+/* Peripheral Clock */
 
 #define APB_CLK_FREQ_ROM        (40 * 1000000)
 #define CPU_CLK_FREQ_ROM        APB_CLK_FREQ_ROM

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_spi.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_spi.h
@@ -1,0 +1,2214 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/hardware/esp32c3_spi.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_SPI_H
+#define __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_SPI_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "esp32c3_soc.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* SPI_CMD_REG register
+ * Command control register
+ */
+
+#define SPI_CMD_REG (DR_REG_SPI2_BASE + 0x0)
+
+/* SPI_USR : R/W/SC; bitpos: [24]; default: 0;
+ * User define command enable.  An operation will be triggered when the bit
+ * is set. The bit will be cleared once the operation done.1: enable 0:
+ * disable. Can not be changed by CONF_buf.
+ */
+
+#define SPI_USR    (BIT(24))
+#define SPI_USR_M  (SPI_USR_V << SPI_USR_S)
+#define SPI_USR_V  0x00000001
+#define SPI_USR_S  24
+
+/* SPI_UPDATE : WT; bitpos: [23]; default: 0;
+ * Set this bit to synchronize SPI registers from APB clock domain into SPI
+ * module clock domain, which is only used in SPI master mode.
+ */
+
+#define SPI_UPDATE    (BIT(23))
+#define SPI_UPDATE_M  (SPI_UPDATE_V << SPI_UPDATE_S)
+#define SPI_UPDATE_V  0x00000001
+#define SPI_UPDATE_S  23
+
+/* SPI_CONF_BITLEN : R/W; bitpos: [17:0]; default: 0;
+ * Define the APB cycles of  SPI_CONF state. Can be configured in CONF state.
+ */
+
+#define SPI_CONF_BITLEN    0x0003FFFF
+#define SPI_CONF_BITLEN_M  (SPI_CONF_BITLEN_V << SPI_CONF_BITLEN_S)
+#define SPI_CONF_BITLEN_V  0x0003FFFF
+#define SPI_CONF_BITLEN_S  0
+
+/* SPI_ADDR_REG register
+ * Address value register
+ */
+
+#define SPI_ADDR_REG (DR_REG_SPI2_BASE + 0x4)
+
+/* SPI_USR_ADDR_VALUE : R/W; bitpos: [31:0]; default: 0;
+ * Address to slave. Can be configured in CONF state.
+ */
+
+#define SPI_USR_ADDR_VALUE    0xFFFFFFFF
+#define SPI_USR_ADDR_VALUE_M  (SPI_USR_ADDR_VALUE_V << SPI_USR_ADDR_VALUE_S)
+#define SPI_USR_ADDR_VALUE_V  0xFFFFFFFF
+#define SPI_USR_ADDR_VALUE_S  0
+
+/* SPI_CTRL_REG register
+ * SPI control register
+ */
+
+#define SPI_CTRL_REG (DR_REG_SPI2_BASE + 0x8)
+
+/* SPI_WR_BIT_ORDER : R/W; bitpos: [26]; default: 0;
+ * In command address write-data (MOSI) phases 1: LSB firs 0: MSB first. Can
+ * be configured in CONF state.
+ */
+
+#define SPI_WR_BIT_ORDER    (BIT(26))
+#define SPI_WR_BIT_ORDER_M  (SPI_WR_BIT_ORDER_V << SPI_WR_BIT_ORDER_S)
+#define SPI_WR_BIT_ORDER_V  0x00000001
+#define SPI_WR_BIT_ORDER_S  26
+
+/* SPI_RD_BIT_ORDER : R/W; bitpos: [25]; default: 0;
+ * In read-data (MISO) phase 1: LSB first 0: MSB first. Can be configured in
+ * CONF state.
+ */
+
+#define SPI_RD_BIT_ORDER    (BIT(25))
+#define SPI_RD_BIT_ORDER_M  (SPI_RD_BIT_ORDER_V << SPI_RD_BIT_ORDER_S)
+#define SPI_RD_BIT_ORDER_V  0x00000001
+#define SPI_RD_BIT_ORDER_S  25
+
+/* SPI_WP_POL : R/W; bitpos: [21]; default: 1;
+ * Write protect signal output when SPI is idle.  1: output high, 0: output
+ * low.  Can be configured in CONF state.
+ */
+
+#define SPI_WP_POL    (BIT(21))
+#define SPI_WP_POL_M  (SPI_WP_POL_V << SPI_WP_POL_S)
+#define SPI_WP_POL_V  0x00000001
+#define SPI_WP_POL_S  21
+
+/* SPI_HOLD_POL : R/W; bitpos: [20]; default: 1;
+ * SPI_HOLD output value when SPI is idle. 1: output high, 0: output low.
+ * Can be configured in CONF state.
+ */
+
+#define SPI_HOLD_POL    (BIT(20))
+#define SPI_HOLD_POL_M  (SPI_HOLD_POL_V << SPI_HOLD_POL_S)
+#define SPI_HOLD_POL_V  0x00000001
+#define SPI_HOLD_POL_S  20
+
+/* SPI_D_POL : R/W; bitpos: [19]; default: 1;
+ * The bit is used to set MOSI line polarity, 1: high 0, low. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_D_POL    (BIT(19))
+#define SPI_D_POL_M  (SPI_D_POL_V << SPI_D_POL_S)
+#define SPI_D_POL_V  0x00000001
+#define SPI_D_POL_S  19
+
+/* SPI_Q_POL : R/W; bitpos: [18]; default: 1;
+ * The bit is used to set MISO line polarity, 1: high 0, low. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_Q_POL    (BIT(18))
+#define SPI_Q_POL_M  (SPI_Q_POL_V << SPI_Q_POL_S)
+#define SPI_Q_POL_V  0x00000001
+#define SPI_Q_POL_S  18
+
+/* SPI_FREAD_QUAD : R/W; bitpos: [15]; default: 0;
+ * In the read operations read-data phase apply 4 signals. 1: enable 0:
+ * disable.  Can be configured in CONF state.
+ */
+
+#define SPI_FREAD_QUAD    (BIT(15))
+#define SPI_FREAD_QUAD_M  (SPI_FREAD_QUAD_V << SPI_FREAD_QUAD_S)
+#define SPI_FREAD_QUAD_V  0x00000001
+#define SPI_FREAD_QUAD_S  15
+
+/* SPI_FREAD_DUAL : R/W; bitpos: [14]; default: 0;
+ * In the read operations, read-data phase apply 2 signals. 1: enable 0:
+ * disable. Can be configured in CONF state.
+ */
+
+#define SPI_FREAD_DUAL    (BIT(14))
+#define SPI_FREAD_DUAL_M  (SPI_FREAD_DUAL_V << SPI_FREAD_DUAL_S)
+#define SPI_FREAD_DUAL_V  0x00000001
+#define SPI_FREAD_DUAL_S  14
+
+/* SPI_FCMD_QUAD : R/W; bitpos: [9]; default: 0;
+ * Apply 4 signals during command phase 1:enable 0: disable. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_FCMD_QUAD    (BIT(9))
+#define SPI_FCMD_QUAD_M  (SPI_FCMD_QUAD_V << SPI_FCMD_QUAD_S)
+#define SPI_FCMD_QUAD_V  0x00000001
+#define SPI_FCMD_QUAD_S  9
+
+/* SPI_FCMD_DUAL : R/W; bitpos: [8]; default: 0;
+ * Apply 2 signals during command phase 1:enable 0: disable. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_FCMD_DUAL    (BIT(8))
+#define SPI_FCMD_DUAL_M  (SPI_FCMD_DUAL_V << SPI_FCMD_DUAL_S)
+#define SPI_FCMD_DUAL_V  0x00000001
+#define SPI_FCMD_DUAL_S  8
+
+/* SPI_FADDR_QUAD : R/W; bitpos: [6]; default: 0;
+ * Apply 4 signals during addr phase 1:enable 0: disable. Can be configured
+ * in CONF state.
+ */
+
+#define SPI_FADDR_QUAD    (BIT(6))
+#define SPI_FADDR_QUAD_M  (SPI_FADDR_QUAD_V << SPI_FADDR_QUAD_S)
+#define SPI_FADDR_QUAD_V  0x00000001
+#define SPI_FADDR_QUAD_S  6
+
+/* SPI_FADDR_DUAL : R/W; bitpos: [5]; default: 0;
+ * Apply 2 signals during addr phase 1:enable 0: disable. Can be configured
+ * in CONF state.
+ */
+
+#define SPI_FADDR_DUAL    (BIT(5))
+#define SPI_FADDR_DUAL_M  (SPI_FADDR_DUAL_V << SPI_FADDR_DUAL_S)
+#define SPI_FADDR_DUAL_V  0x00000001
+#define SPI_FADDR_DUAL_S  5
+
+/* SPI_DUMMY_OUT : R/W; bitpos: [3]; default: 0;
+ * In the dummy phase the signal level of spi is output by the spi
+ * controller. Can be configured in CONF state.
+ */
+
+#define SPI_DUMMY_OUT    (BIT(3))
+#define SPI_DUMMY_OUT_M  (SPI_DUMMY_OUT_V << SPI_DUMMY_OUT_S)
+#define SPI_DUMMY_OUT_V  0x00000001
+#define SPI_DUMMY_OUT_S  3
+
+/* SPI_CLOCK_REG register
+ * SPI clock control register
+ */
+
+#define SPI_CLOCK_REG (DR_REG_SPI2_BASE + 0xc)
+
+/* SPI_CLK_EQU_SYSCLK : R/W; bitpos: [31]; default: 1;
+ * In the master mode 1: spi_clk is eqaul to system 0: spi_clk is divided
+ * from system clock. Can be configured in CONF state.
+ */
+
+#define SPI_CLK_EQU_SYSCLK    (BIT(31))
+#define SPI_CLK_EQU_SYSCLK_M  (SPI_CLK_EQU_SYSCLK_V << SPI_CLK_EQU_SYSCLK_S)
+#define SPI_CLK_EQU_SYSCLK_V  0x00000001
+#define SPI_CLK_EQU_SYSCLK_S  31
+
+/* SPI_CLKDIV_PRE : R/W; bitpos: [21:18]; default: 0;
+ * In the master mode it is pre-divider of spi_clk.  Can be configured in
+ * CONF state.
+ */
+
+#define SPI_CLKDIV_PRE    0x0000000F
+#define SPI_CLKDIV_PRE_M  (SPI_CLKDIV_PRE_V << SPI_CLKDIV_PRE_S)
+#define SPI_CLKDIV_PRE_V  0x0000000F
+#define SPI_CLKDIV_PRE_S  18
+
+/* SPI_CLKCNT_N : R/W; bitpos: [17:12]; default: 3;
+ * In the master mode it is the divider of spi_clk. So spi_clk frequency is
+ * system/(spi_clkdiv_pre+1)/(spi_clkcnt_N+1). Can be configured in CONF
+ * state.
+ */
+
+#define SPI_CLKCNT_N    0x0000003F
+#define SPI_CLKCNT_N_M  (SPI_CLKCNT_N_V << SPI_CLKCNT_N_S)
+#define SPI_CLKCNT_N_V  0x0000003F
+#define SPI_CLKCNT_N_S  12
+
+/* SPI_CLKCNT_H : R/W; bitpos: [11:6]; default: 1;
+ * In the master mode it must be floor((spi_clkcnt_N+1)/2-1). In the slave
+ * mode it must be 0. Can be configured in CONF state.
+ */
+
+#define SPI_CLKCNT_H    0x0000003F
+#define SPI_CLKCNT_H_M  (SPI_CLKCNT_H_V << SPI_CLKCNT_H_S)
+#define SPI_CLKCNT_H_V  0x0000003F
+#define SPI_CLKCNT_H_S  6
+
+/* SPI_CLKCNT_L : R/W; bitpos: [5:0]; default: 3;
+ * In the master mode it must be equal to spi_clkcnt_N. In the slave mode it
+ * must be 0. Can be configured in CONF state.
+ */
+
+#define SPI_CLKCNT_L    0x0000003F
+#define SPI_CLKCNT_L_M  (SPI_CLKCNT_L_V << SPI_CLKCNT_L_S)
+#define SPI_CLKCNT_L_V  0x0000003F
+#define SPI_CLKCNT_L_S  0
+
+/* SPI_USER_REG register
+ * SPI USER control register
+ */
+
+#define SPI_USER_REG (DR_REG_SPI2_BASE + 0x10)
+
+/* SPI_USR_COMMAND : R/W; bitpos: [31]; default: 1;
+ * This bit enable the command phase of an operation. Can be configured in
+ * CONF state.
+ */
+
+#define SPI_USR_COMMAND    (BIT(31))
+#define SPI_USR_COMMAND_M  (SPI_USR_COMMAND_V << SPI_USR_COMMAND_S)
+#define SPI_USR_COMMAND_V  0x00000001
+#define SPI_USR_COMMAND_S  31
+
+/* SPI_USR_ADDR : R/W; bitpos: [30]; default: 0;
+ * This bit enable the address phase of an operation. Can be configured in
+ * CONF state.
+ */
+
+#define SPI_USR_ADDR    (BIT(30))
+#define SPI_USR_ADDR_M  (SPI_USR_ADDR_V << SPI_USR_ADDR_S)
+#define SPI_USR_ADDR_V  0x00000001
+#define SPI_USR_ADDR_S  30
+
+/* SPI_USR_DUMMY : R/W; bitpos: [29]; default: 0;
+ * This bit enable the dummy phase of an operation. Can be configured in
+ * CONF state.
+ */
+
+#define SPI_USR_DUMMY    (BIT(29))
+#define SPI_USR_DUMMY_M  (SPI_USR_DUMMY_V << SPI_USR_DUMMY_S)
+#define SPI_USR_DUMMY_V  0x00000001
+#define SPI_USR_DUMMY_S  29
+
+/* SPI_USR_MISO : R/W; bitpos: [28]; default: 0;
+ * This bit enable the read-data phase of an operation. Can be configured in
+ * CONF state.
+ */
+
+#define SPI_USR_MISO    (BIT(28))
+#define SPI_USR_MISO_M  (SPI_USR_MISO_V << SPI_USR_MISO_S)
+#define SPI_USR_MISO_V  0x00000001
+#define SPI_USR_MISO_S  28
+
+/* SPI_USR_MOSI : R/W; bitpos: [27]; default: 0;
+ * This bit enable the write-data phase of an operation. Can be configured
+ * in CONF state.
+ */
+
+#define SPI_USR_MOSI    (BIT(27))
+#define SPI_USR_MOSI_M  (SPI_USR_MOSI_V << SPI_USR_MOSI_S)
+#define SPI_USR_MOSI_V  0x00000001
+#define SPI_USR_MOSI_S  27
+
+/* SPI_USR_DUMMY_IDLE : R/W; bitpos: [26]; default: 0;
+ * spi clock is disable in dummy phase when the bit is enable. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_USR_DUMMY_IDLE    (BIT(26))
+#define SPI_USR_DUMMY_IDLE_M  (SPI_USR_DUMMY_IDLE_V << SPI_USR_DUMMY_IDLE_S)
+#define SPI_USR_DUMMY_IDLE_V  0x00000001
+#define SPI_USR_DUMMY_IDLE_S  26
+
+/* SPI_USR_MOSI_HIGHPART : R/W; bitpos: [25]; default: 0;
+ * write-data phase only access to high-part of the buffer spi_w8~spi_w15.
+ * 1: enable 0: disable.  Can be configured in CONF state.
+ */
+
+#define SPI_USR_MOSI_HIGHPART    (BIT(25))
+#define SPI_USR_MOSI_HIGHPART_M  (SPI_USR_MOSI_HIGHPART_V << SPI_USR_MOSI_HIGHPART_S)
+#define SPI_USR_MOSI_HIGHPART_V  0x00000001
+#define SPI_USR_MOSI_HIGHPART_S  25
+
+/* SPI_USR_MISO_HIGHPART : R/W; bitpos: [24]; default: 0;
+ * read-data phase only access to high-part of the buffer spi_w8~spi_w15. 1:
+ * enable 0: disable. Can be configured in CONF state.
+ */
+
+#define SPI_USR_MISO_HIGHPART    (BIT(24))
+#define SPI_USR_MISO_HIGHPART_M  (SPI_USR_MISO_HIGHPART_V << SPI_USR_MISO_HIGHPART_S)
+#define SPI_USR_MISO_HIGHPART_V  0x00000001
+#define SPI_USR_MISO_HIGHPART_S  24
+
+/* SPI_SIO : R/W; bitpos: [17]; default: 0;
+ * Set the bit to enable 3-line half duplex communication mosi and miso
+ * signals share the same pin. 1: enable 0: disable. Can be configured in
+ * CONF state.
+ */
+
+#define SPI_SIO    (BIT(17))
+#define SPI_SIO_M  (SPI_SIO_V << SPI_SIO_S)
+#define SPI_SIO_V  0x00000001
+#define SPI_SIO_S  17
+
+/* SPI_USR_CONF_NXT : R/W; bitpos: [15]; default: 0;
+ * 1: Enable the DMA CONF phase of next seg-trans operation, which means
+ * seg-trans will continue. 0: The seg-trans will end after the current SPI
+ * seg-trans or this is not seg-trans mode. Can be configured in CONF state.
+ */
+
+#define SPI_USR_CONF_NXT    (BIT(15))
+#define SPI_USR_CONF_NXT_M  (SPI_USR_CONF_NXT_V << SPI_USR_CONF_NXT_S)
+#define SPI_USR_CONF_NXT_V  0x00000001
+#define SPI_USR_CONF_NXT_S  15
+
+/* SPI_FWRITE_QUAD : R/W; bitpos: [13]; default: 0;
+ * In the write operations read-data phase apply 4 signals. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_FWRITE_QUAD    (BIT(13))
+#define SPI_FWRITE_QUAD_M  (SPI_FWRITE_QUAD_V << SPI_FWRITE_QUAD_S)
+#define SPI_FWRITE_QUAD_V  0x00000001
+#define SPI_FWRITE_QUAD_S  13
+
+/* SPI_FWRITE_DUAL : R/W; bitpos: [12]; default: 0;
+ * In the write operations read-data phase apply 2 signals. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_FWRITE_DUAL    (BIT(12))
+#define SPI_FWRITE_DUAL_M  (SPI_FWRITE_DUAL_V << SPI_FWRITE_DUAL_S)
+#define SPI_FWRITE_DUAL_V  0x00000001
+#define SPI_FWRITE_DUAL_S  12
+
+/* SPI_CK_OUT_EDGE : R/W; bitpos: [9]; default: 0;
+ * the bit combined with spi_mosi_delay_mode bits to set mosi signal delay
+ * mode. Can be configured in CONF state.
+ */
+
+#define SPI_CK_OUT_EDGE    (BIT(9))
+#define SPI_CK_OUT_EDGE_M  (SPI_CK_OUT_EDGE_V << SPI_CK_OUT_EDGE_S)
+#define SPI_CK_OUT_EDGE_V  0x00000001
+#define SPI_CK_OUT_EDGE_S  9
+
+/* SPI_RSCK_I_EDGE : R/W; bitpos: [8]; default: 0;
+ * In the slave mode, this bit can be used to change the polarity of rsck.
+ * 0: rsck = !spi_ck_i. 1:rsck = spi_ck_i.
+ */
+
+#define SPI_RSCK_I_EDGE    (BIT(8))
+#define SPI_RSCK_I_EDGE_M  (SPI_RSCK_I_EDGE_V << SPI_RSCK_I_EDGE_S)
+#define SPI_RSCK_I_EDGE_V  0x00000001
+#define SPI_RSCK_I_EDGE_S  8
+
+/* SPI_CS_SETUP : R/W; bitpos: [7]; default: 1;
+ * spi cs is enable when spi is in  prepare  phase. 1: enable 0: disable.
+ * Can be configured in CONF state.
+ */
+
+#define SPI_CS_SETUP    (BIT(7))
+#define SPI_CS_SETUP_M  (SPI_CS_SETUP_V << SPI_CS_SETUP_S)
+#define SPI_CS_SETUP_V  0x00000001
+#define SPI_CS_SETUP_S  7
+
+/* SPI_CS_HOLD : R/W; bitpos: [6]; default: 1;
+ * spi cs keep low when spi is in  done  phase. 1: enable 0: disable. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_CS_HOLD    (BIT(6))
+#define SPI_CS_HOLD_M  (SPI_CS_HOLD_V << SPI_CS_HOLD_S)
+#define SPI_CS_HOLD_V  0x00000001
+#define SPI_CS_HOLD_S  6
+
+/* SPI_TSCK_I_EDGE : R/W; bitpos: [5]; default: 0;
+ * In the slave mode, this bit can be used to change the polarity of tsck.
+ * 0: tsck = spi_ck_i. 1:tsck = !spi_ck_i.
+ */
+
+#define SPI_TSCK_I_EDGE    (BIT(5))
+#define SPI_TSCK_I_EDGE_M  (SPI_TSCK_I_EDGE_V << SPI_TSCK_I_EDGE_S)
+#define SPI_TSCK_I_EDGE_V  0x00000001
+#define SPI_TSCK_I_EDGE_S  5
+
+/* SPI_QPI_MODE : R/W/SS/SC; bitpos: [3]; default: 0;
+ * Both for master mode and slave mode. 1: spi controller is in QPI mode. 0:
+ * others. Can be configured in CONF state.
+ */
+
+#define SPI_QPI_MODE    (BIT(3))
+#define SPI_QPI_MODE_M  (SPI_QPI_MODE_V << SPI_QPI_MODE_S)
+#define SPI_QPI_MODE_V  0x00000001
+#define SPI_QPI_MODE_S  3
+
+/* SPI_DOUTDIN : R/W; bitpos: [0]; default: 0;
+ * Set the bit to enable full duplex communication. 1: enable 0: disable.
+ * Can be configured in CONF state.
+ */
+
+#define SPI_DOUTDIN    (BIT(0))
+#define SPI_DOUTDIN_M  (SPI_DOUTDIN_V << SPI_DOUTDIN_S)
+#define SPI_DOUTDIN_V  0x00000001
+#define SPI_DOUTDIN_S  0
+
+/* SPI_USER1_REG register
+ * SPI USER control register 1
+ */
+
+#define SPI_USER1_REG (DR_REG_SPI2_BASE + 0x14)
+
+/* SPI_USR_ADDR_BITLEN : R/W; bitpos: [31:27]; default: 23;
+ * The length in bits of address phase. The register value shall be
+ * (bit_num-1). Can be configured in CONF state.
+ */
+
+#define SPI_USR_ADDR_BITLEN    0x0000001F
+#define SPI_USR_ADDR_BITLEN_M  (SPI_USR_ADDR_BITLEN_V << SPI_USR_ADDR_BITLEN_S)
+#define SPI_USR_ADDR_BITLEN_V  0x0000001F
+#define SPI_USR_ADDR_BITLEN_S  27
+
+/* SPI_CS_HOLD_TIME : R/W; bitpos: [26:22]; default: 1;
+ * delay cycles of cs pin by spi clock this bits are combined with
+ * spi_cs_hold bit. Can be configured in CONF state.
+ */
+
+#define SPI_CS_HOLD_TIME    0x0000001F
+#define SPI_CS_HOLD_TIME_M  (SPI_CS_HOLD_TIME_V << SPI_CS_HOLD_TIME_S)
+#define SPI_CS_HOLD_TIME_V  0x0000001F
+#define SPI_CS_HOLD_TIME_S  22
+
+/* SPI_CS_SETUP_TIME : R/W; bitpos: [21:17]; default: 0;
+ * (cycles+1) of prepare phase by spi clock this bits are combined with
+ * spi_cs_setup bit. Can be configured in CONF state.
+ */
+
+#define SPI_CS_SETUP_TIME    0x0000001F
+#define SPI_CS_SETUP_TIME_M  (SPI_CS_SETUP_TIME_V << SPI_CS_SETUP_TIME_S)
+#define SPI_CS_SETUP_TIME_V  0x0000001F
+#define SPI_CS_SETUP_TIME_S  17
+
+/* SPI_MST_WFULL_ERR_END_EN : R/W; bitpos: [16]; default: 1;
+ * 1: SPI transfer is ended when SPI RX AFIFO wfull error is valid in GP-SPI
+ * master FD/HD-mode. 0: SPI transfer is not ended when SPI RX AFIFO wfull
+ * error is valid in GP-SPI master FD/HD-mode.
+ */
+
+#define SPI_MST_WFULL_ERR_END_EN    (BIT(16))
+#define SPI_MST_WFULL_ERR_END_EN_M  (SPI_MST_WFULL_ERR_END_EN_V << SPI_MST_WFULL_ERR_END_EN_S)
+#define SPI_MST_WFULL_ERR_END_EN_V  0x00000001
+#define SPI_MST_WFULL_ERR_END_EN_S  16
+
+/* SPI_USR_DUMMY_CYCLELEN : R/W; bitpos: [7:0]; default: 7;
+ * The length in spi_clk cycles of dummy phase. The register value shall be
+ * (cycle_num-1). Can be configured in CONF state.
+ */
+
+#define SPI_USR_DUMMY_CYCLELEN    0x000000FF
+#define SPI_USR_DUMMY_CYCLELEN_M  (SPI_USR_DUMMY_CYCLELEN_V << SPI_USR_DUMMY_CYCLELEN_S)
+#define SPI_USR_DUMMY_CYCLELEN_V  0x000000FF
+#define SPI_USR_DUMMY_CYCLELEN_S  0
+
+/* SPI_USER2_REG register
+ * SPI USER control register 2
+ */
+
+#define SPI_USER2_REG (DR_REG_SPI2_BASE + 0x18)
+
+/* SPI_USR_COMMAND_BITLEN : R/W; bitpos: [31:28]; default: 7;
+ * The length in bits of command phase. The register value shall be
+ * (bit_num-1). Can be configured in CONF state.
+ */
+
+#define SPI_USR_COMMAND_BITLEN    0x0000000F
+#define SPI_USR_COMMAND_BITLEN_M  (SPI_USR_COMMAND_BITLEN_V << SPI_USR_COMMAND_BITLEN_S)
+#define SPI_USR_COMMAND_BITLEN_V  0x0000000F
+#define SPI_USR_COMMAND_BITLEN_S  28
+
+/* SPI_MST_REMPTY_ERR_END_EN : R/W; bitpos: [27]; default: 1;
+ * 1: SPI transfer is ended when SPI TX AFIFO read empty error is valid in
+ * GP-SPI master FD/HD-mode. 0: SPI transfer is not ended when SPI TX AFIFO
+ * read empty error is valid in GP-SPI master FD/HD-mode.
+ */
+
+#define SPI_MST_REMPTY_ERR_END_EN    (BIT(27))
+#define SPI_MST_REMPTY_ERR_END_EN_M  (SPI_MST_REMPTY_ERR_END_EN_V << SPI_MST_REMPTY_ERR_END_EN_S)
+#define SPI_MST_REMPTY_ERR_END_EN_V  0x00000001
+#define SPI_MST_REMPTY_ERR_END_EN_S  27
+
+/* SPI_USR_COMMAND_VALUE : R/W; bitpos: [15:0]; default: 0;
+ * The value of  command. Can be configured in CONF state.
+ */
+
+#define SPI_USR_COMMAND_VALUE    0x0000FFFF
+#define SPI_USR_COMMAND_VALUE_M  (SPI_USR_COMMAND_VALUE_V << SPI_USR_COMMAND_VALUE_S)
+#define SPI_USR_COMMAND_VALUE_V  0x0000FFFF
+#define SPI_USR_COMMAND_VALUE_S  0
+
+/* SPI_MS_DLEN_REG register
+ * SPI data bit length control register
+ */
+
+#define SPI_MS_DLEN_REG (DR_REG_SPI2_BASE + 0x1c)
+
+/* SPI_MS_DATA_BITLEN : R/W; bitpos: [17:0]; default: 0;
+ * The value of these bits is the configured SPI transmission data bit
+ * length in master mode DMA controlled transfer or CPU controlled transfer.
+ * The value is also the configured bit length in slave mode DMA RX
+ * controlled transfer. The register value shall be (bit_num-1). Can be
+ * configured in CONF state.
+ */
+
+#define SPI_MS_DATA_BITLEN    0x0003FFFF
+#define SPI_MS_DATA_BITLEN_M  (SPI_MS_DATA_BITLEN_V << SPI_MS_DATA_BITLEN_S)
+#define SPI_MS_DATA_BITLEN_V  0x0003FFFF
+#define SPI_MS_DATA_BITLEN_S  0
+
+/* SPI_MISC_REG register
+ * SPI misc register
+ */
+
+#define SPI_MISC_REG (DR_REG_SPI2_BASE + 0x20)
+
+/* SPI_QUAD_DIN_PIN_SWAP : R/W; bitpos: [31]; default: 0;
+ * 1:  spi quad input swap enable  0:  spi quad input swap disable. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_QUAD_DIN_PIN_SWAP    (BIT(31))
+#define SPI_QUAD_DIN_PIN_SWAP_M  (SPI_QUAD_DIN_PIN_SWAP_V << SPI_QUAD_DIN_PIN_SWAP_S)
+#define SPI_QUAD_DIN_PIN_SWAP_V  0x00000001
+#define SPI_QUAD_DIN_PIN_SWAP_S  31
+
+/* SPI_CS_KEEP_ACTIVE : R/W; bitpos: [30]; default: 0;
+ * spi cs line keep low when the bit is set. Can be configured in CONF state.
+ */
+
+#define SPI_CS_KEEP_ACTIVE    (BIT(30))
+#define SPI_CS_KEEP_ACTIVE_M  (SPI_CS_KEEP_ACTIVE_V << SPI_CS_KEEP_ACTIVE_S)
+#define SPI_CS_KEEP_ACTIVE_V  0x00000001
+#define SPI_CS_KEEP_ACTIVE_S  30
+
+/* SPI_CK_IDLE_EDGE : R/W; bitpos: [29]; default: 0;
+ * 1: spi clk line is high when idle     0: spi clk line is low when idle.
+ * Can be configured in CONF state.
+ */
+
+#define SPI_CK_IDLE_EDGE    (BIT(29))
+#define SPI_CK_IDLE_EDGE_M  (SPI_CK_IDLE_EDGE_V << SPI_CK_IDLE_EDGE_S)
+#define SPI_CK_IDLE_EDGE_V  0x00000001
+#define SPI_CK_IDLE_EDGE_S  29
+
+/* SPI_SLAVE_CS_POL : R/W; bitpos: [23]; default: 0;
+ * spi slave input cs polarity select. 1: inv  0: not change. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_SLAVE_CS_POL    (BIT(23))
+#define SPI_SLAVE_CS_POL_M  (SPI_SLAVE_CS_POL_V << SPI_SLAVE_CS_POL_S)
+#define SPI_SLAVE_CS_POL_V  0x00000001
+#define SPI_SLAVE_CS_POL_S  23
+
+/* SPI_MASTER_CS_POL : R/W; bitpos: [12:7]; default: 0;
+ * In the master mode the bits are the polarity of spi cs line, the value is
+ * equivalent to spi_cs ^ spi_master_cs_pol. Can be configured in CONF state.
+ */
+
+#define SPI_MASTER_CS_POL    0x0000003F
+#define SPI_MASTER_CS_POL_M  (SPI_MASTER_CS_POL_V << SPI_MASTER_CS_POL_S)
+#define SPI_MASTER_CS_POL_V  0x0000003F
+#define SPI_MASTER_CS_POL_S  7
+
+/* SPI_CK_DIS : R/W; bitpos: [6]; default: 0;
+ * 1: spi clk out disable,  0: spi clk out enable. Can be configured in CONF
+ * state.
+ */
+
+#define SPI_CK_DIS    (BIT(6))
+#define SPI_CK_DIS_M  (SPI_CK_DIS_V << SPI_CK_DIS_S)
+#define SPI_CK_DIS_V  0x00000001
+#define SPI_CK_DIS_S  6
+
+/* SPI_CS5_DIS : R/W; bitpos: [5]; default: 1;
+ * SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n
+ * pin. Can be configured in CONF state.
+ */
+
+#define SPI_CS5_DIS    (BIT(5))
+#define SPI_CS5_DIS_M  (SPI_CS5_DIS_V << SPI_CS5_DIS_S)
+#define SPI_CS5_DIS_V  0x00000001
+#define SPI_CS5_DIS_S  5
+
+/* SPI_CS4_DIS : R/W; bitpos: [4]; default: 1;
+ * SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n
+ * pin. Can be configured in CONF state.
+ */
+
+#define SPI_CS4_DIS    (BIT(4))
+#define SPI_CS4_DIS_M  (SPI_CS4_DIS_V << SPI_CS4_DIS_S)
+#define SPI_CS4_DIS_V  0x00000001
+#define SPI_CS4_DIS_S  4
+
+/* SPI_CS3_DIS : R/W; bitpos: [3]; default: 1;
+ * SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n
+ * pin. Can be configured in CONF state.
+ */
+
+#define SPI_CS3_DIS    (BIT(3))
+#define SPI_CS3_DIS_M  (SPI_CS3_DIS_V << SPI_CS3_DIS_S)
+#define SPI_CS3_DIS_V  0x00000001
+#define SPI_CS3_DIS_S  3
+
+/* SPI_CS2_DIS : R/W; bitpos: [2]; default: 1;
+ * SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n
+ * pin. Can be configured in CONF state.
+ */
+
+#define SPI_CS2_DIS    (BIT(2))
+#define SPI_CS2_DIS_M  (SPI_CS2_DIS_V << SPI_CS2_DIS_S)
+#define SPI_CS2_DIS_V  0x00000001
+#define SPI_CS2_DIS_S  2
+
+/* SPI_CS1_DIS : R/W; bitpos: [1]; default: 1;
+ * SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n
+ * pin. Can be configured in CONF state.
+ */
+
+#define SPI_CS1_DIS    (BIT(1))
+#define SPI_CS1_DIS_M  (SPI_CS1_DIS_V << SPI_CS1_DIS_S)
+#define SPI_CS1_DIS_V  0x00000001
+#define SPI_CS1_DIS_S  1
+
+/* SPI_CS0_DIS : R/W; bitpos: [0]; default: 0;
+ * SPI CS$n pin enable, 1: disable CS$n, 0: spi_cs$n signal is from/to CS$n
+ * pin. Can be configured in CONF state.
+ */
+
+#define SPI_CS0_DIS    (BIT(0))
+#define SPI_CS0_DIS_M  (SPI_CS0_DIS_V << SPI_CS0_DIS_S)
+#define SPI_CS0_DIS_V  0x00000001
+#define SPI_CS0_DIS_S  0
+
+/* SPI_DIN_MODE_REG register
+ * SPI input delay mode configuration
+ */
+
+#define SPI_DIN_MODE_REG (DR_REG_SPI2_BASE + 0x24)
+
+/* SPI_TIMING_HCLK_ACTIVE : R/W; bitpos: [16]; default: 0;
+ * 1:enable hclk in SPI input timing module.  0: disable it. Can be
+ * configured in CONF state.
+ */
+
+#define SPI_TIMING_HCLK_ACTIVE    (BIT(16))
+#define SPI_TIMING_HCLK_ACTIVE_M  (SPI_TIMING_HCLK_ACTIVE_V << SPI_TIMING_HCLK_ACTIVE_S)
+#define SPI_TIMING_HCLK_ACTIVE_V  0x00000001
+#define SPI_TIMING_HCLK_ACTIVE_S  16
+
+/* SPI_DIN3_MODE : R/W; bitpos: [7:6]; default: 0;
+ * the input signals are delayed by SPI module clock cycles, 0: input
+ * without delayed, 1: input with the posedge of clk_apb,2 input with the
+ * negedge of clk_apb, 3: input with the spi_clk. Can be configured in CONF
+ * state.
+ */
+
+#define SPI_DIN3_MODE    0x00000003
+#define SPI_DIN3_MODE_M  (SPI_DIN3_MODE_V << SPI_DIN3_MODE_S)
+#define SPI_DIN3_MODE_V  0x00000003
+#define SPI_DIN3_MODE_S  6
+
+/* SPI_DIN2_MODE : R/W; bitpos: [5:4]; default: 0;
+ * the input signals are delayed by SPI module clock cycles, 0: input
+ * without delayed, 1: input with the posedge of clk_apb,2 input with the
+ * negedge of clk_apb, 3: input with the spi_clk. Can be configured in CONF
+ * state.
+ */
+
+#define SPI_DIN2_MODE    0x00000003
+#define SPI_DIN2_MODE_M  (SPI_DIN2_MODE_V << SPI_DIN2_MODE_S)
+#define SPI_DIN2_MODE_V  0x00000003
+#define SPI_DIN2_MODE_S  4
+
+/* SPI_DIN1_MODE : R/W; bitpos: [3:2]; default: 0;
+ * the input signals are delayed by SPI module clock cycles, 0: input
+ * without delayed, 1: input with the posedge of clk_apb,2 input with the
+ * negedge of clk_apb, 3: input with the spi_clk. Can be configured in CONF
+ * state.
+ */
+
+#define SPI_DIN1_MODE    0x00000003
+#define SPI_DIN1_MODE_M  (SPI_DIN1_MODE_V << SPI_DIN1_MODE_S)
+#define SPI_DIN1_MODE_V  0x00000003
+#define SPI_DIN1_MODE_S  2
+
+/* SPI_DIN0_MODE : R/W; bitpos: [1:0]; default: 0;
+ * the input signals are delayed by SPI module clock cycles, 0: input
+ * without delayed, 1: input with the posedge of clk_apb,2 input with the
+ * negedge of clk_apb, 3: input with the spi_clk. Can be configured in CONF
+ * state.
+ */
+
+#define SPI_DIN0_MODE    0x00000003
+#define SPI_DIN0_MODE_M  (SPI_DIN0_MODE_V << SPI_DIN0_MODE_S)
+#define SPI_DIN0_MODE_V  0x00000003
+#define SPI_DIN0_MODE_S  0
+
+/* SPI_DIN_NUM_REG register
+ * SPI input delay number configuration
+ */
+
+#define SPI_DIN_NUM_REG (DR_REG_SPI2_BASE + 0x28)
+
+/* SPI_DIN3_NUM : R/W; bitpos: [7:6]; default: 0;
+ * the input signals are delayed by SPI module clock cycles, 0: delayed by 1
+ * cycle, 1: delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+
+#define SPI_DIN3_NUM    0x00000003
+#define SPI_DIN3_NUM_M  (SPI_DIN3_NUM_V << SPI_DIN3_NUM_S)
+#define SPI_DIN3_NUM_V  0x00000003
+#define SPI_DIN3_NUM_S  6
+
+/* SPI_DIN2_NUM : R/W; bitpos: [5:4]; default: 0;
+ * the input signals are delayed by SPI module clock cycles, 0: delayed by 1
+ * cycle, 1: delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+
+#define SPI_DIN2_NUM    0x00000003
+#define SPI_DIN2_NUM_M  (SPI_DIN2_NUM_V << SPI_DIN2_NUM_S)
+#define SPI_DIN2_NUM_V  0x00000003
+#define SPI_DIN2_NUM_S  4
+
+/* SPI_DIN1_NUM : R/W; bitpos: [3:2]; default: 0;
+ * the input signals are delayed by SPI module clock cycles, 0: delayed by 1
+ * cycle, 1: delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+
+#define SPI_DIN1_NUM    0x00000003
+#define SPI_DIN1_NUM_M  (SPI_DIN1_NUM_V << SPI_DIN1_NUM_S)
+#define SPI_DIN1_NUM_V  0x00000003
+#define SPI_DIN1_NUM_S  2
+
+/* SPI_DIN0_NUM : R/W; bitpos: [1:0]; default: 0;
+ * the input signals are delayed by SPI module clock cycles, 0: delayed by 1
+ * cycle, 1: delayed by 2 cycles,...  Can be configured in CONF state.
+ */
+
+#define SPI_DIN0_NUM    0x00000003
+#define SPI_DIN0_NUM_M  (SPI_DIN0_NUM_V << SPI_DIN0_NUM_S)
+#define SPI_DIN0_NUM_V  0x00000003
+#define SPI_DIN0_NUM_S  0
+
+/* SPI_DOUT_MODE_REG register
+ * SPI output delay mode configuration
+ */
+
+#define SPI_DOUT_MODE_REG (DR_REG_SPI2_BASE + 0x2c)
+
+/* SPI_DOUT3_MODE : R/W; bitpos: [3]; default: 0;
+ * The output signal $n is delayed by the SPI module clock, 0: output
+ * without delayed, 1: output delay for a SPI module clock cycle at its
+ * negative edge. Can be configured in CONF state.
+ */
+
+#define SPI_DOUT3_MODE    (BIT(3))
+#define SPI_DOUT3_MODE_M  (SPI_DOUT3_MODE_V << SPI_DOUT3_MODE_S)
+#define SPI_DOUT3_MODE_V  0x00000001
+#define SPI_DOUT3_MODE_S  3
+
+/* SPI_DOUT2_MODE : R/W; bitpos: [2]; default: 0;
+ * The output signal $n is delayed by the SPI module clock, 0: output
+ * without delayed, 1: output delay for a SPI module clock cycle at its
+ * negative edge. Can be configured in CONF state.
+ */
+
+#define SPI_DOUT2_MODE    (BIT(2))
+#define SPI_DOUT2_MODE_M  (SPI_DOUT2_MODE_V << SPI_DOUT2_MODE_S)
+#define SPI_DOUT2_MODE_V  0x00000001
+#define SPI_DOUT2_MODE_S  2
+
+/* SPI_DOUT1_MODE : R/W; bitpos: [1]; default: 0;
+ * The output signal $n is delayed by the SPI module clock, 0: output
+ * without delayed, 1: output delay for a SPI module clock cycle at its
+ * negative edge. Can be configured in CONF state.
+ */
+
+#define SPI_DOUT1_MODE    (BIT(1))
+#define SPI_DOUT1_MODE_M  (SPI_DOUT1_MODE_V << SPI_DOUT1_MODE_S)
+#define SPI_DOUT1_MODE_V  0x00000001
+#define SPI_DOUT1_MODE_S  1
+
+/* SPI_DOUT0_MODE : R/W; bitpos: [0]; default: 0;
+ * The output signal $n is delayed by the SPI module clock, 0: output
+ * without delayed, 1: output delay for a SPI module clock cycle at its
+ * negative edge. Can be configured in CONF state.
+ */
+
+#define SPI_DOUT0_MODE    (BIT(0))
+#define SPI_DOUT0_MODE_M  (SPI_DOUT0_MODE_V << SPI_DOUT0_MODE_S)
+#define SPI_DOUT0_MODE_V  0x00000001
+#define SPI_DOUT0_MODE_S  0
+
+/* SPI_DMA_CONF_REG register
+ * SPI DMA control register
+ */
+
+#define SPI_DMA_CONF_REG (DR_REG_SPI2_BASE + 0x30)
+
+/* SPI_DMA_AFIFO_RST : WT; bitpos: [31]; default: 0;
+ * Set this bit to reset DMA TX AFIFO, which is used to send data out in SPI
+ * slave DMA controlled mode transfer.
+ */
+
+#define SPI_DMA_AFIFO_RST    (BIT(31))
+#define SPI_DMA_AFIFO_RST_M  (SPI_DMA_AFIFO_RST_V << SPI_DMA_AFIFO_RST_S)
+#define SPI_DMA_AFIFO_RST_V  0x00000001
+#define SPI_DMA_AFIFO_RST_S  31
+
+/* SPI_BUF_AFIFO_RST : WT; bitpos: [30]; default: 0;
+ * Set this bit to reset BUF TX AFIFO, which is used send data out in SPI
+ * slave CPU controlled mode transfer and master mode transfer.
+ */
+
+#define SPI_BUF_AFIFO_RST    (BIT(30))
+#define SPI_BUF_AFIFO_RST_M  (SPI_BUF_AFIFO_RST_V << SPI_BUF_AFIFO_RST_S)
+#define SPI_BUF_AFIFO_RST_V  0x00000001
+#define SPI_BUF_AFIFO_RST_S  30
+
+/* SPI_RX_AFIFO_RST : WT; bitpos: [29]; default: 0;
+ * Set this bit to reset RX AFIFO, which is used to receive data in SPI
+ * master and slave mode transfer.
+ */
+
+#define SPI_RX_AFIFO_RST    (BIT(29))
+#define SPI_RX_AFIFO_RST_M  (SPI_RX_AFIFO_RST_V << SPI_RX_AFIFO_RST_S)
+#define SPI_RX_AFIFO_RST_V  0x00000001
+#define SPI_RX_AFIFO_RST_S  29
+
+/* SPI_DMA_TX_ENA : R/W; bitpos: [28]; default: 0;
+ * Set this bit to enable SPI DMA controlled send data mode.
+ */
+
+#define SPI_DMA_TX_ENA    (BIT(28))
+#define SPI_DMA_TX_ENA_M  (SPI_DMA_TX_ENA_V << SPI_DMA_TX_ENA_S)
+#define SPI_DMA_TX_ENA_V  0x00000001
+#define SPI_DMA_TX_ENA_S  28
+
+/* SPI_DMA_RX_ENA : R/W; bitpos: [27]; default: 0;
+ * Set this bit to enable SPI DMA controlled receive data mode.
+ */
+
+#define SPI_DMA_RX_ENA    (BIT(27))
+#define SPI_DMA_RX_ENA_M  (SPI_DMA_RX_ENA_V << SPI_DMA_RX_ENA_S)
+#define SPI_DMA_RX_ENA_V  0x00000001
+#define SPI_DMA_RX_ENA_S  27
+
+/* SPI_RX_EOF_EN : R/W; bitpos: [21]; default: 0;
+ * 1: spi_dma_inlink_eof is set when the number of dma pushed data bytes is
+ * equal to the value of spi_slv/mst_dma_rd_bytelen[19:0] in spi dma
+ * transition.  0: spi_dma_inlink_eof is set by spi_trans_done in
+ * non-seg-trans or spi_dma_seg_trans_done in seg-trans.
+ */
+
+#define SPI_RX_EOF_EN    (BIT(21))
+#define SPI_RX_EOF_EN_M  (SPI_RX_EOF_EN_V << SPI_RX_EOF_EN_S)
+#define SPI_RX_EOF_EN_V  0x00000001
+#define SPI_RX_EOF_EN_S  21
+
+/* SPI_SLV_TX_SEG_TRANS_CLR_EN : R/W; bitpos: [20]; default: 0;
+ * 1: spi_dma_outfifo_empty_vld is cleared by spi slave cmd 6. 0:
+ * spi_dma_outfifo_empty_vld is cleared by spi_trans_done.
+ */
+
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN    (BIT(20))
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_M  (SPI_SLV_TX_SEG_TRANS_CLR_EN_V << SPI_SLV_TX_SEG_TRANS_CLR_EN_S)
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_V  0x00000001
+#define SPI_SLV_TX_SEG_TRANS_CLR_EN_S  20
+
+/* SPI_SLV_RX_SEG_TRANS_CLR_EN : R/W; bitpos: [19]; default: 0;
+ * 1: spi_dma_infifo_full_vld is cleared by spi slave cmd 5. 0:
+ * spi_dma_infifo_full_vld is cleared by spi_trans_done.
+ */
+
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN    (BIT(19))
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_M  (SPI_SLV_RX_SEG_TRANS_CLR_EN_V << SPI_SLV_RX_SEG_TRANS_CLR_EN_S)
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_V  0x00000001
+#define SPI_SLV_RX_SEG_TRANS_CLR_EN_S  19
+
+/* SPI_DMA_SLV_SEG_TRANS_EN : R/W; bitpos: [18]; default: 0;
+ * Enable dma segment transfer in spi dma half slave mode. 1: enable. 0:
+ * disable.
+ */
+
+#define SPI_DMA_SLV_SEG_TRANS_EN    (BIT(18))
+#define SPI_DMA_SLV_SEG_TRANS_EN_M  (SPI_DMA_SLV_SEG_TRANS_EN_V << SPI_DMA_SLV_SEG_TRANS_EN_S)
+#define SPI_DMA_SLV_SEG_TRANS_EN_V  0x00000001
+#define SPI_DMA_SLV_SEG_TRANS_EN_S  18
+
+/* SPI_DMA_INT_ENA_REG register
+ * SPI DMA interrupt enable register
+ */
+
+#define SPI_DMA_INT_ENA_REG (DR_REG_SPI2_BASE + 0x34)
+
+/* SPI_APP1_INT_ENA : R/W; bitpos: [20]; default: 0;
+ * The enable bit for SPI_APP1_INT interrupt.
+ */
+
+#define SPI_APP1_INT_ENA    (BIT(20))
+#define SPI_APP1_INT_ENA_M  (SPI_APP1_INT_ENA_V << SPI_APP1_INT_ENA_S)
+#define SPI_APP1_INT_ENA_V  0x00000001
+#define SPI_APP1_INT_ENA_S  20
+
+/* SPI_APP2_INT_ENA : R/W; bitpos: [19]; default: 0;
+ * The enable bit for SPI_APP2_INT interrupt.
+ */
+
+#define SPI_APP2_INT_ENA    (BIT(19))
+#define SPI_APP2_INT_ENA_M  (SPI_APP2_INT_ENA_V << SPI_APP2_INT_ENA_S)
+#define SPI_APP2_INT_ENA_V  0x00000001
+#define SPI_APP2_INT_ENA_S  19
+
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA : R/W; bitpos: [18]; default: 0;
+ * The enable bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt.
+ */
+
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_V  0x00000001
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ENA_S  18
+
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA : R/W; bitpos: [17]; default: 0;
+ * The enable bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt.
+ */
+
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_V  0x00000001
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ENA_S  17
+
+/* SPI_SLV_CMD_ERR_INT_ENA : R/W; bitpos: [16]; default: 0;
+ * The enable bit for SPI_SLV_CMD_ERR_INT interrupt.
+ */
+
+#define SPI_SLV_CMD_ERR_INT_ENA    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ENA_M  (SPI_SLV_CMD_ERR_INT_ENA_V << SPI_SLV_CMD_ERR_INT_ENA_S)
+#define SPI_SLV_CMD_ERR_INT_ENA_V  0x00000001
+#define SPI_SLV_CMD_ERR_INT_ENA_S  16
+
+/* SPI_SLV_BUF_ADDR_ERR_INT_ENA : R/W; bitpos: [15]; default: 0;
+ * The enable bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt.
+ */
+
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_M  (SPI_SLV_BUF_ADDR_ERR_INT_ENA_V << SPI_SLV_BUF_ADDR_ERR_INT_ENA_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_V  0x00000001
+#define SPI_SLV_BUF_ADDR_ERR_INT_ENA_S  15
+
+/* SPI_SEG_MAGIC_ERR_INT_ENA : R/W; bitpos: [14]; default: 0;
+ * The enable bit for SPI_SEG_MAGIC_ERR_INT interrupt.
+ */
+
+#define SPI_SEG_MAGIC_ERR_INT_ENA    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ENA_M  (SPI_SEG_MAGIC_ERR_INT_ENA_V << SPI_SEG_MAGIC_ERR_INT_ENA_S)
+#define SPI_SEG_MAGIC_ERR_INT_ENA_V  0x00000001
+#define SPI_SEG_MAGIC_ERR_INT_ENA_S  14
+
+/* SPI_DMA_SEG_TRANS_DONE_INT_ENA : R/W; bitpos: [13]; default: 0;
+ * The enable bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt.
+ */
+
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_M  (SPI_DMA_SEG_TRANS_DONE_INT_ENA_V << SPI_DMA_SEG_TRANS_DONE_INT_ENA_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_V  0x00000001
+#define SPI_DMA_SEG_TRANS_DONE_INT_ENA_S  13
+
+/* SPI_TRANS_DONE_INT_ENA : R/W; bitpos: [12]; default: 0;
+ * The enable bit for SPI_TRANS_DONE_INT interrupt.
+ */
+
+#define SPI_TRANS_DONE_INT_ENA    (BIT(12))
+#define SPI_TRANS_DONE_INT_ENA_M  (SPI_TRANS_DONE_INT_ENA_V << SPI_TRANS_DONE_INT_ENA_S)
+#define SPI_TRANS_DONE_INT_ENA_V  0x00000001
+#define SPI_TRANS_DONE_INT_ENA_S  12
+
+/* SPI_SLV_WR_BUF_DONE_INT_ENA : R/W; bitpos: [11]; default: 0;
+ * The enable bit for SPI_SLV_WR_BUF_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_WR_BUF_DONE_INT_ENA    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_M  (SPI_SLV_WR_BUF_DONE_INT_ENA_V << SPI_SLV_WR_BUF_DONE_INT_ENA_S)
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_V  0x00000001
+#define SPI_SLV_WR_BUF_DONE_INT_ENA_S  11
+
+/* SPI_SLV_RD_BUF_DONE_INT_ENA : R/W; bitpos: [10]; default: 0;
+ * The enable bit for SPI_SLV_RD_BUF_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_RD_BUF_DONE_INT_ENA    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_M  (SPI_SLV_RD_BUF_DONE_INT_ENA_V << SPI_SLV_RD_BUF_DONE_INT_ENA_S)
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_V  0x00000001
+#define SPI_SLV_RD_BUF_DONE_INT_ENA_S  10
+
+/* SPI_SLV_WR_DMA_DONE_INT_ENA : R/W; bitpos: [9]; default: 0;
+ * The enable bit for SPI_SLV_WR_DMA_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_WR_DMA_DONE_INT_ENA    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_M  (SPI_SLV_WR_DMA_DONE_INT_ENA_V << SPI_SLV_WR_DMA_DONE_INT_ENA_S)
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_V  0x00000001
+#define SPI_SLV_WR_DMA_DONE_INT_ENA_S  9
+
+/* SPI_SLV_RD_DMA_DONE_INT_ENA : R/W; bitpos: [8]; default: 0;
+ * The enable bit for SPI_SLV_RD_DMA_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_RD_DMA_DONE_INT_ENA    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_M  (SPI_SLV_RD_DMA_DONE_INT_ENA_V << SPI_SLV_RD_DMA_DONE_INT_ENA_S)
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_V  0x00000001
+#define SPI_SLV_RD_DMA_DONE_INT_ENA_S  8
+
+/* SPI_SLV_CMDA_INT_ENA : R/W; bitpos: [7]; default: 0;
+ * The enable bit for SPI slave CMDA interrupt.
+ */
+
+#define SPI_SLV_CMDA_INT_ENA    (BIT(7))
+#define SPI_SLV_CMDA_INT_ENA_M  (SPI_SLV_CMDA_INT_ENA_V << SPI_SLV_CMDA_INT_ENA_S)
+#define SPI_SLV_CMDA_INT_ENA_V  0x00000001
+#define SPI_SLV_CMDA_INT_ENA_S  7
+
+/* SPI_SLV_CMD9_INT_ENA : R/W; bitpos: [6]; default: 0;
+ * The enable bit for SPI slave CMD9 interrupt.
+ */
+
+#define SPI_SLV_CMD9_INT_ENA    (BIT(6))
+#define SPI_SLV_CMD9_INT_ENA_M  (SPI_SLV_CMD9_INT_ENA_V << SPI_SLV_CMD9_INT_ENA_S)
+#define SPI_SLV_CMD9_INT_ENA_V  0x00000001
+#define SPI_SLV_CMD9_INT_ENA_S  6
+
+/* SPI_SLV_CMD8_INT_ENA : R/W; bitpos: [5]; default: 0;
+ * The enable bit for SPI slave CMD8 interrupt.
+ */
+
+#define SPI_SLV_CMD8_INT_ENA    (BIT(5))
+#define SPI_SLV_CMD8_INT_ENA_M  (SPI_SLV_CMD8_INT_ENA_V << SPI_SLV_CMD8_INT_ENA_S)
+#define SPI_SLV_CMD8_INT_ENA_V  0x00000001
+#define SPI_SLV_CMD8_INT_ENA_S  5
+
+/* SPI_SLV_CMD7_INT_ENA : R/W; bitpos: [4]; default: 0;
+ * The enable bit for SPI slave CMD7 interrupt.
+ */
+
+#define SPI_SLV_CMD7_INT_ENA    (BIT(4))
+#define SPI_SLV_CMD7_INT_ENA_M  (SPI_SLV_CMD7_INT_ENA_V << SPI_SLV_CMD7_INT_ENA_S)
+#define SPI_SLV_CMD7_INT_ENA_V  0x00000001
+#define SPI_SLV_CMD7_INT_ENA_S  4
+
+/* SPI_SLV_EN_QPI_INT_ENA : R/W; bitpos: [3]; default: 0;
+ * The enable bit for SPI slave En_QPI interrupt.
+ */
+
+#define SPI_SLV_EN_QPI_INT_ENA    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ENA_M  (SPI_SLV_EN_QPI_INT_ENA_V << SPI_SLV_EN_QPI_INT_ENA_S)
+#define SPI_SLV_EN_QPI_INT_ENA_V  0x00000001
+#define SPI_SLV_EN_QPI_INT_ENA_S  3
+
+/* SPI_SLV_EX_QPI_INT_ENA : R/W; bitpos: [2]; default: 0;
+ * The enable bit for SPI slave Ex_QPI interrupt.
+ */
+
+#define SPI_SLV_EX_QPI_INT_ENA    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ENA_M  (SPI_SLV_EX_QPI_INT_ENA_V << SPI_SLV_EX_QPI_INT_ENA_S)
+#define SPI_SLV_EX_QPI_INT_ENA_V  0x00000001
+#define SPI_SLV_EX_QPI_INT_ENA_S  2
+
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA : R/W; bitpos: [1]; default: 0;
+ * The enable bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt.
+ */
+
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_V  0x00000001
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ENA_S  1
+
+/* SPI_DMA_INFIFO_FULL_ERR_INT_ENA : R/W; bitpos: [0]; default: 0;
+ * The enable bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt.
+ */
+
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_M  (SPI_DMA_INFIFO_FULL_ERR_INT_ENA_V << SPI_DMA_INFIFO_FULL_ERR_INT_ENA_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_V  0x00000001
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ENA_S  0
+
+/* SPI_DMA_INT_CLR_REG register
+ * SPI DMA interrupt clear register
+ */
+
+#define SPI_DMA_INT_CLR_REG (DR_REG_SPI2_BASE + 0x38)
+
+/* SPI_APP1_INT_CLR : WT; bitpos: [20]; default: 0;
+ * The clear bit for SPI_APP1_INT interrupt.
+ */
+
+#define SPI_APP1_INT_CLR    (BIT(20))
+#define SPI_APP1_INT_CLR_M  (SPI_APP1_INT_CLR_V << SPI_APP1_INT_CLR_S)
+#define SPI_APP1_INT_CLR_V  0x00000001
+#define SPI_APP1_INT_CLR_S  20
+
+/* SPI_APP2_INT_CLR : WT; bitpos: [19]; default: 0;
+ * The clear bit for SPI_APP2_INT interrupt.
+ */
+
+#define SPI_APP2_INT_CLR    (BIT(19))
+#define SPI_APP2_INT_CLR_M  (SPI_APP2_INT_CLR_V << SPI_APP2_INT_CLR_S)
+#define SPI_APP2_INT_CLR_V  0x00000001
+#define SPI_APP2_INT_CLR_S  19
+
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR : WT; bitpos: [18]; default: 0;
+ * The clear bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt.
+ */
+
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_V  0x00000001
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_CLR_S  18
+
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR : WT; bitpos: [17]; default: 0;
+ * The clear bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt.
+ */
+
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_V  0x00000001
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_CLR_S  17
+
+/* SPI_SLV_CMD_ERR_INT_CLR : WT; bitpos: [16]; default: 0;
+ * The clear bit for SPI_SLV_CMD_ERR_INT interrupt.
+ */
+
+#define SPI_SLV_CMD_ERR_INT_CLR    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_CLR_M  (SPI_SLV_CMD_ERR_INT_CLR_V << SPI_SLV_CMD_ERR_INT_CLR_S)
+#define SPI_SLV_CMD_ERR_INT_CLR_V  0x00000001
+#define SPI_SLV_CMD_ERR_INT_CLR_S  16
+
+/* SPI_SLV_BUF_ADDR_ERR_INT_CLR : WT; bitpos: [15]; default: 0;
+ * The clear bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt.
+ */
+
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_M  (SPI_SLV_BUF_ADDR_ERR_INT_CLR_V << SPI_SLV_BUF_ADDR_ERR_INT_CLR_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_V  0x00000001
+#define SPI_SLV_BUF_ADDR_ERR_INT_CLR_S  15
+
+/* SPI_SEG_MAGIC_ERR_INT_CLR : WT; bitpos: [14]; default: 0;
+ * The clear bit for SPI_SEG_MAGIC_ERR_INT interrupt.
+ */
+
+#define SPI_SEG_MAGIC_ERR_INT_CLR    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_CLR_M  (SPI_SEG_MAGIC_ERR_INT_CLR_V << SPI_SEG_MAGIC_ERR_INT_CLR_S)
+#define SPI_SEG_MAGIC_ERR_INT_CLR_V  0x00000001
+#define SPI_SEG_MAGIC_ERR_INT_CLR_S  14
+
+/* SPI_DMA_SEG_TRANS_DONE_INT_CLR : WT; bitpos: [13]; default: 0;
+ * The clear bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt.
+ */
+
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_M  (SPI_DMA_SEG_TRANS_DONE_INT_CLR_V << SPI_DMA_SEG_TRANS_DONE_INT_CLR_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_V  0x00000001
+#define SPI_DMA_SEG_TRANS_DONE_INT_CLR_S  13
+
+/* SPI_TRANS_DONE_INT_CLR : WT; bitpos: [12]; default: 0;
+ * The clear bit for SPI_TRANS_DONE_INT interrupt.
+ */
+
+#define SPI_TRANS_DONE_INT_CLR    (BIT(12))
+#define SPI_TRANS_DONE_INT_CLR_M  (SPI_TRANS_DONE_INT_CLR_V << SPI_TRANS_DONE_INT_CLR_S)
+#define SPI_TRANS_DONE_INT_CLR_V  0x00000001
+#define SPI_TRANS_DONE_INT_CLR_S  12
+
+/* SPI_SLV_WR_BUF_DONE_INT_CLR : WT; bitpos: [11]; default: 0;
+ * The clear bit for SPI_SLV_WR_BUF_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_WR_BUF_DONE_INT_CLR    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_M  (SPI_SLV_WR_BUF_DONE_INT_CLR_V << SPI_SLV_WR_BUF_DONE_INT_CLR_S)
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_V  0x00000001
+#define SPI_SLV_WR_BUF_DONE_INT_CLR_S  11
+
+/* SPI_SLV_RD_BUF_DONE_INT_CLR : WT; bitpos: [10]; default: 0;
+ * The clear bit for SPI_SLV_RD_BUF_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_RD_BUF_DONE_INT_CLR    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_M  (SPI_SLV_RD_BUF_DONE_INT_CLR_V << SPI_SLV_RD_BUF_DONE_INT_CLR_S)
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_V  0x00000001
+#define SPI_SLV_RD_BUF_DONE_INT_CLR_S  10
+
+/* SPI_SLV_WR_DMA_DONE_INT_CLR : WT; bitpos: [9]; default: 0;
+ * The clear bit for SPI_SLV_WR_DMA_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_WR_DMA_DONE_INT_CLR    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_M  (SPI_SLV_WR_DMA_DONE_INT_CLR_V << SPI_SLV_WR_DMA_DONE_INT_CLR_S)
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_V  0x00000001
+#define SPI_SLV_WR_DMA_DONE_INT_CLR_S  9
+
+/* SPI_SLV_RD_DMA_DONE_INT_CLR : WT; bitpos: [8]; default: 0;
+ * The clear bit for SPI_SLV_RD_DMA_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_RD_DMA_DONE_INT_CLR    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_M  (SPI_SLV_RD_DMA_DONE_INT_CLR_V << SPI_SLV_RD_DMA_DONE_INT_CLR_S)
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_V  0x00000001
+#define SPI_SLV_RD_DMA_DONE_INT_CLR_S  8
+
+/* SPI_SLV_CMDA_INT_CLR : WT; bitpos: [7]; default: 0;
+ * The clear bit for SPI slave CMDA interrupt.
+ */
+
+#define SPI_SLV_CMDA_INT_CLR    (BIT(7))
+#define SPI_SLV_CMDA_INT_CLR_M  (SPI_SLV_CMDA_INT_CLR_V << SPI_SLV_CMDA_INT_CLR_S)
+#define SPI_SLV_CMDA_INT_CLR_V  0x00000001
+#define SPI_SLV_CMDA_INT_CLR_S  7
+
+/* SPI_SLV_CMD9_INT_CLR : WT; bitpos: [6]; default: 0;
+ * The clear bit for SPI slave CMD9 interrupt.
+ */
+
+#define SPI_SLV_CMD9_INT_CLR    (BIT(6))
+#define SPI_SLV_CMD9_INT_CLR_M  (SPI_SLV_CMD9_INT_CLR_V << SPI_SLV_CMD9_INT_CLR_S)
+#define SPI_SLV_CMD9_INT_CLR_V  0x00000001
+#define SPI_SLV_CMD9_INT_CLR_S  6
+
+/* SPI_SLV_CMD8_INT_CLR : WT; bitpos: [5]; default: 0;
+ * The clear bit for SPI slave CMD8 interrupt.
+ */
+
+#define SPI_SLV_CMD8_INT_CLR    (BIT(5))
+#define SPI_SLV_CMD8_INT_CLR_M  (SPI_SLV_CMD8_INT_CLR_V << SPI_SLV_CMD8_INT_CLR_S)
+#define SPI_SLV_CMD8_INT_CLR_V  0x00000001
+#define SPI_SLV_CMD8_INT_CLR_S  5
+
+/* SPI_SLV_CMD7_INT_CLR : WT; bitpos: [4]; default: 0;
+ * The clear bit for SPI slave CMD7 interrupt.
+ */
+
+#define SPI_SLV_CMD7_INT_CLR    (BIT(4))
+#define SPI_SLV_CMD7_INT_CLR_M  (SPI_SLV_CMD7_INT_CLR_V << SPI_SLV_CMD7_INT_CLR_S)
+#define SPI_SLV_CMD7_INT_CLR_V  0x00000001
+#define SPI_SLV_CMD7_INT_CLR_S  4
+
+/* SPI_SLV_EN_QPI_INT_CLR : WT; bitpos: [3]; default: 0;
+ * The clear bit for SPI slave En_QPI interrupt.
+ */
+
+#define SPI_SLV_EN_QPI_INT_CLR    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_CLR_M  (SPI_SLV_EN_QPI_INT_CLR_V << SPI_SLV_EN_QPI_INT_CLR_S)
+#define SPI_SLV_EN_QPI_INT_CLR_V  0x00000001
+#define SPI_SLV_EN_QPI_INT_CLR_S  3
+
+/* SPI_SLV_EX_QPI_INT_CLR : WT; bitpos: [2]; default: 0;
+ * The clear bit for SPI slave Ex_QPI interrupt.
+ */
+
+#define SPI_SLV_EX_QPI_INT_CLR    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_CLR_M  (SPI_SLV_EX_QPI_INT_CLR_V << SPI_SLV_EX_QPI_INT_CLR_S)
+#define SPI_SLV_EX_QPI_INT_CLR_V  0x00000001
+#define SPI_SLV_EX_QPI_INT_CLR_S  2
+
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR : WT; bitpos: [1]; default: 0;
+ * The clear bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt.
+ */
+
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_V  0x00000001
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_CLR_S  1
+
+/* SPI_DMA_INFIFO_FULL_ERR_INT_CLR : WT; bitpos: [0]; default: 0;
+ * The clear bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt.
+ */
+
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_M  (SPI_DMA_INFIFO_FULL_ERR_INT_CLR_V << SPI_DMA_INFIFO_FULL_ERR_INT_CLR_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_V  0x00000001
+#define SPI_DMA_INFIFO_FULL_ERR_INT_CLR_S  0
+
+/* SPI_DMA_INT_RAW_REG register
+ * SPI DMA interrupt raw register
+ */
+
+#define SPI_DMA_INT_RAW_REG (DR_REG_SPI2_BASE + 0x3c)
+
+/* SPI_APP1_INT_RAW : R/W/WTC; bitpos: [20]; default: 0;
+ * The raw bit for SPI_APP1_INT interrupt. The value is only controlled by
+ * application.
+ */
+
+#define SPI_APP1_INT_RAW    (BIT(20))
+#define SPI_APP1_INT_RAW_M  (SPI_APP1_INT_RAW_V << SPI_APP1_INT_RAW_S)
+#define SPI_APP1_INT_RAW_V  0x00000001
+#define SPI_APP1_INT_RAW_S  20
+
+/* SPI_APP2_INT_RAW : R/W/WTC; bitpos: [19]; default: 0;
+ * The raw bit for SPI_APP2_INT interrupt. The value is only controlled by
+ * application.
+ */
+
+#define SPI_APP2_INT_RAW    (BIT(19))
+#define SPI_APP2_INT_RAW_M  (SPI_APP2_INT_RAW_V << SPI_APP2_INT_RAW_S)
+#define SPI_APP2_INT_RAW_V  0x00000001
+#define SPI_APP2_INT_RAW_S  19
+
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW : R/W/WTC/SS; bitpos: [18]; default:
+ * 0;
+ * The raw bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt. 1: There is a
+ * TX BUF AFIFO read-empty error when SPI outputs data in master mode. 0:
+ * Others.
+ */
+
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_V  0x00000001
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_RAW_S  18
+
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW : R/W/WTC/SS; bitpos: [17]; default: 0;
+ * The raw bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt. 1: There is a
+ * RX AFIFO write-full error when SPI inputs data in master mode. 0: Others.
+ */
+
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_V  0x00000001
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_RAW_S  17
+
+/* SPI_SLV_CMD_ERR_INT_RAW : R/W/WTC/SS; bitpos: [16]; default: 0;
+ * The raw bit for SPI_SLV_CMD_ERR_INT interrupt. 1: The slave command value
+ * in the current SPI slave HD mode transmission is not supported. 0: Others.
+ */
+
+#define SPI_SLV_CMD_ERR_INT_RAW    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_RAW_M  (SPI_SLV_CMD_ERR_INT_RAW_V << SPI_SLV_CMD_ERR_INT_RAW_S)
+#define SPI_SLV_CMD_ERR_INT_RAW_V  0x00000001
+#define SPI_SLV_CMD_ERR_INT_RAW_S  16
+
+/* SPI_SLV_BUF_ADDR_ERR_INT_RAW : R/W/WTC/SS; bitpos: [15]; default: 0;
+ * The raw bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt. 1: The accessing data
+ * address of the current SPI slave mode CPU controlled FD, Wr_BUF or Rd_BUF
+ * transmission is bigger than 63. 0: Others.
+ */
+
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_M  (SPI_SLV_BUF_ADDR_ERR_INT_RAW_V << SPI_SLV_BUF_ADDR_ERR_INT_RAW_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_V  0x00000001
+#define SPI_SLV_BUF_ADDR_ERR_INT_RAW_S  15
+
+/* SPI_SEG_MAGIC_ERR_INT_RAW : R/W/WTC/SS; bitpos: [14]; default: 0;
+ * The raw bit for SPI_SEG_MAGIC_ERR_INT interrupt. 1: The magic value in
+ * CONF buffer is error in the DMA seg-conf-trans. 0: others.
+ */
+
+#define SPI_SEG_MAGIC_ERR_INT_RAW    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_RAW_M  (SPI_SEG_MAGIC_ERR_INT_RAW_V << SPI_SEG_MAGIC_ERR_INT_RAW_S)
+#define SPI_SEG_MAGIC_ERR_INT_RAW_V  0x00000001
+#define SPI_SEG_MAGIC_ERR_INT_RAW_S  14
+
+/* SPI_DMA_SEG_TRANS_DONE_INT_RAW : R/W/WTC/SS; bitpos: [13]; default: 0;
+ * The raw bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt. 1:  spi master DMA
+ * full-duplex/half-duplex seg-conf-trans ends or slave half-duplex
+ * seg-trans ends. And data has been pushed to corresponding memory.  0:
+ * seg-conf-trans or seg-trans is not ended or not occurred.
+ */
+
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_M  (SPI_DMA_SEG_TRANS_DONE_INT_RAW_V << SPI_DMA_SEG_TRANS_DONE_INT_RAW_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_V  0x00000001
+#define SPI_DMA_SEG_TRANS_DONE_INT_RAW_S  13
+
+/* SPI_TRANS_DONE_INT_RAW : R/W/WTC/SS; bitpos: [12]; default: 0;
+ * The raw bit for SPI_TRANS_DONE_INT interrupt. 1: SPI master mode
+ * transmission is ended. 0: others.
+ */
+
+#define SPI_TRANS_DONE_INT_RAW    (BIT(12))
+#define SPI_TRANS_DONE_INT_RAW_M  (SPI_TRANS_DONE_INT_RAW_V << SPI_TRANS_DONE_INT_RAW_S)
+#define SPI_TRANS_DONE_INT_RAW_V  0x00000001
+#define SPI_TRANS_DONE_INT_RAW_S  12
+
+/* SPI_SLV_WR_BUF_DONE_INT_RAW : R/W/WTC/SS; bitpos: [11]; default: 0;
+ * The raw bit for SPI_SLV_WR_BUF_DONE_INT interrupt. 1: SPI slave mode
+ * Wr_BUF transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_WR_BUF_DONE_INT_RAW    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_M  (SPI_SLV_WR_BUF_DONE_INT_RAW_V << SPI_SLV_WR_BUF_DONE_INT_RAW_S)
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_V  0x00000001
+#define SPI_SLV_WR_BUF_DONE_INT_RAW_S  11
+
+/* SPI_SLV_RD_BUF_DONE_INT_RAW : R/W/WTC/SS; bitpos: [10]; default: 0;
+ * The raw bit for SPI_SLV_RD_BUF_DONE_INT interrupt. 1: SPI slave mode
+ * Rd_BUF transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_RD_BUF_DONE_INT_RAW    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_M  (SPI_SLV_RD_BUF_DONE_INT_RAW_V << SPI_SLV_RD_BUF_DONE_INT_RAW_S)
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_V  0x00000001
+#define SPI_SLV_RD_BUF_DONE_INT_RAW_S  10
+
+/* SPI_SLV_WR_DMA_DONE_INT_RAW : R/W/WTC/SS; bitpos: [9]; default: 0;
+ * The raw bit for SPI_SLV_WR_DMA_DONE_INT interrupt. 1: SPI slave mode
+ * Wr_DMA transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_WR_DMA_DONE_INT_RAW    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_M  (SPI_SLV_WR_DMA_DONE_INT_RAW_V << SPI_SLV_WR_DMA_DONE_INT_RAW_S)
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_V  0x00000001
+#define SPI_SLV_WR_DMA_DONE_INT_RAW_S  9
+
+/* SPI_SLV_RD_DMA_DONE_INT_RAW : R/W/WTC/SS; bitpos: [8]; default: 0;
+ * The raw bit for SPI_SLV_RD_DMA_DONE_INT interrupt. 1: SPI slave mode
+ * Rd_DMA transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_RD_DMA_DONE_INT_RAW    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_M  (SPI_SLV_RD_DMA_DONE_INT_RAW_V << SPI_SLV_RD_DMA_DONE_INT_RAW_S)
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_V  0x00000001
+#define SPI_SLV_RD_DMA_DONE_INT_RAW_S  8
+
+/* SPI_SLV_CMDA_INT_RAW : R/W/WTC/SS; bitpos: [7]; default: 0;
+ * The raw bit for SPI slave CMDA interrupt. 1: SPI slave mode CMDA
+ * transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_CMDA_INT_RAW    (BIT(7))
+#define SPI_SLV_CMDA_INT_RAW_M  (SPI_SLV_CMDA_INT_RAW_V << SPI_SLV_CMDA_INT_RAW_S)
+#define SPI_SLV_CMDA_INT_RAW_V  0x00000001
+#define SPI_SLV_CMDA_INT_RAW_S  7
+
+/* SPI_SLV_CMD9_INT_RAW : R/W/WTC/SS; bitpos: [6]; default: 0;
+ * The raw bit for SPI slave CMD9 interrupt. 1: SPI slave mode CMD9
+ * transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_CMD9_INT_RAW    (BIT(6))
+#define SPI_SLV_CMD9_INT_RAW_M  (SPI_SLV_CMD9_INT_RAW_V << SPI_SLV_CMD9_INT_RAW_S)
+#define SPI_SLV_CMD9_INT_RAW_V  0x00000001
+#define SPI_SLV_CMD9_INT_RAW_S  6
+
+/* SPI_SLV_CMD8_INT_RAW : R/W/WTC/SS; bitpos: [5]; default: 0;
+ * The raw bit for SPI slave CMD8 interrupt. 1: SPI slave mode CMD8
+ * transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_CMD8_INT_RAW    (BIT(5))
+#define SPI_SLV_CMD8_INT_RAW_M  (SPI_SLV_CMD8_INT_RAW_V << SPI_SLV_CMD8_INT_RAW_S)
+#define SPI_SLV_CMD8_INT_RAW_V  0x00000001
+#define SPI_SLV_CMD8_INT_RAW_S  5
+
+/* SPI_SLV_CMD7_INT_RAW : R/W/WTC/SS; bitpos: [4]; default: 0;
+ * The raw bit for SPI slave CMD7 interrupt. 1: SPI slave mode CMD7
+ * transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_CMD7_INT_RAW    (BIT(4))
+#define SPI_SLV_CMD7_INT_RAW_M  (SPI_SLV_CMD7_INT_RAW_V << SPI_SLV_CMD7_INT_RAW_S)
+#define SPI_SLV_CMD7_INT_RAW_V  0x00000001
+#define SPI_SLV_CMD7_INT_RAW_S  4
+
+/* SPI_SLV_EN_QPI_INT_RAW : R/W/WTC/SS; bitpos: [3]; default: 0;
+ * The raw bit for SPI slave En_QPI interrupt. 1: SPI slave mode En_QPI
+ * transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_EN_QPI_INT_RAW    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_RAW_M  (SPI_SLV_EN_QPI_INT_RAW_V << SPI_SLV_EN_QPI_INT_RAW_S)
+#define SPI_SLV_EN_QPI_INT_RAW_V  0x00000001
+#define SPI_SLV_EN_QPI_INT_RAW_S  3
+
+/* SPI_SLV_EX_QPI_INT_RAW : R/W/WTC/SS; bitpos: [2]; default: 0;
+ * The raw bit for SPI slave Ex_QPI interrupt. 1: SPI slave mode Ex_QPI
+ * transmission is ended. 0: Others.
+ */
+
+#define SPI_SLV_EX_QPI_INT_RAW    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_RAW_M  (SPI_SLV_EX_QPI_INT_RAW_V << SPI_SLV_EX_QPI_INT_RAW_S)
+#define SPI_SLV_EX_QPI_INT_RAW_V  0x00000001
+#define SPI_SLV_EX_QPI_INT_RAW_S  2
+
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW : R/W/WTC/SS; bitpos: [1]; default: 0;
+ * 1: The current data rate of DMA TX is smaller than that of SPI. SPI will
+ * stop in master mode and send out all 0 in slave mode.  0: Others.
+ */
+
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_V  0x00000001
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_RAW_S  1
+
+/* SPI_DMA_INFIFO_FULL_ERR_INT_RAW : R/W/WTC/SS; bitpos: [0]; default: 0;
+ * 1: The current data rate of DMA Rx is smaller than that of SPI, which
+ * will lose the receive data.  0: Others.
+ */
+
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_M  (SPI_DMA_INFIFO_FULL_ERR_INT_RAW_V << SPI_DMA_INFIFO_FULL_ERR_INT_RAW_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_V  0x00000001
+#define SPI_DMA_INFIFO_FULL_ERR_INT_RAW_S  0
+
+/* SPI_DMA_INT_ST_REG register
+ * SPI DMA interrupt status register
+ */
+
+#define SPI_DMA_INT_ST_REG (DR_REG_SPI2_BASE + 0x40)
+
+/* SPI_APP1_INT_ST : RO; bitpos: [20]; default: 0;
+ * The status bit for SPI_APP1_INT interrupt.
+ */
+
+#define SPI_APP1_INT_ST    (BIT(20))
+#define SPI_APP1_INT_ST_M  (SPI_APP1_INT_ST_V << SPI_APP1_INT_ST_S)
+#define SPI_APP1_INT_ST_V  0x00000001
+#define SPI_APP1_INT_ST_S  20
+
+/* SPI_APP2_INT_ST : RO; bitpos: [19]; default: 0;
+ * The status bit for SPI_APP2_INT interrupt.
+ */
+
+#define SPI_APP2_INT_ST    (BIT(19))
+#define SPI_APP2_INT_ST_M  (SPI_APP2_INT_ST_V << SPI_APP2_INT_ST_S)
+#define SPI_APP2_INT_ST_V  0x00000001
+#define SPI_APP2_INT_ST_S  19
+
+/* SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST : RO; bitpos: [18]; default: 0;
+ * The status bit for SPI_MST_TX_AFIFO_REMPTY_ERR_INT interrupt.
+ */
+
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST    (BIT(18))
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_M  (SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_V << SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_S)
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_V  0x00000001
+#define SPI_MST_TX_AFIFO_REMPTY_ERR_INT_ST_S  18
+
+/* SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST : RO; bitpos: [17]; default: 0;
+ * The status bit for SPI_MST_RX_AFIFO_WFULL_ERR_INT interrupt.
+ */
+
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST    (BIT(17))
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_M  (SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_V << SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_S)
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_V  0x00000001
+#define SPI_MST_RX_AFIFO_WFULL_ERR_INT_ST_S  17
+
+/* SPI_SLV_CMD_ERR_INT_ST : RO; bitpos: [16]; default: 0;
+ * The status bit for SPI_SLV_CMD_ERR_INT interrupt.
+ */
+
+#define SPI_SLV_CMD_ERR_INT_ST    (BIT(16))
+#define SPI_SLV_CMD_ERR_INT_ST_M  (SPI_SLV_CMD_ERR_INT_ST_V << SPI_SLV_CMD_ERR_INT_ST_S)
+#define SPI_SLV_CMD_ERR_INT_ST_V  0x00000001
+#define SPI_SLV_CMD_ERR_INT_ST_S  16
+
+/* SPI_SLV_BUF_ADDR_ERR_INT_ST : RO; bitpos: [15]; default: 0;
+ * The status bit for SPI_SLV_BUF_ADDR_ERR_INT interrupt.
+ */
+
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST    (BIT(15))
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_M  (SPI_SLV_BUF_ADDR_ERR_INT_ST_V << SPI_SLV_BUF_ADDR_ERR_INT_ST_S)
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_V  0x00000001
+#define SPI_SLV_BUF_ADDR_ERR_INT_ST_S  15
+
+/* SPI_SEG_MAGIC_ERR_INT_ST : RO; bitpos: [14]; default: 0;
+ * The status bit for SPI_SEG_MAGIC_ERR_INT interrupt.
+ */
+
+#define SPI_SEG_MAGIC_ERR_INT_ST    (BIT(14))
+#define SPI_SEG_MAGIC_ERR_INT_ST_M  (SPI_SEG_MAGIC_ERR_INT_ST_V << SPI_SEG_MAGIC_ERR_INT_ST_S)
+#define SPI_SEG_MAGIC_ERR_INT_ST_V  0x00000001
+#define SPI_SEG_MAGIC_ERR_INT_ST_S  14
+
+/* SPI_DMA_SEG_TRANS_DONE_INT_ST : RO; bitpos: [13]; default: 0;
+ * The status bit for SPI_DMA_SEG_TRANS_DONE_INT interrupt.
+ */
+
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST    (BIT(13))
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_M  (SPI_DMA_SEG_TRANS_DONE_INT_ST_V << SPI_DMA_SEG_TRANS_DONE_INT_ST_S)
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_V  0x00000001
+#define SPI_DMA_SEG_TRANS_DONE_INT_ST_S  13
+
+/* SPI_TRANS_DONE_INT_ST : RO; bitpos: [12]; default: 0;
+ * The status bit for SPI_TRANS_DONE_INT interrupt.
+ */
+
+#define SPI_TRANS_DONE_INT_ST    (BIT(12))
+#define SPI_TRANS_DONE_INT_ST_M  (SPI_TRANS_DONE_INT_ST_V << SPI_TRANS_DONE_INT_ST_S)
+#define SPI_TRANS_DONE_INT_ST_V  0x00000001
+#define SPI_TRANS_DONE_INT_ST_S  12
+
+/* SPI_SLV_WR_BUF_DONE_INT_ST : RO; bitpos: [11]; default: 0;
+ * The status bit for SPI_SLV_WR_BUF_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_WR_BUF_DONE_INT_ST    (BIT(11))
+#define SPI_SLV_WR_BUF_DONE_INT_ST_M  (SPI_SLV_WR_BUF_DONE_INT_ST_V << SPI_SLV_WR_BUF_DONE_INT_ST_S)
+#define SPI_SLV_WR_BUF_DONE_INT_ST_V  0x00000001
+#define SPI_SLV_WR_BUF_DONE_INT_ST_S  11
+
+/* SPI_SLV_RD_BUF_DONE_INT_ST : RO; bitpos: [10]; default: 0;
+ * The status bit for SPI_SLV_RD_BUF_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_RD_BUF_DONE_INT_ST    (BIT(10))
+#define SPI_SLV_RD_BUF_DONE_INT_ST_M  (SPI_SLV_RD_BUF_DONE_INT_ST_V << SPI_SLV_RD_BUF_DONE_INT_ST_S)
+#define SPI_SLV_RD_BUF_DONE_INT_ST_V  0x00000001
+#define SPI_SLV_RD_BUF_DONE_INT_ST_S  10
+
+/* SPI_SLV_WR_DMA_DONE_INT_ST : RO; bitpos: [9]; default: 0;
+ * The status bit for SPI_SLV_WR_DMA_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_WR_DMA_DONE_INT_ST    (BIT(9))
+#define SPI_SLV_WR_DMA_DONE_INT_ST_M  (SPI_SLV_WR_DMA_DONE_INT_ST_V << SPI_SLV_WR_DMA_DONE_INT_ST_S)
+#define SPI_SLV_WR_DMA_DONE_INT_ST_V  0x00000001
+#define SPI_SLV_WR_DMA_DONE_INT_ST_S  9
+
+/* SPI_SLV_RD_DMA_DONE_INT_ST : RO; bitpos: [8]; default: 0;
+ * The status bit for SPI_SLV_RD_DMA_DONE_INT interrupt.
+ */
+
+#define SPI_SLV_RD_DMA_DONE_INT_ST    (BIT(8))
+#define SPI_SLV_RD_DMA_DONE_INT_ST_M  (SPI_SLV_RD_DMA_DONE_INT_ST_V << SPI_SLV_RD_DMA_DONE_INT_ST_S)
+#define SPI_SLV_RD_DMA_DONE_INT_ST_V  0x00000001
+#define SPI_SLV_RD_DMA_DONE_INT_ST_S  8
+
+/* SPI_SLV_CMDA_INT_ST : RO; bitpos: [7]; default: 0;
+ * The status bit for SPI slave CMDA interrupt.
+ */
+
+#define SPI_SLV_CMDA_INT_ST    (BIT(7))
+#define SPI_SLV_CMDA_INT_ST_M  (SPI_SLV_CMDA_INT_ST_V << SPI_SLV_CMDA_INT_ST_S)
+#define SPI_SLV_CMDA_INT_ST_V  0x00000001
+#define SPI_SLV_CMDA_INT_ST_S  7
+
+/* SPI_SLV_CMD9_INT_ST : RO; bitpos: [6]; default: 0;
+ * The status bit for SPI slave CMD9 interrupt.
+ */
+
+#define SPI_SLV_CMD9_INT_ST    (BIT(6))
+#define SPI_SLV_CMD9_INT_ST_M  (SPI_SLV_CMD9_INT_ST_V << SPI_SLV_CMD9_INT_ST_S)
+#define SPI_SLV_CMD9_INT_ST_V  0x00000001
+#define SPI_SLV_CMD9_INT_ST_S  6
+
+/* SPI_SLV_CMD8_INT_ST : RO; bitpos: [5]; default: 0;
+ * The status bit for SPI slave CMD8 interrupt.
+ */
+
+#define SPI_SLV_CMD8_INT_ST    (BIT(5))
+#define SPI_SLV_CMD8_INT_ST_M  (SPI_SLV_CMD8_INT_ST_V << SPI_SLV_CMD8_INT_ST_S)
+#define SPI_SLV_CMD8_INT_ST_V  0x00000001
+#define SPI_SLV_CMD8_INT_ST_S  5
+
+/* SPI_SLV_CMD7_INT_ST : RO; bitpos: [4]; default: 0;
+ * The status bit for SPI slave CMD7 interrupt.
+ */
+
+#define SPI_SLV_CMD7_INT_ST    (BIT(4))
+#define SPI_SLV_CMD7_INT_ST_M  (SPI_SLV_CMD7_INT_ST_V << SPI_SLV_CMD7_INT_ST_S)
+#define SPI_SLV_CMD7_INT_ST_V  0x00000001
+#define SPI_SLV_CMD7_INT_ST_S  4
+
+/* SPI_SLV_EN_QPI_INT_ST : RO; bitpos: [3]; default: 0;
+ * The status bit for SPI slave En_QPI interrupt.
+ */
+
+#define SPI_SLV_EN_QPI_INT_ST    (BIT(3))
+#define SPI_SLV_EN_QPI_INT_ST_M  (SPI_SLV_EN_QPI_INT_ST_V << SPI_SLV_EN_QPI_INT_ST_S)
+#define SPI_SLV_EN_QPI_INT_ST_V  0x00000001
+#define SPI_SLV_EN_QPI_INT_ST_S  3
+
+/* SPI_SLV_EX_QPI_INT_ST : RO; bitpos: [2]; default: 0;
+ * The status bit for SPI slave Ex_QPI interrupt.
+ */
+
+#define SPI_SLV_EX_QPI_INT_ST    (BIT(2))
+#define SPI_SLV_EX_QPI_INT_ST_M  (SPI_SLV_EX_QPI_INT_ST_V << SPI_SLV_EX_QPI_INT_ST_S)
+#define SPI_SLV_EX_QPI_INT_ST_V  0x00000001
+#define SPI_SLV_EX_QPI_INT_ST_S  2
+
+/* SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST : RO; bitpos: [1]; default: 0;
+ * The status bit for SPI_DMA_OUTFIFO_EMPTY_ERR_INT interrupt.
+ */
+
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST    (BIT(1))
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_M  (SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_V << SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_S)
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_V  0x00000001
+#define SPI_DMA_OUTFIFO_EMPTY_ERR_INT_ST_S  1
+
+/* SPI_DMA_INFIFO_FULL_ERR_INT_ST : RO; bitpos: [0]; default: 0;
+ * The status bit for SPI_DMA_INFIFO_FULL_ERR_INT interrupt.
+ */
+
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST    (BIT(0))
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_M  (SPI_DMA_INFIFO_FULL_ERR_INT_ST_V << SPI_DMA_INFIFO_FULL_ERR_INT_ST_S)
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_V  0x00000001
+#define SPI_DMA_INFIFO_FULL_ERR_INT_ST_S  0
+
+/* SPI_W0_REG register
+ * SPI CPU-controlled buffer0
+ */
+
+#define SPI_W0_REG (DR_REG_SPI2_BASE + 0x98)
+
+/* SPI_BUF0 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF0    0xFFFFFFFF
+#define SPI_BUF0_M  (SPI_BUF0_V << SPI_BUF0_S)
+#define SPI_BUF0_V  0xFFFFFFFF
+#define SPI_BUF0_S  0
+
+/* SPI_W1_REG register
+ * SPI CPU-controlled buffer1
+ */
+
+#define SPI_W1_REG (DR_REG_SPI2_BASE + 0x9c)
+
+/* SPI_BUF1 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF1    0xFFFFFFFF
+#define SPI_BUF1_M  (SPI_BUF1_V << SPI_BUF1_S)
+#define SPI_BUF1_V  0xFFFFFFFF
+#define SPI_BUF1_S  0
+
+/* SPI_W2_REG register
+ * SPI CPU-controlled buffer2
+ */
+
+#define SPI_W2_REG (DR_REG_SPI2_BASE + 0xa0)
+
+/* SPI_BUF2 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF2    0xFFFFFFFF
+#define SPI_BUF2_M  (SPI_BUF2_V << SPI_BUF2_S)
+#define SPI_BUF2_V  0xFFFFFFFF
+#define SPI_BUF2_S  0
+
+/* SPI_W3_REG register
+ * SPI CPU-controlled buffer3
+ */
+
+#define SPI_W3_REG (DR_REG_SPI2_BASE + 0xa4)
+
+/* SPI_BUF3 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF3    0xFFFFFFFF
+#define SPI_BUF3_M  (SPI_BUF3_V << SPI_BUF3_S)
+#define SPI_BUF3_V  0xFFFFFFFF
+#define SPI_BUF3_S  0
+
+/* SPI_W4_REG register
+ * SPI CPU-controlled buffer4
+ */
+
+#define SPI_W4_REG (DR_REG_SPI2_BASE + 0xa8)
+
+/* SPI_BUF4 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF4    0xFFFFFFFF
+#define SPI_BUF4_M  (SPI_BUF4_V << SPI_BUF4_S)
+#define SPI_BUF4_V  0xFFFFFFFF
+#define SPI_BUF4_S  0
+
+/* SPI_W5_REG register
+ * SPI CPU-controlled buffer5
+ */
+
+#define SPI_W5_REG (DR_REG_SPI2_BASE + 0xac)
+
+/* SPI_BUF5 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF5    0xFFFFFFFF
+#define SPI_BUF5_M  (SPI_BUF5_V << SPI_BUF5_S)
+#define SPI_BUF5_V  0xFFFFFFFF
+#define SPI_BUF5_S  0
+
+/* SPI_W6_REG register
+ * SPI CPU-controlled buffer6
+ */
+
+#define SPI_W6_REG (DR_REG_SPI2_BASE + 0xb0)
+
+/* SPI_BUF6 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF6    0xFFFFFFFF
+#define SPI_BUF6_M  (SPI_BUF6_V << SPI_BUF6_S)
+#define SPI_BUF6_V  0xFFFFFFFF
+#define SPI_BUF6_S  0
+
+/* SPI_W7_REG register
+ * SPI CPU-controlled buffer7
+ */
+
+#define SPI_W7_REG (DR_REG_SPI2_BASE + 0xb4)
+
+/* SPI_BUF7 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF7    0xFFFFFFFF
+#define SPI_BUF7_M  (SPI_BUF7_V << SPI_BUF7_S)
+#define SPI_BUF7_V  0xFFFFFFFF
+#define SPI_BUF7_S  0
+
+/* SPI_W8_REG register
+ * SPI CPU-controlled buffer8
+ */
+
+#define SPI_W8_REG (DR_REG_SPI2_BASE + 0xb8)
+
+/* SPI_BUF8 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF8    0xFFFFFFFF
+#define SPI_BUF8_M  (SPI_BUF8_V << SPI_BUF8_S)
+#define SPI_BUF8_V  0xFFFFFFFF
+#define SPI_BUF8_S  0
+
+/* SPI_W9_REG register
+ * SPI CPU-controlled buffer9
+ */
+
+#define SPI_W9_REG (DR_REG_SPI2_BASE + 0xbc)
+
+/* SPI_BUF9 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF9    0xFFFFFFFF
+#define SPI_BUF9_M  (SPI_BUF9_V << SPI_BUF9_S)
+#define SPI_BUF9_V  0xFFFFFFFF
+#define SPI_BUF9_S  0
+
+/* SPI_W10_REG register
+ * SPI CPU-controlled buffer10
+ */
+
+#define SPI_W10_REG (DR_REG_SPI2_BASE + 0xc0)
+
+/* SPI_BUF10 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF10    0xFFFFFFFF
+#define SPI_BUF10_M  (SPI_BUF10_V << SPI_BUF10_S)
+#define SPI_BUF10_V  0xFFFFFFFF
+#define SPI_BUF10_S  0
+
+/* SPI_W11_REG register
+ * SPI CPU-controlled buffer11
+ */
+
+#define SPI_W11_REG (DR_REG_SPI2_BASE + 0xc4)
+
+/* SPI_BUF11 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF11    0xFFFFFFFF
+#define SPI_BUF11_M  (SPI_BUF11_V << SPI_BUF11_S)
+#define SPI_BUF11_V  0xFFFFFFFF
+#define SPI_BUF11_S  0
+
+/* SPI_W12_REG register
+ * SPI CPU-controlled buffer12
+ */
+
+#define SPI_W12_REG (DR_REG_SPI2_BASE + 0xc8)
+
+/* SPI_BUF12 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF12    0xFFFFFFFF
+#define SPI_BUF12_M  (SPI_BUF12_V << SPI_BUF12_S)
+#define SPI_BUF12_V  0xFFFFFFFF
+#define SPI_BUF12_S  0
+
+/* SPI_W13_REG register
+ * SPI CPU-controlled buffer13
+ */
+
+#define SPI_W13_REG (DR_REG_SPI2_BASE + 0xcc)
+
+/* SPI_BUF13 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF13    0xFFFFFFFF
+#define SPI_BUF13_M  (SPI_BUF13_V << SPI_BUF13_S)
+#define SPI_BUF13_V  0xFFFFFFFF
+#define SPI_BUF13_S  0
+
+/* SPI_W14_REG register
+ * SPI CPU-controlled buffer14
+ */
+
+#define SPI_W14_REG (DR_REG_SPI2_BASE + 0xd0)
+
+/* SPI_BUF14 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF14    0xFFFFFFFF
+#define SPI_BUF14_M  (SPI_BUF14_V << SPI_BUF14_S)
+#define SPI_BUF14_V  0xFFFFFFFF
+#define SPI_BUF14_S  0
+
+/* SPI_W15_REG register
+ * SPI CPU-controlled buffer15
+ */
+
+#define SPI_W15_REG (DR_REG_SPI2_BASE + 0xd4)
+
+/* SPI_BUF15 : R/W/SS; bitpos: [31:0]; default: 0;
+ * data buffer
+ */
+
+#define SPI_BUF15    0xFFFFFFFF
+#define SPI_BUF15_M  (SPI_BUF15_V << SPI_BUF15_S)
+#define SPI_BUF15_V  0xFFFFFFFF
+#define SPI_BUF15_S  0
+
+/* SPI_SLAVE_REG register
+ * SPI slave control register
+ */
+
+#define SPI_SLAVE_REG (DR_REG_SPI2_BASE + 0xe0)
+
+/* SPI_USR_CONF : R/W; bitpos: [28]; default: 0;
+ * 1: Enable the DMA CONF phase of current seg-trans operation, which means
+ * seg-trans will start. 0: This is not seg-trans mode.
+ */
+
+#define SPI_USR_CONF    (BIT(28))
+#define SPI_USR_CONF_M  (SPI_USR_CONF_V << SPI_USR_CONF_S)
+#define SPI_USR_CONF_V  0x00000001
+#define SPI_USR_CONF_S  28
+
+/* SPI_SOFT_RESET : WT; bitpos: [27]; default: 0;
+ * Software reset enable, reset the spi clock line cs line and data lines.
+ * Can be configured in CONF state.
+ */
+
+#define SPI_SOFT_RESET    (BIT(27))
+#define SPI_SOFT_RESET_M  (SPI_SOFT_RESET_V << SPI_SOFT_RESET_S)
+#define SPI_SOFT_RESET_V  0x00000001
+#define SPI_SOFT_RESET_S  27
+
+/* SPI_SLAVE_MODE : R/W; bitpos: [26]; default: 0;
+ * Set SPI work mode. 1: slave mode 0: master mode.
+ */
+
+#define SPI_SLAVE_MODE    (BIT(26))
+#define SPI_SLAVE_MODE_M  (SPI_SLAVE_MODE_V << SPI_SLAVE_MODE_S)
+#define SPI_SLAVE_MODE_V  0x00000001
+#define SPI_SLAVE_MODE_S  26
+
+/* SPI_DMA_SEG_MAGIC_VALUE : R/W; bitpos: [25:22]; default: 10;
+ * The magic value of BM table in master DMA seg-trans.
+ */
+
+#define SPI_DMA_SEG_MAGIC_VALUE    0x0000000F
+#define SPI_DMA_SEG_MAGIC_VALUE_M  (SPI_DMA_SEG_MAGIC_VALUE_V << SPI_DMA_SEG_MAGIC_VALUE_S)
+#define SPI_DMA_SEG_MAGIC_VALUE_V  0x0000000F
+#define SPI_DMA_SEG_MAGIC_VALUE_S  22
+
+/* SPI_SLV_WRBUF_BITLEN_EN : R/W; bitpos: [11]; default: 0;
+ * 1: SPI_SLV_DATA_BITLEN stores data bit length of master-write-to-slave
+ * data length in CPU controlled mode(Wr_BUF). 0: others
+ */
+
+#define SPI_SLV_WRBUF_BITLEN_EN    (BIT(11))
+#define SPI_SLV_WRBUF_BITLEN_EN_M  (SPI_SLV_WRBUF_BITLEN_EN_V << SPI_SLV_WRBUF_BITLEN_EN_S)
+#define SPI_SLV_WRBUF_BITLEN_EN_V  0x00000001
+#define SPI_SLV_WRBUF_BITLEN_EN_S  11
+
+/* SPI_SLV_RDBUF_BITLEN_EN : R/W; bitpos: [10]; default: 0;
+ * 1: SPI_SLV_DATA_BITLEN stores data bit length of master-read-slave data
+ * length in CPU controlled mode(Rd_BUF). 0: others
+ */
+
+#define SPI_SLV_RDBUF_BITLEN_EN    (BIT(10))
+#define SPI_SLV_RDBUF_BITLEN_EN_M  (SPI_SLV_RDBUF_BITLEN_EN_V << SPI_SLV_RDBUF_BITLEN_EN_S)
+#define SPI_SLV_RDBUF_BITLEN_EN_V  0x00000001
+#define SPI_SLV_RDBUF_BITLEN_EN_S  10
+
+/* SPI_SLV_WRDMA_BITLEN_EN : R/W; bitpos: [9]; default: 0;
+ * 1: SPI_SLV_DATA_BITLEN stores data bit length of master-write-to-slave
+ * data length in DMA controlled mode(Wr_DMA). 0: others
+ */
+
+#define SPI_SLV_WRDMA_BITLEN_EN    (BIT(9))
+#define SPI_SLV_WRDMA_BITLEN_EN_M  (SPI_SLV_WRDMA_BITLEN_EN_V << SPI_SLV_WRDMA_BITLEN_EN_S)
+#define SPI_SLV_WRDMA_BITLEN_EN_V  0x00000001
+#define SPI_SLV_WRDMA_BITLEN_EN_S  9
+
+/* SPI_SLV_RDDMA_BITLEN_EN : R/W; bitpos: [8]; default: 0;
+ * 1: SPI_SLV_DATA_BITLEN stores data bit length of master-read-slave data
+ * length in DMA controlled mode(Rd_DMA). 0: others
+ */
+
+#define SPI_SLV_RDDMA_BITLEN_EN    (BIT(8))
+#define SPI_SLV_RDDMA_BITLEN_EN_M  (SPI_SLV_RDDMA_BITLEN_EN_V << SPI_SLV_RDDMA_BITLEN_EN_S)
+#define SPI_SLV_RDDMA_BITLEN_EN_V  0x00000001
+#define SPI_SLV_RDDMA_BITLEN_EN_S  8
+
+/* SPI_RSCK_DATA_OUT : R/W; bitpos: [3]; default: 0;
+ * It saves half a cycle when tsck is the same as rsck. 1: output data at
+ * rsck posedge   0: output data at tsck posedge
+ */
+
+#define SPI_RSCK_DATA_OUT    (BIT(3))
+#define SPI_RSCK_DATA_OUT_M  (SPI_RSCK_DATA_OUT_V << SPI_RSCK_DATA_OUT_S)
+#define SPI_RSCK_DATA_OUT_V  0x00000001
+#define SPI_RSCK_DATA_OUT_S  3
+
+/* SPI_CLK_MODE_13 : R/W; bitpos: [2]; default: 0;
+ * {CPOL, CPHA},1: support spi clk mode 1 and 3, first edge output data
+ * B[0]/B[7].  0: support spi clk mode 0 and 2, first edge output data
+ * B[1]/B[6].
+ */
+
+#define SPI_CLK_MODE_13    (BIT(2))
+#define SPI_CLK_MODE_13_M  (SPI_CLK_MODE_13_V << SPI_CLK_MODE_13_S)
+#define SPI_CLK_MODE_13_V  0x00000001
+#define SPI_CLK_MODE_13_S  2
+
+/* SPI_CLK_MODE : R/W; bitpos: [1:0]; default: 0;
+ * SPI clock mode bits. 0: SPI clock is off when CS inactive 1: SPI clock is
+ * delayed one cycle after CS inactive 2: SPI clock is delayed two cycles
+ * after CS inactive 3: SPI clock is alwasy on. Can be configured in CONF
+ * state.
+ */
+
+#define SPI_CLK_MODE    0x00000003
+#define SPI_CLK_MODE_M  (SPI_CLK_MODE_V << SPI_CLK_MODE_S)
+#define SPI_CLK_MODE_V  0x00000003
+#define SPI_CLK_MODE_S  0
+
+/* SPI_SLAVE1_REG register
+ * SPI slave control register 1
+ */
+
+#define SPI_SLAVE1_REG (DR_REG_SPI2_BASE + 0xe4)
+
+/* SPI_SLV_LAST_ADDR : R/W/SS; bitpos: [31:26]; default: 0;
+ * In the slave mode it is the value of address.
+ */
+
+#define SPI_SLV_LAST_ADDR    0x0000003F
+#define SPI_SLV_LAST_ADDR_M  (SPI_SLV_LAST_ADDR_V << SPI_SLV_LAST_ADDR_S)
+#define SPI_SLV_LAST_ADDR_V  0x0000003F
+#define SPI_SLV_LAST_ADDR_S  26
+
+/* SPI_SLV_LAST_COMMAND : R/W/SS; bitpos: [25:18]; default: 0;
+ * In the slave mode it is the value of command.
+ */
+
+#define SPI_SLV_LAST_COMMAND    0x000000FF
+#define SPI_SLV_LAST_COMMAND_M  (SPI_SLV_LAST_COMMAND_V << SPI_SLV_LAST_COMMAND_S)
+#define SPI_SLV_LAST_COMMAND_V  0x000000FF
+#define SPI_SLV_LAST_COMMAND_S  18
+
+/* SPI_SLV_DATA_BITLEN : R/W/SS; bitpos: [17:0]; default: 0;
+ * The transferred data bit length in SPI slave FD and HD mode.
+ */
+
+#define SPI_SLV_DATA_BITLEN    0x0003FFFF
+#define SPI_SLV_DATA_BITLEN_M  (SPI_SLV_DATA_BITLEN_V << SPI_SLV_DATA_BITLEN_S)
+#define SPI_SLV_DATA_BITLEN_V  0x0003FFFF
+#define SPI_SLV_DATA_BITLEN_S  0
+
+/* SPI_CLK_GATE_REG register
+ * SPI module clock and register clock control
+ */
+
+#define SPI_CLK_GATE_REG (DR_REG_SPI2_BASE + 0xe8)
+
+/* SPI_MST_CLK_SEL : R/W; bitpos: [2]; default: 0;
+ * This bit is used to select SPI module clock source in master mode. 1:
+ * PLL_CLK_80M. 0: XTAL CLK.
+ */
+
+#define SPI_MST_CLK_SEL    (BIT(2))
+#define SPI_MST_CLK_SEL_M  (SPI_MST_CLK_SEL_V << SPI_MST_CLK_SEL_S)
+#define SPI_MST_CLK_SEL_V  0x00000001
+#define SPI_MST_CLK_SEL_S  2
+
+/* SPI_MST_CLK_ACTIVE : R/W; bitpos: [1]; default: 0;
+ * Set this bit to power on the SPI module clock.
+ */
+
+#define SPI_MST_CLK_ACTIVE    (BIT(1))
+#define SPI_MST_CLK_ACTIVE_M  (SPI_MST_CLK_ACTIVE_V << SPI_MST_CLK_ACTIVE_S)
+#define SPI_MST_CLK_ACTIVE_V  0x00000001
+#define SPI_MST_CLK_ACTIVE_S  1
+
+/* SPI_CLK_EN : R/W; bitpos: [0]; default: 0;
+ * Set this bit to enable clk gate
+ */
+
+#define SPI_CLK_EN    (BIT(0))
+#define SPI_CLK_EN_M  (SPI_CLK_EN_V << SPI_CLK_EN_S)
+#define SPI_CLK_EN_V  0x00000001
+#define SPI_CLK_EN_S  0
+
+/* SPI_DATE_REG register
+ * Version control
+ */
+
+#define SPI_DATE_REG (DR_REG_SPI2_BASE + 0xf0)
+
+/* SPI_DATE : R/W; bitpos: [27:0]; default: 33583648;
+ * SPI register version.
+ */
+
+#define SPI_DATE    0x0FFFFFFF
+#define SPI_DATE_M  (SPI_DATE_V << SPI_DATE_S)
+#define SPI_DATE_V  0x0FFFFFFF
+#define SPI_DATE_S  0
+
+#endif /* __ARCH_RISCV_SRC_ESP32C3_HARDWARE_ESP32C3_SPI_H */

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
@@ -42,6 +42,10 @@ ifeq ($(CONFIG_DEV_GPIO),y)
 CSRCS += esp32c3_gpio.c
 endif
 
+ifeq ($(CONFIG_ESP32C3_SPI),y)
+CSRCS += esp32c3_board_spi.c
+endif
+
 ifeq ($(CONFIG_I2C_DRIVER),y)
 CSRCS += esp32c3_i2c.c
 endif

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
@@ -46,6 +46,10 @@ ifeq ($(CONFIG_ESP32C3_SPI),y)
 CSRCS += esp32c3_board_spi.c
 endif
 
+ifeq ($(CONFIG_SPI_DRIVER),y)
+CSRCS += esp32c3_board_spidev.c
+endif
+
 ifeq ($(CONFIG_I2C_DRIVER),y)
 CSRCS += esp32c3_i2c.c
 endif

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3-devkit.h
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3-devkit.h
@@ -96,6 +96,25 @@ int board_wdt_init(void);
 #endif
 
 /****************************************************************************
+ * Name: board_spidev_initialize
+ *
+ * Description:
+ *   Initialize SPI driver and register the /dev/spi device.
+ *
+ * Input Parameters:
+ *   bus - The SPI bus number, used to build the device path as /dev/spiN
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   to indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_DRIVER
+int board_spidev_initialize(int bus);
+#endif
+
+/****************************************************************************
  * Name: board_i2c_init
  *
  * Description:
@@ -106,6 +125,7 @@ int board_wdt_init(void);
  *   to indicate the nature of any failure.
  *
  ****************************************************************************/
+
 #ifdef CONFIG_I2C_DRIVER
 int board_i2c_init(void);
 #endif
@@ -154,6 +174,7 @@ int board_bmp180_initialize(int devno, int busno);
  *
  * Description:
  *   Initialize the SPIFLASH and register the MTD device.
+ *
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPIFLASH

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spi.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spi.c
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <debug.h>
+
+#include <nuttx/spi/spi.h>
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_spi2_status
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32C3_SPI2
+
+uint8_t esp32c3_spi2_status(FAR struct spi_dev_s *dev, uint32_t devid)
+{
+  uint8_t status = 0;
+
+  return status;
+}
+
+#endif
+
+/****************************************************************************
+ * Name: esp32c3_spi2_cmddata
+ ****************************************************************************/
+
+#if defined(CONFIG_ESP32C3_SPI2) && defined(CONFIG_SPI_CMDDATA)
+
+int esp32c3_spi2_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
+          "data");
+
+  return -ENODEV;
+}
+
+#endif

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spidev.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spidev.c
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spidev.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/spi/spi_transfer.h>
+
+#include "esp32c3_spi.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_spidev_initialize
+ *
+ * Description:
+ *   Initialize and register SPI driver for the specified SPI port.
+ *
+ ****************************************************************************/
+
+int board_spidev_initialize(int port)
+{
+  int ret;
+  FAR struct spi_dev_s *spi;
+
+  syslog(LOG_INFO, "Initializing /dev/spi%d...\n", port);
+
+  /* Initialize SPI device */
+
+  spi = esp32c3_spibus_initialize(port);
+  if (spi == NULL)
+    {
+      syslog(LOG_ERR, "Failed to initialize SPI%d.\n", port);
+      return -ENODEV;
+    }
+
+  ret = spi_register(spi, port);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to register /dev/spi%d: %d\n", port, ret);
+
+      esp32c3_spibus_uninitialize(spi);
+    }
+
+  return ret;
+}

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
@@ -42,6 +42,10 @@
 #include "esp32c3_partition.h"
 #include "esp32c3-devkit.h"
 
+#ifdef CONFIG_SPI_DRIVER
+#  include "esp32c3_spi.h"
+#endif
+
 #ifdef CONFIG_TIMER
 #  include "esp32c3_tim_lowerhalf.h"
 #endif
@@ -158,6 +162,15 @@ int esp32c3_bringup(void)
     {
       syslog(LOG_ERR, "Failed to initialize GPIO Driver: %d\n", ret);
       return ret;
+    }
+#endif
+
+#if defined(CONFIG_SPI_DRIVER) && defined(CONFIG_ESP32C3_SPI2)
+  ret = board_spidev_initialize(ESP32C3_SPI2);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize SPI%d driver: %d\n",
+             ESP32C3_SPI2, ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary
This PR intends to add support for the GPSPI2 peripheral as Master.
For now, **only Polling mode** is available.

## Impact
New feature for the ESP32-C3 chip, no impact to existing configs.

## Testing
This functionality has been validated with `SPITool` application on the ESP32-C3 DevKit by looping back MOSI and MISO pins on GPSPI2, both using IOMUX pins and routing through the GPIO Matrix.
