### PR TITLE
arch:xtensa: use letter 'i' in inline assemble constraint instead of I

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -238,7 +238,7 @@ static inline uint32_t up_irq_save(void)
 
   __asm__ __volatile__
   (
-    "rsil %0, %1" : "=r"(ps) : "I"(XCHAL_EXCM_LEVEL)
+    "rsil %0, %1" : "=r"(ps) : "i"(XCHAL_EXCM_LEVEL)
   );
 
   /* Return the previous PS value so that it can be restored with

--- a/arch/xtensa/src/common/xtensa_counter.h
+++ b/arch/xtensa/src/common/xtensa_counter.h
@@ -87,7 +87,7 @@ static inline uint32_t xtensa_getcompare(void)
 
   __asm__ __volatile__
   (
-    "rsr %0, %1"  : "=r"(compare) : "I"(XT_CCOMPARE)
+    "rsr %0, %1"  : "=r"(compare) : "i"(XT_CCOMPARE)
   );
 
   return compare;
@@ -105,7 +105,7 @@ static inline void xtensa_setcompare(uint32_t compare)
 {
   __asm__ __volatile__
   (
-    "wsr %0, %1" : : "r"(compare), "I"(XT_CCOMPARE)
+    "wsr %0, %1" : : "r"(compare), "i"(XT_CCOMPARE)
   );
 }
 

--- a/arch/xtensa/src/esp32s2/esp32s2_timerisr.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_timerisr.c
@@ -76,7 +76,7 @@ static inline uint32_t xtensa_getcompare(void)
 
   __asm__ __volatile__
   (
-    "rsr %0, %1"  : "=r"(compare) : "I"(XT_CCOMPARE)
+    "rsr %0, %1"  : "=r"(compare) : "i"(XT_CCOMPARE)
   );
 
   return compare;
@@ -88,7 +88,7 @@ static inline void xtensa_setcompare(uint32_t compare)
 {
   __asm__ __volatile__
   (
-    "wsr %0, %1" : : "r"(compare), "I"(XT_CCOMPARE)
+    "wsr %0, %1" : : "r"(compare), "i"(XT_CCOMPARE)
   );
 }
 


### PR DESCRIPTION
Some toolchain such as xtensa-xcc is unrecognize with constraint letter 'I',
letter 'i' is more common in GNU assembler.

Change-Id: I00f6a33fd7a5f2b95508c683e9954d402b68755f

## Summary

## Impact

## Testing

