### PR TITLE
sched: Don't include nuttx/sched.h inside sched.h

### DIFF
--- a/arch/arm/src/common/arm_modifyreg16.c
+++ b/arch/arm/src/common/arm_modifyreg16.c
@@ -27,8 +27,7 @@
 #include <stdint.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
-#include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 

--- a/arch/arm/src/common/arm_modifyreg32.c
+++ b/arch/arm/src/common/arm_modifyreg32.c
@@ -27,8 +27,7 @@
 #include <stdint.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
-#include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 

--- a/arch/arm/src/common/arm_modifyreg8.c
+++ b/arch/arm/src/common/arm_modifyreg8.c
@@ -27,8 +27,7 @@
 #include <stdint.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
-#include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 

--- a/arch/arm/src/cxd56xx/cxd56_gpioint.c
+++ b/arch/arm/src/cxd56xx/cxd56_gpioint.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 #include "chip.h"

--- a/arch/arm/src/cxd56xx/cxd56_irq.c
+++ b/arch/arm/src/cxd56xx/cxd56_irq.c
@@ -30,7 +30,7 @@
 #include <nuttx/board.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <arch/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "chip.h"

--- a/arch/arm/src/cxd56xx/cxd56_rtc.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc.c
@@ -32,6 +32,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/wdog.h>
 #include <nuttx/clock.h>
 

--- a/arch/arm/src/cxd56xx/cxd56_uart.c
+++ b/arch/arm/src/cxd56xx/cxd56_uart.c
@@ -26,7 +26,7 @@
 
 #include <stdint.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include <errno.h>

--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -38,6 +38,7 @@
 #include <nuttx/wdog.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/signal.h>
 #include <nuttx/net/mii.h>

--- a/arch/arm/src/imxrt/imxrt_edma.c
+++ b/arch/arm/src/imxrt/imxrt_edma.c
@@ -55,6 +55,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/semaphore.h>
 
 #include "arm_arch.h"

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -38,6 +38,7 @@
 #include <nuttx/wdog.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/signal.h>
 #include <nuttx/net/mii.h>

--- a/arch/arm/src/imxrt/imxrt_hprtc.c
+++ b/arch/arm/src/imxrt/imxrt_hprtc.c
@@ -33,6 +33,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/timers/rtc.h>
 
 #include <arch/board/board.h>

--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -38,6 +38,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/init.h>
 #include <nuttx/power/pm.h>
 #include <nuttx/fs/ioctl.h>

--- a/arch/arm/src/imxrt/imxrt_wdog.c
+++ b/arch/arm/src/imxrt/imxrt_wdog.c
@@ -31,6 +31,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <nuttx/spinlock.h>
 #include <nuttx/timers/watchdog.h>
 
 #include "arm_arch.h"

--- a/arch/arm/src/lc823450/lc823450_dma.c
+++ b/arch/arm/src/lc823450/lc823450_dma.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 #include "lc823450_dma.h"

--- a/arch/arm/src/lc823450/lc823450_dvfs2.c
+++ b/arch/arm/src/lc823450/lc823450_dvfs2.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/clock.h>
 #include <arch/board/board.h>
 #include <string.h>

--- a/arch/arm/src/lc823450/lc823450_gpio.c
+++ b/arch/arm/src/lc823450/lc823450_gpio.c
@@ -26,6 +26,7 @@
 #include <nuttx/config.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <errno.h>
 #include <debug.h>
 

--- a/arch/arm/src/lc823450/lc823450_irq.c
+++ b/arch/arm/src/lc823450/lc823450_irq.c
@@ -29,7 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <arch/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/board.h>
 
 #include <arch/armv7-m/nvicpri.h>

--- a/arch/arm/src/lc823450/lc823450_syscontrol.c
+++ b/arch/arm/src/lc823450/lc823450_syscontrol.c
@@ -23,8 +23,8 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <stdint.h>
 #include <debug.h>
 

--- a/arch/arm/src/lc823450/lc823450_timer.c
+++ b/arch/arm/src/lc823450/lc823450_timer.c
@@ -29,6 +29,7 @@
 #include <time.h>
 #include <debug.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "nvic.h"

