### PR TITLE
net/tcp: add window scale support

### DIFF
--- a/include/nuttx/net/tcp.h
+++ b/include/nuttx/net/tcp.h
@@ -171,7 +171,7 @@ struct tcp_hdr_s
   uint8_t  wnd[2];
   uint16_t tcpchksum;
   uint8_t  urgp[2];
-  uint8_t  optdata[4];
+  uint8_t  optdata[0];
 };
 
 /* The structure holding the TCP/IP statistics that are gathered if

--- a/include/nuttx/net/tcp.h
+++ b/include/nuttx/net/tcp.h
@@ -76,8 +76,11 @@
 #define TCP_OPT_END       0   /* End of TCP options list */
 #define TCP_OPT_NOOP      1   /* "No-operation" TCP option */
 #define TCP_OPT_MSS       2   /* Maximum segment size TCP option */
+#define TCP_OPT_WS        3   /* Window size scaling factor */
 
+#define TCP_OPT_NOOP_LEN  1   /* Length of TCP NOOP option. */
 #define TCP_OPT_MSS_LEN   4   /* Length of TCP MSS option. */
+#define TCP_OPT_WS_LEN    3   /* Length of TCP WS option. */
 
 /* The TCP states used in the struct tcp_conn_s tcpstateflags field */
 

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -258,7 +258,7 @@ static int sixlowpan_tcp_header(FAR struct tcp_conn_s *conn,
       /* Update the TCP received window based on I/O buffer availability */
 
       uint32_t rcvseq = tcp_getsequence(conn->rcvseq);
-      uint16_t recvwndo = tcp_get_recvwindow(dev, conn);
+      uint32_t recvwndo = tcp_get_recvwindow(dev, conn);
 
       /* Set the TCP Window */
 

--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -106,6 +106,27 @@ config NET_TCP_FAST_RETRANSMIT_WATERMARK
 			missing segment, without waiting for a retransmission timer to
 			expire.
 
+config NET_TCP_WINDOW_SCALE
+	bool "Enable TCP/IP Window Scale Option"
+	default n
+	---help---
+		RFC1323:
+		2. TCP WINDOW SCALE OPTION
+			The window scale extension expands the definition of the TCP
+			window to 32 bits and then uses a scale factor to carry this 32-
+			bit value in the 16-bit Window field of the TCP header (SEG.WND in
+			RFC-793).
+
+if NET_TCP_WINDOW_SCALE
+
+config NET_TCP_WINDOW_SCALE_FACTOR
+	int "TCP/IP Window Scale Factor"
+	default 0
+	---help---
+		This is the default value for window scale factor.
+
+endif # NET_TCP_WINDOW_SCALE
+
 config NET_TCP_NOTIFIER
 	bool "Support TCP notifications"
 	default n

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1475,7 +1475,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
  *
  ****************************************************************************/
 
-uint16_t tcp_get_recvwindow(FAR struct net_driver_s *dev,
+uint32_t tcp_get_recvwindow(FAR struct net_driver_s *dev,
                             FAR struct tcp_conn_s *conn);
 
 /****************************************************************************

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -96,6 +96,10 @@
 #define TCP_SEQ_ADD(a, b)	((uint32_t)((a) + (b)))
 #define TCP_SEQ_SUB(a, b)	((uint32_t)((a) - (b)))
 
+/* The TCP options flags */
+
+#define TCP_WSCALE            0x01U /* Window Scale option enabled */
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -187,9 +191,16 @@ struct tcp_conn_s
   uint16_t rport;         /* The remoteTCP port, in network byte order */
   uint16_t mss;           /* Current maximum segment size for the
                            * connection */
+  uint32_t rcv_adv;       /* The right edge of the recv window advertized */
+#ifdef CONFIG_NET_TCP_WINDOW_SCALE
+  uint32_t snd_wnd;       /* Sequence and acknowledgement numbers of last
+                           * window update */
+  uint8_t  snd_scale;     /* Sender window scale factor */
+  uint8_t  rcv_scale;     /* Receiver windows scale factor */
+#else
   uint16_t snd_wnd;       /* Sequence and acknowledgement numbers of last
                            * window update */
-  uint32_t rcv_adv;       /* The right edge of the recv window advertized */
+#endif
 #if CONFIG_NET_RECV_BUFSIZE > 0
   int32_t  rcv_bufs;      /* Maximum amount of bytes queued in recv */
 #endif
@@ -198,6 +209,7 @@ struct tcp_conn_s
 #else
   uint16_t tx_unacked;    /* Number bytes sent but not yet ACKed */
 #endif
+  uint16_t flags;         /* Flags of TCP-specific options */
 
   /* If the TCP socket is bound to a local address, then this is
    * a reference to the device that routes traffic on the corresponding

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -375,6 +375,7 @@ static void tcp_input(FAR struct net_driver_s *dev, uint8_t domain,
                       /* NOP option. */
 
                       ++i;
+                      continue;
                     }
                   else if (opt == TCP_OPT_MSS &&
                           dev->d_buf[hdrlen + 1 + i] == TCP_OPT_MSS_LEN)
@@ -386,10 +387,6 @@ static void tcp_input(FAR struct net_driver_s *dev, uint8_t domain,
                       tmp16 = ((uint16_t)dev->d_buf[hdrlen + 2 + i] << 8) |
                                (uint16_t)dev->d_buf[hdrlen + 3 + i];
                       conn->mss = tmp16 > tcp_mss ? tcp_mss : tmp16;
-
-                      /* And we are done processing options. */
-
-                      break;
                     }
                   else
                     {
@@ -405,9 +402,9 @@ static void tcp_input(FAR struct net_driver_s *dev, uint8_t domain,
 
                           break;
                         }
-
-                      i += dev->d_buf[hdrlen + 1 + i];
                     }
+
+                  i += dev->d_buf[hdrlen + 1 + i];
                 }
             }
 
