### PR TITLE
libelf: fix "nsh: nsh_session: readline failed: 13" error

### DIFF
--- a/binfmt/libelf/libelf_init.c
+++ b/binfmt/libelf/libelf_init.c
@@ -134,6 +134,7 @@ int elf_init(FAR const char *filename, FAR struct elf_loadinfo_s *loadinfo)
   /* Clear the load info structure */
 
   memset(loadinfo, 0, sizeof(struct elf_loadinfo_s));
+  loadinfo->filfd = -1;
 
   /* Get the length of the file. */
 


### PR DESCRIPTION
Resolves issue #3751

## Summary

## Impact

## Testing

