### PR TITLE
risc-v/esp32c3: Fix wrong references to ESP32

### DIFF
--- a/arch/risc-v/include/esp32c3/chip.h
+++ b/arch/risc-v/include/esp32c3/chip.h
@@ -31,7 +31,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Characterize each supported ESP32 part */
+/* Characterize each supported ESP32-C3 part */
 
 #define ESP32C3_NGPIOS 22 /* GPIO0-21 */
 

--- a/arch/risc-v/include/esp32c3/irq.h
+++ b/arch/risc-v/include/esp32c3/irq.h
@@ -121,7 +121,7 @@
 
 /* CPU Interrupts.
  *
- * The ESP32 CPU interrupt controller accepts 31 asynchronous interrupts.
+ * The ESP32-C3 CPU interrupt controller accepts 31 asynchronous interrupts.
  */
 
 #define ESP32C3_CPUINT_MIN             1

--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -15,14 +15,14 @@ config ARCH_CHIP_ESP32C3X
 	bool "ESP32-C3"
 	select ESP32C3_ESP32C3XXX
 	---help---
-		ESP32 chip with a single RISC-V IMC core, no embedded Flash memory
+		ESP32-C3 chip with a single RISC-V IMC core, no embedded Flash memory
 
 config ARCH_CHIP_ESP32C3FX4
 	bool "ESP32-C3Fx4"
 	select ESP32C3_ESP32C3XXX
 	select ESP32C3_FLASH_4M
 	---help---
-		ESP32 chip with a single RISC-V IMC core, 4 MB of in-package Flash memory
+		ESP32-C3 chip with a single RISC-V IMC core, 4 MB of in-package Flash memory
 
 config ARCH_CHIP_ESP32C3MINI1
 	bool "ESP32-C3-MINI-1"

--- a/arch/risc-v/src/esp32c3/esp32c3_oneshot_lowerhalf.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_oneshot_lowerhalf.c
@@ -54,7 +54,7 @@ struct esp32c3_oneshot_lowerhalf_s
    */
 
   struct oneshot_lowerhalf_s        lh;   /* Lower half instance */
-  struct esp32c3_oneshot_s     oneshot;   /* ESP32C3-specific oneshot state */
+  struct esp32c3_oneshot_s     oneshot;   /* ESP32-C3-specific oneshot state */
   oneshot_callback_t          callback;   /* Upper half Interrupt callback */
   FAR void                        *arg;   /* Argument passed to handler */
   uint16_t                  resolution;

--- a/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
@@ -601,7 +601,7 @@ int esp32c3_rt_timer_init(void)
   tim = esp32c3_tim_init(ESP32C3_RT_TIMER);
   if (!tim)
     {
-      tmrerr("ERROR: Failed to initialize ESP32 timer0\n");
+      tmrerr("ERROR: Failed to initialize ESP32-C3 timer0\n");
       return -EINVAL;
     }
 
@@ -628,7 +628,7 @@ int esp32c3_rt_timer_init(void)
   flags = enter_critical_section();
 
   /**
-   * ESP32 hardware timer configuration:
+   * ESP32-C3 hardware timer configuration:
    *   - 1 counter = 1us
    *   - Counter increase mode
    *   - Non-reload mode

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -672,7 +672,7 @@ FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(void)
   ASSERT((ESP32C3_MTD_OFFSET % chip->sector_size) == 0);
   ASSERT((ESP32C3_MTD_SIZE % chip->sector_size) == 0);
 
-  finfo("ESP32 SPI Flash information:\n");
+  finfo("ESP32-C3 SPI Flash information:\n");
   finfo("\tID = 0x%" PRIx32 "\n", chip->device_id);
   finfo("\tStatus mask = 0x%" PRIx32 "\n", chip->status_mask);
   finfo("\tChip size = %" PRId32 " KB\n", chip->chip_size / 1024);

--- a/arch/risc-v/src/esp32c3/esp32c3_start.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_start.h
@@ -37,9 +37,10 @@
  * Name: esp32c3_board_initialize
  *
  * Description:
- *   All ESP32 architectures must provide the following entry point.  This
- *   entry point is called early in the initialization -- after all memory
- *   has been configured but before any devices have been initialized.
+ *   All ESP32-C3 architectures must provide the following entry point.
+ *   This entry point is called early in the initialization -- after all
+ *   memory has been configured and mapped but before any devices have been
+ *   initialized.
  *
  * Input Parameters:
  *   None

--- a/arch/risc-v/src/esp32c3/esp32c3_tim.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.c
@@ -87,7 +87,7 @@ static void esp32c3_tim_ackint(FAR struct esp32c3_tim_dev_s *dev);
  * Private Data
  ****************************************************************************/
 
-/* ESP32C3 TIM ops */
+/* ESP32-C3 TIM ops */
 
 struct esp32c3_tim_ops_s esp32c3_tim_ops =
 {

--- a/arch/risc-v/src/esp32c3/esp32c3_tim.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.h
@@ -82,14 +82,14 @@ enum esp32c3_tim_mode_e
   ESP32C3_TIM_MODE_UP,
 };
 
-/* ESP32C3 TIM device */
+/* ESP32-C3 TIM device */
 
 struct esp32c3_tim_dev_s
 {
   struct esp32c3_tim_ops_s *ops;
 };
 
-/* ESP32C3 TIM ops */
+/* ESP32-C3 TIM ops */
 
 /* This is a struct containing the pointers to the timer operations */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.c
@@ -99,7 +99,7 @@ static void esp32c3_wdt_ackint(struct esp32c3_wdt_dev_s *dev);
  * Private Data
  ****************************************************************************/
 
-/* ESP32 WDT ops */
+/* ESP32-C3 WDT ops */
 
 struct esp32c3_wdt_ops_s esp32c3_mwdt_ops =
 {

--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.h
@@ -94,14 +94,14 @@ enum esp32c3_wdt_stage_action_e
                                                */
 };
 
-/* ESP32 WDT device */
+/* ESP32-C3 WDT device */
 
 struct esp32c3_wdt_dev_s
 {
   struct esp32c3_wdt_ops_s *ops;
 };
 
-/* ESP32 WDT ops */
+/* ESP32-C3 WDT ops */
 
 /* This is a struct containing the pointers to the wdt operations */
 

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_soc.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_soc.h
@@ -146,7 +146,7 @@
 #define SOC_BYTE_ACCESSIBLE_HIGH  0x3fd00000
 
 /* Region of memory that is internal, as in on the same silicon die as the
- * ESP32 CPU (excluding RTC data region, that's checked separately.)
+ * ESP32-C3 CPU (excluding RTC data region, that's checked separately.)
  * See esp_ptr_internal().
  */
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_boot.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_boot.c
@@ -38,7 +38,7 @@
  * Name: esp32c3_board_initialize
  *
  * Description:
- *   All ESP32C3 architectures must provide the following entry point.
+ *   All ESP32-C3 architectures must provide the following entry point.
  *   This entry point is called early in the initialization -- after all
  *   memory has been configured and mapped but before any devices have been
  *   initialized.


### PR DESCRIPTION
## Summary
This PR intends to fix some wrong mentions to ESP32 in ESP32-C3-specific code.
Also adds some missing hyphens to ESP32-C3.

## Impact
Should have no impact, most changes are documentation-related.

## Testing
Not applicable.
