### PR TITLE
sched: Identify the stack need to free by TCB_FLAG_FREE_STACK

### DIFF
--- a/arch/arm/src/common/arm_createstack.c
+++ b/arch/arm/src/common/arm_createstack.c
@@ -197,7 +197,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       tcb->adj_stack_size = stack_size;
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
 
 #ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a
@@ -207,6 +207,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       arm_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
 #endif /* CONFIG_STACK_COLORATION */
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/arm/src/common/arm_releasestack.c
+++ b/arch/arm/src/common/arm_releasestack.c
@@ -71,35 +71,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/arm/src/common/arm_usestack.c
+++ b/arch/arm/src/common/arm_usestack.c
@@ -117,7 +117,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
   /* Save the new stack allocation */
 
   tcb->stack_alloc_ptr = stack;
-  tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
   tcb->adj_stack_size  =
       STACK_ALIGN_DOWN((uintptr_t)stack + stack_size) - (uintptr_t)stack;
 

--- a/arch/avr/src/avr/up_createstack.c
+++ b/arch/avr/src/avr/up_createstack.c
@@ -178,8 +178,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = stack_size;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
 #if defined(ARCH_HAVE_LEDS)
       board_autoled_on(LED_STACKCREATED);

--- a/arch/avr/src/avr/up_usestack.c
+++ b/arch/avr/src/avr/up_usestack.c
@@ -106,7 +106,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = stack_size;
 
   return OK;

--- a/arch/avr/src/avr32/up_createstack.c
+++ b/arch/avr/src/avr32/up_createstack.c
@@ -201,8 +201,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/avr/src/avr32/up_usestack.c
+++ b/arch/avr/src/avr32/up_usestack.c
@@ -119,7 +119,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/arch/avr/src/common/up_releasestack.c
+++ b/arch/avr/src/common/up_releasestack.c
@@ -79,35 +79,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/hc/src/common/up_createstack.c
+++ b/arch/hc/src/common/up_createstack.c
@@ -200,8 +200,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->alloc_stack_ptr;
+      tcb->stack_base_ptr = tcb->alloc_stack_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/hc/src/common/up_releasestack.c
+++ b/arch/hc/src/common/up_releasestack.c
@@ -79,35 +79,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/mips/src/common/mips_createstack.c
+++ b/arch/mips/src/common/mips_createstack.c
@@ -227,8 +227,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/mips/src/common/mips_releasestack.c
+++ b/arch/mips/src/common/mips_releasestack.c
@@ -79,35 +79,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/mips/src/common/mips_usestack.c
+++ b/arch/mips/src/common/mips_usestack.c
@@ -145,7 +145,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/arch/misoc/src/lm32/lm32_createstack.c
+++ b/arch/misoc/src/lm32/lm32_createstack.c
@@ -219,8 +219,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/misoc/src/lm32/lm32_releasestack.c
+++ b/arch/misoc/src/lm32/lm32_releasestack.c
@@ -71,35 +71,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/misoc/src/lm32/lm32_usestack.c
+++ b/arch/misoc/src/lm32/lm32_usestack.c
@@ -115,7 +115,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/arch/misoc/src/minerva/minerva_createstack.c
+++ b/arch/misoc/src/minerva/minerva_createstack.c
@@ -212,8 +212,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/misoc/src/minerva/minerva_releasestack.c
+++ b/arch/misoc/src/minerva/minerva_releasestack.c
@@ -71,35 +71,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/misoc/src/minerva/minerva_usestack.c
+++ b/arch/misoc/src/minerva/minerva_usestack.c
@@ -115,7 +115,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/arch/or1k/src/common/up_createstack.c
+++ b/arch/or1k/src/common/up_createstack.c
@@ -191,7 +191,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
@@ -201,8 +201,8 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
-
 #endif /* CONFIG_STACK_COLORATION */
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/or1k/src/common/up_releasestack.c
+++ b/arch/or1k/src/common/up_releasestack.c
@@ -75,35 +75,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/or1k/src/common/up_usestack.c
+++ b/arch/or1k/src/common/up_usestack.c
@@ -115,7 +115,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/arch/renesas/src/common/up_createstack.c
+++ b/arch/renesas/src/common/up_createstack.c
@@ -200,8 +200,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/renesas/src/common/up_releasestack.c
+++ b/arch/renesas/src/common/up_releasestack.c
@@ -79,35 +79,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/renesas/src/common/up_usestack.c
+++ b/arch/renesas/src/common/up_usestack.c
@@ -117,7 +117,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -204,7 +204,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
@@ -216,6 +216,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
       riscv_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
 
 #endif /* CONFIG_STACK_COLORATION */
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/risc-v/src/common/riscv_releasestack.c
+++ b/arch/risc-v/src/common/riscv_releasestack.c
@@ -79,35 +79,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/sim/src/sim/up_createstack.c
+++ b/arch/sim/src/sim/up_createstack.c
@@ -124,7 +124,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       tcb->adj_stack_size  = adj_stack_size;
       tcb->stack_alloc_ptr = stack_alloc_ptr;
-      tcb->stack_base_ptr   = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
 
 #ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a
@@ -133,8 +133,8 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
-
 #endif /* CONFIG_STACK_COLORATION */
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       ret = OK;
     }

--- a/arch/sim/src/sim/up_releasestack.c
+++ b/arch/sim/src/sim/up_releasestack.c
@@ -62,17 +62,15 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
-      if (umm_heapmember(dtcb->stack_alloc_ptr))
-        {
-          kumm_free(dtcb->stack_alloc_ptr);
-        }
+      kumm_free(dtcb->stack_alloc_ptr);
     }
 
   /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
   dtcb->stack_alloc_ptr = NULL;
