### PR TITLE
net/rpmsg: add nonblock connect(2) support 

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -324,7 +324,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
 
               if (len == msg->len)
                 {
-                  /* SOCOK_STREAM */
+                  /* SOCK_STREAM */
 
                   conn->recvpos += conn->recvlen;
                   memcpy(conn->recvdata, buf, conn->recvlen);
@@ -333,7 +333,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
                 }
               else
                 {
-                  /* SOCOK_DGRAM */
+                  /* SOCK_DGRAM */
 
                   conn->recvpos += len;
                   memcpy(conn->recvdata, buf + sizeof(uint32_t),

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -91,6 +91,7 @@ struct rpmsg_socket_conn_s
   uint32_t                       recvlen;
   FAR struct circbuf_s           recvbuf;
 
+  FAR struct socket              *psock;
   FAR struct rpmsg_socket_conn_s *next;
 
   /* server listen-scoket listening: backlog > 0;
@@ -291,7 +292,10 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
   if (head->cmd == RPMSG_SOCKET_CMD_SYNC)
     {
       conn->sendsize = head->size;
+      conn->psock->s_flags |= _SF_CONNECTED;
+      _SO_SETERRNO(conn->psock, OK);
       rpmsg_socket_post(&conn->sendsem);
+      rpmsg_socket_pollnotify(conn, POLLOUT);
     }
   else
     {
@@ -508,6 +512,7 @@ static void rpmsg_socket_ns_bind(FAR struct rpmsg_device *rdev,
     }
 
   tmp->next = new;
+  new->psock = server->psock;
 
   rpmsg_socket_unlock(&server->recvlock);
 
@@ -568,6 +573,7 @@ static int rpmsg_socket_setup(FAR struct socket *psock, int protocol)
     }
 
   psock->s_conn = conn;
+  conn->psock = psock;
   return 0;
 }
 
@@ -647,16 +653,21 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
 
   if (conn->sendsize == 0)
     {
+      if (_SS_ISNONBLOCK(psock->s_flags))
+        {
+          return -EINPROGRESS;
+        }
+
       ret = net_timedwait(&conn->sendsem,
                           _SO_TIMEOUT(psock->s_rcvtimeo));
-    }
 
-  if (ret < 0)
-    {
-      rpmsg_unregister_callback(conn,
-                                rpmsg_socket_device_created,
-                                rpmsg_socket_device_destroy,
-                                rpmsg_socket_device_connect);
+      if (ret < 0)
+        {
+          rpmsg_unregister_callback(conn,
+                                    rpmsg_socket_device_created,
+                                    rpmsg_socket_device_destroy,
+                                    rpmsg_socket_device_connect);
+        }
     }
 
   return ret;
@@ -835,6 +846,11 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
             }
 
           rpmsg_socket_unlock(&conn->recvlock);
+        }
+      else if (!_SS_ISCONNECTED(psock->s_flags) &&
+               _SS_ISNONBLOCK(psock->s_flags))
+        {
+          ret = OK;
         }
       else
         {
@@ -1125,8 +1141,6 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
         {
           return ret;
         }
-
-      psock->s_flags |= _SF_CONNECTED;
     }
 
   if (!_SS_ISCONNECTED(psock->s_flags))

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -290,6 +290,8 @@ static int rpmsg_socket_sync(FAR struct rpmsg_socket_conn_s *conn,
       return ret;
     }
 
+  ret = OK;
+
   if (conn->sendsize == 0)
     {
       ret = net_timedwait(&conn->sendsem, timeout);
@@ -638,7 +640,6 @@ static int rpmsg_socket_listen(FAR struct socket *psock, int backlog)
 static int rpmsg_socket_connect_internal(FAR struct socket *psock)
 {
   FAR struct rpmsg_socket_conn_s *conn = psock->s_conn;
-  unsigned int timeout;
   unsigned int tc;
   int ret;
 
@@ -657,22 +658,7 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
       return ret;
     }
 
-  ret     = -ETIMEDOUT;
-  timeout = _SO_TIMEOUT(psock->s_rcvtimeo);
-
-  for (tc = 0; tc < timeout * 1000; )
-    {
-      ret = rpmsg_socket_sync(conn, timeout);
-      if (ret != RPMSG_ERR_ADDR)
-        {
-          break;
-        }
-
-      if (timeout != UINT_MAX)
-        {
-          tc += RPMSG_TICK_COUNT;
-        }
-    }
+  ret = rpmsg_socket_sync(conn, _SO_TIMEOUT(psock->s_rcvtimeo));
 
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary

net/rpmsg: add nonblock connect(2) support 
net/rpmsg: simplify the socket timeout of connect 
net/rpmsg: move the sync handshark to ns_bind callback 
net/rpmsg: fix typo in comment

https://man7.org/linux/man-pages/man2/connect.2.html

```
       EINPROGRESS
              The socket is nonblocking and the connection cannot be
              completed immediately.  (UNIX domain sockets failed with
              EAGAIN instead.)  It is possible to select(2) or poll(2)
              for completion by selecting the socket for writing.  After
              select(2) indicates writability, use getsockopt(2) to read
              the SO_ERROR option at level SOL_SOCKET to determine
              whether connect() completed successfully (SO_ERROR is
              zero) or unsuccessfully (SO_ERROR is one of the usual
              error codes listed here, explaining the reason for the
              failure).
```


## Impact

rpmsg nonblock connect support

## Testing

run test case https://github.com/apache/incubator-nuttx-apps/tree/master/examples/rpmsgsocket