### PR TITLE
fs/procfs: layout the output of meminfo correctly

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -286,10 +286,9 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
 
   /* The first line is the headers */
 
-  linesize  =
-    procfs_snprintf(procfile->line, MEMINFO_LINELEN,
-             "                     "
-             "total       used       free    largest  nused  nfree\n");
+  linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
+                              "%13s%11s%11s%11s%11s%7s%7s\n", "", "total",
+                              "used", "free", "largest", "nused", "nfree");
 
   copysize  = procfs_memcpy(procfile->line, linesize, buffer, buflen,
                             &offset);
@@ -312,8 +311,7 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
 
           entry->mallinfo(entry->user_data, &minfo);
           linesize   = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
-                                       "%12s:  "
-                                       "%11lu%11lu%11lu%11lu%7lu%7lu\n",
+                                       "%12s:%11lu%11lu%11lu%11lu%7lu%7lu\n",
                                        entry->name,
                                        (unsigned long)minfo.arena,
                                        (unsigned long)minfo.uordblks,
@@ -349,8 +347,8 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
       max        = (unsigned long)pginfo.mxfree << MM_PGSHIFT;
 
       linesize   = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
-                                   "Page:  %11lu%11lu%11lu%11lu\n",
-                                   total, allocated, available, max);
+                                   "%12s:%11lu%11lu%11lu%11lu\n",
+                                   "Page", total, allocated, available, max);
 
       copysize   = procfs_memcpy(procfile->line, linesize, buffer, buflen,
                                  &offset);
@@ -371,7 +369,8 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
       meminfo_progmem(&progmem);
 
       linesize   = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
-                                   "Prog:  %11lu%11lu%11lu%11lu%7lu%7lu\n",
+                                   "%12s:%11lu%11lu%11lu%11lu%7lu%7lu\n",
+                                   "Prog",
                                    (unsigned long)progmem.arena,
                                    (unsigned long)progmem.uordblks,
                                    (unsigned long)progmem.fordblks,


### PR DESCRIPTION
## Summary
Fix the wrong output like this:
```
nsh> free
             total       used       free    largest  nused  nfree
        Umem:      2719744    2495033     152752          0    155      0
```

## Impact
The output from free layout correctly

## Testing
Here is the new output:
```
nsh> free
                   total       used       free    largest  nused  nfree
        Umem:    2719744    2495033     152752          0    155      0
```