### PR TITLE
Licensing: Add ISC license from Rhombus OS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -215,11 +215,21 @@ Rhombus Math Library
 ====================
 
 The math library used in NuttX derives from the Rhombus OS by Nick Johnson
-(with many, many addtions).  The Rhombus OS is/was distributed under the ISC
-license.  The ISC licsense is a permissive license that allows people do
-anything with your code with proper attribution and without warranty.  The
-ISC license is functionally equivalent to the BSD 2-Clause and MIT licenses,
-removing some language that is no longer necessary.
+(with many, many additions):
+
+  Copyright (C) 2009-2011 Nick Johnson <nickbjohnson4224 at gmail.com>
+
+  Permission to use, copy, modify, and distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 IGMP
 ====


### PR DESCRIPTION
## Summary

Add ISC license from Rhombus OS, as the math library used in NuttX derives from it.

Per feedback provided by John D. Ament in the Incubator's general mailing list thread "[VOTE] Release Apache NuttX (Incubating) 10.1.0 [RC1]" on 21 May 2021, archived [here](https://mail-archives.apache.org/mod_mbox/incubator-general/202105.mbox/%3cCAOqetn8dOhKFj8jdprM1_gmuU=WSwKpK3D6W1a+w2dZ8AbjtNw@mail.gmail.com%3e) and [here](https://lists.apache.org/thread.html/r293352a21dfd1112b4dfb0e27265a2ac4741083fa1e7875e4001da86%40%3Cgeneral.incubator.apache.org%3E).

Obtained the license text from [https://github.com/nickbjohnson4224/rhombus/blob/master/LICENSE](https://github.com/nickbjohnson4224/rhombus/blob/master/LICENSE).

## Impact

Incorporates feedback received during release voting.

## Testing

None.