### PR TITLE
drivers/mmcsd:Send cmd0 just once for Increased compatibility

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -3096,9 +3096,8 @@ static int mmcsd_cardidentify(FAR struct mmcsd_state_s *priv)
 
   up_udelay(MMCSD_POWERUP_DELAY);
 
-  /* Then send CMD0 (twice just to be sure) */
+  /* Then send CMD0 just once is standard procedure */
 
-  mmcsd_sendcmdpoll(priv, MMCSD_CMD0, 0);
   mmcsd_sendcmdpoll(priv, MMCSD_CMD0, 0);
   up_udelay(MMCSD_IDLE_DELAY);
 


### PR DESCRIPTION
Signed-off-by: anjianjun <anjianjun@xiaomi.com>

mmcsd_sdio.c

Send cmd0 just once to Increased compatibility.

