### PR TITLE
net: utils: Remove critical section for SMP in net_lock.c

### DIFF
--- a/net/utils/net_lock.c
+++ b/net/utils/net_lock.c
@@ -179,9 +179,6 @@ void net_lockinitialize(void)
 
 int net_lock(void)
 {
-#ifdef CONFIG_SMP
-  irqstate_t flags = enter_critical_section();
-#endif
   pid_t me = getpid();
   int ret = OK;
 
@@ -207,9 +204,6 @@ int net_lock(void)
         }
     }
 
-#ifdef CONFIG_SMP
-  leave_critical_section(flags);
-#endif
   return ret;
 }
 
@@ -232,9 +226,6 @@ int net_lock(void)
 
 int net_trylock(void)
 {
-#ifdef CONFIG_SMP
-  irqstate_t flags = enter_critical_section();
-#endif
   pid_t me = getpid();
   int ret = OK;
 
@@ -258,9 +249,6 @@ int net_trylock(void)
         }
     }
 
-#ifdef CONFIG_SMP
-  leave_critical_section(flags);
-#endif
   return ret;
 }
 
@@ -280,9 +268,6 @@ int net_trylock(void)
 
 void net_unlock(void)
 {
-#ifdef CONFIG_SMP
-  irqstate_t flags = enter_critical_section();
-#endif
   DEBUGASSERT(g_holder == getpid() && g_count > 0);
 
   /* If the count would go to zero, then release the semaphore */
@@ -301,10 +286,6 @@ void net_unlock(void)
 
       g_count--;
     }
-
-#ifdef CONFIG_SMP
-  leave_critical_section(flags);
-#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- The critical section was added in Mar 2018 to improve
  stability in SMP mode
- However, I noticed that this critical section is no longer
  needed

## Impact

- None

## Testing

- Tested with spresense:wifi_smp and spresense:rndis_smp
