### PR TITLE
UCANS32K146 add support for B revision

### DIFF
--- a/boards/arm/s32k1xx/rddrone-uavcan146/include/board.h
+++ b/boards/arm/s32k1xx/rddrone-uavcan146/include/board.h
@@ -73,6 +73,12 @@
 #define BOARD_LED_G_BIT   (1 << BOARD_LED_G)
 #define BOARD_LED_B_BIT   (1 << BOARD_LED_B)
 
+/* Board revision detection pin
+ * 0 equals UCANS32K146-01
+ * 1 equals UCANS32K146B
+ */
+#define BOARD_REVISION_DETECT_PIN  (GPIO_INPUT | PIN_PORTA | PIN10 )
+
 /* If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board
  * the RDDRONE-UAVCAN146.  The following definitions describe how NuttX
  * controls the LEDs:
@@ -138,11 +144,9 @@
 /* CAN selections ***********************************************************/
 #define PIN_CAN0_TX      PIN_CAN0_TX_4      /* PTE5 */
 #define PIN_CAN0_RX      PIN_CAN0_RX_4      /* PTE4 */
-#define PIN_CAN0_ENABLE  (GPIO_OUTPUT | PIN_PORTE | PIN11 )
-#define CAN0_ENABLE_OUT  0
+#define PIN_CAN0_STB     (GPIO_OUTPUT | PIN_PORTE | PIN11 )
 #define PIN_CAN1_TX      PIN_CAN1_TX_1      /* PTA13 */
 #define PIN_CAN1_RX      PIN_CAN1_RX_1      /* PTA12 */
-#define PIN_CAN1_ENABLE  (GPIO_OUTPUT | PIN_PORTE | PIN10 )
-#define CAN1_ENABLE_OUT  0
+#define PIN_CAN1_STB     (GPIO_OUTPUT | PIN_PORTE | PIN10 )
 
 #endif  /* __BOARDS_ARM_RDDRONE_UAVCAN146_INCLUDE_BOARD_H */

--- a/boards/arm/s32k1xx/rddrone-uavcan146/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/rddrone-uavcan146/src/s32k1xx_bringup.c
@@ -23,7 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-
+#include <arch/board/board.h>
 #include <sys/types.h>
 #include <syslog.h>
 
@@ -145,6 +145,24 @@ int s32k1xx_bringup(void)
   /* Register EEEPROM block device */
 
   s32k1xx_eeeprom_register(0, 4096);
+#endif
+
+#ifdef CONFIG_S32K1XX_FLEXCAN
+  s32k1xx_pinconfig(BOARD_REVISION_DETECT_PIN);
+
+  if (s32k1xx_gpioread(BOARD_REVISION_DETECT_PIN))
+    {
+      /* STB high -> active CAN phy */
+
+      s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ONE);
+    }
+  else
+    {
+      /* STB low -> active CAN phy */
+
+      s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ZERO);
+    }
+
 #endif
 
   return ret;


### PR DESCRIPTION
## Summary
Adds support for the UCANS32K146B board revision which has the STB pin functionality inverted, now we autodetect which revision we're and switch STB logic accordingly.

## Impact
Minimal only UCANS32K146 board target

## Testing
Tested on both UCANS32K146B and UCANS32K146-01

