### PR TITLE
Fix in STM32_UART8 Kconfig.

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -9896,7 +9896,7 @@ endif # STM32_UART7_HCIUART
 choice
 	prompt "UART8 Driver Configuration"
 	default STM32_UART8_SERIALDRIVER
-	depends on STM32_UART7
+	depends on STM32_UART8
 
 config STM32_UART8_SERIALDRIVER
 	bool "Standard serial driver"


### PR DESCRIPTION
## Summary
Kconfig in STM32_UART8 was depending on STM32_UART7 which is wrong.

This PR fixes the Kconfig dependency.

## Impact
UART8 can now be used correctly on MCUs that support it.

## Testing
Build test.  
NSH test on custom target based on STM32F427.