@@ -772,6 +769,7 @@ found:
                         /* NOP option. */
 
                         ++i;
+                        continue;
                       }
                     else if (opt == TCP_OPT_MSS &&
                               dev->d_buf[hdrlen + 1 + i] == TCP_OPT_MSS_LEN)
@@ -784,10 +782,6 @@ found:
                           (dev->d_buf[hdrlen + 2 + i] << 8) |
                           dev->d_buf[hdrlen + 3 + i];
                         conn->mss = tmp16 > tcp_mss ? tcp_mss : tmp16;
-
-                        /* And we are done processing options. */
-
-                        break;
                       }
                     else
                       {
@@ -804,8 +798,9 @@ found:
                             break;
                           }
 
-                        i += dev->d_buf[hdrlen + 1 + i];
                       }
+
+                    i += dev->d_buf[hdrlen + 1 + i];
                   }
               }
 

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -363,7 +363,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
       /* Update the TCP received window based on I/O buffer availability */
 
       uint32_t rcvseq = tcp_getsequence(conn->rcvseq);
-      uint16_t recvwndo = tcp_get_recvwindow(dev, conn);
+      uint32_t recvwndo = tcp_get_recvwindow(dev, conn);
 
       /* Update the Receiver Window */
 

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -628,6 +628,7 @@ void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
 {
   struct tcp_hdr_s *tcp;
   uint16_t tcp_mss;
+  int16_t optlen = 0;
 
   /* Get values that vary with the underlying IP domain */
 
@@ -642,7 +643,7 @@ void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
 
       /* Set the packet length for the TCP Maximum Segment Size */
 
-      dev->d_len  = IPv6TCP_HDRLEN + TCP_OPT_MSS_LEN;
+      dev->d_len  = IPv6TCP_HDRLEN;
     }
 #endif /* CONFIG_NET_IPv6 */
 
@@ -657,7 +658,7 @@ void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
 
       /* Set the packet length for the TCP Maximum Segment Size */
 
-      dev->d_len  = IPv4TCP_HDRLEN + TCP_OPT_MSS_LEN;
+      dev->d_len  = IPv4TCP_HDRLEN;
     }
 #endif /* CONFIG_NET_IPv4 */
 
@@ -669,11 +670,12 @@ void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
 
   /* We send out the TCP Maximum Segment Size option with our ACK. */
 
-  tcp->optdata[0] = TCP_OPT_MSS;
-  tcp->optdata[1] = TCP_OPT_MSS_LEN;
-  tcp->optdata[2] = tcp_mss >> 8;
-  tcp->optdata[3] = tcp_mss & 0xff;
-  tcp->tcpoffset  = ((TCP_HDRLEN + TCP_OPT_MSS_LEN) / 4) << 4;
+  tcp->optdata[optlen++] = TCP_OPT_MSS;
+  tcp->optdata[optlen++] = TCP_OPT_MSS_LEN;
+  tcp->optdata[optlen++] = tcp_mss >> 8;
+  tcp->optdata[optlen++] = tcp_mss & 0xff;
+  tcp->tcpoffset         = ((TCP_HDRLEN + optlen) / 4) << 4;
+  dev->d_len            += optlen;
 
   /* Complete the common portions of the TCP message */
 


### PR DESCRIPTION
## Summary

net/tcp: add window scale support
net/tcp: change the tcp optdata to dynamic arrays
net/tcp: remove the invalid break during tcp option loop

Reference here:
https://tools.ietf.org/html/rfc1323

## Impact

High performance network throughput request if the receiving window exceeds 64K

## Testing

HTTP streaming