### PR TITLE
TCP: simplify readahead

### DIFF
--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -106,7 +106,7 @@ struct iob_s
   uint16_t io_len;      /* Length of the data in the entry */
   uint16_t io_offset;   /* Data begins at this offset */
 #endif
-  uint16_t io_pktlen;   /* Total length of the packet */
+  unsigned int io_pktlen; /* Total length of the packet */
 
   uint8_t  io_data[CONFIG_IOB_BUFSIZE];
 };

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -209,7 +209,7 @@ struct tcp_conn_s
    *               where the TCP/IP read-ahead data is retained.
    */
 
-  struct iob_queue_s readahead;   /* Read-ahead buffering */
+  struct iob_s *readahead;   /* Read-ahead buffering */
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   /* Write buffering

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -93,6 +93,7 @@
 #define TCP_SEQ_LTE(a, b)	(!TCP_SEQ_GT(a, b))
 #define TCP_SEQ_GTE(a, b)	(!TCP_SEQ_LT(a, b))
 
+#define TCP_SEQ_ADD(a, b)	((uint32_t)((a) + (b)))
 #define TCP_SEQ_SUB(a, b)	((uint32_t)((a) - (b)))
 
 /****************************************************************************

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <debug.h>
+#include <assert.h>
 
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/netconfig.h>
@@ -234,61 +235,81 @@ uint16_t tcp_datahandler(FAR struct tcp_conn_s *conn, FAR uint8_t *buffer,
                          uint16_t buflen)
 {
   FAR struct iob_s *iob;
-  bool throttled = true;
+  uint16_t copied = 0;
   int ret;
+  unsigned int i;
 
   /* Try to allocate I/O buffers and copy the data into them
    * without waiting (and throttling as necessary).
    */
 
-  while (true)
+  iob = conn->readahead;
+  for (i = 0; i < 2; i++)
     {
-      iob = iob_tryalloc(throttled, IOBUSER_NET_TCP_READAHEAD);
+      bool throttled = i == 0; /* try throttled=true first */
+
+      if (!throttled)
+        {
+#if CONFIG_IOB_THROTTLE > 0
+          if (conn->readahead != NULL)
+            {
+              ninfo("Do not use throttled=false because of "
+                    "non-empty readahead\n");
+              break;
+            }
+#else
+          break;
+#endif
+        }
+
+      if (iob == NULL)
+        {
+          iob = iob_tryalloc(throttled, IOBUSER_NET_TCP_READAHEAD);
+          if (iob == NULL)
+            {
+              continue;
+            }
+
+          iob->io_pktlen = 0;
+        }
+
       if (iob != NULL)
         {
-          ret = iob_trycopyin(iob, buffer, buflen, 0, throttled,
+          uint32_t olen = iob->io_pktlen;
+
+          ret = iob_trycopyin(iob, buffer + copied, buflen - copied,
+                              olen, throttled,
                               IOBUSER_NET_TCP_READAHEAD);
+          copied += iob->io_pktlen - olen;
           if (ret < 0)
             {
               /* On a failure, iob_copyin return a negated error value but
                * does not free any I/O buffers.
                */
 
-              iob_free_chain(iob, IOBUSER_NET_TCP_READAHEAD);
-              iob = NULL;
+              continue;
             }
         }
-
-#if CONFIG_IOB_THROTTLE > 0
-      if (iob == NULL && throttled && IOB_QEMPTY(&conn->readahead))
-        {
-          /* Fallback out of the throttled entry */
-
-          throttled = false;
-          continue;
-        }
-#endif
 
       break;
     }
 
+  DEBUGASSERT(conn->readahead == iob || conn->readahead == NULL);
   if (iob == NULL)
     {
       nerr("ERROR: Failed to create new I/O buffer chain\n");
+      DEBUGASSERT(copied == 0);
       return 0;
     }
 
-  /* Add the new I/O buffer chain to the tail of the read-ahead queue (again
-   * without waiting).
-   */
-
-  ret = iob_tryadd_queue(iob, &conn->readahead);
-  if (ret < 0)
+  if (copied == 0)
     {
-      nerr("ERROR: Failed to queue the I/O buffer chain: %d\n", ret);
-      iob_free_chain(iob, IOBUSER_NET_TCP_READAHEAD);
+      nerr("ERROR: Failed to append new I/O buffer\n");
+      DEBUGASSERT(conn->readahead == iob);
       return 0;
     }
+
+  conn->readahead = iob;
 
 #ifdef CONFIG_NET_TCP_NOTIFIER
   /* Provide notification(s) that additional TCP read-ahead data is
@@ -298,8 +319,8 @@ uint16_t tcp_datahandler(FAR struct tcp_conn_s *conn, FAR uint8_t *buffer,
   tcp_readahead_signal(conn);
 #endif
 
-  ninfo("Buffered %d bytes\n", buflen);
-  return buflen;
+  ninfo("Buffered %" PRIu16 " bytes\n", copied);
+  return copied;
 }
 
 #endif /* NET_TCP_HAVE_STACK */

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -91,19 +91,23 @@ tcp_data_event(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
            * read-ahead buffers to retain the data -- drop the packet.
            */
 
-          ninfo("Dropped %d bytes\n", dev->d_len);
+          ninfo("Dropped %d/%d bytes\n", buflen - recvlen, buflen);
 
 #ifdef CONFIG_NET_STATISTICS
           g_netstats.tcp.drop++;
 #endif
           /* Clear the TCP_SNDACK bit so that no ACK will be sent.
+           * Clear the TCP_CLOSE because we effectively dropped
+           * the FIN as well.
            *
            * Revisit: It might make more sense to send a dup ack
            * to give a hint to the peer.
            */
 
-          ret &= ~TCP_SNDACK;
+          ret &= ~(TCP_SNDACK | TCP_CLOSE);
         }
+
+      net_incr32(conn->rcvseq, recvlen);
     }
 
   /* In any event, the new data has now been handled */

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -726,7 +726,8 @@ void tcp_free(FAR struct tcp_conn_s *conn)
 
   /* Release any read-ahead buffers attached to the connection */
 
