### PR TITLE
boards/arm/imxrt/teensy-4.x: added board level support for GPIO driver

### DIFF
--- a/boards/arm/imxrt/teensy-4.x/src/Makefile
+++ b/boards/arm/imxrt/teensy-4.x/src/Makefile
@@ -54,6 +54,10 @@ ifeq ($(CONFIG_IMXRT_ENET),y)
 CSRCS += imxrt_ethernet.c
 endif
 
+ifeq ($(CONFIG_DEV_GPIO),y)
+CSRCS += imxrt_gpio.c
+endif
+
 ifeq ($(CONFIG_IMXRT_ADC),y)
 CSRCS += imxrt_adc.c
 endif

--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_bringup.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_bringup.c
@@ -192,6 +192,16 @@ int imxrt_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_DEV_GPIO
+  /* Initialize GPIO driver */
+
+  ret = imxrt_gpio_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: imxrt_gpio_initialize() failed: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_IMXRT_ENC
   /* Initialize ENC and register the ENC driver. */
 

--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_gpio.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_gpio.c
@@ -1,0 +1,214 @@
+/****************************************************************************
+ * boards/arm/imxrt/teensy-4.x/src/imxrt_gpio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/clock.h>
+#include <nuttx/wdog.h>
+#include <nuttx/ioexpander/gpio.h>
+
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include "imxrt_gpio.h"
+#include "teensy-4.h"
+
+#if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_GPIO_LOWER_HALF)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct imxrtgpio_dev_s
+{
+  struct gpio_dev_s gpio;
+  uint8_t id;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+#if BOARD_NGPIOIN > 0
+static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value);
+#endif
+#if BOARD_NGPIOOUT > 0
+static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value);
+static int gpout_write(FAR struct gpio_dev_s *dev, bool value);
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#if BOARD_NGPIOIN > 0
+static const struct gpio_operations_s gpin_ops =
+{
+  .go_read   = gpin_read,
+  .go_write  = NULL,
+  .go_attach = NULL,
+  .go_enable = NULL,
+};
+#endif
+
+#if BOARD_NGPIOOUT > 0
+static const struct gpio_operations_s gpout_ops =
+{
+  .go_read   = gpout_read,
+  .go_write  = gpout_write,
+  .go_attach = NULL,
+  .go_enable = NULL,
+};
+#endif
+
+#if BOARD_NGPIOIN > 0
+/* This array maps the GPIO pins used as INPUT */
+
+static const uint32_t g_gpioinputs[BOARD_NGPIOIN] =
+{
+  GPIO_IN1,
+};
+
+static struct imxrtgpio_dev_s g_gpin[BOARD_NGPIOIN];
+#endif
+
+#if BOARD_NGPIOOUT
+/* This array maps the GPIO pins used as OUTPUT */
+
+static const uint32_t g_gpiooutputs[BOARD_NGPIOOUT] =
+{
+  GPIO_OUT1,
+};
+
+static struct imxrtgpio_dev_s g_gpout[BOARD_NGPIOOUT];
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#if BOARD_NGPIOIN > 0
+static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+{
+  FAR struct imxrtgpio_dev_s *imxrtgpio =
+                        (FAR struct imxrtgpio_dev_s *)dev;
+
+  DEBUGASSERT(imxrtgpio != NULL && value != NULL);
+  DEBUGASSERT(imxrtgpio->id < BOARD_NGPIOIN);
+  gpioinfo("Reading...\n");
+
+  *value = imxrt_gpio_read(g_gpioinputs[imxrtgpio->id]);
+  return OK;
+}
+#endif
+
+#if BOARD_NGPIOOUT > 0
+static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+{
+  FAR struct imxrtgpio_dev_s *imxrtgpio =
+                        (FAR struct imxrtgpio_dev_s *)dev;
+
+  DEBUGASSERT(imxrtgpio != NULL && value != NULL);
+  DEBUGASSERT(imxrtgpio->id < BOARD_NGPIOOUT);
+  gpioinfo("Reading...\n");
+
+  *value = imxrt_gpio_read(g_gpiooutputs[imxrtgpio->id]);
+  return OK;
+}
+
+static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
+{
+  FAR struct imxrtgpio_dev_s *imxrtgpio =
+                             (FAR struct imxrtgpio_dev_s *)dev;
+
+  DEBUGASSERT(imxrtgpio != NULL);
+  DEBUGASSERT(imxrtgpio->id < BOARD_NGPIOOUT);
+  gpioinfo("Writing %d\n", (int)value);
+
+  imxrt_gpio_write(g_gpiooutputs[imxrtgpio->id], value);
+  return OK;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imxrt_gpio_initialize
+ *
+ * Description:
+ *   Initialize GPIO drivers for use with /apps/examples/gpio
+ *
+ ****************************************************************************/
+
+int imxrt_gpio_initialize(void)
+{
+  int i;
+  int pincount = 0;
+
+#if BOARD_NGPIOIN > 0
+  for (i = 0; i < BOARD_NGPIOIN; i++)
+    {
+      /* Setup and register the GPIO pin */
+
+      g_gpin[i].gpio.gp_pintype = GPIO_INPUT_PIN;
+      g_gpin[i].gpio.gp_ops     = &gpin_ops;
+      g_gpin[i].id              = i;
+      gpio_pin_register(&g_gpin[i].gpio, pincount);
+
+      /* Configure the pin that will be used as input */
+
+      imxrt_config_gpio(g_gpioinputs[i]);
+
+      pincount++;
+    }
+#endif
+
+#if BOARD_NGPIOOUT > 0
+  for (i = 0; i < BOARD_NGPIOOUT; i++)
+    {
+      /* Setup and register the GPIO pin */
+
+      g_gpout[i].gpio.gp_pintype = GPIO_OUTPUT_PIN;
+      g_gpout[i].gpio.gp_ops     = &gpout_ops;
+      g_gpout[i].id              = i;
+      gpio_pin_register(&g_gpout[i].gpio, pincount);
+
+      /* Configure the pin that will be used as output */
+
+      imxrt_gpio_write(g_gpiooutputs[i], 0);
+      imxrt_config_gpio(g_gpiooutputs[i]);
+
+      pincount++;
+    }
+#endif
+
+  return 0;
+}
+#endif /* CONFIG_DEV_GPIO && !CONFIG_GPIO_LOWER_HALF */

--- a/boards/arm/imxrt/teensy-4.x/src/teensy-4.h
+++ b/boards/arm/imxrt/teensy-4.x/src/teensy-4.h
@@ -118,6 +118,15 @@
 #define GPIO_ENC1_PHASE_B    (GPIO_XBAR1_INOUT08_1|IOMUX_ENC_DEFAULT|PADMUX_MUXMODE_ALT3)  /* EMC_06 */
 #define GPIO_ENC1_INDEX      (GPIO_XBAR1_INOUT10_1|IOMUX_ENC_DEFAULT|PADMUX_MUXMODE_ALT1)  /* B0_12 */
 
+/* GPIO pins used by the GPIO subsystem */
+
+#define BOARD_NGPIOIN   1   /* Amount of GPIO input pins */
+#define BOARD_NGPIOOUT  1   /* Amount of GPIO output pins */
+
+#define GPIO_IN1       (GPIO_INPUT | GPIO_PORT4 | GPIO_PIN4)    /* EMC_04 */
+#define GPIO_OUT1      (GPIO_OUTPUT | GPIO_OUTPUT_ZERO | IOMUX_GOUT_DEFAULT | \
+                        GPIO_PORT4 | GPIO_PIN5)                 /* EMC_05 */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -184,6 +193,21 @@ int imxrt_pwm_setup(void);
 
 #ifdef CONFIG_IMXRT_ADC
 int imxrt_adc_initialize(void);
+#endif
+
+/****************************************************************************
+ * Name: imxrt_gpio_initialize
+ *
+ * Description:
+ *   Initialize GPIO drivers for use with /apps/examples/gpio
+ *
+ * Return Value:
+ *   OK on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEV_GPIO
+int imxrt_gpio_initialize(void);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Adds board level support to Teensy 4.x for GPIO driver. Code mainly based upon stm32_gpio.c for Nucleo F446RE board withou interrupt gpio.

## Impact
Teensy 4.1 only.

## Testing
Tested with gpio example application.

