### PR TITLE
esp32_allocateheap.c: Remove the amount reserved to himem from the heap.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -34,6 +34,11 @@
 #include <arch/board/board.h>
 #include <arch/esp32/memory_layout.h>
 
+#ifdef CONFIG_ESP32_SPIRAM_BANKSWITCH_ENABLE
+#include <nuttx/himem/himem.h>
+#include "esp32_himem.h"
+#endif
+
 #include "xtensa.h"
 
 /****************************************************************************
@@ -143,6 +148,9 @@ void xtensa_add_region(void)
       start = (FAR void *)CONFIG_HEAP2_BASE;
       size = CONFIG_HEAP2_SIZE;
 #    endif
+#  ifdef CONFIG_ESP32_SPIRAM_BANKSWITCH_ENABLE
+    size -= esp_himem_reserved_area_size();
+#  endif
     umm_addregion(start, size);
 #  endif
 #endif


### PR DESCRIPTION
## Summary
The blocks that are reserved for himem should be removed from the heap.
## Impact
ESP32 chips only when himem is enabled.
## Testing
ESP32 configs.
