### PR TITLE
drivers: serial: Remove an unnecessary critical section (cs) for SMP

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -191,10 +191,6 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
   int nexthead;
   int ret;
 
-#ifdef CONFIG_SMP
-  irqstate_t flags2 = enter_critical_section();
-#endif
-
   /* Increment to see what the next head pointer will be.
    * We need to use the "next" head pointer to determine when the circular
    *  buffer would overrun
@@ -329,10 +325,6 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
   ret = OK;
 
 err_out:
-
-#ifdef CONFIG_SMP
-  leave_critical_section(flags2);
-#endif
 
   return ret;
 }


### PR DESCRIPTION
## Summary

- I thought this cs is needed to avoid data corruption
- For example, while executing uart_xmitchar() in the interrupt
  handler on CPU0, an application running on CPU1 can call
  uart_putxmitchar() via write()->uart_write().
- In this case, taking xmit.sem in uart_write() will wait for CPU0
  to finish uart_xmitchar() because CPU0 has already taken a cs
  in uart_xmitchar() then nxsem_wait() on CPU0 takes a new cs
  inside (and release the cs when returning but it's OK)
- Then uart_write() on CPU1 disables UART TX, so uart_xmitchar()
  on CPU0 will not be called while executing uart_write() on CPU1.
- So this critical section in uart_putxmitchar() can be removed.

## Impact

- None

## Testing

- Tested with spresense:wifi_smp, esp32-devkitc:smp
