### PR TITLE
sched/spawn: Support the stack address argument

### DIFF
--- a/include/spawn.h
+++ b/include/spawn.h
@@ -85,7 +85,8 @@ struct posix_spawnattr_s
 #ifndef CONFIG_BUILD_KERNEL
   /* Used only by task_spawn (non-standard) */
 
-  size_t   stacksize;            /* Task stack size */
+  FAR void *stackaddr;           /* Task stack address */
+  size_t    stacksize;           /* Task stack size */
 #endif
 
 #ifdef CONFIG_SCHED_SPORADIC
@@ -211,8 +212,13 @@ int posix_spawnattr_setsigmask(FAR posix_spawnattr_t *attr,
  * task_spawn()
  */
 
+int task_spawnattr_getstackaddr(FAR const posix_spawnattr_t *attr,
+                                FAR void **stackaddr);
+int task_spawnattr_setstackaddr(FAR posix_spawnattr_t *attr,
+                                FAR void *stackaddr);
+
 int task_spawnattr_getstacksize(FAR const posix_spawnattr_t *attr,
-                                size_t *stacksize);
+                                FAR size_t *stacksize);
 int task_spawnattr_setstacksize(FAR posix_spawnattr_t *attr,
                                 size_t stacksize);
 

--- a/libs/libc/spawn/Make.defs
+++ b/libs/libc/spawn/Make.defs
@@ -32,6 +32,7 @@ CSRCS += lib_psa_init.c lib_psa_setflags.c lib_psa_setschedparam.c
 CSRCS += lib_psa_setschedpolicy.c lib_psa_getsigmask.c lib_psa_setsigmask.c
 
 ifneq ($(CONFIG_BUILD_KERNEL),y)
+CSRCS += lib_psa_getstackaddr.c lib_psa_setstackaddr.c
 CSRCS += lib_psa_getstacksize.c lib_psa_setstacksize.c
 ifeq ($(CONFIG_LIB_SYSCALL),y)
 CSRCS += lib_task_spawn.c

--- a/libs/libc/spawn/lib_psa_getstackaddr.c
+++ b/libs/libc/spawn/lib_psa_getstackaddr.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/spawn/lib_psa_getstacksize.c
+ * libs/libc/spawn/lib_psa_getstackaddr.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -35,16 +35,16 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: task_spawnattr_getstacksize
+ * Name: task_spawnattr_getstackaddr
  *
  * Description:
- *   The task_spawnattr_getstacksize() function will obtain the value of
- *   the spawn-stacksize attribute from the attributes object referenced
+ *   The task_spawnattr_getstackaddr() function will obtain the value of
+ *   the spawn-stackaddr attribute from the attributes object referenced
  *   by attr.
  *
  * Input Parameters:
  *   attr - The address spawn attributes to be queried.
- *   stacksize - The location to return the spawn-stacksize value.
+ *   stackaddr - The location to return the spawn-stackaddr value.
  *
  * Returned Value:
  *   On success, these functions return 0; on failure they return an error
@@ -52,11 +52,11 @@
  *
  ****************************************************************************/
 
-int task_spawnattr_getstacksize(FAR const posix_spawnattr_t *attr,
-                                FAR size_t *stacksize)
+int task_spawnattr_getstackaddr(FAR const posix_spawnattr_t *attr,
+                                FAR void **stackaddr)
 {
-  DEBUGASSERT(attr && stacksize);
-  *stacksize = attr->stacksize;
+  DEBUGASSERT(attr && stackaddr);
+  *stackaddr = attr->stackaddr;
   return OK;
 }
 

--- a/libs/libc/spawn/lib_psa_setstackaddr.c
+++ b/libs/libc/spawn/lib_psa_setstackaddr.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/spawn/lib_psa_getstacksize.c
+ * libs/libc/spawn/lib_psa_setstackaddr.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -35,16 +35,16 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: task_spawnattr_getstacksize
+ * Name: task_spawnattr_setstackaddr
  *
  * Description:
- *   The task_spawnattr_getstacksize() function will obtain the value of
- *   the spawn-stacksize attribute from the attributes object referenced
+ *   The task_spawnattr_setstackaddr() function shall set the spawn-
+ *   stackaddr attribute in an initialized attributes object referenced
  *   by attr.
  *
  * Input Parameters:
- *   attr - The address spawn attributes to be queried.
- *   stacksize - The location to return the spawn-stacksize value.
+ *   attr  - The address spawn attributes to be used.
+ *   stackaddr - The new stackaddr to set.
  *
  * Returned Value:
  *   On success, these functions return 0; on failure they return an error
@@ -52,11 +52,11 @@
  *
  ****************************************************************************/
 
-int task_spawnattr_getstacksize(FAR const posix_spawnattr_t *attr,
-                                FAR size_t *stacksize)
+int task_spawnattr_setstackaddr(FAR posix_spawnattr_t *attr,
+                                FAR void *stackaddr)
 {
-  DEBUGASSERT(attr && stacksize);
-  *stacksize = attr->stacksize;
+  DEBUGASSERT(attr);
+  attr->stackaddr = stackaddr;
   return OK;
 }
 


### PR DESCRIPTION
## Summary
This patch enable user pass the custom stack pointer.
Note: The upcoming patch will utilize the new argument.

## Impact
new API

## Testing

