### PR TITLE
drivers/motor/foq: Remove forward declaration for nonexistent type

### DIFF
--- a/include/nuttx/motor/foc/foc.h
+++ b/include/nuttx/motor/foc/foc.h
@@ -108,7 +108,6 @@ struct foc_info_s
 /* FOC device upper-half */
 
 struct foc_lower_s;
-struct foc_typespec_s;
 struct foc_dev_s
 {
   /* Fields managed by common upper-half FOC logic **************************/


### PR DESCRIPTION
## Summary

In include/nuttx/motor/foc/foc.h, remove forward declaration for `struct foc_typespec_s`, which does not exist anywhere in the NuttX tree.

## Impact

Minor code cleanup; no functional changes.

## Testing

None.