### PR TITLE
boards/esp32s2: Remove anything that has to do with QEMU since it's not supported.

### DIFF
--- a/boards/xtensa/esp32s2/common/Kconfig
+++ b/boards/xtensa/esp32s2/common/Kconfig
@@ -2,9 +2,4 @@
 # For a description of the syntax of this configuration file,
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
-config ESP32S2_QEMU_IMAGE
-	bool "ESP32S2 binary image for QEMU"
-	default n
-	---help---
-		Create a binary flash image used for QEMU.
 

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/Make.defs
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/Make.defs
@@ -42,7 +42,6 @@ context:: $(SCRIPTOUT)
 
 distclean::
 	$(call DELFILE, $(SCRIPTOUT))
-	$(call DELFILE, $(TOPDIR)/esp32s2_qemu_img.bin)
 
 DEPPATH += --dep-path board
 VPATH += :board

--- a/tools/esp32s2/Config.mk
+++ b/tools/esp32s2/Config.mk
@@ -69,12 +69,6 @@ ifdef ESPTOOL_BINDIR
 	FLASH_PT=$(PT_OFFSET) $(PARTITION_TABLE)
 endif
 
-ifeq ($(CONFIG_ESP32S2_QEMU_IMAGE),y)
-	MK_QEMU_IMG=$(TOPDIR)/tools/esp32s2/mk_qemu_img.sh -b $(BOOTLOADER) -p $(PARTITION_TABLE)
-else
-	MK_QEMU_IMG=
-endif
-
 # POSTBUILD -- Perform post build operations
 
 define POSTBUILD
@@ -92,7 +86,6 @@ define POSTBUILD
 	fi
 	esptool.py -c esp32-s2 elf2image $(ESPTOOL_ELF2IMG_OPTS) -o nuttx.bin nuttx
 	$(Q) echo "Generated: nuttx.bin (ESP32S2 compatible)"
-	$(Q) $(MK_QEMU_IMG)
 endef
 
 # ESPTOOL_BAUD -- Serial port baud rate used when flashing/reading via esptool.py


### PR DESCRIPTION
## Summary
Remove anything that has to do with QEMU since it's not supported.
## Impact
N/A
## Testing
N/A
