### PR TITLE
rptun: optimize multi-core startup

### DIFF
--- a/arch/sim/src/sim/up_hostmemory.c
+++ b/arch/sim/src/sim/up_hostmemory.c
@@ -86,28 +86,17 @@ void *host_alloc_shmem(const char *name, size_t size, int master)
       oflag |= O_CREAT | O_TRUNC;
     }
 
-  while (1)
+  fd = shm_open(name, oflag, S_IRUSR | S_IWUSR);
+  if (fd < 0)
     {
-      fd = shm_open(name, oflag, S_IRUSR | S_IWUSR);
-      if (fd >= 0)
-        {
-          if (!master)
-            {
-              /* Avoid the second slave instance open successfully */
+      return NULL;
+    }
 
-              shm_unlink(name);
-            }
-          break;
-        }
+  if (!master)
+    {
+      /* Avoid the second slave instance open successfully */
 
-      if (master || errno != ENOENT)
-        {
-          return NULL;
-        }
-
-      /* Master isn't ready, sleep and try again */
-
-      usleep(1000);
+      shm_unlink(name);
     }
 
   ret = ftruncate(fd, size);


### PR DESCRIPTION
## Summary
It's mutually dependent for Multi-core startup, because slave need to wait share-memory file is ready master created,
so we can move the waiting actions to the background thread. 

And move the share-memory file actions to sim_rptun_get_resource so that the main task is not block.
## Impact

## Testing

