### PR TITLE
netlink: fix compile error when enable netlink

### DIFF
--- a/net/netlink/netlink.h
+++ b/net/netlink/netlink.h
@@ -34,6 +34,7 @@
 #include <netpacket/netlink.h>
 #include <nuttx/net/netlink.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/wqueue.h>
 
 #include "devif/devif.h"
 #include "socket/socket.h"

--- a/net/netlink/netlink_route.c
+++ b/net/netlink/netlink_route.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#include <debug.h>
 
 #include <net/route.h>
 #include <netpacket/netlink.h>


### PR DESCRIPTION

## Summary
Fix compile error when enable netlink
## Impact

## Testing

