### PR TITLE
tcp: fix an assertion in "fix iob allocation deadlock" commit

### DIFF
--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1163,7 +1163,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
             {
               wrb = tcp_wrbuffer_tryalloc();
               ninfo("new wrb %p (non blocking)\n", wrb);
-              DEBUGASSERT(TCP_WBPKTLEN(wrb) == 0);
+              DEBUGASSERT(wrb == NULL || TCP_WBPKTLEN(wrb) == 0);
             }
           else
             {


### PR DESCRIPTION
## Summary

Fix a wrong assertion in:

```
commit 98ec46d726b4b58e58f8fc149a38628d7dde193e
Author: YAMAMOTO Takashi <yamamoto@midokura.com>
Date:   Tue Jul 20 09:10:43 2021 +0900

    tcp_send_buffered.c: fix iob allocation deadlock

    Ensure to put the wrb back onto the write_q when blocking
    on iob allocation. Otherwise, it can deadlock with other
    threads doing the same thing.
```

I forget to submit this with https://github.com/apache/incubator-nuttx/pull/4257

## Impact
tcp with assertion enabled

## Testing

tested with the rest of https://github.com/apache/incubator-nuttx/pull/4184