### PR TITLE
fs: nx_dup2 should return zero(OK) in the sucess

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -385,7 +385,7 @@ int fs_getfilep(int fd, FAR struct file **filep)
  *   Clone a file descriptor to a specific descriptor number.
  *
  * Returned Value:
- *   fd2 is returned on success; a negated errno value is return on
+ *   Zero (OK) is returned on success; a negated errno value is return on
  *   any failure.
  *
  ****************************************************************************/
@@ -432,7 +432,7 @@ int nx_dup2(int fd1, int fd2)
                                  [fd2 % CONFIG_NFILE_DESCRIPTORS_PER_BLOCK]);
   _files_semgive(list);
 
-  return ret < 0 ? ret : fd2;
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
to avoid the return value of dup2 become postive number.
Report here:
https://github.com/apache/incubator-nuttx-apps/pull/708

## Impact
Fix the regression by:
[fs: file_dup2 shouldn't hold the file list lock](https://github.com/apache/incubator-nuttx/commit/1e5bfa623aa93b918566e8dc0e2f9c1a1037f45e)

## Testing

