### PR TITLE
xtensa/irq.h: Fixes the routine that clears the processor interrupt

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -281,7 +281,9 @@ static inline void xtensa_intclear(uint32_t mask)
   __asm__ __volatile__
   (
     "wsr %0, INTCLEAR\n"
-    : "=r"(mask) : :
+    :
+    : "r"(mask)
+    :
   );
 }
 


### PR DESCRIPTION
## Summary
Some processor interrupts on xtensa need to be explicitly cleared, e.g, edge triggered interrupts.
 `xtensa_intclear` does this job.
This PR fixes this routine. The issue was not realized before because we still didn't use a processor
interrupt that required clearance on processor level, only on peripheral level.   

## Impact
Fixes a bug.

## Testing
Systimer support is under development and uses edge triggered interrupt. This fix allowed systimer to work properly.
P.S: Systimer is a timer peripheral present on Espressif newer chips.

