### PR TITLE
net/socket: add SO_RCVBUF support

### DIFF
--- a/net/Kconfig
+++ b/net/Kconfig
@@ -117,6 +117,12 @@ config NET_GUARDSIZE
 		packet size will be chopped down to the size indicated in the TCP
 		header.
 
+config NET_RECV_BUFSIZE
+	int "Net Receive buffer size"
+	default 0
+	---help---
+		This is the default value for receive buffer size.
+
 endmenu # Driver buffer configuration
 
 menu "Link layer support"

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -190,6 +190,9 @@ struct tcp_conn_s
   uint16_t snd_wnd;       /* Sequence and acknowledgement numbers of last
                            * window update */
   uint32_t rcv_adv;       /* The right edge of the recv window advertized */
+#if CONFIG_NET_RECV_BUFSIZE > 0
+  int32_t  rcv_bufs;      /* Maximum amount of bytes queued in recv */
+#endif
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   uint32_t tx_unacked;    /* Number bytes sent but not yet ACKed */
 #else

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -673,6 +673,9 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
       conn->keepintvl     = 2 * DSEC_PER_SEC;
       conn->keepcnt       = 3;
 #endif
+#if CONFIG_NET_RECV_BUFSIZE > 0
+      conn->rcv_bufs      = CONFIG_NET_RECV_BUFSIZE;
+#endif
     }
 
   return conn;

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -120,6 +120,9 @@ struct udp_conn_s
   uint8_t  boundto;       /* Index of the interface we are bound to.
                            * Unbound: 0, Bound: 1-MAX_IFINDEX */
 #endif
+#if CONFIG_NET_RECV_BUFSIZE > 0
+  int32_t  rcvbufs;       /* Maximum amount of bytes queued in recv */
+#endif
 
   /* Read-ahead buffering.
    *

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -83,6 +83,14 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
   FAR void  *src_addr;
   uint8_t src_addr_size;
 
+#if CONFIG_NET_RECV_BUFSIZE > 0
+  while (iob_get_queue_size(&conn->readahead) > conn->rcvbufs)
+    {
+      iob = iob_remove_queue(&conn->readahead);
+      iob_free_chain(iob, IOBUSER_NET_UDP_READAHEAD);
+    }
+#endif
+
   /* Allocate on I/O buffer to start the chain (throttling as necessary).
    * We will not wait for an I/O buffer to become available in this context.
    */

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -585,6 +585,9 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
 #endif
       conn->lport   = 0;
       conn->ttl     = IP_TTL;
+#if CONFIG_NET_RECV_BUFSIZE > 0
+      conn->rcvbufs = CONFIG_NET_RECV_BUFSIZE;
+#endif
 
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
       /* Initialize the write buffer lists */


### PR DESCRIPTION
## Summary

net/socket: add SO_RCVBUF support

Reference here:
https://www.freebsd.org/cgi/man.cgi?query=setsockopt&sektion=2&format=html

## Impact

add SO_RCVBUF support to limit the sharing of iob buffers under multiple TCP/UDP connections

## Testing

http audio streaming(client) with multiple instance and playback at same time