### PR TITLE
build.yml: Add "GlobalSign Root CA - R3" to trusted Root CAs for macOS CI runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,8 @@ jobs:
           export CCACHE_DIR=`pwd`/ccache
           mkdir $CCACHE_DIR
           export ARTIFACTDIR=`pwd`/buildartifacts
+          wget http://secure.globalsign.com/cacert/root-r3.crt
+          sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain root-r3.crt
           cd sources/nuttx/tools/ci
           ./cibuild.sh -i -A -c testlist/${{matrix.boards}}.dat
           ccache -s


### PR DESCRIPTION
## Summary
This PR intends to add "GlobalSign Root CA - R3" to the list of trusted CAs on the macOS CI runners.

This is needed for enabling secure download from `developer.arm.com` servers.

## Impact
Fix CI issue on macOS runners during the download of GNU Arm Toolchains:
![image](https://user-images.githubusercontent.com/38959758/133628959-08e24712-ad13-43d5-8a53-67aadab95f06.png)


## Testing
CI pass.
