### PR TITLE
Make: fix use of gcc as LD for modules and ELF executables builds

### DIFF
--- a/boards/arm/cxd56xx/spresense/scripts/Make.defs
+++ b/boards/arm/cxd56xx/spresense/scripts/Make.defs
@@ -70,6 +70,7 @@ LDNXFLATFLAGS = -e main -s 2048
 CMODULEFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 
 LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS += $(CMODULEFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDMODULEFLAGS += -T "${shell cygpath -w $(TOPDIR)/libs/libc/modlib/gnu-elf.ld}"
 else
@@ -82,6 +83,7 @@ CELFFLAGS = $(CFLAGS)
 CXXELFFLAGS = $(CXXFLAGS)
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/imx6/sabre-6quad/scripts/Make.defs
+++ b/boards/arm/imx6/sabre-6quad/scripts/Make.defs
@@ -65,6 +65,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/lc823450/lc823450-xgevk/scripts/Make.defs
+++ b/boards/arm/lc823450/lc823450-xgevk/scripts/Make.defs
@@ -71,6 +71,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/lpc17xx_40xx/lx_cpu/scripts/Make.defs
+++ b/boards/arm/lpc17xx_40xx/lx_cpu/scripts/Make.defs
@@ -73,6 +73,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else
@@ -84,6 +85,7 @@ endif
 CMODULEFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 
 LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS += $(CMODULEFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDMODULEFLAGS += -T "${shell cygpath -w $(TOPDIR)/libs/libc/modlib/gnu-elf.ld}"
 else

--- a/boards/arm/sama5/giant-board/scripts/Make.defs
+++ b/boards/arm/sama5/giant-board/scripts/Make.defs
@@ -74,6 +74,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/sama5/sama5d2-xult/scripts/Make.defs
+++ b/boards/arm/sama5/sama5d2-xult/scripts/Make.defs
@@ -74,6 +74,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/sama5/sama5d3-xplained/scripts/Make.defs
+++ b/boards/arm/sama5/sama5d3-xplained/scripts/Make.defs
@@ -70,6 +70,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/sama5/sama5d3x-ek/scripts/Make.defs
+++ b/boards/arm/sama5/sama5d3x-ek/scripts/Make.defs
@@ -90,6 +90,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/sama5/sama5d4-ek/configs/knsh/Make.defs
+++ b/boards/arm/sama5/sama5d4-ek/configs/knsh/Make.defs
@@ -77,6 +77,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/sama5/sama5d4-ek/scripts/Make.defs
+++ b/boards/arm/sama5/sama5d4-ek/scripts/Make.defs
@@ -74,6 +74,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/stm32/axoloti/scripts/Make.defs
+++ b/boards/arm/stm32/axoloti/scripts/Make.defs
@@ -60,6 +60,7 @@ LDNXFLATFLAGS = -e main -s 2048
 CMODULEFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 
 LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS += $(CMODULEFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDMODULEFLAGS += -T "${shell cygpath -w $(TOPDIR)/libs/libc/modlib/gnu-elf.ld}"
 else
@@ -72,6 +73,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/stm32/olimex-stm32-p407/configs/kelf/Make.defs
+++ b/boards/arm/stm32/olimex-stm32-p407/configs/kelf/Make.defs
@@ -62,6 +62,7 @@ LDNXFLATFLAGS = -e main -s 2048
 CMODULEFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 
 LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS += $(CMODULEFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDMODULEFLAGS += -T "${shell cygpath -w $(TOPDIR)/libs/libc/modlib/gnu-elf.ld}"
 else
@@ -74,6 +75,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w  $(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)modlib$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/stm32/olimex-stm32-p407/configs/kmodule/Make.defs
+++ b/boards/arm/stm32/olimex-stm32-p407/configs/kmodule/Make.defs
@@ -62,6 +62,7 @@ LDNXFLATFLAGS = -e main -s 2048
 CMODULEFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 
 LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS += $(CMODULEFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDMODULEFLAGS += -T "${shell cygpath -w $(TOPDIR)/libs/libc/modlib/gnu-elf.ld}"
 else
@@ -74,6 +75,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w  $(TOPDIR)$(DELIM)libs$(DELIM)libc$(DELIM)modlib$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/stm32/omnibusf4/scripts/Make.defs
+++ b/boards/arm/stm32/omnibusf4/scripts/Make.defs
@@ -60,6 +60,7 @@ LDNXFLATFLAGS = -e main -s 2048
 CMODULEFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 
 LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS += $(CMODULEFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDMODULEFLAGS += -T "${shell cygpath -w $(TOPDIR)/libs/libc/modlib/gnu-elf.ld}"
 else
@@ -72,6 +73,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/stm32/stm32f4discovery/scripts/Make.defs
+++ b/boards/arm/stm32/stm32f4discovery/scripts/Make.defs
@@ -72,6 +72,7 @@ LDNXFLATFLAGS = -e main -s 2048
 CMODULEFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 
 LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS += $(CMODULEFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDMODULEFLAGS += -T "${shell cygpath -w $(TOPDIR)/libs/libc/modlib/gnu-elf.ld}"
 else
@@ -84,6 +85,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/Make.defs
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/Make.defs
@@ -61,6 +61,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/stm32h7/nucleo-h743zi2/scripts/Make.defs
+++ b/boards/arm/stm32h7/nucleo-h743zi2/scripts/Make.defs
@@ -61,6 +61,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/tiva/lm3s6965-ek/scripts/Make.defs
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/Make.defs
@@ -69,6 +69,7 @@ LDNXFLATFLAGS = -e main -s 2048
 CMODULEFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 
 LDMODULEFLAGS = -r -e module_initialize
+LDMODULEFLAGS += $(CMODULEFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDMODULEFLAGS += -T "${shell cygpath -w $(TOPDIR)/libs/libc/modlib/gnu-elf.ld}"
 else
@@ -81,6 +82,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/tms570/launchxl-tms57004/scripts/Make.defs
+++ b/boards/arm/tms570/launchxl-tms57004/scripts/Make.defs
@@ -64,6 +64,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else

--- a/boards/arm/tms570/tms570ls31x-usb-kit/scripts/Make.defs
+++ b/boards/arm/tms570/tms570ls31x-usb-kit/scripts/Make.defs
@@ -64,6 +64,7 @@ CELFFLAGS = $(CFLAGS) -mlong-calls # --target1-abs
 CXXELFFLAGS = $(CXXFLAGS) -mlong-calls # --target1-abs
 
 LDELFFLAGS = -r -e main
+LDELFFLAGS += $(CELFFLAGS) -nostartfiles -nodefaultlibs
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)
   LDELFFLAGS += -T "${shell cygpath -w $(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld}"
 else


### PR DESCRIPTION
## Summary

The patch

  Make: use gcc as LD

introduced use of GCC wrapper as linker. LD variable references GCC
executable now. But when GCC wrapper s used to build relocatable
loadable objects (ELF executables and modules) then it causes
linking of toolchain default libc and other libraries even when -r
is usd. Another problem is that incorrect multiarch variant is selected
for libraries search and possibly even for LTO or C++ templates
instantiating and other glue code which causes fails during linking
if CFLAGS selects non/default miltiarch variant.

Corresponding CFLAGS are passed to LDMODULEFLAGS and LDELFFLAGS
as well as -nostartfiles -nodefaultlibs options.

Separate line is used to easily find and adjust lines if link
process is changed in future.

Signed-off-by: Pavel Pisa <ppisa@pikron.com>


## Impact

## Testing

Tested on LX_CPU board

tools/configure.sh lx_cpu:nsh

This board  default config enables ELF and MODULES which results
in the build errors

/usr/lib/gcc/arm-none-eabi/7.3.1/../../../arm-none-eabi/bin/ld: error: 
chardev.o uses VFP register arguments, chardev does not
/usr/lib/gcc/arm-none-eabi/7.3.1/../../../arm-none-eabi/bin/ld: failed to 
merge target specific data of file chardev.o
collect2: error: ld returned 1 exit status

If only CFLAGS are added then linking of GCC/Newlib provided CRT0 and LIBC
causes attempt t export symbols which are not provided by NuttX build and build
fails in the linking phase.
