### PR TITLE
raspberrypi-pico: add support for lcd_dev

### DIFF
--- a/boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c
+++ b/boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c
@@ -34,11 +34,19 @@
 #include "rp2040_pico.h"
 
 #ifdef CONFIG_LCD_BACKPACK
-#   include "rp2040_lcd_backpack.h"
+#include "rp2040_lcd_backpack.h"
+#endif
+
+#ifdef CONFIG_LCD
+#include <nuttx/board.h>
+#endif
+
+#ifdef CONFIG_LCD_DEV
+#include <nuttx/lcd/lcd_dev.h>
 #endif
 
 #ifdef CONFIG_VIDEO_FB
-#  include <nuttx/video/fb.h>
+#include <nuttx/video/fb.h>
 #endif
 
 /****************************************************************************
@@ -135,6 +143,20 @@ int rp2040_bringup(void)
   if (ret < 0)
     {
       _err("ERROR: Failed to initialize Frame Buffer Driver.\n");
+    }
+#elif defined(CONFIG_LCD)
+  ret = board_lcd_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize LCD.\n");
+    }
+#endif
+
+#ifdef CONFIG_LCD_DEV
+  ret = lcddev_register(0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: lcddev_register() failed: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary
Also fixes lcd_initialize when no video_fb is configured
## Impact

## Testing
Done on 1.3" LCD
