### PR TITLE
boards/xtensa/esp32: Don't include esp32_cpuint.h, it's not needed.

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c
@@ -35,7 +35,6 @@
 #include <nuttx/irq.h>
 #include <arch/irq.h>
 
-#include "esp32_cpuint.h"
 #include "esp32_gpio.h"
 
 #include "esp32-devkitc.h"

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c
@@ -35,7 +35,6 @@
 #include <nuttx/irq.h>
 #include <arch/irq.h>
 
-#include "esp32_cpuint.h"
 #include "esp32_gpio.h"
 
 #include "esp32-ethernet-kit.h"

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c
@@ -35,7 +35,6 @@
 #include <nuttx/irq.h>
 #include <arch/irq.h>
 
-#include "esp32_cpuint.h"
 #include "esp32_gpio.h"
 
 #include "esp32-wrover-kit.h"


### PR DESCRIPTION
## Summary
 Don't include esp32_cpuint.h in board file, it's not needed and a future PR will remove the file completely.
## Impact
esp32 boards
## Testing
The affected defconfigs (buttons) were tested.
