### PR TITLE
Minor fixes in riscv k210 README.txt/typo

### DIFF
--- a/arch/risc-v/src/bl602/bl602_i2c.h
+++ b/arch/risc-v/src/bl602/bl602_i2c.h
@@ -89,4 +89,4 @@ int bl602_i2cbus_uninitialize(FAR struct i2c_master_s *dev);
 #endif
 
 #endif /* __ASSEMBLY__ */
-#endif /* __ARCH_RISCV_SRC_BL602_BL602_HBN_H */
+#endif /* __ARCH_RISCV_SRC_BL602_BL602_I2C_H */

--- a/boards/risc-v/k210/maix-bit/README.txt
+++ b/boards/risc-v/k210/maix-bit/README.txt
@@ -1,6 +1,7 @@
 1. Download and install toolchain and openocd-k210
 
   $ curl https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14.tar.gz
+  $ export PATH=$PATH:/$TOOL_CHAIN_PATH/bin
 
 2. Build openocd-k210
 
@@ -11,8 +12,8 @@
 3. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://github.com/apache/incubator-nuttx.git
-  $ git clone https://github.com/apache/incubator-nuttx-apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git nuttx
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git apps
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh maix-bit:nsh


### PR DESCRIPTION
## Summary
1) Update README.txt with updated clone path.
2) arch/riscv/bl602: Fix typo in i2c driver.

## Impact
Minimal.

## Testing
Tested on k210 maix-bit board.

