### PR TITLE
boards/riscv/esp32c3: Rename the iram_0_2 segment to irom_0_0 to avoid confusions.

### DIFF
--- a/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.template.ld
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/scripts/esp32c3.template.ld
@@ -66,7 +66,7 @@ MEMORY
    * constraint that (paddr % 64KB == vaddr % 64KB).
    */
 
-  iram0_2_seg (RX) :      org = 0x42000020, len = 0x8000000 - 0x20
+  irom0_0_seg (RX) :      org = 0x42000020, len = 0x8000000 - 0x20
 
   /* Shared data RAM, excluding memory reserved for ROM bss/data/stack. */
 
@@ -86,7 +86,7 @@ MEMORY
   REGION_ALIAS("default_code_seg", iram0_0_seg);
 #else
   REGION_ALIAS("default_rodata_seg", drom0_0_seg);
-  REGION_ALIAS("default_code_seg", iram0_2_seg);
+  REGION_ALIAS("default_code_seg", irom0_0_seg);
 #endif /* CONFIG_ESP32C3_DEVKIT_RUN_IRAM */
 
 /* Mark the end of the RTC heap (top of the RTC region) */


### PR DESCRIPTION
## Summary
Rename the iram_0_2 segment to irom_0_0 to avoid confusions.  This is the C3 part for https://github.com/apache/incubator-nuttx/commit/c4b0a85841c61ebccb2ac329c6409461248d3354.
## Impact
ESP32-C3 DevKit.
## Testing
esp32c3-devkit:nsh
