### PR TITLE
inode_getpath: correct get path whether path buffer is clean or not.

### DIFF
--- a/fs/inode/fs_inodegetpath.c
+++ b/fs/inode/fs_inodegetpath.c
@@ -53,7 +53,7 @@ int inode_getpath(FAR struct inode *node, FAR char *path)
       path[0] = '\0';
       return OK;
     }
-  else if (node->i_parent != NULL)
+  else
     {
       int ret = inode_getpath(node->i_parent, path);
       if (ret < 0)


### PR DESCRIPTION


## Summary
inode_getpath: correct get path whether path buffer is clean or not.
## Impact
Get correct path of inode  when the buffer is dirty.
## Testing
daily test
