### PR TITLE
rx65n: Add missing parameters in printf

### DIFF
--- a/arch/renesas/src/rx65n/rx65n_usbdev.c
+++ b/arch/renesas/src/rx65n/rx65n_usbdev.c
@@ -2889,7 +2889,7 @@ static int rx65n_epconfigure(FAR struct usbdev_ep_s *ep,
   if (!ep || !desc)
     {
       usbtrace(TRACE_DEVERROR(RX65N_TRACEERR_INVALIDPARMS), 0);
-      printf("ERROR: ep=%p desc=%p\n");
+      printf("ERROR: ep=%p desc=%p\n", ep, desc);
       return -EINVAL;
     }
 #endif


### PR DESCRIPTION
printf format string requires 2 parameters, but 0
parameter was given. Add these missing parameters.

Signed-off-by: Masanari Iida <standby24x7@gmail.com>

## Summary
Add missing parameters in printf.

## Impact
It may cause syntax error when compile the codes.

