### PR TITLE
risc-v/esp32-c3: refactor the Wi-Fi board logic.

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -749,6 +749,20 @@ config ESP32C3_WIFI_FS_MOUNTPT
 	---help---
 		Mount point of Wi-Fi storage file system.
 
+config ESP32C3_WIFI_MTD_OFFSET
+	hex "Wi-Fi MTD partition offset"
+	default 0x280000
+	depends on ESP32C3_WIFI_SAVE_PARAM
+	---help---
+		This is the base address of the Wi-Fi MTD partition.
+
+config ESP32C3_WIFI_MTD_SIZE
+	hex "Wi-Fi MTD partition size"
+	default 0xb0000
+	depends on ESP32C3_WIFI_SAVE_PARAM
+	---help---
+		This is the size of the Wi-Fi MTD partition.
+
 config ESP32C3_WIFI_STA_DISCONNECT_PM
 	bool "Power Management for station when disconnected"
 	default n

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -77,9 +77,6 @@
 #define SPI_FLASH_ERASED_STATE      (0xff)
 #define SPI_FLASH_SIZE              (4 * 1024 * 1024)
 
-#define ESP32C3_MTD_OFFSET          CONFIG_ESP32C3_MTD_OFFSET
-#define ESP32C3_MTD_SIZE            CONFIG_ESP32C3_MTD_SIZE
-
 #define MTD2PRIV(_dev)              ((FAR struct esp32c3_spiflash_s *)_dev)
 #define MTD_SIZE(_priv)             ((*(_priv)->data)->chip.chip_size)
 #define MTD_BLKSIZE(_priv)          ((*(_priv)->data)->chip.page_size)
