### PR TITLE
wqueue: Fix typos

### DIFF
--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -331,14 +331,14 @@ int work_usrstart(void);
  *   the caller.  Otherwise, the work structure is completely managed by the
  *   work queue logic.  The caller should never modify the contents of the
  *   work queue structure directly.  If work_queue() is called before the
- *   previous work as been performed and removed from the queue, then any
+ *   previous work has been performed and removed from the queue, then any
  *   pending work will be canceled and lost.
  *
  * Input Parameters:
  *   qid    - The work queue ID
  *   work   - The work structure to queue
- *   worker - The worker callback to be invoked.  The callback will invoked
- *            on the worker thread of execution.
+ *   worker - The worker callback to be invoked.  The callback will be
+ *            invoked on the worker thread of execution.
  *   arg    - The argument that will be passed to the worker callback when
  *            it is invoked.
  *   delay  - Delay (in clock ticks) from the time queue until the worker
@@ -357,12 +357,12 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
  *
  * Description:
  *   Cancel previously queued work.  This removes work from the work queue.
- *   After work has been cancelled, it may be re-queue by calling
+ *   After work has been cancelled, it may be requeued by calling
  *   work_queue() again.
  *
  * Input Parameters:
  *   qid    - The work queue ID
- *   work   - The previously queue work structure to cancel
+ *   work   - The previously queued work structure to cancel
  *
  * Returned Value:
  *   Zero on success, a negated errno on failure

--- a/libs/libc/wqueue/work_cancel.c
+++ b/libs/libc/wqueue/work_cancel.c
@@ -44,12 +44,12 @@
  *
  * Description:
  *   Cancel previously queued work.  This removes work from the work queue.
- *   After work has been cancelled, it may be re-queue by calling
+ *   After work has been cancelled, it may be requeued by calling
  *   work_queue() again.
  *
  * Input Parameters:
  *   qid    - The work queue ID
- *   work   - The previously queue work structure to cancel
+ *   work   - The previously queued work structure to cancel
  *
  * Returned Value:
  *   Zero (OK) on success, a negated errno on failure.  This error may be
