### PR TITLE
espressif/esp32/esp32s2/esp32c3: Disable wdt on initialization.

### DIFF
--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -45,7 +45,7 @@ endif
 
 # Specify our C code within this directory to be included
 
-CHIP_CSRCS  = esp32c3_allocateheap.c esp32c3_start.c esp32c3_idle.c
+CHIP_CSRCS  = esp32c3_allocateheap.c esp32c3_start.c esp32c3_wdt.c esp32c3_idle.c
 CHIP_CSRCS += esp32c3_irq.c
 CHIP_CSRCS += esp32c3_clockconfig.c esp32c3_gpio.c
 CHIP_CSRCS += esp32c3_lowputc.c
@@ -85,11 +85,8 @@ ifeq ($(CONFIG_ESP32C3_PARTITION),y)
 CHIP_CSRCS += esp32c3_partition.c
 endif
 
-ifeq ($(CONFIG_ESP32C3_WDT),y)
-CHIP_CSRCS += esp32c3_wdt.c
 ifeq ($(CONFIG_WATCHDOG),y)
 CHIP_CSRCS += esp32c3_wdt_lowerhalf.c
-endif
 endif
 
 ifeq ($(CONFIG_ESP32C3_TIMER),y)

--- a/arch/risc-v/src/esp32c3/esp32c3_start.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_start.c
@@ -34,6 +34,7 @@
 #include "esp32c3_irq.h"
 #include "esp32c3_lowputc.h"
 #include "esp32c3_start.h"
+#include "esp32c3_wdt.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -93,6 +94,10 @@ void __esp32c3_start(void)
     }
 
   showprogress('B');
+
+  /* Disable any wdt enabled by bootloader */
+
+  esp32c3_wdt_early_deinit();
 
   /* Initialize onboard resources */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.c
@@ -877,6 +877,24 @@ struct esp32c3_wdt_dev_s *esp32c3_wdt_init(enum esp32c3_wdt_inst_e wdt_id)
 }
 
 /****************************************************************************
+ * Name: esp32c3_wdt_early_deinit
+ *
+ * Description:
+ *   Disable the WDT(s) that was/were enabled by the bootloader.
+ *
+ ****************************************************************************/
+
+void esp32c3_wdt_early_deinit(void)
+{
+  uint32_t regval;
+  putreg32(RTC_CNTL_WDT_WKEY_VALUE, RTC_CNTL_WDTWPROTECT_REG);
+  regval  = getreg32(RTC_CNTL_WDTCONFIG0_REG);
+  regval &= ~RTC_CNTL_WDT_EN;
+  putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
+  putreg32(0, RTC_CNTL_WDTWPROTECT_REG);
+}
+
+/****************************************************************************
  * Name: esp32c3_wdt_deinit
  *
  * Description:

--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.h
@@ -141,6 +141,7 @@ struct esp32c3_wdt_ops_s
  ****************************************************************************/
 
 struct esp32c3_wdt_dev_s *esp32c3_wdt_init(enum esp32c3_wdt_inst_e wdt_id);
+void esp32c3_wdt_early_deinit(void);
 void esp32c3_wdt_deinit(struct esp32c3_wdt_dev_s *dev);
 bool esp32c3_wdt_is_running(struct esp32c3_wdt_dev_s *dev);
 

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_rtccntl.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_rtccntl.h
@@ -49,13 +49,13 @@
  * write-enable the wdt registers
  */
 
-#define RTC_CNTL_WDT_WKEY_VALUE 0x50D83AA1
+#define RTC_CNTL_WDT_WKEY_VALUE     0x50d83aa1
 
 /* The value that needs to be written to RTC_CNTL_SWD_WPROTECT_REG
  * to write-enable the wdt registers
  */
 
-#define RTC_CNTL_SWD_WKEY_VALUE 0x8F1D312A
+#define RTC_CNTL_SWD_WKEY_VALUE     0x8f1d312a
 
 /* Possible values for RTC_CNTL_WDT_CPU_RESET_LENGTH
  * and RTC_CNTL_WDT_SYS_RESET_LENGTH

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -22,7 +22,7 @@
 
 HEAD_ASRC  = xtensa_vectors.S xtensa_window_vector.S xtensa_windowspill.S
 HEAD_ASRC += xtensa_int_handlers.S  xtensa_user_handler.S
-HEAD_CSRC  = esp32_start.c
+HEAD_CSRC  = esp32_start.c esp32_wdt.c
 
 # Common XTENSA files (arch/xtensa/src/common)
 
@@ -169,11 +169,8 @@ ifeq ($(CONFIG_ESP32_PARTITION),y)
 CHIP_CSRCS += esp32_partition.c
 endif
 
-ifeq ($(CONFIG_ESP32_WDT),y)
-CHIP_CSRCS += esp32_wdt.c
 ifeq ($(CONFIG_WATCHDOG),y)
 CHIP_CSRCS += esp32_wdt_lowerhalf.c
-endif
 endif
 
 ifeq ($(CONFIG_ARCH_HAVE_EXTRA_HEAPS),y)

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -40,6 +40,7 @@
 #include "esp32_region.h"
 #include "esp32_start.h"
 #include "esp32_spiram.h"
+#include "esp32_wdt.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -126,11 +127,7 @@ void IRAM_ATTR __start(void)
    * start the NuttX environment.
    */
 
-  putreg32(RTC_CNTL_WDT_WKEY_VALUE, RTC_CNTL_WDTWPROTECT_REG);
-  regval  = getreg32(RTC_CNTL_WDTCONFIG0_REG);
-  regval &= ~RTC_CNTL_WDT_EN;
-  putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
-  putreg32(0, RTC_CNTL_WDTWPROTECT_REG);
+  esp32_wdt_early_deinit();
 
   /* Set CPU frequency configured in board.h */
 

