### PR TITLE
errno: use staic errno to replace tl_errno before tls initialization

### DIFF
--- a/include/errno.h
+++ b/include/errno.h
@@ -42,7 +42,7 @@
 #define set_errno(e) \
   do \
     { \
-       errno = (int)(e); \
+      errno = (int)(e); \
     } \
   while (0)
 #define get_errno() errno

--- a/libs/libc/errno/lib_errno.c
+++ b/libs/libc/errno/lib_errno.c
@@ -30,6 +30,12 @@
 #include <arch/tls.h>
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static int g_errno;
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -57,5 +63,5 @@ FAR int *__errno(void)
 
   /* And return the return refernce to the error number */
 
-  return &tlsinfo->tl_errno;
+  return tlsinfo ? &tlsinfo->tl_errno : &g_errno;
 }


### PR DESCRIPTION
## Summary
let's use staic errno to replace tl_errno before tls initialization,  otherwise the system will crash.
## Impact
Avoiding crash for using seterrno before tls initialization.
## Testing
daily test.
