### PR TITLE
xtensa/common: save sp before overwriting in level2/3/4 handler and typo fix

### DIFF
--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -416,6 +416,13 @@ _xtensa_level2_handler:
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
 
+	/* Save current SP before (possibly) overwriting it, it's the register save
+	 * area. This value will be used later by dispatch_c_isr to retrieve the
+	 * register save area.
+	 */
+
+	mov  a12, sp
+
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
 	ps_setup	2 a0
@@ -480,6 +487,13 @@ _xtensa_level3_handler:
 	s32i	a2, sp, (4 * REG_A2)
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
+
+	/* Save current SP before (possibly) overwriting it, it's the register save
+	 * area. This value will be used later by dispatch_c_isr to retrieve the
+	 * register save area.
+	 */
+
+	mov  a12, sp
 
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
@@ -546,6 +560,13 @@ _xtensa_level4_handler:
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
 
+	/* Save current SP before (possibly) overwriting it, it's the register save
+	 * area. This value will be used later by dispatch_c_isr to retrieve the
+	 * register save area.
+	 */
+
+	mov  a12, sp
+
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
 	ps_setup	4 a0
@@ -611,6 +632,13 @@ _xtensa_level5_handler:
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
 
+	/* Save current SP before (possibly) overwriting it, it's the register save
+	 * area. This value will be used later by dispatch_c_isr to retrieve the
+	 * register save area.
+	 */
+
+	mov  a12, sp
+
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
 	ps_setup	5 a0
@@ -675,6 +703,13 @@ _xtensa_level6_handler:
 	s32i	a2, sp, (4 * REG_A2)
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
+
+	/* Save current SP before (possibly) overwriting it, it's the register save
+	 * area. This value will be used later by dispatch_c_isr to retrieve the
+	 * register save area.
+	 */
+
+	mov  a12, sp
 
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 

--- a/arch/xtensa/src/common/xtensa_vectors.S
+++ b/arch/xtensa/src/common/xtensa_vectors.S
@@ -109,13 +109,13 @@ _xtensa_level3_vector:
 
 _xtensa_level4_vector:
 	wsr			a0, EXCSAVE_4			/* Preserve a0 */
-	call0		_xtensa_level4_handler	/* Call level 5 interrupt handling */
+	call0		_xtensa_level4_handler	/* Call level 4 interrupt handling */
 
 	/* Never returns here - call0 is used as a jump */
 
 	.end		literal_prefix
 
-	.size	_xtensa_level5_vector, . - _xtensa_level5_vector
+	.size	_xtensa_level4_vector, . - _xtensa_level4_vector
 #endif
 
 #if XCHAL_EXCM_LEVEL >= 5


### PR DESCRIPTION
## Summary
    arch: xtensa: save current SP before overwrting in dispatch_c_isr.
    
    In levelx(2,3,4,5)_handler, first need to save sp in a12,
    then after dispatch_c_isr we can restore sp from a12.
    
    Change-Id: Idb6b64a782da866670a4db80b33435a9b63f02c3

## Impact

## Testing

