### PR TITLE
Licensing: Add BSD-style license from uIP

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -205,11 +205,34 @@
 uIP
 ===
 
-Many lower-level networking components of NuttX derive from uIP which
-has a similar BSD style license:
+Many lower-level networking components of NuttX derive from uIP:
 
    Copyright (c) 2001-2003, Adam Dunkels.
    All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+   3. The name of the author may not be used to endorse or promote
+      products derived from this software without specific prior
+      written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+   GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Rhombus Math Library
 ====================


### PR DESCRIPTION
## Summary

LICENSING: Add the BSD-style license from uIP, as some lower-level networking components derive from it. 

Per feedback of John D. Ament in the general@incubator.a.o thread "[VOTE] Release Apache NuttX (Incubating) 10.1.0 [RC1]" on 21 May 2021, archived at [here](https://mail-archives.apache.org/mod_mbox/incubator-general/202105.mbox/%3cCAOqetn8dOhKFj8jdprM1_gmuU=WSwKpK3D6W1a+w2dZ8AbjtNw@mail.gmail.com%3e) and [here](https://lists.apache.org/thread.html/r293352a21dfd1112b4dfb0e27265a2ac4741083fa1e7875e4001da86%40%3Cgeneral.incubator.apache.org%3E).

Obtained the license text from [https://github.com/adamdunkels/uip/blob/uip-1-0/uip/uip.c](https://github.com/adamdunkels/uip/blob/uip-1-0/uip/uip.c).

## Impact

Incorporates feedback received during release voting of NuttX 10.1.0.

## Testing

None.