### PR TITLE
risc-v/esp32c3: Notifies networking layer whether the carrier is available

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -58,6 +58,7 @@
 #include "esp32c3_wifi_adapter.h"
 #include "esp32c3_rt_timer.h"
 #include "esp32c3_wifi_utils.h"
+#include "esp32c3_wlan.h"
 
 #ifdef CONFIG_PM
 #include "esp32c3_pm.h"
@@ -2192,6 +2193,12 @@ static void esp_evt_work_cb(FAR void *arg)
           case WIFI_ADPT_EVT_STA_CONNECT:
             wlinfo("INFO: Wi-Fi sta connect\n");
             g_sta_connected = true;
+            ret = esp32c3_wlan_sta_set_linkstatus(true);
+            if (ret < 0)
+              {
+                wlerr("ERROR: Failed to set Wi-Fi station link status\n");
+              }
+
             break;
 
           case WIFI_ADPT_EVT_STA_DISCONNECT:
@@ -2199,6 +2206,11 @@ static void esp_evt_work_cb(FAR void *arg)
             wlinfo("INFO: Wi-Fi sta disconnect, reason code: %d\n",
                                               disconnected->reason);
             g_sta_connected = false;
+            ret = esp32c3_wlan_sta_set_linkstatus(false);
+            if (ret < 0)
+              {
+                wlerr("ERROR: Failed to set Wi-Fi station link status\n");
+              }
 #ifdef CONFIG_ESP32C3_WIFI_RECONNECT
             if (g_sta_reconnect)
               {

--- a/arch/risc-v/src/esp32c3/esp32c3_wlan.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wlan.c
@@ -265,11 +265,6 @@ static int wlan_ioctl(struct net_driver_s *dev, int cmd,
                       unsigned long arg);
 #endif
 
-#ifdef ESP32C3_WLAN_HAS_STA
-static int wlan_sta_set_linkstatus(FAR struct net_driver_s *dev,
-                                   bool linkstatus);
-#endif
-
 #ifdef CONFIG_NET_ICMPv6
 static void wlan_ipv6multicast(FAR struct wlan_priv_s *priv);
 #endif
@@ -1536,15 +1531,6 @@ static int wlan_ioctl(FAR struct net_driver_s *dev,
                     nerr("ERROR: Failed to connect\n");
                     break;
                   }
-
-#ifdef ESP32C3_WLAN_HAS_STA
-                ret = wlan_sta_set_linkstatus(dev, true);
-                if (ret < 0)
-                  {
-                    nerr("ERROR: Failed to set linkstatus\n");
-                    break;
-                  }
-#endif
               }
           }
         else
@@ -1555,15 +1541,6 @@ static int wlan_ioctl(FAR struct net_driver_s *dev,
                 nerr("ERROR: Failed to disconnect\n");
                 break;
               }
-
-#ifdef ESP32C3_WLAN_HAS_STA
-            ret = wlan_sta_set_linkstatus(dev, false);
-            if (ret < 0)
-              {
-                nerr("ERROR: Failed to set linkstatus\n");
-                break;
-              }
-#endif
           }
 
         break;
@@ -1590,15 +1567,6 @@ static int wlan_ioctl(FAR struct net_driver_s *dev,
                 nerr("ERROR: Failed to connect\n");
                 break;
               }
-
-#ifdef ESP32C3_WLAN_HAS_STA
-            ret = wlan_sta_set_linkstatus(dev, true);
-            if (ret < 0)
-              {
-                nerr("ERROR: Failed to set linkstatus\n");
-                break;
-              }
-#endif
           }
         else
           {
@@ -1608,15 +1576,6 @@ static int wlan_ioctl(FAR struct net_driver_s *dev,
                 nerr("ERROR: Failed to disconnect\n");
                 break;
               }
-
-#ifdef ESP32C3_WLAN_HAS_STA
-            ret = wlan_sta_set_linkstatus(dev, false);
-            if (ret < 0)
-              {
-                nerr("ERROR: Failed to set linkstatus\n");
-                break;
-              }
-#endif
           }
 
         break;
