### PR TITLE
add support for power management ic axp202

### DIFF
--- a/drivers/power/Kconfig
+++ b/drivers/power/Kconfig
@@ -365,6 +365,51 @@ config BQ2429X
 	---help---
 		The BQ24296/BQ24297/BQ24296M are battery charger for lithium-ion batteries.
 
+config AXP202
+	bool "AXP202 Battery charger support"
+	default n
+	select I2C
+	depends on BATTERY_CHARGER
+	---help---
+		axp202 are battery charger for lithium-ion batteries.
+
+config AXP202_DC2_VOLTAGE
+	int "AXP202 DC2 output voltage"
+	default 0
+	depends on AXP202
+	---help---
+		AXP202 DC2 output voltage. 0 is disable, enable range: [700, 2275] mV.
+
+config AXP202_DC3_VOLTAGE
+	int "AXP202 DC3 output voltage"
+	default 3300
+	depends on AXP202
+	---help---
+		AXP202 DC3 output voltage. 0 is disable, enable range: [700, 3500] mV.
+
+config AXP202_LDO2_VOLTAGE
+	int "AXP202 LDO2 output voltage"
+	default 0
+	depends on AXP202
+	---help---
+		AXP202 LDO2 output voltage. 0 is disable, enable range: [1800, 3300] mV.
+
+config AXP202_LDO3_VOLTAGE
+	int "AXP202 LDO3 output voltage"
+	default 0
+	depends on AXP202
+	---help---
+		Enable LDO3 output voltage. 0 is disable, enable range: [700, 2275] mV.
+
+config AXP202_LDO4_VOLTAGE
+	int "AXP202 LDO4 output voltage"
+	default 0
+	depends on AXP202
+	---help---
+		Enable LDO4 output voltage. 0 is disable, other value: 
+			1250 1300 1400 1500 1600 1700 1800 1900 
+			2000 2500 2700 2800 3000 3100 3200 3300 mV.
+
 config MCP73871
 	bool "Microchip MCP73871 Battery charger support"
 	default n
@@ -426,6 +471,10 @@ config I2C_BQ2425X
 config I2C_BQ2429X
 	bool
 	default y if BQ2429X
+
+config I2C_AXP202
+	bool
+	default y if AXP202
 
 config I2C_MAX1704X
 	bool

--- a/drivers/power/Make.defs
+++ b/drivers/power/Make.defs
@@ -99,6 +99,12 @@ ifeq ($(CONFIG_I2C_BQ2429X),y)
 CSRCS += bq2429x.c
 endif
 
+# Add the axp202 I2C-based battery charger driver
+
+ifeq ($(CONFIG_I2C_AXP202),y)
+CSRCS += axp202.c
+endif
+
 endif
 
 # Include power support in the build

