### PR TITLE
drivers/mmcsd: Pass the right buffer size to SDIO_DMAPREFLIGHT

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -1502,7 +1502,7 @@ static ssize_t mmcsd_readmultiple(FAR struct mmcsd_state_s *priv,
                                   FAR uint8_t *buffer, off_t startblock,
                                   size_t nblocks)
 {
-  size_t nbytes;
+  size_t nbytes = nblocks << priv->blockshift;
   off_t  offset;
   int ret;
 
@@ -1524,7 +1524,7 @@ static ssize_t mmcsd_readmultiple(FAR struct mmcsd_state_s *priv,
 
   if ((priv->caps & SDIO_CAPS_DMASUPPORTED) != 0)
     {
-      ret = SDIO_DMAPREFLIGHT(priv->dev, buffer, priv->blocksize);
+      ret = SDIO_DMAPREFLIGHT(priv->dev, buffer, nbytes);
 
       if (ret != OK)
         {
@@ -1552,7 +1552,6 @@ static ssize_t mmcsd_readmultiple(FAR struct mmcsd_state_s *priv,
    * offset
    */
 
-  nbytes = nblocks << priv->blockshift;
   if (IS_BLOCK(priv->type))
     {
       offset = startblock;
@@ -1878,8 +1877,8 @@ static ssize_t mmcsd_writemultiple(FAR struct mmcsd_state_s *priv,
                                    FAR const uint8_t *buffer,
                                    off_t startblock, size_t nblocks)
 {
+  size_t nbytes = nblocks << priv->blockshift;
   off_t  offset;
-  size_t nbytes;
   int ret;
   int evret = OK;
 
@@ -1903,7 +1902,7 @@ static ssize_t mmcsd_writemultiple(FAR struct mmcsd_state_s *priv,
 
   if ((priv->caps & SDIO_CAPS_DMASUPPORTED) != 0)
     {
-      ret = SDIO_DMAPREFLIGHT(priv->dev, buffer, priv->blocksize);
+      ret = SDIO_DMAPREFLIGHT(priv->dev, buffer, nbytes);
 
       if (ret != OK)
         {
@@ -1931,7 +1930,6 @@ static ssize_t mmcsd_writemultiple(FAR struct mmcsd_state_s *priv,
    * offset
    */
 
-  nbytes = nblocks << priv->blockshift;
   if (IS_BLOCK(priv->type))
     {
       offset = startblock;


### PR DESCRIPTION
## Summary

## Impact
Fix the wrong size in multiple block read/write case.
## Testing

