### PR TITLE
boards: cxd56xx: Change c++ option to -std=c++11

### DIFF
--- a/boards/arm/cxd56xx/spresense/scripts/Make.defs
+++ b/boards/arm/cxd56xx/spresense/scripts/Make.defs
@@ -49,7 +49,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ARCHCFLAGS = -fno-builtin -mabi=aapcs -ffunction-sections -fdata-sections
-ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fno-rtti -std=c++98
+ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fno-rtti -std=c++11
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10


### PR DESCRIPTION
## Summary
Change CXXFLAGS from -std=c++98 to -std=c++11 to use LLVM C++ standard library.
This make it common with other chips and board.

## Impact
Only spresense board.

## Testing
Each spresense defconfig
