### PR TITLE
som byteorder modification

### DIFF
--- a/include/byteswap.h
+++ b/include/byteswap.h
@@ -1,0 +1,45 @@
+/****************************************************************************
+ * include/byteswap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_BYTES_SWAP_H
+#define __INCLUDE_BYTES_SWAP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <endian.h>
+
+/****************************************************************************
+ * Preprocessor definitions
+ ****************************************************************************/
+
+#ifndef bswap_16
+#define bswap_16(x) __swap_uint16(x)
+#endif
+
+#ifndef bswap_32
+#define bswap_32(x) __swap_uint32(x)
+#endif
+
+#ifndef bswap_64
+#define bswap_64(x) __swap_uint64(x)
+#endif
+#endif

--- a/include/endian.h
+++ b/include/endian.h
@@ -45,7 +45,9 @@
  */
 
 #define LITTLE_ENDIAN         1234
+#define __LITTLE_ENDIAN       1234
 #define BIG_ENDIAN            4321
+#define __BIG_ENDIAN          4321
 
 /* Common byte swapping macros */
 
@@ -72,6 +74,7 @@
 /* Big-endian byte order */
 
 #  define BYTE_ORDER          BIG_ENDIAN
+#  define __BYTE_ORDER        BIG_ENDIAN
 
 /* Big-endian byte order macros */
 
@@ -96,6 +99,7 @@
 /* Little-endian byte order */
 
 #  define BYTE_ORDER          LITTLE_ENDIAN
+#  define __BYTE_ORDER        __LITTLE_ENDIAN
 
 /* Little-endian byte order macros */
 


### PR DESCRIPTION
## Summary
1. add byteswap.h header file
2. add __LITTLE/__BIG_ENDIAN, __BYTE_ODRER because __GLIBC__ and __GNU__ define them as standard macro.
## Impact

## Testing

