### PR TITLE
syslog: add CPU id to system when open CONFIG_SMP

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -28,6 +28,7 @@
 #include <syslog.h>
 #include <errno.h>
 
+#include <nuttx/arch.h>
 #include <nuttx/init.h>
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
@@ -145,6 +146,10 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #endif
 #else
   ret = 0;
+#endif
+
+#if defined(CONFIG_SMP)
+  ret += lib_sprintf(&stream.public, "[CPU%d] ", up_cpu_index());
 #endif
 
 #if defined(CONFIG_SYSLOG_PROCESSID)


### PR DESCRIPTION


## Summary

syslog: add CPU id to system when open CONFIG_SMP

Change-Id: Ie8aaf44583ff4146b79b1392d1410b31806a81e8
Signed-off-by: ligd <liguiding1@xiaomi.com>

## Impact

## Testing

