### PR TITLE
nuttx/fs/fs.h: Correct the comment for the return value of nx_dup2

### DIFF
--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -795,7 +795,7 @@ int file_dup2(FAR struct file *filep1, FAR struct file *filep2);
  *   applications.
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is return on
+ *   fd2 is returned on success; a negated errno value is return on
  *   any failure.
  *
  ****************************************************************************/


### PR DESCRIPTION
## Summary
See the discussion here:
https://github.com/apache/incubator-nuttx/pull/3682
https://github.com/apache/incubator-nuttx-apps/pull/708

## Impact
Minor, only change the comment

## Testing
Pass CI