--- a/arch/arm/src/lc823450/lc823450_usbdev.c
+++ b/arch/arm/src/lc823450/lc823450_usbdev.c
@@ -39,6 +39,7 @@
 #endif
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/signal.h>
 #include <nuttx/usb/usb.h>

--- a/arch/arm/src/max326xx/max32660/max32660_dma.c
+++ b/arch/arm/src/max326xx/max32660/max32660_dma.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 

--- a/arch/arm/src/max326xx/max32660/max32660_gpio.c
+++ b/arch/arm/src/max326xx/max32660/max32660_gpio.c
@@ -28,7 +28,7 @@
 #include <stdint.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 

--- a/arch/arm/src/max326xx/max32660/max32660_lowputc.c
+++ b/arch/arm/src/max326xx/max32660/max32660_lowputc.c
@@ -27,6 +27,8 @@
 #include <stdbool.h>
 #include <fixedmath.h>
 
+#include <nuttx/spinlock.h>
+
 #include "arm_arch.h"
 #include "arm_internal.h"
 

--- a/arch/arm/src/max326xx/max32660/max32660_rtc.c
+++ b/arch/arm/src/max326xx/max32660/max32660_rtc.c
@@ -33,6 +33,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/clock.h>
 #include <nuttx/timers/rtc.h>
 

--- a/arch/arm/src/max326xx/max32660/max32660_serial.c
+++ b/arch/arm/src/max326xx/max32660/max32660_serial.c
@@ -34,6 +34,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/serial/serial.h>
 
 #include <arch/board/board.h>

--- a/arch/arm/src/max326xx/max32660/max32660_wdt.c
+++ b/arch/arm/src/max326xx/max32660/max32660_wdt.c
@@ -30,6 +30,7 @@
 #include <debug.h>
 
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/clock.h>
 #include <nuttx/timers/watchdog.h>
 #include <arch/board/board.h>

--- a/arch/arm/src/nrf52/nrf52_gpio.c
+++ b/arch/arm/src/nrf52/nrf52_gpio.c
@@ -30,7 +30,7 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <arch/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 #include "hardware/nrf52_gpio.h"

--- a/arch/arm/src/rp2040/rp2040_uart.c
+++ b/arch/arm/src/rp2040/rp2040_uart.c
@@ -26,7 +26,7 @@
 
 #include <stdint.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include <errno.h>

--- a/arch/arm/src/s32k1xx/s32k1xx_edma.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_edma.c
@@ -56,6 +56,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/semaphore.h>
 
 #include "arm_arch.h"

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -37,6 +37,7 @@
 #include <nuttx/wdog.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/signal.h>
 #include <nuttx/net/mii.h>

--- a/arch/arm/src/s32k1xx/s32k1xx_serial.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_serial.c
@@ -38,6 +38,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/init.h>
 #include <nuttx/power/pm.h>
 #include <nuttx/fs/ioctl.h>

--- a/arch/arm/src/stm32/stm32_hciuart.c
+++ b/arch/arm/src/stm32/stm32_hciuart.c
@@ -35,6 +35,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/wireless/bluetooth/bt_uart.h>
 #include <nuttx/power/pm.h>

--- a/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c
@@ -28,7 +28,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "hardware/tiva_prcm.h"
 #include "tiva_enablepwr.h"

--- a/arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_gpio.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "arm_arch.h"
 #include "tiva_gpio.h"

--- a/arch/arm/src/tiva/common/tiva_hciuart.c
+++ b/arch/arm/src/tiva/common/tiva_hciuart.c
@@ -34,6 +34,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/wireless/bluetooth/bt_uart.h>
 #include <nuttx/power/pm.h>

--- a/arch/or1k/src/common/up_modifyreg16.c
+++ b/arch/or1k/src/common/up_modifyreg16.c
@@ -27,8 +27,7 @@
 #include <stdint.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
-#include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "up_arch.h"
 

--- a/arch/or1k/src/common/up_modifyreg32.c
+++ b/arch/or1k/src/common/up_modifyreg32.c
@@ -27,8 +27,7 @@
 #include <stdint.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
-#include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "up_arch.h"
 

