### PR TITLE
S32K1XXEVB boards: Fix RGB LED output and add comments

### DIFF
--- a/boards/arm/s32k1xx/s32k118evb/README.txt
+++ b/boards/arm/s32k1xx/s32k118evb/README.txt
@@ -1,7 +1,7 @@
 README
 ======
 
-This directory hold the port to the NXP S32K118EVB-Q064 Development board.
+This directory holds the port to the NXP S32K118EVB-Q064 development board.
 
 Contents
 ========

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_autoleds.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_autoleds.c
@@ -121,6 +121,8 @@ void board_autoled_on(int led)
             break;
         }
 
+      /* An output of '1' illuminates the LED */
+
       s32k1xx_gpiowrite(GPIO_LED_R, redon);
       s32k1xx_gpiowrite(GPIO_LED_G, greenon);
       s32k1xx_gpiowrite(GPIO_LED_B, blueon);
@@ -135,6 +137,8 @@ void board_autoled_off(int led)
 {
   if (led == LED_ON_OFF_OFF)
     {
+      /* An output of '1' illuminates the LED */
+
       s32k1xx_gpiowrite(GPIO_LED_R, true);
       s32k1xx_gpiowrite(GPIO_LED_G, false);
       s32k1xx_gpiowrite(GPIO_LED_B, false);

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_userleds.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_userleds.c
@@ -81,6 +81,8 @@ void board_userled(int led, bool ledon)
       return;
     }
 
+  /* An output of '1' illuminates the LED */
+
   s32k1xx_gpiowrite(ledcfg, ledon);
 }
 
@@ -90,6 +92,8 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
+  /* An output of '1' illuminates the LED */
+
   s32k1xx_gpiowrite(GPIO_LED_R, (ledset & BOARD_LED_R_BIT) != 0);
   s32k1xx_gpiowrite(GPIO_LED_G, (ledset & BOARD_LED_G_BIT) != 0);
   s32k1xx_gpiowrite(GPIO_LED_B, (ledset & BOARD_LED_B_BIT) != 0);

--- a/boards/arm/s32k1xx/s32k144evb/README.txt
+++ b/boards/arm/s32k1xx/s32k144evb/README.txt
@@ -1,7 +1,7 @@
 README
 ======
 
-This directory hold the port to the NXP S32K144EVB-Q100 Development board.
+This directory holds the port to the NXP S32K144EVB-Q100 development board.
 
 Contents
 ========
@@ -46,7 +46,7 @@ LEDs and Buttons
     GreenLED  PTD16  (FTM0 CH1)
     BlueLED   PTD0   (FTM0 CH2)
 
-  An output of '1' illuminates the LED.
+  An output of '0' illuminates the LED.
 
   If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in
   any way.  The following definitions are used to access individual RGB

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k144evb.h
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k144evb.h
@@ -48,12 +48,12 @@
  *   GreenLED  PTD16  (FTM0 CH1)
  *   BlueLED   PTD0   (FTM0 CH2)
  *
- * An output of '1' illuminates the LED.
+ * An output of '0' illuminates the LED.
  */
 
