### PR TITLE
syslog: reslove crash because vmov.i32 instruction is not ready

### DIFF
--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -72,15 +72,9 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   struct tcb_s *tcb;
 #endif
 #ifdef CONFIG_SYSLOG_TIMESTAMP
-  struct timespec ts =
-  {
-  };
-
+  struct timespec ts;
 #if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
-  struct tm tm =
-  {
-  };
-
+  struct tm tm;
   char date_buf[CONFIG_SYSLOG_TIMESTAMP_BUFFER];
 #endif
 #endif
@@ -92,6 +86,13 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   syslogstream_create(&stream);
 
 #ifdef CONFIG_SYSLOG_TIMESTAMP
+  ts.tv_sec = 0;
+  ts.tv_nsec = 0;
+
+#if defined(CONFIG_SYSLOG_TIMESTAMP_FORMATTED)
+  memset(&tm, 0, sizeof(tm));
+#endif
+
   /* Get the current time.  Since debug output may be generated very early
    * in the start-up sequence, hardware timer support may not yet be
    * available.


### PR DESCRIPTION
## Summary
 Reslove crash because vmov.i32 instruction is not ready when system boot.
So avoid to use vmov.i32 instruction before FPU is ready.

Before modification:
3c03b35c <nx_vsyslog>:
3c03b35c:	f2c00010 	vmov.i32	d16, #0	; 0x00000000
3c03b360:	f2c02050 	vmov.i32	q9, #0	; 0x00000000
3c03b364:	e92d40f0 	push	{r4, r5, r6, r7, lr}
3c03b368:	e24dd08c 	sub	sp, sp, #140	; 0x8c
3c03b36c:	e28d301c 	add	r3, sp, #28
3c03b370:	e2505000 	subs	r5, r0, #0
3c03b374:	edcd0b0f 	vstr	d16, [sp, #60]	; 0x3c
3c03b378:	edcd0b01 	vstr	d16, [sp, #4]

After modification:
3c03b35c <nx_vsyslog>:
3c03b35c:       e92d40f0        push    {r4, r5, r6, r7, lr}
3c03b360:       e2505000        subs    r5, r0, #0
3c03b364:       e24dd08c        sub     sp, sp, #140    ; 0x8c
3c03b368:       e1a06001        mov     r6, r1
3c03b36c:       e1a07002        mov     r7, r2
3c03b370:       e28d000c        add     r0, sp, #12
3c03b374:       1a00003a        bne     3c03b464 <nx_vsyslog+0x108>

Change-Id: I643c19f5416c94a529764fdaa81f3088fcf95355
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

