### PR TITLE
arch/armv7: add up_backtrace support based on frame pointer

### DIFF
--- a/arch/arm/src/arm/arm_backtrace.c
+++ b/arch/arm/src/arm/arm_backtrace.c
@@ -1,0 +1,162 @@
+/****************************************************************************
+ * arch/arm/src/arm/arm_backtrace.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+
+#include "sched/sched.h"
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: backtrace
+ *
+ * Description:
+ *  backtrace() parsing the return address through frame pointer
+ *
+ ****************************************************************************/
+
+static int backtrace(FAR uintptr_t *base, FAR uintptr_t *limit,
+                     FAR uintptr_t *fp, FAR uintptr_t *pc,
+                     FAR void **buffer, int size)
+{
+  int i = 0;
+
+  if (pc)
+    {
+      buffer[i++] = pc;
+    }
+
+  for (; i < size; fp = (FAR uintptr_t *)*(fp - 1), i++)
+    {
+      if (fp > limit || fp < base || *fp == 0)
+        {
+          break;
+        }
+
+      buffer[i] = (FAR void *)*fp;
+    }
+
+  return i;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_backtrace
+ *
+ * Description:
+ *  up_backtrace()  returns  a backtrace for the TCB, in the array
+ *  pointed to by buffer.  A backtrace is the series of currently active
+ *  function calls for the program.  Each item in the array pointed to by
+ *  buffer is of type void *, and is the return address from the
+ *  corresponding stack frame.  The size argument specifies the maximum
+ *  number of addresses that can be stored in buffer.   If  the backtrace is
+ *  larger than size, then the addresses corresponding to the size most
+ *  recent function calls are returned; to obtain the complete backtrace,
+ *  make sure that buffer and size are large enough.
+ *
+ * Input Parameters:
+ *   tcb    - Address of the task's TCB
+ *   buffer - Return address from the corresponding stack frame
+ *   size   - Maximum number of addresses that can be stored in buffer
+ *
+ * Returned Value:
+ *   up_backtrace() returns the number of addresses returned in buffer
+ *
+ ****************************************************************************/
+
+int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
+{
+  FAR struct tcb_s *rtcb = running_task();
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+  FAR void *istacklimit;
+#endif
+  irqstate_t flags;
+  int ret;
+
+  if (size <= 0 || !buffer)
+    {
+      return 0;
+    }
+
+  if (tcb == NULL || tcb == rtcb)
+    {
+      if (up_interrupt_context())
+        {
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#  ifdef CONFIG_SMP
+          istacklimit = arm_intstack_top();
+#  else
+          istacklimit = &g_intstacktop;
+#  endif /* CONFIG_SMP */
+          ret = backtrace(istacklimit - (CONFIG_ARCH_INTERRUPTSTACK & ~7),
+                          istacklimit,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+#else
+          ret = backtrace(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+#endif /* CONFIG_ARCH_INTERRUPTSTACK > 7 */
+          if (ret < size)
+            {
+              ret += backtrace(rtcb->stack_base_ptr,
+                               rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                               (FAR void *)CURRENT_REGS[REG_FP],
+                               (FAR void *)CURRENT_REGS[REG_PC],
+                               &buffer[ret], size - ret);
+            }
+        }
+      else
+        {
+          ret = backtrace(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+        }
+    }
+  else
+    {
+      flags = enter_critical_section();
+
+      ret = backtrace(tcb->stack_base_ptr,
+                      tcb->stack_base_ptr + tcb->adj_stack_size,
+                      (FAR void *)tcb->xcp.regs[REG_FP],
+                      (FAR void *)tcb->xcp.regs[REG_PC],
+                      buffer, size);
+
+      leave_critical_section(flags);
+    }
+
+  return ret;
+}

--- a/arch/arm/src/armv7-a/arm_backtrace.c
+++ b/arch/arm/src/armv7-a/arm_backtrace.c
@@ -1,0 +1,162 @@
+/****************************************************************************
+ * arch/arm/src/armv7-a/arm_backtrace.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+
+#include "sched/sched.h"
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: backtrace
+ *
+ * Description:
+ *  backtrace() parsing the return address through frame pointer
+ *
+ ****************************************************************************/
+
+static int backtrace(FAR uintptr_t *base, FAR uintptr_t *limit,
+                     FAR uintptr_t *fp, FAR uintptr_t *pc,
+                     FAR void **buffer, int size)
+{
+  int i = 0;
+
+  if (pc)
+    {
+      buffer[i++] = pc;
+    }
+
+  for (; i < size; fp = (FAR uintptr_t *)*(fp - 1), i++)
+    {
+      if (fp > limit || fp < base || *fp == 0)
+        {
+          break;
+        }
+
+      buffer[i] = (FAR void *)*fp;
+    }
+
+  return i;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_backtrace
+ *
+ * Description:
+ *  up_backtrace()  returns  a backtrace for the TCB, in the array
+ *  pointed to by buffer.  A backtrace is the series of currently active
+ *  function calls for the program.  Each item in the array pointed to by
+ *  buffer is of type void *, and is the return address from the
+ *  corresponding stack frame.  The size argument specifies the maximum
+ *  number of addresses that can be stored in buffer.   If  the backtrace is
+ *  larger than size, then the addresses corresponding to the size most
+ *  recent function calls are returned; to obtain the complete backtrace,
+ *  make sure that buffer and size are large enough.
+ *
+ * Input Parameters:
+ *   tcb    - Address of the task's TCB
+ *   buffer - Return address from the corresponding stack frame
+ *   size   - Maximum number of addresses that can be stored in buffer
+ *
+ * Returned Value:
+ *   up_backtrace() returns the number of addresses returned in buffer
+ *
+ ****************************************************************************/
+
+int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
+{
+  FAR struct tcb_s *rtcb = running_task();
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+  FAR void *istacklimit;
+#endif
+  irqstate_t flags;
+  int ret;
+
+  if (size <= 0 || !buffer)
+    {
+      return 0;
+    }
+
+  if (tcb == NULL || tcb == rtcb)
+    {
+      if (up_interrupt_context())
+        {
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#  ifdef CONFIG_SMP
+          istacklimit = arm_intstack_top();
+#  else
+          istacklimit = &g_intstacktop;
+#  endif /* CONFIG_SMP */
+          ret = backtrace(istacklimit - (CONFIG_ARCH_INTERRUPTSTACK & ~7),
+                          istacklimit,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+#else
+          ret = backtrace(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+#endif /* CONFIG_ARCH_INTERRUPTSTACK > 7 */
+          if (ret < size)
+            {
+              ret += backtrace(rtcb->stack_base_ptr,
+                               rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                               (FAR void *)CURRENT_REGS[REG_FP],
+                               (FAR void *)CURRENT_REGS[REG_PC],
+                               &buffer[ret], size - ret);
+            }
+        }
+      else
+        {
+          ret = backtrace(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+        }
+    }
+  else
+    {
+      flags = enter_critical_section();
+
+      ret = backtrace(tcb->stack_base_ptr,
+                      tcb->stack_base_ptr + tcb->adj_stack_size,
+                      (FAR void *)tcb->xcp.regs[REG_FP],
+                      (FAR void *)tcb->xcp.regs[REG_PC],
+                      buffer, size);
+
+      leave_critical_section(flags);
+    }
+
+  return ret;
+}

--- a/arch/arm/src/armv7-r/arm_backtrace.c
+++ b/arch/arm/src/armv7-r/arm_backtrace.c
@@ -1,0 +1,162 @@
+/****************************************************************************
+ * arch/arm/src/armv7-r/arm_backtrace.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+
+#include "sched/sched.h"
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: backtrace
+ *
+ * Description:
+ *  backtrace() parsing the return address through frame pointer
+ *
+ ****************************************************************************/
+
+static int backtrace(FAR uintptr_t *base, FAR uintptr_t *limit,
+                     FAR uintptr_t *fp, FAR uintptr_t *pc,
+                     FAR void **buffer, int size)
+{
+  int i = 0;
+
+  if (pc)
+    {
+      buffer[i++] = pc;
+    }
+
+  for (; i < size; fp = (FAR uintptr_t *)*(fp - 1), i++)
+    {
+      if (fp > limit || fp < base || *fp == 0)
+        {
+          break;
+        }
+
+      buffer[i] = (FAR void *)*fp;
+    }
+
+  return i;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_backtrace
+ *
+ * Description:
+ *  up_backtrace()  returns  a backtrace for the TCB, in the array
+ *  pointed to by buffer.  A backtrace is the series of currently active
+ *  function calls for the program.  Each item in the array pointed to by
+ *  buffer is of type void *, and is the return address from the
+ *  corresponding stack frame.  The size argument specifies the maximum
+ *  number of addresses that can be stored in buffer.   If  the backtrace is
+ *  larger than size, then the addresses corresponding to the size most
+ *  recent function calls are returned; to obtain the complete backtrace,
+ *  make sure that buffer and size are large enough.
+ *
+ * Input Parameters:
+ *   tcb    - Address of the task's TCB
+ *   buffer - Return address from the corresponding stack frame
+ *   size   - Maximum number of addresses that can be stored in buffer
+ *
+ * Returned Value:
+ *   up_backtrace() returns the number of addresses returned in buffer
+ *
+ ****************************************************************************/
+
+int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
+{
+  FAR struct tcb_s *rtcb = running_task();
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+  FAR void *istacklimit;
+#endif
+  irqstate_t flags;
+  int ret;
+
+  if (size <= 0 || !buffer)
+    {
+      return 0;
+    }
+
+  if (tcb == NULL || tcb == rtcb)
+    {
+      if (up_interrupt_context())
+        {
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#  ifdef CONFIG_SMP
+          istacklimit = arm_intstack_top();
+#  else
+          istacklimit = &g_intstacktop;
+#  endif /* CONFIG_SMP */
+          ret = backtrace(istacklimit - (CONFIG_ARCH_INTERRUPTSTACK & ~7),
+                          istacklimit,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+#else
+          ret = backtrace(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+#endif /* CONFIG_ARCH_INTERRUPTSTACK > 7 */
+          if (ret < size)
+            {
+              ret += backtrace(rtcb->stack_base_ptr,
+                               rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                               (FAR void *)CURRENT_REGS[REG_FP],
+                               (FAR void *)CURRENT_REGS[REG_PC],
+                               &buffer[ret], size - ret);
+            }
+        }
+      else
+        {
+          ret = backtrace(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)__builtin_frame_address(0),
+                          NULL, buffer, size);
+        }
+    }
+  else
+    {
+      flags = enter_critical_section();
+
+      ret = backtrace(tcb->stack_base_ptr,
+                      tcb->stack_base_ptr + tcb->adj_stack_size,
+                      (FAR void *)tcb->xcp.regs[REG_FP],
+                      (FAR void *)tcb->xcp.regs[REG_PC],
+                      buffer, size);
+
+      leave_critical_section(flags);
+    }
+
+  return ret;
+}


### PR DESCRIPTION
## Summary

arch/armv7: add up_backtrace support based on frame pointer

This feature depends on frame pointer, "-fno-omit-frame-pointer" is mandatory

This feature can not be used in THUMB2 mode if you are using GCC toolchain,
More details please refer:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92172

## Impact

backtrace

## Testing

Trigger a dataabort exception: 

```
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] arm_dataabort: Data abort. PC: 3c02e450 DFAR: ffffffff DFSR: 00000005, sp: 3c260360, fp: 3c260514, pc: 3c02e450
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_assert: Assertion failed CPU1 at file:armv7-a/arm_dataabort.c line: 164 task: init
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_dumpstate: Call Trace:
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] [BackTrace| 9|0]:  0x3c02e450 0x3c02a7cc 0x3c0329c0 0x3c02fc8c 0x3c029928 0x3c022110 0x3c01a208
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R0: 00000000 00000010 3c2604a4 00000001 3c261090 00000000 00000000 ffffffff
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R8: ffffffff 3c1cf780 3c15deac 3c260514 00000000 3c2604e0 3c023804 3c02e450
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: CPSR: 20000053
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_dumpstate: Current sp: 3c260318
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_dumpstate: Interrupt stack:
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_dumpstate:   base: 3c238388
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_dumpstate:   size: 00001000
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_dumpstate:   used: 000000a8
...
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_dumpstate: CPU1:
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_showtasks: Tasks status:
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: CPU0 IDLE: PID=0
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: Stack Used=840 of 4076
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] [BackTrace| 0|0]:  0x3c016ad0 0x3c0163cc
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R0: 3c23a9ea 00000000 00000000 00000000 00000000 3c22069f 80000153 3c2202bc
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R8: 0000000c 80000153 3c2204ac 3c24dcd4 00000000 3c24dcc0 3c019344 3c016ad0
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: CPSR: 60000153
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: 
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: CPU1 IDLE: PID=1
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: Stack Used=344 of 4076
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] [BackTrace| 1|0]:  0x3c002aa0 0x3c0165a8
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R8: 00000000 00000000 00000000 3c24ccf4 00000000 3c24ccf0 3c0165a8 3c002aa0
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: CPSR: 00000053
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: 
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: hpwork: PID=3
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: Stack Used=336 of 4068
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] [BackTrace| 3|0]:  0x3c0290a0 0x3c018d58 0x3c018d80 0x3c01ab90 0x3c01a1e4
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R0: 00000001 00000000 00000000 00000000 00000001 3c236368 3c2537d4 00000006
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R8: 3c020444 3c221450 00000000 3c254ebc 00000001 3c254ea8 3c02826c 3c0290a0
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: CPSR: 600000d3
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: 
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: hpwork: PID=4
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: Stack Used=336 of 4068
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] [BackTrace| 4|0]:  0x3c0290a0 0x3c018d58 0x3c018d80 0x3c01ab90 0x3c01a1e4
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R0: 00000001 00000000 00000000 00000000 00000001 3c236368 3c254fd4 00000006
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R8: 3c020444 3c221450 00000000 3c2566bc 00000001 3c2566a8 3c02826c 3c0290a0
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: CPSR: 600000d3
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: 
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: lpwork: PID=5
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_taskdump: Stack Used=312 of 4068
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] [BackTrace| 5|0]:  0x3c0290a0 0x3c018d58 0x3c018d80 0x3c01ab90 0x3c01a1e4
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R0: 00000001 00000000 00000000 00000000 00000001 3c236368 3c2567d4 00000006
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: R8: 00000000 00000000 00000000 3c257ebc 00000001 3c257ea8 3c02826c 3c0290a0
[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] up_registerdump: CPSR: 600000d3
```
check the backtrace of pid 3 hpwork:

`[39/04/26 07:27:26] [CPU1] [ 9] [ A7 ] [BackTrace| 3|0]:  0x3c0290a0 0x3c018d58 0x3c018d80 0x3c01ab90 0x3c01a1e4`

```
$ arm-none-eabi-addr2line -e nuttx 0x3c0290a0 0x3c018d58 0x3c018d80 0x3c01ab90 0x3c01a1e4
nuttx/arch/arm/src/armv7-a/arm_saveusercontext.S:134
nuttx/sched/semaphore/sem_wait.c:185 (discriminator 2)
nuttx/sched/semaphore/sem_wait.c:224 (discriminator 1)
nuttx/sched/wqueue/kwork_thread.c:141
nuttx/sched/task/task_start.c:152

```