### PR TITLE
xtensa:coproc: fix XTENSA_CP_ALLSET error in some case

### DIFF
--- a/arch/xtensa/include/xtensa/xtensa_coproc.h
+++ b/arch/xtensa/include/xtensa/xtensa_coproc.h
@@ -56,7 +56,7 @@
 
 /* A set of all co-processors */
 
-#define XTENSA_CP_ALLSET     ((1 << XCHAL_CP_NUM) - 1)
+#define XTENSA_CP_ALLSET     XCHAL_CP_MASK
 
 /* CO-PROCESSOR STATE SAVE AREA FOR A THREAD
  *


### PR DESCRIPTION
Consider follow coprocessor configuration case:

\#define XCHAL_CP_NUM                    1       /* number of coprocessors */
\#define XCHAL_CP_MAX                    2       /* max CP ID + 1 (0 if none) */
\#define XCHAL_CP_MASK                   0x02    /* bitmask of all CPs by ID */
\#define XCHAL_CP_PORT_MASK              0x00    /* bitmask of only port CPs */
\
\#define XCHAL_CP1_NAME                  "AudioEngineLX"
\#define XCHAL_CP1_IDENT                 AudioEngineLX
\#define XCHAL_CP1_SA_SIZE               208     /* size of state save area */
\#define XCHAL_CP1_SA_ALIGN              8       /* min alignment of save area */
\#define XCHAL_CP_ID_AUDIOENGINELX       1       /* coprocessor ID (0..7) */

In this case, XTENSA_CP_ALLSET is 0x1, but valid coprocessors
bitmap is 0x2, use marco XCHAL_CP_MASK instead, it is bitmap of all
vaild coprocs.

Change-Id: I63ec01e4bd0cbafc62d56636cc11bdc4a2f7857f

## Summary

## Impact

## Testing

