### PR TITLE
arch/xtensa/src/common: Use irq_spin APIs in modifyregXX

### DIFF
--- a/arch/xtensa/src/common/xtensa_modifyreg16.c
+++ b/arch/xtensa/src/common/xtensa_modifyreg16.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "xtensa.h"
 
@@ -49,10 +50,10 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/xtensa/src/common/xtensa_modifyreg32.c
+++ b/arch/xtensa/src/common/xtensa_modifyreg32.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "xtensa.h"
 
@@ -49,10 +50,10 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }

--- a/arch/xtensa/src/common/xtensa_modifyreg8.c
+++ b/arch/xtensa/src/common/xtensa_modifyreg8.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/spinlock.h>
 
 #include "xtensa.h"
 
@@ -49,10 +50,10 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }


### PR DESCRIPTION
## Summary
Extracted from #4403

arch/xtensa/src/common: Use irq_spin APIs in modifyregXX
Replace enter_critical_section with spin_lock_irqsave.
Replace leave_critical_section with spin_unlock_irqrestore.
## Impact
Xtensa in SMP
## Testing
esp32-devkitc:smp
esp32-devkitc:wapi_smp