-  dtcb->adj_stack_size  = 0;
-  dtcb->stack_base_ptr   = NULL;
+  dtcb->stack_base_ptr = NULL;
+  dtcb->adj_stack_size = 0;
 }

--- a/arch/x86/src/i486/up_createstack.c
+++ b/arch/x86/src/i486/up_createstack.c
@@ -200,8 +200,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/x86/src/i486/up_releasestack.c
+++ b/arch/x86/src/i486/up_releasestack.c
@@ -79,35 +79,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/x86/src/i486/up_usestack.c
+++ b/arch/x86/src/i486/up_usestack.c
@@ -117,7 +117,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/arch/x86_64/src/intel64/up_createstack.c
+++ b/arch/x86_64/src/intel64/up_createstack.c
@@ -202,8 +202,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/x86_64/src/intel64/up_releasestack.c
+++ b/arch/x86_64/src/intel64/up_releasestack.c
@@ -81,7 +81,7 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
@@ -97,13 +97,12 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 
           kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/x86_64/src/intel64/up_usestack.c
+++ b/arch/x86_64/src/intel64/up_usestack.c
@@ -119,7 +119,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -242,7 +242,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
 
 #ifdef CONFIG_STACK_COLORATION
@@ -253,6 +253,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
 #endif
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/xtensa/src/common/xtensa_releasestack.c
+++ b/arch/xtensa/src/common/xtensa_releasestack.c
@@ -72,35 +72,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (UMM_HEAPMEMEBER(dtcb->stack_alloc_ptr))
-            {
-              UMM_FREE(dtcb->stack_alloc_ptr);
-            }
+          UMM_FREE(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/xtensa/src/common/xtensa_usestack.c
+++ b/arch/xtensa/src/common/xtensa_usestack.c
@@ -123,7 +123,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
 #if defined(CONFIG_STACK_COLORATION)

--- a/arch/z16/src/common/z16_createstack.c
+++ b/arch/z16/src/common/z16_createstack.c
@@ -194,8 +194,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/z16/src/common/z16_releasestack.c
+++ b/arch/z16/src/common/z16_releasestack.c
@@ -73,19 +73,15 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
-      if (umm_heapmember(dtcb->stack_alloc_ptr))
-        {
-          kumm_free(dtcb->stack_alloc_ptr);
-        }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
+      kumm_free(dtcb->stack_alloc_ptr);
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/z80/src/common/z80_createstack.c
+++ b/arch/z80/src/common/z80_createstack.c
@@ -199,8 +199,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       /* Save the adjusted stack values in the struct tcb_s */
 
-      tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+      tcb->stack_base_ptr = tcb->stack_alloc_ptr;
       tcb->adj_stack_size = size_of_stack;
+      tcb->flags |= TCB_FLAG_FREE_STACK;
 
       board_autoled_on(LED_STACKCREATED);
       return OK;

--- a/arch/z80/src/common/z80_releasestack.c
+++ b/arch/z80/src/common/z80_releasestack.c
@@ -79,35 +79,28 @@ void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 
-  if (dtcb->stack_alloc_ptr)
+  if (dtcb->stack_alloc_ptr && (dtcb->flags & TCB_FLAG_FREE_STACK))
     {
 #ifdef CONFIG_MM_KERNEL_HEAP
       /* Use the kernel allocator if this is a kernel thread */
 
       if (ttype == TCB_FLAG_TTYPE_KERNEL)
         {
-          if (kmm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kmm_free(dtcb->stack_alloc_ptr);
-            }
+          kmm_free(dtcb->stack_alloc_ptr);
         }
       else
 #endif
         {
           /* Use the user-space allocator if this is a task or pthread */
 
-          if (umm_heapmember(dtcb->stack_alloc_ptr))
-            {
-              kumm_free(dtcb->stack_alloc_ptr);
-            }
+          kumm_free(dtcb->stack_alloc_ptr);
         }
-
-      /* Mark the stack freed */
-
-      dtcb->stack_alloc_ptr = NULL;
     }
 
-  /* The size of the allocated stack is now zero */
+  /* Mark the stack freed */
 
+  dtcb->flags &= ~TCB_FLAG_FREE_STACK;
+  dtcb->stack_alloc_ptr = NULL;
+  dtcb->stack_base_ptr = NULL;
   dtcb->adj_stack_size = 0;
 }

--- a/arch/z80/src/common/z80_usestack.c
+++ b/arch/z80/src/common/z80_usestack.c
@@ -116,7 +116,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
+  tcb->stack_base_ptr = tcb->stack_alloc_ptr;
   tcb->adj_stack_size = size_of_stack;
 
   return OK;

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -107,7 +107,8 @@
 #define TCB_FLAG_SIGNAL_ACTION     (1 << 9)                      /* Bit 8: In a signal handler */
 #define TCB_FLAG_SYSCALL           (1 << 10)                     /* Bit 9: In a system call */
 #define TCB_FLAG_EXIT_PROCESSING   (1 << 11)                     /* Bit 10: Exitting */
-                                                                 /* Bits 11-15: Available */
+#define TCB_FLAG_FREE_STACK        (1 << 12)                     /* Bit 12: Free stack after exit */
+                                                                 /* Bits 13-15: Available */
 
 /* Values for struct task_group tg_flags */
 


### PR DESCRIPTION
## Summary
instead calling kmm_heapmember or umm_heapmember because:
1.The stack supplied by caller may allocate from heap too
2.It's hard to implement these two function in ASan case

## Impact
Decide whether to release the stack more accurately
## Testing
Pass ostest
