### PR TITLE
xtensa/lx7: Fix the CROSSDEV variable

### DIFF
--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -39,7 +39,7 @@ ifeq ($(CONFIG_XTENSA_TOOLCHAIN_XCLANG), y)
 endif
 
 ifeq ($(CONFIG_XTENSA_TOOLCHAIN_ESP), y)
-  CROSSDEV = xtensa-esp32-elf-
+  CROSSDEV = xtensa-esp32s2-elf-
 endif
 
 ARCHCPUFLAGS =


### PR DESCRIPTION
## Summary

CROSSDEV was set to use esp32 toolchain instead of esp32s2. 
That was causing a crash.

## Impact
No more crash

## Testing
nsh
