### PR TITLE
serial/pty: Initialize the terminal setting as a console

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -1111,6 +1111,10 @@ int pty_register(int minor)
   devpair->pp_master.pd_devpair = devpair;
   devpair->pp_master.pd_master  = true;
   devpair->pp_slave.pd_devpair  = devpair;
+#ifdef CONFIG_SERIAL_TERMIOS
+  devpair->pp_slave.pd_iflag    = ISIG;
+  devpair->pp_slave.pd_oflag    = OPOST | ONLCR;
+#endif
 
   /* Create two pipes:
    *


### PR DESCRIPTION
## Summary
It's also the default setting in Linux kernel:
https://github.com/torvalds/linux/blob/ef1244124349fea36e4a7e260ecaf156b6b6b22a/drivers/tty/pty.c#L597
https://github.com/torvalds/linux/blob/ef1244124349fea36e4a7e260ecaf156b6b6b22a/drivers/tty/tty_io.c#L123-L133

## Impact
Improve the compatiblity with libssh

## Testing
Untunu default ssh client can break the newline correctly with NuttX's sshd(libssh).
