### PR TITLE
Fix various typos in comments and documentation

### DIFF
--- a/Documentation/components/drivers/character/foc.rst
+++ b/Documentation/components/drivers/character/foc.rst
@@ -13,7 +13,7 @@ The device on the kernel side is responsible for the following:
 #. return ADC current samples
 #. synchronize user-space with PWM events
 
-The Nuttx FOC driver is split into two parts:
+The NuttX FOC driver is split into two parts:
 
 #. An "upper half", generic driver that provides the common FOC
    interface to application level code,

--- a/Documentation/guides/cpp_cmake.rst
+++ b/Documentation/guides/cpp_cmake.rst
@@ -76,7 +76,7 @@ Creating the project
 
     project(HelloCpp
             VERSION 1.0
-            DESCRIPTION "Hello world C++ Nuttx"
+            DESCRIPTION "Hello world C++ NuttX"
     )
 
     set(CMAKE_CXX_STANDARD 17)

--- a/Kconfig
+++ b/Kconfig
@@ -1766,7 +1766,7 @@ config STACK_USAGE_SAFE_PERCENT
 	---help---
 		Stack usage precent = up_check_tcbstack() * 100 / tcb->adj_stack_size,
 		this should lower then STACK_USAGE_SAFE_PERCENT.
-		Idle thread will timely check stack usage when this marco value > 0.
+		Idle thread will timely check stack usage when this macro value > 0.
 
 		N.B. This feature should not be used in production code.
 

--- a/arch/arm/src/imxrt/imxrt_lpspi.c
+++ b/arch/arm/src/imxrt/imxrt_lpspi.c
@@ -1261,7 +1261,7 @@ static uint32_t imxrt_lpspi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed

--- a/arch/arm/src/kinetis/kinetis_spi.c
+++ b/arch/arm/src/kinetis/kinetis_spi.c
@@ -1039,7 +1039,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits > 8, the data is packed into
@@ -1142,7 +1142,7 @@ static void spi_exchange_nodma(FAR struct spi_dev_s *dev,
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits > 8, the data is packed into

--- a/arch/arm/src/kl/kl_spi.c
+++ b/arch/arm/src/kl/kl_spi.c
@@ -476,7 +476,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/arm/src/lpc31xx/lpc31_spi.c
+++ b/arch/arm/src/lpc31xx/lpc31_spi.c
@@ -750,7 +750,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t word)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/arm/src/nrf52/nrf52_radio.h
+++ b/arch/arm/src/nrf52/nrf52_radio.h
@@ -134,7 +134,7 @@ struct nrf52_radio_pktcfg_s
   uint8_t s0_len;               /* S0 length */
   uint8_t s1_len;               /* S1 length */
   uint8_t ci_len;               /* CI length */
-  uint8_t pl_len;               /* Preable lenght */
+  uint8_t pl_len;               /* Preamble length */
   uint8_t term_len;             /* TERM length */
   bool    crcinc;               /* LENGTH includes CRC */
   bool    endian;               /* On air endianess of packet:

--- a/arch/arm/src/s32k1xx/s32k1xx_lpspi.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpspi.c
@@ -1347,7 +1347,7 @@ static uint32_t s32k1xx_lpspi_send_dword(FAR struct spi_dev_s *dev,
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -3920,7 +3920,7 @@ config STM32_TIM1_CHANNEL5
 	default n
 	depends on STM32_HAVE_IP_TIMERS_V2
 	---help---
-		Enables channel 5 (no available externaly)
+		Enables channel 5 (not available externally)
 
 if STM32_TIM1_CHANNEL5
 
@@ -3944,7 +3944,7 @@ config STM32_TIM1_CHANNEL6
 	default n
 	depends on STM32_HAVE_IP_TIMERS_V2
 	---help---
-		Enables channel 6 (no available externaly)
+		Enables channel 6 (not available externally)
 
 if STM32_TIM1_CHANNEL6
 
@@ -4950,7 +4950,7 @@ config STM32_TIM8_CHANNEL5
 	default n
 	depends on STM32_HAVE_IP_TIMERS_V2
 	---help---
-		Enables channel 5 (no available externaly)
+		Enables channel 5 (not available externally)
 
 if STM32_TIM8_CHANNEL5
 
@@ -4974,7 +4974,7 @@ config STM32_TIM8_CHANNEL6
 	default n
 	depends on STM32_HAVE_IP_TIMERS_V2
 	---help---
-		Enables channel 6 (no available externaly)
+		Enables channel 6 (not available externally)
 
 if STM32_TIM8_CHANNEL6
 

--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -101,7 +101,7 @@
 
 /* Supported ADC modes:
  *   - SW triggering with/without DMA transfer
- *   - TIM triggering with/without DMA tranfer
+ *   - TIM triggering with/without DMA transfer
  *   - external triggering with/without DMA transfer
  *
  * (tested with ADC example app from NuttX apps repo).

--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -263,7 +263,7 @@
 #    error Not supported
 #  endif
 
-/* ADC trigger offset - must be greather than 0! */
+/* ADC trigger offset - must be greater than 0! */
 
 #  define ADC_TRIGGER_OFFSET (1)
 
