### PR TITLE
arm: fix enable interrupt too earlier caused system crash

### DIFF
--- a/arch/arm/src/arm/arm_fullcontextrestore.S
+++ b/arch/arm/src/arm/arm_fullcontextrestore.S
@@ -87,11 +87,11 @@ arm_fullcontextrestore:
 	 */
 
 	ldr	r1, [r0, #(4*REG_CPSR)]	/* Fetch the stored CPSR value */
-	msr	cpsr, r1		/* Set the CPSR */
+	msr	spsr, r1		/* Set the SPSR */
 
-	/* Now recover r0-r1 and pc, destroying the stack frame */
+	/* Now recover r0-r1, pc and cpsr, destroying the stack frame */
 
-	ldmia	sp!, {r0-r1, r15}
+	ldmia	sp!, {r0-r1, r15}^
 
 	.size	arm_fullcontextrestore, .-arm_fullcontextrestore
 	.end

--- a/arch/arm/src/armv7-a/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-a/arm_fullcontextrestore.S
@@ -144,11 +144,11 @@ arm_fullcontextrestore:
 	 * disabled.
 	 */
 
-	msr		cpsr, r2			/* Set the CPSR */
+	msr		spsr, r2			/* Set the SPSR */
 
-	/* Now recover r0 r1 r2 and R15 */
+	/* Now recover r0-r2, pc and cpsr, destroying the stack frame */
 
-	pop		{r0-r2, pc}
+	ldmia		sp!, {r0-r2, pc}^
 #endif
 
 	.size	arm_fullcontextrestore, .-arm_fullcontextrestore


### PR DESCRIPTION


## Summary

arm: fix enable interrupt too earlier caused system crash

reason:
	msr	cpsr, r2   /* Set the CPSR */

    // interrupt hanppend, context switch

	pop	{r0-r2, pc}

resolve:
    use SPSR instead, and recover with ldmia ^


## Impact

## Testing

