### PR TITLE
net/inet: add support of FIONREAD

### DIFF
--- a/Documentation/reference/os/iob.rst
+++ b/Documentation/reference/os/iob.rst
@@ -165,6 +165,7 @@ Public Function Prototypes
   - :c:func:`iob_peek_queue()`
   - :c:func:`iob_free_queue()`
   - :c:func:`iob_free_queue_qentry()`
+  - :c:func:`iob_get_queue_size()`
   - :c:func:`iob_copyin()`
   - :c:func:`iob_trycopyin()`
   - :c:func:`iob_copyout()`
@@ -241,6 +242,10 @@ Public Function Prototypes
 
 .. c:function:: void iob_free_queue_qentry(FAR struct iob_s *iob, \
                   FAR struct iob_queue_s *iobq);
+
+  Queue helper for get the iob queue buffer size.
+
+.. c:function:: unsigned int iob_get_queue_size(FAR struct iob_queue_s *queue);
 
   Free an iob entire queue of I/O buffer chains.
 

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -440,6 +440,18 @@ void iob_free_queue_qentry(FAR struct iob_s *iob,
 #endif /* CONFIG_IOB_NCHAINS > 0 */
 
 /****************************************************************************
+ * Name: iob_get_queue_size
+ *
+ * Description:
+ *   Queue helper for get the iob queue buffer size.
+ *
+ ****************************************************************************/
+
+#if CONFIG_IOB_NCHAINS > 0
+unsigned int iob_get_queue_size(FAR struct iob_queue_s *queue);
+#endif /* CONFIG_IOB_NCHAINS > 0 */
+
+/****************************************************************************
  * Name: iob_copyin
  *
  * Description:

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -195,14 +195,12 @@ struct sock_intf_s
   CODE ssize_t    (*si_recvmsg)(FAR struct socket *psock,
                     FAR struct msghdr *msg, int flags);
   CODE int        (*si_close)(FAR struct socket *psock);
+  CODE int        (*si_ioctl)(FAR struct socket *psock, int cmd,
+                    FAR void *arg, size_t arglen);
 #ifdef CONFIG_NET_SENDFILE
   CODE ssize_t    (*si_sendfile)(FAR struct socket *psock,
                     FAR struct file *infile, FAR off_t *offset,
                     size_t count);
-#endif
-#ifdef CONFIG_NET_USRSOCK
-  CODE int        (*si_ioctl)(FAR struct socket *psock, int cmd,
-                    FAR void *arg, size_t arglen);
 #endif
 };
 

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -624,9 +624,7 @@ int netdev_carrier_off(FAR struct net_driver_s *dev);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NET_USRSOCK
 ssize_t net_ioctl_arglen(int cmd);
-#endif
 
 /****************************************************************************
  * Name: net_chksum

--- a/mm/iob/Make.defs
+++ b/mm/iob/Make.defs
@@ -28,6 +28,7 @@ CSRCS += iob_free_chain.c iob_free_qentry.c iob_free_queue.c
 CSRCS += iob_initialize.c iob_pack.c iob_peek_queue.c iob_remove_queue.c
 CSRCS += iob_statistics.c iob_trimhead.c iob_trimhead_queue.c iob_trimtail.c
 CSRCS += iob_navail.c iob_free_queue_qentry.c iob_tailroom.c
+CSRCS += iob_get_queue_size.c
 
 ifeq ($(CONFIG_IOB_NOTIFIER),y)
   CSRCS += iob_notifier.c

--- a/mm/iob/iob_get_queue_size.c
+++ b/mm/iob/iob_get_queue_size.c
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * mm/iob/iob_get_queue_size.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/mm/iob.h>
+#include "iob.h"
+
+#if CONFIG_IOB_NCHAINS > 0
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: iob_get_queue_size
+ *
+ * Description:
+ *   Queue helper for get the iob queue buffer size.
+ *
+ ****************************************************************************/
+
+unsigned int iob_get_queue_size(FAR struct iob_queue_s *queue)
+{
+  FAR struct iob_qentry_s *iobq;
+  unsigned int total = 0;
+  FAR struct iob_s *iob;
+
+  for (iobq = queue->qh_head; iobq != NULL; iobq = iobq->qe_flink)
+    {
+      iob = iobq->qe_head;
+      total += iob->io_pktlen;
+    }
+
+  return total;
+}
+
+#endif /* CONFIG_IOB_NCHAINS > 0 */

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -34,6 +34,7 @@
 
 #include <netinet/in.h>
 
+#include <nuttx/fs/ioctl.h>
 #include <nuttx/net/net.h>
 #include <socket/socket.h>
 
@@ -67,6 +68,8 @@ static int        local_accept(FAR struct socket *psock,
 static int        local_poll(FAR struct socket *psock,
                     FAR struct pollfd *fds, bool setup);
 static int        local_close(FAR struct socket *psock);
+static int        local_ioctl(FAR struct socket *psock, int cmd,
+                    FAR void *arg, size_t arglen);
 
 /****************************************************************************
  * Public Data
@@ -86,7 +89,8 @@ const struct sock_intf_s g_local_sockif =
   local_poll,        /* si_poll */
   local_sendmsg,     /* si_sendmsg */
   local_recvmsg,     /* si_recvmsg */
-  local_close        /* si_close */
+  local_close,       /* si_close */
+  local_ioctl        /* si_ioctl */
 };
 
 /****************************************************************************
@@ -680,6 +684,48 @@ static int local_close(FAR struct socket *psock)
       default:
         return -EBADF;
     }
+}
+
+/****************************************************************************
+ * Name: local_ioctl
+ *
+ * Description:
+ *   This function performs local device specific operations.
+ *
+ * Parameters:
+ *   psock    A reference to the socket structure of the socket
+ *   cmd      The ioctl command
+ *   arg      The argument of the ioctl cmd
+ *   arglen   The length of 'arg'
+ *
+ ****************************************************************************/
+
+static int local_ioctl(FAR struct socket *psock, int cmd,
+                       FAR void *arg, size_t arglen)
+{
+  FAR struct local_conn_s *conn;
+  int ret = OK;
+
+  conn = (FAR struct local_conn_s *)psock->s_conn;
+
+  switch (cmd)
+    {
+      case FIONREAD:
+        if (conn->lc_infile.f_inode != NULL)
+          {
+            ret = file_ioctl(&conn->lc_infile, cmd, arg);
+          }
+        else
+          {
+            ret = -ENOTCONN;
+          }
+        break;
+      default:
+        ret = -ENOTTY;
+        break;
+    }
+
+  return ret;
 }
 
 /****************************************************************************

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1454,7 +1454,7 @@ static int netdev_rt_ioctl(FAR struct socket *psock, int cmd,
 #endif
 
 /****************************************************************************
- * Name: netdev_usrsock_ioctl
+ * Name: netdev_ioctl
  *
  * Description:
  *   Perform user private ioctl operations.
@@ -1470,9 +1470,8 @@ static int netdev_rt_ioctl(FAR struct socket *psock, int cmd,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NET_USRSOCK
-static int netdev_usrsock_ioctl(FAR struct socket *psock, int cmd,
-                                unsigned long arg)
+static int netdev_ioctl(FAR struct socket *psock, int cmd,
+                        unsigned long arg)
 {
   if (psock->s_sockif && psock->s_sockif->si_ioctl)
     {
@@ -1491,7 +1490,6 @@ static int netdev_usrsock_ioctl(FAR struct socket *psock, int cmd,
       return -ENOTTY;
     }
 }
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -1512,11 +1510,13 @@ static int netdev_usrsock_ioctl(FAR struct socket *psock, int cmd,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NET_USRSOCK
 ssize_t net_ioctl_arglen(int cmd)
 {
   switch (cmd)
     {
+      case FIONREAD:
+        return sizeof(int);
+
       case SIOCGIFADDR:
       case SIOCSIFADDR:
       case SIOCGIFDSTADDR:
@@ -1607,7 +1607,6 @@ ssize_t net_ioctl_arglen(int cmd)
         return -ENOTTY;
     }
 }
-#endif
 
 /****************************************************************************
  * Name: psock_ioctl and psock_vioctl
@@ -1654,12 +1653,10 @@ int psock_vioctl(FAR struct socket *psock, int cmd, va_list ap)
 
   arg = va_arg(ap, unsigned long);
 
-#ifdef CONFIG_NET_USRSOCK
   /* Check for a USRSOCK ioctl command */
 
-  ret = netdev_usrsock_ioctl(psock, cmd, arg);
+  ret = netdev_ioctl(psock, cmd, arg);
   if (ret == -ENOTTY)
-#endif
     {
       /* Check for a standard network IOCTL command. */
 

--- a/net/tcp/Make.defs
+++ b/net/tcp/Make.defs
@@ -53,7 +53,7 @@ endif
 NET_CSRCS += tcp_conn.c tcp_seqno.c tcp_devpoll.c tcp_finddev.c tcp_timer.c
 NET_CSRCS += tcp_send.c tcp_input.c tcp_appsend.c tcp_listen.c tcp_close.c
 NET_CSRCS += tcp_monitor.c tcp_callback.c tcp_backlog.c tcp_ipselect.c
-NET_CSRCS += tcp_recvwindow.c tcp_netpoll.c
+NET_CSRCS += tcp_recvwindow.c tcp_netpoll.c tcp_ioctl.c
 
 # TCP write buffering
 

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1856,6 +1856,23 @@ int tcp_txdrain(FAR struct socket *psock, unsigned int timeout);
 #  define tcp_txdrain(conn, timeout) (0)
 #endif
 
+/****************************************************************************
+ * Name: tcp_ioctl
+ *
+ * Description:
+ *   This function performs tcp specific ioctl() operations.
+ *
+ * Parameters:
+ *   conn     The TCP connection of interest
+ *   cmd      The ioctl command
+ *   arg      The argument of the ioctl cmd
+ *   arglen   The length of 'arg'
+ *
+ ****************************************************************************/
+
+int tcp_ioctl(FAR struct tcp_conn_s *conn, int cmd,
+              FAR void *arg, size_t arglen);
+
 #ifdef __cplusplus
 }
 #endif

--- a/net/tcp/tcp_ioctl.c
+++ b/net/tcp/tcp_ioctl.c
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * net/tcp/tcp_ioctl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <net/if.h>
+
+#include <nuttx/fs/ioctl.h>
+#include <nuttx/mm/iob.h>
+#include <nuttx/net/net.h>
+
+#include "tcp/tcp.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: tcp_ioctl
+ *
+ * Description:
+ *   This function performs tcp specific ioctl() operations.
+ *
+ * Parameters:
+ *   conn     The TCP connection of interest
+ *   cmd      The ioctl command
+ *   arg      The argument of the ioctl cmd
+ *   arglen   The length of 'arg'
+ *
+ ****************************************************************************/
+
+int tcp_ioctl(FAR struct tcp_conn_s *conn,
+              int cmd, FAR void *arg, size_t arglen)
+{
+  int ret = OK;
+
+  net_lock();
+
+  switch (cmd)
+    {
+      case FIONREAD:
+        if (conn->readahead != NULL)
+          {
+            *(FAR int *)((uintptr_t)arg) = conn->readahead->io_pktlen;
+          }
+        else
+          {
+            *(FAR int *)((uintptr_t)arg) = 0;
+          }
+        break;
+      default:
+        ret = -ENOTTY;
+        break;
+    }
+
+  net_unlock();
+
+  return ret;
+}

--- a/net/udp/Make.defs
+++ b/net/udp/Make.defs
@@ -48,6 +48,7 @@ endif
 
 NET_CSRCS += udp_conn.c udp_devpoll.c udp_send.c udp_input.c udp_finddev.c
 NET_CSRCS += udp_close.c udp_callback.c udp_ipselect.c udp_netpoll.c
+NET_CSRCS += udp_ioctl.c
 
 # UDP write buffering
 

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -869,6 +869,23 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout);
 #  define udp_txdrain(conn, timeout) (0)
 #endif
 
