### PR TITLE
riscv/mpfs: add i2c reset handler

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -95,10 +95,12 @@ config MPFS_UART4
 
 config MPFS_I2C0
         bool "I2C 0"
+        select ARCH_HAVE_I2CRESET
         default n
 
 config MPFS_I2C1
         bool "I2C 1"
+        select ARCH_HAVE_I2CRESET
         default n
 
 endmenu


### PR DESCRIPTION
## Summary
Add reset functionality into the mpfs i2c driver.

## Impact
New feature, no other code changes

## Testing
