### PR TITLE
xtensa/esp32: Fix uart 2 issue.

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -579,7 +579,7 @@ config ESP32_UART0_RTSPIN
 config ESP32_UART0_CTSPIN
 	int "UART0 CTS Pin"
 	depends on SERIAL_OFLOWCONTROL
-	default 19
+	default 23
 	range 0 39
 
 config ESP32_UART0_TXDMA
@@ -624,12 +624,12 @@ if ESP32_UART2
 
 config ESP32_UART2_TXPIN
 	int "UART2 Tx Pin"
-	default 17
+	default 19
 	range 0 39
 
 config ESP32_UART2_RXPIN
 	int "UART2 Rx Pin"
-	default 16
+	default 18
 	range 0 39
 
 config ESP32_UART2_RTSPIN

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -739,22 +739,6 @@ static void esp32_reset_rx_fifo(struct esp32_dev_s *priv)
     }
 }
 
-/****************************************************************************
- * Name: esp32_reset_tx_fifo
- *
- * Description:
- *   Resets the TX FIFO.
- *
- * Parameters:
- *   priv        -  Pointer to the serial driver struct.
- *
- ****************************************************************************/
-
-static void esp32_reset_tx_fifo(struct esp32_dev_s *priv)
-{
-  modifyreg32(UART_CONF0_REG(priv->config->id), 0, UART_TXFIFO_RST_M);
-  modifyreg32(UART_CONF0_REG(priv->config->id), UART_TXFIFO_RST_M, 0);
-}
 #endif
 
 /****************************************************************************
@@ -947,7 +931,6 @@ static int esp32_setup(struct uart_dev_s *dev)
   /* Reset the RX and TX FIFO */
 
   esp32_reset_rx_fifo(priv);
-  esp32_reset_tx_fifo(priv);
 
   /* Configure and enable the UART */
 


### PR DESCRIPTION
## Summary

This MR removes the reset of TX FIFO, which was causing the UART 2 to print garbage after the first print.
It also changes the default UART 2 pins from menuconfig to valid pins.

## Impact

From now on, UART 2 is working again. This regression was added in https://github.com/apache/incubator-nuttx/pull/3642.

## Test

Using `printf` command and writing on `/dev/ttySx` where UART 2 was residing.