### PR TITLE
 sim/rptun: support multi(>2) core interactive by share memory

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -228,17 +228,12 @@ endchoice
 
 endif
 
-config SIM_RPTUN_MASTER
-	bool "Remote Processor Tunneling Role"
-	depends on RPTUN
-
 menu "Simulated Graphics/Input"
 
 config SIM_X11FB
-  bool "X11 graphics/input"
-  default n
-  select SCHED_LPWORK
-	depends on SIM_WALLTIME
+	bool "X11 graphics/input"
+	default n
+	select SCHED_LPWORK
 	---help---
 		Use X11 to provide graphics and input emulation to interact with host.
 

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -312,7 +312,7 @@ void netdriver_loop(void);
 /* up_rptun.c ***************************************************************/
 
 #ifdef CONFIG_RPTUN
-int up_rptun_init(void);
+int up_rptun_init(const char *shmemname, const char *cpuname, bool master);
 void up_rptun_loop(void);
 #endif
 

--- a/arch/sim/src/sim/up_rptun.c
+++ b/arch/sim/src/sim/up_rptun.c
@@ -23,22 +23,10 @@
  ****************************************************************************/
 
 #include <nuttx/drivers/addrenv.h>
-#include <nuttx/fs/hostfs_rpmsg.h>
 #include <nuttx/rptun/rptun.h>
