### PR TITLE
arch: Flush syslog buffer for sim and x86_64 arch

### DIFF
--- a/arch/sim/src/sim/up_assert.c
+++ b/arch/sim/src/sim/up_assert.c
@@ -26,6 +26,7 @@
 #include <sched/sched.h>
 #include <stdlib.h>
 #include <syslog.h>
+#include <nuttx/syslog/syslog.h>
 #include <nuttx/board.h>
 #include "up_internal.h"
 
@@ -68,6 +69,10 @@
 
 void up_assert(const char *filename, int line)
 {
+  /* Flush any buffered SYSLOG data (from prior to the assertion) */
+
+  syslog_flush();
+
   /* Show the location of the failed assertion */
 
 #ifdef CONFIG_SMP
@@ -78,11 +83,19 @@ void up_assert(const char *filename, int line)
           filename, line);
 #endif
 
+  /* Flush any buffered SYSLOG data (from the above) */
+
+  syslog_flush();
+
   /* Allow for any board/configuration specific crash information */
 
 #ifdef CONFIG_BOARD_CRASHDUMP
   board_crashdump(sim_getsp(), this_task(), filename, line);
 #endif
+
+  /* Flush any buffered SYSLOG data */
+
+  syslog_flush();
 
   if (CURRENT_REGS || (running_task())->flink == NULL)
     {

--- a/arch/x86_64/src/common/up_assert.c
+++ b/arch/x86_64/src/common/up_assert.c
@@ -205,6 +205,10 @@ static void up_dumpstate(void)
 
 static void _up_assert(void)
 {
+  /* Flush any buffered SYSLOG data */
+
+  syslog_flush();
+
   /* Are we in an interrupt handler or the idle task? */
 
   if (g_current_regs || (running_task())->flink == NULL)
@@ -249,6 +253,10 @@ void up_assert(const char *filename, int lineno)
 
   board_autoled_on(LED_ASSERTION);
 
+  /* Flush any buffered SYSLOG data (from prior to the assertion) */
+
+  syslog_flush();
+
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   _alert("Assertion failed at file:%s line: %d task: %s\n",
         filename, lineno, rtcb->name);
@@ -258,6 +266,10 @@ void up_assert(const char *filename, int lineno)
 #endif
 
   up_dumpstate();
+
+  /* Flush any buffered SYSLOG data (from the above) */
+
+  syslog_flush();
 
 #ifdef CONFIG_BOARD_CRASHDUMP
   board_crashdump(x64_getsp(), this_task(), filename, lineno);


### PR DESCRIPTION
## Summary
Report here: https://github.com/apache/incubator-nuttx/pull/3736

## Impact
Ensure the buffered log get ouptut finally

## Testing