--- a/arch/or1k/src/common/up_modifyreg8.c
+++ b/arch/or1k/src/common/up_modifyreg8.c
@@ -27,8 +27,7 @@
 #include <stdint.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
-#include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "up_arch.h"
 

--- a/arch/risc-v/src/bl602/bl602_timerisr.c
+++ b/arch/risc-v/src/bl602/bl602_timerisr.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 #include "hardware/bl602_clic.h"
 #include "riscv_arch.h"

--- a/arch/risc-v/src/c906/c906_timerisr.c
+++ b/arch/risc-v/src/c906/c906_timerisr.c
@@ -29,6 +29,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "riscv_arch.h"

--- a/arch/risc-v/src/common/riscv_modifyreg32.c
+++ b/arch/risc-v/src/common/riscv_modifyreg32.c
@@ -27,8 +27,7 @@
 #include <stdint.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
-#include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "riscv_arch.h"
 

--- a/arch/risc-v/src/esp32c3/esp32c3_idle.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_idle.c
@@ -24,8 +24,8 @@
 
 #include <stdint.h>
 #include <nuttx/config.h>
-#include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/power/pm.h>
 
 #include "esp32c3.h"

--- a/arch/risc-v/src/esp32c3/esp32c3_std_atomic.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_std_atomic.c
@@ -26,8 +26,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -37,10 +37,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <irq/irq.h>
-#include "nuttx/kmalloc.h"
+#include <nuttx/kmalloc.h>
 #include <nuttx/mqueue.h>
-#include "nuttx/spinlock.h"
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/kthread.h>
 #include <nuttx/wdog.h>

--- a/arch/risc-v/src/fe310/fe310_gpio.c
+++ b/arch/risc-v/src/fe310/fe310_gpio.c
@@ -29,6 +29,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "riscv_arch.h"

--- a/arch/risc-v/src/fe310/fe310_timerisr.c
+++ b/arch/risc-v/src/fe310/fe310_timerisr.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "riscv_arch.h"

--- a/arch/risc-v/src/k210/k210_timerisr.c
+++ b/arch/risc-v/src/k210/k210_timerisr.c
@@ -29,6 +29,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "riscv_arch.h"

--- a/arch/risc-v/src/litex/litex_timerisr.c
+++ b/arch/risc-v/src/litex/litex_timerisr.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/spinlock.h>
 #include <arch/board/board.h>
 
 #include "riscv_arch.h"

--- a/arch/risc-v/src/rv64gc/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/rv64gc/riscv_schedulesigaction.c
@@ -29,8 +29,8 @@
 #include <sched.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "sched/sched.h"
 #include "riscv_internal.h"

--- a/arch/x86_64/include/intel64/arch.h
+++ b/arch/x86_64/include/intel64/arch.h
@@ -395,10 +395,6 @@ static inline void set_pcid(uint64_t pcid)
                      "%%rbx; mov %%rbx, %%cr3;"
                      ::"g"(pcid):"memory", "rbx", "rax");
       }
-    else
-      {
-        PANIC();
-      }
 }
 
 static inline unsigned long read_msr(unsigned int msr)

--- a/arch/xtensa/include/arch.h
+++ b/arch/xtensa/include/arch.h
@@ -30,6 +30,10 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#ifndef __ASSEMBLY__
+#  include <stddef.h>
+#  include <stdint.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/xtensa/src/esp32/esp32_himem.c
+++ b/arch/xtensa/src/esp32/esp32_himem.c
@@ -26,6 +26,7 @@
 #include <debug.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/himem/himem.h>
+#include <nuttx/spinlock.h>
 
 #include "esp32_spiram.h"
 #include "esp32_himem.h"

--- a/arch/xtensa/src/esp32/esp32_idle.c
+++ b/arch/xtensa/src/esp32/esp32_idle.c
@@ -24,8 +24,8 @@
 
 #include <stdint.h>
 #include <nuttx/config.h>
-#include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/power/pm.h>
 
 #include "esp32_pm.h"

--- a/arch/xtensa/src/esp32/esp32_intercpu_interrupt.c
+++ b/arch/xtensa/src/esp32/esp32_intercpu_interrupt.c
@@ -30,7 +30,6 @@
 #include <errno.h>
 
 #include <nuttx/spinlock.h>
