### PR TITLE
tools/ci: Install imgtool for creating signed firmware images supported by MCUboot

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -63,6 +63,11 @@ function python-tools {
   export PYTHONUSERBASE
   add_path $PYTHONUSERBASE/bin
   pip3 install pexpect
+
+  # MCUboot's tool for image signing and key management
+  if ! command -v imgtool &> /dev/null; then
+    pip3 install imgtool
+  fi
 }
 
 function u-boot-tools {

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -269,6 +269,9 @@ RUN pip3 install esptool
 COPY --from=nuttx-toolchain-renesas /tools/renesas-toolchain/rx-elf-gcc/ renesas-toolchain/rx-elf-gcc/
 ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
 
+# MCUboot's tool for image signing and key management
+RUN pip3 install imgtool
+
 # Configure ccache
 RUN mkdir -p /tools/ccache/bin && \
   ln -sf `which ccache` /tools/ccache/bin/cc && \


### PR DESCRIPTION
## Summary
This PR intends to improve the CI infra for supporting the generation of firmware images as supported by MCUboot bootloader.
`imgtool` is MCUboot's tool for image signing and key management.

## Impact
CI only, these changes are required for https://github.com/apache/incubator-nuttx/pull/4324

## Testing
Successful CI build.

