### PR TITLE
arch:xtensa: remove XCHAL_INT_NLEVELS to XCHAL_NUM_INTLEVELS

### DIFF
--- a/arch/xtensa/include/esp32/core-isa.h
+++ b/arch/xtensa/include/esp32/core-isa.h
@@ -348,7 +348,7 @@
 #define XCHAL_NUM_INTERRUPTS             32   /* number of interrupts */
 #define XCHAL_NUM_INTERRUPTS_LOG2        5    /* ceil(log2(NUM_INTERRUPTS)) */
 #define XCHAL_NUM_EXTINTERRUPTS          26   /* num of external interrupts */
-#define XCHAL_INT_NLEVELS                6    /* number of interrupt levels
+#define XCHAL_NUM_INTLEVELS              6    /* number of interrupt levels
                                                * (not including level zero) */
 #define XCHAL_EXCM_LEVEL                 3    /* level masked by PS.EXCM */
                                               /* (always 1 in XEA1;

--- a/arch/xtensa/include/esp32s2/core-isa.h
+++ b/arch/xtensa/include/esp32s2/core-isa.h
@@ -396,7 +396,7 @@
 #define XCHAL_NUM_INTERRUPTS            32 /* number of interrupts */
 #define XCHAL_NUM_INTERRUPTS_LOG2       5  /* ceil(log2(NUM_INTERRUPTS)) */
 #define XCHAL_NUM_EXTINTERRUPTS         26 /* num of external interrupts */
-#define XCHAL_INT_NLEVELS               6  /* number of interrupt levels
+#define XCHAL_NUM_INTLEVELS             6  /* number of interrupt levels
                                             * (not including level zero)
                                             */
 #define XCHAL_EXCM_LEVEL                3  /* level masked by PS.EXCM */

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -784,7 +784,7 @@ _xtensa_level6_handler:
  *
  ****************************************************************************/
 
-#if XCHAL_INT_NLEVELS >= 2 && XCHAL_EXCM_LEVEL < 2 && XCHAL_DEBUGLEVEL != 2
+#if XCHAL_NUM_INTLEVELS >= 2 && XCHAL_EXCM_LEVEL < 2 && XCHAL_DEBUGLEVEL != 2
 	.section	HANDLER_SECTION, "ax"
 	.type		_xtensa_level2_handler, @function
 	.global		_xtensa_level2_handler
@@ -816,9 +816,9 @@ _xtensa_level2_handler:
 	rfi		2
 
 #endif
-#endif /* XCHAL_INT_NLEVELS >= 2 && XCHAL_EXCM_LEVEL < 2 && XCHAL_DEBUGLEVEL != 2 */
+#endif /* XCHAL_NUM_INTLEVELS >= 2 && XCHAL_EXCM_LEVEL < 2 && XCHAL_DEBUGLEVEL != 2 */
 
-#if XCHAL_INT_NLEVELS >= 3 && XCHAL_EXCM_LEVEL < 3 && XCHAL_DEBUGLEVEL != 3
+#if XCHAL_NUM_INTLEVELS >= 3 && XCHAL_EXCM_LEVEL < 3 && XCHAL_DEBUGLEVEL != 3
 	.section	HANDLER_SECTION, "ax"
 	.type		_xtensa_level3_handler, @function
 	.global		_xtensa_level3_handler
@@ -852,9 +852,9 @@ _xtensa_level3_handler:
 	rfi		3
 
 #endif
-#endif /* XCHAL_INT_NLEVELS >= 3 && XCHAL_EXCM_LEVEL < 3 && XCHAL_DEBUGLEVEL != 3 */
+#endif /* XCHAL_NUM_INTLEVELS >= 3 && XCHAL_EXCM_LEVEL < 3 && XCHAL_DEBUGLEVEL != 3 */
 
-#if XCHAL_INT_NLEVELS >= 4 && XCHAL_EXCM_LEVEL < 4 && XCHAL_DEBUGLEVEL != 4
+#if XCHAL_NUM_INTLEVELS >= 4 && XCHAL_EXCM_LEVEL < 4 && XCHAL_DEBUGLEVEL != 4
 	.section	HANDLER_SECTION, "ax"
 	.type		_xtensa_level4_handler, @function
 	.global		_xtensa_level4_handler
@@ -888,9 +888,9 @@ _xtensa_level4_handler:
 	rfi		4
 
 #endif
-#endif /* XCHAL_INT_NLEVELS >= 4 && XCHAL_EXCM_LEVEL < 4 && XCHAL_DEBUGLEVEL != 4 */
+#endif /* XCHAL_NUM_INTLEVELS >= 4 && XCHAL_EXCM_LEVEL < 4 && XCHAL_DEBUGLEVEL != 4 */
 
-#if XCHAL_INT_NLEVELS >= 5 && XCHAL_EXCM_LEVEL < 5 && XCHAL_DEBUGLEVEL != 5
+#if XCHAL_NUM_INTLEVELS >= 5 && XCHAL_EXCM_LEVEL < 5 && XCHAL_DEBUGLEVEL != 5
 	.section	HANDLER_SECTION, "ax"
 	.type		_xtensa_level5_handler, @function
 	.global		_xtensa_level5_handler
@@ -924,9 +924,9 @@ _xtensa_level5_handler:
 	rfi		5
 
 #endif
-#endif /* XCHAL_INT_NLEVELS >= 5 && XCHAL_EXCM_LEVEL < 5 && XCHAL_DEBUGLEVEL != 5 */
+#endif /* XCHAL_NUM_INTLEVELS >= 5 && XCHAL_EXCM_LEVEL < 5 && XCHAL_DEBUGLEVEL != 5 */
 
-#if XCHAL_INT_NLEVELS >= 6 && XCHAL_EXCM_LEVEL < 6 && XCHAL_DEBUGLEVEL != 6
+#if XCHAL_NUM_INTLEVELS >= 6 && XCHAL_EXCM_LEVEL < 6 && XCHAL_DEBUGLEVEL != 6
 	.section	HANDLER_SECTION, "ax"
 	.type		_xtensa_level6_handler, @function
 	.global		_xtensa_level6_handler
@@ -960,4 +960,4 @@ _xtensa_level6_handler:
 	rfi		6
 
 #endif
-#endif /* XCHAL_INT_NLEVELS >= 6 && XCHAL_EXCM_LEVEL < 6 && XCHAL_DEBUGLEVEL != 6 */
+#endif /* XCHAL_NUM_INTLEVELS >= 6 && XCHAL_EXCM_LEVEL < 6 && XCHAL_DEBUGLEVEL != 6 */


### PR DESCRIPTION
The name used in Tensilica support file core-isa.h for all vendors is
`XCHAL_NUM_INTLEVELS`.
Use a new name may be confused by newer porting xtensa arch.

Change-Id: Ie108d3fdfcc02c81f0eacfca852a1cfc9eea17de

## Summary

## Impact

## Testing

