### PR TITLE
risc-v/esp32c3: Address some minor issues with Kconfig

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -10,7 +10,6 @@ comment "ESP32-C3 Configuration Options"
 choice
 	prompt "ESP32-C3 Chip Selection"
 	default ARCH_CHIP_ESP32C3WROOM02
-	depends on ARCH_CHIP_ESP32C3
 
 config ARCH_CHIP_ESP32C3X
 	bool "ESP32-C3"

--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -382,7 +382,10 @@ config ESP32C3_RT_TIMER_TASK_NAME
 
 config ESP32C3_RT_TIMER_TASK_PRIORITY
 	int "Timer task priority"
-	default 223 # Lower than high priority workqueue
+	default 223
+	---help---
+		Priority level of the RT Timer task.
+		Must be lower than the SCHED_HPWORKPRIORITY.
 
 config ESP32C3_RT_TIMER_TASK_STACK_SIZE
 	int "Timer task stack size"

--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -40,9 +40,6 @@ config ARCH_CHIP_ESP32C3WROOM02
 
 endchoice # ESP32-C3 Chip Selection
 
-comment "Selected ESP32-C3 chip without embedded Flash, an external Flash memory is required."
-	depends on ARCH_CHIP_ESP32C3X
-
 config ESP32C3_SINGLE_CPU
 	bool
 	default n

--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -73,7 +73,7 @@ config ESP32C3_FLASH_16M
 config ESP32C3_FLASH_DETECT
 	bool "Auto-detect FLASH size (to be used with master esptool)"
 	default n
-	help
+	---help---
 		Auto detect flash size when flashing.
 		Current released version of esptool doesn't support auto-detecting flash size.
 		Use latest master from https://github.com/espressif/esptool.
@@ -81,66 +81,66 @@ config ESP32C3_FLASH_DETECT
 choice ESP32C3_FLASH_MODE
 	prompt "SPI FLASH mode"
 	default ESP32C3_FLASH_MODE_DIO
-	help
+	---help---
 		These options control how many I/O pins are used for communication with the attached SPI flash chip.
 		The option selected here is then used by esptool when flashing.
 
-	config ESP32C3_FLASH_MODE_DIO
-		bool "Dual IO (DIO)"
+config ESP32C3_FLASH_MODE_DIO
+	bool "Dual IO (DIO)"
 
-	config ESP32C3_FLASH_MODE_DOUT
-		bool "Dual Output (DOUT)"
+config ESP32C3_FLASH_MODE_DOUT
+	bool "Dual Output (DOUT)"
 
-	config ESP32C3_FLASH_MODE_QIO
-		bool "Quad IO (QIO)"
+config ESP32C3_FLASH_MODE_QIO
+	bool "Quad IO (QIO)"
 
-	config ESP32C3_FLASH_MODE_QOUT
-		bool "Quad Output (QOUT)"
+config ESP32C3_FLASH_MODE_QOUT
+	bool "Quad Output (QOUT)"
 
 endchoice # ESP32C3_FLASH_MODE
 
 choice ESP32C3_FLASH_FREQ
 	prompt "SPI FLASH frequency"
 	default ESP32C3_FLASH_FREQ_40M
-	help
+	---help---
 		SPI FLASH frequency
 		
-	config ESP32C3_FLASH_FREQ_80M
-		bool "80 MHz"
+config ESP32C3_FLASH_FREQ_80M
+	bool "80 MHz"
 
-	config ESP32C3_FLASH_FREQ_40M
-		bool "40 MHz"
+config ESP32C3_FLASH_FREQ_40M
+	bool "40 MHz"
 
-	config ESP32C3_FLASH_FREQ_26M
-		bool "26 MHz"
+config ESP32C3_FLASH_FREQ_26M
+	bool "26 MHz"
 
-	config ESP32C3_FLASH_FREQ_20M
-		bool "20 MHz"
+config ESP32C3_FLASH_FREQ_20M
+	bool "20 MHz"
 
 endchoice # ESP32C3_FLASH_FREQ
 
 choice ESP32C3_CPU_FREQ
 	prompt "CPU frequency"
 	default ESP32C3_CPU_FREQ_160
