### PR TITLE
mtd: include nuttx/fs/fs.h explicitly

### DIFF
--- a/drivers/mtd/mtd_progmem.c
+++ b/drivers/mtd/mtd_progmem.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 
 #include <nuttx/progmem.h>
+#include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/mtd/mtd.h>
 


### PR DESCRIPTION
## Summary
To fix struct partition_info_s undefined type issue if CONFIG_MTD_PROGMEM enabled.

## Impact

## Testing
Verify with local custom board config build with CONFIG_MTD_PROGMEM enabled.
