### PR TITLE
Renesas/RX added setjmp and placeholder ioctl

### DIFF
--- a/arch/renesas/Kconfig
+++ b/arch/renesas/Kconfig
@@ -57,25 +57,32 @@ config ARCH_SH1
 	bool
 	default n
 
+config ARCH_RENESAS_RX
+    bool
+    default n
+    select ARCH_HAVE_SETJMP
+    select CYGWIN_WINTOOL if WINDOWS_CYGWIN
+
 config ARCH_RX65N
 	bool
 	default n
-	select CYGWIN_WINTOOL if WINDOWS_CYGWIN
+	select ARCH_RENESAS_RX
 
 config ARCH_RX65N_RSK1MB
 	bool
 	default n
-	select CYGWIN_WINTOOL if WINDOWS_CYGWIN
+	select ARCH_RENESAS_RX
 
 config ARCH_RX65N_RSK2MB
 	bool
 	default n
-	select CYGWIN_WINTOOL if WINDOWS_CYGWIN
+	select ARCH_RENESAS_RX
+
 
 config ARCH_RX65N_GRROSE
 	bool
 	default n
-	select CYGWIN_WINTOOL if WINDOWS_CYGWIN
+	select ARCH_RENESAS_RX
 
 config ARCH_M16C
 	bool
@@ -85,10 +92,7 @@ config ARCH_CHIP
 	string
 	default "sh1"		if ARCH_SH1
 	default "m16c"		if ARCH_M16C
-	default "rx65n"		if ARCH_RX65N
-	default "rx65n"		if ARCH_RX65N_RSK1MB
-	default "rx65n"		if ARCH_RX65N_RSK2MB
-	default "rx65n"		if ARCH_RX65N_GRROSE
+	default "rx65n"		if ARCH_RENESAS_RX
 
 source arch/renesas/src/common/Kconfig
 source arch/renesas/src/m16c/Kconfig

--- a/arch/renesas/include/setjmp.h
+++ b/arch/renesas/include/setjmp.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * arch/renesas/include/setjmp.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RENESAS_INCLUDE_SETJUMP_H
+#define __ARCH_RENESAS_INCLUDE_SETJUMP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_RENESAS_RX)
+struct setjmp_buf_s
+{
+  unsigned regs[10];
+};
+
+/* Traditional typedef for setjmp_buf */
+
+typedef struct setjmp_buf_s jmp_buf[1];
+
+#else
+#  error "setjmp() not compiled!"
+#endif /* CONFIG_ARCH_RX... */
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int setjmp(jmp_buf env);
+void longjmp(jmp_buf env, int val) noreturn_function;
+
+#endif /* __ARCH_RENESAS_INCLUDE_SETJUMP_H */

--- a/arch/renesas/src/rx65n/rx65n_serial.c
+++ b/arch/renesas/src/rx65n/rx65n_serial.c
@@ -281,6 +281,7 @@ static int  up_setup(struct uart_dev_s *dev);
 static void up_shutdown(struct uart_dev_s *dev);
 static int  up_attach(struct uart_dev_s *dev);
 static void up_detach(struct uart_dev_s *dev);
+static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  up_xmtinterrupt(int irq, void *context, FAR void *arg);
 static int  up_rcvinterrupt(int irq, void *context, FAR void *arg);
 static int  up_eriinterrupt(int irq, void *context, FAR void *arg);
@@ -365,6 +366,7 @@ struct uart_ops_s g_sci_ops =
   .attach      =  up_attach,
   .detach      =  up_detach,
   .receive     =  up_receive,
+  .ioctl       =  up_ioctl,
   .rxint       =  up_rxint,
   .rxavailable =  up_rxavailable,
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
@@ -1280,6 +1282,31 @@ static int  up_xmtinterrupt(int irq, void *context, FAR void *arg)
 
   uart_xmitchars(dev);
   return OK;
