### PR TITLE
libc/string: Skip compile the c version when the optimization is enabled

### DIFF
--- a/libs/libc/string/Make.defs
+++ b/libs/libc/string/Make.defs
@@ -21,19 +21,25 @@
 # Add the string C files to the build
 
 CSRCS += lib_ffs.c lib_ffsl.c lib_ffsll.c lib_fls.c lib_flsl.c
-CSRCS += lib_flsll.c lib_isbasedigit.c lib_memset.c lib_memchr.c
-CSRCS += lib_memccpy.c lib_memcmp.c lib_memmove.c lib_memrchr.c
+CSRCS += lib_flsll.c lib_isbasedigit.c lib_memccpy.c lib_memrchr.c
 CSRCS += lib_popcount.c lib_popcountl.c lib_popcountll.c
 CSRCS += lib_skipspace.c lib_stpcpy.c lib_stpncpy.c lib_strcasecmp.c
-CSRCS += lib_strcat.c lib_strchr.c lib_strcpy.c lib_strcmp.c lib_strcspn.c
-CSRCS += lib_strdup.c lib_strerror.c lib_strlen.c lib_strnlen.c
-CSRCS += lib_strncasecmp.c lib_strncat.c lib_strncmp.c lib_strncpy.c
+CSRCS += lib_strcat.c lib_strcspn.c lib_strdup.c lib_strerror.c
+CSRCS += lib_strncasecmp.c lib_strncat.c lib_strncmp.c
 CSRCS += lib_strndup.c lib_strcasestr.c lib_strpbrk.c lib_strrchr.c
 CSRCS += lib_strspn.c lib_strstr.c lib_strtok.c lib_strtokr.c
 CSRCS += lib_strsep.c lib_strerrorr.c lib_explicit_bzero.c lib_strsignal.c
 CSRCS += lib_anbstr2cstr.c lib_ancstr2bstr.c lib_bmem2cmem.c
 CSRCS += lib_bstrnlen.c lib_cmem2bmem.c lib_nbstr2cstr.c lib_ncstr2bstr.c
-CSRCS += lib_index.c lib_rindex.c lib_strlcpy.c
+CSRCS += lib_index.c lib_rindex.c
+
+ifneq ($(CONFIG_LIBC_ARCH_MEMCHR),y)
+CSRCS += lib_memchr.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_MEMCMP),y)
+CSRCS += lib_memcmp.c
+endif
 
 ifneq ($(CONFIG_LIBC_ARCH_MEMCPY),y)
 ifeq ($(CONFIG_MEMCPY_VIK),y)
@@ -41,6 +47,42 @@ CSRCS += lib_vikmemcpy.c
 else
 CSRCS += lib_memcpy.c
 endif
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_MEMMOVE),y)
+CSRCS += lib_memmove.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_MEMSET),y)
+CSRCS += lib_memset.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_STRCHR),y)
+CSRCS += lib_strchr.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_STRCMP),y)
+CSRCS += lib_strcmp.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_STRCPY),y)
+CSRCS += lib_strcpy.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_STRLCPY),y)
+CSRCS += lib_strlcpy.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_STRLEN),y)
+CSRCS += lib_strlen.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_STRNCPY),y)
+CSRCS += lib_strncpy.c
+endif
+
+ifneq ($(CONFIG_LIBC_ARCH_STRNLEN),y)
+CSRCS += lib_strnlen.c
 endif
 
 ifeq ($(CONFIG_LIBC_LOCALE),y)


### PR DESCRIPTION
## Summary
To avoid the symbol duplication linker error

## Impact
Change Makefile only

## Testing