@@ -914,17 +911,19 @@ static int esp32c3_ioctl(struct mtd_dev_s *dev, int cmd,
  * Name: esp32c3_spiflash_alloc_mtdpart
  *
  * Description:
- *   Allocate SPI Flash MTD.
+ *   Allocate an MTD partition from the ESP32-C3 SPI Flash.
  *
  * Input Parameters:
- *   None
+ *   mtd_offset - MTD Partition offset from the base address in SPI Flash.
+ *   mtd_size   - Size for the MTD partition.
  *
  * Returned Value:
  *   SPI Flash MTD data pointer if success or NULL if fail.
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(void)
+FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(uint32_t mtd_offset,
+                                                     uint32_t mtd_size)
 {
   struct esp32c3_spiflash_s *priv = &g_esp32c3_spiflash;
   const esp32c3_spiflash_chip_t *chip = &(*priv->data)->chip;
@@ -933,9 +932,9 @@ FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(void)
   uint32_t startblock;
   uint32_t size;
 
-  ASSERT((ESP32C3_MTD_OFFSET + ESP32C3_MTD_SIZE) <= chip->chip_size);
-  ASSERT((ESP32C3_MTD_OFFSET % chip->sector_size) == 0);
-  ASSERT((ESP32C3_MTD_SIZE % chip->sector_size) == 0);
+  ASSERT((mtd_offset + mtd_size) <= chip->chip_size);
+  ASSERT((mtd_offset % chip->sector_size) == 0);
+  ASSERT((mtd_size % chip->sector_size) == 0);
 
   finfo("ESP32-C3 SPI Flash information:\n");
   finfo("\tID = 0x%" PRIx32 "\n", chip->device_id);
@@ -945,16 +944,19 @@ FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(void)
   finfo("\tSector size = %" PRId32 " KB\n", chip->sector_size / 1024);
   finfo("\tBlock size = %" PRId32 " KB\n", chip->block_size / 1024);
 
-#if ESP32C3_MTD_SIZE == 0
-  size = chip->chip_size - ESP32C3_MTD_OFFSET;
-#else
-  size = ESP32C3_MTD_SIZE;
-#endif
+  if (mtd_size == 0)
+    {
+      size = chip->chip_size - mtd_offset;
+    }
+  else
+    {
+      size = mtd_size;
+    }
 
-  finfo("\tMTD offset = 0x%x\n", ESP32C3_MTD_OFFSET);
+  finfo("\tMTD offset = 0x%x\n", mtd_offset);
   finfo("\tMTD size = 0x%" PRIx32 "\n", size);
 
-  startblock = MTD_SIZE2BLK(priv, ESP32C3_MTD_OFFSET);
+  startblock = MTD_SIZE2BLK(priv, mtd_offset);
   blocks = MTD_SIZE2BLK(priv, size);
 
   mtd_part = mtd_partition(&priv->mtd, startblock, blocks);

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
+#include <inttypes.h>
 #include <errno.h>
 
 #include <nuttx/arch.h>
@@ -953,7 +954,7 @@ FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(uint32_t mtd_offset,
       size = mtd_size;
     }
 
-  finfo("\tMTD offset = 0x%x\n", mtd_offset);
+  finfo("\tMTD offset = 0x%" PRIx32 "\n", mtd_offset);
   finfo("\tMTD size = 0x%" PRIx32 "\n", size);
 
   startblock = MTD_SIZE2BLK(priv, mtd_offset);

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.h
@@ -66,17 +66,19 @@ struct mtd_dev_s *esp32c3_spiflash_mtd(void);
  * Name: esp32c3_spiflash_alloc_mtdpart
  *
  * Description:
- *   Alloc ESP32-C3 SPI Flash MTD
+ *   Allocate an MTD partition from the ESP32-C3 SPI Flash.
  *
  * Input Parameters:
- *   None
+ *   mtd_offset - MTD Partition offset from the base address in SPI Flash.
+ *   mtd_size   - Size for the MTD partition.
  *
  * Returned Value:
  *   ESP32-C3 SPI Flash MTD data pointer if success or NULL if fail
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(void);
+FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(uint32_t mtd_offset,
+                                                     uint32_t mtd_size);
 
 /****************************************************************************
  * Name: esp32c3_spiflash_encrypt_mtd

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
@@ -38,6 +38,10 @@ ifeq ($(CONFIG_ESP32C3_SPIFLASH),y)
 CSRCS += esp32c3_spiflash.c
 endif
 
+ifeq ($(CONFIG_ESP32C3_WIRELESS),y)
+CSRCS += esp32c3_board_wlan.c
+endif
+
 ifeq ($(CONFIG_DEV_GPIO),y)
 CSRCS += esp32c3_gpio.c
 endif

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3-devkit.h
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3-devkit.h
@@ -189,6 +189,22 @@ int board_bmp180_initialize(int devno, int busno);
 #endif
 
 /****************************************************************************
+ * Name: board_wlan_init
+ *
+ * Description:
+ *   Configure the wireless subsystem.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   to indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32C3_WIRELESS
+int board_wlan_init(void);
+#endif
+
+/****************************************************************************
  * Name: esp32c3_spiflash_init
  *
  * Description:

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_wlan.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_wlan.c
@@ -1,0 +1,81 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_wlan.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <debug.h>
+
+#include <nuttx/wireless/wireless.h>
+
+#include "esp32c3_spiflash.h"
+#include "esp32c3_wlan.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_wlan_init
+ *
+ * Description:
+ *   Configure the wireless subsystem.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; A negated errno value is returned
+ *   to indicate the nature of any failure.
+ *
+ ****************************************************************************/
+
+int board_wlan_init(void)
+{
+  int ret = OK;
+
+#ifdef CONFIG_NET
+#ifdef ESP32C3_WLAN_HAS_STA
+  ret = esp32c3_wlan_sta_initialize();
+  if (ret)
+    {
+      wlerr("ERROR: Failed to initialize Wi-Fi station\n");
+      return ret;
+    }
+#endif
+
+#ifdef ESP32C3_WLAN_HAS_SOFTAP
+  ret = esp32c3_wlan_softap_initialize();
+  if (ret)
+    {
+      wlerr("ERROR: Failed to initialize Wi-Fi softAP\n");
+      return ret;
+    }
+#endif
+#endif
+
+  return ret;
+}
+

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
@@ -83,56 +83,15 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: esp32c3_init_wifi_storage
- *
- * Description:
- *   Initialization of saved Wi-Fi parameters
- *
- ****************************************************************************/
-
-#ifdef CONFIG_ESP32C3_WIFI_SAVE_PARAM
-static int esp32c3_init_wifi_storage(void)
-{
-  int ret;
-  const char *path = "/dev/mtdblock1";
-  FAR struct mtd_dev_s *mtd_part;
-
-  mtd_part = esp32c3_spiflash_alloc_mtdpart(ESP32C3_MTD_OFFSET,
-                                            ESP32C3_MTD_SIZE);
-  if (!mtd_part)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");
-      return -1;
-    }
-
-  ret = register_mtddriver(path, mtd_part, 0777, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to register MTD: %d\n", ret);
-      return -1;
-    }
-
-  ret = nx_mount(path, CONFIG_ESP32C3_WIFI_FS_MOUNTPT, "spiffs", 0, NULL);
-  if (ret < 0)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n", ret);
-      return ret;
-    }
-
-  return 0;
-}
-#endif
-
-/****************************************************************************
  * Name: esp32c3_bringup
  *
  * Description:
  *   Perform architecture-specific initialization
  *
- *   CONFIG_BOARD_LATE_INITIALIZE=y :
+ *   CONFIG_BOARD_LATE_INITIALIZE=y
  *     Called from board_late_initialize().
  *
- *   CONFIG_BOARD_LATE_INITIALIZE=n && CONFIG_BOARDCTL=y :
+ *   CONFIG_BOARD_LATE_INITIALIZE=n && CONFIG_BOARDCTL=y
  *     Called from the NSH library
  *
  ****************************************************************************/
