### PR TITLE
spi: Refactor SPI Slave interface prefix to sync with I2C Slave

### DIFF
--- a/arch/arm/src/samv7/sam_spi.h
+++ b/arch/arm/src/samv7/sam_spi.h
@@ -142,8 +142,8 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
-struct spi_dev_s;    /* Forward reference */
-struct spi_sctrlr_s; /* Forward reference */
+struct spi_dev_s;         /* Forward reference */
+struct spi_slave_ctrlr_s; /* Forward reference */
 
 /****************************************************************************
  * Name: sam_spibus_initialize
@@ -176,7 +176,7 @@ FAR struct spi_dev_s *sam_spibus_initialize(int port);
  *
  ****************************************************************************/
 
-FAR struct spi_sctrlr_s *sam_spi_slave_initialize(int port);
+FAR struct spi_slave_ctrlr_s *sam_spi_slave_initialize(int port);
 
 /****************************************************************************
  * Name:  sam_spi[0|1]select, sam_spi[0|1]status, and sam_spi[0|1]cmddata

--- a/arch/arm/src/stm32h7/stm32_spi.h
+++ b/arch/arm/src/stm32h7/stm32_spi.h
@@ -79,7 +79,7 @@ FAR struct spi_dev_s *stm32_spibus_initialize(int bus);
  *
  ****************************************************************************/
 
-FAR struct spi_sctrlr_s *stm32_spi_slave_initialize(int bus);
+FAR struct spi_slave_ctrlr_s *stm32_spi_slave_initialize(int bus);
 
 /****************************************************************************
  * Name:  stm32_spi1/2/...select and stm32_spi1/2/...status

--- a/arch/arm/src/stm32h7/stm32_spi_slave.c
+++ b/arch/arm/src/stm32h7/stm32_spi_slave.c
@@ -179,9 +179,10 @@ enum spi_config_e
 
 struct stm32_spidev_s
 {
-  struct spi_sctrlr_s sctrlr;    /* Externally visible part of the
-                                  * SPI slave interface */
-  struct spi_sdev_s *sdev;       /* Bound SPI slave device interface */
+  /* Externally visible part of the SPI slave interface */
+
+  struct spi_slave_ctrlr_s ctrlr;
+  struct spi_slave_dev_s *dev;   /* Bound SPI slave device interface */
   uint32_t         spibase;      /* SPIn base address */
   uint32_t         spiclock;     /* Clocking for the SPI module */
   uint8_t          irq;          /* SPI IRQ number */
@@ -268,16 +269,17 @@ static int  spi_nssinterrupt(int irq, void *context, void *arg);
 
 /* SPI slave methods */
 
