### PR TITLE
Fix status register reading in ramtron_read()

### DIFF
--- a/drivers/mtd/ramtron.c
+++ b/drivers/mtd/ramtron.c
@@ -892,6 +892,8 @@ static ssize_t ramtron_read(FAR struct mtd_dev_s *dev,
    * enable state
    */
 
+  SPI_SELECT(priv->dev, SPIDEV_FLASH(0), false);
+  SPI_SELECT(priv->dev, SPIDEV_FLASH(0), true);
   SPI_SEND(priv->dev, RAMTRON_RDSR);
   status = SPI_SEND(priv->dev, RAMTRON_DUMMY);
   if ((status & ~RAMTRON_SR_SRWD) == 0)


### PR DESCRIPTION
## Summary
The status register check in `ramtron_read()` was not correctly reading the status register. According to the documentation for [FM25V02A](https://www.cypress.com/file/139666/download), "A falling edge on CS must occur before every opcode". Through testing, I found this was also true for the read command of [MB85RS128TY](https://www.fujitsu.com/uk/Images/MB85RS128TY-0050-1v0-E.pdf). This makes sense given that the read/write commands of these two FRAMs allow an infinite number of reads/writes per command. A new command must be started by a falling edge on CS.

This pull request adds functionality to reassert the CS line between the read and status register check in `ramtron_read()`.

## Impact
The status register check in `ramtron_read()` now correctly reads the status register instead of failing and returning an error code. Due to reasserting the CS, `ramtron_read()` takes slightly longer to complete when `CONFIG_RAMTRON_WRITEWAIT` is defined. On an stm32h743 running Nuttx from the master branch of PX4, it took about 200us to toggle CS high then low.

## Testing
I tested the fix on an STM32H743 nucleo board and `ramtron_read()` was able to properly read the status register of both a FM25V01A and MB85RS128TY. I can look into creating a test specific to the Nuttx master branch, if needed.

## Additional Information
On a side note, even though `ramtron_read()` returned a negative value, the overall read succeeded because `bchlib_read()` ignores the return value of `bchlib_readsector()`. Is this the desired behavior?


