### PR TITLE
tools/nxstyle: Add _Atomic keyword to whitelisted words

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -221,6 +221,10 @@ static const char *g_white_list[] =
 
   "_Exit",
 
+  /* Ref:  stdatomic.h */
+
+  "_Atomic",
+
   /* Ref:  unwind-arm-common.h */
 
   "_Unwind",


### PR DESCRIPTION
## Summary
This PR intends to add the _Atomic keyword from the C11 standard to the whitelisted words in **nxstyle**.

## Impact
No impact.

## Testing
Simply defined an `_Atomic` qualified variable and checked that nxstyle no longer reported the `Mixed case identifier found` error.
