### PR TITLE
xtensa.h: Remove unused function prototype.

### DIFF
--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -265,7 +265,6 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs);
 /* Software interrupt handler */
 
 #ifdef CONFIG_SMP
-void __cpu1_start(void) noreturn_function;
 int xtensa_intercpu_interrupt(int tocpu, int intcode);
 void xtensa_pause_handler(void);
 #endif


### PR DESCRIPTION
## Summary
ESP32 uses a different function to start the app CPU and no other xtensa
CPU uses this __cpu1_start function.
## Impact
N/A
## Testing
N/A
