### PR TITLE
arch/xtensa/esp32_emac.c: Call phy_enable_interrupt correctly.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -2113,7 +2113,7 @@ static int emac_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
             {
               /* Enable PHY link up/down interrupts */
 
-              ret = phy_enable_interrupt(priv);
+              ret = phy_enable_interrupt();
             }
         }
         break;


### PR DESCRIPTION
## Summary
phy_enable_interrupt() was called with a parameter while it takes none.
## Impact
N/A.  This whole feature is behind a kconfig option.
## Testing
N/A