-static void     spi_bind(struct spi_sctrlr_s *sctrlr,
-                  struct spi_sdev_s *sdev, enum spi_smode_e mode,
-                  int nbits);
-static void     spi_unbind(struct spi_sctrlr_s *sctrlr);
-static int      spi_enqueue(struct spi_sctrlr_s *sctrlr,
+static void     spi_bind(struct spi_slave_ctrlr_s *ctrlr,
+                         struct spi_slave_dev_s *dev,
+                         enum spi_slave_mode_e mode,
+                         int nbits);
+static void     spi_unbind(struct spi_slave_ctrlr_s *ctrlr);
+static int      spi_enqueue(struct spi_slave_ctrlr_s *ctrlr,
                             FAR const void *data,
                             size_t len);
-static bool     spi_qfull(struct spi_sctrlr_s *sctrlr);
-static void     spi_qflush(struct spi_sctrlr_s *sctrlr);
-static size_t   spi_qpoll(struct spi_sctrlr_s *sctrlr);
+static bool     spi_qfull(struct spi_slave_ctrlr_s *ctrlr);
+static void     spi_qflush(struct spi_slave_ctrlr_s *ctrlr);
+static size_t   spi_qpoll(struct spi_slave_ctrlr_s *ctrlr);
 
 /* Initialization */
 
@@ -296,7 +298,7 @@ static int         spi_pm_prepare(FAR struct pm_callback_s *cb, int domain,
 
 /* SPI slave controller driver operations */
 
-static const struct spi_sctrlrops_s g_sctrlr_ops =
+static const struct spi_slave_ctrlrops_s g_ctrlr_ops =
 {
   .bind              = spi_bind,
   .unbind            = spi_unbind,
@@ -327,8 +329,8 @@ static const struct spi_sctrlrops_s g_sctrlr_ops =
 
 #define SPI_SLAVE_INIT(x)                               \
 {                                                       \
-  .sctrlr.ops    = &g_sctrlr_ops,                       \
-  .sdev          = NULL,                                \
+  .ctrlr.ops     = &g_ctrlr_ops,                        \
+  .dev           = NULL,                                \
   .spibase       = STM32_SPI##x##_BASE,                 \
   .spiclock      = SPI45_KERNEL_CLOCK_FREQ,             \
   .irq           = STM32_IRQ_SPI##x,                    \
@@ -346,7 +348,7 @@ __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
 static
 uint8_t SPI_SLAVE_INQ(1)[DMA_ALIGN_UP(CONFIG_STM32H7_SPI_SLAVE_QSIZE)]
 __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
-static struct stm32_spidev_s g_spi1sctrlr = SPI_SLAVE_INIT(1);
+static struct stm32_spidev_s g_spi1ctrlr = SPI_SLAVE_INIT(1);
 
 #endif
 
@@ -358,7 +360,7 @@ __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
 static
 uint8_t SPI_SLAVE_INQ(2)[DMA_ALIGN_UP(CONFIG_STM32H7_SPI_SLAVE_QSIZE)]
 __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
-static struct stm32_spidev_s g_spi2sctrlr = SPI_SLAVE_INIT(2);
+static struct stm32_spidev_s g_spi2ctrlr = SPI_SLAVE_INIT(2);
 
 #endif
 
@@ -370,7 +372,7 @@ __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
 static
 uint8_t SPI_SLAVE_INQ(3)[DMA_ALIGN_UP(CONFIG_STM32H7_SPI_SLAVE_QSIZE)]
 __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
-static struct stm32_spidev_s g_spi3sctrlr = SPI_SLAVE_INIT(3);
+static struct stm32_spidev_s g_spi3ctrlr = SPI_SLAVE_INIT(3);
 
 #endif
 
@@ -382,7 +384,7 @@ __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
 static
 uint8_t SPI_SLAVE_INQ(4)[DMA_ALIGN_UP(CONFIG_STM32H7_SPI_SLAVE_QSIZE)]
 __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
-static struct stm32_spidev_s g_spi4sctrlr = SPI_SLAVE_INIT(4);
+static struct stm32_spidev_s g_spi4ctrlr = SPI_SLAVE_INIT(4);
 
 #endif
 
@@ -394,7 +396,7 @@ __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
 static
 uint8_t SPI_SLAVE_INQ(5)[DMA_ALIGN_UP(CONFIG_STM32H7_SPI_SLAVE_QSIZE)]
 __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
-static struct stm32_spidev_s g_spi5sctrlr = SPI_SLAVE_INIT(5);
+static struct stm32_spidev_s g_spi5ctrlr = SPI_SLAVE_INIT(5);
 
 #endif
 
@@ -408,7 +410,7 @@ __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
 static
 uint8_t SPI_SLAVE_INQ(6)[DMA_ALIGN_UP(CONFIG_STM32H7_SPI_SLAVE_QSIZE)]
 __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
-static struct stm32_spidev_s g_spi6sctrlr = SPI_SLAVE_INIT(6);
+static struct stm32_spidev_s g_spi6ctrlr = SPI_SLAVE_INIT(6);
 
 #endif
 
@@ -898,9 +900,9 @@ static void spi_dmatxstart(FAR struct stm32_spidev_s *priv)
  *
  ****************************************************************************/
 
-static int spi_lock(FAR struct spi_sctrlr_s *sctrlr, bool lock)
+static int spi_lock(FAR struct spi_slave_ctrlr_s *ctrlr, bool lock)
 {
-  FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)sctrlr;
+  FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)ctrlr;
   int ret;
 
   if (lock)
@@ -971,10 +973,10 @@ static inline void spi_enable(FAR struct stm32_spidev_s *priv, bool state)
  *
  ****************************************************************************/
 
-static void spi_setmode(FAR struct spi_sctrlr_s *sctrlr,
+static void spi_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
                         enum spi_mode_e mode)
 {
-  FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)sctrlr;
+  FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)ctrlr;
   uint32_t setbits = 0;
   uint32_t clrbits = 0;
 
@@ -1037,9 +1039,9 @@ static void spi_setmode(FAR struct spi_sctrlr_s *sctrlr,
  *
  ****************************************************************************/
 
-static void spi_setbits(FAR struct spi_sctrlr_s *sctrlr, int nbits)
+static void spi_setbits(FAR struct spi_slave_ctrlr_s *ctrlr, int nbits)
 {
-  FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)sctrlr;
+  FAR struct stm32_spidev_s *priv = (FAR struct stm32_spidev_s *)ctrlr;
   uint32_t setbits = 0;
   uint32_t clrbits = 0;
 
@@ -1087,37 +1089,37 @@ static void spi_setbits(FAR struct spi_sctrlr_s *sctrlr, int nbits)
  *
  * Description:
  *   Bind the SPI slave device interface to the SPI slave controller
- *   interface and configure the SPI interface.  Upon return, the SPI
+ *   interface and configure the SPI interface. Upon return, the SPI
  *   slave controller driver is fully operational and ready to perform
  *   transfers.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
- *   sdev   - SPI slave device interface instance
- *   mode   - The SPI mode requested
- *   nbits  - The number of bits requests.
- *            If value is greater > 0 then it implies MSB first
- *            If value is below < 0, then it implies LSB first with -nbits
+ *   ctrlr - SPI Slave controller interface instance
+ *   dev   - SPI Slave device interface instance
+ *   mode  - The SPI Slave mode requested
+ *   nbits - The number of bits requested.
+ *           If value is greater than 0, then it implies MSB first
+ *           If value is less than 0, then it implies LSB first with -nbits
  *
  * Returned Value:
- *   none
+ *   None.
  *
  ****************************************************************************/
 
-static void spi_bind(struct spi_sctrlr_s *sctrlr,
-                     struct spi_sdev_s *sdev, enum spi_smode_e mode,
+static void spi_bind(struct spi_slave_ctrlr_s *ctrlr,
+                     struct spi_slave_dev_s *dev, enum spi_slave_mode_e mode,
                      int nbits)
 {
-  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)sctrlr;
+  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)ctrlr;
   uint32_t nss_gpio;
 
-  spiinfo("sdev=%p mode=%d nbits=%d\n", sdv, mode, nbits);
+  spiinfo("dev=%p mode=%d nbits=%d\n", sdv, mode, nbits);
 
-  DEBUGASSERT(priv != NULL && priv->sdev == NULL && sdev != NULL);
+  DEBUGASSERT(priv != NULL && priv->dev == NULL && dev != NULL);
 
   /* Get exclusive access to the SPI device */
 
-  spi_lock(sctrlr, true);
+  spi_lock(ctrlr, true);
 
   /* Make sure the spi is disabled */
 
@@ -1137,7 +1139,7 @@ static void spi_bind(struct spi_sctrlr_s *sctrlr,
    * controller interface.
    */
 
-  priv->sdev = sdev;
+  priv->dev = dev;
 
   /* Initialize the circular buffer head */
 
@@ -1145,8 +1147,8 @@ static void spi_bind(struct spi_sctrlr_s *sctrlr,
 
   /* Setup to begin normal SPI operation */
 
-  spi_setmode(sctrlr, mode);
-  spi_setbits(sctrlr, nbits);
+  spi_setmode(ctrlr, mode);
+  spi_setbits(ctrlr, nbits);
 
   /* First, configure NSS as GPIO EXTI input */
 
@@ -1167,7 +1169,7 @@ static void spi_bind(struct spi_sctrlr_s *sctrlr,
   UNUSED(ret);
 #endif
 
-  spi_lock(sctrlr, false);
+  spi_lock(ctrlr, false);
 }
 
 /****************************************************************************
@@ -1252,33 +1254,33 @@ static int spi_nssinterrupt(int irq, void *context, void *arg)
  *
  * Description:
  *   Un-bind the SPI slave device interface from the SPI slave controller
- *   interface.  Reset the SPI interface and restore the SPI slave
- *   controller driver to its initial state,
+ *   interface. Reset the SPI interface and restore the SPI slave
+ *   controller driver to its initial state.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
- *   none
+ *   None.
  *
  ****************************************************************************/
 
-static void spi_unbind(struct spi_sctrlr_s *sctrlr)
+static void spi_unbind(struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)sctrlr;
+  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)ctrlr;
 
   DEBUGASSERT(priv != NULL);
-  spiinfo("Unbinding %p\n", priv->sdev);
+  spiinfo("Unbinding %p\n", priv->dev);
 
-  DEBUGASSERT(priv->sdev != NULL);
+  DEBUGASSERT(priv->dev != NULL);
 
   /* Get exclusive access to the SPI device */
 
-  spi_lock(sctrlr, true);
+  spi_lock(ctrlr, true);
 
   /* Unbind the SPI slave interface */
 
-  priv->sdev = NULL;
+  priv->dev = NULL;
 
   /* Disable DMA */
 
@@ -1289,22 +1291,25 @@ static void spi_unbind(struct spi_sctrlr_s *sctrlr)
 
   spi_enable(priv, false);
 
-  spi_lock(sctrlr, false);
+  spi_lock(ctrlr, false);
 }
 
 /****************************************************************************
  * Name: spi_enqueue
  *
  * Description:
- *   Enqueue the next value to be shifted out from the interface.  This adds
+ *   Enqueue the next value to be shifted out from the interface. This adds
  *   the word the controller driver for a subsequent transfer but has no
- *   effect on anyin-process or currently "committed" transfers
+ *   effect on any in-process or currently "committed" transfers.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
- *   data   - Command/data mode data value to be shifted out.  The width of
- *            the data must be the same as the nbits parameter previously
- *            provided to the bind() methods.
+ *   ctrlr - SPI Slave controller interface instance
+ *   data  - Pointer to the command/data mode data to be shifted out.
+ *           The data width must be aligned to the nbits parameter which was
+ *           previously provided to the bind() method.
+ *   len   - Number of units of "nbits" wide to enqueue,
+ *           "nbits" being the data width previously provided to the bind()
+ *           method.
  *
  * Returned Value:
  *   Zero if the word was successfully queue; A negated errno valid is
@@ -1313,8 +1318,8 @@ static void spi_unbind(struct spi_sctrlr_s *sctrlr)
  *
  ****************************************************************************/
 
-static int spi_enqueue(struct spi_sctrlr_s *sctrlr, FAR const void *data,
-                       size_t len)
+static int spi_enqueue(struct spi_slave_ctrlr_s *ctrlr,
+                       FAR const void *data, size_t len)
 {
   return 0;
 }
@@ -1327,14 +1332,14 @@ static int spi_enqueue(struct spi_sctrlr_s *sctrlr, FAR const void *data,
  *   additional word to the queue.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
- *   true if the output wueue is full
+ *   true if the output queue is full, false otherwise.
  *
  ****************************************************************************/
 
-static bool spi_qfull(struct spi_sctrlr_s *sctrlr)
+static bool spi_qfull(struct spi_slave_ctrlr_s *ctrlr)
 {
   return false;
 }
@@ -1343,24 +1348,24 @@ static bool spi_qfull(struct spi_sctrlr_s *sctrlr)
  * Name: spi_qflush
  *
  * Description:
- *   Discard all saved values in the output queue.  On return from this
- *   function the output queue will be empty.  Any in-progress or otherwise
+ *   Discard all saved values in the output queue. On return from this
+ *   function the output queue will be empty. Any in-progress or otherwise
  *   "committed" output values may not be flushed.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
- *   None
+ *   None.
  *
  ****************************************************************************/
 
-static void spi_qflush(struct spi_sctrlr_s *sctrlr)
+static void spi_qflush(struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)sctrlr;
+  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)ctrlr;
   irqstate_t flags;
 
-  DEBUGASSERT(priv != NULL && priv->sdev != NULL);
+  DEBUGASSERT(priv != NULL && priv->dev != NULL);
 
 #ifdef CONFIG_STM32H7_SPI_DMA
   if (!priv->dmarunning)
@@ -1371,7 +1376,7 @@ static void spi_qflush(struct spi_sctrlr_s *sctrlr)
 
   /* Get exclusive access to the SPI device */
 
-  spi_lock(sctrlr, true);
+  spi_lock(ctrlr, true);
   flags = enter_critical_section();
 
   /* Flush the input buffers */
@@ -1389,7 +1394,7 @@ static void spi_qflush(struct spi_sctrlr_s *sctrlr)
   priv->ohead = 0;
   priv->otail = 0;
   leave_critical_section(flags);
-  spi_lock(sctrlr, false);
+  spi_lock(ctrlr, false);
 }
 
 /****************************************************************************
@@ -1436,21 +1441,21 @@ static inline int spi_rx_buffer_free(uint8_t *ptr, int start, int end)
  *   Tell the controller to output all the receive queue data.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   Number of bytes left in the rx queue. If the device accepted all the
  *
  ****************************************************************************/
 
-static size_t spi_qpoll(struct spi_sctrlr_s *sctrlr)
+static size_t spi_qpoll(struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)sctrlr;
+  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)ctrlr;
   int itail;
   int ihead;
   uint16_t bytes_left;
 
-  DEBUGASSERT(priv != NULL && priv->sdev != NULL);
+  DEBUGASSERT(priv != NULL && priv->dev != NULL);
   DEBUGASSERT(priv->ihead < CONFIG_STM32H7_SPI_SLAVE_QSIZE);
 
 #ifdef CONFIG_STM32H7_SPI_DMA
@@ -1462,7 +1467,7 @@ static size_t spi_qpoll(struct spi_sctrlr_s *sctrlr)
 
   /* Get exclusive access to the SPI device */
 
-  spi_lock(sctrlr, true);
+  spi_lock(ctrlr, true);
 
 #ifdef CONFIG_STM32H7_SPI_DMA
   itail = CONFIG_STM32H7_SPI_SLAVE_QSIZE - stm32_dmaresidual(priv->rxdma);
@@ -1477,7 +1482,7 @@ static size_t spi_qpoll(struct spi_sctrlr_s *sctrlr)
     {
       /* Receive the end of receive buffer */
 
-      priv->ihead += SPI_SDEV_RECEIVE(priv->sdev,
+      priv->ihead += SPIS_DEV_RECEIVE(priv->dev,
                                       (const uint16_t *)&priv->inq[ihead],
                                       CONFIG_STM32H7_SPI_SLAVE_QSIZE -
                                         ihead);
@@ -1492,7 +1497,7 @@ static size_t spi_qpoll(struct spi_sctrlr_s *sctrlr)
     {
       /* Receive the data between ihead and itail */
 
-      priv->ihead += SPI_SDEV_RECEIVE(priv->sdev,
+      priv->ihead += SPIS_DEV_RECEIVE(priv->dev,
                                       (const uint16_t *)&priv->inq[ihead],
                                       itail - ihead);
 
@@ -1507,7 +1512,7 @@ static size_t spi_qpoll(struct spi_sctrlr_s *sctrlr)
     ? CONFIG_STM32H7_SPI_SLAVE_QSIZE - priv->ihead + itail
     : itail - priv->ihead;
 
-  spi_lock(sctrlr, false);
+  spi_lock(ctrlr, false);
 
   return bytes_left;
 }
@@ -1732,7 +1737,7 @@ static void spi_slave_initialize(struct stm32_spidev_s *priv)
 #define GPIO_SPI_NSS(x) GPIO_SPI##x##_NSS
 
 #define SPI_SLAVE_INIT_BUS(x) \
-  priv = &g_spi##x##sctrlr;                                     \
+  priv = &g_spi##x##ctrlr;                                      \
                                                                 \
   /* Only configure if the bus is not already configured */     \
                                                                 \
@@ -1751,7 +1756,7 @@ static void spi_slave_initialize(struct stm32_spidev_s *priv)
       priv->initialized = true;                                 \
     }
 
-FAR struct spi_sctrlr_s *stm32_spi_slave_initialize(int bus)
+FAR struct spi_slave_ctrlr_s *stm32_spi_slave_initialize(int bus)
 {
   FAR struct stm32_spidev_s *priv = NULL;
   irqstate_t flags = enter_critical_section();
@@ -1810,10 +1815,10 @@ FAR struct spi_sctrlr_s *stm32_spi_slave_initialize(int bus)
 
   /* Initialize the SPI operations */
 
-  priv->sctrlr.ops = &g_sctrlr_ops;
+  priv->ctrlr.ops = &g_ctrlr_ops;
 
   leave_critical_section(flags);
-  return (FAR struct spi_sctrlr_s *)priv;
+  return (FAR struct spi_slave_ctrlr_s *)priv;
 }
 
 #endif /* CONFIG_STM32H7_SPI1..6_SLAVE */

--- a/arch/risc-v/src/esp32c3/esp32c3_spi.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi.h
@@ -127,7 +127,7 @@ int esp32c3_spi2_cmddata(FAR struct spi_dev_s *dev,
 int esp32c3_spibus_uninitialize(FAR struct spi_dev_s *dev);
 
 /****************************************************************************
- * Name: esp32c3_spislave_sctrlr_initialize
+ * Name: esp32c3_spislave_ctrlr_initialize
  *
  * Description:
  *   Initialize the selected SPI Slave bus.
@@ -141,23 +141,23 @@ int esp32c3_spibus_uninitialize(FAR struct spi_dev_s *dev);
  *
  ****************************************************************************/
 
-FAR struct spi_sctrlr_s *esp32c3_spislave_sctrlr_initialize(int port);
+FAR struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port);
 
 /****************************************************************************
- * Name: esp32c3_spislave_sctrlr_uninitialize
+ * Name: esp32c3_spislave_ctrlr_uninitialize
  *
  * Description:
  *   Uninitialize an SPI Slave bus.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   Zero (OK) is returned on success. Otherwise -1 (ERROR).
  *
  ****************************************************************************/
 
-int esp32c3_spislave_sctrlr_uninitialize(FAR struct spi_sctrlr_s *sctrlr);
+int esp32c3_spislave_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr);
 
 #endif /* CONFIG_ESP32C3_SPI */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
@@ -119,7 +119,7 @@
 struct spislave_config_s
 {
   int32_t width;              /* SPI Slave default width */
-  enum spi_smode_e mode;      /* SPI Slave default mode */
+  enum spi_slave_mode_e mode; /* SPI Slave default mode */
 
   uint8_t cs_pin;             /* GPIO configuration for CS */
   uint8_t mosi_pin;           /* GPIO configuration for MOSI */
@@ -147,28 +147,28 @@ struct spislave_priv_s
 {
   /* Externally visible part of the SPI Slave controller interface */
 
-  struct spi_sctrlr_s sctrlr;
+  struct spi_slave_ctrlr_s ctrlr;
 
   /* Reference to SPI Slave device interface */
 
-  struct spi_sdev_s *sdev;
+  struct spi_slave_dev_s *dev;
 
   /* Port configuration */
 
   const struct spislave_config_s *config;
-  int refs;              /* Reference count */
-  int cpuint;            /* SPI interrupt ID */
+  int refs;                   /* Reference count */
+  int cpuint;                 /* SPI interrupt ID */
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-  int32_t dma_channel;   /* Channel assigned by the GDMA driver */
+  int32_t dma_channel;        /* Channel assigned by the GDMA driver */
 #endif
-  enum spi_smode_e mode; /* Current SPI Slave hardware mode */
-  uint8_t nbits;         /* Current SPI send/receive bits once transmission */
-  uint32_t tx_length;    /* Location of next TX value */
+  enum spi_slave_mode_e mode; /* Current SPI Slave hardware mode */
+  uint8_t nbits;              /* Current configured bit width */
+  uint32_t tx_length;         /* Location of next TX value */
 
   /* SPI Slave TX queue buffer */
 
   uint8_t tx_buffer[SPI_SLAVE_BUFSIZE];
-  uint32_t rx_length;    /* Location of next RX value */
+  uint32_t rx_length;         /* Location of next RX value */
 
   /* SPI Slave RX queue buffer */
 
@@ -194,9 +194,9 @@ static int spislave_periph_interrupt(int irq, void *context, FAR void *arg);
 
 /* SPI Slave controller internal functions */
 
-static void spislave_setmode(FAR struct spi_sctrlr_s *dev,
-                             enum spi_smode_e mode);
-static void spislave_setbits(FAR struct spi_sctrlr_s *dev, int nbits);
+static void spislave_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
+                             enum spi_slave_mode_e mode);
+static void spislave_setbits(FAR struct spi_slave_ctrlr_s *ctrlr, int nbits);
 static void spislave_store_result(FAR struct spislave_priv_s *priv,
                                   uint32_t recv_bytes);
 static void spislave_prepare_next_rx(FAR struct spislave_priv_s *priv);
@@ -209,22 +209,22 @@ static void spislave_prepare_next_tx(FAR struct spislave_priv_s *priv);
 #else
 static void spislave_write_tx_buffer(FAR struct spislave_priv_s *priv);
 #endif
-static void spislave_initialize(FAR struct spi_sctrlr_s *sctrlr);
-static void spislave_deinitialize(FAR struct spi_sctrlr_s *sctrlr);
+static void spislave_initialize(FAR struct spi_slave_ctrlr_s *ctrlr);
+static void spislave_deinitialize(FAR struct spi_slave_ctrlr_s *ctrlr);
 
 /* SPI Slave controller operations */
 
-static void spislave_bind(FAR struct spi_sctrlr_s *sctrlr,
-                          FAR struct spi_sdev_s *sdev,
-                          enum spi_smode_e mode,
+static void spislave_bind(FAR struct spi_slave_ctrlr_s *ctrlr,
+                          FAR struct spi_slave_dev_s *dev,
+                          enum spi_slave_mode_e mode,
                           int nbits);
-static void spislave_unbind(FAR struct spi_sctrlr_s *sctrlr);
-static int spislave_enqueue(FAR struct spi_sctrlr_s *sctrlr,
+static void spislave_unbind(FAR struct spi_slave_ctrlr_s *ctrlr);
+static int spislave_enqueue(FAR struct spi_slave_ctrlr_s *ctrlr,
                             FAR const void *data,
                             size_t nwords);
-static bool spislave_qfull(FAR struct spi_sctrlr_s *sctrlr);
-static void spislave_qflush(FAR struct spi_sctrlr_s *sctrlr);
-static size_t spislave_qpoll(FAR struct spi_sctrlr_s *sctrlr);
+static bool spislave_qfull(FAR struct spi_slave_ctrlr_s *ctrlr);
+static void spislave_qflush(FAR struct spi_slave_ctrlr_s *ctrlr);
+static size_t spislave_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr);
 
 /****************************************************************************
  * Private Data
@@ -257,7 +257,7 @@ static const struct spislave_config_s esp32c3_spi2slave_config =
   .clk_outsig   = FSPICLK_OUT_IDX
 };
 
-static const struct spi_sctrlrops_s esp32c3_spi2slave_ops =
+static const struct spi_slave_ctrlrops_s esp32c3_spi2slave_ops =
 {
   .bind     = spislave_bind,
   .unbind   = spislave_unbind,
@@ -269,11 +269,11 @@ static const struct spi_sctrlrops_s esp32c3_spi2slave_ops =
 
 static struct spislave_priv_s esp32c3_spi2slave_priv =
 {
-  .sctrlr        =
+  .ctrlr         =
                   {
                     .ops = &esp32c3_spi2slave_ops
                   },
-  .sdev          = NULL,
+  .dev           = NULL,
   .config        = &esp32c3_spi2slave_config,
   .refs          = 0,
   .cpuint        = -ENOMEM,
@@ -403,21 +403,21 @@ static inline void spislave_dma_rx_fifo_reset(void)
  * Name: spislave_setmode
  *
  * Description:
- *   Set the SPI mode.
+ *   Set the SPI Slave mode.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
- *   mode   - Requested SPI Slave mode
+ *   ctrlr - SPI Slave controller interface instance
+ *   mode  - Requested SPI Slave mode
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-static void spislave_setmode(FAR struct spi_sctrlr_s *sctrlr,
-                             enum spi_smode_e mode)
+static void spislave_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
+                             enum spi_slave_mode_e mode)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
 
   spiinfo("mode=%d\n", mode);
 
@@ -490,17 +490,17 @@ static void spislave_setmode(FAR struct spi_sctrlr_s *sctrlr,
  *   Set the number of bits per word.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
- *   nbits  - The number of bits in an SPI word
+ *   ctrlr - SPI Slave controller interface instance
+ *   nbits - The number of bits in an SPI word
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-static void spislave_setbits(FAR struct spi_sctrlr_s *sctrlr, int nbits)
+static void spislave_setbits(FAR struct spi_slave_ctrlr_s *ctrlr, int nbits)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -531,7 +531,7 @@ static int spislave_cs_interrupt(int irq, void *context, FAR void *arg)
   if (priv->is_processing)
     {
       priv->is_processing = false;
-      SPI_SDEV_SELECT(priv->sdev, false);
+      SPIS_DEV_SELECT(priv->dev, false);
     }
 
   return 0;
@@ -857,7 +857,7 @@ static int spislave_periph_interrupt(int irq, void *context, FAR void *arg)
 
   if (!priv->is_processing)
     {
-      SPI_SDEV_SELECT(priv->sdev, true);
+      SPIS_DEV_SELECT(priv->dev, true);
       priv->is_processing = true;
     }
 
@@ -882,7 +882,7 @@ static int spislave_periph_interrupt(int irq, void *context, FAR void *arg)
   if (priv->is_processing && esp32c3_gpioread(priv->config->cs_pin))
     {
       priv->is_processing = false;
-      SPI_SDEV_SELECT(priv->sdev, false);
+      SPIS_DEV_SELECT(priv->dev, false);
     }
 
   /* Clear the trans_done interrupt flag */
@@ -953,19 +953,19 @@ void spislave_dma_init(FAR struct spislave_priv_s *priv)
  *   Initialize ESP32-C3 SPI Slave hardware interface.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-static void spislave_initialize(FAR struct spi_sctrlr_s *sctrlr)
+static void spislave_initialize(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
   const struct spislave_config_s *config = priv->config;
 
-  spiinfo("sctrlr=%p\n", sctrlr);
+  spiinfo("ctrlr=%p\n", ctrlr);
 
   esp32c3_gpiowrite(config->cs_pin, 1);
   esp32c3_gpiowrite(config->mosi_pin, 1);
@@ -1045,16 +1045,16 @@ static void spislave_initialize(FAR struct spi_sctrlr_s *sctrlr)
  *   Deinitialize ESP32-C3 SPI Slave hardware interface.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-static void spislave_deinitialize(FAR struct spi_sctrlr_s *sctrlr)
+static void spislave_deinitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
 
   esp32c3_gpioirqdisable(ESP32C3_PIN2IRQ(priv->config->cs_pin));
 
@@ -1087,10 +1087,10 @@ static void spislave_deinitialize(FAR struct spi_sctrlr_s *sctrlr)
  *   transfers.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
- *   sdev   - SPI Slave device interface instance
- *   mode   - The SPI mode requested
- *   nbits  - The number of bits requests.
+ *   ctrlr - SPI Slave controller interface instance
+ *   dev   - SPI Slave device interface instance
+ *   mode  - The SPI mode requested
+ *   nbits - The number of bits requests.
  *            If value is greater than 0, then it implies MSB first
  *            If value is less than 0, then it implies LSB first with -nbits
  *
@@ -1103,41 +1103,41 @@ static void spislave_deinitialize(FAR struct spi_sctrlr_s *sctrlr)
  *
  ****************************************************************************/
 
-static void spislave_bind(FAR struct spi_sctrlr_s *sctrlr,
-                          FAR struct spi_sdev_s *sdev,
-                          enum spi_smode_e mode,
+static void spislave_bind(FAR struct spi_slave_ctrlr_s *ctrlr,
+                          FAR struct spi_slave_dev_s *dev,
+                          enum spi_slave_mode_e mode,
                           int nbits)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
   FAR const void *data = NULL;
   irqstate_t flags;
   size_t num_words;
 
-  spiinfo("sctrlr=%p sdev=%p mode=%d nbits=%d\n", sctrlr, sdev, mode, nbits);
+  spiinfo("ctrlr=%p dev=%p mode=%d nbits=%d\n", ctrlr, dev, mode, nbits);
 
   DEBUGASSERT(priv != NULL);
-  DEBUGASSERT(priv->sdev == NULL);
-  DEBUGASSERT(sdev != NULL);
+  DEBUGASSERT(priv->dev == NULL);
+  DEBUGASSERT(dev != NULL);
   DEBUGASSERT(nbits > 0);
 
   flags = enter_critical_section();
 
-  priv->sdev = sdev;
+  priv->dev = dev;
 
-  SPI_SDEV_SELECT(sdev, false);
+  SPIS_DEV_SELECT(dev, false);
 
-  SPI_SDEV_CMDDATA(sdev, false);
+  SPIS_DEV_CMDDATA(dev, false);
 
   priv->rx_length = 0;
   priv->tx_length = 0;
   priv->is_tx_enabled = false;
 
-  spislave_initialize(sctrlr);
+  spislave_initialize(ctrlr);
 
-  spislave_setmode(sctrlr, mode);
-  spislave_setbits(sctrlr, nbits);
+  spislave_setmode(ctrlr, mode);
+  spislave_setbits(ctrlr, nbits);
 
-  num_words = SPI_SDEV_GETDATA(sdev, &data);
+  num_words = SPIS_DEV_GETDATA(dev, &data);
 
   if (data != NULL && num_words > 0)
     {
@@ -1162,22 +1162,22 @@ static void spislave_bind(FAR struct spi_sctrlr_s *sctrlr,
  *   controller driver to its initial state.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-static void spislave_unbind(FAR struct spi_sctrlr_s *sctrlr)
+static void spislave_unbind(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
 
   DEBUGASSERT(priv != NULL);
-  DEBUGASSERT(priv->sdev != NULL);
+  DEBUGASSERT(priv->dev != NULL);
 
-  spiinfo("Unbinding %p\n", priv->sdev);
+  spiinfo("Unbinding %p\n", priv->dev);
 
   flags = enter_critical_section();
 
@@ -1195,7 +1195,7 @@ static void spislave_unbind(FAR struct spi_sctrlr_s *sctrlr)
 
   resetbits(priv->config->clk_bit, SYSTEM_PERIP_CLK_EN0_REG);
 
-  priv->sdev = NULL;
+  priv->dev = NULL;
 
   leave_critical_section(flags);
 }
@@ -1209,36 +1209,36 @@ static void spislave_unbind(FAR struct spi_sctrlr_s *sctrlr)
  *   effect on any in-process or currently "committed" transfers.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
- *   data   - Pointer to the command/data mode data to be shifted out.
- *            The data width must be aligned to the nbits parameter which was
- *            previously provided to the bind() method.
- *   len    - Number of units of "nbits" wide to enqueue,
- *            "nbits" being the data width previously provided to the bind()
- *            method.
+ *   ctrlr - SPI Slave controller interface instance
+ *   data  - Pointer to the command/data mode data to be shifted out.
+ *           The data width must be aligned to the nbits parameter which was
+ *           previously provided to the bind() method.
+ *   len   - Number of units of "nbits" wide to enqueue,
+ *           "nbits" being the data width previously provided to the bind()
+ *           method.
  *
  * Returned Value:
  *   Number of data items successfully queued, or a negated errno:
- *          - "len" if all the data was successfully queued
- *          - "0..len-1" if queue is full
- *          - "-errno" in any other error
+ *         - "len" if all the data was successfully queued
+ *         - "0..len-1" if queue is full
+ *         - "-errno" in any other error
  *
  ****************************************************************************/
 
-static int spislave_enqueue(FAR struct spi_sctrlr_s *sctrlr,
+static int spislave_enqueue(FAR struct spi_slave_ctrlr_s *ctrlr,
                             FAR const void *data,
                             size_t len)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
   size_t num_bytes = WORDS2BYTES(priv, len);
   size_t bufsize;
   irqstate_t flags;
   int enqueued_words;
 
-  spiinfo("sctrlr=%p, data=%p, num_bytes=%zu\n", sctrlr, data, num_bytes);
+  spiinfo("ctrlr=%p, data=%p, num_bytes=%zu\n", ctrlr, data, num_bytes);
 
   DEBUGASSERT(priv != NULL);
-  DEBUGASSERT(priv->sdev != NULL);
+  DEBUGASSERT(priv->dev != NULL);
 
   flags = enter_critical_section();
 
@@ -1273,23 +1273,23 @@ static int spislave_enqueue(FAR struct spi_sctrlr_s *sctrlr,
  *   additional word to the queue.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   true if the output queue is full, false otherwise.
  *
  ****************************************************************************/
 
-static bool spislave_qfull(FAR struct spi_sctrlr_s *sctrlr)
+static bool spislave_qfull(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
   bool is_full = false;
 
   DEBUGASSERT(priv != NULL);
-  DEBUGASSERT(priv->sdev != NULL);
+  DEBUGASSERT(priv->dev != NULL);
 
-  spiinfo("sctrlr=%p\n", sctrlr);
+  spiinfo("ctrlr=%p\n", ctrlr);
 
   flags = enter_critical_section();
   is_full = priv->tx_length == SPI_SLAVE_BUFSIZE;
@@ -1307,22 +1307,22 @@ static bool spislave_qfull(FAR struct spi_sctrlr_s *sctrlr)
  *   "committed" output values may not be flushed.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-static void spislave_qflush(FAR struct spi_sctrlr_s *sctrlr)
+static void spislave_qflush(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
 
   DEBUGASSERT(priv != NULL);
-  DEBUGASSERT(priv->sdev != NULL);
+  DEBUGASSERT(priv->dev != NULL);
 
-  spiinfo("sctrlr=%p\n", sctrlr);
+  spiinfo("ctrlr=%p\n", ctrlr);
 
   flags = enter_critical_section();
   priv->tx_length = 0;
@@ -1337,7 +1337,7 @@ static void spislave_qflush(FAR struct spi_sctrlr_s *sctrlr)
  *   Tell the controller to output all the receive queue data.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   Number of units of width "nbits" left in the RX queue. If the device
@@ -1345,22 +1345,22 @@ static void spislave_qflush(FAR struct spi_sctrlr_s *sctrlr)
  *
  ****************************************************************************/
 
-static size_t spislave_qpoll(FAR struct spi_sctrlr_s *sctrlr)
+static size_t spislave_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
   uint32_t tmp;
   uint32_t recv_n;
   size_t remaining_words;
 
   DEBUGASSERT(priv != NULL);
-  DEBUGASSERT(priv->sdev != NULL);
+  DEBUGASSERT(priv->dev != NULL);
 
-  spiinfo("sctrlr=%p\n", sctrlr);
+  spiinfo("ctrlr=%p\n", ctrlr);
 
   flags = enter_critical_section();
 
-  tmp = SPI_SDEV_RECEIVE(priv->sdev, priv->rx_buffer,
+  tmp = SPIS_DEV_RECEIVE(priv->dev, priv->rx_buffer,
                          BYTES2WORDS(priv, priv->rx_length));
   recv_n = WORDS2BYTES(priv, tmp);
   if (recv_n < priv->rx_length)
@@ -1385,7 +1385,7 @@ static size_t spislave_qpoll(FAR struct spi_sctrlr_s *sctrlr)
 }
 
 /****************************************************************************
- * Name: esp32c3_spislave_sctrlr_initialize
+ * Name: esp32c3_spislave_ctrlr_initialize
  *
  * Description:
  *   Initialize the selected SPI Slave bus.
@@ -1399,9 +1399,9 @@ static size_t spislave_qpoll(FAR struct spi_sctrlr_s *sctrlr)
  *
  ****************************************************************************/
 
-FAR struct spi_sctrlr_s *esp32c3_spislave_sctrlr_initialize(int port)
+FAR struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port)
 {
-  FAR struct spi_sctrlr_s *spislave_dev;
+  FAR struct spi_slave_ctrlr_s *spislave_dev;
   FAR struct spislave_priv_s *priv;
   irqstate_t flags;
 
@@ -1416,7 +1416,7 @@ FAR struct spi_sctrlr_s *esp32c3_spislave_sctrlr_initialize(int port)
         return NULL;
     }
 
-  spislave_dev = (FAR struct spi_sctrlr_s *)priv;
+  spislave_dev = (FAR struct spi_slave_ctrlr_s *)priv;
 
   flags = enter_critical_section();
 
@@ -1471,25 +1471,25 @@ FAR struct spi_sctrlr_s *esp32c3_spislave_sctrlr_initialize(int port)
 }
 
 /****************************************************************************
- * Name: esp32c3_spislave_sctrlr_uninitialize
+ * Name: esp32c3_spislave_ctrlr_uninitialize
  *
  * Description:
  *   Uninitialize an SPI Slave bus.
  *
  * Input Parameters:
- *   sctrlr - SPI Slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   Zero (OK) is returned on success. Otherwise -1 (ERROR).
  *
  ****************************************************************************/
 
-int esp32c3_spislave_sctrlr_uninitialize(FAR struct spi_sctrlr_s *sctrlr)
+int esp32c3_spislave_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)sctrlr;
+  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
 
-  DEBUGASSERT(sctrlr != NULL);
+  DEBUGASSERT(ctrlr != NULL);
 
   if (priv->refs == 0)
     {
@@ -1508,7 +1508,7 @@ int esp32c3_spislave_sctrlr_uninitialize(FAR struct spi_sctrlr_s *sctrlr)
   esp32c3_free_cpuint(priv->config->periph);
   priv->cpuint = -ENOMEM;
 
-  spislave_deinitialize(sctrlr);
+  spislave_deinitialize(ctrlr);
 
   leave_critical_section(flags);
 

--- a/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
@@ -27,6 +27,7 @@
 #if defined(CONFIG_ESP32C3_SPI) && defined(CONFIG_SPI_SLAVE)
 
 #include <assert.h>
+#include <debug.h>
 #include <sys/types.h>
 #include <inttypes.h>
 #include <stdint.h>

--- a/arch/xtensa/src/esp32/esp32_spi.h
+++ b/arch/xtensa/src/esp32/esp32_spi.h
@@ -121,7 +121,7 @@ int esp32_spi3_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
 int esp32_spibus_uninitialize(FAR struct spi_dev_s *dev);
 
 /****************************************************************************
- * Name: esp32_spislv_sctrlr_initialize
+ * Name: esp32_spislv_ctrlr_initialize
  *
  * Description:
  *   Initialize the selected SPI slave bus
@@ -134,23 +134,23 @@ int esp32_spibus_uninitialize(FAR struct spi_dev_s *dev);
  *
  ****************************************************************************/
 
-FAR struct spi_sctrlr_s *esp32_spislv_sctrlr_initialize(int port);
+FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port);
 
 /****************************************************************************
- * Name: esp32_spislv_sctrlr_uninitialize
+ * Name: esp32_spislv_ctrlr_uninitialize
  *
  * Description:
  *   Uninitialize an SPI slave bus
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI slave controller interface instance
  *
  * Returned Value:
  *   OK if success or fail
  *
  ****************************************************************************/
 
-int esp32_spislv_sctrlr_uninitialize(FAR struct spi_sctrlr_s *sctrlr);
+int esp32_spislv_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr);
 
 #endif /* CONFIG_ESP32_SPI */
 

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -128,9 +128,11 @@ struct esp32_spislv_priv_s
 {
   /* Externally visible part of the SPI slave controller interface */
 
-  struct spi_sctrlr_s sctrlr;
+  struct spi_slave_ctrlr_s ctrlr;
 
-  struct spi_sdev_s   *sdev;    /* Externally visible part of the SPI interface */
+  /* Externally visible part of the SPI interface */
+
+  struct spi_slave_dev_s   *dev;
 
   const struct esp32_spislv_config_s *config; /* Port configuration */
 
@@ -167,22 +169,23 @@ struct esp32_spislv_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static void esp32_spislv_setmode(FAR struct spi_sctrlr_s *dev,
+static void esp32_spislv_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
                                  enum spi_mode_e mode);
-static void esp32_spislv_setbits(FAR struct spi_sctrlr_s *dev, int nbits);
+static void esp32_spislv_setbits(FAR struct spi_slave_ctrlr_s *ctrlr,
+                                 int nbits);
 static int esp32_spislv_interrupt(int irq, void *context, FAR void *arg);
-static void esp32_spislv_initialize(FAR struct spi_sctrlr_s *dev);
-static void esp32_spislv_bind(struct spi_sctrlr_s *sctrlr,
-                              struct spi_sdev_s *sdev,
-                              enum spi_smode_e mode,
+static void esp32_spislv_initialize(FAR struct spi_slave_ctrlr_s *ctrlr);
+static void esp32_spislv_bind(struct spi_slave_ctrlr_s *ctrlr,
+                              struct spi_slave_dev_s *dev,
+                              enum spi_slave_mode_e mode,
                               int nbits);
-static void esp32_spislv_unbind(struct spi_sctrlr_s *sctrlr);
-static int esp32_spislv_enqueue(struct spi_sctrlr_s *sctrlr,
+static void esp32_spislv_unbind(struct spi_slave_ctrlr_s *ctrlr);
+static int esp32_spislv_enqueue(struct spi_slave_ctrlr_s *ctrlr,
                                 FAR const void *data,
                                 size_t nwords);
-static bool esp32_spislv_qfull(struct spi_sctrlr_s *sctrlr);
-static void esp32_spislv_qflush(struct spi_sctrlr_s *sctrlr);
-static size_t esp32_spislv_qpoll(FAR struct spi_sctrlr_s *sctrlr);
+static bool esp32_spislv_qfull(struct spi_slave_ctrlr_s *ctrlr);
+static void esp32_spislv_qflush(struct spi_slave_ctrlr_s *ctrlr);
+static size_t esp32_spislv_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr);
 
 /****************************************************************************
  * Private Data
@@ -221,7 +224,7 @@ static const struct esp32_spislv_config_s esp32_spi2_config =
   .clk_outsig   = HSPICLK_OUT_IDX
 };
 
-static const struct spi_sctrlrops_s esp32_spi2slv_ops =
+static const struct spi_slave_ctrlrops_s esp32_spi2slv_ops =
 {
   .bind     = esp32_spislv_bind,
   .unbind   = esp32_spislv_unbind,
@@ -233,7 +236,7 @@ static const struct spi_sctrlrops_s esp32_spi2slv_ops =
 
 static struct esp32_spislv_priv_s esp32_spi2slv_priv =
 {
-  .sctrlr =
+  .ctrlr =
               {
                 .ops = &esp32_spi2slv_ops
               },
@@ -275,7 +278,7 @@ static const struct esp32_spislv_config_s esp32_spi3_config =
   .clk_outsig   = VSPICLK_OUT_MUX_IDX
 };
 
-static const struct spi_sctrlrops_s esp32_spi3slv_ops =
+static const struct spi_slave_ctrlrops_s esp32_spi3slv_ops =
 {
   .bind     = esp32_spislv_bind,
   .unbind   = esp32_spislv_unbind,
@@ -287,7 +290,7 @@ static const struct spi_sctrlrops_s esp32_spi3slv_ops =
 
 static struct esp32_spislv_priv_s esp32_spi3slv_priv =
 {
-  .sctrlr =
+  .ctrlr =
               {
                 .ops = &esp32_spi3slv_ops
               },
@@ -446,18 +449,18 @@ static inline bool esp32_spi_iomux(struct esp32_spislv_priv_s *priv)
  * Name: esp32_spislv_setmode
  *
  * Description:
- *   Set the SPI mode.
+ *   Set the SPI Slave mode.
  *
  * Input Parameters:
- *   dev -  Device-specific state data
- *   mode - The SPI mode requested
+ *   ctrlr - SPI Slave controller interface instance
+ *   mode  - Requested SPI Slave mode
  *
  * Returned Value:
- *   none
+ *   None.
  *
  ****************************************************************************/
 
-static void esp32_spislv_setmode(FAR struct spi_sctrlr_s *dev,
+static void esp32_spislv_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
                                  enum spi_mode_e mode)
 {
   uint32_t ck_idle_edge;
@@ -466,7 +469,7 @@ static void esp32_spislv_setmode(FAR struct spi_sctrlr_s *dev,
   uint32_t miso_delay_num;
   uint32_t mosi_delay_mode;
   uint32_t mosi_delay_num;
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)dev;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
 
   spiinfo("mode=%d\n", mode);
 
@@ -575,20 +578,21 @@ static void esp32_spislv_setmode(FAR struct spi_sctrlr_s *dev,
  * Name: esp32_spislv_setbits
  *
  * Description:
- *   Set the number if bits per word.
+ *   Set the number of bits per word.
  *
  * Input Parameters:
- *   dev -  Device-specific state data
- *   nbits - The number of bits in an SPI word.
+ *   ctrlr - SPI Slave controller interface instance
+ *   nbits - The number of bits in an SPI word
  *
  * Returned Value:
- *   none
+ *   None.
  *
  ****************************************************************************/
 
-static void esp32_spislv_setbits(FAR struct spi_sctrlr_s *dev, int nbits)
+static void esp32_spislv_setbits(FAR struct spi_slave_ctrlr_s *ctrlr,
+                                 int nbits)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)dev;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -619,7 +623,7 @@ static int esp32_io_interrupt(int irq, void *context, FAR void *arg)
   if (priv->process == true)
     {
       priv->process = false;
-      SPI_SDEV_SELECT(priv->sdev, false);
+      SPIS_DEV_SELECT(priv->dev, false);
     }
 
   return 0;
@@ -677,7 +681,7 @@ static void esp32_spislv_tx(struct esp32_spislv_priv_s *priv)
  *
  * Description:
  *   Process SPI slave RX. Process SPI slave device receive callback by
- *   calling SPI_SDEV_RECEIVE and prepare for next RX.
+ *   calling SPIS_DEV_RECEIVE and prepare for next RX.
  *
  *   DMA mode : Initialize register to prepare for RX
  *
@@ -695,7 +699,7 @@ static void esp32_spislv_rx(struct esp32_spislv_priv_s *priv)
   uint32_t recv_n;
   uint32_t regval;
 
-  tmp = SPI_SDEV_RECEIVE(priv->sdev, priv->rxbuffer,
+  tmp = SPIS_DEV_RECEIVE(priv->dev, priv->rxbuffer,
                          BYTES2WORDS(priv, priv->rxlen));
   recv_n = WORDS2BYTES(priv, tmp);
 
@@ -770,7 +774,7 @@ static int esp32_spislv_interrupt(int irq, void *context, FAR void *arg)
 
   if (priv->process == false)
     {
-      SPI_SDEV_SELECT(priv->sdev, true);
+      SPIS_DEV_SELECT(priv->dev, true);
       priv->process = true;
     }
 
@@ -824,7 +828,7 @@ static int esp32_spislv_interrupt(int irq, void *context, FAR void *arg)
   if (priv->process == true && esp32_gpioread(priv->config->cs_pin))
     {
       priv->process = false;
-      SPI_SDEV_SELECT(priv->sdev, false);
+      SPIS_DEV_SELECT(priv->dev, false);
     }
 
   return 0;
@@ -834,19 +838,19 @@ static int esp32_spislv_interrupt(int irq, void *context, FAR void *arg)
  * Name: esp32_spislv_initialize
  *
  * Description:
- *   Initialize ESP32 SPI hardware interface
+ *   Initialize ESP32 SPI Slave hardware interface
  *
  * Input Parameters:
- *   dev      - Device-specific state data
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-static void esp32_spislv_initialize(FAR struct spi_sctrlr_s *dev)
+static void esp32_spislv_initialize(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)dev;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   const struct esp32_spislv_config_s *config = priv->config;
   uint32_t regval;
 
@@ -931,8 +935,8 @@ static void esp32_spislv_initialize(FAR struct spi_sctrlr_s *dev)
       esp32_spi_set_reg(priv, SPI_SLV_RDBUF_DLEN_OFFSET, 256 - 1);
     }
 
-  esp32_spislv_setmode(dev, config->mode);
-  esp32_spislv_setbits(dev, 8);
+  esp32_spislv_setmode(ctrlr, config->mode);
+  esp32_spislv_setbits(ctrlr, 8);
 
   esp32_spi_set_regbits(priv, SPI_SLAVE_OFFSET, SPI_SYNC_RESET_M);
   esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_SYNC_RESET_M);
@@ -946,19 +950,19 @@ static void esp32_spislv_initialize(FAR struct spi_sctrlr_s *dev)
  * Name: esp32_spislv_deinit
  *
  * Description:
- *   Deinitialize ESP32 SPI hardware interface
+ *   Deinitialize ESP32 SPI Slave hardware interface
  *
  * Input Parameters:
- *   dev      - Device-specific state data
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-static void esp32_spislv_deinit(FAR struct spi_sctrlr_s *dev)
+static void esp32_spislv_deinit(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)dev;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
 
   esp32_gpioirqdisable(ESP32_PIN2IRQ(priv->config->cs_pin));
   esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_INT_EN_M);
@@ -985,45 +989,45 @@ static void esp32_spislv_deinit(FAR struct spi_sctrlr_s *dev)
  *   transfers.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
- *   sdev   - SPI slave device interface instance
- *   mode   - The SPI mode requested
- *   nbits  - The number of bits requests
+ *   ctrlr - SPI slave controller interface instance
+ *   dev   - SPI slave device interface instance
+ *   mode  - The SPI Slave mode requested
+ *   nbits - The number of bits requested
  *
  * Returned Value:
  *   none
  *
  ****************************************************************************/
 
-static void esp32_spislv_bind(struct spi_sctrlr_s *sctrlr,
-                              struct spi_sdev_s *sdev,
-                              enum spi_smode_e mode,
+static void esp32_spislv_bind(struct spi_slave_ctrlr_s *ctrlr,
+                              struct spi_slave_dev_s *dev,
+                              enum spi_slave_mode_e mode,
                               int nbits)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)sctrlr;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   irqstate_t flags;
 
-  spiinfo("sdev=%p mode=%d nbits=%d\n", sdev, mode, nbits);
+  spiinfo("dev=%p mode=%d nbits=%d\n", dev, mode, nbits);
 
-  DEBUGASSERT(priv != NULL && priv->sdev == NULL && sdev != NULL);
+  DEBUGASSERT(priv != NULL && priv->dev == NULL && dev != NULL);
 
   flags = enter_critical_section();
 
-  priv->sdev = sdev;
+  priv->dev = dev;
 
-  SPI_SDEV_SELECT(sdev, false);
+  SPIS_DEV_SELECT(dev, false);
 
-  SPI_SDEV_CMDDATA(sdev, false);
+  SPIS_DEV_CMDDATA(dev, false);
 
   priv->rxlen = 0;
 
   priv->txlen = 0;
   priv->txen  = false;
 
-  esp32_spislv_initialize(sctrlr);
+  esp32_spislv_initialize(ctrlr);
 
-  esp32_spislv_setmode(sctrlr, mode);
-  esp32_spislv_setbits(sctrlr, nbits);
+  esp32_spislv_setmode(ctrlr, mode);
+  esp32_spislv_setbits(ctrlr, nbits);
 
   up_enable_irq(priv->cpuint);
 
@@ -1041,23 +1045,23 @@ static void esp32_spislv_bind(struct spi_sctrlr_s *sctrlr,
  *   controller driver to its initial state,
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI slave controller interface instance
  *
  * Returned Value:
  *   none
  *
  ****************************************************************************/
 
-static void esp32_spislv_unbind(struct spi_sctrlr_s *sctrlr)
+static void esp32_spislv_unbind(struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)sctrlr;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   irqstate_t flags;
 
   DEBUGASSERT(priv != NULL);
 
-  spiinfo("Unbinding %p\n", priv->sdev);
+  spiinfo("Unbinding %p\n", priv->dev);
 
-  DEBUGASSERT(priv->sdev != NULL);
+  DEBUGASSERT(priv->dev != NULL);
 
   flags = enter_critical_section();
 
@@ -1072,7 +1076,7 @@ static void esp32_spislv_unbind(struct spi_sctrlr_s *sctrlr)
 
   modifyreg32(DPORT_PERIP_CLK_EN_REG, priv->config->clk_bit, 0);
 
-  priv->sdev = NULL;
+  priv->dev = NULL;
 
   leave_critical_section(flags);
 }
@@ -1086,7 +1090,7 @@ static void esp32_spislv_unbind(struct spi_sctrlr_s *sctrlr)
  *   effect on anyin-process or currently "committed" transfers
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI slave controller interface instance
  *   data   - Command/data mode data value to be shifted out.  The width of
  *            the data must be the same as the nbits parameter previously
  *            provided to the bind() methods.
@@ -1098,19 +1102,19 @@ static void esp32_spislv_unbind(struct spi_sctrlr_s *sctrlr)
  *
  ****************************************************************************/
 
-static int esp32_spislv_enqueue(struct spi_sctrlr_s *sctrlr,
+static int esp32_spislv_enqueue(struct spi_slave_ctrlr_s *ctrlr,
                                 FAR const void *data,
                                 size_t nwords)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)sctrlr;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   size_t n = WORDS2BYTES(priv, nwords);
   size_t bufsize;
   irqstate_t flags;
   int ret;
 
-  spiinfo("spi_enqueue(sctrlr=%p, data=%p, nwords=%d)\n",
-          sctrlr, data, nwords);
-  DEBUGASSERT(priv != NULL && priv->sdev != NULL);
+  spiinfo("spi_enqueue(ctrlr=%p, data=%p, nwords=%d)\n",
+          ctrlr, data, nwords);
+  DEBUGASSERT(priv != NULL && priv->dev != NULL);
 
   flags = enter_critical_section();
 
@@ -1146,22 +1150,22 @@ static int esp32_spislv_enqueue(struct spi_sctrlr_s *sctrlr,
  *   additional word to the queue.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI slave controller interface instance
  *
  * Returned Value:
  *   true if the output wueue is full
  *
  ****************************************************************************/
 
-static bool esp32_spislv_qfull(struct spi_sctrlr_s *sctrlr)
+static bool esp32_spislv_qfull(struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)sctrlr;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   irqstate_t flags;
   bool ret = 0;
 
-  DEBUGASSERT(priv != NULL && priv->sdev != NULL);
+  DEBUGASSERT(priv != NULL && priv->dev != NULL);
 
-  spiinfo("spi_qfull(sctrlr=%p)\n", sctrlr);
+  spiinfo("spi_qfull(ctrlr=%p)\n", ctrlr);
 
   flags = enter_critical_section();
   ret = priv->txlen == SPI_SLAVE_BUFSIZE;
@@ -1179,19 +1183,19 @@ static bool esp32_spislv_qfull(struct spi_sctrlr_s *sctrlr)
  *   "committed" output values may not be flushed.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI slave controller interface instance
  *
  * Returned Value:
  *   None
  *
  ****************************************************************************/
 
-static void esp32_spislv_qflush(struct spi_sctrlr_s *sctrlr)
+static void esp32_spislv_qflush(struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)sctrlr;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   irqstate_t flags;
 
-  DEBUGASSERT(priv != NULL && priv->sdev != NULL);
+  DEBUGASSERT(priv != NULL && priv->dev != NULL);
 
   flags = enter_critical_section();
   priv->rxlen = 0;
@@ -1207,7 +1211,7 @@ static void esp32_spislv_qflush(struct spi_sctrlr_s *sctrlr)
  *   Tell the controller to output all the receive queue data.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI slave controller interface instance
  *
  * Returned Value:
  *   Number of units of width "nbits" left in the rx queue. If the device
@@ -1215,13 +1219,13 @@ static void esp32_spislv_qflush(struct spi_sctrlr_s *sctrlr)
  *
  ****************************************************************************/
 
-static size_t esp32_spislv_qpoll(FAR struct spi_sctrlr_s *sctrlr)
+static size_t esp32_spislv_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)sctrlr;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   irqstate_t flags;
   uint32_t n;
 
-  DEBUGASSERT(priv != NULL && priv->sdev != NULL);
+  DEBUGASSERT(priv != NULL && priv->dev != NULL);
 
   flags = enter_critical_section();
 
@@ -1234,7 +1238,7 @@ static size_t esp32_spislv_qpoll(FAR struct spi_sctrlr_s *sctrlr)
 }
 
 /****************************************************************************
- * Name: esp32_spislv_sctrlr_initialize
+ * Name: esp32_spislv_ctrlr_initialize
  *
  * Description:
  *   Initialize the selected SPI slave bus
@@ -1247,10 +1251,10 @@ static size_t esp32_spislv_qpoll(FAR struct spi_sctrlr_s *sctrlr)
  *
  ****************************************************************************/
 
-FAR struct spi_sctrlr_s *esp32_spislv_sctrlr_initialize(int port)
+FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
 {
   int ret;
-  FAR struct spi_sctrlr_s *spislv_dev;
+  FAR struct spi_slave_ctrlr_s *spislv_dev;
   FAR struct esp32_spislv_priv_s *priv;
   irqstate_t flags;
 
@@ -1270,7 +1274,7 @@ FAR struct spi_sctrlr_s *esp32_spislv_sctrlr_initialize(int port)
         return NULL;
     }
 
-  spislv_dev = (FAR struct spi_sctrlr_s *)priv;
+  spislv_dev = (FAR struct spi_slave_ctrlr_s *)priv;
 
   flags = enter_critical_section();
 
@@ -1328,25 +1332,25 @@ FAR struct spi_sctrlr_s *esp32_spislv_sctrlr_initialize(int port)
 }
 
 /****************************************************************************
- * Name: esp32_spislv_sctrlr_uninitialize
+ * Name: esp32_spislv_ctrlr_uninitialize
  *
  * Description:
  *   Uninitialize an SPI slave bus
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI slave controller interface instance
  *
  * Returned Value:
  *   OK if success or fail
  *
  ****************************************************************************/
 
-int esp32_spislv_sctrlr_uninitialize(FAR struct spi_sctrlr_s *sctrlr)
+int esp32_spislv_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
 {
   irqstate_t flags;
-  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)sctrlr;
+  struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
 
-  DEBUGASSERT(sctrlr);
+  DEBUGASSERT(ctrlr);
 
   if (priv->refs == 0)
     {
@@ -1367,7 +1371,7 @@ int esp32_spislv_sctrlr_uninitialize(FAR struct spi_sctrlr_s *sctrlr)
                           priv->cpuint);
   esp32_free_cpuint(priv->cpuint);
 
-  esp32_spislv_deinit(sctrlr);
+  esp32_spislv_deinit(ctrlr);
 
   leave_critical_section(flags);
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spislavedev.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spislavedev.c
@@ -55,25 +55,25 @@ int board_spislavedev_initialize(int bus)
 {
   int ret;
 
-  FAR struct spi_sctrlr_s *sctrlr;
+  FAR struct spi_slave_ctrlr_s *ctrlr;
 
   spiinfo("Initializing /dev/spislv%d...\n", bus);
 
   /* Initialize SPI Slave controller device */
 
-  sctrlr = esp32c3_spislave_sctrlr_initialize(bus);
-  if (sctrlr == NULL)
+  ctrlr = esp32c3_spislave_ctrlr_initialize(bus);
+  if (ctrlr == NULL)
     {
       spierr("Failed to initialize SPI%d as slave.\n", bus);
       return -ENODEV;
     }
 
-  ret = spislave_register(sctrlr, bus);
+  ret = spi_slave_register(ctrlr, bus);
   if (ret < 0)
     {
       spierr("Failed to register /dev/spislv%d: %d\n", bus, ret);
 
-      esp32c3_spislave_sctrlr_uninitialize(sctrlr);
+      esp32c3_spislave_ctrlr_uninitialize(ctrlr);
     }
 
   return ret;

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -58,15 +58,15 @@
  * Private Types
  ****************************************************************************/
 
-struct spislave_driver_s
+struct spi_slave_driver_s
 {
   /* Externally visible part of the SPI Slave device interface */
 
-  struct spi_sdev_s dev;
+  struct spi_slave_dev_s dev;
 
   /* Reference to SPI Slave controller interface */
 
-  struct spi_sctrlr_s *sctrlr;
+  struct spi_slave_ctrlr_s *ctrlr;
 
   /* Receive buffer */
 
@@ -90,21 +90,23 @@ struct spislave_driver_s
 
 /* Character driver methods */
 
-static int     spislave_open(FAR struct file *filep);
-static int     spislave_close(FAR struct file *filep);
-static ssize_t spislave_read(FAR struct file *filep, FAR char *buffer,
+static int     spi_slave_open(FAR struct file *filep);
+static int     spi_slave_close(FAR struct file *filep);
+static ssize_t spi_slave_read(FAR struct file *filep, FAR char *buffer,
                              size_t buflen);
-static ssize_t spislave_write(FAR struct file *filep, FAR const char *buffer,
-                              size_t buflen);
-static int     spislave_unlink(FAR struct inode *inode);
+static ssize_t spi_slave_write(FAR struct file *filep,
+                               FAR const char *buffer, size_t buflen);
+static int     spi_slave_unlink(FAR struct inode *inode);
 
 /* SPI Slave driver methods */
 
-static void    spislave_select(FAR struct spi_sdev_s *sdev, bool selected);
-static void    spislave_cmddata(FAR struct spi_sdev_s *sdev, bool data);
-static size_t  spislave_getdata(FAR struct spi_sdev_s *sdev,
+static void    spi_slave_select(FAR struct spi_slave_dev_s *sdev,
+                                bool selected);
+static void    spi_slave_cmddata(FAR struct spi_slave_dev_s *sdev,
+                                 bool data);
+static size_t  spi_slave_getdata(FAR struct spi_slave_dev_s *sdev,
                                 FAR const void **data);
-static size_t  spislave_receive(FAR struct spi_sdev_s *sdev,
+static size_t  spi_slave_receive(FAR struct spi_slave_dev_s *sdev,
                                 FAR const void *data, size_t nwords);
 
 /****************************************************************************
@@ -114,28 +116,28 @@ static size_t  spislave_receive(FAR struct spi_sdev_s *sdev,
 static const struct file_operations g_spislavefops =
 {
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  spislave_open,                /* open */
-  spislave_close,               /* close */
+  spi_slave_open,               /* open */
+  spi_slave_close,              /* close */
 #else
   NULL,                         /* open */
   NULL,                         /* close */
 #endif
-  spislave_read,                /* read */
-  spislave_write,               /* write */
+  spi_slave_read,               /* read */
+  spi_slave_write,              /* write */
   NULL,                         /* seek */
   NULL,                         /* ioctl */
   NULL                          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , spislave_unlink             /* unlink */
+  , spi_slave_unlink            /* unlink */
 #endif
 };
 
-static const struct spi_sdevops_s g_spisdev_ops =
+static const struct spi_slave_devops_s g_spisdev_ops =
 {
-  spislave_select,              /* select */
-  spislave_cmddata,             /* cmddata */
-  spislave_getdata,             /* getdata */
-  spislave_receive,             /* receive */
+  spi_slave_select,             /* select */
+  spi_slave_cmddata,            /* cmddata */
+  spi_slave_getdata,            /* getdata */
+  spi_slave_receive,            /* receive */
 };
 
 /****************************************************************************
@@ -143,7 +145,7 @@ static const struct spi_sdevops_s g_spisdev_ops =
  ****************************************************************************/
 
 /****************************************************************************
- * Name: spislave_open
+ * Name: spi_slave_open
  *
  * Description:
  *   This function is called whenever the SPI Slave device is opened.
@@ -158,10 +160,10 @@ static const struct spi_sdevops_s g_spisdev_ops =
  ****************************************************************************/
 
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-static int spislave_open(FAR struct file *filep)
+static int spi_slave_open(FAR struct file *filep)
 {
   FAR struct inode *inode;
-  FAR struct spislave_driver_s *priv;
+  FAR struct spi_slave_driver_s *priv;
   int ret;
 
   DEBUGASSERT(filep != NULL);
@@ -173,7 +175,7 @@ static int spislave_open(FAR struct file *filep)
   /* Get our private data structure */
 
   inode = filep->f_inode;
-  priv = (FAR struct spislave_driver_s *)inode->i_private;
+  priv = (FAR struct spi_slave_driver_s *)inode->i_private;
 
   /* Get exclusive access to the SPI Slave driver state structure */
 
@@ -195,7 +197,7 @@ static int spislave_open(FAR struct file *filep)
 #endif
 
 /****************************************************************************
- * Name: spislave_close
+ * Name: spi_slave_close
  *
  * Description:
  *   This routine is called when the SPI Slave device is closed.
@@ -210,10 +212,10 @@ static int spislave_open(FAR struct file *filep)
  ****************************************************************************/
 
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-static int spislave_close(FAR struct file *filep)
+static int spi_slave_close(FAR struct file *filep)
 {
   FAR struct inode *inode;
-  FAR struct spislave_driver_s *priv;
+  FAR struct spi_slave_driver_s *priv;
   int ret;
 
   DEBUGASSERT(filep != NULL);
@@ -225,7 +227,7 @@ static int spislave_close(FAR struct file *filep)
   /* Get our private data structure */
 
   inode = filep->f_inode;
-  priv = (FAR struct spislave_driver_s *)inode->i_private;
+  priv = (FAR struct spi_slave_driver_s *)inode->i_private;
 
   /* Get exclusive access to the SPI Slave driver state structure */
 
@@ -259,7 +261,7 @@ static int spislave_close(FAR struct file *filep)
 #endif
 
 /****************************************************************************
- * Name: spislave_read
+ * Name: spi_slave_read
  *
  * Description:
  *   This routine is called when the application requires to read the data
@@ -276,11 +278,11 @@ static int spislave_close(FAR struct file *filep)
  *
  ****************************************************************************/
 
-static ssize_t spislave_read(FAR struct file *filep, FAR char *buffer,
+static ssize_t spi_slave_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen)
 {
   FAR struct inode *inode;
-  FAR struct spislave_driver_s *priv;
+  FAR struct spi_slave_driver_s *priv;
   size_t read_bytes;
   size_t remaining_words;
 
@@ -289,7 +291,7 @@ static ssize_t spislave_read(FAR struct file *filep, FAR char *buffer,
   /* Get our private data structure */
 
   inode = filep->f_inode;
-  priv  = (FAR struct spislave_driver_s *)inode->i_private;
+  priv  = (FAR struct spi_slave_driver_s *)inode->i_private;
 
   if (buffer == NULL)
     {
@@ -297,7 +299,7 @@ static ssize_t spislave_read(FAR struct file *filep, FAR char *buffer,
       return -ENOBUFS;
     }
 
-  remaining_words = SPI_SCTRLR_QPOLL(priv->sctrlr);
+  remaining_words = SPIS_CTRLR_QPOLL(priv->ctrlr);
   if (remaining_words == 0)
     {
       spiinfo("All words retrieved!\n");
@@ -315,7 +317,7 @@ static ssize_t spislave_read(FAR struct file *filep, FAR char *buffer,
 }
 
 /****************************************************************************
- * Name: spislave_write
+ * Name: spi_slave_write
  *
  * Description:
  *   This routine is called when the application needs to enqueue data to be
@@ -332,11 +334,11 @@ static ssize_t spislave_read(FAR struct file *filep, FAR char *buffer,
  *
  ****************************************************************************/
 
-static ssize_t spislave_write(FAR struct file *filep, FAR const char *buffer,
-                            size_t buflen)
+static ssize_t spi_slave_write(FAR struct file *filep,
+                               FAR const char *buffer, size_t buflen)
 {
   FAR struct inode *inode;
-  FAR struct spislave_driver_s *priv;
+  FAR struct spi_slave_driver_s *priv;
   size_t num_words;
   size_t enqueued_bytes;
 
@@ -345,13 +347,13 @@ static ssize_t spislave_write(FAR struct file *filep, FAR const char *buffer,
   /* Get our private data structure */
 
   inode = filep->f_inode;
-  priv = (FAR struct spislave_driver_s *)inode->i_private;
+  priv = (FAR struct spi_slave_driver_s *)inode->i_private;
 
   memcpy(priv->tx_buffer, buffer, buflen);
   priv->tx_length = buflen;
   num_words = BYTES2WORDS(priv->tx_length);
 
-  enqueued_bytes = WORDS2BYTES(SPI_SCTRLR_ENQUEUE(priv->sctrlr,
+  enqueued_bytes = WORDS2BYTES(SPIS_CTRLR_ENQUEUE(priv->ctrlr,
                                                   priv->tx_buffer,
                                                   num_words));
 
@@ -361,7 +363,7 @@ static ssize_t spislave_write(FAR struct file *filep, FAR const char *buffer,
 }
 
 /****************************************************************************
- * Name: spislave_unlink
+ * Name: spi_slave_unlink
  *
  * Description:
  *   This routine is called when the SPI Slave device is unlinked.
@@ -375,9 +377,9 @@ static ssize_t spislave_write(FAR struct file *filep, FAR const char *buffer,
  ****************************************************************************/
 
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-static int spislave_unlink(FAR struct inode *inode)
+static int spi_slave_unlink(FAR struct inode *inode)
 {
-  FAR struct spislave_driver_s *priv;
+  FAR struct spi_slave_driver_s *priv;
   int ret;
 
   DEBUGASSERT(inode != NULL);
@@ -385,7 +387,7 @@ static int spislave_unlink(FAR struct inode *inode)
 
   /* Get our private data structure */
 
-  priv = (FAR struct spislave_driver_s *)inode->i_private;
+  priv = (FAR struct spi_slave_driver_s *)inode->i_private;
 
   /* Get exclusive access to the SPI Slave driver state structure */
 
@@ -417,14 +419,14 @@ static int spislave_unlink(FAR struct inode *inode)
 #endif
 
 /****************************************************************************
- * Name: spislave_select
+ * Name: spi_slave_select
  *
  * Description:
  *   This is a SPI device callback that is used when the SPI controller
  *   driver detects any change in the chip select pin.
  *
  * Input Parameters:
- *   sdev     - SPI device interface instance
+ *   dev      - SPI Slave device interface instance
  *   selected - Indicates whether the chip select is in active state
  *
  * Returned Value:
@@ -436,13 +438,13 @@ static int spislave_unlink(FAR struct inode *inode)
  *
  ****************************************************************************/
 
-static void spislave_select(FAR struct spi_sdev_s *sdev, bool selected)
+static void spi_slave_select(FAR struct spi_slave_dev_s *dev, bool selected)
 {
-  spiinfo("sdev: %p CS: %s\n", sdev, selected ? "select" : "free");
+  spiinfo("sdev: %p CS: %s\n", dev, selected ? "select" : "free");
 }
 
 /****************************************************************************
- * Name: spislave_cmddata
+ * Name: spi_slave_cmddata
  *
  * Description:
  *   This is a SPI device callback that is used when the SPI controller
@@ -455,7 +457,7 @@ static void spislave_select(FAR struct spi_sdev_s *sdev, bool selected)
  *   current command/data selection.
  *
  * Input Parameters:
- *   sdev - SPI device interface instance
+ *   dev  - SPI Slave device interface instance
  *   data - True: Data is selected
  *
  * Returned Value:
@@ -467,13 +469,13 @@ static void spislave_select(FAR struct spi_sdev_s *sdev, bool selected)
  *
  ****************************************************************************/
 
-static void spislave_cmddata(FAR struct spi_sdev_s *sdev, bool data)
+static void spi_slave_cmddata(FAR struct spi_slave_dev_s *dev, bool data)
 {
-  spiinfo("sdev: %p CMD: %s\n", sdev, data ? "data" : "command");
+  spiinfo("sdev: %p CMD: %s\n", dev, data ? "data" : "command");
 }
 
 /****************************************************************************
- * Name: spislave_getdata
+ * Name: spi_slave_getdata
  *
  * Description:
  *   This is a SPI device callback that is used when the SPI controller
@@ -486,7 +488,7 @@ static void spislave_cmddata(FAR struct spi_sdev_s *sdev, bool data)
  *   method. Normally only LCD devices distinguish command and data.
  *
  * Input Parameters:
- *   sdev - SPI device interface instance
+ *   dev  - SPI Slave device interface instance
  *   data - Pointer to the data buffer pointer to be shifed out.
  *          The device will set the data buffer pointer to the actual data
  *
@@ -499,10 +501,10 @@ static void spislave_cmddata(FAR struct spi_sdev_s *sdev, bool data)
  *
  ****************************************************************************/
 
-static size_t spislave_getdata(FAR struct spi_sdev_s *sdev,
-                             FAR const void **data)
+static size_t spi_slave_getdata(FAR struct spi_slave_dev_s *dev,
+                                FAR const void **data)
 {
-  FAR struct spislave_driver_s *priv = (FAR struct spislave_driver_s *)sdev;
+  FAR struct spi_slave_driver_s *priv = (FAR struct spi_slave_driver_s *)dev;
 
   *data = priv->tx_buffer;
 
@@ -510,7 +512,7 @@ static size_t spislave_getdata(FAR struct spi_sdev_s *sdev,
 }
 
 /****************************************************************************
- * Name: spislave_receive
+ * Name: spi_slave_receive
  *
  * Description:
  *   This is a SPI device callback that is used when the SPI controller
@@ -518,7 +520,7 @@ static size_t spislave_getdata(FAR struct spi_sdev_s *sdev,
  *   synchronization by several words.
  *
  * Input Parameters:
- *   sdev - SPI device interface instance
+ *   dev  - SPI Slave device interface instance
  *   data - Pointer to the new data that has been shifted in
  *   len  - Length of the new data in units of nbits wide,
  *          nbits being the data width previously provided to the bind()
@@ -536,10 +538,10 @@ static size_t spislave_getdata(FAR struct spi_sdev_s *sdev,
  *
  ****************************************************************************/
 
-static size_t spislave_receive(FAR struct spi_sdev_s *sdev,
-                             FAR const void *data, size_t len)
+static size_t spi_slave_receive(FAR struct spi_slave_dev_s *dev,
+                                FAR const void *data, size_t len)
 {
-  FAR struct spislave_driver_s *priv = (FAR struct spislave_driver_s *)sdev;
+  FAR struct spi_slave_driver_s *priv = (FAR struct spi_slave_driver_s *)dev;
   size_t recv_bytes = MIN(len, sizeof(priv->rx_buffer));
 
   memcpy(priv->rx_buffer, data, recv_bytes);
@@ -554,37 +556,37 @@ static size_t spislave_receive(FAR struct spi_sdev_s *sdev,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: spislave_register
+ * Name: spi_slave_register
  *
  * Description:
- *   Register the SPI Slave character device as 'devpath'.
+ *   Register the SPI Slave character device driver as 'devpath'.
  *
  * Input Parameters:
- *   sctrlr  - An instance of the SPI Slave interface to use to communicate
- *             with the SPI Slave device
- *   bus     - The SPI Slave bus number. This will be used as the SPI device
- *             minor number. The SPI Slave character device will be
- *             registered as /dev/spislvN where N is the minor number
+ *   ctrlr - An instance of the SPI Slave interface to use to communicate
+ *           with the SPI Slave device
+ *   bus   - The SPI Slave bus number. This will be used as the SPI device
+ *           minor number. The SPI Slave character device will be
+ *           registered as /dev/spislvN where N is the minor number
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int spislave_register(FAR struct spi_sctrlr_s *sctrlr, int bus)
+int spi_slave_register(FAR struct spi_slave_ctrlr_s *ctrlr, int bus)
 {
-  FAR struct spislave_driver_s *priv;
+  FAR struct spi_slave_driver_s *priv;
   char devname[DEVNAME_FMTLEN];
   int ret;
 
   /* Sanity check */
 
-  DEBUGASSERT(sctrlr != NULL && (unsigned int)bus < 1000);
+  DEBUGASSERT(ctrlr != NULL && (unsigned int)bus < 1000);
 
   /* Initialize the SPI Slave device structure */
 
-  priv = (FAR struct spislave_driver_s *)
-    kmm_zalloc(sizeof(struct spislave_driver_s));
+  priv = (FAR struct spi_slave_driver_s *)
+    kmm_zalloc(sizeof(struct spi_slave_driver_s));
   if (!priv)
     {
       spierr("ERROR: Failed to allocate instance\n");
@@ -592,7 +594,7 @@ int spislave_register(FAR struct spi_sctrlr_s *sctrlr, int bus)
     }
 
   priv->dev.ops = &g_spisdev_ops;
-  priv->sctrlr = sctrlr;
+  priv->ctrlr = ctrlr;
 
 #ifdef CONFIG_SPI_SLAVE_DRIVER_COLORIZE_TX_BUFFER
   memset(priv->tx_buffer,
@@ -618,7 +620,7 @@ int spislave_register(FAR struct spi_sctrlr_s *sctrlr, int bus)
       kmm_free(priv);
     }
 
-  SPI_SCTRLR_BIND(priv->sctrlr, (FAR struct spi_sdev_s *)priv,
+  SPIS_CTRLR_BIND(priv->ctrlr, (FAR struct spi_slave_dev_s *)priv,
                   CONFIG_SPI_SLAVE_DRIVER_MODE,
                   CONFIG_SPI_SLAVE_DRIVER_WIDTH);
 

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <assert.h>
 #include <debug.h>
 
 #include <nuttx/kmalloc.h>

--- a/include/nuttx/spi/slave.h
+++ b/include/nuttx/spi/slave.h
@@ -45,7 +45,7 @@
 /* Access macros ************************************************************/
 
 /****************************************************************************
- * Name: SPI_SCTRLR_BIND
+ * Name: SPIS_CTRLR_BIND
  *
  * Description:
  *   Bind the SPI slave device interface to the SPI slave controller
@@ -54,22 +54,22 @@
  *   transfers.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
- *   sdev   - SPI slave device interface instance
- *   mode   - The SPI mode requested
- *   nbits  - The number of bits requests.
- *            If value is greater than 0, then it implies MSB first
- *            If value is less than 0, then it implies LSB first with -nbits
+ *   ctrlr - SPI Slave controller interface instance
+ *   dev   - SPI Slave device interface instance
+ *   mode  - The SPI Slave mode requested
+ *   nbits - The number of bits requested.
+ *           If value is greater than 0, then it implies MSB first
+ *           If value is less than 0, then it implies LSB first with -nbits
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-#define SPI_SCTRLR_BIND(c,d,m,n) ((c)->ops->bind(c,d,m,n))
+#define SPIS_CTRLR_BIND(c,d,m,n) ((c)->ops->bind(c,d,m,n))
 
 /****************************************************************************
- * Name: SPI_SCTRLR_UNBIND
+ * Name: SPIS_CTRLR_UNBIND
  *
  * Description:
  *   Un-bind the SPI slave device interface from the SPI slave controller
@@ -77,17 +77,17 @@
  *   controller driver to its initial state.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-#define SPI_SCTRLR_UNBIND(c) ((c)->ops->unbind(c))
+#define SPIS_CTRLR_UNBIND(c) ((c)->ops->unbind(c))
 
 /****************************************************************************
- * Name: SPI_SCTRLR_ENQUEUE
+ * Name: SPIS_CTRLR_ENQUEUE
  *
  * Description:
  *   Enqueue the next value to be shifted out from the interface. This adds
@@ -95,43 +95,43 @@
  *   effect on any in-process or currently "committed" transfers.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
- *   data   - Pointer to the command/data mode data to be shifted out.
- *            The data width must be aligned to the nbits parameter which was
- *            previously provided to the bind() method.
- *   len    - Number of units of "nbits" wide to enqueue,
- *            "nbits" being the data width previously provided to the bind()
- *            method.
+ *   ctrlr - SPI Slave controller interface instance
+ *   data  - Pointer to the command/data mode data to be shifted out.
+ *           The data width must be aligned to the nbits parameter which was
+ *           previously provided to the bind() method.
+ *   len   - Number of units of "nbits" wide to enqueue,
+ *           "nbits" being the data width previously provided to the bind()
+ *           method.
  *
  * Returned Value:
  *   Number of data items successfully queued, or a negated errno:
- *          - "len" if all the data was successfully queued
- *          - "0..len-1" if queue is full
- *          - "-errno" in any other error
+ *         - "len" if all the data was successfully queued
+ *         - "0..len-1" if queue is full
+ *         - "-errno" in any other error
  *
  ****************************************************************************/
 
-#define SPI_SCTRLR_ENQUEUE(c,v,l)  ((c)->ops->enqueue(c,v,l))
+#define SPIS_CTRLR_ENQUEUE(c,v,l)  ((c)->ops->enqueue(c,v,l))
 
 /****************************************************************************
- * Name: SPI_SCTRLR_QFULL
+ * Name: SPIS_CTRLR_QFULL
  *
  * Description:
  *   Return true if the queue is full or false if there is space to add an
  *   additional word to the queue.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   true if the output queue is full, false otherwise.
  *
  ****************************************************************************/
 
-#define SPI_SCTRLR_QFULL(c)  ((c)->ops->qfull(c))
+#define SPIS_CTRLR_QFULL(c)  ((c)->ops->qfull(c))
 
 /****************************************************************************
- * Name: SPI_SCTRLR_QFLUSH
+ * Name: SPIS_CTRLR_QFLUSH
  *
  * Description:
  *   Discard all saved values in the output queue. On return from this
@@ -139,22 +139,22 @@
  *   "committed" output values may not be flushed.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-#define SPI_SCTRLR_QFLUSH(c)  ((c)->ops->qflush(c))
+#define SPIS_CTRLR_QFLUSH(c)  ((c)->ops->qflush(c))
 
 /****************************************************************************
- * Name: SPI_SCTRLR_QPOLL
+ * Name: SPIS_CTRLR_QPOLL
  *
  * Description:
  *   Tell the controller to output all the receive queue data.
  *
- *   This will cause 1..n SPI_SDEV_RECEIVE calls back to the slave device,
+ *   This will cause 1..n SPIS_DEV_RECEIVE calls back to the slave device,
  *   offering blocks of data to the device. From each call, the slave device
  *   driver will return the number of data units it accepted/read out.
  *
@@ -175,7 +175,7 @@
  *   of bytes that was offered to each receive call.
  *
  * Input Parameters:
- *   sctrlr - SPI slave controller interface instance
+ *   ctrlr - SPI Slave controller interface instance
  *
  * Returned Value:
  *   Number of units of width "nbits" left in the RX queue. If the device
@@ -183,17 +183,17 @@
  *
  ****************************************************************************/
 
-#define SPI_SCTRLR_QPOLL(c)  ((c)->ops->qpoll(c))
+#define SPIS_CTRLR_QPOLL(c)  ((c)->ops->qpoll(c))
 
 /****************************************************************************
- * Name: SPI_SDEV_SELECT
+ * Name: SPIS_DEV_SELECT
  *
  * Description:
  *   This is a SPI device callback that is used when the SPI controller
  *   driver detects any change in the chip select pin.
  *
  * Input Parameters:
- *   sdev     - SPI device interface instance
+ *   dev      - SPI Slave device interface instance
  *   selected - Indicates whether the chip select is in active state
  *
  * Returned Value:
@@ -205,10 +205,10 @@
  *
  ****************************************************************************/
 
-#define SPI_SDEV_SELECT(d,s) ((d)->ops->select(d,s))
+#define SPIS_DEV_SELECT(d,s) ((d)->ops->select(d,s))
 
 /****************************************************************************
- * Name: SPI_SDEV_CMDDATA
+ * Name: SPIS_DEV_CMDDATA
  *
  * Description:
  *   This is a SPI device callback that is used when the SPI controller
@@ -221,7 +221,7 @@
  *   current command/data selection.
  *
  * Input Parameters:
- *   sdev - SPI device interface instance
+ *   dev  - SPI Slave device interface instance
  *   data - True: Data is selected
  *
  * Returned Value:
@@ -233,10 +233,10 @@
  *
  ****************************************************************************/
 
-#define SPI_SDEV_CMDDATA(d,i) ((d)->ops->cmddata(d,i))
+#define SPIS_DEV_CMDDATA(d,i) ((d)->ops->cmddata(d,i))
 
 /****************************************************************************
- * Name: SPI_SDEV_GETDATA
+ * Name: SPIS_DEV_GETDATA
  *
  * Description:
  *   This is a SPI device callback that is used when the SPI controller
@@ -249,7 +249,7 @@
  *   method. Normally only LCD devices distinguish command and data.
  *
  * Input Parameters:
- *   sdev - SPI device interface instance
+ *   dev  - SPI Slave device interface instance
  *   data - Pointer to the data buffer pointer to be shifed out.
  *          The device will set the data buffer pointer to the actual data
  *
@@ -262,10 +262,10 @@
  *
  ****************************************************************************/
 
-#define SPI_SDEV_GETDATA(d,v)  ((d)->ops->getdata(d,v))
+#define SPIS_DEV_GETDATA(d,v)  ((d)->ops->getdata(d,v))
 
 /****************************************************************************
- * Name: SPI_SDEV_RECEIVE
+ * Name: SPIS_DEV_RECEIVE
  *
  * Description:
  *   This is a SPI device callback that is used when the SPI controller
@@ -273,7 +273,7 @@
  *   synchronization by several words.
  *
  * Input Parameters:
- *   sdev - SPI device interface instance
+ *   dev  - SPI Slave device interface instance
  *   data - Pointer to the new data that has been shifted in
  *   len  - Length of the new data in units of nbits wide,
  *          nbits being the data width previously provided to the bind()
@@ -291,7 +291,7 @@
  *
  ****************************************************************************/
 
-#define SPI_SDEV_RECEIVE(d,v,l)  ((d)->ops->receive(d,v,l))
+#define SPIS_DEV_RECEIVE(d,v,l)  ((d)->ops->receive(d,v,l))
 
 /****************************************************************************
  * Public Types
@@ -299,7 +299,7 @@
 
 /* There are two interfaces defined for the implementation of SPI slave:
  *
- * 1) struct spi_sctrlr_s: Defines one interface between the SPI
+ * 1) struct spi_slave_ctrlr_s: Defines one interface between the SPI
  *    slave device and the SPI slave controller hardware. This interface
  *    is implemented by the SPI slave device controller lower-half driver
  *    and is provided to the SPI slave device driver when that driver
@@ -307,7 +307,7 @@
  *    unique to the SPI slave implementation. The prototype is probably
  *    something like:
  *
- *      FAR struct spi_sctrlr_s *xyz_spi_slave_initialize(int port);
+ *      FAR struct spi_slave_ctrlr_s *xyz_spi_slave_initialize(int port);
  *
  *    Given an SPI port number, this function returns an instance of the
  *    SPI slave controller interface.
@@ -316,24 +316,25 @@
  *    appear in a header file associated with the specific SPI slave
  *    implementation.
  *
- * 2) struct spi_sdev_s: Defines the second interface between the SPI
+ * 2) struct spi_slave_dev_s: Defines the second interface between the SPI
  *    slave device and the SPI slave controller hardware. This interface
  *    is implemented by the SPI slave device. The slave device passes this
- *    interface to the struct spi_sctrlr_s during initialization
- *    by calling the bind() method of the struct spi_sctrlr_s
+ *    interface to the struct spi_slave_ctrlr_s during initialization
+ *    by calling the bind() method of the struct spi_slave_ctrlr_s
  *    interface.
  *
  * The basic initialization steps are:
  *
  * 1) Board-specific logic calls board- or chip-specific logic to create an
- *    instance of the SPI slave controller interface, struct spi_sctrlr_s.
+ *    instance of the SPI slave controller interface,
+ *    struct spi_slave_ctrlr_s.
  *
  * 2) Board-specific logic then calls up_dev_initialize() to initialize
  *    the SPI slave device. The board-specific logic passes the instance
- *    of struct spi_sctrlr_s to support the initialization.
+ *    of struct spi_slave_ctrlr_s to support the initialization.
  *
  * 3) The SPI slave device driver creates and initializes an instance of
- *    struct spi_sdev_s; it passes this instance to the bind() method of
+ *    struct spi_slave_dev_s; it passes this instance to the bind() method of
  *    of the SPI slave controller interface.
  *
  * 4) The SPI slave controller will (1) call the slave device's select()
@@ -466,7 +467,7 @@
  *    solution might not be possible.
  */
 
-enum spi_smode_e
+enum spi_slave_mode_e
 {
   SPISLAVE_MODE0 = 0,     /* CPOL=0 CPHA=0 */
   SPISLAVE_MODE1,         /* CPOL=0 CPHA=1 */
@@ -476,20 +477,20 @@ enum spi_smode_e
 
 /* The SPI slave controller driver vtable */
 
-struct spi_sctrlr_s; /* Forward reference */
-struct spi_sdev_s;   /* Forward reference */
+struct spi_slave_ctrlr_s; /* Forward reference */
+struct spi_slave_dev_s;   /* Forward reference */
 
-struct spi_sctrlrops_s
+struct spi_slave_ctrlrops_s
 {
-  CODE void     (*bind)(FAR struct spi_sctrlr_s *sctrlr,
-                   FAR struct spi_sdev_s *sdev, enum spi_smode_e mode,
-                   int nbits);
-  CODE void     (*unbind)(FAR struct spi_sctrlr_s *sctrlr);
-  CODE int      (*enqueue)(FAR struct spi_sctrlr_s *sctrlr,
-                   FAR const void *data, size_t nwords);
-  CODE bool     (*qfull)(FAR struct spi_sctrlr_s *sctrlr);
-  CODE void     (*qflush)(FAR struct spi_sctrlr_s *sctrlr);
-  CODE size_t   (*qpoll)(FAR struct spi_sctrlr_s *sctrlr);
+  CODE void     (*bind)(FAR struct spi_slave_ctrlr_s *ctrlr,
+                        FAR struct spi_slave_dev_s *sdev,
+                        enum spi_slave_mode_e mode, int nbits);
+  CODE void     (*unbind)(FAR struct spi_slave_ctrlr_s *ctrlr);
+  CODE int      (*enqueue)(FAR struct spi_slave_ctrlr_s *ctrlr,
+                           FAR const void *data, size_t nwords);
+  CODE bool     (*qfull)(FAR struct spi_slave_ctrlr_s *ctrlr);
+  CODE void     (*qflush)(FAR struct spi_slave_ctrlr_s *ctrlr);
+  CODE size_t   (*qpoll)(FAR struct spi_slave_ctrlr_s *ctrlr);
 };
 
 /* SPI slave controller private data. This structure only defines the
@@ -498,22 +499,22 @@ struct spi_sctrlrops_s
  * the vtable structure pointer.
  */
 
-struct spi_sctrlr_s
+struct spi_slave_ctrlr_s
 {
-  FAR const struct spi_sctrlrops_s *ops;
+  FAR const struct spi_slave_ctrlrops_s *ops;
 
   /* Private SPI slave controller driver data may follow */
 };
 
 /* The SPI slave device driver vtable */
 
-struct spi_sdevops_s
+struct spi_slave_devops_s
 {
-  CODE void     (*select)(FAR struct spi_sdev_s *sdev, bool selected);
-  CODE void     (*cmddata)(FAR struct spi_sdev_s *sdev, bool data);
-  CODE size_t   (*getdata)(FAR struct spi_sdev_s *sdev,
+  CODE void     (*select)(FAR struct spi_slave_dev_s *sdev, bool selected);
+  CODE void     (*cmddata)(FAR struct spi_slave_dev_s *sdev, bool data);
+  CODE size_t   (*getdata)(FAR struct spi_slave_dev_s *sdev,
                            FAR const void **data);
-  CODE size_t   (*receive)(FAR struct spi_sdev_s *sdev,
+  CODE size_t   (*receive)(FAR struct spi_slave_dev_s *sdev,
                            FAR const void *data, size_t nwords);
 };
 
@@ -523,9 +524,9 @@ struct spi_sdevops_s
  * the vtable structure pointer.
  */
 
-struct spi_sdev_s
+struct spi_slave_dev_s
 {
-  FAR const struct spi_sdevops_s *ops;
+  FAR const struct spi_slave_devops_s *ops;
 
   /* Private SPI slave device driver data may follow */
 };
@@ -543,17 +544,17 @@ struct spi_sdev_s
  ****************************************************************************/
 
 /****************************************************************************
- * Name: spislave_register
+ * Name: spi_slave_register
  *
  * Description:
- *   Register the SPI Slave echo character device as 'devpath'.
+ *   Register the SPI Slave character device driver as 'devpath'.
  *
  * Input Parameters:
- *   sctrlr  - An instance of the SPI Slave interface to use to communicate
- *             with the SPI Slave echo device
- *   bus     - The SPI Slave bus number. This will be used as the SPI device
- *             minor number. The SPI Slave character device will be
- *             registered as /dev/spislvN where N is the minor number
+ *   ctrlr - An instance of the SPI Slave interface to use to communicate
+ *           with the SPI Slave device
+ *   bus   - The SPI Slave bus number. This will be used as the SPI device
+ *           minor number. The SPI Slave character device will be
+ *           registered as /dev/spislvN where N is the minor number
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
@@ -561,7 +562,7 @@ struct spi_sdev_s
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_SLAVE_DRIVER
-int spislave_register(FAR struct spi_sctrlr_s *sctrlr, int bus);
+int spi_slave_register(FAR struct spi_slave_ctrlr_s *ctrlr, int bus);
 #endif /* CONFIG_SPI_SLAVE_DRIVER */
 
 #undef EXTERN


### PR DESCRIPTION
## Summary
This PR intends to refactor the NuttX SPI Slave interface regarding the module prefix.
As discussed in https://github.com/apache/incubator-nuttx/pull/3809, the motivation for this task is to make the SPI Slave naming sync with the one adopted for I2C Slave.

## Impact
No added feature or changed functionality, but the refactor affected the SPI Slave controller drivers of the following chips:
- `stm32h7`
- `samv7`
- `esp32`
- `esp32c3`

## Testing
CI Build pass success. No functional changes.
