### PR TITLE
xtensa/esp32/esp32_start.c: Remove an old and unnecessary piece of code.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -91,10 +91,6 @@ void IRAM_ATTR __start(void)
   regval &= ~RTC_CNTL_WDT_FLASHBOOT_MOD_EN;
   putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
 
-  regval  = getreg32(0x6001f048); /* DR_REG_BB_BASE+48 */
-  regval &= ~(1 << 14);
-  putreg32(regval, 0x6001f048);
-
   /* Make sure that normal interrupts are disabled.  This is really only an
    * issue when we are started in un-usual ways (such as from IRAM).  In this
    * case, we can at least defer some unexpected interrupts left over from


### PR DESCRIPTION
## Summary
Remove an old and unnecessary piece of code.
## Impact
Only ESP32 chips.
## Testing
All of ESP32 defconfigs.
