### PR TITLE
drivers/serial: Change the default value of SERIAL_NPOLLWAITERS to 4

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -91,11 +91,10 @@ config STANDARD_SERIAL
 
 config SERIAL_NPOLLWAITERS
 	int "Number of poll threads"
-	default 2
-	depends on STANDARD_SERIAL
+	default 4
 	---help---
 		Maximum number of threads than can be waiting for POLL events.
-		Default: 2
+		Default: 4
 
 config SERIAL_IFLOWCONTROL
 	bool

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -45,7 +45,7 @@
 /* Maximum number of threads than can be waiting for POLL events */
 
 #ifndef CONFIG_SERIAL_NPOLLWAITERS
-#  define CONFIG_SERIAL_NPOLLWAITERS 2
+#  define CONFIG_SERIAL_NPOLLWAITERS 4
 #endif
 
 /* RX flow control */


### PR DESCRIPTION
## Summary
since the console is normally opened three time as stdin, stdout and
stderr and remove the dependence on STANDARD_SERIAL because other type
of serial drivers also support the poll through the same codebase.

## Impact
Can accept more poller at the same time

## Testing
with libssh
