### PR TITLE
fs: fstat shouldn't follow the symbol link

### DIFF
--- a/fs/vfs/fs_fstat.c
+++ b/fs/vfs/fs_fstat.c
@@ -200,7 +200,7 @@ int file_fstat(FAR struct file *filep, FAR struct stat *buf)
         {
           /* The inode is part of the root pseudo file system. */
 
-          ret = inode_stat(inode, buf, 1);
+          ret = inode_stat(inode, buf, 0);
         }
     }
 


### PR DESCRIPTION
## Summary
since the decision is already done at open time(from path to fd)

## Impact
How file_stat handle the psuedo soft link

## Testing

