### PR TITLE
sched/waitpid: handle waitpid waitting tcb->group is NULL

### DIFF
--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -167,9 +167,11 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
        */
 
       ctcb = nxsched_get_tcb((pid_t)id);
-      if (ctcb != NULL)
+      if (ctcb && ctcb->group)
         {
-          if (ctcb->group->tg_ppid != rtcb->group->tg_pid)
+          /* Make sure that the thread it is our child. */
+
+          if (ctcb->group->tg_ppid != rtcb->pid)
             {
               ret = -ECHILD;
               goto errout;
@@ -209,7 +211,7 @@ int nx_waitid(int idtype, id_t id, FAR siginfo_t *info, int options)
 
       ctcb = nxsched_get_tcb((pid_t)id);
 
-      if (ctcb == NULL || ctcb->group->tg_ppid != rtcb->group->tg_pid)
+      if (!ctcb || !ctcb->group || ctcb->group->tg_ppid != rtcb->pid)
         {
           ret = -ECHILD;
           goto errout;


### PR DESCRIPTION

sched/waitpid: handle waitpid waitting tcb->group is NULL
## Summary

Fail case:
exit -> nxtask_terminate -> nxtask_exithook -> nxsched_release_tcb
                            group_leave     || nxsched_releasepid & group_leave
                                            /\
                                           /  \
                                       switch out & waitpid()

Thread A group_leave in nxtask_exithook, switch out,
Thread B do waitpid(thread A) then meet traget thread A group is NULL, error.

Change-Id: Ia181d7a13aa645ec1c3141a45839fbf79db35b17
Signed-off-by: ligd <liguiding1@xiaomi.com>



## Impact

## Testing

