### PR TITLE
Espressif: Create option for merging all binaries into a single file

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3219,6 +3219,9 @@ endif
 if ARCH_BOARD_ESP32C3_DEVKIT
 source "boards/risc-v/esp32c3/esp32c3-devkit/Kconfig"
 endif
+if ARCH_CHIP_ESP32S2 && !ARCH_BOARD_CUSTOM
+source "boards/xtensa/esp32s2/common/Kconfig"
+endif
 if ARCH_BOARD_ESP32S2_SAOLA_1
 source "boards/xtensa/esp32s2/esp32s2-saola-1/Kconfig"
 endif

--- a/boards/risc-v/esp32c3/esp32c3-devkit/Kconfig
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/Kconfig
@@ -41,6 +41,15 @@ config ESP32C3_DEVKIT_RUN_IRAM
 	bool "Run from IRAM"
 	default n
 
+config ESP32C3_MERGE_BINS
+	bool "Merge raw binary files into a single file"
+	default n
+	---help---
+		Merge the raw binary files into a single file for flashing to the
+		device.
+		This is only useful when the path to binary files (e.g. bootloader)
+		is provided via the ESPTOOL_BINDIR variable.
+
 choice
   prompt "SPIFLASH File System"
   default ESP32C3_SPIFLASH_SMARTFS

--- a/boards/xtensa/esp32/common/Kconfig
+++ b/boards/xtensa/esp32/common/Kconfig
@@ -2,6 +2,15 @@
 # For a description of the syntax of this configuration file,
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
+config ESP32_MERGE_BINS
+	bool "Merge raw binary files into a single file"
+	default n
+	---help---
+		Merge the raw binary files into a single file for flashing to the
+		device.
+		This is only useful when the path to binary files (e.g. bootloader)
+		is provided via the ESPTOOL_BINDIR variable.
+
 config ESP32_QEMU_IMAGE
 	bool "ESP32 binary image for QEMU"
 	default n

--- a/boards/xtensa/esp32s2/common/Kconfig
+++ b/boards/xtensa/esp32s2/common/Kconfig
@@ -3,3 +3,11 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
+config ESP32S2_MERGE_BINS
+	bool "Merge raw binary files into a single file"
+	default n
+	---help---
+		Merge the raw binary files into a single file for flashing to the
+		device.
+		This is only useful when the path to binary files (e.g. bootloader)
+		is provided via the ESPTOOL_BINDIR variable.

--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -144,6 +144,7 @@ define POSTBUILD
 		-H $(CONFIG_ESP32_APP_MCUBOOT_HEADER_SIZE) --pad-header \
 		-S $(CONFIG_ESP32_OTA_SLOT_SIZE) \
 		nuttx.bin nuttx.signed.bin
+	$(Q) echo nuttx.signed.bin >> nuttx.manifest
 	$(Q) echo "Generated: nuttx.signed.bin (MCUboot compatible)"
 	$(call MERGEBIN)
 endef

--- a/tools/esp32s2/Config.mk
+++ b/tools/esp32s2/Config.mk
@@ -52,8 +52,6 @@ else ifeq ($(CONFIG_ESP32S2_FLASH_FREQ_20M),y)
 	FLASH_FREQ := 20m
 endif
 
-ESPTOOL_ELF2IMG_OPTS := -fs $(FLASH_SIZE) -fm $(FLASH_MODE) -ff $(FLASH_FREQ)
-
 ifeq ($(CONFIG_ESP32S2_FLASH_DETECT),y)
 	ESPTOOL_WRITEFLASH_OPTS := -fs detect -fm dio -ff $(FLASH_FREQ)
 else
@@ -71,6 +69,26 @@ ifdef ESPTOOL_BINDIR
 endif
 
 ESPTOOL_BINS += 0x10000 nuttx.bin
+
+# ELF2IMAGE -- Convert an ELF file into a binary file in Espressif application image format
+
+define ELF2IMAGE
+	$(Q) echo "MKIMAGE: ESP32-S2 binary"
+	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
+		echo ""; \
+		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
+		echo ""; \
+		echo "Run make again to create the nuttx.bin image."; \
+		exit 1; \
+	fi
+	$(Q) if [ -z $(FLASH_SIZE) ]; then \
+		echo "Missing Flash memory size configuration for the ESP32-S2 chip."; \
+		exit 1; \
+	fi
+	$(eval ESPTOOL_ELF2IMG_OPTS := -fs $(FLASH_SIZE) -fm $(FLASH_MODE) -ff $(FLASH_FREQ))
+	esptool.py -c esp32s2 elf2image $(ESPTOOL_ELF2IMG_OPTS) -o nuttx.bin nuttx
+	$(Q) echo "Generated: nuttx.bin (ESP32-S2 compatible)"
+endef
 
 # MERGEBIN -- Merge raw binary files into a single file
 
@@ -99,20 +117,7 @@ endif
 # POSTBUILD -- Perform post build operations
 
 define POSTBUILD
-	$(Q) echo "MKIMAGE: ESP32-S2 binary"
-	$(Q) if ! esptool.py version 1>/dev/null 2>&1; then \
-		echo ""; \
-		echo "esptool.py not found.  Please run: \"pip install esptool\""; \
-		echo ""; \
-		echo "Run make again to create the nuttx.bin image."; \
-		exit 1; \
-	fi
-	$(Q) if [ -z $(FLASH_SIZE) ]; then \
-		echo "Missing Flash memory size configuration for the ESP32-S2 chip."; \
-		exit 1; \
-	fi
-	esptool.py -c esp32s2 elf2image $(ESPTOOL_ELF2IMG_OPTS) -o nuttx.bin nuttx
-	$(Q) echo "Generated: nuttx.bin (ESP32-S2 compatible)"
+	$(call ELF2IMAGE)
 	$(call MERGEBIN)
 endef
 


### PR DESCRIPTION
## Summary
This PR intends to create a new option for generating a merged binary file containing all the raw binaries provided to the build.

This is only useful when the path to binary files (e.g. bootloader) is provided via the `ESPTOOL_BINDIR` variable.

## Impact
Only for currently supported Espressif chips: `esp32`, `esp32-s2` and `esp32-c3`.

## Testing
`esp32-devkitc:nsh` and `esp32-devkic:mcuboot_agent`, with CONFIG_ESP32_MERGE_BINS both `y` and `n`.
`esp32s2-saola-1:nsh`, with CONFIG_ESP32S2_MERGE_BINS both `y` and `n`.
`esp32c3-devkit:nsh`, with CONFIG_ESP32C3_MERGE_BINS both `y` and `n`.