@@ -402,7 +402,7 @@
 #    error CONFIG_STM32_ADC1_ANIOC_TRIGGER must be 1
 #  endif
 #  if CONFIG_STM32_ADC1_INJECTED_CHAN != FOC_ADC_INJ_CHAN_REQUIRED
-#    error Invalid configuration for ADC1 injected channles
+#    error Invalid configuration for ADC1 injected channels
 #  endif
 #endif
 #ifdef CONFIG_STM32_FOC_USE_ADC2
@@ -416,7 +416,7 @@
 #    error CONFIG_STM32_ADC2_ANIOC_TRIGGER must be 1
 #  endif
 #  if CONFIG_STM32_ADC2_INJECTED_CHAN != FOC_ADC_INJ_CHAN_REQUIRED
-#    error Invalid configuration for ADC2 injected channles
+#    error Invalid configuration for ADC2 injected channels
 #  endif
 #endif
 #ifdef CONFIG_STM32_FOC_USE_ADC3
@@ -430,7 +430,7 @@
 #    error CONFIG_STM32_ADC3_ANIOC_TRIGGER must be 1
 #  endif
 #  if CONFIG_STM32_ADC3_INJECTED_CHAN != FOC_ADC_INJ_CHAN_REQUIRED
-#    error Invalid configuration for ADC3 injected channles
+#    error Invalid configuration for ADC3 injected channels
 #  endif
 #endif
 #ifdef CONFIG_STM32_FOC_USE_ADC4
@@ -444,7 +444,7 @@
 #    error CONFIG_STM32_ADC4_ANIOC_TRIGGER must be 1
 #  endif
 #  if CONFIG_STM32_ADC4_INJECTED_CHAN != FOC_ADC_INJ_CHAN_REQUIRED
-#    error Invalid configuration for ADC4 injected channles
+#    error Invalid configuration for ADC4 injected channels
 #  endif
 #endif
 
@@ -465,7 +465,7 @@
 #  define FOC1_ADC_JEXT (ADC_JEXTREG_JEXTEN_DEFAULT | FOC1_ADC_JEXTSEL)
 #endif
 
-/* Generalize ADC interupt flags */
+/* Generalize ADC interrupt flags */
 
 #if defined(CONFIG_STM32_HAVE_IP_ADC_V2)
 #  define FOC_ADC_ISR_FOC ADC_ISR_JEOS
@@ -2129,11 +2129,11 @@ void stm32_foc_trace(FAR struct foc_dev_s *dev, int type, bool state)
  *   Initialize the FOC lower-half.
  *
  * Input Parameters:
- *   inst  - FOC instnace number
+ *   inst  - FOC instance number
  *   board - FOC board-specific data
  *
  * Returned Value:
- *   Valid lower-half FOC controller structure reference on succes;
+ *   Valid lower-half FOC controller structure reference on success;
  *   NULL on failure
  *
  ****************************************************************************/
@@ -2255,7 +2255,7 @@ stm32_foc_initialize(int inst, FAR struct stm32_foc_board_s *board)
   foc_priv->adc_cmn = adc_cmn;
 #endif
 
-  /* Get archspecific devive */
+  /* Get arch-specific device */
 
   foc_dev = (struct stm32_foc_dev_s *)foc_priv->dev;
   DEBUGASSERT(foc_dev);