-#include <nuttx/serial/uart_rpmsg.h>
-#include <nuttx/syslog/syslog_rpmsg.h>
-#include <nuttx/timers/arch_rtc.h>
-#include <nuttx/timers/rpmsg_rtc.h>
+#include <nuttx/list.h>
 
 #include "up_internal.h"
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_SIM_RPTUN_MASTER
-#define CONFIG_SIM_RPTUN_MASTER 0
-#endif
 
 /****************************************************************************
  * Private Types
@@ -47,24 +35,23 @@
 struct sim_rptun_shmem_s
 {
   volatile uintptr_t        base;
-#if CONFIG_SIM_RPTUN_MASTER
-  volatile unsigned int     seqrx;
-  volatile unsigned int     seqtx;
-#else
-  volatile unsigned int     seqtx;
-  volatile unsigned int     seqrx;
-#endif
+  volatile unsigned int     seqs;
+  volatile unsigned int     seqm;
   struct rptun_rsc_s        rsc;
   char                      buf[0x10000];
 };
 
 struct sim_rptun_dev_s
 {
+  struct list_node          node;
   struct rptun_dev_s        rptun;
   rptun_callback_t          callback;
   void                     *arg;
-  unsigned int              seqrx;
+  bool                      master;
+  unsigned int              seq;
   struct sim_rptun_shmem_s *shmem;
+  struct simple_addrenv_s   addrenv[2];
+  char                      cpuname[RPMSG_NAME_SIZE + 1];
 };
 
 /****************************************************************************
@@ -73,7 +60,10 @@ struct sim_rptun_dev_s
 
 static const char *sim_rptun_get_cpuname(struct rptun_dev_s *dev)
 {
-  return CONFIG_SIM_RPTUN_MASTER ? "proxy" : "server";
+  struct sim_rptun_dev_s *priv = container_of(dev,
+                                 struct sim_rptun_dev_s, rptun);
+
+  return priv->cpuname;
 }
 
 static const char *sim_rptun_get_firmware(struct rptun_dev_s *dev)
@@ -82,14 +72,16 @@ static const char *sim_rptun_get_firmware(struct rptun_dev_s *dev)
 }
 
 static const struct rptun_addrenv_s *
-  sim_rptun_get_addrenv(struct rptun_dev_s *dev)
+sim_rptun_get_addrenv(struct rptun_dev_s *dev)
 {
   return NULL;
 }
 
-static struct rptun_rsc_s *sim_rptun_get_resource(struct rptun_dev_s *dev)
+static struct rptun_rsc_s *
+sim_rptun_get_resource(struct rptun_dev_s *dev)
 {
-  struct sim_rptun_dev_s *priv = (struct sim_rptun_dev_s *)dev;
+  struct sim_rptun_dev_s *priv = container_of(dev,
+                                 struct sim_rptun_dev_s, rptun);
   struct sim_rptun_shmem_s *shmem = priv->shmem;
 
   return &shmem->rsc;
@@ -102,7 +94,9 @@ static bool sim_rptun_is_autostart(struct rptun_dev_s *dev)
 
 static bool sim_rptun_is_master(struct rptun_dev_s *dev)
 {
-  return CONFIG_SIM_RPTUN_MASTER;
+  struct sim_rptun_dev_s *priv = container_of(dev,
+                                 struct sim_rptun_dev_s, rptun);
+  return priv->master;
 }
 
 static int sim_rptun_start(struct rptun_dev_s *dev)
@@ -117,17 +111,27 @@ static int sim_rptun_stop(struct rptun_dev_s *dev)
 
 static int sim_rptun_notify(struct rptun_dev_s *dev, uint32_t vqid)
 {
-  struct sim_rptun_dev_s *priv = (struct sim_rptun_dev_s *)dev;
-  struct sim_rptun_shmem_s *shmem = priv->shmem;
+  struct sim_rptun_dev_s *priv = container_of(dev,
+                                 struct sim_rptun_dev_s, rptun);
 
-  shmem->seqtx++;
+  if (priv->master)
+    {
+      priv->shmem->seqm++;
+    }
+  else
+    {
+      priv->shmem->seqs++;
+    }
+
   return 0;
 }
 
 static int sim_rptun_register_callback(struct rptun_dev_s *dev,
-                                       rptun_callback_t callback, void *arg)
+                                       rptun_callback_t callback,
+                                       void *arg)
 {
-  struct sim_rptun_dev_s *priv = (struct sim_rptun_dev_s *)dev;
+  struct sim_rptun_dev_s *priv = container_of(dev,
+                                 struct sim_rptun_dev_s, rptun);
 
   priv->callback = callback;
   priv->arg      = arg;
@@ -152,10 +156,7 @@ static const struct rptun_ops_s g_sim_rptun_ops =
   .register_callback = sim_rptun_register_callback,
 };
 
-static struct sim_rptun_dev_s g_dev =
-{
-  .rptun.ops         = &g_sim_rptun_ops
-};
+static struct list_node g_dev_list = LIST_INITIAL_VALUE(g_dev_list);
 
 /****************************************************************************
  * Public Functions
@@ -163,33 +164,57 @@ static struct sim_rptun_dev_s g_dev =
 
 void up_rptun_loop(void)
 {
-  struct sim_rptun_shmem_s *shmem = g_dev.shmem;
+  struct sim_rptun_dev_s *dev;
 
-  if (shmem != NULL && g_dev.seqrx != shmem->seqrx)
+  list_for_every_entry(&g_dev_list, dev,
+                       struct sim_rptun_dev_s, node)
     {
-      g_dev.seqrx = shmem->seqrx;
-      if (g_dev.callback != NULL)
+      if (dev->shmem != NULL)
         {
-          g_dev.callback(g_dev.arg, RPTUN_NOTIFY_ALL);
+          if (dev->master && dev->seq != dev->shmem->seqs)
+            {
+              dev->seq = dev->shmem->seqs;
+            }
+          else if (!dev->master && dev->seq != dev->shmem->seqm)
+            {
+              dev->seq = dev->shmem->seqm;
+            }
+
+          if (dev->callback != NULL)
+            {
+              dev->callback(dev->arg, RPTUN_NOTIFY_ALL);
+            }
         }
     }
 }
 
-int up_rptun_init(void)
+int up_rptun_init(const char *shmemname, const char *cpuname, bool master)
 {
+  struct sim_rptun_dev_s *dev;
   int ret;
 
-  g_dev.shmem = host_alloc_shmem("rptun-shmem",
-                                 sizeof(*g_dev.shmem),
-                                 CONFIG_SIM_RPTUN_MASTER);
-  if (g_dev.shmem == NULL)
+  dev = kmm_zalloc(sizeof(*dev));
+  if (dev == NULL)
     {
       return -ENOMEM;
     }
 
-  if (CONFIG_SIM_RPTUN_MASTER)
+  dev->shmem = host_alloc_shmem(shmemname, sizeof(*dev->shmem),
+                                master);
+  if (dev->shmem == NULL)
     {
-      struct rptun_rsc_s *rsc = &g_dev.shmem->rsc;
+      kmm_free(dev);
+      return -ENOMEM;
+    }
+
+  dev->master = master;
+  dev->rptun.ops = &g_sim_rptun_ops;
+  strncpy(dev->cpuname, cpuname, RPMSG_NAME_SIZE);
+  list_add_tail(&g_dev_list, &dev->node);
+
+  if (master)
+    {
+      struct rptun_rsc_s *rsc = &dev->shmem->rsc;
 
       rsc->rsc_tbl_hdr.ver          = 1;
       rsc->rsc_tbl_hdr.num          = 1;
@@ -208,59 +233,31 @@ int up_rptun_init(void)
       rsc->config.rxbuf_size        = 0x800;
       rsc->config.txbuf_size        = 0x800;
 
-      g_dev.shmem->base             = (uintptr_t)g_dev.shmem;
+      dev->shmem->base              = (uintptr_t)dev->shmem;
     }
   else
     {
-      static struct simple_addrenv_s s_addrenv[2];
-
       /* Wait untils master is ready */
 
