### PR TITLE
boards: cxd56xx: Update drivers on spresense board

### DIFF
--- a/boards/arm/cxd56xx/common/src/Make.defs
+++ b/boards/arm/cxd56xx/common/src/Make.defs
@@ -88,7 +88,7 @@ ifeq ($(CONFIG_SENSORS_BMI160_SPI),y)
 CSRCS += cxd56_bmi160_spi.c
 endif
 
-ifeq ($(CONFIG_SENSORS_BMP280_I2C),y)
+ifeq ($(CONFIG_SENSORS_BMP280),y)
 CSRCS += cxd56_bmp280_i2c.c
 endif
 

--- a/boards/arm/cxd56xx/common/src/cxd56_altmdm.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_altmdm.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <debug.h>
 #include <errno.h>
+#include <nuttx/arch.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>
@@ -73,6 +74,8 @@
 #else
 #  error "Select LTE SPI 4 or 5"
 #endif
+
+#define WAIT_READY_TO_GPIO_INTERRUPT 300 /* micro seconds */
 
 /****************************************************************************
  * Private Function Prototypes
@@ -313,6 +316,12 @@ static bool altmdm_sready(void)
 
 static void altmdm_master_request(bool request)
 {
+  /* If the GPIO falls within 300us after raising
+   * (or GPIO raises within 300us after falling), the modem may miss the GPIO
+   * interrupt. So delay by 300us before changing the GPIO.
+   */
+
+  up_udelay(WAIT_READY_TO_GPIO_INTERRUPT);
   cxd56_gpio_write(ALTMDM_MASTER_REQ, request);
 }
 

--- a/boards/arm/cxd56xx/spresense/src/cxd56_gpioif.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_gpioif.c
@@ -188,7 +188,8 @@ int board_gpio_intconfig(uint32_t pin, int mode, bool filter, xcpt_t isr)
       gpiocfg |= GPIOINT_NOISE_FILTER_ENABLE;
     }
 
-  ret = cxd56_gpioint_config(pin, gpiocfg, isr, NULL);
+  ret = cxd56_gpioint_config(pin, gpiocfg, isr, (void *)pin);
+
   return ret;
 #else
   return -ENOTSUP;

--- a/boards/arm/cxd56xx/spresense/src/cxd56_power.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_power.c
@@ -206,9 +206,9 @@ int board_power_control(int target, bool en)
     {
       ret = pfunc(PMIC_GET_CH(target), en);
 
-      /* If RTC clock is unstable, delay 1 tick for PMIC setting. */
+      /* If RTC clock is unstable, delay 1 tick for PMIC GPO setting. */
 
-      if (!g_rtc_enabled)
+      if (!g_rtc_enabled && (PMIC_GET_TYPE(target) == PMIC_TYPE_GPO))
         {
           usleep(1);
         }

--- a/boards/arm/cxd56xx/spresense/src/cxd56_power.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_power.c
@@ -205,6 +205,13 @@ int board_power_control(int target, bool en)
   if (pfunc)
     {
       ret = pfunc(PMIC_GET_CH(target), en);
+
+      /* If RTC clock is unstable, delay 1 tick for PMIC setting. */
+
+      if (!g_rtc_enabled)
+        {
+          usleep(1);
+        }
     }
 
   return ret;
@@ -236,6 +243,13 @@ int board_power_control_tristate(int target, int value)
       /* set HiZ to PMIC GPO channel */
 
       ret = cxd56_pmic_set_gpo_hiz(PMIC_GET_CH(target));
+
+      /* If RTC clock is unstable, delay 1 tick for PMIC setting. */
+
+      if (!g_rtc_enabled)
+        {
+          usleep(1);
+        }
     }
   else
     {

--- a/boards/arm/cxd56xx/spresense/src/cxd56_power.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_power.c
@@ -127,7 +127,8 @@ int board_pmic_write(uint8_t addr, void *buf, uint32_t size)
 int board_power_setup(int status)
 {
 #ifdef CONFIG_BOARD_USB_DISABLE_IN_DEEP_SLEEPING
-  uint8_t val;
+  int      ret;
+  uint8_t  val = 0;
   uint32_t bootcause;
 
   /* Enable USB after wakeup from deep sleeping */
@@ -140,8 +141,8 @@ int board_power_setup(int status)
       case PM_BOOT_DEEP_WKUPS:
       case PM_BOOT_DEEP_RTC:
       case PM_BOOT_DEEP_OTHERS:
-        cxd56_pmic_read(PMIC_REG_CNT_USB2, &val, sizeof(val));
-        if (val & PMIC_SET_CHGOFF)
+        ret = cxd56_pmic_read(PMIC_REG_CNT_USB2, &val, sizeof(val));
+        if ((ret == 0) && (val & PMIC_SET_CHGOFF))
           {
             val &= ~PMIC_SET_CHGOFF;
             cxd56_pmic_write(PMIC_REG_CNT_USB2, &val, sizeof(val));

--- a/boards/arm/cxd56xx/spresense/src/cxd56_power.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_power.c
@@ -509,9 +509,12 @@ int board_reset(int status)
 {
   /* Restore the original state for bootup after power cycle  */
 
-  board_xtal_power_control(true);
-  board_flash_power_control(true);
-  up_pm_acquire_freqlock(&g_hv_lock);
+  if (!up_interrupt_context())
+    {
+      board_xtal_power_control(true);
+      board_flash_power_control(true);
+      up_pm_acquire_freqlock(&g_hv_lock);
+    }
 
   /* System reboot */
 


### PR DESCRIPTION
## Summary
* Fix bug that modem may miss the GPIO interrupt
* Fix uninitialized variable
* Fix configuration to compile bmp280 sensor
* Set the pin number to the argument of gpio handler
* Support board_reset on interrupt context
* Add delay only for PMIC GPO setting
* Fix PMIC setting during boot-up

## Impact
Only spresense board.

## Testing
All of spresense defconfigs.
