### PR TITLE
lirc: fix bug about lirc_raw_event

### DIFF
--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -944,9 +944,10 @@ void lirc_raw_event(FAR struct lirc_lowerhalf_s *lower,
                     }
                 }
 
-              leave_critical_section(flags);
               upper->gap = false;
             }
+
+          leave_critical_section(flags);
         }
 
       sample = ev.pulse ? LIRC_PULSE(ev.duration) : LIRC_SPACE(ev.duration);


### PR DESCRIPTION
## Summary
Leave critical_section correctly when using lirc_raw_event

Change-Id: If00d0a7e4e4f9a0d9119b6a170cffd993f23f71a
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact

## Testing

