### PR TITLE
arch/arm/stm32h7: dma and serial: add TRBUFF flag.

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32_dma.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_dma.h
@@ -319,7 +319,7 @@
 
 #define DMA_SCR_DBM               (1 << 18) /* Bit 15: Double buffer mode */
 #define DMA_SCR_CT                (1 << 19) /* Bit 19: Current target */
-                                            /* Bit 20: Reserved */
+#define DMA_TRBUFF                (1 << 20) /* Bit 20: Enable the DMA to handle bufferable transfers*/
 #define DMA_SCR_PBURST_SHIFT      (21)      /* Bits 21-22: Peripheral burst transfer configuration */
 #define DMA_SCR_PBURST_MASK       (3 << DMA_SCR_PBURST_SHIFT)
 #  define DMA_SCR_PBURST_SINGLE   (0 << DMA_SCR_PBURST_SHIFT) /* 00: Single transfer */

--- a/arch/arm/src/stm32h7/stm32_dma.c
+++ b/arch/arm/src/stm32h7/stm32_dma.c
@@ -1350,7 +1350,7 @@ static void stm32_sdma_setup(DMA_HANDLE handle, FAR stm32_dmacfg_t *cfg)
   scr    &=  (DMA_SCR_PFCTRL | DMA_SCR_DIR_MASK | DMA_SCR_PINC |
               DMA_SCR_MINC | DMA_SCR_PSIZE_MASK | DMA_SCR_MSIZE_MASK |
               DMA_SCR_PINCOS | DMA_SCR_DBM | DMA_SCR_CIRC |
-              DMA_SCR_PBURST_MASK | DMA_SCR_MBURST_MASK);
+              DMA_SCR_PBURST_MASK | DMA_SCR_MBURST_MASK | DMA_TRBUFF);
   regval |= scr;
   dmachan_putreg(dmachan, STM32_DMA_SCR_OFFSET, regval);
 }

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -467,7 +467,8 @@
                DMA_SCR_MSIZE_8BITS    | \
                DMA_SCR_PBURST_SINGLE  | \
                DMA_SCR_MBURST_SINGLE  | \
-               CONFIG_USART_TXDMAPRIO)
+               CONFIG_USART_TXDMAPRIO | \
+               DMA_TRBUFF)
 
 #endif /* SERIAL_HAVE_TXDMA */
 


### PR DESCRIPTION

## Summary

A bitfield TRBUFF had appeared in revision 7 (26 Feb 2020) of the Reference manual. It has the following note: 
"This bit must be set to 1 if the DMA stream manages UART/USART/LPUART transfers"

## Impact

Some stability issues can occur if not set this bitfield when working serial over DMA.

## Testing

Custom board stmh7f743