### PR TITLE
vfs: stat_recursive should return -ENOSYS if stat callback is NULL

### DIFF
--- a/fs/vfs/fs_stat.c
+++ b/fs/vfs/fs_stat.c
@@ -120,6 +120,10 @@ static int stat_recursive(FAR const char *path,
 
           ret = inode->u.i_mops->stat(inode, desc.relpath, buf);
         }
+      else
+        {
+          ret = -ENOSYS;
+        }
     }
   else
 #endif


### PR DESCRIPTION
## Summary

## Impact
Minor change for the corner case

## Testing

