### PR TITLE
tools/nxstyle: Fix the check tool incorrectly reported no alignment.

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -2832,7 +2832,9 @@ int main(int argc, char **argv, char **envp)
                */
 
               if ((bstatm ||                              /* Begins with C keyword */
-                  (line[indent] == '/' && bfunctions)) && /* Comment in functions */
+                  (line[indent] == '/' &&
+                  bfunctions &&
+                  line[indent + 1] == '*')) &&            /* Comment in functions */
                   !bswitch &&                             /* Not in a switch */
                   dnest == 0)                             /* Not a data definition */
                 {


### PR DESCRIPTION
## Summary
The nxstyle check tool recognizes the division operator as
a comment. Check the following content to determine whether
it is a comment.

Change-Id: Id07c6668489895b45a1042794bc3acca66cd3c47
Signed-off-by: yangjiukui <yangjiukui@xiaomi.com>

## Impact
Affect the execution result of /nuttx/tools/checkpatch.sh.

## Testing
1. Before modification, report the wrong misalignment.
code:
```
  priv->dev.fifowtm = ROUNDUP(*latency_us, priv->dev.interval)
                    / priv->dev.interval;
```
test:
```
$ ./nuttx/tools/checkpatch.sh -f nuttx/drivers/sensors/<filename>.c 
$ /nuttx/drivers/sensors/<filename>.c:1525:20: error: Bad alignment
```
2. When the operator is aligned, run the script check and no error will be reported.
code:
```
  priv->dev.fifowtm = ROUNDUP(*latency_us, priv->dev.interval)
                    / priv->dev.interval;
```
3. If it is a single line comment, an error is reported.
code:
```
  priv->dev.fifowtm = ROUNDUP(*latency_us, priv->dev.interval)
                    / priv->dev.interval;

                    /* Single-Line Comments. */
```
test:
```
$ ./nuttx/tools/checkpatch.sh -f nuttx/drivers/sensors/<filename>.c
$ /nuttx/drivers/sensors/<filename>.c:1527:20: error: Bad alignment
```
