### PR TITLE
arm/armv7: correct the stack usage of exception interrupt

### DIFF
--- a/arch/arm/src/arm/arm_vectors.S
+++ b/arch/arm/src/arm/arm_vectors.S
@@ -175,7 +175,19 @@ arm_vectorsvc:
 
 	mov	fp, #0			/* Init frame pointer */
 	mov	r0, sp			/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+	/* Call arm_syscall() on the interrupt stack */
+
+	ldr	sp, .Lirqstacktop	/* SP = interrupt stack top */
+	str	r0, [sp, #-4]!		/* Save the xcp address at SP-4 then update SP */
 	bl	arm_syscall		/* Call the handler */
+	ldr	sp, [sp]		/* Restore the user stack pointer */
+#else
+	/* Call arm_syscall() on the user stack */
+
+	bl	arm_syscall		/* Call the handler */
+#endif
 
 	/* Restore the CPSR, SVC mode registers and return */
 
@@ -245,11 +257,27 @@ arm_vectordata:
 
 	mov	fp, #0			/* Init frame pointer */
 	mov	r0, sp			/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+	/* Call arm_dataabort() on the interrupt stack */
+
+	ldr	sp, .Lirqstacktop	/* SP = interrupt stack top */
+	str	r0, [sp, #-4]!		/* Save the xcp address at SP-4 then update SP */
 #ifdef CONFIG_PAGING
 	mrc	p15, 0, r1, c6, c0, 0	/* Get R1=FAR */
 	mrc	p15, 0, r2, c5, c0, 0	/* Get r2=FSR */
 #endif
 	bl	arm_dataabort		/* Call the handler */
+	ldr	sp, [sp]		/* Restore the user stack pointer */
+#else
+	/* Call arm_dataabort() on the user stack */
+
+#ifdef CONFIG_PAGING
+	mrc	p15, 0, r1, c6, c0, 0	/* Get R1=FAR */
+	mrc	p15, 0, r2, c5, c0, 0	/* Get r2=FSR */
+#endif
+	bl	arm_dataabort		/* Call the handler */
+#endif
 
 	/* Restore the CPSR, SVC mode registers and return */
 
@@ -319,7 +347,19 @@ arm_vectorprefetch:
 
 	mov	fp, #0			/* Init frame pointer */
 	mov	r0, sp			/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+	/* Call arm_prefetchabort() on the interrupt stack */
+
+	ldr	sp, .Lirqstacktop	/* SP = interrupt stack top */
+	str	r0, [sp, #-4]!		/* Save the xcp address at SP-4 then update SP */
 	bl	arm_prefetchabort	/* Call the handler */
+	ldr	sp, [sp]		/* Restore the user stack pointer */
+#else
+	/* Call arm_prefetchabort() on the user stack */
+
+	bl	arm_prefetchabort	/* Call the handler */
+#endif
 
 	/* Restore the CPSR, SVC mode registers and return */
 
@@ -387,7 +427,19 @@ arm_vectorundefinsn:
 
 	mov	fp, #0			/* Init frame pointer */
 	mov	r0, sp			/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+	/* Call arm_undefinedinsn() on the interrupt stack */
+
+	ldr	sp, .Lirqstacktop	/* SP = interrupt stack top */
+	str	r0, [sp, #-4]!		/* Save the xcp address at SP-4 then update SP */
 	bl	arm_undefinedinsn	/* Call the handler */
+	ldr	sp, [sp]		/* Restore the user stack pointer */
+#else
+	/* Call arm_undefinedinsn() on the user stack */
+
+	bl	arm_undefinedinsn	/* Call the handler */
+#endif
 
 	/* Restore the CPSR, SVC mode registers and return */
 

--- a/arch/arm/src/armv7-a/arm_vectors.S
+++ b/arch/arm/src/armv7-a/arm_vectors.S
@@ -342,10 +342,24 @@ arm_vectorsvc:
 
 	mov		fp, #0				/* Init frame pointer */
 	mov		r0, sp				/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_syscall() on the interrupt stack */
+
+	setirqstack	r1, r3				/* SP = interrupt stack top */
+	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
+	mov		r4, sp				/* Save the SP in a preserved register */
+	bic		sp, sp, #7			/* Force 8-byte alignment */
+	bl		arm_syscall			/* Call the handler */
+	ldr		sp, [r4]			/* Restore the user stack pointer */
+#else
+	/* Call arm_syscall() on the user stack */
+
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_syscall			/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
+#endif
 
 	/* Upon return from arm_syscall, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -482,12 +496,28 @@ arm_vectordata:
 
 	mov		fp, #0				/* Init frame pointer */
 	mov		r0, sp				/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_dataabort() on the interrupt stack */
+
+	setirqstack	r1, r3				/* SP = interrupt stack top */
+	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
+	mrc		CP15_DFAR(r1)			/* Get R1=DFAR */
+	mrc		CP15_DFSR(r2)			/* Get r2=DFSR */
+	mov		r4, sp				/* Save the SP in a preserved register */
+	bic		sp, sp, #7			/* Force 8-byte alignment */
+	bl		arm_dataabort			/* Call the handler */
+	ldr		sp, [r4]			/* Restore the user stack pointer */
+#else
+	/* Call arm_dataabort() on the user stack */
+
 	mrc		CP15_DFAR(r1)			/* Get R1=DFAR */
 	mrc		CP15_DFSR(r2)			/* Get r2=DFSR */
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_dataabort			/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
+#endif
 
 	/* Upon return from arm_dataabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -624,12 +654,28 @@ arm_vectorprefetch:
 
 	mov		fp, #0				/* Init frame pointer */
 	mov		r0, sp				/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_prefetchabort() on the interrupt stack */
+
+	setirqstack	r1, r3				/* SP = interrupt stack top */
+	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
+	mrc		CP15_IFAR(r1)			/* Get R1=IFAR */
+	mrc		CP15_IFSR(r2)			/* Get r2=IFSR */
+	mov		r4, sp				/* Save the SP in a preserved register */
+	bic		sp, sp, #7			/* Force 8-byte alignment */
+	bl		arm_prefetchabort		/* Call the handler */
+	ldr		sp, [r4]			/* Restore the user stack pointer */
+#else
+	/* Call arm_prefetchabort() on the user stack */
+
 	mrc		CP15_IFAR(r1)			/* Get R1=IFAR */
 	mrc		CP15_IFSR(r2)			/* Get r2=IFSR */
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_prefetchabort		/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
+#endif
 
 	/* Upon return from arm_prefetchabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -764,10 +810,24 @@ arm_vectorundefinsn:
 
 	mov		fp, #0				/* Init frame pointer */
 	mov		r0, sp				/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_undefinedinsn() on the interrupt stack */
+
+	setirqstack	r1, r3				/* SP = interrupt stack top */
+	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
+	mov		r4, sp				/* Save the SP in a preserved register */
+	bic		sp, sp, #7			/* Force 8-byte alignment */
+	bl		arm_undefinedinsn		/* Call the handler */
+	ldr		sp, [r4]			/* Restore the user stack pointer */
+#else
+	/* Call arm_undefinedinsn() on the user stack */
+
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_undefinedinsn		/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
+#endif
 
 	/* Upon return from arm_undefinedinsn, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -903,6 +963,8 @@ arm_vectorfiq:
 	mov		r0, sp				/* Get r0=xcp */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_decodefiq() on the interrupt stack */
+
 	setfiqstack	r1, r4				/* SP = interrupt stack top */
 	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
 	mov		r4, sp				/* Save the SP in a preserved register */
@@ -910,6 +972,8 @@ arm_vectorfiq:
 	bl		arm_decodefiq			/* Call the handler */
 	ldr		sp, [r4]			/* Restore the user stack pointer */
 #else
+	/* Call arm_decodefiq() on the user stack */
+
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_decodefiq			/* Call the handler */

--- a/arch/arm/src/armv7-r/arm_vectors.S
+++ b/arch/arm/src/armv7-r/arm_vectors.S
@@ -296,10 +296,24 @@ arm_vectorsvc:
 
 	mov		fp, #0				/* Init frame pointer */
 	mov		r0, sp				/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_syscall() on the interrupt stack */
+
+	ldr		sp, .Lirqstacktop		/* SP = interrupt stack top */
+	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
+	mov		r4, sp				/* Save the SP in a preserved register */
+	bic		sp, sp, #7			/* Force 8-byte alignment */
+	bl		arm_syscall			/* Call the handler */
+	ldr		sp, [r4]			/* Restore the user stack pointer */
+#else
+	/* Call arm_syscall() on the user stack */
+
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_syscall			/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
+#endif
 
 	/* Upon return from arm_syscall, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -436,12 +450,28 @@ arm_vectordata:
 
 	mov		fp, #0				/* Init frame pointer */
 	mov		r0, sp				/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_dataabort() on the interrupt stack */
+
+	ldr		sp, .Lirqstacktop		/* SP = interrupt stack top */
+	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
+	mrc		CP15_DFAR(r1)			/* Get R1=DFAR */
+	mrc		CP15_DFSR(r2)			/* Get r2=DFSR */
+	mov		r4, sp				/* Save the SP in a preserved register */
+	bic		sp, sp, #7			/* Force 8-byte alignment */
+	bl		arm_dataabort			/* Call the handler */
+	ldr		sp, [r4]			/* Restore the user stack pointer */
+#else
+	/* Call arm_dataabort() on the user stack */
+
 	mrc		CP15_DFAR(r1)			/* Get R1=DFAR */
 	mrc		CP15_DFSR(r2)			/* Get r2=DFSR */
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_dataabort			/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
+#endif
 
 	/* Upon return from arm_dataabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -578,12 +608,26 @@ arm_vectorprefetch:
 
 	mov		fp, #0				/* Init frame pointer */
 	mov		r0, sp				/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_prefetchabort() on the interrupt stack */
+
+	ldr		sp, .Lirqstacktop		/* SP = interrupt stack top */
+	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
+	mov		r4, sp				/* Save the SP in a preserved register */
+	bic		sp, sp, #7			/* Force 8-byte alignment */
+	bl		arm_prefetchabort		/* Call the handler */
+	ldr		sp, [r4]			/* Restore the user stack pointer */
+#else
+	/* Call arm_prefetchabort() on the user stack */
+
 	mrc		CP15_IFAR(r1)			/* Get R1=IFAR */
 	mrc		CP15_IFSR(r2)			/* Get r2=IFSR */
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_prefetchabort		/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
+#endif
 
 	/* Upon return from arm_prefetchabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -718,10 +762,24 @@ arm_vectorundefinsn:
 
 	mov		fp, #0				/* Init frame pointer */
 	mov		r0, sp				/* Get r0=xcp */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_undefinedinsn() on the interrupt stack */
+
+	ldr		sp, .Lirqstacktop		/* SP = interrupt stack top */
+	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
+	mov		r4, sp				/* Save the SP in a preserved register */
+	bic		sp, sp, #7			/* Force 8-byte alignment */
+	bl		arm_undefinedinsn		/* Call the handler */
+	ldr		sp, [r4]			/* Restore the user stack pointer */
+#else
+	/* Call arm_undefinedinsn() on the user stack */
+
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_undefinedinsn		/* Call the handler */
 	mov		sp, r4				/* Restore the possibly unaligned stack pointer */
+#endif
 
 	/* Upon return from arm_undefinedinsn, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not


### PR DESCRIPTION
## Summary

arm/armv7: correct the stack usage of exception interrupt

handle the exception interrupt in irq stack

## Impact

armv7-a/r exception interrupt

## Testing

check the stack pointer after force data abort 