### PR TITLE
rpmsg_socket: fix rpmsg_socket_device_destroy() multi-access

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -386,7 +386,14 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
 static inline void rpmsg_socket_destroy_ept(
                     FAR struct rpmsg_socket_conn_s *conn)
 {
-  if (conn && conn->ept.rdev)
+  if (!conn)
+    {
+      return;
+    }
+
+  rpmsg_socket_lock(&conn->recvlock);
+
+  if (conn->ept.rdev)
     {
       if (conn->backlog)
         {
@@ -400,6 +407,8 @@ static inline void rpmsg_socket_destroy_ept(
       rpmsg_socket_post(&conn->recvsem);
       rpmsg_socket_pollnotify(conn, POLLIN | POLLOUT);
     }
+
+  rpmsg_socket_unlock(&conn->recvlock);
 }
 
 static void rpmsg_socket_ns_unbind(FAR struct rpmsg_endpoint *ept)


### PR DESCRIPTION

## Summary

rpmsg_socket: fix rpmsg_socket_device_destroy() multi-access

Reason:
When user call rpmsg_socket_close() at the same time
rpmsg_socket_ns_unbind() is called by remote CPU,
then will meet multi-access to rpmsg_socket_device_destroy()

Fix:
reuse recvlock to handle this

Change-Id: I8f33658f19c56a4000382ff9355ff052c45afea0
Signed-off-by: ligd <liguiding1@xiaomi.com>

## Impact

## Testing

