### PR TITLE
net/accept: alloc the accept fd after accept success

### DIFF
--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -150,7 +150,7 @@ static int sock_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
  *   Allocate a socket descriptor
  *
  * Input Parameters:
- *   psock    A double pointer to socket structure to be allocated.
+ *   psock    A pointer to socket structure.
  *   oflags   Open mode flags.
  *
  * Returned Value:
@@ -159,23 +159,15 @@ static int sock_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
  *
  ****************************************************************************/
 
-int sockfd_allocate(FAR struct socket **psock, int oflags)
+int sockfd_allocate(FAR struct socket *psock, int oflags)
 {
   int sockfd;
 
-  *psock = kmm_zalloc(sizeof(**psock));
-  if (*psock == NULL)
+  sockfd = files_allocate(&g_sock_inode, oflags, 0, psock, 0);
+  if (sockfd >= 0)
     {
-      return -ENOMEM;
+      inode_addref(&g_sock_inode);
     }
-
-  sockfd = files_allocate(&g_sock_inode, oflags, 0, *psock, 0);
-  if (sockfd < 0)
-    {
-      kmm_free(*psock);
-    }
-
-  inode_addref(&g_sock_inode);
 
   return sockfd;
 }
@@ -261,13 +253,10 @@ int socket(int domain, int type, int protocol)
       oflags |= O_CLOEXEC;
     }
 
-  /* Allocate a socket descriptor */
-
-  sockfd = sockfd_allocate(&psock, oflags);
-  if (sockfd < 0)
+  psock = kmm_zalloc(sizeof(*psock));
+  if (psock == NULL)
     {
-      nerr("ERROR: Failed to allocate a socket descriptor\n");
-      ret = sockfd;
+      ret = -ENOMEM;
       goto errout;
     }
 
@@ -277,13 +266,26 @@ int socket(int domain, int type, int protocol)
   if (ret < 0)
     {
       nerr("ERROR: psock_socket() failed: %d\n", ret);
-      goto errout_with_sockfd;
+      goto errout_with_alloc;
+    }
+
+  /* Allocate a socket descriptor */
+
+  sockfd = sockfd_allocate(psock, oflags);
+  if (sockfd < 0)
+    {
+      nerr("ERROR: Failed to allocate a socket descriptor\n");
+      ret = sockfd;
+      goto errout_with_psock;
     }
 
   return sockfd;
 
-errout_with_sockfd:
-  nx_close(sockfd);
+errout_with_psock:
+  psock_close(psock);
+
+errout_with_alloc:
+  kmm_free(psock);
 
 errout:
   set_errno(-ret);

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -496,7 +496,7 @@ FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid);
  *   Allocate a socket descriptor
  *
  * Input Parameters:
- *   psock    A double pointer to socket structure to be allocated.
+ *   psock    A pointer to socket structure.
  *   oflags   Open mode flags.
  *
  * Returned Value:
@@ -505,7 +505,7 @@ FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid);
  *
  ****************************************************************************/
 
-int sockfd_allocate(FAR struct socket **psock, int oflags);
+int sockfd_allocate(FAR struct socket *psock, int oflags);
 
 /****************************************************************************
  * Name: sockfd_socket


### PR DESCRIPTION
## Summary

net/accept: alloc the accept fd after accept success

The new fd will be in a pending state before accept is successful, if the application creates a task when accepting, the pending fd will be dup(), but since newsock->s_conn has not been initialized, assert will be triggered when inet_addref()

`[  314.683402] [76] [ EMERG] up_assert: Assertion failed at file:inet/inet_sockif.c line: 312 task: pt-0xc19efad`

https://github.com/apache/incubator-nuttx/blob/7c20199a61f61f1bd781cebee34cdc2547841564/net/inet/inet_sockif.c#L312

## Impact

N/A

## Testing

Thread 1 : accept()
Thread 2 : posix_spawn()
