### PR TITLE
risc-v/esp32c3: Fix some ESP32-C3 Wi-Fi driver issues

### DIFF
--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -179,7 +179,7 @@ endif
 
 ifeq ($(CONFIG_ESP32C3_WIRELESS),y)
 WIRELESS_DRV_UNPACK  = esp-wireless-drivers-3rdparty
-WIRELESS_DRV_ID      = df1f8c1
+WIRELESS_DRV_ID      = 024420d
 WIRELESS_DRV_ZIP     = $(WIRELESS_DRV_ID).zip
 WIRELESS_DRV_URL     = https://github.com/espressif/esp-wireless-drivers-3rdparty/archive
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -6494,18 +6494,43 @@ int esp_wifi_softap_password(struct iwreq *iwr, bool set)
       return wifi_errno_trans(ret);
     }
 
-  ext   = (struct iw_encode_ext *)(iwr->u.encoding.pointer);
   pdata = (uint8_t *)(ext + 1);
   len   = ext->key_len;
-
   if (set)
     {
       wifi_cfg.ap.max_connection = ESP_MAX_STA_CONN;
       memset(wifi_cfg.ap.password, 0x0, PWD_MAX_LEN);
-      memcpy(wifi_cfg.ap.password, pdata, len);
       if (len)
         {
-          wifi_cfg.ap.authmode = WIFI_AUTH_WPA_WPA2_PSK;
+          memcpy(wifi_cfg.ap.password, pdata, len);
+          switch (ext->alg)
+            {
+              case IW_ENCODE_ALG_NONE:
+                wifi_cfg.ap.authmode = WIFI_AUTH_OPEN;
+                break;
+
+              case IW_ENCODE_ALG_WEP:
+                wifi_cfg.ap.authmode = WIFI_AUTH_WEP;
+                break;
+
+              case IW_ENCODE_ALG_TKIP:
+                wifi_cfg.ap.authmode = WIFI_AUTH_WPA_PSK;
+                break;
+
+              case IW_ENCODE_ALG_CCMP:
+                wifi_cfg.ap.authmode = WIFI_AUTH_WPA2_PSK;
+                break;
+
+              case IW_ENCODE_ALG_PMK:
+              case IW_ENCODE_ALG_AES_CMAC:
+                wifi_cfg.ap.authmode = WIFI_AUTH_WPA_WPA2_PSK;
+                break;
+
+              default:
+                wlerr("ERROR: Failed to transfer wireless authmode: %d",
+                      ext->alg);
+                return -EINVAL;
+            }
         }
 
       ret = esp_wifi_set_config(WIFI_IF_AP, &wifi_cfg);
@@ -6588,7 +6613,7 @@ int esp_wifi_softap_essid(struct iwreq *iwr, bool set)
     {
       memset(wifi_cfg.ap.ssid, 0x0, SSID_MAX_LEN);
       memcpy(wifi_cfg.ap.ssid, pdata, len);
-
+      wifi_cfg.ap.ssid_len = len;
       ret = esp_wifi_set_config(WIFI_IF_AP, &wifi_cfg);
       if (ret)
         {
@@ -6808,11 +6833,14 @@ int esp_wifi_softap_auth(struct iwreq *iwr, bool set)
             return -EINVAL;
         }
 
-      ret = esp_wifi_set_config(WIFI_IF_AP, &wifi_cfg);
-      if (ret)
+      if (wifi_cfg.ap.authmode == WIFI_AUTH_OPEN)
         {
-          wlerr("ERROR: Failed to set Wi-Fi config data ret=%d\n", ret);
-          return wifi_errno_trans(ret);
+          ret = esp_wifi_set_config(WIFI_IF_AP, &wifi_cfg);
+          if (ret)
+            {
+              wlerr("ERROR: Failed to set Wi-Fi config data ret=%d\n", ret);
+              return wifi_errno_trans(ret);
+            }
         }
     }
   else

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.c
@@ -158,8 +158,7 @@ int esp_wifi_start_scan(struct iwreq *iwr)
           config->ssid[req->essid_len] = '\0';
         }
 
-      if (iwr->u.data.flags & IW_SCAN_THIS_FREQ &&
-          req->num_channels > 0)
+      if (req->num_channels > 0)
         {
           /* Scan specific channels */
 
@@ -364,6 +363,7 @@ void esp_wifi_scan_event_parse(void)
     {
       priv->scan_status = ESP_SCAN_DONE;
       wlinfo("INFO: None AP is scanned\n");
+      nxsem_post(&priv->scan_signal);
       return;
     }
 
@@ -372,6 +372,7 @@ void esp_wifi_scan_event_parse(void)
     {
       priv->scan_status = ESP_SCAN_DONE;
       wlerr("ERROR: Failed to calloc buffer to print scan results");
+      nxsem_post(&priv->scan_signal);
       return;
     }
 


### PR DESCRIPTION
## Summary
Fix some ESP32-C3 Wi-Fi driver issues

1. Fix nvs init status issue.
2. No need to wait for timeout after scanning is completed.
3. Fix the issue of `ssid` being intercepted in softap mode.

## Impact

## Testing

