### PR TITLE
stm32 timers: Prefer GTIM macros and make this use more uniform.

### DIFF
--- a/arch/arm/src/stm32/hardware/stm32_tim_v1v2.h
+++ b/arch/arm/src/stm32/hardware/stm32_tim_v1v2.h
@@ -1199,7 +1199,6 @@
 
 #define GTIM_CCER_CC1E            (1 << 0)  /* Bit 0: Capture/Compare 1 output enable */
 #define GTIM_CCER_CC1P            (1 << 1)  /* Bit 1: Capture/Compare 1 output polarity */
-#define GTIM_CCER_CC1NE           (1 << 2)  /* Bit 2: Capture/Compare 1 complementary output enable (TIM1 and TIM8 only) */
 #ifdef HAVE_GTIM_CCXNP
 #  define GTIM_CCER_CC1NP         (1 << 3)  /* Bit 3: Capture/Compare 1 output Polarity (F2,F3,F4 and TIM15-17) */
 #endif

--- a/arch/arm/src/stm32/hardware/stm32_tim_v1v2.h
+++ b/arch/arm/src/stm32/hardware/stm32_tim_v1v2.h
@@ -826,6 +826,7 @@
 #  define ATIM_CCER_CC6E          (1 << 20) /* Bit 20: Capture/Compare 6 output enable */
 #  define ATIM_CCER_CC6P          (1 << 21) /* Bit 21: Capture/Compare 6 output Polarity */
 #endif
+#define ATIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 
@@ -1222,6 +1223,7 @@
                                              *   no CC4N output, so it does not make sense!
                                              */
 #endif
+#define GTIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 

--- a/arch/arm/src/stm32/hardware/stm32_tim_v3.h
+++ b/arch/arm/src/stm32/hardware/stm32_tim_v3.h
@@ -769,6 +769,7 @@
 #define ATIM_CCER_CC5P                 (1 << 17)                          /* Bit 17: Capture/Compare 5 Output Polarity */
 #define ATIM_CCER_CC6E                 (1 << 20)                          /* Bit 20: Capture/Compare 6 Output Enable */
 #define ATIM_CCER_CC6P                 (1 << 21)                          /* Bit 21: Capture/Compare 6 Output Polarity */
+#define ATIM_CCER_CCXBASE(ch)          (ch << 2)                          /* Each channel uses 4-bits */
 
 /* ATIM Counter (CNT) */
 
@@ -1236,6 +1237,7 @@
 #define GTIM_CCER_CC4E                 (1 << 12)                          /* Bit 12: Capture/Compare 4 Output Enable */
 #define GTIM_CCER_CC4P                 (1 << 13)                          /* Bit 13: Capture/Compare 4 Output Polarity */
 #define GTIM_CCER_CC4NP                (1 << 15)                          /* Bit 15: Capture/Compare 4 Complementary Output Polarity */
+#define GTIM_CCER_CCXBASE(ch)          (ch << 2)                          /* Each channel uses 4-bits */
 
 /* GTIM Counter (CNT) */
 

--- a/arch/arm/src/stm32/stm32_capture.c
+++ b/arch/arm/src/stm32/stm32_capture.c
@@ -963,9 +963,9 @@ static int stm32_cap_setchannel(FAR struct stm32_cap_dev_s *dev,
   /* Shift all CCER bits to corresponding channel */
 
   mask = (GTIM_CCER_CC1E | GTIM_CCER_CC1P | GTIM_CCER_CC1NP);
-  mask          <<= (channel << 2);
-  regval        <<= (channel << 2);
-  ccer_en_bit   <<= (channel << 2);
+  mask          <<= GTIM_CCER_CCXBASE(channel);
+  regval        <<= GTIM_CCER_CCXBASE(channel);
+  ccer_en_bit   <<= GTIM_CCER_CCXBASE(channel);
 
   stm32_modifyreg16(priv, STM32_GTIM_CCER_OFFSET, mask, regval);
 

--- a/arch/arm/src/stm32/stm32_dac.c
+++ b/arch/arm/src/stm32/stm32_dac.c
@@ -1056,7 +1056,7 @@ static int dac_send(FAR struct dac_dev_s *dev, FAR struct dac_msg_s *msg)
 #ifdef HAVE_TIMER
   if (chan->timer != TIM_INDEX_HRTIM)
     {
-      tim_modifyreg(chan, STM32_BTIM_EGR_OFFSET, 0, ATIM_EGR_UG);
+      tim_modifyreg(chan, STM32_GTIM_EGR_OFFSET, 0, GTIM_EGR_UG);
     }
 #endif
 
@@ -1336,26 +1336,26 @@ static int dac_timinit(FAR struct stm32_chan_s *chan)
 
   /* Set the reload and prescaler values */
 
-  tim_putreg(chan, STM32_BTIM_ARR_OFFSET, (uint16_t)reload);
-  tim_putreg(chan, STM32_BTIM_PSC_OFFSET, (uint16_t)(prescaler - 1));
+  tim_putreg(chan, STM32_GTIM_ARR_OFFSET, (uint16_t)reload);
+  tim_putreg(chan, STM32_GTIM_PSC_OFFSET, (uint16_t)(prescaler - 1));
 
   /* Count mode up, auto reload */
 
-  tim_modifyreg(chan, STM32_BTIM_CR1_OFFSET, 0, ATIM_CR1_ARPE);
+  tim_modifyreg(chan, STM32_GTIM_CR1_OFFSET, 0, GTIM_CR1_ARPE);
 
   /* Selection TRGO selection: update */
 
-  tim_modifyreg(chan, STM32_BTIM_CR2_OFFSET, ATIM_CR2_MMS_MASK,
-                ATIM_CR2_MMS_UPDATE);
+  tim_modifyreg(chan, STM32_GTIM_CR2_OFFSET, GTIM_CR2_MMS_MASK,
+                GTIM_CR2_MMS_UPDATE);
 
   /* Update DMA request enable ???? */
 #if 0
-  tim_modifyreg(chan, STM32_BTIM_DIER_OFFSET, 0, ATIM_DIER_UDE);
+  tim_modifyreg(chan, STM32_GTIM_DIER_OFFSET, 0, GTIM_DIER_UDE);
 #endif
 
   /* Enable the counter */
 
-  tim_modifyreg(chan, STM32_BTIM_CR1_OFFSET, 0, ATIM_CR1_CEN);
+  tim_modifyreg(chan, STM32_GTIM_CR1_OFFSET, 0, GTIM_CR1_CEN);
   return OK;
 }
 #endif

--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -895,7 +895,7 @@ void stm32_foc_sync_all(void)
     {
       /* Force update event to reset CNTR */
 
-      putreg32(ATIM_EGR_UG, egr_reg[i]);
+      putreg32(GTIM_EGR_UG, egr_reg[i]);
     }
 }
 #endif

--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -2975,11 +2975,11 @@ static int pwm_outputs_enable(FAR struct pwm_lowerhalf_s *dev,
   /* Get outputs configuration */
 
   regval |= ((outputs & STM32_PWM_OUT1)  ? GTIM_CCER_CC1E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT1N) ? GTIM_CCER_CC1NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT1N) ? ATIM_CCER_CC1NE : 0);
   regval |= ((outputs & STM32_PWM_OUT2)  ? GTIM_CCER_CC2E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT2N) ? GTIM_CCER_CC2NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT2N) ? ATIM_CCER_CC2NE : 0);
   regval |= ((outputs & STM32_PWM_OUT3)  ? GTIM_CCER_CC3E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT3N) ? GTIM_CCER_CC3NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT3N) ? ATIM_CCER_CC3NE : 0);
   regval |= ((outputs & STM32_PWM_OUT4)  ? GTIM_CCER_CC4E  : 0);
 
   /* NOTE: CC4N doesn't exist, but some docs show configuration bits for it */

--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -2647,13 +2647,13 @@ static int pwm_mode_configure(FAR struct pwm_lowerhalf_s *dev,
 
       case STM32_CHANMODE_PWM1:
         {
-          chanmode = ATIM_CCMR_MODE_PWM1;
+          chanmode = GTIM_CCMR_MODE_PWM1;
           break;
         }
 
       case STM32_CHANMODE_PWM2:
         {
-          chanmode = ATIM_CCMR_MODE_PWM2;
+          chanmode = GTIM_CCMR_MODE_PWM2;
           break;
         }
 
@@ -2974,13 +2974,13 @@ static int pwm_outputs_enable(FAR struct pwm_lowerhalf_s *dev,
 
   /* Get outputs configuration */
 
-  regval |= ((outputs & STM32_PWM_OUT1)  ? ATIM_CCER_CC1E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT1N) ? ATIM_CCER_CC1NE : 0);
-  regval |= ((outputs & STM32_PWM_OUT2)  ? ATIM_CCER_CC2E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT2N) ? ATIM_CCER_CC2NE : 0);
-  regval |= ((outputs & STM32_PWM_OUT3)  ? ATIM_CCER_CC3E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT3N) ? ATIM_CCER_CC3NE : 0);
-  regval |= ((outputs & STM32_PWM_OUT4)  ? ATIM_CCER_CC4E  : 0);
+  regval |= ((outputs & STM32_PWM_OUT1)  ? GTIM_CCER_CC1E  : 0);
+  regval |= ((outputs & STM32_PWM_OUT1N) ? GTIM_CCER_CC1NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT2)  ? GTIM_CCER_CC2E  : 0);
+  regval |= ((outputs & STM32_PWM_OUT2N) ? GTIM_CCER_CC2NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT3)  ? GTIM_CCER_CC3E  : 0);
+  regval |= ((outputs & STM32_PWM_OUT3N) ? GTIM_CCER_CC3NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT4)  ? GTIM_CCER_CC4E  : 0);
 
   /* NOTE: CC4N doesn't exist, but some docs show configuration bits for it */
 
@@ -3094,7 +3094,7 @@ static int pwm_soft_update(FAR struct pwm_lowerhalf_s *dev)
 {
   FAR struct stm32_pwmtimer_s *priv = (FAR struct stm32_pwmtimer_s *)dev;
 
-  pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, ATIM_EGR_UG);
+  pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, GTIM_EGR_UG);
 
   return OK;
 }
@@ -3486,7 +3486,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
       /* Clear all pending interrupts and enable the update interrupt. */
 
       pwm_putreg(priv, STM32_GTIM_SR_OFFSET, 0);
-      pwm_putreg(priv, STM32_GTIM_DIER_OFFSET, ATIM_DIER_UIE);
+      pwm_putreg(priv, STM32_GTIM_DIER_OFFSET, GTIM_DIER_UIE);
 
       /* Enable the timer */
 

--- a/arch/arm/src/stm32/stm32_tickless.c
+++ b/arch/arm/src/stm32/stm32_tickless.c
@@ -240,7 +240,8 @@ static int stm32_tickless_setchannel(uint8_t channel)
 
   /* Assume that channel is disabled and polarity is active high */
 
-  ccer_val &= ~(3 << (channel << 2));
+  ccer_val &= ~((GTIM_CCER_CC1P | GTIM_CCER_CC1E) <<
+                GTIM_CCER_CCXBASE(channel));
 
   /* This function is not supported on basic timers. To enable or
    * disable it, simply set its clock to valid frequency or zero.
@@ -267,7 +268,7 @@ static int stm32_tickless_setchannel(uint8_t channel)
 
   /* Set polarity */
 
-  ccer_val |= ATIM_CCER_CC1P << (channel << 2);
+  ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
 
   /* Define its position (shift) and get register offset */
 

--- a/arch/arm/src/stm32/stm32_tim.c
+++ b/arch/arm/src/stm32/stm32_tim.c
@@ -599,9 +599,9 @@ static inline void stm32_putreg32(FAR struct stm32_tim_dev_s *dev,
 
 static void stm32_tim_reload_counter(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_EGR_OFFSET);
-  val |= ATIM_EGR_UG;
-  stm32_putreg16(dev, STM32_BTIM_EGR_OFFSET, val);
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_EGR_OFFSET);
+  val |= GTIM_EGR_UG;
+  stm32_putreg16(dev, STM32_GTIM_EGR_OFFSET, val);
 }
 
 /****************************************************************************
@@ -610,10 +610,10 @@ static void stm32_tim_reload_counter(FAR struct stm32_tim_dev_s *dev)
 
 static void stm32_tim_enable(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_CR1_OFFSET);
-  val |= ATIM_CR1_CEN;
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_CR1_OFFSET);
+  val |= GTIM_CR1_CEN;
   stm32_tim_reload_counter(dev);
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 }
 
 /****************************************************************************
@@ -622,9 +622,9 @@ static void stm32_tim_enable(FAR struct stm32_tim_dev_s *dev)
 
 static void stm32_tim_disable(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_CR1_OFFSET);
-  val &= ~ATIM_CR1_CEN;
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_CR1_OFFSET);
+  val &= ~GTIM_CR1_CEN;
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 }
 
 /****************************************************************************
@@ -669,7 +669,7 @@ static void stm32_tim_gpioconfig(uint32_t cfg, stm32_tim_channel_t mode)
 static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
                              stm32_tim_mode_t mode)
 {
-  uint16_t val = ATIM_CR1_CEN | ATIM_CR1_ARPE;
+  uint16_t val = GTIM_CR1_CEN | GTIM_CR1_ARPE;
 
   DEBUGASSERT(dev != NULL);
 
@@ -699,7 +699,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_MODE_DOWN:
-        val |= ATIM_CR1_DIR;
+        val |= GTIM_CR1_DIR;
 
       case STM32_TIM_MODE_UP:
         break;
@@ -709,11 +709,11 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
          * Interrupts are generated on compare, when counting down
          */
 
-        val |= ATIM_CR1_CENTER1;
+        val |= GTIM_CR1_CENTER1;
         break;
 
       case STM32_TIM_MODE_PULSE:
-        val |= ATIM_CR1_OPM;
+        val |= GTIM_CR1_OPM;
         break;
 
       default:
@@ -721,7 +721,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
     }
 
   stm32_tim_reload_counter(dev);
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 
 #if STM32_NATIM > 0
   /* Advanced registers require Main Output Enable */
@@ -878,7 +878,7 @@ static int stm32_tim_setclock(FAR struct stm32_tim_dev_s *dev, uint32_t freq)
       prescaler = 0xffff;
     }
 
