### PR TITLE
arm/v7-a/fpu: add VFP-v3 D32 support

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -825,6 +825,14 @@ config ARM_HAVE_WFE_SEV
 	---help---
 		Use WFE and SEV instructions for spinlock to reduce power consumption
 
+config ARM_HAVE_FPU_D32
+	bool
+	select ARCH_HAVE_FPU
+	default n
+	---help---
+		FPU implemented in the VFPv3-D32 format that supports
+		32 double-precision floating-point registers.
+
 config ARM_HAVE_MPU_UNIFIED
 	bool
 	default n

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -136,8 +136,29 @@
 #  define REG_D15           (ARM_CONTEXT_REGS+30) /* D15 */
 #  define REG_S30           (ARM_CONTEXT_REGS+30) /* S30 */
 #  define REG_S31           (ARM_CONTEXT_REGS+31) /* S31 */
-#  define REG_FPSCR         (ARM_CONTEXT_REGS+32) /* Floating point status and control */
-#  define FPU_CONTEXT_REGS  (33)
+#  ifdef CONFIG_ARM_HAVE_FPU_D32
+#    define REG_D16         (ARM_CONTEXT_REGS+32) /* D16 */
+#    define REG_D17         (ARM_CONTEXT_REGS+34) /* D17 */
+#    define REG_D18         (ARM_CONTEXT_REGS+36) /* D18 */
+#    define REG_D19         (ARM_CONTEXT_REGS+38) /* D19 */
+#    define REG_D20         (ARM_CONTEXT_REGS+40) /* D20 */
+#    define REG_D21         (ARM_CONTEXT_REGS+42) /* D21 */
+#    define REG_D22         (ARM_CONTEXT_REGS+44) /* D22 */
+#    define REG_D23         (ARM_CONTEXT_REGS+46) /* D23 */
+#    define REG_D24         (ARM_CONTEXT_REGS+48) /* D24 */
+#    define REG_D25         (ARM_CONTEXT_REGS+50) /* D25 */
+#    define REG_D26         (ARM_CONTEXT_REGS+52) /* D26 */
+#    define REG_D27         (ARM_CONTEXT_REGS+54) /* D27 */
+#    define REG_D28         (ARM_CONTEXT_REGS+56) /* D28 */
+#    define REG_D29         (ARM_CONTEXT_REGS+58) /* D29 */
+#    define REG_D30         (ARM_CONTEXT_REGS+60) /* D30 */
+#    define REG_D31         (ARM_CONTEXT_REGS+62) /* D31 */
+#    define REG_FPSCR       (ARM_CONTEXT_REGS+64) /* Floating point status and control */
+#    define FPU_CONTEXT_REGS  (65)
+#  else
+#    define REG_FPSCR       (ARM_CONTEXT_REGS+32) /* Floating point status and control */
+#    define FPU_CONTEXT_REGS  (33)
+#  endif
 #else
 #  define FPU_CONTEXT_REGS  (0)
 #endif

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -136,8 +136,29 @@
 #  define REG_D15           (ARM_CONTEXT_REGS+30) /* D15 */
 #  define REG_S30           (ARM_CONTEXT_REGS+30) /* S30 */
 #  define REG_S31           (ARM_CONTEXT_REGS+31) /* S31 */
-#  define REG_FPSCR         (ARM_CONTEXT_REGS+32) /* Floating point status and control */
-#  define FPU_CONTEXT_REGS  (33)
+#  ifdef CONFIG_ARM_HAVE_FPU_D32
+#    define REG_D16         (ARM_CONTEXT_REGS+32) /* D16 */
+#    define REG_D17         (ARM_CONTEXT_REGS+34) /* D17 */
+#    define REG_D18         (ARM_CONTEXT_REGS+36) /* D18 */
+#    define REG_D19         (ARM_CONTEXT_REGS+38) /* D19 */
+#    define REG_D20         (ARM_CONTEXT_REGS+40) /* D20 */
+#    define REG_D21         (ARM_CONTEXT_REGS+42) /* D21 */
+#    define REG_D22         (ARM_CONTEXT_REGS+44) /* D22 */
+#    define REG_D23         (ARM_CONTEXT_REGS+46) /* D23 */
+#    define REG_D24         (ARM_CONTEXT_REGS+48) /* D24 */
+#    define REG_D25         (ARM_CONTEXT_REGS+50) /* D25 */
+#    define REG_D26         (ARM_CONTEXT_REGS+52) /* D26 */
+#    define REG_D27         (ARM_CONTEXT_REGS+54) /* D27 */
+#    define REG_D28         (ARM_CONTEXT_REGS+56) /* D28 */
+#    define REG_D29         (ARM_CONTEXT_REGS+58) /* D29 */
+#    define REG_D30         (ARM_CONTEXT_REGS+60) /* D30 */
+#    define REG_D31         (ARM_CONTEXT_REGS+62) /* D31 */
+#    define REG_FPSCR       (ARM_CONTEXT_REGS+64) /* Floating point status and control */
+#    define FPU_CONTEXT_REGS  (65)
+#  else
+#    define REG_FPSCR       (ARM_CONTEXT_REGS+32) /* Floating point status and control */
+#    define FPU_CONTEXT_REGS  (33)
+#  endif
 #else
 #  define FPU_CONTEXT_REGS  (0)
 #endif

--- a/arch/arm/src/armv7-a/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-a/arm_fullcontextrestore.S
@@ -79,7 +79,12 @@ arm_fullcontextrestore:
 	 * s0, s1, ... in increasing address order.
 	 */
 
