### PR TITLE
Added CONFIG_ETH0_PHY_DP83825I to imxrt_enet: make teensy 4.1 compile 

### DIFF
--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -1838,7 +1838,7 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
 static int imxrt_phyintenable(struct imxrt_driver_s *priv)
 {
 #if defined(CONFIG_ETH0_PHY_KSZ8051) || defined(CONFIG_ETH0_PHY_KSZ8061) || \
-    defined(CONFIG_ETH0_PHY_KSZ8081)
+    defined(CONFIG_ETH0_PHY_KSZ8081) || defined(CONFIG_ETH0_PHY_DP83825I)
   uint16_t phyval;
   int ret;
 


### PR DESCRIPTION
Added CONFIG_ETH0_PHY_DP83825I to imxrt_enet (used in teensy 4.1, link detection needs more checks to see if it works as expected)

## Summary

This adds the PHY used on the teensy 4.1 board. You can select it, but the PHY interrupt is not enabled. For phy PHY ioctl you need this function. There is code in the source to handle this, but it is not enabled for this Phy.

## Impact

If a CONFIG_ETH0_PHY_DP83825I is defined, the PHY ioctl can be enabled.

## Testing
On a teensy 4.1 board: Enable the Ethernet stack and PHY ioctl. source should compile. Link status should change when an ethernet cable is (un)plugged.
 