### PR TITLE
drivers/syslog: Call up_puts in syslog_default_write instad up_putc

### DIFF
--- a/arch/arm/src/c5471/Make.defs
+++ b/arch/arm/src/c5471/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_exit.c arm_initialize.c arm_initialstate.c arm_interruptcontext
 CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_stackframe.c arm_syscall.c arm_unblocktask.c arm_undefinedinsn.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c arm_puts.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -32,7 +32,7 @@ CMN_CSRCS += arm_memfault.c arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
-CMN_CSRCS += arm_svcall.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_svcall.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/dm320/Make.defs
+++ b/arch/arm/src/dm320/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_initialize.c arm_initialstate.c arm_interruptcontext.c
 CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_syscall.c arm_unblocktask.c
-CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c
+CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c arm_puts.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/efm32/Make.defs
+++ b/arch/arm/src/efm32/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
 CMN_CSRCS += arm_trigger_irq.c arm_udelay.c arm_unblocktask.c arm_usestack.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/eoss3/Make.defs
+++ b/arch/arm/src/eoss3/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
 CMN_CSRCS += arm_trigger_irq.c arm_udelay.c arm_unblocktask.c arm_usestack.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/imx1/Make.defs
+++ b/arch/arm/src/imx1/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_initialize.c arm_initialstate.c arm_interruptcontext.c
 CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_syscall.c arm_unblocktask.c
-CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c
+CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c arm_puts.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -31,7 +31,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_vfork.c arm_trigger_irq.c arm_systemreset.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_releasepending.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_unblocktask.c arm_usestack.c
 CMN_CSRCS += arm_doirq.c arm_hardfault.c arm_svcall.c arm_vfork.c
-CMN_CSRCS += arm_systemreset.c arm_trigger_irq.c arm_switchcontext.c
+CMN_CSRCS += arm_systemreset.c arm_trigger_irq.c arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -29,6 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_systemreset.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_vfork.c arm_trigger_irq.c arm_switchcontext.c
+CMN_CSRCS += arm_puts.c
 
 # CMN_CSRCS += up_dwt.c
 

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -31,7 +31,7 @@ CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_trigger_irq.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_checkstack.c arm_vfork.c arm_switchcontext.c
-CMN_CSRCS += arm_systemreset.c
+CMN_CSRCS += arm_systemreset.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c

--- a/arch/arm/src/lpc214x/Make.defs
+++ b/arch/arm/src/lpc214x/Make.defs
@@ -30,7 +30,7 @@ CMN_CSRCS += arm_interruptcontext.c arm_prefetchabort.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_stackframe.c
 CMN_CSRCS += arm_syscall.c arm_unblocktask.c arm_undefinedinsn.c arm_usestack.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c
-CMN_CSRCS += arm_lowputs.c arm_vfork.c
+CMN_CSRCS += arm_lowputs.c arm_vfork.c arm_puts.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/lpc2378/Make.defs
+++ b/arch/arm/src/lpc2378/Make.defs
@@ -49,7 +49,7 @@ CMN_CSRCS += arm_interruptcontext.c arm_prefetchabort.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_stackframe.c
 CMN_CSRCS += arm_syscall.c arm_unblocktask.c arm_undefinedinsn.c
 CMN_CSRCS += arm_usestack.c arm_lowputs.c arm_vfork.c
-CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c
+CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_puts.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/lpc31xx/Make.defs
+++ b/arch/arm/src/lpc31xx/Make.defs
@@ -30,7 +30,7 @@ CMN_CSRCS += arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_syscall.c arm_unblocktask.c
-CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c
+CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c arm_puts.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_memfault.c arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_memfault.c arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/max326xx/Make.defs
+++ b/arch/arm/src/max326xx/Make.defs
@@ -31,6 +31,7 @@ CMN_CSRCS += arm_modifyreg32.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_stackframe.c arm_svcall.c arm_trigger_irq.c arm_unblocktask.c
 CMN_CSRCS += arm_udelay.c arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/moxart/Make.defs
