### PR TITLE
xtensa/esp32: expose SPI2 as a char driver

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -1440,12 +1440,12 @@ FAR struct spi_dev_s *esp32_spibus_initialize(int port)
   switch (port)
     {
 #ifdef CONFIG_ESP32_SPI2
-      case 2:
+      case ESP32_SPI2:
         priv = &esp32_spi2_priv;
         break;
 #endif
 #ifdef CONFIG_ESP32_SPI3
-      case 3:
+      case ESP32_SPI3:
         priv = &esp32_spi3_priv;
         break;
 #endif

--- a/arch/xtensa/src/esp32/esp32_spi.h
+++ b/arch/xtensa/src/esp32/esp32_spi.h
@@ -46,6 +46,14 @@ extern "C"
 
 #include <nuttx/spi/spi.h>
 
+#ifdef CONFIG_ESP32_SPI2
+#  define ESP32_SPI2 2
+#endif
+
+#ifdef CONFIG_ESP32_SPI3
+#  define ESP32_SPI3 3
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/boards/xtensa/esp32/common/src/Make.defs
+++ b/boards/xtensa/esp32/common/src/Make.defs
@@ -34,6 +34,10 @@ ifeq ($(CONFIG_ESP32_SPI),y)
   CSRCS += esp32_board_spi.c
 endif
 
+ifeq ($(CONFIG_SPI_DRIVER),y)
+  CSRCS += esp32_board_spidev.c
+endif
+
 ifeq ($(CONFIG_ESP32_WIRELESS),y)
   CSRCS += esp32_board_wlan.c
 endif

--- a/boards/xtensa/esp32/common/src/esp32_board_spidev.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spidev.c
@@ -1,0 +1,72 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_board_spidev.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/spi/spi_transfer.h>
+
+#include "esp32_spi.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_spidev_initialize
+ *
+ * Description:
+ *   Initialize and register SPI driver for the specified SPI port.
+ *
+ ****************************************************************************/
+
+int board_spidev_initialize(int port)
+{
+  int ret;
+  FAR struct spi_dev_s *spi;
+
+  spiinfo("Initializing /dev/spi%d...\n", port);
+
+  /* Initialize SPI device */
+
+  spi = esp32_spibus_initialize(port);
+  if (spi == NULL)
+    {
+      spierr("Failed to initialize SPI%d.\n", port);
+      return -ENODEV;
+    }
+
+  ret = spi_register(spi, port);
+  if (ret < 0)
+    {
+      spierr("Failed to register /dev/spi%d: %d\n", port, ret);
+
+      esp32_spibus_uninitialize(spi);
+    }
+
+  return ret;
+}

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32-devkitc.h
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32-devkitc.h
@@ -136,5 +136,24 @@ void esp32_spiflash_encrypt_test(void);
 int esp32_gpio_init(void);
 #endif
 
+/****************************************************************************
+ * Name: board_spidev_initialize
+ *
+ * Description:
+ *   Initialize SPI driver and register the /dev/spi device.
+ *
+ * Input Parameters:
+ *   bus - The SPI bus number, used to build the device path as /dev/spiN
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   to indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_DRIVER
+int board_spidev_initialize(int bus);
+#endif
+
 #endif /* __ASSEMBLY__ */
 #endif /* __BOARDS_XTENSA_ESP32_ESP32_DEVKITC_SRC_ESP32_DEVKITC_H */

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -94,6 +94,10 @@
 #  include "esp32_rtc_lowerhalf.h"
 #endif
 
+#ifdef CONFIG_SPI_DRIVER
+#  include "esp32_spi.h"
+#endif
+
 #include "esp32-devkitc.h"
 
 /****************************************************************************
@@ -388,6 +392,17 @@ int esp32_bringup(void)
       syslog(LOG_ERR,
              "ERROR: Failed to Instantiate the RTC driver: %d\n", ret);
     }
+#endif
+
+#ifdef CONFIG_SPI_DRIVER
+#  ifdef CONFIG_ESP32_SPI2
+  ret = board_spidev_initialize(ESP32_SPI2);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize SPI%d driver: %d\n",
+             ESP32_SPI2, ret);
+    }
+#  endif
 #endif
 
   /* If we got here then perhaps not all initialization was successful, but


### PR DESCRIPTION
## Summary

This MR exposes SPI2 as a character driver on ESP32.

## Impact

Board logic of esp32 Dev Kitc

## Test

There is an SPI DMA test on our internal repository that uses this branch and validates this change.