### PR TITLE
xtensa/esp32: Refactor the text heap and add RTC memory to it

### DIFF
--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -169,7 +169,7 @@ CHIP_CSRCS += esp32c3_rtc_lowerhalf.c
 endif
 
 ifeq ($(CONFIG_ESP32C3_RTC_HEAP),y)
-CHIP_CSRCS += esp32c3_rtc_heap.c
+CHIP_CSRCS += esp32c3_rtcheap.c
 endif
 
 ifeq ($(CONFIG_ESP32C3_WIRELESS),y)

--- a/arch/risc-v/src/esp32c3/esp32c3_rtc_heap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtc_heap.c
@@ -66,12 +66,12 @@ void esp32c3_rtc_heap_initialize(void)
   mm_initialize(&g_rtc_heap, start, size);
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)
-  static struct procfs_meminfo_entry_s g_imm_procfs;
+  static struct procfs_meminfo_entry_s g_rtc_procfs;
 
-  g_imm_procfs.name = "rtc_heap";
-  g_imm_procfs.mallinfo = (void *)mm_mallinfo;
-  g_imm_procfs.user_data = &g_rtc_heap;
-  procfs_register_meminfo(&g_imm_procfs);
+  g_rtc_procfs.name = "rtc_heap";
+  g_rtc_procfs.mallinfo = (void *)mm_mallinfo;
+  g_rtc_procfs.user_data = &g_rtc_heap;
+  procfs_register_meminfo(&g_rtc_procfs);
 #endif
 }
 

--- a/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/esp32c3/esp32c3_rtc_heap.c
+ * arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -29,27 +29,27 @@
 #include <nuttx/mm/mm.h>
 #include <malloc.h>
 
-#include "esp32c3_rtc_heap.h"
+#include "esp32c3_rtcheap.h"
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
-static struct mm_heap_s g_rtc_heap;
+static struct mm_heap_s g_rtcheap;
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_initialize
+ * Name: esp32c3_rtcheap_initialize
  *
  * Description:
  *   Initialize the RTC heap.
  *
  ****************************************************************************/
 
-void esp32c3_rtc_heap_initialize(void)
+void esp32c3_rtcheap_initialize(void)
 {
   void  *start;
   size_t size;
@@ -58,38 +58,38 @@ void esp32c3_rtc_heap_initialize(void)
    * esp32c3.template.ld.)  Check boards/risc-v/esp32c3.
    */
 
-  extern uint8_t *_srtc_heap;
-  extern uint8_t *_ertc_heap;
+  extern uint8_t *_srtcheap;
+  extern uint8_t *_ertcheap;
 
-  start = (FAR void *)&_srtc_heap;
-  size  = (size_t)((uintptr_t)&_ertc_heap - (uintptr_t)&_srtc_heap);
-  mm_initialize(&g_rtc_heap, start, size);
+  start = (FAR void *)&_srtcheap;
+  size  = (size_t)((uintptr_t)&_ertcheap - (uintptr_t)&_srtcheap);
+  mm_initialize(&g_rtcheap, start, size);
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)
   static struct procfs_meminfo_entry_s g_rtc_procfs;
 
-  g_rtc_procfs.name = "rtc_heap";
+  g_rtc_procfs.name = "rtcheap";
   g_rtc_procfs.mallinfo = (void *)mm_mallinfo;
-  g_rtc_procfs.user_data = &g_rtc_heap;
+  g_rtc_procfs.user_data = &g_rtcheap;
   procfs_register_meminfo(&g_rtc_procfs);
 #endif
 }
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_malloc
+ * Name: esp32c3_rtcheap_malloc
  *
  * Description:
  *   Allocate memory from the RTC heap.
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_malloc(size_t size)
+void *esp32c3_rtcheap_malloc(size_t size)
 {
-  return mm_malloc(&g_rtc_heap, size);
+  return mm_malloc(&g_rtcheap, size);
 }
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_calloc
+ * Name: esp32c3_rtcheap_calloc
  *
  * Description:
  *   Calculates the size of the allocation and allocate memory from
@@ -97,52 +97,52 @@ void *esp32c3_rtc_heap_malloc(size_t size)
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_calloc(size_t n, size_t elem_size)
+void *esp32c3_rtcheap_calloc(size_t n, size_t elem_size)
 {
-  return mm_calloc(&g_rtc_heap, n, elem_size);
+  return mm_calloc(&g_rtcheap, n, elem_size);
 }
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_realloc
+ * Name: esp32c3_rtcheap_realloc
  *
  * Description:
  *   Reallocate memory from the RTC heap.
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_realloc(void *ptr, size_t size)
+void *esp32c3_rtcheap_realloc(void *ptr, size_t size)
 {
-  return mm_realloc(&g_rtc_heap, ptr, size);
+  return mm_realloc(&g_rtcheap, ptr, size);
 }
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_zalloc
+ * Name: esp32c3_rtcheap_zalloc
  *
  * Description:
  *   Allocate and zero memory from the RTC heap.
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_zalloc(size_t size)
+void *esp32c3_rtcheap_zalloc(size_t size)
 {
-  return mm_zalloc(&g_rtc_heap, size);
+  return mm_zalloc(&g_rtcheap, size);
 }
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_free
+ * Name: esp32c3_rtcheap_free
  *
  * Description:
  *   Free memory from the RTC heap.
  *
  ****************************************************************************/
 
