### PR TITLE
boards/esp32c3: add ESP32C3 LCD drivers

### DIFF
--- a/boards/risc-v/esp32c3/esp32c3-devkit/Kconfig
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/Kconfig
@@ -94,4 +94,16 @@ config ESP32C3_SPIFLASH_TEST_ADDRESS
 	---help---
 		SPI Flash encryption test read/write address.
 
+if LCD_ST7735 || LCD_ST7789 || LCD_GC9A01
+
+config ESP32C3_LCD_RSTPIN
+	int "LCD reset pin"
+	default 9
+
+config ESP32C3_LCD_BLPIN
+	int "LCD backlight pin"
+	default 18
+
+endif # LCD_ST7735 || LCD_ST7789 || LCD_GC9A01
+
 endif # ARCH_BOARD_ESP32C3_DEVKIT

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/Makefile
@@ -82,6 +82,18 @@ ifeq ($(CONFIG_ADC),y)
 CSRCS += esp32c3_adc.c
 endif
 
+ifeq ($(CONFIG_LCD_ST7735),y)
+CSRCS += esp32c3_st7735.c
+endif
+
+ifeq ($(CONFIG_LCD_ST7789),y)
+CSRCS += esp32c3_st7789.c
+endif
+
+ifeq ($(CONFIG_LCD_GC9A01),y)
+CSRCS += esp32c3_gc9a01.c
+endif
+
 ifeq ($(CONFIG_BOARDCTL_IOCTL),y)
 CSRCS += esp32c3_ioctl.c
 endif

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spi.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spi.c
@@ -30,6 +30,8 @@
 
 #include <nuttx/spi/spi.h>
 
+#include "esp32c3_gpio.h"
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -61,6 +63,20 @@ uint8_t esp32c3_spi2_status(FAR struct spi_dev_s *dev, uint32_t devid)
 
 int esp32c3_spi2_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
+#if defined(CONFIG_LCD_ST7735) || defined(CONFIG_LCD_ST7789) || \
+    defined(CONFIG_LCD_GC9A01)
+  if (devid == SPIDEV_DISPLAY(0))
+    {
+      /*  This is the Data/Command control pad which determines whether the
+       *  data bits are data or a command.
+       */
+
+      esp32c3_gpiowrite(CONFIG_ESP32C3_SPI2_MISOPIN, !cmd);
+
+      return OK;
+    }
+
+#endif
   spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
           "data");
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_bringup.c
@@ -46,6 +46,15 @@
 #  include "esp32c3_spi.h"
 #endif
 
+#ifdef CONFIG_LCD_DEV
+#  include <nuttx/board.h>
+#  include <nuttx/lcd/lcd_dev.h>
+#endif
+
+#ifdef CONFIG_VIDEO_FB
+#  include <nuttx/video/fb.h>
+#endif
+
 #ifdef CONFIG_ESP32C3_RT_TIMER
 #  include "esp32c3_rt_timer.h"
 #endif
