### PR TITLE
sched/task: Remove stack argument from nxtask_init

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -157,7 +157,7 @@ int exec_module(FAR const struct binary_s *binp)
   /* Initialize the task */
 
   ret = nxtask_init(tcb, binp->filename, binp->priority,
-                    NULL, binp->stacksize, binp->entrypt, binp->argv);
+                    binp->stacksize, binp->entrypt, binp->argv);
   if (ret < 0)
     {
       berr("nxtask_init() failed: %d\n", ret);

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -910,7 +910,6 @@ FAR struct streamlist *nxsched_get_streams(void);
  *   tcb        - Address of the new task's TCB
  *   name       - Name of the new task (not used)
  *   priority   - Priority of the new task
- *   stack      - Start of the pre-allocated stack
  *   stack_size - Size (in bytes) of the stack allocated
  *   entry      - Application start point of the new task
  *   argv       - A pointer to an array of input parameters.  The array
@@ -927,8 +926,7 @@ FAR struct streamlist *nxsched_get_streams(void);
  ********************************************************************************/
 
 int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
-                FAR void *stack, uint32_t stack_size, main_t entry,
-                FAR char * const argv[]);
+                uint32_t stack_size, main_t entry, FAR char * const argv[]);
 
 /********************************************************************************
  * Name: nxtask_uninit

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -91,7 +91,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, name, priority, NULL, stack_size, entry, argv);
+  ret = nxtask_init(tcb, name, priority, stack_size, entry, argv);
   if (ret < OK)
     {
       kmm_free(tcb);


### PR DESCRIPTION
## Summary
since nobody really pass the non-null stack pointer

## Impact
Minor

## Testing
Pass CI