-void esp32c3_rtc_heap_free(FAR void *mem)
+void esp32c3_rtcheap_free(FAR void *mem)
 {
-  mm_free(&g_rtc_heap, mem);
+  mm_free(&g_rtcheap, mem);
 }
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_memalign
+ * Name: esp32c3_rtcheap_memalign
  *
  * Description:
  *   memalign requests more than enough space from malloc, finds a region
@@ -154,13 +154,13 @@ void esp32c3_rtc_heap_free(FAR void *mem)
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_memalign(size_t alignment, size_t size)
+void *esp32c3_rtcheap_memalign(size_t alignment, size_t size)
 {
-  return mm_memalign(&g_rtc_heap, alignment, size);
+  return mm_memalign(&g_rtcheap, alignment, size);
 }
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_heapmember
+ * Name: esp32c3_rtcheap_heapmember
  *
  * Description:
  *   Check if an address lies in the RTC heap.
@@ -173,13 +173,13 @@ void *esp32c3_rtc_heap_memalign(size_t alignment, size_t size)
  *
  ****************************************************************************/
 
-bool esp32c3_rtc_heap_heapmember(FAR void *mem)
+bool esp32c3_rtcheap_heapmember(FAR void *mem)
 {
-  return mm_heapmember(&g_rtc_heap, mem);
+  return mm_heapmember(&g_rtcheap, mem);
 }
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_mallinfo
+ * Name: esp32c3_rtcheap_mallinfo
  *
  * Description:
  *   mallinfo returns a copy of updated current heap information for the
@@ -187,7 +187,7 @@ bool esp32c3_rtc_heap_heapmember(FAR void *mem)
  *
  ****************************************************************************/
 
-int esp32c3_rtc_heap_mallinfo(FAR struct mallinfo *info)
+int esp32c3_rtcheap_mallinfo(FAR struct mallinfo *info)
 {
-  return mm_mallinfo(&g_rtc_heap, info);
+  return mm_mallinfo(&g_rtcheap, info);
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_rtcheap.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtcheap.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/esp32c3/esp32c3_rtc_heap.h
+ * arch/risc-v/src/esp32c3/esp32c3_rtcheap.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __ARCH_RISCV_SRC_ESP32C3_ESP32C3_RTC_HEAP_H
-#define __ARCH_RISCV_SRC_ESP32C3_ESP32C3_RTC_HEAP_H
+#ifndef __ARCH_RISCV_SRC_ESP32C3_ESP32C3_RTCHEAP_H
+#define __ARCH_RISCV_SRC_ESP32C3_ESP32C3_RTCHEAP_H
 
 /****************************************************************************
  * Public Function Prototypes
@@ -36,27 +36,27 @@ extern "C"
 struct mallinfo; /* Forward reference, see malloc.h */
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_initialize
+ * Name: esp32c3_rtcheap_initialize
  *
  * Description:
  *   Initialize the RTC heap.
  *
  ****************************************************************************/
 
-void esp32c3_rtc_heap_initialize(void);
+void esp32c3_rtcheap_initialize(void);
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_malloc
+ * Name: esp32c3_rtcheap_malloc
  *
  * Description:
  *   Allocate memory from the RTC heap.
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_malloc(size_t size);
+void *esp32c3_rtcheap_malloc(size_t size);
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_calloc
+ * Name: esp32c3_rtcheap_calloc
  *
  * Description:
  *   Calculates the size of the allocation and allocate memory from
@@ -64,40 +64,40 @@ void *esp32c3_rtc_heap_malloc(size_t size);
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_calloc(size_t n, size_t elem_size);
+void *esp32c3_rtcheap_calloc(size_t n, size_t elem_size);
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_realloc
+ * Name: esp32c3_rtcheap_realloc
  *
  * Description:
  *   Reallocate memory from the RTC heap.
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_realloc(void *ptr, size_t size);
+void *esp32c3_rtcheap_realloc(void *ptr, size_t size);
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_zalloc
+ * Name: esp32c3_rtcheap_zalloc
  *
  * Description:
  *   Allocate and zero memory from the RTC heap.
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_zalloc(size_t size);
+void *esp32c3_rtcheap_zalloc(size_t size);
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_free
+ * Name: esp32c3_rtcheap_free
  *
  * Description:
  *   Free memory from the RTC heap.
  *
  ****************************************************************************/
 
-void esp32c3_rtc_heap_free(FAR void *mem);
+void esp32c3_rtcheap_free(FAR void *mem);
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_memalign
+ * Name: esp32c3_rtcheap_memalign
  *
  * Description:
  *   memalign requests more than enough space from malloc, finds a region
@@ -109,10 +109,10 @@ void esp32c3_rtc_heap_free(FAR void *mem);
  *
  ****************************************************************************/
 
-void *esp32c3_rtc_heap_memalign(size_t alignment, size_t size);
+void *esp32c3_rtcheap_memalign(size_t alignment, size_t size);
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_heapmember
+ * Name: esp32c3_rtcheap_heapmember
  *
  * Description:
  *   Check if an address lies in the RTC heap.
@@ -125,10 +125,10 @@ void *esp32c3_rtc_heap_memalign(size_t alignment, size_t size);
  *
  ****************************************************************************/
 
-bool esp32c3_rtc_heap_heapmember(FAR void *mem);
+bool esp32c3_rtcheap_heapmember(FAR void *mem);
 
 /****************************************************************************
- * Name: esp32c3_rtc_heap_mallinfo
+ * Name: esp32c3_rtcheap_mallinfo
  *
  * Description:
  *   mallinfo returns a copy of updated current heap information for the
@@ -136,11 +136,11 @@ bool esp32c3_rtc_heap_heapmember(FAR void *mem);
  *
  ****************************************************************************/
 
-int esp32c3_rtc_heap_mallinfo(FAR struct mallinfo *info);
+int esp32c3_rtcheap_mallinfo(FAR struct mallinfo *info);
 
 #undef EXTERN
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_RTC_HEAP_H */
+#endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_RTCHEAP_H */

--- a/arch/risc-v/src/esp32c3/esp32c3_textheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_textheap.c
@@ -36,7 +36,7 @@
 #include "hardware/esp32c3_soc.h"
 
 #ifdef CONFIG_ESP32C3_RTC_HEAP
-#include "esp32c3_rtc_heap.h"
+#include "esp32c3_rtcheap.h"
 #endif
 
 /****************************************************************************
@@ -58,7 +58,7 @@ void up_textheap_init()
 #ifdef CONFIG_ESP32C3_RTC_HEAP
   /* Initialize the RTC heap */
 
-  esp32c3_rtc_heap_initialize();
+  esp32c3_rtcheap_initialize();
 #endif
 }
 
