### PR TITLE
mtd: Add MTDIOC_ERASESTATE command for retrieving erase state value

### DIFF
--- a/arch/arm/src/lpc43xx/lpc43_spifi.c
+++ b/arch/arm/src/lpc43xx/lpc43_spifi.c
@@ -895,6 +895,15 @@ static int lpc43_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = SPIFI_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       case MTDIOC_XIPBASE:
       default:
         ret = -ENOTTY; /* Bad command */

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -74,6 +74,7 @@
 
 #define SPI_FLASH_BLK_SIZE          256
 #define SPI_FLASH_ERASE_SIZE        4096
+#define SPI_FLASH_ERASED_STATE      (0xff)
 #define SPI_FLASH_SIZE              (4 * 1024 * 1024)
 
 #define ESP32C3_MTD_OFFSET          CONFIG_ESP32C3_MTD_OFFSET
@@ -872,6 +873,15 @@ static int esp32c3_ioctl(struct mtd_dev_s *dev, int cmd,
                     " neraseblocks: %" PRId32 "\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }
+        }
+        break;
+
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = SPI_FLASH_ERASED_STATE;
+
+          ret = OK;
         }
         break;
 

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -69,6 +69,7 @@
 
 #define SPI_FLASH_ENCRYPT_UNIT_SIZE (32)
 #define SPI_FLASH_ENCRYPT_WORDS     (32 / 4)
+#define SPI_FLASH_ERASED_STATE      (0xff)
 
 #define ESP32_MTD_OFFSET            CONFIG_ESP32_MTD_OFFSET
 #define ESP32_MTD_SIZE              CONFIG_ESP32_MTD_SIZE
@@ -1930,6 +1931,15 @@ static int esp32_ioctl(FAR struct mtd_dev_s *dev, int cmd,
               finfo("blocksize: %d erasesize: %d neraseblocks: %d\n",
                     geo->blocksize, geo->erasesize, geo->neraseblocks);
             }
+        }
+        break;
+
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = SPI_FLASH_ERASED_STATE;
+
+          ret = OK;
         }
         break;
 

--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -449,6 +449,15 @@ static int filemtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = CONFIG_FILEMTD_ERASESTATE;
+
+          ret = OK;
+        }
+        break;
+
       default:
         ret = -ENOTTY; /* Bad command */
         break;

--- a/drivers/mtd/gd25.c
+++ b/drivers/mtd/gd25.c
@@ -957,6 +957,15 @@ static int gd25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = GD25_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       case MTDIOC_XIPBASE:
       default:
         ret = -ENOTTY;

--- a/drivers/mtd/mx25lx.c
+++ b/drivers/mtd/mx25lx.c
@@ -1093,6 +1093,15 @@ static int mx25l_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = MX25L_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       case MTDIOC_XIPBASE:
       default:
         ret = -ENOTTY; /* Bad command */

--- a/drivers/mtd/mx25rxx.c
+++ b/drivers/mtd/mx25rxx.c
@@ -763,6 +763,15 @@ int mx25rxx_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = MX25RXX_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       default:
         ret = -ENOTTY; /* Bad/unsupported command */
         break;

--- a/drivers/mtd/n25qxxx.c
+++ b/drivers/mtd/n25qxxx.c
@@ -1431,6 +1431,15 @@ static int n25qxxx_ioctl(FAR struct mtd_dev_s *dev,
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = N25QXXX_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       default:
         ret = -ENOTTY; /* Bad/unsupported command */
         break;

--- a/drivers/mtd/rammtd.c
+++ b/drivers/mtd/rammtd.c
@@ -410,6 +410,15 @@ static int ram_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = CONFIG_RAMMTD_ERASESTATE;
+
+          ret = OK;
+        }
+        break;
+
       default:
         ret = -ENOTTY; /* Bad command */
         break;

--- a/drivers/mtd/s25fl1.c
+++ b/drivers/mtd/s25fl1.c
@@ -1477,6 +1477,15 @@ static int s25fl1_ioctl(FAR struct mtd_dev_s *dev,
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = S25FL1_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       default:
         ret = -ENOTTY; /* Bad/unsupported command */
         break;

--- a/drivers/mtd/sector512.c
+++ b/drivers/mtd/sector512.c
@@ -557,6 +557,15 @@ static int s512_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = CONFIG_MTD_SECT512_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       case MTDIOC_XIPBASE:
       default:
         ret = -ENOTTY; /* Bad command */

--- a/drivers/mtd/sst25.c
+++ b/drivers/mtd/sst25.c
@@ -1205,6 +1205,15 @@ static int sst25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = SST25_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       case MTDIOC_XIPBASE:
       default:
         ret = -ENOTTY; /* Bad command */

--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -1333,6 +1333,15 @@ static int w25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = W25_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       case MTDIOC_XIPBASE:
       default:
         ret = -ENOTTY; /* Bad command */

--- a/drivers/mtd/w25qxxxjv.c
+++ b/drivers/mtd/w25qxxxjv.c
@@ -1437,6 +1437,15 @@ static int w25qxxxjv_ioctl(FAR struct mtd_dev_s *dev,
         }
         break;
 
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+          *result = W25QXXXJV_ERASED_STATE;
+
+          ret = OK;
+        }
+        break;
+
       default:
         ret = -ENOTTY; /* Bad/unsupported command */
         break;

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -71,6 +71,9 @@
 #define MTDIOC_FLUSH      _MTDIOC(0x0009) /* IN:  None
                                            * OUT: None (ioctl return value provides
                                            *      success/failure indication). */
+#define MTDIOC_ERASESTATE _MTDIOC(0x000a) /* IN:  Pointer to uint8_t
+                                           * OUT: Byte value that represents the
+                                           *      erased state of the MTD cell */
 
 /* Macros to hide implementation */
 


### PR DESCRIPTION
## Summary
This PR intends to add a new `ioctl` command to the MTD subsystem named `MTDIOC_ERASESTATE` for retrieving the byte value of an erased cell of the underlying memory device.

Also implemented the handling of the `MTDIOC_ERASESTATE` command for those drivers that already provide the byte value for their erase states.

## Impact
New `ioctl` command to the MTD API.

## Testing
Tested using `esp32-wrover-kit`.