### PR TITLE
arch/arm/assert: enhance the assert dump 

### DIFF
--- a/arch/arm/src/armv7-a/arm_assert.c
+++ b/arch/arm/src/armv7-a/arm_assert.c
@@ -92,49 +92,12 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 #endif
 
 /****************************************************************************
- * Name: up_taskdump
- ****************************************************************************/
-
-#ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
-{
-  /* Dump interesting properties of this task */
-
-#if CONFIG_TASK_NAME_SIZE > 0
-  _alert("%s: PID=%d Stack Used=%lu of %lu\n",
-        tcb->name, tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-        (unsigned long)tcb->adj_stack_size);
-#else
-  _alert("PID: %d Stack Used=%lu of %lu\n",
-        tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-        (unsigned long)tcb->adj_stack_size);
-#endif
-}
-#endif
-
-/****************************************************************************
- * Name: up_showtasks
- ****************************************************************************/
-
-#ifdef CONFIG_STACK_COLORATION
-static inline void up_showtasks(void)
-{
-  /* Dump interesting properties of each task in the crash environment */
-
-  nxsched_foreach(up_taskdump, NULL);
-}
-#else
-#  define up_showtasks()
-#endif
-
-/****************************************************************************
  * Name: up_registerdump
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_STACKDUMP
-static inline void up_registerdump(void)
+static inline void up_registerdump(FAR volatile uint32_t *regs)
 {
-  volatile uint32_t *regs = CURRENT_REGS;
   int reg;
 
   /* Are user registers available from interrupt processing? */
@@ -160,7 +123,60 @@ static inline void up_registerdump(void)
   _alert("CPSR: %08x\n", regs[REG_CPSR]);
 }
 #else
-# define up_registerdump()
+# define up_registerdump(regs)
+#endif
+
+/****************************************************************************
+ * Name: up_taskdump
+ ****************************************************************************/
+
+#if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
+static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+{
+  /* Dump interesting properties of this task */
+
+  _alert(
+#if CONFIG_TASK_NAME_SIZE > 0
+         "%s: "
+#endif
+         "PID=%d "
+#ifdef CONFIG_STACK_COLORATION
+         "Stack Used=%lu of %lu\n",
+#else
+         "Stack=%lu\n",
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+        tcb->name,
+#endif
+        tcb->pid,
+#ifdef CONFIG_STACK_COLORATION
+        (unsigned long)up_check_tcbstack(tcb),
+#endif
+        (unsigned long)tcb->adj_stack_size);
+
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(tcb->pid);
+#endif
+
+  /* Dump the registers */
+
+  up_registerdump(tcb->xcp.regs);
+}
+
+/****************************************************************************
+ * Name: up_showtasks
+ ****************************************************************************/
+
+static inline void up_showtasks(void)
+{
+  /* Dump interesting properties of each task in the crash environment */
+
+  nxsched_foreach(up_taskdump, NULL);
+}
+#else
+#  define up_showtasks()
 #endif
 
 /****************************************************************************
@@ -206,9 +222,15 @@ static void up_dumpstate(void)
   uint32_t kstackbase = 0;
 #endif
 
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(rtcb->pid);
+#endif
+
   /* Dump the CPU registers (if available) */
 
-  up_registerdump();
+  up_registerdump(CURRENT_REGS);
 
   /* Get the limits on the user stack memory */
 

--- a/arch/arm/src/armv7-m/arm_assert.c
+++ b/arch/arm/src/armv7-m/arm_assert.c
@@ -92,50 +92,12 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 #endif
 
 /****************************************************************************
- * Name: up_taskdump
- ****************************************************************************/
-
-#ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
-{
-  /* Dump interesting properties of this task */
-
-#if CONFIG_TASK_NAME_SIZE > 0
-  _alert("%s: PID=%d Stack Used=%lu of %lu\n",
-        tcb->name, tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-        (unsigned long)tcb->adj_stack_size);
-#else
-  _alert("PID: %d Stack Used=%lu of %lu\n",
-        tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-        (unsigned long)tcb->adj_stack_size);
-#endif
-}
-#endif
-
-/****************************************************************************
- * Name: up_showtasks
- ****************************************************************************/
-
-#ifdef CONFIG_STACK_COLORATION
-static inline void up_showtasks(void)
-{
-  /* Dump interesting properties of each task in the crash environment */
-
-  nxsched_foreach(up_taskdump, NULL);
-}
-#else
-#  define up_showtasks()
-#endif
-
-/****************************************************************************
  * Name: up_registerdump
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_STACKDUMP
-static inline void up_registerdump(void)
+static inline void up_registerdump(FAR volatile uint32_t *regs)
 {
-  volatile uint32_t *regs = CURRENT_REGS;
-
   /* Are user registers available from interrupt processing? */
 
   if (regs == NULL)
