### PR TITLE
xtensa/esp32: Keep track of the CPU where the interrupt was attached.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpuint.c
+++ b/arch/xtensa/src/esp32/esp32_cpuint.c
@@ -399,18 +399,11 @@ int esp32_cpuint_initialize(void)
 
 void up_disable_irq(int cpuint)
 {
-#ifdef CONFIG_SMP
-  int cpu;
-#endif
+  int cpu = up_cpu_index();
 
   DEBUGASSERT(cpuint >= 0 && cpuint <= ESP32_CPUINT_MAX);
 
-#ifdef CONFIG_SMP
-  cpu = up_cpu_index();
   xtensa_disable_cpuint(&g_intenable[cpu], (1ul << cpuint));
-#else
-  xtensa_disable_cpuint(&g_intenable[0], (1ul << cpuint));
-#endif
 }
 
 /****************************************************************************
@@ -423,18 +416,11 @@ void up_disable_irq(int cpuint)
 
 void up_enable_irq(int cpuint)
 {
-#ifdef CONFIG_SMP
-  int cpu;
-#endif
+  int cpu = up_cpu_index();
 
   DEBUGASSERT(cpuint >= 0 && cpuint <= ESP32_CPUINT_MAX);
 
-#ifdef CONFIG_SMP
-  cpu = up_cpu_index();
   xtensa_enable_cpuint(&g_intenable[cpu], (1ul << cpuint));
-#else
-  xtensa_enable_cpuint(&g_intenable[0], (1ul << cpuint));
-#endif
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -417,11 +417,7 @@ void esp32_gpioirqinitialize(void)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-#ifdef CONFIG_SMP
   cpu = up_cpu_index();
-#else
-  cpu = 0;
-#endif
 
   /* Attach the GPIO peripheral to the allocated CPU interrupt */
 

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -1569,6 +1569,9 @@ FAR struct i2c_master_s *esp32_i2cbus_initialize(int port)
       return NULL;
     }
 
+  /* Set up to receive peripheral interrupts on the current CPU */
+
+  config->cpu = up_cpu_index();
   up_disable_irq(priv->cpuint);
   esp32_attach_peripheral(config->cpu, config->periph, priv->cpuint);
 

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -172,7 +172,6 @@ struct esp32_i2c_config_s
   uint8_t sda_pin;            /* GPIO configuration for SDA as SDA */
 
 #ifndef CONFIG_I2C_POLLED
-  uint8_t cpu;                /* CPU ID */
   uint8_t periph;             /* Peripheral ID */
   uint8_t irq;                /* Interrupt ID */
 #endif
@@ -201,6 +200,8 @@ struct esp32_i2c_priv_s
 
 #ifndef CONFIG_I2C_POLLED
   sem_t sem_isr;               /* Interrupt wait semaphore */
+  int     cpuint;              /* CPU interrupt assigned to this I2C */
+  uint8_t cpu;                 /* CPU ID */
 #endif
 
   /* I2C work state (see enum esp32_i2cstate_e) */
@@ -211,10 +212,6 @@ struct esp32_i2c_priv_s
 
   uint8_t msgid;               /* Current message ID */
   ssize_t bytes;               /* Processed data bytes */
-
-#ifndef CONFIG_I2C_POLLED
-  int     cpuint;              /* CPU interrupt assigned to this I2C */
-#endif
 
   uint32_t error;              /* I2C transform error */
 
@@ -289,7 +286,6 @@ static const struct esp32_i2c_config_s esp32_i2c0_config =
   .scl_pin    = CONFIG_ESP32_I2C0_SCLPIN,
   .sda_pin    = CONFIG_ESP32_I2C0_SDAPIN,
 #ifndef CONFIG_I2C_POLLED
-  .cpu        = 0,
   .periph     = ESP32_PERIPH_I2C_EXT0,
   .irq        = ESP32_IRQ_I2C_EXT0,
 #endif
