### PR TITLE
net/tcp/retransmit: recounter the ack counter during obtain newdata 

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -487,6 +487,13 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
             }
           else if (ackno == TCP_WBSEQNO(wrb))
             {
+              /* Reset the duplicate ack counter */
+
+              if ((flags & TCP_NEWDATA) != 0)
+                {
+                  TCP_WBNACK(wrb) = 0;
+                }
+
               /* Duplicate ACK? Retransmit data if need */
 
               if (++TCP_WBNACK(wrb) ==


### PR DESCRIPTION
## Summary

net/tcp/retransmit: recounter the ack counter during obtain newdata

Only accumulate duplicate ACK counter when we receive duplicate ACK data

## Impact

Fast retransmit

## Testing

iperf test