### PR TITLE
FAT32 kconfig entry to enforce computation of free clusters at mount

### DIFF
--- a/fs/fat/Kconfig
+++ b/fs/fat/Kconfig
@@ -12,6 +12,18 @@ config FS_FAT
 
 if FS_FAT
 
+config FAT_COMPUTE_FSINFO
+	bool "FAT compute free space in FSINFO at mount time"
+	default n
+	---help---
+		Enables the computation of free clusters at mount time as suggested by the
+		white paper for FAT. The standard behavior of Nuttx is to trust the stored
+		value and only recompute it once required. This works if the file system
+		is never mounted to another OS. SD-cards which are mounted to Windows to
+		modify the content might report wrong space after reinserting it to Nuttx.
+		It is recommended to activate this setting if the "SD-Card" is swapped
+		between systems.
+
 config FAT_LCNAMES
 	bool "FAT upper/lower names"
 	default n

--- a/fs/fat/fs_fat32util.c
+++ b/fs/fat/fs_fat32util.c
@@ -626,12 +626,22 @@ int fat_mount(struct fat_mountpt_s *fs, bool writeable)
 
   if (fs->fs_type == FSTYPE_FAT32)
     {
-      ret = fat_computefreeclusters(fs);
+      ret = fat_checkfsinfo(fs);
       if (ret != OK)
         {
           goto errout_with_buffer;
         }
     }
+
+  /* Enforce computation of free clusters if configured */
+
+#ifdef CONFIG_FAT_COMPUTE_FSINFO
+  ret = fat_computefreeclusters(fs);
+  if (ret != OK)
+    {
+      goto errout_with_buffer;
+    }
+#endif
 
   /* We did it! */
 
@@ -2028,11 +2038,6 @@ int fat_updatefsinfo(struct fat_mountpt_s *fs)
 
 int fat_computefreeclusters(struct fat_mountpt_s *fs)
 {
-  if (fat_checkfsinfo(fs) != OK)
-    {
-      return -ENODEV;
-    }
-
   /* We have to count the number of free clusters */
 
   uint32_t nfreeclusters = 0;


### PR DESCRIPTION
## Summary
Follow up commit for [1] in response to the request to make the mount
behaviour configurable whether the number of free clusters is read
from the fsinfo section or computed (as the white paper suggests).

Default is the original behaviour of NUTTX, just read fsinfo.

[1] https://github.com/apache/incubator-nuttx/pull/3760

## Impact
If CONFIG_FAT_COMPUTE_FSINFO is configured, boot up might take a bit longer depending on FAT32 partition size, card performance and used interface.