### PR TITLE
fs/vfs/fs_select.c: Fix select() to return EINVAL when nfds is negative

### DIFF
--- a/fs/vfs/fs_select.c
+++ b/fs/vfs/fs_select.c
@@ -90,6 +90,12 @@ int select(int nfds, FAR fd_set *readfds, FAR fd_set *writefds,
 
   enter_cancellation_point();
 
+  if (nfds < 0)
+    {
+      errcode = EINVAL;
+      goto errout;
+    }
+
   /* How many pollfd structures do we need to allocate? */
 
   /* Initialize the descriptor list for poll() */


### PR DESCRIPTION
## Summary
Fix bug that select() did not return when the nfds argument
was set to a negative value. The specification is that -1 is
set to the return value and EINVAL is set to errno.

## Impact

## Testing

