### PR TITLE
libc/dirname: Handle the consecutive '/' correctly

### DIFF
--- a/libs/libc/libgen/lib_basename.c
+++ b/libs/libc/libgen/lib_basename.c
@@ -28,12 +28,6 @@
 #include <libgen.h>
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-static char g_retchar[2];
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -65,16 +59,14 @@ static char g_retchar[2];
 
 FAR char *basename(FAR char *path)
 {
-  char *p;
-  int   len;
-  int   ch;
+  FAR char *p;
+  int       len;
 
   /* Handle some corner cases */
 
   if (!path || *path == '\0')
     {
-      ch = '.';
-      goto out_retchar;
+      return ".";
     }
 
   /* Check for trailing slash characters */
@@ -91,8 +83,7 @@ FAR char *basename(FAR char *path)
         }
       else
         {
-          ch = '/';
-          goto out_retchar;
+          return "/";
         }
     }
 
@@ -109,9 +100,4 @@ FAR char *basename(FAR char *path)
   /* There is no '/' in the path */
 
   return path;
-
-out_retchar:
-  g_retchar[0] = ch;
-  g_retchar[1] = '\0';
-  return g_retchar;
 }

--- a/libs/libc/libgen/lib_dirname.c
+++ b/libs/libc/libgen/lib_dirname.c
@@ -94,18 +94,23 @@ FAR char *dirname(FAR char *path)
   p = strrchr(path, '/');
   if (p)
     {
-      /* Handle the case where the only '/' in the string is the at the
-       * beginning of the path.
-       */
-
-      if (p == path)
+      do
         {
-          return "/";
+          /* Handle the case where the only '/' in the string is the at the
+           * beginning of the path.
+           */
+
+          if (p == path)
+            {
+              return "/";
+            }
+
+          /* No, the directory component is the substring before the '/'. */
+
+          *p-- = '\0';
         }
+      while (*p == '/');
 
-      /* No, the directory component is the substring before the '/'. */
-
-      *p = '\0';
       return path;
     }
 

--- a/libs/libc/libgen/lib_dirname.c
+++ b/libs/libc/libgen/lib_dirname.c
@@ -28,12 +28,6 @@
 #include <libgen.h>
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-static char g_retchar[2];
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -65,16 +59,14 @@ static char g_retchar[2];
 
 FAR char *dirname(FAR char *path)
 {
-  char *p;
-  int   len;
-  int   ch;
+  FAR char *p;
+  int       len;
 
   /* Handle some corner cases */
 
   if (!path || *path == '\0')
     {
-      ch = '.';
-      goto out_retchar;
+      return ".";
     }
 
   /* Check for trailing slash characters */
@@ -91,8 +83,7 @@ FAR char *dirname(FAR char *path)
         }
       else
         {
-          ch = '/';
-          goto out_retchar;
+          return "/";
         }
     }
 
@@ -109,8 +100,7 @@ FAR char *dirname(FAR char *path)
 
       if (p == path)
         {
-          ch = '/';
-          goto out_retchar;
+          return "/";
         }
 
       /* No, the directory component is the substring before the '/'. */
@@ -121,10 +111,5 @@ FAR char *dirname(FAR char *path)
 
   /* There is no '/' in the path */
 
-  ch = '.';
-
-out_retchar:
-  g_retchar[0] = ch;
-  g_retchar[1] = '\0';
-  return g_retchar;
+  return ".";
 }


### PR DESCRIPTION
## Summary
And remove g_retchar from basename/dirname to avoid the race condtion.

## Impact

## Testing
"/home//dwc//test" return "/home//dwc" instead "/home//dwc/"
