### PR TITLE
drivers/Makefile: Use the -include directive for platform/Make.defs

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -65,7 +65,7 @@ include rf/Make.defs
 include rc/Make.defs
 
 ifeq ($(CONFIG_SPECIFIC_DRIVERS),y)
-include platform/Make.defs
+-include platform/Make.defs
 endif
 
 ifeq ($(CONFIG_DEV_SIMPLE_ADDRENV),y)


### PR DESCRIPTION
## Summary
Since `platform` of `platform/Make.defs` is a symbolic link created during
the build process, we use -include directive instead of include for safety.

## Impact
None

## Testing
On spresense board that uses the platform-specific driver,
confirmed successful build and operation.
