### PR TITLE
esp32_serial.c: Don't fake an interrupt when interrupts are not suppressed.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -1726,6 +1726,7 @@ static void esp32_txint(struct uart_dev_s *dev, bool enable)
           modifyreg32(UART_INT_ENA_REG(priv->config->id),
                       0, (UART_TX_DONE_INT_ENA | UART_TXFIFO_EMPTY_INT_ENA));
 
+    #else
           /* Fake a TX interrupt here by just calling uart_xmitchars() with
            * interrupts disabled (note this may recurse).
            */


### PR DESCRIPTION
## Summary
This should've been brought from STM32 and doesn't apply to ESP32.

 Extracted from:
- https://github.com/apache/incubator-nuttx/pull/4403

Related:
 - https://github.com/apache/incubator-nuttx/pull/4437

## Impact
ESP32 serial driver
## Testing
esp32-devkitc:nsh
