### PR TITLE
arch/arm/src/stm32l4: fix STM32L4+ option bytes memory address

### DIFF
--- a/arch/arm/src/stm32l4/hardware/stm32l4_memorymap.h
+++ b/arch/arm/src/stm32l4/hardware/stm32l4_memorymap.h
@@ -60,10 +60,17 @@
 #define STM32L4_SYSMEM_BASE    0x1fff0000     /* 0x1fff0000-0x1fff6fff: System memory */
 #define STM32L4_OTP_BASE       0x1fff7000     /* 0x1fff7000-0x1fff73ff: OTP memory */
                                               /* 0x1fff7400-0x1fff77ff: Reserved */
-#define STM32L4_OPTION_BASE    0x1fff7800     /* 0x1fff7800-0x1fff780f: Option bytes */
+#ifdef CONFIG_STM32L4_STM32L4XR
+#  define STM32L4_OPTION_BASE  0x1ff00000     /* 0x1ff00000-0x1ff0000f: Option bytes */
+                                              /* 0x1ff00010-0x1ff00fff: Reserved */
+#  define STM32L4_OPTION2_BASE 0x1ff01000     /* 0x1ff01000-0x1ff0100f: Option bytes 2 */
+                                              /* 0x1ff01010-0x1ff01fff: Reserved */
+#else
+#  define STM32L4_OPTION_BASE  0x1fff7800     /* 0x1fff7800-0x1fff780f: Option bytes */
                                               /* 0x1fff7810-0x1ffff7ff: Reserved */
-#define STM32L4_OPTION2_BASE   0x1ffff800     /* 0x1ffff800-0x1ffff80f: Option bytes 2 */
+#  define STM32L4_OPTION2_BASE 0x1ffff800     /* 0x1ffff800-0x1ffff80f: Option bytes 2 */
                                               /* 0x1ffff810-0x1fffffff: Reserved */
+#endif
 
 /* System Memory Addresses **************************************************/
 


### PR DESCRIPTION
## Summary
STM32L4+ series has flash option bytes in different address than all other STM32L4. Note that RM432 Rev 9 page 94 Figure 3 has not been updated and shows incorrect option byte addresses. Same document section 3.4.1 has the new addresses that this patch adds. This change is also documented in app note AN5017 "Migrating between STM32L476xx/486xx and STM32L4+ Series microcontrollers" Rev 1 Table 9 page 20,

## Impact

## Testing
Tested with STM32L4R5AI. The ST's production default option byte value 0xffeff8aa can be read.