+#ifdef CONFIG_ARM_HAVE_FPU_D32
+	vldmia.64	r1!, {d0-d15}			/* Restore the full FP context */
+	vldmia.64	r1!, {d16-d31}
+#else
 	vldmia		r1!, {s0-s31}			/* Restore the full FP context */
+#endif
 
 	/* Load the floating point control and status register.   At the end of the
 	 * vstmia, r1 will point to the FPCSR storage location.

--- a/arch/arm/src/armv7-a/arm_restorefpu.S
+++ b/arch/arm/src/armv7-a/arm_restorefpu.S
@@ -72,7 +72,12 @@ arm_restorefpu:
 	 * s0, s1, ... in increasing address order.
 	 */
 
+#ifdef CONFIG_ARM_HAVE_FPU_D32
+	vldmia.64	r1!, {d0-d15}			/* Restore the full FP context */
+	vldmia.64	r1!, {d16-d31}
+#else
 	vldmia		r1!, {s0-s31}			/* Restore the full FP context */
+#endif
 
 	/* Load the floating point control and status register.   At the end of the
 	 * vstmia, r1 will point to the FPCSR storage location.

--- a/arch/arm/src/armv7-a/arm_savefpu.S
+++ b/arch/arm/src/armv7-a/arm_savefpu.S
@@ -76,7 +76,12 @@ arm_savefpu:
 	 * s0, s1, ... in increasing address order.
 	 */
 
+#ifdef CONFIG_ARM_HAVE_FPU_D32
+	vstmia.64	r1!, {d0-d15}			/* Save the full FP context */
+	vstmia.64	r1!, {d16-d31}
+#else
 	vstmia		r1!, {s0-s31}			/* Save the full FP context */
+#endif
 
 	/* Store the floating point control and status register.  At the end of the
 	 * vstmia, r1 will point to the FPCSR storage location.

--- a/arch/arm/src/armv7-a/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-a/arm_saveusercontext.S
@@ -107,7 +107,12 @@ arm_saveusercontext:
 	 * s0, s1, ... in increasing address order.
 	 */
 
+#ifdef CONFIG_ARM_HAVE_FPU_D32
+	vstmia.64	r1!, {d0-d15}		/* Save the full FP context */
+	vstmia.64	r1!, {d16-d31}
+#else
 	vstmia		r1!, {s0-s31}		/* Save the full FP context */
+#endif
 
 	/* Store the floating point control and status register.  At the end of the
 	 * vstmia, r1 will point to the FPCSR storage location.

--- a/arch/arm/src/armv7-r/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-r/arm_fullcontextrestore.S
@@ -78,7 +78,12 @@ arm_fullcontextrestore:
 	 * s0, s1, ... in increasing address order.
 	 */
 
+#ifdef CONFIG_ARM_HAVE_FPU_D32
+	vldmia.64	r1!, {d0-d15}			/* Restore the full FP context */
+	vldmia.64	r1!, {d16-d31}
+#else
 	vldmia		r1!, {s0-s31}			/* Restore the full FP context */
+#endif
 
 	/* Load the floating point control and status register.   At the end of the
 	 * vstmia, r1 will point to the FPCSR storage location.

--- a/arch/arm/src/armv7-r/arm_restorefpu.S
+++ b/arch/arm/src/armv7-r/arm_restorefpu.S
@@ -72,7 +72,12 @@ arm_restorefpu:
 	 * s0, s1, ... in increasing address order.
 	 */
 
+#ifdef CONFIG_ARM_HAVE_FPU_D32
+	vldmia.64	r1!, {d0-d15}			/* Restore the full FP context */
+	vldmia.64	r1!, {d16-d31}
+#else
 	vldmia		r1!, {s0-s31}			/* Restore the full FP context */
+#endif
 
 	/* Load the floating point control and status register.   At the end of the
 	 * vstmia, r1 will point to the FPCSR storage location.

--- a/arch/arm/src/armv7-r/arm_savefpu.S
+++ b/arch/arm/src/armv7-r/arm_savefpu.S
@@ -76,7 +76,12 @@ arm_savefpu:
 	 * s0, s1, ... in increasing address order.
 	 */
 
+#ifdef CONFIG_ARM_HAVE_FPU_D32
+	vstmia.64	r1!, {d0-d15}			/* Save the full FP context */
+	vstmia.64	r1!, {d16-d31}
+#else
 	vstmia		r1!, {s0-s31}			/* Save the full FP context */
+#endif
 
 	/* Store the floating point control and status register.  At the end of the
 	 * vstmia, r1 will point to the FPCSR storage location.

--- a/arch/arm/src/armv7-r/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-r/arm_saveusercontext.S
@@ -106,7 +106,12 @@ arm_saveusercontext:
 	 * s0, s1, ... in increasing address order.
 	 */
 
+#ifdef CONFIG_ARM_HAVE_FPU_D32
+	vstmia.64	r1!, {d0-d15}		/* Save the full FP context */
+	vstmia.64	r1!, {d16-d31}
+#else
 	vstmia		r1!, {s0-s31}		/* Save the full FP context */
+#endif
 
 	/* Store the floating point control and status register.  At the end of the
 	 * vstmia, r1 will point to the FPCSR storage location.


### PR DESCRIPTION
## Summary

arm/v7-a/fpu: add VFP-v3 D32 support

There are some necessary neon registers that have not been properly saved and restored

Reference here:
https://developer.arm.com/documentation/dht0002/a/Introducing-NEON/NEON-architecture-overview/NEON-registers

## Impact

NEON registers

## Testing

check/assign/save/restore the D16-D31 registers after/before context switch