### PR TITLE
tcp: recv window update improvement

### DIFF
--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -257,6 +257,7 @@ static int sixlowpan_tcp_header(FAR struct tcp_conn_s *conn,
     {
       /* Update the TCP received window based on I/O buffer availability */
 
+      uint32_t rcvseq = tcp_getsequence(conn->rcvseq);
       uint16_t recvwndo = tcp_get_recvwindow(dev, conn);
 
       /* Set the TCP Window */
@@ -266,7 +267,7 @@ static int sixlowpan_tcp_header(FAR struct tcp_conn_s *conn,
 
       /* Update the Receiver Window */
 
-      conn->rcv_wnd = recvwndo;
+      conn->rcv_adv = rcvseq + recvwndo;
     }
 
   /* Calculate TCP checksum. */

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -963,6 +963,22 @@ ssize_t tcp_sendfile(FAR struct socket *psock, FAR struct file *infile,
 void tcp_reset(FAR struct net_driver_s *dev);
 
 /****************************************************************************
+ * Name: tcp_rx_mss
+ *
+ * Description:
+ *   Return the MSS to advertize to the peer.
+ *
+ * Input Parameters:
+ *   dev  - The device driver structure
+ *
+ * Returned Value:
+ *   The MSS value.
+ *
+ ****************************************************************************/
+
+uint16_t tcp_rx_mss(FAR struct net_driver_s *dev);
+
+/****************************************************************************
  * Name: tcp_synack
  *
  * Description:

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -188,7 +188,7 @@ struct tcp_conn_s
                            * connection */
   uint16_t snd_wnd;       /* Sequence and acknowledgement numbers of last
                            * window update */
-  uint16_t rcv_wnd;       /* Receiver window available */
+  uint32_t rcv_adv;       /* The right edge of the recv window advertized */
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   uint32_t tx_unacked;    /* Number bytes sent but not yet ACKed */
 #else
@@ -266,12 +266,6 @@ struct tcp_conn_s
    */
 
   FAR struct devif_callback_s *connevents;
-
-  /* Receiver callback to indicate that the data has been consumed and that
-   * an ACK should be send.
-   */
-
-  FAR struct devif_callback_s *rcv_ackcb;
 
   /* accept() is called when the TCP logic has created a connection
    *
@@ -1467,6 +1461,22 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
 
 uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev,
                             FAR struct tcp_conn_s *conn);
+
+/****************************************************************************
+ * Name: tcp_should_send_recvwindow
+ *
+ * Description:
+ *   Determine if we should advertize the new recv window to the peer.
+ *
+ * Input Parameters:
+ *   conn - The TCP connection structure holding connection information.
+ *
+ * Returned Value:
+ *   If we should send an update.
+ *
+ ****************************************************************************/
+
+bool tcp_should_send_recvwindow(FAR struct tcp_conn_s *conn);
 
 /****************************************************************************
  * Name: psock_tcp_cansend

--- a/net/tcp/tcp_appsend.c
+++ b/net/tcp/tcp_appsend.c
@@ -89,10 +89,20 @@ void tcp_appsend(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
   ninfo("result: %04x d_sndlen: %d conn->tx_unacked: %" PRId32 "\n",
         result, dev->d_sndlen, (uint32_t)conn->tx_unacked);
 
+  /* Need to update the recv window? */
+
+  if (tcp_should_send_recvwindow(conn))
+    {
+      result |= TCP_SNDACK;
+#ifdef CONFIG_NET_TCP_DELAYED_ACK
+      conn->rx_unackseg = 0;
+#endif
+    }
+
 #ifdef CONFIG_NET_TCP_DELAYED_ACK
   /* Did the caller request that an ACK be sent? */
 
-  if ((result & TCP_SNDACK) != 0)
+  else if ((result & TCP_SNDACK) != 0)
     {
       /* Yes.. Handle delayed acknowledgments */
 

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -966,6 +966,7 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
       /* rcvseq should be the seqno from the incoming packet + 1. */
 
       memcpy(conn->rcvseq, tcp->seqno, 4);
+      conn->rcv_adv = tcp_getsequence(conn->rcvseq);
 
       /* Initialize the list of TCP read-ahead buffers */
 

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -704,6 +704,7 @@ found:
 
             conn->tcpstateflags = TCP_ESTABLISHED;
             memcpy(conn->rcvseq, tcp->seqno, 4);
+            conn->rcv_adv = tcp_getsequence(conn->rcvseq);
 
             net_incr32(conn->rcvseq, 1);
             conn->tx_unacked    = 0;

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -511,53 +511,6 @@ static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
 }
 
 /****************************************************************************
- * Name: tcp_ackhandler
- *
- * Description:
- *   This function is called with the network locked to send the ACK in
- *   response by the lower, device interfacing layer.
- *
- * Input Parameters:
- *   dev      The structure of the network driver that generated the event.
- *   pvconn   The connection structure associated with the socket
- *   flags    Set of events describing why the callback was invoked
- *
- * Returned Value:
- *   ACK should be send in the response.
- *
- * Assumptions:
- *   The network is locked.
- *
- ****************************************************************************/
-
-static uint16_t tcp_ackhandler(FAR struct net_driver_s *dev,
-                               FAR void *pvconn, FAR void *pvpriv,
-                               uint16_t flags)
-{
-  FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
-
-  ninfo("flags: %04x\n", flags);
-
-  if (conn != NULL && (flags & TCP_POLL) != 0)
-    {
-      /* Indicate that the data has been consumed and that an ACK
-       * should be send.
-       */
-
-      if (tcp_get_recvwindow(dev, conn) != 0 &&
-          conn->rcv_wnd == 0)
-        {
-          flags |= TCP_SNDACK;
-        }
-
-      tcp_callback_free(conn, conn->rcv_ackcb);
-      conn->rcv_ackcb = NULL;
-    }
-
-  return flags;
-}
-
-/****************************************************************************
  * Name: tcp_recvfrom_initialize
  *
  * Description:
@@ -816,15 +769,9 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
    * not only this particular connection.
    */
 
-  if (conn->rcv_wnd == 0 && conn->rcv_ackcb == NULL)
+  if (tcp_should_send_recvwindow(conn))
     {
-      conn->rcv_ackcb = tcp_callback_alloc(conn);
-      if (conn->rcv_ackcb)
-        {
-          conn->rcv_ackcb->flags   = TCP_POLL;
-          conn->rcv_ackcb->event   = tcp_ackhandler;
-          netdev_txnotify_dev(conn->dev);
-        }
+      netdev_txnotify_dev(conn->dev);
     }
 
   net_unlock();

--- a/net/tcp/tcp_recvwindow.c
+++ b/net/tcp/tcp_recvwindow.c
@@ -236,6 +236,10 @@ bool tcp_should_send_recvwindow(FAR struct tcp_conn_s *conn)
 
   if (win <= oldwin)
     {
+      ninfo("tcp_should_send_recvwindow: false: "
+            "rcvseq=%" PRIu32 ", rcv_adv=%" PRIu32 ", "
+            "old win=%" PRIu16 ", new win=%" PRIu16 "\n",
+            rcvseq, conn->rcv_adv, oldwin, win);
       return false;
     }
 
@@ -252,6 +256,9 @@ bool tcp_should_send_recvwindow(FAR struct tcp_conn_s *conn)
   maxwin = tcp_maxrcvwin(conn);
   if (2 * adv >= maxwin)
     {
+      ninfo("tcp_should_send_recvwindow: true: "
+            "adv=%" PRIu16 ", maxwin=%" PRIu16 "\n",
+            adv, maxwin);
       return true;
     }
 
@@ -262,8 +269,14 @@ bool tcp_should_send_recvwindow(FAR struct tcp_conn_s *conn)
   mss = tcp_rx_mss(dev);
   if (adv >= 2 * mss)
     {
+      ninfo("tcp_should_send_recvwindow: true: "
+            "adv=%" PRIu16 ", mss=%" PRIu16 ", maxwin=%" PRIu16 "\n",
+            adv, mss, maxwin);
       return true;
     }
 
+  ninfo("tcp_should_send_recvwindow: false: "
+        "adv=%" PRIu16 ", mss=%" PRIu16 ", maxwin=%" PRIu16 "\n",
+        adv, mss, maxwin);
   return false;
 }

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -362,6 +362,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
     {
       /* Update the TCP received window based on I/O buffer availability */
 
+      uint32_t rcvseq = tcp_getsequence(conn->rcvseq);
       uint16_t recvwndo = tcp_get_recvwindow(dev, conn);
 
       /* Set the TCP Window */
@@ -371,7 +372,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
 
       /* Update the Receiver Window */
 
-      conn->rcv_wnd = recvwndo;
+      conn->rcv_adv = rcvseq + recvwndo;
     }
 
   /* Finish the IP portion of the message and calculate checksums */

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -553,6 +553,45 @@ void tcp_reset(FAR struct net_driver_s *dev)
 }
 
 /****************************************************************************
+ * Name: tcp_rx_mss
+ *
+ * Description:
+ *   Return the MSS to advertize to the peer.
+ *
+ * Input Parameters:
+ *   dev  - The device driver structure
+ *
+ * Returned Value:
+ *   The MSS value.
+ *
+ ****************************************************************************/
+
+uint16_t tcp_rx_mss(FAR struct net_driver_s *dev)
+{
+  uint16_t tcp_mss;
+
+#ifdef CONFIG_NET_IPv6
+#ifdef CONFIG_NET_IPv4
+  if (IFF_IS_IPv6(dev->d_flags))
+#endif
+    {
+      tcp_mss = TCP_IPv6_MSS(dev);
+    }
+#endif /* CONFIG_NET_IPv6 */
+
+#ifdef CONFIG_NET_IPv4
+#ifdef CONFIG_NET_IPv6
+  else
+#endif
+    {
+      tcp_mss = TCP_IPv4_MSS(dev);
+    }
+#endif /* CONFIG_NET_IPv4 */
+
+  return tcp_mss;
+}
+
+/****************************************************************************
  * Name: tcp_synack
  *
  * Description:
@@ -588,10 +627,9 @@ void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
   if (IFF_IS_IPv6(dev->d_flags))
 #endif
     {
-      /* Get the MSS value and offset TCP header address for this packet */
+      /* Get the offset TCP header address for this packet */
 
       tcp     = TCPIPv6BUF;
-      tcp_mss = TCP_IPv6_MSS(dev);
 
       /* Set the packet length for the TCP Maximum Segment Size */
 
@@ -604,16 +642,17 @@ void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
   else
 #endif
     {
-      /* Get the MSS value and offset TCP header address for this packet */
+      /* Get the offset TCP header address for this packet */
 
       tcp     = TCPIPv4BUF;
-      tcp_mss = TCP_IPv4_MSS(dev);
 
       /* Set the packet length for the TCP Maximum Segment Size */
 
       dev->d_len  = IPv4TCP_HDRLEN + TCP_OPT_MSS_LEN;
     }
 #endif /* CONFIG_NET_IPv4 */
+
+  tcp_mss = tcp_rx_mss(dev);
 
   /* Save the ACK bits */
 


### PR DESCRIPTION
## Summary
    tcp: window update improvements
    
    * Fixes the case where the window was small but not zero.
    
    * tcp_recvfrom: Remove tcp_ackhandler. Instead, simply schedule TX for
      a possible window update and make tcp_appsend decide.
    
    * Replace rcv_wnd (the last advertized window size value) with
      rcv_adv. (the window edge sequence number advertized to the peer)
      rcv_wnd was complicated to deal with because its base (rcvseq) is
      also moving.
    
    * tcp_appsend: Send a window update even if there are no other reasons
      to send an ack.
      Namely, send an update if it increases the window by
        * 2 * mss
        * or the half of the max possible window size

## Impact

tcp

## Testing

tested with https://github.com/apache/incubator-nuttx/pull/3827 and a few other patches on a esp32 board.
with and without delayed ack.
examined packet dumps. it seemed working as intended so far.


