### PR TITLE
binfmt: Handle argv/argv[0] == NULL correctly in exec_module

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -168,8 +168,17 @@ int exec_module(FAR const struct binary_s *binp,
 
   /* Initialize the task */
 
-  ret = nxtask_init(tcb, argv[0], binp->priority, NULL,
-                    binp->stacksize, binp->entrypt, &argv[1]);
+  if (argv && argv[0])
+    {
+      ret = nxtask_init(tcb, argv[0], binp->priority, NULL,
+                        binp->stacksize, binp->entrypt, &argv[1]);
+    }
+  else
+    {
+      ret = nxtask_init(tcb, filename, binp->priority, NULL,
+                        binp->stacksize, binp->entrypt, argv);
+    }
+
   binfmt_freeargv(argv);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
Fix crash report here: https://github.com/apache/incubator-nuttx/pull/3923

## Impact

## Testing

