### PR TITLE
[bp-3636] arch/risc-v: Fix interrupt stack alignment

### DIFF
--- a/arch/risc-v/src/bl602/bl602_head.S
+++ b/arch/risc-v/src/bl602/bl602_head.S
@@ -85,7 +85,7 @@ exception_common:
 
   mv   a1, sp      /* context = sp */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   /* Switch to interrupt stack */
 
   lui  sp, %hi(g_intstackbase)

--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -78,10 +78,10 @@ void up_irqinitialize(void)
 
   up_irq_save();
 
-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   /* Colorize the interrupt stack for debug purposes */
 
-  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
   riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif

--- a/arch/risc-v/src/c906/c906_head.S
+++ b/arch/risc-v/src/c906/c906_head.S
@@ -191,7 +191,7 @@ exception_common:
 
   mv   a1, sp      /* context = sp */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   /* Load mhartid (cpuid) */
 
   csrr s0, mhartid
@@ -203,7 +203,7 @@ exception_common:
   j    4f
 3:
   la   sp, g_intstackbase
-  addi sp, sp, -((CONFIG_ARCH_INTERRUPTSTACK) & ~7)
+  addi sp, sp, -((CONFIG_ARCH_INTERRUPTSTACK) & ~15)
 4:
 
 #endif

--- a/arch/risc-v/src/c906/c906_irq.c
+++ b/arch/risc-v/src/c906/c906_irq.c
@@ -72,8 +72,8 @@ void up_irqinitialize(void)
 
   /* Colorize the interrupt stack for debug purposes */
 
-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 7
-  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~7);
+#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
+  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
   riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -191,17 +191,17 @@ ssize_t up_check_stack_remain(void)
   return up_check_tcbstack_remain(this_task());
 }
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
 size_t up_check_intstack(void)
 {
   return do_stackcheck((uintptr_t)&g_intstackalloc,
-                       (CONFIG_ARCH_INTERRUPTSTACK & ~3),
+                       (CONFIG_ARCH_INTERRUPTSTACK & ~15),
                        true);
 }
 
 size_t up_check_intstack_remain(void)
 {
-  return (CONFIG_ARCH_INTERRUPTSTACK & ~3) - up_check_intstack();
+  return (CONFIG_ARCH_INTERRUPTSTACK & ~15) - up_check_intstack();
 }
 #endif
 

--- a/arch/risc-v/src/common/riscv_initialize.c
+++ b/arch/risc-v/src/common/riscv_initialize.c
@@ -53,13 +53,13 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
 static inline void up_color_intstack(void)
 {
   uint32_t *ptr = (uint32_t *)&g_intstackalloc;
   ssize_t size;
 
-  for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+  for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
        size > 0;
        size -= sizeof(uint32_t))
     {

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -133,7 +133,7 @@ EXTERN uint32_t g_idle_topstack;
 
 /* Address of the saved user stack pointer */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
 EXTERN uint32_t g_intstackalloc; /* Allocated stack base */
 EXTERN uint32_t g_intstackbase;  /* Initial top of interrupt stack */
 #endif

--- a/arch/risc-v/src/fe310/fe310_head.S
+++ b/arch/risc-v/src/fe310/fe310_head.S
@@ -126,7 +126,7 @@ exception_common:
 
   mv   a1, sp      /* context = sp */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   /* Switch to interrupt stack */
 
   lui  sp, %hi(g_intstackbase)

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -59,8 +59,8 @@ void up_irqinitialize(void)
 
   /* Colorize the interrupt stack for debug purposes */
 
-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
-  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
+  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
   riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif

--- a/arch/risc-v/src/k210/k210_head.S
+++ b/arch/risc-v/src/k210/k210_head.S
@@ -143,7 +143,7 @@ normal_irq:
 
   mv   a1, sp      /* context = sp */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   /* Load mhartid (cpuid) */
 
   csrr s0, mhartid
@@ -155,7 +155,7 @@ normal_irq:
   j    4f
 3:
   la   sp, g_intstackbase
-  addi sp, sp, -((CONFIG_ARCH_INTERRUPTSTACK) & ~7)
+  addi sp, sp, -((CONFIG_ARCH_INTERRUPTSTACK) & ~15)
 4:
 
 #endif

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -81,7 +81,12 @@ void up_irqinitialize(void)
   /* Colorize the interrupt stack for debug purposes */
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
-  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
+  size_t intstack_size = 0;
+#ifndef CONFIG_SMP
+  intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
+#else
+  intstack_size = ((CONFIG_ARCH_INTERRUPTSTACK * CONFIG_SMP_NCPUS) & ~15);
+#endif
   riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -80,8 +80,8 @@ void up_irqinitialize(void)
 
   /* Colorize the interrupt stack for debug purposes */
 
-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 7
-  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~7);
+#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
+  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
   riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif

--- a/arch/risc-v/src/litex/litex_head.S
+++ b/arch/risc-v/src/litex/litex_head.S
@@ -126,7 +126,7 @@ exception_common:
 
   mv   a1, sp      /* context = sp */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   /* Switch to interrupt stack */
 
   lui  sp, %hi(g_intstackbase)

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -58,8 +58,8 @@ void up_irqinitialize(void)
 
   /* Colorize the interrupt stack for debug purposes */
 
-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
-  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
+  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
   riscv_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
                  intstack_size);
 #endif

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -173,7 +173,7 @@ static void riscv_dumpstate(void)
   uint32_t sp = riscv_getsp();
   uint32_t ustackbase;
   uint32_t ustacksize;
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   uint32_t istackbase;
   uint32_t istacksize;
 #endif
@@ -189,9 +189,9 @@ static void riscv_dumpstate(void)
 
   /* Get the limits on the interrupt stack memory */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   istackbase = (uint32_t)&g_intstackbase;
-  istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3) - 4;
+  istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~15) - 4;
 
   /* Show interrupt stack info */
 

--- a/arch/risc-v/src/rv64gc/riscv_assert.c
+++ b/arch/risc-v/src/rv64gc/riscv_assert.c
@@ -184,7 +184,7 @@ static void up_dumpstate(void)
   uint64_t sp = riscv_getsp();
   uintptr_t ustackbase;
   uintptr_t ustacksize;
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   uintptr_t istackbase;
   uintptr_t istacksize;
 #endif
@@ -200,9 +200,9 @@ static void up_dumpstate(void)
 
   /* Get the limits on the interrupt stack memory */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   istackbase = (uintptr_t)&g_intstackbase;
-  istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~7) - 8;
+  istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~15) - 8;
 
   /* Show interrupt stack info */
 


### PR DESCRIPTION
## Summary
Manual cherr-ypick of #3636

## Impact
10.1

## Testing
Backport
