### PR TITLE
ESP32/ESP32-C3: Allocate .noinit into a dedicated section

### DIFF
--- a/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.ld
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.ld
@@ -75,12 +75,16 @@ SECTIONS
 
     . = ALIGN (8);
     _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
-   /* Uninitialized .bss */
+  .noinit (NOLOAD):
+  {
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
+     */
 
     *(.noinit)
     *(.noinit.*)
-
   } >dram0_0_seg
 
   .dram0.data :

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
@@ -94,8 +94,13 @@ SECTIONS
     *libarch.a:esp32_spiflash.*(.bss  .bss.*  COMMON)
     . = ALIGN(8);
     _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Uninitialized .bss */
+  .noinit (NOLOAD):
+  {
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
+     */
 
     *(.noinit)
   } >dram0_0_seg

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_iram.ld
@@ -100,8 +100,13 @@ SECTIONS
     *(COMMON)
     . = ALIGN(8);
     _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Uninitialized .bss */
+  .noinit (NOLOAD):
+  {
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
+     */
 
     *(.noinit)
   } >dram0_0_seg

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
@@ -97,8 +97,13 @@ SECTIONS
     *libarch.a:esp32_spiflash.*(.bss  .bss.*  COMMON)
     . = ALIGN(8);
     _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Uninitialized .bss */
+  .noinit (NOLOAD):
+  {
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
+     */
 
     *(.noinit)
   } >dram0_0_seg

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_iram.ld
@@ -100,8 +100,13 @@ SECTIONS
     *(COMMON)
     . = ALIGN(8);
     _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Uninitialized .bss */
+  .noinit (NOLOAD):
+  {
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
+     */
 
     *(.noinit)
   } >dram0_0_seg

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
@@ -97,8 +97,13 @@ SECTIONS
     *libarch.a:esp32_spiflash.*(.bss  .bss.*  COMMON)
     . = ALIGN(8);
     _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Uninitialized .bss */
+  .noinit (NOLOAD):
+  {
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
+     */
 
     *(.noinit)
   } >dram0_0_seg

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_iram.ld
@@ -100,8 +100,13 @@ SECTIONS
     *(COMMON)
     . = ALIGN(8);
     _ebss = ABSOLUTE(.);
+  } >dram0_0_seg
 
-    /* Uninitialized .bss */
+  .noinit (NOLOAD):
+  {
+    /* This section contains data that is not initialized during load,
+     * or during the application's initialization sequence.
+     */
 
     *(.noinit)
   } >dram0_0_seg


### PR DESCRIPTION
## Summary
This PR intends to allocate `.noinit` data into a dedicated output section for ESP32 and ESP32-C3 applications.

## Impact
This change brings no impact to the output binary file.

## Testing

**Before** | ![image](https://user-images.githubusercontent.com/38959758/116414425-d4e94d00-a80e-11eb-953f-247e8195553d.png)
--- | ---
**After** | ![image](https://user-images.githubusercontent.com/38959758/116414272-b420f780-a80e-11eb-8251-dc3ff4ea612d.png)