-#include <arch/irq.h>
 
 #include "hardware/esp32_dport.h"
 #include "xtensa.h"

--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -33,7 +33,7 @@
 #include <string.h>
 #include <sys/param.h>
 #include <nuttx/config.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "esp32_spiram.h"
 #include "esp32_spicache.h"

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -37,9 +37,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <irq/irq.h>
-#include "nuttx/kmalloc.h"
+#include <nuttx/kmalloc.h>
 #include <nuttx/mqueue.h>
-#include "nuttx/spinlock.h"
+#include <nuttx/spinlock.h>
 #include <nuttx/irq.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/kthread.h>

--- a/boards/arm/imxrt/imxrt1020-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1020-evk/src/imxrt_ethernet.c
@@ -40,6 +40,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "imxrt_gpio.h"
 

--- a/boards/arm/imxrt/imxrt1050-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1050-evk/src/imxrt_ethernet.c
@@ -40,6 +40,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "imxrt_gpio.h"
 #include "imxrt_enet.h"

--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_ethernet.c
@@ -40,6 +40,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "imxrt_gpio.h"
 #include "imxrt_enet.h"

--- a/boards/arm/imxrt/imxrt1064-evk/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/imxrt1064-evk/src/imxrt_ethernet.c
@@ -40,6 +40,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "imxrt_gpio.h"
 #include "imxrt_enet.h"

--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c
@@ -40,6 +40,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "imxrt_gpio.h"
 #include "imxrt_enet.h"

--- a/boards/arm/max326xx/max32660-evsys/src/max326_button.c
+++ b/boards/arm/max326xx/max32660-evsys/src/max326_button.c
@@ -30,6 +30,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include <nuttx/irq.h>
 

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_gs2200m.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_gs2200m.c
@@ -30,6 +30,7 @@
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/wireless/gs2200m.h>
 
 #include "arm_arch.h"

--- a/drivers/audio/cxd56.c
+++ b/drivers/audio/cxd56.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mqueue.h>
 

--- a/drivers/audio/cxd56_src.c
+++ b/drivers/audio/cxd56_src.c
@@ -30,7 +30,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/config.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mqueue.h>
 

--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -37,7 +37,7 @@
 #include <queue.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/clock.h>

--- a/drivers/i2c/i2c_bitbang.c
+++ b/drivers/i2c/i2c_bitbang.c
@@ -27,7 +27,7 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/i2c/i2c_master.h>

--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/ioexpander/gpio.h>
 
 #ifdef CONFIG_DEV_GPIO

--- a/drivers/usbmonitor/usbmonitor.c
+++ b/drivers/usbmonitor/usbmonitor.c
@@ -30,8 +30,8 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <sched.h>
-#include <syslog.h>
 #include <errno.h>
+#include <debug.h>
 
 #include <nuttx/signal.h>
 #include <nuttx/kthread.h>

--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -52,9 +52,8 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <nuttx/arch.h>
 #include <nuttx/fs/ioctl.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/kthread.h>
 #include <nuttx/semaphore.h>

--- a/graphics/vnc/server/vnc_fbdev.c
+++ b/graphics/vnc/server/vnc_fbdev.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #include <errno.h>
 
 #if defined(CONFIG_VNCSERVER_DEBUG) && !defined(CONFIG_DEBUG_GRAPHICS)

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -78,13 +78,13 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <sched.h>
 
 #include <arch/arch.h>
 #include <arch/types.h>
 
 #include <nuttx/compiler.h>
 #include <nuttx/cache.h>
+#include <nuttx/sched.h>
 
 /****************************************************************************
  * Pre-processor definitions

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -32,11 +32,8 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <semaphore.h>
 
-#ifdef CONFIG_FS_NAMED_SEMAPHORES
-#  include <nuttx/semaphore.h>
-#endif
+#include <nuttx/semaphore.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/include/nuttx/irq.h
+++ b/include/nuttx/irq.h
@@ -30,10 +30,7 @@
 #ifndef __ASSEMBLY__
 # include <stdint.h>
 # include <assert.h>
-# ifdef CONFIG_SMP
-#  include <stdbool.h>
-#  include <nuttx/spinlock.h>
-# endif
+# include <stdbool.h>
 #endif
 
 /* Now include architecture-specific types */
