### PR TITLE
arch: arm: stm: Fix STM32_EXTI2_OFFSET

### DIFF
--- a/arch/arm/src/stm32/hardware/stm32_exti.h
+++ b/arch/arm/src/stm32/hardware/stm32_exti.h
@@ -64,7 +64,7 @@
 
 #if defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX)
 #  define STM32_EXTI1_OFFSET     0x0000  /* Offset to EXTI1 registers */
-#  define STM32_EXTI2_OFFSET     0x0018  /* Offset to EXTI2 registers */
+#  define STM32_EXTI2_OFFSET     0x0020  /* Offset to EXTI2 registers */
 #endif
 
 #define STM32_EXTI_IMR_OFFSET    0x0000  /* Interrupt mask register */


### PR DESCRIPTION
## Summary

arch/arm/src/stm32/hardware/stm32_exti.h: Change `STM32_EXTI2_OFFSET` (offset to EXTI2 registers) from 0x18 to 0x20. This symbol is defined when `CONFIG_STM32_STM32F30XX` or `CONFIG_STM32_STM32F33XX`. According to the current reference manuals for STM32F334xx (RM0364 rev 4) and STM32F302xx (RM0365 rev 8), EXTI_IMR1 is at offset 0x00 and EXTI_IMR2 is at offset 0x20, i.e., 0x20 apart. The same offset applies to the rest of the registers: EMR1/EMR2, RTSR1/RTSR2, etc.

Links to the reference manuals:

STM32F302xx: RM0365 rev 8, table 42 on page 229:
https://www.st.com/resource/en/reference_manual/rm0365-stm32f302xbcde-and-stm32f302x68-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

STM32F334xx: RM0364 rev 4, table 36 on page 208:
https://www.st.com/resource/en/reference_manual/rm0364-stm32f334xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf

## Impact

Will affect all uses of EXTI2 on all STM32F30xx and STM32F33xx family SoCs.

## Testing

**None**: Unfortunately I do not have hardware available to test this change.

I could not find a STM32F30 or STM32F33 for which the RM documents a 0x18 offset; however if I missed a P/N where this is the case, please let me know.