### PR TITLE
drivers/sensors/bmp280.c: Correct bmp280 driver

### DIFF
--- a/drivers/sensors/bmp280.c
+++ b/drivers/sensors/bmp280.c
@@ -506,7 +506,9 @@ static uint32_t bmp280_compensate_press(FAR struct bmp280_dev_s *priv,
 static int bmp280_set_interval(FAR struct sensor_lowerhalf_s *lower,
                                FAR unsigned int *period_us)
 {
-  FAR struct bmp280_dev_s *priv = (FAR struct bmp280_dev_s *)lower->priv;
+  FAR struct bmp280_dev_s *priv = container_of(lower,
+                                               FAR struct bmp280_dev_s,
+                                               sensor_lower);
   int ret = 0;
 
   uint8_t regval;
@@ -653,7 +655,7 @@ static int bmp280_fetch(FAR struct sensor_lowerhalf_s *lower,
 
   memcpy(buffer, &baro_data, sizeof(baro_data));
 
-  return ret;
+  return buflen;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
There were some mistakes in porting to the common sensors, and they
caused the following problems.

- Hardfault by bmp280_set_interval
- Read data always zero

## Impact
bmp280 driver only

## Testing
In CONFIG_TESTING_SENSORTEST=y, verify that bmp280 sensor works well.
```
nsh> sensortest -n 10 baro0
SensorTest: Test /dev/sensor/baro0 with interval(1000000us), latency(0us)
baro0: timestamp:47994323 value1:1008.28 value2:26.54
baro0: timestamp:47994873 value1:1008.28 value2:26.54
baro0: timestamp:47995422 value1:1008.28 value2:26.54
baro0: timestamp:47996002 value1:1008.28 value2:26.54
baro0: timestamp:47996551 value1:1008.28 value2:26.54
baro0: timestamp:47997100 value1:1008.28 value2:26.54
baro0: timestamp:47997650 value1:1008.28 value2:26.54
baro0: timestamp:47998230 value1:1008.28 value2:26.54
baro0: timestamp:47998779 value1:1008.28 value2:26.54
baro0: timestamp:47999328 value1:1008.28 value2:26.54
SensorTest: Received message: baro0, number:10/10
```
