### PR TITLE
Fix compilation error when CONFIG_DEBUG_PWM_INFO on stm32h7

### DIFF
--- a/arch/arm/src/stm32h7/stm32_pwm.c
+++ b/arch/arm/src/stm32h7/stm32_pwm.c
@@ -1725,7 +1725,7 @@ static void pwm_modifyreg(struct stm32_pwmtimer_s *priv, uint32_t offset,
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_PWM_INFO
-static void pwm_dumpregs(struct stm32_pwmtimer_s *priv, FAR const char *msg)
+static void pwm_dumpregs(struct pwm_lowerhalf_s *dev, FAR const char *msg)
 {
   FAR struct stm32_pwmtimer_s *priv = (FAR struct stm32_pwmtimer_s *)dev;
 


### PR DESCRIPTION
## Summary
Fix the compilation error because of function ```pwm_dumpregs``` in arch/arm/src/stm32h7/stm32_pwm.c having unmatch definition and declaration.

## Impact

## Testing
1. Configuration: **stm32h747o-disco:nsh**
2. Enable ```Build Setup/Debug Options/PWM Debug features/PWM Informational Output```.
3. Before this commit, there is a compilation error.
```
chip/stm32_pwm.c: In function 'pwm_dumpregs':
chip/stm32_pwm.c:1730:32: error: 'priv' redeclared as different kind of symbol
 1730 |   FAR struct stm32_pwmtimer_s *priv = (FAR struct stm32_pwmtimer_s *)dev; 
```
4. Apply this commit, the build passed.

