### PR TITLE
stm32/stm32f7 tickless: Fix up_timer_getmask to be correct for the width of the timer.

### DIFF
--- a/arch/arm/src/stm32/stm32_tickless.c
+++ b/arch/arm/src/stm32/stm32_tickless.c
@@ -124,9 +124,6 @@ struct stm32_tickless_s
   uint8_t channel;                 /* The timer channel to use for intervals */
   FAR struct stm32_tim_dev_s *tch; /* Handle returned by stm32_tim_init() */
   uint32_t frequency;
-#ifdef CONFIG_CLOCK_TIMEKEEPING
-  uint64_t counter_mask;
-#endif
   uint32_t overflow;               /* Timer counter overflow */
   volatile bool pending;           /* True: pending task */
   uint32_t period;                 /* Interval period */
@@ -538,13 +535,6 @@ void up_timer_initialize(void)
 
   STM32_TIM_SETCLOCK(g_tickless.tch, g_tickless.frequency);
 
-#ifdef CONFIG_CLOCK_TIMEKEEPING
-
-  /* Should this be changed to 0xffff because we use 16 bit timers? */
-
-  g_tickless.counter_mask = 0xffffffffull;
-#endif
-
   /* Set up to receive the callback when the counter overflow occurs */
 
   STM32_TIM_SETISR(g_tickless.tch, stm32_tickless_handler, NULL, 0);
@@ -731,7 +721,11 @@ int up_timer_getcounter(FAR uint64_t *cycles)
 void up_timer_getmask(FAR uint64_t *mask)
 {
   DEBUGASSERT(mask != NULL);
-  *mask = g_tickless.counter_mask;
+#ifdef HAVE_32BIT_TICKLESS
+  *mask = UINT32_MAX;
+#else
+  *mask = UINT16_MAX;
+#endif
 }
 
 #endif /* CONFIG_CLOCK_TIMEKEEPING */

--- a/arch/arm/src/stm32f7/stm32_tickless.c
+++ b/arch/arm/src/stm32f7/stm32_tickless.c
@@ -132,9 +132,6 @@ struct stm32_tickless_s
   uint8_t channel;                 /* The timer channel to use for intervals */
   FAR struct stm32_tim_dev_s *tch; /* Handle returned by stm32_tim_init() */
   uint32_t frequency;
-#ifdef CONFIG_CLOCK_TIMEKEEPING
-  uint64_t counter_mask;
-#endif
   uint32_t overflow;               /* Timer counter overflow */
   volatile bool pending;           /* True: pending task */
   uint32_t period;                 /* Interval period */
@@ -587,13 +584,6 @@ void up_timer_initialize(void)
 
   STM32_TIM_SETCLOCK(g_tickless.tch, g_tickless.frequency);
 
-#ifdef CONFIG_CLOCK_TIMEKEEPING
-
-  /* Should this be changed to 0xffff because we use 16 bit timers? */
-
-  g_tickless.counter_mask = 0xffffffffull;
-#endif
-
   /* Set up to receive the callback when the counter overflow occurs */
 
   STM32_TIM_SETISR(g_tickless.tch, stm32_tickless_handler, NULL, 0);
@@ -789,7 +779,11 @@ int up_timer_getcounter(FAR uint64_t *cycles)
 void up_timer_getmask(FAR uint64_t *mask)
 {
   DEBUGASSERT(mask != NULL);
-  *mask = g_tickless.counter_mask;
+#ifdef HAVE_32BIT_TICKLESS
+  *mask = UINT32_MAX;
+#else
+  *mask = UINT16_MAX;
+#endif
 }
 
 #endif /* CONFIG_CLOCK_TIMEKEEPING */


### PR DESCRIPTION
## Summary
stm32/stm32f7 tickless: Fix up_timer_getmask to be correct for the width of the timer.

## Impact
Fix timekeeping with 16-bit tickless.

## Testing
CI

