### PR TITLE
group/group_signal: cancel dispatch signal when child process doesn't exist

### DIFF
--- a/sched/group/group_signal.c
+++ b/sched/group/group_signal.c
@@ -245,10 +245,14 @@ int group_signal(FAR struct task_group_s *group, FAR siginfo_t *siginfo)
        * signal to a pending state.
        */
 
-      else /* if (info.dtcb) */
+      else if (info.dtcb)
         {
-          DEBUGASSERT(info.dtcb);
           tcb = info.dtcb;
+        }
+      else
+        {
+          ret = -ECHILD;
+          goto errout;
         }
 
       /* Now deliver the signal to the selected group member */


### PR DESCRIPTION
## Summary
Cancel dispatch signal when the number of members in the group is 
zero of members in the group is zero.

Repetition step:
If using waitpid() to wait a task has exited, the waitpid will use
nxsing_kill with signal number 0 to determine if that task is still
alive, and will call group_signal to dispatch signal for each member
of the group and perform signal handing checks, it will assert at
sched/group/group_signal.c:261.

Change-Id: I75ef015a261101277436d742897ce68fed44b5da
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
Don't assert when dispatch a signal to process doesn't exist. 
## Testing
daily test.