@@ -107,12 +107,12 @@ static int work_qcancel(FAR struct usr_wqueue_s *wqueue,
  *
  * Description:
  *   Cancel previously queued user-mode work.  This removes work from the
- *   user mode work queue.  After work has been cancelled, it may be re-queue
- *   by calling work_queue() again.
+ *   user mode work queue.  After work has been cancelled, it may be
+ *   requeued by calling work_queue() again.
  *
  * Input Parameters:
  *   qid    - The work queue ID (must be USRWORK)
- *   work   - The previously queue work structure to cancel
+ *   work   - The previously queued work structure to cancel
  *
  * Returned Value:
  *   Zero (OK) on success, a negated errno on failure.  This error may be

--- a/libs/libc/wqueue/work_queue.c
+++ b/libs/libc/wqueue/work_queue.c
@@ -58,9 +58,9 @@
  * Input Parameters:
  *   qid    - The work queue ID (index)
  *   work   - The work structure to queue
- *   worker - The worker callback to be invoked.  The callback will invoked
- *            on the worker thread of execution.
- *   arg    - The argument that will be passed to the workder callback when
+ *   worker - The worker callback to be invoked.  The callback will be
+ *            invoked on the worker thread of execution.
+ *   arg    - The argument that will be passed to the worker callback when
  *            int is invoked.
  *   delay  - Delay (in clock ticks) from the time queue until the worker
  *            is invoked. Zero means to perform the work immediately.
@@ -84,7 +84,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
 
   if (work->worker != NULL)
     {
-      /* Remove the entry from the work queue.  It will re requeued at the
+      /* Remove the entry from the work queue.  It will be requeued at the
        * end of the work queue.
        */
 
@@ -123,15 +123,15 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
  *   the caller.  Otherwise, the work structure is completely managed by the
  *   work queue logic.  The caller should never modify the contents of the
  *   work queue structure directly.  If work_queue() is called before the
- *   previous work as been performed and removed from the queue, then any
+ *   previous work has been performed and removed from the queue, then any
  *   pending work will be canceled and lost.
  *
  * Input Parameters:
  *   qid    - The work queue ID (index)
  *   work   - The work structure to queue
- *   worker - The worker callback to be invoked.  The callback will invoked
- *            on the worker thread of execution.
- *   arg    - The argument that will be passed to the workder callback when
+ *   worker - The worker callback to be invoked.  The callback will be
+ *            invoked on the worker thread of execution.
+ *   arg    - The argument that will be passed to the worker callback when
  *            int is invoked.
  *   delay  - Delay (in clock ticks) from the time queue until the worker
  *            is invoked. Zero means to perform the work immediately.

--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -45,12 +45,12 @@
  *
  * Description:
  *   Cancel previously queued work.  This removes work from the work queue.
- *   After work has been cancelled, it may be re-queue by calling
+ *   After work has been cancelled, it may be requeued by calling
  *   work_queue() again.
  *
  * Input Parameters:
  *   qid    - The work queue ID
- *   work   - The previously queue work structure to cancel
+ *   work   - The previously queued work structure to cancel
  *
  * Returned Value:
  *   Zero (OK) on success, a negated errno on failure.  This error may be
@@ -106,12 +106,12 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue,
  *
  * Description:
  *   Cancel previously queued user-mode work.  This removes work from the
- *   user mode work queue.  After work has been cancelled, it may be re-queue
- *   by calling work_queue() again.
+ *   user mode work queue.  After work has been cancelled, it may be
+ *   requeued by calling work_queue() again.
  *
  * Input Parameters:
  *   qid    - The work queue ID (must be HPWORK or LPWORK)
- *   work   - The previously queue work structure to cancel
+ *   work   - The previously queued work structure to cancel
  *
  * Returned Value:
  *   Zero (OK) on success, a negated errno on failure.  This error may be

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -59,9 +59,9 @@
  * Input Parameters:
  *   qid    - The work queue ID (index)
  *   work   - The work structure to queue
- *   worker - The worker callback to be invoked.  The callback will invoked
- *            on the worker thread of execution.
- *   arg    - The argument that will be passed to the workder callback when
+ *   worker - The worker callback to be invoked.  The callback will be
+ *            invoked on the worker thread of execution.
+ *   arg    - The argument that will be passed to the worker callback when
  *            int is invoked.
  *   delay  - Delay (in clock ticks) from the time queue until the worker
  *            is invoked. Zero means to perform the work immediately.
@@ -89,7 +89,7 @@ static void work_qqueue(FAR struct kwork_wqueue_s *wqueue,
 
   if (work->worker != NULL)
     {
-      /* Remove the entry from the work queue.  It will re requeued at the
+      /* Remove the entry from the work queue.  It will be requeued at the
        * end of the work queue.
        */
 
@@ -127,15 +127,15 @@ static void work_qqueue(FAR struct kwork_wqueue_s *wqueue,
  *   the caller.  Otherwise, the work structure is completely managed by the
  *   work queue logic.  The caller should never modify the contents of the
  *   work queue structure directly.  If work_queue() is called before the
- *   previous work as been performed and removed from the queue, then any
+ *   previous work has been performed and removed from the queue, then any
  *   pending work will be canceled and lost.
  *
  * Input Parameters:
  *   qid    - The work queue ID (index)
  *   work   - The work structure to queue
- *   worker - The worker callback to be invoked.  The callback will invoked
- *            on the worker thread of execution.
- *   arg    - The argument that will be passed to the workder callback when
+ *   worker - The worker callback to be invoked.  The callback will be
+ *            invoked on the worker thread of execution.
+ *   arg    - The argument that will be passed to the worker callback when
  *            int is invoked.
  *   delay  - Delay (in clock ticks) from the time queue until the worker
  *            is invoked. Zero means to perform the work immediately.


### PR DESCRIPTION
## Summary

```
include/nuttx/wqueue.h:
libs/libc/wqueue/work_cancel.c:
libs/libc/wqueue/work_queue.c:
sched/wqueue/kwork_cancel.c:
sched/wqueue/kwork_queue.c:

    * Fix spelling, grammar, and typos.
    * Improve wording in a few areas.
```

## Impact

These changes affect comments only. No functional changes.

## Testing

nxstyle