### PR TITLE
risc-v/esp32c3_wifi_adapter.c: Remove a config that's only used in Xtensa chips.

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -1962,16 +1962,7 @@ static void *esp_malloc(unsigned int size)
 
 static void esp_free(void *ptr)
 {
-#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
-  if (xtensa_imm_heapmember(ptr))
-    {
-      xtensa_imm_free(ptr);
-    }
-  else
-#endif
-    {
-      kmm_free(ptr);
-    }
+  kmm_free(ptr);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Remove a config that's only used in Xtensa chips.  That was a leftover from the ESP32 port.
## Impact
No impact, that part was dead code anyway.
## Testing
esp32c3-devkit:wapi