-	help
+	---help---
 		CPU frequency to be set on application startup.
 
 config ESP32C3_CPU_FREQ_40
 	bool "40 MHz"
-	help
-		Set the CPU to 40 MHz.  This frequency is obtained from the XTAL.
+	---help---
+		Set the CPU to 40 MHz. This frequency is obtained from the XTAL.
 
 config ESP32C3_CPU_FREQ_80
 	bool "80 MHz"
-	help
-		Set the CPU to 80 MHz.  This frequency is obtained from the 480 MHz PLL.
+	---help---
+		Set the CPU to 80 MHz. This frequency is obtained from the 480 MHz PLL.
 
 config ESP32C3_CPU_FREQ_160
 	bool "160 MHz"
-	help
-		Set the CPU to 160 MHz.  This frequency is obtained from the 480 MHz PLL.
+	---help---
+		Set the CPU to 160 MHz. This frequency is obtained from the 480 MHz PLL.
 
-endchoice # CPU frequency
+endchoice # ESP32C3_CPU_FREQ
 
 config ESP32C3_CPU_FREQ_MHZ
 	int
@@ -452,20 +452,20 @@ config ESP32C3_WLAN_PKTBUF_NUM
 config ESP32C3_WIFI_CONNECT_TIMEOUT
 	int "Connect timeout by second"
 	default 10
-	help
+	---help---
 		Max waiting time of connecting to AP.
 
 config ESP32C3_WIFI_SCAN_RESULT_SIZE
 	int "Scan result buffer"
 	default 4096
-	help
+	---help---
 		Maximum scan result buffer size.
 
 config ESP32C3_WIFI_SAVE_PARAM
 	bool "Save Wi-Fi Parameters"
 	default n
 	depends on !DISABLE_MOUNTPOINT
-	help
+	---help---
 		If you enable this option, Wi-Fi adapter parameters will be saved
 		into the file system instead of computing them each time.
 
@@ -482,7 +482,7 @@ config ESP32C3_WIFI_FS_MOUNTPT
 	string "Save Wi-Fi Parameters"
 	default "/mnt/esp/wifi"
 	depends on ESP32C3_WIFI_SAVE_PARAM
-	help
+	---help---
 		Mount point of Wi-Fi storage file system.
 
 config ESP32C3_WIFI_STA_DISCONNECT_PM
@@ -500,35 +500,35 @@ menu "SPI Flash configuration"
 config ESP32C3_MTD_OFFSET
 	hex "MTD base address in SPI Flash"
 	default 0x180000
-	help
+	---help---
 		MTD base address in SPI Flash.
 
 config ESP32C3_MTD_SIZE
 	hex "MTD size in SPI Flash"
 	default 0x100000
-	help
+	---help---
 		MTD size in SPI Flash.
 
 config ESP32C3_SPIFLASH_DEBUG
 	bool "Debug SPI Flash"
 	default n
 	depends on DEBUG_FS_INFO
-	help
+	---help---
 		If this option is enabled, SPI Flash driver read and write functions
 		will output input parameters and return values (if applicable).
 
 endmenu # ESP32C3_SPIFLASH
 
 menu "Partition Configuration"
-        depends on ESP32C3_PARTITION
+	depends on ESP32C3_PARTITION
 
 config ESP32C3_PARTITION_OFFSET
-        hex "Partition offset"
-        default "0x8000"
+	hex "Partition offset"
+	default "0x8000"
 
 config ESP32C3_PARTITION_MOUNT
-        string "Partition mount point"
-        default "/dev/esp/partition/"
+	string "Partition mount point"
+	default "/dev/esp/partition/"
 
 endmenu # ESP32C3_PARTITION
 


### PR DESCRIPTION
## Summary
This PR intends to address some minor issues with the ESP32-C3 Kconfig.

## Impact
It does not bring any functional change, should have no impact.

## Testing
Menuconfig navigation test.
