### PR TITLE
binfmt: Move argv copy into exec_module

### DIFF
--- a/binfmt/binfmt.h
+++ b/binfmt/binfmt.h
@@ -88,15 +88,14 @@ int binfmt_dumpmodule(FAR const struct binary_s *bin);
  *   do not have any real option other than to copy the callers argv[] list.
  *
  * Input Parameters:
- *   bin      - Load structure
  *   argv     - Argument list
  *
  * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
+ *   A non-zero copy is returned on success.
  *
  ****************************************************************************/
 
-int binfmt_copyargv(FAR struct binary_s *bin, FAR char * const *argv);
+FAR char * const *binfmt_copyargv(FAR char * const *argv);
 
 /****************************************************************************
  * Name: binfmt_freeargv
@@ -105,7 +104,7 @@ int binfmt_copyargv(FAR struct binary_s *bin, FAR char * const *argv);
  *   Release the copied argv[] list.
  *
  * Input Parameters:
- *   bin      - Load structure
+ *   argv     - Argument list
  *
  * Returned Value:
  *   None
@@ -113,9 +112,9 @@ int binfmt_copyargv(FAR struct binary_s *bin, FAR char * const *argv);
  ****************************************************************************/
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
-void binfmt_freeargv(FAR struct binary_s *bin);
+void binfmt_freeargv(FAR char * const *argv);
 #else
-#  define binfmt_freeargv(bin)
+#  define binfmt_freeargv(argv)
 #endif
 
 /****************************************************************************

--- a/binfmt/binfmt_dumpmodule.c
+++ b/binfmt/binfmt_dumpmodule.c
@@ -58,7 +58,6 @@ int binfmt_dumpmodule(FAR const struct binary_s *bin)
     {
       binfo("Module:\n");
       binfo("  filename:  %s\n", bin->filename);
-      binfo("  argv:      %p\n", bin->argv);
       binfo("  entrypt:   %p\n", bin->entrypt);
       binfo("  mapped:    %p size=%zd\n", bin->mapped, bin->mapsize);
       binfo("  alloc:     %p %p %p\n", bin->alloc[0],

--- a/binfmt/binfmt_dumpmodule.c
+++ b/binfmt/binfmt_dumpmodule.c
@@ -57,7 +57,6 @@ int binfmt_dumpmodule(FAR const struct binary_s *bin)
   if (bin)
     {
       binfo("Module:\n");
-      binfo("  filename:  %s\n", bin->filename);
       binfo("  entrypt:   %p\n", bin->entrypt);
       binfo("  mapped:    %p size=%zd\n", bin->mapped, bin->mapsize);
       binfo("  alloc:     %p %p %p\n", bin->alloc[0],

--- a/binfmt/binfmt_exec.c
+++ b/binfmt/binfmt_exec.c
@@ -86,15 +86,9 @@ int exec_spawn(FAR const char *filename, FAR char * const *argv,
       goto errout;
     }
 
-  /* Initialize the binary structure */
-
-  bin->filename = filename;
-  bin->exports  = exports;
-  bin->nexports = nexports;
-
   /* Load the module into memory */
 
