### PR TITLE
libc/debug: Rename CONFIG_EABI_UNWINDER to CONFIG_UNWINDER

### DIFF
--- a/include/execinfo.h
+++ b/include/execinfo.h
@@ -34,7 +34,7 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#if defined(CONFIG_EABI_UNWINDER)
+#if defined(CONFIG_UNWINDER)
 
 /* Store up to SIZE return address of the current program state in
  * ARRAY and return the exact number of values stored.

--- a/libs/libc/debug/Kconfig
+++ b/libs/libc/debug/Kconfig
@@ -9,8 +9,8 @@
 
 menu "Library Debugging"
 
-config EABI_UNWINDER
-	bool "EABI Stack Unwinder"
+config UNWINDER
+	bool "Stack Unwinder"
 	default "n"
 	---help---
 		This option enables stack unwinding support in NuttX

--- a/libs/libc/debug/Make.defs
+++ b/libs/libc/debug/Make.defs
@@ -18,7 +18,7 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_EABI_UNWINDER),y)
+ifeq ($(CONFIG_UNWINDER),y)
 
 CSRCS += lib_backtrace.c lib_dumpstack.c
 


### PR DESCRIPTION
## Summary
since the unwinder not only work with arm but also other arch(e.g. riscv)

## Impact
Should not, since no mainline defconfig turn on this feature.

## Testing

