### PR TITLE
binfmt: Rename dump_module to binfmt_dumpmodule

### DIFF
--- a/binfmt/binfmt.h
+++ b/binfmt/binfmt.h
@@ -59,7 +59,7 @@ EXTERN FAR struct binfmt_s *g_binfmts;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: dump_module
+ * Name: binfmt_dumpmodule
  *
  * Description:
  *   Dump the contents of struct binary_s.
@@ -73,9 +73,9 @@ EXTERN FAR struct binfmt_s *g_binfmts;
  ****************************************************************************/
 
 #if defined(CONFIG_DEBUG_FEATURES) && defined(CONFIG_DEBUG_BINFMT)
-int dump_module(FAR const struct binary_s *bin);
+int binfmt_dumpmodule(FAR const struct binary_s *bin);
 #else
-#  define dump_module(bin)
+#  define binfmt_dumpmodule(bin)
 #endif
 
 /****************************************************************************

--- a/binfmt/binfmt_dumpmodule.c
+++ b/binfmt/binfmt_dumpmodule.c
@@ -39,7 +39,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: dump_module
+ * Name: binfmt_dumpmodule
  *
  * Description:
  *   Dump the contents of struct binary_s.
@@ -52,7 +52,7 @@
  *
  ****************************************************************************/
 
-int dump_module(FAR const struct binary_s *bin)
+int binfmt_dumpmodule(FAR const struct binary_s *bin)
 {
   if (bin)
     {

--- a/binfmt/binfmt_loadmodule.c
+++ b/binfmt/binfmt_loadmodule.c
@@ -127,7 +127,7 @@ static int load_absmodule(FAR struct binary_s *bin)
           /* Save the unload method for use by unload_module */
 
           bin->unload = binfmt->unload;
-          dump_module(bin);
+          binfmt_dumpmodule(bin);
           break;
         }
     }


### PR DESCRIPTION
## Summary
follow other binfmt function naming convention

## Impact
Minor, rename the internal function

## Testing
Pass CI
