### PR TITLE
include/sys/syscall_lookup.h: Fix table for nx_mkfifo

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -261,6 +261,9 @@ SYSCALL_LOOKUP(telldir,                    1)
 
 #if defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0
   SYSCALL_LOOKUP(nx_pipe,                  3)
+#endif
+
+#if defined(CONFIG_PIPES) && CONFIG_DEV_FIFO_SIZE > 0
   SYSCALL_LOOKUP(nx_mkfifo,                3)
 #endif
 


### PR DESCRIPTION
Fix compilation when CONFIG_DEV_PIPE_SIZE > 0 && CONFIG_DEV_FIFO_SIZE == 0

In this case the nx_mkfifo doesn't exist.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>
