### PR TITLE
fs/inode: add sanity check for inode to avoid nullpointer

### DIFF
--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -189,7 +189,8 @@ int sockfd_allocate(FAR struct socket *psock, int oflags)
 
 FAR struct socket *file_socket(FAR struct file *filep)
 {
-  if (filep != NULL && INODE_IS_SOCKET(filep->f_inode))
+  if (filep != NULL && filep->f_inode != NULL &&
+      INODE_IS_SOCKET(filep->f_inode))
     {
       return filep->f_priv;
     }

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -106,7 +106,7 @@ static FAR struct epoll_head *epoll_head_from_fd(int fd)
 
   /* Check fd come from us */
 
-  if (filep->f_inode->u.i_ops != &g_epoll_ops)
+  if (!filep->f_inode || filep->f_inode->u.i_ops != &g_epoll_ops)
     {
       set_errno(EBADF);
       return NULL;

--- a/fs/vfs/fs_fstat.c
+++ b/fs/vfs/fs_fstat.c
@@ -169,7 +169,13 @@ int file_fstat(FAR struct file *filep, FAR struct stat *buf)
   /* Get the inode from the file structure */
 
   inode = filep->f_inode;
-  DEBUGASSERT(inode != NULL);
+
+  /* Was this file opened ? */
+
+  if (!inode)
+    {
+      return -EBADF;
+    }
 
   /* The way we handle the stat depends on the type of inode that we
    * are dealing with.

--- a/sched/mqueue/mq_notify.c
+++ b/sched/mqueue/mq_notify.c
@@ -106,11 +106,10 @@ int mq_notify(mqd_t mqdes, FAR const struct sigevent *notification)
     }
 
   inode = filep->f_inode;
-  msgq  = inode->i_private;
 
   /* Was a valid message queue descriptor provided? */
 
-  if (!msgq)
+  if (!inode || !inode->i_private)
     {
       /* No.. return EBADF */
 
@@ -128,6 +127,7 @@ int mq_notify(mqd_t mqdes, FAR const struct sigevent *notification)
 
   /* Is there already a notification attached */
 
+  msgq = inode->i_private;
   if (msgq->ntpid == INVALID_PROCESS_ID)
     {
       /* No... Have we been asked to establish one? */


### PR DESCRIPTION
## Summary
The fs_getfilep don't check inode whether is null, so add sanity check for inode to avoid nullpointer.

Change-Id: Ib2c74ba308b8f15756fac4e69632c296243eb4ab
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact

## Testing