@@ -79,7 +79,7 @@ FAR void *up_textheap_memalign(size_t align, size_t size)
    */
 
 #ifdef CONFIG_ESP32C3_RTC_HEAP
-  ret = esp32c3_rtc_heap_memalign(align, size);
+  ret = esp32c3_rtcheap_memalign(align, size);
 #endif
 
   if (ret == NULL)
@@ -113,7 +113,7 @@ void up_textheap_free(FAR void *p)
 #ifdef CONFIG_ESP32C3_RTC_HEAP
       if (esp32c3_ptr_rtc(p))
         {
-          esp32c3_rtc_heap_free(p);
+          esp32c3_rtcheap_free(p);
         }
       else
 #endif

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -231,6 +231,10 @@ config ESP32_RUN_IRAM
 		This loads all of NuttX inside IRAM.  Used to test somewhat small
 		images that can fit entirely in IRAM.
 
+config ESP32_RTC_HEAP
+	bool "Use the RTC memory as a separate heap"
+	default n
+
 menu "ESP32 Peripheral Selection"
 
 config ESP32_UART

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -185,6 +185,7 @@ endif
 endif
 
 ifeq ($(CONFIG_ARCH_USE_TEXT_HEAP),y)
+CHIP_CSRCS += esp32_iramheap.c
 CHIP_CSRCS += esp32_textheap.c
 CMN_ASRCS += xtensa_loadstore.S
 endif

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -97,6 +97,10 @@ ifeq ($(CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP),y)
 CHIP_CSRCS += esp32_imm.c
 endif
 
+ifeq ($(CONFIG_ESP32_RTC_HEAP),y)
+CHIP_CSRCS += esp32_rtcheap.c
+endif
+
 ifeq ($(CONFIG_ESP32_I2C),y)
 CHIP_CSRCS += esp32_i2c.c
 endif

