### PR TITLE
Remove the duplicated IOCTL between mtd and block

### DIFF
--- a/Documentation/components/drivers/special/mtd.rst
+++ b/Documentation/components/drivers/special/mtd.rst
@@ -28,8 +28,6 @@ Memory Technology Device Drivers
    Support other, less frequently used commands:
 
    -  ``MTDIOC_GEOMETRY``: Get MTD geometry
-   -  ``MTDIOC_XIPBASE:``: Convert block to physical address for
-      eXecute-In-Place
    -  ``MTDIOC_BULKERASE``: Erase the entire device
 
    is provided via a single ``ioctl`` method (see

--- a/arch/arm/src/lc823450/lc823450_mtd.c
+++ b/arch/arm/src/lc823450/lc823450_mtd.c
@@ -349,8 +349,8 @@ static int lc823450_ioctl(FAR struct mtd_dev_s *dev, int cmd,
               geo->erasesize, geo->neraseblocks);
         break;
 
-      case MTDIOC_XIPBASE:
-        finfo("MTDIOC_XIPBASE\n");
+      case BIOC_XIPBASE:
+        finfo("BIOC_XIPBASE\n");
         ppv = (FAR void**)arg;
         if (ppv)
           {

--- a/arch/arm/src/tiva/common/tiva_flash.c
+++ b/arch/arm/src/tiva/common/tiva_flash.c
@@ -394,7 +394,7 @@ static int tiva_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
-      case MTDIOC_XIPBASE:
+      case BIOC_XIPBASE:
         {
           FAR void **ppv = (FAR void**)arg;
 

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -540,12 +540,6 @@ static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 
       cmd = MTDIOC_FLUSH;
     }
-  else if (cmd == BIOC_PARTINFO)
-    {
-      /* Change the BIOC_PARTINFO command to the MTDIOC_PARTINFO command. */
-
-      cmd = MTDIOC_PARTINFO;
-    }
 
   /* No other block driver ioctl commands are not recognized by this
    * driver.  Other possible MTD driver ioctl commands are passed through

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -506,31 +506,7 @@ static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 
   dev = (struct ftl_struct_s *)inode->i_private;
 
-  /* Only one block driver ioctl command is supported by this driver (and
-   * that command is just passed on to the MTD driver in a slightly
-   * different form).
-   */
-
-  if (cmd == BIOC_XIPBASE)
-    {
-      /* The argument accompanying the BIOC_XIPBASE should be non-NULL.  If
-       * DEBUG is enabled, we will catch it here instead of in the MTD
-       * driver.
-       */
-
-#ifdef CONFIG_DEBUG_FEATURES
-      if (arg == 0)
-        {
-          ferr("ERROR: BIOC_XIPBASE argument is NULL\n");
-          return -EINVAL;
-        }
-#endif
-
-      /* Change the BIOC_XIPBASE command to the MTDIOC_XIPBASE command. */
-
-      cmd = MTDIOC_XIPBASE;
-    }
-  else if (cmd == BIOC_FLUSH)
+  if (cmd == BIOC_FLUSH)
     {
 #ifdef CONFIG_FTL_WRITEBUFFER
       rwb_flush(&dev->rwb);

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -535,10 +535,6 @@ static int ftl_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 #ifdef CONFIG_FTL_WRITEBUFFER
       rwb_flush(&dev->rwb);
 #endif
-
-      /* Change the BIOC_FLUSH command to the MTDIOC_FLUSH command. */
-
-      cmd = MTDIOC_FLUSH;
     }
 
   /* No other block driver ioctl commands are not recognized by this

--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -432,7 +432,7 @@ static int part_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
-      case MTDIOC_XIPBASE:
+      case BIOC_XIPBASE:
         {
           FAR void **ppv = (FAR void**)arg;
           unsigned long base;
@@ -441,7 +441,7 @@ static int part_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
             {
               /* Get the XIP base of the entire FLASH */
 
-              ret = priv->parent->ioctl(priv->parent, MTDIOC_XIPBASE,
+              ret = priv->parent->ioctl(priv->parent, BIOC_XIPBASE,
                                         (unsigned long)((uintptr_t)&base));
               if (ret == OK)
                 {

--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -414,7 +414,7 @@ static int part_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
-      case MTDIOC_PARTINFO:
+      case BIOC_PARTINFO:
         {
           FAR struct partition_info_s *info =
             (FAR struct partition_info_s *)arg;

--- a/drivers/mtd/mtd_progmem.c
+++ b/drivers/mtd/mtd_progmem.c
@@ -326,7 +326,7 @@ static int progmem_ioctl(FAR struct mtd_dev_s *dev, int cmd,
         }
         break;
 
-      case MTDIOC_XIPBASE:
+      case BIOC_XIPBASE:
         {
           FAR void **ppv = (FAR void**)arg;
 

--- a/drivers/mtd/rammtd.c
+++ b/drivers/mtd/rammtd.c
@@ -386,7 +386,7 @@ static int ram_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
-      case MTDIOC_XIPBASE:
+      case BIOC_XIPBASE:
         {
           FAR void **ppv = (FAR void**)((uintptr_t)arg);
           if (ppv)

--- a/drivers/mtd/skeleton.c
+++ b/drivers/mtd/skeleton.c
@@ -259,7 +259,7 @@ static int skel_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
         }
         break;
 
-      case MTDIOC_XIPBASE:
+      case BIOC_XIPBASE:
         {
           FAR void **ppv = (FAR void**)arg;
 

--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -5467,27 +5467,6 @@ static int smart_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
 
   switch (cmd)
     {
-    case BIOC_XIPBASE:
-      /* The argument accompanying the BIOC_XIPBASE should be non-NULL.  If
-       * DEBUG is enabled, we will catch it here instead of in the MTD
-       * driver.
-       */
-
-#ifdef CONFIG_DEBUG_FEATURES
-      if (arg == 0)
-        {
-          ferr("ERROR: BIOC_XIPBASE argument is NULL\n");
-          return -EINVAL;
-        }
-#endif
-
-      /* Just change the BIOC_XIPBASE command to the MTDIOC_XIPBASE
-       * command.
-       */
-
-      cmd = MTDIOC_XIPBASE;
-      break;
-
     case BIOC_GETFORMAT:
 
       /* Return the format information for the device */

--- a/drivers/mtd/sst39vf.c
+++ b/drivers/mtd/sst39vf.c
@@ -723,7 +723,7 @@ static int sst39vf_ioctl(FAR struct mtd_dev_s *dev,
         }
         break;
 
-      case MTDIOC_XIPBASE:
+      case BIOC_XIPBASE:
         {
           FAR void **ppv = (FAR void **)arg;
           if (ppv)

--- a/fs/driver/fs_blockpartition.c
+++ b/fs/driver/fs_blockpartition.c
@@ -227,7 +227,7 @@ static int part_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
       ret = parent->u.i_bops->ioctl(parent, cmd, arg);
       if (ret >= 0)
         {
-          if (cmd == BIOC_XIPBASE || cmd == MTDIOC_XIPBASE)
+          if (cmd == BIOC_XIPBASE)
             {
               FAR void **base = (FAR void **)ptr_arg;
               struct geometry geo;

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -928,7 +928,7 @@ static int littlefs_sync_block(FAR const struct lfs_config *c)
 
   if (INODE_IS_MTD(drv))
     {
-      ret = MTD_IOCTL(drv->u.i_mtd, MTDIOC_FLUSH, 0);
+      ret = MTD_IOCTL(drv->u.i_mtd, BIOC_FLUSH, 0);
     }
   else
     {

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -530,7 +530,7 @@ int romfs_hwconfigure(struct romfs_mountpt_s *rm)
 
   if (INODE_IS_MTD(inode))
     {
-      ret = MTD_IOCTL(inode->u.i_mtd, MTDIOC_XIPBASE,
+      ret = MTD_IOCTL(inode->u.i_mtd, BIOC_XIPBASE,
                       (unsigned long)&rm->rm_xipbase);
     }
   else if (inode->u.i_bops->ioctl != NULL)

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -41,10 +41,11 @@
 /* Ioctl commands */
 
 /* Note, the following ioctl existed in the past and was removed:
+ * #define MTDIOC_XIPBASE    _MTDIOC(0x0002)
  * #define MTDIOC_FLUSH      _MTDIOC(0x0009)
  * #define MTDIOC_PARTINFO   _MTDIOC(0x000b)
  * try to avoid adding a new ioctl with the same ioctl number and
- * replace with BIOC_FLUSH and BIOC_PARTINFO instead.
+ * replace with BIOC_XIPBASE, BIOC_FLUSH and BIOC_PARTINFO instead.
  */
 
 #define MTDIOC_GEOMETRY   _MTDIOC(0x0001) /* IN:  Pointer to write-able struct
@@ -52,11 +53,6 @@
                                            *      receive geometry data (see mtd.h)
                                            * OUT: Geometry structure is populated
                                            *      with data for the MTD */
-#define MTDIOC_XIPBASE    _MTDIOC(0x0002) /* IN:  Pointer to pointer to void in
-                                           *      which to received the XIP base.
-                                           * OUT: If media is directly accessible,
-                                           *      return (void *) base address
-                                           *      of device memory */
 #define MTDIOC_BULKERASE  _MTDIOC(0x0003) /* IN:  None
                                            * OUT: None */
 #define MTDIOC_PROTECT    _MTDIOC(0x0004) /* IN:  Pointer to read-able struct

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -40,6 +40,12 @@
 
 /* Ioctl commands */
 
+/* Note, the following ioctl existed in the past and was removed:
+ * #define MTDIOC_PARTINFO   _MTDIOC(0x000b)
+ * try to avoid adding a new ioctl with the same ioctl number and
+ * replace with BIOC_PARTINFO instead.
+ */
+
 #define MTDIOC_GEOMETRY   _MTDIOC(0x0001) /* IN:  Pointer to write-able struct
                                            *      mtd_geometry_s in which to receive
                                            *      receive geometry data (see mtd.h)
@@ -74,12 +80,6 @@
 #define MTDIOC_ERASESTATE _MTDIOC(0x000a) /* IN:  Pointer to uint8_t
                                            * OUT: Byte value that represents the
                                            *      erased state of the MTD cell */
-#define MTDIOC_PARTINFO   _MTDIOC(0x000b) /* IN:  Pointer to writable struct
-                                           *      partition_info_s in which to
-                                           *      receive partition information data
-                                           * OUT: Partition information structure
-                                           *      populated with data from the MTD
-                                           *      partition */
 
 /* Macros to hide implementation */
 

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -41,9 +41,10 @@
 /* Ioctl commands */
 
 /* Note, the following ioctl existed in the past and was removed:
+ * #define MTDIOC_FLUSH      _MTDIOC(0x0009)
  * #define MTDIOC_PARTINFO   _MTDIOC(0x000b)
  * try to avoid adding a new ioctl with the same ioctl number and
- * replace with BIOC_PARTINFO instead.
+ * replace with BIOC_FLUSH and BIOC_PARTINFO instead.
  */
 
 #define MTDIOC_GEOMETRY   _MTDIOC(0x0001) /* IN:  Pointer to write-able struct
@@ -74,9 +75,6 @@
                                            * OUT: None */
 #define MTDIOC_ECCSTATUS  _MTDIOC(0x0008) /* IN:  Pointer to uint8_t
                                            * OUT: ECC status */
-#define MTDIOC_FLUSH      _MTDIOC(0x0009) /* IN:  None
-                                           * OUT: None (ioctl return value provides
-                                           *      success/failure indication). */
 #define MTDIOC_ERASESTATE _MTDIOC(0x000a) /* IN:  Pointer to uint8_t
                                            * OUT: Byte value that represents the
                                            *      erased state of the MTD cell */


### PR DESCRIPTION
## Summary

This patchset contain three change:
- mtd: Replace MTDIOC_PARTINFO with BIOC_PARTINFO
- Revert "mtd: Add MTDIOC_FLUSH IOCTL like MTDIOC_XIPBASE" 
- mtd: Replace MTDIOC_XIPBASE with BIOC_XIPBASE

All changes try to consolidate the same IOCTL in block layer and mtd layer:

1. Simplify the general driver(e.g. partition, flt) implementation
2. Reduce the confusion with the same IOCTL in the different layer
3. Share the same IOCTL between block and mtd if the concept is same(e.g. XIPBASE, FLUSH and PART).
4. The different concept still expose with the different IOCTL(e.g. geometry, erase...).

Note: I created this PR because the recent trend show that more and more IOCTL which duplicate in block and mtd make the userspace and the general layer(e.g. partition and flt) hard to maintain.

## Impact
MTD layer

## Testing

