### PR TITLE
ESP32-C3: Small clean up on IRQ functions

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -65,7 +65,7 @@ volatile uint32_t *g_current_regs;
  * Private Data
  ****************************************************************************/
 
-uint8_t g_cpuint_map[ESP32C3_CPUINT_MAX];
+static uint8_t g_cpuint_map[ESP32C3_CPUINT_MAX];
 
 /****************************************************************************
  * Public Functions

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -85,7 +85,7 @@ void up_irqinitialize(void)
 
   /**
    * Initialize specific driver's CPU interrupt ID:
-   *   Object  |  CPU INT  |  Pheripheral
+   *   Object  |  CPU INT  |  Peripheral
    *           |           |
    *    Wi-Fi  |     1     |      1
    */
@@ -245,7 +245,7 @@ void esp32c3_bind_irq(uint8_t cpuint, uint8_t periphid, uint8_t prio,
 int esp32c3_request_irq(uint8_t periphid, uint8_t prio, uint32_t flags)
 {
   int ret;
-  int cpuint;
+  uint8_t cpuint;
   irqstate_t irqstate;
 
   DEBUGASSERT(periphid < ESP32C3_NPERIPHERALS);
@@ -255,7 +255,7 @@ int esp32c3_request_irq(uint8_t periphid, uint8_t prio, uint32_t flags)
   irqstate = enter_critical_section();
 
   /* Skip over already registered interrupts.
-   * NOTE: bit 0 is reserved.
+   * NOTE: bit 0 is reserved for exceptions.
    */
 
   for (cpuint = 1; cpuint <= ESP32C3_CPUINT_MAX; cpuint++)
@@ -266,7 +266,7 @@ int esp32c3_request_irq(uint8_t periphid, uint8_t prio, uint32_t flags)
         }
     }
 
-  irqinfo("periphid:%" PRIu8 " cpuint=%d\n", periphid, cpuint);
+  irqinfo("periphid:%" PRIu8 " cpuint=%" PRIu8 "\n", periphid, cpuint);
 
   if (cpuint <= ESP32C3_CPUINT_MAX)
     {
@@ -315,7 +315,7 @@ int esp32c3_request_irq(uint8_t periphid, uint8_t prio, uint32_t flags)
 void esp32c3_free_cpuint(uint8_t periphid)
 {
   irqstate_t irqstate;
-  uint32_t cpuint;
+  uint8_t cpuint;
 
   DEBUGASSERT(periphid < ESP32C3_NPERIPHERALS);
 
@@ -324,9 +324,10 @@ void esp32c3_free_cpuint(uint8_t periphid)
   /* Get the CPU interrupt ID mapped to this peripheral. */
 
   cpuint = getreg32(DR_REG_INTERRUPT_BASE + periphid * 4) & 0x1f;
-  irqinfo("INFO: irq[%d]=%08lx\n", periphid, cpuint);
 
-  if (cpuint)
+  irqinfo("INFO: irq[%" PRIu8 "]=%" PRIu8 "\n", periphid, cpuint);
+
+  if (cpuint != 0)
     {
       /* Undo the allocation process:
        *   1.  Unmap the peripheral from the CPU interrupt ID.
@@ -364,13 +365,12 @@ void esp32c3_free_cpuint(uint8_t periphid)
 
 IRAM_ATTR uint32_t *esp32c3_dispatch_irq(uint32_t mcause, uint32_t *regs)
 {
-  int cpuint;
   int irq;
 
   DEBUGASSERT(g_current_regs == NULL);
   g_current_regs = regs;
 
-  irqinfo("INFO: mcause=%08lx\n", mcause);
+  irqinfo("INFO: mcause=%08" PRIX32 "\n", mcause);
 
   /* If the board supports LEDs, turn on an LED now to indicate that we are
    * processing an interrupt.
@@ -378,13 +378,13 @@ IRAM_ATTR uint32_t *esp32c3_dispatch_irq(uint32_t mcause, uint32_t *regs)
 
   board_autoled_on(LED_INIRQ);
 
-  if (MCAUSE_INTERRUPT & mcause)
+  if ((MCAUSE_INTERRUPT & mcause) != 0)
     {
-      cpuint = mcause & MCAUSE_INTERRUPT_MASK;
+      uint8_t cpuint = mcause & MCAUSE_INTERRUPT_MASK;
 
       DEBUGASSERT(cpuint <= ESP32C3_CPUINT_MAX);
 
-      irqinfo("INFO: cpuint=%d\n", cpuint);
+      irqinfo("INFO: cpuint=%" PRIu8 "\n", cpuint);
 
       /* Clear edge interrupts. */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -55,18 +55,6 @@
 
 #define CPUINT_UNASSIGNED 0xff
 
-/* Wi-Fi reserved CPU interrupt bit */
-
-#ifdef CONFIG_ESP32C3_WIRELESS
-#  define CPUINT_WMAC_MAP (1 << ESP32C3_CPUINT_WMAC)
-#else
-#  define CPUINT_WMAC_MAP 0
-#endif
-
-/* Reserved CPU interrupt bits */
-
-#define CPUINT_RESERVED_MAPS (CPUINT_WMAC_MAP)
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/


### PR DESCRIPTION
## Summary
This PR intends to perform some small cleanup on the IRQ code of ESP32-C3 chip.

## Impact
ESP32-C3 based platforms. No relevant changes.

## Testing
`esp32c3-devkit:ostest`: Successful execution of `ostest` application.
