### PR TITLE
Use driver-specific spinlock for ESP32 serial driver.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -1733,6 +1733,7 @@ static void esp32_txint(struct uart_dev_s *dev, bool enable)
            * interrupts disabled (note this may recurse).
            */
 
+          spin_unlock_irqrestore(&priv->lock, flags);
           uart_xmitchars(dev);
     #endif
         }


### PR DESCRIPTION
## Summary
This PR replaces the critical sections in ESP32 serial driver by a device specific spin lock.
- See https://github.com/apache/incubator-nuttx/issues/2213
## Impact
ESP32's serial driver in SMP mode.
## Testing
esp32-devkitc:ostest
esp32-devkitc:smp
esp32-devkitc:wapi_smp
