### PR TITLE
arch:xtensa_testset: remove include arch/spinlock.h

### DIFF
--- a/arch/xtensa/src/common/xtensa_testset.c
+++ b/arch/xtensa/src/common/xtensa_testset.c
@@ -25,7 +25,6 @@
 #include <nuttx/config.h>
 
 #include <nuttx/spinlock.h>
-#include <arch/spinlock.h>
 
 #include "xtensa.h"
 


### PR DESCRIPTION
In config with no "CONFIG_SPINLOCK", include arch/spinlock.h will lead to
build error as multi definition with spinlock_t. Nuttx/spinlock.h will
include arch/spinlock.h when needed.

Change-Id: I33b48503f679ec79af3a0ef1f0fb1536aaf1ce7c

## Summary

## Impact

## Testing

