### PR TITLE
arch/sim: Don't add -lc++abi to STDLIBS

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -82,7 +82,7 @@ endif
 HOSTSRCS = up_hostirq.c up_hostmemory.c up_hosttime.c up_simuart.c up_hostmisc.c
 STDLIBS += -lpthread
 ifeq ($(CONFIG_HOST_MACOS),y)
-ifeq ($(CONFIG_LIBCXX),y)
+ifeq ($(CONFIG_HAVE_CXXINITIALIZE),y)
   # Note: up_macho_init.c is not in CSRCS because it's picky about
   # the place in the object list for linking. Namely, its constructor
   # should be the first one in the executable.

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -83,7 +83,6 @@ HOSTSRCS = up_hostirq.c up_hostmemory.c up_hosttime.c up_simuart.c up_hostmisc.c
 STDLIBS += -lpthread
 ifeq ($(CONFIG_HOST_MACOS),y)
 ifeq ($(CONFIG_LIBCXX),y)
-  STDLIBS += -lc++abi
   # Note: up_macho_init.c is not in CSRCS because it's picky about
   # the place in the object list for linking. Namely, its constructor
   # should be the first one in the executable.


### PR DESCRIPTION
## Summary
link libs/libxx/libcxxabi instead, follow up https://github.com/apache/incubator-nuttx/pull/4374.

## Impact
switch the builtin libcxxabi

## Testing
Pass CI
