### PR TITLE
xtensa/esp32: Use IRQ to enable/disable interrupts

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpuint.c
+++ b/arch/xtensa/src/esp32/esp32_cpuint.c
@@ -154,6 +154,16 @@ uint8_t g_cpu0_intmap[ESP32_NCPUINTS];
 uint8_t g_cpu1_intmap[ESP32_NCPUINTS];
 #endif
 
+/* g_intenable[] is a shadow copy of the per-CPU INTENABLE register
+ * content.
+ */
+
+#ifdef CONFIG_SMP
+uint32_t g_intenable[CONFIG_SMP_NCPUS];
+#else
+uint32_t g_intenable[1];
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/

--- a/arch/xtensa/src/esp32/esp32_cpuint.c
+++ b/arch/xtensa/src/esp32/esp32_cpuint.c
@@ -492,7 +492,7 @@ void esp32_free_cpuint(int cpuint)
   flags = enter_critical_section();
 
 #ifdef CONFIG_SMP
-  if (this_cpu() != 0)
+  if (up_cpu_index() != 0)
     {
       freeints = &g_cpu1_freeints;
     }

--- a/arch/xtensa/src/esp32/esp32_cpuint.h
+++ b/arch/xtensa/src/esp32/esp32_cpuint.h
@@ -46,6 +46,16 @@ extern uint8_t g_cpu0_intmap[ESP32_NCPUINTS];
 extern uint8_t g_cpu1_intmap[ESP32_NCPUINTS];
 #endif
 
+/* g_intenable[] is a shadow copy of the per-CPU INTENABLE register
+ * content.
+ */
+
+#ifdef CONFIG_SMP
+extern uint32_t g_intenable[CONFIG_SMP_NCPUS];
+#else
+extern uint32_t g_intenable[1];
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -105,7 +105,7 @@ static inline void xtensa_attach_fromcpu0_interrupt(void)
 
   /* Enable the inter 0 CPU interrupts. */
 
-  up_enable_irq(cpuint);
+  up_enable_irq(ESP32_IRQ_CPU_CPU0);
 }
 #endif
 

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -97,7 +97,6 @@ static inline void xtensa_attach_fromcpu0_interrupt(void)
 
   /* Connect all CPU peripheral source to allocated CPU interrupt */
 
-  up_disable_irq(cpuint);
   esp32_attach_peripheral(1, ESP32_PERIPH_CPU_CPU0, cpuint);
 
   /* Attach the inter-CPU interrupt. */

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -2196,7 +2196,6 @@ int esp32_emac_init(void)
       goto error;
     }
 
-  up_disable_irq(priv->cpuint);
   esp32_attach_peripheral(0, ESP32_PERIPH_EMAC, priv->cpuint);
 
   ret = irq_attach(ESP32_IRQ_EMAC, emac_interrupt, priv);

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -1315,7 +1315,7 @@ static void emac_txtimeout_expiry(wdparm_t arg)
    * Interrupts will be re-enabled when emac_ifup() is called.
    */
 
-  up_disable_irq(priv->cpuint);
+  up_disable_irq(ESP32_IRQ_EMAC);
 
   /* Schedule to perform the TX timeout processing on the worker thread,
    * perhaps canceling any pending IRQ processing.
@@ -1904,7 +1904,7 @@ static int emac_ifup(struct net_driver_s *dev)
 
   /* Enable the Ethernet interrupt */
 
-  up_enable_irq(priv->cpuint);
+  up_enable_irq(ESP32_IRQ_EMAC);
 
   leave_critical_section(flags);
 

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -426,7 +426,7 @@ void esp32_gpioirqinitialize(void)
   /* Attach and enable the interrupt handler */
 
   DEBUGVERIFY(irq_attach(ESP32_IRQ_CPU_GPIO, gpio_interrupt, NULL));
-  up_enable_irq(g_gpio_cpuint);
+  up_enable_irq(ESP32_IRQ_CPU_GPIO);
 }
 #endif
 
@@ -456,7 +456,7 @@ void esp32_gpioirqenable(int irq, gpio_intrtype_t intrtype)
 
   /* Get the address of the GPIO PIN register for this pin */
 
