### PR TITLE
arch/arm/src/stm32h7: qspi use indirect write instead of indirect read

### DIFF
--- a/arch/arm/src/stm32h7/stm32_qspi.c
+++ b/arch/arm/src/stm32h7/stm32_qspi.c
@@ -2147,7 +2147,7 @@ static int qspi_command(struct qspi_dev_s *dev,
        * info
        */
 
-      qspi_ccrconfig(priv, &xctn, CCR_FMODE_INDRD);
+      qspi_ccrconfig(priv, &xctn, CCR_FMODE_INDWR);
     }
 
   /* Wait for the interrupt routine to finish it's magic */


### PR DESCRIPTION
On my stm32h7 board with CONFIG_STM32H7_QSPI_INTERRUPTS QSPI hanged when was making command without data. When I changed sending command from indirect read mode to indirect write mode, it started to work. As per documentation the indirect read and write modes should be equivalent when used without data. So the difference is not documented. At least this change should not do any harm.

