### PR TITLE
sched: Fix crash on early syslog message with prepended process name

### DIFF
--- a/sched/sched/sched_gettcb.c
+++ b/sched/sched/sched_gettcb.c
@@ -56,9 +56,11 @@ FAR struct tcb_s *nxsched_get_tcb(pid_t pid)
   irqstate_t flags;
   int hash_ndx;
 
-  /* Verify that the PID is within range */
+  /* Verify whether g_pidhash hash table has already been allocated and
+   * whether the PID is within range.
+   */
 
-  if (pid >= 0)
+  if (g_pidhash != NULL && pid >= 0)
     {
       /* The test and the return setup should be atomic.  This still does
        * not provide proper protection if the recipient of the TCB does not


### PR DESCRIPTION
## Summary
This PR intends to fix a crash that is triggered when both `CONFIG_DEBUG_SCHED_INFO` and `CONFIG_SYSLOG_PROCESS_NAME` are enabled.
When attempting to output the following message:
https://github.com/apache/incubator-nuttx/blob/a5ac4463c28a0583df320cd294875a3fa2bea57b/sched/init/nx_start.c#L345
`g_pidhash` is still not allocated at this point:
https://github.com/apache/incubator-nuttx/blob/a5ac4463c28a0583df320cd294875a3fa2bea57b/sched/sched/sched_gettcb.c#L77
causing a crash due to NULL pointer dereferencing.

## Impact
NuttX initialization will no longer crash when both `CONFIG_DEBUG_SCHED_INFO` and `CONFIG_SYSLOG_PROCESS_NAME` are enabled.

## Testing
Validated on `sim`.
