### PR TITLE
debug: allow customize EXTRA_FMT

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -78,11 +78,16 @@
  *    really intended only for crash error reporting.
  */
 
-#ifdef CONFIG_HAVE_FUNCTIONNAME
+#if !defined(EXTRA_FMT) && !defined(EXTRA_ARG) && defined(CONFIG_HAVE_FUNCTIONNAME)
 #  define EXTRA_FMT "%s: "
 #  define EXTRA_ARG ,__FUNCTION__
-#else
+#endif
+
+#ifndef EXTRA_FMT
 #  define EXTRA_FMT
+#endif
+
+#ifndef EXTRA_ARG
 #  define EXTRA_ARG
 #endif
 


### PR DESCRIPTION

## Summary
let's can customize EXTRA_FMT to setting a tag for syslog.
## Impact
  using EXTRA_FMT as syslog tag, and it must be defined at first line of file.
## Testing
daily test.