### PR TITLE
arch: k210: remove extra license information

### DIFF
--- a/arch/risc-v/src/k210/hardware/k210_memorymap.h
+++ b/arch/risc-v/src/k210/hardware/k210_memorymap.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/risc-v/src/k210/hardware/k210_memorymap.h
  *
- * Derives from software originally provided by Canaan Inc
- *
- *   Copyright 2018 Canaan Inc
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/risc-v/src/k210/hardware/k210_sysctl.h
+++ b/arch/risc-v/src/k210/hardware/k210_sysctl.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/risc-v/src/k210/hardware/k210_sysctl.h
  *
- * Derives from software originally provided by Canaan Inc
- *
- *   Copyright 2018 Canaan Inc
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/risc-v/src/k210/k210_clockconfig.c
+++ b/arch/risc-v/src/k210/k210_clockconfig.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/risc-v/src/k210/k210_clockconfig.c
  *
- * Derives from software originally provided by Canaan Inc
- *
- *   Copyright 2018 Canaan Inc
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/risc-v/src/k210/k210_gpiohs.c
+++ b/arch/risc-v/src/k210/k210_gpiohs.c
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/risc-v/src/k210/k210_gpiohs.c
  *
- * Derives from software originally provided by Canaan Inc
- *
- *   Copyright 2018 Canaan Inc
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The

--- a/arch/risc-v/src/k210/k210_gpiohs.h
+++ b/arch/risc-v/src/k210/k210_gpiohs.h
@@ -1,10 +1,6 @@
 /****************************************************************************
  * arch/risc-v/src/k210/k210_gpiohs.h
  *
- * Derives from software originally provided by Canaan Inc
- *
- *   Copyright 2018 Canaan Inc
- *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.  The


### PR DESCRIPTION
## Summary
The Apache license header uses a standard format and the extra information
should be removed.

## Impact
LICENSE

## Testing
NONE
