### PR TITLE
libc/sysconf: Add MONOTONIC_CLOCK for consistency

### DIFF
--- a/libs/libc/unistd/lib_sysconf.c
+++ b/libs/libc/unistd/lib_sysconf.c
@@ -225,6 +225,13 @@ long sysconf(int name)
         return 1;
 #endif
 
+      case _SC_MONOTONIC_CLOCK:
+#ifdef CONFIG_CLOCK_MONOTONIC
+        return 1;
+#else
+        return 0;
+#endif
+
       case _SC_PAGESIZE:
 #ifdef CONFIG_MM_PGSIZE
         return CONFIG_MM_PGSIZE;


### PR DESCRIPTION
## Summary
Add _SC_MONOTONIC_CLOCK to sysconf when CONFIG_CLOCK_MONOTONIC is set

## Impact
New functionality

## Testing