--- a/arch/arm/src/stm32/stm32_foc.h
+++ b/arch/arm/src/stm32/stm32_foc.h
@@ -56,7 +56,7 @@ struct stm32_foc_adc_s
 
   uint8_t nchan;
 
-  /* The number of auxliary regular channles (only for DMA transfer) */
+  /* The number of auxiliary regular channels (only for DMA transfer) */
 
   uint8_t regch;
 

--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -684,7 +684,7 @@ static struct stm32_pwmchan_s g_pwm1channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32_TIM1_CH5POL,
       .idle    = CONFIG_STM32_TIM1_CH5IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   },
@@ -699,7 +699,7 @@ static struct stm32_pwmchan_s g_pwm1channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32_TIM1_CH6POL,
       .idle    = CONFIG_STM32_TIM1_CH6IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   }
@@ -1244,7 +1244,7 @@ static struct stm32_pwmchan_s g_pwm8channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32_TIM8_CH5POL,
       .idle    = CONFIG_STM32_TIM8_CH5IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   },
@@ -1259,7 +1259,7 @@ static struct stm32_pwmchan_s g_pwm8channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32_TIM8_CH6POL,
       .idle    = CONFIG_STM32_TIM8_CH6IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   }

--- a/arch/arm/src/stm32/stm32_spi.c
+++ b/arch/arm/src/stm32/stm32_spi.c
@@ -1676,7 +1676,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/arm/src/stm32f0l0g0/stm32_spi.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_spi.c
@@ -1285,7 +1285,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -2582,7 +2582,7 @@ endchoice #"RTC clock source"
 if STM32F7_RTC_LSECLOCK
 
 config STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
-	bool "Automaticaly boost the LSE oscillator drive capability level until it starts-up"
+	bool "Automatically boost the LSE oscillator drive capability level until it starts-up"
 	default n
 	---help---
 		This will cycle through the values from low to high. To avoid
@@ -2660,7 +2660,8 @@ config STM32F7_DMACAPABLE_ASSUME_CACHE_ALIGNED
 	---help---
 		This option configures the stm32_dmacapable to not disqualify
 		DMA operations on memory that is not dcache aligned based solely
-		on the starting addresss and byte count.
+		on the starting address and byte count.
+		
 		Use this when ALL buffer extents are known to be aligned, but the
 		the count does not use the complete buffer.
 

--- a/arch/arm/src/stm32f7/stm32_spi.c
+++ b/arch/arm/src/stm32f7/stm32_spi.c
@@ -1662,7 +1662,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1562,7 +1562,7 @@ endchoice #"RTC clock source"
 if STM32H7_RTC_LSECLOCK
 
 config STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
-	bool "Automaticaly boost the LSE oscillator drive capability level until it starts-up"
+	bool "Automatically boost the LSE oscillator drive capability level until it starts-up"
 	default n
 	---help---
 		This will cycle through the correct* values from low to high. To avoid
@@ -1800,7 +1800,8 @@ config STM32H7_DMACAPABLE_ASSUME_CACHE_ALIGNED
 	---help---
 		This option configures the stm32_dmacapable to not disqualify
 		DMA operations on memory that is not dcache aligned based solely
-		on the starting addresss and byte count.
+		on the starting address and byte count.
+		
 		Use this when ALL buffer extents are known to be aligned, but the
 		the count does not use the complete buffer.
 
@@ -1990,7 +1991,7 @@ config STM32H7_TIM1_CHANNEL5
 	bool "TIM1 Channel 5 (internal)"
 	default n
 	---help---
-		Enables channel 5 (no available externaly)
+		Enables channel 5 (not available externally)
 
 if STM32H7_TIM1_CHANNEL5
 
@@ -2013,7 +2014,7 @@ config STM32H7_TIM1_CHANNEL6
 	bool "TIM1 Channel 6 (internal)"
 	default n
 	---help---
-		Enables channel 6 (no available externaly)
+		Enables channel 6 (not available externally)
 
 if STM32H7_TIM1_CHANNEL6
 
@@ -2993,7 +2994,7 @@ config STM32H7_TIM8_CHANNEL5
 	bool "TIM8 Channel 5 (internal)"
 	default n
 	---help---
