### PR TITLE
net/local: add nonblock connect(2) support 

### DIFF
--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -243,7 +243,8 @@ int pipecommon_open(FAR struct file *filep)
   sched_lock();
   nxsem_post(&dev->d_bfsem);
 
-  if ((filep->f_oflags & O_RDWR) == O_RDONLY &&  /* Read-only */
+  if (!(filep->f_oflags & O_NONBLOCK) &&         /* Non-blocking */
+      (filep->f_oflags & O_RDWR) == O_RDONLY &&  /* Read-only */
       dev->d_nwriters < 1 &&                     /* No writers on the pipe */
       dev->d_wrndx == dev->d_rdndx)              /* Buffer is empty */
     {

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -88,6 +88,7 @@ enum local_state_s
   /* SOCK_STREAM peers only */
 
   LOCAL_STATE_ACCEPT,          /* Client waiting for a connection */
+  LOCAL_STATE_CONNECTING,      /* Non-blocking connect */
   LOCAL_STATE_CONNECTED,       /* Peer connected */
   LOCAL_STATE_DISCONNECTED     /* Peer disconnected */
 };
@@ -149,12 +150,13 @@ struct local_conn_s
   /* SOCK_STREAM fields common to both client and server */
 
   sem_t lc_waitsem;            /* Use to wait for a connection to be accepted */
+  FAR struct socket *lc_psock; /* A reference to the socket structure */
 
   /* The following is a list if poll structures of threads waiting for
    * socket events.
    */
 
-  struct pollfd *lc_accept_fds[LOCAL_NPOLLWAITERS];
+  struct pollfd *lc_event_fds[LOCAL_NPOLLWAITERS];
   struct pollfd lc_inout_fds[2*LOCAL_NPOLLWAITERS];
 
   /* Union of fields unique to SOCK_STREAM client, server, and connected
@@ -617,11 +619,11 @@ int local_open_sender(FAR struct local_conn_s *conn, FAR const char *path,
 #endif
 
 /****************************************************************************
- * Name: local_accept_pollnotify
+ * Name: local_event_pollnotify
  ****************************************************************************/
 
-void local_accept_pollnotify(FAR struct local_conn_s *conn,
-                             pollevent_t eventset);
+void local_event_pollnotify(FAR struct local_conn_s *conn,
+                            pollevent_t eventset);
 
 /****************************************************************************
  * Name: local_pollsetup

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -93,7 +93,6 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
   if (server->lc_state != LOCAL_STATE_LISTENING ||
       server->u.server.lc_pending >= server->u.server.lc_backlog)
     {
-      net_unlock();
       nerr("ERROR: Server is not listening: lc_state=%d\n",
            server->lc_state);
       nerr("   OR: The backlog limit was reached: %d or %d\n",
@@ -114,7 +113,6 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
       nerr("ERROR: Failed to create FIFOs for %s: %d\n",
            client->lc_path, ret);
 
-      net_unlock();
       return ret;
     }
 
@@ -128,7 +126,6 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
       nerr("ERROR: Failed to open write-only FIFOs for %s: %d\n",
            client->lc_path, ret);
 
-      net_unlock();
       goto errout_with_fifos;
     }
 
@@ -137,35 +134,36 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
   /* Set the busy "result" before giving the semaphore. */
 
   client->u.client.lc_result = -EBUSY;
+  client->lc_state = LOCAL_STATE_ACCEPT;
 
   /* Add ourself to the list of waiting connections and notify the server. */
 
   dq_addlast(&client->lc_node, &server->u.server.lc_waiters);
-  client->lc_state = LOCAL_STATE_ACCEPT;
-  local_accept_pollnotify(server, POLLIN);
+  local_event_pollnotify(server, POLLIN);
 
   if (nxsem_get_value(&server->lc_waitsem, &sval) >= 0 && sval < 1)
     {
       _local_semgive(&server->lc_waitsem);
     }
 
-  net_unlock();
-
   /* Wait for the server to accept the connections */
 
-  do
+  if (!nonblock)
     {
-      _local_semtake(&client->lc_waitsem);
-      ret = client->u.client.lc_result;
-    }
-  while (ret == -EBUSY);
+      do
+        {
+          _local_semtake(&client->lc_waitsem);
+          ret = client->u.client.lc_result;
+        }
+      while (ret == -EBUSY);
 
-  /* Did we successfully connect? */
+      /* Did we successfully connect? */
 
-  if (ret < 0)
-    {
-      nerr("ERROR: Failed to connect: %d\n", ret);
-      goto errout_with_outfd;
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to connect: %d\n", ret);
+          goto errout_with_outfd;
+        }
     }
 
   /* Yes.. open the read-only FIFO */
