### PR TITLE
sched/task: Fix wrong return value from nxspawn_open()

### DIFF
--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -128,6 +128,10 @@ static inline int nxspawn_open(FAR struct spawn_open_file_action_s *action)
         {
           serr("ERROR: dup2 failed: %d\n", ret);
         }
+      else
+        {
+          ret = OK;
+        }
 
       sinfo("Closing fd=%d\n", fd);
       nx_close(fd);


### PR DESCRIPTION
## Summary
nxspawn_open() is expected to return "OK" when it success, but
it doesn't return it in case of executing dup2.
Because of this, the "Command as parameter" couldn't work with
Builtin Apps.

## Impact
Related on task_spawn().

## Testing
In CONFIG_FS_TMPFS=y and CONFIG_EXAMPLES_HELLO=y,
Before fixing, it fails as below:
```
nsh> mount -t tmpfs /tmp
nsh> set FOO `hello`
nsh: ``: exec failed: 1
```
By this commit, confirm that it works well.
```
nsh> mount -t tmpfs /tmp
nsh> set FOO `hello`
nsh> echo $FOO
Hello, World!!
```
