### PR TITLE
xtensa/esp32-s2: Add support for serial HW flow control.

### DIFF
--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -448,18 +448,42 @@ config ESP32S2_UART0_RXPIN
 	default 44
 	range 0 46
 
+config ESP32S2_UART0_RTSPIN
+	int "UART0 RTS Pin"
+	depends on SERIAL_IFLOWCONTROL
+	default 16
+	range 0 46
+
+config ESP32S2_UART0_CTSPIN
+	int "UART0 CTS Pin"
+	depends on SERIAL_OFLOWCONTROL
+	default 15
+	range 0 46
+
 endif # ESP32S2_UART0
 
 if ESP32S2_UART1
 
 config ESP32S2_UART1_TXPIN
 	int "UART1 Tx Pin"
-	default 17
+	default 37
 	range 0 46
 
 config ESP32S2_UART1_RXPIN
 	int "UART1 Rx Pin"
-	default 18
+	default 38
+	range 0 46
+
+config ESP32S2_UART1_RTSPIN
+	int "UART1 RTS Pin"
+	depends on SERIAL_IFLOWCONTROL
+	default 35
+	range 0 46
+
+config ESP32S2_UART1_CTSPIN
+	int "UART1 CTS Pin"
+	depends on SERIAL_OFLOWCONTROL
+	default 36
 	range 0 46
 
 endif # ESP32S2_UART1

--- a/arch/xtensa/src/esp32s2/esp32s2_cpuint.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_cpuint.c
@@ -519,7 +519,7 @@ void esp32s2_free_cpuint(int cpuint)
  *   periphid       - The peripheral number from irq.h to be assigned to
  *                    a CPU interrupt.
  *   cpuint         - The CPU interrupt to receive the peripheral interrupt
- *                    assignment. This value is returned by 
+ *                    assignment. This value is returned by
  *                    esp32s2_alloc_edgeint or esp32s2_alloc_levelint.
  *
  * Returned Value:

--- a/arch/xtensa/src/esp32s2/esp32s2_lowputc.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_lowputc.h
@@ -97,6 +97,16 @@ struct esp32s2_uart_s
   uint8_t   txsig;          /* TX signal */
   uint8_t   rxpin;          /* RX pin */
   uint8_t   rxsig;          /* RX signal */
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  uint8_t  rtspin;          /* RTS pin number */
+  uint8_t  rtssig;          /* RTS signal */
+  bool     iflow;           /* Input flow control (RTS) enabled */
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+  uint8_t  ctspin;          /* CTS pin number */
+  uint8_t  ctssig;          /* CTS signal */
+  bool     oflow;           /* Output flow control (CTS) enabled */
+#endif
 };
 
 extern struct esp32s2_uart_s g_uart0_config;
@@ -105,6 +115,38 @@ extern struct esp32s2_uart_s g_uart1_config;
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s2_lowputc_set_iflow
+ *
+ * Description:
+ *   Configure the input hardware flow control.
+ *
+ * Parameters:
+ *   priv           - Pointer to the private driver struct.
+ *   threshold      - RX FIFO value from which RST will automatically be
+ *                    asserted.
+ *   enable         - true = enable, false = disable
+ *
+ ****************************************************************************/
+
+void esp32s2_lowputc_set_iflow(const struct esp32s2_uart_s *priv,
+                               uint8_t threshold, bool enable);
+
+/****************************************************************************
+ * Name: esp32s2_lowputc_set_oflow
+ *
+ * Description:
+ *   Configure the output hardware flow control.
+ *
+ * Parameters:
+ *   priv           - Pointer to the private driver struct.
+ *   enable         - true = enable, false = disable
+ *
+ ****************************************************************************/
+
+void esp32s2_lowputc_set_oflow(const struct esp32s2_uart_s *priv,
+                               bool enable);
 
 /****************************************************************************
  * Name: esp32s2_lowputc_enable_sysclk

--- a/arch/xtensa/src/esp32s2/esp32s2_serial.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_serial.c
@@ -116,6 +116,10 @@ static bool esp32s2_txempty(struct uart_dev_s *dev);
 static void esp32s2_send(struct uart_dev_s *dev, int ch);
 static int  esp32s2_receive(struct uart_dev_s *dev, unsigned int *status);
 static int  esp32s2_ioctl(struct file *filep, int cmd, unsigned long arg);
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+static bool esp32s2_rxflowcontrol(struct uart_dev_s *dev,
+                                  unsigned int nbuffered, bool upper);
+#endif
 
 /****************************************************************************
  * Private Data
@@ -138,7 +142,7 @@ static struct uart_ops_s g_uart_ops =
     .receive     = esp32s2_receive,
     .ioctl       = esp32s2_ioctl,
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-    .rxflowcontrol = NULL,
+    .rxflowcontrol  = esp32s2_rxflowcontrol,
 #endif
 };
 
@@ -328,6 +332,44 @@ static int esp32s2_setup(struct uart_dev_s *dev)
   /* Stop bit */
 
   esp32s2_lowputc_stop_length(priv);
+
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  /* Configure the input flow control */
+
+  if (priv->iflow)
+    {
+      /* Enable input flow control and set the RX FIFO threshold
+       * to assert the RTS line to half the RX FIFO buffer.
+       * It will then save some space on the hardware fifo to
+       * remaining bytes that may arrive after RTS be asserted
+       * and before the transmitter stops sending data.
+       */
+
+      esp32s2_lowputc_set_iflow(priv, (uint8_t)(UART_RX_FIFO_SIZE / 2),
+                                true);
+    }
+  else
+    {
+      /* Just disable input flow control, threshold parameter
+       * will be discarded.
+       */
+
+      esp32s2_lowputc_set_iflow(priv, 0 , false);
+    }
+
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+  /* Configure the ouput flow control */
+
+  if (priv->oflow)
+    {
+      esp32s2_lowputc_set_oflow(priv, true);
+    }
+  else
+    {
+      esp32s2_lowputc_set_oflow(priv, false);
+    }
+#endif
 
   /* Reset FIFOs */
 
