### PR TITLE
Added CONFIG_ETH0_PHY_DP83825I to imxrt_enet: Fixed IRQ  link detection

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -155,7 +155,7 @@ nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT)
 	$(Q) echo "LD: nuttx"
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(NUTTX) $(HEAD_OBJ) $(EXTRA_OBJS) \
-		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
+		-Wl,$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) -Wl,$(LDENDGROUP)
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) $(NM) $(NUTTX) | \
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -1838,7 +1838,7 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
 static int imxrt_phyintenable(struct imxrt_driver_s *priv)
 {
 #if defined(CONFIG_ETH0_PHY_KSZ8051) || defined(CONFIG_ETH0_PHY_KSZ8061) || \
-    defined(CONFIG_ETH0_PHY_KSZ8081)
+    defined(CONFIG_ETH0_PHY_KSZ8081) || defined(CONFIG_ETH0_PHY_DP83825I)
   uint16_t phyval;
   int ret;
 

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1455,7 +1455,7 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
       (FAR struct imxrt_driver_s *)dev->d_private;
   struct flexcan_timeseg data_timing;
   int ret;
-  
+
   switch (cmd)
     {
       case SIOCGCANBITRATE: /* Get bitrate from a CAN controller */

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1455,7 +1455,7 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
       (FAR struct imxrt_driver_s *)dev->d_private;
 
   int ret;
-
+  struct flexcan_timeseg data_timing;
   switch (cmd)
     {
       case SIOCGCANBITRATE: /* Get bitrate from a CAN controller */
@@ -1499,7 +1499,6 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
 
           if (priv->canfd_capable)
           {
-            struct flexcan_timeseg data_timing;
             data_timing.bitrate = req->data_bitrate * 1000;
             data_timing.samplep = req->data_samplep;
 

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1453,9 +1453,9 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
 {
   FAR struct imxrt_driver_s *priv =
       (FAR struct imxrt_driver_s *)dev->d_private;
-
-  int ret;
   struct flexcan_timeseg data_timing;
+  int ret;
+  
   switch (cmd)
     {
       case SIOCGCANBITRATE: /* Get bitrate from a CAN controller */


### PR DESCRIPTION
## Summary

Added the DP83825I PHY (used on the teensy board) to the list of allowed PHYs for PHY interrupt detection. The source does not compile currently if this feature is selected, but all the required infrastructure is there.

## Impact

Source compiles as expected and link detection works on board that have this PHY and the interrupt connection. No side effects expected for other configurations.

## Testing

Configure nuttx for teensy 4.1 board and enable the PHY IRQ (CONFIG_NETDEV_PHY_IOCTL, IMXRT_GPIO_IRQ, CONFIG_ARCH_PHY_INTERRUPT, CONFIG_IMXRT_GPIO2_0_15_IRQ ) and  CONFIG_NETINIT_MONITOR. The source should compile and now the link state should change when a cable is inserted or removed.