@@ -1814,40 +1773,6 @@ static void wlan_sta_tx_done(uint8_t *data, uint16_t *len, bool status)
   wlan_tx_done(priv);
 }
 
-/****************************************************************************
- * Name: wlan_sta_set_linkstatus
- *
- * Description:
- *   Set Wi-Fi station link status
- *
- * Parameters:
- *   dev - Reference to the NuttX driver state structure
- *
- * Returned Value:
- *   0:Success; negated errno on failure
- *
- ****************************************************************************/
-
-static int wlan_sta_set_linkstatus(FAR struct net_driver_s *dev,
-                                   bool linkstatus)
-{
-  if (dev)
-    {
-      if (linkstatus == true)
-        {
-          dev->d_flags |= IFF_RUNNING;
-        }
-      else
-        {
-          dev->d_flags &= ~IFF_RUNNING;
-        }
-
-      return OK;
-    }
-
-  return -EINVAL;
-}
-
 #endif
 
 /****************************************************************************
@@ -1906,6 +1831,48 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: esp32c3_wlan_sta_set_linkstatus
+ *
+ * Description:
+ *   Set Wi-Fi station link status
+ *
+ * Parameters:
+ *   linkstatus - true Notifies the networking layer about an available
+ *                carrier, false Notifies the networking layer about an
+ *                disappeared carrier.
+ *
+ * Returned Value:
+ *   OK on success; Negated errno on failure.
+ *
+ ****************************************************************************/
+
+#ifdef ESP32C3_WLAN_HAS_STA
+int esp32c3_wlan_sta_set_linkstatus(bool linkstatus)
+{
+  int ret = -EINVAL;
+  FAR struct wlan_priv_s *priv = &g_wlan_priv[ESP32C3_WLAN_STA_DEVNO];
+
+  if (priv != NULL)
+    {
+      if (linkstatus == true)
+        {
+          ret = netdev_carrier_on(&priv->dev);
+        }
+      else
+        {
+          ret = netdev_carrier_off(&priv->dev);
+        }
+
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to notify the networking layer\n");
+        }
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Name: esp32c3_wlan_sta_initialize
  *
  * Description:
@@ -1919,7 +1886,6 @@ static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
  *
  ****************************************************************************/
 
-#ifdef ESP32C3_WLAN_HAS_STA
 int esp32c3_wlan_sta_initialize(void)
 {
   int ret;

--- a/arch/risc-v/src/esp32c3/esp32c3_wlan.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_wlan.h
@@ -46,6 +46,26 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
+#ifdef ESP32C3_WLAN_HAS_STA
+
+/****************************************************************************
+ * Name: esp32c3_wlan_sta_set_linkstatus
+ *
+ * Description:
+ *   Set Wi-Fi station link status
+ *
+ * Parameters:
+ *   linkstatus - true Notifies the networking layer about an available
+ *                carrier, false Notifies the networking layer about an
+ *                disappeared carrier.
+ *
+ * Returned Value:
+ *   OK on success; Negated errno on failure.
+ *
+ ****************************************************************************/
+
+int esp32c3_wlan_sta_set_linkstatus(bool linkstatus);
+
 /****************************************************************************
  * Name: esp32c3_wlan_sta_initialize
  *
@@ -60,7 +80,6 @@ extern "C"
  *
  ****************************************************************************/
 
-#ifdef ESP32C3_WLAN_HAS_STA
 int esp32c3_wlan_sta_initialize(void);
 #endif
 


### PR DESCRIPTION
## Summary

Support to notify networking layer whether the carrier is available

## Impact

## Testing

- Tested with ESP32-C3-Devkit

`./tools/configure esp32c3-devkit:wapi` or `./tools/configure esp32c3-devkit:sta_softap`
