### PR TITLE
boards: cxd56xx: Fix some compile errors and warnings

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_audio.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_audio.c
@@ -453,6 +453,7 @@ void board_audio_finalize(void)
   board_audio_i2s_disable();
 }
 
+#ifdef CONFIG_AUDIO_CXD56
 /****************************************************************************
  * Name: board_audio_initialize_driver
  *
@@ -530,3 +531,4 @@ int board_audio_initialize_driver(int minor)
 
   return ret;
 }
+#endif /* CONFIG_AUDIO_CXD56 */

--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -189,7 +189,11 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
   /* Get the limits on the interrupt stack memory */
 
+#ifdef CONFIG_SMP
+  pdump->info.stacks.interrupt.top = (uint32_t)arm_intstack_top();
+#else
   pdump->info.stacks.interrupt.top = (uint32_t)&g_intstacktop;
+#endif
   pdump->info.stacks.interrupt.size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* If In interrupt Context save the interrupt stack data centered

--- a/boards/arm/cxd56xx/drivers/sensors/bmp280_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bmp280_scu.c
@@ -465,7 +465,7 @@ static int bmp280_initialize(FAR struct bmp280_dev_s *priv)
 {
   int ret;
 
-  ret = bmp280_set_standby(priv, BMP280_STANDBY_1_MS);
+  ret = bmp280_set_standby(priv, BMP280_STANDBY_05_MS);
 
   if (ret != OK)
     {

--- a/boards/arm/cxd56xx/spresense/src/cxd56_pwm.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_pwm.c
@@ -60,13 +60,13 @@ static int pwm_initialize(uint32_t channel)
   pwm = cxd56_pwminitialize(channel);
   if (!pwm)
     {
-      pwmerr("Failed to get the CXD56 PWM%d lower half\n", channel);
+      pwmerr("Failed to get the CXD56 PWM%ld lower half\n", channel);
       return -ENODEV;
     }
 
   /* Register the PWM driver at "/dev/pwmX" */
 
-  snprintf(devname, sizeof(devname), "/dev/pwm%d", channel);
+  snprintf(devname, sizeof(devname), "/dev/pwm%ld", channel);
   ret = pwm_register(devname, pwm);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
boards: cxd56xx: Fix crashdump compile error in SMP
boards: cxd56xx: Fix some printf format warnings
boards: cxd56xx: Fix bmp280 compile error
boards: cxd56xx: Fix warning of cxd56 audio driver

## Impact
Only spresense board.

## Testing

