### PR TITLE
riscv/backtrace: add up_backtrace support 

### DIFF
--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -1,0 +1,178 @@
+/****************************************************************************
+ * arch/risc-v/src/common/riscv_backtrace.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+#include "sched/sched.h"
+
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: getfp
+ *
+ * Description:
+ *  getfp() returns current frame pointer
+ *
+ ****************************************************************************/
+
+static inline uintptr_t getfp(void)
+{
+  register uintptr_t fp;
+
+  __asm__
+  (
+    "\tadd  %0, x0, fp\n"
+    : "=r"(fp)
+  );
+
+  return fp;
+}
+
+/****************************************************************************
+ * Name: backtrace
+ *
+ * Description:
+ *  backtrace() parsing the return address through frame pointer
+ *
+ ****************************************************************************/
+
+static int backtrace(FAR uintptr_t *base, FAR uintptr_t *limit,
+                     FAR uintptr_t *fp, FAR uintptr_t *ra,
+                     FAR void **buffer, int size)
+{
+  int i = 0;
+
+  if (ra)
+    {
+      buffer[i++] = ra;
+    }
+
+  for (; i < size; fp = (FAR uintptr_t *)*(fp - 2), i++)
+    {
+      if (fp > limit || fp < base)
+        {
+          break;
+        }
+
+      ra = (FAR uintptr_t *)*(fp - 1);
+      if (ra == NULL)
+        {
+          break;
+        }
+
+      buffer[i] = ra;
+    }
+
+  return i;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_backtrace
+ *
+ * Description:
+ *  up_backtrace()  returns  a backtrace for the TCB, in the array
+ *  pointed to by buffer.  A backtrace is the series of currently active
+ *  function calls for the program.  Each item in the array pointed to by
+ *  buffer is of type void *, and is the return address from the
+ *  corresponding stack frame.  The size argument specifies the maximum
+ *  number of addresses that can be stored in buffer.   If  the backtrace is
+ *  larger than size, then the addresses corresponding to the size most
+ *  recent function calls are returned; to obtain the complete backtrace,
+ *  make sure that buffer and size are large enough.
+ *
+ * Input Parameters:
+ *   tcb    - Address of the task's TCB
+ *   buffer - Return address from the corresponding stack frame
+ *   size   - Maximum number of addresses that can be stored in buffer
+ *
+ * Returned Value:
+ *   up_backtrace() returns the number of addresses returned in buffer
+ *
+ ****************************************************************************/
+
+int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
+{
+  FAR struct tcb_s *rtcb = running_task();
+  irqstate_t flags;
+  int ret;
+
+  if (size <= 0 || !buffer)
+    {
+      return 0;
+    }
+
+  if (tcb == NULL || tcb == rtcb)
+    {
+      if (up_interrupt_context())
+        {
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+          ret = backtrace((FAR void *)&g_intstackalloc,
+                          (FAR void *)((uint32_t)&g_intstackalloc +
+                                       CONFIG_ARCH_INTERRUPTSTACK),
+                          (FAR void *)getfp(), NULL, buffer, size);
+#else
+          ret = backtrace(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)getfp(), NULL, buffer, size);
+#endif
+          if (ret < size)
+            {
+              ret += backtrace(rtcb->stack_base_ptr,
+                               rtcb->stack_base_ptr +
+                               rtcb->adj_stack_size,
+                               (FAR void *)CURRENT_REGS[REG_FP],
+                               (FAR void *)CURRENT_REGS[REG_EPC],
+                               &buffer[ret], size - ret);
+            }
+        }
+      else
+        {
+          ret = backtrace(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)getfp(), NULL, buffer, size);
+        }
+    }
+  else
+    {
+      flags = enter_critical_section();
+
+      ret = backtrace(tcb->stack_base_ptr,
+                      tcb->stack_base_ptr + tcb->adj_stack_size,
+                      (FAR void *)tcb->xcp.regs[REG_FP],
+                      (FAR void *)tcb->xcp.regs[REG_EPC],
+                      buffer, size);
+
+      leave_critical_section(flags);
+    }
+
+  return ret;
+}


