### PR TITLE
stm32h7: serial: use dma tx semaphore as resource holder

### DIFF
--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -2220,7 +2220,7 @@ static int up_dma_setup(struct uart_dev_s *dev)
     {
       priv->txdma = stm32_dmachannel(priv->txdma_channel);
 
-      nxsem_init(&priv->txdmasem, 0, 0);
+      nxsem_init(&priv->txdmasem, 0, 1);
       nxsem_set_protocol(&priv->txdmasem, SEM_PRIO_NONE);
 
       /* Enable receive Tx DMA for the UART */
@@ -3369,16 +3369,10 @@ static void up_dma_txcallback(DMA_HANDLE handle, uint8_t status, void *arg)
 static void up_dma_txavailable(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
-  size_t resid = 0;
-
-  resid = stm32_dmaresidual(priv->txdma);
 
   /* Only send when the DMA is idle */
 
-  if (resid != 0)
-    {
-      nxsem_wait(&priv->txdmasem);
-    }
+  nxsem_wait(&priv->txdmasem);
 
   uart_xmitchars_dma(dev);
 }


### PR DESCRIPTION
## Summary

This commit will correct error in the stm32H7 serial dma transmition.
txdmasem semaphore is posted every time in up_dma_txcallback. But it is waited occasionally in up_dma_txavailable. So its value is always positive and it never falls asleep.

This commit will use semaphore as resource holder

