### PR TITLE
drivers/syslog: Ensure the buffer zero terminate

### DIFF
--- a/drivers/syslog/syslog_stream.c
+++ b/drivers/syslog/syslog_stream.c
@@ -56,6 +56,11 @@ static int syslogstream_flush(FAR struct lib_syslogstream_s *stream)
 
   if (iob != NULL && iob->io_len > 0)
     {
+      /* Ensure the buffer is zero terminated */
+
+      DEBUGASSERT(iob->io_len < CONFIG_IOB_BUFSIZE);
+      iob->io_data[iob->io_len] = '\0';
+
       /* Yes write the buffered data */
 
       do
@@ -100,7 +105,7 @@ static void syslogstream_addchar(FAR struct lib_syslogstream_s *stream,
 
   /* Is the buffer full? */
 
-  if (iob->io_len >= CONFIG_IOB_BUFSIZE)
+  if (iob->io_len >= CONFIG_IOB_BUFSIZE - 1)
     {
       /* Yes.. then flush the buffer */
 


### PR DESCRIPTION
## Summary
This patch fix the regression by:
```
commit 174b2403258cbf0e063ac389beeedcd09b8a0b1a
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Fri Sep 17 11:56:21 2021 +0800

    drivers/syslog: Call up_puts in syslog_default_write instad up_putc

    since some drivers(e.g. semihosting) have more fast implementation.
```
Report here: https://github.com/apache/incubator-nuttx/pull/4566

## Impact
Fix the regression.

## Testing

