### PR TITLE
github: Update links to Docker Linux image

### DIFF
--- a/.github/actions/ci-container/action.yaml
+++ b/.github/actions/ci-container/action.yaml
@@ -18,7 +18,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'docker.pkg.github.com/apache/incubator-nuttx/apache-nuttx-ci-linux'
+  image: 'ghcr.io/apache/incubator-nuttx/apache-nuttx-ci-linux'
   args:
     - "/bin/bash"
     - "-ce"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,12 +127,12 @@ jobs:
       - name: Docker Login
         uses: azure/docker-login@v1
         with:
-          login-server: docker.pkg.github.com
+          login-server: ghcr.io
           username: ${GITHUB_ACTOR}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Pull
-        run: docker pull docker.pkg.github.com/apache/incubator-nuttx/apache-nuttx-ci-linux
+        run: docker pull ghcr.io/apache/incubator-nuttx/apache-nuttx-ci-linux
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
       - name: Run builds

--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
-      IMAGE_TAG: docker.pkg.github.com/${{ github.repository }}/apache-nuttx-ci-linux
+      IMAGE_TAG: ghcr.io/${{ github.repository }}/apache-nuttx-ci-linux
     steps:
       - uses: actions/checkout@v2
 
       - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build Linux image
         run: |


### PR DESCRIPTION
## Summary
This PR intends to update the links to NuttX Docker Linux image used by the CI build.
GitHub's Docker registry has been replaced by the Container registry.
https://github.com/apache/incubator-nuttx/pkgs/container/incubator-nuttx%2Fapache-nuttx-ci-linux
![image](https://user-images.githubusercontent.com/38959758/131740204-3df5fd4d-03ea-4a4f-9ad0-69c658ebd724.png)

This is also an attempt to solving the recurrent timeout failures on `docker pull` step on CI.
![image](https://user-images.githubusercontent.com/38959758/131741011-7613bb6c-9e78-4f55-8420-0cd41f818bdc.png)


## Impact
CI only.

## Testing
CI build pass.