--- a/arch/xtensa/src/esp32/esp32_iramheap.c
+++ b/arch/xtensa/src/esp32/esp32_iramheap.c
@@ -1,0 +1,191 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_iramheap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/fs/procfs.h>
+#include <nuttx/mm/mm.h>
+#include <malloc.h>
+
+#include "esp32_iramheap.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct mm_heap_s g_iramheap;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32_iramheap_initialize
+ *
+ * Description:
+ *   Initialize the IRAM heap.
+ *
+ ****************************************************************************/
+
+void esp32_iramheap_initialize(void)
+{
+  void  *start;
+  size_t size;
+
+  /* These values come from the linker scripts. Check boards/xtensa/esp32. */
+
+  extern uint8_t *_siramheap;
+  extern uint8_t *_eiramheap;
+
+  start = (void *)&_siramheap;
+  size  = (size_t)((uintptr_t)&_eiramheap - (uintptr_t)&_siramheap);
+  mm_initialize(&g_iramheap, start, size);
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)
+  static struct procfs_meminfo_entry_s g_iram_procfs;
+
+  g_iram_procfs.name = "iramheap";
+  g_iram_procfs.mallinfo = (void *)mm_mallinfo;
+  g_iram_procfs.user_data = &g_iramheap;
+  procfs_register_meminfo(&g_iram_procfs);
+#endif
+}
+
+/****************************************************************************
+ * Name: esp32_iramheap_malloc
+ *
+ * Description:
+ *   Allocate memory from the IRAM heap.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_malloc(size_t size)
+{
+  return mm_malloc(&g_iramheap, size);
+}
+
+/****************************************************************************
+ * Name: esp32_iramheap_calloc
+ *
+ * Description:
+ *   Calculates the size of the allocation and allocate memory from
+ *   the IRAM heap.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_calloc(size_t n, size_t elem_size)
+{
+  return mm_calloc(&g_iramheap, n, elem_size);
+}
+
+/****************************************************************************
+ * Name: esp32_iramheap_realloc
+ *
+ * Description:
+ *   Reallocate memory from the IRAM heap.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_realloc(void *ptr, size_t size)
+{
+  return mm_realloc(&g_iramheap, ptr, size);
+}
+
+/****************************************************************************
+ * Name: esp32_iramheap_zalloc
+ *
+ * Description:
+ *   Allocate and zero memory from the IRAM heap.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_zalloc(size_t size)
+{
+  return mm_zalloc(&g_iramheap, size);
+}
+
+/****************************************************************************
+ * Name: esp32_iramheap_free
+ *
+ * Description:
+ *   Free memory from the IRAM heap.
+ *
+ ****************************************************************************/
+
+void esp32_iramheap_free(void *mem)
+{
+  mm_free(&g_iramheap, mem);
+}
+
+/****************************************************************************
+ * Name: esp32_iramheap_memalign
+ *
+ * Description:
+ *   memalign requests more than enough space from malloc, finds a region
+ *   within that chunk that meets the alignment request and then frees any
+ *   leading or trailing space.
+ *
+ *   The alignment argument must be a power of two (not checked).  8-byte
+ *   alignment is guaranteed by normal malloc calls.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_memalign(size_t alignment, size_t size)
+{
+  return mm_memalign(&g_iramheap, alignment, size);
+}
+
+/****************************************************************************
+ * Name: esp32_iramheap_heapmember
+ *
+ * Description:
+ *   Check if an address lies in the IRAM heap.
+ *
+ * Parameters:
+ *   mem - The address to check
+ *
+ * Return Value:
+ *   true if the address is a member of the IRAM heap.  false if not
+ *
+ ****************************************************************************/
+
+bool esp32_iramheap_heapmember(void *mem)
+{
+  return mm_heapmember(&g_iramheap, mem);
+}
+
+/****************************************************************************
+ * Name: esp32_iramheap_mallinfo
+ *
+ * Description:
+ *   mallinfo returns a copy of updated current heap information for the
+ *   user heap.
+ *
+ ****************************************************************************/
+
+int esp32_iramheap_mallinfo(struct mallinfo *info)
+{
+  return mm_mallinfo(&g_iramheap, info);
+}

--- a/arch/xtensa/src/esp32/esp32_iramheap.h
+++ b/arch/xtensa/src/esp32/esp32_iramheap.h
@@ -1,0 +1,146 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_iramheap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_SRC_ESP32_ESP32_IRAMHEAP_H
+#define __ARCH_XTENSA_SRC_ESP32_ESP32_IRAMHEAP_H
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+struct mallinfo; /* Forward reference, see malloc.h */
+
+/****************************************************************************
+ * Name: esp32_iramheap_initialize
+ *
+ * Description:
+ *   Initialize the IRAM heap.
+ *
+ ****************************************************************************/
+
+void esp32_iramheap_initialize(void);
+
+/****************************************************************************
+ * Name: esp32_iramheap_malloc
+ *
+ * Description:
+ *   Allocate memory from the IRAM heap.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_malloc(size_t size);
+
+/****************************************************************************
+ * Name: esp32_iramheap_calloc
+ *
+ * Description:
+ *   Calculates the size of the allocation and allocate memory from
+ *   the IRAM heap.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_calloc(size_t n, size_t elem_size);
+
+/****************************************************************************
+ * Name: esp32_iramheap_realloc
+ *
+ * Description:
+ *   Reallocate memory from the IRAM heap.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_realloc(void *ptr, size_t size);
+
+/****************************************************************************
+ * Name: esp32_iramheap_zalloc
+ *
+ * Description:
+ *   Allocate and zero memory from the IRAM heap.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_zalloc(size_t size);
+
+/****************************************************************************
+ * Name: esp32_iramheap_free
+ *
+ * Description:
+ *   Free memory from the IRAM heap.
+ *
+ ****************************************************************************/
+
+void esp32_iramheap_free(void *mem);
+
+/****************************************************************************
+ * Name: esp32_iramheap_memalign
+ *
+ * Description:
+ *   memalign requests more than enough space from malloc, finds a region
+ *   within that chunk that meets the alignment request and then frees any
+ *   leading or trailing space.
+ *
+ *   The alignment argument must be a power of two (not checked). 8-byte
+ *   alignment is guaranteed by normal malloc calls.
+ *
+ ****************************************************************************/
+
+void *esp32_iramheap_memalign(size_t alignment, size_t size);
+
+/****************************************************************************
+ * Name: esp32_iramheap_heapmember
+ *
+ * Description:
+ *   Check if an address lies in the IRAM heap.
+ *
+ * Parameters:
+ *   mem - The address to check
+ *
+ * Return Value:
+ *   true if the address is a member of the IRAM heap. false if not
+ *
+ ****************************************************************************/
+
+bool esp32_iramheap_heapmember(void *mem);
+
+/****************************************************************************
+ * Name: esp32_iramheap_mallinfo
+ *
+ * Description:
+ *   mallinfo returns a copy of updated current heap information for the
+ *   user heap.
+ *
+ ****************************************************************************/
+
+int esp32_iramheap_mallinfo(struct mallinfo *info);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_IRAMHEAP_H */