-  stm32_putreg16(dev, STM32_BTIM_PSC_OFFSET, prescaler);
+  stm32_putreg16(dev, STM32_GTIM_PSC_OFFSET, prescaler);
   stm32_tim_enable(dev);
 
   return prescaler;
@@ -892,7 +892,7 @@ static void stm32_tim_setperiod(FAR struct stm32_tim_dev_s *dev,
                                 uint32_t period)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_putreg32(dev, STM32_BTIM_ARR_OFFSET, period);
+  stm32_putreg32(dev, STM32_GTIM_ARR_OFFSET, period);
 }
 
 /****************************************************************************
@@ -903,8 +903,8 @@ static uint32_t stm32_tim_getcounter(FAR struct stm32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
   return stm32_tim_getwidth(dev) > 16 ?
-    stm32_getreg32(dev, STM32_BTIM_CNT_OFFSET) :
-    (uint32_t)stm32_getreg16(dev, STM32_BTIM_CNT_OFFSET);
+    stm32_getreg32(dev, STM32_GTIM_CNT_OFFSET) :
+    (uint32_t)stm32_getreg16(dev, STM32_GTIM_CNT_OFFSET);
 }
 
 /****************************************************************************
@@ -918,11 +918,11 @@ static void stm32_tim_setcounter(FAR struct stm32_tim_dev_s *dev,
 
   if (stm32_tim_getwidth(dev) > 16)
     {
-      stm32_putreg32(dev, STM32_BTIM_CNT_OFFSET, count);
+      stm32_putreg32(dev, STM32_GTIM_CNT_OFFSET, count);
     }
   else
     {
-      stm32_putreg16(dev, STM32_BTIM_CNT_OFFSET, (uint16_t)count);
+      stm32_putreg16(dev, STM32_GTIM_CNT_OFFSET, (uint16_t)count);
     }
 }
 
@@ -1013,9 +1013,9 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_CH_OUTPWM:
-        ccmr_val = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
-                   ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
+        ccmr_val = (GTIM_CCMR_MODE_PWM1 << GTIM_CCMR1_OC1M_SHIFT) +
+                   GTIM_CCMR1_OC1PE;
+        ccer_val |= GTIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       default:
@@ -1026,7 +1026,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   if (mode & STM32_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
+      ccer_val |= GTIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */
@@ -1672,7 +1672,7 @@ static int stm32_tim_setisr(FAR struct stm32_tim_dev_s *dev, xcpt_t handler,
 static void stm32_tim_enableint(FAR struct stm32_tim_dev_s *dev, int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_modifyreg16(dev, STM32_BTIM_DIER_OFFSET, 0, source);
+  stm32_modifyreg16(dev, STM32_GTIM_DIER_OFFSET, 0, source);
 }
 
 /****************************************************************************
@@ -1682,7 +1682,7 @@ static void stm32_tim_enableint(FAR struct stm32_tim_dev_s *dev, int source)
 static void stm32_tim_disableint(FAR struct stm32_tim_dev_s *dev, int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_modifyreg16(dev, STM32_BTIM_DIER_OFFSET, source, 0);
+  stm32_modifyreg16(dev, STM32_GTIM_DIER_OFFSET, source, 0);
 }
 
 /****************************************************************************
@@ -1691,7 +1691,7 @@ static void stm32_tim_disableint(FAR struct stm32_tim_dev_s *dev, int source)
 
 static void stm32_tim_ackint(FAR struct stm32_tim_dev_s *dev, int source)
 {
-  stm32_putreg16(dev, STM32_BTIM_SR_OFFSET, ~source);
+  stm32_putreg16(dev, STM32_GTIM_SR_OFFSET, ~source);
 }
 
 /****************************************************************************
@@ -1700,7 +1700,7 @@ static void stm32_tim_ackint(FAR struct stm32_tim_dev_s *dev, int source)
 
 static int stm32_tim_checkint(FAR struct stm32_tim_dev_s *dev, int source)
 {
-  uint16_t regval = stm32_getreg16(dev, STM32_BTIM_SR_OFFSET);
+  uint16_t regval = stm32_getreg16(dev, STM32_GTIM_SR_OFFSET);
   return (regval & source) ? 1 : 0;
 }
 

--- a/arch/arm/src/stm32/stm32_tim.c
+++ b/arch/arm/src/stm32/stm32_tim.c
@@ -985,7 +985,8 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   /* Assume that channel is disabled and polarity is active high */
 
-  ccer_val &= ~(3 << (channel << 2));
+  ccer_val &= ~((GTIM_CCER_CC1P | GTIM_CCER_CC1E) <<
+                GTIM_CCER_CCXBASE(channel));
 
   /* This function is not supported on basic timers. To enable or
    * disable it, simply set its clock to valid frequency or zero.
@@ -1014,7 +1015,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
       case STM32_TIM_CH_OUTPWM:
         ccmr_val = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
                    ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       default:
@@ -1025,7 +1026,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   if (mode & STM32_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << (channel << 2);
+      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */

--- a/arch/arm/src/stm32f0l0g0/hardware/stm32_tim.h
+++ b/arch/arm/src/stm32f0l0g0/hardware/stm32_tim.h
@@ -611,6 +611,7 @@
 #define ATIM_CCER_CC5P            (1 << 17) /* Bit 17: Capture/Compare 5 output Polarity */
 #define ATIM_CCER_CC6E            (1 << 20) /* Bit 20: Capture/Compare 6 output enable */
 #define ATIM_CCER_CC6P            (1 << 21) /* Bit 21: Capture/Compare 6 output Polarity */
+#define ATIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 
@@ -1030,6 +1031,7 @@
 #define GTIM_CCER_CC4E            (1 << 12) /* Bit 12: Capture/Compare 4 output enable (TIM3 only) */
 #define GTIM_CCER_CC4P            (1 << 13) /* Bit 13: Capture/Compare 4 output Polarity (TIM3 only) */
 #define GTIM_CCER_CC4NP           (1 << 15) /* Bit 15: Capture/Compare 4 output Polarity (TIM3 only) */
+#define GTIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 

--- a/arch/arm/src/stm32f0l0g0/stm32_pwm.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_pwm.c
@@ -551,30 +551,30 @@ static struct stm32_pwmtimer_s g_pwm17dev =
 
 static bool stm32pwm_reg_is_32bit(uint8_t timtype, uint32_t offset)
 {
-  if (offset == STM32_ATIM_CCMR1_OFFSET ||
-      offset == STM32_ATIM_SMCR_OFFSET  ||
-      offset == STM32_ATIM_BDTR_OFFSET)
+  if (offset == STM32_GTIM_CCMR1_OFFSET ||
+      offset == STM32_GTIM_SMCR_OFFSET  ||
+      offset == STM32_GTIM_BDTR_OFFSET)
     {
       return true;
     }
 
   if (timtype == TIMTYPE_GENERAL16)
     {
-      if (offset == STM32_ATIM_CCMR2_OFFSET ||
-          offset == STM32_ATIM_AF1_OFFSET   ||
-          offset == STM32_ATIM_TISEL_OFFSET)
+      if (offset == STM32_GTIM_CCMR2_OFFSET ||
+          offset == STM32_GTIM_AF1_OFFSET   ||
+          offset == STM32_GTIM_TISEL_OFFSET)
         {
           return true;
         }
     }
   else if (timtype == TIMTYPE_GENERAL32)
     {
-      if (offset == STM32_ATIM_CNT_OFFSET  ||
-          offset == STM32_ATIM_ARR_OFFSET  ||
-          offset == STM32_ATIM_CCR1_OFFSET ||
-          offset == STM32_ATIM_CCR2_OFFSET ||
-          offset == STM32_ATIM_CCR3_OFFSET ||
-          offset == STM32_ATIM_CCR4_OFFSET)
+      if (offset == STM32_GTIM_CNT_OFFSET  ||
+          offset == STM32_GTIM_ARR_OFFSET  ||
+          offset == STM32_GTIM_CCR1_OFFSET ||
+          offset == STM32_GTIM_CCR2_OFFSET ||
+          offset == STM32_GTIM_CCR3_OFFSET ||
+          offset == STM32_GTIM_CCR4_OFFSET)
         {
           return true;
         }
@@ -751,17 +751,17 @@ static void stm32pwm_dumpregs(struct stm32_pwmtimer_s *priv,
           stm32pwm_getreg(priv, STM32_ATIM_DMAR_OFFSET));
 
           pwminfo("  AF1: %04x TISEL: %04x\n",
-          stm32pwm_getreg(priv, STM32_GTIM_AF1_OFFSET),
-          stm32pwm_getreg(priv, STM32_GTIM_TISEL_OFFSET));
+          stm32pwm_getreg(priv, STM32_ATIM_AF1_OFFSET),
+          stm32pwm_getreg(priv, STM32_ATIM_TISEL_OFFSET));
     }
   else
 #endif
     {
       pwminfo("  RCR: %04x BDTR: %04x DCR:   %04x DMAR:  %04x\n",
-          stm32pwm_getreg(priv, STM32_ATIM_RCR_OFFSET),
-          stm32pwm_getreg(priv, STM32_ATIM_BDTR_OFFSET),
-          stm32pwm_getreg(priv, STM32_ATIM_DCR_OFFSET),
-          stm32pwm_getreg(priv, STM32_ATIM_DMAR_OFFSET));
+          stm32pwm_getreg(priv, STM32_GTIM_RCR_OFFSET),
+          stm32pwm_getreg(priv, STM32_GTIM_BDTR_OFFSET),
+          stm32pwm_getreg(priv, STM32_GTIM_DCR_OFFSET),
+          stm32pwm_getreg(priv, STM32_GTIM_DMAR_OFFSET));
       pwminfo("  AF1: %04x TISEL: %04x\n",
           stm32pwm_getreg(priv, STM32_GTIM_AF1_OFFSET),
           stm32pwm_getreg(priv, STM32_GTIM_TISEL_OFFSET));
@@ -1101,7 +1101,7 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
            * preload the RCR into active repetition counter.
            */
 
-          stm32pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, ATIM_EGR_UG);
+          stm32pwm_putreg(priv, STM32_ATIM_EGR_OFFSET, ATIM_EGR_UG);
 
           /* Now set the value of the RCR that will be loaded on the next
            * update event.
@@ -1123,7 +1123,7 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
 
           /* Generate an update event to reload the prescaler */
 
-          stm32pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, ATIM_EGR_UG);
+          stm32pwm_putreg(priv, STM32_ATIM_EGR_OFFSET, ATIM_EGR_UG);
         }
     }
   else
@@ -1131,7 +1131,7 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
     {
       /* Generate an update event to reload the prescaler (all timers) */
 
-      stm32pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, ATIM_EGR_UG);
+      stm32pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, GTIM_EGR_UG);
     }
 
   /* Handle channel specific setup */
@@ -1199,30 +1199,30 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
       switch (mode)
         {
           case STM32_CHANMODE_PWM1:
-            chanmode = ATIM_CCMR_MODE_PWM1;
+            chanmode = GTIM_CCMR_MODE_PWM1;
             break;
 
           case STM32_CHANMODE_PWM2:
-            chanmode = ATIM_CCMR_MODE_PWM2;
+            chanmode = GTIM_CCMR_MODE_PWM2;
             break;
 
           case STM32_CHANMODE_COMBINED1:
-            chanmode = ATIM_CCMR_MODE_COMBINED1;
+            chanmode = GTIM_CCMR_MODE_COMBINED1;
             ocmbit = true;
             break;
 
           case STM32_CHANMODE_COMBINED2:
-            chanmode = ATIM_CCMR_MODE_COMBINED2;
+            chanmode = GTIM_CCMR_MODE_COMBINED2;
             ocmbit = true;
             break;
 
           case STM32_CHANMODE_ASYMMETRIC1:
-            chanmode = ATIM_CCMR_MODE_ASYMMETRIC1;
+            chanmode = GTIM_CCMR_MODE_ASYMMETRIC1;
             ocmbit = true;
             break;
 
           case STM32_CHANMODE_ASYMMETRIC2:
-            chanmode = ATIM_CCMR_MODE_ASYMMETRIC2;
+            chanmode = GTIM_CCMR_MODE_ASYMMETRIC2;
             ocmbit = true;
             break;
 
@@ -1237,13 +1237,13 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Set the CCMR1 mode values (leave CCMR2 zero) */
 
-              ocmode1  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC1S_SHIFT) |
-                          (chanmode << ATIM_CCMR1_OC1M_SHIFT) |
-                          ATIM_CCMR1_OC1PE;
+              ocmode1  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR1_CC1S_SHIFT) |
+                          (chanmode << GTIM_CCMR1_OC1M_SHIFT) |
+                          GTIM_CCMR1_OC1PE;
 
               if (ocmbit)
                 {
-                  ocmode1 |= ATIM_CCMR1_OC1M;
+                  ocmode1 |= GTIM_CCMR1_OC1M;
                 }
 
               /* Set the duty cycle by writing to the CCR register for this
@@ -1256,8 +1256,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
                * output compare mode.
                */
 
-              ccmr1 &= ~(ATIM_CCMR1_CC1S_MASK | ATIM_CCMR1_OC1M_MASK |
-                         ATIM_CCMR1_OC1PE | ATIM_CCMR1_OC1M);
+              ccmr1 &= ~(GTIM_CCMR1_CC1S_MASK | GTIM_CCMR1_OC1M_MASK |
+                         GTIM_CCMR1_OC1PE | GTIM_CCMR1_OC1M);
               stm32pwm_output_configure(priv, channel);
             }
             break;
@@ -1266,13 +1266,13 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Set the CCMR1 mode values (leave CCMR2 zero) */
 
-              ocmode1  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC2S_SHIFT) |
-                          (chanmode << ATIM_CCMR1_OC2M_SHIFT) |
-                          ATIM_CCMR1_OC2PE;
+              ocmode1  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR1_CC2S_SHIFT) |
+                          (chanmode << GTIM_CCMR1_OC2M_SHIFT) |
+                          GTIM_CCMR1_OC2PE;
 
               if (ocmbit)
                 {
-                  ocmode1 |= ATIM_CCMR1_OC2M;
+                  ocmode1 |= GTIM_CCMR1_OC2M;
                 }
 
               /* Set the duty cycle by writing to the CCR register for this
@@ -1285,8 +1285,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
                * output compare mode.
                */
 
