### PR TITLE
S32k1xx: added PM support

### DIFF
--- a/arch/arm/src/s32k1xx/Make.defs
+++ b/arch/arm/src/s32k1xx/Make.defs
@@ -93,7 +93,11 @@ ifeq ($(CONFIG_S32K1XX_EEEPROM),y)
 CHIP_CSRCS += s32k1xx_eeeprom.c
 endif
 
-ifeq ($(CONFIG_RESET_CAUSE_PROC_FS), y) 
+ifneq ($(CONFIG_ARCH_CUSTOM_PMINIT),y)
+CHIP_CSRCS += s32k1xx_pminitialize.c
+endif
+
+ifeq ($(CONFIG_RESET_CAUSE_PROC_FS), y)
 CHIP_CSRCS += s32k1xx_resetcause.c
 endif
 

--- a/arch/arm/src/s32k1xx/hardware/s32k1xx_pmc.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k1xx_pmc.h
@@ -63,6 +63,7 @@
 
 /* Regulator Status and Control Register */
 
+#define PMC_REGSC_BIASEN            (1 << 0)  /* Bit 0:  Bias Enable Bit */
 #define PMC_REGSC_CLKBIASDIS        (1 << 1)  /* Bit 1:  Clock Bias Disable Bit */
 #define PMC_REGSC_REGFPM            (1 << 2)  /* Bit 2:  Regulator in Full Performance Mode Status Bit */
 #define PMC_REGSC_LPOSTAT           (1 << 6)  /* Bit 6:  LPO Status Bit */

--- a/arch/arm/src/s32k1xx/hardware/s32k1xx_smc.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k1xx_smc.h
@@ -54,13 +54,12 @@
 
 /* SMC Version ID Register */
 
-#define SMC_VERID_FEATURE_SHIFT     (0)        /* Bits 0-15: Feature Identification Number */
+#define SMC_VERID_FEATURE_SHIFT     (0)                            /* Bits 0-15: Feature Identification Number */
 #define SMC_VERID_FEATURE_MASK      (0xffff << SMC_VERID_FEATURE_SHIFT)
 #  define SMC_VERID_FEATURE_STD     (1 << SMC_VERID_FEATURE_SHIFT) /* Standard feature set */
-
-#define SMC_VERID_MINOR_SHIFT       (16)       /* Bits 16-23: Minor Version Number */
+#define SMC_VERID_MINOR_SHIFT       (16)                           /* Bits 16-23: Minor Version Number */
 #define SMC_VERID_MINOR_MASK        (0xff << SMC_VERID_MINOR_SHIFT)
-#define SMC_VERID_MAJOR_SHIFT       (24)       /* Bits 24-31: Major Version Number */
+#define SMC_VERID_MAJOR_SHIFT       (24)                           /* Bits 24-31: Major Version Number */
 #define SMC_VERID_MAJOR_MASK        (0xff << SMC_VERID_MAJOR_SHIFT)
 
 /* SMC Parameter Register */
@@ -72,8 +71,10 @@
 
 /* SMC Power Mode Protection register */
 
-#define SMC_PMPROT_AVLP             (1 << 5)  /* Bit 5:  Allow Very-Low-Power Modes */
-#define SMC_PMPROT_AHSRUN           (1 << 7)  /* Bit 7:  Allow High Speed Run mode */
+#define SMC_PMPROT_AVLP_SHIFT       (5)  /* Bit 5:  Allow Very-Low-Power Modes */
+#define SMC_PMPROT_AVLP             (1 << SMC_PMPROT_AVLP_SHIFT)  
+#define SMC_PMPROT_AHSRUN_SHIFT     (7)  /* Bit 7:  Allow High Speed Run mode */
+#define SMC_PMPROT_AHSRUN           (1 << SMC_PMPROT_AHSRUN_SHIFT)  
 
 /* SMC Power Mode Control register */
 

--- a/arch/arm/src/s32k1xx/s32k1xx_clockconfig.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_clockconfig.h
@@ -440,6 +440,15 @@ struct clock_configuration_s
   struct pmc_config_s pmc;             /* PMC Clock configuration */
 };
 
