### PR TITLE
tools: Add armv7-a support to nuttx-gdbinit

### DIFF
--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -35,9 +35,12 @@ define _examine_arch
   python if (_target_arch.name() == 'armv7e-m') : \
   gdb.execute("set $_target_arch = \"armv7e-m\"")
 
-  # TODO: qemu (need to distinguish cortex-m and cortex-a)
   python if (_target_arch.name() == 'armv7') : \
   gdb.execute("set $_target_arch = \"armv7e-m\"")
+
+  # TODO: need more smart way to detect armv7-a
+  python if (type(gdb.lookup_global_symbol("arm_gic_initialize")) is gdb.Symbol) : \
+  gdb.execute("set $_target_arch = \"armv7-a\"")
 
   python if (_target_arch.name() == 'i386:x86-64') : \
   gdb.execute("set $_target_arch = \"i386:x86-64\"")
@@ -57,6 +60,12 @@ define _examine_target
 
     if ($_streq($_target_arch, "armv7e-m") == 1)
       if ($_xcp_nregs != 19)
+        set $_target_has_fpu = 1
+      end
+    end
+
+    if ($_streq($_target_arch, "armv7-a") == 1)
+      if ($_xcp_nregs != 17)
         set $_target_has_fpu = 1
       end
     end
@@ -108,6 +117,9 @@ define _save_tcb
   _examine_target
 
   set $tcb = $arg0
+  if ($_streq($_target_arch, "armv7-a") == 1)
+    _save_tcb_armv7-a $tcb
+  end
   if ($_streq($_target_arch, "armv7e-m") == 1)
     if ($_target_has_fpu == 0)
       _save_tcb_armv7e-m $tcb
@@ -149,6 +161,9 @@ define _switch_tcb
   gdb.newest_frame().select()
 
   set $tcb = $arg0
+  if ($_streq($_target_arch, "armv7-a") == 1)
+    _switch_tcb_armv7-a $tcb
+  end
   if ($_streq($_target_arch, "armv7e-m") == 1)
     if ($_target_has_fpu == 0)
       _switch_tcb_armv7e-m $tcb
@@ -165,6 +180,51 @@ define _switch_tcb
 
   # update _current_tcb
   set $_current_tcb = $tcb
+end
+
+# see nuttx/arch/arm/include/armv7-a/irq.h
+define _save_tcb_armv7-a
+  set $tcb = (struct tcb_s *)$arg0
+  set $tcb.xcp.regs[0] = $r0
+  set $tcb.xcp.regs[1] = $r1
+  set $tcb.xcp.regs[2] = $r2
+  set $tcb.xcp.regs[3] = $r3
+  set $tcb.xcp.regs[4] = $r4
+  set $tcb.xcp.regs[5] = $r5
+  set $tcb.xcp.regs[6] = $r6
+  set $tcb.xcp.regs[7] = $r7
+  set $tcb.xcp.regs[8] = $r8
+  set $tcb.xcp.regs[9] = $r9
+  set $tcb.xcp.regs[10] = $r10
+  set $tcb.xcp.regs[11] = $r11
+  set $tcb.xcp.regs[12] = $r12
+  set $tcb.xcp.regs[13] = $r13
+  set $tcb.xcp.regs[14] = $r14
+  set $tcb.xcp.regs[15] = $r15
+  # TODO: xPSR
+
+  set $_pc_reg_idx = 15
+end
+
+define _switch_tcb_armv7-a
+  set $tcb = (struct tcb_s *)$arg0
+  set $r0 = $tcb.xcp.regs[0]
+  set $r1 = $tcb.xcp.regs[1]
+  set $r2 = $tcb.xcp.regs[2]
+  set $r3 = $tcb.xcp.regs[3]
+  set $r4 = $tcb.xcp.regs[4]
+  set $r5 = $tcb.xcp.regs[5]
+  set $r6 = $tcb.xcp.regs[6]
+  set $r7 = $tcb.xcp.regs[7]
+  set $r8 = $tcb.xcp.regs[8]
+  set $r9 = $tcb.xcp.regs[9]
+  set $r10 = $tcb.xcp.regs[10]
+  set $r11 = $tcb.xcp.regs[11]
+  set $r12 = $tcb.xcp.regs[12]
+  set $r13 = $tcb.xcp.regs[13]
+  set $r14 = $tcb.xcp.regs[14]
+  set $r15 = $tcb.xcp.regs[15]
+  # TODO: xPSR
 end
 
 # see nuttx/arch/arm/include/armv7-m/irq_cmnvector.h


### PR DESCRIPTION
## Summary

- This commit adds armv7-a support to nuttx-gdbinit

## Impact

- None

## Testing

- Tested sabre-6quad:smp with QEMU

