### PR TITLE
Fix stm32xx GPIO glitches from configuration bad order of operations

### DIFF
--- a/arch/arm/src/stm32/stm32_gpio.c
+++ b/arch/arm/src/stm32/stm32_gpio.c
@@ -406,6 +406,7 @@ int stm32_configgpio(uint32_t cfgset)
   uintptr_t base;
   uint32_t regval;
   uint32_t setting;
+  uint32_t alt_setting;
   unsigned int regoffset;
   unsigned int port;
   unsigned int pin;
@@ -463,6 +464,41 @@ int stm32_configgpio(uint32_t cfgset)
 
   flags = enter_critical_section();
 
+  /* Determine the alternate function (Only alternate function pins) */
+
+  if (pinmode == GPIO_MODER_ALT)
+    {
+      alt_setting = (cfgset & GPIO_AF_MASK) >> GPIO_AF_SHIFT;
+    }
+  else
+    {
+      alt_setting = 0;
+    }
+
+  /* Set the alternate function (Only alternate function pins)
+   * This is done before configuring the Outputs on a change to
+   * an Alternate function.
+   */
+
+  if (alt_setting != 0)
+    {
+      if (pin < 8)
+        {
+          regoffset = STM32_GPIO_AFRL_OFFSET;
+          pos       = pin;
+        }
+      else
+        {
+          regoffset = STM32_GPIO_AFRH_OFFSET;
+          pos       = pin - 8;
+        }
+
+      regval  = getreg32(base + regoffset);
+      regval &= ~GPIO_AFR_MASK(pos);
+      regval |= (alt_setting << GPIO_AFR_SHIFT(pos));
+      putreg32(regval, base + regoffset);
+    }
+
   /* Now apply the configuration to the mode register */
 
   regval  = getreg32(base + STM32_GPIO_MODER_OFFSET);
@@ -496,32 +532,29 @@ int stm32_configgpio(uint32_t cfgset)
   regval |= (setting << GPIO_PUPDR_SHIFT(pin));
   putreg32(regval, base + STM32_GPIO_PUPDR_OFFSET);
 
-  /* Set the alternate function (Only alternate function pins) */
+  /* Set the alternate function (Only alternate function pins)
+   * This is done after configuring the the pin's connection
+   * on a change away from an Alternate function.
+   */
 
-  if (pinmode == GPIO_MODER_ALT)
-    {
-      setting = (cfgset & GPIO_AF_MASK) >> GPIO_AF_SHIFT;
-    }
-  else
-    {
-      setting = 0;
-    }
+  if (alt_setting == 0)
+      {
+        if (pin < 8)
+          {
+            regoffset = STM32_GPIO_AFRL_OFFSET;
+            pos       = pin;
+          }
+        else
+          {
+            regoffset = STM32_GPIO_AFRH_OFFSET;
+            pos       = pin - 8;
+          }
 
-  if (pin < 8)
-    {
-      regoffset = STM32_GPIO_AFRL_OFFSET;
-      pos       = pin;
-    }
-  else
-    {
-      regoffset = STM32_GPIO_AFRH_OFFSET;
-      pos       = pin - 8;
-    }
-
-  regval  = getreg32(base + regoffset);
-  regval &= ~GPIO_AFR_MASK(pos);
-  regval |= (setting << GPIO_AFR_SHIFT(pos));
-  putreg32(regval, base + regoffset);
+        regval  = getreg32(base + regoffset);
+        regval &= ~GPIO_AFR_MASK(pos);
+        regval |= (alt_setting << GPIO_AFR_SHIFT(pos));
+        putreg32(regval, base + regoffset);
+      }
 
   /* Set speed (Only outputs and alternate function pins) */
 

--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -667,19 +667,18 @@ static void stm32_configwaitints(struct stm32_dev_s *priv, uint32_t waitmask,
       pinset = GPIO_SDIO_D0 & (GPIO_PORT_MASK | GPIO_PIN_MASK);
       pinset |= (GPIO_INPUT | GPIO_FLOAT | GPIO_EXTI);
 
-      /* Arm the SDIO_D Ready and install Isr */
+      /* Arm the SDIO_D0 Ready and install Isr */
 
       stm32_gpiosetevent(pinset, true, false, false,
                          stm32_rdyinterrupt, priv);
     }
 
