### PR TITLE
lpc17_40: fixed compiler warnings.

### DIFF
--- a/arch/arm/src/lpc17xx_40xx/lpc176x_rtc.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc176x_rtc.c
@@ -176,30 +176,6 @@ static int rtc_setup(void)
 }
 
 /****************************************************************************
- * Name: rtc_resume
- *
- * Description:
- *   Called when the RTC was already initialized on a previous power cycle.
- *   This just brings the RTC back into full operation.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno on failure
- *
- ****************************************************************************/
-
-static int rtc_resume(void)
-{
-  /* Clear the RTC alarm flags */
-
-#ifdef CONFIG_RTC_ALARM
-#endif
-  return OK;
-}
-
-/****************************************************************************
  * Name: rtc_interrupt
  *
  * Description:
@@ -273,7 +249,7 @@ int up_rtc_initialize(void)
 
   g_rtc_enabled = true;
   rtc_dumpregs("After Initialization");
-  return OK;
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Fixed a couple of compiler warnings in LPC17xx/LPC40xx RTC driver.

1. In `up_rtc_initialize()` variable `ret` was not always used, causing a warning. Now it is returned as it should.
2. The function `rtc_resume()` was neither implemented, nor used anywhere. It was just causing an unused function warning.

## Impact

None.

## Testing

Builds without warnings.

