### PR TITLE
local/stream: remove preamble header in stream mode

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -176,7 +176,6 @@ struct local_conn_s
 
     struct
     {
-      uint16_t lc_remaining;   /* (For binary compatibility with peer) */
       volatile int lc_result;  /* Result of the connection operation (client) */
     } client;
 

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -178,13 +178,6 @@ struct local_conn_s
     {
       volatile int lc_result;  /* Result of the connection operation (client) */
     } client;
-
-    /* Fields common to connected peers (connected or accepted) */
-
-    struct
-    {
-      uint16_t lc_remaining;   /* Bytes remaining in the incoming stream */
-    } peer;
   } u;
 #endif /* CONFIG_NET_LOCAL_STREAM */
 };
@@ -401,6 +394,7 @@ ssize_t local_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  *   filep    File structure of write-only FIFO.
  *   buf      Data to send
  *   len      Length of data to send
+ *   preamble Flag to indicate the preamble sync header assembly
  *
  * Returned Value:
  *   Zero is returned on success; a negated errno value is returned on any
@@ -409,7 +403,7 @@ ssize_t local_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  ****************************************************************************/
 
 int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
-                      size_t len);
+                      size_t len, bool preamble);
 
 /****************************************************************************
  * Name: local_recvmsg
@@ -450,6 +444,7 @@ ssize_t local_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  *   buf   - Local to store the received data
  *   len   - Length of data to receive [in]
  *           Length of data actually received [out]
+ *   once  - Flag to indicate the buf may only be read once
  *
  * Returned Value:
  *   Zero is returned on success; a negated errno value is returned on any
@@ -459,7 +454,8 @@ ssize_t local_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  *
  ****************************************************************************/
 
-int local_fifo_read(FAR struct file *filep, FAR uint8_t *buf, size_t *len);
+int local_fifo_read(FAR struct file *filep, FAR uint8_t *buf,
+                    size_t *len, bool once);
 
 /****************************************************************************
  * Name: local_getaddr

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -60,12 +60,12 @@
  ****************************************************************************/
 
 static int psock_fifo_read(FAR struct socket *psock, FAR void *buf,
-                           FAR size_t *readlen)
+                           FAR size_t *readlen, bool once)
 {
   FAR struct local_conn_s *conn = (FAR struct local_conn_s *)psock->s_conn;
   int ret;
 
-  ret = local_fifo_read(&conn->lc_infile, buf, readlen);
+  ret = local_fifo_read(&conn->lc_infile, buf, readlen, once);
   if (ret < 0)
     {
       /* -ECONNRESET is a special case.  We may or not have received
@@ -134,7 +134,7 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
                       FAR socklen_t *fromlen)
 {
   FAR struct local_conn_s *conn = (FAR struct local_conn_s *)psock->s_conn;
-  size_t readlen;
+  size_t readlen = len;
   int ret;
 
   /* Verify that this is a connected peer socket */
@@ -149,42 +149,13 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
   DEBUGASSERT(conn->lc_infile.f_inode != NULL);
 
-  /* Are there still bytes in the FIFO from the last packet? */
-
-  if (conn->u.peer.lc_remaining == 0)
-    {
-      /* No.. Sync to the start of the next packet in the stream and get
-       * the size of the next packet.
-       */
-
-      ret = local_sync(&conn->lc_infile);
-      if (ret < 0)
-        {
-          nerr("ERROR: Failed to get packet length: %d\n", ret);
-          return ret;
-        }
-      else if (ret > UINT16_MAX)
-        {
-          nerr("ERROR: Packet is too big: %d\n", ret);
-          return -E2BIG;
-        }
-
-      conn->u.peer.lc_remaining = (uint16_t)ret;
-    }
-
   /* Read the packet */
 
-  readlen = MIN(conn->u.peer.lc_remaining, len);
-  ret     = psock_fifo_read(psock, buf, &readlen);
+  ret = psock_fifo_read(psock, buf, &readlen, true);
   if (ret < 0)
     {
       return ret;
     }
-
-  /* Adjust the number of bytes remaining to be read from the packet */
-
-  DEBUGASSERT(readlen <= conn->u.peer.lc_remaining);
-  conn->u.peer.lc_remaining -= readlen;
 
   /* Return the address family */
 
@@ -296,7 +267,7 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
   /* Read the packet */
 
   readlen = MIN(pktlen, len);
-  ret     = psock_fifo_read(psock, buf, &readlen);
+  ret     = psock_fifo_read(psock, buf, &readlen, false);
   if (ret < 0)
     {
       goto errout_with_infd;
@@ -319,7 +290,7 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
           /* Read 32 bytes into the bit bucket */
 
           readlen = MIN(remaining, 32);
-          ret     = psock_fifo_read(psock, bitbucket, &tmplen);
+          ret     = psock_fifo_read(psock, bitbucket, &tmplen, false);
           if (ret < 0)
             {
               goto errout_with_infd;

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -91,7 +91,7 @@ static ssize_t local_send(FAR struct socket *psock,
 
           /* Send the packet */
 
-          ret = local_send_packet(&peer->lc_outfile, buf, len);
+          ret = local_send_packet(&peer->lc_outfile, buf, len, false);
         }
         break;
 #endif /* CONFIG_NET_LOCAL_STREAM */
@@ -231,7 +231,7 @@ static ssize_t local_sendto(FAR struct socket *psock,
 
   /* Send the packet */
 
-  ret = local_send_packet(&conn->lc_outfile, buf, len);
+  ret = local_send_packet(&conn->lc_outfile, buf, len, true);
   if (ret < 0)
     {
       nerr("ERROR: Failed to send the packet: %zd\n", ret);


### PR DESCRIPTION
## Summary

local/stream: remove preamble header in stream mode
net/local: remove unused client lc_remaining 

Preamble sync header is no necessary in stream mode

## Impact

local socket with AF_UNIX & SOCK_STREAM

## Testing

socket & socketpair