### PR TITLE
arch:xtensa:include chip/irq.h instead of depend on chip config.

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -42,29 +42,17 @@
 #include <arch/xtensa/xtensa_corebits.h>
 #include <arch/xtensa/xtensa_coproc.h>
 
+/* Include chip-specific IRQ definitions (including IRQ numbers) */
+
+#include <arch/chip/irq.h>
+
 /* Include architecture-specific IRQ definitions */
 
 #ifdef CONFIG_ARCH_FAMILY_LX6
 #  include <arch/lx6/irq.h>
 
-/* Include implementation-specific IRQ definitions (including IRQ numbers) */
-
-#  ifdef CONFIG_ARCH_CHIP_ESP32
-#    include <arch/esp32/irq.h>
-#  else
-#    error Unknown LX6 implementation
-#  endif
-
 #elif CONFIG_ARCH_FAMILY_LX7
 #  include <arch/lx7/irq.h>
-
-/* Include implementation-specific IRQ definitions (including IRQ numbers) */
-
-#  ifdef CONFIG_ARCH_CHIP_ESP32S2
-#    include <arch/esp32s2/irq.h>
-#  else
-#    error Unknown LX7 implementation
-#  endif
 
 #else
 #  error Unknown XTENSA architecture


### PR DESCRIPTION
Many duplicate code when more chips add-in,
follow arch/arm/include/irq.h method, use chip/irq.h instead.

Change-Id: I42f516c1dda68e973939c669f627c457cd0bc65e

## Summary

## Impact

## Testing