+enum scg_system_clock_mode_e
+{
+  SCG_SYSTEM_CLOCK_MODE_CURRENT = 0,  /* Current mode. */
+  SCG_SYSTEM_CLOCK_MODE_RUN     = 1,  /* Run mode. */
+  SCG_SYSTEM_CLOCK_MODE_VLPR    = 2,  /* Very Low Power Run mode. */
+  SCG_SYSTEM_CLOCK_MODE_HSRUN   = 3,  /* High Speed Run mode. */
+  SCG_SYSTEM_CLOCK_MODE_NONE          /* MAX value. */
+};
+
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
@@ -462,6 +471,39 @@ extern "C"
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: s32k1xx_get_runmode
+ *
+ * Description:
+ *   Get the current running mode.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   The current running mode.
+ *
+ ****************************************************************************/
+
+enum scg_system_clock_mode_e s32k1xx_get_runmode(void);
+
+/****************************************************************************
+ * Name: s32k1xx_set_runmode
+ *
+ * Description:
+ *   Set the running mode.
+ *
+ * Input Parameters:
+ *   next_run_mode - The next running mode.
+ *
+ * Returned Value:
+ *   The current running mode.
+ *
+ ****************************************************************************/
+
+enum scg_system_clock_mode_e s32k1xx_set_runmode(enum scg_system_clock_mode_e
+  next_run_mode);
 
 /****************************************************************************
  * Name: s32k1xx_clockconfig

--- a/arch/arm/src/s32k1xx/s32k1xx_periphclocks.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_periphclocks.c
@@ -107,29 +107,6 @@ static uint32_t *s32k1xx_get_pclkctrl(enum clock_names_e clkname)
 }
 
 /****************************************************************************
- * Name: s32k1xx_pclk_disable
- *
- * Description:
- *   This function enables/disables the clock for a given peripheral.
- *
- * Input Parameters:
- *   clkname - The name of the peripheral clock to be disabled
- *   enable  - true:  Enable the peripheral clock.
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-static void s32k1xx_pclk_disable(enum clock_names_e clkname)
-{
-  uint32_t *ctrlp = s32k1xx_get_pclkctrl(clkname);
-  DEBUGASSERT(ctrlp != NULL);
-
-  *ctrlp &= ~PCC_CGC;
-}
-
-/****************************************************************************
  * Name: s32k1xx_set_pclkctrl
  *
  * Description:
@@ -279,7 +256,7 @@ void s32k1xx_periphclocks(unsigned int count,
     {
       /* Disable the peripheral clock */
 
-      s32k1xx_pclk_disable(pclks->clkname);
+      s32k1xx_pclk_enable(pclks->clkname, false);
 
       /* Set peripheral clock control */
 
@@ -397,4 +374,40 @@ int s32k1xx_get_pclkfreq(enum clock_names_e clkname, uint32_t *frequency)
     }
 
   return ret;
+}
+
+/****************************************************************************
+ * Name: s32k1xx_pclk_enable
+ *
+ * Description:
+ *   This function enables/disables the clock for a given peripheral.
+ *
+ * Input Parameters:
+ *   clkname - The name of the peripheral clock to be disabled
+ *   enable  - true:  Enable the peripheral clock.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void s32k1xx_pclk_enable(enum clock_names_e clkname, bool enable)
+{
+  uint32_t *ctrlp = s32k1xx_get_pclkctrl(clkname);
+  DEBUGASSERT(ctrlp != NULL);
+
+  /* check if it needs to be enabled */
+
+  if (enable)
+    {
+      /* enable it */
+
+      *ctrlp |= PCC_CGC;
+    }
+  else
+    {
+      /* disable it */
+
+      *ctrlp &= ~PCC_CGC;
+    }
 }

--- a/arch/arm/src/s32k1xx/s32k1xx_periphclocks.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_periphclocks.h
@@ -267,6 +267,23 @@ void s32k1xx_periphclocks(unsigned int count,
 
 int s32k1xx_get_pclkfreq(enum clock_names_e clkname, uint32_t *frequency);
 
+/****************************************************************************
+ * Name: s32k1xx_pclk_enable
+ *
+ * Description:
+ *   This function enables/disables the clock for a given peripheral.
+ *
+ * Input Parameters:
+ *   clkname - The name of the peripheral clock to be disabled
+ *   enable  - true:  Enable the peripheral clock.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void s32k1xx_pclk_enable(enum clock_names_e clkname, bool enable);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/arch/arm/src/s32k1xx/s32k1xx_pminitialize.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_pminitialize.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * arch/arm/src/s32k1xx/s32k1xx_pminitialize.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/power/pm.h>
+
+#include "arm_internal.h"
+
+#ifdef CONFIG_PM
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm_pminitialize
+ *
+ * Description:
+ *   This function is called by MCU-specific logic at power-on reset in
+ *   order to provide one-time initialization the power management subsystem.
+ *   This function must be called *very* early in the initialization sequence
+ *   *before* any other device drivers are initialized (since they may
+ *   attempt to register with the power management subsystem).
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void arm_pminitialize(void)
+{
+  /* Then initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+}
+
+#endif /* CONFIG_PM */


### PR DESCRIPTION
## Summary
Added PM support for the S32K1xx, in this case for MCU clocks/modes, UART (serial) and the LPSPI, could later be extended for other peripherals as well if needed. 

## Impact
Minimal, only extended the peripherals with the PM. 

## Testing
Tested on RDDRONE-BMS772, MCU mode switch, clock switch, UART clock switch, separate LPSPI bus clock switch works.
