### PR TITLE
libc/pthread_barrierattr_destory.c: Destroy shouldn't reinitialize the attributes

### DIFF
--- a/libs/libc/pthread/pthread_barrierattr_destroy.c
+++ b/libs/libc/pthread/pthread_barrierattr_destroy.c
@@ -59,10 +59,6 @@ int pthread_barrierattr_destroy(FAR pthread_barrierattr_t *attr)
     {
       ret = EINVAL;
     }
-  else
-    {
-      attr->pshared = PTHREAD_PROCESS_PRIVATE;
-    }
 
   return ret;
 }


### PR DESCRIPTION
## Summary
libc/pthread_barrierattr_destory.c: Destroy shouldn't reinitialize the attributes.  It looks like the code was copied from pthread_barrierattr_init.c

## Impact
N/A
## Testing
esp32-devkitc:smp
esp32-devkitc:ostest
