### PR TITLE
[bp-3613]xtensa/esp32: Fix crash issue caused by null pointer operation

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -1802,8 +1802,10 @@ static int32_t esp_task_create_pinned_to_core(void *entry,
                       (char * const *)param);
   if (pid > 0)
     {
-      *((int *)task_handle) = pid;
-
+      if (task_handle != NULL)
+        {
+          *((int *)task_handle) = pid;
+        }
 #ifdef CONFIG_SMP
       if (core_id < CONFIG_SMP_NCPUS)
         {


### PR DESCRIPTION
## Summary
Fix crash issue caused by null pointer operation 

## Impact
10.1

## Testing
BACKPORT
