### PR TITLE
sched/clock: add nsec range check in clock_settime

### DIFF
--- a/sched/clock/clock_settime.c
+++ b/sched/clock/clock_settime.c
@@ -64,7 +64,8 @@ int clock_settime(clockid_t clock_id, FAR const struct timespec *tp)
    * time clock.
    */
 
-  if (clock_id == CLOCK_REALTIME)
+  if (clock_id == CLOCK_REALTIME &&
+      tp->tv_nsec >= 0 && tp->tv_nsec < 1000000000)
     {
 #ifndef CONFIG_CLOCK_TIMEKEEPING
       /* Interrupts are disabled here so that the in-memory time


### PR DESCRIPTION
## Summary
Return error when tv_nsec <0 or >=1000 million.

## Impact
Minor corner case

## Testing