-  iob_free_queue(&conn->readahead, IOBUSER_NET_TCP_READAHEAD);
+  iob_free_chain(conn->readahead, IOBUSER_NET_TCP_READAHEAD);
+  conn->readahead = NULL;
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   /* Release any write buffers attached to the connection */
@@ -970,7 +971,7 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
 
       /* Initialize the list of TCP read-ahead buffers */
 
-      IOB_QINIT(&conn->readahead);
+      conn->readahead = NULL;
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
       /* Initialize the write buffer lists */
@@ -1244,7 +1245,7 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
 
   /* Initialize the list of TCP read-ahead buffers */
 
-  IOB_QINIT(&conn->readahead);
+  conn->readahead = NULL;
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   /* Initialize the TCP write buffer lists */

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -229,7 +229,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
 
   /* Check for read data or backlogged connection availability now */
 
-  if (!IOB_QEMPTY(&conn->readahead) || tcp_backlogavailable(conn))
+  if (conn->readahead != NULL || tcp_backlogavailable(conn))
     {
       /* Normal data may be read without blocking. */
 

--- a/net/tcp/tcp_notifier.c
+++ b/net/tcp/tcp_notifier.c
@@ -78,7 +78,7 @@ int tcp_readahead_notifier_setup(worker_t worker,
    * setting up the notification.
    */
 
-  if (conn->readahead.qh_head != NULL)
+  if (conn->readahead != NULL)
     {
       return 0;
     }

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -166,9 +166,13 @@ static size_t tcp_recvfrom_newdata(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-static inline void tcp_newdata(FAR struct net_driver_s *dev,
-                               FAR struct tcp_recvfrom_s *pstate)
+static inline uint16_t tcp_newdata(FAR struct net_driver_s *dev,
+                                   FAR struct tcp_recvfrom_s *pstate,
+                                   uint16_t flags)
 {
+  FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)
+                                pstate->ir_sock->s_conn;
+
   /* Take as much data from the packet as we can */
 
   size_t recvlen = tcp_recvfrom_newdata(dev, pstate);
@@ -179,40 +183,39 @@ static inline void tcp_newdata(FAR struct net_driver_s *dev,
 
   if (recvlen < dev->d_len)
     {
-      FAR struct tcp_conn_s *conn =
-        (FAR struct tcp_conn_s *)pstate->ir_sock->s_conn;
       FAR uint8_t *buffer = (FAR uint8_t *)dev->d_appdata + recvlen;
       uint16_t buflen = dev->d_len - recvlen;
-#ifdef CONFIG_DEBUG_NET
       uint16_t nsaved;
 
       nsaved = tcp_datahandler(conn, buffer, buflen);
-#else
-      tcp_datahandler(conn, buffer, buflen);
-#endif
-
-      /* There are complicated buffering issues that are not addressed fully
-       * here.  For example, what if up_datahandler() cannot buffer the
-       * remainder of the packet?  In that case, the data will be dropped but
-       * still ACKed.  Therefore it would not be resent.
-       *
-       * This is probably not an issue here because we only get here if the
-       * read-ahead buffers are empty and there would have to be something
-       * serioulsy wrong with the configuration not to be able to buffer a
-       * partial packet in this context.
-       */
-
-#ifdef CONFIG_DEBUG_NET
       if (nsaved < buflen)
         {
-          nerr("ERROR: packet data not saved (%d bytes)\n", buflen - nsaved);
+          nwarn("WARNING: packet data not fully saved "
+                "(%d/%u/%zu/%u bytes)\n",
+                buflen - nsaved,
+                (unsigned int)nsaved,
+                recvlen,
+                (unsigned int)dev->d_len);
         }
-#endif
+
+      recvlen += nsaved;
     }
+
+  if (recvlen < dev->d_len)
+    {
+      /* Clear the TCP_CLOSE because we effectively dropped the FIN as well.
+       */
+
+      flags &= ~TCP_CLOSE;
+    }
+
+  net_incr32(conn->rcvseq, recvlen);
 
   /* Indicate no data in the buffer */
 
   dev->d_len = 0;
+
+  return flags;
 }
 
 /****************************************************************************
@@ -418,7 +421,7 @@ static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
            * packet in the read-ahead buffer).
            */
 
-          tcp_newdata(dev, pstate);
+          flags = tcp_newdata(dev, pstate, flags);
 
           /* Save the sender's address in the caller's 'from' location */
 


### PR DESCRIPTION
## Summary
    tcp: simplify readahead
    
    Do not bother to preserve segment boundaries in the tcp
    readahead queues.
    
    * Avoid wasting the tail IOB space for each segments.
      Instead, pack the newly received data into the tail space
      of the last IOB. Also, advertise the tail space as
      a part of the window.
    
    * Use IOB chain directly. Eliminate IOB queue overhead.
    
    * Allow to accept only a part of a segment.
    
    * This change improves the memory efficiency.
      And probably more importantly, allows less-confusing
      recv window advertisement behavior.
      Previously, even when we advertise N bytes window,
      we often couldn't actually accept N bytes. Depending on
      the segment sizes and IOB configurations, it was causing
      segment drops.
      Also, the previous code was moving the right edge of the
      window back and forth too often, even when nothing in
      the system was competing on the IOBs. Shrinking the
      window that way is a kinda well known recipe to confuse
      the peer stack.

## Impact
tcp

## Testing

a few concurrent receiving connections on esp32
