### PR TITLE
net/dev: link the net device as order of registration

### DIFF
--- a/net/netdev/netdev_register.c
+++ b/net/netdev/netdev_register.c
@@ -240,6 +240,7 @@ static int get_ifindex(void)
 
 int netdev_register(FAR struct net_driver_s *dev, enum net_lltype_e lltype)
 {
+  FAR struct net_driver_s **last;
   FAR char devfmt_str[IFNAMSIZ];
   FAR const char *devfmt;
   uint16_t pktsize = 0;
@@ -428,8 +429,15 @@ int netdev_register(FAR struct net_driver_s *dev, enum net_lltype_e lltype)
 
       /* Add the device to the list of known network devices */
 
-      dev->flink  = g_netdevices;
-      g_netdevices = dev;
+      last = &g_netdevices;
+      while (*last)
+        {
+          last = &((*last)->flink);
+        }
+
+      *last = dev;
+
+      dev->flink = NULL;
 
 #ifdef CONFIG_NET_IGMP
       /* Configure the device for IGMP support */


### PR DESCRIPTION
## Summary

net/dev: link the net device as order of registration

When multiple network cards are available on the device (with IFF_UP flag), 
the flipped list will cause the netdev_default() to find a invalid default device

https://github.com/apache/incubator-nuttx/blob/7a49fade033adf373004631f6e53e202cd97e143/net/netdev/netdev_default.c#L57-L86

## Impact

netdev_register order

## Testing

data receive/send works as expected if multiple network cards in IFF_UP/RUNNING status
