### PR TITLE
sim: Inhibit stack protector on stack coloration function

### DIFF
--- a/arch/sim/src/sim/up_createstack.c
+++ b/arch/sim/src/sim/up_createstack.c
@@ -151,7 +151,8 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes)
+void nostackprotect_function up_stack_color(FAR void *stackbase,
+                                            size_t nbytes)
 {
   /* Take extra care that we do not write outsize the stack boundaries */
 

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -163,6 +163,29 @@
 
 #  define noinstrument_function __attribute__ ((no_instrument_function))
 
+/* The nostackprotect_function attribute disables stack protection in
+ * sensitive functions, e.g., stack coloration routines.
+ */
+
+#if defined(__has_attribute)
+#  if __has_attribute(no_stack_protector)
+#    define nostackprotect_function __attribute__ ((no_stack_protector))
+#  endif
+#endif
+
+/* nostackprotect_function definition for older versions of GCC and Clang.
+ * Note that Clang does not support setting per-function optimizations,
+ * simply disable the entire optimization pass for the required function.
+ */
+
+#ifndef nostackprotect_function
+#  if defined(__clang__)
+#    define nostackprotect_function __attribute__ ((optnone))
+#  else
+#    define nostackprotect_function __attribute__ ((__optimize__ ("-fno-stack-protector")))
+#  endif
+#endif
+
 /* The unsued code or data */
 
 #  define unused_code __attribute__((unused))
@@ -425,6 +448,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define nostackprotect_function
 
 #  define unused_code
 #  define unused_data
@@ -564,6 +588,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define nostackprotect_function
 #  define unused_code
 #  define unused_data
 #  define formatlike(a)
@@ -674,6 +699,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define nostackprotect_function
 #  define unused_code
 #  define unused_data
 #  define formatlike(a)
@@ -739,6 +765,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define nostackprotect_function
 #  define unused_code
 #  define unused_data
 #  define formatlike(a)


### PR DESCRIPTION
## Summary
This PR intends to inhibit the stack protector on the stack coloration function, which purposely writes outside the `up_stack_color`  function's reserved stack area.
Some `sim` configurations were crashing on the stack protector check.
The exact reason on why the issue does not manifest for every configuration is not clear.

## Impact
Closes #4446 

## Testing
`sim:lvgl` and `sim:nettest` were crashing without the PR changes.
The changes enable them to initialize properly.