+++ b/arch/arm/src/moxart/Make.defs
@@ -47,6 +47,7 @@ CMN_CSRCS += arm_interruptcontext.c arm_prefetchabort.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_syscall.c arm_unblocktask.c
 CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c arm_etherstub.c
+CMN_CSRCS += arm_puts.c
 
 CHIP_ASRCS  = moxart_lowputc.S
 

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_modifyreg32.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_stackframe.c arm_svcall.c arm_trigger_irq.c arm_udelay.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_vfork.c arm_systemreset.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_NRF52_SYSTIMER_SYSTICK),y)
 CMN_CSRCS += arm_systick.c nrf52_systick.c

--- a/arch/arm/src/nuc1xx/Make.defs
+++ b/arch/arm/src/nuc1xx/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CMN_CSRCS += arm_task_start.c arm_pthread_start.c

--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += arm_ramvec_initialize.c arm_ramvec_attach.c

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -32,7 +32,7 @@ CMN_CSRCS += arm_memfault.c arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifneq ($(CONFIG_SMP),y)
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)

--- a/arch/arm/src/samd2l2/Make.defs
+++ b/arch/arm/src/samd2l2/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CMN_CSRCS += arm_task_start.c arm_pthread_start.c

--- a/arch/arm/src/samd5e5/Make.defs
+++ b/arch/arm/src/samd5e5/Make.defs
@@ -32,7 +32,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_trigger_irq.c
 CMN_CSRCS += arm_unblocktask.c arm_udelay.c arm_usestack.c arm_doirq.c
-CMN_CSRCS += arm_hardfault.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_hardfault.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += arm_memfault.c arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
 CMN_CSRCS += arm_trigger_irq.c arm_unblocktask.c arm_udelay.c arm_usestack.c
-CMN_CSRCS += arm_doirq.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_doirq.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_STM32_TICKLESS_SYSTICK),y)
 CMN_CSRCS += arm_systick.c

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += arm_memfault.c arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_systemreset.c arm_trigger_irq.c arm_unblocktask.c
-CMN_CSRCS += arm_udelay.c arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_udelay.c arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c arm_svcall.c
 CMN_CSRCS += arm_systemreset.c arm_trigger_irq.c arm_udelay.c arm_unblocktask.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -34,6 +34,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_systemreset.c arm_trigger_irq.c arm_udelay.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_puts.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/stm32l5/Make.defs
+++ b/arch/arm/src/stm32l5/Make.defs
@@ -39,6 +39,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_systemreset.c arm_trigger_irq.c arm_udelay.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_puts.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/str71x/Make.defs
+++ b/arch/arm/src/str71x/Make.defs
@@ -30,7 +30,7 @@ CMN_CSRCS += arm_interruptcontext.c arm_prefetchabort.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_stackframe.c
 CMN_CSRCS += arm_syscall.c arm_unblocktask.c arm_undefinedinsn.c arm_usestack.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c
-CMN_CSRCS += arm_lowputs.c arm_vfork.c
+CMN_CSRCS += arm_lowputs.c arm_vfork.c arm_puts.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_memfault.c arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARM_SEMIHOSTING_HOSTFS),y)
   CMN_CSRCS += arm_hostfs.c

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_releasepending.c arm_sigdeliver.c arm_stackframe.c arm_svcall.c
 CMN_CSRCS += arm_systemreset.c arm_udelay.c arm_unblocktask.c arm_usestack.c
-CMN_CSRCS += arm_vfork.c arm_switchcontext.c
+CMN_CSRCS += arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c

--- a/arch/avr/src/at32uc3/Make.defs
+++ b/arch/avr/src/at32uc3/Make.defs
@@ -31,7 +31,7 @@ CMN_CSRCS += up_initialize.c up_initialstate.c up_interruptcontext.c
 CMN_CSRCS += up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
 CMN_CSRCS += up_releasepending.c up_releasestack.c up_reprioritizertr.c
 CMN_CSRCS += up_schedulesigaction.c up_sigdeliver.c up_stackframe.c
