### PR TITLE
select: fix asan report error

### DIFF
--- a/include/sys/select.h
+++ b/include/sys/select.h
@@ -71,11 +71,11 @@
 /* Standard helper macros */
 
 #define FD_CLR(fd,set) \
-  ((((fd_set*)(set))->arr)[_FD_NDX(fd)] &= ~(1 << _FD_BIT(fd)))
+  ((((fd_set*)(set))->arr)[_FD_NDX(fd)] &= ~(UINT32_C(1)<< _FD_BIT(fd)))
 #define FD_SET(fd,set) \
-  ((((fd_set*)(set))->arr)[_FD_NDX(fd)] |= (1 << _FD_BIT(fd)))
+  ((((fd_set*)(set))->arr)[_FD_NDX(fd)] |= (UINT32_C(1) << _FD_BIT(fd)))
 #define FD_ISSET(fd,set) \
-  (((((fd_set*)(set))->arr)[_FD_NDX(fd)] & (1 << _FD_BIT(fd))) != 0)
+ (((((fd_set*)(set))->arr)[_FD_NDX(fd)] & (UINT32_C(1) << _FD_BIT(fd))) != 0)
 #define FD_ZERO(set) \
    memset((set), 0, sizeof(fd_set))
 


### PR DESCRIPTION

## Summary

select: fix asan report error

vfs/fs_select.c:116:25: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
vfs/fs_select.c:153:22: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'

Change-Id: I2e32bb8a3db8ff5a5955b83b382ac2fa5756122c
Signed-off-by: ligd <liguiding1@xiaomi.com>


## Impact

## Testing

