### PR TITLE
makefile: let `clean_context` in `distclean` command

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -568,10 +568,11 @@ $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
 
 subdir_distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
 
-distclean: clean subdir_distclean clean_context
+distclean: clean subdir_distclean
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) distclean
 endif
+	$(Q) $(MAKE) clean_context
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
 	$(call DELFILE, .config)

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -517,10 +517,11 @@ $(foreach SDIR, $(CLEANDIRS), $(eval $(call SDIR_template,$(SDIR),distclean)))
 
 subdir_distclean: $(foreach SDIR, $(CLEANDIRS), $(SDIR)_distclean)
 
-distclean: clean subdir_distclean clean_context
+distclean: clean subdir_distclean
 ifeq ($(CONFIG_BUILD_2PASS),y)
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) distclean
 endif
+	$(Q) $(MAKE) clean_context
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
 	$(call DELFILE, .config)


### PR DESCRIPTION
In multi-jobs build, `distclean` may be faster than `clean_context`,
Fix the case `distclean` use the dirctorys that have been
removed by `clean_context`

Change-Id: I99f5c6e401289493f51b909bafd4c465e097175b

## Summary

## Impact
No

## Testing

make clean/distclean pass on sim/arm
