### PR TITLE
Refine tls_info_s and task_info_s

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -430,6 +430,8 @@ struct exitinfo_s
 #endif
 };
 
+struct task_info_s;
+
 /* struct task_group_s ******************************************************/
 
 /* All threads created by pthread_create belong in the same task group (along
@@ -532,6 +534,8 @@ struct task_group_s
 #endif
 
   /* Thread local storage ***************************************************/
+
+  FAR struct task_info_s *tg_info;
 
 #if CONFIG_TLS_NELEM > 0
   tls_ndxset_t tg_tlsset;                   /* Set of TLS indexes allocated */

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -61,6 +61,13 @@
  * Public Types
  ****************************************************************************/
 
+struct task_info_s
+{
+#ifndef CONFIG_BUILD_KERNEL
+  struct getopt_s   ta_getopt; /* Globals used by getopt() */
+#endif
+};
+
 /* When TLS is enabled, up_createstack() will align allocated stacks to the
  * TLS_STACK_ALIGN value.  An instance of the following structure will be
  * implicitly positioned at the "lower" end of the stack.  Assuming a
@@ -78,9 +85,9 @@
  *
  *      Push Down             Push Up
  *   +-------------+      +-------------+ <- Stack memory allocation
- *   |  TLS Data   |      |  TLS Data   |
- *   +-------------+      +-------------+
  *   | Task Data*  |      | Task Data*  |
+ *   +-------------+      +-------------+
+ *   |  TLS Data   |      |  TLS Data   |
  *   +-------------+      +-------------+
  *   |  Arguments  |      |  Arguments  |
  *   +-------------+      +-------------+ |
@@ -92,11 +99,12 @@
  *   |             | ^    |             |
  *   +-------------+ |    +-------------+
  *
- *  Task data is allocated in the main's thread's stack only
+ *  Task data is a pointer that pointed to a user space memory region.
  */
 
 struct tls_info_s
 {
+  FAR struct task_info_s * tl_task;
 #if CONFIG_TLS_NELEM > 0
   uintptr_t tl_elem[CONFIG_TLS_NELEM]; /* TLS elements */
 #endif
@@ -111,14 +119,6 @@ struct tls_info_s
 #endif
 
   int tl_errno;                        /* Per-thread error number */
-};
-
-struct task_info_s
-{
-  struct tls_info_s ta_tls;    /* Must be first field */
-#ifndef CONFIG_BUILD_KERNEL
-  struct getopt_s   ta_getopt; /* Globals used by getopt() */
-#endif
 };
 
 /****************************************************************************

--- a/libs/libc/tls/task_getinfo.c
+++ b/libs/libc/tls/task_getinfo.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/sched.h>
 #include <nuttx/tls.h>
+#include <arch/tls.h>
 
 /****************************************************************************
  * Public Functions
@@ -48,15 +49,7 @@
 
 FAR struct task_info_s *task_get_info(void)
 {
-  FAR struct task_info_s *info = NULL;
-  struct stackinfo_s stackinfo;
-  int ret;
+  FAR struct tls_info_s *info = up_tls_info();
 
-  ret = nxsched_get_stackinfo(-1, &stackinfo);
-  if (ret >= 0)
-    {
-      info = (FAR struct task_info_s *)stackinfo.stack_alloc_ptr;
-    }
-
-  return info;
+  return info->tl_task;
 }

--- a/sched/group/group.h
+++ b/sched/group/group.h
@@ -73,6 +73,7 @@ void weak_function task_initialize(void);
 /* Task group data structure management */
 
 int  group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype);
+void group_deallocate(FAR struct task_group_s *group);
 int  group_initialize(FAR struct task_tcb_s *tcb);
 #ifndef CONFIG_DISABLE_PTHREAD
 int  group_bind(FAR struct pthread_tcb_s *tcb);

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -33,6 +33,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/sched.h>
+#include <nuttx/tls.h>
 
 #include "environ/environ.h"
 #include "sched/sched.h"
@@ -126,7 +127,7 @@ static inline void group_inherit_identity(FAR struct task_group_s *group)
 int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 {
   FAR struct task_group_s *group;
-  int ret;
+  int ret = -ENOMEM;
 
   DEBUGASSERT(tcb && !tcb->cmn.group);
 
@@ -138,7 +139,7 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
       return -ENOMEM;
     }
 
-#if defined(CONFIG_FILE_STREAM) && defined(CONFIG_MM_KERNEL_HEAP)
+#if defined(CONFIG_MM_KERNEL_HEAP)
   /* If this group is being created for a privileged thread, then all
    * elements of the group must be created for privileged access.
    */
@@ -147,6 +148,8 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
     {
       group->tg_flags |= GROUP_FLAG_PRIVILEGED;
     }
+
+# if defined(CONFIG_FILE_STREAM)
 
   /* In a flat, single-heap build.  The stream list is allocated with the
    * group structure.  But in a kernel build with a kernel allocator, it
@@ -161,11 +164,21 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 
   if (!group->tg_streamlist)
     {
-      kmm_free(group);
-      return -ENOMEM;
+      goto errout_with_group;
     }
 
-#endif
+# endif /* defined(CONFIG_FILE_STREAM) */
+#endif /* defined(CONFIG_MM_KERNEL_HEAP) */
+
+  /* Alloc task info for group  */
+
+  group->tg_info = (FAR struct task_info_s *)
+    group_zalloc(group, sizeof(struct task_info_s));
+
+  if (!group->tg_info)
+    {
+      goto errout_with_stream;
+    }
 
   /* Attach the group to the TCB */
 
