### PR TITLE
efm32: Fix missing closing bracket 

### DIFF
--- a/arch/arm/src/efm32/efm32_timer.c
+++ b/arch/arm/src/efm32/efm32_timer.c
@@ -107,7 +107,7 @@ void efm32_timer_dumpregs(uintptr_t base, FAR const char *msg)
   tmrinfo("DTFAULT: %04x DTFAULTC: %04x  DTLOCK: %04x \n",
           getreg32(base + EFM32_TIMER_CTRL_OFFSET),
           getreg32(base + EFM32_TIMER_STATUS_OFFSET),
-          getreg32(base + EFM32_TIMER_IEN_OFFSET),
+          getreg32(base + EFM32_TIMER_IEN_OFFSET));
 #endif
 }
 


### PR DESCRIPTION
This patch fixes missing closing bracket and semicolon.

Signed-off-by: Masanari Iida <standby24x7@gmail.com>

## Summary
This patch adds missing closing bracket and semicolon.

## Impact
It may cause syntax error.

## Testing
This error was found by cppcheck. 
