### PR TITLE
nuttx: Initialize chmod\fchmod\chown\fchown\lchown

### DIFF
--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -24,6 +24,7 @@ CSRCS += fs_close.c fs_dup.c fs_dup2.c fs_fcntl.c
 CSRCS += fs_epoll.c fs_fstat.c fs_fstatfs.c fs_ioctl.c
 CSRCS += fs_lseek.c fs_mkdir.c fs_open.c fs_poll.c  fs_read.c fs_rename.c
 CSRCS += fs_rmdir.c fs_statfs.c fs_stat.c fs_select.c fs_unlink.c fs_write.c
+CSRCS += fs_chmod.c fs_fchmod.c fs_chown.c fs_fchown.c fs_lchown.c
 
 # Certain interfaces are not available if there is no mountpoint support
 

--- a/fs/vfs/fs_chmod.c
+++ b/fs/vfs/fs_chmod.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ * fs/vfs/fs_chmod.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <errno.h>
+#include <assert.h>
+
+#include <nuttx/fs/fs.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: chown
+ *
+ * Description:
+ *   changes the mode of the file specified whose pathname is given in
+ *   pathname, which is dereferenced if it is a symbolic link.
+ *
+ * NOTE: Due to the characteristics of fs, this function is incomplete.
+ *
+ * Input Parameters:
+ *   fd    : fd.
+ *   mode  : Permission value.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -1 is returned on fail, and errno is
+ *   set appropriately.
+ *
+ ****************************************************************************/
+
+int chmod(FAR const char *path, mode_t mode)
+{
+  if (path == NULL)
+    {
+      return -EINVAL;
+    }
+
+#ifdef CONFIG_FILE_MODE
+  struct inode_search_s desc;
+  FAR struct inode *inode;
+  int ret;
+
+  /* Get an inode for this file */
+
+  SETUP_SEARCH(&desc, path, false);
+
+  ret = inode_find(&desc);
+  if (ret < 0)
+    {
+      /* "O_CREAT is not set and the named file does not exist.  Or, a
+       * directory component in pathname does not exist or is a dangling
+       * symbolic link."
+       */
+
+      RELEASE_SEARCH(&desc);
+      set_errno(ret);
+      return ERROR;
+    }
+
+  /* Get the search results */
+
+  inode = desc.node;
+  DEBUGASSERT(inode != NULL);
+
+  inode->i_mode = mode;
+
+  RELEASE_SEARCH(&desc);
+  inode_release(inode);
+  return OK;
+#endif
+
+  set_errno(-EACCES);
+  return ERROR;
+}

--- a/fs/vfs/fs_chown.c
+++ b/fs/vfs/fs_chown.c
@@ -1,0 +1,105 @@
+/****************************************************************************
+ * fs/vfs/fs_chown.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <errno.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <grp.h>
+#include <assert.h>
+
+#include <nuttx/fs/fs.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: chown
+ *
+ * Description:
+ *   changes the ownership of the file specified by pathname, which is
+ *   dereferenced if it is a symbolic link.
+ *
+ * NOTE: Due to the characteristics of fs, this function is incomplete.s
+ *
+ * Input Parameters:
+ *   pathname: path of file.
+ *   owner   : User id.
+ *   group   : Group id.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -1 is returned on fail, and errno is
+ *   set appropriately.
+ *
+ ****************************************************************************/
+
+int chown(FAR const char *pathname, uid_t owner, gid_t group)
+{
+  struct inode_search_s desc;
+  FAR struct inode *inode;
+  int ret;
+
+  if (pathname == NULL || (owner <= -1 && group <= -1))
+    {
+      set_errno(-EINVAL);
+      return ERROR;
+    }
+  /* Get an inode for this file */
+
+  SETUP_SEARCH(&desc, pathname, false);
+
+  ret = inode_find(&desc);
+  if (ret < 0)
+    {
+      /* "O_CREAT is not set and the named file does not exist.  Or, a
+       * directory component in pathname does not exist or is a dangling
+       * symbolic link."
+       */
+
+      RELEASE_SEARCH(&desc);
+      set_errno(ret);
+      return ERROR;
+    }
+
+  /* Get the search results */
+
+  inode = desc.node;
+  DEBUGASSERT(inode != NULL);
+
+  /* Set uid and gid */
+
+  inode->i_uid = owner > -1 ? owner : inode->i_uid;
+  inode->i_gid = group > -1 ? group : inode->i_gid;
+
+  RELEASE_SEARCH(&desc);
+  inode_release(inode);
+  return OK;
+}

--- a/fs/vfs/fs_fchmod.c
+++ b/fs/vfs/fs_fchmod.c
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * fs/vfs/fs_fchmod.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <errno.h>
+#include <assert.h>
+
+#include <nuttx/fs/fs.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: chown
+ *
+ * Description:
+ *   changes the mode of the file referred to by the open file descriptor fd.
+ *
+ * NOTE: Due to the characteristics of fs, this function is incomplete.
+ *
+ * Input Parameters:
+ *   fd    : fd.
+ *   mode  : Permission value.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -1 is returned on fail, and errno is
+ *   set appropriately.
+ *
+ ****************************************************************************/
+
+int fchmod(int fd, mode_t mode)
+{
+#ifdef CONFIG_FILE_MODE
+  FAR struct file *filep;
+  FAR struct inode *inode;
+  ssize_t ret;
+
+  /* First, get the file structure.
+   * Note that fs_getfilep() will return the errno on failure.
+   */
+
+  ret = (ssize_t)fs_getfilep(fd, &filep);
+  if (ret >= 0)
+    {
+      inode = filep->f_inode;
+      DEBUGASSERT(inode != NULL);
+
+      inode->i_mode = mode;
+      return OK;
+    }
+#endif
+
+  set_errno(-EACCES);
+  return ERROR;
+}