@@ -168,7 +130,60 @@ static inline void up_registerdump(void)
 #endif
 }
 #else
-# define up_registerdump()
+# define up_registerdump(regs)
+#endif
+
+/****************************************************************************
+ * Name: up_taskdump
+ ****************************************************************************/
+
+#if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
+static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+{
+  /* Dump interesting properties of this task */
+
+  _alert(
+#if CONFIG_TASK_NAME_SIZE > 0
+         "%s: "
+#endif
+         "PID=%d "
+#ifdef CONFIG_STACK_COLORATION
+         "Stack Used=%lu of %lu\n",
+#else
+         "Stack=%lu\n",
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+        tcb->name,
+#endif
+        tcb->pid,
+#ifdef CONFIG_STACK_COLORATION
+        (unsigned long)up_check_tcbstack(tcb),
+#endif
+        (unsigned long)tcb->adj_stack_size);
+
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(tcb->pid);
+#endif
+
+  /* Dump the registers */
+
+  up_registerdump(tcb->xcp.regs);
+}
+
+/****************************************************************************
+ * Name: up_showtasks
+ ****************************************************************************/
+
+static inline void up_showtasks(void)
+{
+  /* Dump interesting properties of each task in the crash environment */
+
+  nxsched_foreach(up_taskdump, NULL);
+}
+#else
+#  define up_showtasks()
 #endif
 
 /****************************************************************************
@@ -211,9 +226,15 @@ static void up_dumpstate(void)
   uint32_t istacksize;
 #endif
 
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(rtcb->pid);
+#endif
+
   /* Dump the registers (if available) */
 
-  up_registerdump();
+  up_registerdump(CURRENT_REGS);
 
   /* Get the limits on the user stack memory */
 

--- a/arch/arm/src/armv7-r/arm_assert.c
+++ b/arch/arm/src/armv7-r/arm_assert.c
@@ -89,49 +89,12 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 #endif
 
 /****************************************************************************
- * Name: up_taskdump
- ****************************************************************************/
-
-#ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
-{
-  /* Dump interesting properties of this task */
-
-#if CONFIG_TASK_NAME_SIZE > 0
-  _alert("%s: PID=%d Stack Used=%lu of %lu\n",
-        tcb->name, tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-        (unsigned long)tcb->adj_stack_size);
-#else
-  _alert("PID: %d Stack Used=%lu of %lu\n",
-        tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-        (unsigned long)tcb->adj_stack_size);
-#endif
-}
-#endif
-
-/****************************************************************************
- * Name: up_showtasks
- ****************************************************************************/
-
-#ifdef CONFIG_STACK_COLORATION
-static inline void up_showtasks(void)
-{
-  /* Dump interesting properties of each task in the crash environment */
-
-  nxsched_foreach(up_taskdump, NULL);
-}
-#else
-#  define up_showtasks()
-#endif
-
-/****************************************************************************
  * Name: up_registerdump
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_STACKDUMP
-static inline void up_registerdump(void)
+static inline void up_registerdump(FAR volatile uint32_t *regs)
 {
-  volatile uint32_t *regs = CURRENT_REGS;
   int reg;
 
   /* Are user registers available from interrupt processing? */
@@ -157,7 +120,60 @@ static inline void up_registerdump(void)
   _alert("CPSR: %08x\n", regs[REG_CPSR]);
 }
 #else
-# define up_registerdump()
+# define up_registerdump(regs)
+#endif
+
+/****************************************************************************
+ * Name: up_taskdump
+ ****************************************************************************/
+
+#if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
+static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+{
+  /* Dump interesting properties of this task */
+
+  _alert(
+#if CONFIG_TASK_NAME_SIZE > 0
+         "%s: "
+#endif
+         "PID=%d "
+#ifdef CONFIG_STACK_COLORATION
+         "Stack Used=%lu of %lu\n",
+#else
+         "Stack=%lu\n",
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+        tcb->name,
+#endif
+        tcb->pid,
+#ifdef CONFIG_STACK_COLORATION
+        (unsigned long)up_check_tcbstack(tcb),
+#endif
+        (unsigned long)tcb->adj_stack_size);
+
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(tcb->pid);
+#endif
+
+  /* Dump the registers */
+
+  up_registerdump(tcb->xcp.regs);
+}
+
+/****************************************************************************
+ * Name: up_showtasks
+ ****************************************************************************/
+
+static inline void up_showtasks(void)
+{
+  /* Dump interesting properties of each task in the crash environment */
+
+  nxsched_foreach(up_taskdump, NULL);
+}
+#else
+#  define up_showtasks()
 #endif
 
 /****************************************************************************
@@ -203,9 +219,15 @@ static void up_dumpstate(void)
   uint32_t kstackbase = 0;
 #endif
 
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(rtcb->pid);
+#endif
+
   /* Dump the registers (if available) */
 
