### PR TITLE
iob_trimhead: fix an integer truncation

### DIFF
--- a/mm/iob/iob_trimhead.c
+++ b/mm/iob/iob_trimhead.c
@@ -55,7 +55,7 @@
 FAR struct iob_s *iob_trimhead(FAR struct iob_s *iob, unsigned int trimlen,
                                enum iob_user_e producerid)
 {
-  uint16_t pktlen;
+  unsigned int pktlen;
 
   iobinfo("iob=%p trimlen=%d\n", iob, trimlen);
 


### PR DESCRIPTION
## Summary
I guess this fixes https://github.com/apache/incubator-nuttx/issues/4181

## Impact
tcp

## Testing
tested using a modified version of apps/netutils/iperf on esp32 with the rest of https://github.com/apache/incubator-nuttx/pull/4184
especially the "mm/iob: Perform some sanity checks on IOB chain" commit.