### PR TITLE
risc-v/esp32c3: Improve interrupt handler documentation and perform code cleanup

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_interrupt.S
+++ b/arch/risc-v/src/esp32c3/esp32c3_interrupt.S
@@ -130,7 +130,7 @@ _interrupt_handler:
   lw   s0,  32*4(sp)  /* restore mstatus */
   csrw mstatus, s0
 
-
+  lw   x1,  1*4(sp)  /* ra */
   lw   x4,  4*4(sp)  /* tp */
   lw   x5,  5*4(sp)  /* t0 */
   lw   x6,  6*4(sp)  /* t1 */
@@ -159,8 +159,6 @@ _interrupt_handler:
   lw  x29, 29*4(sp)  /* t4 */
   lw  x30, 30*4(sp)  /* t5 */
   lw  x31, 31*4(sp)  /* t6 */
-
-  lw  x1,  1*4(sp)   /* ra */
 
   lw  sp,  2*4(sp)  /* restore original sp */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_interrupt.S
+++ b/arch/risc-v/src/esp32c3/esp32c3_interrupt.S
@@ -45,7 +45,7 @@
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
   .balign   16
   .type     g_intstackalloc, @object
-  .type     g_intstacktop,  @object
+  .type     g_intstacktop,   @object
 g_intstackalloc:
   .skip     ((CONFIG_ARCH_INTERRUPTSTACK + 8) & ~15)
 g_intstacktop:
@@ -138,40 +138,40 @@ _interrupt_handler:
   lw   s0,  32*4(sp)
   csrw mstatus, s0
 
-  lw   x1,  1*4(sp)  /* ra */
+  lw   x1,  1*4(sp)   /* ra */
 
   /* GP must not be changed after start-up due to relaxing optimization */
 
-  lw   x4,  4*4(sp)  /* tp */
-  lw   x5,  5*4(sp)  /* t0 */
-  lw   x6,  6*4(sp)  /* t1 */
-  lw   x7,  7*4(sp)  /* t2 */
-  lw   x8,  8*4(sp)  /* s0 */
-  lw   x9,  9*4(sp)  /* s1 */
-  lw  x10, 10*4(sp)  /* a0 */
-  lw  x11, 11*4(sp)  /* a1 */
-  lw  x12, 12*4(sp)  /* a2 */
-  lw  x13, 13*4(sp)  /* a3 */
-  lw  x14, 14*4(sp)  /* a4 */
-  lw  x15, 15*4(sp)  /* a5 */
-  lw  x16, 16*4(sp)  /* a6 */
-  lw  x17, 17*4(sp)  /* a7 */
-  lw  x18, 18*4(sp)  /* s2 */
-  lw  x19, 19*4(sp)  /* s3 */
-  lw  x20, 20*4(sp)  /* s4 */
-  lw  x21, 21*4(sp)  /* s5 */
-  lw  x22, 22*4(sp)  /* s6 */
-  lw  x23, 23*4(sp)  /* s7 */
-  lw  x24, 24*4(sp)  /* s8 */
-  lw  x25, 25*4(sp)  /* s9 */
-  lw  x26, 26*4(sp)  /* s10 */
-  lw  x27, 27*4(sp)  /* s11 */
-  lw  x28, 28*4(sp)  /* t3 */
-  lw  x29, 29*4(sp)  /* t4 */
-  lw  x30, 30*4(sp)  /* t5 */
-  lw  x31, 31*4(sp)  /* t6 */
+  lw   x4,  4*4(sp)   /* tp */
+  lw   x5,  5*4(sp)   /* t0 */
+  lw   x6,  6*4(sp)   /* t1 */
+  lw   x7,  7*4(sp)   /* t2 */
+  lw   x8,  8*4(sp)   /* s0 */
+  lw   x9,  9*4(sp)   /* s1 */
+  lw   x10, 10*4(sp)  /* a0 */
+  lw   x11, 11*4(sp)  /* a1 */
+  lw   x12, 12*4(sp)  /* a2 */
+  lw   x13, 13*4(sp)  /* a3 */
+  lw   x14, 14*4(sp)  /* a4 */
+  lw   x15, 15*4(sp)  /* a5 */
+  lw   x16, 16*4(sp)  /* a6 */
+  lw   x17, 17*4(sp)  /* a7 */
+  lw   x18, 18*4(sp)  /* s2 */
+  lw   x19, 19*4(sp)  /* s3 */
+  lw   x20, 20*4(sp)  /* s4 */
+  lw   x21, 21*4(sp)  /* s5 */
+  lw   x22, 22*4(sp)  /* s6 */
+  lw   x23, 23*4(sp)  /* s7 */
+  lw   x24, 24*4(sp)  /* s8 */
+  lw   x25, 25*4(sp)  /* s9 */
+  lw   x26, 26*4(sp)  /* s10 */
+  lw   x27, 27*4(sp)  /* s11 */
+  lw   x28, 28*4(sp)  /* t3 */
+  lw   x29, 29*4(sp)  /* t4 */
+  lw   x30, 30*4(sp)  /* t5 */
+  lw   x31, 31*4(sp)  /* t6 */
 
