### PR TITLE
drivers/ioexpander/gpio_lower_half.c: add missing debug.h

### DIFF
--- a/drivers/ioexpander/gpio_lower_half.c
+++ b/drivers/ioexpander/gpio_lower_half.c
@@ -26,6 +26,7 @@
 
 #include <sys/types.h>
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <nuttx/kmalloc.h>


### PR DESCRIPTION
## Summary
Fixes compiler warnings like:

```
ioexpander/gpio_lower_half.c: In function 'gplh_read':
ioexpander/gpio_lower_half.c:162:3: warning: implicit declaration of function 'gpioinfo'; did you mean 'psiginfo'? [-Wimplicit-function-declaration]
   gpioinfo("pin%u: value=%p\n", priv->pin, value);
   ^~~~~~~~
   psiginfo
```

## Impact
No functional change

## Testing
Compile tested only
