### PR TITLE
risc-v/esp32-c3: Complete the support for RWDT

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_rtc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtc.c
@@ -80,14 +80,6 @@
 
 #define EXT_OSC_FLAG    BIT(3)
 
-/* Number of cycles to wait from the 32k XTAL oscillator to
- * consider it running. Larger values increase startup delay.
- * Smaller values may cause false positive detection
- * (i.e. oscillator runs for a few cycles and then stops).
- */
-
-#define SLOW_CLK_CAL_CYCLES         1024
-
 #define RTC_FAST_CLK_FREQ_8M        8500000
 
 /* With the default value of CK8M_DFREQ,

--- a/arch/risc-v/src/esp32c3/esp32c3_rtc.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtc.h
@@ -50,6 +50,14 @@ extern "C"
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Number of cycles to wait from the 32k XTAL oscillator to
+ * consider it running. Larger values increase startup delay.
+ * Smaller values may cause false positive detection
+ * (i.e. oscillator runs for a few cycles and then stops).
+ */
+
+#define SLOW_CLK_CAL_CYCLES         1024
+
 /* Cycles for RTC Timer clock source (internal oscillator) calibrate */
 
 #define RTC_CLK_SRC_CAL_CYCLES           (10)


### PR DESCRIPTION
## Summary
This MR finishes the RTC WDT, which is a special WDT that allows the full system reset (including RTC domain).

## Impact
This support was incomplete.
Now, it's possible to reset all system using this wdt.

## Test
Tested using the wdog example.

