### PR TITLE
drivers: serial: Remove unnecessary DEBUGASSERT in serial.c

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1403,7 +1403,6 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               /* Save the PID of the recipient of the SIGINT signal. */
 
               dev->pid = (pid_t)arg;
-              DEBUGASSERT((unsigned long)(dev->pid) == arg);
             }
             break;
 #endif


### PR DESCRIPTION
## Summary

- This commit removes unnecessary DEBUGASSERT in serial.c

## Impact

- None

## Testing

- Tested with sabre-6quad (QEMU) and sim

