### PR TITLE
stm32h7 rcc: Sync h7x7xx and h7x3xx. Changes are relevant to both

### DIFF
--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -486,7 +486,7 @@ static inline void rcc_enableapb2(void)
 #endif
 
 #ifdef CONFIG_STM32H7_USART6
-  /* USART1 clock enable */
+  /* USART6 clock enable */
 
   regval |= RCC_APB2ENR_USART6EN;
 #endif

--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -247,9 +247,15 @@ static inline void rcc_enableahb2(void)
   regval = getreg32(STM32_RCC_AHB2ENR);
 
 #ifdef CONFIG_STM32H7_SDMMC2
-  /* SDMMC clock enable */
+  /* SDMMC2 clock enable */
 
   regval |= RCC_AHB2ENR_SDMMC2EN;
+#endif
+
+#ifdef CONFIG_STM32H7_RNG
+  /* Random number generator clock enable */
+
+  regval |= RCC_AHB2ENR_RNGEN;
 #endif
 
   putreg32(regval, STM32_RCC_AHB2ENR);   /* Enable peripherals */
@@ -471,6 +477,18 @@ static inline void rcc_enableapb2(void)
   /* SPI5 clock enable */
 
   regval |= RCC_APB2ENR_SPI5EN;
+#endif
+
+#ifdef CONFIG_STM32H7_USART1
+  /* USART1 clock enable */
+
+  regval |= RCC_APB2ENR_USART1EN;
+#endif
+
+#ifdef CONFIG_STM32H7_USART6
+  /* USART1 clock enable */
+
+  regval |= RCC_APB2ENR_USART6EN;
 #endif
 
   putreg32(regval, STM32_RCC_APB2ENR);   /* Enable peripherals */

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -246,7 +246,17 @@ static inline void rcc_enableahb2(void)
 
   regval = getreg32(STM32_RCC_AHB2ENR);
 
-  /* TODO: ... */
+#ifdef CONFIG_STM32H7_SDMMC2
+  /* SDMMC2 clock enable */
+
+  regval |= RCC_AHB2ENR_SDMMC2EN;
+#endif
+
+#ifdef CONFIG_STM32H7_RNG
+  /* Random number generator clock enable */
+
+  regval |= RCC_AHB2ENR_RNGEN;
+#endif
 
   putreg32(regval, STM32_RCC_AHB2ENR);   /* Enable peripherals */
 }
@@ -467,12 +477,6 @@ static inline void rcc_enableapb2(void)
   /* SPI5 clock enable */
 
   regval |= RCC_APB2ENR_SPI5EN;
-#endif
-
-#ifdef CONFIG_STM32H7_SDMMC2
-  /* SDMMC2 clock enable */
-
-  regval |= RCC_APB2ENR_SDMMC2EN;
 #endif
 
 #ifdef CONFIG_STM32H7_USART1
@@ -826,8 +830,6 @@ void stm32_stdclockconfig(void)
       regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_LDOESCUEN;
       putreg32(regval, STM32_PWR_CR3);
 
-#if 0
-
       /* Set the voltage output scale */
 
       regval = getreg32(STM32_PWR_D3CR);
@@ -836,6 +838,12 @@ void stm32_stdclockconfig(void)
       putreg32(regval, STM32_PWR_D3CR);
 
       while ((getreg32(STM32_PWR_D3CR) & STM32_PWR_D3CR_VOSRDY) == 0)
+        {
+        }
+
+      /* See Reference manual Section 5.4.1, System supply startup */
+
+      while ((getreg32(STM32_PWR_CSR1) & PWR_CSR1_ACTVOSRDY) == 0)
         {
         }
 
@@ -863,7 +871,6 @@ void stm32_stdclockconfig(void)
             {
             }
         }
-#endif
 
       /* Configure FLASH wait states */
 
@@ -950,6 +957,15 @@ void stm32_stdclockconfig(void)
       regval &= ~RCC_D3CCIPR_ADCSEL_MASK;
       regval |= STM32_RCC_D3CCIPR_ADCSEL;
       putreg32(regval, STM32_RCC_D3CCIPR);
+#endif
+
+      /* Configure FDCAN source clock */
+
+#if defined(STM32_RCC_D2CCIP1R_FDCANSEL)
+      regval = getreg32(STM32_RCC_D2CCIP1R);
+      regval &= ~RCC_D2CCIP1R_FDCANSEL_MASK;
+      regval |= STM32_RCC_D2CCIP1R_FDCANSEL;
+      putreg32(regval, STM32_RCC_D2CCIP1R);
 #endif
 
 #if defined(CONFIG_STM32H7_IWDG) || defined(CONFIG_STM32H7_RTC_LSICLOCK)

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -486,7 +486,7 @@ static inline void rcc_enableapb2(void)
 #endif
 
 #ifdef CONFIG_STM32H7_USART6
-  /* USART1 clock enable */
+  /* USART6 clock enable */
 
   regval |= RCC_APB2ENR_USART6EN;
 #endif


### PR DESCRIPTION
## Summary
stm32h7 rcc: Sync h7x7xx and h7x3xx. Each of the differences is relevant to it's counterpart.

## Impact
Correct features supported on both platforms.

## Testing
CI


