### PR TITLE
net/devif/devif_callback.c: made the connection event list doubly linked

### DIFF
--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -260,6 +260,7 @@ typedef CODE uint16_t (*devif_callback_event_t)(FAR struct net_driver_s *dev,
 struct devif_callback_s
 {
   FAR struct devif_callback_s *nxtconn;
+  FAR struct devif_callback_s *prevconn;
   FAR struct devif_callback_s *nxtdev;
   FAR devif_callback_event_t event;
   FAR void *priv;


### PR DESCRIPTION
## Summary
The initial PR is #4433.
This new PR implements Approach 3.d explained in #4433.

The resulting time complexities are as follows:
* devif_callback_alloc() time complexity is O(1) (i.e. O(n) to fill the whole list).
* devif_callback_free() time complexity is O(1) (i.e. O(n) to empty the whole list).
* devif_conn_event() time complexity is O(n).

## Impact
The entire network protocol stack.