### PR TITLE
libc/time: Implement timegm function 

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_rtc_lowerhalf.c
+++ b/arch/arm/src/cxd56xx/cxd56_rtc_lowerhalf.c
@@ -270,7 +270,7 @@ static int cxd56_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -325,7 +325,7 @@ static int cxd56_setalarm(FAR struct rtc_lowerhalf_s *lower,
 
       /* Convert the RTC time to a timespec (1 second accuracy) */
 
-      lowerinfo.as_time.tv_sec  = mktime((FAR struct tm *)&alarminfo->time);
+      lowerinfo.as_time.tv_sec  = timegm((FAR struct tm *)&alarminfo->time);
       lowerinfo.as_time.tv_nsec = 0;
 
       /* And set the alarm */

--- a/arch/arm/src/imxrt/imxrt_rtc_lowerhalf.c
+++ b/arch/arm/src/imxrt/imxrt_rtc_lowerhalf.c
@@ -238,7 +238,7 @@ static int imxrt_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -312,7 +312,7 @@ static int imxrt_setalarm(FAR struct rtc_lowerhalf_s *lower,
 
       /* Convert the RTC time to a timespec (1 second accuracy) */
 
-      ts.tv_sec   = mktime((FAR struct tm *)&alarminfo->time);
+      ts.tv_sec   = timegm((FAR struct tm *)&alarminfo->time);
       ts.tv_nsec  = 0;
 
       /* Remember the callback information */

--- a/arch/arm/src/kinetis/kinetis_rtc_lowerhalf.c
+++ b/arch/arm/src/kinetis/kinetis_rtc_lowerhalf.c
@@ -274,7 +274,7 @@ static int kinetis_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Set the time (to one second accuracy) */
@@ -325,7 +325,7 @@ static int kinetis_setalarm(FAR struct rtc_lowerhalf_s *lower,
 
       /* Convert from Julian calendar time to epoch time */
 
-      tp.tv_sec = mktime((FAR struct tm *)&alarminfo->time) ;
+      tp.tv_sec = timegm((FAR struct tm *)&alarminfo->time) ;
 
       /* And set the alarm */
 
@@ -393,7 +393,7 @@ kinetis_setrelative(FAR struct rtc_lowerhalf_s *lower,
           return ret;
         }
 
-      ts.tv_sec  = mktime(&time);
+      ts.tv_sec  = timegm(&time);
       ts.tv_nsec = 0;
 #else
       /* Get the current time in broken out format */

--- a/arch/arm/src/lc823450/lc823450_rtc.c
+++ b/arch/arm/src/lc823450/lc823450_rtc.c
@@ -170,7 +170,7 @@ volatile bool g_rtc_enabled = false;
 static void tm_divider(struct tm *tm, int divn, int divm)
 {
   time_t tt;
-  tt = mktime(tm);
+  tt = timegm(tm);
   tt = (time_t) ((uint64_t)tt * divn / divm);
   gmtime_r(&tt, tm);
 }
@@ -690,7 +690,7 @@ int up_rtc_getrawtime(FAR struct timespec *ts)
 #endif /* CONFIG_RTC_DIV */
 
   ts->tv_nsec = 0;
-  ts->tv_sec = mktime(&tm);
+  ts->tv_sec = timegm(&tm);
   return 0;
 }
 

--- a/arch/arm/src/lpc54xx/lpc54_rtc_lowerhalf.c
+++ b/arch/arm/src/lpc54xx/lpc54_rtc_lowerhalf.c
@@ -253,7 +253,7 @@ static int lpc54_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -321,7 +321,7 @@ static int lpc54_setalarm(FAR struct rtc_lowerhalf_s *lower,
 
       /* Convert the RTC time to a timespec (1 second accuracy) */
 
-      ts.tv_sec   = mktime((FAR struct tm *)&alarminfo->time);
+      ts.tv_sec   = timegm((FAR struct tm *)&alarminfo->time);
       ts.tv_nsec  = 0;
 
       /* Remember the callback information */

--- a/arch/arm/src/max326xx/common/max326_rtc_lowerhalf.c
+++ b/arch/arm/src/max326xx/common/max326_rtc_lowerhalf.c
@@ -314,7 +314,7 @@ static int max326_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -383,7 +383,7 @@ static int max326_setalarm(FAR struct rtc_lowerhalf_s *lower,
 
       /* Convert the RTC time to a timespec (1 second accuracy) */
 
-      ts.tv_sec   = mktime((FAR struct tm *)&alarminfo->time);
+      ts.tv_sec   = timegm((FAR struct tm *)&alarminfo->time);
       ts.tv_nsec  = 0;
 
       /* Remember the callback information */
@@ -460,7 +460,7 @@ static int max326_setrelative(FAR struct rtc_lowerhalf_s *lower,
           return ret;
         }
 
-      ts.tv_sec  = mktime(&time);
+      ts.tv_sec  = timegm(&time);
       ts.tv_nsec = 0;
 
 #elif defined(CONFIG_RTC_HIRES)

--- a/arch/arm/src/sam34/sam_rtc.c
+++ b/arch/arm/src/sam34/sam_rtc.c
@@ -788,7 +788,7 @@ int up_rtc_gettime(FAR struct timespec *tp)
                             RTC_CALR_YEAR_SHIFT)
              - 1900;
 
-  tp->tv_sec = mktime(&t);
+  tp->tv_sec = timegm(&t);
   tp->tv_nsec = (((rtt_val - g_rtt_offset) & (CONFIG_RTC_FREQUENCY - 1)) *
                    1000000000ull) / CONFIG_RTC_FREQUENCY;
 

--- a/arch/arm/src/stm32/stm32_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32/stm32_rtc_lowerhalf.c
@@ -347,7 +347,7 @@ static int stm32_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -470,7 +470,7 @@ static int stm32_setalarm(FAR struct rtc_lowerhalf_s *lower,
 
       /* Convert the RTC time to a timespec (1 second accuracy) */
 
-      ts.tv_sec   = mktime((FAR struct tm *)&alarminfo->time);
+      ts.tv_sec   = timegm((FAR struct tm *)&alarminfo->time);
       ts.tv_nsec  = 0;
 
       /* Remember the callback information */
@@ -542,7 +542,7 @@ static int stm32_setrelative(FAR struct rtc_lowerhalf_s *lower,
         {
           /* Convert to seconds since the epoch */
 
-          seconds = mktime(&time);
+          seconds = timegm(&time);
 
           /* Add the seconds offset.  Add one to the number of seconds
            * because we are unsure of the phase of the timer.
@@ -600,7 +600,7 @@ static int stm32_setrelative(FAR struct rtc_lowerhalf_s *lower,
           return ret;
         }
 
-      ts.tv_sec  = mktime(&time);
+      ts.tv_sec  = timegm(&time);
       ts.tv_nsec = 0;
 
 #elif defined(CONFIG_RTC_HIRES)

--- a/arch/arm/src/stm32f7/stm32_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32f7/stm32_rtc_lowerhalf.c
@@ -312,7 +312,7 @@ static int stm32_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -459,7 +459,7 @@ static int stm32_setrelative(FAR struct rtc_lowerhalf_s *lower,
         {
           /* Convert to seconds since the epoch */
 
-          seconds = mktime(&time);
+          seconds = timegm(&time);
 
           /* Add the seconds offset.  Add one to the number of seconds
            * because we are unsure of the phase of the timer.

--- a/arch/arm/src/stm32h7/stm32_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32h7/stm32_rtc_lowerhalf.c
@@ -313,7 +313,7 @@ static int stm32_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -460,7 +460,7 @@ static int stm32_setrelative(FAR struct rtc_lowerhalf_s *lower,
         {
           /* Convert to seconds since the epoch */
 
-          seconds = mktime(&time);
+          seconds = timegm(&time);
 
           /* Add the seconds offset.  Add one to the number of seconds
            * because we are unsure of the phase of the timer.

--- a/arch/arm/src/stm32l4/stm32l4_rtc_lowerhalf.c
+++ b/arch/arm/src/stm32l4/stm32l4_rtc_lowerhalf.c
@@ -426,7 +426,7 @@ stm32l4_setrelative(FAR struct rtc_lowerhalf_s *lower,
         {
           /* Convert to seconds since the epoch */
 
-          seconds = mktime(&time);
+          seconds = timegm(&time);
 
           /* Add the seconds offset.  Add one to the number of seconds
            * because we are unsure of the phase of the timer.

--- a/arch/renesas/src/rx65n/rx65n_rtc.c
+++ b/arch/renesas/src/rx65n/rx65n_rtc.c
@@ -532,7 +532,7 @@ int up_rtc_gettime(FAR struct timespec *tp)
 
       t.tm_year = rtc_bcd2dec((uint8_t) (bcd_years & 0xff)) + 100;
 
-          tp->tv_sec = mktime(&t);
+          tp->tv_sec = timegm(&t);
           tp->tv_nsec = 0;
     }
 

--- a/arch/renesas/src/rx65n/rx65n_rtc_lowerhalf.c
+++ b/arch/renesas/src/rx65n/rx65n_rtc_lowerhalf.c
@@ -303,7 +303,7 @@ static int rx65n_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -446,7 +446,7 @@ static int rx65n_setrelative(FAR struct rtc_lowerhalf_s *lower,
           return ret;
         }
 
-      ts.tv_sec  = mktime(&time);
+      ts.tv_sec  = timegm(&time);
       ts.tv_nsec = 0;
 
 #elif defined(CONFIG_RTC_HIRES)
@@ -457,7 +457,7 @@ static int rx65n_setrelative(FAR struct rtc_lowerhalf_s *lower,
         {
           /* Convert to seconds since the epoch */
 
-          seconds = mktime(&time);
+          seconds = timegm(&time);
 
           /* Add the seconds offset.  Add one to the number of seconds
            * because we are unsure of the phase of the timer.

--- a/arch/sim/src/sim/up_rtc.c
+++ b/arch/sim/src/sim/up_rtc.c
@@ -83,7 +83,7 @@ static int sim_rtc_rdtime(FAR struct rtc_lowerhalf_s *lower,
 static int sim_rtc_settime(FAR struct rtc_lowerhalf_s *lower,
                            FAR const struct rtc_time *rtctime)
 {
-  g_sim_delta = mktime((FAR struct tm *)rtctime);
+  g_sim_delta = timegm((FAR struct tm *)rtctime);
   g_sim_delta *= NSEC_PER_SEC;
   g_sim_delta += rtctime->tm_nsec;
   g_sim_delta -= host_gettime(true);

--- a/arch/z80/src/ez80/ez80_rtc_lowerhalf.c
+++ b/arch/z80/src/ez80/ez80_rtc_lowerhalf.c
@@ -297,7 +297,7 @@ static int ez80_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = timegm((FAR struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (to one second accuracy) */
@@ -432,7 +432,7 @@ static int ez80_setrelative(FAR struct rtc_lowerhalf_s *lower,
     {
       /* Convert to seconds since the epoch */
 
-      seconds = mktime(&time);
+      seconds = timegm(&time);
 
       /* Add the seconds offset.  Add one to the number of seconds
        * because we are unsure of the phase of the timer.

--- a/drivers/timers/arch_rtc.c
+++ b/drivers/timers/arch_rtc.c
@@ -89,7 +89,7 @@ time_t up_rtc_time(void)
 
       if (g_rtc_lower->ops->rdtime(g_rtc_lower, &rtctime) == 0)
         {
-          time = mktime((FAR struct tm *)&rtctime);
+          time = timegm((FAR struct tm *)&rtctime);
         }
     }
 
@@ -125,7 +125,7 @@ int up_rtc_gettime(FAR struct timespec *tp)
       ret = g_rtc_lower->ops->rdtime(g_rtc_lower, &rtctime);
       if (ret == 0)
         {
-          tp->tv_sec = mktime((FAR struct tm *)&rtctime);
+          tp->tv_sec = timegm((FAR struct tm *)&rtctime);
           tp->tv_nsec = rtctime.tm_nsec;
         }
     }

--- a/drivers/timers/rpmsg_rtc.c
+++ b/drivers/timers/rpmsg_rtc.c
@@ -367,7 +367,7 @@ static int rpmsg_rtc_settime(FAR struct rtc_lowerhalf_s *lower,
 {
   struct rpmsg_rtc_set_s msg =
   {
-    .sec  = mktime((FAR struct tm *)rtctime),
+    .sec  = timegm((FAR struct tm *)rtctime),
     .nsec = rtctime->tm_nsec,
   };
 
@@ -388,7 +388,7 @@ static int rpmsg_rtc_setalarm(FAR struct rtc_lowerhalf_s *lower_,
     (FAR struct rpmsg_rtc_lowerhalf_s *)lower_;
   struct rpmsg_rtc_alarm_set_s msg =
   {
-    .sec  = mktime((FAR struct tm *)&alarminfo->time),
+    .sec  = timegm((FAR struct tm *)&alarminfo->time),
     .nsec = alarminfo->time.tm_nsec,
     .id   = alarminfo->id,
   };
@@ -419,7 +419,7 @@ rpmsg_rtc_setrelative(FAR struct rtc_lowerhalf_s *lower,
   time_t time;
 
   rpmsg_rtc_rdtime(lower, &alarminfo.time);
-  time = mktime((FAR struct tm *)&alarminfo.time);
+  time = timegm((FAR struct tm *)&alarminfo.time);
   time = time + relinfo->reltime;
   gmtime_r(&time, (FAR struct tm *)&alarminfo.time);
 

--- a/fs/fat/fs_fat32util.c
+++ b/fs/fat/fs_fat32util.c
@@ -465,7 +465,7 @@ time_t fat_fattime2systime(uint16_t fattime, uint16_t fatdate)
 
   /* Then convert the broken out time into seconds since the epoch */
 
-  return mktime(&tm);
+  return timegm(&tm);
 #else
   return 0;
 #endif

--- a/include/time.h
+++ b/include/time.h
@@ -91,7 +91,6 @@
 
 #define TIME_UTC           1
 
-
 /* Redirect the timelocal */
 
 #define timelocal         mktime

--- a/include/time.h
+++ b/include/time.h
@@ -91,9 +91,10 @@
 
 #define TIME_UTC           1
 
-/* Redirect the timegm */
 
-#define timegm mktime
+/* Redirect the timelocal */
+
+#define timelocal         mktime
 
 /********************************************************************************
  * Public Types
@@ -192,7 +193,9 @@ int clock_gettime(clockid_t clockid, FAR struct timespec *tp);
 int clock_getres(clockid_t clockid, FAR struct timespec *res);
 int timespec_get(FAR struct timespec *t, int b);
 
+time_t timegm(FAR struct tm *tp);
 time_t mktime(FAR struct tm *tp);
+
 FAR struct tm *gmtime(FAR const time_t *timep);
 FAR struct tm *gmtime_r(FAR const time_t *timep, FAR struct tm *result);
 

--- a/libs/libc/time/Make.defs
+++ b/libs/libc/time/Make.defs
@@ -29,7 +29,7 @@ CSRCS += lib_gethrtime.c
 ifdef CONFIG_LIBC_LOCALTIME
 CSRCS += lib_localtime.c
 else
-CSRCS += lib_mktime.c lib_gmtime.c lib_gmtimer.c
+CSRCS += lib_timegm.c lib_gmtime.c lib_gmtimer.c
 endif
 
 # Add the time directory to the build

--- a/libs/libc/time/lib_gmtime.c
+++ b/libs/libc/time/lib_gmtime.c
@@ -48,9 +48,7 @@ FAR struct tm *gmtime(FAR const time_t *timep)
   return gmtime_r(timep, &tm);
 }
 
-#ifndef CONFIG_LIBC_LOCALTIME
 FAR struct tm *localtime(FAR const time_t *timep)
 {
   return gmtime(timep);
 }
-#endif

--- a/libs/libc/time/lib_gmtimer.c
+++ b/libs/libc/time/lib_gmtimer.c
@@ -344,9 +344,7 @@ FAR struct tm *gmtime_r(FAR const time_t *timep, FAR struct tm *result)
   return result;
 }
 
-#ifndef CONFIG_LIBC_LOCALTIME
 FAR struct tm *localtime_r(FAR const time_t *timep, FAR struct tm *result)
 {
   return gmtime_r(timep, result);
 }
-#endif

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -2604,3 +2604,8 @@ time_t mktime(struct tm * const tmp)
   tzset();
   return time1(tmp, localsub, 0L);
 }
+
+time_t timegm(FAR struct tm *tmp)
+{
+  return time1(tmp, gmtsub, 0L);
+}

--- a/libs/libc/time/lib_timegm.c
+++ b/libs/libc/time/lib_timegm.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/time/lib_mktime.c
+ * libs/libc/time/lib_timegm.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -62,14 +62,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name:  mktime
+ * Name:  timegm
  *
  * Description:
  *   Time conversion (based on the POSIX API)
  *
  ****************************************************************************/
 
-time_t mktime(FAR struct tm *tp)
+time_t timegm(FAR struct tm *tp)
 {
   time_t ret;
   time_t jdn;
@@ -89,4 +89,9 @@ time_t mktime(FAR struct tm *tp)
         (int)ret, tp->tm_hour, tp->tm_min, tp->tm_sec);
 
   return ret;
+}
+
+time_t mktime(FAR struct tm *tp)
+{
+  return timegm(tp);
 }

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -92,7 +92,7 @@ int clock_basetime(FAR struct timespec *tp)
     {
       /* And use the broken-out time to initialize the system time */
 
-      tp->tv_sec  = mktime(&rtctime);
+      tp->tv_sec  = timegm(&rtctime);
       tp->tv_nsec = nsecs;
     }
 


### PR DESCRIPTION
## Summary
and replace mktime to timegm for more security

## Impact

## Testing
ostest