### PR TITLE
xtensa: #ifdef SYMBOL is always true if SYMBOL defined as 0

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -89,7 +89,7 @@
 
 #define _REG_LOOPS_START    (21)
 
-#ifdef XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_LOOPS != 0
 #  define REG_LBEG          (_REG_LOOPS_START + 0)
 #  define REG_LEND          (_REG_LOOPS_START + 1)
 #  define REG_LCOUNT        (_REG_LOOPS_START + 2)

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -138,7 +138,7 @@ _xtensa_context_save:
 	rsr		a3, SAR
 	s32i	a3, a2, (4 * REG_SAR)
 
-#ifdef XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_LOOPS != 0
 	rsr		a3, LBEG
 	s32i	a3, a2, (4 * REG_LBEG)
 	rsr		a3, LEND
@@ -344,7 +344,7 @@ _xtensa_save_hook:
 	rsr		a3, SAR
 	s32i	a3, a2, (4 * REG_SAR)
 
-#ifdef XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_LOOPS != 0
 	rsr		a3, LBEG
 	s32i	a3, a2, (4 * REG_LBEG)
 	rsr		a3, LEND
@@ -449,7 +449,7 @@ xtensa_context_save:
 
 _xtensa_context_restore:
 
-#ifdef XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_LOOPS != 0
 	l32i	a3, a2, (4 * REG_LBEG)
 	l32i	a4, a2, (4 * REG_LEND)
 	wsr		a3, LBEG

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -140,7 +140,7 @@ static inline void xtensa_registerdump(void)
   _alert("  SAR: %08lx CAUSE: %08lx VADDR: %08lx\n",
          (unsigned long)regs[REG_SAR], (unsigned long)regs[REG_EXCCAUSE],
          (unsigned long)regs[REG_EXCVADDR]);
-#ifdef XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_LOOPS != 0
   _alert(" LBEG: %08lx  LEND: %08lx  LCNT: %08lx\n",
          (unsigned long)regs[REG_LBEG], (unsigned long)regs[REG_LEND],
          (unsigned long)regs[REG_LCOUNT]);

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -311,7 +311,7 @@ _xtensa_syscall_handler:
 
 	/* Save EPC */
 
-#ifdef XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_LOOPS != 0
 	/* Save A2 and A3 now to give us some registers to work with.  A0, A2
 	 * and A3 are now available.  NOTE that A3 will get saved again in
 	 * _xtensa_context_save().

--- a/arch/xtensa/src/esp32/esp32_user.c
+++ b/arch/xtensa/src/esp32/esp32_user.c
@@ -293,7 +293,7 @@ static void advance_pc(uint32_t *regs, int diff)
   /* Advance to the next instruction. */
 
   nextpc = regs[REG_PC] + diff;
-#ifdef XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_LOOPS != 0
   /* See Xtensa ISA 4.3.2.4 Loopback Semantics */
 
   if (regs[REG_LCOUNT] != 0 && nextpc == regs[REG_LEND])


### PR DESCRIPTION
## Summary
The "#ifdef XCHAL_HAVE_LOOPS" was always true because XCHAL_HAVE_LOOPS as defined (but as 0)
## Impact
only ESP32
## Testing
ESP32-Devkitc

NOTE: The CI will fail because arch/xtensa/include/xtensa/core.h was MiXed variables
