### PR TITLE
xtensa/esp32: Enable the allocation of multiple SPI Flash partitions

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.h
+++ b/arch/xtensa/src/esp32/esp32_spiflash.h
@@ -49,20 +49,22 @@ extern "C"
  ****************************************************************************/
 
 /****************************************************************************
- * Name: esp32_spiflash_init
+ * Name: esp32_spiflash_alloc_mtdpart
  *
  * Description:
- *   Alloc ESP32 SPI Flash MTD.
+ *   Allocate an MTD partition from the ESP32 SPI Flash.
  *
  * Input Parameters:
- *   None
+ *   mtd_offset - MTD Partition offset from the base address in SPI Flash.
+ *   mtd_size   - Size for the MTD partition.
  *
  * Returned Value:
  *   ESP32 SPI Flash MTD data pointer if success or NULL if fail.
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(void);
+FAR struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
+                                                   uint32_t mtd_size);
 
 /****************************************************************************
  * Name: esp32_spiflash_get_mtd
@@ -81,7 +83,7 @@ FAR struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(void);
 FAR struct mtd_dev_s *esp32_spiflash_get_mtd(void);
 
 /****************************************************************************
- * Name: esp32_spiflash_get_mtd
+ * Name: esp32_spiflash_encrypt_get_mtd
  *
  * Description:
  *   Get ESP32 SPI Flash encryption raw MTD.

--- a/boards/xtensa/esp32/common/src/esp32_board_wlan.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_wlan.c
@@ -37,6 +37,13 @@
 #include "esp32_wlan.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ESP32_MTD_OFFSET            CONFIG_ESP32_MTD_OFFSET
+#define ESP32_MTD_SIZE              CONFIG_ESP32_MTD_SIZE
+
+/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -47,7 +54,7 @@ static int esp32_init_wifi_storage(void)
   const char *path = "/dev/mtdblock1";
   FAR struct mtd_dev_s *mtd_part;
 
-  mtd_part = esp32_spiflash_alloc_mtdpart();
+  mtd_part = esp32_spiflash_alloc_mtdpart(ESP32_MTD_OFFSET, ESP32_MTD_SIZE);
   if (!mtd_part)
     {
       syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_spiflash.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_spiflash.c
@@ -40,6 +40,13 @@
 #include "esp32-devkitc.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ESP32_MTD_OFFSET            CONFIG_ESP32_MTD_OFFSET
+#define ESP32_MTD_SIZE              CONFIG_ESP32_MTD_SIZE
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -55,7 +62,7 @@ int esp32_spiflash_init(void)
   FAR struct mtd_dev_s *mtd;
   int ret = ERROR;
 
-  mtd = esp32_spiflash_alloc_mtdpart();
+  mtd = esp32_spiflash_alloc_mtdpart(ESP32_MTD_OFFSET, ESP32_MTD_SIZE);
 
 #if defined (CONFIG_ESP32_SPIFLASH_SMARTFS)
   ret = smart_initialize(0, mtd, NULL);

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_spiflash.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_spiflash.c
@@ -40,6 +40,13 @@
 #include "esp32-ethernet-kit.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ESP32_MTD_OFFSET            CONFIG_ESP32_MTD_OFFSET
+#define ESP32_MTD_SIZE              CONFIG_ESP32_MTD_SIZE
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -55,7 +62,7 @@ int esp32_spiflash_init(void)
   FAR struct mtd_dev_s *mtd;
   int ret = ERROR;
 
-  mtd = esp32_spiflash_alloc_mtdpart();
+  mtd = esp32_spiflash_alloc_mtdpart(ESP32_MTD_OFFSET, ESP32_MTD_SIZE);
 
 #if defined (CONFIG_ESP32_SPIFLASH_SMARTFS)
   ret = smart_initialize(0, mtd, NULL);

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_spiflash.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_spiflash.c
@@ -40,6 +40,13 @@
 #include "esp32-wrover-kit.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ESP32_MTD_OFFSET            CONFIG_ESP32_MTD_OFFSET
+#define ESP32_MTD_SIZE              CONFIG_ESP32_MTD_SIZE
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -55,7 +62,7 @@ int esp32_spiflash_init(void)
   FAR struct mtd_dev_s *mtd;
   int ret = ERROR;
 
-  mtd = esp32_spiflash_alloc_mtdpart();
+  mtd = esp32_spiflash_alloc_mtdpart(ESP32_MTD_OFFSET, ESP32_MTD_SIZE);
 
 #if defined (CONFIG_ESP32_SPIFLASH_SMARTFS)
   ret = smart_initialize(0, mtd, NULL);


### PR DESCRIPTION
## Summary
This PR intends to refactor the `esp32_spiflash_alloc_mtdpart` interface for enabling the creation of multiple MTD partitions with different offsets and sizes.
Currently the `esp32_spiflash_alloc_mtdpart` function allocates a statically-defined partition from *offset* and *size* set via Kconfig.
This commit then changes the function interface to receive those information as arguments.

## Impact
ESP32-based platforms. Should have no impact due to no functional changes.

## Testing
`esp32-wrover-kit` with ongoing development.

