### PR TITLE
board/ctrl: add BOARDCTL_UNIQUEKEY support

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3373,6 +3373,22 @@ config BOARDCTL_UNIQUEID_SIZE
 		Provides the size of the memory buffer that must be provided by the
 		caller of board_uniqueid() in which to receive the board unique ID.
 
+config BOARDCTL_UNIQUEKEY
+	bool "Return board unique KEY"
+	default n
+	---help---
+		Enables support for the BOARDIOC_UNIQUEKEY boardctl() command.
+		Architecture specific logic must provide the board_uniquekey()
+		interface.
+
+config BOARDCTL_UNIQUEKEY_SIZE
+	int "Size of the board unique KEY (bytes)"
+	default 16
+	depends on BOARDCTL_UNIQUEKEY
+	---help---
+		Provides the size of the memory buffer that must be provided by the
+		caller of board_uniquekey() in which to receive the board unique KEY.
+
 config BOARDCTL_MKRD
 	bool "Enable application space creation of RAM disks"
 	default n

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -418,6 +418,24 @@ int boardctl(unsigned int cmd, uintptr_t arg)
         break;
 #endif
 
+#ifdef CONFIG_BOARDCTL_UNIQUEKEY
+      /* CMD:           BOARDIOC_UNIQUEKEY
+       * DESCRIPTION:   Return a unique KEY associated with the board (such
+       *                as a trusted key or a private identity).
+       * ARG:           A writable array of size
+       *                CONFIG_BOARDCTL_UNIQUEKEY_SIZE in which to receive
+       *                the board unique KEY.
+       * DEPENDENCIES:  Board logic must provide the board_uniquekey()
+       *                interface.
+       */
+
+      case BOARDIOC_UNIQUEKEY:
+        {
+          ret = board_uniquekey((FAR uint8_t *)arg);
+        }
+        break;
+#endif
+
 #ifdef CONFIG_BOARDCTL_MKRD
       /* CMD:           BOARDIOC_MKRD
        * DESCRIPTION:   Create a RAM disk

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -286,6 +286,31 @@ int board_uniqueid(FAR uint8_t *uniqueid);
 #endif
 
 /****************************************************************************
+ * Name: board_uniquekey
+ *
+ * Description:
+ *   Return a unique KEY associated with the board.  The meaning of this
+ *   unique KEY is not specified.  It may be a trusted key or a private
+ *   identity, etc.  The only requirement is that the length of the
+ *   unique KEY be exactly CONFIG_BOARDCTL_UNIQUEKEY_SIZE in length.
+ *
+ * Input Parameters:
+ *   uniquekey - A reference to a writable memory location provided by the
+ *     caller to receive the board unique KEY.  The memory memory referenced
+ *     by this pointer must be at least CONFIG_BOARDCTL_UNIQUEKEY_SIZE in
+ *     length.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise a negated errno value is
+ *   returned indicating the nature of the failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARDCTL_UNIQUEKEY
+int board_uniquekey(FAR uint8_t *uniquekey);
+#endif
+
+/****************************************************************************
  * Name:  board_timerhook
  *
  * Description:

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -200,6 +200,7 @@
 #define BOARDIOC_NXTERM            _BOARDIOC(0x000f)
 #define BOARDIOC_NXTERM_IOCTL      _BOARDIOC(0x0010)
 #define BOARDIOC_TESTSET           _BOARDIOC(0x0011)
+#define BOARDIOC_UNIQUEKEY         _BOARDIOC(0x0012)
 
 /* If CONFIG_BOARDCTL_IOCTL=y, then board-specific commands will be support.
  * In this case, all commands not recognized by boardctl() will be forwarded


### PR DESCRIPTION
## Summary

board/ctrl: add BOARDCTL_UNIQUEKEY support

Add unique key to support get trusted data from the trusted field

## Impact

boardctl to get the trusted key, certificate, private data, from trusted zone

## Testing

api test