### PR TITLE
docker/linux: Add ESP32-S2 toolchain and binaries.

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -106,12 +106,18 @@ RUN mkdir -p xtensa-esp32-elf-gcc && \
   curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-2020r3/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz" \
   | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xz
 
-RUN echo "ESP Binaries: 2021/02/20"
+RUN mkdir -p xtensa-esp32s2-elf-gcc && \
+  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-2020r3/xtensa-esp32s2-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz" \
+  | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xz
+
+RUN echo "ESP Binaries: 2021/06/01"
 RUN mkdir -p /tools/blobs && cd /tools/blobs \
   && curl -s -L "https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/bootloader-esp32.bin" -o bootloader-esp32.bin \
   && curl -s -L "https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/bootloader-esp32c3.bin" -o bootloader-esp32c3.bin \
+  && curl -s -L "https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/bootloader-esp32s2.bin" -o bootloader-esp32s2.bin \
   && curl -s -L "https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32.bin" -o partition-table-esp32.bin \
-  && curl -s -L "https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32c3.bin" -o partition-table-esp32c3.bin
+  && curl -s -L "https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32c3.bin" -o partition-table-esp32c3.bin \
+  && curl -s -L "https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32s2.bin" -o partition-table-esp32s2.bin
 
 ###############################################################################
 # Build image for tool required by Renesas builds
@@ -250,6 +256,11 @@ ENV PATH="/tools/riscv64-unknown-elf-gcc/bin:$PATH"
 # ESP32 toolchain
 COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp32-elf-gcc/ xtensa-esp32-elf-gcc/
 ENV PATH="/tools/xtensa-esp32-elf-gcc/bin:$PATH"
+
+# ESP32-S2 toolchain
+COPY --from=nuttx-toolchain-esp32 /tools/xtensa-esp32s2-elf-gcc/ xtensa-esp32s2-elf-gcc/
+ENV PATH="/tools/xtensa-esp32s2-elf-gcc/bin:$PATH"
+
 RUN mkdir -p /tools/blobs/esp-bins
 COPY --from=nuttx-toolchain-esp32 /tools/blobs/* /tools/blobs/esp-bins/
 RUN pip3 install esptool
@@ -273,6 +284,8 @@ RUN mkdir -p /tools/ccache/bin && \
   ln -sf `which ccache` /tools/ccache/bin/riscv64-unknown-elf-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32-elf-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32-elf-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32s2-elf-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32s2-elf-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/avr-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/avr-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/rx-elf-gcc


### PR DESCRIPTION
## Summary
Add ESP32-S2 toolchain and binaries.
## Impact
Fix the broken build.
## Testing
I didn't build locally, I'm relying on the CI job.
