### PR TITLE
libc/gettext: Change g_domain to array

### DIFF
--- a/libs/libc/locale/lib_gettext.c
+++ b/libs/libc/locale/lib_gettext.c
@@ -77,7 +77,7 @@ static sem_t g_sem = SEM_INITIALIZER(1);
 static FAR struct mofile_s *g_mofile;
 
 #ifndef CONFIG_BUILD_KERNEL
-static FAR char *g_domain;
+static FAR char g_domain[NAME_MAX];
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
otherwise textdomain will deference NULL pointer in the default case

## Impact
Fix the bug

## Testing

