### PR TITLE
Move aligned_alloc, posix_memalign and valloc from mm/umm to libs/libc/stdlib

### DIFF
--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -26,6 +26,7 @@ CSRCS += lib_itoa.c lib_labs.c lib_llabs.c lib_realpath.c lib_bsearch.c
 CSRCS += lib_rand.c lib_qsort.c lib_srand.c lib_strtol.c
 CSRCS += lib_strtoll.c lib_strtoul.c lib_strtoull.c lib_strtod.c lib_strtof.c
 CSRCS += lib_strtold.c lib_checkbase.c lib_mktemp.c lib_mkstemp.c lib_mkdtemp.c
+CSRCS += lib_aligned_alloc.c lib_posix_memalign.c lib_valloc.c
 
 ifeq ($(CONFIG_LIBC_WCHAR),y)
 CSRCS += lib_mblen.c lib_mbtowc.c lib_wctomb.c

--- a/libs/libc/stdlib/lib_aligned_alloc.c
+++ b/libs/libc/stdlib/lib_aligned_alloc.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * mm/umm_heap/umm_aligned_alloc.c
+ * libs/libc/stdlib/lib_aligned_alloc.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -24,11 +24,13 @@
 
 #include <stdlib.h>
 
+#include "libc.h"
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 FAR void *aligned_alloc(size_t align, size_t size)
 {
-  return memalign(align, size);
+  return lib_memalign(align, size);
 }

--- a/libs/libc/stdlib/lib_posix_memalign.c
+++ b/libs/libc/stdlib/lib_posix_memalign.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * mm/umm_heap/umm_posix_memalign.c
+ * libs/libc/stdlib/lib_posix_memalign.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,12 +25,14 @@
 #include <stdlib.h>
 #include <errno.h>
 
+#include "libc.h"
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 int posix_memalign(FAR void **mem, size_t align, size_t size)
 {
-  *mem = memalign(align, size);
+  *mem = lib_memalign(align, size);
   return *mem ? OK : ENOMEM;
 }

--- a/libs/libc/stdlib/lib_valloc.c
+++ b/libs/libc/stdlib/lib_valloc.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * mm/umm_heap/umm_valloc.c
+ * libs/libc/stdlib/lib_valloc.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,6 +25,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "libc.h"
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -49,5 +51,5 @@
 
 FAR void *valloc(size_t size)
 {
-  return memalign(sysconf(_SC_PAGESIZE), size);
+  return lib_memalign(sysconf(_SC_PAGESIZE), size);
 }

--- a/mm/umm_heap/Make.defs
+++ b/mm/umm_heap/Make.defs
@@ -20,10 +20,9 @@
 
 # User heap allocator
 
-CSRCS += umm_initialize.c umm_addregion.c
+CSRCS += umm_globals.c umm_initialize.c umm_addregion.c
 CSRCS += umm_brkaddr.c umm_calloc.c umm_extend.c umm_free.c umm_mallinfo.c
 CSRCS += umm_malloc.c umm_memalign.c umm_realloc.c umm_zalloc.c umm_heapmember.c
-CSRCS += umm_globals.c umm_valloc.c umm_aligned_alloc.c umm_posix_memalign.c
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
 CSRCS += umm_sbrk.c


### PR DESCRIPTION
## Summary
since the similar functions(e.g. strdup/strndup) put into libs/libc/string

## Impact
No, source code reorginize

## Testing

