### PR TITLE
libxx: Move the partial c++ abi implementation to libcxxmini sub folder

### DIFF
--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -24,10 +24,10 @@ if HAVE_CXX
 
 choice
 	prompt "C++ Library"
-	default NOCXXLIB
+	default LIBCXXMINI
 
-config NOCXXLIB
-	bool "NuttX Basic C++ support"
+config LIBCXXMINI
+	bool "Basic C++ support"
 	---help---
 		A fragmentary C++ library that will allow to build only
 		the simplest of C++ applications. Only contain basic C++

--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -19,14 +19,6 @@
 
 include $(TOPDIR)/Make.defs
 
-CXXSRCS = libxx_cxa_atexit.cxx
-
-ifeq ($(CONFIG_LIBSUPCXX),y)
-CXXSRCS += libxx_impure.cxx
-else
-CXXSRCS += libxx_eabi_atexit.cxx
-endif
-
 # Include the uClibc++ Make.defs file if selected.  If it is included,
 # the uClibc++/Make.defs file will add its files to the source file list,
 # add its DEPPATH info, and will add the appropriate paths to the VPATH
@@ -42,12 +34,20 @@ include uClibc++.defs
 else ifeq ($(CONFIG_LIBCXX),y)
 include libcxx.defs
 else
-include cxx.defs
+include libcxxmini.defs
 endif
 
 ifeq ($(CONFIG_LIBCXXABI),y)
 include libcxxabi.defs
 endif
+
+ifeq ($(CONFIG_LIBSUPCXX),y)
+CXXSRCS += libxx_impure.cxx
+else
+CXXSRCS += libxx_eabi_atexit.cxx
+endif
+
+CXXSRCS += libxx_cxa_atexit.cxx
 
 # Object Files
 

--- a/libs/libxx/libcxxmini.defs
+++ b/libs/libxx/libcxxmini.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# libs/libxx/cxx.defs
+# libs/libxx/libcxxmini.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -34,3 +34,6 @@ ifneq ($(CONFIG_XTENSA_TOOLCHAIN_XCC), y)
   libxx_new.cxx_CXXFLAGS += -Wno-missing-exception-spec
   libxx_newa.cxx_CXXFLAGS += -Wno-missing-exception-spec
 endif
+
+DEPPATH += --dep-path libcxxmini
+VPATH += libcxxmini

--- a/libs/libxx/libcxxmini/libxx_cxa_guard.cxx
+++ b/libs/libxx/libcxxmini/libxx_cxa_guard.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libxx_cxa_guard.cxx
+// libs/libxx/libcxxmini/libxx_cxa_guard.cxx
 //
 //   Copyright (C) 2015 Omni Hoverboards Inc. All rights reserved.
 //   Author: Paul Alexander Patience <paul-a.patience@polymtl.ca>

--- a/libs/libxx/libcxxmini/libxx_cxapurevirtual.cxx
+++ b/libs/libxx/libcxxmini/libxx_cxapurevirtual.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libxx_newa.cxx
+// libs/libxx/libcxxmini/libxx_cxapurevirtual.cxx
 //
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
@@ -21,11 +21,7 @@
 // Included Files
 //***************************************************************************
 
-#include <nuttx/config.h>
-#include <cstddef>
-#include <debug.h>
-
-#include "libxx.hxx"
+#include <cassert>
 
 //***************************************************************************
 // Pre-processor Definitions
@@ -40,58 +36,17 @@
 //***************************************************************************
 
 //***************************************************************************
-// Name: new
+// Name:  __cxa_pure_virtual
 //
-// NOTE:
-//   This should take a type of size_t.  But size_t has an unknown underlying
-//   type.  In the nuttx sys/types.h header file, size_t is typed as uint32_t
-//   (which is determined by architecture-specific logic).  But the C++
-//   compiler may believe that size_t is of a different type resulting in
-//   compilation errors in the operator.  Using the underlying integer type
-//   instead of size_t seems to resolve the compilation issues. Need to
-//   REVISIT this.
+// Description:
+//    Crash when an un-implemented pure virtual function is called
 //
 //***************************************************************************
 
