### PR TITLE
drivers/mmcsd: Add RPMB ioctl

### DIFF
--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -88,6 +88,7 @@
 #define _EFUSEBASE      (0x3000) /* Efuse device ioctl commands */
 #define _MTRIOBASE      (0x3100) /* Motor device ioctl commands */
 #define _MATHIOBASE     (0x3200) /* MATH device ioctl commands */
+#define _MMCSDIOBASE    (0x3300) /* MMCSD device ioctl commands */
 #define _WLIOCBASE      (0x8b00) /* Wireless modules ioctl network commands */
 
 /* boardctl() commands share the same number space */
@@ -558,6 +559,11 @@
 
 #define _MATHIOCVALID(c)    (_IOC_TYPE(c) == _MATHIOBASE)
 #define _MATHIOC(nr)        _IOC(_MATHIOBASE, nr)
+
+/* MMCSD drivers ************************************************************/
+
+#define _MMCSDIOCVALID(c)   (_IOC_TYPE(c) == _MMCSDIOBASE)
+#define _MMCSDIOC(nr)       _IOC(_MMCSDIOBASE, nr)
 
 /* Wireless driver network ioctl definitions ********************************/
 

--- a/include/nuttx/mmcsd.h
+++ b/include/nuttx/mmcsd.h
@@ -27,6 +27,47 @@
 
 #include <nuttx/config.h>
 
+#include <stdint.h>
+#include <nuttx/fs/ioctl.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* mmcsd ioctl */
+
+#define MMC_RPMB_TRANSFER       _MMCSDIOC(0x0000)
+
+/* rpmb request */
+
+#define MMC_RPMB_WRITE_KEY      0x01
+#define MMC_RPMB_READ_CNT       0x02
+#define MMC_RPMB_WRITE          0x03
+#define MMC_RPMB_READ           0x04
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct mmc_rpmb_frame_s
+{
+  uint8_t  stuff[196];
+  uint8_t  key_mac[32];
+  uint8_t  data[256];
+  uint8_t  nonce[16];
+  uint32_t write_counter;
+  uint16_t addr;
+  uint16_t block_count;
+  uint16_t result;
+  uint16_t req_resp;
+};
+
+struct mmc_rpmb_transfer_s
+{
+  unsigned int num_of_frames;
+  struct mmc_rpmb_frame_s frames[0];
+};
+
 /****************************************************************************
  * Public Functions Definitions
  ****************************************************************************/
@@ -76,8 +117,7 @@ int mmcsd_slotinitialize(int minor, FAR struct sdio_dev_s *dev);
  ****************************************************************************/
 
 struct spi_dev_s; /* See nuttx/spi/spi.h */
-int mmcsd_spislotinitialize(int minor,
-                            int slotno,
+int mmcsd_spislotinitialize(int minor, int slotno,
                             FAR struct spi_dev_s *spi);
 
 #undef EXTERN


### PR DESCRIPTION
## Summary
The similar ioctl exist on Linux mmc subsystem:
https://git.kernel.org/pub/scm/linux/kernel/git/cjb/mmc-utils-old.git/tree/mmc_cmds.c#n1862

## Impact
New IOCTL for RPMB

## Testing

