### PR TITLE
net/tcp: only print the error when disable the TCP_NODELAY

### DIFF
--- a/net/tcp/tcp_getsockopt.c
+++ b/net/tcp/tcp_getsockopt.c
@@ -139,8 +139,20 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
         break;
 
       case TCP_NODELAY:  /* Avoid coalescing of small segments. */
-        nerr("ERROR: TCP_NODELAY not supported\n");
-        ret = -ENOSYS;
+        if (*value_len < sizeof(int))
+          {
+            ret                = -EINVAL;
+          }
+        else
+          {
+            FAR int *nodelay   = (FAR int *)value;
+
+            /* Always true here since we do not support Nagle. */
+
+            *nodelay           = 1;
+            *value_len         = sizeof(int);
+            ret                = OK;
+          }
         break;
 
       case TCP_KEEPIDLE:  /* Start keepalives after this IDLE period */

--- a/net/tcp/tcp_setsockopt.c
+++ b/net/tcp/tcp_setsockopt.c
@@ -133,8 +133,24 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
         break;
 
       case TCP_NODELAY: /* Avoid coalescing of small segments. */
-        nerr("ERROR: TCP_NODELAY not supported\n");
-        ret = -ENOSYS;
+        if (value_len != sizeof(int))
+          {
+            ret = -EDOM;
+          }
+        else
+          {
+            int nodelay = *(FAR int *)value;
+
+            if (nodelay)
+              {
+                ret = OK;
+              }
+            else
+              {
+                nerr("ERROR: TCP_NODELAY not supported\n");
+                ret = -ENOSYS;
+              }
+          }
         break;
 
       case TCP_KEEPIDLE:  /* Start keepalives after this IDLE period */


### PR DESCRIPTION
## Summary
Since we do not have the Nagle's algorithm,
the TCP_NODELAY socket option is enabled by default.

## Impact

## Testing