-FAR void *operator new[](std::size_t nbytes)
+extern "C"
 {
-  // We have to allocate something
-
-  if (nbytes < 1)
-    {
-      nbytes = 1;
-    }
-
-  // Perform the allocation
-
-  FAR void *alloc = lib_malloc(nbytes);
-
-#ifdef CONFIG_DEBUG_ERROR
-  if (alloc == 0)
-    {
-      // Oh my.. we are required to return a valid pointer and
-      // we cannot throw an exception!  We are bad.
-
-      _err("ERROR: Failed to allocate\n");
-    }
-#endif
-
-  // Return the allocated value
-
-  return alloc;
-}
-
-FAR void *operator new[](std::size_t nbytes, FAR void *ptr)
-{
-
-#ifdef CONFIG_DEBUG_ERROR
-  if (ptr == 0)
-    {
-      _err("ERROR: Failed to placement new[]\n");
-    }
-#endif
-
-  // Return the ptr pointer
-
-  return ptr;
+  void __cxa_pure_virtual(void)
+  {
+    DEBUGPANIC();
+  }
 }

--- a/libs/libxx/libcxxmini/libxx_delete.cxx
+++ b/libs/libxx/libcxxmini/libxx_delete.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libxx_deletea_sized.cxx
+// libs/libxx/libcxxmini/libxx_delete.cxx
 //
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
@@ -22,25 +22,18 @@
 //***************************************************************************
 
 #include <nuttx/config.h>
-#include <nuttx/compiler.h>
 
-#include <cstddef>
-
-#include "libxx.hxx"
-
-#ifdef CONFIG_HAVE_CXX14
+#include <nuttx/lib/lib.h>
 
 //***************************************************************************
 // Operators
 //***************************************************************************
 
 //***************************************************************************
-// Name: delete[]
+// Name: delete
 //***************************************************************************
 
-void operator delete[](FAR void *ptr, std::size_t size)
+void operator delete(FAR void *ptr) throw()
 {
   lib_free(ptr);
 }
-
-#endif /* CONFIG_HAVE_CXX14 */

--- a/libs/libxx/libcxxmini/libxx_delete_sized.cxx
+++ b/libs/libxx/libcxxmini/libxx_delete_sized.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libxx_deletea.cxx
+// libs/libxx/libcxxmini/libxx_delete_sized.cxx
 //
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
@@ -21,19 +21,35 @@
 // Included Files
 //***************************************************************************
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
-#include "libxx.hxx"
+#include <cstddef>
+
+#include <nuttx/lib/lib.h>
+
+#ifdef CONFIG_HAVE_CXX14
 
 //***************************************************************************
 // Operators
 //***************************************************************************
 
 //***************************************************************************
-// Name: delete[]
+// Name: delete
+//
+// NOTE:
+//   This should take a type of size_t.  But size_t has an unknown underlying
+//   type.  In the nuttx sys/types.h header file, size_t is typed as uint32_t
+//   (which is determined by architecture-specific logic).  But the C++
+//   compiler may believe that size_t is of a different type resulting in
+//   compilation errors in the operator.  Using the underlying integer type
+//   instead of size_t seems to resolve the compilation issues. Need to
+//   REVISIT this.
+//
 //***************************************************************************
 
-void operator delete[](FAR void *ptr) throw()
+void operator delete(FAR void *ptr, std::size_t size)
 {
   lib_free(ptr);
 }
+
+#endif /* CONFIG_HAVE_CXX14 */

--- a/libs/libxx/libcxxmini/libxx_deletea.cxx
+++ b/libs/libxx/libcxxmini/libxx_deletea.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libxx_delete.cxx
+// libs/libxx/libcxxmini/libxx_deletea.cxx
 //
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
@@ -23,17 +23,17 @@
 
 #include <nuttx/config.h>
 
-#include "libxx.hxx"
+#include <nuttx/lib/lib.h>
 
 //***************************************************************************
 // Operators
 //***************************************************************************
 
 //***************************************************************************
-// Name: delete
+// Name: delete[]
 //***************************************************************************
 
-void operator delete(FAR void *ptr) throw()
+void operator delete[](FAR void *ptr) throw()
 {
   lib_free(ptr);
 }

--- a/libs/libxx/libcxxmini/libxx_deletea_sized.cxx
+++ b/libs/libxx/libcxxmini/libxx_deletea_sized.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libxx_cxapurevirtual.cxx
+// libs/libxx/libcxxmini/libxx_deletea_sized.cxx
 //
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
@@ -21,32 +21,26 @@
 // Included Files
 //***************************************************************************
 
