### PR TITLE
drivers: wireless: Fix to set the address family for recvfrom() in gs2200m

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -666,6 +666,12 @@ errout:
 
       memcpy(&msg->addr, &pkt_dat->addr, sizeof(pkt_dat->addr));
 
+      /* Set the address family
+       * NOTE: gs2200m only supports IPv4
+       */
+
+      msg->addr.sin_family = AF_INET;
+
       /* In udp case, treat the packet separately */
 
       ret = false;


### PR DESCRIPTION
## Summary

- I noticed that the ntpclient does not work with gs2200m
- Finally, I found that the address family for recvfrom() is not
  set correctly
- This commit fixes this issue

## Impact

- None

## Testing

- Tested with ntpclient

