### PR TITLE
syslog/emerg: fix bug about printing LOG_EMERG log from iob buffer

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -223,10 +223,7 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #ifdef CONFIG_SYSLOG_BUFFER
   /* Flush and destroy the syslog stream buffer */
 
-  if (priority != LOG_EMERG)
-    {
-      syslogstream_destroy(&stream);
-    }
+  syslogstream_destroy(&stream);
 #endif
 
   return ret;


### PR DESCRIPTION
## Summary
The patch is related to: commit 5f7c98b6e1b6da9f4765572a63ac678d407c8095

Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Mon May 17 22:38:22 2021 +0800

    drivers/syslog: Remove emergstream implementation and caller

    since emergstream always call syslog_force, but syslog_force is designed
    for the interrupt context, and then doesn't mean any emergency thing.
    On the other hand, emergstream has other bad side effect:
    1.Can't output to file or dev channel
    2.Can't work well with the interrupt buffer

    Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
normal using for _alert and syslog(LOG_EMERY, ...)
## Testing
local test.
