### PR TITLE
Fix various typos

### DIFF
--- a/arch/arm/src/eoss3/eoss3_serial.c
+++ b/arch/arm/src/eoss3/eoss3_serial.c
@@ -478,8 +478,8 @@ static void eoss3_send(struct uart_dev_s *dev, int ch)
  * Name: eoss3_txint
  *
  * Description:
- *   Normally would turn on and off the tx empty interrupt instead we are
- *   enableing a kernel worker because there is no interrupt. This worker
+ *   Normally would turn on and off the tx empty interrupt; instead, we are
+ *   enabling a kernel worker because there is no interrupt. This worker
  *   will requeue and dequeue itself as needed.
  *
  ****************************************************************************/

--- a/arch/arm/src/imxrt/hardware/imxrt_flexcan.h
+++ b/arch/arm/src/imxrt/hardware/imxrt_flexcan.h
@@ -418,11 +418,11 @@
 
 /* CAN FD CRC register */
 
-#define CAN_FDCRC_FD_TXCRC_SHIFT   (0)      /* Bits 0-20: Extended Tranmitted CRC value */
+#define CAN_FDCRC_FD_TXCRC_SHIFT   (0)      /* Bits 0-20: Extended Transmitted CRC value */
 #define CAN_FDCRC_FD_TXCRC_MASK    (0x1fffff << CAN_FDCRC_FD_TXCRC_SHIFT)
 #define CAN_FDCRC_FD_TXCRC(x)      (((uint32_t)(((uint32_t)(x)) << CAN_FDCRC_FD_TXCRC_SHIFT)) & CAN_FDCRC_FD_TXCRC_MASK)
                                             /* Bits 21-23: Reserved */
-#define CAN_FDCRC_FD_MBCRC_SHIFT   (24)     /* Bits 24-30: Extended Tranmitted CRC value */
+#define CAN_FDCRC_FD_MBCRC_SHIFT   (24)     /* Bits 24-30: Extended Transmitted CRC value */
 #define CAN_FDCRC_FD_MBCRC_MASK    (0x7f << CAN_FDCRC_FD_MBCRC_SHIFT)
 #define CAN_FDCRC_FD_MBCRC(x)      (((uint32_t)(((uint32_t)(x)) << CAN_FDCRC_FD_MBCRC_SHIFT)) & CAN_FDCRC_FD_MBCRC_MASK)
                                             /* Bit 31: Reserved */

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -354,7 +354,7 @@ static inline uint32_t arm_lsb(unsigned int value)
  *            classical can timings
  *
  * Returned Value:
- *   return 1 on succes, return 0 on failure
+ *   return 1 on success, return 0 on failure
  *
  ****************************************************************************/
 

--- a/arch/arm/src/imxrt/imxrt_flexpwm.c
+++ b/arch/arm/src/imxrt/imxrt_flexpwm.c
@@ -90,7 +90,7 @@ struct imxrt_flexpwm_s
   FAR struct imxrt_flexpwm_module_s *modules;
   uint8_t modules_num;            /* Number of modules */
   uint32_t frequency;             /* PWM frequency */
-  uint32_t base;                  /* Base addres of peripheral register */
+  uint32_t base;                  /* Base address of peripheral register */
 };
 
 /* PWM driver methods */

