### PR TITLE
pwm: add option to break the loops when using multiple PWM channels

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexpwm.c
+++ b/arch/arm/src/imxrt/imxrt_flexpwm.c
@@ -894,9 +894,19 @@ static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
     {
       for (int i = 0; i < PWM_NCHANNELS; i++)
         {
+          /* Break the loop if all following channels are not configured */
+
+          if (info->channels[i].channel == -1)
+            {
+              break;
+            }
+
           /* Configure the module freq only if is set to be used */
 
-          ret = pwm_change_freq(dev, info, i);
+          if (info->channels[i].channel != 0)
+            {
+              ret = pwm_change_freq(dev, info, i);
+            }
         }
 
       /* Save current frequency */
@@ -910,10 +920,20 @@ static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
 #ifdef CONFIG_PWM_MULTICHAN
   for (int i = 0; ret == OK && i < PWM_NCHANNELS; i++)
     {
+      /* Break the loop if all following channels are not configured */
+
+      if (info->channels[i].channel == -1)
+        {
+          break;
+        }
+
       /* Enable PWM output for each channel */
 
-      ret = pwm_set_output(dev, info->channels[i].channel,
-                                info->channels[i].duty);
+      if (info->channels[i].channel != 0)
+        {
+          ret = pwm_set_output(dev, info->channels[i].channel,
+                                    info->channels[i].duty);
+        }
     }
 #else
   /* Enable PWM output just for first channel */

--- a/arch/arm/src/nrf52/nrf52_pwm.c
+++ b/arch/arm/src/nrf52/nrf52_pwm.c
@@ -574,6 +574,13 @@ static int nrf52_pwm_start(FAR struct pwm_lowerhalf_s *dev,
 #ifdef CONFIG_PWM_MULTICHAN
       for (i = 0; ret == OK && i < CONFIG_PWM_NCHANNELS; i++)
         {
+          /* Break the loop if all following channels are not configured */
+
+          if (info->channels[i].channel == -1)
+            {
+              break;
+            }
+
           /* Set output if channel configured */
 
           if (info->channels[i].channel != 0)

--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -3645,6 +3645,13 @@ static int pwm_duty_channels_update(FAR struct pwm_lowerhalf_s *dev,
 #endif
     {
 #ifdef CONFIG_PWM_MULTICHAN
+      /* Break the loop if all following channels are not configured */
+
+      if (info->channels[i].channel == -1)
+        {
+          break;
+        }
+
       duty    = info->channels[i].duty;
       channel = info->channels[i].channel;
 
@@ -4390,6 +4397,13 @@ static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
 
       for (i = 0; ret == OK && i < CONFIG_PWM_NCHANNELS; i++)
         {
+          /* Break the loop if all following channels are not configured */
+
+          if (info->channels[i].channel == -1)
+            {
+              break;
+            }
+
           /* Set output if channel configured */
 
           if (info->channels[i].channel != 0)

--- a/arch/arm/src/stm32f0l0g0/stm32_pwm.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_pwm.c
@@ -1155,6 +1155,13 @@ static int stm32pwm_timer(FAR struct stm32_pwmtimer_s *priv,
       enum stm32_chanmode_e mode;
 
 #ifdef CONFIG_PWM_MULTICHAN
+      /* Break the loop if all following channels are not configured */
+
+      if (info->channels[i].channel == -1)
+        {
+          break;
+        }
+
       duty = info->channels[i].duty;
       channel = info->channels[i].channel;
 
@@ -1946,6 +1953,13 @@ static int stm32pwm_start(FAR struct pwm_lowerhalf_s *dev,
 
       for (i = 0; ret == OK && i < CONFIG_PWM_NCHANNELS; i++)
         {
+          /* Break the loop if all following channels are not configured */
+
+          if (info->channels[i].channel == -1)
+            {
+              break;
+            }
+
           /* Set output if channel configured */
 
           if (info->channels[i].channel != 0)

--- a/arch/arm/src/stm32f7/stm32_pwm.c
+++ b/arch/arm/src/stm32f7/stm32_pwm.c
@@ -1375,6 +1375,13 @@ static int pwm_timer(FAR struct stm32_pwmtimer_s *priv,
       enum stm32_chanmode_e mode;
 
 #ifdef CONFIG_PWM_MULTICHAN
+      /* Break the loop if all following channels are not configured */
+
+      if (info->channels[i].channel == -1)
+        {
+          break;
+        }
+
       duty = info->channels[i].duty;
       channel = info->channels[i].channel;
 
@@ -2187,6 +2194,13 @@ static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
 
       for (i = 0; ret == OK && i < CONFIG_PWM_NCHANNELS; i++)
         {
+          /* Break the loop if all following channels are not configured */
+
+          if (info->channels[i].channel == -1)
+            {
+              break;
+            }
+
           /* Set output if channel configured */
 
           if (info->channels[i].channel != 0)

--- a/arch/arm/src/stm32h7/stm32_pwm.c
+++ b/arch/arm/src/stm32h7/stm32_pwm.c
@@ -3324,6 +3324,13 @@ static int pwm_duty_channels_update(FAR struct pwm_lowerhalf_s *dev,
 #endif
     {
 #ifdef CONFIG_PWM_MULTICHAN
+      /* Break the loop if all following channels are not configured */
+
+      if (info->channels[i].channel == -1)
+        {
+          break;
+        }
+
       duty    = info->channels[i].duty;
       channel = info->channels[i].channel;
 
@@ -4029,6 +4036,13 @@ static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
 
       for (i = 0; ret == OK && i < CONFIG_PWM_NCHANNELS; i++)
         {
+          /* Break the loop if all following channels are not configured */
+
+          if (info->channels[i].channel == -1)
+            {
+              break;
+            }
+
           /* Set output if channel configured */
 
           if (info->channels[i].channel != 0)

--- a/arch/arm/src/stm32l4/stm32l4_pwm.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwm.c
@@ -3105,6 +3105,13 @@ static int pwm_duty_channels_update(FAR struct pwm_lowerhalf_s *dev,
 #endif
     {
 #ifdef CONFIG_STM32L4_PWM_MULTICHAN
+      /* Break the loop if all following channels are not configured */
+
+      if (info->channels[i].channel == -1)
+        {
+          break;
+        }
+
       duty    = info->channels[i].duty;
       channel = info->channels[i].channel;
 
@@ -3930,6 +3937,13 @@ static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
 
       for (i = 0; ret == OK && i < CONFIG_PWM_NCHANNELS; i++)
         {
+          /* Break the loop if all following channels are not configured */
+
+          if (info->channels[i].channel == -1)
+            {
+              break;
+            }
+
           /* Set output if channel configured */
 
           if (info->channels[i].channel != 0)

--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -120,7 +120,7 @@
 struct pwm_chan_s
 {
   ub16_t  duty;
-  uint8_t channel;
+  int8_t channel;
 };
 #endif
 


### PR DESCRIPTION
## Summary
PWM drivers currently use channel number 0 for the channels that are not
used by the application. This commit adds number -1 which indicates that
all following channels are not configured and that the loop can be broken.

## Impact
PWM drivers supporting multiple channels option.

## Testing
Tested with iMXRT and STM32 boards.