-              ccmr1 &= ~(ATIM_CCMR1_CC2S_MASK | ATIM_CCMR1_OC2M_MASK |
-                         ATIM_CCMR1_OC2PE | ATIM_CCMR1_OC2M);
+              ccmr1 &= ~(GTIM_CCMR1_CC2S_MASK | GTIM_CCMR1_OC2M_MASK |
+                         GTIM_CCMR1_OC2PE | GTIM_CCMR1_OC2M);
               stm32pwm_output_configure(priv, channel);
             }
             break;
@@ -1296,13 +1296,13 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Set the CCMR2 mode values (leave CCMR1 zero) */
 
-              ocmode2  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR2_CC3S_SHIFT) |
-                          (chanmode << ATIM_CCMR2_OC3M_SHIFT) |
-                          ATIM_CCMR2_OC3PE;
+              ocmode2  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR2_CC3S_SHIFT) |
+                          (chanmode << GTIM_CCMR2_OC3M_SHIFT) |
+                          GTIM_CCMR2_OC3PE;
 
               if (ocmbit)
                 {
-                  ocmode2 |= ATIM_CCMR2_OC3M;
+                  ocmode2 |= GTIM_CCMR2_OC3M;
                 }
 
               /* Set the duty cycle by writing to the CCR register for this
@@ -1315,8 +1315,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
                * output compare mode.
                */
 
-              ccmr2 &= ~(ATIM_CCMR2_CC3S_MASK | ATIM_CCMR2_OC3M_MASK |
-                         ATIM_CCMR2_OC3PE | ATIM_CCMR2_OC3M);
+              ccmr2 &= ~(GTIM_CCMR2_CC3S_MASK | GTIM_CCMR2_OC3M_MASK |
+                         GTIM_CCMR2_OC3PE | GTIM_CCMR2_OC3M);
               stm32pwm_output_configure(priv, channel);
             }
             break;
@@ -1325,13 +1325,13 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Set the CCMR2 mode values (leave CCMR1 zero) */
 
-              ocmode2  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR2_CC4S_SHIFT) |
-                          (chanmode << ATIM_CCMR2_OC4M_SHIFT) |
-                          ATIM_CCMR2_OC4PE;
+              ocmode2  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR2_CC4S_SHIFT) |
+                          (chanmode << GTIM_CCMR2_OC4M_SHIFT) |
+                          GTIM_CCMR2_OC4PE;
 
               if (ocmbit)
                 {
-                  ocmode2 |= ATIM_CCMR2_OC4M;
+                  ocmode2 |= GTIM_CCMR2_OC4M;
                 }
 
               /* Set the duty cycle by writing to the CCR register for this
@@ -1344,8 +1344,8 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
                * output compare mode.
                */
 
-              ccmr2 &= ~(ATIM_CCMR2_CC4S_MASK | ATIM_CCMR2_OC4M_MASK |
-                         ATIM_CCMR2_OC4PE | ATIM_CCMR2_OC4M);
+              ccmr2 &= ~(GTIM_CCMR2_CC4S_MASK | GTIM_CCMR2_OC4M_MASK |
+                         GTIM_CCMR2_OC4PE | GTIM_CCMR2_OC4M);
               stm32pwm_output_configure(priv, channel);
             }
             break;
@@ -1406,7 +1406,7 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
       /* Clear all pending interrupts and enable the update interrupt. */
 
       stm32pwm_putreg(priv, STM32_GTIM_SR_OFFSET, 0);
-      stm32pwm_putreg(priv, STM32_GTIM_DIER_OFFSET, ATIM_DIER_UIE);
+      stm32pwm_putreg(priv, STM32_GTIM_DIER_OFFSET, GTIM_DIER_UIE);
 
       /* Enable the timer */
 

--- a/arch/arm/src/stm32f0l0g0/stm32_pwm.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_pwm.c
@@ -1296,27 +1296,27 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Set the CCMR2 mode values (leave CCMR1 zero) */
 
-              ocmode2  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR2_CC3S_SHIFT) |
-                          (chanmode << GTIM_CCMR2_OC3M_SHIFT) |
-                          GTIM_CCMR2_OC3PE;
+              ocmode2  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR2_CC3S_SHIFT) |
+                          (chanmode << ATIM_CCMR2_OC3M_SHIFT) |
+                          ATIM_CCMR2_OC3PE;
 
               if (ocmbit)
                 {
-                  ocmode2 |= GTIM_CCMR2_OC3M;
+                  ocmode2 |= ATIM_CCMR2_OC3M;
                 }
 
               /* Set the duty cycle by writing to the CCR register for this
                * channel.
                */
 
-              stm32pwm_putreg(priv, STM32_GTIM_CCR3_OFFSET, ccr);
+              stm32pwm_putreg(priv, STM32_ATIM_CCR3_OFFSET, ccr);
 
               /* Reset the Output Compare Mode Bits and set the select
                * output compare mode.
                */
 
-              ccmr2 &= ~(GTIM_CCMR2_CC3S_MASK | GTIM_CCMR2_OC3M_MASK |
-                         GTIM_CCMR2_OC3PE | GTIM_CCMR2_OC3M);
+              ccmr2 &= ~(ATIM_CCMR2_CC3S_MASK | ATIM_CCMR2_OC3M_MASK |
+                         ATIM_CCMR2_OC3PE | ATIM_CCMR2_OC3M);
               stm32pwm_output_configure(priv, channel);
             }
             break;
@@ -1325,27 +1325,27 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Set the CCMR2 mode values (leave CCMR1 zero) */
 
-              ocmode2  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR2_CC4S_SHIFT) |
-                          (chanmode << GTIM_CCMR2_OC4M_SHIFT) |
-                          GTIM_CCMR2_OC4PE;
+              ocmode2  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR2_CC4S_SHIFT) |
+                          (chanmode << ATIM_CCMR2_OC4M_SHIFT) |
+                          ATIM_CCMR2_OC4PE;
 
               if (ocmbit)
                 {
-                  ocmode2 |= GTIM_CCMR2_OC4M;
+                  ocmode2 |= ATIM_CCMR2_OC4M;
                 }
 
               /* Set the duty cycle by writing to the CCR register for this
                * channel.
                */
 
-              stm32pwm_putreg(priv, STM32_GTIM_CCR4_OFFSET, ccr);
+              stm32pwm_putreg(priv, STM32_ATIM_CCR4_OFFSET, ccr);
 
               /* Reset the Output Compare Mode Bits and set the select
                * output compare mode.
                */
 
-              ccmr2 &= ~(GTIM_CCMR2_CC4S_MASK | GTIM_CCMR2_OC4M_MASK |
-                         GTIM_CCMR2_OC4PE | GTIM_CCMR2_OC4M);
+              ccmr2 &= ~(ATIM_CCMR2_CC4S_MASK | ATIM_CCMR2_OC4M_MASK |
+                         ATIM_CCMR2_OC4PE | ATIM_CCMR2_OC4M);
               stm32pwm_output_configure(priv, channel);
             }
             break;
@@ -1371,14 +1371,14 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
 
       /* Get current register state */
 
-      bdtr  = stm32pwm_getreg(priv, STM32_GTIM_BDTR_OFFSET);
+      bdtr  = stm32pwm_getreg(priv, STM32_ATIM_BDTR_OFFSET);
 
       /* Update deadtime */
 
-      bdtr &= ~(GTIM_BDTR_OSSI | GTIM_BDTR_OSSR);
-      bdtr |= GTIM_BDTR_MOE;
+      bdtr &= ~(ATIM_BDTR_OSSI | ATIM_BDTR_OSSR);
+      bdtr |= ATIM_BDTR_MOE;
 
-      stm32pwm_putreg(priv, STM32_GTIM_BDTR_OFFSET, bdtr);
+      stm32pwm_putreg(priv, STM32_ATIM_BDTR_OFFSET, bdtr);
     }
 #endif
 
@@ -1386,7 +1386,7 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
 
   putreg32(ccmr1, priv->base + STM32_GTIM_CCMR1_OFFSET);
 #if defined(HAVE_CCMR2)
-  putreg32(ccmr2, priv->base + STM32_GTIM_CCMR2_OFFSET);
+  putreg32(ccmr2, priv->base + STM32_ATIM_CCMR2_OFFSET);
 #endif
 
   /* Set the ARR Preload Bit */

--- a/arch/arm/src/stm32f0l0g0/stm32_tim.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_tim.c
@@ -969,7 +969,8 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   /* Assume that channel is disabled and polarity is active high */
 
-  ccer_val &= ~(3 << (channel << 2));
+  ccer_val &= ~((GTIM_CCER_CC1P | GTIM_CCER_CC1E) <<
+                GTIM_CCER_CCXBASE(channel));
 
   /* This function is not supported on basic timers. To enable or
    * disable it, simply set its clock to valid frequency or zero.
@@ -991,7 +992,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
       case STM32_TIM_CH_OUTPWM:
         ccmr_val  = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
                     ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       default:
@@ -1002,7 +1003,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   if (mode & STM32_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << (channel << 2);
+      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */

--- a/arch/arm/src/stm32f0l0g0/stm32_tim.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_tim.c
@@ -490,24 +490,24 @@ static inline void stm32_putreg32(FAR struct stm32_tim_dev_s *dev,
 
 static void stm32_tim_reload_counter(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_EGR_OFFSET);
-  val |= ATIM_EGR_UG;
-  stm32_putreg16(dev, STM32_BTIM_EGR_OFFSET, val);
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_EGR_OFFSET);
+  val |= GTIM_EGR_UG;
+  stm32_putreg16(dev, STM32_GTIM_EGR_OFFSET, val);
 }
 
 static void stm32_tim_enable(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_CR1_OFFSET);
-  val |= ATIM_CR1_CEN;
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_CR1_OFFSET);
+  val |= GTIM_CR1_CEN;
   stm32_tim_reload_counter(dev);
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 }
 
 static void stm32_tim_disable(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_CR1_OFFSET);
-  val &= ~ATIM_CR1_CEN;
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_CR1_OFFSET);
+  val &= ~GTIM_CR1_CEN;
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 }
 
 /* Reset timer into system default state, but do not affect output/input
@@ -648,7 +648,7 @@ static int stm32_tim_setclock(FAR struct stm32_tim_dev_s *dev, uint32_t freq)
 
   /* PSC_OFFSET is the same for ATIM, BTIM or GTIM */
 
-  stm32_putreg16(dev, STM32_BTIM_PSC_OFFSET, prescaler);
+  stm32_putreg16(dev, STM32_GTIM_PSC_OFFSET, prescaler);
   stm32_tim_enable(dev);
 
   return prescaler;
@@ -718,7 +718,7 @@ static uint32_t stm32_tim_getclock(FAR struct stm32_tim_dev_s *dev)
         return -EINVAL;
     }
 
-  prescaler = stm32_getreg16(dev, STM32_BTIM_PSC_OFFSET);
+  prescaler = stm32_getreg16(dev, STM32_GTIM_PSC_OFFSET);
   clock = freqin / (prescaler + 1);
   return clock;
 }
@@ -731,13 +731,13 @@ static void stm32_tim_setperiod(FAR struct stm32_tim_dev_s *dev,
 
   /* ARR_OFFSET is the same for ATIM, BTIM or GTIM */
 
-  stm32_putreg32(dev, STM32_BTIM_ARR_OFFSET, period);
+  stm32_putreg32(dev, STM32_GTIM_ARR_OFFSET, period);
 }
 
 static uint32_t stm32_tim_getperiod (FAR struct stm32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
-  return stm32_getreg32 (dev, STM32_BTIM_ARR_OFFSET);
+  return stm32_getreg32 (dev, STM32_GTIM_ARR_OFFSET);
 }
 
 static uint32_t stm32_tim_getcounter(FAR struct stm32_tim_dev_s *dev)
@@ -752,7 +752,7 @@ static uint32_t stm32_tim_getcounter(FAR struct stm32_tim_dev_s *dev)
    * reset it it result when not TIM2 or TIM5.
    */
 
-  uint32_t counter = stm32_getreg32(dev, STM32_BTIM_CNT_OFFSET);
+  uint32_t counter = stm32_getreg32(dev, STM32_GTIM_CNT_OFFSET);
   counter &= 0xffff;
   return counter;
 }
@@ -853,7 +853,7 @@ static void stm32_tim_enableint(FAR struct stm32_tim_dev_s *dev, int source)
 
   /* DIER_OFFSET is the same for ATIM, BTIM or GTIM */
 
-  stm32_modifyreg16(dev, STM32_BTIM_DIER_OFFSET, 0, source);
+  stm32_modifyreg16(dev, STM32_GTIM_DIER_OFFSET, 0, source);
 }
 
 static void stm32_tim_disableint(FAR struct stm32_tim_dev_s *dev, int source)
@@ -862,14 +862,14 @@ static void stm32_tim_disableint(FAR struct stm32_tim_dev_s *dev, int source)
 
   /* DIER_OFFSET is the same for ATIM, BTIM or GTIM */
 
-  stm32_modifyreg16(dev, STM32_BTIM_DIER_OFFSET, source, 0);
+  stm32_modifyreg16(dev, STM32_GTIM_DIER_OFFSET, source, 0);
 }
 
 static void stm32_tim_ackint(FAR struct stm32_tim_dev_s *dev, int source)
 {
   /* SR_OFFSET is the same for ATIM, BTIM or GTIM */
 
-  stm32_putreg16(dev, STM32_BTIM_SR_OFFSET, ~source);
+  stm32_putreg16(dev, STM32_GTIM_SR_OFFSET, ~source);
 }
 
 /****************************************************************************
@@ -880,7 +880,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
                              stm32_tim_mode_t mode)
 {
   tmrinfo("Set mode=%d\n", mode);
-  uint16_t val = ATIM_CR1_CEN | ATIM_CR1_ARPE;
+  uint16_t val = GTIM_CR1_CEN | GTIM_CR1_ARPE;
 
   DEBUGASSERT(dev != NULL);
 
@@ -903,13 +903,13 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_MODE_DOWN:
-        val |= ATIM_CR1_DIR;
+        val |= GTIM_CR1_DIR;
 
       case STM32_TIM_MODE_UP:
         break;
 
       case STM32_TIM_MODE_UPDOWN:
-        val |= ATIM_CR1_CENTER1;
+        val |= GTIM_CR1_CENTER1;
 
         /* Our default: Interrupts are generated on compare, when counting
          * down
@@ -918,7 +918,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_MODE_PULSE:
-        val |= ATIM_CR1_OPM;
+        val |= GTIM_CR1_OPM;
         break;
 
       default:
@@ -929,7 +929,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
 
   /* CR1_OFFSET is the same for ATIM, BTIM or GTIM */
 
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 
   /* Advanced registers require Main Output Enable */
 #if defined(CONFIG_STM32F0L0G0_TIM1) || defined(CONFIG_STM32F0L0G0_TIM8)
