### PR TITLE
stm32*7/stm32_serial.c: Don't fake a TX interrupt when interrupts are not suppressed

### DIFF
--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -3336,6 +3336,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
 
       up_restoreusartint(priv, ie);
 
+#else
       /* Fake a TX interrupt here by just calling uart_xmitchars() with
        * interrupts disabled (note this may recurse).
        */

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -3531,6 +3531,7 @@ static void up_txint(struct uart_dev_s *dev, bool enable)
 
       up_restoreusartint(priv, ie);
 
+#else
       /* Fake a TX interrupt here by just calling uart_xmitchars() with
        * interrupts disabled (note this may recurse).
        */


### PR DESCRIPTION
## Summary
Don't fake a TX interrupt when interrupts are not suppressed. We have already enabled interrupts, we can just wait for the next TX interrupt.
## Impact
STM32*7 serial driver.
## Testing
see https://github.com/apache/incubator-nuttx/pull/4437