### PR TITLE
arch:xtensa: add full bactrace support

### DIFF
--- a/arch/xtensa/include/arch.h
+++ b/arch/xtensa/include/arch.h
@@ -47,6 +47,7 @@
  * Name: up_getsp
  ****************************************************************************/
 
+static inline uint32_t up_getsp(void) inline_function;
 static inline uint32_t up_getsp(void)
 {
   register uint32_t sp;

--- a/arch/xtensa/include/xtensa/core.h
+++ b/arch/xtensa/include/xtensa/core.h
@@ -71,6 +71,12 @@
 #  define XCHAL_SEP2                    },{
 #endif
 
+/* WSBITS and WBBITS are the width of the WINDOWSTART and WINDOWBASE
+ * registers
+ */
+#define WSBITS  (XCHAL_NUM_AREGS / 4)      /* width of WINDOWSTART in bits */
+#define WBBITS  (XCHAL_NUM_AREGS_LOG2 - 2) /* width of WINDOWBASE in bits */
+
 /* ISA **********************************************************************/
 
 #if XCHAL_HAVE_BE

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -1,0 +1,287 @@
+/****************************************************************************
+ * arch/xtensa/src/common/xtensa_backtrace.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
+#include <arch/irq.h>
+#include <arch/xtensa/core.h>
+
+#include "sched/sched.h"
+#include "xtensa.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Convert return address to a valid pc  */
+
+#define MAKE_PC_FROM_RA(ra)    ((ra) & 0x3fffffff)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+#ifndef __XTENSA_CALL0_ABI__
+struct xtensa_windowregs_s
+{
+  uint32_t windowbase;
+  uint32_t windowstart;
+  uint32_t areg[16];
+};
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: get_window_regs
+ *
+ * Description:
+ *  getfp() returns current frame pointer
+ *
+ ****************************************************************************/
+
+#ifndef __XTENSA_CALL0_ABI__
+static void get_window_regs(struct xtensa_windowregs_s *frame)
+inline_function
+{
+  __asm__ __volatile__("\trsr %0, WINDOWSTART\n": "=r"(frame->windowstart));
+  __asm__ __volatile__("\trsr %0, WINDOWBASE\n": "=r"(frame->windowbase));
+
+  __asm__ __volatile__("\tmov %0, a0\n": "=r"(frame->areg[0]));
+  __asm__ __volatile__("\tmov %0, a1\n": "=r"(frame->areg[1]));
+  __asm__ __volatile__("\tmov %0, a2\n": "=r"(frame->areg[2]));
+  __asm__ __volatile__("\tmov %0, a3\n": "=r"(frame->areg[3]));
+  __asm__ __volatile__("\tmov %0, a4\n": "=r"(frame->areg[4]));
+  __asm__ __volatile__("\tmov %0, a5\n": "=r"(frame->areg[5]));
+  __asm__ __volatile__("\tmov %0, a6\n": "=r"(frame->areg[6]));
+  __asm__ __volatile__("\tmov %0, a7\n": "=r"(frame->areg[7]));
+  __asm__ __volatile__("\tmov %0, a8\n": "=r"(frame->areg[8]));
+  __asm__ __volatile__("\tmov %0, a9\n": "=r"(frame->areg[9]));
+  __asm__ __volatile__("\tmov %0, a10\n": "=r"(frame->areg[10]));
+  __asm__ __volatile__("\tmov %0, a11\n": "=r"(frame->areg[11]));
+  __asm__ __volatile__("\tmov %0, a12\n": "=r"(frame->areg[12]));
+  __asm__ __volatile__("\tmov %0, a13\n": "=r"(frame->areg[13]));
+  __asm__ __volatile__("\tmov %0, a14\n": "=r"(frame->areg[14]));
+  __asm__ __volatile__("\tmov %0, a15\n": "=r"(frame->areg[15]));
+}
+#endif
+
+/****************************************************************************
+ * Name: backtrace_window
+ *
+ * Description:
+ *  backtrace_window() parsing the return address in register window
+ *
+ ****************************************************************************/
+
+#ifndef __XTENSA_CALL0_ABI__
+static int backtrace_window(FAR uintptr_t *base, FAR uintptr_t *limit,
+                     struct xtensa_windowregs_s *frame,
+                     FAR void **buffer, int size)
+{
+  uint32_t windowstart;
+  uint32_t ra;
+  uint32_t sp;
+  int index;
+  int i;
+
+  /* Rotate WINDOWSTART to move the bit corresponding to
+   * the current window to the bit #0
+   */
+
+  windowstart = (frame->windowstart << WSBITS | frame->windowstart) >>
+        frame->windowbase;
+
+  /* Look for bits that are set, they correspond to valid windows. */
+
+  for (i = 0, index = WSBITS - 1; (index > 0) && (i < size); index--)
+    {
+      if (windowstart & (1 << index))
+        {
+          ra = frame->areg[index * 4];
+          sp = frame->areg[index * 4 + 1];
+
+          if (sp > limit || sp < base || ra == 0)
+            {
+              continue;
+            }
+
+          buffer[i++] = MAKE_PC_FROM_RA(ra);
+        }
+    }
+
+  return i;
+}
+#endif
+
+/****************************************************************************
+ * Name: backtrace_stack
+ *
+ * Description:
+ * backtrace_stack() parsing the return address in stack
+ *
+ ****************************************************************************/
+
+static int backtrace_stack(FAR uintptr_t *base, FAR uintptr_t *limit,
+                     FAR uintptr_t *sp, FAR uintptr_t *ra,
+                     FAR void **buffer, int size)
+{
+  int i = 0;
+
+  if (ra)
+    {
+      buffer[i++] = MAKE_PC_FROM_RA((uintptr_t)ra);
+    }
+
+  for (; i < size; sp = (FAR uintptr_t *)*(sp - 3), i++)
+    {
+      if (sp > limit || sp < base)
+        {
+          break;
+        }
+
+      ra = (FAR uintptr_t *)*(sp - 4);
+      if (ra == NULL)
+        {
+          break;
+        }
+
+      buffer[i] = MAKE_PC_FROM_RA((uintptr_t)ra);
+    }
+
+  return i;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_backtrace
+ *
+ * Description:
+ *  up_backtrace()  returns  a backtrace for the TCB, in the array
+ *  pointed to by buffer.  A backtrace is the series of currently active
+ *  function calls for the program.  Each item in the array pointed to by
+ *  buffer is of type void *, and is the return address from the
+ *  corresponding stack frame.  The size argument specifies the maximum
+ *  number of addresses that can be stored in buffer.   If  the backtrace is
+ *  larger than size, then the addresses corresponding to the size most
+ *  recent function calls are returned; to obtain the complete backtrace,
+ *  make sure that buffer and size are large enough.
+ *
+ * Input Parameters:
+ *   tcb    - Address of the task's TCB
+ *   buffer - Return address from the corresponding stack frame
+ *   size   - Maximum number of addresses that can be stored in buffer
+ *
+ * Returned Value:
+ *   up_backtrace() returns the number of addresses returned in buffer
+ *
+ ****************************************************************************/
+
+int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
+{
+  FAR struct tcb_s *rtcb = running_task();
+  irqstate_t flags;
+  int ret;
+
+  if (size <= 0 || !buffer)
+    {
+      return 0;
+    }
+
+  if (tcb == NULL || tcb == rtcb)
+    {
+      if (up_interrupt_context())
+        {
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+          uintptr_t istackbase;
+#ifdef CONFIG_SMP
+          istackbase = xtensa_intstack_alloc();
+#else
+          istackbase = &g_intstackalloc;
+#endif
+          ret = bactrace_stack((FAR void *)istackbase,
+                          (FAR void *)((uint32_t)&g_intstackalloc +
+                                       CONFIG_ARCH_INTERRUPTSTACK),
+                          (FAR void *)up_getsp(), NULL, buffer, size);
+#else
+          ret = backtrace_stack(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)up_getsp(), NULL, buffer, size);
+#endif
+          ret += backtrace_stack(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr +
+                          rtcb->adj_stack_size,
+                          (FAR void *)CURRENT_REGS[REG_A1],
+                          (FAR void *)CURRENT_REGS[REG_A0],
+                          &buffer[ret], size - ret);
+        }
+      else
+        {
+          /* Two steps for current task:
+           *
+           * 1. Look through the register window for the
+           * previous PCs in the call trace.
+           *
+           * 2. Look on the stack.
+           */
+
+#ifndef __XTENSA_CALL0_ABI__
+          static struct xtensa_windowregs_s frame;
+
+          xtensa_window_spill();
+
+          get_window_regs(&frame);
+
+          ret = backtrace_window(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          &frame, buffer, size);
+#endif
+          ret += backtrace_stack(rtcb->stack_base_ptr,
+                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                          (FAR void *)up_getsp(), NULL, buffer, size - ret);
+        }
+    }
+  else
+    {
+      /* For non-current task, only check in stack. */
+
+      flags = enter_critical_section();
+
+      ret = backtrace_stack(tcb->stack_base_ptr,
+                      tcb->stack_base_ptr + tcb->adj_stack_size,
+                      (FAR void *)tcb->xcp.regs[REG_A1],
+                      (FAR void *)tcb->xcp.regs[REG_A0],
+                      buffer, size);
+
+      leave_critical_section(flags);
+    }
+
+  return ret;
+}

--- a/arch/xtensa/src/common/xtensa_windowspill.S
+++ b/arch/xtensa/src/common/xtensa_windowspill.S
@@ -40,6 +40,7 @@
  ****************************************************************************/
 
 #include <arch/chip/core-isa.h>
+#include <arch/xtensa/core.h>
 #include <arch/xtensa/xtensa_specregs.h>
 #include <arch/xtensa/xtensa_corebits.h>
 
@@ -116,8 +117,6 @@ _xtensa_window_spill:
 	ret
 
 #else /* XCHAL_HAVE_WINDOWED */
-#  define WSBITS  (XCHAL_NUM_AREGS / 4)			/* Width of WINDOWSTART register in bits */
-#  define WBBITS  (XCHAL_NUM_AREGS_LOG2 - 2)	/* Width of WINDOWBASE register in bits */
 
 	/*
 	 * Rearrange (rotate) window start bits relative to the current


### PR DESCRIPTION
## Summary

Add for all tasks/interrupt backtrace support

1 backtrace in other task, backtrace from stack.
2 backtrace in current task, spill the register window, and backtrace from window and stack.
Follow the linux backtrace step.
https://github.com/jcmvbkbc/linux-xtensa/blob/master/arch/xtensa/kernel/stacktrace.c

## Impact

No

## Testing

**1. bactrace on the interrupt**

```
diff --git a/examples/hello/hello_main.c b/examples/hello/hello_main.c
index 2cd6cb400..9db692fdb 100644
--- a/examples/hello/hello_main.c
+++ b/examples/hello/hello_main.c
@@ -36,5 +36,8 @@
 int main(int argc, FAR char *argv[])
 {
   printf("Hello, World!!\n");
+
+  *(unsigned int *)(0xffffaaaa) = 0x12345678;
+
   return 0;
 }
```
```
nsh> hello
Hello, World!!
xtensa_user_panic: User Exception: EXCCAUSE=0009 task: hello
xtensa_registerdump:    PC: 202b32b8    PS: 00060030
xtensa_registerdump:    A0: a02acb87    A1: 20998d10    A2: ffffaaaa    A3: 12345678
xtensa_registerdump:    A4: a02ba26c    A5: 209949c0    A6: 20990994    A7: 00000258
xtensa_registerdump:    A8: a02b32af    A9: 20998cb0   A10: 0000000f   A11: 209949a0
xtensa_registerdump:   A12: a02be95c   A13: 20994980   A14: 00000003   A15: 209949d0
xtensa_registerdump:   SAR: 00000000 CAUSE: 00000009 VADDR: ffffaaaa
xtensa_registerdump:  LBEG: 00000000  LEND: 00000000  LCNT: 00000000
xtensa_registerdump:  TMP0: 202b1512  TMP1: 20998af0
sched_dumpstack: [BackTrace| 3|0]:  0x202acbae 0x202b232e 0x202b1912 0x202b19f5 0x202b24f1 0x202b152f    0x40023 0x202b32b0
sched_dumpstack: [BackTrace| 3|1]:  0x202acb87 0x202a86a4
xtensa_dumpstate: sp:         20998a20
xtensa_dumpstate: stack base: 20994cf0
xtensa_dumpstate: stack size: 000040b0
xtensa_stackdump: 20998a20: 20994ce0 20998a10 0000000f 000040b0 20994cf0 20998a20 2098c7a0 20998a20
xtensa_stackdump: 20998a40: 000040b0 20998a70 20998980 00000004 a02b24f1 20998a90 20998af0 202cee0c
xtensa_stackdump: 20998a60: 5000b000 0000000a 2098c974 00000000 5000b000 0000000a 0000011e 00000000
xtensa_stackdump: 20998a80: 602b152f 20998ac0 00000009 20998af0 a02af1bc 20998ae0 20998af0 00000009

$ xt-addr2line -e nuttx/nuttx 0x202acbae 0x202b232e 0x202b1912 0x202b19f5 0x202b24f1 0x202b152f    0x40023 0x202b32b0 0x202acb87 0x202a86a4
/home/zyl/bes2003/nuttx/libs/libc/sched/sched_dumpstack.c:63
/home/zyl/bes2003/nuttx/arch/xtensa/src/common/xtensa_dumpstate.c:298
/home/zyl/bes2003/nuttx/arch/xtensa/src/common/xtensa_assert.c:109
/home/zyl/bes2003/nuttx/arch/xtensa/src/common/xtensa_assert.c:309
??:?
/home/zyl/bes2003/nuttx/arch/xtensa/src/common/xtensa_user_handler.S:258
??:0
/home/zyl/bes2003/apps/examples/hello/hello_main.c:40
/home/zyl/bes2003/nuttx/libs/libc/sched/task_startup.c:151
/home/zyl/bes2003/nuttx/sched/task/task_start.c:130
```


 **2 backtrace on current task**
```
diff --git a/examples/hello/hello_main.c b/examples/hello/hello_main.c
index 2cd6cb400..f4a0dafae 100644
--- a/examples/hello/hello_main.c
+++ b/examples/hello/hello_main.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 #include <stdio.h>
+#include <execinfo.h>
 
 /****************************************************************************
  * Public Functions
@@ -36,5 +37,7 @@
 int main(int argc, FAR char *argv[])
 {
   printf("Hello, World!!\n");
+  dump_stack();
+
   return 0;
 }
```
```
nsh> hello
Hello, World!!
[BackTrace| 3|0]:  0x202acd6c 0x202b36b0 0x202acd4f 0x202a86cc
up_exit: TCB=0x2098c820 exiting
$ xt-addr2line -e nuttx/nuttx 0x202acd6c 0x202b36b0 0x202acd4f 0x202a86cc
/home/zyl/bes2003/nuttx/libs/libc/sched/sched_dumpstack.c:60
/home/zyl/bes2003/apps/examples/hello/hello_main.c:42
/home/zyl/bes2003/nuttx/libs/libc/sched/task_startup.c:151
/home/zyl/bes2003/nuttx/sched/task/task_start.c:130
```


**3 backtrace  other task**
```
nsh> ps
  PID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK COMMAND
- Ready              00000000 016352 Idle Task
    2 100 RR       Task    --- Running            00000000 016560 init

nsh> dumpstack 2
[BackTrace| 2|0]:  0x202b1ce4 0x202a6569 0x202a627b 0x202a62e4 0x202bed54 0x202ba664 0x202b9c26 0x202b983f
[BackTrace| 2|1]:  0x202be814 0x202bf1be 0x202b3c4a 0x202acd4b 0x202a86c8
up_exit: TCB=0x2098c810 exiting
```
```
$ xt-addr2line -e nuttx/nuttx 0x202b1ce4 0x202a6569 0x202a627b 0x202a62e4 0x202bed54 0x202ba664 0x202b9c26 0x202b983f 0x202be814 0x202bf1be 0x202b3c4a 0x202acd4b 0x202a86c8
/home/zyl/bes2003/nuttx/arch/xtensa/src/common/xtensa_blocktask.c:134
/home/zyl/bes2003/nuttx/sched/semaphore/sem_wait.c:185
/home/zyl/bes2003/nuttx/sched/sched/sched_waitpid.c:129
/home/zyl/bes2003/nuttx/sched/sched/sched_waitpid.c:593
/home/zyl/bes2003/apps/nshlib/nsh_builtin.c:160
/home/zyl/bes2003/apps/nshlib/nsh_parse.c:528
/home/zyl/bes2003/apps/nshlib/nsh_parse.c:2578
/home/zyl/bes2003/apps/nshlib/nsh_parse.c:2662
/home/zyl/bes2003/apps/nshlib/nsh_session.c:219
/home/zyl/bes2003/apps/nshlib/nsh_consolemain.c:100
/home/zyl/bes2003/apps/system/nsh/nsh_main.c:153
/home/zyl/bes2003/nuttx/libs/libc/sched/task_startup.c:151
/home/zyl/bes2003/nuttx/sched/task/task_start.c:130
```
