### PR TITLE
risc-v/esp32c3: Remove useless parameter from DMA macro

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_dma.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_dma.c
@@ -50,7 +50,7 @@
 #define REG_OFF  (DMA_OUT_CONF0_CH1_REG - DMA_OUT_CONF0_CH0_REG)
 
 #define SET_REG(_r, _ch, _v)    putreg32((_v), (_r) + (_ch) * REG_OFF)
-#define GET_REG(_r, _ch, _v)    getreg32((_r) + (_ch) * REG_OFF)
+#define GET_REG(_r, _ch)        getreg32((_r) + (_ch) * REG_OFF)
 
 #define SET_BITS(_r, _ch, _b)   modifyreg32((_r) + (_ch) * REG_OFF, 0, (_b))
 #define CLR_BITS(_r, _ch, _b)   modifyreg32((_r) + (_ch) * REG_OFF, (_b), 0)


### PR DESCRIPTION
## Summary
This PR intends to provide a simple fix to a macro from the DMA driver of the ESP32-C3 chip.
The `GET_REG` macro currently requires 3 parameters, but actually just uses the first two.

## Impact
No impact, macro was not being used anywhere.

## Testing
CI build pass.