-      while (g_dev.shmem->base == 0)
+      while (dev->shmem->base == 0)
         {
           host_sleep(1000);
         }
 
-      s_addrenv[0].va               = (uintptr_t)g_dev.shmem;
-      s_addrenv[0].pa               = g_dev.shmem->base;
-      s_addrenv[0].size             = sizeof(*g_dev.shmem);
+      dev->addrenv[0].va          = (uintptr_t)dev->shmem;
+      dev->addrenv[0].pa          = dev->shmem->base;
+      dev->addrenv[0].size        = sizeof(*dev->shmem);
 
-      simple_addrenv_initialize(s_addrenv);
+      simple_addrenv_initialize(dev->addrenv);
     }
 
-  ret = rptun_initialize(&g_dev.rptun);
+  ret = rptun_initialize(&dev->rptun);
   if (ret < 0)
     {
-      host_free_shmem(g_dev.shmem);
-      return ret;
+      list_delete(&dev->node);
+      host_free_shmem(dev->shmem);
+      kmm_free(dev);
     }
 
-#ifdef CONFIG_SYSLOG_RPMSG_SERVER
-  syslog_rpmsg_server_init();
-#endif
-
-#ifndef CONFIG_RTC_RPMSG_SERVER
-  up_rtc_set_lowerhalf(rpmsg_rtc_initialize(0));
-#endif
-
-#ifdef CONFIG_FS_HOSTFS_RPMSG
-  hostfs_rpmsg_init("server");
-#endif
-
-#ifdef CONFIG_FS_HOSTFS_RPMSG_SERVER
-  hostfs_rpmsg_server_init();
-#endif
-
-  return 0;
+  return ret;
 }
-
-#if CONFIG_RPMSG_UART
-void rpmsg_serialinit(void)
-{
-#if CONFIG_SIM_RPTUN_MASTER
-  uart_rpmsg_init("proxy", "proxy", 4096, false);
-#else
-  uart_rpmsg_init("server", "proxy", 4096, true);
-#endif
-}
-#endif

--- a/boards/sim/sim/sim/Kconfig
+++ b/boards/sim/sim/sim/Kconfig
@@ -10,6 +10,11 @@ config EXAMPLES_TOUCHSCREEN_BGCOLOR
 	default 0x007b68ee
 	depends on EXAMPLES_TOUCHSCREEN
 
+config SIM_RPTUN_MASTER
+	bool "Remote Processor Tunneling Role"
+	default n
+	depends on RPTUN
+
 if SIM_TOUCHSCREEN
 
 comment "NX Server Options"

--- a/boards/sim/sim/sim/src/sim_appinit.c
+++ b/boards/sim/sim/sim/src/sim_appinit.c
@@ -24,12 +24,8 @@
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>
-#include <nuttx/sensors/wtgahrs2.h>
-#include <nuttx/rc/lirc_dev.h>
-#include <nuttx/rc/dummy.h>
 
 #include "sim.h"
