### PR TITLE
arch/arm/src/stm32/stm32_qencoder.c: print uint32_t by using PRIx32

### DIFF
--- a/arch/arm/src/stm32/stm32_qencoder.c
+++ b/arch/arm/src/stm32/stm32_qencoder.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <inttypes.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
@@ -1039,7 +1040,9 @@ static int stm32_shutdown(FAR struct qe_lowerhalf_s *lower)
   putreg32(regval, regaddr);
   leave_critical_section(flags);
 
-  sninfo("regaddr: %08x resetbit: %08x\n", regaddr, resetbit);
+  sninfo("regaddr: %08" PRIx32 " resetbit: %08" PRIx32 "\n",
+         regaddr, resetbit);
+
   stm32_dumpregs(priv, "After stop");
 
   /* Disable clocking to the timer */


### PR DESCRIPTION
## Summary
Printing uint32_t with %x was causing compilation warnings therefore the change to standard format defined in inttypes.h.

## Impact
Just coding style,

## Testing
Compilation without warnings and errors.
