### PR TITLE
sim/smp: fix smp can't start, caused by signal too busy

### DIFF
--- a/arch/sim/src/sim/up_hosttime.c
+++ b/arch/sim/src/sim/up_hosttime.c
@@ -66,7 +66,7 @@ uint64_t host_gettime(bool rtc)
 
 void host_sleep(uint64_t nsec)
 {
-  usleep(nsec / 1000);
+  usleep((nsec + 999) / 1000);
 }
 
 /****************************************************************************

--- a/arch/sim/src/sim/up_simsmp.c
+++ b/arch/sim/src/sim/up_simsmp.c
@@ -148,7 +148,7 @@ static void *sim_host_timer_handler(void *arg)
 
   while (g_nx_initstate < 5)
     {
-      host_sleep(10 * 1000); /* 10ms */
+      host_sleep(10 * 1000 * 1000); /* 10ms */
     }
 
   /* Send a periodic timer event to CPU0 */
@@ -156,7 +156,7 @@ static void *sim_host_timer_handler(void *arg)
   while (1)
     {
       pthread_kill(g_cpu_thread[0], SIGUSR1);
-      host_sleep(10 * 1000); /* 10ms */
+      host_sleep(10 * 1000 * 1000); /* 10ms */
     }
 
   return NULL;


### PR DESCRIPTION

## Summary
sim/smp: fix smp can't start, caused by signal too busy

This will fix bug caused by:
https://github.com/apache/incubator-nuttx/pull/4015

## Impact

## Testing

