### PR TITLE
binfmt: Introduce a separate text memory for ELF

### DIFF
--- a/include/nuttx/binfmt/elf.h
+++ b/include/nuttx/binfmt/elf.h
@@ -95,6 +95,9 @@ struct elf_loadinfo_s
   uintptr_t         textalloc;   /* .text memory allocated when ELF file was loaded */
   uintptr_t         dataalloc;   /* .bss/.data memory allocated when ELF file was loaded */
   size_t            textsize;    /* Size of the ELF .text memory allocation */
+#ifdef CONFIG_ARCH_USE_MODULE_TEXT
+  size_t            textalign;   /* Necessary alignment of .text */
+#endif
   size_t            datasize;    /* Size of the ELF .bss/.data memory allocation */
   off_t             filelen;     /* Length of the entire ELF file */
 


### PR DESCRIPTION
## Summary

- This commit introduces a separate text memory for ELF
- The logic is similar to modlib

## Impact

- None

## Testing

- Tested with spresense:elf
- NOTE: needs separate commits

