### PR TITLE
sim/cmdline: save boot cmdline

### DIFF
--- a/arch/sim/src/sim/up_head.c
+++ b/arch/sim/src/sim/up_head.c
@@ -38,6 +38,13 @@
 #include "up_internal.h"
 
 /****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+int g_argc;
+char **g_argv;
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -62,6 +69,9 @@ static char g_logbuffer[4096];
 
 int main(int argc, char **argv, char **envp)
 {
+  g_argc = argc;
+  g_argv = argv;
+
 #ifdef CONFIG_SYSLOG_RPMSG
   syslog_rpmsg_init_early(g_logbuffer, sizeof(g_logbuffer));
 #endif

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -120,6 +120,11 @@ extern volatile void *g_current_regs[1];
 
 #endif
 
+/* The command line  arguments passed to simulator */
+
+extern int g_argc;
+extern char **g_argv;
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION

## Summary
Save boot cmdline to g_argc and g_argv on sim platform, they can be parsed for some application use them.

Change-Id: I989850a09528e3868957284c9f419d0992ae8d1f
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

