### PR TITLE
profs: Print StackAlloc by procfs_snprintf

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -171,6 +171,7 @@ static void meminfo_progmem(FAR struct progmem_info_s *progmem)
             }
 
           progmem->fordblks += pagesize;
+          progmem->ordblks++;
         }
       else if (status != 0)
         {

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -894,7 +894,7 @@ static ssize_t proc_stack(FAR struct proc_file_s *procfile,
 
   /* Show the stack alloc address */
 
-  linesize   = snprintf(procfile->line, STATUS_LINELEN, "%-12s%p\n",
+  linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN, "%-12s%p\n",
                                "StackAlloc:", tcb->stack_alloc_ptr);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                              &offset);
@@ -1010,7 +1010,7 @@ static ssize_t proc_groupstatus(FAR struct proc_file_s *procfile,
   linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN, "%-12s%d\n",
                                "Members:", group->tg_nmembers);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer,
-                            remaining, &offset);
+                             remaining, &offset);
 
   totalsize += copysize;
   buffer    += copysize;


### PR DESCRIPTION
## Summary
since snprintf return the wrong number in case of insufficient buffer

## Impact
Minor fix

## Testing