--- a/drivers/power/axp202.c
+++ b/drivers/power/axp202.c
@@ -1,0 +1,719 @@
+/****************************************************************************
+ * drivers/power/axp202.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <debug.h>
+#include <assert.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/i2c/i2c_master.h>
+#include <nuttx/power/battery_charger.h>
+#include <nuttx/power/axp202.h>
+
+#if defined(CONFIG_I2C) && defined(CONFIG_I2C_AXP202)
+
+/****************************************************************************
+ * Private type
+ ****************************************************************************/
+
+struct axp202_dev_s
+{
+  /* The common part of the battery driver visible to the upper-half driver */
+
+  FAR const struct battery_charger_operations_s *ops; /* Battery operations */
+  sem_t batsem;                                       /* Enforce mutually exclusive access */
+
+  /* Data fields specific to the lower half axp202 driver follow */
+
+  FAR struct i2c_master_s *i2c;       /* I2C interface */
+  uint8_t                  addr;      /* I2C address */
+  uint32_t                 frequency; /* I2C frequency */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/* I2C support */
+
+static int axp202_getreg8(FAR struct axp202_dev_s *priv, uint8_t regaddr,
+                          FAR uint8_t *regval);
+static int axp202_putreg8(FAR struct axp202_dev_s *priv, uint8_t regaddr,
+                          uint8_t regval);
+
+/* Battery driver lower half methods */
+
+static int axp202_state(FAR struct battery_charger_dev_s *dev,
+                        FAR int *                         status);
+static int axp202_health(FAR struct battery_charger_dev_s *dev,
+                         FAR int *                         health);
+static int axp202_online(FAR struct battery_charger_dev_s *dev,
+                         FAR bool *                        status);
+static int axp202_voltage(FAR struct battery_charger_dev_s *dev, int value);
+static int axp202_current(FAR struct battery_charger_dev_s *dev, int value);
+static int axp202_input_current(FAR struct battery_charger_dev_s *dev,
+                                int                               value);
+static int axp202_operate(FAR struct battery_charger_dev_s *dev,
+                          uintptr_t                         param);
+
+static int axp202_set_ldo2_valtage(FAR struct axp202_dev_s *dev,
+                                   int                      voltage);
+static int axp202_set_ldo3_valtage(FAR struct axp202_dev_s *dev,
+                                   int                      voltage);
+static int axp202_set_ldo4_valtage(FAR struct axp202_dev_s *dev,
+                                   int                      voltage);
+static int axp202_set_dc2_valtage(FAR struct axp202_dev_s *dev,
+                                  int                      voltage);
+static int axp202_set_dc2_valtage(FAR struct axp202_dev_s *dev,
+                                  int                      voltage);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct battery_charger_operations_s g_axp202ops =
+{
+  axp202_state,
+  axp202_health,
+  axp202_online,
+  axp202_voltage,
+  axp202_current,
+  axp202_input_current,
+  axp202_operate
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int axp202_getreg8(FAR struct axp202_dev_s *priv, uint8_t regaddr,
+                          FAR uint8_t *regval)
+{
+  struct i2c_config_s config;
+  int                 ret;
+
+  /* Sanity check */
+
+  DEBUGASSERT(priv != NULL);
+  DEBUGASSERT(regval != NULL);
+
+  /* Set up the I2C configuration */
+
+  config.frequency = priv->frequency;
+  config.address   = priv->addr;
+  config.addrlen   = 7;
+
+  /* Write the register address */
+
+  ret = i2c_write(priv->i2c, &config, &regaddr, sizeof(regaddr));
+  if (ret < 0)
+    {
+      snerr("ERROR: i2c_write failed: %d\n", ret);
+      return ret;
+    }
+
+  /* Restart and read 8 bits from the register */
+
+  ret = i2c_read(priv->i2c, &config, regval, sizeof(*regval));
+  if (ret < 0)
+    {
+      snerr("ERROR: i2c_read failed: %d\n", ret);
+      return ret;
+    }
+
+  sninfo("addr: %02x value: %02x\n", regaddr, *regval);
+
+  return OK;
+}
+
+static int axp202_putreg8(FAR struct axp202_dev_s *priv, uint8_t regaddr,
+                          uint8_t regval)
+{
+  struct i2c_config_s config;
+  uint8_t             buffer[2];
+  int                 ret;
+
+  /* Sanity check */
+
+  DEBUGASSERT(priv != NULL);
+
+  /* Set up a 2-byte message to send */
+
+  buffer[0] = regaddr;
+  buffer[1] = regval;
+
+  /* Set up the I2C configuration */
+
+  config.frequency = priv->frequency;
+  config.address   = priv->addr;
+  config.addrlen   = 7;
+
+  /* Write the register address followed by the data (no RESTART) */
+
+  ret = i2c_write(priv->i2c, &config, buffer, sizeof(buffer));
+  if (ret < 0)
+    {
+      snerr("ERROR: i2c_write failed: %d\n", ret);
+      return ret;
+    }
+
+  sninfo("addr: %02x value: %02x\n", regaddr, regval);
+
+  return OK;
+}
+
+static int axp202_state(struct battery_charger_dev_s *dev, int *status)
+{
+  FAR struct axp202_dev_s *priv = (FAR struct axp202_dev_s *)dev;
+  uint8_t                  val  = 0;
+  int                      ret  = 0;
+
+  /* Only a few of the possible battery states are supported by this driver:
+   *
+   *  BATTERY_UNKNOWN - Returned on error conditions
+   *  BATTERY_IDLE - This is what will usually be reported
+   *  BATTERY_FULL - This will be reported if the SoC is greater than 95%
+   *  BATTERY_CHARGING and BATTERY_DISCHARGING - I don't think this hardware
+   *    knows anything about current (charging or dischargin).
+   *
+   */
+
+  ret = axp202_getreg8(priv, AXP202_MODE_CHGSTATUS, &val);
+
+  if (ret != OK)
+    {
+      *status = BATTERY_UNKNOWN;
+      return ret;
+    }
+
+  if (val & (1 << 6))
+    {
+      *status = BATTERY_CHARGING;
+    }
+  else
+    {
+      *status = BATTERY_DISCHARGING;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: axp202_health
+ *
+ * Description:
+ *   Return the current battery health state
+ *
+ * Note: if more than one fault happened the user needs to call this ioctl
+ * again to read a new fault, repeat until receive a BATTERY_HEALTH_GOOD.
+ *
+ ****************************************************************************/
+
+static int axp202_health(FAR struct battery_charger_dev_s *dev,
+                         FAR int *                         health)
+{
+  FAR struct axp202_dev_s *priv = (FAR struct axp202_dev_s *)dev;
+  uint8_t                  val  = 0;
+  int                      ret  = 0;
+
+  /*  Only a few of the possible states are supported by this driver:
+   *   BATTERY_HEALTH_UNKNOWN       - health state is not known
+   *   BATTERY_HEALTH_GOOD          - is in good condiction
+   *   BATTERY_HEALTH_DEAD          - is dead, nothing we can do
+   *   BATTERY_HEALTH_OVERHEAT      - is over recommended temperature
+   *   BATTERY_HEALTH_OVERVOLTAGE   - voltage is over recommended level
+   *   BATTERY_HEALTH_UNSPEC_FAIL   - charger reported an unspected failure
+   *   BATTERY_HEALTH_COLD          - is under recommended temperature
+   *   BATTERY_HEALTH_WD_TMR_EXP    - WatchDog Timer Expired
+   *   BATTERY_HEALTH_SAFE_TMR_EXP  - Safety Timer Expired
+   *   BATTERY_HEALTH_DISCONNECTED  - is not connected
+   */
+
+  ret = axp202_getreg8(priv, AXP202_MODE_CHGSTATUS, &val);
+  if (ret < 0)
+    {
+      *health = BATTERY_HEALTH_UNKNOWN;
+      return ret;
+    }
+
+  if (val & (1 << 7))
+    {
+      *health = BATTERY_HEALTH_OVERHEAT;
+    }
+  else if (!(val & (1 << 5)))
+    {
+      *health = BATTERY_HEALTH_DISCONNECTED;
+    }
+  else
+    {
+      *health = BATTERY_HEALTH_GOOD;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: axp202_online
+ *
+ * Description:
+ *   Return true if the batter is online
+ *
+ ****************************************************************************/
+
+static int axp202_online(struct battery_charger_dev_s *dev, bool *status)
+{
+  FAR struct axp202_dev_s *priv = (FAR struct axp202_dev_s *)dev;
+  uint8_t                  val  = 0;
+  int                      ret  = 0;
+
+  ret = axp202_getreg8(priv, AXP202_MODE_CHGSTATUS, &val);
+
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  if (val & (1 << 5))
+    {
+      *status = true;
+    }
+  else
+    {
+      *status = false;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: axp202_voltage
+ *
+ * Description:
+ *   Set battery charger voltage
+ *
+ ****************************************************************************/
+
+static int axp202_voltage(FAR struct battery_charger_dev_s *dev, int value)
+{
+  FAR struct axp202_dev_s *priv = (FAR struct axp202_dev_s *)dev;
+  int                      ret;
+  uint8_t                  reg = 0;
+
+  /* Set voltage to battery charger */
+
+  ret = axp202_getreg8(priv, AXP202_CHARGE1, &reg);
+
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  reg &= ~(3 << 5);
+
+  switch (value)
+  {
+  case 4100:
+    reg |= (0 << 5);
+    break;
+
+  case 4150:
+    reg |= (1 << 5);
+    break;
+
+  case 4200:
+    reg |= (2 << 5);
+    break;
+
+  case 4360:
+    reg |= (3 << 5);
+    break;
+
+  default:
+    return -EINVAL;
+  }
+
+  ret = axp202_putreg8(priv, AXP202_CHARGE1, reg);
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: axp202_current
+ *
+ * Description:
+ *   Set the battery charger current rate for charging
+ *
+ ****************************************************************************/
+
+static int axp202_current(FAR struct battery_charger_dev_s *dev, int value)
+{
+  FAR struct axp202_dev_s *priv = (FAR struct axp202_dev_s *)dev;
+  int                      ret;
+  uint8_t                  reg = 0;
+
+  /* Set current to battery charger */
+
+  ret = axp202_getreg8(priv, AXP202_CHARGE1, &reg);
+
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  /**
+   * Charge current setting
+   * Icharge= [300+(Bit3-0)*100] mA
+   */
+
+  value = (value - 300) / 100;
+  value &= 0x0f;
+
+  reg &= 0xf0;
+  reg |= value;
+
+  ret = axp202_putreg8(priv, AXP202_CHARGE1, reg);
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: axp202_input_current
+ *
+ * Description:
+ *   Set the power-supply input current limit
+ *
+ ****************************************************************************/
+
+static int axp202_input_current(FAR struct battery_charger_dev_s *dev,
+                                int                               value)
+{
+  FAR struct axp202_dev_s *priv = (FAR struct axp202_dev_s *)dev;
+  int                      ret;
+  uint8_t                  reg = 0;
+
+  ret = axp202_getreg8(priv, AXP202_IPS_SET, &reg);
+
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  reg &= ~(3 << 0);
+
+  switch (value)
+  {
+  case BATTERY_INPUT_CURRENT_EXT_LIM:
+    reg |= (3 << 0);
+    break;
+
+  case 900:
+    reg |= (0 << 0);
+    break;
+
+  case 500:
+    reg |= (1 << 0);
+    break;
+
+  case 100:
+    reg |= (2 << 0);
+    break;
+
+  default:
+    return -EINVAL;
+  }
+
+  ret = axp202_putreg8(priv, AXP202_IPS_SET, reg);
+  if (ret != OK)
+    {
+      return ret;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: axp202_operate
+ *
+ * Description:
+ *   Do miscellaneous battery ioctl()
+ *
+ ****************************************************************************/
+
+static int axp202_operate(FAR struct battery_charger_dev_s *dev,
+                          uintptr_t                         param)
+{
+  return -ENOSYS;
+}
+
+static int axp202_set_ldo2_valtage(FAR struct axp202_dev_s *priv,
+                                   int                      voltage)
+{
+  uint8_t reg = 0;
+
+  axp202_getreg8(priv, AXP202_LDO234_DC23_CTL, &reg);
+
+  if (voltage == 0)
+    {
+      reg &= ~(1 << 2);
+    }
+  else
+    {
+      reg |= (1 << 2);
+    }
+
+  axp202_putreg8(priv, AXP202_LDO234_DC23_CTL, reg);
+
+  if (voltage != 0)
+    {
+      axp202_getreg8(priv, AXP202_LDO24OUT_VOL, &reg);
+      reg &= ~(0xf << 4);
+      reg |= ((((voltage - 1800) / 100) & 0x0f) << 4);
+      axp202_putreg8(priv, AXP202_LDO24OUT_VOL, reg);
+    }
+
+  return OK;
+}
+
+static int axp202_set_ldo3_valtage(FAR struct axp202_dev_s *priv,
+                                   int                      voltage)
+{
+  uint8_t reg = 0;
+
+  axp202_getreg8(priv, AXP202_LDO234_DC23_CTL, &reg);
+
+  if (voltage == 0)
+    {
+      reg &= ~(1 << 6);
+    }
+  else
+    {
+      reg |= (1 << 6);
+    }
+
+  axp202_putreg8(priv, AXP202_LDO234_DC23_CTL, reg);
+
+  if (voltage != 0)
+    {
+      axp202_getreg8(priv, AXP202_LDO3OUT_VOL, &reg);
+      reg &= ~(0xf << 4);
+      reg |= ((((voltage - 700) / 25) & 0x7f) << 0);
+      axp202_putreg8(priv, AXP202_LDO3OUT_VOL, reg);
+    }
+
+  return OK;
+}
+
+static int axp202_set_ldo4_valtage(FAR struct axp202_dev_s *priv,
+                                   int                      voltage)
+{
+  uint8_t reg = 0;
+
+  axp202_getreg8(priv, AXP202_LDO234_DC23_CTL, &reg);
+
+  if (voltage == 0)
+    {
+      reg &= ~(1 << 3);
+    }
+  else
+    {
+      reg |= (1 << 3);
+    }
+
+  axp202_putreg8(priv, AXP202_LDO234_DC23_CTL, reg);
+
+  if (voltage != 0)
+    {
+      axp202_getreg8(priv, AXP202_LDO24OUT_VOL, &reg);
+      reg &= ~(0xf << 0);
+
+      switch (voltage)
+      {
+      case 1250:
+        reg |= 0;  break;
+      case 1300:
+        reg |= 1;  break;
+      case 1400:
+        reg |= 2;  break;
+      case 1500:
+        reg |= 3;  break;
+      case 1600:
+        reg |= 4;  break;
+      case 1700:
+        reg |= 5;  break;
+      case 1800:
+        reg |= 6;  break;
+      case 1900:
+        reg |= 7;  break;
+      case 2000:
+        reg |= 8;  break;
+      case 2500:
+        reg |= 9;  break;
+      case 2700:
+        reg |= 10; break;
+      case 2800:
+        reg |= 11; break;
+      case 3000:
+        reg |= 12; break;
+      case 3100:
+        reg |= 13; break;
+      case 3200:
+        reg |= 14; break;
+      case 3300:
+        reg |= 15; break;
+      default:
+        break;
+      }
+
+      axp202_putreg8(priv, AXP202_LDO24OUT_VOL, reg);
+    }
+
+  return OK;
+}
+
+static int axp202_set_dc2_valtage(FAR struct axp202_dev_s *priv,
+                                  int                      voltage)
+{
+  uint8_t reg = 0;
+
+  axp202_getreg8(priv, AXP202_LDO234_DC23_CTL, &reg);
+
+  if (voltage == 0)
+    {
+      reg &= ~(1 << 4);
+    }
+  else
+    {
+      reg |= (1 << 4);
+    }
+
+  axp202_putreg8(priv, AXP202_LDO234_DC23_CTL, reg);
+
+  if (voltage != 0)
+    {
+      axp202_getreg8(priv, AXP202_DC2OUT_VOL, &reg);
+      reg &= ~(0xf << 4);
+      reg |= ((((voltage - 700) / 25) & 0x3f) << 0);
+      axp202_putreg8(priv, AXP202_DC2OUT_VOL, reg);
+    }
+
+  return OK;
+}
+
+static int axp202_set_dc3_valtage(FAR struct axp202_dev_s *priv,
+                                  int                      voltage)
+{
+  uint8_t reg = 0;
+
+  axp202_getreg8(priv, AXP202_LDO234_DC23_CTL, &reg);
+
+  if (voltage == 0)
+    {
+      reg &= ~(1 << 1);
+    }
+  else
+    {
+      reg |= (1 << 1);
+    }
+
+  axp202_putreg8(priv, AXP202_LDO234_DC23_CTL, reg);
+
+  if (voltage != 0)
+    {
+      axp202_getreg8(priv, AXP202_DC3OUT_VOL, &reg);
+      reg &= ~(0xf << 4);
+      reg |= ((((voltage - 700) / 25) & 0x7f) << 0);
+      axp202_putreg8(priv, AXP202_DC3OUT_VOL, reg);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct battery_charger_dev_s *
+axp202_initialize(FAR struct i2c_master_s *i2c, uint8_t addr,
+                  uint32_t frequency)
+{
+  FAR struct axp202_dev_s *priv;
+  uint8_t                  chipid = 0;
+
+  /* Initialize the axp202 device structure */
+
+  priv = (FAR struct axp202_dev_s *)kmm_zalloc(sizeof(struct axp202_dev_s));
+
+  if (priv)
+    {
+      /* Initialize the axp202 device structure */
+
+      priv->ops       = &g_axp202ops;
+      priv->i2c       = i2c;
+      priv->addr      = addr;
+      priv->frequency = frequency;
+    }
+
+  axp202_getreg8(priv, AXP202_IC_TYPE, &chipid);
+
+  if (AXP202_CHIP_ID != chipid)
+    {
+      kmm_free(priv);
+      return NULL;
+    }
+
+  /* Initialize ldo2 output voltage */
+
+  axp202_set_ldo2_valtage(priv, CONFIG_AXP202_LDO2_VOLTAGE);
+
+  /* Initialize ldo3 output voltage */
+
+  axp202_set_ldo3_valtage(priv, CONFIG_AXP202_LDO3_VOLTAGE);
+
+  /* Initialize ldo4 output voltage */
+
+  axp202_set_ldo4_valtage(priv, CONFIG_AXP202_LDO4_VOLTAGE);
+
+  /* Initialize dc2 output voltage */
+
+  axp202_set_dc2_valtage(priv, CONFIG_AXP202_DC2_VOLTAGE);
+
+  /* Initialize dc3 output voltage */
+
+  axp202_set_dc3_valtage(priv, CONFIG_AXP202_DC3_VOLTAGE);
+
+  return (FAR struct battery_charger_dev_s *)priv;
+}
+
+#endif /* CONFIG_I2C && CONFIG_I2C_AXP202 */

--- a/include/nuttx/power/axp202.h
+++ b/include/nuttx/power/axp202.h
@@ -1,0 +1,191 @@
+/****************************************************************************
+ * include/nuttx/power/axp202.h
+ * msa301 Driver declaration
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_POWER_BATTERY_AXP202_H
+#define __INCLUDE_NUTTX_POWER_BATTERY_AXP202_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/fs/ioctl.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define AXP202_SLAVE_ADDRESS 0x35
+#define AXP202_CHIP_ID                          (0x41)
+
+#define AXP202_STATUS                           (0x00)
+#define AXP202_MODE_CHGSTATUS                   (0x01)
+#define AXP202_OTG_STATUS                       (0x02)
+#define AXP202_IC_TYPE                          (0x03)
+#define AXP202_DATA_BUFFER1                     (0x04)
+#define AXP202_DATA_BUFFER2                     (0x05)
+#define AXP202_DATA_BUFFER3                     (0x06)
+#define AXP202_DATA_BUFFER4                     (0x07)
+#define AXP202_DATA_BUFFER5                     (0x08)
+#define AXP202_DATA_BUFFER6                     (0x09)
+#define AXP202_DATA_BUFFER7                     (0x0A)
+#define AXP202_DATA_BUFFER8                     (0x0B)
+#define AXP202_DATA_BUFFER9                     (0x0C)
+#define AXP202_DATA_BUFFERA                     (0x0D)
+#define AXP202_DATA_BUFFERB                     (0x0E)
+#define AXP202_DATA_BUFFERC                     (0x0F)
+#define AXP202_LDO234_DC23_CTL                  (0x12)
+#define AXP202_DC2OUT_VOL                       (0x23)
+#define AXP202_LDO3_DC2_DVM                     (0x25)
+#define AXP202_DC3OUT_VOL                       (0x27)
+#define AXP202_LDO24OUT_VOL                     (0x28)
+#define AXP202_LDO3OUT_VOL                      (0x29)
+#define AXP202_IPS_SET                          (0x30)
+#define AXP202_VOFF_SET                         (0x31)
+#define AXP202_OFF_CTL                          (0x32)
+#define AXP202_CHARGE1                          (0x33)
+#define AXP202_CHARGE2                          (0x34)
+#define AXP202_BACKUP_CHG                       (0x35)
+#define AXP202_POK_SET                          (0x36)
+#define AXP202_DCDC_FREQSET                     (0x37)
+#define AXP202_VLTF_CHGSET                      (0x38)
+#define AXP202_VHTF_CHGSET                      (0x39)
+#define AXP202_APS_WARNING1                     (0x3A)
+#define AXP202_APS_WARNING2                     (0x3B)
+#define AXP202_TLTF_DISCHGSET                   (0x3C)
+#define AXP202_THTF_DISCHGSET                   (0x3D)
+#define AXP202_DCDC_MODESET                     (0x80)
+#define AXP202_ADC_EN1                          (0x82)
+#define AXP202_ADC_EN2                          (0x83)
+#define AXP202_ADC_SPEED                        (0x84)
+#define AXP202_ADC_INPUTRANGE                   (0x85)
+#define AXP202_ADC_IRQ_RETFSET                  (0x86)
+#define AXP202_ADC_IRQ_FETFSET                  (0x87)
+#define AXP202_TIMER_CTL                        (0x8A)
+#define AXP202_VBUS_DET_SRP                     (0x8B)
+#define AXP202_HOTOVER_CTL                      (0x8F)
+#define AXP202_GPIO0_CTL                        (0x90)
+#define AXP202_GPIO0_VOL                        (0x91)
+#define AXP202_GPIO1_CTL                        (0x92)
+#define AXP202_GPIO2_CTL                        (0x93)
+#define AXP202_GPIO012_SIGNAL                   (0x94)
+#define AXP202_GPIO3_CTL                        (0x95)
+#define AXP202_INTEN1                           (0x40)
+#define AXP202_INTEN2                           (0x41)
+#define AXP202_INTEN3                           (0x42)
+#define AXP202_INTEN4                           (0x43)
+#define AXP202_INTEN5                           (0x44)
+#define AXP202_INTSTS1                          (0x48)
+#define AXP202_INTSTS2                          (0x49)
+#define AXP202_INTSTS3                          (0x4A)
+#define AXP202_INTSTS4                          (0x4B)
+#define AXP202_INTSTS5                          (0x4C)
+
+/* axp 192/202 adc data register */
+
+#define AXP202_BAT_AVERVOL_H8                   (0x78)
+#define AXP202_BAT_AVERVOL_L4                   (0x79)
+#define AXP202_BAT_AVERCHGCUR_H8                (0x7A)
+#define AXP202_BAT_AVERCHGCUR_L4                (0x7B)
+#define AXP202_BAT_AVERCHGCUR_L5                (0x7B)
+#define AXP202_ACIN_VOL_H8                      (0x56)
+#define AXP202_ACIN_VOL_L4                      (0x57)
+#define AXP202_ACIN_CUR_H8                      (0x58)
+#define AXP202_ACIN_CUR_L4                      (0x59)
+#define AXP202_VBUS_VOL_H8                      (0x5A)
+#define AXP202_VBUS_VOL_L4                      (0x5B)
+#define AXP202_VBUS_CUR_H8                      (0x5C)
+#define AXP202_VBUS_CUR_L4                      (0x5D)
+#define AXP202_INTERNAL_TEMP_H8                 (0x5E)
+#define AXP202_INTERNAL_TEMP_L4                 (0x5F)
+#define AXP202_TS_IN_H8                         (0x62)
+#define AXP202_TS_IN_L4                         (0x63)
+#define AXP202_GPIO0_VOL_ADC_H8                 (0x64)
+#define AXP202_GPIO0_VOL_ADC_L4                 (0x65)
+#define AXP202_GPIO1_VOL_ADC_H8                 (0x66)
+#define AXP202_GPIO1_VOL_ADC_L4                 (0x67)
+
+#define AXP202_BAT_AVERDISCHGCUR_H8             (0x7C)
+#define AXP202_BAT_AVERDISCHGCUR_L5             (0x7D)
+#define AXP202_APS_AVERVOL_H8                   (0x7E)
+#define AXP202_APS_AVERVOL_L4                   (0x7F)
+#define AXP202_INT_BAT_CHGCUR_H8                (0xA0)
+#define AXP202_INT_BAT_CHGCUR_L4                (0xA1)
+#define AXP202_EXT_BAT_CHGCUR_H8                (0xA2)
+#define AXP202_EXT_BAT_CHGCUR_L4                (0xA3)
+#define AXP202_INT_BAT_DISCHGCUR_H8             (0xA4)
+#define AXP202_INT_BAT_DISCHGCUR_L4             (0xA5)
+#define AXP202_EXT_BAT_DISCHGCUR_H8             (0xA6)
+#define AXP202_EXT_BAT_DISCHGCUR_L4             (0xA7)
+#define AXP202_BAT_CHGCOULOMB3                  (0xB0)
+#define AXP202_BAT_CHGCOULOMB2                  (0xB1)
+#define AXP202_BAT_CHGCOULOMB1                  (0xB2)
+#define AXP202_BAT_CHGCOULOMB0                  (0xB3)
+#define AXP202_BAT_DISCHGCOULOMB3               (0xB4)
+#define AXP202_BAT_DISCHGCOULOMB2               (0xB5)
+#define AXP202_BAT_DISCHGCOULOMB1               (0xB6)
+#define AXP202_BAT_DISCHGCOULOMB0               (0xB7)
+#define AXP202_COULOMB_CTL                      (0xB8)
+#define AXP202_BAT_POWERH8                      (0x70)
+#define AXP202_BAT_POWERM8                      (0x71)
+#define AXP202_BAT_POWERL8                      (0x72)
+
+#define AXP202_VREF_TEM_CTRL                    (0xF3)
+#define AXP202_BATT_PERCENTAGE                  (0xB9)
+
+#define AXP202_BATT_VOLTAGE_STEP                (1.1F)
+#define AXP202_BATT_DISCHARGE_CUR_STEP          (0.5F)
+#define AXP202_BATT_CHARGE_CUR_STEP             (0.5F)
+#define AXP202_ACIN_VOLTAGE_STEP                (1.7F)
+#define AXP202_ACIN_CUR_STEP                    (0.625F)
+#define AXP202_VBUS_VOLTAGE_STEP                (1.7F)
+#define AXP202_VBUS_CUR_STEP                    (0.375F)
+#define AXP202_INTERNAL_TEMP_STEP               (0.1F)
+#define AXP202_APS_VOLTAGE_STEP                 (1.4F)
+#define AXP202_TS_PIN_OUT_STEP                  (0.8F)
+#define AXP202_GPIO0_STEP                       (0.5F)
+#define AXP202_GPIO1_STEP                       (0.5F)
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#if defined(CONFIG_I2C) && defined(CONFIG_I2C_AXP202)
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+struct i2c_master_s;
+FAR struct battery_charger_dev_s *axp202_initialize(
+                                     FAR struct i2c_master_s *i2c,
+                                     uint8_t addr,
+                                     uint32_t frequency
+                                     );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_I2C && CONFIG_I2C_AXP202 */
+#endif
+


### PR DESCRIPTION
## Summary
add support for power management ic axp202.
can config LDO or DC-DC output voltage of axp202.

## Impact
no

## Testing
tested on esp32 platform and our platform.
