### PR TITLE
avr32dev1: USART1 RX: Reassign pin

### DIFF
--- a/boards/avr/at32uc3/avr32dev1/include/board.h
+++ b/boards/avr/at32uc3/avr32dev1/include/board.h
@@ -123,7 +123,7 @@
 
 /* Pin muliplexing selecion *************************************************/
 
-#define PINMUX_USART1_RXD     PINMUX_USART1_RXD_1
+#define PINMUX_USART1_RXD     PINMUX_USART1_RXD_2
 #define PINMUX_USART1_TXD     PINMUX_USART1_TXD_1
 
 /* LED definitions **********************************************************/


### PR DESCRIPTION
## Summary

The USART1's RX pin seems to be assigned incorrectly. This patch
assigns the right pin.

From the AVR32UC3B manual, I present the following:

  1) Previously, the RX pin was assigned to PA17, function D. The
  manual [1] mentions that function D is only available for UC3Bx512
  devices (page - 7). The AVR32DEV1 however uses a UC3B0256
  microcontroller. Hence, invalid.

  2) The newly assigned pin PA24 (Function A, USART1 - RXD) is the
  right choice for I/O over USART1.

## Impact

Not applicable.

## Testing

I am almost certain that this pin assignment is correct. But I don't
have an AVR32DEV1 with me yet.

References:
[1]: http://ww1.microchip.com/downloads/en/devicedoc/doc32059.pdf