--- a/arch/xtensa/src/esp32/esp32_rtcheap.c
+++ b/arch/xtensa/src/esp32/esp32_rtcheap.c
@@ -1,0 +1,201 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_rtcheap.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/fs/procfs.h>
+#include <nuttx/mm/mm.h>
+#include <malloc.h>
+
+#include "esp32_rtcheap.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct mm_heap_s g_rtcheap;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32_rtcheap_initialize
+ *
+ * Description:
+ *   Initialize the RTC heap.
+ *
+ ****************************************************************************/
+
+void esp32_rtcheap_initialize(void)
+{
+  void  *start;
+  size_t size;
+
+  /* These values come from the linker scripts. Check boards/xtensa/esp32. */
+
+  extern uint8_t *_srtcheap;
+  extern uint8_t *_ertcheap;
+
+  start = (void *)&_srtcheap;
+  size  = (size_t)((uintptr_t)&_ertcheap - (uintptr_t)&_srtcheap);
+  mm_initialize(&g_rtcheap, start, size);
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)
+  static struct procfs_meminfo_entry_s g_rtc_procfs;
+
+  g_rtc_procfs.name = "rtcheap";
+  g_rtc_procfs.mallinfo = (void *)mm_mallinfo;
+  g_rtc_procfs.user_data = &g_rtcheap;
+  procfs_register_meminfo(&g_rtc_procfs);
+#endif
+}
+
+/****************************************************************************
+ * Name: esp32_rtcheap_malloc
+ *
+ * Description:
+ *   Allocate memory from the RTC heap.
+ *
+ * Parameters:
+ *   size - Size (in bytes) of the memory region to be allocated.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_malloc(size_t size)
+{
+  return mm_malloc(&g_rtcheap, size);
+}
+
+/****************************************************************************
+ * Name: esp32_rtcheap_calloc
+ *
+ * Description:
+ *   Calculates the size of the allocation and allocate memory from
+ *   the RTC heap.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_calloc(size_t n, size_t elem_size)
+{
+  return mm_calloc(&g_rtcheap, n, elem_size);
+}
+
+/****************************************************************************
+ * Name: esp32_rtcheap_realloc
+ *
+ * Description:
+ *   Reallocate memory from the RTC heap.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_realloc(void *ptr, size_t size)
+{
+  return mm_realloc(&g_rtcheap, ptr, size);
+}
+
+/****************************************************************************
+ * Name: esp32_rtcheap_zalloc
+ *
+ * Description:
+ *   Allocate and zero memory from the RTC heap.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_zalloc(size_t size)
+{
+  return mm_zalloc(&g_rtcheap, size);
+}
+
+/****************************************************************************
+ * Name: esp32_rtcheap_free
+ *
+ * Description:
+ *   Free memory from the RTC heap.
+ *
+ ****************************************************************************/
+
+void esp32_rtcheap_free(void *mem)
+{
+  mm_free(&g_rtcheap, mem);
+}
+
+/****************************************************************************
+ * Name: esp32_rtcheap_memalign
+ *
+ * Description:
+ *   memalign requests more than enough space from malloc, finds a region
+ *   within that chunk that meets the alignment request and then frees any
+ *   leading or trailing space.
+ *
+ *   The alignment argument must be a power of two (not checked).  8-byte
+ *   alignment is guaranteed by normal malloc calls.
+ *
+ * Parameters:
+ *   alignment - Requested alignment.
+ *   size - Size (in bytes) of the memory region to be allocated.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_memalign(size_t alignment, size_t size)
+{
+  return mm_memalign(&g_rtcheap, alignment, size);
+}
+
+/****************************************************************************
+ * Name: esp32_rtcheap_heapmember
+ *
+ * Description:
+ *   Check if an address lies in the RTC heap.
+ *
+ * Parameters:
+ *   mem - The address to check.
+ *
+ * Return Value:
+ *   True if the address is a member of the RTC heap.  False if not.
+ *
+ ****************************************************************************/
+
+bool esp32_rtcheap_heapmember(void *mem)
+{
+  return mm_heapmember(&g_rtcheap, mem);
+}
+
+/****************************************************************************
+ * Name: esp32_rtcheap_mallinfo
+ *
+ * Description:
+ *   mallinfo returns a copy of updated current heap information for the
+ *   user heap.
+ *
+ * Parameters:
+ *   info - Where memory information will be copied.
+ *
+ ****************************************************************************/
+
+int esp32_rtcheap_mallinfo(struct mallinfo *info)
+{
+  return mm_mallinfo(&g_rtcheap, info);
+}

