### PR TITLE
drivers/mtd/smart.c: Recover the missing link of directory entry

### DIFF
--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -5894,6 +5894,10 @@ static int smart_fsck_directory(FAR struct smart_struct_s *dev,
           ferr("Invalidate next log sector %d\n", nextsector);
 
           *(uint16_t *)chain->nextsector = 0xffff;
+
+          /* Set flag to relocate later */
+
+          relocate = 1;
         }
     }
 


### PR DESCRIPTION
## Summary
SmartFS: Recover from file system corruption caused by power failure

When creating the next chain of directory entries, (1) add the position
of next entry to the current sector, and then (2) update the sector of
next entry. If the power is turned off between (1) and (2), the next
entry will not be found, and the chain of directory entries will break.
It causes the SmartFS file system corruption, and we will not be able
to add files.

To avoid this issue, in checking the filesystem by smart_fsck_directory,
if the sector of next entry does not exist, update the sector of
directory entry to invalidate the field of next entry.

## Impact
SmartFS, and only abnormal cases where it has been corrupted by a power failure.

## Testing
Create a corrupted file system with a missing link of directory entry
and verify that the file system can be recovered in the next power cycle.