@@ -740,6 +782,13 @@ static int esp32s2_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         termiosp->c_cflag |= (priv->stop_b2) ? CSTOPB : 0;
 
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+        termiosp->c_cflag |=  (priv->oflow) ? CCTS_OFLOW : 0;
+#endif
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+        termiosp->c_cflag |=  (priv->iflow) ? CRTS_IFLOW : 0;
+#endif
+
         /* Set the baud rate in the termiosp using the
          * cfsetispeed interface.
          */
@@ -779,6 +828,12 @@ static int esp32s2_ioctl(struct file *filep, int cmd, unsigned long arg)
         uint8_t  parity;
         uint8_t  bits;
         uint8_t  stop2;
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+        bool iflow;
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+        bool oflow;
+#endif
 
         if (!termiosp)
           {
@@ -830,6 +885,13 @@ static int esp32s2_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         stop2 = (termiosp->c_cflag & CSTOPB) ? 1 : 0;
 
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+        iflow = (termiosp->c_cflag & CRTS_IFLOW) != 0;
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+        oflow = (termiosp->c_cflag & CCTS_OFLOW) != 0;
+#endif
+
         /* Verify that all settings are valid before
          * performing the changes.
          */
@@ -842,6 +904,13 @@ static int esp32s2_ioctl(struct file *filep, int cmd, unsigned long arg)
             priv->parity    = parity;
             priv->bits      = bits;
             priv->stop_b2   = stop2;
+
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+            priv->iflow     = iflow;
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+            priv->oflow     = oflow;
+#endif
 
             /* Effect the changes immediately - note that we do not
              * implement TCSADRAIN or TCSAFLUSH, only TCSANOW option.
@@ -866,6 +935,78 @@ static int esp32s2_ioctl(struct file *filep, int cmd, unsigned long arg)
 
   return ret;
 }
+
+/****************************************************************************
+ * Name: esp32s2_rxflowcontrol
+ *
+ * Description:
+ *   Called when upper half RX buffer is full (or exceeds configured
+ *   watermark levels if CONFIG_SERIAL_IFLOWCONTROL_WATERMARKS is defined).
+ *   Return true if UART activated RX flow control to block more incoming
+ *   data.
+ *   NOTE: ESP32-S2 has a hardware RX FIFO threshold mechanism to control
+ *   RTS line and to stop receiving data. This is very similar to the concept
+ *   behind upper watermark level. The hardware threshold is used here
+ *   to control the RTS line. When setting the threshold to zero, RTS will
+ *   immediately be asserted. If nbuffered = 0 or the lower watermark is
+ *   crossed and the serial driver decides to disable RX flow control, the
+ *   threshold will be changed to UART_RX_FLOW_THRHD_VALUE, which is almost
+ *   half the HW RX FIFO capacity. It keeps some space to keep the data
+ *   received between the RTS assertion and the stop by the sender.
+ *
+ * Input Parameters:
+ *   dev       - UART device instance
+ *   nbuffered - the number of characters currently buffered
+ *               (if CONFIG_SERIAL_IFLOWCONTROL_WATERMARKS is
+ *               not defined the value will be 0 for an empty buffer or the
+ *               defined buffer size for a full buffer)
+ *   upper     - true indicates the upper watermark was crossed where
+ *               false indicates the lower watermark has been crossed
+ *
+ * Returned Value:
+ *   true if RX flow control activated.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+static bool esp32s2_rxflowcontrol(struct uart_dev_s *dev,
+                                  unsigned int nbuffered, bool upper)
+{
+  bool ret = false;
+  struct esp32s2_uart_s *priv = dev->priv;
+  if (priv->iflow)
+    {
+      if (nbuffered == 0 || upper == false)
+        {
+          /* Empty buffer, RTS should be de-asserted and logic in above
+           * layers should re-enable RX interrupt.
+           */
+
+          esp32s2_lowputc_set_iflow(priv, (uint8_t)(UART_RX_FIFO_SIZE / 2),
+                                    true);
+          esp32s2_rxint(dev, true);
+          ret = false;
+        }
+      else
+        {
+          /* If the RX buffer is not zero and watermarks are not enabled,
+           * then this function is called to announce RX buffer is full.
+           * The first thing it should do is to immediately assert RTS.
+           * Software RX FIFO is full, so besides asserting RTS, it's
+           * necessary to disable RX interrupts to prevent remaining bytes
+           * (that arrive after asserting RTS) to be pushed to the
+           * SW RX FIFO.
+           */
+
+          esp32s2_lowputc_set_iflow(priv, 0 , true);
+          esp32s2_rxint(dev, false);
+          ret = true;
+        }
+    }
+
+  return ret;
+}
+#endif
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary

This MR aims to support HW flow control in ESP32-S2.

## Impact

From now on, the feature works. May affect only UART HW flow control users for ESP32-S2.

## Testing

Testing the input HW flow control is a little bit tricky, because it requires that we create some scenarios (like the SW serial FIFO empty, full and above the upper watermark but below the full size) and observe the behavior of the RTS line. So, to test the input HW flow control, I had to adjust the RX interrupt to load the data into the SW FIFO at once to ensure a specific value of items in the SW FIFO and to observe the behavior of RTS in the LA. Testing the output is pretty much easier, and requires only to change the CTS line to high and low level and observe that the echo arrive when the CTS is low.

To test the HW flow control change using the termios interface, I used the termios example from /apps/ which disables the HW flow control and we can have a communication regardless the state of the RTS/CTS pins.

