### PR TITLE
net/socket: add SO_SNDBUF support

### DIFF
--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -201,6 +201,10 @@
 #  define NET_LO_PKTSIZE        CONFIG_NET_LOOPBACK_PKTSIZE
 #endif
 
+#ifndef CONFIG_NET_SEND_BUFSIZE
+#define CONFIG_NET_SEND_BUFSIZE 0
+#endif
+
 /* Layer 3/4 Configuration Options ******************************************/
 
 /* IP configuration options */

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -123,6 +123,13 @@ config NET_RECV_BUFSIZE
 	---help---
 		This is the default value for receive buffer size.
 
+config NET_SEND_BUFSIZE
+	int "Net Send buffer size"
+	depends on NET_TCP_WRITE_BUFFERS || NET_UDP_WRITE_BUFFERS
+	default 0
+	---help---
+		This is the default value for send buffer size.
+
 endmenu # Driver buffer configuration
 
 menu "Link layer support"

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -196,6 +196,68 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
           return OK;
         }
 #endif
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+      case SO_SNDBUF:     /* Sets send buffer size */
+        {
+          int buffersize;
+
+          /* Verify that option is the size of an 'int'.  Should also check
+           * that 'value' is properly aligned for an 'int'
+           */
+
+          if (value_len != sizeof(int))
+            {
+              return -EINVAL;
+            }
+
+          /* Get the value.  Is the option being set or cleared? */
+
+          buffersize = *(FAR int *)value;
+
+          if (buffersize < 0 || buffersize > INT_MAX)
+            {
+              return -EINVAL;
+            }
+
+          net_lock();
+
+#if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
+          if (psock->s_type == SOCK_STREAM)
+            {
+              FAR struct tcp_conn_s *conn;
+
+              conn = (FAR struct tcp_conn_s *)psock->s_conn;
+
+              /* Save the send buffer size */
+
+              conn->snd_bufs = buffersize;
+            }
+          else
+#endif
+#if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
+          if (psock->s_type == SOCK_DGRAM)
+            {
+              FAR struct udp_conn_s *conn;
+
+              conn = (FAR struct udp_conn_s *)psock->s_conn;
+
+              /* Save the send buffer size */
+
+              conn->sndbufs = buffersize;
+            }
+          else
+#endif
+            {
+              net_unlock();
+              return -ENOPROTOOPT;
+            }
+
+          net_unlock();
+
+          return OK;
+        }
+#endif
     }
 
 #ifdef CONFIG_NET_USRSOCK
@@ -337,7 +399,6 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
       /* The following are not yet implemented */
 
       case SO_RCVLOWAT:   /* Sets the minimum number of bytes to input */
-      case SO_SNDBUF:     /* Sets send buffer size */
       case SO_SNDLOWAT:   /* Sets the minimum number of bytes to output */
 
       /* There options are only valid when used with getopt */

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -31,6 +31,7 @@
 #include <queue.h>
 
 #include <nuttx/clock.h>
+#include <nuttx/semaphore.h>
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/ip.h>
 
@@ -203,6 +204,10 @@ struct tcp_conn_s
 #endif
 #if CONFIG_NET_RECV_BUFSIZE > 0
   int32_t  rcv_bufs;      /* Maximum amount of bytes queued in recv */
+#endif
+#if CONFIG_NET_SEND_BUFSIZE > 0
+  int32_t  snd_bufs;      /* Maximum amount of bytes queued in send */
+  sem_t    snd_sem;       /* Semaphore signals send completion */
 #endif
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   uint32_t tx_unacked;    /* Number bytes sent but not yet ACKed */
@@ -1887,6 +1892,24 @@ int tcp_txdrain(FAR struct socket *psock, unsigned int timeout);
 
 int tcp_ioctl(FAR struct tcp_conn_s *conn, int cmd,
               FAR void *arg, size_t arglen);
+
+/****************************************************************************
+ * Name: tcp_sendbuffer_notify
+ *
+ * Description:
+ *   Notify the send buffer semaphore
+ *
+ * Input Parameters:
+ *   conn - The TCP connection of interest
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+void tcp_sendbuffer_notify(FAR struct tcp_conn_s *conn);
+#endif /* CONFIG_NET_SEND_BUFSIZE */
 
 #ifdef __cplusplus
 }

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -676,6 +676,12 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
 #if CONFIG_NET_RECV_BUFSIZE > 0
       conn->rcv_bufs      = CONFIG_NET_RECV_BUFSIZE;
 #endif
+#if CONFIG_NET_SEND_BUFSIZE > 0
+      conn->snd_bufs      = CONFIG_NET_SEND_BUFSIZE;
+
+      nxsem_init(&conn->snd_sem, 0, 0);
+      nxsem_set_protocol(&conn->snd_sem, SEM_PRIO_NONE);
+#endif
     }
 
   return conn;
