### PR TITLE
fs/ioctl: using FIOC_FILEPATH instead of FIOC_FILENAME

### DIFF
--- a/binfmt/builtin.c
+++ b/binfmt/builtin.c
@@ -78,6 +78,7 @@ static int builtin_loadbinary(FAR struct binary_s *binp,
                               int nexports)
 {
   FAR const struct builtin_s *builtin;
+  FAR char *name;
   struct file file;
   int index;
   int ret;
@@ -93,22 +94,13 @@ static int builtin_loadbinary(FAR struct binary_s *binp,
       return ret;
     }
 
-  /* If this file is a BINFS file system, then we can recover the name of
-   * the file using the FIOC_FILENAME ioctl() call.
-   */
-
-  ret = file_ioctl(&file, FIOC_FILENAME,
-                   (unsigned long)((uintptr_t)&filename));
-  if (ret < 0)
+  name = strrchr(filename, '/');
+  if (name != NULL)
     {
-      berr("ERROR: FIOC_FILENAME ioctl failed: %d\n", ret);
-      file_close(&file);
-      return ret;
+      filename = name + 1;
     }
 
-  /* Other file systems may also support FIOC_FILENAME, so the real proof
-   * is that we can look up the index to this name in g_builtins[].
-   */
+  /* Looking up the index to this name in g_builtins[] */
 
   index = builtin_isavail(filename);
   if (index < 0)

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -42,6 +42,8 @@
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/lib/builtin.h>
 
+#include "inode/inode.h"
+
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_BINFS)
 
 /****************************************************************************
@@ -196,22 +198,26 @@ static int binfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
   /* Only one IOCTL command is supported */
 
-  if (cmd == FIOC_FILENAME)
+  if (cmd == FIOC_FILEPATH)
     {
-      /* IN:  FAR char const ** pointer
-       * OUT: Pointer to a persistent file name (Guaranteed to persist while
-       *      the file is open).
+      /* IN:  FAR char *(length >= PATH_MAX)
+       * OUT: The full file path
        */
 
-      FAR const char **ptr = (FAR const char **)((uintptr_t)arg);
+      FAR char *ptr = (FAR char *)((uintptr_t)arg);
       if (ptr == NULL)
         {
           ret = -EINVAL;
         }
       else
         {
-          *ptr = builtin_getname((int)((uintptr_t)filep->f_priv));
-          ret = OK;
+          ret = inode_getpath(filep->f_inode, ptr);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          strcat(ptr, builtin_getname((int)((uintptr_t)filep->f_priv)));
         }
     }
   else

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -140,10 +140,8 @@
                                            *      (ignored on most file systems)
                                            * OUT: None
                                            */
-#define FIOC_FILENAME   _FIOC(0x0004)     /* IN:  FAR const char ** pointer
-                                           * OUT: Pointer to a persistent file name
-                                           *      (Guaranteed to persist while the
-                                           *      file is open).
+#define FIOC_FILEPATH   _FIOC(0x0004)     /* IN:  FAR char *(length >= PATH_MAX)
+                                           * OUT: The full file path
                                            */
 #define FIOC_INTEGRITY  _FIOC(0x0005)     /* Run a consistency check on the
                                            *      file system media.
@@ -180,9 +178,6 @@
                                            */
 #define FIONCLEX        _FIOC(0x000e)     /* IN:  None
                                            * OUT: None
-                                           */
-#define FIOC_FILEPATH   _FIOC(0x000f)     /* IN:  FAR char *(length >= PATH_MAX)
-                                           * OUT: The full file path
                                            */
 
 /* NuttX file system ioctl definitions **************************************/


### PR DESCRIPTION
## Summary
let's remove FIOC_FILENAME and done it by FIOC_FILEPATH and strrchr(path, '/')
## Impact
remove FIOC_FILENAME
## Testing
daily test