### PR TITLE
net/socket: Minor fix code logic 

### DIFF
--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -289,7 +289,7 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
         {
           /* Read 32 bytes into the bit bucket */
 
-          readlen = MIN(remaining, 32);
+          tmplen = MIN(remaining, 32);
           ret     = psock_fifo_read(psock, bitbucket, &tmplen, false);
           if (ret < 0)
             {
@@ -302,6 +302,7 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
           DEBUGASSERT(tmplen <= remaining);
           remaining -= tmplen;
+          readlen += tmplen;
         }
       while (remaining > 0);
     }

--- a/net/socket/sendto.c
+++ b/net/socket/sendto.c
@@ -110,6 +110,11 @@ ssize_t psock_sendto(FAR struct socket *psock, FAR const void *buf,
   struct iovec iov;
   struct msghdr msg;
 
+  if (tolen != 0 && to == NULL)
+    {
+      return -EINVAL;
+    }
+
   iov.iov_base = (FAR void *)buf;
   iov.iov_len = len;
   msg.msg_name = (FAR struct sockaddr *)to;


### PR DESCRIPTION
## Summary
net/local: Fix receive data size calculation for local_recvmsg
In psock_dgram_recvfrom function, fix code logic.

net/socket: Fix bug that sendto did not return an error
When `tolen` is not 0 and `to` is NULL, it causes illegal buffer access.
Add a parameter check in this condition.

## Impact

## Testing

