### PR TITLE
Add support for 3-phase Hall effect sensor driver

### DIFF
--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -232,6 +232,10 @@ ifeq ($(CONFIG_SENSORS_QENCODER),y)
 CHIP_CSRCS += stm32_qencoder.c
 endif
 
+ifeq ($(CONFIG_SENSORS_HALL3PHASE),y)
+CHIP_CSRCS += stm32_hall3ph.c
+endif
+
 ifeq ($(CONFIG_STM32_CAN),y)
 CHIP_CSRCS += stm32_can.c
 endif

--- a/arch/arm/src/stm32/stm32_hall3ph.c
+++ b/arch/arm/src/stm32/stm32_hall3ph.c
@@ -1,0 +1,209 @@
+/****************************************************************************
+ * arch/arm/src/stm32/stm32_hall3ph.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <debug.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/sensors/hall3ph.h>
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include "arm_arch.h"
+#include "stm32_hall3ph.h"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct stm32_lowerhalf_s
+{
+  /* The first field of this state structure must be a pointer to the lower-
+   * half callback structure:
+   */
+
+  FAR const struct hall3_ops_s *ops;  /* Lower half callback structure */
+  struct stm32_hall3ph_cfg_s    cfg;  /* Configuration */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+int stm32_hall3ph_setup(FAR struct hall3_lowerhalf_s *lower);
+int stm32_hall3ph_shutdown(FAR struct hall3_lowerhalf_s *lower);
+int stm32_hall3ph_position(FAR struct hall3_lowerhalf_s *lower,
+                           FAR uint8_t *pos);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+struct hall3_ops_s g_hall3ph_ops =
+{
+  .setup    = stm32_hall3ph_setup,
+  .shutdown = stm32_hall3ph_shutdown,
+  .position = stm32_hall3ph_position
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_hall3ph_setup
+ *
+ * Description:
+ *   Configure the 3-phase Hall effect sensor
+ *
+ ****************************************************************************/
+
+int stm32_hall3ph_setup(FAR struct hall3_lowerhalf_s *lower)
+{
+  FAR struct stm32_lowerhalf_s *priv = (FAR struct stm32_lowerhalf_s *)lower;
+
+  DEBUGASSERT(priv);
+
+  /* Configure input pins */
+
+  stm32_configgpio(priv->cfg.gpio_pha);
+  stm32_configgpio(priv->cfg.gpio_phb);
+  stm32_configgpio(priv->cfg.gpio_phc);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: stm32_hall3ph_shutdown
+ *
+ * Description:
+ *   Disable the 3-phase Hall effect sensor
+ *
+ ****************************************************************************/
+
+int stm32_hall3ph_shutdown(FAR struct hall3_lowerhalf_s *lower)
+{
+  FAR struct stm32_lowerhalf_s *priv = (FAR struct stm32_lowerhalf_s *)lower;
+
+  DEBUGASSERT(priv);
+
+  /* Unconfigure input pins */
+
+  stm32_unconfiggpio(priv->cfg.gpio_pha);
+  stm32_unconfiggpio(priv->cfg.gpio_phb);
+  stm32_unconfiggpio(priv->cfg.gpio_phc);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: stm32_hall3ph_position
+ *
+ * Description:
+ *   Return the current 3-phase Hall effect sensor position
+ *
+ ****************************************************************************/
+
+int stm32_hall3ph_position(FAR struct hall3_lowerhalf_s *lower,
+                           FAR uint8_t *pos)
+{
+  FAR struct stm32_lowerhalf_s *priv = (FAR struct stm32_lowerhalf_s *)lower;
+  uint8_t                       ha   = 0;
+  uint8_t                       hb   = 0;
+  uint8_t                       hc   = 0;
+  uint8_t                       i    = 0;
+  uint8_t                       thr  = (priv->cfg.samples / 2);
+
+  DEBUGASSERT(priv);
+
+  /* Sample pins */
+
+  for (i = 0; i < priv->cfg.samples; i += 1)
+    {
+      ha += stm32_gpioread(priv->cfg.gpio_pha);
+      hb += stm32_gpioread(priv->cfg.gpio_phb);
+      hc += stm32_gpioread(priv->cfg.gpio_phc);
+    }
+
+  /* Get state based on threshold */
+
+  *pos = ((ha > thr) << 0) |
+         ((hb > thr) << 1) |
+         ((hc > thr) << 2);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_hall3ph_initialize
+ *
+ * Description:
+ *   Initialize the 3-phase Hall effect driver
+ *
+ ****************************************************************************/
+
+int stm32_hall3ph_initialize(FAR const char *devpath,
+                             FAR struct stm32_hall3ph_cfg_s *cfg)
+{
+  FAR struct stm32_lowerhalf_s *priv = NULL;
+  int                           ret  = OK;
+
+  /* Allocate the lower-half data structure */
+
+  priv = (FAR struct stm32_lowerhalf_s *)
+         kmm_zalloc(sizeof(struct stm32_lowerhalf_s));
+  if (priv == NULL)
+    {
+      snerr("ERROR: Allocation failed\n");
+      ret = -ENOMEM;
+      goto errout;
+    }
+
+  /* Copy configuration */
+
+  memcpy(&priv->cfg, cfg, sizeof(struct stm32_hall3ph_cfg_s));
+
+  /* Connect ops */
+
+  priv->ops = &g_hall3ph_ops;
+
+  /* Initialize a Hall effect sensor interface. */
+
+  ret = hall3_register(devpath, (FAR struct hall3_lowerhalf_s *)priv);
+  if (ret < 0)
+    {
+      snerr("ERROR: hall3ph_register failed: %d\n", ret);
+    }
+
+errout:
+  return ret;
+}

--- a/arch/arm/src/stm32/stm32_hall3ph.h
+++ b/arch/arm/src/stm32/stm32_hall3ph.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * arch/arm/src/stm32/stm32_hall3ph.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32_STM32_HALL3PH_H
+#define __ARCH_ARM_SRC_STM32_STM32_HALL3PH_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* 3-phase Hall effect sensor configuration */
+
+struct stm32_hall3ph_cfg_s
+{
+  int gpio_pha;                 /* Hall phase A pincfg */
+  int gpio_phb;                 /* Hall phase B pincfg */
+  int gpio_phc;                 /* Hall phase C pincfg */
+  int samples;                  /* Number of samples taken from GPIO */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_hall3ph_initialize
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_hall3ph_initialize
+ *
+ * Description:
+ *   Initialize the 3-phase Hall effect driver
+ *
+ ****************************************************************************/
+
+int stm32_hall3ph_initialize(FAR const char *devpath,
+                             FAR struct stm32_hall3ph_cfg_s *cfg);
+
+#endif /* __ARCH_ARM_SRC_STM32_STM32_HALL3PH_H */

--- a/boards/arm/stm32/common/Kconfig
+++ b/boards/arm/stm32/common/Kconfig
@@ -70,4 +70,12 @@ endif # BOARD_STM32_IHM16M1
 
 endif # STM32_FOC
 
+if SENSORS_HALL3PHASE
+
+config BOARD_STM32_HALL3PHASE_SAMPLES
+       int "3-phase Hall effect sensor number of samples"
+       default 10
+
+endif # SENSORS_HALL3PHASE
+
 endif # BOARD_STM32_COMMON

--- a/boards/arm/stm32/common/include/board_hall3ph.h
+++ b/boards/arm/stm32/common/include/board_hall3ph.h
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * boards/arm/stm32/common/include/board_hall3ph.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARD_HALL3PH_H
+#define __BOARD_HALL3PH_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_hall3ph_initialize
+ *
+ * Description:
+ *   Initialize the 3-phase Hall effect sensor driver for the given timer
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/hallN
+ *   pha   - phase A Hall effect sensor pin configuration
+ *   phb   - phase B Hall effect sensor pin configuration
+ *   phc   - phase C Hall effect sensor pin configuration
+ *
+ ****************************************************************************/
+
+int board_hall3ph_initialize(int devno, int pha, int phb, int phc);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __BOARD_HALL3PH_H

--- a/boards/arm/stm32/common/src/Make.defs
+++ b/boards/arm/stm32/common/src/Make.defs
@@ -78,6 +78,10 @@ ifeq ($(CONFIG_SENSORS_QENCODER),y)
   CSRCS += stm32_qencoder.c
 endif
 
+ifeq ($(CONFIG_SENSORS_HALL3PHASE),y)
+  CSRCS += board_hall3ph.c
+endif
+
 ifeq ($(CONFIG_SENSORS_INA219),y)
   CSRCS += stm32_ina219.c
 endif

--- a/boards/arm/stm32/common/src/board_hall3ph.c
+++ b/boards/arm/stm32/common/src/board_hall3ph.c
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * boards/arm/stm32/common/src/board_hall3ph.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <debug.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/sensors/hall3ph.h>
+#include <arch/board/board.h>
+
+#include "stm32_hall3ph.h"
+#include "board_hall3ph.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_hall3ph_initialize
+ *
+ * Description:
+ *   Initialize the 3-phase Hall effect sensor driver
+ *
+ ****************************************************************************/
+
+int board_hall3ph_initialize(int devno, int pha, int phb, int phc)
+{
+  struct stm32_hall3ph_cfg_s cfg;
+  char                       devpath[12];
+  int                        ret = OK;
+
+  /* Get configuration */
+
+  cfg.gpio_pha = pha;
+  cfg.gpio_phb = phb;
+  cfg.gpio_phc = phc;
+  cfg.samples  = CONFIG_BOARD_STM32_HALL3PHASE_SAMPLES;
+
+  /* Initialize a Hall effect sensor interface. */
+
+  snprintf(devpath, 12, "/dev/hall%d", devno);
+
+  ret = stm32_hall3ph_initialize(devpath, &cfg);
+  if (ret < 0)
+    {
+      snerr("ERROR: stm32_hall3ph_initialize failed: %d\n", ret);
+    }
+
+  return ret;
+}

--- a/boards/arm/stm32/nucleo-f446re/src/nucleo-f446re.h
+++ b/boards/arm/stm32/nucleo-f446re/src/nucleo-f446re.h
@@ -216,6 +216,17 @@
 #define GPIO_FIRE     GPIO_BUTTON_2
 #define GPIO_JUMP     GPIO_BUTTON_3
 
+#ifdef CONFIG_SENSORS_HALL3PHASE
+/* GPIO pins used by the 3-phase Hall effect sensor */
+
+#  define GPIO_HALL_PHA (GPIO_INPUT | GPIO_SPEED_2MHz | \
+                         GPIO_PORTA | GPIO_PIN15)
+#  define GPIO_HALL_PHB (GPIO_INPUT | GPIO_SPEED_2MHz | \
+                         GPIO_PORTB | GPIO_PIN3)
+#  define GPIO_HALL_PHC (GPIO_INPUT | GPIO_SPEED_2MHz | \
+                         GPIO_PORTB | GPIO_PIN10)
+#endif
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
@@ -44,11 +44,15 @@
 #endif
 
 #ifdef CONFIG_SENSORS_QENCODER
-#include "board_qencoder.h"
+#  include "board_qencoder.h"
+#endif
+
+#ifdef CONFIG_SENSORS_HALL3PHASE
+#  include "board_hall3ph.h"
 #endif
 
 #ifdef CONFIG_VIDEO_FB
-#include <nuttx/video/fb.h>
+#  include <nuttx/video/fb.h>
 #endif
 
 #include "nucleo-f446re.h"
@@ -164,6 +168,20 @@ int stm32_bringup(void)
     {
       syslog(LOG_ERR,
              "ERROR: Failed to register the qencoder: %d\n",
+             ret);
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_HALL3PHASE
+  /* Initialize and register the 3-phase Hall effect sensor driver */
+
+  ret = board_hall3ph_initialize(0, GPIO_HALL_PHA, GPIO_HALL_PHB,
+                                 GPIO_HALL_PHC);
+  if (ret != OK)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to register the hall : %d\n",
              ret);
       return ret;
     }

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -927,6 +927,10 @@ config SENSORS_QENCODER
 	bool "Qencoder"
 	default n
 
+config SENSORS_HALL3PHASE
+	bool "3-phase Hall effect sensor"
+	default n
+
 config SENSORS_VEML6070
 	bool "Vishay VEML6070 UV-A Light Sensor support"
 	default n

--- a/drivers/sensors/Make.defs
+++ b/drivers/sensors/Make.defs
@@ -280,6 +280,12 @@ ifeq ($(CONFIG_SENSORS_QENCODER),y)
   CSRCS += qencoder.c
 endif
 
+# 3-phase Hall effect sensor upper half
+
+ifeq ($(CONFIG_SENSORS_HALL3PHASE),y)
+  CSRCS += hall3ph.c
+endif
+
 # Vishay VEML6070
 
 ifeq ($(CONFIG_SENSORS_VEML6070),y)

--- a/drivers/sensors/hall3ph.c
+++ b/drivers/sensors/hall3ph.c
@@ -1,0 +1,356 @@
+/****************************************************************************
+ * drivers/sensors/hall3ph.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/arch.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/sensors/hall3ph.h>
+
+#include <arch/irq.h>
+
+/****************************************************************************
+ * Private Type Definitions
+ ****************************************************************************/
+
+/* This structure describes the state of the upper half driver */
+
+struct hall3_upperhalf_s
+{
+  uint8_t                       crefs;
+  sem_t                         exclsem;
+  FAR struct hall3_lowerhalf_s *lower;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int hall3_open(FAR struct file *filep);
+static int hall3_close(FAR struct file *filep);
+static ssize_t hall3_read(FAR struct file *filep, FAR char *buffer,
+                       size_t buflen);
+static ssize_t hall3_write(FAR struct file *filep, FAR const char *buffer,
+                        size_t buflen);
+static int hall3_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations g_hall3ops =
+{
+  hall3_open,  /* open */
+  hall3_close, /* close */
+  hall3_read,  /* read */
+  hall3_write, /* write */
+  NULL  ,      /* seek */
+  hall3_ioctl, /* ioctl */
+  NULL         /* poll */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: hall3_open
+ *
+ * Description:
+ *   This function is called whenever the hall device is opened.
+ *
+ ****************************************************************************/
+
+static int hall3_open(FAR struct file *filep)
+{
+  FAR struct inode             *inode = filep->f_inode;
+  FAR struct hall3_upperhalf_s *upper = inode->i_private;
+  uint8_t                       tmp;
+  int                           ret;
+
+  sninfo("crefs: %d\n", upper->crefs);
+
+  /* Get exclusive access to the device structures */
+
+  ret = nxsem_wait(&upper->exclsem);
+  if (ret < 0)
+    {
+      goto errout;
+    }
+
+  /* Increment the count of references to the device.  If this is the first
+   * time that the driver has been opened for this device, then initialize
+   * the device.
+   */
+
+  tmp = upper->crefs + 1;
+  if (tmp == 0)
+    {
+      /* More than 255 opens; uint8_t overflows to zero */
+
+      ret = -EMFILE;
+      goto errout_with_sem;
+    }
+
+  /* Check if this is the first time that the driver has been opened. */
+
+  if (tmp == 1)
+    {
+      FAR struct hall3_lowerhalf_s *lower = upper->lower;
+
+      /* Yes.. perform one time hardware initialization. */
+
+      DEBUGASSERT(lower->ops->setup != NULL);
+      sninfo("calling setup\n");
+
+      ret = lower->ops->setup(lower);
+      if (ret < 0)
+        {
+          goto errout_with_sem;
+        }
+    }
+
+  /* Save the new open count on success */
+
+  upper->crefs = tmp;
+  ret = OK;
+
+errout_with_sem:
+  nxsem_post(&upper->exclsem);
+
+errout:
+  return ret;
+}
+
+/****************************************************************************
+ * Name: hall3_close
+ *
+ * Description:
+ *   This function is called when the hall device is closed.
+ *
+ ****************************************************************************/
+
+static int hall3_close(FAR struct file *filep)
+{
+  FAR struct inode             *inode = filep->f_inode;
+  FAR struct hall3_upperhalf_s *upper = inode->i_private;
+  int                           ret;
+
+  sninfo("crefs: %d\n", upper->crefs);
+
+  /* Get exclusive access to the device structures */
+
+  ret = nxsem_wait(&upper->exclsem);
+  if (ret < 0)
+    {
+      goto errout;
+    }
+
+  /* Decrement the references to the driver.  If the reference count will
+   * decrement to 0, then uninitialize the driver.
+   */
+
+  if (upper->crefs > 1)
+    {
+      upper->crefs--;
+    }
+  else
+    {
+      FAR struct hall3_lowerhalf_s *lower = upper->lower;
+
+      /* There are no more references to the port */
+
+      upper->crefs = 0;
+
+      /* Disable the hall device */
+
+      DEBUGASSERT(lower->ops->shutdown != NULL);
+      sninfo("calling shutdown\n");
+
+      lower->ops->shutdown(lower);
+    }
+
+  nxsem_post(&upper->exclsem);
+  ret = OK;
+
+errout:
+  return ret;
+}
+
+/****************************************************************************
+ * Name: hall3_read
+ *
+ * Description:
+ *   A dummy read method.  This is provided only to satisfy the VFS layer.
+ *
+ ****************************************************************************/
+
+static ssize_t hall3_read(FAR struct file *filep,
+                          FAR char *buffer,
+                          size_t buflen)
+{
+  /* Return zero -- usually meaning end-of-file */
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: hall3_write
+ *
+ * Description:
+ *   A dummy write method.  This is provided only to satisfy the VFS layer.
+ *
+ ****************************************************************************/
+
+static ssize_t hall3_write(FAR struct file *filep,
+                           FAR const char *buffer,
+                           size_t buflen)
+{
+  /* Return a failure */
+
+  return -EPERM;
+}
+
+/****************************************************************************
+ * Name: hall3_ioctl
+ *
+ * Description:
+ *   The standard ioctl method.
+ *   This is where ALL of the hall work is done.
+ *
+ ****************************************************************************/
+
+static int hall3_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+  FAR struct inode            *inode = filep->f_inode;
+  FAR struct hall3_upperhalf_s *upper;
+  FAR struct hall3_lowerhalf_s *lower;
+  int                           ret;
+
+  sninfo("cmd: %d arg: %ld\n", cmd, arg);
+  upper = inode->i_private;
+  DEBUGASSERT(upper != NULL);
+  lower = upper->lower;
+  DEBUGASSERT(lower != NULL);
+
+  /* Get exclusive access to the device structures */
+
+  ret = nxsem_wait(&upper->exclsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Handle built-in ioctl commands */
+
+  switch (cmd)
+    {
+      /* SNIOC_GET_POSITION - Get the current position from the Hall sensor.
+       *   Argument: uint8_t pointer to the location to return the position.
+       */
+
+    case SNIOC_GET_POSITION:
+        {
+          FAR uint8_t *ptr = (FAR uint8_t *)((uintptr_t)arg);
+          DEBUGASSERT(lower->ops->position != NULL && ptr);
+          ret = lower->ops->position(lower, ptr);
+        }
+        break;
+
+      default:
+        {
+          ret = -ENOTTY;
+        }
+        break;
+    }
+
+  nxsem_post(&upper->exclsem);
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: hall3_register
+ *
+ * Description:
+ *   Register the 3-phase Hall effect sensor lower half device as 'devpath'
+ *
+ * Input Parameters:
+ *   devpath - The full path to the driver to register. E.g., "/dev/hall0"
+ *   lower - An instance of the lower half interface
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.  The following
+ *   possible error values may be returned (most are returned by
+ *   register_driver()):
+ *
+ *   EINVAL - 'path' is invalid for this operation
+ *   EEXIST - An inode already exists at 'path'
+ *   ENOMEM - Failed to allocate in-memory resources for the operation
+ *
+ ****************************************************************************/
+
+int hall3_register(FAR const char *devpath,
+                   FAR struct hall3_lowerhalf_s *lower)
+{
+  FAR struct hall3_upperhalf_s *upper = NULL;
+
+  /* Allocate the upper-half data structure */
+
+  upper = (FAR struct hall3_upperhalf_s *)
+           kmm_zalloc(sizeof(struct hall3_upperhalf_s));
+  if (upper == NULL)
+    {
+      snerr("ERROR: Allocation failed\n");
+      return -ENOMEM;
+    }
+
+  /* Initialize the hall 3-phase sensor device structure
+   * (it was already zeroed by kmm_zalloc())
+   */
+
+  nxsem_init(&upper->exclsem, 0, 1);
+  upper->lower = lower;
+
+  /* Register the Hall effect sensor device */
+
+  sninfo("Registering %s\n", devpath);
+  return register_driver(devpath, &g_hall3ops, 0666, upper);
+}

--- a/include/nuttx/sensors/hall3ph.h
+++ b/include/nuttx/sensors/hall3ph.h
@@ -1,0 +1,138 @@
+/****************************************************************************
+ * include/nuttx/sensors/hall3ph.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_SENSORS_HALL3PH_H
+#define __INCLUDE_NUTTX_SENSORS_HALL3PH_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/fs/ioctl.h>
+
+#include <nuttx/sensors/ioctl.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* 120-degree Hall effect sensors positions */
+
+enum hall3_120deg_position_e
+{
+  HALL3_120DEG_POS_1 = 0b001,
+  HALL3_120DEG_POS_2 = 0b011,
+  HALL3_120DEG_POS_3 = 0b010,
+  HALL3_120DEG_POS_4 = 0b110,
+  HALL3_120DEG_POS_5 = 0b100,
+  HALL3_120DEG_POS_6 = 0b101
+};
+
+/* 60-degree Hall effect sensors postions */
+
+enum hall3_60deg_position_e
+{
+  HALL3_60DEG_POS_1 = 0b000,
+  HALL3_60DEG_POS_2 = 0b001,
+  HALL3_60DEG_POS_3 = 0b101,
+  HALL3_60DEG_POS_4 = 0b111,
+  HALL3_60DEG_POS_5 = 0b110,
+  HALL3_60DEG_POS_6 = 0b010
+};
+
+/* This structure provides the "lower-half" driver operations available to
+ * the "upper-half" driver.
+ */
+
+struct hall3_lowerhalf_s;
+struct hall3_ops_s
+{
+  /* Configure the 3-phase Hall effect sensor device */
+
+  CODE int (*setup)(FAR struct hall3_lowerhalf_s *lower);
+
+  /* Disable the 3-phase Hall effect sensor device */
+
+  CODE int (*shutdown)(FAR struct hall3_lowerhalf_s *lower);
+
+  /* Return the current 3-phase Hall effect sensor position */
+
+  CODE int (*position)(FAR struct hall3_lowerhalf_s *lower,
+                       FAR uint8_t *pos);
+};
+
+/* This structure provides the publicly visible representation of the
+ * "lower-half" driver state structure.  "lower half" drivers will have an
+ * internal structure definition that will be cast-compatible with this
+ * structure definitions.
+ */
+
+struct hall3_lowerhalf_s
+{
+  FAR const struct hall3_ops_s *ops;
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: hall3_register
+ *
+ * Description:
+ *   Register the 3-phase Hall effect sensor lower half device as 'devpath'
+ *
+ * Input Parameters:
+ *   devpath - The full path to the driver to register. E.g., "/dev/hall0"
+ *   lower - An instance of the lower half interface
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.  The following
+ *   possible error values may be returned (most are returned by
+ *   register_driver()):
+ *
+ *   EINVAL - 'path' is invalid for this operation
+ *   EEXIST - An inode already exists at 'path'
+ *   ENOMEM - Failed to allocate in-memory resources for the operation
+ *
+ ****************************************************************************/
+
+int hall3_register(FAR const char *devpath,
+                   FAR struct hall3_lowerhalf_s *lower);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_SENSORS_HALL3PH_H */

--- a/include/nuttx/sensors/ioctl.h
+++ b/include/nuttx/sensors/ioctl.h
@@ -284,4 +284,8 @@
 
 #define SNIOC_SET_BUFFER_NUMBER    _SNIOC(0x0084)
 
+/* IOCTL commands unique to the Hall effect sensor */
+
+#define SNIOC_GET_POSITION         _SNIOC(0x0085)
+
 #endif /* __INCLUDE_NUTTX_SENSORS_IOCTL_H */


### PR DESCRIPTION
## Summary

- drivers/sensors: add an upper half 3-phase Hall effect sensor driver
- arch/stm32: add 3-phase Hall effect sensor lower-half
- boards/stm32/common: add 3-phase Hall effect sensor common logic
- nucleo-f446re: add 3-phase Hall effect sensor support

## Impact

## Testing
nucleo-f446re
