### PR TITLE
cmd/df: Fix the abnormal output after off_t change

### DIFF
--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 
+#include <inttypes.h>
 #include <sys/types.h>
 #include <sys/statfs.h>
 #include <sys/stat.h>
@@ -255,7 +256,8 @@ static int blocks_entry(FAR const char *mountpoint,
 
   /* Generate blocks list one line at a time */
 
-  mount_sprintf(info, "%6lu %10lu %10lu  %10lu %s\n",
+  mount_sprintf(info, "%6lu %10" PRIuOFF " %10" PRIuOFF
+                "  %10" PRIuOFF " %s\n",
                 statbuf->f_bsize, statbuf->f_blocks,
                 statbuf->f_blocks - statbuf->f_bavail, statbuf->f_bavail,
                 mountpoint);


### PR DESCRIPTION

## Summary
cmd/df: Fix the abnormal output after off_t change

Change-Id: Ieaf063cb636a77eea971cb19e6eaeea6421bff4b
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

