### PR TITLE
Add ST7789 LCD controller support for SAMV71 XPlained Ultra board

### DIFF
--- a/arch/arm/src/samv7/sam_spi.c
+++ b/arch/arm/src/samv7/sam_spi.c
@@ -1421,20 +1421,31 @@ static void spi_setbits(struct spi_dev_s *dev, int nbits)
 
 static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd)
 {
-  uint8_t txbyte;
-  uint8_t rxbyte;
+  struct sam_spics_s *spics = (struct sam_spics_s *)dev;
+  if (spics->nbits <= 8)
+    {
+      uint8_t txbyte;
+      uint8_t rxbyte;
 
-  /* spi_exchange can do this. Note: right now, this only deals with 8-bit
-   * words.  If the SPI interface were configured for words of other sizes,
-   * this would fail.
-   */
+      txbyte = (uint8_t)wd;
+      rxbyte = (uint8_t)0;
+      spi_exchange(dev, &txbyte, &rxbyte, 1);
 
-  txbyte = (uint8_t)wd;
-  rxbyte = (uint8_t)0;
-  spi_exchange(dev, &txbyte, &rxbyte, 1);
+      spiinfo("Sent %02x received %02x\n", txbyte, rxbyte);
+      return (uint32_t)rxbyte;
+    }
+  else
+    {
+      uint16_t txword;
+      uint16_t rxword;
 
-  spiinfo("Sent %02x received %02x\n", txbyte, rxbyte);
-  return (uint32_t)rxbyte;
+      txword = (uint16_t)wd;
+      rxword = (uint16_t)0;
+      spi_exchange(dev, &txword, &rxword, 1);
+
+      spiinfo("Sent %02x received %02x\n", txword, rxword);
+      return (uint32_t)rxword;
+    }
 }
 
 /****************************************************************************

--- a/boards/arm/samv7/samv71-xult/src/Makefile
+++ b/boards/arm/samv7/samv71-xult/src/Makefile
@@ -110,4 +110,8 @@ ifeq ($(CONFIG_IEEE802154_MRF24J40),y)
 CSRCS += sam_mrf24j40.c
 endif
 
+ifeq ($(CONFIG_LCD_ST7789),y)
+CSRCS += sam_st7789.c
+endif
+
 include $(TOPDIR)/boards/Board.mk

--- a/boards/arm/samv7/samv71-xult/src/sam_spi.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_spi.c
@@ -73,6 +73,14 @@ void sam_spidev_initialize(void)
   sam_configgpio(CLICK_MB2_CS);
 
 #endif
+
+#ifdef CONFIG_LCD_ST7789
+  /* Enable CS and CMD/DATA for LCD */
+
+  sam_configgpio(SPI0_NPCS1);
+  sam_configgpio(GPIO_LCD_CD);
+#endif
+
 #endif /* CONFIG_SAMV7_SPI0_MASTER */
 
 #ifdef CONFIG_SAMV7_SPI0_SLAVE
@@ -167,6 +175,12 @@ void sam_spi0select(uint32_t devid, bool selected)
         break;
 #endif
 
+#ifdef CONFIG_LCD_ST7789
+      case SPIDEV_DISPLAY(0):
+        sam_gpiowrite(SPI0_NPCS1, !selected);
+        break;
+#endif
+
       default:
         break;
     }
@@ -208,5 +222,46 @@ uint8_t sam_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
   return 0;
 }
 #endif
+
+/****************************************************************************
+ * Name: sam_spi[n]cmddata
+ *
+ * Description:
+ *   Some SPI devices require an additional control to determine if the SPI
+ *   data being sent is a command or is data.  If CONFIG_SPI_CMDDATA then
+ *   this function will be called to different be command and data transfers.
+ *
+ *   This is often needed, for example, by LCD drivers.  Some LCD hardware
+ *   may be configured to use 9-bit data transfers with the 9th bit
+ *   indicating command or data.  That same hardware may be configurable,
+ *   instead, to use 8-bit data but to require an additional, board-
+ *   specific GPIO control to distinguish command and data.  This function
+ *   would be needed in that latter case.
+ *
+ * Input Parameters:
+ *   dev - SPI device info
+ *   devid - Identifies the (logical) device
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_CMDDATA
+#ifdef CONFIG_SAMV7_SPI0_MASTER
+int sam_spi0cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  if (devid == SPIDEV_DISPLAY(0))
+    {
+      sam_gpiowrite(GPIO_LCD_CD, !cmd);
+      return OK;
+    }
+  else
+    {
+      return -ENODEV;
+    }
+}
+#endif /* CONFIG_SAMV7_SPI0_MASTER */
+#endif /* CONFIG_SPI_CMDDATA */
 
 #endif /* CONFIG_SAMV7_SPI */