@@ -268,80 +265,6 @@ irqstate_t enter_critical_section(void);
 void leave_critical_section(irqstate_t flags);
 #else
 #  define leave_critical_section(f) up_irq_restore(f)
-#endif
-
-/****************************************************************************
- * Name: spin_lock_irqsave
- *
- * Description:
- *   If SMP is are enabled:
- *     If the argument lock is not specified (i.e. NULL),
- *     disable local interrupts and take the global spinlock (g_irq_spin)
- *     if the call counter (g_irq_spin_count[cpu]) equals to 0. Then the
- *     counter on the CPU is increment to allow nested call and return
- *     the interrupt state.
- *
- *     If the argument lock is specified,
- *     disable local interrupts and take the lock spinlock and return
- *     the interrupt state.
- *
- *     NOTE: This API is very simple to protect data (e.g. H/W register
- *     or internal data structure) in SMP mode. But do not use this API
- *     with kernel APIs which suspend a caller thread. (e.g. nxsem_wait)
- *
- *   If SMP is not enabled:
- *     This function is equivalent to up_irq_save().
- *
- * Input Parameters:
- *   lock - Caller specific spinlock. If specified NULL, g_irq_spin is used
- *          and can be nested. Otherwise, nested call for the same lock
- *          would cause a deadlock
- *
- * Returned Value:
- *   An opaque, architecture-specific value that represents the state of
- *   the interrupts prior to the call to spin_lock_irqsave(lock);
- *
- ****************************************************************************/
-
-#if defined(CONFIG_SMP)
-irqstate_t spin_lock_irqsave(spinlock_t *lock);
-#else
-#  define spin_lock_irqsave(l) up_irq_save()
-#endif
-
-/****************************************************************************
- * Name: spin_unlock_irqrestore
- *
- * Description:
- *   If SMP is enabled:
- *     If the argument lock is not specified (i.e. NULL),
- *     decrement the call counter (g_irq_spin_count[cpu]) and if it
- *     decrements to zero then release the spinlock (g_irq_spin) and
- *     restore the interrupt state as it was prior to the previous call to
- *     spin_lock_irqsave(NULL).
- *
- *     If the argument lock is specified, release the the lock and
- *     restore the interrupt state as it was prior to the previous call to
- *     spin_lock_irqsave(lock).
- *
- *   If SMP is not enabled:
- *     This function is equivalent to up_irq_restore().
- *
- * Input Parameters:
- *   lock - Caller specific spinlock. If specified NULL, g_irq_spin is used.
- *
- *   flags - The architecture-specific value that represents the state of
- *           the interrupts prior to the call to spin_lock_irqsave(lock);
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-#if defined(CONFIG_SMP)
-void spin_unlock_irqrestore(spinlock_t *lock, irqstate_t flags);
-#else
-#  define spin_unlock_irqrestore(l, f) up_irq_restore(f)
 #endif
 
 #undef EXTERN

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <stdint.h>
 #include <queue.h>
+#include <sched.h>
 #include <signal.h>
 #include <semaphore.h>
 #include <pthread.h>

--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -36,12 +36,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Values for protocol attribute */
-
-#define SEM_PRIO_NONE             0
-#define SEM_PRIO_INHERIT          1
-#define SEM_PRIO_PROTECT          2
-
 /* Most internal nxsem_* interfaces are not available in the user space in
  * PROTECTED and KERNEL builds.  In that context, the application semaphore
  * interfaces must be used.  The differences between the two sets of
@@ -462,27 +456,6 @@ int nxsem_reset(FAR sem_t *sem, int16_t count);
 #define nxsem_get_protocol(s,p) sem_getprotocol(s,p)
 
 /****************************************************************************
- * Name: sem_getprotocol
- *
- * Description:
- *    Return the value of the semaphore protocol attribute.
- *
- * Input Parameters:
- *    sem      - A pointer to the semaphore whose attributes are to be
- *               queried.
- *    protocol - The user provided location in which to store the protocol
- *               value.
- *
- * Returned Value:
- *   This function is exposed as a non-standard application interface.  It
- *   returns zero (OK) if successful.  Otherwise, -1 (ERROR) is returned and
- *   the errno value is set appropriately.
- *
- ****************************************************************************/
-
-int sem_getprotocol(FAR sem_t *sem, FAR int *protocol);
-
-/****************************************************************************
  * Name: nxsem_set_protocol
  *
  * Description:
@@ -520,45 +493,6 @@ int sem_getprotocol(FAR sem_t *sem, FAR int *protocol);
  ****************************************************************************/
 
 int nxsem_set_protocol(FAR sem_t *sem, int protocol);
