### PR TITLE
drivers/mmcsd: Fix the wrong format argument in mmcsd_dmpcsd

### DIFF
--- a/drivers/mmcsd/mmcsd_debug.c
+++ b/drivers/mmcsd/mmcsd_debug.c
@@ -79,8 +79,7 @@ void mmcsd_dmpcsd(FAR const uint8_t *csd, uint8_t cardtype)
       finfo("  MMC SPEC_VERS:           %d\n", MMC_CSD_SPECVERS(csd));
     }
 
-  finfo("  TAAC:\n",
-      sd2 ? SD20_CSD_TAC_TIMEVALUE(csd) : MMCSD_CSD_TAAC_TIMEVALUE(csd));
+  finfo("  TAAC:\n");
   finfo("    TIME_VALUE:            0x%02x\n",
       sd2 ? SD20_CSD_TAC_TIMEVALUE(csd) : MMCSD_CSD_TAAC_TIMEVALUE(csd));
   finfo("    TIME_UNIT:             0x%02x\n",


### PR DESCRIPTION
## Summary
Minor change

## Impact

## Testing
Pass CI
