### PR TITLE
mtd: Add MTDIOC_FLUSH IOCTL like MTDIOC_XIPBASE

### DIFF
--- a/arch/risc-v/src/bl602/bl602_spiflash.c
+++ b/arch/risc-v/src/bl602/bl602_spiflash.c
@@ -322,9 +322,9 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
           finfo("cmd(0x%x) MTDIOC_XIPBASE not support.\n", cmd);
         }
         break;
-      case BIOC_FLUSH:
+      case MTDIOC_FLUSH:
         {
-          finfo("cmd(0x%x) BIOC_FLUSH.\n", cmd);
+          finfo("cmd(0x%x) MTDIOC_FLUSH.\n", cmd);
           ret = OK;
         }
         break;

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -530,12 +530,16 @@ static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 
       cmd = MTDIOC_XIPBASE;
     }
-#ifdef CONFIG_FTL_WRITEBUFFER
   else if (cmd == BIOC_FLUSH)
     {
-      return rwb_flush(&dev->rwb);
-    }
+#ifdef CONFIG_FTL_WRITEBUFFER
+      rwb_flush(&dev->rwb);
 #endif
+
+      /* Change the BIOC_FLUSH command to the MTDIOC_FLUSH command. */
+
+      cmd = MTDIOC_FLUSH;
+    }
 
   /* No other block driver ioctl commands are not recognized by this
    * driver.  Other possible MTD driver ioctl commands are passed through

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -926,7 +926,7 @@ static int littlefs_sync_block(FAR const struct lfs_config *c)
 
   if (INODE_IS_MTD(drv))
     {
-      ret = MTD_IOCTL(drv->u.i_mtd, BIOC_FLUSH, 0);
+      ret = MTD_IOCTL(drv->u.i_mtd, MTDIOC_FLUSH, 0);
     }
   else
     {

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -68,6 +68,9 @@
                                            * OUT: None */
 #define MTDIOC_ECCSTATUS  _MTDIOC(0x0008) /* IN:  Pointer to uint8_t
                                            * OUT: ECC status */
+#define MTDIOC_FLUSH      _MTDIOC(0x0009) /* IN:  None
+                                           * OUT: None (ioctl return value provides
+                                           *      success/failure indication). */
 
 /* Macros to hide implementation */
 


### PR DESCRIPTION
## Summary
since the old design reuse BIOC_FLUSH for MTD device which make some confusion(see here: https://github.com/apache/incubator-nuttx/issues/3839).

## Impact
New MTDIOC_FLUSH, to avoid reuse BIOC_FLUSH. Mainline MTD driver doesn't really ulitize it yet. 

## Testing

