### PR TITLE
arch:xtensa: remove chip_marcos.h from common code

### DIFF
--- a/arch/xtensa/include/esp32/chip.h
+++ b/arch/xtensa/include/esp32/chip.h
@@ -31,6 +31,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* This is the name of the section containing the Xtensa low level handlers
+ * that is used by the board linker scripts.
+ */
+
+#define HANDLER_SECTION .iram1
+
 /* Characterize each supported ESP32 part */
 
 #define ESP32_NSPI   4 /* SPI0-3 */

--- a/arch/xtensa/include/esp32/chip.h
+++ b/arch/xtensa/include/esp32/chip.h
@@ -58,6 +58,11 @@
  * Public Function Prototypes
  ****************************************************************************/
 
+#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
+uintptr_t xtensa_intstack_alloc(void);
+uintptr_t xtensa_intstack_top(void);
+#endif
+
 #ifdef __cplusplus
 #define EXTERN extern "C"
 extern "C"

--- a/arch/xtensa/include/esp32s2/chip.h
+++ b/arch/xtensa/include/esp32s2/chip.h
@@ -31,6 +31,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* This is the name of the section containing the Xtensa low level handlers
+ * that is used by the board linker scripts.
+ */
+
+#define HANDLER_SECTION .iram1
+
 /* Characterize each supported ESP32S2 part */
 
 #define ESP32S2_NDAC     2  /* DAC0-1 */

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -35,7 +35,6 @@
 
 #include "xtensa.h"
 #include "sched/sched.h"
-#include "chip_macros.h"
 
 #ifdef CONFIG_STACK_COLORATION
 

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -38,7 +38,6 @@
 #include "sched/sched.h"
 #include "xtensa.h"
 #include "chip_memory.h"
-#include "chip_macros.h"
 
 #ifdef CONFIG_DEBUG_ALERT
 

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -42,7 +42,6 @@
 #include <arch/board/board.h>
 
 #include "xtensa.h"
-#include "chip_macros.h"
 
 /****************************************************************************
  * Private Functions

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -65,7 +65,6 @@
 
 #include "xtensa.h"
 #include "xtensa_abi.h"
-#include "chip_macros.h"
 #include "xtensa_timer.h"
 
 #if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15

--- a/arch/xtensa/src/common/xtensa_panic.S
+++ b/arch/xtensa/src/common/xtensa_panic.S
@@ -64,8 +64,6 @@
 #include <arch/xtensa/core.h>
 #include <arch/xtensa/xtensa_specregs.h>
 
-#include "chip_macros.h"
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -64,8 +64,6 @@
 #include <arch/xtensa/core.h>
 #include <arch/xtensa/xtensa_specregs.h>
 
-#include "chip_macros.h"
-
 /****************************************************************************
  * Assembly Language Macros
  ****************************************************************************/

--- a/arch/xtensa/src/esp32/chip_macros.h
+++ b/arch/xtensa/src/esp32/chip_macros.h
@@ -108,11 +108,6 @@ extern "C"
  * Public Functions Prototypes
  ****************************************************************************/
 
-#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
-uintptr_t xtensa_intstack_alloc(void);
-uintptr_t xtensa_intstack_top(void);
-#endif
-
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/arch/xtensa/src/esp32/chip_macros.h
+++ b/arch/xtensa/src/esp32/chip_macros.h
@@ -43,12 +43,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* This is the name of the section containing the Xtensa low level handlers
- * that is used by the board linker scripts.
- */
-
-#define HANDLER_SECTION .iram1
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/arch/xtensa/src/esp32s2/chip_macros.h
+++ b/arch/xtensa/src/esp32s2/chip_macros.h
@@ -43,12 +43,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* This is the name of the section containing the Xtensa low level handlers
- * that is used by the board linker scripts.
- */
-
-#define HANDLER_SECTION .iram1
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/


### PR DESCRIPTION
## Summary
arch:xtensa:

move HANDLER_SECTION/xtensa_intstack_xxx from src/chip/*.h to include/chip/*.h
and remove chip_marco.h in common , as it is in src/chip/ and should not
be used by common code

## Impact

## Testing
