### PR TITLE
sched/idle: disable sched when idle call nx_bringup

### DIFF
--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -759,6 +759,13 @@ void nx_start(void)
 
   syslog_initialize();
 
+  /* Disables context switching beacuse we need take the memory manager
+   * semaphore on this CPU so that it will not be available on the other
+   * CPUs until we have finished initialization.
+   */
+
+  sched_lock();
+
 #ifdef CONFIG_SMP
   /* Start all CPUs *********************************************************/
 
@@ -781,6 +788,10 @@ void nx_start(void)
   /* Create initial tasks and bring-up the system */
 
   DEBUGVERIFY(nx_bringup());
+
+  /* Let other threads have access to the memory manager */
+
+  sched_unlock();
 
   /* The IDLE Loop **********************************************************/
 


### PR DESCRIPTION
## Summary
Because idle task will call mm_malloc to create some task
and will take sem of mm. But if smp enable, the sem of mm may be
taken by other cpu, so idle may be block because take this sem and crash.

Change-Id: I22f0233ef6c59a1b81607d4389e68f8646c89395
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
normal boot for smp
## Testing
maual test