-
-/****************************************************************************
- * Name: sem_setprotocol
- *
- * Description:
- *    Set semaphore protocol attribute.
- *
- *    One particularly important use of this function is when a semaphore
- *    is used for inter-task communication like:
- *
- *      TASK A                 TASK B
- *      sem_init(sem, 0, 0);
- *      sem_wait(sem);
- *                             sem_post(sem);
- *      Awakens as holder
- *
- *    In this case priority inheritance can interfere with the operation of
- *    the semaphore.  The problem is that when TASK A is restarted it is a
- *    holder of the semaphore.  However, it never calls sem_post(sem) so it
- *    becomes *permanently* a holder of the semaphore and may have its
- *    priority boosted when any other task tries to acquire the semaphore.
- *
- *    The fix is to call sem_setprotocol(SEM_PRIO_NONE) immediately after
- *    the sem_init() call so that there will be no priority inheritance
- *    operations on this semaphore.
- *
- * Input Parameters:
- *    sem      - A pointer to the semaphore whose attributes are to be
- *               modified
- *    protocol - The new protocol to use
- *
- * Returned Value:
- *   This function is exposed as a non-standard application interface.  It
- *   returns zero (OK) if successful.  Otherwise, -1 (ERROR) is returned and
- *   the errno value is set appropriately.
- *
- ****************************************************************************/
-
-int sem_setprotocol(FAR sem_t *sem, int protocol);
 
 /****************************************************************************
  * Name: nxsem_wait_uninterruptible

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -36,8 +36,7 @@
 #include <unistd.h>          /* For getpid */
 #include <signal.h>          /* Needed for sigset_t, includes this file */
 #include <time.h>            /* Needed for struct timespec */
-
-#include <nuttx/semaphore.h> /* For sem_t and SEM_PRIO_* defines */
+#include <semaphore.h>       /* For sem_t and SEM_PRIO_* defines */
 
 #ifdef CONFIG_PTHREAD_SPINLOCKS
 /* The architecture specific spinlock.h header file must provide the

--- a/include/sched.h
+++ b/include/sched.h
@@ -31,9 +31,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <strings.h>
+#include <time.h>
 #include "queue.h"
-
-#include <nuttx/sched.h>
 
 /********************************************************************************
  * Pre-processor Definitions

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -35,6 +35,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Values for protocol attribute */
+
+#define SEM_PRIO_NONE             0
+#define SEM_PRIO_INHERIT          1
+#define SEM_PRIO_PROTECT          2
+
 /* Value returned by sem_open() in the event of a failure. */
 
 #define SEM_FAILED ((FAR sem_t *)NULL)
@@ -139,6 +145,66 @@ FAR sem_t *sem_open(FAR const char *name, int oflag, ...);
 int        sem_close(FAR sem_t *sem);
 int        sem_unlink(FAR const char *name);
 #endif
