### PR TITLE
sys/select.h: Should include sys/time.h instead of time.h 

### DIFF
--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -29,7 +29,7 @@
 
 #include <stdint.h>
 #include <signal.h>
-#include <time.h>
+#include <sys/time.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary
User should compile without error by just including sys/select.h.

## Impact
Minor the change for the header file inclusion

## Testing
This code snippet can build without error:
```
#include <sys/select.h>

int main()
{
  select(0, NULL, NULL, NULL, NULL);
  return 0;
}
```