### PR TITLE
fix active close for CONFIG_NET_TCP_WRITE_BUFFERS

### DIFF
--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -266,19 +266,7 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
   /* If we have a semi-permanent write buffer callback in place, then
    * is needs to be be nullified.
    *
-   * Commit f1ef2c6cdeb032eaa1833cc534a63b50c5058270:
-   * "When a socket is closed, it should make sure that any pending write
-   *  data is sent before the FIN is sent.  It already would wait for all
-   *  sent data to be acked, however it would discard any pending write
-   *  data that had not been sent at least once.
-   *
-   * "This change adds a check for pending write data in addition to unacked
-   *  data.  However, to be able to actually send any new data, the send
-   *  callback must be left.  The callback should be freed later when the
-   *  socket is actually destroyed."
-   *
-   * REVISIT:  Where and how exactly is s_sndcb ever freed?  Is there a
-   * memory leak here?
+   * Note: the callback will be freed by tcp_free.
    */
 
   psock->s_sndcb = NULL;

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -262,16 +262,6 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
     }
 #endif
 
-#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-  /* If we have a semi-permanent write buffer callback in place, then
-   * is needs to be be nullified.
-   *
-   * Note: the callback will be freed by tcp_free.
-   */
-
-  psock->s_sndcb = NULL;
-#endif
-
   /* Check for the case where the host beat us and disconnected first */
 
   if (conn->tcpstateflags == TCP_ESTABLISHED &&

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -139,6 +139,22 @@ static uint16_t tcp_close_eventhandler(FAR struct net_driver_s *dev,
        * is set in the response
        */
 
+#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
+      FAR struct socket *psock = pstate->cl_psock;
+
+      /* We don't need the send callback anymore. */
+
+      if (psock->s_sndcb != NULL)
+        {
+          psock->s_sndcb->flags = 0;
+          psock->s_sndcb->event = NULL;
+
+          /* The callback will be freed by tcp_free. */
+
+          psock->s_sndcb = NULL;
+        }
+#endif
+
       dev->d_len = 0;
       flags = (flags & ~TCP_NEWDATA) | TCP_CLOSE;
     }

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -703,8 +703,8 @@ void tcp_free(FAR struct tcp_conn_s *conn)
   DEBUGASSERT(conn->crefs == 0);
   net_lock();
 
-  /* Free remaining callbacks, actually there should be only the close
-   * callback left.
+  /* Free remaining callbacks, actually there should be only the send
+   * callback for CONFIG_NET_TCP_WRITE_BUFFERS is left.
    */
 
   for (cb = conn->list; cb; cb = next)


### PR DESCRIPTION
## Summary
    tcp_close: disable send callback before sending FIN
    
    This fixes connection closing issues with CONFIG_NET_TCP_WRITE_BUFFERS.
    
    Because TCP_CLOSE is used for both of input and output for tcp_callback,
    the close callback and the send callback confuses each other as
    the following. As it effectively disposes the connection immediately,
    we end up with responding to the consequent ACK and FIN/ACK from the peer
    with RSTs.
```
    tcp_timer
        -> tcp_close_eventhandler
            returns TCP_CLOSE (meaning an active close)
        -> psock_send_eventhandler
            called with TCP_CLOSE from tcp_close_eventhandler, misinterpet as
            a passive close.
            -> tcp_lost_connection
                -> tcp_shutdown_monitor
                    -> tcp_callback
                        -> tcp_close_eventhandler
                            misinterpret TCP_CLOSE from itself as
                            a passive close
```

extracted from https://github.com/apache/incubator-nuttx/pull/3991

## Impact

tcp

## Testing

tested on esp32, with the rest of https://github.com/apache/incubator-nuttx/pull/3991