### PR TITLE
lpc17_40_progmem: fixed compilation issues.

### DIFF
--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -160,6 +160,6 @@ ifeq ($(CONFIG_LPC17_40_TMR0),y)
 CHIP_CSRCS += lpc17_40_timer.c
 endif
 
-ifeq ($(CONFIG_MTD_PROGMEM),y)
+ifeq ($(CONFIG_LPC17_40_PROGMEM),y)
 CHIP_CSRCS += lpc17_40_progmem.c
 endif

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_progmem.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_progmem.c
@@ -74,7 +74,7 @@ static void lpc17_40_iap(FAR void *in, FAR void *out)
 
   flags = enter_critical_section();
 
-  ((void *(FAR void *, FAR void *))LPC17_40_IAP_ENTRY_ADDR)(in, out);
+  ((void (*)(FAR void *, FAR void *))LPC17_40_IAP_ENTRY_ADDR)(in, out);
 
   leave_critical_section(flags);
 }


### PR DESCRIPTION
## Summary
Fixes a couple of issues with the PROGMEM driver of the LPC17xx and LPC40xx MCUs.

1. The file `lpc17_40_progmem.c` was incorrectly build only when `CONFIG_MTD_PROGMEM` was set. In fact there is a specific option for this, `CONFIG_LPC17_40_PROGMEM`, which was not used.

2. Also a fix in a cast that, at least for me, caused a compiler error.

## Impact
1. PROGMEM can be used without MTD.
2. Code builds.

## Testing
Build test only.
