### PR TITLE
bcm43xxx: supported IW_AUTH_CIPHER_NONE mode

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -1294,6 +1294,10 @@ int bcmf_wl_set_auth_param(FAR struct bcmf_dev_s *priv, struct iwreq *iwr)
 
           switch (iwr->u.param.value)
             {
+              case IW_AUTH_CIPHER_NONE:
+                cipher_mode = OPEN_AUTH;
+                break;
+
               case IW_AUTH_CIPHER_WEP40:
               case IW_AUTH_CIPHER_WEP104:
                 cipher_mode = WEP_ENABLED;

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -1066,7 +1066,7 @@ int bcmf_wl_start_scan(FAR struct bcmf_dev_s *priv, struct iwreq *iwr)
           /* Scan specific ESSID */
 
           memcpy(scan_params.params.ssid.SSID, req->essid, req->essid_len);
-          scan_params.params.ssid.SSID_len = req->essid_len;
+          scan_params.params.ssid.ssid_len = req->essid_len;
         }
     }
   else
@@ -1428,7 +1428,7 @@ int bcmf_wl_set_ssid(FAR struct bcmf_dev_s *priv, struct iwreq *iwr)
       return -EINVAL;
     }
 
-  ssid.SSID_len = iwr->u.essid.length;
+  ssid.ssid_len = iwr->u.essid.length;
   memcpy(ssid.SSID, iwr->u.essid.pointer, iwr->u.essid.length);
 
   /* Configure AP SSID and trig authentication request */

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_ioctl.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_ioctl.h
@@ -61,7 +61,7 @@ typedef struct wl_action_frame
 {
   struct ether_addr da;
   uint16_t          len;
-  uint32_t          packetId;
+  uint32_t          packet_id;
   uint8_t           data[ACTION_FRAME_SIZE];
 } wl_action_frame_t;
 
@@ -87,7 +87,7 @@ typedef struct wl_bss_info
   struct ether_addr BSSID;
   uint16_t      beacon_period;          /* units are Kusec */
   uint16_t      capability;             /* Capability information */
-  uint8_t       SSID_len;
+  uint8_t       ssid_len;
   uint8_t       SSID[32];
   struct
   {
@@ -123,7 +123,7 @@ typedef struct wl_bss_info
 
 typedef struct wlc_ssid
 {
-  uint32_t SSID_len;
+  uint32_t ssid_len;
   uint8_t  SSID[32];
 } wlc_ssid_t;
 
@@ -1210,13 +1210,13 @@ typedef struct
   uint8_t txpwr_local_constraint;
   uint8_t txpwr_chan_reg_max;
   uint8_t txpwr_target[2][NUM_PWRCTRL_RATES];
-  uint8_t txpwr_est_Pout[2];
+  uint8_t txpwr_est_pout[2];
   uint8_t txpwr_opo[NUM_PWRCTRL_RATES];
   uint8_t txpwr_bphy_cck_max[NUM_PWRCTRL_RATES];
   uint8_t txpwr_bphy_ofdm_max;
   uint8_t txpwr_aphy_max[NUM_PWRCTRL_RATES];
   int8_t txpwr_antgain[2];
-  uint8_t txpwr_est_Pout_gofdm;
+  uint8_t txpwr_est_pout_gofdm;
 } tx_power_legacy_t;
 
 #define WL_TX_POWER_RATES         45
@@ -1246,8 +1246,8 @@ typedef struct
   uint8_t local_constraint;
   int8_t antgain[2];
   uint8_t rf_cores;
-  uint8_t est_Pout[4];
-  uint8_t est_Pout_cck;
+  uint8_t est_pout[4];
+  uint8_t est_pout_cck;
   uint8_t user_limit[WL_TX_POWER_RATES];
   uint8_t reg_limit[WL_TX_POWER_RATES];
   uint8_t board_limit[WL_TX_POWER_RATES];
@@ -1256,8 +1256,8 @@ typedef struct
 
 typedef struct tx_inst_power
 {
-  uint8_t txpwr_est_Pout[2];
-  uint8_t txpwr_est_Pout_gofdm;
+  uint8_t txpwr_est_pout[2];
+  uint8_t txpwr_est_pout_gofdm;
 } tx_inst_power_t;
 
 #define WLC_MEASURE_TPC           1
@@ -2161,18 +2161,18 @@ typedef struct
   uint32_t rxampdu_stbc;
   uint32_t rxmpdu_sgi;
   uint32_t rxmpdu_stbc;
-  uint32_t rxmcs0_40M;
-  uint32_t rxmcs1_40M;
-  uint32_t rxmcs2_40M;
-  uint32_t rxmcs3_40M;
-  uint32_t rxmcs4_40M;
-  uint32_t rxmcs5_40M;
-  uint32_t rxmcs6_40M;
-  uint32_t rxmcs7_40M;
-  uint32_t rxmcs32_40M;
-  uint32_t txfrmsnt_20Mlo;
-  uint32_t txfrmsnt_20Mup;
-  uint32_t txfrmsnt_40M;
+  uint32_t rxmcs0_40;
+  uint32_t rxmcs1_40;
+  uint32_t rxmcs2_40;
+  uint32_t rxmcs3_40;
+  uint32_t rxmcs4_40;
+  uint32_t rxmcs5_40;
+  uint32_t rxmcs6_40;
+  uint32_t rxmcs7_40;
+  uint32_t rxmcs32_40;
+  uint32_t txfrmsnt_20lo;
+  uint32_t txfrmsnt_20up;
+  uint32_t txfrmsnt_40;
   uint32_t rx_20ul;
 } wl_cnt_ext_t;
 #define    WL_RXDIV_STATS_T_VERSION    1
@@ -2687,20 +2687,20 @@ typedef struct wl_rssi_event
 
 typedef struct sta_prbreq_wps_ie_hdr
 {
-  struct ether_addr staAddr;
-  uint16_t ieLen;
+  struct ether_addr sta_addr;
+  uint16_t ie_len;
 } sta_prbreq_wps_ie_hdr_t;
 
 typedef struct sta_prbreq_wps_ie_data
 {
   sta_prbreq_wps_ie_hdr_t hdr;
-  uint8_t ieData[1];
+  uint8_t ie_data[1];
 } sta_prbreq_wps_ie_data_t;
 
 typedef  struct sta_prbreq_wps_ie_list
 {
-  uint32_t totLen;
-  uint8_t ieDataList[1];
+  uint32_t tot_len;
+  uint8_t ie_data_list[1];
 } sta_prbreq_wps_ie_list_t;
 
 /* EDCF related items from 802.11.h */


### PR DESCRIPTION
## Summary
Added support for IW_AUTH_CIPHER_NONE mode. May be useful e.g. for debug purposes or other ones.

## Impact
bcm43xxx