### PR TITLE
risc-v/esp32c3: Add board_ioctl and board_uniqueid

### DIFF
--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -50,6 +50,7 @@ CHIP_CSRCS += esp32c3_irq.c
 CHIP_CSRCS += esp32c3_clockconfig.c esp32c3_gpio.c
 CHIP_CSRCS += esp32c3_lowputc.c
 CHIP_CSRCS += esp32c3_systemreset.c esp32c3_resetcause.c
+CHIP_CSRCS += esp32c3_uid.c
 
 ifeq ($(CONFIG_SCHED_TICKLESS),y)
 CHIP_CSRCS += esp32c3_tickless.c

--- a/arch/risc-v/src/esp32c3/esp32c3_uid.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_uid.c
@@ -1,0 +1,58 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/esp32c3_uid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#include "hardware/esp32c3_efuse.h"
+#include "esp32c3.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_get_uniqueid
+ *
+ * Description:
+ *   Get CPU unique ID.
+ *
+ * Parameters:
+ *   uniqueid - unique ID buffer
+ *
+ ****************************************************************************/
+
+void esp32c3_get_uniqueid(uint8_t *uniqueid)
+{
+  int i;
+
+  for (i = 0; i < 16; i++)
+    {
+      uniqueid[i] = getreg8(EFUSE_RD_SYS_DATA_PART1_0_REG + i);
+    }
+}

--- a/arch/risc-v/src/esp32c3/esp32c3_uid.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_uid.h
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/esp32c3_uid.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_ESP32C3_ESP32C3_UID_H
+#define __ARCH_RISCV_SRC_ESP32C3_ESP32C3_UID_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/irq.h>
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32c3_get_uniqueid
+ *
+ * Description:
+ *   Get CPU unique ID.
+ *
+ * Parameters:
+ *   uniqueid - unique ID buffer
+ *
+ ****************************************************************************/
+
+void esp32c3_get_uniqueid(uint8_t *uniqueid);
+
+#endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_UID_H */

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
@@ -78,6 +78,14 @@ ifeq ($(CONFIG_ADC),y)
 CSRCS += esp32c3_adc.c
 endif
 
+ifeq ($(CONFIG_BOARDCTL_IOCTL),y)
+CSRCS += esp32c3_ioctl.c
+endif
+
+ifeq ($(CONFIG_BOARDCTL_UNIQUEID),y)
+CSRCS += esp32c3_uid.c
+endif
+
 SCRIPTIN = $(SCRIPTDIR)$(DELIM)esp32c3.template.ld
 SCRIPTOUT = $(SCRIPTDIR)$(DELIM)esp32c3_out.ld
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_ioctl.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_ioctl.c
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_ioctl.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include <nuttx/board.h>
+
+#ifdef CONFIG_BOARDCTL_IOCTL
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_ioctl
+ *
+ * Description:
+ *   The "landing site" for much of the boardctl() interface. Generic board-
+ *   control functions invoked via ioctl() get routed through here.
+ *
+ *   Since we don't do anything unusual at the moment, this function
+ *   accomplishes nothing except avoid a missing-function linker error if
+ *   CONFIG_BOARDCTL_IOCTL is selected.
+ *
+ * Input Parameters:
+ *   cmd - IOCTL command being requested.
+ *   arg - Arguments for the IOCTL.
+ *
+ * Returned Value:
+ *   we don't yet support any boardctl IOCTLs.  This function always returns
+ *  -ENOTTY which is the standard IOCTL return value when a command is not
+ *  supported
+ *
+ ****************************************************************************/
+
+int board_ioctl(unsigned int cmd, uintptr_t arg)
+{
+  switch (cmd)
+    {
+      default:
+        return -ENOTTY;
+    }
+
+  return OK;
+}
+
+#endif /* CONFIG_BOARDCTL_IOCTL */

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_uid.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_uid.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_uid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+
+#include <nuttx/board.h>
+
+#include "esp32c3_uid.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#if defined(CONFIG_BOARDCTL_UNIQUEID)
+int board_uniqueid(uint8_t *uniqueid)
+{
+  if (uniqueid == NULL)
+    {
+      return -EINVAL;
+    }
+
+  esp32c3_get_uniqueid(uniqueid);
+  return OK;
+}
+#endif


### PR DESCRIPTION
## Summary

Add ESP32-C3 board_ioctl and board_uniqueid.

## Impact

## Testing

