### PR TITLE
LTP: fix stacke overflow in ltp_interfaces_pthread_attr_setstacksize_1_1

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1819,7 +1819,7 @@ config IDLETHREAD_STACKSIZE
 
 config PTHREAD_STACK_MIN
 	int "Minimum pthread stack size"
-	default 256
+	default DEFAULT_TASK_STACKSIZE
 	---help---
 		Minimum pthread stack size
 


### PR DESCRIPTION
## Summary
beause the default value(256) of PTHREAD_STACK_MIN is too small to run a thread.
Let's change PTHREAD_STACK_MIN to DEFAULT_TASK_STACKSIZE(a more safe value).
Here is the code for reference:
https://github.com/linux-test-project/ltp/blob/master/testcases/open_posix_testsuite/conformance/interfaces/pthread_attr_setstacksize/1-1.c

## Impact
pass LTP

## Testing

