### PR TITLE
spinlock.h: In single CPU case indicate that the lock is unused.

### DIFF
--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -389,7 +389,7 @@ void spin_clrbit(FAR volatile cpu_set_t *set, unsigned int cpu,
 #if defined(CONFIG_SMP)
 irqstate_t spin_lock_irqsave(spinlock_t *lock);
 #else
-#  define spin_lock_irqsave(l) up_irq_save()
+#  define spin_lock_irqsave(l) ((void)(l), up_irq_save())
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
In single CPU case indicate that the lock is unused.  This will avoids warnings and spreading the "unused" operation throughout the code base.
## Impact
N/A
## Testing
esp32-devkitc:wapi
esp32-devkitc:wapi_smp
