### PR TITLE
stm32{H7|F7} Disables/Enabled the use of GPIO_OTG_ID pin

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1734,6 +1734,19 @@ config STM32F7_SYSCFG_IOCOMPENSATION
 		The I/O compensation cell can be used only when the supply voltage ranges
 		from 2.4 to 3.6 V.
 
+menu "OTG Configuration"
+	depends on STM32F7_OTGFS
+
+config OTG_ID_GPIO_DISABLE
+	bool "Disable the use of GPIO_OTG_ID pin."
+	default n
+	---help---
+		Disables/Enabled the use of GPIO_OTG_ID pin. This allows non OTG use
+		cases to reuse this GPIO pin and ensure it is not set incorrectlty
+		during OS boot.
+
+endmenu
+
 menu "U[S]ART Configuration"
 	depends on STM32F7_USART
 

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -5726,7 +5726,11 @@ void arm_usbinitialize(void)
 
   stm32_configgpio(GPIO_OTG_DM);
   stm32_configgpio(GPIO_OTG_DP);
-  stm32_configgpio(GPIO_OTG_ID);        /* Only needed for OTG */
+
+  /* Only needed for OTG */
+#  ifndef CONFIG_OTG_ID_GPIO_DISABLE
+  stm32_configgpio(GPIO_OTG_ID);
+#  endif
 
   /* SOF output pin configuration is configurable. */
 

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -843,6 +843,19 @@ config STM32H7_I2CTIMEOTICKS
 
 endmenu # "I2C Configuration"
 
+menu "OTG Configuration"
+	depends on STM32H7_OTGFS
+
+config OTG_ID_GPIO_DISABLE
+	bool "Disable the use of GPIO_OTG_ID pin."
+	default n
+	---help---
+		Disables/Enabled the use of GPIO_OTG_ID pin. This allows non OTG use
+		cases to reuse this GPIO pin and ensure it is not set incorrectlty
+		during OS boot.
+
+endmenu
+
 menu "SPI Configuration"
 	depends on STM32H7_SPI
 

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -5585,7 +5585,11 @@ void arm_usbinitialize(void)
 
   stm32_configgpio(GPIO_OTG_DM);
   stm32_configgpio(GPIO_OTG_DP);
-  stm32_configgpio(GPIO_OTG_ID);    /* Only needed for OTG */
+
+  /* Only needed for OTG */
+#  ifndef CONFIG_OTG_ID_GPIO_DISABLE
+  stm32_configgpio(GPIO_OTG_ID);
+#  endif
 
   /* SOF output pin configuration is configurable. */
 


### PR DESCRIPTION
## Summary

Allows one to Disables/Enabled the use of GPIO_OTG_ID pin. This allows non OTG use
		cases to reuse this GPIO pin and ensure it is not set incorrectly during OS boot.
## Impact

none - behing a Knob

## Testing

PX4 fmu_v5
