### PR TITLE
STM32 {F7|H7} Use 250 Ms Data path timeout, regardless of Card Clock frequency

### DIFF
--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -153,7 +153,7 @@
 #  define SDIO_CLKCR_EDGE SDIO_CLKCR_RISINGEDGE
 #endif
 
-/* Mode dependent settings.  These depend on clock devisor settings that must
+/* Mode dependent settings.  These depend on clock divisor settings that must
  * be defined in the board-specific board.h header file: SDIO_INIT_CLKDIV,
  * SDIO_MMCXFR_CLKDIV, and SDIO_SDXFR_CLKDIV.
  */
@@ -172,9 +172,12 @@
 #define SDIO_CMDTIMEOUT          (100000)
 #define SDIO_LONGTIMEOUT         (0x7fffffff)
 
-/* Big DTIMER setting */
+/* DTIMER setting */
 
-#define SDIO_DTIMER_DATATIMEOUT  (0x000fffff)
+/* Assuming Max timeout in bypass 48 Mhz */
+
+#define IP_CLCK_FREQ               UINT32_C(48000000)
+#define SDIO_DTIMER_DATATIMEOUT_MS 250
 
 /* DMA channel/stream configuration register settings.  The following
  * must be selected.  The DMA driver will select the remaining fields.
@@ -1016,9 +1019,24 @@ static uint8_t stm32_log2(uint16_t value)
 
 static void stm32_dataconfig(uint32_t timeout, uint32_t dlen, uint32_t dctrl)
 {
-  uint32_t regval = 0;
+  uint32_t clkdiv;
+  uint32_t regval;
+  uint32_t sdio_clk = IP_CLCK_FREQ;
 
-  /* Enable data path */
+  /* Enable data path using a timeout scaled to the SD_CLOCK (the card
+   * clock).
+   */
+
+  regval = getreg32(STM32_SDIO_CLKCR);
+  clkdiv = (regval & SDIO_CLKCR_CLKDIV_MASK) >> SDIO_CLKCR_CLKDIV_SHIFT;
+  if ((regval & SDIO_CLKCR_BYPASS) == 0)
+    {
+      sdio_clk = sdio_clk / (2 + clkdiv);
+    }
+
+  /*  Convert Timeout in Ms to SD_CLK counts */
+
+  timeout  = timeout * (sdio_clk / 1000);
 
   putreg32(timeout, STM32_SDIO_DTIMER); /* Set DTIMER */
   putreg32(dlen,    STM32_SDIO_DLEN);   /* Set DLEN */
@@ -1049,10 +1067,15 @@ static void stm32_datadisable(void)
 {
   uint32_t regval;
 
-  /* Disable the data path */
+  /* Disable the data path  */
 
-  putreg32(SDIO_DTIMER_DATATIMEOUT, STM32_SDIO_DTIMER); /* Reset DTIMER */
-  putreg32(0,                       STM32_SDIO_DLEN);   /* Reset DLEN */
+  /* Reset DTIMER */
+
+  putreg32(UINT32_MAX, STM32_SDIO_DTIMER);
+
+  /* Reset DLEN */
+
+  putreg32(0, STM32_SDIO_DLEN);
 
   /* Reset DCTRL DTEN, DTDIR, DTMODE, DMAEN, and DBLOCKSIZE fields */
 
@@ -1992,7 +2015,7 @@ static int stm32_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
       dblocksize = stm32_log2(nbytes) << SDIO_DCTRL_DBLOCKSIZE_SHIFT;
     }
 
