### PR TITLE
mm: Fix a typo in Kconfig

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -15,7 +15,7 @@ config MM_DEFAULT_MANAGER
 config MM_CUSTOMIZE_MANAGER
 	bool "Customized heap manager"
 	---help---
-		Customized memory manger policy. The build will fail
+		Customized memory manager policy. The build will fail
 		if the MM heap module not defined by customer.
 
 endchoice


### PR DESCRIPTION
This patch fixes a spelling typo in mm/Kconfig.

Signed-off-by: Masanari Iida <standby24x7@gmail.com>