-#include "up_internal.h"
 
 /****************************************************************************
  * Public Functions
@@ -65,26 +61,6 @@ int board_app_initialize(uintptr_t arg)
 {
 #ifndef CONFIG_BOARD_LATE_INITIALIZE
   sim_bringup();
-#endif
-
-#ifdef CONFIG_RPTUN
-  up_rptun_init();
-#endif
-
-#ifdef CONFIG_SIM_WTGAHRS2_UARTN
-#if CONFIG_SIM_WTGAHRS2_UARTN == 0
-  wtgahrs2_initialize(CONFIG_SIM_UART0_NAME, 0);
-#elif CONFIG_SIM_WTGAHRS2_UARTN == 1
-  wtgahrs2_initialize(CONFIG_SIM_UART1_NAME, 1);
-#elif CONFIG_SIM_WTGAHRS2_UARTN == 2
-  wtgahrs2_initialize(CONFIG_SIM_UART2_NAME, 2);
-#elif CONFIG_SIM_WTGAHRS2_UARTN == 3
-  wtgahrs2_initialize(CONFIG_SIM_UART3_NAME, 3);
-#endif
-#endif
-
-#ifdef CONFIG_RC_DUMMY
-  rc_dummy_initialize(0);
 #endif
 
   return 0;

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -34,14 +34,18 @@
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/nxffs.h>
-#include <nuttx/video/fb.h>
+#include <nuttx/i2c/i2c_master.h>
+#include <nuttx/rc/lirc_dev.h>
+#include <nuttx/rc/dummy.h>
+#include <nuttx/sensors/fakesensor.h>
+#include <nuttx/sensors/mpu60x0.h>
+#include <nuttx/sensors/wtgahrs2.h>
 #include <nuttx/timers/oneshot.h>
+#include <nuttx/video/fb.h>
 #include <nuttx/wireless/pktradio.h>
 #include <nuttx/wireless/bluetooth/bt_null.h>
 #include <nuttx/wireless/bluetooth/bt_uart_shim.h>
 #include <nuttx/wireless/ieee802154/ieee802154_loopback.h>
-#include <nuttx/i2c/i2c_master.h>
-#include <nuttx/sensors/mpu60x0.h>
 
 #ifdef CONFIG_LCD_DEV
 #include <nuttx/lcd/lcd_dev.h>
@@ -418,6 +422,37 @@ int sim_bringup(void)
     {
       syslog(LOG_ERR, "ERROR: sim_foc_setup() failed: %d\n", ret);
     }
+#endif
+
+#ifdef CONFIG_RPTUN
+  up_rptun_init();
+#endif
+
+#ifdef CONFIG_SIM_WTGAHRS2_UARTN
+#if CONFIG_SIM_WTGAHRS2_UARTN == 0
+  wtgahrs2_initialize(CONFIG_SIM_UART0_NAME, 0);
+#elif CONFIG_SIM_WTGAHRS2_UARTN == 1
+  wtgahrs2_initialize(CONFIG_SIM_UART1_NAME, 1);
+#elif CONFIG_SIM_WTGAHRS2_UARTN == 2
+  wtgahrs2_initialize(CONFIG_SIM_UART2_NAME, 2);
+#elif CONFIG_SIM_WTGAHRS2_UARTN == 3
+  wtgahrs2_initialize(CONFIG_SIM_UART3_NAME, 3);
+#endif
+#endif
+
+#ifdef CONFIG_SENSORS_FAKESENSOR
+  fakesensor_init(SENSOR_TYPE_ACCELEROMETER,
+                  "/data/boards/sim/sim/sim/src/csv/accel.csv", 0, 50);
+
+  fakesensor_init(SENSOR_TYPE_MAGNETIC_FIELD,
+                  "/data/boards/sim/sim/sim/src/csv/mag.csv", 0, 50);
+
+  fakesensor_init(SENSOR_TYPE_GYROSCOPE,
+                  "/data/boards/sim/sim/sim/src/csv/gyro.csv", 0, 50);
+#endif
+
+#ifdef CONFIG_RC_DUMMY
+  rc_dummy_initialize(0);
 #endif
 
   return ret;

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -34,14 +34,20 @@
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/nxffs.h>
+#include <nuttx/fs/hostfs_rpmsg.h>
 #include <nuttx/i2c/i2c_master.h>
 #include <nuttx/rc/lirc_dev.h>
 #include <nuttx/rc/dummy.h>
 #include <nuttx/sensors/fakesensor.h>
 #include <nuttx/sensors/mpu60x0.h>
 #include <nuttx/sensors/wtgahrs2.h>
+#include <nuttx/serial/uart_rpmsg.h>
+#include <nuttx/syslog/syslog_rpmsg.h>
+#include <nuttx/timers/arch_rtc.h>
 #include <nuttx/timers/oneshot.h>
+#include <nuttx/timers/rpmsg_rtc.h>
 #include <nuttx/video/fb.h>
+#include <nuttx/timers/oneshot.h>
 #include <nuttx/wireless/pktradio.h>
 #include <nuttx/wireless/bluetooth/bt_null.h>
 #include <nuttx/wireless/bluetooth/bt_uart_shim.h>
@@ -62,8 +68,19 @@
  * Public Functions
  ****************************************************************************/
 
