### PR TITLE
drivers/motor - Fix CFLAGS path

### DIFF
--- a/drivers/motor/Make.defs
+++ b/drivers/motor/Make.defs
@@ -28,7 +28,7 @@ endif
 
 MOTOR_DEPPATH := --dep-path motor
 MOTOR_VPATH := :motor
-MOTOR_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)motr}
+MOTOR_CFLAGS := ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)motor}
 
 DEPPATH += $(MOTOR_DEPPATH)
 VPATH += $(MOTOR_VPATH)


### PR DESCRIPTION
## Summary

In drivers/motor/Make.defs b/drivers/motor/Make.defs, fix typo in MOTOR_CFLAGS path (motr -> motor)

## Impact

Improves correctness of CFLAGS when building with motor drivers. Strangely, the typo does not seem to break the build at this time and therefore went unnoticed. However, if not fixed, it might break the build in the future.

## Testing

This can be seen in the build command lines when building a configuration that uses motor drivers with `make V=1`.

For example:

```
$ tools/configure.sh nucleo-f302r8:ihm07m1_b16
$ make V=1 2>&1 | tee log.txt
$ cat log.txt | grep -w motr
```