+
+/****************************************************************************
+ * Name: sem_setprotocol
+ *
+ * Description:
+ *    Set semaphore protocol attribute.
+ *
+ *    One particularly important use of this function is when a semaphore
+ *    is used for inter-task communication like:
+ *
+ *      TASK A                 TASK B
+ *      sem_init(sem, 0, 0);
+ *      sem_wait(sem);
+ *                             sem_post(sem);
+ *      Awakens as holder
+ *
+ *    In this case priority inheritance can interfere with the operation of
+ *    the semaphore.  The problem is that when TASK A is restarted it is a
+ *    holder of the semaphore.  However, it never calls sem_post(sem) so it
+ *    becomes *permanently* a holder of the semaphore and may have its
+ *    priority boosted when any other task tries to acquire the semaphore.
+ *
+ *    The fix is to call sem_setprotocol(SEM_PRIO_NONE) immediately after
+ *    the sem_init() call so that there will be no priority inheritance
+ *    operations on this semaphore.
+ *
+ * Input Parameters:
+ *    sem      - A pointer to the semaphore whose attributes are to be
+ *               modified
+ *    protocol - The new protocol to use
+ *
+ * Returned Value:
+ *   This function is exposed as a non-standard application interface.  It
+ *   returns zero (OK) if successful.  Otherwise, -1 (ERROR) is returned and
+ *   the errno value is set appropriately.
+ *
+ ****************************************************************************/
+
+int sem_setprotocol(FAR sem_t *sem, int protocol);
+
+/****************************************************************************
+ * Name: sem_getprotocol
+ *
+ * Description:
+ *    Return the value of the semaphore protocol attribute.
+ *
+ * Input Parameters:
+ *    sem      - A pointer to the semaphore whose attributes are to be
+ *               queried.
+ *    protocol - The user provided location in which to store the protocol
+ *               value.
+ *
+ * Returned Value:
+ *   This function is exposed as a non-standard application interface.  It
+ *   returns zero (OK) if successful.  Otherwise, -1 (ERROR) is returned and
+ *   the errno value is set appropriately.
+ *
+ ****************************************************************************/
+
+int sem_getprotocol(FAR sem_t *sem, FAR int *protocol);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -29,10 +29,10 @@
 
 #include <sys/types.h>
 #include <stdarg.h>
-#include <sched.h>
 #include <time.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/sched.h>
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/libs/libc/pthread/pthread_create.c
+++ b/libs/libc/pthread/pthread_create.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#include <debug.h>
+#include <assert.h>
 
 #include <nuttx/pthread.h>
 

--- a/libs/libc/pthread/pthread_spinlock.c
+++ b/libs/libc/pthread/pthread_spinlock.c
@@ -27,18 +27,11 @@
 #include <sys/types.h>
 #include <sys/boardctl.h>
 
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
 #include <pthread.h>
 #include <sched.h>
-
-/* The architecture specific spinlock.h header file must provide the
- * following:
- *
- *   SP_LOCKED    - A definition of the locked state value (usually 1)
- *   SP_UNLOCKED  - A definition of the unlocked state value (usually 0)
- *   spinlock_t   - The type of a spinlock memory object (usually uint8_t).
- */
-
-#include <arch/spinlock.h>
 
 #ifdef CONFIG_PTHREAD_SPINLOCKS
 

--- a/libs/libc/sched/task_startup.c
+++ b/libs/libc/sched/task_startup.c
@@ -27,6 +27,7 @@
 #include <sched.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <debug.h>
 
 #ifndef CONFIG_BUILD_KERNEL
 

--- a/libs/libc/tls/task_getinfo.c
+++ b/libs/libc/tls/task_getinfo.c
@@ -24,8 +24,7 @@
 
 #include <nuttx/config.h>
 
