### PR TITLE
Kconfig: Enable logging for Segment LCD devices

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1140,7 +1140,7 @@ comment "Driver Debug Options"
 config DEBUG_LCD
 	bool "Low-level LCD Debug Features"
 	default n
-	depends on LCD
+	depends on LCD || SLCD
 	---help---
 		Enable LCD driver debug features.
 


### PR DESCRIPTION
## Summary
This PR intends to enable logging for Segment LCD devices.
Currently `SLCD` was missing as a dependency of `DEBUG_LCD` on Kconfig.
 
## Impact
Only for defconfigs that enable `SLCD`.

## Testing
`esp32-wrover-kit:lcd1602`

