### PR TITLE
smp: fix pid assign issue

### DIFF
--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -390,7 +390,6 @@ void nx_start(void)
 
   /* Initialize the logic that determine unique process IDs. */
 
-  g_lastpid = 0;
   for (i = 0; i < CONFIG_MAX_TASKS; i++)
     {
       g_pidhash[i].tcb = NULL;
@@ -400,7 +399,7 @@ void nx_start(void)
   /* Initialize the IDLE task TCB *******************************************/
 
 #ifdef CONFIG_SMP
-  for (cpu = 0; cpu < CONFIG_SMP_NCPUS; cpu++, g_lastpid++)
+  for (cpu = 0; cpu < CONFIG_SMP_NCPUS; cpu++)
 #endif
     {
       FAR dq_queue_t *tasklist;
@@ -408,9 +407,9 @@ void nx_start(void)
 
       /* Assign the process ID(s) of ZERO to the idle task(s) */
 
-      hashndx                = PIDHASH(g_lastpid);
+      hashndx                = PIDHASH(cpu);
       g_pidhash[hashndx].tcb = &g_idletcb[cpu].cmn;
-      g_pidhash[hashndx].pid = g_lastpid;
+      g_pidhash[hashndx].pid = cpu;
 
       /* Initialize a TCB for this thread of execution.  NOTE:  The default
        * value for most components of the g_idletcb are zero.  The entire
@@ -420,7 +419,7 @@ void nx_start(void)
        */
 
       memset((void *)&g_idletcb[cpu], 0, sizeof(struct task_tcb_s));
-      g_idletcb[cpu].cmn.pid        = g_lastpid;
+      g_idletcb[cpu].cmn.pid        = cpu;
       g_idletcb[cpu].cmn.task_state = TSTATE_TASK_RUNNING;
 
       /* Set the entry point.  This is only for debug purposes.  NOTE: that
@@ -521,6 +520,8 @@ void nx_start(void)
           up_stack_frame(&g_idletcb[cpu].cmn, sizeof(struct task_info_s));
         }
     }
+
+  g_lastpid = cpu ? cpu - 1 : 0;
 
   /* Task lists are initialized */
 


### PR DESCRIPTION
## Summary
smp: fix pid assign issue
example:lack pid:4 when CONFIG_SMP_NCPUS=4
nsh> ps
  PID  PPID CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK COMMAND
    0     0   0   0 FIFO     Kthread N-- Assigned           00000000 000944 CPU0 IDLE
    1     0   1   0 FIFO     Kthread N-- Running            00000000 000000 CPU1 IDLE
    2     0   2   0 FIFO     Kthread N-- Running            00000000 000000 CPU2 IDLE
    3     0   3   0 FIFO     Kthread N-- Running            00000000 000000 CPU3 IDLE
    5     0   0 100 FIFO     Task    --- Running            00000000 065504 init

Change-Id: I30a7e50c418332ec89edfd42473d9bebb2b02bbc
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