-  up_disable_irq(g_gpio_cpuint);
+  up_disable_irq(ESP32_IRQ_CPU_GPIO);
 
   regaddr = GPIO_REG(pin);
   regval  = getreg32(regaddr);
@@ -490,7 +490,7 @@ void esp32_gpioirqenable(int irq, gpio_intrtype_t intrtype)
   regval |= (intrtype << GPIO_PIN_INT_TYPE_S);
   putreg32(regval, regaddr);
 
-  up_enable_irq(g_gpio_cpuint);
+  up_enable_irq(ESP32_IRQ_CPU_GPIO);
 }
 #endif
 
@@ -517,14 +517,14 @@ void esp32_gpioirqdisable(int irq)
 
   /* Get the address of the GPIO PIN register for this pin */
 
-  up_disable_irq(g_gpio_cpuint);
+  up_disable_irq(ESP32_IRQ_CPU_GPIO);
 
   regaddr = GPIO_REG(pin);
   regval  = getreg32(regaddr);
   regval &= ~(GPIO_PIN_INT_ENA_M | GPIO_PIN_INT_TYPE_M);
   putreg32(regval, regaddr);
 
-  up_enable_irq(g_gpio_cpuint);
+  up_enable_irq(ESP32_IRQ_CPU_GPIO);
 }
 #endif
 

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -421,7 +421,6 @@ void esp32_gpioirqinitialize(void)
 
   /* Attach the GPIO peripheral to the allocated CPU interrupt */
 
-  up_disable_irq(g_gpio_cpuint);
   esp32_attach_peripheral(cpu, ESP32_PERIPH_CPU_GPIO, g_gpio_cpuint);
 
   /* Attach and enable the interrupt handler */

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -1580,7 +1580,7 @@ FAR struct i2c_master_s *esp32_i2cbus_initialize(int port)
       return NULL;
     }
 
-  up_enable_irq(priv->cpuint);
+  up_enable_irq(config->irq);
 #endif
 
   esp32_i2c_sem_init(priv);
@@ -1623,7 +1623,7 @@ int esp32_i2cbus_uninitialize(FAR struct i2c_master_s *dev)
   leave_critical_section(flags);
 
 #ifndef CONFIG_I2C_POLLED
-  up_disable_irq(priv->cpuint);
+  up_disable_irq(priv->config->irq);
   esp32_detach_peripheral(priv->cpu,
                           priv->config->periph,
                           priv->cpuint);

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -1567,7 +1567,6 @@ FAR struct i2c_master_s *esp32_i2cbus_initialize(int port)
   /* Set up to receive peripheral interrupts on the current CPU */
 
   priv->cpu = up_cpu_index();
-  up_disable_irq(priv->cpuint);
   esp32_attach_peripheral(priv->cpu, config->periph, priv->cpuint);
 
   ret = irq_attach(config->irq, esp32_i2c_irq, priv);

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -139,7 +139,6 @@ static inline void xtensa_attach_fromcpu1_interrupt(void)
 
   /* Connect all CPU peripheral source to allocated CPU interrupt */
 
-  up_disable_irq(cpuint);
   esp32_attach_peripheral(0, ESP32_PERIPH_CPU_CPU1, cpuint);
 
   /* Attach the inter-CPU interrupt. */

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -167,6 +167,14 @@ void up_irqinitialize(void)
       g_irqmap[i] = IRQ_UNMAPPED;
     }
 
+  /* Hard code special cases. */
+
+  g_irqmap[XTENSA_IRQ_TIMER0] = IRQ_MKMAP(0, ESP32_CPUINT_TIMER0);
+
+#ifdef CONFIG_ESP32_WIRELESS
+  g_irqmap[ESP32_IRQ_MAC] = IRQ_MKMAP(0, ESP32_CPUINT_MAC);
+#endif
+
   /* Initialize CPU interrupts */
 
   esp32_cpuint_initialize();
