### PR TITLE
Use  inttypes in stm32{f7|h7}, Kinetis, s32k drivers.

### DIFF
--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <unistd.h>
@@ -634,7 +635,7 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
 
   if (mbi == TXMBCOUNT)
     {
-      nwarn("No TX MB available mbi %i\n", mbi);
+      nwarn("No TX MB available mbi %" PRIu32 "\n", mbi);
       NETDEV_TXERRORS(&priv->dev);
       return 0;       /* No transmission for you! */
     }
@@ -1654,7 +1655,7 @@ static int kinetis_initialize(struct kinetis_driver_s *priv)
 
   for (i = 0; i < RXMBCOUNT; i++)
     {
-      ninfo("Set MB%i to receive %p\n", i, &priv->rx[i]);
+      ninfo("Set MB%" PRIu32 " to receive %p\n", i, &priv->rx[i]);
       priv->rx[i].cs.edl = 0x1;
       priv->rx[i].cs.brs = 0x1;
       priv->rx[i].cs.esi = 0x0;
@@ -1718,8 +1719,8 @@ static void kinetis_reset(struct kinetis_driver_s *priv)
 
   for (i = 0; i < TOTALMBCOUNT; i++)
     {
-      ninfo("MB %i %p\n", i, &priv->rx[i]);
-      ninfo("MB %i %p\n", i, &priv->rx[i].id.w);
+      ninfo("MB %" PRIu32 " %p\n", i, &priv->rx[i]);
+      ninfo("MB %" PRIu32 " %p\n", i, &priv->rx[i].id.w);
       priv->rx[i].cs.cs = 0x0;
       priv->rx[i].id.w = 0x0;
       priv->rx[i].data[0].w00 = 0x0;

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -636,7 +636,7 @@ static int s32k1xx_transmit(FAR struct s32k1xx_driver_s *priv)
 
   if (mbi == TXMBCOUNT)
     {
-      nwarn("No TX MB available mbi %" PRIi32 "\n", mbi);
+      nwarn("No TX MB available mbi %" PRIu32 "\n", mbi);
       NETDEV_TXERRORS(&priv->dev);
       return 0;       /* No transmission for you! */
     }
@@ -1658,7 +1658,7 @@ static int s32k1xx_initialize(struct s32k1xx_driver_s *priv)
 
   for (i = 0; i < RXMBCOUNT; i++)
     {
-      ninfo("Set MB%" PRIi32 " to receive %p\n", i, &priv->rx[i]);
+      ninfo("Set MB%" PRIu32 " to receive %p\n", i, &priv->rx[i]);
       priv->rx[i].cs.edl = 0x1;
       priv->rx[i].cs.brs = 0x1;
       priv->rx[i].cs.esi = 0x0;
@@ -1722,8 +1722,8 @@ static void s32k1xx_reset(struct s32k1xx_driver_s *priv)
 
   for (i = 0; i < TOTALMBCOUNT; i++)
     {
-      ninfo("MB %" PRIi32 " %p\n", i, &priv->rx[i]);
-      ninfo("MB %" PRIi32 " %p\n", i, &priv->rx[i].id.w);
+      ninfo("MB %" PRIu32 " %p\n", i, &priv->rx[i]);
+      ninfo("MB %" PRIu32 " %p\n", i, &priv->rx[i].id.w);
       priv->rx[i].cs.cs = 0x0;
       priv->rx[i].id.w = 0x0;
       priv->rx[i].data[0].w00 = 0x0;

--- a/arch/arm/src/stm32f7/stm32_can.c
+++ b/arch/arm/src/stm32f7/stm32_can.c
@@ -43,6 +43,7 @@
 
 #include <nuttx/config.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <stdint.h>
@@ -322,7 +323,7 @@ static uint32_t stm32can_vgetreg(uint32_t addr)
         {
           /* Yes.. then show how many times the value repeated */
 
-          caninfo("[repeats %d more times]\n", count - 3);
+          caninfo("[repeats %" PRIu32 " more times]\n", count - 3);
         }
 
       /* Save the new address, value, and count */
@@ -334,7 +335,7 @@ static uint32_t stm32can_vgetreg(uint32_t addr)
 
   /* Show the register value read */
 
-  caninfo("%08x->%08x\n", addr, val);
+  caninfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 
@@ -383,7 +384,7 @@ static void stm32can_vputreg(uint32_t addr, uint32_t value)
 {
   /* Show the register value being written */
 
-  caninfo("%08x<-%08x\n", addr, value);
+  caninfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 
@@ -445,16 +446,16 @@ static void stm32can_dumpctrlregs(FAR struct stm32_can_s *priv,
 
   /* CAN control and status registers */
 
-  caninfo("  MCR: %08x   MSR: %08x   TSR: %08x\n",
+  caninfo("  MCR: %08" PRIx32 "   MSR: %08" PRIx32 "   TSR: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_MCR_OFFSET),
           getreg32(priv->base + STM32_CAN_MSR_OFFSET),
           getreg32(priv->base + STM32_CAN_TSR_OFFSET));
 
-  caninfo(" RF0R: %08x  RF1R: %08x\n",
+  caninfo(" RF0R: %08" PRIx32 "  RF1R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_RF0R_OFFSET),
           getreg32(priv->base + STM32_CAN_RF1R_OFFSET));
 
-  caninfo("  IER: %08x   ESR: %08x   BTR: %08x\n",
+  caninfo("  IER: %08" PRIx32 "   ESR: %08" PRIx32 "   BTR: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_IER_OFFSET),
           getreg32(priv->base + STM32_CAN_ESR_OFFSET),
           getreg32(priv->base + STM32_CAN_BTR_OFFSET));
@@ -490,31 +491,36 @@ static void stm32can_dumpmbregs(FAR struct stm32_can_s *priv,
 
   /* CAN mailbox registers (3 TX and 2 RX) */
 
-  caninfo(" TI0R: %08x TDT0R: %08x TDL0R: %08x TDH0R: %08x\n",
+  caninfo(" TI0R: %08" PRIx32 " TDT0R: %08" PRIx32 " TDL0R: %08"
+          PRIx32 " TDH0R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_TI0R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDT0R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDL0R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDH0R_OFFSET));
 
-  caninfo(" TI1R: %08x TDT1R: %08x TDL1R: %08x TDH1R: %08x\n",
+  caninfo(" TI1R: %08" PRIx32 " TDT1R: %08" PRIx32 " TDL1R: %08"
+          PRIx32 " TDH1R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_TI1R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDT1R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDL1R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDH1R_OFFSET));
 
-  caninfo(" TI2R: %08x TDT2R: %08x TDL2R: %08x TDH2R: %08x\n",
+  caninfo(" TI2R: %08" PRIx32 " TDT2R: %08" PRIx32 " TDL2R: %08"
+          PRIx32 " TDH2R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_TI2R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDT2R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDL2R_OFFSET),
           getreg32(priv->base + STM32_CAN_TDH2R_OFFSET));
 
-  caninfo(" RI0R: %08x RDT0R: %08x RDL0R: %08x RDH0R: %08x\n",
+  caninfo(" RI0R: %08" PRIx32 " RDT0R: %08" PRIx32 " RDL0R: %08"
+          PRIx32 " RDH0R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_RI0R_OFFSET),
           getreg32(priv->base + STM32_CAN_RDT0R_OFFSET),
           getreg32(priv->base + STM32_CAN_RDL0R_OFFSET),
           getreg32(priv->base + STM32_CAN_RDH0R_OFFSET));
 
-  caninfo(" RI1R: %08x RDT1R: %08x RDL1R: %08x RDH1R: %08x\n",
+  caninfo(" RI1R: %08" PRIx32 " RDT1R: %08" PRIx32 " RDL1R: %08"
+          PRIx32 " RDH1R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_RI1R_OFFSET),
           getreg32(priv->base + STM32_CAN_RDT1R_OFFSET),
           getreg32(priv->base + STM32_CAN_RDL1R_OFFSET),
@@ -551,7 +557,8 @@ static void stm32can_dumpfiltregs(FAR struct stm32_can_s *priv,
       caninfo("Filter Registers:\n");
     }
 
-  caninfo(" FMR: %08x   FM1R: %08x  FS1R: %08x FFA1R: %08x  FA1R: %08x\n",
+  caninfo(" FMR: %08" PRIx32 "   FM1R: %08" PRIx32 "  FS1R: %08"
+          PRIx32 " FFA1R: %08" PRIx32 "  FA1R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32_CAN_FMR_OFFSET),
           getreg32(priv->base + STM32_CAN_FM1R_OFFSET),
           getreg32(priv->base + STM32_CAN_FS1R_OFFSET),
@@ -560,7 +567,7 @@ static void stm32can_dumpfiltregs(FAR struct stm32_can_s *priv,
 
   for (i = 0; i < CAN_NFILTERS; i++)
     {
-      caninfo(" F%dR1: %08x F%dR2: %08x\n",
+      caninfo(" F%dR1: %08" PRIx32 " F%dR2: %08" PRIx32 "\n",
               i, getreg32(priv->base + STM32_CAN_FIR_OFFSET(i, 1)),
               i, getreg32(priv->base + STM32_CAN_FIR_OFFSET(i, 2)));
     }
@@ -589,7 +596,7 @@ static void stm32can_reset(FAR struct can_dev_s *dev)
   uint32_t regbit = 0;
   irqstate_t flags;
 
-  caninfo("CAN%d\n", priv->port);
+  caninfo("CAN%" PRIu8 "\n", priv->port);
 
   /* Get the bits in the AHB1RSTR register needed to reset this CAN device */
 
@@ -615,7 +622,7 @@ static void stm32can_reset(FAR struct can_dev_s *dev)
   else
 #endif
     {
-      canerr("ERROR: Unsupported port %d\n", priv->port);
+      canerr("ERROR: Unsupported port %" PRIu8 "\n", priv->port);
       return;
     }
 
@@ -658,7 +665,8 @@ static int stm32can_setup(FAR struct can_dev_s *dev)
   FAR struct stm32_can_s *priv = dev->cd_priv;
   int ret;
 
-  caninfo("CAN%d RX0 irq: %d RX1 irq: %d TX irq: %d\n",
+  caninfo("CAN%" PRIu8 " RX0 irq: %" PRIu8 " RX1 irq: %" PRIu8
+          " TX irq: %" PRIu8 "\n",
           priv->port, priv->canrx[0], priv->canrx[1], priv->cantx);
 
   /* CAN cell initialization */
@@ -666,7 +674,7 @@ static int stm32can_setup(FAR struct can_dev_s *dev)
   ret = stm32can_cellinit(priv);
   if (ret < 0)
     {
-      canerr("ERROR: CAN%d cell initialization failed: %d\n",
+      canerr("ERROR: CAN%" PRId8 " cell initialization failed: %d\n",
              priv->port, ret);
       return ret;
     }
@@ -679,7 +687,7 @@ static int stm32can_setup(FAR struct can_dev_s *dev)
   ret = stm32can_filterinit(priv);
   if (ret < 0)
     {
-      canerr("ERROR: CAN%d filter initialization failed: %d\n",
+      canerr("ERROR: CAN%" PRIu8 " filter initialization failed: %d\n",
              priv->port, ret);
       return ret;
     }
@@ -693,7 +701,7 @@ static int stm32can_setup(FAR struct can_dev_s *dev)
   ret = irq_attach(priv->canrx[0], stm32can_rx0interrupt, dev);
   if (ret < 0)
     {
-      canerr("ERROR: Failed to attach CAN%d RX0 IRQ (%d)",
+      canerr("ERROR: Failed to attach CAN%" PRIu8 " RX0 IRQ (%" PRIu8 ")",
              priv->port, priv->canrx[0]);
       return ret;
     }
@@ -701,7 +709,7 @@ static int stm32can_setup(FAR struct can_dev_s *dev)
   ret = irq_attach(priv->canrx[1], stm32can_rx1interrupt, dev);
   if (ret < 0)
     {
-      canerr("ERROR: Failed to attach CAN%d RX1 IRQ (%d)",
+      canerr("ERROR: Failed to attach CAN%" PRIu8 " RX1 IRQ (%" PRIu8 ")",
              priv->port, priv->canrx[1]);
       return ret;
     }
@@ -709,7 +717,7 @@ static int stm32can_setup(FAR struct can_dev_s *dev)
   ret = irq_attach(priv->cantx, stm32can_txinterrupt, dev);
   if (ret < 0)
     {
-      canerr("ERROR: Failed to attach CAN%d TX IRQ (%d)",
+      canerr("ERROR: Failed to attach CAN%" PRIu8 " TX IRQ (%" PRIu8 ")",
              priv->port, priv->cantx);
       return ret;
     }
@@ -744,7 +752,7 @@ static void stm32can_shutdown(FAR struct can_dev_s *dev)
 {
   FAR struct stm32_can_s *priv = dev->cd_priv;
 
-  caninfo("CAN%d\n", priv->port);
+  caninfo("CAN%" PRIu8 "\n", priv->port);
 
   /* Disable the RX FIFO 0/1 and TX interrupts */
 
@@ -782,7 +790,7 @@ static void stm32can_rxint(FAR struct can_dev_s *dev, bool enable)
   FAR struct stm32_can_s *priv = dev->cd_priv;
   uint32_t regval;
 
-  caninfo("CAN%d enable: %d\n", priv->port, enable);
+  caninfo("CAN%" PRIu8 " enable: %d\n", priv->port, enable);
 
   /* Enable/disable the FIFO 0/1 message pending interrupt */
 
@@ -818,7 +826,7 @@ static void stm32can_txint(FAR struct can_dev_s *dev, bool enable)
   FAR struct stm32_can_s *priv = dev->cd_priv;
   uint32_t regval;
 
-  caninfo("CAN%d enable: %d\n", priv->port, enable);
+  caninfo("CAN%" PRIu8 " enable: %d\n", priv->port, enable);
 
   /* Support only disabling the transmit mailbox interrupt */
 
@@ -850,7 +858,7 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
   FAR struct stm32_can_s *priv;
   int ret = -ENOTTY;
 
-  caninfo("cmd=%04x arg=%" PRIu32 "\n", cmd, arg);
+  caninfo("cmd=%04x arg=%lu\n", cmd, arg);
 
   DEBUGASSERT(dev && dev->cd_priv);
   priv = dev->cd_priv;
@@ -956,7 +964,7 @@ static int stm32can_ioctl(FAR struct can_dev_s *dev, int cmd,
               DEBUGASSERT(brp >= 1 && brp <= CAN_BTR_BRP_MAX);
             }
 
-          caninfo("TS1: %"PRId8 " TS2: %" PRId8 " BRP: %" PRIu32 "\n",
+          caninfo("TS1: %"PRIu8 " TS2: %" PRIu8 " BRP: %" PRIu32 "\n",
                   bt->bt_tseg1, bt->bt_tseg2, brp);
 
           /* Configure bit timing. */
@@ -1252,8 +1260,8 @@ static int stm32can_send(FAR struct can_dev_s *dev,
   int dlc;
   int txmb;
 
-  caninfo("CAN%d ID: %d DLC: %d\n",
-          priv->port, msg->cm_hdr.ch_id, msg->cm_hdr.ch_dlc);
+  caninfo("CAN%" PRIu8 " ID: %" PRIu32 " DLC: %" PRIu8 "\n",
+          priv->port, (uint32_t)msg->cm_hdr.ch_id, msg->cm_hdr.ch_dlc);
 
   /* Select one empty transmit mailbox */
 
@@ -1414,7 +1422,7 @@ static bool stm32can_txready(FAR struct can_dev_s *dev)
   /* Return true if any mailbox is available */
 
   regval = stm32can_getreg(priv, STM32_CAN_TSR_OFFSET);
-  caninfo("CAN%d TSR: %08" PRIx32 "\n", priv->port, regval);
+  caninfo("CAN%" PRIu8 " TSR: %08" PRIx32 "\n", priv->port, regval);
 
   return stm32can_txmb0empty(regval) || stm32can_txmb1empty(regval) ||
          stm32can_txmb2empty(regval);
@@ -1446,7 +1454,7 @@ static bool stm32can_txempty(FAR struct can_dev_s *dev)
   /* Return true if all mailboxes are available */
 
   regval = stm32can_getreg(priv, STM32_CAN_TSR_OFFSET);
-  caninfo("CAN%d TSR: %08" PRIx32 "\n", priv->port, regval);
+  caninfo("CAN%" PRIu8 " TSR: %08" PRIx32 "\n", priv->port, regval);
 
   return stm32can_txmb0empty(regval) && stm32can_txmb1empty(regval) &&
          stm32can_txmb2empty(regval);
@@ -1752,8 +1760,8 @@ static int stm32can_bittiming(FAR struct stm32_can_s *priv)
   uint32_t ts1;
   uint32_t ts2;
 
-  caninfo("CAN%d PCLK1: %" PRId32 " baud: %" PRId32 "\n",
-          priv->port, STM32_PCLK1_FREQUENCY, priv->baud);
+  caninfo("CAN%" PRIu8 " PCLK1: %lu baud: %" PRIu32 "\n",
+          priv->port, (unsigned long) STM32_PCLK1_FREQUENCY, priv->baud);
 
   /* Try to get CAN_BIT_QUANTA quanta in one bit_time.
    *
@@ -1805,7 +1813,7 @@ static int stm32can_bittiming(FAR struct stm32_can_s *priv)
       DEBUGASSERT(brp >= 1 && brp <= CAN_BTR_BRP_MAX);
     }
 
-  caninfo("TS1: %" PRId32 " TS2: %" PRId32 " BRP: %" PRId32 "\n",
+  caninfo("TS1: %" PRIu32 " TS2: %" PRIu32 " BRP: %" PRIu32 "\n",
                ts1, ts2, brp);
 
   /* Configure bit timing.  This also does the following, less obvious
@@ -1851,7 +1859,7 @@ static int stm32can_enterinitmode(FAR struct stm32_can_s *priv)
   uint32_t regval;
   volatile uint32_t timeout;
 
-  caninfo("CAN%d\n", priv->port);
+  caninfo("CAN%" PRIu8 "\n", priv->port);
 
   /* Enter initialization mode */
 
@@ -1952,7 +1960,7 @@ static int stm32can_cellinit(FAR struct stm32_can_s *priv)
   uint32_t regval;
   int ret;
 
-  caninfo("CAN%d\n", priv->port);
+  caninfo("CAN%" PRIu8 "\n", priv->port);
 
   /* Exit from sleep mode */
 
@@ -2035,7 +2043,7 @@ static int stm32can_filterinit(FAR struct stm32_can_s *priv)
   uint32_t regval;
   uint32_t bitmask;
 
-  caninfo("CAN%d filter: %d\n", priv->port, priv->filter);
+  caninfo("CAN%" PRIu8 " filter: %" PRIu8 "\n", priv->port, priv->filter);
 
   /* Get the bitmask associated with the filter used by this CAN block */
 
@@ -2268,7 +2276,7 @@ FAR struct can_dev_s *stm32_caninitialize(int port)
 {
   FAR struct can_dev_s *dev = NULL;
 
-  caninfo("CAN%d\n", port);
+  caninfo("CAN%" PRIu8 "\n", port);
 
   /* NOTE:  Peripherical clocking for CAN1 and/or CAN2 was already provided
    * by stm32_clockconfig() early in the reset sequence.

--- a/arch/arm/src/stm32f7/stm32_dma.c
+++ b/arch/arm/src/stm32f7/stm32_dma.c
@@ -921,8 +921,8 @@ bool stm32_dmacapable(uintptr_t maddr, uint32_t count, uint32_t ccr)
       ((mend + 1) & (ARMV7M_DCACHE_LINESIZE - 1)) != 0)
     {
       dmawarn("stm32_dmacapable:"
-              " dcache unaligned maddr:0x%08x mend:0x%08x\n",
-              maddr, mend);
+              " dcache unaligned maddr:0x%08" PRIxPTR " mend:0x%08"
+              PRIx32 "\n", maddr, mend);
 #if !defined(CONFIG_STM32F7_DMACAPABLE_ASSUME_CACHE_ALIGNED)
       return false;
 #endif

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -2510,7 +2510,7 @@ static int stm32_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R5_RESPONSE &&
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R6_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2538,7 +2538,8 @@ static int stm32_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
           if ((uint8_t)(respcmd & STM32_SDMMC_RESPCMD_MASK) !=
               (cmd & MMCSD_CMDIDX_MASK))
             {
-              mcerr("ERROR: RESCMD=%02x CMD=%08x\n", respcmd, cmd);
+              mcerr("ERROR: RESCMD=%02" PRIx32 " CMD=%08" PRIx32 "\n",
+                    respcmd, cmd);
               ret = -EINVAL;
             }
         }
@@ -2576,7 +2577,7 @@ static int stm32_recvlong(FAR struct sdio_dev_s *dev, uint32_t cmd,
 
   if ((cmd & MMCSD_RESPONSE_MASK) != MMCSD_R2_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else

--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -3641,10 +3641,10 @@ void arm_serialinit(void)
 
 #if !defined(SERIAL_HAVE_ONLY_DMA)
 #  if defined(SERIAL_HAVE_RXDMA)
-  UNUSED(g_uart_rxdma_ops);
+  UNUSED(&g_uart_rxdma_ops);
 #  endif
 #  if defined(SERIAL_HAVE_TXDMA)
-  UNUSED(g_uart_txdma_ops);
+  UNUSED(&g_uart_txdma_ops);
 #  endif
 #endif
 

--- a/arch/arm/src/stm32h7/stm32_dma.c
+++ b/arch/arm/src/stm32h7/stm32_dma.c
@@ -2054,7 +2054,7 @@ static bool stm32_bdma_capable(FAR stm32_dmacfg_t *cfg)
       ((mend + 1) & (ARMV7M_DCACHE_LINESIZE - 1)) != 0)
     {
       dmainfo("stm32_dmacapable: dcache unaligned "
-              "maddr:0x%08" PRIx32 " mend:0x%08x\n",
+              "maddr:0x%08" PRIx32 " mend:0x%08" PRIx32 "\n",
               cfg->maddr, mend);
 #if !defined(CONFIG_STM32H7_DMACAPABLE_ASSUME_CACHE_ALIGNED)
       return false;

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -905,7 +906,7 @@ static uint32_t stm32_getreg(uint32_t addr)
         {
           /* Yes.. then show how many times the value repeated */
 
-          uinfo("[repeats %d more times]\n", count - 3);
+          uinfo("[repeats %" PRId32 " more times]\n", count - 3);
         }
 
       /* Save the new address, value, and count */
@@ -917,7 +918,7 @@ static uint32_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%08x\n", addr, val);
+  uinfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -935,7 +936,7 @@ static void stm32_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%08x\n", addr, val);
+  uinfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 
@@ -1289,8 +1290,8 @@ static void stm32_epin_request(FAR struct stm32_usbdev_s *priv,
       return;
     }
 
-  uinfo("EP%d req=%p: len=%d xfrd=%d zlp=%d\n",
-          privep->epphy, privreq, privreq->req.len,
+  uinfo("EP%"  PRId8 " req=%p: len=%" PRId16 " xfrd=%"  PRId16" zlp=%"
+        PRId8 "\n", privep->epphy, privreq, privreq->req.len,
           privreq->req.xfrd, privep->zlp);
 
   /* Check for a special case:  If we are just starting a request (xfrd==0)
@@ -2731,7 +2732,7 @@ static inline void stm32_epout_interrupt(FAR struct stm32_usbdev_s *priv)
           if ((daint & 1) != 0)
             {
               regval = stm32_getreg(STM32_OTG_DOEPINT(epno));
-              uerr("DOEPINT(%d) = %08x\n", epno, regval);
+              uerr("DOEPINT(%d) = %08" PRIx32 "\n", epno, regval);
               stm32_putreg(0xff, STM32_OTG_DOEPINT(epno));
             }
 
@@ -2970,7 +2971,7 @@ static inline void stm32_epin_interrupt(FAR struct stm32_usbdev_s *priv)
         {
           if ((daint & 1) != 0)
             {
-              uerr("DIEPINT(%d) = %08x\n",
+              uerr("DIEPINT(%d) = %08" PRIx32 "\n",
                      epno, stm32_getreg(STM32_OTG_DIEPINT(epno)));
               stm32_putreg(0xff, STM32_OTG_DIEPINT(epno));
             }

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -742,7 +743,7 @@ static inline void stm32_setclkcr(struct stm32_dev_s *priv, uint32_t clkcr)
 
   sdmmc_putreg32(priv, regval, STM32_SDMMC_CLKCR_OFFSET);
 
-  mcinfo("CLKCR: %08x PWR: %08x\n",
+  mcinfo("CLKCR: %08" PRIx32 " PWR: %08" PRIx32 "\n",
          sdmmc_getreg32(priv, STM32_SDMMC_CLKCR_OFFSET),
          sdmmc_getreg32(priv, STM32_SDMMC_POWER_OFFSET));
 }
@@ -981,14 +982,22 @@ static void stm32_sample(struct stm32_dev_s *priv, int index)
 static void stm32_sdiodump(struct stm32_sdioregs_s *regs, const char *msg)
 {
   mcinfo("SDIO Registers: %s\n", msg);
-  mcinfo("  POWER[%08x]: %08x\n", STM32_SDMMC_POWER_OFFSET,   regs->power);
-  mcinfo("  CLKCR[%08x]: %08x\n", STM32_SDMMC_CLKCR_OFFSET,   regs->clkcr);
-  mcinfo("  DCTRL[%08x]: %08x\n", STM32_SDMMC_DCTRL_OFFSET,   regs->dctrl);
-  mcinfo(" DTIMER[%08x]: %08x\n", STM32_SDMMC_DTIMER_OFFSET,  regs->dtimer);
-  mcinfo("   DLEN[%08x]: %08x\n", STM32_SDMMC_DLEN_OFFSET,    regs->dlen);
-  mcinfo(" DCOUNT[%08x]: %08x\n", STM32_SDMMC_DCOUNT_OFFSET,  regs->dcount);
-  mcinfo("    STA[%08x]: %08x\n", STM32_SDMMC_STA_OFFSET,     regs->sta);
-  mcinfo("   MASK[%08x]: %08x\n", STM32_SDMMC_MASK_OFFSET,    regs->mask);
+  mcinfo("  POWER[%08x]: %08" PRIx8 "\n", STM32_SDMMC_POWER_OFFSET,
+         regs->power);
+  mcinfo("  CLKCR[%08x]: %08" PRIx16 "\n", STM32_SDMMC_CLKCR_OFFSET,
+         regs->clkcr);
+  mcinfo("  DCTRL[%08x]: %08" PRIx16 "\n", STM32_SDMMC_DCTRL_OFFSET,
+         regs->dctrl);
+  mcinfo(" DTIMER[%08x]: %08" PRIx32 "\n", STM32_SDMMC_DTIMER_OFFSET,
+         regs->dtimer);
+  mcinfo("   DLEN[%08x]: %08" PRIx32 "\n", STM32_SDMMC_DLEN_OFFSET,
+         regs->dlen);
+  mcinfo(" DCOUNT[%08x]: %08" PRIx32 "\n", STM32_SDMMC_DCOUNT_OFFSET,
+         regs->dcount);
+  mcinfo("    STA[%08x]: %08" PRIx32 "\n", STM32_SDMMC_STA_OFFSET,
+         regs->sta);
+  mcinfo("   MASK[%08x]: %08" PRIx32 "\n", STM32_SDMMC_MASK_OFFSET,
+         regs->mask);
 }
 #endif
 
@@ -1403,7 +1412,7 @@ static void stm32_eventtimeout(wdparm_t arg)
   DEBUGASSERT((priv->waitevents & SDIOWAIT_TIMEOUT) != 0 ||
               priv->wkupevent != 0);
 
-  mcinfo("sta: %08x enabled irq: %08x\n",
+  mcinfo("sta: %08" PRIx32 " enabled irq: %08" PRIx32 "\n",
          sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET),
          sdmmc_getreg32(priv, STM32_SDMMC_MASK_OFFSET));
 
@@ -1414,7 +1423,7 @@ static void stm32_eventtimeout(wdparm_t arg)
       /* Yes.. wake up any waiting threads */
 
       stm32_endwait(priv, SDIOWAIT_TIMEOUT);
-      mcerr("Timeout: remaining: %d\n", priv->remaining);
+      mcerr("Timeout: remaining: %u\n", priv->remaining);
     }
 }
 
@@ -1712,7 +1721,7 @@ static int stm32_sdmmc_interrupt(int irq, void *context, void *arg)
                *  Sets STM32_SDMMC_ICR_DCRCFAILC
                */
 
-              mcerr("ERROR: Data block CRC failure, remaining: %d\n",
+              mcerr("ERROR: Data block CRC failure, remaining: %u\n",
                     priv->remaining);
 
               stm32_endtransfer(priv,
@@ -1727,7 +1736,7 @@ static int stm32_sdmmc_interrupt(int irq, void *context, void *arg)
                *  Sets STM32_SDMMC_ICR_DTIMEOUTC
                */
 
-              mcerr("ERROR: Data timeout, remaining: %d\n",
+              mcerr("ERROR: Data timeout, remaining: %u\n",
                     priv->remaining);
 
               stm32_endtransfer(priv, SDIOWAIT_TRANSFERDONE |
@@ -1742,7 +1751,7 @@ static int stm32_sdmmc_interrupt(int irq, void *context, void *arg)
                * Sets STM32_SDMMC_ICR_RXOVERRC
                */
 
-              mcerr("ERROR: RX FIFO overrun, remaining: %d\n",
+              mcerr("ERROR: RX FIFO overrun, remaining: %u\n",
                     priv->remaining);
 
               stm32_endtransfer(priv, SDIOWAIT_TRANSFERDONE |
@@ -1757,7 +1766,7 @@ static int stm32_sdmmc_interrupt(int irq, void *context, void *arg)
                * Sets STM32_SDMMC_ICR_TXUNDERRC
                */
 
-              mcerr("ERROR: TX FIFO underrun, remaining: %d\n",
+              mcerr("ERROR: TX FIFO underrun, remaining: %u\n",
                     priv->remaining);
 
               stm32_endtransfer(priv, SDIOWAIT_TRANSFERDONE |
@@ -1943,7 +1952,7 @@ static void stm32_reset(FAR struct sdio_dev_s *dev)
 
   leave_critical_section(flags);
 
-  mcinfo("CLCKR: %08x POWER: %08x\n",
+  mcinfo("CLCKR: %08" PRIx32 " POWER: %08" PRIx32 "\n",
          sdmmc_getreg32(priv, STM32_SDMMC_CLKCR_OFFSET),
          sdmmc_getreg32(priv, STM32_SDMMC_POWER_OFFSET));
 }
@@ -2212,7 +2221,8 @@ static int stm32_sendcmd(FAR struct sdio_dev_s *dev, uint32_t cmd,
   sdmmc_putreg32(priv, STM32_SDMMC_CMDDONE_ICR | STM32_SDMMC_RESPDONE_ICR,
                  STM32_SDMMC_ICR_OFFSET);
 
-  mcinfo("cmd: %08x arg: %08x regval: %08x enabled irq: %08x\n",
+  mcinfo("cmd: %08" PRIx32 " arg: %08" PRIx32 " regval: %08" PRIx32
+         " enabled irq: %08" PRIx32 "\n",
          cmd, arg, regval, sdmmc_getreg32(priv, STM32_SDMMC_MASK_OFFSET));
 
   /* Write the SDIO CMD */
@@ -2486,7 +2496,8 @@ static int stm32_waitresponse(FAR struct sdio_dev_s *dev, uint32_t cmd)
     {
       if (--timeout <= 0)
         {
-          mcerr("ERROR: Timeout cmd: %08x events: %08x STA: %08x\n",
+          mcerr("ERROR: Timeout cmd: %08" PRIx32 " events: %08" PRIx32
+                " STA: %08" PRIx32 "\n",
                 cmd, events, sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET));
 
           return -ETIMEDOUT;
@@ -2565,7 +2576,7 @@ static int stm32_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R5_RESPONSE &&
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R6_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2576,12 +2587,12 @@ static int stm32_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
       regval = sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET);
       if ((regval & STM32_SDMMC_STA_CTIMEOUT) != 0)
         {
-          mcerr("ERROR: Command timeout: %08x\n", regval);
+          mcerr("ERROR: Command timeout: %08" PRIx32 "\n", regval);
           ret = -ETIMEDOUT;
         }
       else if ((regval & STM32_SDMMC_STA_CCRCFAIL) != 0)
         {
-          mcerr("ERROR: CRC failure: %08x\n", regval);
+          mcerr("ERROR: CRC failure: %08" PRIx32 "\n", regval);
           ret = -EIO;
         }
 #if defined(CONFIG_DEBUG_FEATURES)
@@ -2593,7 +2604,8 @@ static int stm32_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
           if ((uint8_t)(respcmd & STM32_SDMMC_RESPCMD_MASK) !=
               (cmd & MMCSD_CMDIDX_MASK))
             {
-              mcerr("ERROR: RESCMD=%02x CMD=%08x\n", respcmd, cmd);
+              mcerr("ERROR: RESCMD=%02" PRIx32 " CMD=%08" PRIx32
+                    "\n", respcmd, cmd);
               ret = -EINVAL;
             }
         }
@@ -2631,7 +2643,7 @@ static int stm32_recvlong(FAR struct sdio_dev_s *dev, uint32_t cmd,
 
   if ((cmd & MMCSD_RESPONSE_MASK) != MMCSD_R2_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2642,12 +2654,12 @@ static int stm32_recvlong(FAR struct sdio_dev_s *dev, uint32_t cmd,
       regval = sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET);
       if (regval & STM32_SDMMC_STA_CTIMEOUT)
         {
-          mcerr("ERROR: Timeout STA: %08x\n", regval);
+          mcerr("ERROR: Timeout STA: %08" PRIx32 "\n", regval);
           ret = -ETIMEDOUT;
         }
       else if (regval & STM32_SDMMC_STA_CCRCFAIL)
         {
-          mcerr("ERROR: CRC fail STA: %08x\n", regval);
+          mcerr("ERROR: CRC fail STA: %08" PRIx32 "\n", regval);
           ret = -EIO;
         }
     }
@@ -2690,7 +2702,7 @@ static int stm32_recvshort(FAR struct sdio_dev_s *dev, uint32_t cmd,
       (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R4_RESPONSE &&
       (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R7_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2703,7 +2715,7 @@ static int stm32_recvshort(FAR struct sdio_dev_s *dev, uint32_t cmd,
       regval = sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET);
       if (regval & STM32_SDMMC_STA_CTIMEOUT)
         {
-          mcerr("ERROR: Timeout STA: %08x\n", regval);
+          mcerr("ERROR: Timeout STA: %08" PRIx32 "\n", regval);
           ret = -ETIMEDOUT;
         }
     }
@@ -2969,7 +2981,7 @@ static void stm32_callbackenable(FAR struct sdio_dev_s *dev,
 {
   struct stm32_dev_s *priv = (struct stm32_dev_s *)dev;
 
-  mcinfo("eventset: %02x\n", eventset);
+  mcinfo("eventset: %02" PRIx8 "\n", eventset);
   DEBUGASSERT(priv != NULL);
 
   priv->cbevents = eventset;
@@ -3050,8 +3062,8 @@ static int stm32_dmapreflight(FAR struct sdio_dev_s *dev,
           (uintptr_t)buffer + buflen <= SRAM4_END))
         {
           mcerr("invalid IDMA address "
-                "buffer:0x%08x end:0x%08x\n",
-                buffer, buffer + buflen - 1);
+                "buffer:0x%08" PRIxPTR " end:0x%08" PRIxPTR "\n",
+                (uintptr_t)buffer, (uintptr_t)(buffer + buflen - 1));
           return -EFAULT;
         }
     }
@@ -3070,7 +3082,7 @@ static int stm32_dmapreflight(FAR struct sdio_dev_s *dev,
       ((uintptr_t)(buffer + buflen) & (ARMV7M_DCACHE_LINESIZE - 1)) != 0))
     {
       mcerr("dcache unaligned "
-            "buffer:0x%08x end:0x%08x\n",
+            "buffer:%p end:%p\n",
             buffer, buffer + buflen - 1);
       return -EFAULT;
     }
@@ -3282,7 +3294,7 @@ static void stm32_callback(void *arg)
   /* Is a callback registered? */
 
   DEBUGASSERT(priv != NULL);
-  mcinfo("Callback %p(%p) cbevents: %02x cdstatus: %02x\n",
+  mcinfo("Callback %p(%p) cbevents: %02" PRIx8 " cdstatus: %02" PRIx8 "\n",
          priv->callback, priv->cbarg, priv->cbevents, priv->cdstatus);
 
   if (priv->callback)
@@ -3518,7 +3530,8 @@ void sdio_mediachange(FAR struct sdio_dev_s *dev, bool cardinslot)
 
   leave_critical_section(flags);
 
-  mcinfo("cdstatus OLD: %02x NEW: %02x\n", cdstatus, priv->cdstatus);
+  mcinfo("cdstatus OLD: %02" PRIx8 " NEW: %02" PRIx8 "\n",
+         cdstatus, priv->cdstatus);
 
   /* Perform any requested callback if the status has changed */
 
@@ -3561,7 +3574,7 @@ void sdio_wrprotect(FAR struct sdio_dev_s *dev, bool wrprotect)
       priv->cdstatus &= ~SDIO_STATUS_WRPROTECTED;
     }
 
-  mcinfo("cdstatus: %02x\n", priv->cdstatus);
+  mcinfo("cdstatus: %02" PRIx8 "\n", priv->cdstatus);
   leave_critical_section(flags);
 }
 #endif /* CONFIG_STM32H7_SDMMC1 || CONFIG_STM32H7_SDMMC2 */

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -48,6 +48,7 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -1026,11 +1027,13 @@ static inline void spi_writebyte(FAR struct stm32_spidev_s *priv,
 #ifdef CONFIG_DEBUG_SPI_INFO
 static void spi_dumpregs(FAR struct stm32_spidev_s *priv)
 {
-  spiinfo("CR1: 0x%08x CFG1: 0x%08x CFG2: 0x%08x\n",
+  spiinfo("CR1: 0x%08" PRIx32 " CFG1: 0x%08" PRIx32
+          " CFG2: 0x%08" PRIx32 "\n",
           spi_getreg(priv, STM32_SPI_CR1_OFFSET),
           spi_getreg(priv, STM32_SPI_CFG1_OFFSET),
           spi_getreg(priv, STM32_SPI_CFG2_OFFSET));
-  spiinfo("IER: 0x%08x SR: 0x%08x I2SCFGR: 0x%08x\n",
+  spiinfo("IER: 0x%08" PRIx32 " SR: 0x%08" PRIx32
+          " I2SCFGR: 0x%08" PRIx32 "\n",
           spi_getreg(priv, STM32_SPI_IER_OFFSET),
           spi_getreg(priv, STM32_SPI_SR_OFFSET),
           spi_getreg(priv, STM32_SPI_I2SCFGR_OFFSET));
@@ -1527,7 +1530,7 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
        * will be faster.
        */
 
-      spiinfo("Frequency %d->%d\n", frequency, actual);
+      spiinfo("Frequency %" PRId32 "->%" PRId32 "\n", frequency, actual);
 
       priv->frequency = frequency;
       priv->actual    = actual;
@@ -1557,7 +1560,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
   uint32_t setbits = 0;
   uint32_t clrbits = 0;
 
-  spiinfo("mode=%d\n", mode);
+  spiinfo("mode=%" PRIx32 "\n", (uint32_t) mode);
 
   /* Has the mode changed? */
 
@@ -1697,7 +1700,7 @@ static int spi_hwfeatures(FAR struct spi_dev_s *dev,
   uint32_t setbits = 0;
   uint32_t clrbits = 0;
 
-  spiinfo("features=%08x\n", features);
+  spiinfo("features=%08" PRIx8 "\n", features);
 
   /* Transfer data LSB first? */
 
@@ -1802,11 +1805,13 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
 
   if (priv->nbits > 8)
     {
-      spiinfo("Sent: %04x Return: %04x Status: %02x\n", wd, ret, regval);
+      spiinfo("Sent: %04" PRIx32 " Return: %04" PRIx32 " Status: %02" PRIx32
+              "\n", wd, ret, regval);
     }
   else
     {
-      spiinfo("Sent: %02x Return: %02x Status: %02x\n", wd, ret, regval);
+      spiinfo("Sent: %02" PRIx32 " Return: %02" PRIx32 " Status: %02" PRIx32
+              "\n", wd, ret, regval);
     }
 
   UNUSED(regval);


### PR DESCRIPTION
## Summary

Use the intypes in syslog macros.

## Impact

Allows files to compile.

## Testing

CI