--- a/fs/vfs/fs_fchown.c
+++ b/fs/vfs/fs_fchown.c
@@ -1,0 +1,90 @@
+/****************************************************************************
+ * fs/vfs/fs_fchown.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <errno.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <grp.h>
+#include <assert.h>
+
+#include <nuttx/fs/fs.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: fchown
+ *
+ * Description:
+ *   changes the ownership of the file referred to by the open file
+ *   descriptor fd.
+ *
+ * NOTE: Due to the characteristics of fs, this function is incomplete.
+ *
+ * Input Parameters:
+ *   pathname: path of file.
+ *   owner   : User id.
+ *   group   : Group id.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -1 is returned on fail, and errno is
+ *   set appropriately.
+ *
+ ****************************************************************************/
+
+int fchown(int fd, uid_t owner, gid_t group)
+{
+  FAR struct file *filep;
+  FAR struct inode *inode;
+  int ret;
+
+  /* First, get the file structure.
+   * Note that fs_getfilep() will return the errno on failure.
+   */
+
+  ret = (ssize_t)fs_getfilep(fd, &filep);
+  if (ret < 0)
+    {
+      set_errno(ret);
+      return ERROR;
+    }
+
+  inode = filep->f_inode;
+  DEBUGASSERT(inode != NULL);
+
+  /* Set uid and gid */
+
+  inode->i_uid = owner > -1 ? owner : inode->i_uid;
+  inode->i_gid = group > -1 ? group : inode->i_gid;
+
+  return OK;
+}

--- a/fs/vfs/fs_lchown.c
+++ b/fs/vfs/fs_lchown.c
@@ -1,0 +1,106 @@
+/****************************************************************************
+ * fs/vfs/fs_lchown.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <errno.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <grp.h>
+#include <assert.h>
+
+#include <nuttx/fs/fs.h>
+
+#include "inode/inode.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lchown
+ *
+ * Description:
+ *   changes the ownership of the file specified by pathname, but does not
+ *   dereference symbolic links.
+ *
+ * NOTE: Due to the characteristics of fs, this function is incomplete.
+ *
+ * Input Parameters:
+ *   pathname: path of file.
+ *   owner   : User id.
+ *   group   : Group id.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -1 is returned on fail, and errno is
+ *   set appropriately.
+ *
+ ****************************************************************************/
+
+int lchown(FAR const char *pathname, uid_t owner, gid_t group)
+{
+  struct inode_search_s desc;
+  FAR struct inode *inode;
+  int ret;
+
+  if (pathname == NULL || (owner <= -1 && group <= -1))
+    {
+      set_errno(-EINVAL);
+      return ERROR;
+    }
+
+  /* Get an inode for this file */
+
+  SETUP_SEARCH(&desc, pathname, true);
+
+  ret = inode_find(&desc);
+  if (ret < 0)
+    {
+      /* "O_CREAT is not set and the named file does not exist.  Or, a
+       * directory component in pathname does not exist or is a dangling
+       * symbolic link."
+       */
+
+      RELEASE_SEARCH(&desc);
+      set_errno(ret);
+      return ERROR;
+    }
+
+  /* Get the search results */
+
+  inode = desc.node;
+  DEBUGASSERT(inode != NULL);
+
+  /* Set uid and gid */
+
+  inode->i_uid = owner > -1 ? owner : inode->i_uid;
+  inode->i_gid = group > -1 ? group : inode->i_gid;
+
+  RELEASE_SEARCH(&desc);
+  inode_release(inode);
+  return OK;
+}

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -352,6 +352,8 @@ struct inode
   int16_t           i_crefs;    /* References to inode */
   uint16_t          i_flags;    /* Flags for inode */
   union inode_ops_u u;          /* Inode operations */
+  uid_t             i_uid;      /* The ID of the inode owner */
+  gid_t             i_gid;      /* The ID of the inode owner group */
 #ifdef CONFIG_FILE_MODE
   mode_t            i_mode;     /* Access mode flags */
 #endif

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -315,6 +315,7 @@ ssize_t write(int fd, FAR const void *buf, size_t nbytes);
 ssize_t pread(int fd, FAR void *buf, size_t nbytes, off_t offset);
 ssize_t pwrite(int fd, FAR const void *buf, size_t nbytes, off_t offset);
 int     ftruncate(int fd, off_t length);
+int     fchown(int fd, uid_t owner, gid_t group);
 
 #ifdef CONFIG_SERIAL_TERMIOS
 /* Check if a file descriptor corresponds to a terminal I/O file */
@@ -351,6 +352,8 @@ int     unlink(FAR const char *pathname);
 int     truncate(FAR const char *path, off_t length);
 int     symlink(FAR const char *path1, FAR const char *path2);
 ssize_t readlink(FAR const char *path, FAR char *buf, size_t bufsize);
+int     chown(FAR const char *pathname, uid_t owner, gid_t group);
+int     lchown(FAR const char *pathname, uid_t owner, gid_t group);
 
 /* Execution of programs from files */
 


### PR DESCRIPTION
Because some open source libraries need to use these system functions, such as libuv, but nuttx is not very complete in terms of file system permissions, so I added the basic functions of these functions and returned as much as possible to success.