### PR TITLE
fs: nfs: Reconnect to the NFS server in TCP mode

### DIFF
--- a/fs/nfs/nfs_util.c
+++ b/fs/nfs/nfs_util.c
@@ -128,7 +128,32 @@ int nfs_request(FAR struct nfsmount *nmp, int procnum,
   if (error != 0)
     {
       ferr("ERROR: rpcclnt_request failed: %d\n", error);
-      return error;
+
+      if (error != -ENOTCONN)
+        {
+          return error;
+        }
+
+      /* Reconnect */
+
+      finfo("Reconnect due to timeout \n");
+
+      error = rpcclnt_connect(nmp->nm_rpcclnt);
+
+      if (error != 0)
+        {
+          return error;
+        }
+
+      /* Send the request again */
+
+      error = rpcclnt_request(clnt, procnum, NFS_PROG, NFS_VER3,
+                              request, reqlen, response, resplen);
+
+      if (error != 0)
+        {
+          return error;
+        }
     }
 
   memcpy(&replyh, response, sizeof(struct nfs_reply_header));


### PR DESCRIPTION
## Summary

- I noticed that an NFS connection is automatically dropped.
- Actually, this happens in TCP mode if no traffic happens
  for 600 seconds.
- I confirmed that the NFS client on Ubuntu automatically
  reconnects to the NFS server when an RPC call failed.
- This commit adds the same behavior to fix the issue.

## Impact

- NFS client in TCP mode

## Testing

- Tested with spresense:rndis_smp
