### PR TITLE
esp32&esp32c3/wifi: Fix the issues of Wi-Fi configuration being overwritten

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -747,6 +747,12 @@ choice EXAMPLE_POWER_SAVE_MODE
 		bool "maximum modem"
 endchoice
 
+config ESP32C3_WIFI_RECONNECT
+	bool "Enable Wi-Fi to reconnect"
+	default n
+	---help---
+		Select this option to enable Wi-Fi to reconnect for station when disconnected.
+
 endmenu # ESP32C3_WIRELESS
 
 menu "SPI Flash configuration"

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -2056,6 +2056,7 @@ static void esp_evt_work_cb(FAR void *arg)
   irqstate_t flags;
   struct evt_adpt *evt_adpt;
   struct wifi_notify *notify;
+  wifi_event_sta_disconnected_t *disconnected;
 
   while (1)
     {
@@ -2092,8 +2093,11 @@ static void esp_evt_work_cb(FAR void *arg)
             break;
 
           case WIFI_ADPT_EVT_STA_DISCONNECT:
-            wlinfo("INFO: Wi-Fi sta disconnect\n");
+            disconnected = (wifi_event_sta_disconnected_t *)evt_adpt->buf;
+            wlinfo("INFO: Wi-Fi sta disconnect, reason code: %d\n",
+                                              disconnected->reason);
             g_sta_connected = false;
+#ifdef CONFIG_ESP32C3_WIFI_RECONNECT
             if (g_sta_reconnect)
               {
                 ret = esp_wifi_connect();
@@ -2102,6 +2106,7 @@ static void esp_evt_work_cb(FAR void *arg)
                     wlerr("ERROR: Failed to connect AP error=%d\n", ret);
                   }
               }
+#endif
             break;
 
           case WIFI_ADPT_EVT_STA_STOP:

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -5202,6 +5202,7 @@ int esp_wifi_sta_password(struct iwreq *iwr, bool set)
           return -EINVAL;
         }
 
+      memset(wifi_cfg.sta.password, 0x0, PWD_MAX_LEN);
       memcpy(wifi_cfg.sta.password, pdata, len);
 
       wifi_cfg.sta.pmf_cfg.capable = true;
@@ -5328,6 +5329,7 @@ int esp_wifi_sta_essid(struct iwreq *iwr, bool set)
 
   if (set)
     {
+      memset(wifi_cfg.sta.ssid, 0x0, SSID_MAX_LEN);
       memcpy(wifi_cfg.sta.ssid, pdata, len);
 
       ret = esp_wifi_set_config(WIFI_IF_STA, &wifi_cfg);
@@ -6284,8 +6286,8 @@ int esp_wifi_softap_password(struct iwreq *iwr, bool set)
   if (set)
     {
       wifi_cfg.ap.max_connection = ESP_MAX_STA_CONN;
+      memset(wifi_cfg.ap.password, 0x0, PWD_MAX_LEN);
       memcpy(wifi_cfg.ap.password, pdata, len);
-      wifi_cfg.ap.password[len] = '\0';
       if (len)
         {
           wifi_cfg.ap.authmode = WIFI_AUTH_WPA_WPA2_PSK;
@@ -6369,6 +6371,7 @@ int esp_wifi_softap_essid(struct iwreq *iwr, bool set)
 
   if (set)
     {
+      memset(wifi_cfg.ap.ssid, 0x0, SSID_MAX_LEN);
       memcpy(wifi_cfg.ap.ssid, pdata, len);
 
       ret = esp_wifi_set_config(WIFI_IF_AP, &wifi_cfg);

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -5231,6 +5231,7 @@ int esp_wifi_sta_password(struct iwreq *iwr, bool set)
 
   if (set)
     {
+      memset(wifi_cfg.sta.password, 0x0, PWD_MAX_LEN);
       memcpy(wifi_cfg.sta.password, pdata, len);
 
       wifi_cfg.sta.pmf_cfg.capable = true;
@@ -5355,6 +5356,7 @@ int esp_wifi_sta_essid(struct iwreq *iwr, bool set)
 
   if (set)
     {
+      memset(wifi_cfg.sta.ssid, 0x0, SSID_MAX_LEN);
       memcpy(wifi_cfg.sta.ssid, pdata, len);
 
       ret = esp_wifi_set_config(WIFI_IF_STA, &wifi_cfg);
@@ -6302,6 +6304,7 @@ int esp_wifi_softap_password(struct iwreq *iwr, bool set)
 
   if (set)
     {
+      memset(wifi_cfg.ap.password, 0x0, PWD_MAX_LEN);
       memcpy(wifi_cfg.ap.password, pdata, len);
 
       ret = esp_wifi_set_config(WIFI_IF_AP, &wifi_cfg);
@@ -6381,6 +6384,7 @@ int esp_wifi_softap_essid(struct iwreq *iwr, bool set)
 
   if (set)
     {
+      memset(wifi_cfg.ap.ssid, 0x0, SSID_MAX_LEN);
       memcpy(wifi_cfg.ap.ssid, pdata, len);
 
       ret = esp_wifi_set_config(WIFI_IF_AP, &wifi_cfg);


### PR DESCRIPTION
## Summary

- esp32&esp32c3/wifi: Fix the issues of Wi-Fi configuration being overwritten
- risc-v/esp32c3: Disable Wi-Fi reconnect by default

## Impact

## Testing

- Tested with ESP32-Devkitc or ESP32-C3-Devkitc
`./tools/configure esp32c3-devkit:wapi` or `./tools/configure esp32c3-devkit:sta_softap`
`./tools/configure esp32-devkitc:wapi` or `./tools/configure esp32-devkitc:sta_softap`