### PR TITLE
arch/: Clean what was made during `context` in distclean.

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_ARMV7A),y)          # ARMv7-A
 ARCH_SUBDIR = armv7-a
@@ -193,8 +193,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -206,7 +204,7 @@ ifneq ($(EXTRADELFILE),)
 endif
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -172,7 +172,7 @@ chip/$(NRFXLIB_UNPACK): $(NRFXLIB_TGZ)
 
 context:: chip/$(NRFXLIB_UNPACK)
 
-clean_context::
+distclean::
 	$(call DELFILE, chip/$(NRFXLIB_TGZ))
 	$(call DELDIR, chip/$(NRFXLIB_UNPACK))
 

--- a/arch/avr/src/Makefile
+++ b/arch/avr/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_FAMILY_AVR32),y)
 ARCH_SUBDIR = avr32
@@ -140,8 +140,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -149,7 +147,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/hc/src/Makefile
+++ b/arch/hc/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_HC12),y)
 ARCH_SUBDIR = hc12
@@ -155,8 +155,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -164,7 +162,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/mips/src/Makefile
+++ b/arch/mips/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_MIPS),y)
 ARCH_SUBDIR = mips32
@@ -138,8 +138,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -147,7 +145,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/misoc/src/Makefile
+++ b/arch/misoc/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_CHIP_LM32),y)
  ARCH_SUBDIR = lm32
@@ -141,8 +141,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -150,7 +148,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/or1k/src/Makefile
+++ b/arch/or1k/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_MOR1KX),y)          # OpenRISC mor1kx
 ARCH_SUBDIR = mor1kx
@@ -181,8 +181,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -191,7 +189,7 @@ endif
 	$(call DELFILE, $(BIN))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/renesas/src/Makefile
+++ b/arch/renesas/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ARCH_SRCDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src
 
@@ -149,8 +149,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -158,7 +156,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_RV32I),y)           # Base Integer support
 ARCH_SUBDIR = rv32i
@@ -182,8 +182,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -193,7 +191,7 @@ endif
 	$(call DELFILE, $(HEAD_OBJ))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -100,7 +100,7 @@ chip/$(WIRELESS_DRV_UNPACK): $(WIRELESS_DRV_ZIP)
 
 context:: chip/$(WIRELESS_DRV_UNPACK)
 
-clean_context::
+distclean::
 	$(call DELFILE, chip/$(WIRELESS_DRV_ZIP))
 	$(call DELDIR, chip/$(WIRELESS_DRV_UNPACK))
 

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -195,7 +195,7 @@ chip/$(WIRELESS_DRV_UNPACK): $(WIRELESS_DRV_ZIP)
 
 context:: chip/$(WIRELESS_DRV_UNPACK)
 
-clean_context::
+distclean::
 	$(call DELFILE, chip/$(WIRELESS_DRV_ZIP))
 	$(call DELDIR, chip/$(WIRELESS_DRV_UNPACK))
 

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -339,8 +339,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board clean ; \
@@ -351,7 +349,7 @@ clean:
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board distclean ; \
 	fi

--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_I486),y)
 ARCH_SUBDIR = i486
@@ -153,8 +153,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -162,7 +160,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_INTEL64),y)
 ARCH_SUBDIR = intel64
@@ -163,8 +163,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -172,7 +170,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 ifeq ($(CONFIG_ARCH_FAMILY_LX6),y)
 ARCH_SUBDIR = lx6
@@ -143,8 +143,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
@@ -152,7 +150,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -223,7 +223,7 @@ chip/$(WIRELESS_DRV_UNPACK): $(WIRELESS_DRV_ZIP)
 
 context:: chip/$(WIRELESS_DRV_UNPACK)
 
-clean_context::
+distclean::
 	$(call DELFILE, chip/$(WIRELESS_DRV_ZIP))
 	$(call DELDIR, chip/$(WIRELESS_DRV_UNPACK))
 

--- a/arch/z16/src/Makefile
+++ b/arch/z16/src/Makefile
@@ -19,7 +19,7 @@
 ############################################################################
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 COMPILER = ${shell basename "$(CC)"}
 ARCHSRCDIR = $(TOPDIR)/arch/$(CONFIG_ARCH)/src
@@ -140,8 +140,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board clean )
@@ -159,7 +157,7 @@ endif
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board distclean )
 else

--- a/arch/z80/src/Makefile
+++ b/arch/z80/src/Makefile
@@ -21,7 +21,7 @@
 # Makefile fragments
 
 include $(TOPDIR)/Make.defs
--include chip/Make.defs
+include chip/Make.defs
 
 # Compiler-Dependent Make:  SDCC, Clang, or ZiLOG ZDS-II
 

--- a/arch/z80/src/Makefile.clang
+++ b/arch/z80/src/Makefile.clang
@@ -115,8 +115,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
 		$(MAKE) -C board clean ; \
@@ -125,7 +123,7 @@ clean:
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
 		$(MAKE) -C board distclean ; \
 	fi

--- a/arch/z80/src/Makefile.sdccl
+++ b/arch/z80/src/Makefile.sdccl
@@ -203,8 +203,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board clean ; \
@@ -214,7 +212,7 @@ clean:
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board distclean ; \
 	fi

--- a/arch/z80/src/Makefile.sdccw
+++ b/arch/z80/src/Makefile.sdccw
@@ -195,8 +195,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 	$(Q) if exist board\Makefile ( $(MAKE) -C board clean )
 	$(call DELFILE, asm_mem.h)
@@ -204,7 +202,7 @@ clean:
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 	$(Q) if exist board\Makefile ( $(MAKE) -C board distclean )
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/arch/z80/src/Makefile.zdsiil
+++ b/arch/z80/src/Makefile.zdsiil
@@ -144,8 +144,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
 		$(MAKE) -C board clean ; \
@@ -157,7 +155,7 @@ clean:
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 	$(Q) if [ -e board$(DELIM)Makefile ]; then \
 		$(MAKE) -C board distclean ; \
 	fi

--- a/arch/z80/src/Makefile.zdsiiw
+++ b/arch/z80/src/Makefile.zdsiiw
@@ -126,8 +126,6 @@ depend: .depend
 
 context::
 
-clean_context::
-
 clean:
 	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board clean )
 	$(call DELFILE, nuttx.linkcmd)
@@ -137,7 +135,7 @@ clean:
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 
-distclean: clean
+distclean:: clean
 	$(Q) if exist board$(DELIM)Makefile ( $(MAKE) -C board distclean )
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -37,7 +37,7 @@
 #   CONFIG_BUILD_KERNEL is selected, then applications are not build at all.
 
 CLEANDIRS :=
-CCLEANDIRS := boards $(APPDIR) graphics $(ARCH_SRC)
+CCLEANDIRS := boards $(APPDIR) graphics
 KERNDEPDIRS :=
 USERDEPDIRS :=
 


### PR DESCRIPTION
## Summary
Cleaning during `clean_context` had the issue of remaking everything when `menuconfig` was called.  That's because `menuconfig` has a `clean_context` on its way.

Closes #4194 

## Impact
`make clean_context` won't clean `context` of the arch directory anymore.  We do have this asymmetry in few other places, most notably in apps.

## Testing
Tested with esp32-devkitc:wapi and built few other configs to make sure everything is still working fine.