@@ -286,18 +294,6 @@ void up_enable_irq(int irq)
 {
   int cpu = IRQ_GETCPU(g_irqmap[irq]);
   int cpuint = IRQ_GETCPUINT(g_irqmap[irq]);
-
-  /* The internal Timer 0 interrupt is not attached to any peripheral, and
-   * thus has no mapping, it has to be handled separately.
-   * We know it's enabled early before the second CPU has started, so we don't
-   * need any IPC call.
-   */
-
-  if (irq == XTENSA_IRQ_TIMER0)
-    {
-      cpu = 0;
-      cpuint = ESP32_CPUINT_TIMER0;
-    }
 
   DEBUGASSERT(cpuint >= 0 && cpuint <= ESP32_CPUINT_MAX);
 #ifdef CONFIG_SMP

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -147,7 +147,7 @@ static inline void xtensa_attach_fromcpu1_interrupt(void)
 
   /* Enable the inter 0 CPU interrupt. */
 
-  up_enable_irq(cpuint);
+  up_enable_irq(ESP32_IRQ_CPU_CPU1);
 }
 #endif
 

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -59,16 +59,6 @@
  * Public Data
  ****************************************************************************/
 
-/* g_intenable[] is a shadow copy of the per-CPU INTENABLE register
- * content.
- */
-
-#ifdef CONFIG_SMP
-static uint32_t g_intenable[CONFIG_SMP_NCPUS];
-#else
-static uint32_t g_intenable[1];
-#endif
-
 /* g_current_regs[] holds a reference to the current interrupt level
  * register storage structure.  It is non-NULL only during interrupt
  * processing.  Access to g_current_regs[] must be through the macro

--- a/arch/xtensa/src/esp32/esp32_irq.h
+++ b/arch/xtensa/src/esp32/esp32_irq.h
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * arch/xtensa/src/esp32/esp32_irq.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_SRC_ESP32_ESP32_IRQ_H
+#define __ARCH_XTENSA_SRC_ESP32_ESP32_IRQ_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  esp32_mapirq
+ *
+ * Description:
+ *   Map the given IRQ to the CPU and allocated CPU interrupt.
+ *
+ * Input Parameters:
+ *   irq      - IRQ number (see esp32/include/irq.h)
+ *   cpu      - The CPU receiving the interrupt 0=PRO CPU 1=APP CPU
+ *   cpuint   - The allocated CPU interrupt.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp32_mapirq(int irq, int cpu, int cpuint);
+
+/****************************************************************************
+ * Name:  esp32_unmapirq
+ *
+ * Description:
+ *   Unmap the given IRQ.
+ *
+ * Input Parameters:
+ *   irq      - IRQ number (see esp32/include/irq.h)
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void esp32_unmapirq(int irq);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_IRQ_H */

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -1041,7 +1041,7 @@ static int esp32_attach(struct uart_dev_s *dev)
        * in the UART
        */
 
-      up_enable_irq(priv->cpuint);
+      up_enable_irq(priv->config->irq);
     }
 
   return ret;
@@ -1063,7 +1063,7 @@ static void esp32_detach(struct uart_dev_s *dev)
 
   /* Disable and detach the CPU interrupt */
 
-  up_disable_irq(priv->cpuint);
+  up_disable_irq(priv->config->irq);
   irq_detach(priv->config->irq);
 
   /* Disassociate the peripheral interrupt from the CPU interrupt */
@@ -1133,6 +1133,8 @@ static void dma_attach(uint8_t dma_chan)
   int dma_cpuint;
   int cpu;
   int ret;
+  int periph;
+  int irq;
 
   /* Clear the interrupts */
 
@@ -1159,20 +1161,22 @@ static void dma_attach(uint8_t dma_chan)
 
   if (dma_chan == 0)
     {
-      esp32_attach_peripheral(cpu, ESP32_PERIPH_UHCI0, dma_cpuint);
-      ret = irq_attach(ESP32_IRQ_UHCI0, esp32_interrupt_dma, NULL);
+      periph = ESP32_PERIPH_UHCI0;
+      irq = ESP32_IRQ_UHCI0;
     }
   else
     {
-      esp32_attach_peripheral(cpu, ESP32_PERIPH_UHCI1, dma_cpuint);
-      ret = irq_attach(ESP32_IRQ_UHCI1, esp32_interrupt_dma, NULL);
+      periph = ESP32_PERIPH_UHCI1;
+      irq = ESP32_IRQ_UHCI1;
     }
 