-		Enables channel 5 (no available externaly)
+		Enables channel 5 (not available externally)
 
 if STM32H7_TIM8_CHANNEL5
 
@@ -3016,7 +3017,7 @@ config STM32H7_TIM8_CHANNEL6
 	bool "TIM8 Channel 6 (internal)"
 	default n
 	---help---
-		Enables channel 6 (no available externaly)
+		Enables channel 6 (not available externally)
 
 if STM32H7_TIM8_CHANNEL6
 

--- a/arch/arm/src/stm32h7/stm32_allocateheap.c
+++ b/arch/arm/src/stm32h7/stm32_allocateheap.c
@@ -79,7 +79,7 @@
  *      Define CONFIG_STM32H7_DTCMEXCLUDE to exclude the DTCM from heap.
  *      +1 to CONFIG_MM_REGIONS if you want to use DTCM.
  *
- * - External SDRAM can be connected to the FMC peripherial. Initialization
+ * - External SDRAM can be connected to the FMC peripheral. Initialization
  *      of FMC is done as arm_addregion() will invoke stm32_fmc_init().
  *      Please read the comment in stm32_fmc.c how to initialize FMC
  *      correctly.

--- a/arch/arm/src/stm32h7/stm32_fmc.c
+++ b/arch/arm/src/stm32h7/stm32_fmc.c
@@ -236,7 +236,7 @@ static int stm32_fmc_sdram_wait(unsigned timeout);
  * Name: stm32_fmc_init
  *
  * Description:
- *   Initialize the FMC peripherial. Because FMC initialization is highly
+ *   Initialize the FMC peripheral. Because FMC initialization is highly
  *   dependent on the used parts, definition of the initial values for FMC
  *   registers is mostly left to board designer.
  *
@@ -284,7 +284,7 @@ void stm32_fmc_init(void)
   modreg32(BOARD_FMC_SDTR2, FMC_SDTR_MASK, STM32_FMC_SDTR2);
 #endif
 
-  /* Enable the FMC peripherial */
+  /* Enable the FMC peripheral */
 
   modreg32(FMC_BCR_FMCEN, FMC_BCR_FMCEN, STM32_FMC_BCR1);
 

--- a/arch/arm/src/stm32h7/stm32_fmc.h
+++ b/arch/arm/src/stm32h7/stm32_fmc.h
@@ -49,7 +49,7 @@ extern "C"
  * Name: stm32_fmc_init
  *
  * Description:
- *   Initialize the FMC peripherial. Because FMC initialization is highly
+ *   Initialize the FMC peripheral. Because FMC initialization is highly
  *   dependent on the used parts, definition of the initial values for FMC
  *   registers is mostly left to board designer.
  *

--- a/arch/arm/src/stm32h7/stm32_pwm.c
+++ b/arch/arm/src/stm32h7/stm32_pwm.c
@@ -560,7 +560,7 @@ static struct stm32_pwmchan_s g_pwm1channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32H7_TIM1_CH5POL,
       .idle    = CONFIG_STM32H7_TIM1_CH5IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   },
@@ -575,7 +575,7 @@ static struct stm32_pwmchan_s g_pwm1channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32H7_TIM1_CH6POL,
       .idle    = CONFIG_STM32H7_TIM1_CH6IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   }
@@ -1120,7 +1120,7 @@ static struct stm32_pwmchan_s g_pwm8channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32H7_TIM8_CH5POL,
       .idle    = CONFIG_STM32H7_TIM8_CH5IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   },
@@ -1135,7 +1135,7 @@ static struct stm32_pwmchan_s g_pwm8channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32H7_TIM8_CH6POL,
       .idle    = CONFIG_STM32H7_TIM8_CH6IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   }

