### PR TITLE
tools/ci: Revert workaround for issue with avr-binutils

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -227,12 +227,7 @@ function avr-gcc-toolchain {
     case $os in
       Darwin)
         brew tap osx-cross/avr
-        # Rolling back avr-gcc version as a temporary workaround to conflict between
-        # x86_64-elf-binutils-2.36.1 and avr-binutils-2.36.1
-        pushd "$(brew --repository)"/Library/Taps/osx-cross/homebrew-avr &>/dev/null
-        git checkout c1a94c9
-        popd &>/dev/null
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install avr-gcc
+        brew install avr-gcc
         ;;
     esac
   fi


### PR DESCRIPTION
## Summary
This PR intends to revert a recent workaround fix to the failure of macOS CI jobs.

**avr-binutils** homebrew recipe has been fixed upstream:
https://github.com/osx-cross/homebrew-avr/issues/243

This reverts commit 37e30ccc54b938a658fd211ed7e2ffa752900f0a.

**NOTE**: this PR depends on the fixes from https://github.com/apache/incubator-nuttx/pull/3836.

## Impact
CI build only

## Testing
CI build pass
