### PR TITLE
tools/nxstyle: Extend check to any URI scheme

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1862,10 +1862,9 @@ int main(int argc, char **argv, char **envp)
 
               else if (line[n + 1] == '/')
                 {
-                  /* Check for "http://" or "https://" */
+                  /* Check for URI schemes, e.g. "http://" or "https://" */
 
-                  if ((n < 5 || strncmp(&line[n - 5], "http://", 7) != 0) &&
-                      (n < 6 || strncmp(&line[n - 6], "https://", 8) != 0))
+                  if (n == 0 || strncmp(&line[n - 1], "://", 3) != 0)
                     {
                       ERROR("C++ style comment", lineno, n);
                       n++;


### PR DESCRIPTION
## Summary
This PR intends to extend the **nxstyle** HTTP and HTTPS schemes checking to any string that matches the pattern "://".

It is a proposal for fixing the false positive from https://github.com/apache/incubator-nuttx-apps/pull/705.

There may be some scenarios that may induce false negatives, but I believe that will not be much frequent.

## Impact
No more false positive reports from nxstyle on schemes other than HTTP and HTTPS.

## Testing
https://github.com/apache/incubator-nuttx-apps/pull/705 successful check.
