### PR TITLE
Fix error in s32k118_pinmux.h

### DIFF
--- a/arch/arm/src/s32k1xx/hardware/s32k118_pinmux.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k118_pinmux.h
@@ -182,7 +182,7 @@
 #define PIN_LPSPI0_PCS2           (PIN_ALT2   | PIN_PORTE | PIN6)
 #define PIN_LPSPI0_SCK_1          (PIN_ALT2   | PIN_PORTE | PIN0)
 #define PIN_LPSPI0_SCK_2          (PIN_ALT3   | PIN_PORTB | PIN2)
-#define PIN_LPSPI0_SCK            (PIN_ALT4   | PIN_PORTD | PIN15)
+#define PIN_LPSPI0_SCK_3          (PIN_ALT4   | PIN_PORTD | PIN15)
 #define PIN_LPSPI0_SIN_1          (PIN_ALT2   | PIN_PORTE | PIN1)
 #define PIN_LPSPI0_SIN_2          (PIN_ALT3   | PIN_PORTB | PIN3)
 #define PIN_LPSPI0_SIN_3          (PIN_ALT4   | PIN_PORTD | PIN16)


### PR DESCRIPTION
## Summary

The S32K118 pinmux contains a small error, "_3" is missing from the third alternative for LPSPI0_SCK. As far as I am aware, this particular pinmux definition is not used anywhere in upstream code, so this change should not cause any issues.

## Impact

Potentially impacts S32K118 board configurations that select this particular pinmux setting.

## Testing

S32K118EVB board builds without issues.