--- a/arch/xtensa/src/esp32/esp32_rtcheap.h
+++ b/arch/xtensa/src/esp32/esp32_rtcheap.h
@@ -1,0 +1,149 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_rtcheap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_SRC_ESP32_ESP32_RTCHEAP_H
+#define __ARCH_XTENSA_SRC_ESP32_ESP32_RTCHEAP_H
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+struct mallinfo; /* Forward reference, see malloc.h */
+
+/****************************************************************************
+ * Name: esp32_rtcheap_initialize
+ *
+ * Description:
+ *   Initialize the RTC heap.
+ *
+ ****************************************************************************/
+
+void esp32_rtcheap_initialize(void);
+
+/****************************************************************************
+ * Name: esp32_rtcheap_malloc
+ *
+ * Description:
+ *   Allocate memory from the RTC heap.
+ *
+ * Parameters:
+ *   size - Size (in bytes) of the memory region to be allocated.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_malloc(size_t size);
+
+/****************************************************************************
+ * Name: esp32_rtcheap_calloc
+ *
+ * Description:
+ *   Calculates the size of the allocation and allocate memory from
+ *   the RTC heap.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_calloc(size_t n, size_t elem_size);
+
+/****************************************************************************
+ * Name: esp32_rtcheap_realloc
+ *
+ * Description:
+ *   Reallocate memory from the RTC heap.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_realloc(void *ptr, size_t size);
+
+/****************************************************************************
+ * Name: esp32_rtcheap_zalloc
+ *
+ * Description:
+ *   Allocate and zero memory from the RTC heap.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_zalloc(size_t size);
+
+/****************************************************************************
+ * Name: esp32_rtcheap_free
+ *
+ * Description:
+ *   Free memory from the RTC heap.
+ *
+ ****************************************************************************/
+
+void esp32_rtcheap_free(void *mem);
+
+/****************************************************************************
+ * Name: esp32_rtcheap_memalign
+ *
+ * Description:
+ *   memalign requests more than enough space from malloc, finds a region
+ *   within that chunk that meets the alignment request and then frees any
+ *   leading or trailing space.
+ *
+ *   The alignment argument must be a power of two (not checked). 8-byte
+ *   alignment is guaranteed by normal malloc calls.
+ *
+ ****************************************************************************/
+
+void *esp32_rtcheap_memalign(size_t alignment, size_t size);
+
+/****************************************************************************
+ * Name: esp32_rtcheap_heapmember
+ *
+ * Description:
+ *   Check if an address lies in the RTC heap.
+ *
+ * Parameters:
+ *   mem - The address to check
+ *
+ * Return Value:
+ *   True if the address is a member of the RTC heap. False if not.
+ *
+ ****************************************************************************/
+
+bool esp32_rtcheap_heapmember(void *mem);
+
+/****************************************************************************
+ * Name: esp32_rtcheap_mallinfo
+ *
+ * Description:
+ *   mallinfo returns a copy of updated current heap information for the
+ *   user heap.
+ *
+ ****************************************************************************/
+
+int esp32_rtcheap_mallinfo(struct mallinfo *info);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_RTCHEAP_H */

