### PR TITLE
syslog/ramlog:  optimize code and fix init issue

### DIFF
--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -209,6 +209,60 @@ static void ramlog_pollnotify(FAR struct ramlog_dev_s *priv,
 }
 
 /****************************************************************************
+ * Name: ramlog_initbuf
+ *
+ * Description:
+ *  Initialize g_sysdev based on the current system ramlog buffer.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_RAMLOG_SYSLOG
+static void ramlog_initbuf(void)
+{
+  FAR struct ramlog_dev_s *priv = &g_sysdev;
+  bool is_empty = true;
+  char prev;
+  char cur;
+  size_t i;
+
+  if (priv->rl_head != CONFIG_RAMLOG_BUFSIZE ||
+      priv->rl_tail != CONFIG_RAMLOG_BUFSIZE)
+    {
+      return;
+    }
+
+  prev = priv->rl_buffer[priv->rl_bufsize - 1];
+
+  for (i = 0; i < priv->rl_bufsize; i++)
+    {
+      cur = priv->rl_buffer[i];
+
+      if (!isascii(cur))
+        {
+          memset(priv->rl_buffer, 0, priv->rl_bufsize);
+          break;
+        }
+      else if (prev && !cur)
+        {
+          priv->rl_head = i;
+          is_empty = false;
+        }
+      else if (!prev && cur)
+        {
+          priv->rl_tail = i;
+        }
+
+      prev = cur;
+    }
+
+  if (i != priv->rl_bufsize || is_empty)
+    {
+      priv->rl_head = priv->rl_tail = 0;
+    }
+}
+#endif
+
+/****************************************************************************
  * Name: ramlog_addchar
  ****************************************************************************/
 
@@ -216,6 +270,13 @@ static int ramlog_addchar(FAR struct ramlog_dev_s *priv, char ch)
 {
   irqstate_t flags;
   size_t nexthead;
+
+#ifdef CONFIG_RAMLOG_SYSLOG
+  if (priv == &g_sysdev)
+    {
+      ramlog_initbuf();
+    }
+#endif
 
   /* Disable interrupts (in case we are NOT called from interrupt handler) */
 
@@ -697,61 +758,6 @@ errout:
 }
 
 /****************************************************************************
- * Name: ramlog_initbuf
- *
- * Description:
- *   Initialize g_sysdev based on the current system ramlog buffer.
- *
- ****************************************************************************/
-
-#ifdef CONFIG_RAMLOG_SYSLOG
-static void ramlog_initbuf(void)
-{
-  FAR struct ramlog_dev_s *priv = &g_sysdev;
-  char prev, cur;
-  size_t i;
-
-  if (priv->rl_head != CONFIG_RAMLOG_BUFSIZE ||
-      priv->rl_tail != CONFIG_RAMLOG_BUFSIZE)
-    {
-      return;
-    }
-
-  prev = priv->rl_buffer[priv->rl_bufsize - 1];
-
-  for (i = 0; i < priv->rl_bufsize; i++)
-    {
-      cur = priv->rl_buffer[i];
-
-      if (!isascii(cur))
-        {
-          goto out;
-        }
-
-      if (prev && !cur)
-        {
-          priv->rl_head = i;
-        }
-
-      if (!prev && cur)
-        {
-          priv->rl_tail = i;
-        }
-
-      prev = cur;
-    }
-
-out:
-  if (i != priv->rl_bufsize)
-    {
-      priv->rl_head = 0;
-      priv->rl_tail = 0;
-      memset(priv->rl_buffer, 0, priv->rl_bufsize);
-    }
-}
-#endif
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -839,8 +845,6 @@ int ramlog_putc(FAR struct syslog_channel_s *channel, int ch)
   int ret;
 
   UNUSED(channel);
-
-  ramlog_initbuf();
 
   /* Add the character to the RAMLOG */
 

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -347,7 +347,8 @@ ssize_t syslog_rpmsg_write(FAR struct syslog_channel_s *channel,
 void syslog_rpmsg_init_early(FAR void *buffer, size_t size)
 {
   FAR struct syslog_rpmsg_s *priv = &g_syslog_rpmsg;
-  char prev, cur;
+  char prev;
+  char cur;
   size_t i;
   size_t j;
 
@@ -364,15 +365,14 @@ void syslog_rpmsg_init_early(FAR void *buffer, size_t size)
 
           if (!isascii(cur))
             {
-              goto out;
+              memset(priv->buffer, 0, size);
+              break;
             }
-
-          if (prev && !cur)
+          else if (prev && !cur)
             {
               priv->head = C2B(i) + j;
             }
-
-          if (!prev && cur)
+          else if (!prev && cur)
             {
               priv->tail = i;
             }
@@ -381,11 +381,9 @@ void syslog_rpmsg_init_early(FAR void *buffer, size_t size)
         }
     }
 
-out:
   if (i != size)
     {
       priv->head = priv->tail = 0;
-      memset(priv->buffer, 0, size);
     }
 }
 


### PR DESCRIPTION
## Summary
ramlog: init head and tail when buffer is empty on boot
syslog: optimize init logic for early buffer initialize
## Impact
normal loading log from ramlog and syslog buffer
## Testing
daily test