@@ -990,9 +990,9 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_CH_OUTPWM:
-        ccmr_val  = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
-                    ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
+        ccmr_val  = (GTIM_CCMR_MODE_PWM1 << GTIM_CCMR1_OC1M_SHIFT) +
+                    GTIM_CCMR1_OC1PE;
+        ccer_val |= GTIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       default:
@@ -1003,7 +1003,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   if (mode & STM32_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
+      ccer_val |= GTIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */

--- a/arch/arm/src/stm32f7/hardware/stm32f72xx73xx_tim.h
+++ b/arch/arm/src/stm32f7/hardware/stm32f72xx73xx_tim.h
@@ -694,6 +694,7 @@
 #define ATIM_CCER_CC5P            (1 << 17) /* Bit 17: Capture/Compare 5 output Polarity */
 #define ATIM_CCER_CC6E            (1 << 20) /* Bit 20: Capture/Compare 6 output enable */
 #define ATIM_CCER_CC6P            (1 << 21) /* Bit 21: Capture/Compare 6 output Polarity */
+#define ATIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 
@@ -1073,6 +1074,7 @@
 #define GTIM_CCER_CC4E            (1 << 12) /* Bit 12: Capture/Compare 4 output enable (TIM2-5 only) */
 #define GTIM_CCER_CC4P            (1 << 13) /* Bit 13: Capture/Compare 4 output Polarity (TIM2-5 only) */
 #define GTIM_CCER_CC4NP           (1 << 15) /* Bit 15: Capture/Compare 4 output Polarity */
+#define GTIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 

--- a/arch/arm/src/stm32f7/hardware/stm32f74xx75xx_tim.h
+++ b/arch/arm/src/stm32f7/hardware/stm32f74xx75xx_tim.h
@@ -696,6 +696,7 @@
 #define ATIM_CCER_CC5P            (1 << 17) /* Bit 17: Capture/Compare 5 output Polarity */
 #define ATIM_CCER_CC6E            (1 << 20) /* Bit 20: Capture/Compare 6 output enable */
 #define ATIM_CCER_CC6P            (1 << 21) /* Bit 21: Capture/Compare 6 output Polarity */
+#define ATIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 
@@ -1075,6 +1076,7 @@
 #define GTIM_CCER_CC4E            (1 << 12) /* Bit 12: Capture/Compare 4 output enable (TIM2-5 only) */
 #define GTIM_CCER_CC4P            (1 << 13) /* Bit 13: Capture/Compare 4 output Polarity (TIM2-5 only) */
 #define GTIM_CCER_CC4NP           (1 << 15) /* Bit 15: Capture/Compare 4 output Polarity */
+#define GTIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 

--- a/arch/arm/src/stm32f7/hardware/stm32f76xx77xx_tim.h
+++ b/arch/arm/src/stm32f7/hardware/stm32f76xx77xx_tim.h
@@ -702,6 +702,7 @@
 #define ATIM_CCER_CC5P            (1 << 17) /* Bit 17: Capture/Compare 5 output Polarity */
 #define ATIM_CCER_CC6E            (1 << 20) /* Bit 20: Capture/Compare 6 output enable */
 #define ATIM_CCER_CC6P            (1 << 21) /* Bit 21: Capture/Compare 6 output Polarity */
+#define ATIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 
@@ -1093,6 +1094,7 @@
 #define GTIM_CCER_CC4E            (1 << 12) /* Bit 12: Capture/Compare 4 output enable (TIM2-5 only) */
 #define GTIM_CCER_CC4P            (1 << 13) /* Bit 13: Capture/Compare 4 output Polarity (TIM2-5 only) */
 #define GTIM_CCER_CC4NP           (1 << 15) /* Bit 15: Capture/Compare 4 output Polarity */
+#define GTIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 

--- a/arch/arm/src/stm32f7/stm32_capture.c
+++ b/arch/arm/src/stm32f7/stm32_capture.c
@@ -969,9 +969,9 @@ static int stm32_cap_setchannel(FAR struct stm32_cap_dev_s *dev,
   /* Shift all CCER bits to corresponding channel */
 
   mask = (GTIM_CCER_CC1E | GTIM_CCER_CC1P | GTIM_CCER_CC1NP);
-  mask          <<= (channel << 2);
-  regval        <<= (channel << 2);
-  ccer_en_bit   <<= (channel << 2);
+  mask          <<= GTIM_CCER_CCXBASE(channel);
+  regval        <<= GTIM_CCER_CCXBASE(channel);
+  ccer_en_bit   <<= GTIM_CCER_CCXBASE(channel);
 
   stm32_modifyreg16(priv, STM32_GTIM_CCER_OFFSET, mask, regval);
 

--- a/arch/arm/src/stm32f7/stm32_pwm.c
+++ b/arch/arm/src/stm32f7/stm32_pwm.c
@@ -1345,7 +1345,7 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
 
           /* Generate an update event to reload the prescaler */
 
-          pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, ATIM_EGR_UG);
+          pwm_putreg(priv, STM32_ATIM_EGR_OFFSET, ATIM_EGR_UG);
         }
     }
   else
@@ -1353,7 +1353,7 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
     {
       /* Generate an update event to reload the prescaler (all timers) */
 
-      pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, ATIM_EGR_UG);
+      pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, GTIM_EGR_UG);
     }
 
   /* Handle channel specific setup */
@@ -1419,11 +1419,11 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
       switch (mode)
         {
           case STM32_CHANMODE_PWM1:
-            chanmode = ATIM_CCMR_MODE_PWM1;
+            chanmode = GTIM_CCMR_MODE_PWM1;
             break;
 
           case STM32_CHANMODE_PWM2:
-            chanmode = ATIM_CCMR_MODE_PWM2;
+            chanmode = GTIM_CCMR_MODE_PWM2;
             break;
 
           default:
@@ -1437,13 +1437,13 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Select the CCER enable bit for this channel */
 
-              ccenable |= ATIM_CCER_CC1E;
+              ccenable |= GTIM_CCER_CC1E;
 
               /* Set the CCMR1 mode values (leave CCMR2 zero) */
 
-              ocmode1  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC1S_SHIFT) |
-                          (chanmode << ATIM_CCMR1_OC1M_SHIFT) |
-                          ATIM_CCMR1_OC1PE;
+              ocmode1  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR1_CC1S_SHIFT) |
+                          (chanmode << GTIM_CCMR1_OC1M_SHIFT) |
+                          GTIM_CCMR1_OC1PE;
 
               /* Set the duty cycle by writing to the CCR register for this
                * channel
@@ -1457,13 +1457,13 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Select the CCER enable bit for this channel */
 
-              ccenable |= ATIM_CCER_CC2E;
+              ccenable |= GTIM_CCER_CC2E;
 
               /* Set the CCMR1 mode values (leave CCMR2 zero) */
 
-              ocmode1  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC2S_SHIFT) |
-                          (chanmode << ATIM_CCMR1_OC2M_SHIFT) |
-                          ATIM_CCMR1_OC2PE;
+              ocmode1  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR1_CC2S_SHIFT) |
+                          (chanmode << GTIM_CCMR1_OC2M_SHIFT) |
+                          GTIM_CCMR1_OC2PE;
 
               /* Set the duty cycle by writing to the CCR register for this
                * channel
@@ -1477,13 +1477,13 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Select the CCER enable bit for this channel */
 
-              ccenable |= ATIM_CCER_CC3E;
+              ccenable |= GTIM_CCER_CC3E;
 
               /* Set the CCMR2 mode values (leave CCMR1 zero) */
 
-              ocmode2  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR2_CC3S_SHIFT) |
-                          (chanmode << ATIM_CCMR2_OC3M_SHIFT) |
-                          ATIM_CCMR2_OC3PE;
+              ocmode2  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR2_CC3S_SHIFT) |
+                          (chanmode << GTIM_CCMR2_OC3M_SHIFT) |
+                          GTIM_CCMR2_OC3PE;
 
               /* Set the duty cycle by writing to the CCR register for this
                * channel
@@ -1497,13 +1497,13 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
             {
               /* Select the CCER enable bit for this channel */
 
-              ccenable |= ATIM_CCER_CC4E;
+              ccenable |= GTIM_CCER_CC4E;
 
               /* Set the CCMR2 mode values (leave CCMR1 zero) */
 
-              ocmode2  |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR2_CC4S_SHIFT) |
-                          (chanmode << ATIM_CCMR2_OC4M_SHIFT) |
-                          ATIM_CCMR2_OC4PE;
+              ocmode2  |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR2_CC4S_SHIFT) |
+                          (chanmode << GTIM_CCMR2_OC4M_SHIFT) |
+                          GTIM_CCMR2_OC4PE;
 
               /* Set the duty cycle by writing to the CCR register for this
                * channel
@@ -1535,10 +1535,10 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
    * mode
    */
 
-  ccmr1 &= ~(ATIM_CCMR1_CC1S_MASK | ATIM_CCMR1_OC1M_MASK | ATIM_CCMR1_OC1PE |
-             ATIM_CCMR1_CC2S_MASK | ATIM_CCMR1_OC2M_MASK | ATIM_CCMR1_OC2PE);
-  ccmr2 &= ~(ATIM_CCMR2_CC3S_MASK | ATIM_CCMR2_OC3M_MASK | ATIM_CCMR2_OC3PE |
-             ATIM_CCMR2_CC4S_MASK | ATIM_CCMR2_OC4M_MASK | ATIM_CCMR2_OC4PE);
+  ccmr1 &= ~(GTIM_CCMR1_CC1S_MASK | GTIM_CCMR1_OC1M_MASK | GTIM_CCMR1_OC1PE |
+             GTIM_CCMR1_CC2S_MASK | GTIM_CCMR1_OC2M_MASK | GTIM_CCMR1_OC2PE);
+  ccmr2 &= ~(GTIM_CCMR2_CC3S_MASK | GTIM_CCMR2_OC3M_MASK | GTIM_CCMR2_OC3PE |
+             GTIM_CCMR2_CC4S_MASK | GTIM_CCMR2_OC4M_MASK | GTIM_CCMR2_OC4PE);
   ccmr1 |= ocmode1;
   ccmr2 |= ocmode2;
 
@@ -1546,13 +1546,13 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
    * polarity)
    */
 
-  ccer &= ~(ATIM_CCER_CC1P | ATIM_CCER_CC2P | ATIM_CCER_CC3P |
-            ATIM_CCER_CC4P);
+  ccer &= ~(GTIM_CCER_CC1P | GTIM_CCER_CC2P | GTIM_CCER_CC3P |
+            GTIM_CCER_CC4P);
 
   /* Enable the output state of the selected channels */
 
-  ccer &= ~(ATIM_CCER_CC1E | ATIM_CCER_CC2E | ATIM_CCER_CC3E |
-            ATIM_CCER_CC4E);
+  ccer &= ~(GTIM_CCER_CC1E | GTIM_CCER_CC2E | GTIM_CCER_CC3E |
+            GTIM_CCER_CC4E);
   ccer |= ccenable;
 
   /* Some special setup for advanced timers */
@@ -1621,7 +1621,7 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
       /* Clear all pending interrupts and enable the update interrupt. */
 
       pwm_putreg(priv, STM32_GTIM_SR_OFFSET, 0);
-      pwm_putreg(priv, STM32_GTIM_DIER_OFFSET, ATIM_DIER_UIE);
+      pwm_putreg(priv, STM32_GTIM_DIER_OFFSET, GTIM_DIER_UIE);
 
       /* Enable the timer */
 

--- a/arch/arm/src/stm32f7/stm32_tickless.c
+++ b/arch/arm/src/stm32f7/stm32_tickless.c
@@ -113,13 +113,13 @@
 #endif
 
 #if CONFIG_STM32F7_TICKLESS_CHANNEL == 1
-#define DIER_CAPT_IE          ATIM_DIER_CC1IE
+#define DIER_CAPT_IE          GTIM_DIER_CC1IE
 #elif CONFIG_STM32F7_TICKLESS_CHANNEL == 2
-#define DIER_CAPT_IE          ATIM_DIER_CC2IE
+#define DIER_CAPT_IE          GTIM_DIER_CC2IE
 #elif CONFIG_STM32F7_TICKLESS_CHANNEL == 3
-#define DIER_CAPT_IE          ATIM_DIER_CC3IE
+#define DIER_CAPT_IE          GTIM_DIER_CC3IE
 #elif CONFIG_STM32F7_TICKLESS_CHANNEL == 4
-#define DIER_CAPT_IE          ATIM_DIER_CC4IE
+#define DIER_CAPT_IE          GTIM_DIER_CC4IE
 #endif
 
 /****************************************************************************
@@ -251,7 +251,8 @@ static int stm32_tickless_setchannel(uint8_t channel)
 
   /* Assume that channel is disabled and polarity is active high */
 
-  ccer_val &= ~(3 << (channel << 2));
+  ccer_val &= ~((GTIM_CCER_CC1P | GTIM_CCER_CC1E) <<
+                GTIM_CCER_CCXBASE(channel));
 
   /* This function is not supported on basic timers. To enable or
    * disable it, simply set its clock to valid frequency or zero.
@@ -267,11 +268,11 @@ static int stm32_tickless_setchannel(uint8_t channel)
    * disabled.
    */
 
-  ccmr_val = (ATIM_CCMR_MODE_FRZN << ATIM_CCMR1_OC1M_SHIFT);
+  ccmr_val = (GTIM_CCMR_MODE_FRZN << GTIM_CCMR1_OC1M_SHIFT);
 
   /* Set polarity */
 
-  ccer_val |= ATIM_CCER_CC1P << (channel << 2);
+  ccer_val |= GTIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
 
   /* Define its position (shift) and get register offset */
 
