### PR TITLE
drivers/serial: fix Rx interrupt enable for cdcacm

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -900,17 +900,13 @@ static ssize_t uart_read(FAR struct file *filep,
 
       else
         {
-#ifdef CONFIG_SERIAL_RXDMA
-          /* Disable all interrupts and test again...
-           * uart_disablerxint() is insufficient for the check in DMA mode.
-           */
+          /* Disable all interrupts and test again... */
 
           flags = enter_critical_section();
-#else
+
           /* Disable Rx interrupts and test again... */
 
           uart_disablerxint(dev);
-#endif
 
           /* If the Rx ring buffer still empty?  Bytes may have been added
            * between the last time that we checked and when we disabled
@@ -927,13 +923,11 @@ static ssize_t uart_read(FAR struct file *filep,
               /* Notify DMA that there is free space in the RX buffer */
 
               uart_dmarxfree(dev);
-#else
+#endif
               /* Wait with the RX interrupt re-enabled.  All interrupts are
                * disabled briefly to assure that the following operations
                * are atomic.
                */
-
-              flags = enter_critical_section();
 
               /* Re-enable UART Rx interrupts */
 
@@ -952,7 +946,6 @@ static ssize_t uart_read(FAR struct file *filep,
                   leave_critical_section(flags);
                   continue;
                 }
-#endif
 
 #ifdef CONFIG_SERIAL_REMOVABLE
               /* Check again if the removable device is still connected
@@ -1020,11 +1013,9 @@ static ssize_t uart_read(FAR struct file *filep,
                * the loop.
                */
 
-#ifdef CONFIG_SERIAL_RXDMA
               leave_critical_section(flags);
-#else
+
               uart_enablerxint(dev);
-#endif
             }
         }
     }
@@ -1037,11 +1028,9 @@ static ssize_t uart_read(FAR struct file *filep,
   leave_critical_section(flags);
 #endif
 
-#ifndef CONFIG_SERIAL_RXDMA
   /* RX interrupt could be disabled by RX buffer overflow. Enable it now. */
 
   uart_enablerxint(dev);
-#endif
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
 #ifdef CONFIG_SERIAL_IFLOWCONTROL_WATERMARKS


### PR DESCRIPTION
The debugging and work leading to this pull request was done together with @davids5.

## Summary

This is addressing an issue where Rx interrupts were not restored for cdcacm after the buffer had been filled (in a burst).
The Rx interrupts were only restored after the [watchdog](https://github.com/apache/incubator-nuttx/blob/940c5b69c36fd1210ada473a5665e4c83420be77/drivers/usbdev/cdcacm.c#L734-L735) timeout of 200ms fired.

This happened because `CONFIG_SERIAL_RXDMA` was set, however, for the cdcacm driver this does not actually matter as it is relying on `uart_enablerxint` to be called via the ops table.

This patch makes sure that `uart_enablerxint` and `uart_disablerxint` are always called, independent of CONFIG_SERIAL_RXDMA, relying on the ops table to be correct for the case where it should be only a no-op.

Also note: This is without `CONFIG_CDCACM_IFLOWCONTROL`.

## Impact

- Before applying this patch we need to check all archs/platforms whether they have the `uart_enablerxint` and `uart_disablerxint` correctly set (or not set) in the ops table.
- Also, the location of `enter_critical_section` and `leave_critical_section` need to be reviewed as I'm not quite sure of how it should exactly be, for the "normal" and DMA case.

## Testing

Testing so far was done on a stm32f4 and stm32f7 running PX4 by sending a burst of serial data and basically disabling the cdcacm watchdog by making the [timeout](https://github.com/apache/incubator-nuttx/blob/940c5b69c36fd1210ada473a5665e4c83420be77/drivers/usbdev/cdcacm.c#L65) very big.

Further testing on stml4 was done with `stm32l467-DISCO:nsh` That board does not work correctly in master.
Ii does work correctly with GPIO flow control, but not with HW flow control (on chip) or DMA with GPIO flow control. 
This pr did not fix nor break further the performance of that board.

