### PR TITLE
binfmt/elf: Don't close filfd in the fail path

### DIFF
--- a/binfmt/libelf/libelf_init.c
+++ b/binfmt/libelf/libelf_init.c
@@ -161,7 +161,6 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
   if (ret < 0)
     {
       berr("Failed to read ELF header: %d\n", ret);
-      nx_close(loadinfo->filfd);
       return ret;
     }
 
@@ -181,7 +180,6 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
        */
 
       berr("Bad ELF header: %d\n", ret);
-      nx_close(loadinfo->filfd);
       return ret;
     }
 


### PR DESCRIPTION
## Summary
to avoid close the same handle twice because
the caller also call elf_uninit in this case

## Impact
Fix the side effect by https://github.com/apache/incubator-nuttx/pull/3670

## Testing

