### PR TITLE
mqueue, btqueue: Fix some typos (e.g., essage -> message)

### DIFF
--- a/include/nuttx/mqueue.h
+++ b/include/nuttx/mqueue.h
@@ -360,12 +360,12 @@ ssize_t nxmq_timedreceive(mqd_t mqdes, FAR char *msg, size_t msglen,
  * Description:
  *   This function deallocates an initialized message queue structure.
  *   First, it deallocates all of the queued messages in the message
- *   queue.  It is assumed that this message is fully unlinked and
- *   closed so that no thread will attempt access it while it is being
- *   deleted.
+ *   queue.  It is assumed that this message queue is fully unlinked
+ *   and closed so that no thread will attempt to access it while it
+ *   is being deleted.
  *
  * Input Parameters:
- *   msgq - Named essage queue to be freed
+ *   msgq - Named message queue to be freed
  *
  * Returned Value:
  *   None
@@ -400,10 +400,10 @@ FAR struct mqueue_inode_s *nxmq_alloc_msgq(mode_t mode,
  * Name: nxmq_pollnotify
  *
  * Description:
- *   pollnotify, used for notify the poll
+ *   pollnotify, used for notifying the poll
  *
  * Input Parameters:
- *   msgq     - Named essage queue
+ *   msgq     - Named message queue
  *   eventset - evnet
  *
  * Returned Value:

--- a/sched/mqueue/mq_msgqfree.c
+++ b/sched/mqueue/mq_msgqfree.c
@@ -38,12 +38,12 @@
  * Description:
  *   This function deallocates an initialized message queue structure.
  *   First, it deallocates all of the queued messages in the message
- *   queue.  It is assumed that this message is fully unlinked and
- *   closed so that no thread will attempt access it while it is being
- *   deleted.
+ *   queue.  It is assumed that this message queue is fully unlinked
+ *   and closed so that no thread will attempt to access it while it
+ *   is being deleted.
  *
  * Input Parameters:
- *   msgq - Named essage queue to be freed
+ *   msgq - Named message queue to be freed
  *
  * Returned Value:
  *   None

--- a/wireless/bluetooth/bt_queue.c
+++ b/wireless/bluetooth/bt_queue.c
@@ -40,7 +40,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Common essage queue attributes */
+/* Common message queue attributes */
 
 #define BT_MSGSIZE   sizeof(struct bt_bufmsg_s)
 #define BT_MSGFLAGS  0


### PR DESCRIPTION
## Summary

Fix some typos in comments only:

- include/nuttx/mqueue.h
- sched/mqueue/mq_msgqfree.c
- wireless/bluetooth/bt_queue.c

## Impact

Improve correctness of comments. No functional changes.

## Testing

nxstyle