### PR TITLE
sensor: directly return -ENOTSUP without the set_interval or batch

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -371,13 +371,18 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case SNIOC_SET_INTERVAL:
         {
+          if (lower->ops->set_interval == NULL)
+            {
+              ret = -ENOTSUP;
+              break;
+            }
+
           if (upper->interval == *val)
             {
               break;
             }
 
-          ret = lower->ops->set_interval ?
-                lower->ops->set_interval(lower, val) : -ENOTSUP;
+          ret = lower->ops->set_interval(lower, val);
           if (ret >= 0)
             {
               upper->interval = *val;
@@ -387,6 +392,12 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case SNIOC_BATCH:
         {
+          if (lower->ops->batch == NULL)
+            {
+              ret = -ENOTSUP;
+              break;
+            }
+
           if (upper->interval == 0)
             {
               ret = -EINVAL;
@@ -398,8 +409,7 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               break;
             }
 
-          ret = lower->ops->batch ?
-                lower->ops->batch(lower, val) : -ENOTSUP;
+          ret = lower->ops->batch(lower, val);
           if (ret >= 0)
             {
               upper->latency = *val;


### PR DESCRIPTION

## Summary
sensor: directly return -ENOTSUP without the set_interval or batch implementation for lowerhalf driver.

Change-Id: I7b02e0331e5f8b89b39896049a9e24ce30116f8a
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact

## Testing

