### PR TITLE
tcp_reset: Don't copy the peer window

### DIFF
--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -510,6 +510,14 @@ void tcp_reset(FAR struct net_driver_s *dev)
   tcp->srcport  = tcp->destport;
   tcp->destport = tmp16;
 
+  /* Initialize the rest of the tcp header to sane values.
+   *
+   * Note: urgp is set by tcp_ipv4_sendcomplete/tcp_ipv6_sendcomplete.
+   */
+
+  tcp->wnd[0] = 0;
+  tcp->wnd[1] = 0;
+
   /* Set the packet length and swap IP addresses. */
 
 #ifdef CONFIG_NET_IPv6


### PR DESCRIPTION
## Summary

The current code just leave the window value from the segment
from the peer. It doesn't make sense.

Instead, always use 0.
This matches what NetBSD and Linux do.
(As far as I read their code correctly.)

extracted from https://github.com/apache/incubator-nuttx/pull/3991

## Impact

tcp

## Testing

tested on esp32, with the rest of https://github.com/apache/incubator-nuttx/pull/3991