@@ -746,6 +752,13 @@ void tcp_free(FAR struct tcp_conn_s *conn)
     {
       tcp_wrbuffer_release(wrbuffer);
     }
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+  /* Notify the send buffer available */
+
+  tcp_sendbuffer_notify(conn);
+#endif /* CONFIG_NET_SEND_BUFSIZE */
+
 #endif
 
 #ifdef CONFIG_NET_TCPBACKLOG

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -95,6 +95,44 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: tcp_inqueue_wrb_size
+ *
+ * Description:
+ *   Get the in-queued write buffer size from connection
+ *
+ * Input Parameters:
+ *   conn - The TCP connection of interest
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+static uint32_t tcp_inqueue_wrb_size(FAR struct tcp_conn_s *conn)
+{
+  FAR struct tcp_wrbuffer_s *wrb;
+  FAR sq_entry_t *entry;
+  uint32_t total = 0;
+
+  if (conn)
+    {
+      for (entry = sq_peek(&conn->unacked_q); entry; entry = sq_next(entry))
+        {
+          wrb = (FAR struct tcp_wrbuffer_s *)entry;
+          total += TCP_WBPKTLEN(wrb);
+        }
+
+      for (entry = sq_peek(&conn->write_q); entry; entry = sq_next(entry))
+        {
+          wrb = (FAR struct tcp_wrbuffer_s *)entry;
+          total += TCP_WBPKTLEN(wrb);
+        }
+    }
+
+  return total;
+}
+
+/****************************************************************************
  * Name: psock_insert_segment
  *
  * Description:

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -31,6 +31,7 @@
 #include <sys/socket.h>
 #include <queue.h>
 
+#include <nuttx/semaphore.h>
 #include <nuttx/net/ip.h>
 #include <nuttx/mm/iob.h>
 
@@ -122,6 +123,10 @@ struct udp_conn_s
 #endif
 #if CONFIG_NET_RECV_BUFSIZE > 0
   int32_t  rcvbufs;       /* Maximum amount of bytes queued in recv */
+#endif
+#if CONFIG_NET_SEND_BUFSIZE > 0
+  int32_t  sndbufs;       /* Maximum amount of bytes queued in send */
+  sem_t    sndsem;        /* Semaphore signals send completion */
 #endif
 
   /* Read-ahead buffering.
@@ -888,6 +893,24 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout);
 
 int udp_ioctl(FAR struct udp_conn_s *conn,
               int cmd, FAR void *arg, size_t arglen);
+
+/****************************************************************************
+ * Name: udp_sendbuffer_notify
+ *
+ * Description:
+ *   Notify the send buffer semaphore
+ *
+ * Input Parameters:
+ *   conn - The UDP connection of interest
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+void udp_sendbuffer_notify(FAR struct udp_conn_s *conn);
+#endif /* CONFIG_NET_SEND_BUFSIZE */
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -588,6 +588,12 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
 #if CONFIG_NET_RECV_BUFSIZE > 0
       conn->rcvbufs = CONFIG_NET_RECV_BUFSIZE;
 #endif
+#if CONFIG_NET_SEND_BUFSIZE > 0
+      conn->sndbufs = CONFIG_NET_SEND_BUFSIZE;
+
+      nxsem_init(&conn->sndsem, 0, 0);
+      nxsem_set_protocol(&conn->sndsem, SEM_PRIO_NONE);
+#endif
 
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
       /* Initialize the write buffer lists */
@@ -641,6 +647,13 @@ void udp_free(FAR struct udp_conn_s *conn)
     {
       udp_wrbuffer_release(wrbuffer);
     }
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+  /* Notify the send buffer available */
+
+  udp_sendbuffer_notify(conn);
+#endif /* CONFIG_NET_SEND_BUFSIZE */
+
 #endif
 
   /* Free the connection */

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -106,6 +106,38 @@ static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: udp_inqueue_wrb_size
+ *
+ * Description:
+ *   Get the in-queued write buffer size from connection
+ *
+ * Input Parameters:
+ *   conn - The UDP connection of interest
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+static uint32_t udp_inqueue_wrb_size(FAR struct udp_conn_s *conn)
+{
+  FAR struct udp_wrbuffer_s *wrb;
+  FAR sq_entry_t *entry;
+  uint32_t total = 0;
+
+  if (conn)
+    {
+      for (entry = sq_peek(&conn->write_q); entry; entry = sq_next(entry))
+        {
+          wrb = (FAR struct udp_wrbuffer_s *)entry;
+          total += wrb->wb_iob->io_pktlen;
+        }
+    }
+
+  return total;
+}
+
+/****************************************************************************
  * Name: sendto_writebuffer_release
  *
  * Description:


### PR DESCRIPTION
## Summary

net/socket: add SO_SNDBUF support
net/wrbuffer: add tcp/udp_wrbuffer_inqueue_size() interface

Reference here:
https://www.freebsd.org/cgi/man.cgi?query=setsockopt&sektion=2&format=html

## Impact

add SO_SNDBUF support to limit the the sharing of iob buffers usage under multiple TCP/UDP connections 

## Testing

iperf client with multiple instance to run the net performance at same time