### PR TITLE
nuttx net warning:add initialization of pointer *aiocbp in lio_listio

### DIFF
--- a/libs/libc/aio/lio_listio.c
+++ b/libs/libc/aio/lio_listio.c
@@ -507,7 +507,7 @@ static int lio_waitall(FAR struct aiocb * const *list, int nent)
 int lio_listio(int mode, FAR struct aiocb * const list[], int nent,
                FAR struct sigevent *sig)
 {
-  FAR struct aiocb *aiocbp;
+  FAR struct aiocb *aiocbp = NULL;
   int nqueued;
   int errcode;
   int retcode;

--- a/libs/libc/debug/lib_backtrace.c
+++ b/libs/libc/debug/lib_backtrace.c
@@ -44,7 +44,7 @@ struct trace_arg
  * Private Functions
  ****************************************************************************/
 
-static inline weak_function
+weak_function
 FAR void *unwind_arch_adjustment(FAR void *prev, FAR void *addr)
 {
   return addr;


### PR DESCRIPTION
## Summary
and nuttx net warning:cancel the conflict between weak and inline in unwind_arch_adjustment

## Impact
Warning fix

## Testing

