### PR TITLE
ESP32-C3: Fix configuration of TX Burst support for GDMA

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_dma.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_dma.c
@@ -157,12 +157,12 @@ int32_t esp32c3_dma_request(enum esp32c3_dma_periph_e periph,
     {
       /* Enable DMA TX/RX channels burst sending data */
 
-      SET_BITS(DMA_IN_CONF0_CH0_REG, chan, DMA_OUT_DATA_BURST_EN_CH0_M);
+      SET_BITS(DMA_OUT_CONF0_CH0_REG, chan, DMA_OUT_DATA_BURST_EN_CH0_M);
       SET_BITS(DMA_IN_CONF0_CH0_REG, chan, DMA_IN_DATA_BURST_EN_CH0_M);
 
       /* Enable DMA TX/RX channels burst reading descriptor link */
 
-      SET_BITS(DMA_IN_CONF0_CH0_REG, chan, DMA_OUTDSCR_BURST_EN_CH0_M);
+      SET_BITS(DMA_OUT_CONF0_CH0_REG, chan, DMA_OUTDSCR_BURST_EN_CH0_M);
       SET_BITS(DMA_IN_CONF0_CH0_REG, chan, DMA_INDSCR_BURST_EN_CH0_M);
     }
 

--- a/arch/risc-v/src/esp32c3/esp32c3_dma.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_dma.h
@@ -97,7 +97,7 @@ enum esp32c3_dma_periph_e
 struct esp32c3_dmadesc_s
 {
   uint32_t ctrl;                    /* DMA control block */
-  uint8_t *pbuf;                    /* DMA TX/RX buffer address */
+  const uint8_t *pbuf;              /* DMA TX/RX buffer address */
   struct esp32c3_dmadesc_s *next;   /* Next DMA descriptor address */
 };
 


### PR DESCRIPTION
## Summary
This PR intends to provide a fix for the TX Burst support of the GDMA peripheral.
Currently, it erroneously applies the configuration to the input-related registers, making the TX operation inconsistent.

As a bonus, there is another commit to constify the DMA descriptor pointer to a buffer. Should have no impact.

## Impact
Only for ESP32-C3-based configurations and for applications that might be using the DMA Burst feature.

## Testing
`esp32c3-devkit` testing a SPI Slave peripheral driver to be submitted soon.