@@ -180,12 +193,8 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
   ret = env_dup(group);
   if (ret < 0)
     {
-#if defined(CONFIG_FILE_STREAM) && defined(CONFIG_MM_KERNEL_HEAP)
-      group_free(group, group->tg_streamlist);
-#endif
-      kmm_free(group);
       tcb->cmn.group = NULL;
-      return ret;
+      goto errout_with_group;
     }
 
 #ifndef CONFIG_DISABLE_PTHREAD
@@ -206,6 +215,38 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 #endif
 
   return OK;
+
+errout_with_stream:
+#if defined(CONFIG_FILE_STREAM) && defined(CONFIG_MM_KERNEL_HEAP)
+      group_free(group, group->tg_streamlist);
+#endif
+errout_with_group:
+  group_deallocate(group);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: group_deallocate
+ *
+ * Description:
+ *   Free an existing task group structure.
+ *
+ * Input Parameters:
+ *   group  = The group structure
+ *
+ ****************************************************************************/
+
+void group_deallocate(FAR struct task_group_s *group)
+{
+  if (group)
+    {
+      if (group->tg_info)
+        {
+          group_free(group, group->tg_info);
+        }
+
+      kmm_free(group);
+    }
 }
 
 /****************************************************************************
@@ -245,7 +286,7 @@ int group_initialize(FAR struct task_tcb_s *tcb)
   group->tg_members = kmm_malloc(GROUP_INITIAL_MEMBERS * sizeof(pid_t));
   if (!group->tg_members)
     {
-      kmm_free(group);
+      group_deallocate(group);
       tcb->cmn.group = NULL;
       return -ENOMEM;
     }

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -250,7 +250,7 @@ static inline void group_release(FAR struct task_group_s *group)
     {
       /* Release the group container itself */
 
-      kmm_free(group);
+      group_deallocate(group);
     }
 }
 

--- a/sched/group/group_waiter.c
+++ b/sched/group/group_waiter.c
@@ -76,7 +76,7 @@ void group_del_waiter(FAR struct task_group_s *group)
        * freed).
        */
 
-      kmm_free(group);
+      group_deallocate(group);
     }
 }
 

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -336,6 +336,10 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
 
   DEBUGASSERT(info == ptcb->cmn.stack_alloc_ptr);
 
+  /* Attach per-task info in group to TLS */
+
+  info->tl_task = ptcb->cmn.group->tg_info;
+
   /* Should we use the priority and scheduler specified in the pthread
    * attributes?  Or should we use the current thread's priority and
    * scheduler?

--- a/sched/sched/sched_get_stackinfo.c
+++ b/sched/sched/sched_get_stackinfo.c
@@ -69,16 +69,6 @@ int nxsched_get_stackinfo(pid_t pid, FAR struct stackinfo_s *stackinfo)
 
       qtcb = rtcb;
     }
-  else if (pid == -1)
-    {
-      /* We can always query our main thread */
-
-      qtcb = nxsched_get_tcb(rtcb->group->tg_pid);
-      if (qtcb == NULL)
-        {
-          return -ENOENT;
-        }
-    }
   else
     {
       /* Get the task to be queried */

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -86,7 +86,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
                 main_t entry, FAR char * const argv[])
 {
   uint8_t ttype = tcb->cmn.flags & TCB_FLAG_TTYPE_MASK;
-  FAR struct task_info_s *info;
+  FAR struct tls_info_s *info;
   int ret;
 
 #ifndef CONFIG_DISABLE_PTHREAD
@@ -122,7 +122,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
       /* Allocate the stack for the TCB */
 
       ret = up_create_stack(&tcb->cmn,
-                            sizeof(struct task_info_s) + stack_size,
+                            sizeof(struct tls_info_s) + stack_size,
                             ttype);
     }
 
@@ -133,7 +133,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
 
   /* Initialize thread local storage */
 
-  info = up_stack_frame(&tcb->cmn, sizeof(struct task_info_s));
+  info = up_stack_frame(&tcb->cmn, sizeof(struct tls_info_s));
   if (info == NULL)
     {
       ret = -ENOMEM;
@@ -141,6 +141,8 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
     }
 
   DEBUGASSERT(info == tcb->cmn.stack_alloc_ptr);
+
+  info->tl_task = tcb->cmn.group->tg_info;
 
   /* Initialize the task control block */
 


### PR DESCRIPTION
## Summary

* Refine tls_info_s and task_info_s
  * Move task_info_s from thread stack into task_group_s
  * Create task_info_s by kumm_zalloc when allocating task_group_s
  * Attach task_info_s to tls_info_s (in thread stack)

This is the infrastructure to remove all user space data from kernel like:
* at_exit/on_exit callbacks
* pthread_cleanup_s
* pthread_key_create's destructor

Then user space could access these directly instead of by syscall.

## Impact
Should be none.
## Testing
Tested on main-bit with FLAT build & PROTECTED build.
