### PR TITLE
rptun: fix compile break when disable openamp

### DIFF
--- a/include/nuttx/rptun/openamp.h
+++ b/include/nuttx/rptun/openamp.h
@@ -26,10 +26,11 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <openamp/open_amp.h>
-#include <openamp/remoteproc_loader.h>
 
 #ifdef CONFIG_RPTUN
+
+#include <openamp/open_amp.h>
+#include <openamp/remoteproc_loader.h>
 
 /****************************************************************************
  * Public Types


### PR DESCRIPTION
## Summary
rptun: fix compile break when disable openamp

Change-Id: I63251524d94fae43bfb0a71c324d55bf91d363f8
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

