### PR TITLE
net_ioballoc: remove redundant critical section

### DIFF
--- a/net/utils/net_lock.c
+++ b/net/utils/net_lock.c
@@ -499,7 +499,6 @@ FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid)
   iob = iob_tryalloc(throttled, consumerid);
   if (iob == NULL)
     {
-      irqstate_t flags;
       unsigned int count;
       int blresult;
 
@@ -507,15 +506,12 @@ FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid)
        * become available. But let's not do that with the network locked.
        */
 
-      flags    = enter_critical_section();
       blresult = net_breaklock(&count);
       iob      = iob_alloc(throttled, consumerid);
       if (blresult >= 0)
         {
           net_restorelock(count);
         }
-
-      leave_critical_section(flags);
     }
 
   return iob;


### PR DESCRIPTION
## Summary
net_ioballoc: remove redundant critical section

## Impact
tcp/udp/etc

## Testing
tested with the rest of https://github.com/apache/incubator-nuttx/pull/4184
(only tcp case is tested well)