--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -962,6 +962,24 @@ FAR struct esp32_wdt_dev_s *esp32_wdt_init(uint8_t wdt_id)
 }
 
 /****************************************************************************
+ * Name: esp32_wdt_early_deinit
+ *
+ * Description:
+ *   Disable the WDT(s) that was/were enabled by the bootloader.
+ *
+ ****************************************************************************/
+
+void esp32_wdt_early_deinit(void)
+{
+  uint32_t regval;
+  putreg32(RTC_CNTL_WDT_WKEY_VALUE, RTC_CNTL_WDTWPROTECT_REG);
+  regval  = getreg32(RTC_CNTL_WDTCONFIG0_REG);
+  regval &= ~RTC_CNTL_WDT_EN;
+  putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
+  putreg32(0, RTC_CNTL_WDTWPROTECT_REG);
+}
+
+/****************************************************************************
  * Name: esp32_wdt_deinit
  *
  * Description:

--- a/arch/xtensa/src/esp32/esp32_wdt.h
+++ b/arch/xtensa/src/esp32/esp32_wdt.h
@@ -99,6 +99,7 @@ struct esp32_wdt_ops_s
  ****************************************************************************/
 
 FAR struct esp32_wdt_dev_s *esp32_wdt_init(uint8_t wdt_id);
+void esp32_wdt_early_deinit(void);
 int esp32_wdt_deinit(FAR struct esp32_wdt_dev_s *dev);
 bool esp32_wdt_is_running(FAR struct esp32_wdt_dev_s *dev);
 

--- a/arch/xtensa/src/esp32s2/Make.defs
+++ b/arch/xtensa/src/esp32s2/Make.defs
@@ -22,7 +22,7 @@
 
 HEAD_ASRC  = xtensa_vectors.S xtensa_window_vector.S xtensa_windowspill.S
 HEAD_ASRC += xtensa_int_handlers.S  xtensa_user_handler.S
-HEAD_CSRC  = esp32s2_start.c
+HEAD_CSRC  = esp32s2_start.c esp32s2_wdt.c 
 
 # Common XTENSA files (arch/xtensa/src/common)
 

--- a/arch/xtensa/src/esp32s2/esp32s2_start.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_start.c
@@ -38,6 +38,7 @@
 #include "esp32s2_region.h"
 #include "esp32s2_start.h"
 #include "esp32s2_lowputc.h"
+#include "esp32s2_wdt.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -78,11 +79,9 @@ void IRAM_ATTR __start(void)
   uint32_t regval;
   uint32_t sp;
 
-  /* Kill the watchdog timer */
+  /* Disable any wdt enabled by bootloader */
 
-  regval  = getreg32(RTC_CNTL_WDTCONFIG0_REG);
-  regval &= ~RTC_CNTL_WDT_FLASHBOOT_MOD_EN;
-  putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
+  esp32s2_wdt_early_deinit();
 
   regval  = getreg32(DR_REG_BB_BASE + 0x48); /* DR_REG_BB_BASE+48 */
   regval &= ~(1 << 14);

--- a/arch/xtensa/src/esp32s2/esp32s2_wdt.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wdt.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32s2/esp32s2_wdt.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "xtensa.h"
+#include "hardware/esp32s2_rtccntl.h"
+
+#include "esp32s2_wdt.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s2_wdt_early_deinit
+ *
+ * Description:
+ *   Disable the WDT(s) that was/were enabled by the bootloader.
+ *
+ ****************************************************************************/
+
+void esp32s2_wdt_early_deinit(void)
+{
+  uint32_t regval;
+  putreg32(RTC_CNTL_WDT_WKEY_VALUE, RTC_CNTL_WDTWPROTECT_REG);
+  regval  = getreg32(RTC_CNTL_WDTCONFIG0_REG);
+  regval &= ~RTC_CNTL_WDT_EN;
+  putreg32(regval, RTC_CNTL_WDTCONFIG0_REG);
+  putreg32(0, RTC_CNTL_WDTWPROTECT_REG);
+}

--- a/arch/xtensa/src/esp32s2/esp32s2_wdt.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_wdt.h
@@ -1,0 +1,34 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32s2/esp32s2_wdt.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_SRC_ESP32S2_ESP32S2_WDT_H
+#define __ARCH_XTENSA_SRC_ESP32S2_ESP32S2_WDT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+void esp32s2_wdt_early_deinit(void);
+
+#endif /* __ARCH_XTENSA_SRC_ESP32S2_ESP32S2_WDT_H */

--- a/arch/xtensa/src/esp32s2/hardware/esp32s2_rtccntl.h
+++ b/arch/xtensa/src/esp32s2/hardware/esp32s2_rtccntl.h
@@ -31,6 +31,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* The value that needs to be written to RTC_CNTL_WDT_WKEY to
+ * write-enable the wdt registers
+ */
+
+#define RTC_CNTL_WDT_WKEY_VALUE         0x50d83aa1
+
 #define DPORT_CPUPERIOD_SEL_80          0
 #define DPORT_CPUPERIOD_SEL_160         1
 #define DPORT_CPUPERIOD_SEL_240         2


### PR DESCRIPTION
## Summary

This MR aims to:
* Fix esp32s2 wdt disabling and wrap it under a function.
* Wrap wdt disabling in esp32.
* Implement wdt disabling in esp32c3.

## Impact

From now on, it's not necessary to disable WDT in bootloader. Start initialization will take care of disabling wdt that was enabled by bootloader.

## Test

I used a bootloader with RWDT enabled for the 3 SoCs and I commented the function that disables it and could see the chips rebooting then I uncommented and the nsh was kept.
