### PR TITLE
lcd/st77xx: change 16 bit cmd send to 8 bit

### DIFF
--- a/drivers/lcd/gc9a01.c
+++ b/drivers/lcd/gc9a01.c
@@ -482,17 +482,21 @@ static void gc9a01_setarea(FAR struct gc9a01_dev_s *dev,
   /* Set row address */
 
   gc9a01_sendcmd(dev, GC9A01_RASET);
-  gc9a01_select(dev->spi, 16);
-  SPI_SEND(dev->spi, y0 + GC9A01_YOFFSET);
-  SPI_SEND(dev->spi, y1 + GC9A01_YOFFSET);
+  gc9a01_select(dev->spi, 8);
+  SPI_SEND(dev->spi, (y0 + GC9A01_YOFFSET) >> 8);
+  SPI_SEND(dev->spi, (y0 + GC9A01_YOFFSET) & 0xff);
+  SPI_SEND(dev->spi, (y1 + GC9A01_YOFFSET) >> 8);
+  SPI_SEND(dev->spi, (y1 + GC9A01_YOFFSET) & 0xff);
   gc9a01_deselect(dev->spi);
 
   /* Set column address */
 
   gc9a01_sendcmd(dev, GC9A01_CASET);
-  gc9a01_select(dev->spi, 16);
-  SPI_SEND(dev->spi, x0 + GC9A01_XOFFSET);
-  SPI_SEND(dev->spi, x1 + GC9A01_XOFFSET);
+  gc9a01_select(dev->spi, 8);
+  SPI_SEND(dev->spi, (x0 + GC9A01_XOFFSET) >> 8);
+  SPI_SEND(dev->spi, (x0 + GC9A01_XOFFSET) & 0xff);
+  SPI_SEND(dev->spi, (x1 + GC9A01_XOFFSET) >> 8);
+  SPI_SEND(dev->spi, (x1 + GC9A01_XOFFSET) & 0xff);
   gc9a01_deselect(dev->spi);
 }
 

--- a/drivers/lcd/st7735.c
+++ b/drivers/lcd/st7735.c
@@ -405,17 +405,21 @@ static void st7735_setarea(FAR struct st7735_dev_s *dev,
   /* Set row address */
 
   st7735_sendcmd(dev, ST7735_RASET);
-  st7735_select(dev->spi, 16);
-  SPI_SEND(dev->spi, y0 + ST7735_YOFFSET);
-  SPI_SEND(dev->spi, y1 + ST7735_YOFFSET);
+  st7735_select(dev->spi, 8);
+  SPI_SEND(dev->spi, (y0 + ST7735_YOFFSET) >> 8);
+  SPI_SEND(dev->spi, (y0 + ST7735_YOFFSET) & 0xff);
+  SPI_SEND(dev->spi, (y1 + ST7735_YOFFSET) >> 8);
+  SPI_SEND(dev->spi, (y1 + ST7735_YOFFSET) & 0xff);
   st7735_deselect(dev->spi);
 
   /* Set column address */
 
   st7735_sendcmd(dev, ST7735_CASET);
-  st7735_select(dev->spi, 16);
-  SPI_SEND(dev->spi, x0 + ST7735_XOFFSET);
-  SPI_SEND(dev->spi, x1 + ST7735_XOFFSET);
+  st7735_select(dev->spi, 8);
+  SPI_SEND(dev->spi, (x0 + ST7735_XOFFSET) >> 8);
+  SPI_SEND(dev->spi, (x0 + ST7735_XOFFSET) & 0xff);
+  SPI_SEND(dev->spi, (x1 + ST7735_XOFFSET) >> 8);
+  SPI_SEND(dev->spi, (x1 + ST7735_XOFFSET) & 0xff);
   st7735_deselect(dev->spi);
 }
 

--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -300,7 +300,7 @@ static void st7789_deselect(FAR struct spi_dev_s *spi)
 
 static inline void st7789_sendcmd(FAR struct st7789_dev_s *dev, uint8_t cmd)
 {
-  st7789_select(dev->spi, ST7789_BYTESPP * 8);
+  st7789_select(dev->spi, 8);
   SPI_CMDDATA(dev->spi, SPIDEV_DISPLAY(0), true);
   SPI_SEND(dev->spi, cmd);
   SPI_CMDDATA(dev->spi, SPIDEV_DISPLAY(0), false);
@@ -386,17 +386,21 @@ static void st7789_setarea(FAR struct st7789_dev_s *dev,
   /* Set row address */
 
   st7789_sendcmd(dev, ST7789_RASET);
-  st7789_select(dev->spi, 16);
-  SPI_SEND(dev->spi, y0 + ST7789_YOFFSET);
-  SPI_SEND(dev->spi, y1 + ST7789_YOFFSET);
+  st7789_select(dev->spi, 8);
+  SPI_SEND(dev->spi, (y0 + ST7789_YOFFSET) >> 8);
+  SPI_SEND(dev->spi, (y0 + ST7789_YOFFSET) & 0xff);
+  SPI_SEND(dev->spi, (y1 + ST7789_YOFFSET) >> 8);
+  SPI_SEND(dev->spi, (y1 + ST7789_YOFFSET) & 0xff);
   st7789_deselect(dev->spi);
 
   /* Set column address */
 
   st7789_sendcmd(dev, ST7789_CASET);
-  st7789_select(dev->spi, 16);
-  SPI_SEND(dev->spi, x0 + ST7789_XOFFSET);
-  SPI_SEND(dev->spi, x1 + ST7789_XOFFSET);
+  st7789_select(dev->spi, 8);
+  SPI_SEND(dev->spi, (x0 + ST7789_XOFFSET) >> 8);
+  SPI_SEND(dev->spi, (x0 + ST7789_XOFFSET) & 0xff);
+  SPI_SEND(dev->spi, (x1 + ST7789_XOFFSET) >> 8);
+  SPI_SEND(dev->spi, (x1 + ST7789_XOFFSET) & 0xff);
   st7789_deselect(dev->spi);
 }
 


### PR DESCRIPTION
Make sending commands independent of processor endianness. The data can
be handled by application side, such as LVGL has SWAP16 option.

Signed-off-by: Peter Bee <bijunda1@xiaomi.com>

## Summary

## Impact

## Testing

