### PR TITLE
Implement utime and futimes

### DIFF
--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -171,6 +171,7 @@ int lstat(FAR const char *path, FAR struct stat *buf);
 int fstat(int fd, FAR struct stat *buf);
 int chmod(FAR const char *path, mode_t mode);
 int fchmod(int fd, mode_t mode);
+int futimens(int fd, const struct timespec times[2]);
 
 mode_t umask(mode_t mask);
 

--- a/include/sys/time.h
+++ b/include/sys/time.h
@@ -341,30 +341,32 @@ int setitimer(int which, FAR const struct itimerval *value,
  * Name: utimes
  *
  * Description:
- * The utimes() function shall set the access and modification times of the
- * file pointed to by the path argument to the value of the times argument.
- * utimes() function allows time specifications accurate to the microsecond.
-
- * For utimes(), the times argument is an array of timeval structures. The
- * first array member represents the date and time of last access, and the
- * second member represents the date and time of last modification. The times
- * in the timeval structure are measured in seconds and microseconds since
- * the Epoch, although rounding toward the nearest second may occur.
-
- * If the times argument is a null pointer, the access and modification times
- * of the file shall be set to the current time. The effective user ID of the
- * process shall match the owner of the file, has write access to the file or
- * appropriate privileges to use this call in this manner. Upon completion,
- * utimes() shall mark the time of the last file status change, st_ctime, for
- * update.
+ *   The utimes() function shall set the access and modification times of
+ *   the file pointed to by the path argument to the value of the times
+ *   argument. utimes() function allows time specifications accurate to
+ *   the microsecond.
+ *
+ *   For utimes(), the times argument is an array of timeval structures.
+ *   The first array member represents the date and time of last access,
+ *   and the second member represents the date and time of last
+ *   modification. The times in the timeval structure are measured in
+ *   seconds and microseconds since the Epoch, although rounding toward
+ *   the nearest second may occur.
+ *
+ *   If the times argument is a null pointer, the access and modification
+ *   times of the file shall be set to the current time. The effective
+ *   user ID of the process shall match the owner of the file, has write
+ *   access to the file or appropriate privileges to use this call in this
+ *   manner. Upon completion, utimes() shall mark the time of the last
+ *   file status change, st_ctime, for update.
  *
  * Input Parameters:
  *   path  - Specifies the file to be modified
  *   times - Specifies the time value to set
  *
  * Returned Value:
- *   Upon successful completion, 0 shall be returned. Otherwise, -1 shall be
- *   returned and errno shall be set to indicate the error, and the file
+ *   Upon successful completion, 0 shall be returned. Otherwise, -1 shall
+ *   be returned and errno shall be set to indicate the error, and the file
  *   times shall not be affected.
  *
  ****************************************************************************/
@@ -375,44 +377,21 @@ int utimes(FAR const char *path, const struct timeval times[2]);
  * Name: futimes
  *
  * Description:
- *  futimens() update the timestamps of a file with nanosecond precision.
- *  This contrasts with the historical utime(2) and utimes(2), which permit
- *  only second and microsecond precision, respectively, when setting file
- *  timestamps. With futimens() the file whose timestamps are to be updated
- *  is specified via an open file descriptor, fd.
+ *   futimes() update the timestamps of a file with microsecond precision.
+ *   With futimes() the file whose timestamps are to be updated is specified
+ *   via an open file descriptor, fd.
  *
  * Input Parameters:
  *   fd  - Specifies the fd to be modified
  *   times - Specifies the time value to set
  *
  * Returned Value:
- *   On success, futimens() return 0.
+ *   On success, futimes() return 0.
  *   On error, -1 is returned and errno is set to indicate the error.
  *
  ****************************************************************************/
 
 int futimes(int fd, const struct timeval tv[2]);
-
-/****************************************************************************
- * Name: futimes
- *
- * Description:
- *  futimens() update the timestamps of a file with nanosecond precision.
- *  This contrasts with the historical utime(2) and utimes(2), which permit
- *  only second and microsecond precision, respectively, when setting file
- *  timestamps.
- *
- * Input Parameters:
- *   fd  - Specifies the fd to be modified
- *   times - Specifies the time value to set
- *
- * Returned Value:
- *   On success, futimens() return 0.
- *   On error, -1 is returned and errno is set to indicate the error.
- *
- ****************************************************************************/
-
-int futimens(int fd, const struct timespec times[2]);
 
 /****************************************************************************
  * Name: gethrtime

--- a/include/utime.h
+++ b/include/utime.h
@@ -1,0 +1,81 @@
+/****************************************************************************
+ * include/utime.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_UTIME_H
+#define __INCLUDE_UTIME_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <time.h>
+
+/****************************************************************************
+ * Public Type Definitions
+ ****************************************************************************/
+
+struct utimbuf
+{
+  time_t actime;  /* Access time */
+  time_t modtime; /* Modification time */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: utime
+ *
+ * Description:
+ *   The utime() system call changes the access and modification times of
+ *   the inode specified by path to the actime and modtime fields of times
+ *   respectively.
+ *   If times is NULL, then the access and modification times of the file
+ *   are set to the current time.
+ *
+ * Input Parameters:
+ *   path  - Specifies the file to be modified
+ *   times - Specifies the time value to set
+ *
+ * Returned Value:
+ *   Upon successful completion, 0 shall be returned. Otherwise, -1 shall
+ *   be returned and errno shall be set to indicate the error, and the file
+ *   times shall not be affected.
+ *
+ ****************************************************************************/
+
+int utime(FAR const char *path, FAR const struct utimbuf *times);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __INCLUDE_UTIME_H */

--- a/libs/libc/unistd/Make.defs
+++ b/libs/libc/unistd/Make.defs
@@ -26,7 +26,7 @@ CSRCS += lib_getopt_longonly.c lib_getoptvars.c lib_getoptargp.c
 CSRCS += lib_getopterrp.c lib_getoptindp.c lib_getoptoptp.c
 CSRCS += lib_alarm.c lib_fstatvfs.c lib_statvfs.c lib_sleep.c lib_nice.c
 CSRCS += lib_usleep.c lib_seteuid.c lib_setegid.c lib_geteuid.c lib_getegid.c
-CSRCS += lib_setreuid.c lib_setregid.c lib_getrusage.c lib_utimes.c
+CSRCS += lib_setreuid.c lib_setregid.c lib_getrusage.c lib_utime.c lib_utimes.c
 CSRCS += lib_setrlimit.c lib_getrlimit.c lib_setpriority.c lib_getpriority.c
 CSRCS += lib_futimes.c lib_futimens.c lib_gethostname.c lib_sethostname.c
 

--- a/libs/libc/unistd/lib_futimens.c
+++ b/libs/libc/unistd/lib_futimens.c
@@ -24,11 +24,30 @@
 
 #include <nuttx/config.h>
 
-#include <sys/time.h>
+#include <sys/stat.h>
 #include <errno.h>
 
 /****************************************************************************
  * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: futimens
+ *
+ * Description:
+ *   futimens() update the timestamps of a file with nanosecond precision.
+ *   This contrasts with the historical utime(2) and utimes(2), which permit
+ *   only second and microsecond precision, respectively, when setting file
+ *   timestamps.
+ *
+ * Input Parameters:
+ *   fd  - Specifies the fd to be modified
+ *   times - Specifies the time value to set
+ *
+ * Returned Value:
+ *   On success, futimens() return 0.
+ *   On error, -1 is returned and errno is set to indicate the error.
+ *
  ****************************************************************************/
 
 int futimens(int fd, const struct timespec times[2])

--- a/libs/libc/unistd/lib_futimes.c
+++ b/libs/libc/unistd/lib_futimes.c
@@ -22,10 +22,8 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
-
+#include <sys/stat.h>
 #include <sys/time.h>
-#include <errno.h>
 
 /****************************************************************************
  * Public Functions
@@ -33,6 +31,17 @@
 
 int futimes(int fd, const struct timeval tv[2])
 {
-  set_errno(ENOTSUP);
-  return ERROR;
+  struct timespec times[2];
+
+  if (tv == NULL)
+    {
+      return futimens(fd, NULL);
+    }
+
+  times[0].tv_sec  = tv[0].tv_sec;
+  times[0].tv_nsec = tv[0].tv_usec * 1000;
+  times[1].tv_sec  = tv[1].tv_sec;
+  times[1].tv_nsec = tv[1].tv_usec * 1000;
+
+  return futimens(fd, times);
 }

--- a/libs/libc/unistd/lib_utime.c
+++ b/libs/libc/unistd/lib_utime.c
@@ -1,0 +1,47 @@
+/****************************************************************************
+ * libs/libc/unistd/lib_utime.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <sys/time.h>
+#include <utime.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int utime(FAR const char *path, FAR const struct utimbuf *times)
+{
+  struct timeval timbuf[2];
+
+  if (times == NULL)
+    {
+      return utimes(path, NULL);
+    }
+
+  timbuf[0].tv_sec  = times->actime;
+  timbuf[0].tv_usec = 0;
+  timbuf[1].tv_sec  = times->modtime;
+  timbuf[1].tv_usec = 0;
+
+  return utimes(path, timbuf);
+}


### PR DESCRIPTION
## Summary
libc: Move the declaration of futimens from sys/time.h to sys/stat.h
libc: Implement utime on top of utimes
libc: Implement futimes on top of futimens
Note: the real file system level change will provide in the upcoming patchset.

## Impact
New API

## Testing

