### PR TITLE
Use exit func iml host_abort.

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -75,7 +75,7 @@ ifeq ($(CONFIG_HOST_MACOS),y)
   HOSTCFLAGS += -Wno-deprecated-declarations
 endif
 
-HOSTSRCS = up_hostirq.c up_hostmemory.c up_hosttime.c up_simuart.c
+HOSTSRCS = up_hostirq.c up_hostmemory.c up_hosttime.c up_simuart.c up_host_abort.c
 STDLIBS += -lpthread
 ifeq ($(CONFIG_HOST_MACOS),y)
 ifeq ($(CONFIG_LIBCXX),y)

--- a/arch/sim/src/sim/up_head.c
+++ b/arch/sim/src/sim/up_head.c
@@ -48,9 +48,6 @@ char **g_argv;
  * Private Data
  ****************************************************************************/
 
-static jmp_buf g_simabort;
-static int g_exitcode = EXIT_SUCCESS;
-
 #ifdef CONFIG_SYSLOG_RPMSG
 static char g_logbuffer[4096];
 #endif
@@ -78,37 +75,16 @@ int main(int argc, char **argv, char **envp)
 
   /* Start NuttX */
 
-  if (setjmp(g_simabort) == 0)
-    {
 #ifdef CONFIG_SMP
-      /* Start the CPU0 emulation.  This should not return. */
+  /* Start the CPU0 emulation.  This should not return. */
 
-      sim_cpu0_start();
+  sim_cpu0_start();
 #endif
-      /* Start the NuttX emulation.  This should not return. */
+  /* Start the NuttX emulation.  This should not return. */
 
-      nx_start();
-    }
+  nx_start();
 
-  return g_exitcode;
-}
-
-/****************************************************************************
- * Name: host_abort
- *
- * Description:
- *   Abort the simulation
- *
- * Input Parameters:
- *   status - Exit status to set
- ****************************************************************************/
-
-void host_abort(int status)
-{
-  /* Save the return code and exit the simulation */
-
-  g_exitcode = status;
-  longjmp(g_simabort, 1);
+  return EXIT_FAILURE;
 }
 
 /****************************************************************************

--- a/arch/sim/src/sim/up_host_abort.c
+++ b/arch/sim/src/sim/up_host_abort.c
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_host_abort.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdlib.h>
+
+#include "up_internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: host_abort
+ *
+ * Description:
+ *   Abort the simulation
+ *
+ * Input Parameters:
+ *   status - Exit status to set
+ ****************************************************************************/
+
+void host_abort(int status)
+{
+  /* exit the simulation */
+
+  exit(status);
+}
+


### PR DESCRIPTION
When use poweroff command,host_abort will be called,but may be make __stack_chk_fail irq, and host_abort be called in PANIC(), so bring infinite loop, in turn it can not exit SIM.