-  lw  sp,  2*4(sp)  /* restore original sp */
+  lw   sp,  2*4(sp)   /* Restore original SP */
 
   /* Return from Machine Interrupt */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_interrupt.S
+++ b/arch/risc-v/src/esp32c3/esp32c3_interrupt.S
@@ -69,7 +69,7 @@ _interrupt_handler:
   addi sp,  sp, -XCPTCONTEXT_SIZE
 
   sw   x1,  1*4(sp)   /* ra */
-  sw   x3,  3*4(sp)   /* gp */
+  sw   x3,  3*4(sp)   /* gp (For register dumping on exception handler) */
   sw   x4,  4*4(sp)   /* tp */
   sw   x5,  5*4(sp)   /* t0 */
   sw   x6,  6*4(sp)   /* t1 */
@@ -100,16 +100,20 @@ _interrupt_handler:
   sw   x31, 31*4(sp)  /* t6 */
 
   addi s0,  sp, XCPTCONTEXT_SIZE
-  sw   s0,  2*4(sp)   /* original SP */
+  sw   s0,  2*4(sp)   /* Save original SP */
+
+  /* Save MSTATUS (Machine Status Register) */
 
   csrr s0,  mstatus
-  sw   s0,  32*4(sp)  /* mstatus */
+  sw   s0,  32*4(sp)
+
+  /* Save MEPC (Machine Exception Program Counter) */
 
   csrr s0,  mepc
-  sw   s0,  0(sp)     /* exception PC */
+  sw   s0,  0(sp)
 
-  csrr a0,  mcause    /* exception cause */
-  mv   a1,  sp        /* context = sp */
+  csrr a0,  mcause    /* Handler arg0: Exception cause */
+  mv   a1,  sp        /* Handler arg1: Context (saved registers on stack) */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
   lui  sp,  %hi(g_intstacktop)
@@ -120,17 +124,24 @@ _interrupt_handler:
 
   jal  x1, esp32c3_dispatch_irq
 
-  /* If context switch is needed, return a new sp */
+  /* If context switch is needed, return a new SP */
 
   mv   sp,  a0
 
-  lw   s0,  0(sp)     /* restore mepc */
+  /* Restore MEPC (Machine Exception Program Counter) */
+
+  lw   s0,  0(sp)
   csrw mepc, s0
 
-  lw   s0,  32*4(sp)  /* restore mstatus */
+  /* Restore MSTATUS (Machine Status Register) */
+
+  lw   s0,  32*4(sp)
   csrw mstatus, s0
 
   lw   x1,  1*4(sp)  /* ra */
+
+  /* GP must not be changed after start-up due to relaxing optimization */
+
   lw   x4,  4*4(sp)  /* tp */
   lw   x5,  5*4(sp)  /* t0 */
   lw   x6,  6*4(sp)  /* t1 */


### PR DESCRIPTION
## Summary
This PR intends to improve the documentation of the ESP32-C3 Exception/Interrupt handlers.

The most important detail is regarding the skipping of Global Pointer on register restoration on the handler epilogue, which might be misinterpreted as it had been forgotten.

Also uniformized the alignment of the assembly instructions.

## Impact
No functional changes, should have no impact.

## Testing
Running `ostest` on `esp32c3-devkit:nsh`