@@ -354,7 +355,7 @@ static void stm32_timing_handler(void)
 {
   g_tickless.overflow++;
 
-  STM32_TIM_ACKINT(g_tickless.tch, ATIM_SR_UIF);
+  STM32_TIM_ACKINT(g_tickless.tch, GTIM_SR_UIF);
 }
 
 /****************************************************************************
@@ -376,7 +377,7 @@ static int stm32_tickless_handler(int irq, void *context, void *arg)
 {
   int interrupt_flags = stm32_tickless_getint();
 
-  if (interrupt_flags & ATIM_SR_UIF)
+  if (interrupt_flags & GTIM_SR_UIF)
     {
       stm32_timing_handler();
     }
@@ -694,7 +695,7 @@ int up_timer_gettime(FAR struct timespec *ts)
 
   overflow = g_tickless.overflow;
   counter  = STM32_TIM_GETCOUNTER(g_tickless.tch);
-  pending  = STM32_TIM_CHECKINT(g_tickless.tch, ATIM_SR_UIF);
+  pending  = STM32_TIM_CHECKINT(g_tickless.tch, GTIM_SR_UIF);
   verify   = STM32_TIM_GETCOUNTER(g_tickless.tch);
 
   /* If an interrupt was pending before we re-enabled interrupts,
@@ -703,7 +704,7 @@ int up_timer_gettime(FAR struct timespec *ts)
 
   if (pending)
     {
-      STM32_TIM_ACKINT(g_tickless.tch, ATIM_SR_UIF);
+      STM32_TIM_ACKINT(g_tickless.tch, GTIM_SR_UIF);
 
       /* Increment the overflow count and use the value of the
        * guaranteed to be AFTER the overflow occurred.

--- a/arch/arm/src/stm32f7/stm32_tim.c
+++ b/arch/arm/src/stm32f7/stm32_tim.c
@@ -750,7 +750,8 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   /* Assume that channel is disabled and polarity is active high */
 
-  ccer_val &= ~(3 << (channel << 2));
+  ccer_val &= ~((GTIM_CCER_CC1P | GTIM_CCER_CC1E) <<
+                GTIM_CCER_CCXBASE(channel));
 
   /* This function is not supported on basic timers. To enable or
    * disable it, simply set its clock to valid frequency or zero.
@@ -772,13 +773,13 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
       case STM32_TIM_CH_OUTPWM:
         ccmr_val  = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
                      ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       case STM32_TIM_CH_OUTTOGGLE:
           ccmr_val  = (ATIM_CCMR_MODE_OCREFTOG << ATIM_CCMR1_OC1M_SHIFT) +
                        ATIM_CCMR1_OC1PE;
-          ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+          ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
           break;
 
       default:
@@ -789,7 +790,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   if (mode & STM32_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << (channel << 2);
+      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */

--- a/arch/arm/src/stm32f7/stm32_tim.c
+++ b/arch/arm/src/stm32f7/stm32_tim.c
@@ -289,24 +289,24 @@ static inline void stm32_putreg32(FAR struct stm32_tim_dev_s *dev,
 
 static void stm32_tim_reload_counter(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_EGR_OFFSET);
-  val |= ATIM_EGR_UG;
-  stm32_putreg16(dev, STM32_BTIM_EGR_OFFSET, val);
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_EGR_OFFSET);
+  val |= GTIM_EGR_UG;
+  stm32_putreg16(dev, STM32_GTIM_EGR_OFFSET, val);
 }
 
 static void stm32_tim_enable(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_CR1_OFFSET);
-  val |= ATIM_CR1_CEN;
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_CR1_OFFSET);
+  val |= GTIM_CR1_CEN;
   stm32_tim_reload_counter(dev);
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 }
 
 static void stm32_tim_disable(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_CR1_OFFSET);
-  val &= ~ATIM_CR1_CEN;
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_CR1_OFFSET);
+  val &= ~GTIM_CR1_CEN;
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 }
 
 /****************************************************************************
@@ -351,8 +351,8 @@ static uint32_t stm32_tim_getcounter(FAR struct stm32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
   return stm32_tim_getwidth(dev) > 16 ?
-    stm32_getreg32(dev, STM32_BTIM_CNT_OFFSET) :
-    (uint32_t)stm32_getreg16(dev, STM32_BTIM_CNT_OFFSET);
+    stm32_getreg32(dev, STM32_GTIM_CNT_OFFSET) :
+    (uint32_t)stm32_getreg16(dev, STM32_GTIM_CNT_OFFSET);
 }
 
 /****************************************************************************
@@ -366,11 +366,11 @@ static void stm32_tim_setcounter(FAR struct stm32_tim_dev_s *dev,
 
   if (stm32_tim_getwidth(dev) > 16)
     {
-      stm32_putreg32(dev, STM32_BTIM_CNT_OFFSET, count);
+      stm32_putreg32(dev, STM32_GTIM_CNT_OFFSET, count);
     }
   else
     {
-      stm32_putreg16(dev, STM32_BTIM_CNT_OFFSET, (uint16_t)count);
+      stm32_putreg16(dev, STM32_GTIM_CNT_OFFSET, (uint16_t)count);
     }
 }
 
@@ -525,7 +525,7 @@ static int stm32_tim_setclock(FAR struct stm32_tim_dev_s *dev, uint32_t freq)
       prescaler = 0xffff;
     }
 
-  stm32_putreg16(dev, STM32_BTIM_PSC_OFFSET, prescaler);
+  stm32_putreg16(dev, STM32_GTIM_PSC_OFFSET, prescaler);
   stm32_tim_enable(dev);
 
   return prescaler;
@@ -535,7 +535,7 @@ static void stm32_tim_setperiod(FAR struct stm32_tim_dev_s *dev,
                                 uint32_t period)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_putreg32(dev, STM32_BTIM_ARR_OFFSET, period);
+  stm32_putreg32(dev, STM32_GTIM_ARR_OFFSET, period);
 }
 
 static int stm32_tim_setisr(FAR struct stm32_tim_dev_s *dev,
@@ -643,24 +643,24 @@ static int stm32_tim_setisr(FAR struct stm32_tim_dev_s *dev,
 static void stm32_tim_enableint(FAR struct stm32_tim_dev_s *dev, int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_modifyreg16(dev, STM32_BTIM_DIER_OFFSET, 0, ATIM_DIER_UIE);
+  stm32_modifyreg16(dev, STM32_GTIM_DIER_OFFSET, 0, GTIM_DIER_UIE);
 }
 
 static void stm32_tim_disableint(FAR struct stm32_tim_dev_s *dev, int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_modifyreg16(dev, STM32_BTIM_DIER_OFFSET, ATIM_DIER_UIE, 0);
+  stm32_modifyreg16(dev, STM32_GTIM_DIER_OFFSET, GTIM_DIER_UIE, 0);
 }
 
 static int stm32_tim_checkint(FAR struct stm32_tim_dev_s *dev, int source)
 {
-  uint16_t regval = stm32_getreg16(dev, STM32_BTIM_SR_OFFSET);
+  uint16_t regval = stm32_getreg16(dev, STM32_GTIM_SR_OFFSET);
   return (regval & source) ? 1 : 0;
 }
 
 static void stm32_tim_ackint(FAR struct stm32_tim_dev_s *dev, int source)
 {
-  stm32_putreg16(dev, STM32_BTIM_SR_OFFSET, ~source);
+  stm32_putreg16(dev, STM32_GTIM_SR_OFFSET, ~source);
 }
 
 /****************************************************************************
@@ -670,7 +670,7 @@ static void stm32_tim_ackint(FAR struct stm32_tim_dev_s *dev, int source)
 static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
                              stm32_tim_mode_t mode)
 {
-  uint16_t val = ATIM_CR1_CEN | ATIM_CR1_ARPE;
+  uint16_t val = GTIM_CR1_CEN | GTIM_CR1_ARPE;
 
   DEBUGASSERT(dev != NULL);
 
@@ -693,7 +693,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_MODE_DOWN:
-        val |= ATIM_CR1_DIR;
+        val |= GTIM_CR1_DIR;
 
       case STM32_TIM_MODE_UP:
         break;
@@ -704,11 +704,11 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
          * Interrupts are generated on compare, when counting down
          */
 
-        val |= ATIM_CR1_CENTER1;
+        val |= GTIM_CR1_CENTER1;
         break;
 
       case STM32_TIM_MODE_PULSE:
-        val |= ATIM_CR1_OPM;
+        val |= GTIM_CR1_OPM;
         break;
 
       default:
@@ -716,7 +716,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
     }
 
   stm32_tim_reload_counter(dev);
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 
   /* Advanced registers require Main Output Enable */
 
@@ -771,15 +771,15 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_CH_OUTPWM:
-        ccmr_val  = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
-                     ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
+        ccmr_val  = (GTIM_CCMR_MODE_PWM1 << GTIM_CCMR1_OC1M_SHIFT) +
+                     GTIM_CCMR1_OC1PE;
+        ccer_val |= GTIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       case STM32_TIM_CH_OUTTOGGLE:
-          ccmr_val  = (ATIM_CCMR_MODE_OCREFTOG << ATIM_CCMR1_OC1M_SHIFT) +
-                       ATIM_CCMR1_OC1PE;
-          ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
+          ccmr_val  = (GTIM_CCMR_MODE_OCREFTOG << GTIM_CCMR1_OC1M_SHIFT) +
+                       GTIM_CCMR1_OC1PE;
+          ccer_val |= GTIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
           break;
 
       default:
@@ -790,7 +790,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   if (mode & STM32_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
+      ccer_val |= GTIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */

--- a/arch/arm/src/stm32h7/stm32_pwm.c
+++ b/arch/arm/src/stm32h7/stm32_pwm.c
@@ -2324,13 +2324,13 @@ static int pwm_mode_configure(FAR struct pwm_lowerhalf_s *dev,
 
       case STM32_CHANMODE_PWM1:
         {
-          chanmode = ATIM_CCMR_MODE_PWM1;
+          chanmode = GTIM_CCMR_MODE_PWM1;
           break;
         }
 
       case STM32_CHANMODE_PWM2:
         {
-          chanmode = ATIM_CCMR_MODE_PWM2;
+          chanmode = GTIM_CCMR_MODE_PWM2;
           break;
         }
 
@@ -2651,13 +2651,13 @@ static int pwm_outputs_enable(FAR struct pwm_lowerhalf_s *dev,
 
   /* Get outputs configuration */
 
-  regval |= ((outputs & STM32_PWM_OUT1)  ? ATIM_CCER_CC1E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT1N) ? ATIM_CCER_CC1NE : 0);
-  regval |= ((outputs & STM32_PWM_OUT2)  ? ATIM_CCER_CC2E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT2N) ? ATIM_CCER_CC2NE : 0);
-  regval |= ((outputs & STM32_PWM_OUT3)  ? ATIM_CCER_CC3E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT3N) ? ATIM_CCER_CC3NE : 0);
-  regval |= ((outputs & STM32_PWM_OUT4)  ? ATIM_CCER_CC4E  : 0);
+  regval |= ((outputs & STM32_PWM_OUT1)  ? GTIM_CCER_CC1E  : 0);
+  regval |= ((outputs & STM32_PWM_OUT1N) ? GTIM_CCER_CC1NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT2)  ? GTIM_CCER_CC2E  : 0);
+  regval |= ((outputs & STM32_PWM_OUT2N) ? GTIM_CCER_CC2NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT3)  ? GTIM_CCER_CC3E  : 0);
+  regval |= ((outputs & STM32_PWM_OUT3N) ? GTIM_CCER_CC3NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT4)  ? GTIM_CCER_CC4E  : 0);
 
   /* NOTE: CC4N doesn't exist, but some docs show configuration bits for it */
 
@@ -2770,7 +2770,7 @@ static int pwm_soft_update(FAR struct pwm_lowerhalf_s *dev)
 {
   FAR struct stm32_pwmtimer_s *priv = (FAR struct stm32_pwmtimer_s *)dev;
 
-  pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, ATIM_EGR_UG);
+  pwm_putreg(priv, STM32_GTIM_EGR_OFFSET, GTIM_EGR_UG);
 
   return OK;
 }
@@ -3113,7 +3113,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
        */
 
       priv->prev  = pwm_pulsecount(info->count);
-      pwm_putreg(priv, STM32_ATIM_RCR_OFFSET, (uint16_t)priv->prev - 1);
+      pwm_putreg(priv, STM32_GTIM_RCR_OFFSET, (uint16_t)priv->prev - 1);
 
       /* Generate an update event to reload the prescaler.  This should
        * preload the RCR into active repetition counter.
@@ -3127,7 +3127,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
 
       priv->count = info->count;
       priv->curr  = pwm_pulsecount(info->count - priv->prev);
-      pwm_putreg(priv, STM32_ATIM_RCR_OFFSET, (uint16_t)priv->curr - 1);
+      pwm_putreg(priv, STM32_GTIM_RCR_OFFSET, (uint16_t)priv->curr - 1);
     }
 
   /* Otherwise, just clear the repetition counter */
@@ -3136,7 +3136,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
     {
       /* Set the repetition counter to zero */
 
-      pwm_putreg(priv, STM32_ATIM_RCR_OFFSET, 0);
+      pwm_putreg(priv, STM32_GTIM_RCR_OFFSET, 0);
 
       /* Generate an update event to reload the prescaler */
 
@@ -3165,7 +3165,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
       /* Clear all pending interrupts and enable the update interrupt. */
 
       pwm_putreg(priv, STM32_GTIM_SR_OFFSET, 0);
-      pwm_putreg(priv, STM32_GTIM_DIER_OFFSET, ATIM_DIER_UIE);
+      pwm_putreg(priv, STM32_GTIM_DIER_OFFSET, GTIM_DIER_UIE);
 
       /* Enable the timer */
 

--- a/arch/arm/src/stm32h7/stm32_pwm.c
+++ b/arch/arm/src/stm32h7/stm32_pwm.c
@@ -2652,11 +2652,11 @@ static int pwm_outputs_enable(FAR struct pwm_lowerhalf_s *dev,
   /* Get outputs configuration */
 
   regval |= ((outputs & STM32_PWM_OUT1)  ? GTIM_CCER_CC1E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT1N) ? GTIM_CCER_CC1NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT1N) ? ATIM_CCER_CC1NE : 0);
   regval |= ((outputs & STM32_PWM_OUT2)  ? GTIM_CCER_CC2E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT2N) ? GTIM_CCER_CC2NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT2N) ? ATIM_CCER_CC2NE : 0);
   regval |= ((outputs & STM32_PWM_OUT3)  ? GTIM_CCER_CC3E  : 0);
