### PR TITLE
risc-v/esp32-c3: Add support for HW flow control.

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -413,17 +413,41 @@ config ESP32C3_UART0_RXPIN
 	int "UART0 RX Pin"
 	default 20
 
+config ESP32C3_UART0_RTSPIN
+	int "UART0 RTS Pin"
+	depends on SERIAL_IFLOWCONTROL
+	default 16
+	range 0 21
+
+config ESP32C3_UART0_CTSPIN
+	int "UART0 CTS Pin"
+	depends on SERIAL_OFLOWCONTROL
+	default 15
+	range 0 21
+
 endif # ESP32C3_UART0
 
 if ESP32C3_UART1
 
 config ESP32C3_UART1_TXPIN
 	int "UART1 TX Pin"
-	default 6
+	default 8
 
 config ESP32C3_UART1_RXPIN
 	int "UART1 RX Pin"
-	default 7
+	default 9
+
+config ESP32C3_UART1_RTSPIN
+	int "UART1 RTS Pin"
+	depends on SERIAL_IFLOWCONTROL
+	default 1
+	range 0 21
+
+config ESP32C3_UART1_CTSPIN
+	int "UART1 CTS Pin"
+	depends on SERIAL_OFLOWCONTROL
+	default 2
+	range 0 21
 
 endif # ESP32C3_UART1
 

--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.c
@@ -74,6 +74,24 @@ struct esp32c3_uart_s g_uart0_config =
   .txsig = U0TXD_OUT_IDX,
   .rxpin = CONFIG_ESP32C3_UART0_RXPIN,
   .rxsig = U0RXD_IN_IDX,
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  .rtspin = CONFIG_ESP32C3_UART0_RTSPIN,
+  .rtssig = U0RTS_OUT_IDX,
+#ifdef CONFIG_UART0_IFLOWCONTROL
+  .iflow          = true,    /* input flow control (RTS) enabled */
+#else
+  .iflow          = false,   /* input flow control (RTS) disabled */
+#endif
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+  .ctspin = CONFIG_ESP32C3_UART0_CTSPIN,
+  .ctssig = U0CTS_IN_IDX,
+#ifdef CONFIG_UART0_OFLOWCONTROL
+  .oflow          = true,    /* output flow control (CTS) enabled */
+#else
+  .oflow          = false,   /* output flow control (CTS) disabled */
+#endif
+#endif
 };
 
 #endif /* CONFIG_ESP32C3_UART0 */
@@ -95,6 +113,24 @@ struct esp32c3_uart_s g_uart1_config =
   .txsig = U1TXD_OUT_IDX,
   .rxpin = CONFIG_ESP32C3_UART1_RXPIN,
   .rxsig = U1RXD_IN_IDX,
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  .rtspin = CONFIG_ESP32C3_UART1_RTSPIN,
+  .rtssig = U1RTS_OUT_IDX,
+#ifdef CONFIG_UART1_IFLOWCONTROL
+  .iflow          = true,    /* input flow control (RTS) enabled */
+#else
+  .iflow          = false,   /* input flow control (RTS) disabled */
+#endif
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+  .ctspin = CONFIG_ESP32C3_UART1_CTSPIN,
+  .ctssig = U1CTS_IN_IDX,
+#ifdef CONFIG_UART1_OFLOWCONTROL
+  .oflow          = true,    /* output flow control (CTS) enabled */
+#else
+  .oflow          = false,   /* output flow control (CTS) disabled */
+#endif
+#endif
 };
 
 #endif /* CONFIG_ESP32C3_UART1 */
