### PR TITLE
TLS: Correct handling of returned error values.

### DIFF
--- a/libs/libc/tls/tls_alloc.c
+++ b/libs/libc/tls/tls_alloc.c
@@ -66,10 +66,9 @@ int tls_alloc(void)
    */
 
   ret = _SEM_WAIT(&tinfo->ta_tlssem);
-
-  if (ERROR == ret)
+  if (ret < 0)
     {
-      ret = -get_errno();
+      ret = _SEM_ERRVAL(ret);
       goto errout_with_errno;
     }
 

--- a/libs/libc/tls/tls_free.c
+++ b/libs/libc/tls/tls_free.c
@@ -79,7 +79,7 @@ int tls_free(int tlsindex)
         }
       else
         {
-          ret = -get_errno();
+          ret = _SEM_ERRVAL(ret);
         }
     }
 


### PR DESCRIPTION
## Summary

I note two problems in handling of the return error values in PR #3858:

1. In PROTECTED and KERNEL modes, the error return value of _SEM_WAIT() will be a negated errno value; in all other modes, it will be -1 (ERROR) with the errno variable set.  This must be handled in the test of the returned value:  Don't compare with -1; rather check if < 0
2. Also, conversion of the returned value to a negated errno value must be handled differently.  This is handled by replacing -get_errno() with the macro _ERRVAL(ret)

## Impact

This effects only error handling (it fixes it) and no other impacts are expected.

## Testing

CI only

