### PR TITLE
mtd: Return MTD Partition Information

### DIFF
--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -540,6 +540,12 @@ static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 
       cmd = MTDIOC_FLUSH;
     }
+  else if (cmd == BIOC_PARTINFO)
+    {
+      /* Change the BIOC_PARTINFO command to the MTDIOC_PARTINFO command. */
+
+      cmd = MTDIOC_PARTINFO;
+    }
 
   /* No other block driver ioctl commands are not recognized by this
    * driver.  Other possible MTD driver ioctl commands are passed through

--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -414,6 +414,25 @@ static int part_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
+      case MTDIOC_PARTINFO:
+        {
+          FAR struct partition_info_s *info =
+            (FAR struct partition_info_s *)arg;
+          if (info != NULL)
+            {
+              info->magic       = 0;
+              info->numsectors  = priv->neraseblocks * priv->blkpererase;
+              info->sectorsize  = priv->blocksize;
+              info->startsector = priv->firstblock;
+              info->endsector   = priv->firstblock + info->numsectors;
+
+              strncpy(info->parent, priv->parent->name, NAME_MAX);
+
+              ret = OK;
+          }
+        }
+        break;
+
       case MTDIOC_XIPBASE:
         {
           FAR void **ppv = (FAR void**)arg;

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -224,6 +224,24 @@ struct geometry
   blksize_t geo_sectorsize;   /* Size of one sector */
 };
 
+struct partition_info_s
+{
+  uint32_t        magic;        /* File system magic, 0 for RAW
+                                 * (see <sys/statfs.h>) */
+  size_t          numsectors;   /* Number of sectors in the partition */
+  size_t          sectorsize;   /* Size in bytes of a single sector */
+  off_t           startsector;  /* Offset to the first section/block of the
+                                 * managed sub-region */
+  off_t           endsector;    /* Offset to the last section/block of the
+                                 * managed sub-region */
+
+  /* NULL-terminated string representing the name of the parent node of the
+   * partition.
+   */
+
+  char            parent[NAME_MAX + 1];
+};
+
 /* This structure is provided by block devices when they register with the
  * system.  It is used by file systems to perform filesystem transfers.  It
  * differs from the normal driver vtable in several ways -- most notably in

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -278,6 +278,14 @@
                                            * IN:  None
                                            * OUT: None (ioctl return value provides
                                            *      success/failure indication). */
+#define BIOC_PARTINFO   _BIOC(0x000e)     /* Retrieve partition information from the
+                                           * block device.
+                                           * IN:  Pointer to writable struct
+                                           *      partition_info_s in which to
+                                           *      receive partition information data
+                                           * OUT: Partition information structure
+                                           *      populated with data from the block
+                                           *      device partition */
 
 /* NuttX MTD driver ioctl definitions ***************************************/
 

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -74,6 +74,12 @@
 #define MTDIOC_ERASESTATE _MTDIOC(0x000a) /* IN:  Pointer to uint8_t
                                            * OUT: Byte value that represents the
                                            *      erased state of the MTD cell */
+#define MTDIOC_PARTINFO   _MTDIOC(0x000b) /* IN:  Pointer to writable struct
+                                           *      partition_info_s in which to
+                                           *      receive partition information data
+                                           * OUT: Partition information structure
+                                           *      populated with data from the MTD
+                                           *      partition */
 
 /* Macros to hide implementation */
 


### PR DESCRIPTION
## Summary
This PR intends to add a new interface for Partition Information and provide an implementation for MTD partitions.

## Impact
New feature, no impact if not used.

## Testing
`esp32-wrover-kit` with WIP development (see #4233)