@@ -337,34 +296,11 @@ int esp32c3_bringup(void)
 
 #ifdef CONFIG_ESP32C3_WIFI
 
-#ifdef CONFIG_ESP32C3_WIFI_SAVE_PARAM
-  ret = esp32c3_init_wifi_storage();
-  if (ret)
+  ret = board_wlan_init();
+  if (ret < 0)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize Wi-Fi storage\n");
-      return ret;
+      syslog(LOG_ERR, "ERROR: board_wlan_init() failed: %d\n", ret);
     }
-#endif
-
-#ifdef CONFIG_NET
-#ifdef ESP32C3_WLAN_HAS_STA
-  ret = esp32c3_wlan_sta_initialize();
-  if (ret)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to initialize Wi-Fi station\n");
-      return ret;
-    }
-#endif
-
-#ifdef ESP32C3_WLAN_HAS_SOFTAP
-  ret = esp32c3_wlan_softap_initialize();
-  if (ret)
-    {
-      syslog(LOG_ERR, "ERROR: Failed to initialize Wi-Fi softAP\n");
-      return ret;
-    }
-#endif
-#endif
 
 #endif
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
@@ -75,6 +75,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define ESP32C3_MTD_OFFSET            CONFIG_ESP32C3_MTD_OFFSET
+#define ESP32C3_MTD_SIZE              CONFIG_ESP32C3_MTD_SIZE
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -94,7 +97,8 @@ static int esp32c3_init_wifi_storage(void)
   const char *path = "/dev/mtdblock1";
   FAR struct mtd_dev_s *mtd_part;
 
