### PR TITLE
sched/init: initialize all idle thread's tl_task

### DIFF
--- a/arch/sim/src/sim/up_cpuidlestack.c
+++ b/arch/sim/src/sim/up_cpuidlestack.c
@@ -78,10 +78,5 @@
 
 int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
 {
-  /* REVISIT:  I don't think anything is needed here */
-
-  tcb->adj_stack_size  = 0;
-  tcb->stack_alloc_ptr = NULL;
-  tcb->stack_base_ptr   = NULL;
-  return OK;
+  return up_create_stack(tcb, stack_size, TCB_FLAG_TTYPE_KERNEL);
 }

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -165,16 +165,15 @@ void sim_sigdeliver(void);
 
 #ifdef CONFIG_SMP
 void sim_cpu0_start(void);
+int sim_cpu_start(int cpu, void *stack, size_t size);
+void sim_send_ipi(int cpu);
 #endif
 
 /* up_smpsignal.c ***********************************************************/
 
 #ifdef CONFIG_SMP
 void up_cpu_started(void);
-int up_cpu_paused(int cpu);
-struct tcb_s *up_this_task(void);
 int up_cpu_set_pause_handler(int irq);
-void sim_send_ipi(int cpu);
 #endif
 
 /* up_oneshot.c *************************************************************/

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1800,6 +1800,7 @@ config DEFAULT_TASK_STACKSIZE
 
 config IDLETHREAD_STACKSIZE
 	int "Idle thread stack size"
+	default DEFAULT_TASK_STACKSIZE if ARCH_SIM
 	default 1024
 	---help---
 		The size of the initial stack used by the IDLE thread.  The IDLE thread

--- a/sched/init/nx_smpstart.c
+++ b/sched/init/nx_smpstart.c
@@ -34,7 +34,6 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/sched.h>
 #include <nuttx/sched_note.h>
-#include <nuttx/tls.h>
 
 #include "group/group.h"
 #include "sched/sched.h"
@@ -113,31 +112,7 @@ int nx_smp_start(void)
   int ret;
   int cpu;
 
-  /* Create a stack for all CPU IDLE threads (except CPU0 which already has
-   * a stack).
-   */
-
-  for (cpu = 1; cpu < CONFIG_SMP_NCPUS; cpu++)
-    {
-      FAR struct tcb_s *tcb = current_task(cpu);
-      DEBUGASSERT(tcb != NULL);
-
-      ret = up_cpu_idlestack(cpu, tcb, CONFIG_IDLETHREAD_STACKSIZE);
-      if (ret < 0)
-        {
-          serr("ERROR: Failed to allocate stack for CPU%d\n", cpu);
-          return ret;
-        }
-
-      /* Initialize the processor-specific portion of the TCB */
-
-      up_initial_state(tcb);
-      up_stack_frame(tcb, sizeof(struct task_info_s));
-    }
-
-  /* Then start all of the other CPUs after we have completed the memory
-   * allocations.  CPU0 is already running.
-   */
+  /* Start all of the other CPUs.  CPU0 is already running. */
 
   for (cpu = 1; cpu < CONFIG_SMP_NCPUS; cpu++)
     {

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -67,11 +67,9 @@
 #  define CONFIG_SMP_NCPUS       1
 #endif
 
-#ifdef CONFIG_SMP
 /* This set of all CPUs */
 
-#  define SCHED_ALL_CPUS         ((1 << CONFIG_SMP_NCPUS) - 1)
-#endif /* CONFIG_SMP */
+#define SCHED_ALL_CPUS           ((1 << CONFIG_SMP_NCPUS) - 1)
 
 /****************************************************************************
  * Public Data
@@ -422,12 +420,7 @@ void nx_start(void)
                                 TCB_FLAG_NONCANCELABLE |
                                 TCB_FLAG_CPU_LOCKED);
       g_idletcb[i].cmn.cpu   = i;
-#else
-      g_idletcb[i].cmn.flags = (TCB_FLAG_TTYPE_KERNEL |
-                                TCB_FLAG_NONCANCELABLE);
-#endif
 
-#ifdef CONFIG_SMP
       /* Set the affinity mask to allow the thread to run on all CPUs.  No,
        * this IDLE thread can only run on its assigned CPU.  That is
        * enforced by the TCB_FLAG_CPU_LOCKED which overrides the affinity
@@ -437,6 +430,9 @@ void nx_start(void)
        */
 
       g_idletcb[i].cmn.affinity = SCHED_ALL_CPUS;
+#else
+      g_idletcb[i].cmn.flags = (TCB_FLAG_TTYPE_KERNEL |
+                                TCB_FLAG_NONCANCELABLE);
 #endif
 
 #if CONFIG_TASK_NAME_SIZE > 0
@@ -449,7 +445,6 @@ void nx_start(void)
       strncpy(g_idletcb[i].cmn.name, g_idlename, CONFIG_TASK_NAME_SIZE);
       g_idletcb[i].cmn.name[CONFIG_TASK_NAME_SIZE] = '\0';
 #  endif
-#endif
 
       /* Configure the task name in the argument list.  The IDLE task does
        * not really have an argument list, but this name is still useful
@@ -459,7 +454,6 @@ void nx_start(void)
        * stack and there is no support that yet.
        */
 
-#if CONFIG_TASK_NAME_SIZE > 0
       g_idleargv[i][0]  = g_idletcb[i].cmn.name;
 #else
       g_idleargv[i][0]  = (FAR char *)g_idlename;


### PR DESCRIPTION
## Summary
since this patch(#4048) forget to initialize the idle tls info:
```
commit 50c08bf
Author: Huang Qi <huangqi3@xiaomi.com>
Date:   Tue Jun 29 16:01:02 2021 +0800

    libc: Move pthread_key_destructor to task_info_s
```
## Impact
Fix the crash in the boot by #4118.

## Testing
pass ostest both up and smp config for device and sim.
