### PR TITLE
Fix xtensa

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -203,7 +203,11 @@ static inline void xtensa_setps(uint32_t ps)
 {
   __asm__ __volatile__
   (
-    "wsr %0, PS"  : : "r"(ps)
+    "wsr %0, PS \n"
+    "rsync \n"
+    :
+    : "r"(ps)
+    : "memory"
   );
 }
 
@@ -213,7 +217,11 @@ static inline void up_irq_restore(uint32_t ps)
 {
   __asm__ __volatile__
   (
-    "wsr %0, PS"  : : "r"(ps)
+    "wsr %0, PS \n"
+    "rsync \n"
+    :
+    : "r"(ps)
+    : "memory"
   );
 }
 

--- a/arch/xtensa/src/common/xtensa_testset.c
+++ b/arch/xtensa/src/common/xtensa_testset.c
@@ -57,7 +57,6 @@ static inline uint32_t xtensa_compareset(FAR volatile uint32_t *addr,
   __asm__ __volatile__
   (
     "WSR    %2, SCOMPARE1\n" /* Initialize SCOMPARE1 */
-    "ISYNC\n"                /* Wait sync */
     "S32C1I %0, %1, 0\n"     /* Store id into the lock, if the lock is the
                               * same as comparel. Otherwise, no write-access */
     : "=r"(set) : "r"(addr), "r"(compare), "0"(set)


### PR DESCRIPTION
## Summary

- This PR consists of the following 2 commits
- commit1: arch: xtensa: Fix the PS register handling
  - I noticed that DEBUGASSERT sometimes happens in nxsem_wait()
      when testing Wi-Fi with esp32-devkitc:wsifi_smp
  - The call stack was not from an interrupt handler and actually
      g_current_regs[] were correct, even though asserted with
      (up_interrupt_handler() == false)
  - Finally, I found that we need to call rsync after we set
      a new value to the PS register which is described in the
      Xtensa document.
  - This commit fixes this issue
- commit2:
   - According to the Xtensa ISA document, this ISYNC instruction
      between WSR SCOMPARE1 and S32C1I is unnecessary

## Impact

- All xtensa architectures

## Testing

- Tested with esp32-devkitc:wifi_smp and esp32-devkitc:wifi
- Tested with QEMU