### PR DESCRIPTION
## Summary

riscv/backtrace: add up_backtrace support based on frame pointer

To use call trace facilities, enable compiler's frame pointer feature:
 -fno-omit-frame-pointer

## Impact

depends on:
https://github.com/apache/incubator-nuttx/pull/4363

## Testing

enable config:
CONFIG_SCHED_BACKTRACE=y
CONFIG_SYSTEM_DUMPSTACK=y

enable frame pointer:
ARCHOPTIMIZATION += -fno-omit-frame-pointer

Check the dumpstack from esp32c3 board:

```
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED    CPU COMMAND
    0         0 FIFO     Kthread N-- Ready              00000000 000976 000596  61.0%   97.5% Idle Task
    1       224 FIFO     Kthread --- Waiting  Signal    00000000 002016 000292  14.4%    0.0% hpwork
    2       100 FIFO     Kthread --- Waiting  Signal    00000000 002016 000996  49.4%    0.0% lpwork
    3       100 FIFO     Task    --- Running            00000000 002016 001780  88.2%!   1.4% init
    4       252 FIFO     Kthread --- Waiting  Semaphore 00000000 002000 000516  25.8%    0.0% rt_timer
    5       253 FIFO     Kthread --- Waiting  MQ empty  00000000 006624 001360  20.5%    0.1% wifi
    7       100 FIFO     Task    --- Waiting  Semaphore 00000000 004048 002196  54.2%    1.0% miio_client
    8       227 FIFO     Kthread --- Waiting  Semaphore 00000000 000928 000724  78.0%    0.0% BT TX  0x3fc9ed80
    9       228 FIFO     Kthread --- Waiting  Semaphore 00000000 001216 000532  43.7%    0.0% BT RX  0x3fc9ed80
   10       230 FIFO     Kthread --- Waiting  Semaphore 00000000 004048 000500  12.3%    0.0% btController
   11       228 FIFO     Kthread --- Waiting  Semaphore 00000000 001216 000452  37.1%    0.0% BT Driver  0x3fcb0a90
   12       100 FIFO     pthread --- Waiting  MQ empty  00000000 005104 000756  14.8%    0.0% httpc_task 0x3fcb3290
   13       100 FIFO     pthread --- Waiting  MQ empty  00000000 004080 001348  33.0%    0.0% otu_task 0x3fcb1084
   14       100 FIFO     pthread --- Waiting  MQ empty  00000000 004080 000964  23.6%    0.0% ots_task 0x3fcb1878
   15       100 FIFO     pthread --- Waiting  MQ empty  00000000 004080 001876  45.9%    0.0% mi_otn 0x3fcb1038
   17       100 FIFO     Task    --- Waiting  Semaphore 00000000 002000 001204  60.2%    0.0% mible_mesh_common_bt
   18       100 FIFO     pthread --- Waiting  MQ empty  00000000 003056 001700  55.6%    0.1% netMonitorTask 0x3fc88d60
   19       100 FIFO     pthread --- Waiting  Semaphore 00000000 001008 000820  81.3%!   0.0% timer 0
   21       100 FIFO     pthread --- Waiting  Semaphore 00000000 003312 000916  27.6%    0.0% rpc_consume 0x3fcbb890
   22       100 FIFO     pthread --- Waiting  Semaphore 00000000 004080 001156  28.3%    0.0% mi_mcmd 0x3fcbcbb0
   23       100 FIFO     pthread --- Waiting  Semaphore 00000000 002032 001124  55.3%    0.0% ble_gateway 0

```

