### PR TITLE
xtensa_dumpstate.c: Fix the name of the TCB variable

### DIFF
--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -74,7 +74,7 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 
 #if defined(CONFIG_XTENSA_DUMPBT_ON_ASSERT) && \
     defined(CONFIG_SCHED_BACKTRACE)
-  sched_dumpstack(rtcb->pid);
+  sched_dumpstack(tcb->pid);
 #endif
 }
 #endif

--- a/libs/libc/sched/sched_backtrace.c
+++ b/libs/libc/sched/sched_backtrace.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
+#include <unistd.h>
 #include <execinfo.h>
 #include <unwind.h>
 


### PR DESCRIPTION
## Summary
- Commit 1: Fix the name of the TCB variable, `rtcb` was used instead of `tcb`
- Commit 2: Include "unistd.h" to avoid an implicit declaration warning.
## Impact
Xtensa dump state.
## Testing
ESP32 with SCHED_BACKTRACE enabled.
