### PR TITLE
tools/esp32/Config.mk: Allow ESPTOOL_BINDIR to be omitted when flashing the board

### DIFF
--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -65,12 +65,7 @@ ESPTOOL_BINDIR ?= .
 
 # Configure the variables according to build environment
 
-ifeq ($(CONFIG_ESP32_BOOTLOADER_BUILD),y)
-	BL_OFFSET       := 0x1000
-	BOOTLOADER      := nuttx.bin
-	FLASH_BL        := $(BL_OFFSET) $(BOOTLOADER)
-	ESPTOOL_BINS    := $(FLASH_BL)
-else ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
+ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
 	BL_OFFSET       := 0x1000
 	PT_OFFSET       := 0x8000
 	APP_OFFSET      := 0x10000


### PR DESCRIPTION
## Summary
Bring the old behavior when flashing the device where `ESPTOOL_BINDIR` can be omitted when flashing.

## Impact
ESP32 chips
## Testing
esp32-devkitc:nsh
