### PR TITLE
risc-v/esp32c3: Fix overwriting of registered-but-disabled interrupts

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -163,6 +163,8 @@ void up_enable_irq(int cpuint)
 {
   irqstate_t irqstate;
 
+  irqinfo("cpuint=%d\n", cpuint);
+
   DEBUGASSERT(cpuint >= ESP32C3_CPUINT_MIN && cpuint <= ESP32C3_CPUINT_MAX);
 
   irqstate = enter_critical_section();
@@ -181,6 +183,8 @@ void up_enable_irq(int cpuint)
 void up_disable_irq(int cpuint)
 {
   irqstate_t irqstate;
+
+  irqinfo("cpuint=%d\n", cpuint);
 
   DEBUGASSERT(cpuint >= ESP32C3_CPUINT_MIN && cpuint <= ESP32C3_CPUINT_MAX);
 
@@ -252,7 +256,6 @@ void esp32c3_bind_irq(uint8_t cpuint, uint8_t periphid, uint8_t prio,
 int esp32c3_request_irq(uint8_t periphid, uint8_t prio, uint32_t flags)
 {
   int ret;
-  uint32_t regval;
   int cpuint;
   irqstate_t irqstate;
 
@@ -262,33 +265,27 @@ int esp32c3_request_irq(uint8_t periphid, uint8_t prio, uint32_t flags)
 
   irqstate = enter_critical_section();
 
-  /* Skip over enabled interrupts.  NOTE: bit 0 is reserved. */
-
-  regval = getreg32(INTERRUPT_CPU_INT_ENABLE_REG);
-
-  /* Skip over reserved CPU interrupts */
-
-  regval |= CPUINT_RESERVED_MAPS;
+  /* Skip over already registered interrupts.
+   * NOTE: bit 0 is reserved.
+   */
 
   for (cpuint = 1; cpuint <= ESP32C3_CPUINT_MAX; cpuint++)
     {
-      if (!(regval & (1 << cpuint)))
+      if (g_cpuint_map[cpuint] == CPUINT_UNASSIGNED)
         {
           break;
         }
     }
 
-  irqinfo("INFO: cpuint=%d\n", cpuint);
+  irqinfo("periphid:%" PRIu8 " cpuint=%d\n", periphid, cpuint);
 
   if (cpuint <= ESP32C3_CPUINT_MAX)
     {
-      DEBUGASSERT(g_cpuint_map[cpuint] == CPUINT_UNASSIGNED);
-
-      /* We have a free CPU interrupt.  We can continue with mapping the
+      /* We have a free CPU interrupt. We can continue with mapping the
        * peripheral.
        */
 
-      /* Save the CPU interrupt ID.  We will return this value. */
+      /* Save the CPU interrupt ID. We will return this value. */
 
       ret = cpuint;
 


### PR DESCRIPTION
## Summary
This PR intends to the provide a fix to the unintended overwrite of a previously registered IRQ when it is in disabled state at the time of a new request.
This scenario was found during the development of the SPI Slave driver for the ESP32-C3. For testing purposes, it was added interrupt support to the DMA driver.
The SPI Slave driver behaves a bit different regarding the interrupt enable process. It first requests the IRQ, but does not enable the interrupts right away. Instead, it performs the remaining initialization, triggers the interrupt flag for TRANS_DONE and then finally enabled the interrupts with `up_enable_irq`.
The found issue is that the DMA interrupt enabling was part of the remaining initialization, which overwrote the SPI Slave interrupt from the `g_cpuint_map`.

## Impact
Just for ESP32-C3 boards. No impact to current upstream drivers.

## Testing
DEBUGASSERT was previously being triggered when any interrupt was disabled during the request of a new one. This is now fixed.
