### PR TITLE
net/tcp: fix tcp crash when net meet popen syscall

### DIFF
--- a/net/tcp/tcp_monitor.c
+++ b/net/tcp/tcp_monitor.c
@@ -346,15 +346,13 @@ void tcp_close_monitor(FAR struct socket *psock)
   /* Find and free the the connection event callback */
 
   net_lock();
-  for (cb = conn->connevents;
-       cb != NULL && cb->priv != (FAR void *)psock;
-       cb = cb->nxtconn)
-    {
-    }
 
-  if (cb != NULL)
+  for (cb = conn->connevents; cb != NULL; cb = cb->nxtconn)
     {
-      devif_conn_callback_free(conn->dev, cb, &conn->connevents);
+      if (cb->priv == (FAR void *)psock)
+        {
+          devif_conn_callback_free(conn->dev, cb, &conn->connevents);
+        }
     }
 
   /* Make sure that this socket is explicitly marked as closed */


### PR DESCRIPTION

## Summary

net/tcp: fix tcp crash when net meet syscall (like popen)

Root cause:
When there is one tcp connect, and called syscall like (popen), then tcp_start_monitor() will create callback,
That means one pcock corresponding mult callback, when tcp_close_monitor(), should free all the callabck.


tcp_close_monitor should free all the connevents which
belong to current psock

## Impact

## Testing

