### PR TITLE
lpc17_40: Fixed I2C port sanity check.

### DIFF
--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
@@ -516,12 +516,6 @@ struct i2c_master_s *lpc17_40_i2cbus_initialize(int port)
 {
   struct lpc17_40_i2cdev_s *priv;
 
-  if (port > 1)
-    {
-      i2cerr("ERROR: LPC I2C Only supports ports 0 and 1\n");
-      return NULL;
-    }
-
   irqstate_t flags;
   uint32_t regval;
 
@@ -615,6 +609,7 @@ struct i2c_master_s *lpc17_40_i2cbus_initialize(int port)
   else
 #endif
     {
+      i2cerr("ERROR: LPC I2C Only supports ports 0, 1 and 2\n");
       return NULL;
     }
 


### PR DESCRIPTION
## Summary
In LPC17xx / LPC40xx I2C driver there is a sanity check on the requested port.  
This check was wrong, as it was expecting only 0 or 1 as inputs, while the hardware also supports the port 2.

This PR fixes this check.

## Impact
I2C2 can now be used in LPC17xx MCUs.

## Testing
Build test.
Tested on custom hardware based on LPC1769.