-#define GPIO_LED_R  (PIN_PTD15 | GPIO_LOWDRIVE | GPIO_OUTPUT_ZERO)
-#define GPIO_LED_G  (PIN_PTD16 | GPIO_LOWDRIVE | GPIO_OUTPUT_ZERO)
-#define GPIO_LED_B  (PIN_PTD0  | GPIO_LOWDRIVE | GPIO_OUTPUT_ZERO)
+#define GPIO_LED_R  (PIN_PTD15 | GPIO_LOWDRIVE | GPIO_OUTPUT_ONE)
+#define GPIO_LED_G  (PIN_PTD16 | GPIO_LOWDRIVE | GPIO_OUTPUT_ONE)
+#define GPIO_LED_B  (PIN_PTD0  | GPIO_LOWDRIVE | GPIO_OUTPUT_ONE)
 
 /* Buttons.  The S32K144EVB supports two buttons:
  *

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_autoleds.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_autoleds.c
@@ -24,7 +24,7 @@
  *   GreenLED  PTD16  (FTM0 CH1)
  *   BlueLED   PTD0   (FTM0 CH2)
  *
- * An output of '1' illuminates the LED.
+ * An output of '0' illuminates the LED.
  *
  * If CONFIG_ARCH_LEDs is defined, then NuttX will control the LED on board
  * the S32K144EVB.  The following definitions describe how NuttX controls the
@@ -121,9 +121,11 @@ void board_autoled_on(int led)
             break;
         }
 
-      s32k1xx_gpiowrite(GPIO_LED_R, redon);
-      s32k1xx_gpiowrite(GPIO_LED_G, greenon);
-      s32k1xx_gpiowrite(GPIO_LED_B, blueon);
+      /* Invert output, an output of '0' illuminates the LED */
+
+      s32k1xx_gpiowrite(GPIO_LED_R, !redon);
+      s32k1xx_gpiowrite(GPIO_LED_G, !greenon);
+      s32k1xx_gpiowrite(GPIO_LED_B, !blueon);
     }
 }
 
@@ -135,9 +137,11 @@ void board_autoled_off(int led)
 {
   if (led == LED_ON_OFF_OFF)
     {
-      s32k1xx_gpiowrite(GPIO_LED_R, true);
-      s32k1xx_gpiowrite(GPIO_LED_G, false);
-      s32k1xx_gpiowrite(GPIO_LED_B, false);
+      /* Invert outputs, an output of '0' illuminates the LED */
+
+      s32k1xx_gpiowrite(GPIO_LED_R, !true);
+      s32k1xx_gpiowrite(GPIO_LED_G, !false);
+      s32k1xx_gpiowrite(GPIO_LED_B, !false);
     }
 }
 

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_userleds.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_userleds.c
@@ -81,7 +81,9 @@ void board_userled(int led, bool ledon)
       return;
     }
 
-  s32k1xx_gpiowrite(ledcfg, ledon);
+  /* Invert output, an output of '0' illuminates the LED */
+
+  s32k1xx_gpiowrite(ledcfg, !ledon);
 }
 
 /****************************************************************************
@@ -90,9 +92,11 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
-  s32k1xx_gpiowrite(GPIO_LED_R, (ledset & BOARD_LED_R_BIT) != 0);
-  s32k1xx_gpiowrite(GPIO_LED_G, (ledset & BOARD_LED_G_BIT) != 0);
-  s32k1xx_gpiowrite(GPIO_LED_B, (ledset & BOARD_LED_B_BIT) != 0);
+  /* Invert output, an output of '0' illuminates the LED */
+
+  s32k1xx_gpiowrite(GPIO_LED_R, !((ledset & BOARD_LED_R_BIT) != 0));
+  s32k1xx_gpiowrite(GPIO_LED_G, !((ledset & BOARD_LED_G_BIT) != 0));
+  s32k1xx_gpiowrite(GPIO_LED_B, !((ledset & BOARD_LED_B_BIT) != 0));
 }
 
 #endif /* !CONFIG_ARCH_LEDS */

--- a/boards/arm/s32k1xx/s32k146evb/README.txt
+++ b/boards/arm/s32k1xx/s32k146evb/README.txt
@@ -1,7 +1,7 @@
 README
 ======
 
-This directory hold the port to the NXP S32K146EVB-Q144 Development board.
+This directory holds the port to the NXP S32K146EVB-Q144 development board.
 
 Contents
 ========

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_autoleds.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_autoleds.c
@@ -121,6 +121,8 @@ void board_autoled_on(int led)
             break;
         }
 
+      /* An output of '1' illuminates the LED */
+
       s32k1xx_gpiowrite(GPIO_LED_R, redon);
       s32k1xx_gpiowrite(GPIO_LED_G, greenon);
       s32k1xx_gpiowrite(GPIO_LED_B, blueon);