@@ -179,8 +177,15 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
     }
 
   DEBUGASSERT(client->lc_infile.f_inode != NULL);
-  client->lc_state = LOCAL_STATE_CONNECTED;
-  return OK;
+
+  if (!nonblock)
+    {
+      client->lc_state = LOCAL_STATE_CONNECTED;
+      return ret;
+    }
+
+  client->lc_state = LOCAL_STATE_CONNECTING;
+  return -EINPROGRESS;
 
 errout_with_outfd:
   file_close(&client->lc_outfile);
@@ -291,6 +296,7 @@ int psock_local_connect(FAR struct socket *psock,
 
                 /* Bind the address and protocol */
 
+                client->lc_type  = conn->lc_type;
                 client->lc_proto = conn->lc_proto;
                 strncpy(client->lc_path, unaddr->sun_path,
                         UNIX_PATH_MAX - 1);
@@ -309,11 +315,8 @@ int psock_local_connect(FAR struct socket *psock,
                       local_stream_connect(client, conn,
                                            _SS_ISNONBLOCK(psock->s_flags));
                   }
-                else
-                  {
-                    net_unlock();
-                  }
 
+                net_unlock();
                 return ret;
               }
           }

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -141,6 +141,11 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
   if (conn->lc_state != LOCAL_STATE_CONNECTED)
     {
+      if (conn->lc_state == LOCAL_STATE_CONNECTING)
+        {
+          return -EAGAIN;
+        }
+
       nerr("ERROR: not connected\n");
       return -ENOTCONN;
     }

--- a/net/local/local_release.c
+++ b/net/local/local_release.c
@@ -68,6 +68,7 @@ int local_release(FAR struct local_conn_s *conn)
   /* If the socket is connected (SOCK_STREAM client), then disconnect it */
 
   if (conn->lc_state == LOCAL_STATE_CONNECTED ||
+      conn->lc_state == LOCAL_STATE_CONNECTING ||
       conn->lc_state == LOCAL_STATE_DISCONNECTED)
     {
       DEBUGASSERT(conn->lc_proto == SOCK_STREAM);
@@ -92,6 +93,7 @@ int local_release(FAR struct local_conn_s *conn)
         {
           client->u.client.lc_result = -ENOTCONN;
           nxsem_post(&client->lc_waitsem);
+          local_event_pollnotify(client, POLLOUT);
         }
 
       conn->u.server.lc_pending = 0;

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -85,6 +85,11 @@ static ssize_t local_send(FAR struct socket *psock,
           if (peer->lc_state != LOCAL_STATE_CONNECTED ||
               peer->lc_outfile.f_inode == NULL)
             {
+              if (peer->lc_state == LOCAL_STATE_CONNECTING)
+                {
+                  return -EAGAIN;
+                }
+
               nerr("ERROR: not connected\n");
               return -ENOTCONN;
             }

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -131,6 +131,9 @@ static int local_sockif_alloc(FAR struct socket *psock)
   /* Save the pre-allocated connection in the socket structure */
 
   psock->s_conn = conn;
+#if defined(CONFIG_NET_LOCAL_STREAM)
+  conn->lc_psock = psock;
+#endif
   return OK;
 }
 #endif


### PR DESCRIPTION
## Summary

net/local: add nonblock connect(2) support 
driver/pipe: add nonblock open support 

https://man7.org/linux/man-pages/man2/connect.2.html

```
       EINPROGRESS
              The socket is nonblocking and the connection cannot be
              completed immediately.  (UNIX domain sockets failed with
              EAGAIN instead.)  It is possible to select(2) or poll(2)
              for completion by selecting the socket for writing.  After
              select(2) indicates writability, use getsockopt(2) to read
              the SO_ERROR option at level SOL_SOCKET to determine
              whether connect() completed successfully (SO_ERROR is
              zero) or unsuccessfully (SO_ERROR is one of the usual
              error codes listed here, explaining the reason for the
              failure).
```

## Impact

local  socket nonblock connect support

## Testing

local socket nonblock connect test