### PR TITLE
fs: Remove endsector from partition_info_s

### DIFF
--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -424,7 +424,6 @@ static int part_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
               info->numsectors  = priv->neraseblocks * priv->blkpererase;
               info->sectorsize  = priv->blocksize;
               info->startsector = priv->firstblock;
-              info->endsector   = priv->firstblock + info->numsectors;
 
               strncpy(info->parent, priv->parent->name, NAME_MAX);
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -232,8 +232,6 @@ struct partition_info_s
   size_t          sectorsize;   /* Size in bytes of a single sector */
   off_t           startsector;  /* Offset to the first section/block of the
                                  * managed sub-region */
-  off_t           endsector;    /* Offset to the last section/block of the
-                                 * managed sub-region */
 
   /* NULL-terminated string representing the name of the parent node of the
    * partition.


### PR DESCRIPTION
## Summary
since it can be computed from startsector and numsectors simply.

## Impact
Remove the unused field

## Testing

