### PR TITLE
sched/wqueue: added debug option to tag and print worker name

### DIFF
--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -256,6 +256,9 @@ struct work_s
   } u;
   worker_t  worker;         /* Work callback */
   FAR void *arg;            /* Callback argument */
+#ifdef CONFIG_WQUEUE_TAG_WORKER_NAME
+  FAR const char *name_tag; /* Work callback name tag */
+#endif
 };
 
 /* This is an enumeration of the various events that may be
@@ -356,8 +359,12 @@ int work_usrstart(void);
  *
  ****************************************************************************/
 
-int work_queue(int qid, FAR struct work_s *work, worker_t worker,
-               FAR void *arg, clock_t delay);
+int work_queue_nt(int qid, FAR struct work_s *work, worker_t worker,
+                  FAR void *arg, clock_t delay, FAR const char *name_tag);
+
+/* Stringificate the worker name for debug purposes */
+
+#define work_queue(qid, work, worker, arg, delay) work_queue_nt(qid, work, worker, arg, delay, #worker)
 
 /****************************************************************************
  * Name: work_cancel

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1787,6 +1787,14 @@ config SCHED_LPWORKSTACKSIZE
 		The stack size allocated for the lower priority worker thread.  Default: 2K.
 
 endif # SCHED_LPWORK
+
+config WQUEUE_TAG_WORKER_NAME
+	bool "Enable worker name tag for debug"
+	default n
+	depends on SCHED_WORKQUEUE && DEBUG_SCHED_INFO
+	---help---
+		Enables printing worker name to the informational debug output.
+
 endmenu # Work Queue Support
 
 menu "Stack and heap information"

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -28,6 +28,7 @@
 #include <queue.h>
 #include <assert.h>
 #include <errno.h>
+#include <debug.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
@@ -75,7 +76,7 @@ static void lp_work_timer_expiry(wdparm_t arg)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: work_queue
+ * Name: work_queue_nt
  *
  * Description:
  *   Queue kernel-mode work to be performed at a later time.  All queued
@@ -98,14 +99,15 @@ static void lp_work_timer_expiry(wdparm_t arg)
  *            int is invoked.
  *   delay  - Delay (in clock ticks) from the time queue until the worker
  *            is invoked. Zero means to perform the work immediately.
+ *   name_tag - The work callback name tag.
  *
  * Returned Value:
  *   Zero on success, a negated errno on failure
  *
  ****************************************************************************/
 
-int work_queue(int qid, FAR struct work_s *work, worker_t worker,
-               FAR void *arg, clock_t delay)
+int work_queue_nt(int qid, FAR struct work_s *work, worker_t worker,
+                  FAR void *arg, clock_t delay, FAR const char *name_tag)
 {
   irqstate_t flags;
 
@@ -123,6 +125,9 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
 
   work->worker = worker;           /* Work callback. non-NULL means queued */
   work->arg = arg;                 /* Callback argument */
+#ifdef CONFIG_WQUEUE_TAG_WORKER_NAME
+  work->name_tag = name_tag;       /* Work callback name tag */
+#endif
 
   /* Queue the new work */
 

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -115,6 +115,9 @@ static int work_thread(int argc, FAR char *argv[])
   worker_t  worker;
   irqstate_t flags;
   FAR void *arg;
+#ifdef CONFIG_WQUEUE_TAG_WORKER_NAME
+  FAR const char *name_tag;
+#endif
 
   wqueue = (FAR struct kwork_wqueue_s *)
            ((uintptr_t)strtoul(argv[1], NULL, 0));
@@ -152,6 +155,12 @@ static int work_thread(int argc, FAR char *argv[])
 
           arg = work->arg;
 
+#ifdef CONFIG_WQUEUE_TAG_WORKER_NAME
+          /* Extract the worker name tag */
+
+          name_tag = work->name_tag;
+#endif
+
           /* Mark the work as no longer being queued */
 
           work->worker = NULL;
@@ -161,7 +170,15 @@ static int work_thread(int argc, FAR char *argv[])
            */
 
           leave_critical_section(flags);
+
+#ifdef CONFIG_WQUEUE_TAG_WORKER_NAME
+          sinfo("WORKER %s started\n", name_tag);
+#endif
           CALL_WORKER(worker, arg);
+
+#ifdef CONFIG_WQUEUE_TAG_WORKER_NAME
+          sinfo("WORKER %s finished\n", name_tag);
+#endif
           flags = enter_critical_section();
         }
     }


### PR DESCRIPTION
## Summary

sched/wqueue: added debug option to tag and print worker name to the informational debug output.
This may be useful e.g. to identify a hung up worker that stalled the whole queue of the other workers.

## Impact

sched/wqueue