-  regval |= ((outputs & STM32_PWM_OUT3N) ? GTIM_CCER_CC3NE : 0);
+  regval |= ((outputs & STM32_PWM_OUT3N) ? ATIM_CCER_CC3NE : 0);
   regval |= ((outputs & STM32_PWM_OUT4)  ? GTIM_CCER_CC4E  : 0);
 
   /* NOTE: CC4N doesn't exist, but some docs show configuration bits for it */

--- a/arch/arm/src/stm32h7/stm32_tim.c
+++ b/arch/arm/src/stm32h7/stm32_tim.c
@@ -466,24 +466,24 @@ static inline void stm32_putreg32(FAR struct stm32_tim_dev_s *dev,
 
 static void stm32_tim_reload_counter(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_EGR_OFFSET);
-  val |= ATIM_EGR_UG;
-  stm32_putreg16(dev, STM32_BTIM_EGR_OFFSET, val);
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_EGR_OFFSET);
+  val |= GTIM_EGR_UG;
+  stm32_putreg16(dev, STM32_GTIM_EGR_OFFSET, val);
 }
 
 static void stm32_tim_enable(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_CR1_OFFSET);
-  val |= ATIM_CR1_CEN;
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_CR1_OFFSET);
+  val |= GTIM_CR1_CEN;
   stm32_tim_reload_counter(dev);
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 }
 
 static void stm32_tim_disable(FAR struct stm32_tim_dev_s *dev)
 {
-  uint16_t val = stm32_getreg16(dev, STM32_BTIM_CR1_OFFSET);
-  val &= ~ATIM_CR1_CEN;
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  uint16_t val = stm32_getreg16(dev, STM32_GTIM_CR1_OFFSET);
+  val &= ~GTIM_CR1_CEN;
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 }
 
 /* Reset timer into system default state, but do not affect output/input
@@ -641,7 +641,7 @@ static int stm32_tim_setclock(FAR struct stm32_tim_dev_s *dev, uint32_t freq)
       prescaler = 0xffff;
     }
 
-  stm32_putreg16(dev, STM32_BTIM_PSC_OFFSET, prescaler);
+  stm32_putreg16(dev, STM32_GTIM_PSC_OFFSET, prescaler);
   stm32_tim_enable(dev);
 
   return prescaler;
@@ -651,7 +651,7 @@ static void stm32_tim_setperiod(FAR struct stm32_tim_dev_s *dev,
                                 uint32_t period)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_putreg32(dev, STM32_BTIM_ARR_OFFSET, period);
+  stm32_putreg32(dev, STM32_GTIM_ARR_OFFSET, period);
 }
 
 static int stm32_tim_setisr(FAR struct stm32_tim_dev_s *dev,
@@ -765,18 +765,18 @@ static int stm32_tim_setisr(FAR struct stm32_tim_dev_s *dev,
 static void stm32_tim_enableint(FAR struct stm32_tim_dev_s *dev, int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_modifyreg16(dev, STM32_BTIM_DIER_OFFSET, 0, source);
+  stm32_modifyreg16(dev, STM32_GTIM_DIER_OFFSET, 0, source);
 }
 
 static void stm32_tim_disableint(FAR struct stm32_tim_dev_s *dev, int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32_modifyreg16(dev, STM32_BTIM_DIER_OFFSET, source, 0);
+  stm32_modifyreg16(dev, STM32_GTIM_DIER_OFFSET, source, 0);
 }
 
 static void stm32_tim_ackint(FAR struct stm32_tim_dev_s *dev, int source)
 {
-  stm32_putreg16(dev, STM32_BTIM_SR_OFFSET, ~source);
+  stm32_putreg16(dev, STM32_GTIM_SR_OFFSET, ~source);
 }
 
 /****************************************************************************
@@ -786,7 +786,7 @@ static void stm32_tim_ackint(FAR struct stm32_tim_dev_s *dev, int source)
 static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
                              stm32_tim_mode_t mode)
 {
-  uint16_t val = ATIM_CR1_CEN | ATIM_CR1_ARPE;
+  uint16_t val = GTIM_CR1_CEN | GTIM_CR1_ARPE;
 
   DEBUGASSERT(dev != NULL);
 
@@ -809,13 +809,13 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_MODE_DOWN:
-        val |= ATIM_CR1_DIR;
+        val |= GTIM_CR1_DIR;
 
       case STM32_TIM_MODE_UP:
         break;
 
       case STM32_TIM_MODE_UPDOWN:
-        val |= ATIM_CR1_CENTER1;
+        val |= GTIM_CR1_CENTER1;
 
         /* Our default: Interrupts are generated on compare, when counting
          * down
@@ -824,7 +824,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_MODE_PULSE:
-        val |= ATIM_CR1_OPM;
+        val |= GTIM_CR1_OPM;
         break;
 
       default:
@@ -832,7 +832,7 @@ static int stm32_tim_setmode(FAR struct stm32_tim_dev_s *dev,
     }
 
   stm32_tim_reload_counter(dev);
-  stm32_putreg16(dev, STM32_BTIM_CR1_OFFSET, val);
+  stm32_putreg16(dev, STM32_GTIM_CR1_OFFSET, val);
 
   /* Advanced registers require Main Output Enable */
 
@@ -885,14 +885,14 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
         break;
 
       case STM32_TIM_CH_OUTTOGGLE:
-        ccmr_val  = (ATIM_CCMR_MODE_OCREFTOG << ATIM_CCMR1_OC1M_SHIFT);
-        ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+        ccmr_val  = (GTIM_CCMR_MODE_OCREFTOG << GTIM_CCMR1_OC1M_SHIFT);
+        ccer_val |= GTIM_CCER_CC1E << (channel << 2);
         break;
 
       case STM32_TIM_CH_OUTPWM:
-        ccmr_val  = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
-                    ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+        ccmr_val  = (GTIM_CCMR_MODE_PWM1 << GTIM_CCMR1_OC1M_SHIFT) +
+                    GTIM_CCMR1_OC1PE;
+        ccer_val |= GTIM_CCER_CC1E << (channel << 2);
         break;
 
       default:
@@ -903,7 +903,7 @@ static int stm32_tim_setchannel(FAR struct stm32_tim_dev_s *dev,
 
   if (mode & STM32_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << (channel << 2);
+      ccer_val |= GTIM_CCER_CC1P << (channel << 2);
     }
 
   /* Define its position (shift) and get register offset */

--- a/arch/arm/src/stm32l4/hardware/stm32l4_tim.h
+++ b/arch/arm/src/stm32l4/hardware/stm32l4_tim.h
@@ -674,6 +674,7 @@
 #define ATIM_CCER_CC5P            (1 << 17) /* Bit 17: Capture/Compare 5 output Polarity */
 #define ATIM_CCER_CC6E            (1 << 20) /* Bit 20: Capture/Compare 6 output enable */
 #define ATIM_CCER_CC6P            (1 << 21) /* Bit 21: Capture/Compare 6 output Polarity */
+#define ATIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 
@@ -1049,6 +1050,7 @@
 #define GTIM_CCER_CC4E            (1 << 12) /* Bit 12: Capture/Compare 4 output enable (TIM2-5 only) */
 #define GTIM_CCER_CC4P            (1 << 13) /* Bit 13: Capture/Compare 4 output Polarity (TIM2-5 only) */
 #define GTIM_CCER_CC4NP           (1 << 15) /* Bit 15: Capture/Compare 4 output Polarity */
+#define GTIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 

--- a/arch/arm/src/stm32l4/stm32l4_adc.c
+++ b/arch/arm/src/stm32l4/stm32l4_adc.c
@@ -959,12 +959,13 @@ static int adc_timinit(FAR struct stm32_dev_s *priv)
   /* Assume that channel is disabled and polarity is active high */
 
   ccer_val = tim_getreg(priv, STM32L4_GTIM_CCER_OFFSET);
-  ccer_val &= ~(3 << (channel << 2));
+  ccer_val &= ~((GTIM_CCER_CC1P | GTIM_CCER_CC1E) <<
+                GTIM_CCER_CCXBASE(channel));
 
   ccmr_val = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) |
              (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC1S_SHIFT) |
               ATIM_CCMR1_OC1PE;
-  ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+  ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
 
   if (channel & 1)
     {

--- a/arch/arm/src/stm32l4/stm32l4_dac.c
+++ b/arch/arm/src/stm32l4/stm32l4_dac.c
@@ -809,7 +809,7 @@ static int dac_send(FAR struct dac_dev_s *dev, FAR struct dac_msg_s *msg)
   /* Reset counters (generate an update) */
 
 #ifdef HAVE_DMA
-  tim_modifyreg(chan, STM32L4_BTIM_EGR_OFFSET, 0, ATIM_EGR_UG);
+  tim_modifyreg(chan, STM32L4_GTIM_EGR_OFFSET, 0, GTIM_EGR_UG);
 #endif
   return OK;
 }
@@ -978,26 +978,26 @@ static int dac_timinit(FAR struct stm32_chan_s *chan)
 
   /* Set the reload and prescaler values */
 
-  tim_putreg(chan, STM32L4_BTIM_ARR_OFFSET, (uint16_t)reload);
-  tim_putreg(chan, STM32L4_BTIM_PSC_OFFSET, (uint16_t)(prescaler - 1));
+  tim_putreg(chan, STM32L4_GTIM_ARR_OFFSET, (uint16_t)reload);
+  tim_putreg(chan, STM32L4_GTIM_PSC_OFFSET, (uint16_t)(prescaler - 1));
 
   /* Count mode up, auto reload */
 
-  tim_modifyreg(chan, STM32L4_BTIM_CR1_OFFSET, 0, ATIM_CR1_ARPE);
+  tim_modifyreg(chan, STM32L4_GTIM_CR1_OFFSET, 0, GTIM_CR1_ARPE);
 
   /* Selection TRGO selection: update */
 
-  tim_modifyreg(chan, STM32L4_BTIM_CR2_OFFSET, ATIM_CR2_MMS_MASK,
-                ATIM_CR2_MMS_UPDATE);
+  tim_modifyreg(chan, STM32L4_GTIM_CR2_OFFSET, GTIM_CR2_MMS_MASK,
+                GTIM_CR2_MMS_UPDATE);
 
   /* Update DMA request enable ???? */
 #if 0
-  tim_modifyreg(chan, STM32L4_BTIM_DIER_OFFSET, 0, ATIM_DIER_UDE);
+  tim_modifyreg(chan, STM32L4_GTIM_DIER_OFFSET, 0, GTIM_DIER_UDE);
 #endif
 
   /* Enable the counter */
 
-  tim_modifyreg(chan, STM32L4_BTIM_CR1_OFFSET, 0, ATIM_CR1_CEN);
+  tim_modifyreg(chan, STM32L4_GTIM_CR1_OFFSET, 0, GTIM_CR1_CEN);
   return OK;
 }
 #endif

--- a/arch/arm/src/stm32l4/stm32l4_pwm.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwm.c
@@ -2240,13 +2240,13 @@ static int pwm_mode_configure(FAR struct pwm_lowerhalf_s *dev,
 
       case STM32L4_CHANMODE_PWM1:
         {
-          chanmode = ATIM_CCMR_MODE_PWM1;
+          chanmode = GTIM_CCMR_MODE_PWM1;
           break;
         }
 
       case STM32L4_CHANMODE_PWM2:
         {
-          chanmode = ATIM_CCMR_MODE_PWM2;
+          chanmode = GTIM_CCMR_MODE_PWM2;
           break;
         }
 
@@ -2339,30 +2339,30 @@ static int pwm_mode_configure(FAR struct pwm_lowerhalf_s *dev,
         {
           /* Reset current channel 1/3/5 mode configuration */
 
-          ccmr &= ~(ATIM_CCMR1_CC1S_MASK | ATIM_CCMR1_OC1M_MASK |
-                     ATIM_CCMR1_OC1PE);
+          ccmr &= ~(GTIM_CCMR1_CC1S_MASK | GTIM_CCMR1_OC1M_MASK |
+                     GTIM_CCMR1_OC1PE);
 
           /* Configure CC1/3/5 as output */
 
-          ocmode |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC1S_SHIFT);
+          ocmode |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR1_CC1S_SHIFT);
 
           /* Configure Compare 1/3/5 mode */
 
-          ocmode |= (chanmode << ATIM_CCMR1_OC1M_SHIFT);
+          ocmode |= (chanmode << GTIM_CCMR1_OC1M_SHIFT);
 
           /* Enable CCR1/3/5 preload */
 
-          ocmode |= ATIM_CCMR1_OC1PE;
+          ocmode |= GTIM_CCMR1_OC1PE;
 
           /* Reset current OC bit */
 
-          ccmr &= ~(ATIM_CCMR1_OC1M);
+          ccmr &= ~(GTIM_CCMR1_OC1M);
 
           /* Set an additional OC1/3/5M bit */
 
           if (ocmbit)
             {
-              ocmode |= ATIM_CCMR1_OC1M;
+              ocmode |= GTIM_CCMR1_OC1M;
             }
           break;
         }
@@ -2375,30 +2375,30 @@ static int pwm_mode_configure(FAR struct pwm_lowerhalf_s *dev,
         {
           /* Reset current channel 2/4/6 mode configuration */
 
-          ccmr &= ~(ATIM_CCMR1_CC2S_MASK | ATIM_CCMR1_OC2M_MASK |
-                     ATIM_CCMR1_OC2PE);
+          ccmr &= ~(GTIM_CCMR1_CC2S_MASK | GTIM_CCMR1_OC2M_MASK |
+                     GTIM_CCMR1_OC2PE);
 
           /* Configure CC2/4/6 as output */
 
-          ocmode |= (ATIM_CCMR_CCS_CCOUT << ATIM_CCMR1_CC2S_SHIFT);
+          ocmode |= (GTIM_CCMR_CCS_CCOUT << GTIM_CCMR1_CC2S_SHIFT);
 
           /* Configure Compare 2/4/6 mode */
 
-          ocmode |= (chanmode << ATIM_CCMR1_OC2M_SHIFT);
+          ocmode |= (chanmode << GTIM_CCMR1_OC2M_SHIFT);
 
           /* Enable CCR2/4/6 preload */
 
-          ocmode |= ATIM_CCMR1_OC2PE;
+          ocmode |= GTIM_CCMR1_OC2PE;
 
           /* Reset current OC bit */
 
-          ccmr &= ~(ATIM_CCMR1_OC2M);
+          ccmr &= ~(GTIM_CCMR1_OC2M);
 
           /* Set an additioneal OC2/4/6M bit */
 
           if (ocmbit)
             {
-              ocmode |= ATIM_CCMR1_OC2M;
+              ocmode |= GTIM_CCMR1_OC2M;
             }
           break;
         }
@@ -2550,13 +2550,13 @@ static int pwm_outputs_enable(FAR struct pwm_lowerhalf_s *dev,
 
   /* Get outputs configuration */
 
-  regval |= ((outputs & STM32L4_PWM_OUT1)  ? ATIM_CCER_CC1E  : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT1N) ? ATIM_CCER_CC1NE : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT2)  ? ATIM_CCER_CC2E  : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT2N) ? ATIM_CCER_CC2NE : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT3)  ? ATIM_CCER_CC3E  : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT3N) ? ATIM_CCER_CC3NE : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT4)  ? ATIM_CCER_CC4E  : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT1)  ? GTIM_CCER_CC1E  : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT1N) ? GTIM_CCER_CC1NE : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT2)  ? GTIM_CCER_CC2E  : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT2N) ? GTIM_CCER_CC2NE : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT3)  ? GTIM_CCER_CC3E  : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT3N) ? GTIM_CCER_CC3NE : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT4)  ? GTIM_CCER_CC4E  : 0);
 
   /* NOTE: CC4N does not exist, but some docs show configuration bits for it
    */
