### PR TITLE
xtensa: Fixes names of architecture serial functions

### DIFF
--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -311,8 +311,8 @@ void xtensa_add_region(void);
 /* Serial output */
 
 void up_lowputc(char ch);
-void xtensa_early_serial_initialize(void);
-void xtensa_serial_initialize(void);
+void xtensa_earlyserialinit(void);
+void xtensa_serialinit(void);
 
 void rpmsg_serialinit(void);
 

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -181,7 +181,7 @@ void up_initialize(void)
   /* Initialize the serial device driver */
 
 #ifdef USE_SERIALDRIVER
-  xtensa_serial_initialize();
+  xtensa_serialinit();
 #endif
 
 #ifdef CONFIG_RPMSG_UART

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -1285,7 +1285,7 @@ void esp32_lowsetup(void)
  ****************************************************************************/
 
 #ifdef USE_EARLYSERIALINIT
-void xtensa_early_serial_initialize(void)
+void xtensa_earlyserialinit(void)
 {
   /* NOTE:  All GPIO configuration for the UARTs was performed in
    * esp32_lowsetup
@@ -1319,7 +1319,7 @@ void xtensa_early_serial_initialize(void)
  *
  ****************************************************************************/
 
-void xtensa_serial_initialize(void)
+void xtensa_serialinit(void)
 {
   /* Register the console */
 

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -155,7 +155,7 @@ void IRAM_ATTR __start(void)
 #ifdef USE_EARLYSERIALINIT
   /* Perform early serial initialization */
 
-  xtensa_early_serial_initialize();
+  xtensa_earlyserialinit();
 #endif
 
   showprogress("A");


### PR DESCRIPTION
## Summary

This is a small fix on the name of some xtensa APIs related to serial.

## Impact

All xtensa architecture chips.

## Testing
This change passed on our building tests against several defconfigs.
And also running the nsh. 
