### PR TITLE
Added automatic log rotation, when log file is opened.

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -13,6 +13,8 @@ config ARCH_SYSLOG
 
 # Selected if the SYSLOG device supports multi-byte write operations
 
+comment "SYSLOG options"
+
 config SYSLOG_MAX_CHANNELS
 	int "Maximum SYSLOG channels"
 	default 1
@@ -105,6 +107,8 @@ config SYSLOG_INTBUFSIZE
 	---help---
 		The size of the interrupt buffer in bytes.
 
+comment "Formatting options"
+
 config SYSLOG_TIMESTAMP
 	bool "Prepend timestamp to syslog message"
 	default n
@@ -188,6 +192,8 @@ config SYSLOG_COLOR_OUTPUT
 	---help---
 		Enables colored output in syslog, according to message priority.
 
+comment "SYSLOG channels"
+
 if !ARCH_SYSLOG
 config SYSLOG_CHAR
 	bool "Log to a character device"
@@ -251,7 +257,7 @@ config SYSLOG_RPMSG_SERVER
 	---help---
 		Use rpmsg to receive message from remote proc.
 
-config SYSLOG_FILE
+menuconfig SYSLOG_FILE
 	bool "Syslog file output"
 	default n
 	---help---
@@ -264,6 +270,32 @@ config SYSLOG_FILE
 
 		NOTE interrupt level SYSLOG output will be lost in this case unless
 		the interrupt buffer is used.
+
+if SYSLOG_FILE
+
+config SYSLOG_FILE_ROTATE
+	bool "Log file rotate"
+	default n
+	depends on SYSLOG_FILE
+	---help---
+		If enabled, the log file size will be checked before opening.
+		If it is larger than the specified limit it will be "rotated",
+		i.e. the old file will be kept as a backup, and a new empty
+		file will be created.
+		
+		This option is useful to ensure that log files do not get
+		huge after prolonged periods of system operation.
+
+config SYSLOG_FILE_SIZE_LIMIT
+	int "Log file size limit"
+	default 524288
+	depends on SYSLOG_FILE_ROTATE
+	---help---
+		File size limit when the log is rotated automatically.
+		If a log file is found larger than this limit, it will
+		be rotated.
+
+endif # SYSLOG_FILE
 
 config CONSOLE_SYSLOG
 	bool "Use SYSLOG for /dev/console"

--- a/drivers/syslog/syslog_filechannel.c
+++ b/drivers/syslog/syslog_filechannel.c
@@ -25,9 +25,13 @@
 #include <nuttx/config.h>
 
 #include <sys/stat.h>
+#include <unistd.h>
 #include <sched.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
 
 #include <nuttx/syslog/syslog.h>
 
@@ -49,6 +53,62 @@
 /* Handle to the SYSLOG channel */
 
 FAR static struct syslog_channel_s *g_syslog_file_channel;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_SYSLOG_FILE_ROTATE
+static void log_rotate(FAR const char *log_file)
+{
+  int fd;
+  off_t size;
+  struct stat f_stat;
+  char *backup_file;
+
+  /* Get the size of the current log file. */
+
+  fd = open(log_file, O_RDONLY);
+  if (fd < 0)
+    {
+      return;
+    }
+
+  fstat(fd, &f_stat);
+  size = f_stat.st_size;
+  close(fd);
+
+  /* If it does not exceed the limit we are OK. */
+
+  if (size < CONFIG_SYSLOG_FILE_SIZE_LIMIT)
+    {
+      return;
+    }
+
+  /* Construct the backup file name. */
+
+  backup_file = malloc(strlen(log_file) + 3);
+  if (backup_file == NULL)
+    {
+      return;
+    }
+
+  sprintf(backup_file, "%s.0", log_file);
+
+  /* Delete any old backup files. */
+
+  if (access(backup_file, F_OK) == 0)
+    {
+      remove(backup_file);
+    }
+
+  /* Rotate the log. */
+
+  rename(log_file, backup_file);
+
+  free(backup_file);
+}
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -107,6 +167,12 @@ FAR struct syslog_channel_s *syslog_file_channel(FAR const char *devpath)
     {
       syslog_dev_uninitialize(g_syslog_file_channel);
     }
+
+  /* Rotate the log file, if needed. */
+
+#ifdef CONFIG_SYSLOG_FILE_ROTATE
+  log_rotate(devpath);
+#endif
 
   /* Then initialize the file interface */
 


### PR DESCRIPTION
## Summary
Automatic log rotation mechanism.

When a log file is opened, its size is checked. If it is found larger than the specified limit, it is rotated automatically.  
This feature is very useful in file loggers so a) the log file does not get excessively large, b) the physical memory does not get exhausted due to log files.

This implementation tries to be as lightweight as possible:

- The log file is only checked during opening, so there is no additional overhead during normal logging.
- The existing log file is kept as a backup, and a new empty file is created for logging. This approach is very fast and simple compared to actually manipulating the contents of the log file (in order to shrink it).

Limitations / Assumptions

- Since the file is only checked during opening, the log file can (and will !) exceed the limit. The file system must have enough space available to allow for this "overflow", till next check.
- It is assumed that re-opening of the log file will happen occasionally. Either by any system reset, or by (un)mounting of the file system. 

Regardless of the above limitations, I have tested the this exact mechanism in other applications, and I found it to work nicely. In real-life applications I wouldn't expect the above limitations to be met. 

## Impact
None on existing configurations.

## Testing
Pending. I will comment bellow when ready.
