### PR TITLE
syslog: fix crash when print localtime by syslog

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -66,53 +66,22 @@ static FAR const char * g_priority_str[] =
 int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 {
   struct lib_syslogstream_s stream;
-  int ret;
+  int ret = 0;
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
   struct tcb_s *tcb;
 #endif
+#ifdef CONFIG_SYSLOG_TIMESTAMP
+  struct timespec ts =
+  {
+  };
+
 #if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
-  time_t time;
-  struct tm tm;
+  struct tm tm =
+  {
+  };
+
   char date_buf[CONFIG_SYSLOG_TIMESTAMP_BUFFER];
 #endif
-
-#ifdef CONFIG_SYSLOG_TIMESTAMP
-  struct timespec ts;
-
-  /* Get the current time.  Since debug output may be generated very early
-   * in the start-up sequence, hardware timer support may not yet be
-   * available.
-   */
-
-  ret = -EAGAIN;
-  if (OSINIT_HW_READY())
-    {
-#if defined(CONFIG_SYSLOG_TIMESTAMP_REALTIME)
-      /* Use CLOCK_REALTIME if so configured */
-
-      ret = clock_gettime(CLOCK_REALTIME, &ts);
-
-#elif defined(CONFIG_CLOCK_MONOTONIC)
-      /* Prefer monotonic when enabled, as it can be synchronized to
-       * RTC with clock_resynchronize.
-       */
-
-      ret = clock_gettime(CLOCK_MONOTONIC, &ts);
-
-#else
-      /* Otherwise, fall back to the system timer */
-
-      ret = clock_systime_timespec(&ts);
-#endif
-    }
-
-  if (ret < 0)
-    {
-      /* Timer hardware is not available, or clock function failed */
-
-      ts.tv_sec  = 0;
-      ts.tv_nsec = 0;
-    }
 #endif
 
   /* Wrap the low-level output in a stream object and let lib_vsprintf
@@ -121,17 +90,44 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 
   syslogstream_create(&stream);
 
-#if defined(CONFIG_SYSLOG_TIMESTAMP)
-  /* Prepend the message with the current time, if available */
+#ifdef CONFIG_SYSLOG_TIMESTAMP
+  /* Get the current time.  Since debug output may be generated very early
+   * in the start-up sequence, hardware timer support may not yet be
+   * available.
+   */
 
-#if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
-  time = ts.tv_sec;
-#if defined(CONFIG_SYSLOG_TIMESTAMP_LOCALTIME)
-  localtime_r(&time, &tm);
+  if (OSINIT_HW_READY())
+    {
+#if defined(CONFIG_SYSLOG_TIMESTAMP_REALTIME)
+      /* Use CLOCK_REALTIME if so configured */
+
+      clock_gettime(CLOCK_REALTIME, &ts);
+
+#elif defined(CONFIG_CLOCK_MONOTONIC)
+      /* Prefer monotonic when enabled, as it can be synchronized to
+       * RTC with clock_resynchronize.
+       */
+
+      clock_gettime(CLOCK_MONOTONIC, &ts);
+
 #else
-  gmtime_r(&time, &tm);
+      /* Otherwise, fall back to the system timer */
+
+      clock_systime_timespec(&ts);
 #endif
 
+      /* Prepend the message with the current time, if available */
+
+#if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
+#if defined(CONFIG_SYSLOG_TIMESTAMP_LOCALTIME)
+      localtime_r(&ts.tv_sec, &tm);
+#else
+      gmtime_r(&ts.tv_sec, &tm);
+#endif
+#endif
+    }
+
+#if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
   ret = strftime(date_buf, CONFIG_SYSLOG_TIMESTAMP_BUFFER,
                  CONFIG_SYSLOG_TIMESTAMP_FORMAT, &tm);
 
@@ -143,8 +139,6 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   ret = lib_sprintf(&stream.public, "[%5jd.%06ld] ",
                     (uintmax_t)ts.tv_sec, ts.tv_nsec / 1000);
 #endif
-#else
-  ret = 0;
 #endif
 
 #if defined(CONFIG_SYSLOG_PROCESSID)


### PR DESCRIPTION
## Summary
syslog: fix crash when print localtime by syslog

test need to enable config:
CONFIG_LIBC_LOCATIME=y
CONFIG_SYSLOG_TIMESTAMP_FORMATTED=y
CONFIG_SYSLOG_TIMESTAMP_LOCALTIME=y
CONFIG_SYSLOG_TIMESTAMP_REALTIME=y

Change-Id: I322830e0818237a7eb65a158a6a0dea8f9da9b6c
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
output local time in syslog.
## Testing
daily test.