--- a/boards/arm/samv7/samv71-xult/src/sam_st7789.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_st7789.c
@@ -1,0 +1,126 @@
+/****************************************************************************
+ * boards/arm/samv7/samv71-xult/src/sam_st7789.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/lcd/lcd.h>
+#include <nuttx/lcd/st7789.h>
+
+#include "sam_gpio.h"
+#include "sam_spi.h"
+#include "samv71-xult.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define LCD_SPI_PORTNO 0
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct spi_dev_s *g_spidev;
+static struct lcd_dev_s *g_lcd = NULL;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  board_lcd_initialize
+ *
+ * Description:
+ *   Initialize the LCD video hardware.  The initial state of the LCD is
+ *   fully initialized, display memory cleared, and the LCD ready to use, but
+ *   with the power setting at 0 (full off).
+ *
+ ****************************************************************************/
+
+int board_lcd_initialize(void)
+{
+  sam_configgpio(GPIO_LCD_RST);
+
+  g_spidev = sam_spibus_initialize(LCD_SPI_PORTNO);
+  if (!g_spidev)
+    {
+      lcderr("ERROR: Failed to initialize SPI port %d\n", LCD_SPI_PORTNO);
+      return -ENODEV;
+    }
+
+  sam_gpiowrite(GPIO_LCD_RST, 0);
+  up_mdelay(1);
+  sam_gpiowrite(GPIO_LCD_RST, 1);
+  up_mdelay(120);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_getdev
+ *
+ * Description:
+ *   Return a a reference to the LCD object for the specified LCD.  This
+ *   allows support for multiple LCD devices.
+ *
+ ****************************************************************************/
+
+FAR struct lcd_dev_s *board_lcd_getdev(int devno)
+{
+  g_lcd = st7789_lcdinitialize(g_spidev);
+  if (!g_lcd)
+    {
+      lcderr("ERROR: Failed to bind SPI port 4 to LCD %d\n", devno);
+    }
+  else
+    {
+      lcdinfo("SPI port 4 bound to LCD %d\n", devno);
+      return g_lcd;
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_uninitialize
+ *
+ * Description:
+ *   Uninitialize the LCD support
+ *
+ ****************************************************************************/
+
+void board_lcd_uninitialize(void)
+{
+  /* Turn the display off */
+
+  g_lcd->setpower(g_lcd, 0);
+}

--- a/boards/arm/samv7/samv71-xult/src/samv71-xult.h
+++ b/boards/arm/samv7/samv71-xult/src/samv71-xult.h
@@ -621,6 +621,17 @@
 
 #define EDBG_CSNO           SPI0_CS2
 
+/* LCD display (over SPI) */
+
+#define GPIO_LCD_CD       (GPIO_OUTPUT | GPIO_CFG_DEFAULT | GPIO_OUTPUT_SET | \
+                           GPIO_PORT_PIOB | GPIO_PIN2)
+
+#define GPIO_LCD_RST      (GPIO_OUTPUT | GPIO_CFG_DEFAULT | GPIO_OUTPUT_SET | \
+                           GPIO_PORT_PIOB | GPIO_PIN3)
+
+#define SPI0_NPCS1        (GPIO_OUTPUT | GPIO_CFG_DEFAULT | GPIO_OUTPUT_SET | \
+                           GPIO_PORT_PIOD | GPIO_PIN25)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Commit a0cfd5f adds support for 16-bit word transfers in spi_send for SAMv7 SPI driver implementation.
Until then, any data sent over SPI on SAMv7 using SPI_SEND was truncated to 8 bits, although the transfer size
was set to more than 8 bits.

Commit 5eaaa51 contains board specific part of ST7789 driver for SAMv71 XPlained Ultra evaluation board.
Its structure is derived from i.MX RT (Teensy 4.x) driver for the same LCD controller.

## Impact

These changes are backward compatible.

## Testing

Tested on SAMv71 XPlained Ultra evaluation board and EastRising ER-TFT1.14-1 LCD panel.

