### PR TITLE
SYSLOG channel add functions return handle to the channel.

### DIFF
--- a/Documentation/components/drivers/special/syslog.rst
+++ b/Documentation/components/drivers/special/syslog.rst
@@ -392,7 +392,8 @@ mounting of the file systems.
 The interface ``syslog_file_channel()`` is used to configure the
 SYSLOG file channel:
 
-.. c:function:: int syslog_file_channel(FAR const char *devpath);
+.. c:function:: FAR struct syslog_channel_s *
+                    syslog_file_channel(FAR const char *devpath);
 
   Configure to use a file in a mounted file system
   at ``devpath`` as the SYSLOG channel.
@@ -423,8 +424,8 @@ SYSLOG file channel:
     ``syslog_file_channel()`` will create the file.
 
   :return:
-    Zero (``OK``) is returned on success; a
-    negated ``errno`` value is returned on any failure.
+    A pointer to the new syslog channel; ``NULL`` is returned
+    on any failure.
 
   References: ``drivers/syslog/syslog_filechannel.c``,
   ``drivers/syslog/syslog_device.c``, and

--- a/boards/arm/stm32/clicker2-stm32/src/stm32_appinit.c
+++ b/boards/arm/stm32/clicker2-stm32/src/stm32_appinit.c
@@ -96,11 +96,12 @@ int board_app_initialize(uintptr_t arg)
 
   nxsig_usleep(CONFIG_CLICKER2_STM32_SYSLOG_FILE_DELAY * 1000);
 
-  ret = syslog_file_channel(CONFIG_CLICKER2_STM32_SYSLOG_FILE_PATH);
-  if (ret < 0)
+  FAR struct syslog_channel_s *channel;
+  channel = syslog_file_channel(CONFIG_CLICKER2_STM32_SYSLOG_FILE_PATH);
+  if (channel == NULL)
     {
-      syslog(LOG_ERR, "ERROR: syslog_file_channel() failed: %d\n", ret);
-      return ret;
+      syslog(LOG_ERR, "ERROR: syslog_file_channel() failed\n");
+      return -EINVAL;
     }
 #endif
 

--- a/drivers/syslog/README.txt
+++ b/drivers/syslog/README.txt
@@ -372,7 +372,7 @@ SYSLOG Channel Options
   Prototype:
 
     #ifdef CONFIG_SYSLOG_FILE
-    int syslog_file_channel(FAR const char *devpath);
+    FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath);
     #endif
 
   Description:
@@ -406,8 +406,7 @@ SYSLOG Channel Options
 
   Returned Value:
 
-    Zero (OK) is returned on success; a negated errno value is returned on
-    any failure.
+    A pointer to the new SYSLOG channel; NULL is returned on any failure.
 
   References: drivers/syslog/syslog_filechannel.c,
   drivers/syslog/syslog_device.c, and include/nuttx/syslog/syslog.h.

--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -125,13 +125,12 @@ void syslog_dev_uninitialize(FAR struct syslog_channel_s *channel);
  *   None
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   A pointer to the new SYSLOG channel; NULL is returned on any failure.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_CHAR
-int syslog_dev_channel(void);
+FAR struct syslog_channel_s *syslog_dev_channel(void);
 #endif
 
 /****************************************************************************
@@ -156,13 +155,12 @@ int syslog_dev_channel(void);
  *   None
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   A pointer to the new SYSLOG channel; NULL is returned on any failure.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_CONSOLE
-int syslog_console_channel(void);
+FAR struct syslog_channel_s *syslog_console_channel(void);
 #endif
 
 /****************************************************************************

--- a/drivers/syslog/syslog_consolechannel.c
+++ b/drivers/syslog/syslog_consolechannel.c
@@ -75,12 +75,11 @@ FAR static struct syslog_channel_s *g_syslog_console_channel;
  *   None
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   A pointer to the new SYSLOG channel; NULL is returned on any failure.
  *
  ****************************************************************************/
 
-int syslog_console_channel(void)
+FAR struct syslog_channel_s *syslog_console_channel(void)
 {
   /* Initialize the character driver interface */
 
@@ -88,12 +87,18 @@ int syslog_console_channel(void)
                                                    OPEN_FLAGS, OPEN_MODE);
   if (g_syslog_console_channel == NULL)
     {
-      return -ENOMEM;
+      return NULL;
     }
 
   /* Use the character driver as the SYSLOG channel */
 
-  return syslog_channel(g_syslog_console_channel);
+  if (syslog_channel(g_syslog_console_channel) != OK)
+    {
+      syslog_dev_uninitialize(g_syslog_console_channel);
+      g_syslog_console_channel = NULL;
+    }
+
+  return g_syslog_console_channel;
 }
 
 #endif /* CONFIG_SYSLOG_CONSOLE */

--- a/drivers/syslog/syslog_devchannel.c
+++ b/drivers/syslog/syslog_devchannel.c
@@ -72,12 +72,11 @@ FAR static struct syslog_channel_s *g_syslog_dev_channel;
  *   None
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   A pointer to the new SYSLOG channel; NULL is returned on any failure.
  *
  ****************************************************************************/
 
-int syslog_dev_channel(void)
+FAR struct syslog_channel_s *syslog_dev_channel(void)
 {
   /* Initialize the character driver interface */
 
@@ -85,12 +84,18 @@ int syslog_dev_channel(void)
                                                OPEN_FLAGS, OPEN_MODE);
   if (g_syslog_dev_channel == NULL)
     {
-      return -ENOMEM;
+      return NULL;
     }
 
   /* Use the character driver as the SYSLOG channel */
 
-  return syslog_channel(g_syslog_dev_channel);
+  if (syslog_channel(g_syslog_dev_channel) != OK)
+    {
+      syslog_dev_uninitialize(g_syslog_dev_channel);
+      g_syslog_dev_channel = NULL;
+    }
+
+  return g_syslog_dev_channel;
 }
 
 #endif /* CONFIG_SYSLOG_CHAR */

--- a/drivers/syslog/syslog_initialize.c
+++ b/drivers/syslog/syslog_initialize.c
@@ -72,11 +72,11 @@ int syslog_initialize(void)
 #if defined(CONFIG_SYSLOG_CHAR)
   /* Enable use of a character device as the SYSLOG device */
 
-  ret = syslog_dev_channel();
+  syslog_dev_channel();
 #elif defined(CONFIG_SYSLOG_CONSOLE)
   /* Use the console device as the SYSLOG device */
 
-  ret = syslog_console_channel();
+  syslog_console_channel();
 #endif
 
 #ifdef CONFIG_RAMLOG_SYSLOG

--- a/include/nuttx/syslog/syslog.h
+++ b/include/nuttx/syslog/syslog.h
@@ -233,13 +233,12 @@ int syslog_initialize(void);
  *     file.
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   A pointer to the new SYSLOG channel; NULL is returned on any failure.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_SYSLOG_FILE
-int syslog_file_channel(FAR const char *devpath);
+FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Functions that where creating a new SYSLOG channel (e.g. `syslog_dev_channel()`, `syslog_file_channel()` etc), were not providing the handle to the new channel.

Since it was kept internally, the user was not able to manipulate this channel in any way.

For example a later call to `syslog_channel_remove()` was not possible, as there was no access to the `struct syslog_channel_s *` to be passed.

## Impact
The user has now access to the created channels for later manipulation.  
Most notably, `syslog_channel_remove()` can now be used.

## Testing
Build test only.