+  esp32_attach_peripheral(cpu, periph, dma_cpuint);
+  ret = irq_attach(irq, esp32_interrupt_dma, NULL);
   if (ret == OK)
     {
       /* Enable the CPU interrupt */
 
-      up_enable_irq(dma_cpuint);
+      up_enable_irq(irq);
     }
   else
     {

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -1029,7 +1029,6 @@ static int esp32_attach(struct uart_dev_s *dev)
 
   /* Attach the GPIO peripheral to the allocated CPU interrupt */
 
-  up_disable_irq(priv->cpuint);
   esp32_attach_peripheral(priv->cpu, priv->config->periph,
                           priv->cpuint);
 
@@ -1157,8 +1156,6 @@ static void dma_attach(uint8_t dma_chan)
   /* Attach the UHCI interrupt to the allocated CPU interrupt
    * and attach and enable the IRQ.
    */
-
-  up_disable_irq(dma_cpuint);
 
   if (dma_chan == 0)
     {

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -1474,7 +1474,6 @@ FAR struct spi_dev_s *esp32_spibus_initialize(int port)
       /* Set up to receive peripheral interrupts on the current CPU */
 
       priv->cpu = up_cpu_index();
-      up_disable_irq(priv->cpuint);
       esp32_attach_peripheral(priv->cpu,
                               priv->config->periph,
                               priv->cpuint);

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -1489,7 +1489,7 @@ FAR struct spi_dev_s *esp32_spibus_initialize(int port)
           return NULL;
         }
 
-      up_enable_irq(priv->cpuint);
+      up_enable_irq(priv->config->irq);
     }
 
   esp32_spi_init(spi_dev);
@@ -1533,7 +1533,7 @@ int esp32_spibus_uninitialize(FAR struct spi_dev_s *dev)
 
   if (priv->config->use_dma)
     {
-      up_disable_irq(priv->cpuint);
+      up_disable_irq(priv->config->irq);
       esp32_detach_peripheral(priv->cpu,
                               priv->config->periph,
                               priv->cpuint);

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -1027,7 +1027,7 @@ static void esp32_spislv_bind(struct spi_slave_ctrlr_s *ctrlr,
   esp32_spislv_setmode(ctrlr, mode);
   esp32_spislv_setbits(ctrlr, nbits);
 
-  up_enable_irq(priv->cpuint);
+  up_enable_irq(priv->config->irq);
 
   esp32_spi_set_regbits(priv, SPI_CMD_OFFSET, SPI_USR_M);
 
@@ -1063,7 +1063,7 @@ static void esp32_spislv_unbind(struct spi_slave_ctrlr_s *ctrlr)
 
   flags = enter_critical_section();
 
-  up_disable_irq(priv->cpuint);
+  up_disable_irq(priv->config->irq);
 
   esp32_gpioirqdisable(ESP32_PIN2IRQ(priv->config->cs_pin));
   esp32_spi_reset_regbits(priv, SPI_SLAVE_OFFSET, SPI_INT_EN_M);
@@ -1365,7 +1365,7 @@ int esp32_spislv_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
       return OK;
     }
 
-  up_disable_irq(priv->cpuint);
+  up_disable_irq(priv->config->irq);
   esp32_detach_peripheral(priv->cpu,
                           priv->config->periph,
                           priv->cpuint);

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -1307,7 +1307,6 @@ FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
   /* Set up to receive peripheral interrupts on the current CPU */
 
   priv->cpu = up_cpu_index();
-  up_disable_irq(priv->cpuint);
   esp32_attach_peripheral(priv->cpu,
                           priv->config->periph,
                           priv->cpuint);

--- a/arch/xtensa/src/esp32/esp32_tickless.c
+++ b/arch/xtensa/src/esp32/esp32_tickless.c
@@ -499,7 +499,7 @@ void up_timer_initialize(void)
 
   /* Enable the timer 0 CPU interrupt. */
 
-  up_enable_irq(ESP32_CPUINT_TIMER0);
+  up_enable_irq(XTENSA_IRQ_TIMER0);
 
   return;
 }

