### PR TITLE
xtensa/esp32: Fix warning "is not defined"

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiram.c
+++ b/arch/xtensa/src/esp32/esp32_spiram.c
@@ -67,9 +67,9 @@
 
 /* Let's to assume SPIFLASH SPEED == SPIRAM SPEED for now */
 
-#if CONFIG_ESP32_SPIRAM_SPEED_40M
+#if defined(CONFIG_ESP32_SPIRAM_SPEED_40M)
 #  define PSRAM_SPEED PSRAM_CACHE_F40M_S40M
-#elif CONFIG_ESP32_SPIRAM_SPEED_80M
+#elif defined(CONFIG_ESP32_SPIRAM_SPEED_80M)
 #  define PSRAM_SPEED PSRAM_CACHE_F80M_S80M
 #else
 #  error "FLASH speed can only be equal to or higher than SRAM speed while SRAM is enabled!"


### PR DESCRIPTION
## Summary
Setting `CONFIG_ESP32_SPIRAM_SPEED_80M=y` makes `CONFIG_ESP32_SPIRAM_SPEED_40M` not defined.
Building enabling `-Werror` the build process fails with:

```
/esp32_spiram.c:70:5: error: "CONFIG_ESP32_SPIRAM_SPEED_40M" is not defined, evaluates to 0 [-Werror=undef]
 #if CONFIG_ESP32_SPIRAM_SPEED_40M
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Impact
All xtensa/esp32 boards

## Testing
esp32 board

