### PR TITLE
drivers/syslog: Avoid prepending process name when no TCB is available

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -206,7 +206,8 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   /* Prepend the process name */
 
   tcb = nxsched_get_tcb(getpid());
-  ret += lib_sprintf(&stream.public, "%s: ", tcb->name);
+  ret += lib_sprintf(&stream.public, "%s: ",
+                     (tcb != NULL) ? tcb->name : "(null)");
 #endif
 
   /* Generate the output */


### PR DESCRIPTION
## Summary
This PR intends to fix a crash that occurs when `CONFIG_SYSLOG_PROCESS_NAME` is enabled and `syslog` is invoked before the TCB is setup for the running task, which results in a NULL-dereference of the TCB pointer on the following line:

https://github.com/apache/incubator-nuttx/blob/13651cde99e7724dfeb36173ed9464efecd46220/sched/init/nx_start.c#L358

## Impact
Fix for an issue that is reproducible when `CONFIG_SYSLOG_PROCESS_NAME` and `CONFIG_DEBUG` were enabled in some specific scenarios.

## Testing
Issue reproduced using `sim:nsh` with the following patch to defconfig:
```patch
diff --git a/boards/sim/sim/sim/configs/nsh/defconfig b/boards/sim/sim/sim/configs/nsh/defconfig
index cc2c542f0d..982d0a7b09 100644
--- a/boards/sim/sim/sim/configs/nsh/defconfig
+++ b/boards/sim/sim/sim/configs/nsh/defconfig
@@ -16,7 +16,13 @@ CONFIG_BOARDCTL_POWEROFF=y
 CONFIG_BOARD_LOOPSPERMSEC=0
 CONFIG_BOOT_RUNFROMEXTSRAM=y
 CONFIG_BUILTIN=y
+CONFIG_DEBUG_ERROR=y
+CONFIG_DEBUG_FEATURES=y
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_SCHED=y
+CONFIG_DEBUG_SCHED_INFO=y
 CONFIG_DEBUG_SYMBOLS=y
+CONFIG_DEBUG_WARN=y
 CONFIG_DEV_LOOP=y
 CONFIG_DEV_ZERO=y
 CONFIG_EXAMPLES_HELLO=y
@@ -52,5 +58,6 @@ CONFIG_SCHED_WAITPID=y
 CONFIG_SDCLONE_DISABLE=y
 CONFIG_START_MONTH=6
 CONFIG_START_YEAR=2008
+CONFIG_SYSLOG_PROCESS_NAME=y
 CONFIG_SYSTEM_NSH=y
 CONFIG_USER_ENTRYPOINT="nsh_main"
```


