### PR TITLE
tcp: make our sequence number a bit more monotonic

### DIFF
--- a/net/tcp/tcp_appsend.c
+++ b/net/tcp/tcp_appsend.c
@@ -319,11 +319,18 @@ void tcp_rexmit(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
   if (dev->d_sndlen > 0 && conn->tx_unacked > 0)
 #endif
     {
+      uint32_t seq;
+
       /* We always set the ACK flag in response packets adding the length of
        * the IP and TCP headers.
        */
 
       tcp_send(dev, conn, TCP_ACK | TCP_PSH, dev->d_sndlen + hdrlen);
+
+      /* Advance sndseq */
+
+      seq = tcp_getsequence(conn->sndseq);
+      tcp_setsequence(conn->sndseq, seq + dev->d_sndlen);
     }
 
   /* If there is no data to send, just send out a pure ACK if one is

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -582,6 +582,7 @@ found:
     {
       uint32_t unackseq;
       uint32_t ackseq;
+      uint32_t sndseq;
 
       /* The next sequence number is equal to the current sequence
        * number (sndseq) plus the size of the outstanding, unacknowledged
@@ -639,11 +640,15 @@ found:
        * be beyond ackseq.
        */
 
-      ninfo("sndseq: %08" PRIx32 "->%08" PRIx32
-            " unackseq: %08" PRIx32 " new tx_unacked: %" PRId32 "\n",
-            tcp_getsequence(conn->sndseq), ackseq, unackseq,
-            (uint32_t)conn->tx_unacked);
-      tcp_setsequence(conn->sndseq, ackseq);
+      sndseq = tcp_getsequence(conn->sndseq);
+      if (TCP_SEQ_LT(sndseq, ackseq))
+        {
+          ninfo("sndseq: %08" PRIx32 "->%08" PRIx32
+                " unackseq: %08" PRIx32 " new tx_unacked: %" PRId32 "\n",
+                tcp_getsequence(conn->sndseq), ackseq, unackseq,
+                (uint32_t)conn->tx_unacked);
+          tcp_setsequence(conn->sndseq, ackseq);
+        }
 
       /* Do RTT estimation, unless we have done retransmissions. */
 


### PR DESCRIPTION
## Summary
in some cases, we send tcp segments with sequence numbers back and forth.
especially when sending an empty segment. (eg. pure ack, window updates)
this PR fixes it for some cases, if not all.

## Impact
tcp

## Testing
tested with the rest of https://github.com/apache/incubator-nuttx/pull/4184
