### PR TITLE
bcm43xxx: added SDPCM frame pool size parameter

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/Kconfig
+++ b/drivers/wireless/ieee80211/bcm43xxx/Kconfig
@@ -109,4 +109,11 @@ config IEEE80211_BROADCOM_DMABUF_ALIGNMENT
 		This parameter should be set depending on
 		the used SOC DMA configuration.
 
+config IEEE80211_BROADCOM_FRAME_POOL_SIZE
+	int "SDPCM frame pool size"
+	default 8
+	---help---
+		This parameter sets the size of the shared SDPCM frame pool
+		used for both RX and TX transfers.
+
 endif # IEEE80211_BROADCOM_FULLMAC

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -116,7 +116,8 @@ FAR struct bcmf_dev_s *g_sdio_priv;
  * This pool is shared between all driver devices
  */
 
-static struct bcmf_sdio_frame g_pktframes[BCMF_PKT_POOL_SIZE];
+static struct bcmf_sdio_frame
+  g_pktframes[CONFIG_IEEE80211_BROADCOM_FRAME_POOL_SIZE];
 
 /* TODO free_queue should be static */
 
@@ -664,7 +665,7 @@ int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
 
   /* FIXME this should be static to driver */
 
-  for (ret = 0; ret < BCMF_PKT_POOL_SIZE; ret++)
+  for (ret = 0; ret < CONFIG_IEEE80211_BROADCOM_FRAME_POOL_SIZE; ret++)
     {
       bcmf_dqueue_push(&sbus->free_queue, &g_pktframes[ret].list_entry);
     }
@@ -931,7 +932,9 @@ struct bcmf_sdio_frame *bcmf_sdio_allocate_frame(FAR struct bcmf_dev_s *priv,
         }
 
 #if 0
-      if (!tx || sbus->tx_queue_count < BCMF_PKT_POOL_SIZE - 1)
+      if (!tx ||
+          sbus->tx_queue_count <
+            CONFIG_IEEE80211_BROADCOM_FRAME_POOL_SIZE - 1)
 #endif
         {
           if ((entry = bcmf_dqueue_pop_tail(&sbus->free_queue)) != NULL)

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.h
@@ -44,10 +44,6 @@
 #define HEADER_SIZE        0x12 /* Default sdpcm + bdc header size */
 #define FIRST_WORD_SIZE    4
 
-/* TODO move to Kconfig */
-
-#define BCMF_PKT_POOL_SIZE 4    /* Frame pool size */
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Added SDPCM frame pool size parameter to Kconfig.

Also I have set it to 8 instead of 4 by default because there were many "alloc failed" messages in debug log even during initialization / automatic IP address assignment via DHCP negotiation.

## Impact

bcm43xxx driver
Photon board
EMW3162 board