### PR TITLE
esp32_spiflash.c: Correctly disable APP's CPU cache.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -426,7 +426,7 @@ static inline void IRAM_ATTR
 
   spi_disable_cache(state->cpu, &state->val[state->cpu]);
 #ifdef CONFIG_SMP
-  spi_disable_cache(state->cpu, &state->val[other]);
+  spi_disable_cache(other, &state->val[other]);
 #endif
 }
 


### PR DESCRIPTION
## Summary
Correctly disable APP's CPU cache during SPI flash operation.
## Impact
ESP32 SPI Flash driver.
## Testing
esp32-devkitc:spiflash with SMP.