--- a/arch/arm/src/stm32h7/stm32_qspi.c
+++ b/arch/arm/src/stm32h7/stm32_qspi.c
@@ -145,7 +145,7 @@
 /* Clocking *****************************************************************/
 
 /* The board.h file may choose a different clock source for QUADSPI
- * peripherial by defining the BOARD_QSPI_CLK macro to one of the
+ * peripheral by defining the BOARD_QSPI_CLK macro to one of the
  * RCC_D1CCIPR_QSPISEL_XXX values (XXX = HCLK, PLL1, PLL2, PER).
  * QUADSPI clock defaults to HCLK.
  */

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -1829,7 +1829,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/arm/src/stm32l4/stm32l4_pwm.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwm.c
@@ -473,7 +473,7 @@ static struct stm32l4_pwmchan_s g_pwm1channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32L4_TIM1_CH5POL,
       .idle    = CONFIG_STM32L4_TIM1_CH5IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   },
@@ -488,7 +488,7 @@ static struct stm32l4_pwmchan_s g_pwm1channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32L4_TIM1_CH6POL,
       .idle    = CONFIG_STM32L4_TIM1_CH6IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   }
@@ -1034,7 +1034,7 @@ static struct stm32l4_pwmchan_s g_pwm8channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32L4_TIM8_CH5POL,
       .idle    = CONFIG_STM32L4_TIM8_CH5IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   },
@@ -1049,7 +1049,7 @@ static struct stm32l4_pwmchan_s g_pwm8channels[] =
       .in_use  = 1,
       .pol     = CONFIG_STM32L4_TIM8_CH6POL,
       .idle    = CONFIG_STM32L4_TIM8_CH6IDLE,
-      .pincfg  = 0,    /* No available externaly */
+      .pincfg  = 0,    /* Not available externally */
     }
 #endif
   }

--- a/arch/arm/src/stm32l4/stm32l4_spi.c
+++ b/arch/arm/src/stm32l4/stm32l4_spi.c
@@ -1334,7 +1334,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/arm/src/stm32l5/Kconfig
+++ b/arch/arm/src/stm32l5/Kconfig
@@ -416,7 +416,7 @@ endchoice
 if STM32L5_RTC_LSECLOCK
 
 config STM32L5_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
-	bool "Automaticaly boost the LSE oscillator drive capability level until it starts-up"
+	bool "Automatically boost the LSE oscillator drive capability level until it starts-up"
 	default n
 	---help---
 		This will cycle through the values from low to high. To avoid

--- a/arch/arm/src/stm32l5/stm32l5_spi.c
+++ b/arch/arm/src/stm32l5/stm32l5_spi.c
@@ -1343,7 +1343,7 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *   dev      - Device-specific state data
  *   txbuffer - A pointer to the buffer of data to be sent
  *   rxbuffer - A pointer to a buffer in which to receive data
- *   nwords   - the length of data to be exchaned in units of words.
+ *   nwords   - the length of data to be exchanged in units of words.
  *              The wordsize is determined by the number of bits-per-word
  *              selected for the SPI interface.  If nbits <= 8, the data is
  *              packed into uint8_t's; if nbits >8, the data is packed into

--- a/arch/renesas/src/rx65n/rx65n_dtc.c
+++ b/arch/renesas/src/rx65n/rx65n_dtc.c
@@ -1752,7 +1752,7 @@ void rx65n_dtc_initialize(void)
 
 #if defined(CONFIG_RX65N_DTC_SEQUENCE_TRANSFER_MODE)
 
-      /* In sequence transfer mode, set full addresss mode */
+      /* In sequence transfer mode, set full address mode */
 
       DTC.DTCADMOD.BIT.SHORT = 0;
       dtchandle->addmode = 0;

--- a/arch/renesas/src/rx65n/rx65n_usbdev.c
+++ b/arch/renesas/src/rx65n/rx65n_usbdev.c
@@ -5426,7 +5426,7 @@ void usb_pstd_brdy_pipe_process(uint16_t bitsts)
  * Name: usb_pstd_brdy_pipe
  *
  * Description:
- *  Handle BRDY Interupt
+ *  Handle BRDY Interrupt
  *
  ****************************************************************************/
 

--- a/arch/risc-v/src/rv32m1/rv32m1_serial.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_serial.c
@@ -1087,7 +1087,7 @@ void riscv_serialinit(void)
           continue;
         }
 
