### PR TITLE
sched/init: don't check remain stack for idle task

### DIFF
--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -790,7 +790,7 @@ void nx_start(void)
       kmm_checkcorruption();
 
 #if defined(CONFIG_STACK_COLORATION) && defined(CONFIG_DEBUG_MM)
-      for (i = 0; i < CONFIG_MAX_TASKS && g_pidhash[i].tcb; i++)
+      for (i = 1; i < CONFIG_MAX_TASKS && g_pidhash[i].tcb; i++)
         {
           assert(up_check_tcbstack_remain(g_pidhash[i].tcb) > 0);
         }


### PR DESCRIPTION
## Summary
We shouldn't check the remain stack for idle task because tt may not have been colored.

Change-Id: I0bd5808efabd395157d2530f2423b18f0c1eeabd
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
no
## Testing
daily test.
