### PR TITLE
Ramlog: recover last crash log from ram buffer.

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -39,8 +39,8 @@ config RAMLOG_BUFFER_SECTION
 	default ".bss"
 	depends on RAMLOG_SYSLOG
 	---help---
-		The section where ramlog buffer is located, this section cannot
-		be initialized each time when the system boot.
+		The section where ramlog buffer is located.
+		The section shall not be initialized on system boot.
 
 config RAMLOG_BUFSIZE
 	int "RAMLOG buffer size"

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -34,6 +34,14 @@ config RAMLOG
 		details as needed to support logging.
 
 if RAMLOG
+config RAMLOG_BUFFER_SECTION
+	string "The section where ramlog buffer is located"
+	default ".bss"
+	depends on RAMLOG_SYSLOG
+	---help---
+		The section where ramlog buffer is located, this section cannot
+		be initialized each time when the system boot.
+
 config RAMLOG_BUFSIZE
 	int "RAMLOG buffer size"
 	default 1024

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -120,7 +120,8 @@ static const struct file_operations g_ramlogfops =
  */
 
 #ifdef CONFIG_RAMLOG_SYSLOG
-static char g_sysbuffer[CONFIG_RAMLOG_BUFSIZE];
+static char g_sysbuffer[CONFIG_RAMLOG_BUFSIZE]
+                               locate_data(CONFIG_RAMLOG_BUFFER_SECTION);
 
 /* This is the device structure for the console or syslogging function.  It
  * must be statically initialized because the RAMLOG ramlog_putc function


### PR DESCRIPTION
## Summary
Ramlog: recover last crash log from ram buffer.
We need place ram buffer to a fixed section, it will not be initialized on boot.
## Impact

## Testing
daily test.