--- a/arch/xtensa/src/esp32/esp32_user.c
+++ b/arch/xtensa/src/esp32/esp32_user.c
@@ -39,8 +39,8 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USE_TEXT_HEAP
-extern uint32_t _stextheap;
-extern uint32_t _etextheap;
+extern uint32_t _siramheap;
+extern uint32_t _eiramheap;
 #endif
 
 /****************************************************************************
@@ -338,8 +338,8 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
    */
 
   if (exccause == XCHAL_EXCCAUSE_LOAD_STORE_ERROR &&
-      (uintptr_t)&_stextheap <= regs[REG_EXCVADDR] &&
-      (uintptr_t)&_etextheap > regs[REG_EXCVADDR])
+      (uintptr_t)&_siramheap <= regs[REG_EXCVADDR] &&
+      (uintptr_t)&_eiramheap > regs[REG_EXCVADDR])
     {
       uint8_t *pc = (uint8_t *)regs[REG_PC];
       uint8_t imm8;

--- a/arch/xtensa/src/esp32/hardware/esp32_soc.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_soc.h
@@ -281,8 +281,8 @@
 #define SOC_RTC_IRAM_HIGH       0x400c2000
 #define SOC_RTC_DRAM_LOW        0x3ff80000
 #define SOC_RTC_DRAM_HIGH       0x3ff82000
-#define SOC_RTC_DATA_LOW        0x50000000
-#define SOC_RTC_DATA_HIGH       0x50002000
+#define SOC_RTC_SLOW_LOW        0x50000000
+#define SOC_RTC_SLOW_HIGH       0x50002000
 #define SOC_EXTRAM_DATA_LOW     0x3f800000
 #define SOC_EXTRAM_DATA_HIGH    0x3fc00000
 
@@ -853,6 +853,23 @@ static inline bool IRAM_ATTR esp32_ptr_exec(const void *p)
       || (ip >= SOC_CACHE_APP_LOW && ip < SOC_CACHE_APP_HIGH)
 #endif
       || (ip >= SOC_RTC_IRAM_LOW && ip < SOC_RTC_IRAM_HIGH);
+}
+
+/****************************************************************************
+ * Name: esp32_ptr_rtcslow
+ *
+ * Description:
+ *   Check if the buffer comes from the RTC Slow RAM.
+ *
+ * Parameters:
+ *   p          - Pointer to the buffer.
+ *
+ ****************************************************************************/
+
+static inline bool IRAM_ATTR esp32_ptr_rtcslow(const void *p)
+{
+  return ((intptr_t)p >= SOC_RTC_SLOW_LOW &&
+          (intptr_t)p < SOC_RTC_SLOW_HIGH);
 }
 
 #endif /* __ARCH_XTENSA_SRC_ESP32_HARDWARE_ESP32_SOC_H */

--- a/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.ld
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.ld
@@ -250,7 +250,7 @@ SECTIONS
 
    /* Whatever is left from the RTC memory is used as a special heap. */
 
-    _srtc_heap = ABSOLUTE(.);
+    _srtcheap = ABSOLUTE(.);
 
   } >rtc_seg
 }

--- a/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.template.ld
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.template.ld
@@ -91,4 +91,4 @@ MEMORY
 
 /* Mark the end of the RTC heap (top of the RTC region) */
 
-_ertc_heap = 0x50001fff;
+_ertcheap = 0x50001fff;

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
@@ -78,9 +78,9 @@ MEMORY
 
 _eheap = 0x40000000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM;
 
-/* Text heap ends at top of dram0_0_seg */
+/* IRAM heap ends at top of dram0_0_seg */
 
-_etextheap = 0x400a0000;
+_eiramheap = 0x400a0000;
 
 /* Mark the end of the RTC heap (top of the RTC region) */
 

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
@@ -81,3 +81,7 @@ _eheap = 0x40000000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM;
 /* Text heap ends at top of dram0_0_seg */
 
 _etextheap = 0x400a0000;
+
+/* Mark the end of the RTC heap (top of the RTC region) */
+
+_ertcheap = 0x50001fff;

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
@@ -63,10 +63,10 @@ SECTIONS
     *(.phyiram .phyiram.*)
     _iram_text_end = ABSOLUTE(.);
 
-    /* Text heap starts at the end of iram0_0_seg */
+    /* IRAM heap starts at the end of iram0_0_seg */
 
     . = ALIGN (4);
-    _stextheap = ABSOLUTE(.);
+    _siramheap = ABSOLUTE(.);
   } > iram0_0_seg
 
   /* Shared RAM */

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_flash.ld
@@ -215,5 +215,10 @@ SECTIONS
   {
     *(.rtc.data)
     *(.rtc.rodata)
+
+   /* Whatever is left from the RTC memory is used as a special heap. */
+
+    . = ALIGN (4);
+    _srtcheap = ABSOLUTE(.);
   } > rtc_slow_seg
 }

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_iram.ld
@@ -70,10 +70,10 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _etext = .;
 
-    /* Text heap starts at the end of iram0_0_seg */
+    /* IRAM heap starts at the end of iram0_0_seg */
 
     . = ALIGN (4);
-    _stextheap = ABSOLUTE(.);
+    _siramheap = ABSOLUTE(.);
   } > iram0_0_seg
 
   /* Shared RAM */

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32_iram.ld
@@ -192,5 +192,10 @@ SECTIONS
   {
     *(.rtc.data)
     *(.rtc.rodata)
+
+   /* Whatever is left from the RTC memory is used as a special heap. */
+
+    . = ALIGN (4);
+    _srtcheap = ABSOLUTE(.);
   } > rtc_slow_seg
 }

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
@@ -78,9 +78,9 @@ MEMORY
 
 _eheap = 0x40000000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM;
 