+#ifdef CONFIG_RPMSG_UART
+void rpmsg_serialinit(void)
+{
+#ifdef CONFIG_SIM_RPTUN_MASTER
+  uart_rpmsg_init("proxy", "proxy", 4096, false);
+#else
+  uart_rpmsg_init("server", "proxy", 4096, true);
+#endif
+}
+#endif
+
 /****************************************************************************
- * Name: sam_bringup
+ * Name: sim_bringup
  *
  * Description:
  *   Bring up simulated board features
@@ -425,7 +442,27 @@ int sim_bringup(void)
 #endif
 
 #ifdef CONFIG_RPTUN
-  up_rptun_init();
+#ifdef CONFIG_SIM_RPTUN_MASTER
+  up_rptun_init("server-proxy", "proxy", true);
+#else
+  up_rptun_init("server-proxy", "server", false);
+#endif
+
+#ifdef CONFIG_SYSLOG_RPMSG_SERVER
+  syslog_rpmsg_server_init();
+#endif
+
+#ifndef CONFIG_RTC_RPMSG_SERVER
+  up_rtc_set_lowerhalf(rpmsg_rtc_initialize(0));
+#endif
+
+#ifdef CONFIG_FS_HOSTFS_RPMSG
+  hostfs_rpmsg_init("server");
+#endif
+
+#ifdef CONFIG_FS_HOSTFS_RPMSG_SERVER
+  hostfs_rpmsg_server_init();
+#endif
 #endif
 
 #ifdef CONFIG_SIM_WTGAHRS2_UARTN

--- a/drivers/addrenv.c
+++ b/drivers/addrenv.c
@@ -23,53 +23,89 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/list.h>
+#include <nuttx/kmalloc.h>
 
 #include <string.h>
 
 #include <nuttx/drivers/addrenv.h>
 
 /****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct simple_addrenv_node_s
+{
+  struct list_node node;
+  FAR const struct simple_addrenv_s *addrenv;
+};
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
-static const struct simple_addrenv_s g_addrenv_dummy;
-static const struct simple_addrenv_s *g_addrenv = &g_addrenv_dummy;
+static struct list_node g_addrenv_list = LIST_INITIAL_VALUE(g_addrenv_list);
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-void simple_addrenv_initialize(const struct simple_addrenv_s *addrenv)
+void simple_addrenv_initialize(FAR const struct simple_addrenv_s *addrenv)
 {
-  g_addrenv = addrenv;
+  FAR struct simple_addrenv_node_s *node;
+
+  if (addrenv != NULL)
+    {
+      node = kmm_malloc(sizeof(*node));
+      if (node != NULL)
+        {
+          node->addrenv = addrenv;
+          list_add_tail(&g_addrenv_list, &node->node);
+        }
+    }
 }
 
-void *up_addrenv_pa_to_va(uintptr_t pa)
+FAR void *up_addrenv_pa_to_va(uintptr_t pa)
 {
+  FAR struct simple_addrenv_node_s *node;
+  FAR const struct simple_addrenv_s *addrenv;
   uint32_t i;
 
-  for (i = 0; g_addrenv[i].size; i++)
+  list_for_every_entry(&g_addrenv_list, node,
+                       struct simple_addrenv_node_s, node)
     {
-      if (pa - g_addrenv[i].pa < g_addrenv[i].size)
+      addrenv = node->addrenv;
+      for (i = 0; addrenv[i].size; i++)
         {
-          return (void *)(g_addrenv[i].va + B2C(pa - g_addrenv[i].pa));
+          if (pa - addrenv[i].pa < addrenv[i].size)
+            {
+              return (FAR void *)(addrenv[i].va +
+                     B2C(pa - addrenv[i].pa));
+            }
         }
     }
 
-  return (void *)B2C(pa);
+  return (FAR void *)B2C(pa);
 }
 
-uintptr_t up_addrenv_va_to_pa(void *va_)
+uintptr_t up_addrenv_va_to_pa(FAR void *va_)
 {
+  FAR struct simple_addrenv_node_s *node;
+  FAR const struct simple_addrenv_s *addrenv;
   uintptr_t va = C2B((uintptr_t)va_);
   uint32_t i;
 
-  for (i = 0; g_addrenv[i].size; i++)
+  list_for_every_entry(&g_addrenv_list, node,
+                       struct simple_addrenv_node_s, node)
     {
-      uintptr_t tmp = C2B(g_addrenv[i].va);
-      if (va - tmp < g_addrenv[i].size)
+      addrenv = node->addrenv;
+      for (i = 0; addrenv[i].size; i++)
         {
-          return g_addrenv[i].pa + (va - tmp);
+          uintptr_t tmp = C2B(addrenv[i].va);
+          if (va - tmp < addrenv[i].size)
+            {
+              return addrenv[i].pa + (va - tmp);
+            }
         }
     }
 

--- a/include/nuttx/drivers/addrenv.h
+++ b/include/nuttx/drivers/addrenv.h
@@ -57,7 +57,7 @@ extern "C"
 #define EXTERN extern
 #endif
 
-void simple_addrenv_initialize(const struct simple_addrenv_s *addrenv);
+void simple_addrenv_initialize(FAR const struct simple_addrenv_s *addrenv);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
Support multi >2 core interactive by share memory in simulation.
Example of relationships between the three processes:
AP->BP
AP->CP
BP->CP
## Impact
Support multi-core heterogeneous simulation.
## Testing
daily test.
