### PR TITLE
esp32c3:modify esp32c3 flash block size

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -261,6 +261,10 @@ config ESP32C3_SPIFLASH
 	select MTD_BYTE_WRITE
 	select MTD_PARTITION
 
+config ESP32C3_SPIFLASH_BLOCK_SIZE
+	int "SPI FLASH BLOCK SIZE"
+	default 64
+
 config ESP32C3_SPI2
 	bool "SPI 2"
 	default n

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -72,7 +72,7 @@
 #define MMU_BYTES2PAGES(_n)         (((_n) + SPI_FLASH_MMU_PAGE_SIZE - 1) / \
                                      SPI_FLASH_MMU_PAGE_SIZE)
 
-#define SPI_FLASH_BLK_SIZE          256
+#define SPI_FLASH_BLK_SIZE          CONFIG_ESP32C3_SPIFLASH_BLOCK_SIZE
 #define SPI_FLASH_ERASE_SIZE        4096
 #define SPI_FLASH_ERASED_STATE      (0xff)
 #define SPI_FLASH_SIZE              (4 * 1024 * 1024)


### PR DESCRIPTION
## Summary
In littlefs file system ,flash erase sum is limited. To reduce flash erase num, flash memory usage should be added. In esp32c3, littlefs cache size default value is 4*block size, prog size is same as block size,so modify flash block size from 256 to 64.
## Impact
improve the flash memory usage
## Testing
in experment, we find that prog size is smaller, the flash erase num is more less
