### PR TITLE
sched/wdog: Remove flags field from wdog_s to save memory

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -34,15 +34,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Watchdog Definitions *****************************************************/
-
-/* Flag bits for the flags field of struct wdog_s */
-
-#define WDOGF_ACTIVE       (1 << 0) /* Bit 0: 1=Watchdog is actively timing */
-
-#define WDOG_SETACTIVE(w)  do { (w)->flags |= WDOGF_ACTIVE; } while (0)
-#define WDOG_CLRACTIVE(w)  do { (w)->flags &= ~WDOGF_ACTIVE; } while (0)
-#define WDOG_ISACTIVE(w)   (((w)->flags & WDOGF_ACTIVE) != 0)
+#define WDOG_ISACTIVE(w)   ((w)->func != NULL)
 
 /****************************************************************************
  * Public Type Declarations
@@ -78,7 +70,6 @@ struct wdog_s
   FAR void          *picbase;    /* PIC base address */
 #endif
   int                lag;        /* Timer associated with the delay */
-  uint8_t            flags;      /* See WDOGF_* definitions above */
   wdparm_t           arg;        /* Callback argument */
 };
 

--- a/sched/wdog/wd_cancel.c
+++ b/sched/wdog/wd_cancel.c
@@ -126,8 +126,7 @@ int wd_cancel(FAR struct wdog_s *wdog)
 
       /* Mark the watchdog inactive */
 
-      wdog->next = NULL;
-      WDOG_CLRACTIVE(wdog);
+      wdog->func = NULL;
 
       /* Return success */
 

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -72,6 +72,7 @@
 static inline void wd_expiration(void)
 {
   FAR struct wdog_s *wdog;
+  wdentry_t func;
 
   /* Check if the watchdog at the head of the list is ready to run */
 
@@ -99,12 +100,13 @@ static inline void wd_expiration(void)
 
           /* Indicate that the watchdog is no longer active. */
 
-          WDOG_CLRACTIVE(wdog);
+          func = wdog->func;
+          wdog->func = NULL;
 
           /* Execute the watchdog function */
 
           up_setpicbase(wdog->picbase);
-          wdog->func(wdog->arg);
+          func(wdog->arg);
         }
     }
 }
@@ -160,7 +162,7 @@ int wd_start(FAR struct wdog_s *wdog, int32_t delay,
 
   /* Verify the wdog and setup parameters */
 
-  if (wdog == NULL || delay < 0)
+  if (wdog == NULL || wdentry == NULL || delay < 0)
     {
       return -EINVAL;
     }
@@ -297,7 +299,6 @@ int wd_start(FAR struct wdog_s *wdog, int32_t delay,
   /* Put the lag into the watchdog structure and mark it as active. */
 
   wdog->lag = delay;
-  WDOG_SETACTIVE(wdog);
 
 #ifdef CONFIG_SCHED_TICKLESS
   /* Resume the interval timer that will generate the next interval event.


### PR DESCRIPTION
## Summary
since WDOG_ISACTIVE can check func field instead

## Impact
Save four bytes for each wdog_s

## Testing
Pass ostest
