### PR TITLE
net: Fix: left shift of 1 by 31 places cannot be represented in type long int

### DIFF
--- a/net/netdev/netdev_findbyindex.c
+++ b/net/netdev/netdev_findbyindex.c
@@ -75,7 +75,7 @@ FAR struct net_driver_s *netdev_findbyindex(int ifindex)
 #ifdef CONFIG_NETDEV_IFINDEX
   /* Check if this index has been assigned */
 
-  if ((g_devset & (1L << (ifindex - 1))) == 0)
+  if ((g_devset & (1UL << (ifindex - 1))) == 0)
     {
       /* This index has not been assigned */
 
@@ -142,7 +142,7 @@ int netdev_nextindex(int ifindex)
       net_lock();
       for (; ifindex < MAX_IFINDEX; ifindex++)
         {
-          if ((g_devset & (1L << ifindex)) != 0)
+          if ((g_devset & (1UL << ifindex)) != 0)
             {
               /* NOTE that the index + 1 is returned.  Zero is reserved to
                * mean no-index in the POSIX standards.

--- a/net/netdev/netdev_register.c
+++ b/net/netdev/netdev_register.c
@@ -189,7 +189,7 @@ static int get_ifindex(void)
 
   for (ndx = 0; ndx < MAX_IFINDEX; ndx++)
     {
-      uint32_t bit = 1L << ndx;
+      uint32_t bit = 1UL << ndx;
       if ((devset & bit) == 0)
         {
           /* Indicate that this index is in use */


### PR DESCRIPTION
## Summary

## Impact
Avoid the undefined behaviour reported by UBSan

## Testing

