### PR TITLE
fs/mount: fix crash becauseof bad release order

### DIFF
--- a/fs/mount/fs_mount.c
+++ b/fs/mount/fs_mount.c
@@ -476,8 +476,8 @@ int nx_mount(FAR const char *source, FAR const char *target,
   /* A lot of goto's!  But they make the error handling much simpler */
 
 errout_with_mountpt:
-  inode_remove(target);
   inode_release(mountpt_inode);
+  inode_remove(target);
 
 errout_with_semaphore:
   inode_semgive();


### PR DESCRIPTION
## Summary
fs/mount: fix crash becauseof bad release order

Change-Id: I850f0706f4554d140a86f935b8dce07d23beedaf
Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact

## Testing

