### PR TITLE
libs: libnx: nxfonts: Fix prefix of generated fonts data

### DIFF
--- a/libs/libnx/nxfonts/Makefile.sources
+++ b/libs/libnx/nxfonts/Makefile.sources
@@ -207,12 +207,12 @@ GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-6x13.c
 endif
 
 ifeq ($(NXFONTS_FONTID),28)
-NXFONTS_PREFIX := g_x11_misc_fixed_6x13B_
+NXFONTS_PREFIX := g_x11_misc_fixed_6x13b_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-6x13b.c
 endif
 
 ifeq ($(NXFONTS_FONTID),29)
-NXFONTS_PREFIX := g_x11_misc_fixed_6x13O_
+NXFONTS_PREFIX := g_x11_misc_fixed_6x13o_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-6x13o.c
 endif
 
@@ -222,12 +222,12 @@ GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-7x13.c
 endif
 
 ifeq ($(NXFONTS_FONTID),31)
-NXFONTS_PREFIX := g_x11_misc_fixed_7x13B_
+NXFONTS_PREFIX := g_x11_misc_fixed_7x13b_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-7x13b.c
 endif
 
 ifeq ($(NXFONTS_FONTID),32)
-NXFONTS_PREFIX := g_x11_misc_fixed_7x13O_
+NXFONTS_PREFIX := g_x11_misc_fixed_7x13o_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-7x13o.c
 endif
 
@@ -237,7 +237,7 @@ GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-7x14.c
 endif
 
 ifeq ($(NXFONTS_FONTID),34)
-NXFONTS_PREFIX := g_x11_misc_fixed_7x14B_
+NXFONTS_PREFIX := g_x11_misc_fixed_7x14b_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-7x14b.c
 endif
 
@@ -247,12 +247,12 @@ GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-8x13.c
 endif
 
 ifeq ($(NXFONTS_FONTID),36)
-NXFONTS_PREFIX := g_x11_misc_fixed_8x13B_
+NXFONTS_PREFIX := g_x11_misc_fixed_8x13b_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-8x13b.c
 endif
 
 ifeq ($(NXFONTS_FONTID),37)
-NXFONTS_PREFIX := g_x11_misc_fixed_8x13O_
+NXFONTS_PREFIX := g_x11_misc_fixed_8x13o_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-8x13o.c
 endif
 
@@ -262,7 +262,7 @@ GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-9x15.c
 endif
 
 ifeq ($(NXFONTS_FONTID),39)
-NXFONTS_PREFIX := g_x11_misc_fixed_9x15B_
+NXFONTS_PREFIX := g_x11_misc_fixed_9x15b_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-9x15b.c
 endif
 
@@ -272,7 +272,7 @@ GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-9x18.c
 endif
 
 ifeq ($(NXFONTS_FONTID),41)
-NXFONTS_PREFIX := g_x11_misc_fixed_9x18B_
+NXFONTS_PREFIX := g_x11_misc_fixed_9x18b_
 GEN_CSRC = nxfonts_bitmaps_x11-misc-fixed-9x18b.c
 endif
 


### PR DESCRIPTION
## Summary
This commit fixes a compile error caused by the following commit.
fe9ccff libs: libnx: nxfonts: fix Mixed case identifier
Change the prefix of generated font data to lower case.

## Impact
None

## Testing
