### PR TITLE
drivers: wireless: Remove ASSERT() in _check_pkt_q_empty() in gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -216,6 +216,8 @@ static int     gs2200m_poll(FAR struct file *filep, FAR struct pollfd *fds,
 static int     gs2200m_irq(int irq, FAR void *context, FAR void *arg);
 static void    gs2200m_irq_worker(FAR void *arg);
 
+static void _remove_all_pkt(FAR struct gs2200m_dev_s *dev, uint8_t c);
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -524,7 +526,7 @@ static void _check_pkt_q_empty(FAR struct gs2200m_dev_s *dev, char cid)
           pkt_dat = (FAR struct pkt_dat_s *)pkt_dat->dq.flink;
         }
 
-      ASSERT(false);
+      _remove_all_pkt(dev, c);
     }
 }
 


### PR DESCRIPTION
Summary:
Impact:


## Summary

- During Wi-Fi stress test, sometimes ASSERT() happens in gs2200m.c
- This commit removes the ASSERT() but calls _remove_all_pkt()
  for a workaround.

## Impact

- None

## Testing

- Tested with spresense:wifi_smp