-CMN_CSRCS += up_unblocktask.c up_usestack.c up_doirq.c
+CMN_CSRCS += up_unblocktask.c up_usestack.c up_doirq.c up_puts.c
 
 # Configuration-dependent common files
 

--- a/arch/or1k/src/mor1kx/Make.defs
+++ b/arch/or1k/src/mor1kx/Make.defs
@@ -42,6 +42,7 @@ CMN_CSRCS  = up_initialize.c \
              up_mdelay.c \
              up_idle.c \
              up_irq.c \
+             up_puts.c \
              up_uart.c \
              up_timer.c \
              up_doirq.c \

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -200,7 +200,6 @@ void riscv_pminitialize(void);
 /* Low level serial output **************************************************/
 
 void riscv_lowputc(char ch);
-void riscv_puts(const char *str);
 void riscv_lowputs(const char *str);
 
 #ifdef USE_SERIALDRIVER

--- a/arch/risc-v/src/common/riscv_puts.c
+++ b/arch/risc-v/src/common/riscv_puts.c
@@ -32,14 +32,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: riscv_puts
+ * Name: up_puts
  *
  * Description:
  *   This is a low-level helper function used to support debug.
  *
  ****************************************************************************/
 
-void riscv_puts(const char *str)
+void up_puts(const char *str)
 {
   while (*str)
     {

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -57,7 +57,7 @@ CSRCS  = up_initialize.c up_idle.c up_interruptcontext.c up_initialstate.c
 CSRCS += up_createstack.c up_usestack.c up_releasestack.c up_stackframe.c
 CSRCS += up_unblocktask.c up_blocktask.c up_releasepending.c
 CSRCS += up_reprioritizertr.c up_exit.c up_schedulesigaction.c
-CSRCS += up_heap.c up_uart.c up_assert.c
+CSRCS += up_heap.c up_uart.c up_assert.c up_puts.c
 CSRCS += up_copyfullstate.c
 CSRCS += up_sigdeliver.c
 

--- a/arch/sim/src/sim/up_puts.c
+++ b/arch/sim/src/sim/up_puts.c
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_puts.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
+#include "up_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_puts
+ *
+ * Description:
+ *   This is a low-level helper function used to support debug.
+ *
+ ****************************************************************************/
+
+void up_puts(const char *str)
+{
+  while (*str)
+    {
+      up_putc(*str++);
+    }
+}

--- a/arch/x86/src/qemu/Make.defs
+++ b/arch/x86/src/qemu/Make.defs
@@ -32,7 +32,7 @@ CMN_CSRCS += up_irq.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
 CMN_CSRCS += up_regdump.c up_releasepending.c up_releasestack.c
 CMN_CSRCS += up_reprioritizertr.c up_savestate.c up_sigdeliver.c
 CMN_CSRCS += up_schedulesigaction.c up_stackframe.c up_unblocktask.c
-CMN_CSRCS += up_usestack.c
+CMN_CSRCS += up_usestack.c up_puts.c
 
 # Required QEMU files
 

--- a/arch/x86_64/src/intel64/Make.defs
+++ b/arch/x86_64/src/intel64/Make.defs
@@ -27,7 +27,7 @@ CMN_CSRCS += up_irq.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
 CMN_CSRCS += up_regdump.c up_releasepending.c up_releasestack.c
 CMN_CSRCS += up_reprioritizertr.c up_savestate.c up_sigdeliver.c
 CMN_CSRCS += up_schedulesigaction.c up_stackframe.c up_unblocktask.c
-CMN_CSRCS += up_usestack.c
+CMN_CSRCS += up_usestack.c up_puts.c
 CMN_CSRCS += up_rtc.c
 CMN_CSRCS += up_map_region.c
 

--- a/arch/z16/src/common/z16_puts.c
+++ b/arch/z16/src/common/z16_puts.c
@@ -1,0 +1,46 @@
+/****************************************************************************
+ * arch/z16/src/common/z16_puts.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_puts
+ *
+ * Description:
+ *   This is a low-level helper function used to support debug.
+ *
+ ****************************************************************************/
+
+void up_puts(const char *str)
+{
+  while (*str)
+    {
+      up_putc(*str++);
+    }
+}

--- a/arch/z16/src/z16f/Make.defs
+++ b/arch/z16/src/z16f/Make.defs
@@ -26,7 +26,7 @@ CMN_CSRCS += z16_interruptcontext.c z16_stackdump.c z16_copystate.c
 CMN_CSRCS += z16_mdelay.c z16_udelay.c z16_createstack.c z16_registerdump.c
 CMN_CSRCS += z16_unblocktask.c z16_doirq.c z16_releasepending.c z16_usestack.c
 CMN_CSRCS += z16_exit.c z16_releasestack.c z16_stackframe.c z16_idle.c
-CMN_CSRCS += z16_reprioritizertr.c
+CMN_CSRCS += z16_reprioritizertr.c z16_puts.c
 
 CHIP_SSRCS = z16f_lowuart.S z16f_saveusercontext.S z16f_restoreusercontext.S
 CHIP_CSRCS = z16f_clkinit.c z16f_sysexec.c z16f_irq.c z16f_serial.c

--- a/arch/z80/src/z180/Make.defs
+++ b/arch/z80/src/z180/Make.defs
@@ -30,7 +30,7 @@ CMN_CSRCS  = z80_allocateheap.c z80_assert.c z80_blocktask.c z80_createstack.c
 CMN_CSRCS += z80_doirq.c z80_exit.c z80_idle.c z80_initialize.c
 CMN_CSRCS += z80_interruptcontext.c z80_mdelay.c z80_releasepending.c
 CMN_CSRCS += z80_releasestack.c z80_stackframe.c z80_reprioritizertr.c
-CMN_CSRCS += z80_unblocktask.c z80_udelay.c z80_usestack.c
+CMN_CSRCS += z80_unblocktask.c z80_udelay.c z80_usestack.c z80_puts.c
 
 CHIP_ASRCS  = z180_restoreusercontext.asm z180_saveusercontext.asm
 CHIP_ASRCS += z180_vectcommon.asm

--- a/arch/z80/src/z8/Make.defs
+++ b/arch/z80/src/z8/Make.defs
@@ -25,6 +25,7 @@ CMN_CSRCS += z80_releasestack.c z80_interruptcontext.c z80_blocktask.c
 CMN_CSRCS += z80_unblocktask.c z80_exit.c z80_releasepending.c
 CMN_CSRCS += z80_reprioritizertr.c z80_idle.c z80_assert.c z80_doirq.c
 CMN_CSRCS += z80_mdelay.c z80_stackframe.c z80_udelay.c z80_usestack.c
+CMN_CSRCS += z80_puts.c
 
 CHIP_SSRCS  = z8_vector.S z8_saveusercontext.S z8_restorecontext.S
 CHIP_CSRCS  = z8_initialstate.c z8_irq.c z8_saveirqcontext.c

--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -161,14 +161,8 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
                                     FAR const char *buffer, size_t buflen)
 {
 #if defined(CONFIG_ARCH_LOWPUTC)
-  size_t nwritten;
-
   nxsem_wait(&g_syslog_default_sem);
-  for (nwritten = 0; nwritten < buflen; nwritten++)
-    {
-      up_putc(buffer[nwritten]);
-    }
-
+  up_puts(buffer);
   nxsem_post(&g_syslog_default_sem);
 #endif
 


### PR DESCRIPTION
## Summary
since some drivers(e.g. semihosting) have more fast implementation.

## Impact
More fast speed in some special case(e.g. semihosting)

## Testing

