### PR TITLE
Fix tcp seq wrap around issues

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -86,6 +86,15 @@
 #  endif
 #endif
 
+/* 32-bit modular arithmetics for tcp sequence numbers */
+
+#define TCP_SEQ_LT(a, b)	((int32_t)((a) - (b)) < 0)
+#define TCP_SEQ_GT(a, b)	TCP_SEQ_LT(b, a)
+#define TCP_SEQ_LTE(a, b)	(!TCP_SEQ_GT(a, b))
+#define TCP_SEQ_GTE(a, b)	(!TCP_SEQ_LT(a, b))
+
+#define TCP_SEQ_SUB(a, b)	((uint32_t)((a) - (b)))
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -429,7 +429,7 @@ found:
       ackseq = tcp_getsequence(tcp->seqno);
       rcvseq = tcp_getsequence(conn->rcvseq);
 
-      if (ackseq < rcvseq)
+      if (TCP_SEQ_LT(ackseq, rcvseq))
         {
           /* Send a "normal" acknowledgment of the KeepAlive probe */
 
@@ -492,7 +492,7 @@ found:
        * new sequence number.
        */
 
-      if (ackseq <= unackseq)
+      if (TCP_SEQ_LTE(ackseq, unackseq))
         {
           /* Calculate the new number of outstanding, unacknowledged bytes */
 

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -419,17 +419,13 @@ found:
       (dev->d_len == 0 || dev->d_len == 1) &&
       conn->tx_unacked <= 0)
     {
-      uint32_t ackseq;
+      uint32_t seq;
       uint32_t rcvseq;
 
-      /* Get the sequence number of that has just been acknowledged by this
-       * incoming packet.
-       */
-
-      ackseq = tcp_getsequence(tcp->seqno);
+      seq = tcp_getsequence(tcp->seqno);
       rcvseq = tcp_getsequence(conn->rcvseq);
 
-      if (TCP_SEQ_LT(ackseq, rcvseq))
+      if (TCP_SEQ_LT(seq, rcvseq))
         {
           /* Send a "normal" acknowledgment of the KeepAlive probe */
 

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -220,7 +220,8 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
        * of bytes to be acknowledged.
        */
 
-      pstate->snd_acked = tcp_getsequence(tcp->ackno) - pstate->snd_isn;
+      pstate->snd_acked = TCP_SEQ_SUB(tcp_getsequence(tcp->ackno),
+                                      pstate->snd_isn);
       ninfo("ACK: acked=%" PRId32 " sent=%zd buflen=%zd\n",
             pstate->snd_acked, pstate->snd_sent, pstate->snd_buflen);
 


### PR DESCRIPTION
## Summary
deal with tcp sequence number wrap around by using 32-bit modular arithmetic.

## Impact
tcp

## Testing
survived >5GB transfer for both of tx and rx. (tested with a NetBSD peer.)