--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -1296,7 +1296,7 @@ static int imxrt_lpi2c_isr_process(struct imxrt_lpi2c_priv_s *priv)
         {
           imxrt_lpi2c_traceevent(priv, I2CEVENT_RCVBYTE, priv->dcnt);
 
-          /* No interrupts or contex switches should occur in the following
+          /* No interrupts or context switches should occur in the following
            * sequence. Otherwise, additional bytes may be sent by the device.
            */
 

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -385,7 +385,7 @@ static inline uint32_t arm_lsb(unsigned int value)
  *            classical can timings
  *
  * Returned Value:
- *   return 1 on succes, return 0 on failure
+ *   return 1 on success, return 0 on failure
  *
  ****************************************************************************/
 

--- a/arch/arm/src/nrf52/hardware/nrf52_rtc.h
+++ b/arch/arm/src/nrf52/hardware/nrf52_rtc.h
@@ -103,6 +103,6 @@
 
 /* CC Register */
 
-#define RTC_CC_MASK                (0x00ffffff)                    /* Bits 0-23: Comapre register */
+#define RTC_CC_MASK                (0x00ffffff)                    /* Bits 0-23: Compare register */
 
 #endif /* __ARCH_ARM_SRC_NRF52_HARDWARE_NRF52_RTC_H */

--- a/arch/arm/src/nrf52/nrf52_clockconfig.c
+++ b/arch/arm/src/nrf52/nrf52_clockconfig.c
@@ -55,7 +55,7 @@
 void nrf52_clockconfig(void)
 {
 #ifdef CONFIG_NRF52_HFCLK_XTAL
-  /* Initilize HFCLK crystal oscillator */
+  /* Initialize HFCLK crystal oscillator */
 
   putreg32(0x0, NRF52_CLOCK_EVENTS_HFCLKSTARTED);
   putreg32(0x1, NRF52_CLOCK_TASKS_HFCLKSTART);

--- a/arch/arm/src/nrf52/nrf52_radio.c
+++ b/arch/arm/src/nrf52/nrf52_radio.c
@@ -323,7 +323,7 @@ static int nrf52_radio_rssi_get(FAR struct nrf52_radio_dev_s *dev,
  * Name: nrf52_radio_addr_set
  *
  * Description:
- *   Set radio logical adress
+ *   Set radio logical address
  *
  ****************************************************************************/
 
@@ -347,7 +347,7 @@ static int nrf52_radio_addr_set(FAR struct nrf52_radio_dev_s *dev, uint8_t i,
       goto errout;
     }
 
-  /* Get data specific for given logical adress */
+  /* Get data specific for given logical address */
 
   if (i == 0)
     {
@@ -360,7 +360,7 @@ static int nrf52_radio_addr_set(FAR struct nrf52_radio_dev_s *dev, uint8_t i,
     }
   else if (i < 4)
     {
-      /* Logical addres 1-3 - BASE1 and PREFIX0 */
+      /* Logical address 1-3 - BASE1 and PREFIX0 */
 
       basereg   = NRF52_RADIO_BASE1_OFFSET;
       prefixreg = NRF52_RADIO_PREFIX0_OFFSET;
@@ -369,7 +369,7 @@ static int nrf52_radio_addr_set(FAR struct nrf52_radio_dev_s *dev, uint8_t i,
     }
   else
     {
-      /* Logical addres 1-3 - BASE1 and PREFIX1 */
+      /* Logical address 1-3 - BASE1 and PREFIX1 */
 
       basereg   = NRF52_RADIO_BASE1_OFFSET;
       prefixreg = NRF52_RADIO_PREFIX1_OFFSET;

--- a/arch/arm/src/nrf52/nrf52_tim.c
+++ b/arch/arm/src/nrf52/nrf52_tim.c
@@ -218,7 +218,7 @@ static void nrf52_tim_putreg(FAR struct nrf52_tim_dev_s *dev,
  * Name: nrf52_tim_irq2reg
  *
  * Description:
- *   Get the vaule of the interrupt register corresponding to the given
+ *   Get the value of the interrupt register corresponding to the given
  *   interrupt source
  *
  ****************************************************************************/

--- a/arch/arm/src/rtl8720c/amebaz_depend.c
+++ b/arch/arm/src/rtl8720c/amebaz_depend.c
@@ -50,7 +50,7 @@ int __wrap_printf(const char *fmt, ...)
 
 static int uxcriticalnesting = 0;
 
-/* Critical Opration Start */
+/* Critical Operation Start */
 
 void save_and_cli(void)
 {
@@ -88,7 +88,7 @@ void rtw_exit_critical_from_isr(void **plock, unsigned long *pirql)
   restore_flags();
 }
 
-/* Critical Opration End */
+/* Critical Operation End */
 
 /* arpa/inet.h Wrapper Start */
 

--- a/arch/arm/src/s32k1xx/Kconfig
+++ b/arch/arm/src/s32k1xx/Kconfig
@@ -342,7 +342,7 @@ config S32K1XX_EEEPROM
 	default n
     ---help---
        Enables Emulated EEPROM function which uses the FlexRAM and FlexNVM
-       memory to emulate non-volatile memory. The EEEPROM wil be registered
+       memory to emulate non-volatile memory. The EEEPROM will be registered
        as a ramdisk block device
 
 endmenu # S32K1XX Peripheral Selection

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -386,7 +386,7 @@ static inline uint32_t arm_lsb(unsigned int value)
  *            classical can timings
  *
  * Returned Value:
- *   return 1 on succes, return 0 on failure
+ *   return 1 on success, return 0 on failure
  *
  ****************************************************************************/
 

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -1238,7 +1238,7 @@ static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s *priv)
         {
           s32k1xx_lpi2c_traceevent(priv, I2CEVENT_RCVBYTE, priv->dcnt);
 
-          /* No interrupts or contex switches should occur in the following
+          /* No interrupts or context switches should occur in the following
            * sequence. Otherwise, additional bytes may be sent by the device.
            */
 

--- a/arch/arm/src/sama5/hardware/sam_sdmmc.h
+++ b/arch/arm/src/sama5/hardware/sam_sdmmc.h
@@ -49,8 +49,8 @@
 #define SAMA5_SDMMC_PRSSTAT_OFFSET       0x0024 /* Present State Register */
 #define SAMA5_SDMMC_PROCTL_OFFSET        0x0028 /* Protocol Control Register */
 #define SAMA5_SDMMC_PWRCTL_OFFSET        0x0029 /* Power Control Control Register */
-#define SAMA5_SDMMC_SYSCTL_OFFSET        0x002c /* System Control Register, or Clock Control Register/Timout Control Register */
-#define SAMA5_SDMMC_TCR_OFFSET           0x002e /* Timout Control Register (8 bit) */
+#define SAMA5_SDMMC_SYSCTL_OFFSET        0x002c /* System Control Register, or Clock Control Register/Timeout Control Register */
+#define SAMA5_SDMMC_TCR_OFFSET           0x002e /* Timeout Control Register (8 bit) */
 #define SAMA5_SDMMC_SRR_OFFSET           0x002f /* Software Reset Register (8 bit) */
 #define SAMA5_SDMMC_IRQSTAT_OFFSET       0x0030 /* Interrupt Status Register */
 #define SAMA5_SDMMC_IRQSTATEN_OFFSET     0x0034 /* Interrupt Status Enable Register */

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -725,7 +725,7 @@ static int sam_transmit(struct sam_gmac_s *priv)
   up_clean_dcache((uint32_t)txdesc,
                   (uint32_t)txdesc + sizeof(struct gmac_txdesc_s));
 
-  /* Setup/Copy data to transmition buffer */
+  /* Setup/Copy data to transmission buffer */
 
   if (dev->d_len > 0)
     {

--- a/arch/arm/src/samd5e5/sam_wdt.c
+++ b/arch/arm/src/samd5e5/sam_wdt.c
@@ -416,7 +416,7 @@ static int sam_settimeout(FAR struct watchdog_lowerhalf_s *lower,
     putreg8(timeout_period, SAM_WDT_CONFIG);
 
   priv->reload = timeout_period;
-  wdinfo("fwdt=%d reload=%d timout=%d\n",
+  wdinfo("fwdt=%d reload=%d timeout=%d\n",
          WDT_FCLK, timeout_period, priv->timeout);
   leave_critical_section(flags);
 

--- a/arch/avr/src/avr32/up_exceptions.S
+++ b/arch/avr/src/avr32/up_exceptions.S
@@ -36,7 +36,7 @@
 	.global		avr32_int2irqno			/* Returns IRQ number of INT2 event */
 	.global		avr32_int3irqno			/* Returns IRQ number of INT3 event */
 	.global		up_doirq				/* Dispatch an IRQ                  */
-	.global		up_fullcontextrestore	/* Restore new task contex          */
+	.global		up_fullcontextrestore	/* Restore new task context         */
 
 /****************************************************************************
  * Macros
@@ -303,7 +303,7 @@ avr32_common:
 #endif
 
 	/* On return, r12 will hold the new address of the register context     */
-	/* save area.  On an interrupt contex switch, this will (1) not be the  */
+	/* save area.  On an interrupt context switch, this will (1) not be the  */
 	/* same as the value of r12 passed to up_doirq(), and (2) may not       */
 	/* reside on a stack.                                                   */
 

--- a/arch/avr/src/avr32/up_fullcontextrestore.S
+++ b/arch/avr/src/avr32/up_fullcontextrestore.S
@@ -39,7 +39,7 @@
  * Name: up_fullcontextrestore
  *
  * Description:
- *   Restore the full-running contex of a thread.
+ *   Restore the full-running context of a thread.
  *
  *   NOTE: Thus function must handle one very strange case.  That is when
  *   this function is called with up_sigdeliver().  That case is strange in

--- a/arch/renesas/src/rx65n/rx65n_dtc.c
+++ b/arch/renesas/src/rx65n/rx65n_dtc.c
@@ -1252,7 +1252,7 @@ void rx65n_dtc_srcdeactivation(DTC_HANDLE handle, uint8_t src)
 
   if (dtchandle->initialized)
     {
-      /* Disable the interrupt soure */
+      /* Disable the interrupt source */
 
       ICU.DTCER[act_source].BIT.DTCE = 0;
     }

--- a/arch/renesas/src/rx65n/rx65n_usbhost.c
+++ b/arch/renesas/src/rx65n/rx65n_usbhost.c
@@ -7209,7 +7209,7 @@ static int rx65n_usbhost_ctrlout(struct usbhost_driver_s *drvr,
   static int dev_addressed_state = 0;
 
   /* Assumption : This control out is called first time for
-   * set address command. Just reseting the bus after the
+   * set address command. Just resetting the bus after the
    * set address command
    */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_tickless.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tickless.c
@@ -247,7 +247,7 @@ static void IRAM_ATTR up_tmr_setcounter(uint64_t ticks)
   putreg32(alarm_ticks & 0xffffffff, SYS_TIMER_SYSTIMER_TARGET0_LO_REG);
   putreg32((alarm_ticks >> 32) & 0xfffff, SYS_TIMER_SYSTIMER_TARGET0_HI_REG);
 
-  /* apply alarm vaule */
+  /* apply alarm value */
 
   REG_SET_BIT(SYS_TIMER_SYSTIMER_COMP0_LOAD_REG, SYS_TIMER_TIMER_COMP0_LOAD);
 

--- a/boards/arm/stm32h7/stm32h747i-disco/include/board.h
+++ b/boards/arm/stm32h7/stm32h747i-disco/include/board.h
@@ -304,7 +304,7 @@
       (FMC_SDCR_COLBITS_9 | FMC_SDCR_ROWBITS_12 | FMC_SDCR_WIDTH_32 |\
        FMC_SDCR_BANKS_4 | FMC_SDCR_CASLAT_2)
 
-/* BOARD_FMC_SDTR[1..2] - Initial value for SDRAM timing registeres for SDRAM
+/* BOARD_FMC_SDTR[1..2] - Initial value for SDRAM timing registers for SDRAM
  *      bank 1-2. Note that some bits in SDTR1 influence both SDRAM banks and
  *      are unused in SDTR2!
  */

--- a/include/nuttx/lcd/ili9225.h
+++ b/include/nuttx/lcd/ili9225.h
@@ -229,7 +229,7 @@
  * Horizontal GRAM Address Set, Offset: 0x20
  */
 
-#define ILI9225_HORIZONTAL_GRAM_ADDR_SET_AD_SHIFT (0)   /* Set the initial vaue of adress counter */
+#define ILI9225_HORIZONTAL_GRAM_ADDR_SET_AD_SHIFT (0)   /* Set the initial value of address counter */
 #define ILI9225_HORIZONTAL_GRAM_ADDR_SET_AD_MASK  (0xff << ILI9225_HORIZONTAL_GRAM_ADDR_SET_AD_SHIFT)
 #define ILI9225_HORIZONTAL_GRAM_ADDR_SET_AD(n)    (((uint16_t)(n) << ILI9225_HORIZONTAL_GRAM_ADDR_SET_AD_SHIFT) & ILI9225_HORIZONTAL_GRAM_ADDR_SET_AD_MASK)
 
@@ -237,7 +237,7 @@
  * Vertical  GRAM Address Set, Offset: 0x21
  */
 
-#define ILI9225_VERTICAL_GRAM_ADDR_SET_AD_SHIFT   (0)  /* Set the initial vaue of adress counter */
+#define ILI9225_VERTICAL_GRAM_ADDR_SET_AD_SHIFT   (0)  /* Set the initial value of address counter */
 #define ILI9225_VERTICAL_GRAM_ADDR_SET_AD_MASK    (0xff << ILI9225_VERTICAL_GRAM_ADDR_SET_AD_SHIFT)
 #define ILI9225_VERTICAL_GRAM_ADDR_SET_AD(n)      (((uint16_t)(n) << ILI9225_VERTICAL_GRAM_ADDR_SET_AD_SHIFT) & ILI9225_VERTICAL_GRAM_ADDR_SET_AD_MASK)
 

--- a/libs/libc/stdio/lib_fgetpos.c
+++ b/libs/libc/stdio/lib_fgetpos.c
@@ -45,7 +45,7 @@
  *   reposition a stream.
  *
  * Returned Value:
- *   Zero on succes; -1 on failure with errno set appropriately.
+ *   Zero on success; -1 on failure with errno set appropriately.
  *
  ****************************************************************************/
 

--- a/libs/libc/stdio/lib_fseek.c
+++ b/libs/libc/stdio/lib_fseek.c
@@ -50,7 +50,7 @@
  *   ungetc(3) function on the same stream.
  *
  * Returned Value:
- *   Zero on succes; -1 on failure with errno set appropriately.
+ *   Zero on success; -1 on failure with errno set appropriately.
  *
  ****************************************************************************/
 

--- a/libs/libc/stdio/lib_fsetpos.c
+++ b/libs/libc/stdio/lib_fsetpos.c
@@ -47,7 +47,7 @@
  *   only way to portably reposition a stream.
  *
  * Returned Value:
- *   Zero on succes; -1 on failure with errno set appropriately.
+ *   Zero on success; -1 on failure with errno set appropriately.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

Fix typos in these files:

- arch/arm/src/eoss3/eoss3_serial.c,
- arch/arm/src/imxrt/hardware/imxrt_flexcan.h,
- arch/arm/src/imxrt/imxrt_flexcan.c,
- arch/arm/src/imxrt/imxrt_flexpwm.c,
- arch/arm/src/imxrt/imxrt_lpi2c.c,
- arch/arm/src/kinetis/kinetis_flexcan.c,
- arch/arm/src/nrf52/hardware/nrf52_rtc.h,
- arch/arm/src/nrf52/nrf52_clockconfig.c,
- arch/arm/src/nrf52/nrf52_radio.c,
- arch/arm/src/nrf52/nrf52_tim.c,
- arch/arm/src/rtl8720c/amebaz_depend.c,
- arch/arm/src/s32k1xx/Kconfig,
- arch/arm/src/s32k1xx/s32k1xx_flexcan.c,
- arch/arm/src/s32k1xx/s32k1xx_lpi2c.c,
- arch/arm/src/sama5/hardware/sam_sdmmc.h,
- arch/arm/src/sama5/sam_gmac.c,
- arch/arm/src/samd5e5/sam_wdt.c,
- arch/avr/src/avr32/up_exceptions.S,
- arch/avr/src/avr32/up_fullcontextrestore.S,
- arch/renesas/src/rx65n/rx65n_dtc.c,
- arch/renesas/src/rx65n/rx65n_usbhost.c,
- arch/risc-v/src/esp32c3/esp32c3_tickless.c,
- boards/arm/stm32h7/stm32h747i-disco/include/board.h,
- include/nuttx/lcd/ili9225.h,
- libs/libc/stdio/lib_fgetpos.c,
- libs/libc/stdio/lib_fseek.c, and
- libs/libc/stdio/lib_fsetpos.c.

## Impact

Improve readability.

No functional changes.

## Testing

nxstyle