@@ -135,6 +137,8 @@ void board_autoled_off(int led)
 {
   if (led == LED_ON_OFF_OFF)
     {
+      /* An output of '1' illuminates the LED */
+
       s32k1xx_gpiowrite(GPIO_LED_R, true);
       s32k1xx_gpiowrite(GPIO_LED_G, false);
       s32k1xx_gpiowrite(GPIO_LED_B, false);

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_userleds.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_userleds.c
@@ -81,6 +81,8 @@ void board_userled(int led, bool ledon)
       return;
     }
 
+  /* An output of '1' illuminates the LED */
+
   s32k1xx_gpiowrite(ledcfg, ledon);
 }
 
@@ -90,6 +92,8 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
+  /* An output of '1' illuminates the LED */
+
   s32k1xx_gpiowrite(GPIO_LED_R, (ledset & BOARD_LED_R_BIT) != 0);
   s32k1xx_gpiowrite(GPIO_LED_G, (ledset & BOARD_LED_G_BIT) != 0);
   s32k1xx_gpiowrite(GPIO_LED_B, (ledset & BOARD_LED_B_BIT) != 0);

--- a/boards/arm/s32k1xx/s32k148evb/README.txt
+++ b/boards/arm/s32k1xx/s32k148evb/README.txt
@@ -1,7 +1,7 @@
 README
 ======
 
-This directory hold the port to the NXP S32K148EVB-Q176 Development board.
+This directory holds the port to the NXP S32K148EVB-Q176 development board.
 
 Contents
 ========

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_autoleds.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_autoleds.c
@@ -121,6 +121,8 @@ void board_autoled_on(int led)
             break;
         }
 
+      /* An output of '1' illuminates the LED */
+
       s32k1xx_gpiowrite(GPIO_LED_R, redon);
       s32k1xx_gpiowrite(GPIO_LED_G, greenon);
       s32k1xx_gpiowrite(GPIO_LED_B, blueon);
@@ -135,6 +137,8 @@ void board_autoled_off(int led)
 {
   if (led == LED_ON_OFF_OFF)
     {
+      /* An output of '1' illuminates the LED */
+
       s32k1xx_gpiowrite(GPIO_LED_R, true);
       s32k1xx_gpiowrite(GPIO_LED_G, false);
       s32k1xx_gpiowrite(GPIO_LED_B, false);

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_userleds.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_userleds.c
@@ -81,6 +81,8 @@ void board_userled(int led, bool ledon)
       return;
     }
 
+  /* An output of '1' illuminates the LED */
+
   s32k1xx_gpiowrite(ledcfg, ledon);
 }
 
@@ -90,6 +92,8 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
+  /* An output of '1' illuminates the LED */
+
   s32k1xx_gpiowrite(GPIO_LED_R, (ledset & BOARD_LED_R_BIT) != 0);
   s32k1xx_gpiowrite(GPIO_LED_G, (ledset & BOARD_LED_G_BIT) != 0);
   s32k1xx_gpiowrite(GPIO_LED_B, (ledset & BOARD_LED_B_BIT) != 0);

--- a/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_userleds.c
+++ b/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_userleds.c
@@ -81,7 +81,9 @@ void board_userled(int led, bool ledon)
       return;
     }
 
-  s32k1xx_gpiowrite(ledcfg, !ledon); /* Invert output, an output of '0' illuminates the LED */
+  /* Invert output, an output of '0' illuminates the LED */
+
+  s32k1xx_gpiowrite(ledcfg, !ledon);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
- Inverts the output that controls the RGB LED on the S32K144EVB. Out of all S32K1XXEVB boards this seems to be the only board where the LED cathode is directly connected to the MCU through a resistor, instead of through an NPN transistor like on the other boards.
- Added/adapted comments for all S32K1XXEVB boards to indicate what output is required to illuminate the LED.
- Sneaked in some very minor changes in the README files as well.

## Impact
- Should only affect behavior on the S32K144EVB, the other EVB boards already had the correct behavior.

## Testing
- Tested on a S32K144EVB board. Works fine now.

