### PR TITLE
arch/arm/src/stm32l4: add control for Vddio2 independent I/Os supply valid

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_pwr.h
+++ b/arch/arm/src/stm32l4/stm32l4_pwr.h
@@ -106,6 +106,25 @@ bool stm32l4_pwr_enablebkp(bool writable);
 bool stm32l4_pwr_enableusv(bool set);
 
 /****************************************************************************
+ * Name: stm32l4_pwr_vddio2_valid
+ *
+ * Description:
+ *   Report that the Vddio2 independent I/Os supply voltage is valid or not.
+ *   Setting this bit is mandatory to use the PG2 - PG15 I/Os.
+ *
+ * Input Parameters:
+ *   set - True: Vddio2 is value; False: Vddio2 is not present.  Logical and
+ *         electrical isolation is applied to ignore this supply.
+ *
+ * Returned Value:
+ *   True: The bit was previously set.
+ ****************************************************************************/
+
+#if !defined(CONFIG_STM32L4_STM32L4X3)
+bool stm32l4_pwr_vddio2_valid(bool set);
+#endif
+
+/****************************************************************************
  * Name: stm32_pwr_setvos
  *
  * Description:

--- a/arch/arm/src/stm32l5/stm32l5_pwr.c
+++ b/arch/arm/src/stm32l5/stm32l5_pwr.c
@@ -251,14 +251,14 @@ bool stm32l5_pwr_vddio2_valid(bool set)
 
   if (was_set && !set)
     {
-      /* Reset the Vddio2 invalid I/O supply valid bit. */
+      /* Reset the Vddio2 independent I/O supply valid bit. */
 
       regval &= ~PWR_CR2_IOSV;
       stm32l5_pwr_putreg(STM32L5_PWR_CR2_OFFSET, regval);
     }
   else if (!was_set && set)
     {
-      /* Set the Vddio2 invalid I/O supply valid bit. */
+      /* Set the Vddio2 independent I/O supply valid bit. */
 
       regval |= PWR_CR2_IOSV;
       stm32l5_pwr_putreg(STM32L5_PWR_CR2_OFFSET, regval);

--- a/boards/arm/stm32l5/nucleo-l552ze/src/stm32_boot.c
+++ b/boards/arm/stm32l5/nucleo-l552ze/src/stm32_boot.c
@@ -42,7 +42,7 @@
  *
  * Description:
  *   All STM32 architectures must provide the following entry point.  This
- *   entry point is called early in the intitialization -- after all memory
+ *   entry point is called early in the initialization -- after all memory
  *   has been configured and mapped but before any devices have been
  *   initialized.
  *

--- a/boards/arm/stm32l5/stm32l562e-dk/src/stm32_boot.c
+++ b/boards/arm/stm32l5/stm32l562e-dk/src/stm32_boot.c
@@ -43,7 +43,7 @@
  *
  * Description:
  *   All STM32 architectures must provide the following entry point.  This
- *   entry point is called early in the intitialization -- after all memory
+ *   entry point is called early in the initialization -- after all memory
  *   has been configured and mapped but before any devices have been
  *   initialized.
  *


### PR DESCRIPTION
## Summary
This change adds a function to PWR peripheral code that board code can use to tell MCU that VDDIO2 independent power supply is valid or not. This is just a backport of same function from STM32L5 arch to STM32L4.

## Impact
New feature for STM32L4, already used for other STM32

## Testing
Tested with STM32L4R5AI. GPIOG port works when VDDIO2 is supplied by custom board logic.
