### PR TITLE
sched: Remove unused TLS member from task_group_s

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -537,12 +537,6 @@ struct task_group_s
 
   FAR struct task_info_s *tg_info;
 
-#if CONFIG_TLS_NELEM > 0
-  tls_ndxset_t tg_tlsset;                   /* Set of TLS indexes allocated */
-
-  tls_dtor_t  tg_tlsdestr[CONFIG_TLS_NELEM];  /* List of TLS destructors    */
-#endif
-
   /* POSIX Signal Control Fields ********************************************/
 
   sq_queue_t tg_sigactionq;         /* List of actions for signals              */

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -348,27 +348,6 @@ struct pthread_cleanup_s
 };
 #endif
 
-/* type tls_ndxset_t & tls_dtor_t *******************************************/
-
-/* Smallest addressable type that can hold the entire configured number of
- * TLS data indexes.
- */
-
-#if CONFIG_TLS_NELEM > 0
-#  if CONFIG_TLS_NELEM > 32
-#    error Too many TLS elements
-#  elif CONFIG_TLS_NELEM > 16
-     typedef uint32_t tls_ndxset_t;
-#  elif CONFIG_TLS_NELEM > 8
-     typedef uint16_t tls_ndxset_t;
-#  else
-     typedef uint8_t tls_ndxset_t;
-#  endif
-
-typedef CODE void (*tls_dtor_t)(FAR void *);
-
-#endif
-
 /* struct dspace_s **********************************************************/
 
 /* This structure describes a reference counted D-Space region.

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -61,6 +61,27 @@
  * Public Types
  ****************************************************************************/
 
+/* type tls_ndxset_t & tls_dtor_t *******************************************/
+
+/* Smallest addressable type that can hold the entire configured number of
+ * TLS data indexes.
+ */
+
+#if CONFIG_TLS_NELEM > 0
+#  if CONFIG_TLS_NELEM > 32
+#    error Too many TLS elements
+#  elif CONFIG_TLS_NELEM > 16
+     typedef uint32_t tls_ndxset_t;
+#  elif CONFIG_TLS_NELEM > 8
+     typedef uint16_t tls_ndxset_t;
+#  else
+     typedef uint8_t tls_ndxset_t;
+#  endif
+
+typedef CODE void (*tls_dtor_t)(FAR void *);
+
+#endif
+
 struct task_info_s
 {
   sem_t           ta_sem;


### PR DESCRIPTION
## Summary
Remove tg_tlsset and tg_tlsdestr since them had been moved to task_info_s.
## Impact
None
## Testing
Tested with sabrelite (qemu).
