### PR TITLE
riscv/esp32c3: Fix SPI Flash driver internal chip data address error

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -51,9 +51,9 @@
 #define ESP32C3_MTD_SIZE            CONFIG_ESP32C3_MTD_SIZE
 
 #define MTD2PRIV(_dev)              ((FAR struct esp32c3_spiflash_s *)_dev)
-#define MTD_SIZE(_priv)             ((_priv)->chip->chip_size)
-#define MTD_BLKSIZE(_priv)          ((_priv)->chip->page_size)
-#define MTD_ERASESIZE(_priv)        ((_priv)->chip->sector_size)
+#define MTD_SIZE(_priv)             ((*(_priv)->data)->chip.chip_size)
+#define MTD_BLKSIZE(_priv)          ((*(_priv)->data)->chip.page_size)
+#define MTD_ERASESIZE(_priv)        ((*(_priv)->data)->chip.sector_size)
 #define MTD_BLK2SIZE(_priv, _b)     (MTD_BLKSIZE(_priv) * (_b))
 #define MTD_SIZE2BLK(_priv, _s)     ((_s) / MTD_BLKSIZE(_priv))
 
@@ -69,7 +69,7 @@ struct esp32c3_spiflash_s
 
   /* SPI Flash data */
 
-  esp32c3_spiflash_chip_t *chip;
+  const struct spiflash_legacy_data_s **data;
 };
 
 /****************************************************************************
@@ -104,6 +104,12 @@ static int esp32c3_ioctl(struct mtd_dev_s *dev, int cmd,
                          unsigned long arg);
 
 /****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern const struct spiflash_legacy_data_s *rom_spiflash_legacy_data;
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -121,7 +127,7 @@ static struct esp32c3_spiflash_s g_esp32c3_spiflash =
 #endif
             .name   = "esp32c3_spiflash"
           },
-  .chip = &g_rom_flashchip,
+  .data = &rom_spiflash_legacy_data,
 };
 
 static struct esp32c3_spiflash_s g_esp32c3_spiflash_encrypt =
@@ -662,7 +668,7 @@ static int esp32c3_ioctl(struct mtd_dev_s *dev, int cmd,
 FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(void)
 {
   struct esp32c3_spiflash_s *priv = &g_esp32c3_spiflash;
-  esp32c3_spiflash_chip_t *chip = priv->chip;
+  const esp32c3_spiflash_chip_t *chip = &(*priv->data)->chip;
   FAR struct mtd_dev_s *mtd_part;
   uint32_t blocks;
   uint32_t startblock;

--- a/arch/risc-v/src/esp32c3/rom/esp32c3_spiflash.h
+++ b/arch/risc-v/src/esp32c3/rom/esp32c3_spiflash.h
@@ -143,6 +143,17 @@ typedef struct
     uint16_t data;
 } esp_rom_spiflash_common_cmd_t;
 
+/**
+ * Global ROM spiflash data, as used by legacy SPI flash functions
+ */
+
+struct spiflash_legacy_data_s
+{
+  esp32c3_spiflash_chip_t chip;
+  uint8_t dummy_len_plus[3];
+  uint8_t sig_matrix;
+};
+
 /*****************************************************************************
  * Public Function Prototypes
  *****************************************************************************/

--- a/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3_rom.ld
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3_rom.ld
@@ -173,7 +173,6 @@ PROVIDE( Enable_QMode = 0x40000228 );
 /* Data (.data, .bss, .rodata) */
 PROVIDE( rom_spiflash_legacy_funcs = 0x3fcdfff4 );
 PROVIDE( rom_spiflash_legacy_data = 0x3fcdfff0 );
-PROVIDE( g_rom_flashchip = 0x3fcdf730 );
 PROVIDE( g_flash_guard_ops = 0x3fcdfff8 );
 
 


### PR DESCRIPTION
## Summary

Fix SPI Flash driver internal chip data address error.

"g_rom_flashchip" is not in fixed address between all ESP32-C3's different versions.

## Impact

## Testing