--- a/arch/xtensa/src/esp32/esp32_tim.c
+++ b/arch/xtensa/src/esp32/esp32_tim.c
@@ -528,7 +528,7 @@ static int esp32_tim_setisr(FAR struct esp32_tim_dev_s *dev, xcpt_t handler,
            * CPU Interrupt
            */
 
-          up_disable_irq(tim->cpuint);
+          up_disable_irq(tim->irq);
           esp32_detach_peripheral(tim->core, tim->periph, tim->cpuint);
           esp32_free_cpuint(tim->cpuint);
           irq_detach(tim->irq);
@@ -545,7 +545,7 @@ static int esp32_tim_setisr(FAR struct esp32_tim_dev_s *dev, xcpt_t handler,
         {
           /* Disable the previous CPU Interrupt */
 
-          up_disable_irq(tim->cpuint);
+          up_disable_irq(tim->irq);
 
           /* Free cpu interrupt
            * because we will get another from esp32_alloc_levelint
@@ -585,7 +585,7 @@ static int esp32_tim_setisr(FAR struct esp32_tim_dev_s *dev, xcpt_t handler,
 
       /* Enable the CPU Interrupt that is linked to the timer */
 
-      up_enable_irq(tim->cpuint);
+      up_enable_irq(tim->irq);
     }
 
 errout:

--- a/arch/xtensa/src/esp32/esp32_timerisr.c
+++ b/arch/xtensa/src/esp32/esp32_timerisr.c
@@ -135,5 +135,5 @@ void up_timer_initialize(void)
 
   /* Enable the timer 0 CPU interrupt. */
 
-  up_enable_irq(ESP32_CPUINT_TIMER0);
+  up_enable_irq(XTENSA_IRQ_TIMER0);
 }

--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -752,10 +752,6 @@ static int esp32_wdt_setisr(FAR struct esp32_wdt_dev_s *dev, xcpt_t handler,
 
       wdt->cpu = up_cpu_index();
 
-      /* Disable the provided CPU Interrupt to configure it */
-
-      up_disable_irq(wdt->cpuint);
-
       /* Attach a peripheral interrupt to the available CPU interrupt in
        * the current core
        */

--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -726,7 +726,7 @@ static int esp32_wdt_setisr(FAR struct esp32_wdt_dev_s *dev, xcpt_t handler,
            * CPU Interrupt
            */
 
-          up_disable_irq(wdt->cpuint);
+          up_disable_irq(wdt->irq);
           esp32_detach_peripheral(wdt->cpu, wdt->periph, wdt->cpuint);
           esp32_free_cpuint(wdt->cpuint);
           irq_detach(wdt->irq);
@@ -772,7 +772,7 @@ static int esp32_wdt_setisr(FAR struct esp32_wdt_dev_s *dev, xcpt_t handler,
 
       /* Enable the CPU Interrupt that is linked to the wdt */
 
-      up_enable_irq(wdt->cpuint);
+      up_enable_irq(wdt->irq);
     }
 
 errout:

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -844,7 +844,7 @@ static void esp32_ints_on(uint32_t mask)
 
   wlinfo("INFO mask=%08x irq=%d\n", mask, irq);
 
-  up_enable_irq(irq);
+  up_enable_irq(ESP32_IRQ_MAC);
 }
 
 /****************************************************************************
@@ -867,7 +867,7 @@ static void esp32_ints_off(uint32_t mask)
 
   wlinfo("INFO mask=%08x irq=%d\n", mask, irq);
 
-  up_disable_irq(irq);
+  up_disable_irq(ESP32_IRQ_MAC);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Extracted from #4304

Use the IRQ number when enabling/disabling an interrupt instead of the CPU interrupt.
This helps whith:
1.  Have the same semantics as other chips
2.  Make it easy to extract the CPU that enabled the interrupt. This will be used in a follow-up PR.

## Impact
ESP32 only.
## Testing
All of ESP32 defconfig were tested.
