### PR TITLE
fs/eventfd: add EVENT_FD_POLL as a Kconfig dependency for EVENT_FD_NPOLLWAITERS

### DIFF
--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -82,6 +82,7 @@ config EVENT_FD_POLL
 config EVENT_FD_NPOLLWAITERS
 	int "Number of eventFD poll waiters"
 	default 2
+	depends on EVENT_FD_POLL
 	---help---
 		Maximum number of threads that can be waiting on poll()
 


### PR DESCRIPTION
## Summary
Add EVENT_FD_POLL as a Kconfig dependency for EVENT_FD_NPOLLWAITERS

## Impact

## Testing

