### PR TITLE
[ESP32][ESP32-C3] Reduce the 10 second semaphore timeout on I2C

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -375,6 +375,14 @@ config ESP32C3_I2C0_SDAPIN
 
 endif # ESP32C3_I2C0
 
+config ESP32C3_I2CTIMEOSEC
+	int "Timeout seconds"
+	default 0
+
+config ESP32C3_I2CTIMEOMS
+	int "Timeout milliseconds"
+	default 500
+
 endmenu # I2C configuration
 
 menu "SPI configuration"

--- a/arch/risc-v/src/esp32c3/esp32c3_i2c.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_i2c.c
@@ -799,8 +799,18 @@ static int esp32c3_i2c_sem_waitdone(struct esp32c3_i2c_priv_s *priv)
 
   clock_gettime(CLOCK_REALTIME, &abstime);
 
-  abstime.tv_sec += 10;
-  abstime.tv_nsec += 0;
+#if CONFIG_ESP32C3_I2CTIMEOSEC > 0
+  abstime.tv_sec += CONFIG_ESP32C3_I2CTIMEOSEC;
+#endif
+
+#if CONFIG_ESP32C3_I2CTIMEOMS > 0
+  abstime.tv_nsec += CONFIG_ESP32C3_I2CTIMEOMS * NSEC_PER_MSEC;
+  if (abstime.tv_nsec >= 1000 * NSEC_PER_MSEC)
+    {
+      abstime.tv_sec++;
+      abstime.tv_nsec -= 1000 * NSEC_PER_MSEC;
+    }
+#endif
 
   ret = nxsem_timedwait_uninterruptible(&priv->sem_isr, &abstime);
 

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -728,6 +728,14 @@ config ESP32_I2C1_SDAPIN
 
 endif # ESP32_I2C1
 
+config ESP32_I2CTIMEOSEC
+	int "Timeout seconds"
+	default 0
+
+config ESP32_I2CTIMEOMS
+	int "Timeout milliseconds"
+	default 500
+
 endmenu # I2C configuration
 
 menu "SPI configuration"

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -727,8 +727,18 @@ static int esp32_i2c_sem_waitdone(FAR struct esp32_i2c_priv_s *priv)
 
   clock_gettime(CLOCK_REALTIME, &abstime);
 
-  abstime.tv_sec += 10;
-  abstime.tv_nsec += 0;
+#if CONFIG_ESP32_I2CTIMEOSEC > 0
+  abstime.tv_sec += CONFIG_ESP32_I2CTIMEOSEC;
+#endif
+
+#if CONFIG_ESP32_I2CTIMEOMS > 0
+  abstime.tv_nsec += CONFIG_ESP32_I2CTIMEOMS * NSEC_PER_MSEC;
+  if (abstime.tv_nsec >= 1000 * NSEC_PER_MSEC)
+    {
+      abstime.tv_sec++;
+      abstime.tv_nsec -= 1000 * NSEC_PER_MSEC;
+    }
+#endif
 
   /* Wait on ISR semaphore */
 


### PR DESCRIPTION
## Summary
This PR intends to reduce the 10 seconds semaphore timeout on the I2C drivers of ESP32 and ESP32-C3.

## Impact
ESP32 and ESP32-C3 configs using the I2C controller.

## Testing
`esp32-wrover-kit:lcd1602`