@@ -322,7 +318,6 @@ static const struct esp32_i2c_config_s esp32_i2c1_config =
   .scl_pin    = CONFIG_ESP32_I2C1_SCLPIN,
   .sda_pin    = CONFIG_ESP32_I2C1_SDAPIN,
 #ifndef CONFIG_I2C_POLLED
-  .cpu        = 0,
   .periph     = ESP32_PERIPH_I2C_EXT1,
   .irq        = ESP32_IRQ_I2C_EXT1,
 #endif
@@ -1571,14 +1566,14 @@ FAR struct i2c_master_s *esp32_i2cbus_initialize(int port)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  config->cpu = up_cpu_index();
+  priv->cpu = up_cpu_index();
   up_disable_irq(priv->cpuint);
-  esp32_attach_peripheral(config->cpu, config->periph, priv->cpuint);
+  esp32_attach_peripheral(priv->cpu, config->periph, priv->cpuint);
 
   ret = irq_attach(config->irq, esp32_i2c_irq, priv);
   if (ret != OK)
     {
-      esp32_detach_peripheral(config->cpu, config->periph, priv->cpuint);
+      esp32_detach_peripheral(priv->cpu, config->periph, priv->cpuint);
       esp32_free_cpuint(priv->cpuint);
 
       leave_critical_section(flags);
@@ -1630,7 +1625,7 @@ int esp32_i2cbus_uninitialize(FAR struct i2c_master_s *dev)
 
 #ifndef CONFIG_I2C_POLLED
   up_disable_irq(priv->cpuint);
-  esp32_detach_peripheral(priv->config->cpu,
+  esp32_detach_peripheral(priv->cpu,
                           priv->config->periph,
                           priv->cpuint);
   esp32_free_cpuint(priv->cpuint);

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -1025,11 +1025,7 @@ static int esp32_attach(struct uart_dev_s *dev)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-#ifdef CONFIG_SMP
   cpu = up_cpu_index();
-#else
-  cpu = 0;
-#endif
 
   /* Attach the GPIO peripheral to the allocated CPU interrupt */
 
@@ -1073,12 +1069,7 @@ static void esp32_detach(struct uart_dev_s *dev)
 
   /* Disassociate the peripheral interrupt from the CPU interrupt */
 
-#ifdef CONFIG_SMP
   cpu = up_cpu_index();
-#else
-  cpu = 0;
-#endif
-
   esp32_detach_peripheral(cpu, priv->config->periph, priv->cpuint);
 
   /* And release the CPU interrupt */
@@ -1161,11 +1152,7 @@ static void dma_attach(uint8_t dma_chan)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-#ifdef CONFIG_SMP
   cpu = up_cpu_index();
-#else
-  cpu = 0;
-#endif
 
   /* Attach the UHCI interrupt to the allocated CPU interrupt
    * and attach and enable the IRQ.

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -227,7 +227,6 @@ struct esp32_dmadesc_s s_dma_txdesc[UART_DMA_CONTROLLERS_NUM]
 struct esp32_config_s
 {
   const uint8_t id;             /* UART id */
-  uint8_t  cpu;                 /* CPU ID */
   uint8_t  periph;              /* UART peripheral ID */
   uint8_t  irq;                 /* IRQ number assigned to the peripheral */
   uint8_t  txpin;               /* Tx pin number (0-39) */
@@ -256,6 +255,7 @@ struct esp32_dev_s
   uint32_t baud;                       /* Configured baud */
   uint32_t status;                     /* Saved status bits */
   int      cpuint;                     /* CPU interrupt assigned to this UART */
+  uint8_t  cpu;                        /* CPU ID */
   uint8_t  parity;                     /* 0=none, 1=odd, 2=even */
   uint8_t  bits;                       /* Number of bits (5-9) */
   bool     stopbits2;                  /* true: Configure with 2 stop bits instead of 1 */
@@ -1025,12 +1025,12 @@ static int esp32_attach(struct uart_dev_s *dev)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->config->cpu = up_cpu_index();
+  priv->cpu = up_cpu_index();
 
   /* Attach the GPIO peripheral to the allocated CPU interrupt */
 
   up_disable_irq(priv->cpuint);
-  esp32_attach_peripheral(priv->config->cpu, priv->config->periph,
+  esp32_attach_peripheral(priv->cpu, priv->config->periph,
                           priv->cpuint);
 
   /* Attach and enable the IRQ */
@@ -1069,7 +1069,7 @@ static void esp32_detach(struct uart_dev_s *dev)
 
   /* Disassociate the peripheral interrupt from the CPU interrupt */
 
-  esp32_detach_peripheral(priv->config->cpu, priv->config->periph,
+  esp32_detach_peripheral(priv->cpu, priv->config->periph,
                           priv->cpuint);
 
   /* And release the CPU interrupt */

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -109,7 +109,6 @@ struct esp32_spi_config_s
   uint8_t miso_pin;           /* GPIO configuration for MISO */
   uint8_t clk_pin;            /* GPIO configuration for CLK */
 
-  uint8_t cpu;                /* CPU ID */
   uint8_t periph;             /* peripher ID */
   uint8_t irq;                /* Interrupt ID */
 
@@ -153,6 +152,7 @@ struct esp32_spi_priv_s
   sem_t            sem_isr;
 
   int              cpuint;      /* SPI interrupt ID */
+  uint8_t          cpu;         /* CPU ID */
 
   uint32_t         frequency;   /* Requested clock frequency */
   uint32_t         actual;      /* Actual clock frequency */
@@ -214,7 +214,6 @@ static const struct esp32_spi_config_s esp32_spi2_config =
   .mosi_pin     = CONFIG_ESP32_SPI2_MOSIPIN,
   .miso_pin     = CONFIG_ESP32_SPI2_MISOPIN,
   .clk_pin      = CONFIG_ESP32_SPI2_CLKPIN,
-  .cpu          = 0,
   .periph       = ESP32_PERIPH_SPI2,
   .irq          = ESP32_IRQ_SPI2,
   .clk_bit      = DPORT_SPI_CLK_EN_2,
@@ -289,7 +288,6 @@ static const struct esp32_spi_config_s esp32_spi3_config =
   .mosi_pin     = CONFIG_ESP32_SPI3_MOSIPIN,
   .miso_pin     = CONFIG_ESP32_SPI3_MISOPIN,
   .clk_pin      = CONFIG_ESP32_SPI3_CLKPIN,
-  .cpu          = 0,
   .periph       = ESP32_PERIPH_SPI3,
   .irq          = ESP32_IRQ_SPI3,
   .clk_bit      = DPORT_SPI_CLK_EN,
@@ -1475,15 +1473,15 @@ FAR struct spi_dev_s *esp32_spibus_initialize(int port)
 
       /* Set up to receive peripheral interrupts on the current CPU */
 
-      priv->config->cpu = up_cpu_index();
+      priv->cpu = up_cpu_index();
       up_disable_irq(priv->cpuint);
-      esp32_attach_peripheral(priv->config->cpu,
+      esp32_attach_peripheral(priv->cpu,
                               priv->config->periph,
                               priv->cpuint);
       ret = irq_attach(priv->config->irq, esp32_spi_interrupt, priv);
       if (ret != OK)
         {
-          esp32_detach_peripheral(priv->config->cpu,
+          esp32_detach_peripheral(priv->cpu,
                                   priv->config->periph,
                                   priv->cpuint);
           esp32_free_cpuint(priv->cpuint);
@@ -1537,7 +1535,7 @@ int esp32_spibus_uninitialize(FAR struct spi_dev_s *dev)
   if (priv->config->use_dma)
     {
       up_disable_irq(priv->cpuint);
-      esp32_detach_peripheral(priv->config->cpu,
+      esp32_detach_peripheral(priv->cpu,
                               priv->config->periph,
                               priv->cpuint);
       esp32_free_cpuint(priv->cpuint);

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -1473,6 +1473,9 @@ FAR struct spi_dev_s *esp32_spibus_initialize(int port)
           return NULL;
         }
 
+      /* Set up to receive peripheral interrupts on the current CPU */
+
+      priv->config->cpu = up_cpu_index();
       up_disable_irq(priv->cpuint);
       esp32_attach_peripheral(priv->config->cpu,
                               priv->config->periph,

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -101,7 +101,6 @@ struct esp32_spislv_config_s
   uint8_t miso_pin;           /* GPIO configuration for MISO */
   uint8_t clk_pin;            /* GPIO configuration for CLK */
 
-  uint8_t cpu;                /* CPU ID */
   uint8_t periph;             /* peripher ID */
   uint8_t irq;                /* Interrupt ID */
 
@@ -136,6 +135,7 @@ struct esp32_spislv_priv_s
 
   const struct esp32_spislv_config_s *config; /* Port configuration */
 
+  uint8_t          cpu;         /* CPU ID */
   int              cpuint;      /* SPI interrupt ID */
 
   enum spi_mode_e  mode;        /* Actual SPI hardware mode */
@@ -200,7 +200,6 @@ static const struct esp32_spislv_config_s esp32_spi2_config =
   .mosi_pin     = CONFIG_ESP32_SPI2_MOSIPIN,
   .miso_pin     = CONFIG_ESP32_SPI2_MISOPIN,
   .clk_pin      = CONFIG_ESP32_SPI2_CLKPIN,
-  .cpu          = 0,
   .periph       = ESP32_PERIPH_SPI2,
   .irq          = ESP32_IRQ_SPI2,
   .clk_bit      = DPORT_SPI_CLK_EN_2,
@@ -254,7 +253,6 @@ static const struct esp32_spislv_config_s esp32_spi3_config =
   .mosi_pin     = CONFIG_ESP32_SPI3_MOSIPIN,
   .miso_pin     = CONFIG_ESP32_SPI3_MISOPIN,
   .clk_pin      = CONFIG_ESP32_SPI3_CLKPIN,
-  .cpu          = 0,
   .periph       = ESP32_PERIPH_SPI3,
   .irq          = ESP32_IRQ_SPI3,
   .clk_bit      = DPORT_SPI_CLK_EN,
@@ -1308,16 +1306,16 @@ FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
 
   /* Set up to receive peripheral interrupts on the current CPU */
 
-  priv->config->cpu = up_cpu_index();
+  priv->cpu = up_cpu_index();
   up_disable_irq(priv->cpuint);
-  esp32_attach_peripheral(priv->config->cpu,
+  esp32_attach_peripheral(priv->cpu,
                           priv->config->periph,
                           priv->cpuint);
 
   ret = irq_attach(priv->config->irq, esp32_spislv_interrupt, priv);
   if (ret != OK)
     {
-      esp32_detach_peripheral(priv->config->cpu,
+      esp32_detach_peripheral(priv->cpu,
                               priv->config->periph,
                               priv->cpuint);
       esp32_free_cpuint(priv->cpuint);
@@ -1369,7 +1367,7 @@ int esp32_spislv_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
     }
 
   up_disable_irq(priv->cpuint);
-  esp32_detach_peripheral(priv->config->cpu,
+  esp32_detach_peripheral(priv->cpu,
                           priv->config->periph,
                           priv->cpuint);
   esp32_free_cpuint(priv->cpuint);

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -1306,6 +1306,9 @@ FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
       return NULL;
     }
 
+  /* Set up to receive peripheral interrupts on the current CPU */
+
+  priv->config->cpu = up_cpu_index();
   up_disable_irq(priv->cpuint);
   esp32_attach_peripheral(priv->config->cpu,
                           priv->config->periph,


### PR DESCRIPTION
## Summary
In some drivers the current CPU was fixed or not saved when attaching an interrupt.  We have to keep track of the CPU where an interrupt was attached, it is used when detaching it.
## Impact
ESP32 SMP
## Testing
esp32-devkitc:smp
