### PR TITLE
avr32dev1: Fix compilation problems for default configuration

### DIFF
--- a/arch/avr/src/at32uc3/at32uc3_gpioirq.c
+++ b/arch/avr/src/at32uc3/at32uc3_gpioirq.c
@@ -211,7 +211,7 @@ static void gpio_porthandler(uint32_t regbase, int irqbase,
               xcpt_t handler = g_gpiohandler[irq].handler;
               if (handler != NULL)
                 {
-                  handler(irq, contex, g_gpiohandler[irq].arg);
+                  handler(irq, context, g_gpiohandler[irq].arg);
                 }
               else
                 {

--- a/boards/avr/at32uc3/avr32dev1/src/Makefile
+++ b/boards/avr/at32uc3/avr32dev1/src/Makefile
@@ -27,5 +27,7 @@ endif
 ifeq ($(CONFIG_ARCH_BUTTONS),y)
 CSRCS += avr32_buttons.c
 endif
+CSRCS += avr32_appinit.c
+CSRCS += avr32_bringup.c
 
 include $(TOPDIR)/boards/Board.mk

--- a/boards/avr/at32uc3/avr32dev1/src/avr32_appinit.c
+++ b/boards/avr/at32uc3/avr32dev1/src/avr32_appinit.c
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * boards/avr/at32uc3/avr32dev1/src/avr32_appinit.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include <arch/board/board.h>
+
+#include "avr32dev1.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_app_initialize
+ *
+ * Description:
+ *   Perform application specific initialization.  This function is never
+ *   called directly from application code, but only indirectly via the
+ *   (non-standard) boardctl() interface using the command BOARDIOC_INIT.
+ *
+ * Input Parameters:
+ *   arg - The boardctl() argument is passed to the board_app_initialize()
+ *         implementation without modification.  The argument has no
+ *         meaning to NuttX; the meaning of the argument is a contract
+ *         between the board-specific initialization logic and the
+ *         matching application logic.  The value could be such things as a
+ *         mode enumeration value, a set of DIP switch switch settings, a
+ *         pointer to configuration data read from a file or serial FLASH,
+ *         or whatever you would like to do with it.  Every implementation
+ *         should accept zero/NULL as a default configuration.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   any failure to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+int board_app_initialize(uintptr_t arg)
+{
+#ifndef CONFIG_BOARD_LATE_INITIALIZE
+  /* Perform board initialization */
+
+  return avr32_bringup();
+#else
+  return OK;
+#endif /* CONFIG_BOARD_LATE_INITIALIZE */
+}

--- a/boards/avr/at32uc3/avr32dev1/src/avr32_bringup.c
+++ b/boards/avr/at32uc3/avr32dev1/src/avr32_bringup.c
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * boards/avr/at32uc3/avr32dev1/src/avr32_bringup.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <debug.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: avr32_bringup
+ *
+ * Description:
+ *   Bring up board features
+ *
+ ****************************************************************************/
+
+int avr32_bringup(void)
+{
+  int ret = OK;
+
+  #warning "Not Implemented"
+
+  return ret;
+}


### PR DESCRIPTION

Firstly, many thanks for NuttX.

## Summary

I am attempting to bring NuttX to the Mizar32 platform [1] designed by
SimpleMachines, Italy. I checked arch/avr to see what is already
supported. I am trying to evaluate the parts of code I can reuse for
AT32UC3A0.

I simply tried compiling the code with its default configuration. This
PR fixes the compilation problems for avr32dev1.

## Impact

Not applicable.

## Testing

Unfortunately, I don't have an avr32dev1 kit. This PR doesn't
introduce any new code. The bringup and initialize functions return OK for
now.

I noticed the PIN_MUX changes between AT32UC3B0256 and AT32UC3A0256
(reference manual). Perhaps with UART1 pin specific (and clock)
changes, I hope I can get `nsh' working on Mizar32 though.

Please let me know if this acceptable OR if there's anything else I
can do to help. Thanks.

References:
[1]: https://simplemachines.it/index.php/historical-projects/mizar-project