-  ret = load_module(bin);
+  ret = load_module(bin, filename, exports, nexports);
   if (ret < 0)
     {
       berr("ERROR: Failed to load program '%s': %d\n", filename, ret);
@@ -127,7 +121,7 @@ int exec_spawn(FAR const char *filename, FAR char * const *argv,
 
   /* Then start the module */
 
-  pid = exec_module(bin, argv);
+  pid = exec_module(bin, filename, argv);
   if (pid < 0)
     {
       ret = pid;

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -111,7 +111,8 @@ static void exec_ctors(FAR void *arg)
  *
  ****************************************************************************/
 
-int exec_module(FAR const struct binary_s *binp, FAR char * const *argv)
+int exec_module(FAR const struct binary_s *binp,
+                FAR const char *filename, FAR char * const *argv)
 {
   FAR struct task_tcb_s *tcb;
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
@@ -129,7 +130,7 @@ int exec_module(FAR const struct binary_s *binp, FAR char * const *argv)
     }
 #endif
 
-  binfo("Executing %s\n", binp->filename);
+  binfo("Executing %s\n", filename);
 
   /* Allocate a TCB for the new task. */
 
@@ -167,7 +168,7 @@ int exec_module(FAR const struct binary_s *binp, FAR char * const *argv)
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, binp->filename, binp->priority,
+  ret = nxtask_init(tcb, filename, binp->priority,
                     NULL, binp->stacksize, binp->entrypt, argv);
   binfmt_freeargv(argv);
   if (ret < 0)

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -111,7 +111,7 @@ static void exec_ctors(FAR void *arg)
  *
  ****************************************************************************/
 
-int exec_module(FAR const struct binary_s *binp)
+int exec_module(FAR const struct binary_s *binp, FAR char * const *argv)
 {
   FAR struct task_tcb_s *tcb;
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
@@ -139,6 +139,16 @@ int exec_module(FAR const struct binary_s *binp)
       return -ENOMEM;
     }
 
+  if (argv)
+    {
+      argv = binfmt_copyargv(argv);
+      if (!argv)
+        {
+          ret = -ENOMEM;
+          goto errout_with_tcb;
+        }
+    }
+
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
   /* Instantiate the address environment containing the user heap */
 
@@ -146,6 +156,7 @@ int exec_module(FAR const struct binary_s *binp)
   if (ret < 0)
     {
       berr("ERROR: up_addrenv_select() failed: %d\n", ret);
+      binfmt_freeargv(argv);
       goto errout_with_tcb;
     }
 #endif
@@ -157,20 +168,13 @@ int exec_module(FAR const struct binary_s *binp)
   /* Initialize the task */
 
   ret = nxtask_init(tcb, binp->filename, binp->priority,
-                    NULL, binp->stacksize, binp->entrypt, binp->argv);
+                    NULL, binp->stacksize, binp->entrypt, argv);
+  binfmt_freeargv(argv);
   if (ret < 0)
     {
       berr("nxtask_init() failed: %d\n", ret);
       goto errout_with_addrenv;
     }
-
-  /* We can free the argument buffer now.
-   * REVISIT:  It is good to free up memory as soon as possible, but
-   * unfortunately here 'binp' is 'const'.  So to do this properly, we will
-   * have to make some more extensive changes.
-   */
-
-  binfmt_freeargv((FAR struct binary_s *)binp);
 
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
   /* Allocate the kernel stack */
@@ -264,9 +268,8 @@ errout_with_tcbinit:
 errout_with_addrenv:
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
   up_addrenv_restore(&oldenv);
-
-errout_with_tcb:
 #endif
+errout_with_tcb:
   kmm_free(tcb);
   return ret;
 }

--- a/binfmt/binfmt_loadmodule.c
+++ b/binfmt/binfmt_loadmodule.c
@@ -86,7 +86,7 @@ static int load_default_priority(FAR struct binary_s *bin)
  *
  * Description:
  *   Load a module into memory, bind it to an exported symbol take, and
- *   prep the module for execution.  bin->filename is known to be an absolute
+ *   prep the module for execution.  filename is known to be an absolute
  *   path to the file to be loaded.
  *
  * Returned Value:
@@ -95,12 +95,13 @@ static int load_default_priority(FAR struct binary_s *bin)
  *
  ****************************************************************************/
 
-static int load_absmodule(FAR struct binary_s *bin)
+static int load_absmodule(FAR struct binary_s *bin, FAR const char *filename,
+                          FAR const struct symtab_s *exports, int nexports)
 {
   FAR struct binfmt_s *binfmt;
   int ret = -ENOENT;
 
-  binfo("Loading %s\n", bin->filename);
+  binfo("Loading %s\n", filename);
 
   /* Disabling pre-emption should be sufficient protection while accessing
    * the list of registered binary format handlers.
@@ -117,12 +118,12 @@ static int load_absmodule(FAR struct binary_s *bin)
     {
       /* Use this handler to try to load the format */
 
-      ret = binfmt->load(bin);
+      ret = binfmt->load(bin, filename, exports, nexports);
       if (ret == OK)
         {
           /* Successfully loaded -- break out with ret == 0 */
 
-          binfo("Successfully loaded module %s\n", bin->filename);
+          binfo("Successfully loaded module %s\n", filename);
 
           /* Save the unload method for use by unload_module */
 
@@ -154,14 +155,15 @@ static int load_absmodule(FAR struct binary_s *bin)
  *
  ****************************************************************************/
 
-int load_module(FAR struct binary_s *bin)
+int load_module(FAR struct binary_s *bin, FAR const char *filename,
+                FAR const struct symtab_s *exports, int nexports)
 {
   int ret = -EINVAL;
 
   /* Verify that we were provided something to work with */
 
 #ifdef CONFIG_DEBUG_FEATURES
-  if (bin && bin->filename)
+  if (bin && filename)
 #endif
     {
       /* Set the default priority of the new program. */
@@ -177,16 +179,12 @@ int load_module(FAR struct binary_s *bin)
        */
 
 #ifdef CONFIG_LIB_ENVPATH
-      if (bin->filename[0] != '/')
+      if (filename[0] != '/')
         {
-          FAR const char *relpath;
           FAR char *fullpath;
           ENVPATH_HANDLE handle;
 
-          /* Set aside the relative path */
-
-          relpath = bin->filename;
-          ret     = -ENOENT;
+          ret = -ENOENT;
 
           /* Initialize to traverse the PATH variable */
 
@@ -195,12 +193,11 @@ int load_module(FAR struct binary_s *bin)
             {
               /* Get the next absolute file path */
 
-              while ((fullpath = envpath_next(handle, relpath)) != NULL)
+              while ((fullpath = envpath_next(handle, filename)) != NULL)
                 {
                   /* Try to load the file at this path */
 
-                  bin->filename = fullpath;
-                  ret = load_absmodule(bin);
+                  ret = load_absmodule(bin, fullpath, exports, nexports);
 
                   /* Free the allocated fullpath */
 
@@ -218,12 +215,6 @@ int load_module(FAR struct binary_s *bin)
 
               envpath_release(handle);
             }
-
-          /* Restore the relative path.  This is not needed for anything
-           * but debug output after the file has been loaded.
-           */
-
-          bin->filename = relpath;
         }
       else
 #endif
@@ -232,7 +223,7 @@ int load_module(FAR struct binary_s *bin)
            * be loaded.
            */
 
-          ret = load_absmodule(bin);
+          ret = load_absmodule(bin, filename, exports, nexports);
         }
     }
 

--- a/binfmt/binfmt_unloadmodule.c
+++ b/binfmt/binfmt_unloadmodule.c
@@ -150,10 +150,6 @@ int unload_module(FAR struct binary_s *binp)
         }
 #endif
 
-      /* Free any allocated argv[] strings */
-
-      binfmt_freeargv(binp);
-
       /* Unmap mapped address spaces */
 
       if (binp->mapped)

--- a/binfmt/builtin.c
+++ b/binfmt/builtin.c
@@ -44,7 +44,10 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int builtin_loadbinary(FAR struct binary_s *binp);
+static int builtin_loadbinary(FAR struct binary_s *binp,
+                              FAR const char *filename,
+                              FAR const struct symtab_s *exports,
+                              int nexports);
 
 /****************************************************************************
  * Private Data
@@ -69,22 +72,24 @@ static struct binfmt_s g_builtin_binfmt =
  *
  ****************************************************************************/
 
-static int builtin_loadbinary(struct binary_s *binp)
+static int builtin_loadbinary(FAR struct binary_s *binp,
+                              FAR const char *filename,
+                              FAR const struct symtab_s *exports,
+                              int nexports)
 {
-  FAR const char *filename;
   FAR const struct builtin_s *builtin;
   int fd;
   int index;
   int ret;
 
-  binfo("Loading file: %s\n", binp->filename);
+  binfo("Loading file: %s\n", filename);
 
   /* Open the binary file for reading (only) */
 
-  fd = nx_open(binp->filename, O_RDONLY);
+  fd = nx_open(filename, O_RDONLY);
   if (fd < 0)
     {
-      berr("ERROR: Failed to open binary %s: %d\n", binp->filename, fd);
+      berr("ERROR: Failed to open binary %s: %d\n", filename, fd);
       return fd;
     }
 

--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -68,7 +68,10 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int elf_loadbinary(FAR struct binary_s *binp);
+static int elf_loadbinary(FAR struct binary_s *binp,
+                          FAR const char *filename,
+                          FAR const struct symtab_s *exports,
+                          int nexports);
 #if defined(CONFIG_DEBUG_FEATURES) && defined(CONFIG_DEBUG_BINFMT)
 static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo);
 #endif
@@ -206,16 +209,19 @@ static void elf_dumpentrypt(FAR struct binary_s *binp,
  *
  ****************************************************************************/
 
-static int elf_loadbinary(FAR struct binary_s *binp)
+static int elf_loadbinary(FAR struct binary_s *binp,
+                          FAR const char *filename,
+                          FAR const struct symtab_s *exports,
+                          int nexports)
 {
   struct elf_loadinfo_s loadinfo;  /* Contains globals for libelf */
   int                   ret;
 
-  binfo("Loading file: %s\n", binp->filename);
+  binfo("Loading file: %s\n", filename);
 
   /* Initialize the ELF library to load the program binary. */
 
-  ret = elf_init(binp->filename, &loadinfo);
+  ret = elf_init(filename, &loadinfo);
   elf_dumploadinfo(&loadinfo);
   if (ret != 0)
     {
@@ -235,7 +241,7 @@ static int elf_loadbinary(FAR struct binary_s *binp)
 
   /* Bind the program to the exported symbol table */
 
-  ret = elf_bind(&loadinfo, binp->exports, binp->nexports);
+  ret = elf_bind(&loadinfo, exports, nexports);
   if (ret != 0)
     {
       berr("Failed to bind symbols program binary: %d\n", ret);

--- a/binfmt/nxflat.c
+++ b/binfmt/nxflat.c
@@ -65,7 +65,10 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int nxflat_loadbinary(FAR struct binary_s *binp);
+static int nxflat_loadbinary(FAR struct binary_s *binp,
+                             FAR const char *filename,
+                             FAR const struct symtab_s *exports,
+                             int nexports);
 static int nxflat_unloadbinary(FAR struct binary_s *binp);
 
 #if defined(CONFIG_DEBUG_FEATURES) && defined(CONFIG_DEBUG_BINFMT)
@@ -137,16 +140,19 @@ static void nxflat_dumploadinfo(FAR struct nxflat_loadinfo_s *loadinfo)
  *
  ****************************************************************************/
 
-static int nxflat_loadbinary(FAR struct binary_s *binp)
+static int nxflat_loadbinary(FAR struct binary_s *binp,
+                             FAR const char *filename,
+                             FAR const struct symtab_s *exports,
+                             int nexports)
 {
   struct nxflat_loadinfo_s loadinfo;  /* Contains globals for libnxflat */
   int                      ret;
 
-  binfo("Loading file: %s\n", binp->filename);
+  binfo("Loading file: %s\n", filename);
 
   /* Initialize the xflat library to load the program binary. */
 
-  ret = nxflat_init(binp->filename, &loadinfo);
+  ret = nxflat_init(filename, &loadinfo);
   nxflat_dumploadinfo(&loadinfo);
   if (ret != 0)
     {
@@ -166,7 +172,7 @@ static int nxflat_loadbinary(FAR struct binary_s *binp)
 
   /* Bind the program to the exported symbol table */
 
-  ret = nxflat_bind(&loadinfo, binp->exports, binp->nexports);
+  ret = nxflat_bind(&loadinfo, exports, nexports);
   if (ret != 0)
     {
       berr("Failed to bind symbols program binary: %d\n", ret);

--- a/include/nuttx/binfmt/binfmt.h
+++ b/include/nuttx/binfmt/binfmt.h
@@ -64,12 +64,6 @@ struct binary_s
   /* Information provided to the loader to load and bind a module */
 
   FAR const char *filename;            /* Full path to the binary to be loaded (See NOTE 1 above) */
-#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
-  FAR char *argbuffer;                 /* Allocated argument list */
-  FAR char **argv;                     /* Copy of argument list */
-#else
-  FAR char * const *argv;              /* Argument list */
-#endif
   FAR const struct symtab_s *exports;  /* Table of exported symbols */
   int nexports;                        /* The number of symbols in exports[] */
 
@@ -234,7 +228,7 @@ int unload_module(FAR struct binary_s *bin);
  *
  ****************************************************************************/
 
-int exec_module(FAR const struct binary_s *bin);
+int exec_module(FAR const struct binary_s *binp, FAR char * const *argv);
 
 /****************************************************************************
  * Name: exec

--- a/include/nuttx/binfmt/binfmt.h
+++ b/include/nuttx/binfmt/binfmt.h
@@ -61,12 +61,6 @@ typedef FAR void (*binfmt_dtor_t)(void);
 struct symtab_s;
 struct binary_s
 {
-  /* Information provided to the loader to load and bind a module */
-
-  FAR const char *filename;            /* Full path to the binary to be loaded (See NOTE 1 above) */
-  FAR const struct symtab_s *exports;  /* Table of exported symbols */
-  int nexports;                        /* The number of symbols in exports[] */
-
   /* Information provided from the loader (if successful) describing the
    * resources used by the loaded module.
    */
@@ -118,7 +112,10 @@ struct binfmt_s
 
   /* Verify and load binary into memory */
 
-  CODE int (*load)(FAR struct binary_s *bin);
+  CODE int (*load)(FAR struct binary_s *bin,
+                   FAR const char *filename,
+                   FAR const struct symtab_s *exports,
+                   int nexports);
 
   /* Unload module callback */
 
@@ -192,7 +189,8 @@ int unregister_binfmt(FAR struct binfmt_s *binfmt);
  *
  ****************************************************************************/
 
-int load_module(FAR struct binary_s *bin);
+int load_module(FAR struct binary_s *bin, FAR const char *filename,
+                FAR const struct symtab_s *exports, int nexports);
 
 /****************************************************************************
  * Name: unload_module
@@ -228,7 +226,8 @@ int unload_module(FAR struct binary_s *bin);
  *
  ****************************************************************************/
 
-int exec_module(FAR const struct binary_s *binp, FAR char * const *argv);
+int exec_module(FAR const struct binary_s *binp,
+                FAR const char *filename, FAR char * const *argv);
 
 /****************************************************************************
  * Name: exec


### PR DESCRIPTION
## Summary
binfmt: Move argv copy into exec_module
binfmt: Remove filename/exports/nexports from binary_s

## Impact
Minor code restructure

## Testing
Pass posix_spawn test
