### PR TITLE
boards/sim/sim/sim: correct LDLINKFLAGS after migrating from ld to gcc

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -199,3 +199,5 @@ endif
 
 HOSTCFLAGS = $(ARCHWARNINGS) $(ARCHOPTIMIZATION) \
    $(ARCHCPUFLAGS) $(HOSTINCLUDES) $(EXTRAFLAGS) -pipe
+
+LDLINKFLAGS += -nostartfiles -nodefaultlibs


### PR DESCRIPTION
## Summary

After migrating from LD to GCC sim board became uncompilable under Ubuntu 18.04 (GCC 7.5).
https://github.com/apache/incubator-nuttx/pull/3836

## Impact

sim board under Ubuntu 18.04 (GCC 7.5).

