### PR TITLE
arch: adjust idle stack offset to reserve space of stack info

### DIFF
--- a/sched/init/nx_smpstart.c
+++ b/sched/init/nx_smpstart.c
@@ -34,6 +34,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/sched.h>
 #include <nuttx/sched_note.h>
+#include <nuttx/tls.h>
 
 #include "group/group.h"
 #include "sched/sched.h"
@@ -131,6 +132,7 @@ int nx_smp_start(void)
       /* Initialize the processor-specific portion of the TCB */
 
       up_initial_state(tcb);
+      up_stack_frame(tcb, sizeof(struct task_info_s));
     }
 
   /* Then start all of the other CPUs after we have completed the memory

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -44,6 +44,7 @@
 #include <nuttx/syslog/syslog.h>
 #include <nuttx/binfmt/binfmt.h>
 #include <nuttx/init.h>
+#include <nuttx/tls.h>
 
 #include "sched/sched.h"
 #include "signal/signal.h"
@@ -517,6 +518,7 @@ void nx_start(void)
       if (cpu == 0)
         {
           up_initial_state(&g_idletcb[cpu].cmn);
+          up_stack_frame(&g_idletcb[cpu].cmn, sizeof(struct task_info_s));
         }
     }
 


### PR DESCRIPTION
## Summary

arch: adjust idle stack offset to reserve space of stack info

## Impact

idle thread stack usage

## Testing

```
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED    CPU COMMAND
    0     0   0   0 FIFO     Kthread N-- Assigned           00000000 004096 004080  99.6%!  50.0% CPU0 IDLE
```

After patch:

```
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED    CPU COMMAND
    0     0   0   0 FIFO     Kthread N-- Assigned           00000000 004076 000920  22.5%   50.0% CPU0 IDLE
```
