### PR TITLE
syslog: Added channel close callback.

### DIFF
--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -94,10 +94,6 @@ FAR struct syslog_channel_s *syslog_dev_initialize(FAR const char *devpath,
  * Input Parameters:
  *   channel    - Handle to syslog channel to be used.
  *
- * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
- *
  * Assumptions:
  *   The caller has already switched the SYSLOG source to some safe channel
  *   (the default channel).

--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -243,6 +243,15 @@ int syslog_channel_remove(FAR struct syslog_channel_s *channel)
 
               g_syslog_channel[i] = NULL;
 
+              /* The channel is now removed from the list and its driver
+               * can be safely uninitialized.
+               */
+
+              if (channel->sc_ops->sc_close)
+                {
+                  channel->sc_ops->sc_close(channel);
+                }
+
               return OK;
             }
         }

--- a/drivers/syslog/syslog_device.c
+++ b/drivers/syslog/syslog_device.c
@@ -110,7 +110,8 @@ static const struct syslog_channel_ops_s g_syslog_dev_ops =
   syslog_dev_putc,
   syslog_dev_force,
   syslog_dev_flush,
-  syslog_dev_write
+  syslog_dev_write,
+  syslog_dev_uninitialize
 };
 
 static const uint8_t g_syscrlf[2] =

--- a/include/nuttx/syslog/syslog.h
+++ b/include/nuttx/syslog/syslog.h
@@ -93,6 +93,7 @@ typedef CODE ssize_t (*syslog_write_t)(FAR struct syslog_channel_s *channel,
 typedef CODE int (*syslog_putc_t)(FAR struct syslog_channel_s *channel,
                                   int ch);
 typedef CODE int (*syslog_flush_t)(FAR struct syslog_channel_s *channel);
+typedef CODE void (*syslog_close_t)(FAR struct syslog_channel_s *channel);
 
 /* SYSLOG device operations */
 
@@ -102,6 +103,7 @@ struct syslog_channel_ops_s
   syslog_putc_t  sc_force;  /* Low-level output for interrupt handlers */
   syslog_flush_t sc_flush;  /* Flush buffered output (on crash) */
   syslog_write_t sc_write;  /* Write multiple bytes */
+  syslog_close_t sc_close;  /* Channel close callback */
 };
 
 /* This structure provides the interface to a SYSLOG channel */


### PR DESCRIPTION
## Summary
A new callback is added in Syslog channels, that properly uninitializes the channel's driver when removed.

Before, a call to `syslog_channel_remove` only removed the channel from the list of the used channels. But it was up to the user to properly close the channel and deallocate any resources, if needed.

Now, a call to `syslog_channel_remove` will also uninitialize the channel, and no further actions are needed.

## Impact
Syslog channels are properly uninitialized when the channel is removed.

## Testing
Tested on custom STM32F4 board, with log stored in SD card.
