### PR TITLE
Fixing BMP180 and INA219 in RP2040

### DIFF
--- a/boards/arm/rp2040/common/include/rp2040_ina219.h
+++ b/boards/arm/rp2040/common/include/rp2040_ina219.h
@@ -75,4 +75,4 @@ int board_ina219_initialize(int busno);
 }
 #endif
 
-#endif // __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_INA219_H
+#endif /* __BOARDS_ARM_RP2040_COMMON_INCLUDE_RP2040_INA219_H  */

--- a/boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c
+++ b/boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c
@@ -49,6 +49,16 @@
 #include <nuttx/video/fb.h>
 #endif
 
+#ifdef CONFIG_SENSORS_INA219
+#include <nuttx/sensors/ina219.h>
+#include "rp2040_ina219.h"
+#endif
+
+#ifdef CONFIG_SENSORS_BMP180
+#include <nuttx/sensors/bmp180.h>
+#include "rp2040_bmp180.h"
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/


### PR DESCRIPTION
## Summary

This commit does the following:
1- Add BMP180 and INA219 header files to rp2040_bringup.c (otherwise, both sensors couldn't be initalized)
2- Fix comment format at the end of rp2040_ina219.h file

## Impact

None (it just fixes things regarding to BMP180 and INA219 sensors usage in RP2040)

## Testing

It worked fine.
