### PR TITLE
serial: add ctrl+@ to force crash system for debugging

### DIFF
--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -173,6 +173,21 @@ config SERIAL_TERMIOS
 		If this is not defined, then the terminal settings (baud, parity, etc).
 		are not configurable at runtime; serial streams cannot be flushed, etc..
 
+config TTY_FORCE_PANIC
+	bool "Enable TTY force crash"
+	default n
+	depends on DEBUG_FEATURES
+	---help---
+		This is for debugging system busyloop or deadlock, when the shell can't run,
+		then use this force crash the system to see the dumplog.
+
+config TTY_FORCE_PANIC_CHAR
+	hex "TTY force crash characters"
+	default 0x0
+	depends on TTY_FORCE_PANIC
+	---help---
+		Use Ctrl-@  NULL(0x0) inputs to determine whether panic system
+
 config TTY_SIGINT
 	bool "Support SIGINT"
 	default n

--- a/drivers/serial/serial_io.c
+++ b/drivers/serial/serial_io.c
@@ -28,6 +28,7 @@
 #  include <nuttx/irq.h>
 #endif
 
+#include <assert.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <debug.h>
@@ -237,6 +238,17 @@ void uart_recvchars(FAR uart_dev_t *dev)
 
               signo = SIGTSTP;
             }
+        }
+      else
+#endif
+#ifdef CONFIG_TTY_FORCE_PANIC
+      /* Is this the special character that will generate the SIGTSTP
+       * signal?
+       */
+
+      if ((dev->tc_lflag & ISIG) && ch == CONFIG_TTY_FORCE_PANIC_CHAR)
+        {
+          PANIC();
         }
       else
 #endif


### PR DESCRIPTION

## Summary

serial: add ctrl+@ to force crash system for debugging

For debugging system, sometime shell blocked (dealock or busyloop), then we want see all the thread running location,
then we can force crash the system
So there is the patch, force crash the system & get dump log by check one specific CHAR in uart irq handler.

## Impact

## Testing