-#include <cassert>
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
-//***************************************************************************
-// Pre-processor Definitions
-//***************************************************************************
+#include <cstddef>
 
-//***************************************************************************
-// Private Data
-//***************************************************************************
+#include <nuttx/lib/lib.h>
+
+#ifdef CONFIG_HAVE_CXX14
 
 //***************************************************************************
 // Operators
 //***************************************************************************
 
 //***************************************************************************
-// Name:  __cxa_pure_virtual
-//
-// Description:
-//    Crash when an un-implemented pure virtual function is called
-//
+// Name: delete[]
 //***************************************************************************
 
-extern "C"
+void operator delete[](FAR void *ptr, std::size_t size)
 {
-  void __cxa_pure_virtual(void)
-  {
-    DEBUGPANIC();
-  }
+  lib_free(ptr);
 }
+
+#endif /* CONFIG_HAVE_CXX14 */

--- a/libs/libxx/libcxxmini/libxx_new.cxx
+++ b/libs/libxx/libcxxmini/libxx_new.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libxx_new.cxx
+// libs/libxx/libcxxmini/libxx_new.cxx
 //
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
@@ -25,7 +25,7 @@
 #include <cstddef>
 #include <debug.h>
 
-#include "libxx.hxx"
+#include <nuttx/lib/lib.h>
 
 //***************************************************************************
 // Operators

--- a/libs/libxx/libcxxmini/libxx_newa.cxx
+++ b/libs/libxx/libcxxmini/libxx_newa.cxx
@@ -1,5 +1,5 @@
 //***************************************************************************
-// libs/libxx/libxx_delete_sized.cxx
+// libs/libxx/libcxxmini/libxx_newa.cxx
 //
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with
@@ -21,20 +21,26 @@
 // Included Files
 //***************************************************************************
 
-#include <nuttx/compiler.h>
-
+#include <nuttx/config.h>
 #include <cstddef>
+#include <debug.h>
 
-#include "libxx.hxx"
+#include <nuttx/lib/lib.h>
 
-#ifdef CONFIG_HAVE_CXX14
+//***************************************************************************
+// Pre-processor Definitions
+//***************************************************************************
+
+//***************************************************************************
+// Private Data
+//***************************************************************************
 
 //***************************************************************************
 // Operators
 //***************************************************************************
 
 //***************************************************************************
-// Name: delete
+// Name: new
 //
 // NOTE:
 //   This should take a type of size_t.  But size_t has an unknown underlying
@@ -47,9 +53,45 @@
 //
 //***************************************************************************
 
-void operator delete(FAR void *ptr, std::size_t size)
+FAR void *operator new[](std::size_t nbytes)
 {
-  lib_free(ptr);
+  // We have to allocate something
+
+  if (nbytes < 1)
+    {
+      nbytes = 1;
+    }
+
+  // Perform the allocation
+
+  FAR void *alloc = lib_malloc(nbytes);
+
+#ifdef CONFIG_DEBUG_ERROR
+  if (alloc == 0)
+    {
+      // Oh my.. we are required to return a valid pointer and
+      // we cannot throw an exception!  We are bad.
+
+      _err("ERROR: Failed to allocate\n");
+    }
+#endif
+
+  // Return the allocated value
+
+  return alloc;
 }
 
-#endif /* CONFIG_HAVE_CXX14 */
+FAR void *operator new[](std::size_t nbytes, FAR void *ptr)
+{
+
+#ifdef CONFIG_DEBUG_ERROR
+  if (ptr == 0)
+    {
+      _err("ERROR: Failed to placement new[]\n");
+    }
+#endif
+
+  // Return the ptr pointer
+
+  return ptr;
+}

--- a/libs/libxx/libxx.hxx
+++ b/libs/libxx/libxx.hxx
@@ -26,7 +26,7 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/lib/lib.h>
+#include <nuttx/compiler.h>
 
 //***************************************************************************
 // Public Types

--- a/libs/libxx/libxx_cxa_atexit.cxx
+++ b/libs/libxx/libxx_cxa_atexit.cxx
@@ -24,6 +24,7 @@
 #include <nuttx/config.h>
 
 #include <cassert>
+#include <nuttx/lib/lib.h>
 
 #include "libxx.hxx"
 


### PR DESCRIPTION
## Summary
Align the layout with other similar libraries(e.g. libcxxabi, libcxx, uClibc++).

## Impact
Code refactor, no real change

## Testing
Pass CI
