### PR TITLE
Add BOARDCTL_SWITCH_BOOT to support switch boot system

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3389,6 +3389,16 @@ config BOARDCTL_UNIQUEKEY_SIZE
 		Provides the size of the memory buffer that must be provided by the
 		caller of board_uniquekey() in which to receive the board unique KEY.
 
+config BOARDCTL_SWITCH_BOOT
+	bool "Enable switch boot system support"
+	default n
+	---help---
+		BOARDIOC_SWITCH_BOOT is required to communicate the boot partition
+		from userspace (OTA subsystem) to board for A/B boot or single boot
+		case. It can be used to change the system boot behavior. For instance,
+		once a firmware updated successfully, this boardctl can be used to
+		modify FLASH bank selection.
+
 config BOARDCTL_MKRD
 	bool "Enable application space creation of RAM disks"
 	default n

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -436,6 +436,22 @@ int boardctl(unsigned int cmd, uintptr_t arg)
         break;
 #endif
 
+#ifdef CONFIG_BOARDCTL_SWITCH_BOOT
+      /* CMD:           BOARDIOC_SWITCH_BOOT
+       * DESCRIPTION:   Used to change the system boot behavior. Switch to
+       *                the updated or specified boot system.
+       * ARG:           Boot system updated or specified
+       * DEPENDENCIES:  Board logic must provide the board_switch_boot()
+       *                interface.
+       */
+
+      case BOARDIOC_SWITCH_BOOT:
+        {
+          ret = board_switch_boot((FAR const char *)arg);
+        }
+        break;
+#endif
+
 #ifdef CONFIG_BOARDCTL_MKRD
       /* CMD:           BOARDIOC_MKRD
        * DESCRIPTION:   Create a RAM disk

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -311,6 +311,27 @@ int board_uniquekey(FAR uint8_t *uniquekey);
 #endif
 
 /****************************************************************************
+ * Name:  board_switch_boot
+ *
+ * Description:
+ *   BOARDIOC_SWITCH_BOOT is required to communicate the boot partition from
+ *   userspace (OTA subsystem) to board, it can be used to change the system
+ *   boot behavior. It's useful for A/B boot or even in the single boot case.
+ *
+ * Input Parameters:
+ *   system - The boot system updated or specified
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  Otherwise a negated errno value is
+ *   returned indicating the nature of the failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARDCTL_SWITCH_BOOT
+int board_switch_boot(FAR const char *system);
+#endif
+
+/****************************************************************************
  * Name:  board_timerhook
  *
  * Description:

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -201,6 +201,7 @@
 #define BOARDIOC_NXTERM_IOCTL      _BOARDIOC(0x0010)
 #define BOARDIOC_TESTSET           _BOARDIOC(0x0011)
 #define BOARDIOC_UNIQUEKEY         _BOARDIOC(0x0012)
+#define BOARDIOC_SWITCH_BOOT       _BOARDIOC(0x0013)
 
 /* If CONFIG_BOARDCTL_IOCTL=y, then board-specific commands will be support.
  * In this case, all commands not recognized by boardctl() will be forwarded
@@ -209,7 +210,7 @@
  * User defined board commands may begin with this value:
  */
 
-#define BOARDIOC_USER              _BOARDIOC(0x0013)
+#define BOARDIOC_USER              _BOARDIOC(0x0014)
 
 /****************************************************************************
  * Public Type Definitions

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -209,7 +209,7 @@
  * User defined board commands may begin with this value:
  */
 
-#define BOARDIOC_USER              _BOARDIOC(0x0012)
+#define BOARDIOC_USER              _BOARDIOC(0x0013)
 
 /****************************************************************************
  * Public Type Definitions


### PR DESCRIPTION
## Summary

board/ctrl: add BOARDCTL_SWITCH_BOOT switch boot system support

BOARDIOC_SWITCH_BOOT is required to communicate the boot partition from
userspace (OTA subsystem) to board. It can be used to change the system
boot behavior. So it's useful for A/B boot or even single boot case.

## Impact

## Testing

