### PR TITLE
xtensa/esp32:  Wi-Fi board logic refactoring.

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -1089,6 +1089,7 @@ config ESP32_WIFI_SCAN_RESULT_SIZE
 config ESP32_WIFI_SAVE_PARAM
 	bool "Save WiFi Parameters"
 	default n
+	depends on ESP32_SPIFLASH
 	---help---
 		If you enable this option, WiFi adapter parameters will be saved
 		into the file system instead of computing them each time.
@@ -1108,6 +1109,21 @@ config ESP32_WIFI_FS_MOUNTPT
 	depends on ESP32_WIFI_SAVE_PARAM
 	---help---
 		Mount point of WiFi storage file system.
+
+config ESP32_WIFI_MTD_OFFSET
+	hex "Wi-Fi MTD partition offset"
+	default 0x280000 if !ESP32_HAVE_OTA_PARTITION
+	default 0x350000 if ESP32_HAVE_OTA_PARTITION
+	depends on ESP32_WIFI_SAVE_PARAM
+	---help---
+		This is the base address of the Wi-Fi MTD partition.
+
+config ESP32_WIFI_MTD_SIZE
+	hex "Wi-Fi MTD partition size"
+	default 0xb0000
+	depends on ESP32_WIFI_SAVE_PARAM
+	---help---
+		This is the size of the Wi-Fi MTD partition.
 
 config ESP32_WIFI_STA_DISCONNECT_PM
 	bool "Power Management for station when disconnected"

--- a/boards/xtensa/esp32/common/src/esp32_board_wlan.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_wlan.c
@@ -40,44 +40,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ESP32_MTD_OFFSET            CONFIG_ESP32_MTD_OFFSET
-#define ESP32_MTD_SIZE              CONFIG_ESP32_MTD_SIZE
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-#ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
-static int esp32_init_wifi_storage(void)
-{
-  int ret;
-  const char *path = "/dev/mtdblock1";
-  FAR struct mtd_dev_s *mtd_part;
-
-  mtd_part = esp32_spiflash_alloc_mtdpart(ESP32_MTD_OFFSET, ESP32_MTD_SIZE);
-  if (!mtd_part)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");
-      return -1;
-    }
-
-  ret = register_mtddriver(path, mtd_part, 0777, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to regitser MTD: %d\n", ret);
-      return -1;
-    }
-
-  ret = nx_mount(path, CONFIG_ESP32_WIFI_FS_MOUNTPT, "spiffs", 0, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
-      return ret;
-    }
-
-  return 0;
-}
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -99,20 +64,11 @@ int board_wlan_init(void)
 {
   int ret = OK;
 
-#ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
-  ret = esp32_init_wifi_storage();
-  if (ret)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi storage\n");
-      return ret;
-    }
-#endif
-
 #ifdef ESP32_WLAN_HAS_STA
   ret = esp32_wlan_sta_initialize();
   if (ret)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi station\n");
+      wlerr("ERROR: Failed to initialize WiFi station\n");
       return ret;
     }
 #endif
@@ -121,7 +77,7 @@ int board_wlan_init(void)
   ret = esp32_wlan_softap_initialize();
   if (ret)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize WiFi softAP\n");
+      wlerr("ERROR: Failed to initialize WiFi softAP\n");
       return ret;
     }
 #endif


### PR DESCRIPTION
## Summary

This PR does the following:
1.Reserve MTD partition exclusive to Wi-Fi
2.Allow mount Wi-Fi in any FS, except NXFFS.

## Impact

On saving Wi-Fi parameters.

## Testing

I used the sta_softap defconfig with multiple FSs (SmartFS, LittleFS and SPIFFS). I configured the Wi-Fi parameters, reset the board and navigated until mnt/esp/wifi and used cat to visualize if parameters were still there.

Note: To use SmartFS, it's important to have in mind that Wi-Fi filenames are large and CONFIG_SMARTFS_MAXNAMLEN should be adjusted.

