### PR TITLE
group/child_status: Dynamically expand group child_status

### DIFF
--- a/sched/group/group_childstatus.c
+++ b/sched/group/group_childstatus.c
@@ -156,8 +156,7 @@ void task_initialize(void)
  *
  * Returned Value:
  *   On success, a non-NULL pointer to a child status structure.  NULL is
- *   returned if there are no remaining, pre-allocated child status
- *   structures.
+ *   returned when memory allocation fails.
  *
  * Assumptions:
  *   Called during task creation in a safe context.  No special precautions
@@ -176,6 +175,10 @@ FAR struct child_status_s *group_alloc_child(void)
     {
       g_child_pool.freelist = ret->flink;
       ret->flink            = NULL;
+    }
+  else
+    {
+      ret = kmm_zalloc(sizeof(*ret));
     }
 
   return ret;


### PR DESCRIPTION
## Summary
This patch is associated with PR: https://github.com/apache/incubator-nuttx/pull/4117.

Before PR:https://github.com/apache/incubator-nuttx/pull/4117, The CONFIG_PREALLOC_CHILDSTATUS's default value  is 2 *CONFIG_MAX_TASKS if no one set CONFIG_PREALLOC_CHILDSTATUS. But now if no one has set it, CONFIG_PREALLOC_CHILDSTATUS is 16, it may be small for some case, so we need to expand group child status pool dynamically.

Change-Id: I4033e93b6adceb01eebe1c2a12ffe8737042b1a6
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact

## Testing
daily test.
