### PR TITLE
drivers/mmcsd:fix build error of debug 

### DIFF
--- a/drivers/mmcsd/mmcsd_debug.c
+++ b/drivers/mmcsd/mmcsd_debug.c
@@ -70,9 +70,7 @@
 void mmcsd_dmpcsd(FAR const uint8_t *csd, uint8_t cardtype)
 {
   bool mmc = (cardtype == MMCSD_CARDTYPE_MMC);
-#if defined(CONFIG_DEBUG_FS_INFO)
   bool sd2 = (MMCSD_CSD_CSDSTRUCT(csd) == 1);
-#endif
 
   finfo("CSD\n");
   finfo("  CSD_STRUCTURE:           1.%d\n",   MMCSD_CSD_CSDSTRUCT(csd));


### PR DESCRIPTION
mmcsd_debug.c build error

fix a build error   when CONFIG_DEBUG_FS_INFO not defined:
symbol sd2 is not defined

