### PR TITLE
libs/libxx: Download C++ libraries during context.

### DIFF
--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -58,7 +58,7 @@ OBJS = $(AOBJS) $(COBJS) $(CXXOBJS) $(CPPOBJS)
 BIN = libxx$(LIBEXT)
 
 all: $(BIN)
-.PHONY: depend clean distclean dirlinks
+.PHONY: depend clean distclean context
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -75,7 +75,7 @@ $(CPPOBJS): %$(OBJEXT): %.cpp
 $(BIN):	$(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-dirlinks::
+context::
 
 makedepfile: $(CXXSRCS:.cxx=.ddx) $(CPPSRCS:.cpp=.ddp)
 	$(call CATFILE, Make.dep, $^)

--- a/libs/libxx/libcxx.defs
+++ b/libs/libxx/libcxx.defs
@@ -33,7 +33,7 @@ libcxx: libcxx-$(VERSION).src.tar.xz
 $(TOPDIR)/include/libcxx: libcxx
 	$(Q) $(DIRLINK) $(CURDIR)/libcxx/include $(TOPDIR)/include/libcxx
 
-dirlinks:: $(TOPDIR)/include/libcxx
+context:: $(TOPDIR)/include/libcxx
 
 distclean::
 	$(Q) $(DELFILE) libcxx-$(VERSION).src.tar.xz

--- a/libs/libxx/uClibc++.defs
+++ b/libs/libxx/uClibc++.defs
@@ -28,7 +28,7 @@ $(TOPDIR)/include/uClibc++:
 	$(Q) $(DIRLINK) $(CURDIR)/uClibc++/include $(TOPDIR)/include/uClibc++
 	$(Q) $(COPYFILE) $(CURDIR)/system_configuration.h $(TOPDIR)/include/uClibc++
 
-dirlinks:: $(TOPDIR)/include/uClibc++
+context:: $(TOPDIR)/include/uClibc++
 
 distclean::
 	$(Q) $(DELFILE) $(TOPDIR)/include/uClibc++/system_configuration.h

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -97,6 +97,9 @@ endif
 endif
 
 CONTEXTDIRS += libs$(DELIM)libc
+ifeq ($(CONFIG_HAVE_CXX),y)
+CONTEXTDIRS += libs$(DELIM)libxx
+endif
 
 ifeq ($(CONFIG_NX),y)
 KERNDEPDIRS += graphics

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -326,7 +326,6 @@ endif
 	$(Q) touch $@
 
 dirlinks: include/arch include/arch/board include/arch/chip $(ARCH_SRC)/board $(ARCH_SRC)/chip drivers/platform
-	$(Q) $(MAKE) -C libs/libxx dirlinks
 	$(Q) $(MAKE) -C boards dirlinks
 	$(Q) $(MAKE) -C openamp dirlinks
 	$(Q) $(MAKE) -C $(CONFIG_APPS_DIR) dirlinks

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -305,7 +305,6 @@ endif
 	$(Q) touch $@
 
 dirlinks: include\arch include\arch\board include\arch\chip $(ARCH_SRC)\board $(ARCH_SRC)\chip drivers\platform
-	$(Q) $(MAKE) -C libs/libxx dirlinks
 	$(Q) $(MAKE) -C boards dirlinks
 	$(Q) $(MAKE) -C openamp dirlinks
 	$(Q) $(MAKE) -C $(CONFIG_APPS_DIR) dirlinks


### PR DESCRIPTION
## Summary
`context` is the target where external libraries are downloaded, use that for C++ libraries instead of `dirlinks`.
Doing them during `dirlinks` also had the (side)effect of the libraries being downloaded when configuring the project.
## Impact
C++ Libraries (uClibc++ & libcxx)
## Testing
sim:cxxtest
sim:libcxxtest
