### PR TITLE
drivers: wireless: Fix error handling in gs2200m_ioctl_send()

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -2383,6 +2383,7 @@ static int gs2200m_ioctl_send(FAR struct gs2200m_dev_s *dev,
     {
       wlinfo("+++ already closed \n");
       type = TYPE_DISCONNECT;
+      ret = -ENOTCONN;
       goto errout;
     }
 
@@ -2392,7 +2393,7 @@ static int gs2200m_ioctl_send(FAR struct gs2200m_dev_s *dev,
 
 errout:
 
-  if (type != TYPE_OK)
+  if (type != TYPE_OK && type != TYPE_DISCONNECT)
     {
       ret = -EINVAL;
     }


### PR DESCRIPTION
## Summary

- I noticed that NFS over TCP does not work correctly when
  it tried to reconnect to the NFS server.
- This commit fixes this issue


## Impact

- gs2200m only

## Testing

- Tested with spresense:wifi_smp
- NOTE: need to update gs2200m_main.c
