### PR TITLE
libs/libxx: Enforce RTTI for building libcxxabi

### DIFF
--- a/libs/libxx/libcxxabi.defs
+++ b/libs/libxx/libcxxabi.defs
@@ -55,6 +55,9 @@ else
 CPPSRCS += cxa_noexception.cpp
 endif
 
+# RTTI is required for building the libcxxabi library
+CXXFLAGS += -frtti
+
 DEPPATH += --dep-path libcxxabi/src
 VPATH += libcxxabi/src
 


### PR DESCRIPTION
## Summary
This PR intends to enable the integration of `libcxxabi` on applications that disable RTTI (via `-fno-rtti`).

It is okay for the application to be built without RTTI (-fno-rrti), but libcxxabi requires RTTI at least for the library.

## Impact
Just for users of `libcxxabi`. Since this library was recently integrated, impact is minimal.

## Testing
`esp32-wrover-kit` with `cxxtest` example application.
