### PR TITLE
serial/pty: Don't return -NOSYS if pollfd::events equals 0

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -944,8 +944,6 @@ static int pty_poll(FAR struct file *filep, FAR struct pollfd *fds,
       return ret;
     }
 
-  ret = -ENOSYS;
-
   if (setup)
     {
       for (i = 0; i < CONFIG_DEV_PTY_NPOLLWAITERS; i++)


### PR DESCRIPTION
## Summary
since the caller is free not to monitor any event

## Impact
Improve the compablity, libssh may call poll without any event flag

## Testing
Run libssh's sshd example.