@@ -186,6 +195,28 @@ int esp32c3_bringup(void)
     {
       syslog(LOG_ERR, "Failed to initialize SPI%d Slave driver: %d\n",
              ESP32C3_SPI2, ret);
+    }
+#endif
+
+#ifdef CONFIG_VIDEO_FB
+  ret = fb_register(0, 0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize Frame Buffer Driver.\n");
+    }
+#elif defined(CONFIG_LCD)
+  ret = board_lcd_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize LCD.\n");
+    }
+#endif
+
+#ifdef CONFIG_LCD_DEV
+  ret = lcddev_register(0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: lcddev_register() failed: %d\n", ret);
     }
 #endif
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_gc9a01.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_gc9a01.c
@@ -1,0 +1,148 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_gc9a01.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/lcd/lcd.h>
+#include <nuttx/lcd/gc9a01.h>
+
+#include "esp32c3_spi.h"
+#include "esp32c3_gpio.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define LCD_SPI_PORTNO ESP32C3_SPI2
+#define LCD_DC         CONFIG_ESP32C3_SPI2_MISOPIN
+#define LCD_RST        CONFIG_ESP32C3_LCD_RSTPIN
+#define LCD_BL         CONFIG_ESP32C3_LCD_BLPIN
+
+#ifndef CONFIG_SPI_CMDDATA
+#  error "The GC9A01 driver requires CONFIG_SPI_CMDATA in the config"
+#endif
+
+#ifndef CONFIG_ESP32C3_SPI_SWCS
+#  error "The GC9A01 driver requires CONFIG_ESP32C3_SPI_SWCS in the config"
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct spi_dev_s *g_spidev;
+static struct lcd_dev_s *g_lcd = NULL;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  board_lcd_initialize
+ *
+ * Description:
+ *   Initialize the LCD video hardware.  The initial state of the LCD is
+ *   fully initialized, display memory cleared, and the LCD ready to use, but
+ *   with the power setting at 0 (full off).
+ *
+ ****************************************************************************/
+
+int board_lcd_initialize(void)
+{
+  g_spidev = esp32c3_spibus_initialize(LCD_SPI_PORTNO);
+  if (!g_spidev)
+    {
+      lcderr("ERROR: Failed to initialize SPI port %d\n", LCD_SPI_PORTNO);
+      return -ENODEV;
+    }
+
+  /* SPI RX is not used. Same pin is used as LCD Data/Command control */
+
+  esp32c3_configgpio(LCD_DC, OUTPUT);
+  esp32c3_gpiowrite(LCD_DC, true);
+
+  /* Pull LCD_RESET high */
+
+  esp32c3_configgpio(LCD_RST, OUTPUT);
+  esp32c3_gpiowrite(LCD_RST, false);
+  up_mdelay(50);
+  esp32c3_gpiowrite(LCD_RST, true);
+  up_mdelay(50);
+
+  /* Set full brightness */
+
+  esp32c3_configgpio(LCD_BL, OUTPUT);
+  esp32c3_gpiowrite(LCD_BL, true);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_getdev
+ *
+ * Description:
+ *   Return a a reference to the LCD object for the specified LCD.  This
+ *   allows support for multiple LCD devices.
+ *
+ ****************************************************************************/
+
+FAR struct lcd_dev_s *board_lcd_getdev(int devno)
+{
+  g_lcd = gc9a01_lcdinitialize(g_spidev);
+  if (!g_lcd)
+    {
+      lcderr("ERROR: Failed to bind SPI port %d to LCD %d\n", LCD_SPI_PORTNO,
+      devno);
+    }
+  else
+    {
+      lcdinfo("SPI port %d bound to LCD %d\n", LCD_SPI_PORTNO, devno);
+      return g_lcd;
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_uninitialize
+ *
+ * Description:
+ *   Uninitialize the LCD support
+ *
+ ****************************************************************************/
+
+void board_lcd_uninitialize(void)
+{
+  /* Turn the display off */
+
+  g_lcd->setpower(g_lcd, 0);
+}

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_st7735.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_st7735.c
@@ -1,0 +1,148 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_st7735.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/lcd/lcd.h>
+#include <nuttx/lcd/st7735.h>
+
+#include "esp32c3_spi.h"
+#include "esp32c3_gpio.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define LCD_SPI_PORTNO ESP32C3_SPI2
+#define LCD_DC         CONFIG_ESP32C3_SPI2_MISOPIN
+#define LCD_RST        CONFIG_ESP32C3_LCD_RSTPIN
+#define LCD_BL         CONFIG_ESP32C3_LCD_BLPIN
+
+#ifndef CONFIG_SPI_CMDDATA
+#  error "The ST7735 driver requires CONFIG_SPI_CMDATA in the config"
+#endif
+
+#ifndef CONFIG_ESP32C3_SPI_SWCS
+#  error "The ST7735 driver requires CONFIG_ESP32C3_SPI_SWCS in the config"
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct spi_dev_s *g_spidev;
+static struct lcd_dev_s *g_lcd = NULL;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  board_lcd_initialize
+ *
+ * Description:
+ *   Initialize the LCD video hardware.  The initial state of the LCD is
+ *   fully initialized, display memory cleared, and the LCD ready to use, but
+ *   with the power setting at 0 (full off).
+ *
+ ****************************************************************************/
+
+int board_lcd_initialize(void)
+{
+  g_spidev = esp32c3_spibus_initialize(LCD_SPI_PORTNO);
+  if (!g_spidev)
+    {
+      lcderr("ERROR: Failed to initialize SPI port %d\n", LCD_SPI_PORTNO);
+      return -ENODEV;
+    }
+
+  /* SPI RX is not used. Same pin is used as LCD Data/Command control */
+
+  esp32c3_configgpio(LCD_DC, OUTPUT);
+  esp32c3_gpiowrite(LCD_DC, true);
+
+  /* Pull LCD_RESET high */
+
+  esp32c3_configgpio(LCD_RST, OUTPUT);
+  esp32c3_gpiowrite(LCD_RST, false);
+  up_mdelay(1);
+  esp32c3_gpiowrite(LCD_RST, true);
+  up_mdelay(120);
+
+  /* Set full brightness */
+
+  esp32c3_configgpio(LCD_BL, OUTPUT);
+  esp32c3_gpiowrite(LCD_BL, true);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_getdev
+ *
+ * Description:
+ *   Return a a reference to the LCD object for the specified LCD.  This
+ *   allows support for multiple LCD devices.
+ *
+ ****************************************************************************/
+
+FAR struct lcd_dev_s *board_lcd_getdev(int devno)
+{
+  g_lcd = st7735_lcdinitialize(g_spidev);
+  if (!g_lcd)
+    {
+      lcderr("ERROR: Failed to bind SPI port %d to LCD %d\n", LCD_SPI_PORTNO,
+      devno);
+    }
+  else
+    {
+      lcdinfo("SPI port %d bound to LCD %d\n", LCD_SPI_PORTNO, devno);
+      return g_lcd;
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_uninitialize
+ *
+ * Description:
+ *   Uninitialize the LCD support
+ *
+ ****************************************************************************/
+
+void board_lcd_uninitialize(void)
+{
+  /* Turn the display off */
+
+  g_lcd->setpower(g_lcd, 0);
+}

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_st7789.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_st7789.c
@@ -1,0 +1,148 @@
+/****************************************************************************
+ * boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_st7789.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/lcd/lcd.h>
+#include <nuttx/lcd/st7789.h>
+
+#include "esp32c3_spi.h"
+#include "esp32c3_gpio.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define LCD_SPI_PORTNO ESP32C3_SPI2
+#define LCD_DC         CONFIG_ESP32C3_SPI2_MISOPIN
+#define LCD_RST        CONFIG_ESP32C3_LCD_RSTPIN
+#define LCD_BL         CONFIG_ESP32C3_LCD_BLPIN
+
+#ifndef CONFIG_SPI_CMDDATA
+#  error "The ST7789 driver requires CONFIG_SPI_CMDATA in the config"
+#endif
+
+#ifndef CONFIG_ESP32C3_SPI_SWCS
+#  error "The ST7789 driver requires CONFIG_ESP32C3_SPI_SWCS in the config"
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct spi_dev_s *g_spidev;
+static struct lcd_dev_s *g_lcd = NULL;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  board_lcd_initialize
+ *
+ * Description:
+ *   Initialize the LCD video hardware.  The initial state of the LCD is
+ *   fully initialized, display memory cleared, and the LCD ready to use, but
+ *   with the power setting at 0 (full off).
+ *
+ ****************************************************************************/
+
+int board_lcd_initialize(void)
+{
+  g_spidev = esp32c3_spibus_initialize(LCD_SPI_PORTNO);
+  if (!g_spidev)
+    {
+      lcderr("ERROR: Failed to initialize SPI port %d\n", LCD_SPI_PORTNO);
+      return -ENODEV;
+    }
+
+  /* SPI RX is not used. Same pin is used as LCD Data/Command control */
+
+  esp32c3_configgpio(LCD_DC, OUTPUT);
+  esp32c3_gpiowrite(LCD_DC, true);
+
+  /* Pull LCD_RESET high */
+
+  esp32c3_configgpio(LCD_RST, OUTPUT);
+  esp32c3_gpiowrite(LCD_RST, false);
+  up_mdelay(1);
+  esp32c3_gpiowrite(LCD_RST, true);
+  up_mdelay(10);
+
+  /* Set full brightness */
+
+  esp32c3_configgpio(LCD_BL, OUTPUT);
+  esp32c3_gpiowrite(LCD_BL, true);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_getdev
+ *
+ * Description:
+ *   Return a a reference to the LCD object for the specified LCD.  This
+ *   allows support for multiple LCD devices.
+ *
+ ****************************************************************************/
+
+FAR struct lcd_dev_s *board_lcd_getdev(int devno)
+{
+  g_lcd = st7789_lcdinitialize(g_spidev);
+  if (!g_lcd)
+    {
+      lcderr("ERROR: Failed to bind SPI port %d to LCD %d\n", LCD_SPI_PORTNO,
+      devno);
+    }
+  else
+    {
+      lcdinfo("SPI port %d bound to LCD %d\n", LCD_SPI_PORTNO, devno);
+      return g_lcd;
+    }
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Name:  board_lcd_uninitialize
+ *
+ * Description:
+ *   Uninitialize the LCD support
+ *
+ ****************************************************************************/
+
+void board_lcd_uninitialize(void)
+{
+  /* Turn the display off */
+
+  g_lcd->setpower(g_lcd, 0);
+}


### PR DESCRIPTION
Add board driver for ST7735, ST7789 and GC9A01

Signed-off-by: Peter Bee <bijunda1@xiaomi.com>

## Summary

## Impact

## Testing