-  mtd_part = esp32c3_spiflash_alloc_mtdpart();
+  mtd_part = esp32c3_spiflash_alloc_mtdpart(ESP32C3_MTD_OFFSET,
+                                            ESP32C3_MTD_SIZE);
   if (!mtd_part)
     {
       syslog(LOG_ERR, "ERROR: Failed to alloc MTD partition of SPI Flash\n");

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_spiflash.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_spiflash.c
@@ -46,12 +46,347 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ESP32C3_MTD_PATH      "/dev/esp32c3flash"
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
 
-#define ESP32C3_FS_MOUNT_PT   CONFIG_ESP32C3_SPIFLASH_FS_MOUNT_PT
+/****************************************************************************
+ * Name: setup_smartfs
+ *
+ * Description:
+ *   Provide a block driver wrapper around MTD partition and mount a
+ *   SMART FS over it.
+ *
+ * Parameters:
+ *   smartn - Number used to register the mtd partition: /dev/smartx, where
+ *            x = smartn.
+ *   mtd    - Pointer to a pre-allocated mtd partition.
+ *   mnt_pt - Mount point
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
 
-#define ESP32C3_MTD_OFFSET            CONFIG_ESP32C3_MTD_OFFSET
-#define ESP32C3_MTD_SIZE              CONFIG_ESP32C3_MTD_SIZE
+#if defined (CONFIG_ESP32C3_SPIFLASH_SMARTFS)
+static int setup_smartfs(int smartn, FAR struct mtd_dev_s *mtd,
+                         const char *mnt_pt)
+{
+  int ret = OK;
+  char path[22];
+
+  ret = smart_initialize(smartn, mtd, NULL);
+  if (ret < 0)
+    {
+      finfo("smart_initialize failed, Trying to erase first...\n");
+      ret = mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
+      if (ret < 0)
+        {
+          ferr("ERROR: ioctl(BULKERASE) failed: %d\n", ret);
+          return ret;
+        }
+
+      finfo("Erase successful, initializing it again.\n");
+      ret = smart_initialize(smartn, mtd, NULL);
+      if (ret < 0)
+        {
+          ferr("ERROR: smart_initialize failed: %d\n", ret);
+          return ret;
+        }
+    }
+
+  if (mnt_pt != NULL)
+    {
+      snprintf(path, sizeof(path), "/dev/smart%d", smartn);
+
+      ret = nx_mount(path, mnt_pt, "smartfs", 0, NULL);
+      if (ret < 0)
+        {
+          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          return ret;
+        }
+    }
+
+  return ret;
+}
+
+#endif
+
+/****************************************************************************
+ * Name: setup_littlefs
+ *
+ * Description:
+ *   Register a mtd driver and mount a Little FS over it.
+ *
+ * Parameters:
+ *   path   - Path name used to register the mtd driver.
+ *   mtd    - Pointer to a pre-allocated mtd partition.
+ *   mnt_pt - Mount point
+ *   priv   - Privileges
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#if defined (CONFIG_ESP32C3_SPIFLASH_LITTLEFS)
+static int setup_littlefs(const char *path, FAR struct mtd_dev_s *mtd,
+                          const char *mnt_pt, int priv)
+{
+  int ret = OK;
+
+  ret = register_mtddriver(path, mtd, priv, NULL);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      return ERROR;
+    }
+
+  if (mnt_pt != NULL)
+    {
+      ret = nx_mount(path, mnt_pt, "littlefs", 0, NULL);
+      if (ret < 0)
+        {
+          ret = nx_mount(path, mnt_pt, "littlefs", 0, "forceformat");
+          if (ret < 0)
+            {
+              ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+              return ret;
+            }
+        }
+    }
+
+  return OK;
+}
+
+#endif
+
+/****************************************************************************
+ * Name: setup_spiffs
+ *
+ * Description:
+ *   Register a mtd driver and mount a SPIFFS over it.
+ *
+ * Parameters:
+ *   path   - Path name used to register the mtd driver.
+ *   mtd    - Pointer to a pre-allocated mtd partition.
+ *   mnt_pt - Mount point
+ *   priv   - Privileges
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#if defined  (CONFIG_ESP32C3_SPIFLASH_SPIFFS)
+static int setup_spiffs(const char *path, FAR struct mtd_dev_s *mtd,
+                        const char *mnt_pt, int priv)
+{
+  int ret = OK;
+
+  ret = register_mtddriver(path, mtd, priv, NULL);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      return ERROR;
+    }
+
+  if (mnt_pt != NULL)
+    {
+      ret = nx_mount(path, mnt_pt, "spiffs", 0, NULL);
+      if (ret < 0)
+        {
+          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          return ret;
+        }
+    }
+
+  return ret;
+}
+
+#endif
+
+/****************************************************************************
+ * Name: setup_nxffs
+ *
+ * Description:
+ *   Register a mtd driver and mount a SPIFFS over it.
+ *
+ * Parameters:
+ *   mtd    - Pointer to a pre-allocated mtd partition.
+ *   mnt_pt - Mount point
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#if defined (CONFIG_ESP32C3_SPIFLASH_NXFFS)
+static int setup_nxffs(FAR struct mtd_dev_s *mtd, const char *mnt_pt)
+{
+  int ret = OK;
+
+  ret = nxffs_initialize(mtd);
+  if (ret < 0)
+    {
+      ferr("ERROR: NXFFS init failed: %d\n", ret);
+      return ret;
+    }
+
+  if (mnt_pt != NULL)
+    {
+      ret = nx_mount(NULL, mnt_pt, "nxffs", 0, NULL);
+      if (ret < 0)
+        {
+          ferr("ERROR: Failed to mount the FS volume: %d\n", ret);
+          return ret;
+        }
+    }
+
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Name: init_wifi_partition
+ *
+ * Description:
+ *   Initialize partition that is dedicated to Wi-Fi.
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#if defined (CONFIG_ESP32C3_WIFI_SAVE_PARAM)
+static int init_wifi_partition(void)
+{
+  int ret = OK;
+  FAR struct mtd_dev_s *mtd;
+
+  mtd = esp32c3_spiflash_alloc_mtdpart(CONFIG_ESP32C3_WIFI_MTD_OFFSET,
+                                       CONFIG_ESP32C3_WIFI_MTD_SIZE);
+  if (!mtd)
+    {
+      ferr("ERROR: Failed to alloc MTD partition of SPI Flash\n");
+      return ERROR;
+    }
+
+#if defined (CONFIG_ESP32C3_SPIFLASH_SMARTFS)
+
+  ret = setup_smartfs(1, mtd, CONFIG_ESP32C3_WIFI_FS_MOUNTPT);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to setup smartfs\n");
+      return ret;
+    }
+
+#elif defined (CONFIG_ESP32C3_SPIFLASH_LITTLEFS)
+
+  const char *path = "/dev/mtdblock1";
+  ret = setup_littlefs(path, mtd, CONFIG_ESP32C3_WIFI_FS_MOUNTPT, 0777);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to setup littlefs\n");
+      return ret;
+    }
+
+#elif defined (CONFIG_ESP32C3_SPIFLASH_SPIFFS)
+
+  const char *path = "/dev/mtdblock1";
+  ret = setup_spiffs(path, mtd, CONFIG_ESP32C3_WIFI_FS_MOUNTPT, 0777);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to setup spiffs\n");
+      return ret;
+    }
+
+#else
+
+    ferr("ERROR: No supported FS selected. Wi-Fi partition "
+         "should be mounted before Wi-Fi initialization\n");
+
+#endif
+
+  return ret;
+}
+
+#endif
+/****************************************************************************
+ * Name: init_storage_partition
+ *
+ * Description:
+ *   Initialize partition that is dedicated to general use.
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+static int init_storage_partition(void)
+{
+  int ret = OK;
+  FAR struct mtd_dev_s *mtd;
+
+  mtd = esp32c3_spiflash_alloc_mtdpart(CONFIG_ESP32C3_MTD_OFFSET,
+                                       CONFIG_ESP32C3_MTD_SIZE);
+  if (!mtd)
+    {
+      ferr("ERROR: Failed to alloc MTD partition of SPI Flash\n");
+      return ERROR;
+    }
+
+#if defined (CONFIG_ESP32C3_SPIFLASH_SMARTFS)
+
+  ret = setup_smartfs(0, mtd, NULL);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to setup smartfs\n");
+      return ret;
+    }
+
+#elif defined (CONFIG_ESP32C3_SPIFLASH_NXFFS)
+
+  ret = setup_nxffs(mtd, "/mnt");
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to setup nxffs\n");
+      return ret;
+    }
+
+#elif defined (CONFIG_ESP32C3_SPIFLASH_LITTLEFS)
+
+  const char *path = "/dev/esp32c3flash";
+  ret = setup_littlefs(path, mtd, NULL, 0755);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to setup littlefs\n");
+      return ret;
+    }
+
+#elif defined (CONFIG_ESP32C3_SPIFLASH_SPIFFS)
+
+  const char *path = "/dev/esp32c3flash";
+  ret = setup_spiffs(path, mtd, NULL, 0755);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to setup spiffs\n");
+      return ret;
+    }
+
+#else
+
+  ret = register_mtddriver("/dev/esp32c3flash", mtd, 0755, NULL);
+  if (ret < 0)
+    {
+      ferr("ERROR: Failed to register MTD: %d\n", ret);
+      return ret;
+    }
+
+#endif
+
+  return ret;
+}
 
 /****************************************************************************
  * Public Functions
@@ -66,70 +401,21 @@
 
 int esp32c3_spiflash_init(void)
 {
-  FAR struct mtd_dev_s *mtd;
-  int ret = ERROR;
+  int ret = OK;
 
-  mtd = esp32c3_spiflash_alloc_mtdpart(ESP32C3_MTD_OFFSET,
-                                       ESP32C3_MTD_SIZE);
-
-#if defined (CONFIG_ESP32C3_SPIFLASH_SMARTFS)
-  ret = smart_initialize(0, mtd, NULL);
+#ifdef CONFIG_ESP32C3_WIFI_SAVE_PARAM
+  ret = init_wifi_partition();
   if (ret < 0)
     {
-      finfo("smart_initialize failed, Trying to erase first...\n");
-      ret = mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
-      if (ret < 0)
-        {
-          ferr("ERROR: ioctl(BULKERASE) failed: %d\n", ret);
-          return ret;
-        }
-
-      finfo("Erase successful, initializing it again.\n");
-      ret = smart_initialize(0, mtd, NULL);
-      if (ret < 0)
-        {
-          ferr("ERROR: smart_initialize failed: %d\n", ret);
-          return ret;
-        }
-    }
-
-#elif defined (CONFIG_ESP32C3_SPIFLASH_NXFFS)
-  ret = nxffs_initialize(mtd);
-  if (ret < 0)
-    {
-      ferr("ERROR: NXFFS init failed: %d\n", ret);
-      return ret;
-    }
-
-#elif defined (CONFIG_ESP32C3_SPIFLASH_LITTLEFS)
-  ret = register_mtddriver(ESP32C3_MTD_PATH, mtd, 0755, NULL);
-  if (ret < 0)
-    {
-      ferr("ERROR: Register MTD failed: %d\n", ret);
-      return ret;
-    }
-
-  ret = mount(ESP32C3_MTD_PATH, ESP32C3_FS_MOUNT_PT,
-              "littlefs", 0, NULL);
-  if (ret < 0)
-    {
-      ret = mount(ESP32C3_MTD_PATH, ESP32C3_FS_MOUNT_PT,
-                  "littlefs", 0, "forceformat");
-      if (ret < 0)
-        {
-          syslog(LOG_ERR, "ERROR: Failed to mount the FS volume: %d\n",
-                 errno);
-          return ret;
-        }
-    }
-#else
-  ret = register_mtddriver("/dev/esp32c3flash", mtd, 0755, NULL);
-  if (ret < 0)
-    {
-      ferr("ERROR: Register MTD failed: %d\n", ret);
       return ret;
     }
 #endif
+
+  ret = init_storage_partition();
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   return ret;
 }

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_spiflash.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_spiflash.c
@@ -50,6 +50,9 @@
 
 #define ESP32C3_FS_MOUNT_PT   CONFIG_ESP32C3_SPIFLASH_FS_MOUNT_PT
 
+#define ESP32C3_MTD_OFFSET            CONFIG_ESP32C3_MTD_OFFSET
+#define ESP32C3_MTD_SIZE              CONFIG_ESP32C3_MTD_SIZE
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -66,7 +69,8 @@ int esp32c3_spiflash_init(void)
   FAR struct mtd_dev_s *mtd;
   int ret = ERROR;
 
-  mtd = esp32c3_spiflash_alloc_mtdpart();
+  mtd = esp32c3_spiflash_alloc_mtdpart(ESP32C3_MTD_OFFSET,
+                                       ESP32C3_MTD_SIZE);
 
 #if defined (CONFIG_ESP32C3_SPIFLASH_SMARTFS)
   ret = smart_initialize(0, mtd, NULL);


### PR DESCRIPTION
## Summary

This PR does the following:

1.Allow different regions for MTD partitions\
2.Reorganize Wi-Fi board logic\
3.Allow mount Wi-Fi using multiple FS.

## Impact

On saving Wi-Fi parameters. 

## Test

I used the `sta_softap` defconfig with multiple FSs (SmartFS, LittleFS and SPIFFS). I configured the Wi-Fi parameters, reset the board and navigated until `mnt/esp/wifi` and used cat to visualize if parameters were still there.
