### PR TITLE
some follow-up patches for the recent tcp readahead

### DIFF
--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -479,6 +479,17 @@ int iob_copyout(FAR uint8_t *dest, FAR const struct iob_s *iob,
                 unsigned int len, unsigned int offset);
 
 /****************************************************************************
+ * Name: iob_tailroom
+ *
+ * Description:
+ *  Return the number of bytes at the tail of the I/O buffer chain which
+ *  can be used to append data without additional allocations.
+ *
+ ****************************************************************************/
+
+unsigned int iob_tailroom(FAR struct iob_s *iob);
+
+/****************************************************************************
  * Name: iob_clone
  *
  * Description:

--- a/mm/iob/Kconfig
+++ b/mm/iob/Kconfig
@@ -47,6 +47,9 @@ config IOB_NCHAINS
 		I/O buffer chain containers that also carry a payload of usage
 		specific information.
 
+		Note: TCP doesn't use this.
+		Note: UDP and CAN use this.
+
 config IOB_THROTTLE
 	int "I/O buffer throttle value"
 	default 0 if !NET_WRITE_BUFFERS || !NET_READAHEAD

--- a/mm/iob/Make.defs
+++ b/mm/iob/Make.defs
@@ -27,7 +27,7 @@ CSRCS += iob_concat.c iob_copyin.c iob_copyout.c iob_contig.c iob_free.c
 CSRCS += iob_free_chain.c iob_free_qentry.c iob_free_queue.c
 CSRCS += iob_initialize.c iob_pack.c iob_peek_queue.c iob_remove_queue.c
 CSRCS += iob_statistics.c iob_trimhead.c iob_trimhead_queue.c iob_trimtail.c
-CSRCS += iob_navail.c iob_free_queue_qentry.c
+CSRCS += iob_navail.c iob_free_queue_qentry.c iob_tailroom.c
 
 ifeq ($(CONFIG_IOB_NOTIFIER),y)
   CSRCS += iob_notifier.c

--- a/mm/iob/iob_tailroom.c
+++ b/mm/iob/iob_tailroom.c
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * mm/iob/iob_tailroom.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/mm/iob.h>
+
+#include "iob.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: iob_tailroom
+ *
+ * Description:
+ *  Return the number of bytes at the tail of the I/O buffer chain which
+ *  can be used to append data without additional allocations.
+ *
+ ****************************************************************************/
+
+unsigned int iob_tailroom(FAR struct iob_s *iob)
+{
+  while (iob->io_flink != NULL)
+    {
+      iob = iob->io_flink;
+    }
+
+  return CONFIG_IOB_BUFSIZE - (iob->io_offset + iob->io_len);
+}

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -205,7 +205,7 @@ struct tcp_conn_s
 
   /* Read-ahead buffering.
    *
-   *   readahead - A singly linked list of type struct iob_qentry_s
+   *   readahead - A singly linked list of type struct iob_s
    *               where the TCP/IP read-ahead data is retained.
    */
 

--- a/net/tcp/tcp_recvwindow.c
+++ b/net/tcp/tcp_recvwindow.c
@@ -110,17 +110,7 @@ uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev,
 
   if (conn->readahead != NULL)
     {
-      /* XXX move this to mm/iob */
-
-      const struct iob_s *iob;
-
-      iob = conn->readahead;
-      while (iob->io_flink != NULL)
-        {
-          iob = iob->io_flink;
-        }
-
-      tailroom = CONFIG_IOB_BUFSIZE - (iob->io_offset + iob->io_len);
+      tailroom = iob_tailroom(conn->readahead);
     }
   else
     {


### PR DESCRIPTION
## Summary
some follow-up changes for https://github.com/apache/incubator-nuttx/pull/3948

## Impact
tcp

## Testing
tested on esp32 with other recent tcp patches.
