### PR TITLE
libs/libxx/uClibc++.defs: Download the correct file type.

### DIFF
--- a/libs/libxx/uClibc++.defs
+++ b/libs/libxx/uClibc++.defs
@@ -21,9 +21,9 @@
 VERSION=0.2.5
 
 $(TOPDIR)/include/uClibc++:
-	$(Q) curl -O -L https://git.busybox.net/uClibc++/snapshot/uClibc++-$(VERSION).tar.gz
-	$(Q) tar -xzf uClibc++-$(VERSION).tar.gz
-	$(Q) $(DELFILE) uClibc++-$(VERSION).tar.gz
+	$(Q) curl -O -L https://git.busybox.net/uClibc++/snapshot/uClibc++-$(VERSION).tar.bz2
+	$(Q) tar -xf uClibc++-$(VERSION).tar.bz2
+	$(Q) $(DELFILE) uClibc++-$(VERSION).tar.bz2
 	$(Q) mv uClibc++-$(VERSION) uClibc++
 	$(Q) $(DIRLINK) $(CURDIR)/uClibc++/include $(TOPDIR)/include/uClibc++
 	$(Q) $(COPYFILE) $(CURDIR)/system_configuration.h $(TOPDIR)/include/uClibc++


### PR DESCRIPTION

## Summary
The archive type has changed apparently.
## Impact
Fix current build breakage.
## Testing

sim:cxxtest