### PR TITLE
libc/gettext: Initialize path field when creating mofile struct.

### DIFF
--- a/libs/libc/locale/lib_gettext.c
+++ b/libs/libc/locale/lib_gettext.c
@@ -312,6 +312,7 @@ FAR char *dcngettext(FAR const char *domainname,
           return notrans;
         }
 
+      strlcpy(mofile->path, path, PATH_MAX);
       mofile->map = momap(path, &mofile->size);
       if (mofile->map == MAP_FAILED)
         {


### PR DESCRIPTION

## Summary
Fix the missing path field initilization when creating new mofile structure.
## Impact
No.
## Testing