dumpstack from pid 0 to  50
```
nsh> dumpstack 0 50
[22705.463000] [  INFO] [BackTrace| 0|0]:  0x4200787e
[22705.464000] [  INFO] [BackTrace| 1|0]:  0x42008242 0x4200328c 0x42001ab4 0x42001a42
[22705.465000] [  INFO] [BackTrace| 2|0]:  0x42008242 0x4200486c 0x42004468 0x42003302 0x42001b38 0x42001a42
[22705.474000] [  INFO] [BackTrace| 3|0]:  0x42008242 0x4201db38 0x4201db92 0x4200bd58 0x42009660 0x4200a5ca 0x42008e26 0x420083ba
[22705.486000] [  INFO] [BackTrace| 3|1]:  0x420082bc 0x42005ad0 0x42001a56
[22705.492000] [  INFO] [BackTrace| 4|0]:  0x42008242 0x4209c01a 0x42001a42
[22705.499000] [  INFO] [BackTrace| 5|0]:  0x42008242 0x4209767c 0x4209d8fc
[22705.506000] [  INFO] [BackTrace| 7|0]:  0x42008242 0x4209804a 0x4207688e 0x42076a14 0x42036dba 0x42005ad0 0x42001a56
[22705.516000] [  INFO] [BackTrace| 8|0]:  0x42008242 0x42003b1a 0x42035ba6 0x4203569e 0x42029028 0x42035fb2 0x42001a42
[22705.527000] [  INFO] [BackTrace| 9|0]:  0x42008242 0x42003b1a 0x42035ba6 0x4203569e 0x42035ed2 0x42036366 0x420272f6 0x42035fb2
[22705.538000] [  INFO] [BackTrace| 9|1]:  0x42001a42
[22705.543000] [  INFO] [BackTrace|10|0]:  0x42008242 0x42003b1a 0x4209f6d4
[22705.550000] [  INFO] [BackTrace|11|0]:  0x42008242 0x42003afc 0x420fca78 0x420368a6 0x420368e4 0x42035fb2 0x42001a42
[22705.560000] [  INFO] [BackTrace|12|0]:  0x42008242 0x4209767c 0x4203d402 0x4208a920 0x4201d1f4
[22705.569000] [  INFO] [BackTrace|13|0]:  0x42008242 0x4209767c 0x4203d402 0x420856f6 0x420861c8 0x4201d1f4
[22705.578000] [  INFO] [BackTrace|14|0]:  0x42008242 0x4209767c 0x4203d402 0x42082178 0x42082984 0x4201d1f4
[22705.588000] [  INFO] [BackTrace|15|0]:  0x42008242 0x420977e2 0x4203d47c 0x4203d494 0x42089dc6 0x4201d1f4
[22705.597000] [  INFO] [BackTrace|17|0]:  0x42008242 0x420769a8 0x42076a14 0x420981b4 0x4207643a 0x42024976 0x42023b3a 0x42005ad0
[22705.609000] [  INFO] [BackTrace|17|1]:  0x42001a56
[22705.614000] [  INFO] [BackTrace|18|0]:  0x42008242 0x420977e2 0x4203d47c 0x42041830 0x4201d1f4
[22705.622000] [  INFO] [BackTrace|19|0]:  0x42008242 0x420fc4e6 0x420251a8 0x4201d1f4
[22705.630000] [  INFO] [BackTrace|21|0]:  0x42008242 0x42003c1c 0x42003c6a 0x420243dc 0x42090ece 0x4201d1f4
[22705.639000] [  INFO] [BackTrace|22|0]:  0x42008242 0x4209804a 0x4207688e 0x42076a14 0x4204fd22 0x4204524e 0x42047e3c 0x4201d1f4
[22705.651000] [  INFO] [BackTrace|23|0]:  0x42008242 0x42003b1a 0x420243f2 0x420245ba 0x42091b2e 0x4201d1f4
[22705.660000] [  INFO] [BackTrace|30|0]:  0x420fd4a6 0x42099de6 0x4202330c 0x42005ad0 0x42001a56

```

check the dump trace: 

`    3       100 FIFO     Task    --- Running            00000000 002016 001780  88.2%!   1.4% init`

```
$ riscv64-unknown-elf-addr2line -e nuttx -f -C -s 0x42008242 0x4201db38 0x4201db92 0x4200bd58 0x42009660 0x4200a5ca 0x42008e26 0x420083ba 0x420082bc 0x42005ad0 0x42001a56
sys_call1
nx_waitpid
waitpid
nsh_builtin
nsh_execute
nsh_parse_command
nsh_session
nsh_consolemain
nsh_main
nxtask_startup
nxtask_start
```


