### PR TITLE
arch/arm/src/stm32l4/stm32l4_flash.c: fix FLASH_CONFIG_I to use dual-bank access

### DIFF
--- a/arch/arm/src/stm32l4/hardware/stm32l4_flash.h
+++ b/arch/arm/src/stm32l4/hardware/stm32l4_flash.h
@@ -34,14 +34,35 @@
 /* Flash size is known from the chip selection:
  *
  *  When CONFIG_STM32L4_FLASH_OVERRIDE_DEFAULT is set the
- *  CONFIG_STM32L4_FLASH_CONFIG_x selects the default FLASH size based on the
- *  chip part number. This value can be overridden with
- *  CONFIG_STM32L4_FLASH_OVERRIDE_x
+ *  CONFIG_STM32L4_FLASH_CONFIG_x selects the default FLASH size based
+ *  on the chip part number. This value can be overridden with
+ *  CONFIG_STM32L4_FLASH_OVERRIDE_x. For example:
  *
  *  Parts STM32L4xxE have 512Kb of FLASH
  *  Parts STM32L4xxG have 1024Kb of FLASH
+ *  Parts STM32L4xxI have 2048Kb of FLASH
  *
- *  N.B. Only Single bank mode is supported
+ * The STM32L4x5/STM32L4x6 devices have two banks, but on 512 and 256 Kb
+ * devices an option byte is available to map all pages to the first bank.
+ *
+ * The STM32L43x/44x/45x/46x chips (CONFIG_STM32L4_STM32L4X3) have a
+ * single bank only.
+ *
+ * STM32L4+ devices (CONFIG_STM32L4_STM32L4XR) have single and dual bank
+ * operating modes.
+ *
+ *  The STM32L4R/Sxx devices have 1 Mb or 2 Mb of flash
+ *  The STM32L4P/Q5x devices have 512 Kb or 1 Mb of flash
+ *
+ * STM32L4+ flash page size is 4 Kb (dual mode) or 8 Kb (single mode).
+ * Dual bank mode is the default and this flash driver does not support
+ * single bank mode on these devices.
+ *
+ * For STM32L+ bank mode is controlled by two different bits
+ * in option bytes:
+ *
+ *  In 2 Mb devices bit 22 (DBANK) controls dual bank mode.
+ *  In 1 Mb devices bit 21 (DB1M) controls dual bank mode.
  */
 
 #define _K(x) ((x)*1024)
@@ -104,9 +125,9 @@
 #elif defined(CONFIG_STM32L4_FLASH_CONFIG_G) /* 1 MB */
 #  define STM32L4_FLASH_NPAGES      512
 #  define STM32L4_FLASH_PAGESIZE    2048
-#elif defined(CONFIG_STM32L4_FLASH_CONFIG_I) /* 2 MB */
-#  define STM32L4_FLASH_NPAGES      256
-#  define STM32L4_FLASH_PAGESIZE    8192
+#elif defined(CONFIG_STM32L4_FLASH_CONFIG_I) /* 2 MB, STM32L4+ only */
+#  define STM32L4_FLASH_NPAGES      512
+#  define STM32L4_FLASH_PAGESIZE    4096
 #else
 #  error "unknown flash configuration!"
 #endif
@@ -257,10 +278,14 @@
 #  define FLASH_OPTCR_BFB2          (1 << 20)               /* Bit 20: Dual bank boot */
 #  define FLASH_OPTCR_DUALBANK      (1 << 21)               /* Bit 21: Dual bank enable */
 #endif
+#if defined(CONFIG_STM32L4_STM32L4XR)
+#  define FLASH_OPTCR_DBANK         (1 << 22)               /* Bit 22: Dual bank mode for 2MB devices */
+#endif
 #define FLASH_OPTCR_NBOOT1          (1 << 23)               /* Bit 23: Boot configuration */
 #define FLASH_OPTCR_SRAM2_PE        (1 << 24)               /* Bit 24: SRAM2 parity check enable */
 #define FLASH_OPTCR_SRAM2_RST       (1 << 25)               /* Bit 25: SRAM2 Erase when system reset */
-#if defined(CONFIG_STM32L4_STM32L4X3) || defined(CONFIG_STM32L4_STM32L496XX) || defined(CONFIG_STM32L4_STM32L4XR)
+#if defined(CONFIG_STM32L4_STM32L4X3) || defined(CONFIG_STM32L4_STM32L496XX) || \
+    defined(CONFIG_STM32L4_STM32L4XR)
 #  define FLASH_OPTCR_NSWBOOT0      (1 << 26)               /* Bit 26: Software BOOT0 */
 #  define FLASH_OPTCR_NBOOT0        (1 << 27)               /* Bit 27: nBOOT0 option bit */
 #endif

--- a/arch/arm/src/stm32l4/stm32l4_flash.c
+++ b/arch/arm/src/stm32l4/stm32l4_flash.c
@@ -89,8 +89,8 @@
 #define FLASH_PAGE_MASK    (FLASH_PAGE_SIZE - 1)
 #if FLASH_PAGE_SIZE == 2048
 #  define FLASH_PAGE_SHIFT   (11)    /* 2**11  = 2048B */
-#elif FLASH_PAGE_SIZE == 8192
-#  define FLASH_PAGE_SHIFT   (13)    /* 2**13  = 8192B */
+#elif FLASH_PAGE_SIZE == 4096
+#  define FLASH_PAGE_SHIFT   (12)    /* 2**12  = 4096B */
 #else
 #  error Unsupported STM32L4_FLASH_PAGESIZE
 #endif
@@ -186,10 +186,14 @@ static inline void flash_erase(size_t page)
     defined(CONFIG_STM32L4_STM32L4XR)
   if (page <= 0xff)
     {
+      /* Select bank 1 */
+
       modifyreg32(STM32L4_FLASH_CR, FLASH_CR_BKER, 0);
     }
   else
     {
+      /* Select bank 2 */
+
       modifyreg32(STM32L4_FLASH_CR, 0, FLASH_CR_BKER);
     }
 #endif


### PR DESCRIPTION
## Summary
CONFIG_STM32L4_FLASH_CONFIG_I for 2 Mb STM32L4+ devices incorrectly used page size for single bank mode while flash driver supports only dual bank mode, which is also the default for these chips when they leave ST's factory. Older STM32L4 chips do not use CONFIG_STM32L4_FLASH_CONFIG_I.

Also replace incorrect comment with clarification, what parts use single bank and which use dual bank mode in STM32L4/STM32L4+ universe. (The description here is likely not complete!)

## Impact
up_progmem API broken on all 2 Mb STM32L4+ chips without this.

## Testing
Tested with STM32L4R5AI
