### PR TITLE
libs/libc/spawn: fix posix_spawn_file_actions_adddup2 alloc size error

### DIFF
--- a/libs/libc/spawn/lib_psfa_adddup2.c
+++ b/libs/libc/spawn/lib_psfa_adddup2.c
@@ -70,7 +70,7 @@ int posix_spawn_file_actions_adddup2(
   /* Allocate the action list entry */
 
   entry = (FAR struct spawn_dup2_file_action_s *)
-    lib_zalloc(sizeof(struct spawn_close_file_action_s));
+    lib_zalloc(sizeof(struct spawn_dup2_file_action_s));
 
   if (!entry)
     {


### PR DESCRIPTION


## Summary
libs/libc/spawn: fix posix_spawn_file_actions_adddup2 alloc size error

## Impact

## Testing