@@ -2636,7 +2636,7 @@ static int pwm_soft_update(FAR struct pwm_lowerhalf_s *dev)
 {
   FAR struct stm32l4_pwmtimer_s *priv = (FAR struct stm32l4_pwmtimer_s *)dev;
 
-  pwm_putreg(priv, STM32L4_GTIM_EGR_OFFSET, ATIM_EGR_UG);
+  pwm_putreg(priv, STM32L4_GTIM_EGR_OFFSET, GTIM_EGR_UG);
 
   return OK;
 }
@@ -3009,7 +3009,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
        */
 
       priv->prev  = pwm_pulsecount(info->count);
-      pwm_putreg(priv, STM32L4_ATIM_RCR_OFFSET, (uint16_t)priv->prev - 1);
+      pwm_putreg(priv, STM32L4_GTIM_RCR_OFFSET, (uint16_t)priv->prev - 1);
 
       /* Generate an update event to reload the prescaler.  This should
        * preload the RCR into active repetition counter.
@@ -3023,7 +3023,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
 
       priv->count = info->count;
       priv->curr  = pwm_pulsecount(info->count - priv->prev);
-      pwm_putreg(priv, STM32L4_ATIM_RCR_OFFSET, (uint16_t)priv->curr - 1);
+      pwm_putreg(priv, STM32L4_GTIM_RCR_OFFSET, (uint16_t)priv->curr - 1);
     }
 
   /* Otherwise, just clear the repetition counter */
@@ -3032,7 +3032,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
     {
       /* Set the repetition counter to zero */
 
-      pwm_putreg(priv, STM32L4_ATIM_RCR_OFFSET, 0);
+      pwm_putreg(priv, STM32L4_GTIM_RCR_OFFSET, 0);
 
       /* Generate an update event to reload the prescaler */
 
@@ -3061,7 +3061,7 @@ static int pwm_pulsecount_timer(FAR struct pwm_lowerhalf_s *dev,
       /* Clear all pending interrupts and enable the update interrupt. */
 
       pwm_putreg(priv, STM32L4_GTIM_SR_OFFSET, 0);
-      pwm_putreg(priv, STM32L4_GTIM_DIER_OFFSET, ATIM_DIER_UIE);
+      pwm_putreg(priv, STM32L4_GTIM_DIER_OFFSET, GTIM_DIER_UIE);
 
       /* Enable the timer */
 

--- a/arch/arm/src/stm32l4/stm32l4_pwm.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwm.c
@@ -2551,11 +2551,11 @@ static int pwm_outputs_enable(FAR struct pwm_lowerhalf_s *dev,
   /* Get outputs configuration */
 
   regval |= ((outputs & STM32L4_PWM_OUT1)  ? GTIM_CCER_CC1E  : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT1N) ? GTIM_CCER_CC1NE : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT1N) ? ATIM_CCER_CC1NE : 0);
   regval |= ((outputs & STM32L4_PWM_OUT2)  ? GTIM_CCER_CC2E  : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT2N) ? GTIM_CCER_CC2NE : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT2N) ? ATIM_CCER_CC2NE : 0);
   regval |= ((outputs & STM32L4_PWM_OUT3)  ? GTIM_CCER_CC3E  : 0);
-  regval |= ((outputs & STM32L4_PWM_OUT3N) ? GTIM_CCER_CC3NE : 0);
+  regval |= ((outputs & STM32L4_PWM_OUT3N) ? ATIM_CCER_CC3NE : 0);
   regval |= ((outputs & STM32L4_PWM_OUT4)  ? GTIM_CCER_CC4E  : 0);
 
   /* NOTE: CC4N does not exist, but some docs show configuration bits for it

--- a/arch/arm/src/stm32l4/stm32l4_tim.c
+++ b/arch/arm/src/stm32l4/stm32l4_tim.c
@@ -507,9 +507,9 @@ static inline void stm32l4_putreg32(FAR struct stm32l4_tim_dev_s *dev,
 
 static void stm32l4_tim_reload_counter(FAR struct stm32l4_tim_dev_s *dev)
 {
-  uint16_t val = stm32l4_getreg16(dev, STM32L4_BTIM_EGR_OFFSET);
-  val |= ATIM_EGR_UG;
-  stm32l4_putreg16(dev, STM32L4_BTIM_EGR_OFFSET, val);
+  uint16_t val = stm32l4_getreg16(dev, STM32L4_GTIM_EGR_OFFSET);
+  val |= GTIM_EGR_UG;
+  stm32l4_putreg16(dev, STM32L4_GTIM_EGR_OFFSET, val);
 }
 
 /****************************************************************************
@@ -518,11 +518,11 @@ static void stm32l4_tim_reload_counter(FAR struct stm32l4_tim_dev_s *dev)
 
 static void stm32l4_tim_enable(FAR struct stm32l4_tim_dev_s *dev)
 {
-  uint16_t val = stm32l4_getreg16(dev, STM32L4_BTIM_CR1_OFFSET);
+  uint16_t val = stm32l4_getreg16(dev, STM32L4_GTIM_CR1_OFFSET);
 
-  val |= ATIM_CR1_CEN;
+  val |= GTIM_CR1_CEN;
   stm32l4_tim_reload_counter(dev);
-  stm32l4_putreg16(dev, STM32L4_BTIM_CR1_OFFSET, val);
+  stm32l4_putreg16(dev, STM32L4_GTIM_CR1_OFFSET, val);
 }
 
 /****************************************************************************
@@ -531,9 +531,9 @@ static void stm32l4_tim_enable(FAR struct stm32l4_tim_dev_s *dev)
 
 static void stm32l4_tim_disable(FAR struct stm32l4_tim_dev_s *dev)
 {
-  uint16_t val = stm32l4_getreg16(dev, STM32L4_BTIM_CR1_OFFSET);
-  val &= ~ATIM_CR1_CEN;
-  stm32l4_putreg16(dev, STM32L4_BTIM_CR1_OFFSET, val);
+  uint16_t val = stm32l4_getreg16(dev, STM32L4_GTIM_CR1_OFFSET);
+  val &= ~GTIM_CR1_CEN;
+  stm32l4_putreg16(dev, STM32L4_GTIM_CR1_OFFSET, val);
 }
 
 /****************************************************************************
@@ -633,7 +633,7 @@ static void stm32l4_tim_dumpregs(FAR struct stm32l4_tim_dev_s *dev)
 static int stm32l4_tim_setmode(FAR struct stm32l4_tim_dev_s *dev,
                                enum stm32l4_tim_mode_e mode)
 {
-  uint16_t val = ATIM_CR1_CEN | ATIM_CR1_ARPE;
+  uint16_t val = GTIM_CR1_CEN | GTIM_CR1_ARPE;
 
   DEBUGASSERT(dev != NULL);
 
@@ -663,15 +663,15 @@ static int stm32l4_tim_setmode(FAR struct stm32l4_tim_dev_s *dev,
         break;
 
       case STM32L4_TIM_MODE_DOWN:
-        val |= ATIM_CR1_DIR;
+        val |= GTIM_CR1_DIR;
         break;
 
       case STM32L4_TIM_MODE_UP:
-        val &= ~ATIM_CR1_DIR;
+        val &= ~GTIM_CR1_DIR;
         break;
 
       case STM32L4_TIM_MODE_UPDOWN:
-        val |= ATIM_CR1_CENTER1;
+        val |= GTIM_CR1_CENTER1;
 
         /* Our default:
          * Interrupts are generated on compare, when counting down
@@ -680,7 +680,7 @@ static int stm32l4_tim_setmode(FAR struct stm32l4_tim_dev_s *dev,
         break;
 
       case STM32L4_TIM_MODE_PULSE:
-        val |= ATIM_CR1_OPM;
+        val |= GTIM_CR1_OPM;
         break;
 
       default:
@@ -688,7 +688,7 @@ static int stm32l4_tim_setmode(FAR struct stm32l4_tim_dev_s *dev,
     }
 
   stm32l4_tim_reload_counter(dev);
-  stm32l4_putreg16(dev, STM32L4_BTIM_CR1_OFFSET, val);
+  stm32l4_putreg16(dev, STM32L4_GTIM_CR1_OFFSET, val);
 
 #if STM32L4_NATIM > 0
   /* Advanced registers require Main Output Enable */
@@ -983,7 +983,7 @@ static int stm32l4_tim_setclock(FAR struct stm32l4_tim_dev_s *dev,
       prescaler = 0xffff;
     }
 
-  stm32l4_putreg16(dev, STM32L4_BTIM_PSC_OFFSET, prescaler);
+  stm32l4_putreg16(dev, STM32L4_GTIM_PSC_OFFSET, prescaler);
 
   return prescaler;
 }
@@ -1074,7 +1074,7 @@ static uint32_t stm32l4_tim_getclock(FAR struct stm32l4_tim_dev_s *dev)
 
   /* From chip datasheet, at page 1179. */
 
-  clock = freqin / (stm32l4_getreg16(dev, STM32L4_BTIM_PSC_OFFSET) + 1);
+  clock = freqin / (stm32l4_getreg16(dev, STM32L4_GTIM_PSC_OFFSET) + 1);
   return clock;
 }
 
@@ -1086,7 +1086,7 @@ static void stm32l4_tim_setperiod(FAR struct stm32l4_tim_dev_s *dev,
                                 uint32_t period)
 {
   DEBUGASSERT(dev != NULL);
-  stm32l4_putreg32(dev, STM32L4_BTIM_ARR_OFFSET, period);
+  stm32l4_putreg32(dev, STM32L4_GTIM_ARR_OFFSET, period);
 }
 
 /****************************************************************************
@@ -1096,7 +1096,7 @@ static void stm32l4_tim_setperiod(FAR struct stm32l4_tim_dev_s *dev,
 static uint32_t stm32l4_tim_getperiod (FAR struct stm32l4_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
-  return stm32l4_getreg32 (dev, STM32L4_BTIM_ARR_OFFSET);
+  return stm32l4_getreg32 (dev, STM32L4_GTIM_ARR_OFFSET);
 }
 
 /****************************************************************************
@@ -1106,7 +1106,7 @@ static uint32_t stm32l4_tim_getperiod (FAR struct stm32l4_tim_dev_s *dev)
 static uint32_t stm32l4_tim_getcounter(FAR struct stm32l4_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
-  uint32_t counter = stm32l4_getreg32(dev, STM32L4_BTIM_CNT_OFFSET);
+  uint32_t counter = stm32l4_getreg32(dev, STM32L4_GTIM_CNT_OFFSET);
 
   /* In datasheet page 988, there is a useless bit named UIFCPY in TIMx_CNT.
    * reset it it result when not TIM2 or TIM5.
@@ -1185,9 +1185,9 @@ static int stm32l4_tim_setchannel(FAR struct stm32l4_tim_dev_s *dev,
         break;
 
       case STM32L4_TIM_CH_OUTPWM:
-        ccmr_val  =  (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
-                     ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
+        ccmr_val  =  (GTIM_CCMR_MODE_PWM1 << GTIM_CCMR1_OC1M_SHIFT) +
+                     GTIM_CCMR1_OC1PE;
+        ccer_val |= GTIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       default:
@@ -1198,7 +1198,7 @@ static int stm32l4_tim_setchannel(FAR struct stm32l4_tim_dev_s *dev,
 
   if (mode & STM32L4_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
+      ccer_val |= GTIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */
@@ -1696,7 +1696,7 @@ static void stm32l4_tim_enableint(FAR struct stm32l4_tim_dev_s *dev,
                                   int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32l4_modifyreg16(dev, STM32L4_BTIM_DIER_OFFSET, 0, ATIM_DIER_UIE);
+  stm32l4_modifyreg16(dev, STM32L4_GTIM_DIER_OFFSET, 0, GTIM_DIER_UIE);
 }
 
 /****************************************************************************
@@ -1707,7 +1707,7 @@ static void stm32l4_tim_disableint(FAR struct stm32l4_tim_dev_s *dev,
                                    int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32l4_modifyreg16(dev, STM32L4_BTIM_DIER_OFFSET, ATIM_DIER_UIE, 0);
+  stm32l4_modifyreg16(dev, STM32L4_GTIM_DIER_OFFSET, GTIM_DIER_UIE, 0);
 }
 
 /****************************************************************************
@@ -1716,7 +1716,7 @@ static void stm32l4_tim_disableint(FAR struct stm32l4_tim_dev_s *dev,
 
 static void stm32l4_tim_ackint(FAR struct stm32l4_tim_dev_s *dev, int source)
 {
-  stm32l4_putreg16(dev, STM32L4_BTIM_SR_OFFSET, ~ATIM_SR_UIF);
+  stm32l4_putreg16(dev, STM32L4_GTIM_SR_OFFSET, ~GTIM_SR_UIF);
 }
 
 /****************************************************************************
@@ -1726,8 +1726,8 @@ static void stm32l4_tim_ackint(FAR struct stm32l4_tim_dev_s *dev, int source)
 static int stm32l4_tim_checkint(FAR struct stm32l4_tim_dev_s *dev,
                                 int source)
 {
-  uint16_t regval = stm32l4_getreg16(dev, STM32L4_BTIM_SR_OFFSET);
-  return (regval & ATIM_SR_UIF) ? 1 : 0;
+  uint16_t regval = stm32l4_getreg16(dev, STM32L4_GTIM_SR_OFFSET);
+  return (regval & GTIM_SR_UIF) ? 1 : 0;
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32l4/stm32l4_tim.c
+++ b/arch/arm/src/stm32l4/stm32l4_tim.c
@@ -1157,7 +1157,8 @@ static int stm32l4_tim_setchannel(FAR struct stm32l4_tim_dev_s *dev,
   /* Assume that channel is disabled and polarity is active high */
 
   ccer_val = stm32l4_getreg16(dev, STM32L4_GTIM_CCER_OFFSET);
