### PR TITLE
s32k1xx:eeprom fix missing debug.h

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <errno.h>
+#include <debug.h>
 
 #include "arm_arch.h"
 


### PR DESCRIPTION
## Summary

Fixes build breakage from header reorg 

## Impact

Fixes build

## Testing

nxp_ucans32k146_default
