### PR TITLE
arch/arm: correct the frame pointer register declare 

### DIFF
--- a/arch/arm/include/arm/irq.h
+++ b/arch/arm/include/arm/irq.h
@@ -84,7 +84,11 @@
 #define REG_V7              REG_R10
 #define REG_SB              REG_R9
 #define REG_SL              REG_R10
-#define REG_FP              REG_R11
+#ifdef CONFIG_ARM_THUMB
+  #define REG_FP            REG_R7
+#else
+  #define REG_FP            REG_R11
+#endif /* CONFIG_ARM_THUMB */
 #define REG_IP              REG_R12
 #define REG_SP              REG_R13
 #define REG_LR              REG_R14

--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -119,7 +119,7 @@
 #define REG_V7              REG_R10
 #define REG_SB              REG_R9
 #define REG_SL              REG_R10
-#define REG_FP              REG_R11
+#define REG_FP              REG_R7
 #define REG_IP              REG_R12
 #define REG_SP              REG_R13
 #define REG_LR              REG_R14

--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -183,7 +183,11 @@
 #define REG_V7              REG_R10
 #define REG_SB              REG_R9
 #define REG_SL              REG_R10
-#define REG_FP              REG_R11
+#ifdef CONFIG_ARM_THUMB
+  #define REG_FP            REG_R7
+#else
+  #define REG_FP            REG_R11
+#endif /* CONFIG_ARM_THUMB */
 #define REG_IP              REG_R12
 #define REG_SP              REG_R13
 #define REG_LR              REG_R14

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -75,7 +75,7 @@
 #define REG_V7              REG_R10
 #define REG_SB              REG_R9
 #define REG_SL              REG_R10
-#define REG_FP              REG_R11
+#define REG_FP              REG_R7
 #define REG_IP              REG_R12
 #define REG_SP              REG_R13
 #define REG_LR              REG_R14

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -183,7 +183,11 @@
 #define REG_V7              REG_R10
 #define REG_SB              REG_R9
 #define REG_SL              REG_R10
-#define REG_FP              REG_R11
+#ifdef CONFIG_ARM_THUMB
+  #define REG_FP            REG_R7
+#else
+  #define REG_FP            REG_R11
+#endif /* CONFIG_ARM_THUMB */
 #define REG_IP              REG_R12
 #define REG_SP              REG_R13
 #define REG_LR              REG_R14

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -75,7 +75,7 @@
 #define REG_V7              REG_R10
 #define REG_SB              REG_R9
 #define REG_SL              REG_R10
-#define REG_FP              REG_R11
+#define REG_FP              REG_R7
 #define REG_IP              REG_R12
 #define REG_SP              REG_R13
 #define REG_LR              REG_R14


### PR DESCRIPTION
## Summary

arch/arm: correct the frame pointer register declare 

In AArch32, the frame pointer is stored in register R11 for ARM code or register R7 for Thumb code.
In AArch64, the frame pointer is stored in register X29.

https://developer.arm.com/documentation/dui0774/g/Compiler-Command-line-Options/-fomit-frame-pointer---fno-omit-frame-pointer

## Impact

N/A

## Testing

enable framepointer(-fno-omit-frame-pointer) and test and check fp member tcb->xcp.regs[REG_FP]