### PR TITLE
libs:cxx.defs: bypass -Wno-missing-exception-spec flag in xcc

### DIFF
--- a/libs/libxx/cxx.defs
+++ b/libs/libxx/cxx.defs
@@ -31,5 +31,7 @@ CXXSRCS += libxx_stdthrow.cxx
 # FAR void *operator new(std::size_t nbytes)
 #           ^
 #                                            throw(std::bad_alloc)
-libxx_new.cxx_CXXFLAGS += -Wno-missing-exception-spec
-libxx_newa.cxx_CXXFLAGS += -Wno-missing-exception-spec
+ifneq ($(CONFIG_XTENSA_TOOLCHAIN_XCC), y)
+  libxx_new.cxx_CXXFLAGS += -Wno-missing-exception-spec
+  libxx_newa.cxx_CXXFLAGS += -Wno-missing-exception-spec
+endif


### PR DESCRIPTION
Xtensa-toolchain do not recognize -Wno-missing-exception-spec flags

## Summary

Xtensa-xcc do not recognize -Wno-missing-exception-spec flags

## Impact

no

## Testing

success
