### PR TITLE
libxx:libxx_impure: fix build break in __has_include

### DIFF
--- a/libs/libxx/libxx_impure.cxx
+++ b/libs/libxx/libxx_impure.cxx
@@ -22,7 +22,8 @@
 // Included Files
 //***************************************************************************
 
-#if defined(__has_include) && __has_include(<reent.h>)
+#if defined(__has_include)
+#if __has_include(<reent.h>)
 
 #include <reent.h>
 
@@ -58,4 +59,5 @@ extern "C"
    struct _reent *const __ATTRIBUTE_IMPURE_PTR__ _global_impure_ptr = &impure_data;
 }
 
+#  endif
 #endif


### PR DESCRIPTION
As `__has_include` is c++17 language.

Change-Id: I8250b2ebe74da2ae37a1d2c8fbca2c1365496067

## Summary

## Impact

## Testing

