### PR TITLE
boards/xtensa/esp32: Add license headers to the linker script files and correct some old names.

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.ld
@@ -1,5 +1,21 @@
 /****************************************************************************
  * boards/xtensa/esp32/esp32-devkitc/scripts/esp32.ld
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
  ****************************************************************************/
 
 /* Default entry point: */

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
@@ -1,15 +1,34 @@
 /****************************************************************************
  * boards/xtensa/esp32/esp32-devkitc/scripts/esp32.template.ld
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
  * ESP32 Linker Script Memory Layout
  *
  * This file describes the memory layout (memory blocks) as virtual
  * memory addresses.
  *
- * esp32.common.ld contains output sections to link compiler output
+ * esp32.ld contains output sections to link compiler output
  * into these memory blocks.
  *
  * NOTE: That this is not the actual linker script but rather a "template"
- * for the elf32_out.ld script.  This template script is passed through
+ * for the esp32_out.ld script.  This template script is passed through
  * the C preprocessor to include selected configuration options.
  *
  ****************************************************************************/

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.ld
@@ -1,5 +1,21 @@
 /****************************************************************************
  * boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.ld
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
  ****************************************************************************/
 
 /* Default entry point: */

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
@@ -1,15 +1,34 @@
 /****************************************************************************
  * boards/xtensa/esp32/esp32-ethernet-kit/scripts/esp32.template.ld
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
  * ESP32 Linker Script Memory Layout
  *
  * This file describes the memory layout (memory blocks) as virtual
  * memory addresses.
  *
- * esp32.common.ld contains output sections to link compiler output
+ * esp32.ld contains output sections to link compiler output
  * into these memory blocks.
  *
  * NOTE: That this is not the actual linker script but rather a "template"
- * for the elf32_out.ld script.  This template script is passed through
+ * for the esp32_out.ld script.  This template script is passed through
  * the C preprocessor to include selected configuration options.
  *
  ****************************************************************************/

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.ld
@@ -1,5 +1,21 @@
 /****************************************************************************
  * boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.ld
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
  ****************************************************************************/
 
 /* Default entry point: */

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
@@ -1,15 +1,34 @@
 /****************************************************************************
  * boards/xtensa/esp32/esp32-wrover-kit/scripts/esp32.template.ld
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
  * ESP32 Linker Script Memory Layout
  *
  * This file describes the memory layout (memory blocks) as virtual
  * memory addresses.
  *
- * esp32.common.ld contains output sections to link compiler output
+ * esp32.ld contains output sections to link compiler output
  * into these memory blocks.
  *
  * NOTE: That this is not the actual linker script but rather a "template"
- * for the elf32_out.ld script.  This template script is passed through
+ * for the esp32_out.ld script.  This template script is passed through
  * the C preprocessor to include selected configuration options.
  *
  ****************************************************************************/


### PR DESCRIPTION
## Summary
Add license headers to the linker script files in ESP32 boards.
## Impact
ESP32 boards
## Testing
All of ESP32 defconfig.