-/* Text heap ends at top of dram0_0_seg */
+/* IRAM heap ends at top of dram0_0_seg */
 
-_etextheap = 0x400a0000;
+_eiramheap = 0x400a0000;
 
 /* Mark the end of the RTC heap (top of the RTC region) */
 

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
@@ -81,3 +81,7 @@ _eheap = 0x40000000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM;
 /* Text heap ends at top of dram0_0_seg */
 
 _etextheap = 0x400a0000;
+
+/* Mark the end of the RTC heap (top of the RTC region) */
+
+_ertcheap = 0x50001fff;

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
@@ -66,10 +66,10 @@ SECTIONS
     *(.phyiram .phyiram.*)
     _iram_text_end = ABSOLUTE(.);
 
-    /* Text heap starts at the end of iram0_0_seg */
+    /* IRAM heap starts at the end of iram0_0_seg */
 
     . = ALIGN (4);
-    _stextheap = ABSOLUTE(.);
+    _siramheap = ABSOLUTE(.);
   } > iram0_0_seg
 
   /* Shared RAM */

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_flash.ld
@@ -217,5 +217,10 @@ SECTIONS
   {
     *(.rtc.data)
     *(.rtc.rodata)
+
+   /* Whatever is left from the RTC memory is used as a special heap. */
+
+    . = ALIGN (4);
+    _srtcheap = ABSOLUTE(.);
   } > rtc_slow_seg
 }

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_iram.ld
@@ -70,10 +70,10 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _etext = .;
 
-    /* Text heap starts at the end of iram0_0_seg */
+    /* IRAM heap starts at the end of iram0_0_seg */
 
     . = ALIGN (4);
-    _stextheap = ABSOLUTE(.);
+    _siramheap = ABSOLUTE(.);
   } > iram0_0_seg
 
   /* Shared RAM */

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32_iram.ld
@@ -192,5 +192,10 @@ SECTIONS
   {
     *(.rtc.data)
     *(.rtc.rodata)
+
+   /* Whatever is left from the RTC memory is used as a special heap. */
+
+    . = ALIGN (4);
+    _srtcheap = ABSOLUTE(.);
   } > rtc_slow_seg
 }

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
@@ -78,9 +78,9 @@ MEMORY
 
 _eheap = 0x40000000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM;
 
-/* Text heap ends at top of dram0_0_seg */
+/* IRAM heap ends at top of dram0_0_seg */
 
-_etextheap = 0x400a0000;
+_eiramheap = 0x400a0000;
 
 /* Mark the end of the RTC heap (top of the RTC region) */
 

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
@@ -81,3 +81,7 @@ _eheap = 0x40000000 - CONFIG_ESP32_TRACEMEM_RESERVE_DRAM;
 /* Text heap ends at top of dram0_0_seg */
 
 _etextheap = 0x400a0000;
+
+/* Mark the end of the RTC heap (top of the RTC region) */
+
+_ertcheap = 0x50001fff;

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
@@ -217,5 +217,10 @@ SECTIONS
   {
     *(.rtc.data)
     *(.rtc.rodata)
+
+   /* Whatever is left from the RTC memory is used as a special heap. */
+
+    . = ALIGN (4);
+    _srtcheap = ABSOLUTE(.);
   } > rtc_slow_seg
 }

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_flash.ld
@@ -66,10 +66,10 @@ SECTIONS
     *(.phyiram .phyiram.*)
     _iram_text_end = ABSOLUTE(.);
 
-    /* Text heap starts at the end of iram0_0_seg */
+    /* iram heap starts at the end of iram0_0_seg */
 
     . = ALIGN (4);
-    _stextheap = ABSOLUTE(.);
+    _siramheap = ABSOLUTE(.);
   } > iram0_0_seg
 
   /* Shared RAM */

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_iram.ld
@@ -70,10 +70,10 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _etext = .;
 
-    /* Text heap starts at the end of iram0_0_seg */
+    /* IRAM heap starts at the end of iram0_0_seg */
 
     . = ALIGN (4);
-    _stextheap = ABSOLUTE(.);
+    _siramheap = ABSOLUTE(.);
   } > iram0_0_seg
 
   /* Shared RAM */

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_iram.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32_iram.ld
@@ -192,5 +192,10 @@ SECTIONS
   {
     *(.rtc.data)
     *(.rtc.rodata)
+
+   /* Whatever is left from the RTC memory is used as a special heap. */
+
+    . = ALIGN (4);
+    _srtcheap = ABSOLUTE(.);
   } > rtc_slow_seg
 }


### PR DESCRIPTION
## Summary
1. Use the slow RTC memory (8KB) as a separate heap.  This is used to allocate text for dynamic code loading.
2. Refactor the text heap section to use both IRAM and RTC memories.
## Impact
ESP32 only.  The RTC option is disabled by default.
## Testing
esp32-devkitc:elf esp32-devkitc:module esp32-devkitc:sotest
