### PR TITLE
riscv/bl602:Remove the direct call of syslog in the flash driver

### DIFF
--- a/arch/risc-v/src/bl602/bl602_flash.c
+++ b/arch/risc-v/src/bl602/bl602_flash.c
@@ -68,8 +68,7 @@ int bl602_flash_erase(uint32_t addr, int len)
 {
   irqstate_t flags;
 
-  syslog(LOG_INFO,
-    "bl602_flash_erase addr = %08lx, len = %d\n", addr, len);
+  finfo("addr = %08lx, len = %d\n", addr, len);
 
   flags = up_irq_save();
   ((bl602_romdrv_erase_fn)(*((uint32_t *)(ROMAPI_SFLASH_EREASE_NEEDLOCK))))
@@ -83,8 +82,7 @@ int bl602_flash_write(uint32_t addr, const uint8_t *src, int len)
 {
   irqstate_t flags;
 
-  syslog(LOG_INFO,
-    "bl602_flash_write addr = %08lx, len = %d\n", addr, len);
+  finfo("addr = %08lx, len = %d\n", addr, len);
 
   flags = up_irq_save();
   ((bl602_romdrv_write_fn)(*((uint32_t *)(ROMAPI_SFLASH_WRITE_NEEDLOCK))))
@@ -98,8 +96,7 @@ int bl602_flash_read(uint32_t addr, uint8_t *dst, int len)
 {
   irqstate_t flags;
 
-  syslog(LOG_INFO,
-    "bl602_flash_read addr = %08lx, len = %d\n", addr, len);
+  finfo("addr = %08lx, len = %d\n", addr, len);
 
   flags = up_irq_save();
   ((bl602_romdrv_read_fn)(*((uint32_t *)(ROMAPI_SFLASH_READ_NEEDLOCK))))

--- a/arch/risc-v/src/bl602/bl602_spiflash.c
+++ b/arch/risc-v/src/bl602/bl602_spiflash.c
@@ -146,8 +146,7 @@ static int bl602_erase(FAR struct mtd_dev_s *dev, off_t startblock,
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
 
-  syslog(LOG_INFO, "bl602_erase dev=%p, addr=0x%lx, size=0x%lx\n",
-      dev, addr, size);
+  finfo("dev=%p, addr=0x%lx, size=0x%lx\n", dev, addr, size);
 
   ret = bl602_flash_erase(addr, size);
 
@@ -184,8 +183,7 @@ static ssize_t bl602_read(FAR struct mtd_dev_s *dev, off_t offset,
   uint32_t addr = priv->config->flash_offset + offset;
   uint32_t size = nbytes;
 
-  syslog(LOG_INFO, "bl602_read dev=%p, addr=0x%lx, size=0x%lx\n",
-      dev, addr, size);
+  finfo("dev=%p, addr=0x%lx, size=0x%lx\n", dev, addr, size);
 
   if (0 == bl602_flash_read(addr, buffer, size))
     {
@@ -221,8 +219,7 @@ static ssize_t bl602_bread(FAR struct mtd_dev_s *dev, off_t startblock,
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
 
-  syslog(LOG_INFO, "bl602_bread dev=%p, addr=0x%lx, size=0x%lx\n",
-      dev, addr, size);
+  finfo("dev=%p, addr=0x%lx, size=0x%lx\n", dev, addr, size);
 
   if (0 == bl602_flash_read(addr, buffer, size))
     {
@@ -259,8 +256,7 @@ static ssize_t bl602_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
 
-  syslog(LOG_INFO, "bl602_bwrite dev=%p, addr=0x%lx, size=0x%lx\n",
-      dev, addr, size);
+  finfo("bl602_bwrite dev=%p, addr=0x%lx, size=0x%lx\n", dev, addr, size);
 
   if (0 == bl602_flash_write(addr, buffer, size))
     {
@@ -297,7 +293,7 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
     {
       case MTDIOC_GEOMETRY:
         {
-          syslog(LOG_INFO, "cmd(0x%x) MTDIOC_GEOMETRY.\n", cmd);
+          finfo("cmd(0x%x) MTDIOC_GEOMETRY.\n", cmd);
           geo = (FAR struct mtd_geometry_s *)arg;
           if (geo)
             {
@@ -307,8 +303,7 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
                                   SPIFLASH_BLOCKSIZE;
               ret               = OK;
 
-              syslog(LOG_INFO,
-                    "blocksize: %ld erasesize: %ld neraseblocks: %ld\n",
+              finfo("blocksize: %ld erasesize: %ld neraseblocks: %ld\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }
         }
@@ -317,27 +312,25 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
         {
           /* Erase the entire partition */
 
-          syslog(LOG_INFO,
-            "cmd(0x%x) MTDIOC_BULKERASE not support.\n", cmd);
+          finfo("cmd(0x%x) MTDIOC_BULKERASE not support.\n", cmd);
         }
         break;
       case MTDIOC_XIPBASE:
         {
           /* Get the XIP base of the entire FLASH */
 
-          syslog(LOG_INFO,
-            "cmd(0x%x) MTDIOC_XIPBASE not support.\n", cmd);
+          finfo("cmd(0x%x) MTDIOC_XIPBASE not support.\n", cmd);
         }
         break;
       case BIOC_FLUSH:
         {
-          syslog(LOG_INFO, "cmd(0x%x) BIOC_FLUSH.\n", cmd);
+          finfo("cmd(0x%x) BIOC_FLUSH.\n", cmd);
           ret = OK;
         }
         break;
       default:
         {
-          syslog(LOG_INFO, "cmd(0x%x) not support.\n", cmd);
+          finfo("cmd(0x%x) not support.\n", cmd);
           ret = -ENOTTY;
         }
         break;
@@ -376,7 +369,7 @@ FAR struct mtd_dev_s *bl602_spiflash_alloc_mtdpart(void)
     CONFIG_BL602_MTD_SIZE / SPIFLASH_BLOCKSIZE);
   if (!mtd_part)
     {
-      syslog(LOG_ERR, "ERROR: create MTD partition");
+      ferr("ERROR: create MTD partition");
       return NULL;
     }
 


### PR DESCRIPTION
## Summary
Remove the direct call of syslog in the flash driver
## Impact

## Testing
BL602 Boards
