### PR TITLE
ESP32-C3: Add DMA support for SPI Slave

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
@@ -533,15 +533,7 @@ static void spislave_prepare_next_rx(FAR struct spislave_priv_s *priv)
 {
   if (priv->rx_length < SPI_SLAVE_BUFSIZE)
     {
-      setbits(SPI_USR_MOSI_M, SPI_USER_REG);
-    }
-  else
-    {
-      spiwarn("RX buffer full! Disabling RX for next transaction\n");
 
-      /* Disable SPI Slave input data phase. */
-
-      resetbits(SPI_USR_MOSI_M, SPI_USER_REG);
     }
 }
 
@@ -644,10 +636,6 @@ static void spislave_prepare_next_tx(FAR struct spislave_priv_s *priv)
       spislave_cpu_tx_fifo_reset();
 
       priv->is_tx_enabled = true;
-
-      /* Enable SPI Slave output data phase. */
-
-      setbits(SPI_USR_MISO_M, SPI_USER_REG);
     }
   else
     {
@@ -656,10 +644,6 @@ static void spislave_prepare_next_tx(FAR struct spislave_priv_s *priv)
       spislave_cpu_tx_fifo_reset();
 
       priv->is_tx_enabled = false;
-
-      /* Disable SPI Slave output data phase. */
-
-      resetbits(SPI_USR_MISO_M, SPI_USER_REG);
     }
 }
 
@@ -799,10 +783,6 @@ static void spislave_initialize(FAR struct spi_sctrlr_s *sctrlr)
   /* Disable interrupts */
 
   resetbits(SPI_INT_MASK, SPI_DMA_INT_ENA_REG);
-
-  /* Set the maximum data length to the size of the HW buffer in bits */
-
-  putreg32((SPI_SLAVE_HW_BUF_SIZE * 8) - 1, SPI_MS_DLEN_REG);
 
   esp32c3_gpioirqenable(ESP32C3_PIN2IRQ(config->cs_pin), RISING);
 


### PR DESCRIPTION
## Summary
This PR intends to add DMA support to the SPI Slave driver of the ESP32-C3 microcontroller.

## Impact
Only for ESP32-C3-based configurations using the SPI peripheral in Slave mode.
DMA support needs to be explicitly enabled.

## Testing
Validated using a setup according to the following description:
- Two interconnected ESP32-C3 DevKit boards via the SPI interface
  - One assuming the Master role, the other as Slave
- SPI Master sending data via spi tool application
- SPI Slave with a custom app reading data from SPI Slave chardev driver and replying back to SPI Master
- SPI Master receiving reply as part of the next TX transfer
