### PR TITLE
arch/sim: Don't need pass CONFIG_SCHED_INSTRUMENTATION to host side

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -98,9 +98,6 @@ ifeq ($(CONFIG_SMP),y)
   CSRCS += up_smpsignal.c up_cpuidlestack.c
   REQUIREDOBJS += up_smpsignal$(OBJEXT)
   HOSTCFLAGS += -DCONFIG_SMP=1 -DCONFIG_SMP_NCPUS=$(CONFIG_SMP_NCPUS)
-ifeq ($(CONFIG_SCHED_INSTRUMENTATION),y)
-  HOSTCFLAGS += -DCONFIG_SCHED_INSTRUMENTATION=1
-endif
   HOSTSRCS += up_simsmp.c
 endif
 


### PR DESCRIPTION
## Summary
since this macro isn't check from host side after:
commit cee43ce280cfe1e704a16d860cf5087a8e014838
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Fri Jul 16 02:23:59 2021 +0800

    arch/sim: Initialize the idle thread stack info correctly

    and change the default value of IDLETHREAD_STACKSIZE to 65536

## Impact
No, remove the unused macro

## Testing

