### PR TITLE
sim: Use cc as linker, which usually aliases to either GCC or Clang

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -83,7 +83,7 @@ endif
 CC = $(CROSSDEV)cc
 CXX = $(CROSSDEV)c++
 CPP = $(CROSSDEV)cc -E -P -x c
-LD = $(CROSSDEV)gcc
+LD = $(CROSSDEV)cc
 ifeq ($(CONFIG_HOST_MACOS),y)
 STRIP = $(CROSSDEV)strip
 AR = $(TOPDIR)/tools/macar-rcs.sh


### PR DESCRIPTION
## Summary
This PR intends to fix a regression introduced after #3836 on the support for building the NuttX simulator on systems with clang as the default compiler.

## Impact
Fix for building simulator on systems with clang as the default compiler.

## Testing
`sim:nsh` after forcing clang as the default compiler on Ubuntu 21.04. and also on macOS
