### PR TITLE
boards/romfs: fix romfs folder size increase when append-compile rcS

### DIFF
--- a/boards/Board.mk
+++ b/boards/Board.mk
@@ -49,6 +49,7 @@ $(RCOBJS): $(ETCDIR)$(DELIM)%: %
 
 $(ETCSRC): $(RCRAWS) $(RCOBJS)
 	$(foreach raw, $(RCRAWS), \
+	  $(shell rm -rf $(ETCDIR)$(DELIM)$(raw)) \
 	  $(shell mkdir -p $(dir $(ETCDIR)$(DELIM)$(raw))) \
 	  $(shell cp -rfp $(raw) $(ETCDIR)$(DELIM)$(raw)))
 	$(Q) genromfs -f romfs.img -d $(ETCDIR)$(DELIM)$(CONFIG_NSH_ROMFSMOUNTPT) -V "$(basename $<)"


### PR DESCRIPTION

## Summary

boards/romfs: fix romfs folder size increase when append-compile rcS

Change-Id: I29b2a745d61147da6dfa9dfc08ddc81aabecf507
Signed-off-by: ligd <liguiding1@xiaomi.com>

## Impact

## Testing

