### PR TITLE
stm32,stm32f7,stm32h7: supported ETH MAC promiscuous mode

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -406,7 +406,6 @@
 
 /* The following bits are set or left zero unconditionally in all modes.
  *
- * ETH_MACFFR_PM   Promiscuous mode         0 (disabled)
  * ETH_MACFFR_HU   Hash unicast             0 (perfect dest filtering)
  * ETH_MACFFR_HM   Hash multicast           0 (perfect dest filtering)
  * ETH_MACFFR_DAIF Destination address      0 (normal)
@@ -421,7 +420,11 @@
  * ETH_MACFFR_RA   Receive all              0 (disabled)
  */
 
-#define MACFFR_SET_BITS (ETH_MACFFR_PCF_PAUSE)
+#ifdef CONFIG_NET_PROMISCUOUS
+#  define MACFFR_SET_BITS (ETH_MACFFR_PCF_PAUSE | ETH_MACFFR_PM)
+#else
+#  define MACFFR_SET_BITS (ETH_MACFFR_PCF_PAUSE)
+#endif
 
 /* Clear the MACFCR bits that will be setup during MAC initialization (or
  * that are cleared unconditionally). Per the reference manual, all reserved

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -400,7 +400,6 @@
 
 /* The following bits are set or left zero unconditionally in all modes.
  *
- * ETH_MACFFR_PM   Promiscuous mode         0 (disabled)
  * ETH_MACFFR_HU   Hash unicast             0 (perfect dest filtering)
  * ETH_MACFFR_HM   Hash multicast           0 (perfect dest filtering)
  * ETH_MACFFR_DAIF Destination address      0 (normal)
@@ -415,7 +414,11 @@
  * ETH_MACFFR_RA   Receive all              0 (disabled)
  */
 
-#define MACFFR_SET_BITS (ETH_MACFFR_PCF_PAUSE)
+#ifdef CONFIG_NET_PROMISCUOUS
+#  define MACFFR_SET_BITS (ETH_MACFFR_PCF_PAUSE | ETH_MACFFR_PM)
+#else
+#  define MACFFR_SET_BITS (ETH_MACFFR_PCF_PAUSE)
+#endif
 
 /* Clear the MACFCR bits that will be setup during MAC initialization (or
  * that are cleared unconditionally). Per the reference manual, all reserved

--- a/arch/arm/src/stm32h7/hardware/stm32_ethernet.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_ethernet.h
@@ -196,11 +196,11 @@
 
 /* Ethernet MAC frame filter register */
 
-#define ETH_MACPFR_PR                (1 << 0)  /* Bit 0: Promiscuous mode */
+#define ETH_MACPFR_PM                (1 << 0)  /* Bit 0: Promiscuous mode */
 #define ETH_MACPFR_HUC               (1 << 1)  /* Bit 1: Hash unicast */
 #define ETH_MACPFR_HMC               (1 << 2)  /* Bit 2: Hash multicast */
 #define ETH_MACPFR_DAIF              (1 << 3)  /* Bit 3: Destination address inverse filtering */
-#define ETH_MACPFR_PM                (1 << 4)  /* Bit 4: Pass all multicast */
+#define ETH_MACPFR_PAM               (1 << 4)  /* Bit 4: Pass all multicast */
 #define ETH_MACPFR_DBF               (1 << 5)  /* Bit 5: Disable broadcast packets */
 #define ETH_MACPFR_PCF_SHIFT         (6)       /* Bits 6-7: Pass control frames */
 #define ETH_MACPFR_PCF_MASK          (3 << ETH_MACPFR_PCF_SHIFT)

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -371,11 +371,11 @@
  * that are cleared unconditionally).  Per the reference manual, all reserved
  * bits must be retained at their reset value.
  *
- * ETH_MACPFR_PR    Bit 0: Promiscuous mode
+ * ETH_MACPFR_PM    Bit 0: Promiscuous mode
  * ETH_MACPFR_HUC   Bit 1: Hash unicast
  * ETH_MACPFR_HMC   Bit 2: Hash multicast
  * ETH_MACPFR_DAIF  Bit 3: Destination address inverse filtering
- * ETH_MACPFR_PM    Bit 4: Pass all multicast
+ * ETH_MACPFR_PAM   Bit 4: Pass all multicast
  * ETH_MACPFR_DBF   Bit 5: Broadcast frames disable
  * ETH_MACPFR_PCF   Bits 6-7: Pass control frames
  * ETH_MACPFR_SAIF  Bit 8: Source address inverse filtering
@@ -388,20 +388,19 @@
  */
 
 #define MACPFR_CLEAR_BITS                                               \
-  (ETH_MACPFR_PR | ETH_MACPFR_HUC | ETH_MACPFR_HMC | ETH_MACPFR_DAIF |  \
-   ETH_MACPFR_PM | ETH_MACPFR_DBF | ETH_MACPFR_PCF_MASK | ETH_MACPFR_SAIF | \
+  (ETH_MACPFR_PM | ETH_MACPFR_HUC | ETH_MACPFR_HMC | ETH_MACPFR_DAIF |  \
+   ETH_MACPFR_PAM | ETH_MACPFR_DBF | ETH_MACPFR_PCF_MASK | ETH_MACPFR_SAIF | \
    ETH_MACPFR_SAF | ETH_MACPFR_HPF | ETH_MACPFR_VTFE | ETH_MACPFR_IPFE | \
    ETH_MACPFR_DNTU | ETH_MACPFR_RA)
 
 /* The following bits are set or left zero unconditionally in all modes.
  *
- * ETH_MACPFR_PR    Promiscuous mode                       0 (disabled)
  * ETH_MACPFR_HUC   Hash unicast                           0 (perfect
  *                                                            dest filtering)
  * ETH_MACPFR_HMC   Hash multicast                         0 (perfect
  *                                                            dest filtering)
  * ETH_MACPFR_DAIF  Destination address inverse filtering  0 (normal)
- * ETH_MACPFR_PM    Pass all multicast                     0 (Depends on HMC
+ * ETH_MACPFR_PAM   Pass all multicast                     0 (Depends on HMC
  *                                                            bit)
  * ETH_MACPFR_DBF   Broadcast frames disable               0 (enabled)
  * ETH_MACPFR_PCF   Pass control frames                    1 (block all but
@@ -413,7 +412,11 @@
  * ETH_MACPFR_RA    Receive all                            0 (disabled)
  */
 
-#define MACPFR_SET_BITS (ETH_MACPFR_PCF_PAUSE)
+#ifdef CONFIG_NET_PROMISCUOUS
+#  define MACPFR_SET_BITS (ETH_MACPFR_PCF_PAUSE | ETH_MACPFR_PM)
+#else
+#  define MACPFR_SET_BITS (ETH_MACPFR_PCF_PAUSE)
+#endif
 
 /* Clear the MACQTXFCR and MACRXFCR bits that will be setup during MAC
  * initialization (or that are cleared unconditionally).  Per the reference


### PR DESCRIPTION
## Summary
Support for ETH MAC promiscuous mode to pass all frames without any filtering e.g. for network monitoring.

## Impact
stm32, stm32f7, stm32h7