### PR TITLE
Fix nfs and statfs

### DIFF
--- a/fs/fat/fs_fat32.h
+++ b/fs/fat/fs_fat32.h
@@ -1084,7 +1084,7 @@ EXTERN int    fat_ffcacheinvalidate(struct fat_mountpt_s *fs,
 EXTERN int    fat_updatefsinfo(struct fat_mountpt_s *fs);
 EXTERN int    fat_computefreeclusters(struct fat_mountpt_s *fs);
 EXTERN int    fat_nfreeclusters(struct fat_mountpt_s *fs,
-                                off_t *pfreeclusters);
+                                fsblkcnt_t *pfreeclusters);
 EXTERN int    fat_currentsector(struct fat_mountpt_s *fs,
                                 struct fat_file_s *ff, off_t position);
 

--- a/fs/fat/fs_fat32util.c
+++ b/fs/fat/fs_fat32util.c
@@ -2135,7 +2135,7 @@ int fat_computefreeclusters(struct fat_mountpt_s *fs)
  *
  ****************************************************************************/
 
-int fat_nfreeclusters(struct fat_mountpt_s *fs, off_t *pfreeclusters)
+int fat_nfreeclusters(struct fat_mountpt_s *fs, fsblkcnt_t *pfreeclusters)
 {
   /* If number of the first free cluster is valid, then just return that
    * value.

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -246,14 +246,16 @@ static int blocks_entry(FAR const char *mountpoint,
 
   if (!info->header)
     {
-      mount_sprintf(info, "  Block  Number\n");
-      mount_sprintf(info, "  Size   Blocks     Used Available Mounted on\n");
+      mount_sprintf(info,
+                    "  Block    Number\n");
+      mount_sprintf(info,
+                    "  Size     Blocks       Used   Available Mounted on\n");
       info->header = true;
     }
 
   /* Generate blocks list one line at a time */
 
-  mount_sprintf(info, "%6ld %8ld %8ld  %8ld %s\n",
+  mount_sprintf(info, "%6lu %10lu %10lu  %10lu %s\n",
                 statbuf->f_bsize, statbuf->f_blocks,
                 statbuf->f_blocks - statbuf->f_bavail, statbuf->f_bavail,
                 mountpoint);

--- a/fs/nfs/nfs_proto.h
+++ b/fs/nfs/nfs_proto.h
@@ -308,7 +308,6 @@ struct nfsv3_sattr
 struct nfs_statfs
 {
   uint32_t           obj_attributes_follow;
-  struct nfs_fattr   obj_attributes;
   nfsuint64          sf_tbytes;
   nfsuint64          sf_fbytes;
   nfsuint64          sf_abytes;

--- a/include/sys/statfs.h
+++ b/include/sys/statfs.h
@@ -100,14 +100,14 @@
 
 struct statfs
 {
-  uint32_t f_type;     /* Type of filesystem (see definitions above) */
-  size_t   f_namelen;  /* Maximum length of filenames */
-  size_t   f_bsize;    /* Optimal block size for transfers */
-  off_t    f_blocks;   /* Total data blocks in the file system of this size */
-  off_t    f_bfree;    /* Free blocks in the file system */
-  off_t    f_bavail;   /* Free blocks avail to non-superuser */
-  off_t    f_files;    /* Total file nodes in the file system */
-  off_t    f_ffree;    /* Free file nodes in the file system */
+  uint32_t   f_type;     /* Type of filesystem (see definitions above) */
+  size_t     f_namelen;  /* Maximum length of filenames */
+  size_t     f_bsize;    /* Optimal block size for transfers */
+  fsblkcnt_t f_blocks;   /* Total data blocks in the file system of this size */
+  fsblkcnt_t f_bfree;    /* Free blocks in the file system */
+  fsblkcnt_t f_bavail;   /* Free blocks avail to non-superuser */
+  fsfilcnt_t f_files;    /* Total file nodes in the file system */
+  fsfilcnt_t f_ffree;    /* Free file nodes in the file system */
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- This PR consists of the following 3 commits
- commit1: fs: nfs: Fix statfs for NFS
  - I noticed that the results of the df command are incorrect for NFS.
  - Finally, I found that obj_attributes is not needed to
      communicate with the NFS server on Linux
  - This commit fixes this issue
- commit2: fs, include: Use fsblkcnt_t and fsfilcnt_t instead of off_t
  - On Linux, fsblkcnt_t and fsfilcnt_t are used in struct statfs
  - This commit applies the same logic
- commit3: fs: mount: Change the format for df
  - This commit changes the format for df to support big
      storage up to 2TB.

## Impact

- None

## Testing

- Tested with spresense:rndis_smp (nfs/fat32/smartfs)
