### PR TITLE
Documentation/esp32-wrover-kit: update the name of the GPIO interrupt device.

### DIFF
--- a/Documentation/platforms/xtensa/esp32/boards/esp32-wrover-kit/index.rst
+++ b/Documentation/platforms/xtensa/esp32/boards/esp32-wrover-kit/index.rst
@@ -107,7 +107,7 @@ At the nsh, we can turn LEDs on and off with the following::
 
 We can use the interrupt pin to send a signal when the interrupt fires::
 
-    nsh> gpio -w 14 /dev/gpint3
+    nsh> gpio -w 14 /dev/gpint0
 
 The pin is configured to as a rising edge interrupt, so after issuing the
 above command, connect it to 3.3V.


### PR DESCRIPTION
## Summary
The name of the GPIO interrupt device has changed to be /dev/gpint0
## Impact
N/A
## Testing
N/A
