### PR TITLE
stm32f7: Remove references to BOARD_ENABLE_USBOTG_HSULPI. 

### DIFF
--- a/arch/arm/src/stm32f7/stm32f72xx73xx_rcc.c
+++ b/arch/arm/src/stm32f7/stm32f72xx73xx_rcc.c
@@ -211,7 +211,9 @@ static inline void rcc_enableahb1(void)
 #endif
 
 #ifdef CONFIG_STM32F7_OTGFSHS
-#if defined(CONFIG_STM32F7_INTERNAL_ULPI) || defined(CONFIG_STM32F7_EXTERNAL_ULPI)
+#  if defined(CONFIG_STM32F7_INTERNAL_ULPI) ||
+      defined(CONFIG_STM32F7_EXTERNAL_ULPI)
+
   /* Enable clocking for  USB OTG HS and external PHY */
 
   regval |= (RCC_AHB1ENR_OTGHSEN | RCC_AHB1ENR_OTGHSULPIEN);

--- a/arch/arm/src/stm32f7/stm32f74xx75xx_rcc.c
+++ b/arch/arm/src/stm32f7/stm32f74xx75xx_rcc.c
@@ -215,12 +215,13 @@ static inline void rcc_enableahb1(void)
 #endif
 
 #ifdef CONFIG_STM32F7_OTGFSHS
- #if defined(CONFIG_STM32F7_INTERNAL_ULPI) || defined(CONFIG_STM32F7_EXTERNAL_ULPI)
+#  if defined(CONFIG_STM32F7_INTERNAL_ULPI) || \
+      defined(CONFIG_STM32F7_EXTERNAL_ULPI)
+
   /* Enable clocking for  USB OTG HS and external PHY */
 
   regval |= (RCC_AHB1ENR_OTGHSEN | RCC_AHB1ENR_OTGHSULPIEN);
 #else
-
   /* Enable only clocking for USB OTG HS */
 
   regval |= RCC_AHB1ENR_OTGHSEN;

--- a/arch/arm/src/stm32f7/stm32f76xx77xx_rcc.c
+++ b/arch/arm/src/stm32f7/stm32f76xx77xx_rcc.c
@@ -221,7 +221,9 @@ static inline void rcc_enableahb1(void)
 #endif
 
 #ifdef CONFIG_STM32F7_OTGFSHS
-#ifdef BOARD_ENABLE_USBOTG_HSULPI
+#  if defined(CONFIG_STM32F7_INTERNAL_ULPI) || \
+      defined(CONFIG_STM32F7_EXTERNAL_ULPI)
+
   /* Enable clocking for  USB OTG HS and external PHY */
 
   regval |= (RCC_AHB1ENR_OTGHSEN | RCC_AHB1ENR_OTGHSULPIEN);


### PR DESCRIPTION
## Summary
stm32f7: Remove references to BOARD_ENABLE_USBOTG_HSULPI. 
Prefer Kconfig option instead.

## Impact
BOARD_ENABLE_USBOTG_HSULPI no longer has an affect. Boards should remove this definition and ensure the ULPI setting is correct - which it probably is for things to be working.

## Testing
CI

