### PR TITLE
stm32l4/b-l475e-iot01a/src/stm32_timer.c: Fix missing closing bracket

### DIFF
--- a/boards/arm/stm32l4/b-l475e-iot01a/src/stm32_timer.c
+++ b/boards/arm/stm32l4/b-l475e-iot01a/src/stm32_timer.c
@@ -59,6 +59,7 @@ int stm32l4_timer_driver_setup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to setup TIM1 at /dev/timer0: %d\n",
+            ret);
     }
 #endif
 
@@ -121,6 +122,7 @@ int stm32l4_timer_driver_setup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to setup TIM8 at /dev/timer7: %d\n",
+            ret);
     }
 #endif
 


### PR DESCRIPTION
This patch add missing ret and closing bracket for 2 syslog messages.
It was found by cppcheck.

Signed-off-by: Masanari Iida <standby24x7@gmail.com>

## Summary
2 syslog messages missing closing bracket as well as ret. 

## Impact
Without closing bracket, it will cause syntax error.

## Testing

