### PR TITLE
arch/riscv/rv32m/riscv_assert.c: Fix a couple of build issues

### DIFF
--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -331,7 +331,7 @@ void up_assert(const char *filename, int lineno)
 
   syslog_flush();
 
-#if CONFIG_TASK_NAME_SIZE > 0
+#if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_DEBUG_ALERT)
   _alert("Assertion failed at file:%s line: %d task: %s\n",
         filename, lineno, rtcb->name);
 #else

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -59,8 +59,6 @@
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_ARCH_STACKDUMP
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -69,6 +67,7 @@
  * Name: riscv_stackdump
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_STACKDUMP
 static void riscv_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack ;
@@ -81,6 +80,9 @@ static void riscv_stackdump(uint32_t sp, uint32_t stack_top)
              ptr[4], ptr[5], ptr[6], ptr[7]);
     }
 }
+#else
+#  define riscv_stackdump(sp, stack_top)
+#endif
 
 /****************************************************************************
  * Name: riscv_taskdump
@@ -122,6 +124,7 @@ static inline void riscv_showtasks(void)
  * Name: riscv_registerdump
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_STACKDUMP
 static inline void riscv_registerdump(void)
 {
   /* Are user registers available from interrupt processing? */
@@ -162,11 +165,15 @@ static inline void riscv_registerdump(void)
 #endif
     }
 }
+#else
+#  define riscv_registerdump()
+#endif
 
 /****************************************************************************
  * Name: riscv_dumpstate
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_STACKDUMP
 static void riscv_dumpstate(void)
 {
   struct tcb_s *rtcb = running_task();
@@ -248,8 +255,9 @@ static void riscv_dumpstate(void)
       riscv_stackdump(ustackbase, ustackbase + ustacksize);
     }
 }
-
-#endif /* CONFIG_ARCH_STACKDUMP */
+#else
+#  define riscv_dumpstate()
+#endif
 
 /****************************************************************************
  * Name: riscv_assert


### PR DESCRIPTION
## Summary
1.  Use the correct preprocessor condition when trying to print the task name.
2. Provide dummy implementations of dump functions when ARCH_STACKDUMP isn't defined.
## Impact
RV32 chips only.
## Testing
All of ESP32-C3 configs run successfully.