+/****************************************************************************
+ * Name: udp_ioctl
+ *
+ * Description:
+ *   This function performs udp specific ioctl() operations.
+ *
+ * Parameters:
+ *   conn     The TCP connection of interest
+ *   cmd      The ioctl command
+ *   arg      The argument of the ioctl cmd
+ *   arglen   The length of 'arg'
+ *
+ ****************************************************************************/
+
+int udp_ioctl(FAR struct udp_conn_s *conn,
+              int cmd, FAR void *arg, size_t arglen);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/net/udp/udp_ioctl.c
+++ b/net/udp/udp_ioctl.c
@@ -1,0 +1,87 @@
+/****************************************************************************
+ * net/udp/udp_ioctl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <net/if.h>
+
+#include <nuttx/fs/ioctl.h>
+#include <nuttx/mm/iob.h>
+#include <nuttx/net/net.h>
+
+#include "udp/udp.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: udp_ioctl
+ *
+ * Description:
+ *   This function performs udp specific ioctl() operations.
+ *
+ * Parameters:
+ *   conn     The TCP connection of interest
+ *   cmd      The ioctl command
+ *   arg      The argument of the ioctl cmd
+ *   arglen   The length of 'arg'
+ *
+ ****************************************************************************/
+
+int udp_ioctl(FAR struct udp_conn_s *conn,
+              int cmd, FAR void *arg, size_t arglen)
+{
+  FAR struct iob_s *iob;
+  int ret = OK;
+
+  net_lock();
+
+  switch (cmd)
+    {
+      case FIONREAD:
+        iob = iob_peek_queue(&conn->readahead);
+        if (iob)
+          {
+            *(FAR int *)((uintptr_t)arg) = iob->io_pktlen;
+          }
+        else
+          {
+            *(FAR int *)((uintptr_t)arg) = 0;
+          }
+        break;
+      default:
+        ret = -ENOTTY;
+        break;
+    }
+
+  net_unlock();
+
+  return ret;
+}


### PR DESCRIPTION
## Summary

net/inet: add support of FIONREAD
mm/iob: add iob_get_queue_size() helper

## Impact

```
   Buffer count and flushing
       FIONREAD  int *argp
              Get the number of bytes in the input buffer.
```


## Testing

ioctl(socketfd, FIONREAD, &size)
