### PR TITLE
drivers/sensors/hdc1008: add missing break

### DIFF
--- a/drivers/sensors/hdc1008.c
+++ b/drivers/sensors/hdc1008.c
@@ -299,6 +299,7 @@ static int hdc1008_set_operational_mode(struct hdc1008_dev_s *priv,
       case HDC1008_MEAS_T_AND_RH:
         {
           reg |= HDC1008_CONFIGURATION_MODE;
+          break;
         }
 
       default:


### PR DESCRIPTION
## Summary
Add missing break
It was not possible to use the HDC1008_MEAS_T_AND_RH operation mode since it was running the default case too.

## Impact
HCD1008 sensor

## Testing
Tested on custom board and it is now possible to use the DC1008_MEAS_T_AND_RH operation mode ioctl

Thanks!

