### PR TITLE
xtensa/esp32: Fix RTC WDT deinitialization on start routine

### DIFF
--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -88,9 +88,11 @@ void IRAM_ATTR __start(void)
 
   /* Kill the watchdog timer */
 
+  putreg32(RTC_CNTL_WDT_WKEY_VALUE, RTC_CNTL_WDTWPROTECT_REG);
   regval  = getreg32(RTC_CNTL_WDTCONFIG0_REG);
-  regval &= ~RTC_CNTL_WDT_FLASHBOOT_MOD_EN;
+  regval &= ~RTC_CNTL_WDT_EN;
   putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
+  putreg32(0, RTC_CNTL_WDTWPROTECT_REG);
 
   /* Make sure that normal interrupts are disabled.  This is really only an
    * issue when we are started in un-usual ways (such as from IRAM).  In this

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -86,14 +86,6 @@ void IRAM_ATTR __start(void)
   uint32_t regval;
   uint32_t sp;
 
-  /* Kill the watchdog timer */
-
-  putreg32(RTC_CNTL_WDT_WKEY_VALUE, RTC_CNTL_WDTWPROTECT_REG);
-  regval  = getreg32(RTC_CNTL_WDTCONFIG0_REG);
-  regval &= ~RTC_CNTL_WDT_EN;
-  putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
-  putreg32(0, RTC_CNTL_WDTWPROTECT_REG);
-
   /* Make sure that normal interrupts are disabled.  This is really only an
    * issue when we are started in un-usual ways (such as from IRAM).  In this
    * case, we can at least defer some unexpected interrupts left over from
@@ -128,6 +120,17 @@ void IRAM_ATTR __start(void)
   regval  = getreg32(DPORT_APPCPU_CTRL_B_REG);
   regval &= ~DPORT_APPCPU_CLKGATE_EN;
   putreg32(regval, DPORT_APPCPU_CTRL_B_REG);
+
+  /* The 2nd stage bootloader enables RTC WDT to check on startup sequence
+   * related issues in application. Hence disable that as we are about to
+   * start the NuttX environment.
+   */
+
+  putreg32(RTC_CNTL_WDT_WKEY_VALUE, RTC_CNTL_WDTWPROTECT_REG);
+  regval  = getreg32(RTC_CNTL_WDTCONFIG0_REG);
+  regval &= ~RTC_CNTL_WDT_EN;
+  putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
+  putreg32(0, RTC_CNTL_WDTWPROTECT_REG);
 
   /* Set CPU frequency configured in board.h */
 

--- a/arch/xtensa/src/esp32/hardware/esp32_rtccntl.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_rtccntl.h
@@ -47,6 +47,12 @@
 #define RWDT_INT_ENA_REG_OFFSET     0x003c
 #define RWDT_INT_CLR_REG_OFFSET     0x0048
 
+/* The value that needs to be written to RTC_CNTL_WDT_WKEY to
+ * write-enable the wdt registers
+ */
+
+#define RTC_CNTL_WDT_WKEY_VALUE     0x50d83aa1
+
 /* CLK */
 #define CK_XTAL_32K_MASK            (BIT(30))
 #define CK8M_D256_OUT_MASK          (BIT(31))


### PR DESCRIPTION
## Summary
This PR intends to fix the RTC WDT deinitialization on the NuttX startup.
Write protection must be disabled before performing changes to the WDT registers. Furthermore, the routine was resetting the wrong field from the RTC WDT register.
The `RTC_CNTL_WDT_FLASHBOOT_MOD_EN` field relates to Flash Boot Protection and it is enabled by the 1st stage bootloader. The 2nd stage bootloader takes care of disabling it.

Then the 2nd stage bootloader enables the RTC WDT for checking the startup sequence of the application image.

## Impact
Now it is now possible to once again enable the RTC WDT on the ESP32 2nd stage bootloader.

## Testing
Tested `esp32-wrover-kit:nsh` with ESP-IDF vanilla 2nd stage bootloader.

