### PR TITLE
libc/pty: Make ptsname[_r] support PSEUDOTERM_BSD config too

### DIFF
--- a/include/cxx/cstdlib
+++ b/include/cxx/cstdlib
@@ -104,10 +104,8 @@ namespace std
 #ifdef CONFIG_PSEUDOTERM
   // Pseudo-Terminals
 
-#ifdef CONFIG_PSEUDOTERM_SUSV1
   using ::ptsname;
   using ::ptsname_r;
-#endif
   using ::unlockpt;
 #endif
 

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -211,12 +211,9 @@ int       posix_memalign(FAR void **, size_t, size_t);
 
 /* Pseudo-Terminals */
 
-#ifdef CONFIG_PSEUDOTERM_SUSV1
+#ifdef CONFIG_PSEUDOTERM
 FAR char *ptsname(int fd);
 int       ptsname_r(int fd, FAR char *buf, size_t buflen);
-#endif
-
-#ifdef CONFIG_PSEUDOTERM
 int       unlockpt(int fd);
 
 /* int grantpt(int fd); Not implemented */

--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -32,12 +32,8 @@ CSRCS += lib_mblen.c lib_mbtowc.c lib_wctomb.c
 CSRCS += lib_mbstowcs.c lib_wcstombs.c
 endif
 
-ifeq ($(CONFIG_PSEUDOTERM_SUSV1),y)
-CSRCS += lib_ptsname.c lib_ptsnamer.c
-endif
-
 ifeq ($(CONFIG_PSEUDOTERM),y)
-CSRCS += lib_unlockpt.c
+CSRCS += lib_ptsname.c lib_ptsnamer.c lib_unlockpt.c
 endif
 
 # Add the stdlib directory to the build

--- a/libs/libc/stdlib/lib_ptsname.c
+++ b/libs/libc/stdlib/lib_ptsname.c
@@ -26,7 +26,7 @@
 
 #include <stdlib.h>
 
-#ifdef CONFIG_PSEUDOTERM_SUSV1
+#ifdef CONFIG_PSEUDOTERM
 
 /****************************************************************************
  * Public Functions
@@ -55,4 +55,4 @@ FAR char *ptsname(int fd)
   return ret < 0 ? NULL : devname;
 }
 
-#endif /* CONFIG_PSEUDOTERM_SUSV1 */
+#endif /* CONFIG_PSEUDOTERM */

--- a/libs/libc/stdlib/lib_ptsnamer.c
+++ b/libs/libc/stdlib/lib_ptsnamer.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <assert.h>
 
-#ifdef CONFIG_PSEUDOTERM_SUSV1
+#ifdef CONFIG_PSEUDOTERM
 
 /****************************************************************************
  * Public Functions
@@ -73,8 +73,13 @@ int ptsname_r(int fd, FAR char *buf, size_t buflen)
    * error detection.
    */
 
+#ifdef CONFIG_PSEUDOTERM_SUSV1
   snprintf(buf, buflen, "/dev/pts/%d", ptyno);
+#else
+  snprintf(buf, buflen, "/dev/ttyp%d", ptyno);
+#endif
+
   return OK;
 }
 
-#endif /* CONFIG_PSEUDOTERM_SUSV1 */
+#endif /* CONFIG_PSEUDOTERM */


### PR DESCRIPTION
## Summary
It's very easy to support these two functions in PSEUDOTERM_BSD case, let's do it. 

## Impact
ptsname[_r] can work with the old BSD pseudo terminal.

## Testing

