### PR TITLE
Revert "drivers: wireless: Fix ASSERT() in _read_data_len() in gs2200…

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -872,18 +872,18 @@ retry:
 
   _write_data(dev, hdr, sizeof(hdr));
 
-  /* NOTE: busy wait 30us
-   * workaround to avoid an invalid frame response
-   */
-
-  up_udelay(30);
-
   /* Wait for data ready */
 
   while (!dev->lower->dready(NULL))
     {
       /* TODO: timeout */
     }
+
+  /* NOTE: busy wait 50us
+   * workaround to avoid an invalid frame response
+   */
+
+  up_udelay(50);
 
   /* Read frame response */
 


### PR DESCRIPTION
## Summary

- We found that the change caused a problem when running a VPN application.
   and also confirmed that reverting the commit fixed the issue.

## Impact

- None

## Testing

- Tested with spresense:wifi and spresense:wifi_smp
