### PR TITLE
tcp_send_buffered.c: Fix broken retransmit

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -506,7 +506,7 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
                   ninfo("ACK: wrb=%p trim %u bytes\n", wrb, trimlen);
 
                   TCP_WBTRIM(wrb, trimlen);
-                  TCP_WBSEQNO(wrb) = ackno;
+                  TCP_WBSEQNO(wrb) += trimlen;
                   TCP_WBSENT(wrb) -= trimlen;
 
                   /* Set the new sequence number for what remains */
@@ -571,7 +571,7 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           /* Trim the ACKed bytes from the beginning of the write buffer. */
 
           TCP_WBTRIM(wrb, nacked);
-          TCP_WBSEQNO(wrb) = ackno;
+          TCP_WBSEQNO(wrb) += nacked;
           TCP_WBSENT(wrb) -= nacked;
 
           ninfo("ACK: wrb=%p seqno=%" PRIu32 " pktlen=%u sent=%u\n",


### PR DESCRIPTION
## Summary

With an applictation using mbedtls, I observed retransmitted segments
with corrupted user data, detected by the peer tls during mac processing.

Looking at the packet dump, I suspect that a wrb which has been put back
onto the write_q for retransmission was partially sent but fully acked.
Note: it's normal for a retransmission to be acked before sent.

In that case, the bug fixed in this commit would cause the wrb have
a wrong sequence number, possibly the same as the next wrb. It matches
what I saw in the packet dump. That is, the broken segments contain the
payload identical to one of the previous segment.

## Impact

tcp

## Testing

tested with some of other patches in https://github.com/apache/incubator-nuttx/pull/4184
on esp32 and sim