### PR TITLE
stm32_pwm: improvements for PULSECOUNT support

### DIFF
--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -3384,7 +3384,8 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
 
   DEBUGASSERT(priv != NULL && info != NULL);
 
-  pwminfo("TIM%u channel: %u frequency: %u duty: %08x count: %u\n",
+  pwminfo("TIM%u channel: %u frequency: %" PRIx32 " duty: %08" PRIx32
+          " count: %" PRIx32 "\n",
           priv->timid, priv->channels[0].channel, info->frequency,
           info->duty, info->count);
 
@@ -3873,7 +3874,7 @@ static int pwm_interrupt(FAR struct pwm_lowerhalf_s *dev)
    * output.
    */
 
-  pwminfo("Update interrupt SR: %04x prev: %u curr: %u count: %u\n",
+  pwminfo("Update interrupt SR: %04x prev: %u curr: %u count: %" PRIx32 "\n",
           regval, priv->prev, priv->curr, priv->count);
 
   return OK;
@@ -4358,7 +4359,7 @@ static int pwm_start_pulsecount(FAR struct pwm_lowerhalf_s *dev,
 
       if (priv->timtype != TIMTYPE_ADVANCED)
         {
-          pwmerr("ERROR: TIM%u cannot support pulse count: %u\n",
+          pwmerr("ERROR: TIM%u cannot support pulse count: %" PRIx32 "\n",
                  priv->timid, info->count);
           return -EPERM;
         }

--- a/drivers/timers/pwm.c
+++ b/drivers/timers/pwm.c
@@ -131,7 +131,7 @@ static void pwm_dump(FAR const char *msg, FAR const struct pwm_info_s *info,
 #endif
 
 #ifdef CONFIG_PWM_PULSECOUNT
-  pwminfo(" count: %d\n", info->count);
+  pwminfo(" count: %" PRIx32 "\n", info->count);
 #endif
 
   pwminfo(" started: %d\n", started);


### PR DESCRIPTION
## Summary
- drivers/timers/pwm.c: fix compilation warnings
- stm32_pwm.c: fix compilation warnings
- stm32_pwm: fixes for PULSECOUNT support:
    1. generate an indefinite number of pulses when info->count = 0
    2. timers that don't support pulse-count shouldn't use pulse-count logic

## Impact

## Testing
PWM example on nucleo-f446re with TIM1 PWM and TIM2 PWM enabled.
