### PR TITLE
arch:xtensa: add new GNU toolchain for xtensa.

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -17,7 +17,6 @@ config ARCH_CHIP_ESP32
 	select ARCH_HAVE_TEXT_HEAP
 	select ARCH_HAVE_SDRAM
 	select ARCH_HAVE_RESET
-	select ARCH_TOOLCHAIN_GNU
 	select ARCH_VECNOTIRQ
 	select LIBC_ARCH_MEMCPY
 	select LIBC_ARCH_MEMCHR
@@ -44,7 +43,6 @@ config ARCH_CHIP_ESP32S2
 	select ARCH_HAVE_TEXT_HEAP
 	select ARCH_HAVE_SDRAM
 	select ARCH_HAVE_RESET
-	select ARCH_TOOLCHAIN_GNU
 	select ARCH_VECNOTIRQ
 	select LIBC_ARCH_MEMCPY
 	select LIBC_ARCH_MEMCHR
@@ -172,7 +170,25 @@ config XTENSA_EXTMEM_BSS
 		Adds a section and an attribute that allows to force variables into
 		the external memory.
 
-source "arch/xtensa/src/lx6/Kconfig"
+choice
+	prompt "Toolchain Selection"
+	default XTENSA_TOOLCHAIN_ESP
+
+config XTENSA_TOOLCHAIN_XCC
+	bool "Xtensa Toolchain use GCC as front end"
+	select ARCH_TOOLCHAIN_GNU
+
+config XTENSA_TOOLCHAIN_XCLANG
+	bool "Xtensa Toolchain use CLANG as front end"
+	select ARCH_TOOLCHAIN_GNU
+
+config XTENSA_TOOLCHAIN_ESP
+	bool "ESP toolchain for xtensa"
+	select ARCH_TOOLCHAIN_GNU
+
+endchoice
+
+source arch/xtensa/src/lx6/Kconfig
 if ARCH_CHIP_ESP32
 source "arch/xtensa/src/esp32/Kconfig"
 endif

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -29,7 +29,17 @@
 #                   reliable code generation.
 #
 
-CROSSDEV = xtensa-esp32-elf-
+ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCC), y)
+  CROSSDEV = xt-
+endif
+
+ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCLANG), y)
+  CROSSDEV = xt-
+endif
+
+ifeq ($(CONFIG_XTENSA_TOOLCHAIN_ESP), y)
+  CROSSDEV = xtensa-esp32-elf-
+endif
 
 ARCHCPUFLAGS =
 
@@ -40,10 +50,20 @@ else
 endif
 
 # Default toolchain
+ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCC), y)
+  CC = $(CROSSDEV)xcc
+  CXX = $(CROSSDEV)xc++
+  CPP = $(CROSSDEV)xcc -E -P -x c
+else ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCLANG), y)
+  CC = $(CROSSDEV)clang
+  CXX = $(CROSSDEV)clang++
+  CPP = $(CROSSDEV)clang -E -P -x c
+else
+  CC = $(CROSSDEV)gcc
+  CXX = $(CROSSDEV)g++
+  CPP = $(CROSSDEV)gcc -E -P -x c
+endif
 
-CC = $(CROSSDEV)gcc
-CXX = $(CROSSDEV)g++
-CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -29,21 +29,42 @@
 #                   reliable code generation.
 #
 
-CROSSDEV = xtensa-esp32s2-elf-
+
+ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCC), y)
+  CROSSDEV = xt-
+endif
+
+ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCLANG), y)
+  CROSSDEV = xt-
+endif
+
+ifeq ($(CONFIG_XTENSA_TOOLCHAIN_ESP), y)
+  CROSSDEV = xtensa-esp32-elf-
+endif
 
 ARCHCPUFLAGS =
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
   MAXOPTIMIZATION := $(CONFIG_DEBUG_OPTLEVEL)
 else
- MAXOPTIMIZATION := -Os
+  MAXOPTIMIZATION := -Os
 endif
 
 # Default toolchain
+ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCC), y)
+  CC = $(CROSSDEV)xcc
+  CXX = $(CROSSDEV)xc++
+  CPP = $(CROSSDEV)xcc -E -P -x c
+else ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCLANG), y)
+  CC = $(CROSSDEV)clang
+  CXX = $(CROSSDEV)clang++
+  CPP = $(CROSSDEV)clang -E -P -x c
+else
+  CC = $(CROSSDEV)gcc
+  CXX = $(CROSSDEV)g++
+  CPP = $(CROSSDEV)gcc -E -P -x c
+endif
 
-CC = $(CROSSDEV)gcc
-CXX = $(CROSSDEV)g++
-CPP = $(CROSSDEV)gcc -E -P -x c
 LD = $(CROSSDEV)ld
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs


### PR DESCRIPTION
Add support xcc,xclang GUN toolchin in xtensa,
ESP toolchain is default.

Change-Id: Id00bcf4a16c1e16862a106db32b1da3f3713a14c

## Summary

## Impact

## Testing