-  /* Disarm SDIO_D ready */
+  /* Disarm SDIO_D0 ready and return it to SDIO D0 */
 
   if ((wkupevent & SDIOWAIT_WRCOMPLETE) != 0)
     {
       stm32_gpiosetevent(GPIO_SDIO_D0, false, false, false,
                          NULL, NULL);
-      stm32_configgpio(GPIO_SDIO_D0);
     }
 #endif
 

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -862,19 +862,18 @@ static void stm32_configwaitints(struct stm32_dev_s *priv, uint32_t waitmask,
                                 GPIO_PUPD_MASK);
       pinset |= (GPIO_INPUT | GPIO_EXTI);
 
-      /* Arm the SDMMC_D Ready and install Isr */
+      /* Arm the SDMMC_D0 Ready and install Isr */
 
       stm32_gpiosetevent(pinset, true, false, false,
                          stm32_sdmmc_rdyinterrupt, priv);
     }
 
-  /* Disarm SDMMC_D ready */
+  /* Disarm SDMMC_D0 ready and return it to SDMMC D0 */
 
   if ((wkupevent & SDIOWAIT_WRCOMPLETE) != 0)
     {
       stm32_gpiosetevent(priv->d0_gpio, false, false, false,
                          NULL, NULL);
-      stm32_configgpio(priv->d0_gpio);
     }
 #endif
 

--- a/arch/arm/src/stm32h7/stm32_gpio.c
+++ b/arch/arm/src/stm32h7/stm32_gpio.c
@@ -140,6 +140,7 @@ int stm32_configgpio(uint32_t cfgset)
   uintptr_t base;
   uint32_t regval;
   uint32_t setting;
+  uint32_t alt_setting;
   unsigned int regoffset;
   unsigned int port;
   unsigned int pin;
@@ -201,6 +202,50 @@ int stm32_configgpio(uint32_t cfgset)
 
   flags = enter_critical_section();
 
+  /* Determine the alternate function (Only alternate function pins) */
+
+  if (pinmode == GPIO_MODER_ALT)
+    {
+      setting = (cfgset & GPIO_AF_MASK) >> GPIO_AF_SHIFT;
+    }
+  else
+    {
+      setting = 0;
+    }
+
+  if (pinmode == GPIO_MODER_ALT)
+    {
+      alt_setting = (cfgset & GPIO_AF_MASK) >> GPIO_AF_SHIFT;
+    }
+  else
+    {
+      alt_setting = 0;
+    }
+
+  /* Set the alternate function (Only alternate function pins)
+   * This is done before configuring the Outputs on a change to
+   * an Alternate function.
+   */
+
+  if (alt_setting != 0)
+    {
+      if (pin < 8)
+        {
+          regoffset = STM32_GPIO_AFRL_OFFSET;
+          pos       = pin;
+        }
+      else
+        {
+          regoffset = STM32_GPIO_AFRH_OFFSET;
+          pos       = pin - 8;
+        }
+
+      regval  = getreg32(base + regoffset);
+      regval &= ~GPIO_AFR_MASK(pos);
+      regval |= (alt_setting << GPIO_AFR_SHIFT(pos));
+      putreg32(regval, base + regoffset);
+    }
+
   /* Now apply the configuration to the mode register */
 
   regval  = getreg32(base + STM32_GPIO_MODER_OFFSET);
@@ -234,32 +279,29 @@ int stm32_configgpio(uint32_t cfgset)
   regval |= (setting << GPIO_PUPDR_SHIFT(pin));
   putreg32(regval, base + STM32_GPIO_PUPDR_OFFSET);
 
-  /* Set the alternate function (Only alternate function pins) */
+  /* Set the alternate function (Only alternate function pins)
+   * This is done after configuring the the pin's connection
+   * on a change away from an Alternate function.
+   */
 
