### PR TITLE
syslog: Added separator in file logs.

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -273,6 +273,19 @@ menuconfig SYSLOG_FILE
 
 if SYSLOG_FILE
 
+config SYSLOG_FILE_SEPARATE
+	bool "Log file separation"
+	default n
+	depends on SYSLOG_FILE
+	---help---
+		If enabled, every time the file logger is re-attached, a separator
+		will be printed in the file.
+		
+		This can be useful to easily distinguish between log entries that
+		belong to different log sessions (e.g. system reboot), and to 
+		indicate that between the separated lines there may be more logs
+		that were lost.
+
 config SYSLOG_FILE_ROTATIONS
 	int "Log file rotations"
 	default 0


### PR DESCRIPTION
## Summary
Added the ability to separate log sessions in files.

This can be useful to easily distinguish between log entries that belong to different log sessions (e.g. system reboot), and to  indicate that between the separated lines there may be more logs that were lost.

Note that the separator is hard-coded (currently set to two newlines).  
Unfortunately this is not possible to be configurable. Kconfig does not support escaped characters in strings, so chars like `\n` are not possible to be set. Since a separator is expected to contain at least one `\n`, Kconfig is unsuitable.

If anyone has any idea on how this can be configurable, please let me know.

## Impact
None on existing configurations.

## Testing
Tested on file logged in SD card.
