### PR TITLE
task_spawn: release g_spawn_parmsem and sched_unlock at the ending

### DIFF
--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -437,7 +437,7 @@ int task_spawn(FAR const char *name, main_t entry,
       goto errout_with_lock;
     }
 
-  return (int)pid;
+  ret = (int)pid;
 
 errout_with_lock:
 #ifdef CONFIG_SCHED_WAITPID


### PR DESCRIPTION
## Summary
task_spawn: release g_spawn_parmsem and sched_unlock at the ending
Change-Id: Ifcb5b9921e82fc495c4457fdb5f0607f40b07fc0
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact

## Testing

