### PR TITLE
arch/arm: correct the function name from arm_getsp() to up_getsp()

### DIFF
--- a/arch/arm/src/armv6-m/arm_backtrace.c
+++ b/arch/arm/src/armv6-m/arm_backtrace.c
@@ -460,7 +460,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
     {
       if (up_interrupt_context())
         {
-          sp = (FAR void *)arm_getsp();
+          sp = (FAR void *)up_getsp();
 
           ret = backtrace_push(rtcb->stack_base_ptr +
                                rtcb->adj_stack_size,
@@ -477,7 +477,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
         }
       else
         {
-          sp = (FAR void *)arm_getsp();
+          sp = (FAR void *)up_getsp();
           ret = backtrace_push(rtcb->stack_base_ptr +
                                rtcb->adj_stack_size, &sp,
                                (FAR void *)up_backtrace + 10,

--- a/arch/arm/src/armv7-m/arm_backtrace.c
+++ b/arch/arm/src/armv7-m/arm_backtrace.c
@@ -460,7 +460,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
     {
       if (up_interrupt_context())
         {
-          sp = (FAR void *)arm_getsp();
+          sp = (FAR void *)up_getsp();
 
           ret = backtrace_push(rtcb->stack_base_ptr +
                                rtcb->adj_stack_size,
@@ -477,7 +477,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
         }
       else
         {
-          sp = (FAR void *)arm_getsp();
+          sp = (FAR void *)up_getsp();
           ret = backtrace_push(rtcb->stack_base_ptr +
                                rtcb->adj_stack_size, &sp,
                                (FAR void *)up_backtrace + 10,

--- a/arch/arm/src/armv8-m/arm_backtrace.c
+++ b/arch/arm/src/armv8-m/arm_backtrace.c
@@ -460,7 +460,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
     {
       if (up_interrupt_context())
         {
-          sp = (FAR void *)arm_getsp();
+          sp = (FAR void *)up_getsp();
 
           ret = backtrace_push(rtcb->stack_base_ptr +
                                rtcb->adj_stack_size,
@@ -477,7 +477,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
         }
       else
         {
-          sp = (FAR void *)arm_getsp();
+          sp = (FAR void *)up_getsp();
           ret = backtrace_push(rtcb->stack_base_ptr +
                                rtcb->adj_stack_size, &sp,
                                (FAR void *)up_backtrace + 10,


### PR DESCRIPTION
## Summary

arch/arm: correct the function name from arm_getsp() to up_getsp()

## Impact

N/A

## Testing

compile pass