### PR TITLE
drivers: serial: Remove an unnecessary critical section for SMP

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -191,10 +191,6 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
   int nexthead;
   int ret;
 
-#ifdef CONFIG_SMP
-  irqstate_t flags2 = enter_critical_section();
-#endif
-
   /* Increment to see what the next head pointer will be.
    * We need to use the "next" head pointer to determine when the circular
    *  buffer would overrun
@@ -329,10 +325,6 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
   ret = OK;
 
 err_out:
-
-#ifdef CONFIG_SMP
-  leave_critical_section(flags2);
-#endif
 
   return ret;
 }


### PR DESCRIPTION
## Summary

- Since the caller already holds xmit.sem in uart_write(),
  this critical section in serial.c is unnecessary for SMP

## Impact

- None

## Testing

- Tested with spresense:wifi_smp, esp32-devkitc:smp
