### PR TITLE
tools/ci: Workaround conflict with x86_64-elf-binutils after avr-gcc version bump

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -227,7 +227,12 @@ function avr-gcc-toolchain {
     case $os in
       Darwin)
         brew tap osx-cross/avr
-        brew install avr-gcc
+        # Rolling back avr-gcc version as a temporary workaround to conflict between
+        # x86_64-elf-binutils-2.36.1 and avr-binutils-2.36.1
+        pushd "$(brew --repository)"/Library/Taps/osx-cross/homebrew-avr &>/dev/null
+        git checkout c1a94c9
+        popd &>/dev/null
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install avr-gcc
         ;;
     esac
   fi


### PR DESCRIPTION
## Summary
This PR intends to add a quick workaround to restore NuttX CI activity.
After `avr-gcc` tap formula version bump in Homebrew, macOS builds are failing to start.
Issue has been opened at https://github.com/osx-cross/homebrew-avr/issues/243 to understand how to correctly address it.

## Impact
macOS jobs of CI build

## Testing
Tested in macOS Big Sur 11.2.1.
Reproduced the issue locally with HEAD of `avr-binutils` tap formula
`avr-binutils` installed again after rolling back to previous version.

