### PR TITLE
fs: move out nx_close from filelock

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -483,6 +483,8 @@ int dup2(int fd1, int fd2)
 int nx_close(int fd)
 {
   FAR struct filelist *list;
+  FAR struct file     *filep;
+  FAR struct file      file;
   int                  ret;
 
   /* Get the thread-specific file list.  It should never be NULL in this
@@ -510,11 +512,14 @@ int nx_close(int fd)
       return -EBADF;
     }
 
-  ret = file_close(&list->fl_files[fd / CONFIG_NFILE_DESCRIPTORS_PER_BLOCK]
-                                  [fd % CONFIG_NFILE_DESCRIPTORS_PER_BLOCK]);
+  filep = &list->fl_files[fd / CONFIG_NFILE_DESCRIPTORS_PER_BLOCK]
+                         [fd % CONFIG_NFILE_DESCRIPTORS_PER_BLOCK];
+  memcpy(&file, filep, sizeof(struct file));
+  memset(filep, 0,     sizeof(struct file));
+
   _files_semgive(list);
 
-  return ret;
+  return file_close(&file);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

fs: move out nx_close from filelock. To fix:
If someone close blocked, like net close timeout 5s, then in this 5s other file operation can't access.

## Impact

file_close 

## Testing

