### PR TITLE
net/tcp: add nonblock connect(2) support 

### DIFF
--- a/fs/vfs/fs_select.c
+++ b/fs/vfs/fs_select.c
@@ -242,7 +242,7 @@ int select(int nfds, FAR fd_set *readfds, FAR fd_set *writefds,
 
           if (writefds)
             {
-              if (pollset[ndx].revents & POLLOUT)
+              if (pollset[ndx].revents & (POLLOUT | POLLHUP))
                 {
                   FD_SET(pollset[ndx].fd, writefds);
                   ret++;


### PR DESCRIPTION
## Summary

net/tcp: add nonblock connect(2) support 

https://man7.org/linux/man-pages/man2/connect.2.html

```
       EINPROGRESS
              The socket is nonblocking and the connection cannot be
              completed immediately.  (UNIX domain sockets failed with
              EAGAIN instead.)  It is possible to select(2) or poll(2)
              for completion by selecting the socket for writing.  After
              select(2) indicates writability, use getsockopt(2) to read
              the SO_ERROR option at level SOL_SOCKET to determine
              whether connect() completed successfully (SO_ERROR is
              zero) or unsuccessfully (SO_ERROR is one of the usual
              error codes listed here, explaining the reason for the
              failure).
```

## Impact

tcp nonblock connect support

## Testing

tcp nonblock connect test