-  ccer_val &= ~(3 << (channel << 2));
+  ccer_val &= ~((GTIM_CCER_CC1P | GTIM_CCER_CC1E) <<
+                GTIM_CCER_CCXBASE(channel));
 
   /* This function is not supported on basic timers. To enable or
    * disable it, simply set its clock to valid frequency or zero.
@@ -1186,7 +1187,7 @@ static int stm32l4_tim_setchannel(FAR struct stm32l4_tim_dev_s *dev,
       case STM32L4_TIM_CH_OUTPWM:
         ccmr_val  =  (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
                      ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       default:
@@ -1197,7 +1198,7 @@ static int stm32l4_tim_setchannel(FAR struct stm32l4_tim_dev_s *dev,
 
   if (mode & STM32L4_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << (channel << 2);
+      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */

--- a/arch/arm/src/stm32l5/hardware/stm32l5_tim.h
+++ b/arch/arm/src/stm32l5/hardware/stm32l5_tim.h
@@ -625,6 +625,7 @@
 #define ATIM_CCER_CC5P            (1 << 17) /* Bit 17: Capture/Compare 5 output Polarity */
 #define ATIM_CCER_CC6E            (1 << 20) /* Bit 20: Capture/Compare 6 output enable */
 #define ATIM_CCER_CC6P            (1 << 21) /* Bit 21: Capture/Compare 6 output Polarity */
+#define ATIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 
@@ -970,6 +971,7 @@
 #define GTIM_CCER_CC4E            (1 << 12) /* Bit 12: Capture/Compare 4 output enable (TIM2-5 only) */
 #define GTIM_CCER_CC4P            (1 << 13) /* Bit 13: Capture/Compare 4 output Polarity (TIM2-5 only) */
 #define GTIM_CCER_CC4NP           (1 << 15) /* Bit 15: Capture/Compare 4 output Polarity */
+#define GTIM_CCER_CCXBASE(ch)     (ch << 2) /* Each channel uses 4-bits */
 
 /* 16-bit counter register */
 

--- a/arch/arm/src/stm32l5/stm32l5_tim.c
+++ b/arch/arm/src/stm32l5/stm32l5_tim.c
@@ -943,7 +943,8 @@ static int stm32l5_tim_setchannel(FAR struct stm32l5_tim_dev_s *dev,
   /* Assume that channel is disabled and polarity is active high */
 
   ccer_val = stm32l5_getreg16(dev, STM32L5_GTIM_CCER_OFFSET);
-  ccer_val &= ~(3 << (channel << 2));
+  ccer_val &= ~((GTIM_CCER_CC1P | GTIM_CCER_CC1E) <<
+                GTIM_CCER_CCXBASE(channel));
 
   /* This function is not supported on basic timers. To enable or
    * disable it, simply set its clock to valid frequency or zero.
@@ -972,7 +973,7 @@ static int stm32l5_tim_setchannel(FAR struct stm32l5_tim_dev_s *dev,
       case STM32L5_TIM_CH_OUTPWM:
         ccmr_val  = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
                     ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << (channel << 2);
+        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       default:
@@ -983,7 +984,7 @@ static int stm32l5_tim_setchannel(FAR struct stm32l5_tim_dev_s *dev,
 
   if (mode & STM32L5_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << (channel << 2);
+      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */

--- a/arch/arm/src/stm32l5/stm32l5_tim.c
+++ b/arch/arm/src/stm32l5/stm32l5_tim.c
@@ -506,9 +506,9 @@ static inline void stm32l5_putreg32(FAR struct stm32l5_tim_dev_s *dev,
 
 static void stm32l5_tim_reload_counter(FAR struct stm32l5_tim_dev_s *dev)
 {
-  uint16_t val = stm32l5_getreg16(dev, STM32L5_BTIM_EGR_OFFSET);
-  val |= ATIM_EGR_UG;
-  stm32l5_putreg16(dev, STM32L5_BTIM_EGR_OFFSET, val);
+  uint16_t val = stm32l5_getreg16(dev, STM32L5_GTIM_EGR_OFFSET);
+  val |= GTIM_EGR_UG;
+  stm32l5_putreg16(dev, STM32L5_GTIM_EGR_OFFSET, val);
 }
 
 /****************************************************************************
@@ -517,10 +517,10 @@ static void stm32l5_tim_reload_counter(FAR struct stm32l5_tim_dev_s *dev)
 
 static void stm32l5_tim_enable(FAR struct stm32l5_tim_dev_s *dev)
 {
-  uint16_t val = stm32l5_getreg16(dev, STM32L5_BTIM_CR1_OFFSET);
-  val |= ATIM_CR1_CEN;
+  uint16_t val = stm32l5_getreg16(dev, STM32L5_GTIM_CR1_OFFSET);
+  val |= GTIM_CR1_CEN;
   stm32l5_tim_reload_counter(dev);
-  stm32l5_putreg16(dev, STM32L5_BTIM_CR1_OFFSET, val);
+  stm32l5_putreg16(dev, STM32L5_GTIM_CR1_OFFSET, val);
 }
 
 /****************************************************************************
@@ -529,9 +529,9 @@ static void stm32l5_tim_enable(FAR struct stm32l5_tim_dev_s *dev)
 
 static void stm32l5_tim_disable(FAR struct stm32l5_tim_dev_s *dev)
 {
-  uint16_t val = stm32l5_getreg16(dev, STM32L5_BTIM_CR1_OFFSET);
-  val &= ~ATIM_CR1_CEN;
-  stm32l5_putreg16(dev, STM32L5_BTIM_CR1_OFFSET, val);
+  uint16_t val = stm32l5_getreg16(dev, STM32L5_GTIM_CR1_OFFSET);
+  val &= ~GTIM_CR1_CEN;
+  stm32l5_putreg16(dev, STM32L5_GTIM_CR1_OFFSET, val);
 }
 
 /****************************************************************************
@@ -581,7 +581,7 @@ static void stm32l5_tim_gpioconfig(uint32_t cfg,
 static int stm32l5_tim_setmode(FAR struct stm32l5_tim_dev_s *dev,
                                enum stm32l5_tim_mode_e mode)
 {
-  uint16_t val = ATIM_CR1_CEN | ATIM_CR1_ARPE;
+  uint16_t val = GTIM_CR1_CEN | GTIM_CR1_ARPE;
 
   DEBUGASSERT(dev != NULL);
 
@@ -611,13 +611,13 @@ static int stm32l5_tim_setmode(FAR struct stm32l5_tim_dev_s *dev,
         break;
 
       case STM32L5_TIM_MODE_DOWN:
-        val |= ATIM_CR1_DIR;
+        val |= GTIM_CR1_DIR;
 
       case STM32L5_TIM_MODE_UP:
         break;
 
       case STM32L5_TIM_MODE_UPDOWN:
-        val |= ATIM_CR1_CENTER1;
+        val |= GTIM_CR1_CENTER1;
 
         /* Our default: Interrupts are generated on compare, when counting
          * down
@@ -626,7 +626,7 @@ static int stm32l5_tim_setmode(FAR struct stm32l5_tim_dev_s *dev,
         break;
 
       case STM32L5_TIM_MODE_PULSE:
-        val |= ATIM_CR1_OPM;
+        val |= GTIM_CR1_OPM;
         break;
 
       default:
@@ -634,7 +634,7 @@ static int stm32l5_tim_setmode(FAR struct stm32l5_tim_dev_s *dev,
     }
 
   stm32l5_tim_reload_counter(dev);
-  stm32l5_putreg16(dev, STM32L5_BTIM_CR1_OFFSET, val);
+  stm32l5_putreg16(dev, STM32L5_GTIM_CR1_OFFSET, val);
 
 #if STM32L5_NATIM > 0
   /* Advanced registers require Main Output Enable */
@@ -768,7 +768,7 @@ static int stm32l5_tim_setclock(FAR struct stm32l5_tim_dev_s *dev,
       prescaler = 0xffff;
     }
 
-  stm32l5_putreg16(dev, STM32L5_BTIM_PSC_OFFSET, prescaler);
+  stm32l5_putreg16(dev, STM32L5_GTIM_PSC_OFFSET, prescaler);
   stm32l5_tim_enable(dev);
 
   return prescaler;
@@ -860,7 +860,7 @@ static uint32_t stm32l5_tim_getclock(FAR struct stm32l5_tim_dev_s *dev)
 
   /* From chip datasheet, at page 1179. */
 
-  clock = freqin / (stm32l5_getreg16(dev, STM32L5_BTIM_PSC_OFFSET) + 1);
+  clock = freqin / (stm32l5_getreg16(dev, STM32L5_GTIM_PSC_OFFSET) + 1);
   return clock;
 }
 
@@ -872,7 +872,7 @@ static void stm32l5_tim_setperiod(FAR struct stm32l5_tim_dev_s *dev,
                                 uint32_t period)
 {
   DEBUGASSERT(dev != NULL);
-  stm32l5_putreg32(dev, STM32L5_BTIM_ARR_OFFSET, period);
+  stm32l5_putreg32(dev, STM32L5_GTIM_ARR_OFFSET, period);
 }
 
 /****************************************************************************
@@ -882,7 +882,7 @@ static void stm32l5_tim_setperiod(FAR struct stm32l5_tim_dev_s *dev,
 static uint32_t stm32l5_tim_getperiod (FAR struct stm32l5_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
-  return stm32l5_getreg32 (dev, STM32L5_BTIM_ARR_OFFSET);
+  return stm32l5_getreg32 (dev, STM32L5_GTIM_ARR_OFFSET);
 }
 
 /****************************************************************************
@@ -892,7 +892,7 @@ static uint32_t stm32l5_tim_getperiod (FAR struct stm32l5_tim_dev_s *dev)
 static uint32_t stm32l5_tim_getcounter(FAR struct stm32l5_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
-  uint32_t counter = stm32l5_getreg32(dev, STM32L5_BTIM_CNT_OFFSET);
+  uint32_t counter = stm32l5_getreg32(dev, STM32L5_GTIM_CNT_OFFSET);
 
   /* In datasheet page 988, there is a useless bit named UIFCPY in TIMx_CNT.
    * reset it it result when not TIM2 or TIM5.
@@ -971,9 +971,9 @@ static int stm32l5_tim_setchannel(FAR struct stm32l5_tim_dev_s *dev,
         break;
 
       case STM32L5_TIM_CH_OUTPWM:
-        ccmr_val  = (ATIM_CCMR_MODE_PWM1 << ATIM_CCMR1_OC1M_SHIFT) +
-                    ATIM_CCMR1_OC1PE;
-        ccer_val |= ATIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
+        ccmr_val  = (GTIM_CCMR_MODE_PWM1 << GTIM_CCMR1_OC1M_SHIFT) +
+                    GTIM_CCMR1_OC1PE;
+        ccer_val |= GTIM_CCER_CC1E << GTIM_CCER_CCXBASE(channel);
         break;
 
       default:
@@ -984,7 +984,7 @@ static int stm32l5_tim_setchannel(FAR struct stm32l5_tim_dev_s *dev,
 
   if (mode & STM32L5_TIM_CH_POLARITY_NEG)
     {
-      ccer_val |= ATIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
+      ccer_val |= GTIM_CCER_CC1P << GTIM_CCER_CCXBASE(channel);
     }
 
   /* Define its position (shift) and get register offset */
@@ -1482,7 +1482,7 @@ static void stm32l5_tim_enableint(FAR struct stm32l5_tim_dev_s *dev,
                                   int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32l5_modifyreg16(dev, STM32L5_BTIM_DIER_OFFSET, 0, ATIM_DIER_UIE);
+  stm32l5_modifyreg16(dev, STM32L5_GTIM_DIER_OFFSET, 0, GTIM_DIER_UIE);
 }
 
 /****************************************************************************
@@ -1493,7 +1493,7 @@ static void stm32l5_tim_disableint(FAR struct stm32l5_tim_dev_s *dev,
                                    int source)
 {
   DEBUGASSERT(dev != NULL);
-  stm32l5_modifyreg16(dev, STM32L5_BTIM_DIER_OFFSET, ATIM_DIER_UIE, 0);
+  stm32l5_modifyreg16(dev, STM32L5_GTIM_DIER_OFFSET, GTIM_DIER_UIE, 0);
 }
 
 /****************************************************************************
@@ -1502,7 +1502,7 @@ static void stm32l5_tim_disableint(FAR struct stm32l5_tim_dev_s *dev,
 
 static void stm32l5_tim_ackint(FAR struct stm32l5_tim_dev_s *dev, int source)
 {
-  stm32l5_putreg16(dev, STM32L5_BTIM_SR_OFFSET, ~ATIM_SR_UIF);
+  stm32l5_putreg16(dev, STM32L5_GTIM_SR_OFFSET, ~GTIM_SR_UIF);
 }
 
 /****************************************************************************
@@ -1512,8 +1512,8 @@ static void stm32l5_tim_ackint(FAR struct stm32l5_tim_dev_s *dev, int source)
 static int stm32l5_tim_checkint(FAR struct stm32l5_tim_dev_s *dev,
                                 int source)
 {
-  uint16_t regval = stm32l5_getreg16(dev, STM32L5_BTIM_SR_OFFSET);
-  return (regval & ATIM_SR_UIF) ? 1 : 0;
+  uint16_t regval = stm32l5_getreg16(dev, STM32L5_GTIM_SR_OFFSET);
+  return (regval & GTIM_SR_UIF) ? 1 : 0;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
stm32 timers: Prefer GTIM macros and make this use more uniform. Also, make a few register operations more readable.

## Impact
This change should have no code effect. It just makes things more readable and consistent.

## Testing
CI

