### PR TITLE
syslog: fix bug about syslog_default_write

### DIFF
--- a/drivers/syslog/syslog_write.c
+++ b/drivers/syslog/syslog_write.c
@@ -66,7 +66,7 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
 #ifdef CONFIG_SYSLOG_INTBUFFER
           if (up_interrupt_context())
             {
-              syslog_add_intbuffer(*buffer++);
+              syslog_add_intbuffer(buffer[nwritten]);
             }
           else
 #endif
@@ -80,7 +80,7 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
 
                   DEBUGASSERT(g_syslog_channel[i]->sc_ops->sc_force != NULL);
                   g_syslog_channel[i]->sc_ops->sc_force(g_syslog_channel[i],
-                                                        *buffer++);
+                                                        buffer[nwritten]);
                 }
             }
         }
@@ -107,7 +107,7 @@ static ssize_t syslog_default_write(FAR const char *buffer, size_t buflen)
               for (nwritten = 0; nwritten < buflen; nwritten++)
                 {
                   g_syslog_channel[i]->sc_ops->sc_putc(g_syslog_channel[i],
-                                                       *buffer++);
+                                                       buffer[nwritten]);
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fix bug about syslog_default_write when supporting multi channels.
Change-Id: I6d8b5bce8071f11b1903fe1fa0fe8dbc34bf3a09
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact
normal output log when enable ramlog and default syslog.
## Testing
daily test.
