### PR TITLE
arch/sim: Fix bt and audio simulation stop work in SMP mode

### DIFF
--- a/arch/sim/src/sim/up_idle.c
+++ b/arch/sim/src/sim/up_idle.c
@@ -54,7 +54,6 @@
  *
  ****************************************************************************/
 
-#ifndef CONFIG_SMP
 void up_idle(void)
 {
 #ifdef CONFIG_PM
@@ -115,30 +114,3 @@ void up_idle(void)
   sim_foc_update();
 #endif
 }
-#endif /* !CONFIG_SMP */
-
-#ifdef CONFIG_SMP
-void up_idle(void)
-{
-  host_sleep(100 * 1000);
-}
-#endif
-
-/****************************************************************************
- * Name: sim_timer_handler
- ****************************************************************************/
-
-#ifdef CONFIG_SMP
-void sim_timer_handler(void)
-{
-  /* Handle UART data availability */
-
-  up_uartloop();
-
-#ifdef CONFIG_ONESHOT
-  /* Driver the simulated interval timer */
-
-  up_timer_update();
-#endif
-}
-#endif /* CONFIG_SMP */

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -174,7 +174,6 @@ int up_cpu_paused(int cpu);
 struct tcb_s *up_this_task(void);
 int up_cpu_set_pause_handler(int irq);
 void sim_send_ipi(int cpu);
-void sim_timer_handler(void);
 #endif
 
 /* up_oneshot.c *************************************************************/

--- a/arch/sim/src/sim/up_smpsignal.c
+++ b/arch/sim/src/sim/up_smpsignal.c
@@ -98,14 +98,6 @@ static int sim_cpupause_handler(int irq, FAR void *context, FAR void *arg)
 
       leave_critical_section(flags);
     }
-  else
-    {
-      /* NOTE: sim specific logic
-       * In the case of no pause request, call sim_timer_handler()
-       */
-
-      sim_timer_handler();
-    }
 
   return OK;
 }


### PR DESCRIPTION
## Summary
by removing the SMP up_idle and sim_timer_handler

## Impact
Make audo and bt work in SMP mode

## Testing
Pass ostest in SMP mode
