### PR TITLE
mm: fix memory corruption when loop create/exit thread in SMP mode

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -202,7 +202,11 @@ struct mm_heap_impl_s
 
   /* Free delay list, for some situation can't do free immdiately */
 
-  FAR struct mm_delaynode_s *mm_delaylist;
+#ifdef CONFIG_SMP
+  FAR struct mm_delaynode_s *mm_delaylist[CONFIG_SMP_NCPUS];
+#else
+  FAR struct mm_delaynode_s *mm_delaylist[1];
+#endif
 };
 
 /* Functions contained in mm_sem.c ******************************************/

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -50,8 +50,8 @@ static void mm_add_delaylist(FAR struct mm_heap_s *heap, FAR void *mem)
 
   flags = enter_critical_section();
 
-  tmp->flink = heap_impl->mm_delaylist;
-  heap_impl->mm_delaylist = tmp;
+  tmp->flink = heap_impl->mm_delaylist[up_cpu_index()];
+  heap_impl->mm_delaylist[up_cpu_index()] = tmp;
 
   leave_critical_section(flags);
 }

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -197,20 +197,10 @@ void mm_initialize(FAR struct mm_heap_s *heap, FAR void *heapstart,
 
   /* Set up global variables */
 
-  heap_impl->mm_heapsize = 0;
-
-#if CONFIG_MM_REGIONS > 1
-  heap_impl->mm_nregions = 0;
-#endif
-
-  /* Initialize mm_delaylist */
-
-  heap_impl->mm_delaylist = NULL;
+  memset(heap_impl, 0, sizeof(struct mm_heap_impl_s));
 
   /* Initialize the node array */
 
-  memset(heap_impl->mm_nodelist, 0,
-         sizeof(struct mm_freenode_s) * MM_NNODES);
   for (i = 1; i < MM_NNODES; i++)
     {
       heap_impl->mm_nodelist[i - 1].flink = &heap_impl->mm_nodelist[i];

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -59,8 +59,8 @@ static void mm_free_delaylist(FAR struct mm_heap_s *heap)
 
   flags = enter_critical_section();
 
-  tmp = heap_impl->mm_delaylist;
-  heap_impl->mm_delaylist = NULL;
+  tmp = heap_impl->mm_delaylist[up_cpu_index()];
+  heap_impl->mm_delaylist[up_cpu_index()] = NULL;
 
   leave_critical_section(flags);
 


### PR DESCRIPTION

## Summary

Root casue:
when do thread exit, need add free stack operation to mm_delaylist,
but in SMP mode, CPU0 thread1 exit, at this time, CPU1 call malloc
and free mm_delaylist.

Fix:
Divide mm_delaylist for per CPU in SMP mode.

Change-Id: Ibf7d04614ea2f99fb5b506356b7346a0d94f0590
Signed-off-by: ligd <liguiding1@xiaomi.com>


## Impact

## Testing