-      /* OS(Nuttx) is primordial and so many resources are uninitialized
+      /* OS (NuttX) is primordial and so many resources are uninitialized
        * while we are in 'riscv_serialinit'. The high level C lib functions
        * may not work well. Codes such as the following
        * 'snprintf(devpath, "/dev/ttyS%d\n", devno)...'

--- a/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
+++ b/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
@@ -203,7 +203,7 @@ static void board_foc_trace(FAR struct foc_dev_s *dev, int type, bool state);
  *   - Current W+ - OPAMP3_VINP0 (PB0)
  *   - Current W- - OPAMP3_VINP0 (PB2)
  *
- * ADC configration:
+ * ADC configuration:
  *    - Current Phase V    -> ADC1 INJ1 -> ADC1_IN3 (OPAMP1_VOUT/PA2)
  *    - Current Phase U    -> Not used, no ADC1 connection
  *    - Current Phase W    -> ADC1 INJ2 -> ADC1_IN12 (OPAMP3_VOUT/PB12)

--- a/boards/arm/stm32/nucleo-f103rb/src/stm32_foc_ihm07m1.c
+++ b/boards/arm/stm32/nucleo-f103rb/src/stm32_foc_ihm07m1.c
@@ -69,7 +69,7 @@
  * Private Data
  ****************************************************************************/
 
-/* FOC ADC configration:
+/* FOC ADC configuration:
  *    - Current Phase V    -> ADC1 INJ1 -> ADC1_IN0  (PA0)
  *    - Current Phase U    -> ADC1 INJ2 -> ADC1_IN11 (PC1)
  *    - Current Phase W    -> ADC1 INJ3 -> ADC1_I10  (PC0)

--- a/boards/arm/stm32/nucleo-f302r8/src/stm32_foc_ihm07m1.c
+++ b/boards/arm/stm32/nucleo-f302r8/src/stm32_foc_ihm07m1.c
@@ -67,7 +67,7 @@
  * Private Data
  ****************************************************************************/
 
-/* FOC ADC configration:
+/* FOC ADC configuration:
  *    - Current Phase V    -> ADC1 INJ1 -> ADC1_IN1  (PA0)
  *    - Current Phase U    -> ADC1 INJ2 -> ADC1_IN7  (PC1)
  *    - Current Phase W    -> ADC1 INJ3 -> ADC1_IN6  (PC0)

--- a/boards/arm/stm32h7/nucleo-h743zi2/README.txt
+++ b/boards/arm/stm32h7/nucleo-h743zi2/README.txt
@@ -78,7 +78,7 @@ Configurations
 
   jumbo:
 
-    This configuration enables many Apache Nuttx features.  This is
+    This configuration enables many Apache NuttX features.  This is
     mostly to help provide additional code coverage in CI, but also
     allows for a users to see a wide range of features that are
     supported by the OS.

--- a/boards/risc-v/rv32m1/rv32m1-vega/README.txt
+++ b/boards/risc-v/rv32m1/rv32m1-vega/README.txt
@@ -20,7 +20,7 @@ The RV32M1-VEGA board features:
 
 Refer to https://open-isa.org for further information about this board.
 
-Currently Nuttx is ported to RV32M1 RI5CY only. RI5CY is RV32IMC RISC-V CPU
+Currently NuttX is ported to RV32M1 RI5CY only. RI5CY is RV32IMC RISC-V CPU
 with PULP extensions features:
   - Post-Incrementing load and stores,
   - Multiply-Accumulate extenstions,
@@ -210,7 +210,7 @@ by risc64-unknown-elf-* tools.
 Configuration Sub-directories
 ========
 
-Nuttx of All configurations in rv32m1-vega/configs can be compiled by
+NuttX of all configurations in rv32m1-vega/configs can be compiled by
 the generic GNU RVG Toolchain and OPEN ISA Toolchain.
 
 buttons

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -96,7 +96,7 @@ OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 
 # Note: -fshort-wchar for the case where NuttX and the host OS have
-# differnt wchar_t. On Nuttx, it's uint16_t. On macOS, it's 32-bit.
+# different wchar_t. On NuttX, it's uint16_t. On macOS, it's 32-bit.
 CFLAGS := $(ARCHWARNINGS) $(ARCHOPTIMIZATION) \
    $(ARCHCPUFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS) -pipe \
    -fshort-wchar

--- a/drivers/1wire/1wire.c
+++ b/drivers/1wire/1wire.c
@@ -542,7 +542,7 @@ int onewire_search(FAR struct onewire_master_s *master,
 
   DEBUGASSERT(master->insearch == false);
 
-  /* Make complete search on the bus mutal exlusive */
+  /* Make complete search on the bus mutal exclusive */
 
   ret = onewire_sem_wait(master);
   if (ret < 0)

