### PR TITLE
signal: Fix docs and comments related to SIGWORK and its config

### DIFF
--- a/Documentation/reference/os/wqueue.rst
+++ b/Documentation/reference/os/wqueue.rst
@@ -72,7 +72,8 @@ to match the highest priority client.
 queues:
 
 -  ``CONFIG_SIG_SIGWORK`` The signal number that will be used to
-   wake-up the worker thread. This same signal is used with the
+   wake-up the worker thread. This same signal is used with various
+   internal worker threads.
    Default: 17
 
 Low Priority Kernel Work Queue

--- a/include/signal.h
+++ b/include/signal.h
@@ -224,7 +224,7 @@
 #  endif
 #endif
 
-/* SIGWORK is used to wake up various internal, NuttX worker thread */
+/* SIGWORK is used to wake up various internal NuttX worker threads */
 
 #if defined(CONFIG_SCHED_WORKQUEUE) || defined(CONFIG_PAGING)
 #  ifndef CONFIG_SIG_SIGWORK

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1509,9 +1509,9 @@ config SIG_SIGWORK
 	default 17
 	depends on SCHED_WORKQUEUE || LIB_USRWORK
 	---help---
-		SIGWORK is a non-standard signal used to wake up the internal NuttX
-		worker thread.  This setting specifies the signal number that will be
-		used for SIGWORK.  Default: 17
+		SIGWORK is a non-standard signal used to wake up various internal
+		NuttX worker threads.  This setting specifies the signal number
+		that will be used for SIGWORK.  Default: 17
 
 endmenu # Signal Numbers
 endmenu # Signal Configuration


### PR DESCRIPTION
## Summary

- Documentation/reference/os/wqueue.rst: CONFIG_SIG_SIGWORK: Fix sentence that was cut off in the middle.
- include/signal.h: SIGWORK: Fix grammar in comment.
- sched/Kconfig: config SIG_SIGWORK: Fix ---help--- text to indicate that this user-configured signal number may be used by various internal worker threads.

## Impact

Improves documentation.

## Testing

nxstyle