### PR TITLE
fs: pseudorename should call inode_release in the error path

### DIFF
--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -89,6 +89,7 @@ next_subdir:
 
       if (oldinode == newinode)
         {
+          inode_release(newinode);
           ret = OK;
           goto errout; /* Bad naming, this is not an error case. */
         }
@@ -112,6 +113,8 @@ next_subdir:
         {
           FAR char *subdirname;
           FAR char *tmp;
+
+          inode_release(newinode);
 
           /* Yes.. In this case, the target of the rename must be a
            * subdirectory of newinode, not the newinode itself.  For


### PR DESCRIPTION
## Summary
to avoid the memory leak

## Impact
Minor fix

## Testing

