### PR TITLE
risc-v/esp32-c3: Adds systimer support and make rt_timer rely on it

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -151,7 +151,9 @@ config ESP32C3_CPU_FREQ_MHZ
 config ESP32C3_RT_TIMER
 	bool "Real-time Timer"
 	default n
-	select ESP32C3_TIMER0
+	select ESP32C3_TIMER
+	---help---
+		Real-time Timer is relying upon the Systimer 1.
 
 config ESP32C3_DISABLE_STDC_ATOMIC
 	bool "Disable standard C atomic"
@@ -166,7 +168,6 @@ config ESP32C3_WIRELESS
 	bool
 	default n
 	select ESP32C3_RT_TIMER
-	select ESP32C3_TIMER0
 
 menu "ESP32-C3 Peripheral Support"
 
@@ -309,7 +310,6 @@ config ESP32C3_WIRELESS
 	select NET
 	select ARCH_PHY_INTERRUPT
 	select ESP32C3_RT_TIMER
-	select ESP32C3_TIMER0
 	---help---
 		Enable Wireless support
 
@@ -876,7 +876,6 @@ config ESP32C3_AUTO_SLEEP
 	default n
 	select PM
 	select ESP32C3_RT_TIMER
-	select ESP32C3_TIMER0
 	select ESP32C3_TICKLESS
 	---help---
 		Enable ESP32-C3 Auto-sleep

--- a/arch/risc-v/src/esp32c3/esp32c3_tim.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.h
@@ -65,6 +65,7 @@ enum esp32c3_tim_inst_e
 {
   ESP32C3_TIMER0 = 0,  /* Timer 0 from Timer Group 0 */
   ESP32C3_TIMER1,      /* Timer 0 from Timer Group 1 */
+  ESP32C3_SYSTIM,      /* SYSTIMER 1 */
 };
 
 /* Timer mode */

--- a/arch/risc-v/src/esp32c3/hardware/esp32c3_tim.h
+++ b/arch/risc-v/src/esp32c3/hardware/esp32c3_tim.h
@@ -73,6 +73,8 @@
 
 #define LOW_32_MASK                0xffffffff
 #define LOW_22_MASK                0x003fffff
+#define LOW_20_MASK                0x000fffff
+#define LOW_26_MASK                0x03ffffff
 #define SHIFT_32                   32
 
 #define TIMG_T0CONFIG_REG(i)          (REG_TIMG_BASE(i) + 0x0000)


### PR DESCRIPTION
## Summary

This MR:
- Adds systimer support under the same generic timer API.
- Makes `rt_timer` rely on this added systimer.

## Impact 

From now on, we have the 2 generic timers available for users. 😃 

## Test

Since `rt_timer` has many "clients", I used the following defconfigs to make a simple validation:
- `esp32c3-devkit:wapi`  
- `esp32c3-devkit:rtc`
- `esp32c3-devkit:pm`  

Besides that, another customized application was used
to separately test the `rt_timer` API.