### PR TITLE
sched/posix_spawn: Don't insert name at the begin of argv

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -168,8 +168,8 @@ int exec_module(FAR const struct binary_s *binp,
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, filename, binp->priority,
-                    NULL, binp->stacksize, binp->entrypt, argv);
+  ret = nxtask_init(tcb, argv[0], binp->priority, NULL,
+                    binp->stacksize, binp->entrypt, &argv[1]);
   binfmt_freeargv(argv);
   if (ret < 0)
     {

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -168,7 +168,7 @@ int exec_module(FAR const struct binary_s *binp,
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, false, filename, binp->priority,
+  ret = nxtask_init(tcb, filename, binp->priority,
                     NULL, binp->stacksize, binp->entrypt, argv);
   binfmt_freeargv(argv);
   if (ret < 0)

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -908,16 +908,15 @@ FAR struct streamlist *nxsched_get_streams(void);
  *     - Task type may be set in the TCB flags to create kernel thread
  *
  * Input Parameters:
- *   tcb         - Address of the new task's TCB
- *   insert_name - Insert name to the first argv
- *   name        - Name of the new task
- *   priority    - Priority of the new task
- *   stack       - Start of the pre-allocated stack
- *   stack_size  - Size (in bytes) of the stack allocated
- *   entry       - Application start point of the new task
- *   argv        - A pointer to an array of input parameters.  The array
- *                 should be terminated with a NULL argv[] value. If no
- *                 parameters are required, argv may be NULL.
+ *   tcb        - Address of the new task's TCB
+ *   name       - Name of the new task (not used)
+ *   priority   - Priority of the new task
+ *   stack      - Start of the pre-allocated stack
+ *   stack_size - Size (in bytes) of the stack allocated
+ *   entry      - Application start point of the new task
+ *   argv       - A pointer to an array of input parameters.  The array
+ *                should be terminated with a NULL argv[] value. If no
+ *                parameters are required, argv may be NULL.
  *
  * Returned Value:
  *   OK on success; negative error value on failure appropriately.  (See
@@ -928,8 +927,7 @@ FAR struct streamlist *nxsched_get_streams(void);
  *
  ****************************************************************************/
 
-int nxtask_init(FAR struct task_tcb_s *tcb, bool insert_name,
-                const char *name, int priority,
+int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 FAR void *stack, uint32_t stack_size, main_t entry,
                 FAR char * const argv[]);
 

--- a/sched/task/task.h
+++ b/sched/task/task.h
@@ -44,8 +44,8 @@ struct tcb_s; /* Forward reference */
 void nxtask_start(void);
 int  nxtask_setup_scheduler(FAR struct task_tcb_s *tcb, int priority,
        start_t start, main_t main, uint8_t ttype);
-int  nxtask_setup_arguments(FAR struct task_tcb_s *tcb, FAR const char *name,
-       FAR char * const argv[]);
+int  nxtask_setup_arguments(FAR struct task_tcb_s *tcb,
+       FAR const char *name, FAR char * const argv[]);
 
 /* Task exit */
 

--- a/sched/task/task.h
+++ b/sched/task/task.h
@@ -44,8 +44,8 @@ struct tcb_s; /* Forward reference */
 void nxtask_start(void);
 int  nxtask_setup_scheduler(FAR struct task_tcb_s *tcb, int priority,
        start_t start, main_t main, uint8_t ttype);
-int  nxtask_setup_arguments(FAR struct task_tcb_s *tcb, bool insert_name,
-       FAR const char *name, FAR char * const argv[]);
+int  nxtask_setup_arguments(FAR struct task_tcb_s *tcb, FAR const char *name,
+       FAR char * const argv[]);
 
 /* Task exit */
 

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -91,8 +91,7 @@ static int nxthread_create(FAR const char *name, uint8_t ttype,
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, true, name, priority,
-                    NULL, stack_size, entry, argv);
+  ret = nxtask_init(tcb, name, priority, NULL, stack_size, entry, argv);
   if (ret < OK)
     {
       kmm_free(tcb);

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -62,16 +62,15 @@
  *     - Task type may be set in the TCB flags to create kernel thread
  *
  * Input Parameters:
- *   tcb         - Address of the new task's TCB
- *   insert_name - Insert name to the first argv
- *   name        - Name of the new task
- *   priority    - Priority of the new task
- *   stack       - Start of the pre-allocated stack
- *   stack_size  - Size (in bytes) of the stack allocated
- *   entry       - Application start point of the new task
- *   argv        - A pointer to an array of input parameters.  The array
- *                 should be terminated with a NULL argv[] value. If no
- *                 parameters are required, argv may be NULL.
+ *   tcb        - Address of the new task's TCB
+ *   name       - Name of the new task (not used)
+ *   priority   - Priority of the new task
+ *   stack      - Start of the pre-allocated stack
+ *   stack_size - Size (in bytes) of the stack allocated
+ *   entry      - Application start point of the new task
+ *   argv       - A pointer to an array of input parameters.  The array
+ *                should be terminated with a NULL argv[] value. If no
+ *                parameters are required, argv may be NULL.
  *
  * Returned Value:
  *   OK on success; negative error value on failure appropriately.  (See
@@ -82,8 +81,7 @@
  *
  ****************************************************************************/
 
-int nxtask_init(FAR struct task_tcb_s *tcb, bool insert_name,
-                const char *name, int priority,
+int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 FAR void *stack, uint32_t stack_size,
                 main_t entry, FAR char * const argv[])
 {
@@ -155,7 +153,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, bool insert_name,
 
   /* Setup to pass parameters to the new task */
 
-  nxtask_setup_arguments(tcb, insert_name, name, argv);
+  nxtask_setup_arguments(tcb, name, argv);
 
   /* Now we have enough in place that we can join the group */
 

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -452,13 +452,6 @@ static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
 static void nxtask_setup_name(FAR struct task_tcb_s *tcb,
                               FAR const char *name)
 {
-  /* Give a name to the unnamed tasks */
-
-  if (!name)
-    {
-      name = (FAR char *)g_noname;
-    }
-
   /* Copy the name into the TCB */
 
   strncpy(tcb->cmn.name, name, CONFIG_TASK_NAME_SIZE);
@@ -489,25 +482,17 @@ static void nxtask_setup_name(FAR struct task_tcb_s *tcb,
  *
  ****************************************************************************/
 
-static inline int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
-                                         FAR char * const argv[])
+static int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
+                                  FAR const char *name,
+                                  FAR char * const argv[])
 {
   FAR char **stackargv;
-  FAR const char *name;
   FAR char *str;
   size_t strtablen;
   size_t argvlen;
   int nbytes;
   int argc;
   int i;
-
-  /* Get the name string that we will use as the first argument */
-
-#if CONFIG_TASK_NAME_SIZE > 0
-  name = tcb->cmn.name;
-#else
-  name = (FAR const char *)g_noname;
-#endif /* CONFIG_TASK_NAME_SIZE */
 
   /* Get the size of the task name (including the NUL terminator) */
 
@@ -707,9 +692,16 @@ int pthread_setup_scheduler(FAR struct pthread_tcb_s *tcb, int priority,
  *
  ****************************************************************************/
 
-int nxtask_setup_arguments(FAR struct task_tcb_s *tcb, FAR const char *name,
-                           FAR char * const argv[])
+int nxtask_setup_arguments(FAR struct task_tcb_s *tcb,
+                           FAR const char *name, FAR char * const argv[])
 {
+  /* Give a name to the unnamed tasks */
+
+  if (!name)
+    {
+      name = (FAR char *)g_noname;
+    }
+
   /* Setup the task name */
 
   nxtask_setup_name(tcb, name);
@@ -719,5 +711,5 @@ int nxtask_setup_arguments(FAR struct task_tcb_s *tcb, FAR const char *name,
    * privilege mode the task runs in.
    */
 
-  return nxtask_setup_stackargs(tcb, argv);
+  return nxtask_setup_stackargs(tcb, name, argv);
 }

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -97,7 +97,6 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
   FAR struct task_tcb_s *parent;
   FAR struct task_tcb_s *child;
   FAR struct task_info_s *info;
-  FAR const char *name = NULL;
   size_t stack_size;
   uint8_t ttype;
   int priority;
@@ -204,11 +203,7 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
 
   /* Setup to pass parameters to the new task */
 
-#if CONFIG_TASK_NAME_SIZE > 0
-  name = parent->cmn.name;
-#endif
-
-  nxtask_setup_arguments(child, name, parent->argv);
+  nxtask_setup_arguments(child, parent->argv[0], &parent->argv[1]);
 
   /* Now we have enough in place that we can join the group */
 

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -208,7 +208,7 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
   name = parent->cmn.name;
 #endif
 
-  nxtask_setup_arguments(child, false, name, parent->argv);
+  nxtask_setup_arguments(child, name, parent->argv);
 
   /* Now we have enough in place that we can join the group */
 


### PR DESCRIPTION
## Summary

## Impact

## Testing

