### PR TITLE
arch/sim: The second CPU shouldn't call up_irqinitialize

### DIFF
--- a/arch/sim/src/sim/up_hostirq.c
+++ b/arch/sim/src/sim/up_hostirq.c
@@ -114,7 +114,7 @@ void up_irqinitialize(void)
 #ifdef CONFIG_SMP
   /* Register the pause handler */
 
-  up_cpu_set_pause_handler(SIGUSR1);
+  up_init_ipi(SIGUSR1);
 #endif
 }
 

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -173,7 +173,7 @@ void sim_send_ipi(int cpu);
 
 #ifdef CONFIG_SMP
 void up_cpu_started(void);
-int up_cpu_set_pause_handler(int irq);
+int up_init_ipi(int irq);
 #endif
 
 /* up_oneshot.c *************************************************************/

--- a/arch/sim/src/sim/up_simsmp.c
+++ b/arch/sim/src/sim/up_simsmp.c
@@ -52,12 +52,6 @@ static pthread_key_t g_cpu_key;
 static pthread_t     g_cpu_thread[CONFIG_SMP_NCPUS];
 
 /****************************************************************************
- * NuttX domain function prototypes
- ****************************************************************************/
-
-void up_irqinitialize(void);
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -95,10 +89,6 @@ static void *sim_idle_trampoline(void *arg)
     {
       return NULL;
     }
-
-  /* Initialize IRQ */
-
-  up_irqinitialize();
 
   /* Let up_cpu_start() continue */
 

--- a/arch/sim/src/sim/up_smpsignal.c
+++ b/arch/sim/src/sim/up_smpsignal.c
@@ -273,7 +273,7 @@ int up_cpu_start(int cpu)
 }
 
 /****************************************************************************
- * Name: up_cpu_set_pause_handler
+ * Name: up_init_ipi
  *
  * Description:
  *   Attach the CPU pause request interrupt to the NuttX logic.
@@ -285,7 +285,7 @@ int up_cpu_start(int cpu)
  *   On success returns OK (0), otherwise a negative value.
  ****************************************************************************/
 
-int up_cpu_set_pause_handler(int irq)
+int up_init_ipi(int irq)
 {
   up_enable_irq(irq);
   return irq_attach(irq, sim_cpupause_handler, NULL);


### PR DESCRIPTION
## Summary
since the signal handler the process concept

## Impact
Same as before

## Testing
ostest an smp