+}
+
+/****************************************************************************
+ * Name: up_ioctl
+ *
+ * Description:
+ *   All ioctl calls will be routed through this method
+ *
+ ****************************************************************************/
+
+static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
+{
+    int                ret    = OK;
+
+    switch (cmd)
+    {
+#ifdef CONFIG_SERIAL_TERMIOS
+#error CONFIG_SERIAL_TERMIOS NOT IMPLEMENTED
+#endif /* CONFIG_SERIAL_TERMIOS */
+       default:
+            ret = -ENOTTY;
+            break;
+    }
+
+    return ret;
 }
 
 /****************************************************************************

--- a/libs/libc/machine/Kconfig
+++ b/libs/libc/machine/Kconfig
@@ -174,5 +174,8 @@ endif
 if ARCH_XTENSA
 source libs/libc/machine/xtensa/Kconfig
 endif
+if ARCH_RENESAS
+source libs/libc/machine/renesas/Kconfig
+endif
 
 endmenu # Architecture-Specific Support

--- a/libs/libc/machine/renesas/Kconfig
+++ b/libs/libc/machine/renesas/Kconfig
@@ -1,0 +1,9 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+#if ARCH_RENESAS_RX
+#source libs/libc/machine/renesas/rx/Kconfig
+#endif
+

--- a/libs/libc/machine/renesas/Make.defs
+++ b/libs/libc/machine/renesas/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# libs/libc/machine/Make.defs
+# libs/libc/machine/renesas/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,21 +18,6 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_ARCH_ARM),y)
-include $(TOPDIR)/libs/libc/machine/arm/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_RISCV),y)
-include $(TOPDIR)/libs/libc/machine/risc-v/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_SIM),y)
-include $(TOPDIR)/libs/libc/machine/sim/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_X86),y)
-include $(TOPDIR)/libs/libc/machine/x86/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_XTENSA),y)
-include $(TOPDIR)/libs/libc/machine/xtensa/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_RENESAS),y)
-include $(TOPDIR)/libs/libc/machine/renesas/Make.defs
+ifeq ($(CONFIG_ARCH_RENESAS_RX),y)
+include $(TOPDIR)/libs/libc/machine/renesas/rx/Make.defs
 endif

--- a/libs/libc/machine/renesas/rx/Kconfig
+++ b/libs/libc/machine/renesas/rx/Kconfig
@@ -1,0 +1,7 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+if ARCH_RENESAS_RX
+endif

--- a/libs/libc/machine/renesas/rx/Make.defs
+++ b/libs/libc/machine/renesas/rx/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# libs/libc/machine/Make.defs
+# libs/libc/machine/renesas/rx/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,21 +18,9 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_ARCH_ARM),y)
-include $(TOPDIR)/libs/libc/machine/arm/Make.defs
+ifeq ($(CONFIG_ARCH_SETJMP_H),y)
+ASRCS += arch_setjmp.S
 endif
-ifeq ($(CONFIG_ARCH_RISCV),y)
-include $(TOPDIR)/libs/libc/machine/risc-v/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_SIM),y)
-include $(TOPDIR)/libs/libc/machine/sim/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_X86),y)
-include $(TOPDIR)/libs/libc/machine/x86/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_XTENSA),y)
-include $(TOPDIR)/libs/libc/machine/xtensa/Make.defs
-endif
-ifeq ($(CONFIG_ARCH_RENESAS),y)
-include $(TOPDIR)/libs/libc/machine/renesas/Make.defs
-endif
+
+DEPPATH += --dep-path machine/renesas/rx/gnu
+VPATH += :machine/renesas/rx/gnu

--- a/libs/libc/machine/renesas/rx/gnu/arch_setjmp.S
+++ b/libs/libc/machine/renesas/rx/gnu/arch_setjmp.S
@@ -1,0 +1,146 @@
+/****************************************************************************
+ * libs/libc/machine/renesas/rx/gnu/arm_setjmp.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.text
+	.global	_setjmp
+	.global	_longjmp
+
+	.file	"setjmp.S"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: setjmp
+ *
+ * Description:
+ *   Given the pointer to a register save area (in R1), save the state of the
+ *   all callee-saved registers
+ *
+ * C Function Prototype:
+ *   int setjmp(jmp_buf env);
+ *
+ * Input Parameters:
+ *   env - A pointer to the register save area in which to save the floating point
+ *     registers and core registers.  Since setjmp() can not be inlined, we
+ *     only need to save the ABI-specified callee-saved registers.
+ *
+ * Returned Value:
+ *   0      setjmp called directly
+ *   non-0  we justed returned from a longjmp()
+ *
+ ****************************************************************************/
+
+	.type	_setjmp, function
+_setjmp:
+	/* save Stack Pointer */
+	mov.l		r0, [r1]
+
+	/* Store callee-saved registers R6-R13 */
+	mov.l		r6, 0x4[r1]
+        mov.l   	r7, 0x8[r1]
+        mov.l   	r8, 0xc[r1]
+        mov.l   	r9, 0x10[r1]
+        mov.l   	r10, 0x14[r1]
+        mov.l   	r11, 0x18[r1]
+        mov.l   	r12, 0x1c[r1]
+        mov.l   	r13, 0x20[r1]
+
+	/* get return address from stack */
+        mov.l   	[r0], r2
+
+	/* save return address */
+        mov.l   	r2, 0x24[r1]
+	
+	/* return 0 */
+        mov     	#0, r1
+	rts
+
+	.size	_setjmp, .-_setjmp
+
+/****************************************************************************
+ * Name: longjmp
+ *
+ * Description:
+ *   The longjmp() function used the information saved in env to transfer control
+ *   control back to the point where setjmp() was called and to restore ("rewind")
+ *   the stack to its state at the time of the setjmp() call.  When control is
+ *   passed back to where setjmp() had been called, setjmp() will return with
+ *   'val', the second parameter passed to longjmp().
+ *
+ * C Function Prototype:
+ *   void longjmp(jmp_buf env, int val);
+ *
+ * Input Parameters:
+ *   jmp_buf env
+ *   int     val
+ *
+ * Returned Value:
+ *   This function does not return anything explicitly.
+ *
+ ****************************************************************************/
+
+	.type	_longjmp, function
+_longjmp:
+	/* check if r2 is zero */
+	tst     	r2, r2
+	/* set r2 to 1 if it was zero */
+        stz     	#1, r2
+
+	/* restore stack pointer */
+        mov.l   	[r1], r0
+
+	/* get the saved return address */
+        mov.l   	0x24[r1], r3
+	/* set our return address */
+        mov.l   	r3, [r0]
+
+	/* restore callee-saved registers R6-R13 */
+        mov.l   	0x20[r1], r13
+        mov.l   	0x1c[r1], r12
+        mov.l   	0x18[r1], r11
+        mov.l   	0x14[r1], r10
+        mov.l   	0x10[r1], r9
+        mov.l   	0xc[r1], r8
+        mov.l   	0x8[r1], r7
+        mov.l   	0x4[r1], r6
+
+	/* return val */
+	mov.l		r2, r1
+	/* return */
+        rts
+
+	.size	_longjmp, .-_longjmp
+	.end


### PR DESCRIPTION
## Summary
- Renesas RX setjmp based on armv7-m with changes for RX and Renesas ABI.
- Placeholder Ioctl for rx65n serial to prevent hardfault (because the ioctl member of uart_ops_s was a null pointer before).

## Impact
Minimal impact, only affects Renesas RX port and the changes are minor.

## Testing

- Tested on RX65N-RSK2MB port by checking register values before and after as well as running interpreters that use setjmp/longjmp.
- ioctl tested by verifying hardfault no longer occurs when ioctl called.