-  if (pinmode == GPIO_MODER_ALT)
-    {
-      setting = (cfgset & GPIO_AF_MASK) >> GPIO_AF_SHIFT;
-    }
-  else
-    {
-      setting = 0;
-    }
+  if (alt_setting == 0)
+      {
+        if (pin < 8)
+          {
+            regoffset = STM32_GPIO_AFRL_OFFSET;
+            pos       = pin;
+          }
+        else
+          {
+            regoffset = STM32_GPIO_AFRH_OFFSET;
+            pos       = pin - 8;
+          }
 
-  if (pin < 8)
-    {
-      regoffset = STM32_GPIO_AFRL_OFFSET;
-      pos       = pin;
-    }
-  else
-    {
-      regoffset = STM32_GPIO_AFRH_OFFSET;
-      pos       = pin - 8;
-    }
-
-  regval  = getreg32(base + regoffset);
-  regval &= ~GPIO_AFR_MASK(pos);
-  regval |= (setting << GPIO_AFR_SHIFT(pos));
-  putreg32(regval, base + regoffset);
+        regval  = getreg32(base + regoffset);
+        regval &= ~GPIO_AFR_MASK(pos);
+        regval |= (alt_setting << GPIO_AFR_SHIFT(pos));
+        putreg32(regval, base + regoffset);
+      }
 
   /* Set speed (Only outputs and alternate function pins) */
 

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -801,19 +801,18 @@ static void stm32_configwaitints(struct stm32_dev_s *priv, uint32_t waitmask,
                                 GPIO_PUPD_MASK);
       pinset |= (GPIO_INPUT | GPIO_EXTI);
 
-      /* Arm the SDMMC_D Ready and install Isr */
+      /* Arm the SDMMC_D0 Ready and install Isr */
 
       stm32_gpiosetevent(pinset, true, false, false,
                          stm32_sdmmc_rdyinterrupt, priv);
     }
 
-  /* Disarm SDMMC_D ready */
+  /* Disarm SDMMC_D0 ready and return it to SDMMC D0 */
 
   if ((wkupevent & SDIOWAIT_WRCOMPLETE) != 0)
     {
       stm32_gpiosetevent(priv->d0_gpio, false, false, false,
                          NULL, NULL);
-      stm32_configgpio(priv->d0_gpio);
     }
 #endif
 

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -782,19 +782,18 @@ static void stm32_configwaitints(struct stm32_dev_s *priv, uint32_t waitmask,
       pinset = priv->d0_gpio & (GPIO_PORT_MASK | GPIO_PIN_MASK);
       pinset |= (GPIO_INPUT | GPIO_FLOAT | GPIO_EXTI);
 
-      /* Arm the SDMMC_D Ready and install ISR */
+      /* Arm the SDMMC_D0 Ready and install ISR */
 
       stm32_gpiosetevent(pinset, true, false, false,
                          stm32_sdmmc_rdyinterrupt, priv);
     }
 
-  /* Disarm SDMMC_D ready */
+  /* Disarm SDMMC_D0 ready and return it to SDMMC D0 */
 
   if ((wkupevent & SDIOWAIT_WRCOMPLETE) != 0)
     {
       stm32_gpiosetevent(priv->d0_gpio, false, false, false,
                          NULL, NULL);
-      stm32_configgpio(priv->d0_gpio);
     }
 #endif
 


### PR DESCRIPTION
## Summary

The PR fixes stm32xx GPIO glitches from GPIO configuration with bad order of operations

When I2C was initialized the SDA and SCL lines would glitch low. The Bosch BMM150 was locking up from this.
 
<img width="1708" alt="Glitch on init Capture" src="https://user-images.githubusercontent.com/1945821/134233245-0d0ae952-8df3-4e34-8f9d-e829e6504ba3.PNG">

The root cause on a STM32F12 was that the IO PAD was connected and driven (by the default IP block) BEFORE the IP block (I2C) was routed to the PAD via the alternate selection mux.

The fix is two fold: 

1. On a to-ALT configuration: Configure the ALT selection MUX **before** the IO direction is changed. 
2. On a from-ALT configuration (unconfigure): Configure the ALT selection MUX **after** the IO direction is changed. 
<img width="519" alt="On_deinit" src="https://user-images.githubusercontent.com/1945821/134233296-9c09ade6-a8c5-485e-9dd1-407d4d6978e9.PNG">

On a Conner case testing HW stack checking this change exposed a timing related bug in the SDIO/SDMMC driver that was the result of redundant GPIO configurations dropping interrupts. This is fixed in https://github.com/apache/incubator-nuttx/commit/18d720407140d361d1d606852e5e4185d80c4935

## Impact

STM32, STM32F7, STM32H7

## Testing

Bench tested on 
PX4 holybro-can-gps-v1

F4, F7, H7 HW

![image](https://user-images.githubusercontent.com/1945821/134235053-73d3aee7-f66f-4c8d-8194-22cb8c583339.png)