@@ -103,6 +139,72 @@ struct esp32c3_uart_s g_uart1_config =
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_lowputc_set_iflow
+ *
+ * Description:
+ *   Configure the input hardware flow control.
+ *
+ * Parameters:
+ *   priv           - Pointer to the private driver struct.
+ *   threshold      - RX FIFO value from which RST will automatically be
+ *                    asserted.
+ *   enable         - true = enable, false = disable
+ *
+ ****************************************************************************/
+
+void esp32c3_lowputc_set_iflow(const struct esp32c3_uart_s *priv,
+                               uint8_t threshold, bool enable)
+{
+  uint32_t mask;
+  if (enable)
+    {
+      /* Enable RX flow control */
+
+      modifyreg32(UART_CONF1_REG(priv->id), 0, UART_RX_FLOW_EN);
+
+      /* Configure the threshold */
+
+      mask = VALUE_TO_FIELD(threshold, UART_RX_FLOW_THRHD);
+      modifyreg32(UART_MEM_CONF_REG(priv->id), UART_RX_FLOW_THRHD_M, mask);
+    }
+  else
+    {
+      /* Disable RX flow control */
+
+      modifyreg32(UART_CONF1_REG(priv->id), UART_RX_FLOW_EN, 0);
+    }
+}
+
+/****************************************************************************
+ * Name: esp32c3_lowputc_set_oflow
+ *
+ * Description:
+ *   Configure the output hardware flow control.
+ *
+ * Parameters:
+ *   priv           - Pointer to the private driver struct.
+ *   enable         - true = enable, false = disable
+ *
+ ****************************************************************************/
+
+void esp32c3_lowputc_set_oflow(const struct esp32c3_uart_s *priv,
+                               bool enable)
+{
+  if (enable)
+    {
+      /* Enable TX flow control */
+
+      modifyreg32(UART_CONF0_REG(priv->id), 0, UART_TX_FLOW_EN);
+    }
+  else
+    {
+      /* Disable TX flow control */
+
+      modifyreg32(UART_CONF0_REG(priv->id), UART_TX_FLOW_EN, 0);
+    }
+}
 
 /****************************************************************************
  * Name: esp32c3_lowputc_reset_core
@@ -642,6 +744,23 @@ void esp32c3_lowputc_config_pins(const struct esp32c3_uart_s *priv)
 
   esp32c3_configgpio(priv->rxpin, INPUT_FUNCTION_1);
   esp32c3_gpio_matrix_in(priv->rxpin, priv->rxsig, 0);
+
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  if (priv->iflow)
+    {
+      esp32c3_configgpio(priv->rtspin, OUTPUT_FUNCTION_1);
+      esp32c3_gpio_matrix_out(priv->rtspin, priv->rtssig,
+                              0, 0);
+    }
+
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+  if (priv->oflow)
+    {
+      esp32c3_configgpio(priv->ctspin, INPUT_FUNCTION_1);
+      esp32c3_gpio_matrix_in(priv->ctspin, priv->ctssig, 0);
+    }
+#endif
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
@@ -105,6 +105,16 @@ struct esp32c3_uart_s
   uint8_t   txsig;          /* TX signal */
   uint8_t   rxpin;          /* RX pin */
   uint8_t   rxsig;          /* RX signal */
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  uint8_t  rtspin;          /* RTS pin number */
+  uint8_t  rtssig;          /* RTS signal */
+  bool     iflow;           /* Input flow control (RTS) enabled */
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+  uint8_t  ctspin;          /* CTS pin number */
+  uint8_t  ctssig;          /* CTS signal */
+  bool     oflow;           /* Output flow control (CTS) enabled */
+#endif
 };
 
 extern struct esp32c3_uart_s g_uart0_config;
@@ -113,6 +123,38 @@ extern struct esp32c3_uart_s g_uart1_config;
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_lowputc_set_iflow
+ *
+ * Description:
+ *   Configure the input hardware flow control.
+ *
+ * Parameters:
+ *   priv           - Pointer to the private driver struct.
+ *   threshold      - RX FIFO value from which RST will automatically be
+ *                    asserted.
+ *   enable         - true = enable, false = disable
+ *
+ ****************************************************************************/
+
+void esp32c3_lowputc_set_iflow(const struct esp32c3_uart_s *priv,
+                               uint8_t threshold, bool enable);
+
+/****************************************************************************
+ * Name: esp32c3_lowputc_set_oflow
+ *
+ * Description:
+ *   Configure the output hardware flow control.
+ *
+ * Parameters:
+ *   priv           - Pointer to the private driver struct.
+ *   enable         - true = enable, false = disable
+ *
+ ****************************************************************************/
+
+void esp32c3_lowputc_set_oflow(const struct esp32c3_uart_s *priv,
+                               bool enable);
 
 /****************************************************************************
  * Name: esp32c3_lowputc_reset_core


### PR DESCRIPTION
## Summary

This MR aims to support HW flow control in ESP32-C3.

## Impact

From now on, the feature works. May affect only UART HW flow control users for ESP32-C3.

## Testing

Testing the input HW flow control is a little bit tricky, because it requires that we create some scenarios (like the SW serial FIFO empty, full and above the upper watermark but below the full size) and observe the behavior of the RTS line. So, to test the input HW flow control, I had to adjust the RX interrupt to load the data into the SW FIFO at once to ensure a specific value of items in the SW FIFO and to observe the behavior of RTS in the LA. Testing the output is pretty much easier, and requires only to change the CTS line to high and low level and observe that the echo arrive when the CTS is low.

To test the HW flow control change using the termios interface, I used the termios example from /apps/ which disables the HW flow control and we can have a communication regardless the state of the RTS/CTS pins.

