### PR TITLE
docker: add ninja-build

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -203,6 +203,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   libxext-dev libxext-dev:i386 \
   linux-libc-dev:i386 \
   linux-headers-generic \
+  ninja-build \
   python3 \
   python3-pip \
   python-is-python3 \


### PR DESCRIPTION
## Summary

Add ninja-build to docker in order to support CMake ninja generation

## Impact

None, not used in mainline

## Testing

CI