-  stm32_dataconfig(SDIO_DTIMER_DATATIMEOUT, nbytes,
+  stm32_dataconfig(SDIO_DTIMER_DATATIMEOUT_MS, nbytes,
                    dblocksize | SDIO_DCTRL_DTDIR);
 
   /* And enable interrupts */
@@ -2057,7 +2080,7 @@ static int stm32_sendsetup(FAR struct sdio_dev_s *dev,
       dblocksize = stm32_log2(nbytes) << SDIO_DCTRL_DBLOCKSIZE_SHIFT;
     }
 
-  stm32_dataconfig(SDIO_DTIMER_DATATIMEOUT, nbytes, dblocksize);
+  stm32_dataconfig(SDIO_DTIMER_DATATIMEOUT_MS, nbytes, dblocksize);
 
   /* Enable TX interrupts */
 
@@ -2800,7 +2823,7 @@ static int stm32_dmarecvsetup(FAR struct sdio_dev_s *dev,
       dblocksize = stm32_log2(buflen) << SDIO_DCTRL_DBLOCKSIZE_SHIFT;
     }
 
-  stm32_dataconfig(SDIO_DTIMER_DATATIMEOUT, buflen,
+  stm32_dataconfig(SDIO_DTIMER_DATATIMEOUT_MS, buflen,
                    dblocksize | SDIO_DCTRL_DTDIR);
 
   /* Configure the RX DMA */
@@ -2880,7 +2903,7 @@ static int stm32_dmasendsetup(FAR struct sdio_dev_s *dev,
       dblocksize = stm32_log2(buflen) << SDIO_DCTRL_DBLOCKSIZE_SHIFT;
     }
 
-  stm32_dataconfig(SDIO_DTIMER_DATATIMEOUT, buflen, dblocksize);
+  stm32_dataconfig(SDIO_DTIMER_DATATIMEOUT_MS, buflen, dblocksize);
 
   /* Configure the TX DMA */
 

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -49,6 +49,7 @@
 #include "stm32_dtcm.h"
 #include "stm32_dma.h"
 #include "stm32_gpio.h"
+#include "stm32_rcc.h"
 #include "stm32_sdmmc.h"
 
 #if defined(CONFIG_STM32F7_SDMMC1) || defined(CONFIG_STM32F7_SDMMC2)
@@ -130,6 +131,11 @@
 #  else
 #    undef CONFIG_STM32F7_SDMMC1_DMAPRIO
 #  endif
+#  if STM32_RCC_DCKCFGR2_SDMMCSRC == RCC_DCKCFGR2_SDMMCSEL_48MHZ
+#      define STM32_SDMMC1_CLK UINT32_C(48000000)
+#  else
+#      define STM32_SDMMC1_CLK STM32_SYSCLK_FREQUENCY
+#  endif
 #endif
 
 #ifdef CONFIG_STM32F7_SDMMC2
@@ -142,6 +148,11 @@
 #    endif
 #  else
 #    undef CONFIG_STM32F7_SDMMC2_DMAPRIO
+#  endif
+#  if STM32_RCC_DCKCFGR2_SDMMCSRC == RCC_DCKCFGR2_SDMMCSEL_48MHZ
+#      define STM32_SDMMC2_CLK UINT32_C(48000000)
+#  else
+#      define STM32_SDMMC2_CLK STM32_SYSCLK_FREQUENCY
 #  endif
 #endif
 
@@ -214,9 +225,9 @@
 #define SDMMC_CMDTIMEOUT         (100000)
 #define SDMMC_LONGTIMEOUT        (0x7fffffff)
 
-/* Big DTIMER setting */
+/* DTIMER setting */
 
-#define SDMMC_DTIMER_DATATIMEOUT (0x003d0900) /* 250 ms @ 16 MHz */
+#define SDMMC_DTIMER_DATATIMEOUT_MS 250
 
 /* DMA channel/stream configuration register settings.  The following
  * must be selected.  The DMA driver will select the remaining fields.
@@ -368,6 +379,7 @@ struct stm32_dev_s
 
   uint32_t          base;
   int               nirq;
+  uint32_t          sdio_clk;
 #ifdef CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE
   uint32_t          d0_gpio;
 #endif
@@ -625,6 +637,7 @@ struct stm32_dev_s g_sdmmcdev1 =
   },
   .base              = STM32_SDMMC1_BASE,
   .nirq              = STM32_IRQ_SDMMC1,
+  .sdio_clk          = STM32_SDMMC1_CLK,
 #ifdef CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE
   .d0_gpio           = SDMMC1_SDIO_PULL(GPIO_SDMMC1_D0),
 #endif
@@ -684,6 +697,7 @@ struct stm32_dev_s g_sdmmcdev2 =
   },
   .base              = STM32_SDMMC2_BASE,
   .nirq              = STM32_IRQ_SDMMC2,
+  .sdio_clk          = STM32_SDMMC2_CLK,
 #ifdef CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE
   .d0_gpio           = SDMMC2_SDIO_PULL(GPIO_SDMMC2_D0),
 #endif
@@ -1223,9 +1237,26 @@ static uint8_t stm32_log2(uint16_t value)
 static void stm32_dataconfig(struct stm32_dev_s *priv, uint32_t timeout,
                              uint32_t dlen, uint32_t dctrl)
 {
-  uint32_t regval = 0;
+  uint32_t clkdiv;
+  uint32_t regval;
+  uint32_t sdio_clk = priv->sdio_clk;
 
-  /* Enable data path */
+  /* Enable data path using a timeout scaled to the SD_CLOCK (the card
+   * clock).
+   */
+
+  regval = sdmmc_getreg32(priv, STM32_SDMMC_CLKCR_OFFSET);
+  clkdiv = (regval & STM32_SDMMC_CLKCR_CLKDIV_MASK) >>
+            STM32_SDMMC_CLKCR_CLKDIV_SHIFT;
+
+  if ((regval & STM32_SDMMC_CLKCR_BYPASS) == 0)
+    {
+      sdio_clk = sdio_clk / (2 + clkdiv);
+    }
+
+  /*  Convert Timeout in Ms to SD_CLK counts */
+
+  timeout  = timeout * (sdio_clk / 1000);
 
   sdmmc_putreg32(priv, timeout, STM32_SDMMC_DTIMER_OFFSET); /* Set DTIMER */
   sdmmc_putreg32(priv, dlen,    STM32_SDMMC_DLEN_OFFSET);   /* Set DLEN */
@@ -1271,8 +1302,11 @@ static void stm32_datadisable(struct stm32_dev_s *priv)
 
   /* Reset DTIMER */
 
-  sdmmc_putreg32(priv, SDMMC_DTIMER_DATATIMEOUT, STM32_SDMMC_DTIMER_OFFSET);
-  sdmmc_putreg32(priv, 0, STM32_SDMMC_DLEN_OFFSET);   /* Reset DLEN */
+  sdmmc_putreg32(priv, UINT32_MAX, STM32_SDMMC_DTIMER_OFFSET);
+
+  /* Reset DLEN */
+
+  sdmmc_putreg32(priv,  0, STM32_SDMMC_DLEN_OFFSET);
 
   /* Reset DCTRL DTEN, DTDIR, DTMODE, DMAEN, and DBLOCKSIZE fields */
 
@@ -2254,8 +2288,8 @@ static int stm32_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
 
   dblksize = stm32_log2(priv->blocksize) <<
              STM32_SDMMC_DCTRL_DBLOCKSIZE_SHIFT;
-  stm32_dataconfig(priv, SDMMC_DTIMER_DATATIMEOUT * ((nbytes + 511) >> 9),
-                   nbytes, dblksize | STM32_SDMMC_DCTRL_DTDIR);
+  stm32_dataconfig(priv, SDMMC_DTIMER_DATATIMEOUT_MS, nbytes,
+                   dblksize | STM32_SDMMC_DCTRL_DTDIR);
 
   /* And enable interrupts */
 
@@ -2310,8 +2344,7 @@ static int stm32_sendsetup(FAR struct sdio_dev_s *dev, FAR const
 
   dblksize = stm32_log2(priv->blocksize) <<
              STM32_SDMMC_DCTRL_DBLOCKSIZE_SHIFT;
-  stm32_dataconfig(priv, SDMMC_DTIMER_DATATIMEOUT * ((nbytes + 511) >> 9),
-                   nbytes, dblksize);
+  stm32_dataconfig(priv, SDMMC_DTIMER_DATATIMEOUT_MS, nbytes, dblksize);
 
   /* Enable TX interrupts */
 
@@ -3061,8 +3094,8 @@ static int stm32_dmarecvsetup(FAR struct sdio_dev_s *dev,
 
   dblksize = stm32_log2(priv->blocksize) <<
              STM32_SDMMC_DCTRL_DBLOCKSIZE_SHIFT;
-  stm32_dataconfig(priv, SDMMC_DTIMER_DATATIMEOUT * ((buflen + 511) >> 9),
-                   buflen, dblksize | STM32_SDMMC_DCTRL_DTDIR);
+  stm32_dataconfig(priv, SDMMC_DTIMER_DATATIMEOUT_MS, buflen,
+                   dblksize | STM32_SDMMC_DCTRL_DTDIR);
 
   /* Configure the RX DMA */
 
@@ -3165,8 +3198,7 @@ static int stm32_dmasendsetup(FAR struct sdio_dev_s *dev,
 
   dblksize = stm32_log2(priv->blocksize) <<
              STM32_SDMMC_DCTRL_DBLOCKSIZE_SHIFT;
-  stm32_dataconfig(priv, SDMMC_DTIMER_DATATIMEOUT * ((buflen + 511) >> 9),
-                   buflen, dblksize);
+  stm32_dataconfig(priv, SDMMC_DTIMER_DATATIMEOUT_MS, buflen, dblksize);
 
   /* Configure the TX DMA */
 


### PR DESCRIPTION
## Summary

Timeouts were occurring on STMF4 based platforms on differnt SD card based on formatting, and age. For additional information [See](https://github.com/PX4/PX4-Autopilot/issues/17442#issuecomment-834209116) 

## Impact

The hard coded contestant would timeout at 100+ Ms. The spec is 250.

## Testing
PX4 fmu-v3 (stm32F4)
PX4 fmu-v5X (stm32F7)
PX4 fmu-v6X (stm32H7)
