### PR TITLE
sched: Allow CONFIG_SMP_NCPUS=1 without CONFIG_DEBUG_FEATURES

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -292,8 +292,7 @@ if SMP
 config SMP_NCPUS
 	int "Number of CPUs"
 	default 4
-	range 1 32 if DEBUG_FEATURES
-	range 2 32 if !DEBUG_FEATURES
+	range 1 32
 	---help---
 		This value identifies the number of CPUs supported by the processor
 		that will be used for SMP.


### PR DESCRIPTION
## Summary

- This commit allows CONFIG_SMP_NCPUS=1 without CONFIG_DEBUG_FEATURES

## Impact

- None

## Testing

- Tested with sim:smp
