### PR TITLE
tools/mksyscall: Fix build break of syscall instrumentation wrapper

### DIFF
--- a/tools/mksyscall.c
+++ b/tools/mksyscall.c
@@ -612,8 +612,16 @@ static void generate_wrapper(int nfixed, int nparms)
    * prototype
    */
 
-  fprintf(stream, "%s UP_WRAPSYM(%s)(", g_parm[RETTYPE_INDEX],
-          g_parm[NAME_INDEX]);
+  if (strcmp(g_parm[RETTYPE_INDEX], "noreturn") == 0)
+    {
+      fprintf(stream, "void ");
+    }
+  else
+    {
+      fprintf(stream, "%s ", g_parm[RETTYPE_INDEX]);
+    }
+
+  fprintf(stream, "UP_WRAPSYM(%s)(", g_parm[NAME_INDEX]);
 
   /* Generate the formal parameter list */
 
@@ -655,15 +663,24 @@ static void generate_wrapper(int nfixed, int nparms)
 
   /* Generate the result variable definition for non-void function */
 
-  if (strcmp(g_parm[RETTYPE_INDEX], "void") != 0)
+  if (strcmp(g_parm[RETTYPE_INDEX], "void") != 0 &&
+      strcmp(g_parm[RETTYPE_INDEX], "noreturn") != 0)
     {
       fprintf(stream, "  %s result;\n", g_parm[RETTYPE_INDEX]);
     }
 
   /* Generate the wrapped (real) function prototype definition */
 
-  fprintf(stream, "  %s UP_REALSYM(%s)(", g_parm[RETTYPE_INDEX],
-          g_parm[NAME_INDEX]);
+  if (strcmp(g_parm[RETTYPE_INDEX], "noreturn") == 0)
+    {
+      fprintf(stream, "  void ");
+    }
+  else
+    {
+      fprintf(stream, "  %s ", g_parm[RETTYPE_INDEX]);
+    }
+
+  fprintf(stream, "UP_REALSYM(%s)(", g_parm[NAME_INDEX]);
 
   /* Generate the formal parameter list */
 
@@ -767,7 +784,8 @@ static void generate_wrapper(int nfixed, int nparms)
    * value are a special case.
    */
 
-  if (strcmp(g_parm[RETTYPE_INDEX], "void") == 0)
+  if (strcmp(g_parm[RETTYPE_INDEX], "void") == 0 ||
+      strcmp(g_parm[RETTYPE_INDEX], "noreturn") == 0)
     {
       fprintf(stream, "  UP_REALSYM(%s)(", g_parm[NAME_INDEX]);
     }
@@ -798,7 +816,8 @@ static void generate_wrapper(int nfixed, int nparms)
 
   fprintf(stream, "  sched_note_syscall_leave(SYS_%s, ", g_parm[NAME_INDEX]);
 
-  if (strcmp(g_parm[RETTYPE_INDEX], "void") == 0)
+  if (strcmp(g_parm[RETTYPE_INDEX], "void") == 0 ||
+      strcmp(g_parm[RETTYPE_INDEX], "noreturn") == 0)
     {
       fprintf(stream, "0");
     }
@@ -813,7 +832,8 @@ static void generate_wrapper(int nfixed, int nparms)
    * value, do nothing.
    */
 
-  if (strcmp(g_parm[RETTYPE_INDEX], "void") == 0)
+  if (strcmp(g_parm[RETTYPE_INDEX], "void") == 0 ||
+      strcmp(g_parm[RETTYPE_INDEX], "noreturn") == 0)
     {
       fprintf(stream, "}\n");
     }


### PR DESCRIPTION
## Summary

8334843 "Make noreturn proxies and stubs actually not return" doesn't support the syscall wrapper generation which is used by syscall instrumentation. So, the generated wrapper code occurs build break.
This PR fixes the problem.

## Impact

Only when  CONFIG_SCHED_INSTRUMENTATION_SYSCALL=y

## Testing

Verified syscall instrumentation works.