-#include <sched.h>
-
+#include <nuttx/sched.h>
 #include <nuttx/tls.h>
 
 /****************************************************************************

--- a/libs/libc/unistd/lib_getpriority.c
+++ b/libs/libc/unistd/lib_getpriority.c
@@ -24,8 +24,9 @@
 
 #include <nuttx/config.h>
 #include <sys/resource.h>
-#include <sched.h>
 
+#include <sched.h>
+#include <unistd.h>
 #include <errno.h>
 
 /****************************************************************************

--- a/libs/libc/unistd/lib_setpriority.c
+++ b/libs/libc/unistd/lib_setpriority.c
@@ -26,6 +26,7 @@
 #include <sched.h>
 
 #include <errno.h>
+#include <unistd.h>
 
 /****************************************************************************
  * Public Functions

--- a/libs/libc/wqueue/work_lock.c
+++ b/libs/libc/wqueue/work_lock.c
@@ -28,6 +28,8 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <nuttx/semaphore.h>
+
 #include "wqueue/wqueue.h"
 
 #if defined(CONFIG_LIB_USRWORK) && !defined(__KERNEL__)

--- a/net/socket/net_dup2.c
+++ b/net/socket/net_dup2.c
@@ -27,6 +27,7 @@
 #include <sys/socket.h>
 #include <string.h>
 #include <sched.h>
+#include <assert.h>
 #include <errno.h>
 #include <debug.h>
 

--- a/net/tcp/tcp_txdrain.c
+++ b/net/tcp/tcp_txdrain.c
@@ -29,8 +29,10 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <nuttx/net/net.h>
 #include <nuttx/semaphore.h>
 
+#include "utils/utils.h"
 #include "tcp/tcp.h"
 
 #if defined(CONFIG_NET_TCP_WRITE_BUFFERS) && defined(CONFIG_NET_TCP_NOTIFIER)

--- a/net/udp/udp_txdrain.c
+++ b/net/udp/udp_txdrain.c
@@ -29,8 +29,10 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <nuttx/net/net.h>
 #include <nuttx/semaphore.h>
 
+#include "utils/utils.h"
 #include "udp/udp.h"
 
 #if defined(CONFIG_NET_UDP_WRITE_BUFFERS) && defined(CONFIG_NET_UDP_NOTIFIER)

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -30,8 +30,8 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <arch/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "clock/clock.h"
 #ifdef CONFIG_CLOCK_TIMEKEEPING

--- a/sched/group/group_exitinfo.c
+++ b/sched/group/group_exitinfo.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 
 #include <nuttx/sched.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/binfmt/binfmt.h>
 
 #include "sched/sched.h"

--- a/sched/group/group_tlsalloc.c
+++ b/sched/group/group_tlsalloc.c
@@ -29,7 +29,7 @@
 #include <assert.h>
 #include <debug.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/tls.h>
 
 #include "sched/sched.h"

--- a/sched/group/group_tlsfree.c
+++ b/sched/group/group_tlsfree.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <assert.h>
 
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/tls.h>
 
 #include "sched/sched.h"

--- a/sched/group/group_tlsgetdtor.c
+++ b/sched/group/group_tlsgetdtor.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/tls.h>
 #include <arch/tls.h>
 

--- a/sched/group/group_tlsgetset.c
+++ b/sched/group/group_tlsgetset.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/tls.h>
 #include <arch/tls.h>
 

--- a/sched/group/group_tlssetdtor.c
+++ b/sched/group/group_tlssetdtor.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/tls.h>
 #include <arch/tls.h>
 

--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -31,9 +31,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <pthread.h>
-#include <sched.h>
 
 #include <nuttx/compiler.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/sched.h>
 
 /****************************************************************************
  * Public Type Declarations

--- a/sched/semaphore/semaphore.h
+++ b/sched/semaphore/semaphore.h
@@ -28,10 +28,10 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/sched.h>
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <sched.h>
 #include <queue.h>
 
 /****************************************************************************

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -33,7 +33,7 @@
 #include <assert.h>
 
 #include <nuttx/sched.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/signal.h>
 
 #include "group/group.h"

--- a/wireless/bluetooth/bt_atomic.c
+++ b/wireless/bluetooth/bt_atomic.c
@@ -24,7 +24,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include "bt_atomic.h"
 

--- a/wireless/bluetooth/bt_buf.c
+++ b/wireless/bluetooth/bt_buf.c
@@ -51,7 +51,7 @@
 #include <errno.h>
 #include <debug.h>
 
-#include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/bluetooth.h>

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -58,6 +58,7 @@
 
 #include <nuttx/clock.h>
 #include <nuttx/kthread.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/net/bluetooth.h>
 #include <nuttx/wireless/bluetooth/bt_core.h>

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -35,8 +35,7 @@
 
 #include <arpa/inet.h>
 
-#include <nuttx/arch.h>
-#include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/signal.h>
 #include <nuttx/wdog.h>


### PR DESCRIPTION
## Summary
But let nuttx/sched.h include sched.h instead to avoid expose nuttx kernel API to userspace

## Impact
Minor, header file reorganize

## Testing
Pass CI
