### PR TITLE
drivers/qencoder: add command to set the maximum encoder position

### DIFF
--- a/arch/arm/src/imxrt/imxrt_enc.c
+++ b/arch/arm/src/imxrt/imxrt_enc.c
@@ -336,11 +336,12 @@ static int imxrt_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
 
 static const struct qe_ops_s g_qecallbacks =
 {
-  .setup    = imxrt_setup,
-  .shutdown = imxrt_shutdown,
-  .position = imxrt_position,
-  .reset    = imxrt_reset,
-  .ioctl    = imxrt_ioctl,
+  .setup     = imxrt_setup,
+  .shutdown  = imxrt_shutdown,
+  .position  = imxrt_position,
+  .setposmax = NULL,            /* not supported yet */
+  .reset     = imxrt_reset,
+  .ioctl     = imxrt_ioctl,
 };
 
 /* Per-timer state structures */

--- a/arch/arm/src/stm32f7/stm32_qencoder.c
+++ b/arch/arm/src/stm32f7/stm32_qencoder.c
@@ -263,11 +263,12 @@ static int stm32_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
 
 static const struct qe_ops_s g_qecallbacks =
 {
-  .setup    = stm32_setup,
-  .shutdown = stm32_shutdown,
-  .position = stm32_position,
-  .reset    = stm32_reset,
-  .ioctl    = stm32_ioctl,
+  .setup     = stm32_setup,
+  .shutdown  = stm32_shutdown,
+  .position  = stm32_position,
+  .setposmax = NULL,            /* not supported yet */
+  .reset     = stm32_reset,
+  .ioctl     = stm32_ioctl,
 };
 
 /* Per-timer state structures */

--- a/arch/arm/src/stm32h7/stm32_qencoder.c
+++ b/arch/arm/src/stm32h7/stm32_qencoder.c
@@ -263,11 +263,12 @@ static int stm32_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
 
 static const struct qe_ops_s g_qecallbacks =
 {
-  .setup    = stm32_setup,
-  .shutdown = stm32_shutdown,
-  .position = stm32_position,
-  .reset    = stm32_reset,
-  .ioctl    = stm32_ioctl,
+  .setup     = stm32_setup,
+  .shutdown  = stm32_shutdown,
+  .position  = stm32_position,
+  .setposmax = NULL,            /* not supported yet */
+  .reset     = stm32_reset,
+  .ioctl     = stm32_ioctl,
 };
 
 /* Per-timer state structures */

--- a/arch/arm/src/stm32l4/stm32l4_qencoder.c
+++ b/arch/arm/src/stm32l4/stm32l4_qencoder.c
@@ -258,11 +258,12 @@ static int stm32l4_ioctl(FAR struct qe_lowerhalf_s *lower,
 
 static const struct qe_ops_s g_qecallbacks =
 {
-  .setup    = stm32l4_setup,
-  .shutdown = stm32l4_shutdown,
-  .position = stm32l4_position,
-  .reset    = stm32l4_reset,
-  .ioctl    = stm32l4_ioctl,
+  .setup     = stm32l4_setup,
+  .shutdown  = stm32l4_shutdown,
+  .position  = stm32l4_position,
+  .setposmax = NULL,            /* not supported yet */
+  .reset     = stm32l4_reset,
+  .ioctl     = stm32l4_ioctl,
 };
 
 /* Per-timer state structures */

--- a/arch/arm/src/tiva/common/tiva_qencoder.c
+++ b/arch/arm/src/tiva/common/tiva_qencoder.c
@@ -107,11 +107,12 @@ static int tiva_qe_resetatindex(FAR struct tiva_qe_s *qe);
 
 static const struct qe_ops_s g_qe_ops =
 {
-  .setup    = tiva_qe_setup,
-  .shutdown = tiva_qe_shutdown,
-  .position = tiva_qe_position,
-  .reset    = tiva_qe_reset,
-  .ioctl    = tiva_qe_ioctl,
+  .setup     = tiva_qe_setup,
+  .shutdown  = tiva_qe_shutdown,
+  .position  = tiva_qe_position,
+  .setposmax = NULL,            /* not supported yet */
+  .reset     = tiva_qe_reset,
+  .ioctl     = tiva_qe_ioctl,
 };
 
 #ifdef CONFIG_TIVA_QEI0

--- a/drivers/sensors/qencoder.c
+++ b/drivers/sensors/qencoder.c
@@ -310,6 +310,24 @@ static int qe_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      /* QEIOC_SETPOSMAX - Set the maximum encoder position.
+       *   Argument: uint32
+       */
+
+      case QEIOC_SETPOSMAX:
+        {
+          uint32_t maxpos = (uint32_t)arg;
+          if (lower->ops->setposmax != NULL)
+            {
+              ret = lower->ops->setposmax(lower, maxpos);
+            }
+          else
+            {
+              ret = -ENOTTY;
+            }
+        }
+        break;
+
       /* Any unrecognized IOCTL commands might be platform-specific ioctl
        * commands
        */

--- a/include/nuttx/sensors/qencoder.h
+++ b/include/nuttx/sensors/qencoder.h
@@ -50,13 +50,16 @@
  *   Argument: int32_t pointer to the location to return the position.
  * QEIOC_RESET - Reset the position to zero.
  *   Argument: None
+ * QEIOC_POSMAX - Set the maximum position for the encoder.
+ *   Argument: uint32_t maximum position
  */
 
 #define QEIOC_POSITION     _QEIOC(0x0001) /* Arg: int32_t* pointer */
 #define QEIOC_RESET        _QEIOC(0x0002) /* Arg: None */
+#define QEIOC_SETPOSMAX    _QEIOC(0x0003) /* Arg: uint32_t */
 
 #define QE_FIRST           0x0001         /* First required command */
-#define QE_NCMDS           2              /* Two required commands */
+#define QE_NCMDS           3              /* Two required commands */
 
 /* User defined ioctl commands are also supported. These will be forwarded
  * by the upper-half QE driver to the lower-half QE driver via the ioctl()
@@ -108,6 +111,10 @@ struct qe_ops_s
   /* Return the current position measurement. */
 
   CODE int (*position)(FAR struct qe_lowerhalf_s *lower, FAR int32_t *pos);
+
+  /* Set the maximum encoder position. */
+
+  CODE int (*setposmax)(FAR struct qe_lowerhalf_s *lower, uint32_t pos);
 
   /* Reset the position measurement to zero. */
 


### PR DESCRIPTION
## Summary
This PR introduce a new qencoder command that allows you to configure the maximum encoder position. 
At the moment, only stm32 has been modified to support a new command.

I think that Tivia and IMXRT support this feature by not portable commands - QEIOC_RESETAT and QEIOC_RESETATMAXPOS but I don't have any hardware to verify this.

Depends on https://github.com/apache/incubator-nuttx/pull/4310

## Impact
A new command to interact with the encoder device.
This can be useful for measuring the motor shaft angle.

## Testing
stm32