-  up_registerdump();
+  up_registerdump(CURRENT_REGS);
 
   /* Get the limits on the user stack memory */
 

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -92,50 +92,12 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 #endif
 
 /****************************************************************************
- * Name: up_taskdump
- ****************************************************************************/
-
-#ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
-{
-  /* Dump interesting properties of this task */
-
-#if CONFIG_TASK_NAME_SIZE > 0
-  _alert("%s: PID=%d Stack Used=%lu of %lu\n",
-        tcb->name, tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-        (unsigned long)tcb->adj_stack_size);
-#else
-  _alert("PID: %d Stack Used=%lu of %lu\n",
-        tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-        (unsigned long)tcb->adj_stack_size);
-#endif
-}
-#endif
-
-/****************************************************************************
- * Name: up_showtasks
- ****************************************************************************/
-
-#ifdef CONFIG_STACK_COLORATION
-static inline void up_showtasks(void)
-{
-  /* Dump interesting properties of each task in the crash environment */
-
-  nxsched_foreach(up_taskdump, NULL);
-}
-#else
-#  define up_showtasks()
-#endif
-
-/****************************************************************************
  * Name: up_registerdump
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_STACKDUMP
-static inline void up_registerdump(void)
+static inline void up_registerdump(FAR volatile uint32_t *regs)
 {
-  volatile uint32_t *regs = CURRENT_REGS;
-
   /* Are user registers available from interrupt processing? */
 
   if (regs == NULL)
@@ -168,7 +130,60 @@ static inline void up_registerdump(void)
 #endif
 }
 #else
-# define up_registerdump()
+# define up_registerdump(regs)
+#endif
+
+/****************************************************************************
+ * Name: up_taskdump
+ ****************************************************************************/
+
+#if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
+static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+{
+  /* Dump interesting properties of this task */
+
+  _alert(
+#if CONFIG_TASK_NAME_SIZE > 0
+         "%s: "
+#endif
+         "PID=%d "
+#ifdef CONFIG_STACK_COLORATION
+         "Stack Used=%lu of %lu\n",
+#else
+         "Stack=%lu\n",
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+        tcb->name,
+#endif
+        tcb->pid,
+#ifdef CONFIG_STACK_COLORATION
+        (unsigned long)up_check_tcbstack(tcb),
+#endif
+        (unsigned long)tcb->adj_stack_size);
+
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(tcb->pid);
+#endif
+
+  /* Dump the registers */
+
+  up_registerdump(tcb->xcp.regs);
+}
+
+/****************************************************************************
+ * Name: up_showtasks
+ ****************************************************************************/
+
+static inline void up_showtasks(void)
+{
+  /* Dump interesting properties of each task in the crash environment */
+
+  nxsched_foreach(up_taskdump, NULL);
+}
+#else
+#  define up_showtasks()
 #endif
 
 /****************************************************************************
@@ -211,9 +226,15 @@ static void up_dumpstate(void)
   uint32_t istacksize;
 #endif
 
+  /* Show back trace */
+
+#ifdef CONFIG_SCHED_BACKTRACE
+  sched_dumpstack(rtcb->pid);
+#endif
+
   /* Dump the registers (if available) */
 
-  up_registerdump();
+  up_registerdump(CURRENT_REGS);
 
   /* Get the limits on the user stack memory */
 


### PR DESCRIPTION
## Summary

arch/arm/assert: enhance the assert dump 

show the all tasks info including backtrace and registers

## Impact

N/A

## Testing

```
[23:34:16] [17] arm_hardfault: Hard Fault:
[23:34:16] [17] arm_hardfault:   IRQ: 6 regs: 0x20157478
[23:34:16] [17] arm_hardfault:   BASEPRI: 000000e0 PRIMASK: 00000000 IPSR: 00000006 CONTROL: 00000004
[23:34:16] [17] arm_hardfault:   CFAULTS: 01000000 HFAULTS: 00000000 DFAULTS: 00000000 BFAULTADDR: e000ed38 AFAULTS: 00000000
[23:34:16] [17] arm_hardfault: PANIC!!! Hard fault: 00000000
[23:34:16] [17] up_assert: Assertion failed at file:armv8-m/arm_hardfault.c line: 134 task: init
[23:34:16] [17] [BackTrace|17|0]:   0xc0f946e  0xc0ec74a  0xc0f9868  0xc0e9f28  0xc0f919e   0x2124b8   0x2390e6  0xc0f3912
[23:34:16] [17] [BackTrace|17|1]:   0xc10f5a2  0xc10c7ac  0xc0e686a  0xc0ef23e  0xc10f8e2  0xc11090e  0xc1129a4  0xc0ec706
```