--- a/drivers/1wire/1wire_internal.h
+++ b/drivers/1wire/1wire_internal.h
@@ -81,7 +81,7 @@ struct onewire_slave_s
  * Public Function Prototypes
  ****************************************************************************/
 
-/* Aditional CRC helpers from 1wire_crc.c */
+/* Additional CRC helpers from 1wire_crc.c */
 
 bool onewire_valid_rom(uint64_t rom);
 

--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -1465,8 +1465,8 @@ config LCD_HT16K33_MULT_MODULE
 	default n
 	depends on I2C
 	---help---
-		It is possible to connect many HT16K33 modules with sequencial
-		I2C addresses to work as a single display to support lenght
+		It is possible to connect many HT16K33 modules with sequential
+		I2C addresses to work as a single display to support length
 		text strings. The device at the I2C address 0x70 will display the
 		4 more significant characters, the device 0x71 will display the
 		previous 4 more significant characters and so on.

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -337,8 +337,8 @@ static ssize_t ramlog_addbuf(FAR struct ramlog_dev_s *priv,
 
       /* If there are multiple readers, some of them might block despite
        * POLLIN because first reader might read all data. Favor readers
-       * and notify poll waiters only if no reader was awaken, even if the
-       * latter may starve.
+       * and notify poll waiters only if no reader was awakened, even if
+       * the latter may starve.
        *
        * This also implies we do not have to make these two notify
        * operations a critical section.
@@ -860,8 +860,8 @@ int ramlog_putc(FAR struct syslog_channel_s *channel, int ch)
 
   /* If there are multiple readers, some of them might block despite
    * POLLIN because first reader might read all data. Favor readers
-   * and notify poll waiters only if no reader was awaken, even if the
-   * latter may starve.
+   * and notify poll waiters only if no reader was awakened, even if
+   * the latter may starve.
    *
    * This also implies we do not have to make these two notify
    * operations a critical section.

--- a/fs/fat/Kconfig
+++ b/fs/fat/Kconfig
@@ -17,10 +17,10 @@ config FAT_COMPUTE_FSINFO
 	default n
 	---help---
 		Enables the computation of free clusters at mount time as suggested by the
-		white paper for FAT. The standard behavior of Nuttx is to trust the stored
+		white paper for FAT. The standard behavior of NuttX is to trust the stored
 		value and only recompute it once required. This works if the file system
 		is never mounted to another OS. SD-cards which are mounted to Windows to
-		modify the content might report wrong space after reinserting it to Nuttx.
+		modify the content might report wrong space after reinserting it to NuttX.
 		It is recommended to activate this setting if the "SD-Card" is swapped
 		between systems.
 

--- a/libs/libc/debug/Kconfig
+++ b/libs/libc/debug/Kconfig
@@ -3,7 +3,7 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-# These are library functions that may be overriden by architecture-
+# These are library functions that may be overridden by architecture-
 # specific implementations.  Not all architectures support implementations
 # for every library function.
 

--- a/libs/libc/machine/Kconfig
+++ b/libs/libc/machine/Kconfig
@@ -3,7 +3,7 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-# These are library functions that may be overriden by architecture-
+# These are library functions that may be overridden by architecture-
 # specific implementations.  Not all architectures support implementations
 # for every library function.
 

--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -375,7 +375,7 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
                 }
             }
 
-          /* Note: On Nuttx, ptrdiff_t == intptr_t == ssize_t. */
+          /* Note: On NuttX, ptrdiff_t == intptr_t == ssize_t. */
 
           if (c == 'z' || c == 't')
             {

--- a/libs/libc/stdlib/lib_div.c
+++ b/libs/libc/stdlib/lib_div.c
@@ -62,7 +62,7 @@
  *   denom - Denominator of the division
  *
  * Returned Value:
- *   The result of the devision represent as values of type div_t
+ *   The result of the division represented as values of type div_t
  *
  ****************************************************************************/
 

--- a/libs/libc/stdlib/lib_ldiv.c
+++ b/libs/libc/stdlib/lib_ldiv.c
@@ -67,7 +67,7 @@
  *   denom - Denominator of the division
  *
  * Returned Value:
- *   The result of the devision represent as values of type ldiv_t
+ *   The result of the division represented as values of type ldiv_t
  *
  ****************************************************************************/
 

--- a/libs/libc/stdlib/lib_lldiv.c
+++ b/libs/libc/stdlib/lib_lldiv.c
@@ -69,7 +69,7 @@
  *   denom - Denominator of the division
  *
  * Returned Value:
- *   The result of the devision represent as values of type lldiv_t
+ *   The result of the division represented as values of type lldiv_t
  *
  ****************************************************************************/
 

--- a/libs/libdsp/lib_observer.c
+++ b/libs/libdsp/lib_observer.c
@@ -440,7 +440,7 @@ void motor_sobserver_div(FAR struct motor_observer_f32_s *o,
       so->angle_diff += dir * 2 * M_PI_F;
     }
 
-  /* Get absoulte value */
+  /* Get absolute value */
 
   if (so->angle_diff < 0.0f)
     {


### PR DESCRIPTION
## Summary

Fix typos in these files:
- Documentation/components/drivers/character/foc.rst
- Documentation/guides/cpp_cmake.rst
- Kconfig
- arch/arm/src/imxrt/imxrt_lpspi.c
- arch/arm/src/kinetis/kinetis_spi.c
- arch/arm/src/kl/kl_spi.c
- arch/arm/src/lpc31xx/lpc31_spi.c
- arch/arm/src/nrf52/nrf52_radio.h
- arch/arm/src/s32k1xx/s32k1xx_lpspi.c
- arch/arm/src/stm32/Kconfig
- arch/arm/src/stm32/stm32_adc.c
- arch/arm/src/stm32/stm32_foc.c
- arch/arm/src/stm32/stm32_foc.h
- arch/arm/src/stm32/stm32_pwm.c
- arch/arm/src/stm32/stm32_spi.c
- arch/arm/src/stm32f0l0g0/stm32_spi.c
- arch/arm/src/stm32f7/Kconfig
- arch/arm/src/stm32f7/stm32_spi.c
- arch/arm/src/stm32h7/Kconfig
- arch/arm/src/stm32h7/stm32_allocateheap.c
- arch/arm/src/stm32h7/stm32_fmc.c
- arch/arm/src/stm32h7/stm32_fmc.h
- arch/arm/src/stm32h7/stm32_pwm.c
- arch/arm/src/stm32h7/stm32_qspi.c
- arch/arm/src/stm32h7/stm32_spi.c
- arch/arm/src/stm32l4/stm32l4_pwm.c
- arch/arm/src/stm32l4/stm32l4_spi.c
- arch/arm/src/stm32l5/Kconfig
- arch/arm/src/stm32l5/stm32l5_spi.c
- arch/renesas/src/rx65n/rx65n_dtc.c
- arch/renesas/src/rx65n/rx65n_usbdev.c
- arch/risc-v/src/rv32m1/rv32m1_serial.c
- boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
- boards/arm/stm32/nucleo-f103rb/src/stm32_foc_ihm07m1.c
- boards/arm/stm32/nucleo-f302r8/src/stm32_foc_ihm07m1.c
- boards/arm/stm32h7/nucleo-h743zi2/README.txt
- boards/risc-v/rv32m1/rv32m1-vega/README.txt
- boards/sim/sim/sim/scripts/Make.defs
- drivers/1wire/1wire.c
- drivers/1wire/1wire_internal.h
- drivers/lcd/Kconfig
- drivers/syslog/ramlog.c
- fs/fat/Kconfig
- libs/libc/debug/Kconfig
- libs/libc/machine/Kconfig
- libs/libc/stdio/lib_libvsprintf.c
- libs/libc/stdlib/lib_div.c
- libs/libc/stdlib/lib_ldiv.c
- libs/libc/stdlib/lib_lldiv.c
- libs/libdsp/lib_observer.c

## Impact

Improves readability (and in some cases greppability) of comments and documentation.

## Testing

nxstyle.